### PR TITLE
Fix starting from start candidate.

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -130,9 +130,9 @@ def plot_fills(df, fdf, side_: int = 0, liq_thr=0.1):
 
 def cleanup_candidate(config: dict) -> dict:
     cleaned = config.copy()
-    for k in cleaned:
-        if k in config['ranges']:
-            cleaned[k] = round_(cleaned[k], config['ranges'][k][2])
+    # for k in cleaned:
+    #     if k in config['ranges']:
+    #         cleaned[k] = round_(cleaned[k], config['ranges'][k][2])
     if cleaned['ema_span'] != cleaned['ema_span']:
         cleaned['ema_span'] = 1.0
     if cleaned['ema_spread'] != cleaned['ema_spread']:
@@ -529,12 +529,12 @@ def create_config(backtest_config: dict) -> dict:
     config = {k: backtest_config[k] for k in backtest_config
               if k not in {'session_name', 'user', 'symbol', 'start_date', 'end_date', 'ranges'}}
     for k in backtest_config['ranges']:
-        if backtest_config['ranges'][k][0] == backtest_config['ranges'][k][1] == backtest_config['ranges'][k][2]:
+        if backtest_config['ranges'][k][0] == backtest_config['ranges'][k][1]:
             config[k] = backtest_config['ranges'][k][0]
+        elif k in ['n_close_orders', 'leverage']:
+            config[k] = tune.randint(backtest_config['ranges'][k][0], backtest_config['ranges'][k][1] + 1)
         else:
-            config[k] = tune.choice(np.arange(backtest_config['ranges'][k][0],
-                                              backtest_config['ranges'][k][1] + backtest_config['ranges'][k][2],
-                                              backtest_config['ranges'][k][2]))
+            config[k] = tune.uniform(backtest_config['ranges'][k][0], backtest_config['ranges'][k][1])
     return config
 
 
@@ -550,15 +550,8 @@ def find_closest(value: float, distribution: np.ndarray) -> float:
 def clean_start_config(start_config: dict, backtest_config: dict) -> dict:
     clean_start = {}
     for k, v in start_config.items():
-        if k in backtest_config:
-            try:
-                if v in backtest_config[k]:
-                    clean_start[k] = v
-                else:
-                    closest = find_closest(v, backtest_config[k])
-                    clean_start[k] = closest
-            except:
-                pass
+        if k in backtest_config and k not in ['do_long', 'do_shrt']:
+            clean_start[k] = v
     return clean_start
 
 

--- a/backtest.py
+++ b/backtest.py
@@ -538,15 +538,6 @@ def create_config(backtest_config: dict) -> dict:
     return config
 
 
-def find_closest(value: float, distribution: np.ndarray) -> float:
-    closest = 0
-    error = 100
-    for i in distribution:
-        if i - value < error:
-            closest = i
-    return closest
-
-
 def clean_start_config(start_config: dict, backtest_config: dict) -> dict:
     clean_start = {}
     for k, v in start_config.items():

--- a/backtest.py
+++ b/backtest.py
@@ -1,5 +1,7 @@
 import gc
+import glob
 from hashlib import sha256
+from typing import Union
 
 import matplotlib.pyplot as plt
 import nevergrad as ng
@@ -7,6 +9,7 @@ import ray
 from ray import tune
 from ray.tune.schedulers import AsyncHyperBandScheduler
 from ray.tune.suggest import ConcurrencyLimiter
+# from ray.tune.suggest.hyperopt import HyperOptSearch
 from ray.tune.suggest.nevergrad import NevergradSearch
 
 from downloader import Downloader, prep_backtest_config
@@ -535,11 +538,27 @@ def create_config(backtest_config: dict) -> dict:
     return config
 
 
+def find_closest(value: float, distribution: np.ndarray) -> float:
+    closest = 0
+    error = 100
+    for i in distribution:
+        if i - value < error:
+            closest = i
+    return closest
+
+
 def clean_start_config(start_config: dict, backtest_config: dict) -> dict:
     clean_start = {}
     for k, v in start_config.items():
         if k in backtest_config:
