### PR TITLE
Proposal: Improve indexing

### DIFF
--- a/jitted.py
+++ b/jitted.py
@@ -1,9 +1,12 @@
 import sys
-import numpy as np
+from enum import IntEnum
 
+import numpy as np
 
 if '--nojit' in sys.argv:
     print('not using numba')
+
+
     def njit(pyfunc=None, **kwargs):
         def wrap(func):
             return func
@@ -15,6 +18,12 @@ if '--nojit' in sys.argv:
 else:
     print('using numba')
     from numba import njit
+
+Config = IntEnum('Config', ['inverse', 'do_long', 'do_shrt', 'qty_step', 'price_step', 'min_qty', 'min_cost',
+                            'contract_multiplier', 'ddown_factor', 'qty_pct', 'leverage', 'n_close_orders',
+                            'grid_spacing', 'pos_margin_grid_coeff', 'volatility_grid_coeff', 'volatility_qty_coeff',
+                            'min_markup', 'markup_range', 'ema_span', 'ema_spread', 'stop_loss_liq_diff',
+                            'stop_loss_pos_pct'], start=0)
 
 
 @njit
@@ -75,114 +84,121 @@ def calc_stds(xs: [float], span: int) -> np.ndarray:
 
 
 @njit
-def calc_initial_long_entry_price(xk: tuple, ema: float, highest_bid: float) -> float:
-    return min(highest_bid, round_dn(ema * (1 - xk[19]), xk[4]))
+def calc_initial_long_entry_price(xk: np.ndarray, ema: float, highest_bid: float) -> float:
+    return min(highest_bid, round_dn(ema * (1 - xk[np.intp(Config.ema_spread)]), xk[np.intp(Config.price_step)]))
 
 
 @njit
-def calc_initial_shrt_entry_price(xk: tuple, ema: float, lowest_ask: float) -> float:
-    return max(lowest_ask, round_up(ema * (1 + xk[19]), xk[4]))
+def calc_initial_shrt_entry_price(xk: np.ndarray, ema: float, lowest_ask: float) -> float:
+    return max(lowest_ask, round_up(ema * (1 + xk[np.intp(Config.ema_spread)]), xk[np.intp(Config.price_step)]))
 
 
 @njit
-def calc_min_entry_qty(xk: tuple, price: float) -> float:
-    return max(xk[5], round_up(xk[6] * (price / xk[7] if xk[0] else 1 / price), xk[4]))
+def calc_min_entry_qty(xk: np.ndarray, price: float) -> float:
+    return max(xk[np.intp(Config.min_qty)], round_up(xk[np.intp(Config.min_cost)] * (
+        price / xk[np.intp(Config.contract_multiplier)] if xk[np.intp(Config.inverse)] else 1 / price),
+                                                     xk[np.intp(Config.price_step)]))
 
 
 @njit
-def calc_initial_entry_qty(xk: tuple,
+def calc_initial_entry_qty(xk: np.ndarray,
                            balance: float,
                            price: float,
                            available_margin: float,
                            volatility: float) -> float:
     min_entry_qty = calc_min_entry_qty(xk, price)
-    if xk[0]:
+    if xk[np.intp(Config.inverse)]:
         qty = round_dn(
-            min(available_margin * price / xk[7],
+            min(available_margin * price / xk[np.intp(Config.contract_multiplier)],
                 max(min_entry_qty,
-                    (balance / xk[7]) * price * xk[10] * xk[9] * (1 + volatility * xk[15]))),
-            xk[3]
+                    (balance / xk[np.intp(Config.contract_multiplier)]) * price * xk[np.intp(Config.leverage)] * xk[
+                        np.intp(Config.qty_pct)] * (1 + volatility * xk[np.intp(Config.volatility_qty_coeff)]))),
+            xk[np.intp(Config.qty_step)]
         )
     else:
         qty = round_dn(
             min(available_margin / price,
                 max(min_entry_qty,
-                    (balance / price) * xk[10] * xk[9] * (1 + volatility * xk[15]))),
-            xk[3]
+                    (balance / price) * xk[np.intp(Config.leverage)] * xk[np.intp(Config.qty_pct)] * (
+                            1 + volatility * xk[np.intp(Config.volatility_qty_coeff)]))),
+            xk[np.intp(Config.qty_step)]
         )
     return qty if qty >= min_entry_qty else 0.0
 
 
 @njit
