### PR TITLE
pandas: 1.4.0 -> 1.4.3 workaround for numpy/pdb bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ tqdm==4.62.3
 python-dateutil==2.8.2
 numba==0.59.1; python_version>='3.9'
 numba==0.58.1; python_version<'3.9'
-pandas==1.4.0
+pandas==1.4.3
 PyYAML==6.0
 asyncio==3.4.3
 pyecharts==1.9.1


### PR DESCRIPTION
I encountered a bug while trying to debug another bug linked to an interation with pdb (my debugger) and numpy/pandas plotting. It seems that pandas added a workaround for this and it works for passivbot.

Here is the exception. Thanks for your work 🙇 

<details>

```
Traceback (most recent call last):
  File "/home/eliott/.local/share/JetBrains/Toolbox/apps/pycharm-professional/plugins/python/helpers-pro/pydevd_asyncio/pydevd_nest_asyncio.py", line 138, in run
    return loop.run_until_complete(task)
  File "/home/eliott/.local/share/JetBrains/Toolbox/apps/pycharm-professional/plugins/python/helpers-pro/pydevd_asyncio/pydevd_nest_asyncio.py", line 243, in run_until_complete
    return f.result()
  File "/usr/lib/python3.10/asyncio/futures.py", line 201, in result
    raise self._exception.with_traceback(self._exception_tb)
  File "/usr/lib/python3.10/asyncio/tasks.py", line 232, in __step
    result = coro.send(None)
  File "/home/eliott/git/github.com/passivbot/src/backtest.py", line 518, in main
    post_process(
  File "/home/eliott/git/github.com/passivbot/src/backtest.py", line 400, in post_process
    plot_forager(
  File "/home/eliott/git/github.com/passivbot/src/backtest.py", line 420, in plot_forager
    bal_eq[["balance", "equity"]].plot()
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/pandas/plotting/_core.py", line 972, in __call__
    return plot_backend.plot(data, kind=kind, **kwargs)
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/pandas/plotting/_matplotlib/__init__.py", line 71, in plot
    plot_obj.generate()
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/pandas/plotting/_matplotlib/core.py", line 335, in generate
    self._post_plot_logic_common(ax, self.data)
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/pandas/plotting/_matplotlib/core.py", line 526, in _post_plot_logic_common
    self._apply_axis_properties(ax.xaxis, rot=self.rot, fontsize=self.fontsize)
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/pandas/plotting/_matplotlib/core.py", line 614, in _apply_axis_properties
    labels = axis.get_majorticklabels() + axis.get_minorticklabels()
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/matplotlib/axis.py", line 1201, in get_majorticklabels
    ticks = self.get_major_ticks()
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/matplotlib/axis.py", line 1371, in get_major_ticks
    numticks = len(self.get_majorticklocs())
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/matplotlib/axis.py", line 1277, in get_majorticklocs
    return self.major.locator()
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/matplotlib/ticker.py", line 2113, in __call__
    vmin, vmax = self.axis.get_view_interval()
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/matplotlib/axis.py", line 1987, in getter
    return getattr(getattr(self.axes, lim_name), attr_name)
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/matplotlib/axes/_base.py", line 781, in viewLim
    self._unstale_viewLim()
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/matplotlib/axes/_base.py", line 776, in _unstale_viewLim
    self.autoscale_view(**{f"scale{name}": scale
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/matplotlib/axes/_base.py", line 2932, in autoscale_view
    handle_single_axis(
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/matplotlib/axes/_base.py", line 2895, in handle_single_axis
    x0, x1 = locator.nonsingular(x0, x1)
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/matplotlib/ticker.py", line 1654, in nonsingular
    return mtransforms.nonsingular(v0, v1, expander=.05)
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/matplotlib/transforms.py", line 2880, in nonsingular
    if maxabsvalue < (1e6 / tiny) * np.finfo(float).tiny:
  File "/home/eliott/git/github.com/passivbot/venv/lib/python3.10/site-packages/numpy/core/getlimits.py", line 462, in __new__
    dtype = numeric.dtype(type(dtype))
TypeError: 'NoneType' object is not callable
```

</details>

See the [issue](https://bugs.python.org/issue46535)

Side note as a new contributor: I would loved to have few contributing guidelines or a `CONTRIBUTING.md` file. 