-            clean_start[k] = v
+            try:
+                if v in backtest_config[k]:
+                    clean_start[k] = v
+                else:
+                    closest = find_closest(v, backtest_config[k])
+                    clean_start[k] = closest
+            except:
+                pass
     return clean_start
 
 
@@ -552,7 +571,7 @@ def clean_result_config(config: dict) -> dict:
     return config
 
 
-def backtest_tune(ticks: np.ndarray, backtest_config: dict, current_best: dict = None):
+def backtest_tune(ticks: np.ndarray, backtest_config: dict, current_best: Union[dict, list] = None):
     config = create_config(backtest_config)
     n_days = round_((ticks[-1][2] - ticks[0][2]) / (1000 * 60 * 60 * 24), 0.1)
     session_dirpath = make_get_filepath(os.path.join('reports', backtest_config['exchange'], backtest_config['symbol'],
@@ -579,8 +598,13 @@ def backtest_tune(ticks: np.ndarray, backtest_config: dict, current_best: dict =
         omega = backtest_config['options']['w']
     current_best_params = []
     if current_best:
-        current_best = clean_start_config(current_best, config)
-        current_best_params.append(current_best)
+        if type(current_best) == list:
+            for c in current_best:
+                c = clean_start_config(c, config)
+                current_best_params.append(c)
+        else:
+            current_best = clean_start_config(current_best, config)
+            current_best_params.append(current_best)
 
     ray.init(num_cpus=num_cpus)
     pso = ng.optimizers.ConfiguredPSO(transform='identity', popsize=n_particles, omega=omega, phip=phi1, phig=phi2)
@@ -644,8 +668,13 @@ async def main(args: list):
     start_candidate = None
     if (s := '--start') in args:
         try:
-            start_candidate = json.load(open(args[args.index(s) + 1]))
-            print('Starting with specified configuration.')
+            if os.path.isdir(args[args.index(s) + 1]):
+                start_candidate = [json.load(open(f)) for f in
+                                   glob.glob(os.path.join(args[args.index(s) + 1], '*.json'))]
+                print('Starting with all configurations in directory.')
+            else:
+                start_candidate = json.load(open(args[args.index(s) + 1]))
+                print('Starting with specified configuration.')
         except:
             print('Could not find specified configuration.')
     if start_candidate:

--- a/backtest_configs/xmr.hjson
+++ b/backtest_configs/xmr.hjson
@@ -8,8 +8,6 @@
 
   do_long: true
   do_shrt: true
-  leverage: 12
-  n_close_orders: 16
 
   # pso options
   iters: 100
@@ -24,16 +22,18 @@
   # set end_date=-1 to use now as end date
   end_date: -1
 
-  # If start, stop, and step are set to same value, it's treated as a fixed variable.
+  # If start and stop are set to same value, it's treated as a fixed variable.
   ranges:
   {
-    qty_pct: [0.0, 0.5, 0.0001]
-    ddown_factor: [0, 3.5, 0.05]
-    grid_coefficient: [0, 400, 0.1]
-    grid_spacing: [0.0002, 0.02, 0.0001]
-    markup_range: [0.0, 0.02, 0.0001]
-    min_markup: [0.0005, 0.012, 0.00001]
-    ema_span: [10.0, 60000.0, 10.0]
-    ema_spread: [0.0, 0.0075, 0.0001]
+    leverage: [1, 100]
+    n_close_orders: [8, 20]
+    qty_pct: [0.0, 0.5]
+    ddown_factor: [0, 3.5]
+    grid_coefficient: [0, 400]
+    grid_spacing: [0.0002, 0.02]
+    markup_range: [0.0, 0.02]
+    min_markup: [0.0005, 0.012]
+    ema_span: [10.0, 60000.0]
+    ema_spread: [0.0, 0.0075]
   }
 }


### PR DESCRIPTION
Enable starting from one or multiple start candidates. If it is a directory, it takes all json files in that directory. Otherwise, it reads one file. 
The actual issue was that the configs produced by the backtester round the values for the parameters. Some values have some imprecision and the rounded value is not in the distribution of values for that parameter. Finding the closest value fixes this.