### PR TITLE
add bounds steps feature

### DIFF
--- a/src/bounds_utils.py
+++ b/src/bounds_utils.py
@@ -6,10 +6,15 @@ to discrete steps and enforcing bounds on configuration dictionaries.
 """
 
 import logging
-from typing import Dict
+from typing import Dict, Optional, Tuple
 
 
-def quantize_to_step(value: float, low: float, high: float, step: float = None) -> float:
+# Bound: (low, high) for continuous, or (low, high, step) for stepped params
+# step=None or step=0 means continuous (no quantization)
+Bound = Tuple[float, float, Optional[float]]  # (low, high, step)
+
+
+def quantize_to_step(value: float, low: float, high: float, step: Optional[float] = None) -> float:
     """
     Quantize a value to the nearest step within bounds [low, high].
 
@@ -20,20 +25,100 @@ def quantize_to_step(value: float, low: float, high: float, step: float = None) 
         step: step size (if None or <= 0, no quantization)
 
     Returns:
-        float: quantized value clamped to [low, high]
+        float: quantized value clamped to the valid grid within [low, high]
     """
     if step is None or step <= 0:
-        return value
+        return max(low, min(high, value))
 
     # Clamp to bounds first
     clamped = max(low, min(high, value))
 
     # Find nearest step (using int + 0.5 for proper rounding, not banker's rounding)
     n_steps_from_low = int((clamped - low) / step + 0.5)
-    quantized = low + n_steps_from_low * step
 
-    # Ensure we're still within bounds after quantization
+    # Calculate max valid index: largest n where low + n*step <= high
+    # Use floor to ensure we don't exceed high bound
+    # Add small epsilon to handle floating point precision issues
+    max_index = int((high - low + 1e-9) / step)
+
+    # Clamp index to valid range
+    clamped_index = max(0, min(max_index, n_steps_from_low))
+
+    quantized = low + clamped_index * step
+
+    # Final safety clamp (should be redundant but kept for safety)
     return max(low, min(high, quantized))
+
+
+def value_to_index(value: float, low: float, high: float, step: Optional[float]) -> float:
+    """
+    Convert a parameter value to index space for stepped parameters.
+
+    For continuous parameters (step=None or step<=0), returns the value unchanged.
+    For stepped parameters, returns the index (0-based) of the step.
+
+    Args:
+        value: parameter value
+        low: lower bound
+        high: upper bound
+        step: step size
+
+    Returns:
+        float: index in step space, or original value if continuous
+    """
+    if step is None or step <= 0:
+        return value
+    return (value - low) / step
+
+
+def index_to_value(index: float, low: float, high: float, step: Optional[float]) -> float:
+    """
+    Convert an index back to a parameter value for stepped parameters.
+
+    For continuous parameters (step=None or step<=0), returns the index unchanged.
+    For stepped parameters, converts the index to a value and quantizes to grid.
+
+    Args:
+        index: index in step space (or original value if continuous)
+        low: lower bound
+        high: upper bound
+        step: step size
+
+    Returns:
+        float: parameter value, quantized to step if applicable
+    """
+    if step is None or step <= 0:
+        return max(low, min(high, index))
+    # Round to nearest integer index and convert back to value
+    rounded_index = int(index + 0.5)
+    # Calculate max valid index: largest n where low + n*step <= high
+    # Add small epsilon to handle floating point precision issues
+    max_index = int((high - low + 1e-9) / step)
+    clamped_index = max(0, min(max_index, rounded_index))
+    return low + clamped_index * step
+
+
+def get_index_bounds(low: float, high: float, step: Optional[float]) -> Tuple[float, float]:
+    """
+    Get the bounds in index space for a parameter.
+
+    For continuous parameters, returns (low, high).
+    For stepped parameters, returns (0, max_index).
+
+    Args:
+        low: lower bound
+        high: upper bound
+        step: step size
+
+    Returns:
+        Tuple[float, float]: (low_index, high_index)
+    """
+    if step is None or step <= 0:
+        return (low, high)
+    # Calculate max valid index: largest n where low + n*step <= high
+    # Add small epsilon to handle floating point precision issues
+    max_index = int((high - low + 1e-9) / step)
+    return (0.0, float(max_index))
 
 
 def enforce_bounds_on_config(config: dict, sig_digits: int = None) -> dict:

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -124,7 +124,7 @@ from opt_utils import make_json_serializable, generate_incremental_diff, round_f
 from limit_utils import expand_limit_checks, compute_limit_violation
 from pareto_store import ParetoStore
 import msgpack
-from typing import Sequence, Tuple, List, Dict, Any
+from typing import Sequence, Tuple, List, Dict, Any, Optional
 from itertools import permutations
 from shared_arrays import SharedArrayManager, attach_shared_array
 from optimize_suite import (
@@ -139,6 +139,13 @@ from suite_runner import (
     build_suite_metrics_payload,
 )
 from metrics_schema import build_scenario_metrics, flatten_metric_stats
+from bounds_utils import (
+    Bound,
+    quantize_to_step,
+    value_to_index,
+    index_to_value,
+    get_index_bounds,
+)
 
 
 def _ignore_sigint_in_worker():
@@ -306,44 +313,77 @@ def _format_objectives(values: Sequence[float]) -> str:
 
 
 # === bounds helpers =========================================================
-
-Bound = Tuple[float, float]  # (low, high)
+# Note: Core bounds functions (quantize_to_step, value_to_index, index_to_value,
+# get_index_bounds) are imported from bounds_utils.py
 
 
 def enforce_bounds(
     values: Sequence[float], bounds: Sequence[Bound], sig_digits: int = None
 ) -> List[float]:
     """
