### PR TITLE
Enable memory sharing through multiprocessing Array.

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -16,6 +16,7 @@ from bybit import create_bot as create_bot_bybit
 from bybit import fetch_trades as bybit_fetch_trades
 from binance import create_bot as create_bot_binance
 from binance import fetch_trades as binance_fetch_trades
+import gc
 
 from typing import Iterator, Callable
 
@@ -544,16 +545,30 @@ def get_downloaded_trades(filepath: str, age_limit_millis: float) -> (pd.DataFra
                            key=lambda x: int(x[:x.find('_')].replace('.cs', '').replace('v', '')))
         chunks = []
         chunk_lengths = {}
+        df = pd.DataFrame()
         for f in filenames[::-1]:
-            chunk = pd.read_csv(filepath + f).set_index('trade_id')
+            chunk = pd.read_csv(os.path.join(filepath, f), dtype=np.float64).set_index('trade_id')
             chunk_lengths[f] = len(chunk)
+            chunks.append(chunk)
+            if len(chunks) >= 100:
+                if df.empty:
+                    df = pd.concat(chunks, axis=0)
+                else:
+                    chunks.insert(0, df)
+                    df = pd.concat(chunks, axis=0)
+                chunks = []
             print('\rloaded chunk of trades', f, ts_to_date(chunk.timestamp.iloc[0] / 1000),
                   end='     ')
-            chunks.append(chunk)
             if chunk.timestamp.iloc[0] < age_limit_millis:
                 break
         if chunks:
-            df = pd.concat(chunks, axis=0).sort_index()
+            if df.empty:
+                df = pd.concat(chunks, axis=0)
+            else:
+                chunks.insert(0, df)
+                df = pd.concat(chunks, axis=0)
+            del chunks
+        if not df.empty:
             return df[~df.index.duplicated()], chunk_lengths
         else:
             return None, {}
@@ -571,13 +586,19 @@ async def load_trades(exchange: str, user: str, symbol: str, n_days: float) -> p
             print('           to', id_)
         return id_
 
-    def load_cache():
+    def load_cache(index_only=False):
         cache_filenames = [f for f in os.listdir(cache_filepath) if '.csv' in f]
         if cache_filenames:
             print('loading cached ticks')
-            cache_df = pd.concat([pd.read_csv(cache_filepath + f) for f in cache_filenames], axis=0)
+            if index_only:
+                cache_df = pd.concat(
+                    [pd.read_csv(os.path.join(cache_filepath, f), dtype=np.float64, usecols=["trade_id"]) for f in
+                     cache_filenames], axis=0)
+            else:
+                cache_df = pd.concat(
+                    [pd.read_csv(os.path.join(cache_filepath, f), dtype=np.float64) for f in cache_filenames], axis=0)
             cache_df = cache_df.set_index('trade_id')
-            return cache_df
+            return cache_df[~cache_df.index.duplicated()]
         return None
 
     if exchange == 'binance':
@@ -594,13 +615,15 @@ async def load_trades(exchange: str, user: str, symbol: str, n_days: float) -> p
     age_limit = time() - 60 * 60 * 24 * n_days
     age_limit_millis = age_limit * 1000
     print('age_limit', ts_to_date(age_limit))
-    cache_df = load_cache()
+    cache_df = load_cache(True)
     trades_df, chunk_lengths = get_downloaded_trades(filepath, age_limit_millis)
     ids = set()
     if trades_df is not None:
         ids.update(trades_df.index)
     if cache_df is not None:
         ids.update(cache_df.index)
+    del cache_df
+    gc.collect()
     gaps = []
     if trades_df is not None and len(trades_df) > 0:
         # 
@@ -610,7 +633,10 @@ async def load_trades(exchange: str, user: str, symbol: str, n_days: float) -> p
                 gaps.append((sids[i-1], sids[i]))
         if gaps:
             print('gaps', gaps)
-        # 
+
+    del sids
+    gc.collect()
+
     prev_fetch_ts = time()
     new_trades = await fetch_trades_func(cc, symbol)
     k = 0
