### PR TITLE
bybit overwrite corrupted market info cache in error handling

### DIFF
--- a/exchanges/bybit.py
+++ b/exchanges/bybit.py
@@ -58,6 +58,8 @@ class BybitBot(Bot):
             print_async_exception(info)
             if info is None:
                 info = {"info": await self.cc.fetch_markets(), "dump_ts": utc_ms()}
+                json.dump(info, open(fname, "w"))
+                logging.info("dumped market info to cache")
         return info["info"]
 
     async def _init(self):

--- a/passivbot.py
+++ b/passivbot.py
@@ -222,6 +222,7 @@ class Bot:
                 self.config["short"]["delay_between_fills_minutes_close"] * 60 * 1000.0,
             )
         print("initiating position, open orders, fills, exchange config, order book, and emas...")
+        await asyncio.sleep(self.countdown_offset)
         await asyncio.gather(
             self.update_position(),
             self.update_open_orders(),


### PR DESCRIPTION
If there is a corupted caches/bybit_market_info.json on disk, it will never be overwritten. 
With this small fix, the file get saved in error handling.