### PR TITLE
Fixing api keys location when given as command line argument

### DIFF
--- a/passivbot.py
+++ b/passivbot.py
@@ -107,7 +107,7 @@ class Bot:
 
         self.log_filepath = make_get_filepath(f"logs/{self.exchange}/{config['config_name']}.log")
 
-        _, self.key, self.secret = load_exchange_key_secret(self.user)
+        _, self.key, self.secret = load_exchange_key_secret(self.user, config["api_keys"])
 
         self.log_level = 0
 
@@ -1157,6 +1157,7 @@ async def main() -> None:
         logging.error(f"{e} failed to load config {args.live_config_path}")
         return
     config["user"] = args.user
+    config["api-keys"] = args.api_keys
     config["exchange"] = account["exchange"]
     config["symbol"] = args.symbol
     config["market_type"] = args.market_type if args.market_type is not None else "futures"

--- a/passivbot.py
+++ b/passivbot.py
@@ -1157,7 +1157,7 @@ async def main() -> None:
         logging.error(f"{e} failed to load config {args.live_config_path}")
         return
     config["user"] = args.user
-    config["api-keys"] = args.api_keys
+    config["api_keys"] = args.api_keys
     config["exchange"] = account["exchange"]
     config["symbol"] = args.symbol
     config["market_type"] = args.market_type if args.market_type is not None else "futures"

--- a/passivbot.py
+++ b/passivbot.py
@@ -1143,6 +1143,7 @@ async def main() -> None:
     args = parser.parse_args()
     try:
         accounts = json.load(args.api_keys)
+        args.api_keys.close()
     except Exception as e:
         logging.error(f"{e} failed to load api-keys.json file")
         return
@@ -1157,7 +1158,7 @@ async def main() -> None:
         logging.error(f"{e} failed to load config {args.live_config_path}")
         return
     config["user"] = args.user
-    config["api_keys"] = args.api_keys
+    config["api_keys"] = args.api_keys.name
     config["exchange"] = account["exchange"]
     config["symbol"] = args.symbol
     config["market_type"] = args.market_type if args.market_type is not None else "futures"

--- a/procedures.py
+++ b/procedures.py
@@ -151,9 +151,9 @@ def make_get_filepath(filepath: str) -> str:
     return filepath
 
 
-def load_exchange_key_secret(user: str) -> (str, str, str):
+def load_exchange_key_secret(user: str, api_keys_path="api-keys.json") -> (str, str, str):
     try:
-        keyfile = json.load(open("api-keys.json"))
+        keyfile = json.load(open(api_keys_path))
         if user in keyfile:
             return (
                 keyfile[user]["exchange"],


### PR DESCRIPTION
I have tried to run the bot with the `-ak` parameter, and I got an error saying the API Keys file is missing.
I noticed that in the `load_exchange_key_secret` function the location of the file is a constant and not updated according to the `-ak` flag.
Here is a backwards compatible fix.

P.S:
I also closed the `api-keys.json` file after it was read because there is no reason for it to remain open during the execution of the bot.