@@ -636,6 +662,8 @@ async def load_trades(exchange: str, user: str, symbol: str, n_days: float) -> p
             fetched_new_trades = await fetch_trades_func(cc, symbol, from_id=from_id)
         new_trades = fetched_new_trades + new_trades
         ids.update([e['trade_id'] for e in new_trades])
+    del ids
+    gc.collect()
     tdf = pd.concat([load_cache(), trades_df], axis=0).sort_index()
     tdf = tdf[~tdf.index.duplicated()]
     dump_chunks(filepath, tdf, chunk_lengths)
@@ -651,7 +679,7 @@ async def load_trades(exchange: str, user: str, symbol: str, n_days: float) -> p
 def dump_chunks(filepath: str, tdf: pd.DataFrame, chunk_lengths: dict, chunk_size=100000):
     chunk_ids = tdf.index // chunk_size * chunk_size
     for g in tdf.groupby(chunk_ids):
-        filename = f'{g[1].index[0]}_{g[1].index[-1]}.csv'
+        filename = f'{int(g[1].index[0])}_{int(g[1].index[-1])}.csv'
         if filename not in chunk_lengths or chunk_lengths[filename] != chunk_size:
             print('dumping chunk', filename)
             g[1].to_csv(f'{filepath}{filename}')
@@ -994,6 +1022,10 @@ async def load_ticks(backtest_config: dict) -> [dict]:
     if os.path.exists(ticks_filepath):
         print('loading cached trade list', ticks_filepath)
         ticks = np.load(ticks_filepath, allow_pickle=True)
+        if ticks.dtype != np.float64:
+            print('converting cached trade list')
+            np.save(ticks_filepath, ticks.astype("float64"))
+            ticks = np.load(ticks_filepath, allow_pickle=True)
     else:
         agg_trades = await load_trades(backtest_config['exchange'], backtest_config['user'],
                                        backtest_config['symbol'], backtest_config['n_days'])

--- a/backtest.py
+++ b/backtest.py
@@ -9,7 +9,7 @@ import pprint
 import matplotlib.pyplot as plt
 import aiomultiprocess
 from hashlib import sha256
-from multiprocessing import cpu_count, Lock, Value
+from multiprocessing import cpu_count, Lock, Value, Array
 from time import time
 from passivbot import *
 from bybit import create_bot as create_bot_bybit
@@ -843,7 +843,8 @@ def get_next_candidate(backtest_config: dict, candidate: dict, ms: [float], k: V
         lock.release()
 
 
-async def jackrabbit_worker(ticks: np.ndarray,
+async def jackrabbit_worker(ticks: Array,
+                            dim: (),
                             backtest_config: dict,
                             candidate: dict,
                             score_func: Callable,
@@ -851,6 +852,7 @@ async def jackrabbit_worker(ticks: np.ndarray,
                             ks: int,
                             ms: [float],
                             lock: Lock):
+    ticks = np.frombuffer(ticks.get_obj(), dtype='d').reshape(dim)
     start_time = time()
     while True:
         if k.value >= ks:
@@ -895,9 +897,12 @@ async def jackrabbit_multi_core(results: dict,
     lock = Lock()
     k = Value('i', k_)
     workers = []
+    ticks_m = Array('d', int(np.prod(ticks.shape)), lock=True)
+    ticks_n = np.frombuffer(ticks_m.get_obj(), dtype='d').reshape(ticks.shape)
+    ticks_n[:] = ticks
     for _ in range(min(n_cpus, ks)):
         workers.append(asyncio.create_task(multiprocess_wrap(
-            jackrabbit_worker, (ticks, backtest_config, candidate, score_func, k, ks, ms, lock)
+            jackrabbit_worker, (ticks_m, ticks.shape, backtest_config, candidate, score_func, k, ks, ms, lock)
         )))
         await asyncio.sleep(0.05)
     for w in workers:


### PR DESCRIPTION
Pull request for the changes we discussed to enable memory sharing across processes. Uses a multiprocessing array for sharing and frombuffer from numpy to create a numpy view to that array. The view is created before starting the workers to fill the array and in each worker to make it available.