### PR TITLE
Add the symbol to the filename

### DIFF
--- a/multi_symbol_optimize.py
+++ b/multi_symbol_optimize.py
@@ -127,8 +127,9 @@ class FuncWrap:
         self.bounds = numpyize([[self.base_config['ranges'][k][0] for k in self.xs_conf_map],
                                 [self.base_config['ranges'][k][1] for k in self.xs_conf_map]])
         self.now_date = ts_to_date(time())[:19].replace(':', '-')
-        self.results_fname = make_get_filepath(f'tmp/harmony_search_results_{self.now_date}.txt')
-        self.best_conf_fname = f'tmp/harmony_search_best_config_{self.now_date}.json'
+        self.test_symbol = base_config['symbols'][0]
+        self.results_fname = make_get_filepath(f'tmp/harmony_search_results_{self.test_symbol}_{self.now_date}.txt')
+        self.best_conf_fname = f'tmp/harmony_search_best_config_{self.test_symbol}_{self.now_date}.json'
 
     def xs_to_config(self, xs):
         config = unpack_config(self.base_config.copy())


### PR DESCRIPTION
Put the first symbol in the filename in order to know which file is which coin when multiple single coin instances are launched at the same time
(credit to Doftorul for the fix)