-def calc_reentry_qty(xk: tuple, psize: float, price: float, available_margin: float) -> float:
+def calc_reentry_qty(xk: np.ndarray, psize: float, price: float, available_margin: float) -> float:
     min_entry_qty = calc_min_entry_qty(xk, price)
-    qty = min(round_dn(available_margin * (price / xk[7] if xk[0] else 1 / price), xk[3]),
-              max(min_entry_qty, round_dn(abs(psize) * xk[8], xk[3])))
+    qty = min(round_dn(available_margin * (
+        price / xk[np.intp(Config.contract_multiplier)] if xk[np.intp(Config.inverse)] else 1 / price),
+                       xk[np.intp(Config.qty_step)]),
+              max(min_entry_qty, round_dn(abs(psize) * xk[np.intp(Config.ddown_factor)], xk[np.intp(Config.qty_step)])))
     return qty if qty >= min_entry_qty else 0.0
 
 
 @njit
-def calc_long_reentry_price(xk: tuple,
+def calc_long_reentry_price(xk: np.ndarray,
                             balance: float,
                             psize: float,
                             pprice: float,
                             volatility: float) -> float:
-    modifier = (1 + (calc_margin_cost(xk, psize, pprice) / balance) * xk[13]) * \
-               (1 + volatility * xk[14])
-    return round_dn(pprice * (1 - xk[12] * modifier), xk[4])
+    modifier = (1 + (calc_margin_cost(xk, psize, pprice) / balance) * xk[np.intp(Config.pos_margin_grid_coeff)]) * \
+               (1 + volatility * xk[np.intp(Config.volatility_grid_coeff)])
+    return round_dn(pprice * (1 - xk[np.intp(Config.grid_spacing)] * modifier), xk[np.intp(Config.price_step)])
 
 
 @njit
-def calc_shrt_reentry_price(xk: tuple,
+def calc_shrt_reentry_price(xk: np.ndarray,
                             balance: float,
                             psize: float,
                             pprice: float,
                             volatility: float) -> float:
-    modifier = (1 + (calc_margin_cost(xk, psize, pprice) / balance) * xk[13]) * \
-               (1 + volatility * xk[14])
-    return round_dn(pprice * (1 + xk[12] * modifier), xk[4])
+    modifier = (1 + (calc_margin_cost(xk, psize, pprice) / balance) * xk[np.intp(Config.pos_margin_grid_coeff)]) * \
+               (1 + volatility * xk[np.intp(Config.volatility_grid_coeff)])
+    return round_dn(pprice * (1 + xk[np.intp(Config.grid_spacing)] * modifier), xk[np.intp(Config.price_step)])
 
 
 @njit
-def calc_new_psize_pprice(xk: tuple,
+def calc_new_psize_pprice(xk: np.ndarray,
                           psize: float,
                           pprice: float,
                           qty: float,
                           price: float) -> (float, float):
     if qty == 0.0:
         return psize, pprice
-    new_psize = round_(psize + qty, xk[3])
+    new_psize = round_(psize + qty, xk[np.intp(Config.qty_step)])
     return new_psize, nan_to_0(pprice) * (psize / new_psize) + price * (qty / new_psize)
 
 
 @njit
-def calc_long_pnl(xk: tuple, entry_price: float, close_price: float, qty: float) -> float:
-    if xk[0]:
-        return abs(qty) * xk[7] * (1 / entry_price - 1 / close_price)
+def calc_long_pnl(xk: np.ndarray, entry_price: float, close_price: float, qty: float) -> float:
+    if xk[np.intp(Config.inverse)]:
+        return abs(qty) * xk[np.intp(Config.contract_multiplier)] * (1 / entry_price - 1 / close_price)
     else:
         return abs(qty) * (close_price - entry_price)
 
 
 @njit
-def calc_shrt_pnl(xk: tuple, entry_price: float, close_price: float, qty: float) -> float:
-    if xk[0]:
-        return abs(qty) * xk[7] * (1 / close_price - 1 / entry_price)
+def calc_shrt_pnl(xk: np.ndarray, entry_price: float, close_price: float, qty: float) -> float:
+    if xk[np.intp(Config.inverse)]:
+        return abs(qty) * xk[np.intp(Config.contract_multiplier)] * (1 / close_price - 1 / entry_price)
     else:
         return abs(qty) * (entry_price - close_price)
 
 
 @njit
-def calc_cost(xk: tuple, qty: float, price: float) -> float:
-    return abs(qty / price) * xk[7] if xk[0] else abs(qty * price)
+def calc_cost(xk: np.ndarray, qty: float, price: float) -> float:
+    return abs(qty / price) * xk[np.intp(Config.contract_multiplier)] if xk[np.intp(Config.inverse)] else abs(
+        qty * price)
 
 
 @njit
-def calc_margin_cost(xk: tuple, qty: float, price: float) -> float:
-    return calc_cost(xk, qty, price) / xk[10]
+def calc_margin_cost(xk: np.ndarray, qty: float, price: float) -> float:
+    return calc_cost(xk, qty, price) / xk[np.intp(Config.leverage)]
 
 
 @njit
-def calc_available_margin(xk: tuple,
+def calc_available_margin(xk: np.ndarray,
                           balance: float,
                           long_psize: float,
                           long_pprice: float,
@@ -192,18 +208,18 @@ def calc_available_margin(xk: tuple,
     used_margin = 0.0
     equity = balance
     if long_pprice and long_psize:
-        long_psize_real = long_psize * xk[7]
+        long_psize_real = long_psize * xk[np.intp(Config.contract_multiplier)]
         equity += calc_long_pnl(xk, long_pprice, last_price, long_psize_real)
-        used_margin += calc_cost(xk, long_psize_real, long_pprice) / xk[10]
+        used_margin += calc_cost(xk, long_psize_real, long_pprice) / xk[np.intp(Config.leverage)]
     if shrt_pprice and shrt_psize:
-        shrt_psize_real = shrt_psize * xk[7]
+        shrt_psize_real = shrt_psize * xk[np.intp(Config.contract_multiplier)]
         equity += calc_shrt_pnl(xk, shrt_pprice, last_price, shrt_psize_real)
-        used_margin += calc_cost(xk, shrt_psize_real, shrt_pprice) / xk[10]
+        used_margin += calc_cost(xk, shrt_psize_real, shrt_pprice) / xk[np.intp(Config.leverage)]
     return equity - used_margin
 
 
 @njit
-def iter_entries(xk: tuple,
+def iter_entries(xk: np.ndarray,
                  balance: float,
                  long_psize: float,
                  long_pprice: float,
@@ -238,13 +254,13 @@ def iter_entries(xk: tuple,
             shrt_psize, shrt_pprice = stop_loss_order[2:4]
         available_margin -= calc_margin_cost(xk, stop_loss_order[0], stop_loss_order[1])
     while True:
-        if xk[1]:
+        if xk[np.intp(Config.do_long)]:
             long_entry = calc_next_long_entry(xk, balance, long_psize, long_pprice,
                                               highest_bid, ema, available_margin, volatility)
         else:
             long_entry = (0.0, 0.0, long_psize, long_pprice, '')
 
-        if xk[2]:
+        if xk[np.intp(Config.do_shrt)]:
             shrt_entry = calc_next_shrt_entry(xk, balance, shrt_psize, shrt_pprice,
                                               lowest_ask, ema, available_margin, volatility)
         else:
@@ -273,7 +289,7 @@ def iter_entries(xk: tuple,
 
 
 @njit
-def calc_stop_loss(xk: tuple,
+def calc_stop_loss(xk: np.ndarray,
                    balance: float,
                    long_psize: float,
                    long_pprice: float,
@@ -295,40 +311,42 @@ def calc_stop_loss(xk: tuple,
     '''
     # returns (qty, price, psize if taken, pprice if taken, comment)
     abs_shrt_psize = abs(shrt_psize)
-    if calc_diff(liq_price, last_price) < xk[20]:
+    if calc_diff(liq_price, last_price) < xk[np.intp(Config.stop_loss_liq_diff)]:
         if long_psize > abs_shrt_psize:
             stop_loss_qty = min(long_psize, max(calc_min_entry_qty(xk, lowest_ask),
-                                                round_dn(long_psize * xk[21], xk[3])))
+                                                round_dn(long_psize * xk[np.intp(Config.stop_loss_pos_pct)],
+                                                         xk[np.intp(Config.qty_step)])))
             # if sufficient margin available, increase short pos, otherwise reduce long pos
             margin_cost = calc_margin_cost(xk, stop_loss_qty, lowest_ask)
-            if margin_cost < available_margin and xk[2]:
+            if margin_cost < available_margin and xk[np.intp(Config.do_shrt)]:
                 # add to shrt pos
                 shrt_psize, shrt_pprice = calc_new_psize_pprice(xk, shrt_psize, shrt_pprice,
                                                                 -stop_loss_qty, lowest_ask)
                 return -stop_loss_qty, lowest_ask, shrt_psize, shrt_pprice, 'stop_loss_shrt_entry'
             else:
                 # reduce long pos
-                long_psize = round_(long_psize - stop_loss_qty, xk[3])
+                long_psize = round_(long_psize - stop_loss_qty, xk[np.intp(Config.qty_step)])
                 return -stop_loss_qty, lowest_ask, long_psize, long_pprice, 'stop_loss_long_close'
         else:
             stop_loss_qty = min(abs_shrt_psize, max(calc_min_entry_qty(xk, highest_bid),
-                                                    round_dn(abs_shrt_psize * xk[21], xk[3])))
+                                                    round_dn(abs_shrt_psize * xk[np.intp(Config.stop_loss_pos_pct)],
+                                                             xk[np.intp(Config.qty_step)])))
             # if sufficient margin available, increase long pos, otherwise, reduce shrt pos
             margin_cost = calc_margin_cost(xk, stop_loss_qty, highest_bid)
-            if margin_cost < available_margin and xk[1]:
+            if margin_cost < available_margin and xk[np.intp(Config.do_long)]:
                 # add to long pos
                 long_psize, long_pprice = calc_new_psize_pprice(xk, long_psize, long_pprice,
                                                                 stop_loss_qty, highest_bid)
                 return stop_loss_qty, highest_bid, long_psize, long_pprice, 'stop_loss_long_entry'
             else:
                 # reduce shrt pos
-                shrt_psize = round_(shrt_psize + stop_loss_qty, xk[3])
+                shrt_psize = round_(shrt_psize + stop_loss_qty, xk[np.intp(Config.qty_step)])
                 return stop_loss_qty, highest_bid, shrt_psize, shrt_pprice, 'stop_loss_shrt_close'
     return 0.0, 0.0, 0.0, 0.0, ''
 
 
 @njit
-def calc_next_long_entry(xk: tuple,
+def calc_next_long_entry(xk: np.ndarray,
                          balance: float,
                          psize: float,
                          pprice: float,
@@ -341,8 +359,9 @@ def calc_next_long_entry(xk: tuple,
         qty = calc_initial_entry_qty(xk, balance, price, available_margin, volatility)
         return qty, price, qty, price, 'initial_long_entry'
     else:
-        price = min(round_(highest_bid, xk[4]), calc_long_reentry_price(xk, balance, psize, pprice,
-                                                                        volatility))
+        price = min(round_(highest_bid, xk[np.intp(Config.price_step)]),
+                    calc_long_reentry_price(xk, balance, psize, pprice,
+                                            volatility))
         if price <= 0.0:
             return 0.0, 0.0, psize, pprice, 'long_reentry'
         qty = calc_reentry_qty(xk, psize, price, available_margin)
@@ -351,7 +370,7 @@ def calc_next_long_entry(xk: tuple,
 
 
 @njit
-def calc_next_shrt_entry(xk: tuple,
+def calc_next_shrt_entry(xk: np.ndarray,
                          balance: float,
                          psize: float,
                          pprice: float,
@@ -364,15 +383,16 @@ def calc_next_shrt_entry(xk: tuple,
         qty = -calc_initial_entry_qty(xk, balance, price, available_margin, volatility)
         return qty, price, qty, price, 'initial_shrt_entry'
     else:
-        price = max(round_(lowest_ask, xk[4]), calc_shrt_reentry_price(xk, balance, psize, pprice,
-                                                                       volatility))
+        price = max(round_(lowest_ask, xk[np.intp(Config.price_step)]),
+                    calc_shrt_reentry_price(xk, balance, psize, pprice,
+                                            volatility))
         qty = -calc_reentry_qty(xk, psize, price, available_margin)
         psize, pprice = calc_new_psize_pprice(xk, psize, pprice, qty, price)
         return qty, price, psize, pprice, 'shrt_reentry'
 
 
 @njit
-def iter_long_closes(xk: tuple, balance: float, psize: float, pprice: float, lowest_ask: float):
+def iter_long_closes(xk: np.ndarray, balance: float, psize: float, pprice: float, lowest_ask: float):
     '''
     xk index/value
      0 inverse      6 min_cost             12 grid_spacing           18 ema_span
@@ -385,33 +405,35 @@ def iter_long_closes(xk: tuple, balance: float, psize: float, pprice: float, low
     # yields (qty, price, psize_if_taken)
     if psize == 0.0 or pprice == 0.0:
         return
-    minm = pprice * (1 + xk[16])
-    prices = np.linspace(minm, pprice * (1 + xk[16] + xk[17]), int(xk[11]))
-    prices = [p for p in sorted(set([round_up(p_, xk[4]) for p_ in prices])) if p >= lowest_ask]
+    minm = pprice * (1 + xk[np.intp(Config.min_markup)])
+    prices = np.linspace(minm, pprice * (1 + xk[np.intp(Config.min_markup)] + xk[np.intp(Config.markup_range)]),
+                         int(xk[np.intp(Config.n_close_orders)]))
+    prices = [p for p in sorted(set([round_up(p_, xk[np.intp(Config.price_step)]) for p_ in prices])) if
+              p >= lowest_ask]
     if len(prices) == 0:
-        yield -psize, max(lowest_ask, round_up(minm, xk[4])), 0.0
+        yield -psize, max(lowest_ask, round_up(minm, xk[np.intp(Config.price_step)])), 0.0
     else:
-        n_orders = int(min([xk[11], len(prices), int(psize / xk[5])]))
+        n_orders = int(min([xk[np.intp(Config.n_close_orders)], len(prices), int(psize / xk[np.intp(Config.min_qty)])]))
         for price in prices:
             if n_orders == 0:
                 break
             else:
                 qty = min(psize, max(calc_initial_entry_qty(xk, balance, lowest_ask, balance, 0.0),
-                                     round_up(psize / n_orders, xk[3])))
+                                     round_up(psize / n_orders, xk[np.intp(Config.qty_step)])))
                 if psize != 0.0 and qty / psize > 0.75:
                     qty = psize
             if qty == 0.0:
                 break
-            psize = round_(psize - qty, xk[3])
+            psize = round_(psize - qty, xk[np.intp(Config.qty_step)])
             yield -qty, price, psize
             lowest_ask = price
             n_orders -= 1
         if psize > 0.0:
-            yield -psize, max(lowest_ask, round_up(minm, xk[4])), 0.0
+            yield -psize, max(lowest_ask, round_up(minm, xk[np.intp(Config.price_step)])), 0.0
 
 
 @njit
-def iter_shrt_closes(xk: tuple, balance: float, psize: float, pprice: float, highest_bid: float):
+def iter_shrt_closes(xk: np.ndarray, balance: float, psize: float, pprice: float, highest_bid: float):
     '''
     xk index/value
      0 inverse      6 min_cost             12 grid_spacing           18 ema_span
@@ -425,34 +447,36 @@ def iter_shrt_closes(xk: tuple, balance: float, psize: float, pprice: float, hig
     abs_psize = abs(psize)
     if psize == 0.0:
         return
-    minm = pprice * (1 - xk[16])
-    prices = np.linspace(minm, pprice * (1 - (xk[16] + xk[17])), int(xk[11]))
-    prices = [p for p in sorted(set([round_dn(p_, xk[4]) for p_ in prices]), reverse=True)
+    minm = pprice * (1 - xk[np.intp(Config.min_markup)])
+    prices = np.linspace(minm, pprice * (1 - (xk[np.intp(Config.min_markup)] + xk[np.intp(Config.markup_range)])),
+                         int(xk[np.intp(Config.n_close_orders)]))
+    prices = [p for p in sorted(set([round_dn(p_, xk[np.intp(Config.price_step)]) for p_ in prices]), reverse=True)
               if p <= highest_bid]
     if len(prices) == 0:
-        yield abs_psize, min(highest_bid, round_dn(minm, xk[4])), 0.0
+        yield abs_psize, min(highest_bid, round_dn(minm, xk[np.intp(Config.price_step)])), 0.0
     else:
-        n_orders = int(min([xk[11], len(prices), int(abs_psize / xk[5])]))
+        n_orders = int(
+            min([xk[np.intp(Config.n_close_orders)], len(prices), int(abs_psize / xk[np.intp(Config.min_qty)])]))
         for price in prices:
             if n_orders == 0:
                 break
             else:
                 qty = min(abs_psize, max(calc_initial_entry_qty(xk, balance, highest_bid, balance, 0.0),
-                                         round_up(abs_psize / n_orders, xk[3])))
+                                         round_up(abs_psize / n_orders, xk[np.intp(Config.qty_step)])))
                 if abs_psize != 0.0 and qty / abs_psize > 0.75:
                     qty = abs_psize
             if qty == 0.0:
                 break
-            abs_psize = round_(abs_psize - qty, xk[3])
+            abs_psize = round_(abs_psize - qty, xk[np.intp(Config.qty_step)])
             yield qty, price, abs_psize
             highest_bid = price
             n_orders -= 1
         if abs_psize > 0.0:
-            yield abs_psize, min(highest_bid, round_dn(minm, xk[4])), 0.0
+            yield abs_psize, min(highest_bid, round_dn(minm, xk[np.intp(Config.price_step)])), 0.0
 
 
 @njit
-def calc_liq_price_binance(xk: tuple,
+def calc_liq_price_binance(xk: np.ndarray,
                            balance: float,
                            long_psize: float,
                            long_pprice: float,
@@ -462,13 +486,13 @@ def calc_liq_price_binance(xk: tuple,
     abs_shrt_psize = abs(shrt_psize)
     long_pprice = nan_to_0(long_pprice)
     shrt_pprice = nan_to_0(shrt_pprice)
-    if xk[0]:
+    if xk[np.intp(Config.inverse)]:
         mml = 0.02
         mms = 0.02
         numerator = abs_long_psize * mml + abs_shrt_psize * mms + abs_long_psize - abs_shrt_psize
         long_pcost = abs_long_psize / long_pprice if long_pprice > 0.0 else 0.0
         shrt_pcost = abs_shrt_psize / shrt_pprice if shrt_pprice > 0.0 else 0.0
-        denom = balance / xk[7] + long_pcost - shrt_pcost
+        denom = balance / xk[np.intp(Config.contract_multiplier)] + long_pcost - shrt_pcost
         if denom == 0.0:
             return 0.0
         return max(0.0, numerator / denom)
@@ -484,7 +508,7 @@ def calc_liq_price_binance(xk: tuple,
 
 
 @njit
-def calc_liq_price_bybit(xk: tuple,
+def calc_liq_price_bybit(xk: np.ndarray,
                          balance: float,
                          long_psize: float,
                          long_pprice: float,
@@ -492,11 +516,11 @@ def calc_liq_price_bybit(xk: tuple,
                          shrt_pprice: float):
     mm = 0.005
     abs_shrt_psize = abs(shrt_psize)
-    if xk[0]:
+    if xk[np.intp(Config.inverse)]:
         if long_psize > abs_shrt_psize:
             long_pprice = nan_to_0(long_pprice)
             order_cost = long_psize / long_pprice if long_pprice > 0.0 else 0.0
-            order_margin = order_cost / xk[10]
+            order_margin = order_cost / xk[np.intp(Config.leverage)]
             bankruptcy_price = (1.00075 * long_psize) / (order_cost + (balance - order_margin))
             if bankruptcy_price == 0.0:
                 return 0.0
@@ -506,7 +530,7 @@ def calc_liq_price_bybit(xk: tuple,
         else:
             shrt_pprice = nan_to_0(shrt_pprice)
             order_cost = abs_shrt_psize / shrt_pprice if shrt_pprice > 0.0 else 0.0
-            order_margin = order_cost / xk[10]
+            order_margin = order_cost / xk[np.intp(Config.leverage)]
             bankruptcy_price = (0.99925 * abs_shrt_psize) / (order_cost - (balance - order_margin))
             if bankruptcy_price == 0.0:
                 return 0.0

--- a/optimize.py
+++ b/optimize.py
@@ -118,7 +118,9 @@ def backtest_tune(ticks: np.ndarray, backtest_config: dict, current_best: Union[
                         search_alg=algo, scheduler=scheduler, num_samples=iters, config=config, verbose=1,
                         reuse_actors=True, local_dir=session_dirpath,
                         progress_reporter=LogReporter(metric_columns=['daily_gain', 'closest_liquidation', 'objective'],
-                                                      parameter_columns=[k for k in backtest_config['ranges']]))
+                                                      parameter_columns=[k for k in backtest_config['ranges'] if type(
+                                                          config[k]) == ray.tune.sample.Float or type(
+                                                          config[k]) == ray.tune.sample.Integer]))
 
     ray.shutdown()
     return analysis

--- a/passivbot.py
+++ b/passivbot.py
@@ -9,7 +9,7 @@ from time import time
 import numpy as np
 import websockets
 
-from jitted import round_, calc_diff, iter_entries, iter_shrt_closes, iter_long_closes, calc_ema
+from jitted import round_, calc_diff, iter_entries, iter_shrt_closes, iter_long_closes, calc_ema, Config
 
 
 def format_float(n: float):
@@ -27,7 +27,8 @@ def get_keys():
             'volatility_qty_coeff', 'min_markup', 'markup_range', 'ema_span', 'ema_spread',
             'stop_loss_liq_diff', 'stop_loss_pos_pct']
 
-def config_to_xk(config: dict) -> tuple:
+
+def config_to_xk(config: dict) -> np.ndarray:
     '''
     xk index/value
      0 inverse      6 min_cost             12 grid_spacing           18 ema_span
@@ -37,8 +38,7 @@ def config_to_xk(config: dict) -> tuple:
      4 price_step  10 leverage             16 min_markup
      5 min_qty     11 n_close_orders       17 markup_range
     '''
-    return tuple(float(config[k]) if type(config[k]) not in [bool, str] else config[k]
-                 for k in get_keys())
+    return np.asarray([float(config[k]) if type(config[k]) not in [bool, str] else config[k] for k in get_keys()])
 
 
 def sort_dict_keys(d):
@@ -304,9 +304,8 @@ class Bot:
 
         long_entry_orders, shrt_entry_orders, long_close_orders, shrt_close_orders = [], [], [], []
         stop_loss_close = False
-        xk_list = list(self.xk)
-        xk_list[1], xk_list[2] = do_long, do_shrt
-        xk = tuple(xk_list)
+        self.xk[np.intp(Config.do_long)], self.xk[np.intp(Config.do_shrt)] = do_long, do_shrt
+        xk = self.xk
 
         for tpl in iter_entries(xk, balance, long_psize, long_pprice, shrt_psize, shrt_pprice,
                                 liq_price, self.ob[0], self.ob[1], self.ema, self.price,


### PR DESCRIPTION
Improve indexing by using an enum to track the index of the parameter array. The index needs to be cast with np.intp to work with numba. It aims to make the code more readable and maintainable. The performance is the same as with direct access to the tuple. Also replaces the tuple with a numpy array to allow booleans in it. As numpy arrays only support single data types, those are cast to float, but we can still check against them.