-    Clamp each value to its corresponding [low, high] interval.
+    Clamp each value to its corresponding [low, high] interval and quantize to step if defined.
     Also round to significant digits (optional).
 
     Args:
         values : iterable of floats (length == len(bounds))
-        bounds : iterable of (low, high) pairs
+        bounds : iterable of (low, high, step) tuples
         sig_digits: int
 
     Returns
-        List[float]  – clamped copy (original is *not* modified)
+        List[float]  – clamped and quantized copy (original is *not* modified)
     """
     assert len(values) == len(bounds), "values/bounds length mismatch"
     rounded = values if sig_digits is None else round_floats(values, sig_digits)
-    return [high if v > high else low if v < low else v for v, (low, high) in zip(rounded, bounds)]
+    result = []
+    for v, bound in zip(rounded, bounds):
+        low, high = bound[0], bound[1]
+        step = bound[2] if len(bound) > 2 else None
+        result.append(quantize_to_step(v, low, high, step))
+    return result
 
 
-def extract_bounds_tuple_list_from_config(config) -> [Bound]:
+def extract_bounds_tuple_list_from_config(config) -> List[Bound]:
     """
-    extracts list of tuples (low, high) which are lower and upper bounds for bot parameters.
-    also sets all bounds to (low, low) if pside is not enabled.
+    Extracts list of tuples (low, high, step) which are lower/upper bounds
+    and optional step size for bot parameters.
+    Also sets all bounds to (low, low, step) if pside is not enabled.
+
+    Supported formats:
+        - [low, high]: continuous optimization (step=None)
+        - [low, high, step]: discrete optimization with given step
+        - [low, high, 0] or [low, high, null]: treated as continuous
+        - single value: fixed parameter (low=high, step=None)
     """
 
-    def extract_bound_vals(key, val) -> tuple:
+    def extract_bound_vals(key, val) -> Bound:
+        """Extract (low, high, step) from a bound specification."""
         if isinstance(val, (float, int)):
-            return (val, val)
+            # Single value means fixed
+            return (float(val), float(val), None)
         elif isinstance(val, (tuple, list)):
             if len(val) == 1:
-                return (val[0], val[0])
+                return (float(val[0]), float(val[0]), None)
             elif len(val) == 2:
-                return tuple(sorted([val[0], val[1]]))
+                low, high = sorted([float(val[0]), float(val[1])])
+                return (low, high, None)
+            elif len(val) >= 3:
+                low, high = sorted([float(val[0]), float(val[1])])
+                step_raw = val[2]
+                # Treat 0, None, or null as continuous
+                if step_raw is None or step_raw == 0:
+                    step = None
+                else:
+                    step = float(step_raw)
+                    # Validate step is positive and not larger than range
+                    if step <= 0:
+                        step = None
+                    elif step > (high - low) and high != low:
+                        logging.warning(
+                            f"Step {step} for bound {key} is larger than range [{low}, {high}], "
+                            f"treating as continuous"
+                        )
+                        step = None
+                return (low, high, step)
         raise Exception(f"malformed bound {key}: {val}")
 
     template_config = get_template_config()
@@ -364,7 +404,11 @@ def extract_bounds_tuple_list_from_config(config) -> [Bound]:
                 bound_key in config["optimize"]["bounds"]
             ), f"bound {bound_key} missing from optimize.bounds"
             bound_vals = extract_bound_vals(bound_key, config["optimize"]["bounds"][bound_key])
-            bounds.append(bound_vals if is_enabled else (bound_vals[0], bound_vals[0]))
+            if is_enabled:
+                bounds.append(bound_vals)
+            else:
+                # Disabled: fix to low value, preserve step for consistency
+                bounds.append((bound_vals[0], bound_vals[0], bound_vals[2]))
     return bounds
 
 
@@ -375,10 +419,13 @@ def get_bound_keys_ignored():
 # ============================================================================
 
 
-def mutPolynomialBoundedWrapper(individual, eta, low, up, indpb):
+def mutPolynomialBoundedWrapper(individual, eta, low, up, indpb, bounds=None):
     """
     A wrapper around DEAP's mutPolynomialBounded function to pre-process
     bounds and handle the case where lower and upper bounds may be equal.
