### PR TITLE
add metrics total_wallet_exposure_max, mean, median

### DIFF
--- a/passivbot-rust/src/analysis.rs
+++ b/passivbot-rust/src/analysis.rs
@@ -354,7 +354,7 @@ fn analyze_backtest_basic(fills: &[Fill], equities: &Vec<f64>) -> Analysis {
     analysis
 }
 
-pub fn analyze_backtest(fills: &[Fill], equities: &Vec<f64>) -> Analysis {
+pub fn analyze_backtest(fills: &[Fill], equities: &Vec<f64>, total_wallet_exposures: &[f64],) -> Analysis {
     let mut analysis = analyze_backtest_basic(fills, equities);
 
     if fills.len() <= 1 {
@@ -433,6 +433,26 @@ pub fn analyze_backtest(fills: &[Fill], equities: &Vec<f64>) -> Analysis {
         .map(|a| a.volume_pct_per_day_avg)
         .sum::<f64>()
         / 10.0;
+
+    if total_wallet_exposures.len() > 0 {
+        analysis.total_wallet_exposure_max = total_wallet_exposures
+            .iter()
+            .copied()
+            .max_by(|a, b| a.partial_cmp(b).unwrap())
+            .unwrap_or(0.0);
+        
+        analysis.total_wallet_exposure_mean = 
+            total_wallet_exposures.iter().sum::<f64>() / total_wallet_exposures.len() as f64;
+        
+        let mut sorted = total_wallet_exposures.to_vec();
+        sorted.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+        let mid = sorted.len() / 2;
+        analysis.total_wallet_exposure_median = if sorted.len() % 2 == 0 {
+            (sorted[mid - 1] + sorted[mid]) / 2.0
+        } else {
+            sorted[mid]
+        };
+    }
     analysis
 }
 
@@ -442,8 +462,9 @@ pub fn analyze_backtest_pair(
     fills: &[Fill],
     equities: &Equities,
     use_btc_collateral: bool,
+    total_wallet_exposures: &[f64],
 ) -> (Analysis, Analysis) {
-    let analysis_usd = analyze_backtest(fills, &equities.usd);
+    let analysis_usd = analyze_backtest(fills, &equities.usd, total_wallet_exposures);
     if !use_btc_collateral {
         return (analysis_usd.clone(), analysis_usd);
     }
@@ -452,7 +473,7 @@ pub fn analyze_backtest_pair(
         fill.balance_usd_total /= fill.btc_price; // Use actual BTC balance if available
         fill.pnl = fill.pnl / fill.btc_price; // Convert PNL to BTC
     }
-    let analysis_btc = analyze_backtest(&btc_fills, &equities.btc);
+    let analysis_btc = analyze_backtest(&btc_fills, &equities.btc, total_wallet_exposures);
     (analysis_usd, analysis_btc)
 }
 

--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -125,7 +125,12 @@ pub fn run_backtest(
     Python::with_gil(|py| {
         let (fills, equities) = backtest.run();
         let (analysis_usd, analysis_btc) =
-            analyze_backtest_pair(&fills, &equities, backtest.balance.use_btc_collateral);
+            analyze_backtest_pair(
+                &fills, 
+                &equities, 
+                backtest.balance.use_btc_collateral, 
+                &backtest.total_wallet_exposures
+            );
 
         // Create a dictionary to store analysis results using a more concise approach
         let py_analysis_usd = struct_to_py_dict(py, &analysis_usd)?;

--- a/passivbot-rust/src/types.rs
+++ b/passivbot-rust/src/types.rs
@@ -302,6 +302,10 @@ pub struct Analysis {
     pub loss_profit_ratio_w: f64,
     pub volume_pct_per_day_avg: f64,
     pub volume_pct_per_day_avg_w: f64,
+
+    pub total_wallet_exposure_max: f64,
+    pub total_wallet_exposure_mean: f64,
+    pub total_wallet_exposure_median: f64,
 }
 
 impl Default for Analysis {
@@ -344,6 +348,9 @@ impl Default for Analysis {
             exponential_fit_error_w: 1.0,
             volume_pct_per_day_avg: 0.0,
             volume_pct_per_day_avg_w: 0.0,
+            total_wallet_exposure_max: 0.0,
+            total_wallet_exposure_mean: 0.0,
+            total_wallet_exposure_median: 0.0,
         }
     }
 }

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -634,6 +634,9 @@ class Evaluator:
             "sortino_ratio_w": -1.0,
             "sterling_ratio": -1.0,
             "sterling_ratio_w": -1.0,
+            "total_wallet_exposure_max": 1.0,
+            "total_wallet_exposure_mean": 1.0,
+            "total_wallet_exposure_median": 1.0,
             "volume_pct_per_day_avg": -1.0,
             "volume_pct_per_day_avg_w": -1.0,
         }


### PR DESCRIPTION
Adds three new metrics to track total wallet exposure across all coins during backtests:
- total_wallet_exposure_max: Maximum total wallet exposure observed
- total_wallet_exposure_mean: Average total wallet exposure  
- total_wallet_exposure_median: Median total wallet exposure

They can be used as a score for the optimizer (no bounds), default behavior is to lower them

