### PR TITLE
Compute returns for arbitrary periods and with improved accuracy, add new metrics

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -648,13 +648,28 @@ def prepare_result(fills: list, stats: list, ticks: np.ndarray, do_long: bool, d
 
     result.update(prepare_result_sampled(stats))
     return result
+                
 
+def obj_adg(result: dict, liq_cap: float, n_daily_entries_cap: int) -> float:
+    return (result['average_daily_gain'] *
+            min(1.0, (result['n_entries'] / result['n_days']) / n_daily_entries_cap) *
+            min(1.0, result['closest_liq'] / liq_cap))
+
+
+def obj_vwr_daily(result: dict, liq_cap: float, n_daily_entries_cap: int) -> float:
+    return (result['VWR_daily'] *
+            min(1.0, (result['n_entries'] / result['n_days']) / n_daily_entries_cap) *
+            min(1.0, result['closest_liq'] / liq_cap))
+ 
 
 def objective_function(result: dict, liq_cap: float, n_daily_entries_cap: int) -> float:
     try:
-        return (result['VWR_daily'] *
-                min(1.0, (result['n_entries'] / result['n_days']) / n_daily_entries_cap) *
-                min(1.0, result['closest_liq'] / liq_cap))
+        # scoring metric and any parameters belonging thereto could eventually be defined in backtest config,
+        # e.g. [adg, vwr_daily, vwr_weekly, ]
+        # letting default remain 'average_daily_gain' for now
+
+        return obj_adg(result, liq_cap, n_daily_entries_cap)
+        # return obj_vwr_daily(result, liq_cap, n_daily_entries_cap)
     except Exception as e:
         print('error with objective function', e, result)
         return 0.0

--- a/backtest.py
+++ b/backtest.py
@@ -253,26 +253,24 @@ def backtest(config: dict, ticks: np.ndarray, return_fills=False, do_print=False
     delayed_update = ticks[0][2] + min_trade_delay_millis
     prev_update_ts = 0
 
-    last_update = None
+    next_stats_update = 0
     stats = []
 
     def stats_update():
         upnl_l = x if (x := long_pnl_f(long_pprice, tick[0], long_psize)) == x else 0.0
         upnl_s = y if (y := shrt_pnl_f(shrt_pprice, tick[0], shrt_psize)) == y else 0.0
-        s = {}
-        s['timestamp'] = tick[2]
-        s['balance'] = balance # Not needed because redondant with fills, but makes plotting easier
-        s['equity'] = balance + upnl_l + upnl_s
-        stats.append(s)
+        stats.append({'timestamp': tick[2],
+                      'balance': balance, # Redundant with fills, but makes plotting easier
+                      'equity': balance + upnl_l + upnl_s})
 
     for k, tick in enumerate(ticks):
 
         liq_diff = calc_diff(liq_price, tick[0])
 
         # Update the stats every hour
-        if last_update == None or tick[2] - last_update > 3600*1000:
+        if tick[2] > next_stats_update:
             stats_update()
-            last_update = tick[2]
+            next_stats_update = tick[2] + 1000 * 60 * 60
 
         if tick[2] > delayed_update:
             # after simulated delay, update open orders


### PR DESCRIPTION
The current way of computing statistics such as the _pnl_ or _drawdown_ has few shortcomings. Most of them

- Are computed during a backtest run, which is bad for redundancy and separation of concerns
- Can be computed afterwards using a very limited amount of information

It does not allow for a simple calculation of metrics traditionally constructed from equally spaced time series either, such as the Sharpe Ratio. Morever, the resulting _adg_ – the most important metric used to this day – lacks precision.

My proposition thus consists in computing the minimum amount of data possible during a run to  produce the `result` dictionnary. In addition to computing them after each fill, it does so after every `x` amount of time as well. I've set `x` to represent one hour.

The heart of this PR is the the `prepare_result_sampled` function that resamples this data with pandas. It uses the resulting evenly distributed dataframe to compute for a given period:

- The expected compounded returns (daily corresponds to `adg-1`, weekly to the `gain-1` after a week, etc.)
- The [Sharpe Ratio](https://en.wikipedia.org/wiki/Sharpe_ratio), a metric at the foundation of portfolio theory
- The [Variability-Weighted Return](https://www.crystalbull.com/sharpe-ratio-better-with-log-returns/) (VWR), extensively detailed in the comments

All it needs to compute all of these statistics is a dictionnary of equities and timestamps.

The objective function now uses the daily VWR instead of _adg_. As explained in the comments, the daily VWR simply is `(adg-1) * weight = daily_expected_returns * weight`, where the factor `weight` is smaller than one and accounts for risk.

Note that two parameters define how this weighting factor is computed: `tau` and `sdev_max`. Users thereby can specify how much risks they're comfortable with. These parameters are currently hard-coded to 1.4 and 0.16 respectively. The link above provides an interactive tool to get a better feeling of their effects.

Lastly, my code makes it possible to plot nicer and more accurate graphs, thanks to the statistics computed every hour. Let's showcase this while illustrating why the VWR is such a cool metric. Here are the results of two backtest runs:

![](https://i.imgur.com/EAM84EF.png)
![](https://i.imgur.com/OcWWAM5.png)

|  **Metric**  |  **First** |  **Second**  | 
|---|---|---|
| **Final equity** (last tick) | 836.564675046595 | 842.247078391022   | 
| **Gain** |  1.6704160700931996  |  1.6844335767820446  |  
| **Average daily returns** | 1.0373279112286244  |  **1.0379472786136403** | 
| **Daily returns** | 0.03744813456324447  |  **0.03794990500316264** |  
| **Daily VWR** `tau=2.6`, `sdev_max=0.22` | 0.03246110288974068  |  **0.03246168034175821** | 
| **Daily VWR** `tau=1.4`, `sdev_max=0.16` | **0.017697390054560704**  | 0.017025848727939906  | 
| **Daily VWR** `tau=1.1`, `sdev_max=0.13` | **0.00898279644585094**  |  0.008079100564652173 | 

Note that the code to produce these graph isn't committed yet.

When maximizing for the expected daily returns, the second graph will score higher than the first one (ignoring the capping values). With VWR, you can choose the kind of equity curve you aim for. If you're not scared of the drop in equity of the second graph, you may want to choose the first couple of parameters. If you are, please choose lower values.

As for the accuracy, it's only expected that we fail to retrieve the equity of the very last tick using the _adg_ instead of the daily returns:

- adg: `500 * 1.0373279112286244^13.999985532407408 = 835.2080350465993`
- expected daily return: `500 * (1+0.03744813456324447)^14 = 836.564675046595`

Since we only have access to informations at the time of the last fill with the current implementation. The 13.9999... comes from the `n_days` variable, which is defined through the first and last tick timestamp. However it doesn't account *too* much for the error in most cases.

As a closing note, here are few other graphs we could make with this PR:

- Expected returns for a given period
- Drawdown
- Rolling maximum drawdown
- Rolling Sharpe Ratio
- Rolling VWR

Let me know what you think!