### PR TITLE
Bring back forward/backward TP grid logic

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -269,7 +269,10 @@ When optimizing, parameter values are within the lower and upper bounds.
 ### Other Optimization Parameters
 
 - **compress_results_file**: If `true`, compresses optimize output results file to save space.
-- **enable_overrides**: List of custom optimizer overrides to enable. Use `optimizer_overrides.py` for overrides. Defaults to none.
+- **enable_overrides**: List of constraint overrides applied during optimization to enforce specific parameter relationships. The optimizer evaluator checks these conditions and apply the overrides before running each backtest (defaults to none):
+  - **"lossless_close_trailing"**: Ensures trailing stops are profitable by enforcing `close_trailing_threshold_pct` > `close_trailing_retracement_pct`. This prevents the retracement from triggering before reaching the minimum profit threshold.
+  - **"forward_tp_grid"**: Creates an ascending take-profit grid where `close_grid_markup_start` < `close_grid_markup_end`
+  - **"backward_tp_grid"**: Creates a descending take-profit grid where `close_grid_markup_start` > `close_grid_markup_end`.
 - **crossover_probability**: Probability of performing crossover between two individuals in the genetic algorithm. Determines how often parents exchange genetic information to create offspring.
 - **crossover_eta**: Crowding factor (η) for simulated-binary crossover. Lower values (<20) allow offspring to move farther away from their parents; higher values keep them closer. Default is `20.0`.
 - **iters**: Number of backtests per optimize session.

--- a/src/optimizer_overrides.py
+++ b/src/optimizer_overrides.py
@@ -14,6 +14,20 @@ def optimizer_overrides(overrides_list, config, pside):
             retracement = require_config_value(config, f"bot.{pside}.close_trailing_retracement_pct")
             config["bot"][pside]["close_trailing_threshold_pct"] = max(threshold, retracement)
 
+        elif override == "forward_tp_grid":
+            close_grid_markup_start = require_config_value(config, f"bot.{pside}.close_grid_markup_start")
+            close_grid_markup_end = require_config_value(config, f"bot.{pside}.close_grid_markup_end")
+
+            config["bot"][pside]["close_grid_markup_start"] = min(close_grid_markup_start, close_grid_markup_end)
+            config["bot"][pside]["close_grid_markup_end"] = max(close_grid_markup_start, close_grid_markup_end)
+
+        elif override == "backward_tp_grid":
+            close_grid_markup_start = require_config_value(config, f"bot.{pside}.close_grid_markup_start")
+            close_grid_markup_end = require_config_value(config, f"bot.{pside}.close_grid_markup_end")
+
+            config["bot"][pside]["close_grid_markup_start"] = max(close_grid_markup_start, close_grid_markup_end)
+            config["bot"][pside]["close_grid_markup_end"] = min(close_grid_markup_start, close_grid_markup_end)
+
         elif override == "example":
             # Logic for override 'example'
             pass


### PR DESCRIPTION
To have more control on our optimizations this branch propose to bring back the legacy forward/backward TP grid notion we had in v6 but as simple overrides