### PR TITLE
V3.3

### DIFF
--- a/binance.py
+++ b/binance.py
@@ -93,9 +93,13 @@ async def fetch_ticks_time(cc, symbol: str, start_time: int, end_time: int = Non
                'qty': float(t['q']),
                'timestamp': t['T'],
                'is_buyer_maker': t['m']} for t in fetched_trades]
-    if do_print:
-        print_(['fetched trades', symbol, trades[0]['trade_id'],
-                ts_to_date(float(trades[0]['timestamp']) / 1000)])
+    try:
+        if do_print:
+            print_(['fetched trades', symbol, trades[0]['trade_id'],
+                    ts_to_date(float(trades[0]['timestamp']) / 1000)])
+    except:
+        if do_print:
+            print_(['fetched no new trades', symbol])
     return trades
 
 

--- a/bybit.py
+++ b/bybit.py
@@ -314,10 +314,15 @@ class Bybit(Bot):
         except Exception as e:
             print('error fetching ticks', e)
             return []
-        trades = list(map(format_tick, ticks['result']))
-        if do_print:
-            print_(['fetched trades', self.symbol, trades[0]['trade_id'],
-                    ts_to_date(float(trades[0]['timestamp']) / 1000)])
+        try:
+            trades = list(map(format_tick, ticks['result']))
+            if do_print:
+                print_(['fetched trades', self.symbol, trades[0]['trade_id'],
+                        ts_to_date(float(trades[0]['timestamp']) / 1000)])
+        except:
+            trades = []
+            if do_print:
+                print_(['fetched no new trades', self.symbol])
         return trades
 
     def calc_margin_cost(self, qty: float, price: float) -> float:

--- a/bybit.py
+++ b/bybit.py
@@ -86,11 +86,10 @@ async def fetch_ticks(cc, symbol: str, from_id: int = None, do_print=True) -> [d
     return trades
 
 def date_to_ts(date: str):
-    date = date[:23].replace('Z', '')
     try:
-        return datetime.strptime(date, "%Y-%m-%dT%H:%M:%S.%f").timestamp() * 1000
+        return datetime.strptime(date, "%Y-%m-%dT%H:%M:%S.%f%z").timestamp() * 1000
     except ValueError:
-        formats = ["%Y-%m-%dT%H:%M:%S"]
+        formats = ["%Y-%m-%dT%H:%M:%S%z"]
         for f in formats:
             try:
                 return datetime.strptime(date, f).timestamp() * 1000


### PR DESCRIPTION
Fix bugs in the downloader in the case of several edge cases. Start fetching from id 1 when starting. Start from id 1 when find_time overshoots into negative values. Break in the case no new trades happened and it fetches the same trades again or when no trades are returned. Also fixes timestamp conversion for bybit and catches the case for binance and bybit when no trades are returned.