+
+    For stepped parameters (where bounds[i][2] is defined and > 0), mutation
+    is performed in index space to ensure offspring values stay on the grid.
 
     Args:
         individual: Sequence individual to be mutated.
@@ -386,38 +433,82 @@ def mutPolynomialBoundedWrapper(individual, eta, low, up, indpb):
         low: A value or sequence of values that is the lower bound of the search space.
         up: A value or sequence of values that is the upper bound of the search space.
         indpb: Independent probability for each attribute to be mutated.
+        bounds: Optional list of (low, high, step) tuples. If provided, stepped
+                parameters are mutated in index space.
 
     Returns:
         A tuple of one individual, mutated with consideration for equal lower and upper bounds.
     """
-    # Convert low and up to numpy arrays for easier manipulation
-    low_array = np.array(low)
-    up_array = np.array(up)
+    n = len(individual)
+
+    # Determine which parameters are stepped
+    has_steps = bounds is not None and len(bounds) == n
+    steps = []
+    if has_steps:
+        for bound in bounds:
+            step = bound[2] if len(bound) > 2 else None
+            steps.append(step if step is not None and step > 0 else None)
+    else:
+        steps = [None] * n
+
+    # Convert to index space for stepped parameters
+    index_individual = []
+    index_low = []
+    index_up = []
+
+    for i in range(n):
+        step = steps[i]
+        if step is not None:
+            # Stepped: work in index space
+            low_val, high_val = bounds[i][0], bounds[i][1]
+            idx = value_to_index(individual[i], low_val, high_val, step)
+            idx_low, idx_up = get_index_bounds(low_val, high_val, step)
+            index_individual.append(idx)
+            index_low.append(idx_low)
+            index_up.append(idx_up)
+        else:
+            # Continuous: keep original bounds
+            index_individual.append(individual[i])
+            index_low.append(low[i])
+            index_up.append(up[i])
+
+    # Convert to numpy arrays for easier manipulation
+    low_array = np.array(index_low)
+    up_array = np.array(index_up)
 
     # Identify dimensions where lower and upper bounds are equal
     equal_bounds_mask = low_array == up_array
 
     # Temporarily adjust bounds for those dimensions
-    # This adjustment is arbitrary and won't affect the outcome since the mutation
-    # won't be effective in these dimensions
     temp_low = np.where(equal_bounds_mask, low_array - 1e-6, low_array)
     temp_up = np.where(equal_bounds_mask, up_array + 1e-6, up_array)
 
     # Call the original mutPolynomialBounded function with the temporarily adjusted bounds
-    tools.mutPolynomialBounded(individual, eta, list(temp_low), list(temp_up), indpb)
+    tools.mutPolynomialBounded(index_individual, eta, list(temp_low), list(temp_up), indpb)
 
-    # Reset values in dimensions with originally equal bounds to ensure they remain unchanged
-    for i, equal in enumerate(equal_bounds_mask):
-        if equal:
+    # Convert back from index space and ensure bounds
+    for i in range(n):
+        step = steps[i]
+        if equal_bounds_mask[i]:
             individual[i] = low[i]
+        elif step is not None:
+            # Stepped: convert from index space back to value
+            low_val, high_val = bounds[i][0], bounds[i][1]
+            individual[i] = index_to_value(index_individual[i], low_val, high_val, step)
+        else:
+            # Continuous: copy directly
+            individual[i] = index_individual[i]
 
     return (individual,)
 
 
-def cxSimulatedBinaryBoundedWrapper(ind1, ind2, eta, low, up):
+def cxSimulatedBinaryBoundedWrapper(ind1, ind2, eta, low, up, bounds=None):
     """
     A wrapper around DEAP's cxSimulatedBinaryBounded function to pre-process
     bounds and handle the case where lower and upper bounds may be equal.
