### PR TITLE
V2.2.0 multiprocess sliding window

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -808,8 +808,6 @@ def candidate_to_live_settings(exchange: str, candidate: dict) -> dict:
 
 
 def calc_candidate_hash_key(candidate: dict, keys: [str]) -> str:
-    print(candidate)
-    print(keys)
     return sha256(json.dumps({k: candidate[k] for k in sorted(keys)}).encode()).hexdigest()
 
 


### PR DESCRIPTION
Pull request for the changes we discussed to enable memory sharing across processes. Uses a multiprocessing array for sharing and frombuffer from numpy to create a numpy view to that array. The view is created before starting the workers to fill the array and in each worker to make it available.