### PR TITLE
skipping get_first_timestamp exception

### DIFF
--- a/src/downloader.py
+++ b/src/downloader.py
@@ -982,7 +982,12 @@ async def prepare_hlcvs_internal(config, coins, exchange, start_date, end_date, 
             logging.info(f"coin {coin} missing from first_timestamps_unified, skipping")
             continue
         if minimum_coin_age_days > 0.0:
-            first_ts = await om.get_first_timestamp(coin)
+            try:
+                first_ts = await om.get_first_timestamp(coin)
+            except Exception as e:
+                logging.error(f"error with get_first_timestamp for {coin} {e}. Skipping")
+                traceback.print_exc()
+                continue  
             if first_ts >= end_ts:
                 logging.info(
                     f"{exchange} Coin {coin} too young, start date {ts_to_date_utc(first_ts)}. Skipping"


### PR DESCRIPTION
I am encountering an error when loading BTCDOM.
I handled it in the same way as the exception for get_ohlcvs.

Traceback (most recent call last):
  File "C:\passivbot\src\optimize.py", line 960, in main
    coins, hlcvs, mss, results_path, cache_dir, btc_usd_prices = await tasks[exchange]
  File "C:\passivbot\src\backtest.py", line 284, in prepare_hlcvs_mss
    mss, timestamps, hlcvs, btc_usd_prices = await prepare_hlcvs(config, exchange)
  File "C:\passivbot\src\downloader.py", line 936, in prepare_hlcvs
    mss, timestamps, hlcvs = await prepare_hlcvs_internal(
  File "C:\passivbot\src\downloader.py", line 985, in prepare_hlcvs_internal
    try:
  File "C:\passivbot\src\downloader.py", line 432, in get_first_timestamp
    ohlcvs = await self.cc.fetch_ohlcv(self.get_symbol(coin), since=1, timeframe="1d")
  File "C:\passivbot\venv\lib\site-packages\ccxt\async_support\binance.py", line 4502, in fetch_ohlcv
    response = await self.fapiPublicGetKlines(self.extend(request, params))
  File "C:\passivbot\venv\lib\site-packages\ccxt\async_support\binance.py", line 11331, in request
    response = await self.fetch2(path, api, method, params, headers, body, config)
  File "C:\passivbot\venv\lib\site-packages\ccxt\async_support\base\exchange.py", line 897, in fetch2
    raise e
  File "C:\passivbot\venv\lib\site-packages\ccxt\async_support\base\exchange.py", line 886, in fetch2
    return await self.fetch(request['url'], request['method'], request['headers'], request['body'])
  File "C:\passivbot\venv\lib\site-packages\ccxt\async_support\base\exchange.py", line 256, in fetch
    self.handle_errors(http_status_code, http_status_text, url, method, headers, http_response, json_response, request_headers, request_body)
  File "C:\passivbot\venv\lib\site-packages\ccxt\async_support\binance.py", line 11298, in handle_errors
    self.throw_exactly_matched_exception(self.get_exceptions_by_url(url, 'exact'), error, feedback)
  File "C:\passivbot\venv\lib\site-packages\ccxt\base\exchange.py", line 4790, in throw_exactly_matched_exception
    raise exact[string](message)
ccxt.base.errors.BadRequest: binanceusdm {"code":-1122,"msg":"Invalid symbol status."}