+
+    For stepped parameters (where bounds[i][2] is defined and > 0), crossover
+    is performed in index space to ensure offspring values stay on the grid.
 
     Args:
         ind1: The first individual participating in the crossover.
@@ -425,32 +516,80 @@ def cxSimulatedBinaryBoundedWrapper(ind1, ind2, eta, low, up):
         eta: Crowding degree of the crossover.
         low: A value or sequence of values that is the lower bound of the search space.
         up: A value or sequence of values that is the upper bound of the search space.
+        bounds: Optional list of (low, high, step) tuples. If provided, stepped
+                parameters are crossed over in index space.
 
     Returns:
         A tuple of two individuals after crossover operation.
     """
-    # Convert low and up to numpy arrays for easier manipulation
-    low_array = np.array(low)
-    up_array = np.array(up)
+    n = len(ind1)
+
+    # Determine which parameters are stepped
+    has_steps = bounds is not None and len(bounds) == n
+    steps = []
+    if has_steps:
+        for bound in bounds:
+            step = bound[2] if len(bound) > 2 else None
+            steps.append(step if step is not None and step > 0 else None)
+    else:
+        steps = [None] * n
+
+    # Convert to index space for stepped parameters
+    index_ind1 = []
+    index_ind2 = []
+    index_low = []
+    index_up = []
+
+    for i in range(n):
+        step = steps[i]
+        if step is not None:
+            # Stepped: work in index space
+            low_val, high_val = bounds[i][0], bounds[i][1]
+            idx1 = value_to_index(ind1[i], low_val, high_val, step)
+            idx2 = value_to_index(ind2[i], low_val, high_val, step)
+            idx_low, idx_up = get_index_bounds(low_val, high_val, step)
+            index_ind1.append(idx1)
+            index_ind2.append(idx2)
+            index_low.append(idx_low)
+            index_up.append(idx_up)
+        else:
+            # Continuous: keep original bounds
+            index_ind1.append(ind1[i])
+            index_ind2.append(ind2[i])
+            index_low.append(low[i])
+            index_up.append(up[i])
+
+    # Convert to numpy arrays for easier manipulation
+    low_array = np.array(index_low)
+    up_array = np.array(index_up)
 
     # Identify dimensions where lower and upper bounds are equal
     equal_bounds_mask = low_array == up_array
 
     # Temporarily adjust bounds for those dimensions to prevent division by zero
-    # This adjustment is arbitrary and won't affect the outcome since the crossover
-    # won't modify these dimensions
-    low_array[equal_bounds_mask] -= 1e-6
-    up_array[equal_bounds_mask] += 1e-6
+    low_array_temp = low_array.copy()
+    up_array_temp = up_array.copy()
+    low_array_temp[equal_bounds_mask] -= 1e-6
+    up_array_temp[equal_bounds_mask] += 1e-6
 
     # Call the original cxSimulatedBinaryBounded function with adjusted bounds
-    tools.cxSimulatedBinaryBounded(ind1, ind2, eta, list(low_array), list(up_array))
+    tools.cxSimulatedBinaryBounded(index_ind1, index_ind2, eta, list(low_array_temp), list(up_array_temp))
 
-    # Ensure that values in dimensions with originally equal bounds are reset
-    # to the bound value (since they should not be modified)
-    for i, equal in enumerate(equal_bounds_mask):
-        if equal:
+    # Convert back from index space and ensure bounds
+    for i in range(n):
+        step = steps[i]
+        if equal_bounds_mask[i]:
             ind1[i] = low[i]
             ind2[i] = low[i]
+        elif step is not None:
+            # Stepped: convert from index space back to value
+            low_val, high_val = bounds[i][0], bounds[i][1]
+            ind1[i] = index_to_value(index_ind1[i], low_val, high_val, step)
+            ind2[i] = index_to_value(index_ind2[i], low_val, high_val, step)
+        else:
+            # Continuous: copy directly
+            ind1[i] = index_ind1[i]
+            ind2[i] = index_ind2[i]
 
     return ind1, ind2
 
@@ -837,41 +976,56 @@ class Evaluator:
             if np.random.random() < change_chance:  # x% chance of leaving unchanged
                 perturbed.append(val)
                 continue
-            low, high = self.bounds[i]
+            bound = self.bounds[i]
+            low, high = bound[0], bound[1]
+            bound_step = bound[2] if len(bound) > 2 else None
             if high == low:
                 perturbed.append(val)
                 continue
 
-            if val != 0.0:
+            # For stepped parameters, move by the defined step
+            if bound_step is not None and bound_step > 0:
+                step = bound_step
+            elif val != 0.0:
                 exponent = math.floor(math.log10(abs(val))) - (self.sig_digits - 1)
                 step = 10**exponent
             else:
                 step = (high - low) * 10 ** -(self.sig_digits - 1)
 
             direction = np.random.choice([-1.0, 1.0])
-            perturbed.append(pbr.round_dynamic(val + step * direction, self.sig_digits))
+            new_val = val + step * direction
+            # For stepped params, don't round_dynamic; quantization will happen in enforce_bounds
+            if bound_step is not None and bound_step > 0:
+                perturbed.append(new_val)
+            else:
+                perturbed.append(pbr.round_dynamic(new_val, self.sig_digits))
 
         return perturbed
 
     def perturb_x_pct(self, individual, magnitude=0.01):
         perturbed = []
         for i, val in enumerate(individual):
-            low, high = self.bounds[i]
+            bound = self.bounds[i]
+            low, high = bound[0], bound[1]
+            bound_step = bound[2] if len(bound) > 2 else None
             if high == low:
                 perturbed.append(val)
                 continue
-            new_val = pbr.round_dynamic(
-                val * (1 + np.random.uniform(-magnitude, magnitude)), self.sig_digits
-            )
-            perturbed.append(new_val)
+            new_val = val * (1 + np.random.uniform(-magnitude, magnitude))
+            # For stepped params, don't round_dynamic; quantization will happen in enforce_bounds
+            if bound_step is not None and bound_step > 0:
+                perturbed.append(new_val)
+            else:
+                perturbed.append(pbr.round_dynamic(new_val, self.sig_digits))
         return perturbed
 
     def perturb_random_subset(self, individual, frac=0.2):
-        perturbed = individual.copy()
+        perturbed = list(individual)
         n = len(individual)
         indices = np.random.choice(n, max(1, int(frac * n)), replace=False)
         for i in indices:
-            low, high = self.bounds[i]
+            bound = self.bounds[i]
+            low, high = bound[0], bound[1]
             if low != high:
                 delta = (high - low) * 0.01
                 step = delta * np.random.uniform(-1.0, 1.0)
@@ -879,19 +1033,28 @@ class Evaluator:
         return perturbed
 
     def perturb_sample_some(self, individual, frac=0.2):
-        perturbed = individual.copy()
+        perturbed = list(individual)
         n = len(individual)
         indices = np.random.choice(n, max(1, int(frac * n)), replace=False)
         for i in indices:
-            low, high = self.bounds[i]
+            bound = self.bounds[i]
+            low, high = bound[0], bound[1]
+            bound_step = bound[2] if len(bound) > 2 else None
             if low != high:
-                perturbed[i] = np.random.uniform(low, high)
+                # For stepped params, sample on-grid directly
+                if bound_step is not None and bound_step > 0:
+                    max_index = int((high - low) / bound_step + 0.5)
+                    random_index = np.random.randint(0, max_index + 1)
+                    perturbed[i] = low + random_index * bound_step
+                else:
+                    perturbed[i] = np.random.uniform(low, high)
         return perturbed
 
     def perturb_gaussian(self, individual, scale=0.01):
         perturbed = []
         for i, val in enumerate(individual):
-            low, high = self.bounds[i]
+            bound = self.bounds[i]
+            low, high = bound[0], bound[1]
             if high == low:
                 perturbed.append(val)
                 continue
@@ -902,9 +1065,16 @@ class Evaluator:
     def perturb_large_uniform(self, individual):
         perturbed = []
         for i in range(len(individual)):
-            low, high = self.bounds[i]
+            bound = self.bounds[i]
+            low, high = bound[0], bound[1]
+            bound_step = bound[2] if len(bound) > 2 else None
             if low == high:
                 perturbed.append(low)
+            elif bound_step is not None and bound_step > 0:
+                # For stepped params, sample on-grid directly
+                max_index = int((high - low) / bound_step + 0.5)
+                random_index = np.random.randint(0, max_index + 1)
+                perturbed.append(low + random_index * bound_step)
             else:
                 perturbed.append(np.random.uniform(low, high))
         return perturbed
@@ -1659,25 +1829,39 @@ async def main():
         if not isinstance(offspring_multiplier, (int, float)) or offspring_multiplier <= 0.0:
             offspring_multiplier = 1.0
 
-        # Register attribute generators
-        for i, (low, high) in enumerate(bounds):
-            toolbox.register(f"attr_{i}", np.random.uniform, low, high)
+        # Register attribute generators (generating on-grid values for stepped params)
+        def _make_random_attr(bound):
+            """Generate a random value respecting step constraints."""
+            low, high = bound[0], bound[1]
+            step = bound[2] if len(bound) > 2 else None
+            if step is not None and step > 0:
+                # Generate a random index and convert to value
+                max_index = int((high - low) / step + 0.5)
+                random_index = np.random.randint(0, max_index + 1)
+                return low + random_index * step
+            else:
+                return np.random.uniform(low, high)
 
-        # Register genetic operators
+        for i, bound in enumerate(bounds):
+            toolbox.register(f"attr_{i}", _make_random_attr, bound)
+
+        # Register genetic operators with bounds for step-aware crossover/mutation
         toolbox.register(
             "mate",
             cxSimulatedBinaryBoundedWrapper,
             eta=crossover_eta,
-            low=[low for low, high in bounds],
-            up=[high for low, high in bounds],
+            low=[b[0] for b in bounds],
+            up=[b[1] for b in bounds],
+            bounds=bounds,
         )
         toolbox.register(
             "mutate",
             mutPolynomialBoundedWrapper,
             eta=mutation_eta,
-            low=[low for low, high in bounds],
-            up=[high for low, high in bounds],
+            low=[b[0] for b in bounds],
+            up=[b[1] for b in bounds],
             indpb=mutation_indpb,
+            bounds=bounds,
         )
         toolbox.register("select", tools.selNSGA2)
         toolbox.register("evaluate", evaluator_for_pool.evaluate, overrides_list=overrides_list)
@@ -1758,7 +1942,19 @@ async def main():
         )
 
         def _make_random_individual():
-            return creator.Individual([np.random.uniform(low, high) for low, high in bounds])
+            """Generate a random individual respecting step constraints."""
+            values = []
+            for bound in bounds:
+                low, high = bound[0], bound[1]
+                step = bound[2] if len(bound) > 2 else None
+                if step is not None and step > 0:
+                    # Generate a random index and convert to value
+                    max_index = int((high - low) / step + 0.5)
+                    random_index = np.random.randint(0, max_index + 1)
+                    values.append(low + random_index * step)
+                else:
+                    values.append(np.random.uniform(low, high))
+            return creator.Individual(values)
 
         population = [_make_random_individual() for _ in range(population_size)]
         if starting_individuals:


### PR DESCRIPTION
When a step is defined, the optimizer only explores values on the discrete grid. The genetic algorithm performs crossover and mutation in *index space* (i.e., the indices of valid grid values) to ensure offspring values always land on the grid.

For example, with bounds `[0.01, 0.10, 0.02]`:
- Valid values are: 0.01, 0.03, 0.05, 0.07, 0.09
- The optimizer will never produce values like 0.02 or 0.04