### PR TITLE
Force the version of ccxt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 websockets>=8.1
 pandas>=1.2.2
-ccxt>=1.42.18
+ccxt==1.42.38
 numpy>=1.20.1
 hjson>=3.0.2
 numba>=0.52.0


### PR DESCRIPTION
Fix https://github.com/enarjord/passivbot_futures/issues/36

There is a change in the interface with the 1.42.39 version of ccxt.

Since the v3 does not use the ccxt and the v2 may not be pursued, you may force the ccxt to a version that works.