### PR TITLE
fix(pyo3): show key name in 'Value is None' error

### DIFF
--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -272,7 +272,7 @@ fn extract_value<'a, T: pyo3::FromPyObject<'a>>(dict: &'a PyDict, key: &str) -> 
         .map_err(|_| {
             PyErr::new::<pyo3::exceptions::PyKeyError, _>(format!("Key '{}' not found", key))
         })?
-        .ok_or_else(|| PyErr::new::<pyo3::exceptions::PyValueError, _>("Value is None"))
+        .ok_or_else(|| PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Value for key '{}' is None", key)))
         .and_then(pyo3::FromPyObject::extract)
 }
 


### PR DESCRIPTION
Include key name in 'Value is None' error in extract_value()

Updated extract_value() to display the affected key in PyValueError
message when the value for that key is None, improving debugging
and error traceability.