### PR TITLE
Fix config key sorting and rust mtime detection

### DIFF
--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -1549,16 +1549,22 @@ def remove_unused_keys_recursively(
         return
     if not isinstance(dst, dict) or not isinstance(src, dict):
         return
-    for k in sorted(list(dst.keys())):
+    def _sort_key(value) -> tuple[str, str]:
+        return (type(value).__name__, str(value))
+
+    for k in sorted(list(dst.keys()), key=_sort_key):
         current_path = parent + [k]
         if _path_is_preserved(current_path):
             continue
-        if k.startswith("_"):
+        if isinstance(k, str) and k.startswith("_"):
             continue
         if k not in src:
             removed = dst.pop(k)
             _log_config(
-                verbose, logging.INFO, "Removed unused key from config: %s", ".".join(current_path)
+                verbose,
+                logging.INFO,
+                "Removed unused key from config: %s",
+                ".".join(map(str, current_path)),
             )
             if tracker is not None:
                 tracker.remove(current_path, removed)

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -1550,6 +1550,7 @@ def remove_unused_keys_recursively(
     if not isinstance(dst, dict) or not isinstance(src, dict):
         return
     def _sort_key(value) -> tuple[str, str]:
+        """Sort keys by type name, then by string representation."""
         return (type(value).__name__, str(value))
 
     for k in sorted(list(dst.keys()), key=_sort_key):

--- a/src/rust_utils.py
+++ b/src/rust_utils.py
@@ -115,6 +115,12 @@ def latest_source_mtime(root: Path = Path("passivbot-rust")) -> Optional[float]:
                 mtimes.append(file_path.stat().st_mtime)
         except OSError:
             continue
+    for file_path in root.glob("*.rs"):
+        try:
+            if file_path.exists():
+                mtimes.append(file_path.stat().st_mtime)
+        except OSError:
+            continue
     for scan_root in tracked_roots:
         if not scan_root.exists():
             continue

--- a/tests/test_config_mixed_type_keys.py
+++ b/tests/test_config_mixed_type_keys.py
@@ -1,0 +1,149 @@
+"""
+Tests for handling mixed-type (non-string) keys in config dictionaries.
+Addresses the fix in PR #537 for config key sorting when keys are not all strings.
+"""
+
+import pytest
+from config_utils import format_config, get_template_config, remove_unused_keys_recursively
+
+
+def test_remove_unused_keys_handles_integer_keys():
+    """Test that remove_unused_keys_recursively handles integer keys without crashing."""
+    template = {"a": 1, "b": 2}
+    config = {"a": 1, "b": 2, 123: "invalid_int_key", 456: "another_int"}
+    
+    # Should not crash, and should remove integer keys
+    remove_unused_keys_recursively(template, config, verbose=False)
+    
+    assert 123 not in config
+    assert 456 not in config
+    assert "a" in config
+    assert "b" in config
+
+
+def test_remove_unused_keys_handles_mixed_type_keys():
+    """Test handling of various non-string key types."""
+    template = {"valid_key": {"nested": 1}}
+    config = {
+        "valid_key": {"nested": 1},
+        123: "int_key",
+        45.6: "float_key",
+        (1, 2): "tuple_key",
+        True: "bool_key",
+    }
+    
+    # Should remove all non-string keys
+    remove_unused_keys_recursively(template, config, verbose=False)
+    
+    assert "valid_key" in config
+    assert 123 not in config
+    assert 45.6 not in config
+    assert (1, 2) not in config
+    assert True not in config
+
+
+def test_remove_unused_keys_preserves_underscore_string_keys():
+    """Test that string keys starting with underscore are preserved."""
+    template = {"a": 1}
+    config = {"a": 1, "_internal": "should_stay", "_raw": "metadata"}
+    
+    remove_unused_keys_recursively(template, config, verbose=False)
+    
+    assert "_internal" in config
+    assert "_raw" in config
+    assert "a" in config
+
+
+def test_remove_unused_keys_sorting_stability():
+    """Test that mixed-type key sorting doesn't cause crashes."""
+    template = {"x": 1, "y": 2}
+    config = {
+        "x": 1,
+        "y": 2,
+        "z": 3,  # Will be removed
+        100: "int",
+        200: "int2",
+        "a": 4,  # Will be removed
+    }
+    
+    # Should process without crashes despite mixed types
+    remove_unused_keys_recursively(template, config, verbose=False)
+    
+    # Template keys preserved
+    assert "x" in config
+    assert "y" in config
+    # Non-template string keys removed
+    assert "z" not in config
+    assert "a" not in config
+    # Integer keys removed
+    assert 100 not in config
+    assert 200 not in config
+
+
+def test_remove_unused_keys_in_nested_structure():
+    """
+    Test that remove_unused_keys_recursively properly handles integer keys
+    in nested structures during config cleanup (the core fix in PR #537).
+    """
+    template = {"section": {"valid_key": 1, "another_key": 2}}
+    config = {
+        "section": {
+            "valid_key": 1,
+            "another_key": 2,
+            123: "invalid_int_key",
+            "extra_string": "remove_me"
+        },
+        456: "root_level_int"
+    }
+    
+    # This is what format_config does - should not crash
+    remove_unused_keys_recursively(template, config, verbose=False)
+    
+    # Integer keys should be removed
+    assert 456 not in config
+    assert 123 not in config["section"]
+    # Extra string keys should be removed
+    assert "extra_string" not in config["section"]
+    # Valid structure preserved
+    assert "valid_key" in config["section"]
+    assert "another_key" in config["section"]
+
+
+def test_remove_unused_keys_with_numeric_string_keys():
+    """Test that string representations of numbers are handled as strings."""
+    template = {"1": "one", "2": "two"}
+    config = {"1": "one", "2": "two", 1: "int_one", 2: "int_two"}
+    
+    remove_unused_keys_recursively(template, config, verbose=False)
+    
+    # String keys preserved
+    assert "1" in config
+    assert "2" in config
+    # Integer keys removed
+    assert 1 not in config
+    assert 2 not in config
+
+
+def test_json_coercion_scenario():
+    """
+    Test scenario where JSON parsing might coerce numeric strings to integers.
+    This simulates real-world cases where configs might have mixed key types.
+    """
+    import json
+    
+    # This can happen when JSON is parsed in certain ways
+    template = {"setting_1": True, "setting_2": False}
+    config_with_int_keys = {
+        "setting_1": True,
+        "setting_2": False,
+        0: "zero",  # Could come from JSON coercion
+        1: "one",
+    }
+    
+    # Should handle gracefully
+    remove_unused_keys_recursively(template, config_with_int_keys, verbose=False)
+    
+    assert "setting_1" in config_with_int_keys
+    assert "setting_2" in config_with_int_keys
+    assert 0 not in config_with_int_keys
+    assert 1 not in config_with_int_keys

--- a/tests/test_rust_utils.py
+++ b/tests/test_rust_utils.py
@@ -41,3 +41,63 @@ def test_check_and_maybe_compile_errors_on_import(monkeypatch):
     monkeypatch.setitem(sys.modules, "passivbot_rust", object())
     with pytest.raises(RuntimeError):
         check_and_maybe_compile(force=True)
+
+
+def test_latest_source_mtime_includes_root_level_rs_files(tmp_path: Path):
+    """Test that latest_source_mtime detects root-level .rs files (PR #537 fix)."""
+    src_dir = tmp_path / "passivbot-rust"
+    src_dir.mkdir()
+    
+    # Create a root-level .rs file
+    root_rs = src_dir / "lib.rs"
+    root_rs.write_text("// root level rust file")
+    
+    # Create a subdirectory .rs file
+    sub_dir = src_dir / "src"
+    sub_dir.mkdir()
+    nested_rs = sub_dir / "main.rs"
+    nested_rs.write_text("// nested rust file")
+    
+    # Get mtime
+    src_mtime = latest_source_mtime(src_dir)
+    
+    assert src_mtime is not None
+    assert isinstance(src_mtime, float)
+    
+    # The mtime should be the max of both files
+    root_mtime = root_rs.stat().st_mtime
+    nested_mtime = nested_rs.stat().st_mtime
+    expected_max = max(root_mtime, nested_mtime)
+    
+    assert abs(src_mtime - expected_max) < 0.001  # Allow small floating point difference
+
+
+def test_latest_source_mtime_only_root_level_rs(tmp_path: Path):
+    """Test that latest_source_mtime works with only root-level .rs files."""
+    src_dir = tmp_path / "passivbot-rust"
+    src_dir.mkdir()
+    
+    # Only create root-level .rs files
+    (src_dir / "lib.rs").write_text("// lib")
+    (src_dir / "build.rs").write_text("// build")
+    
+    src_mtime = latest_source_mtime(src_dir)
+    
+    assert src_mtime is not None
+    assert isinstance(src_mtime, float)
+
+
+def test_latest_source_mtime_no_root_level_rs(tmp_path: Path):
+    """Test that latest_source_mtime still works without root-level .rs files."""
+    src_dir = tmp_path / "passivbot-rust"
+    src_dir.mkdir()
+    
+    # Only create nested .rs files
+    sub_dir = src_dir / "src"
+    sub_dir.mkdir()
+    (sub_dir / "main.rs").write_text("// nested")
+    
+    src_mtime = latest_source_mtime(src_dir)
+    
+    assert src_mtime is not None
+    assert isinstance(src_mtime, float)


### PR DESCRIPTION
## Summary
- handle mixed-type config keys in removal pass
- include root-level Rust files in source mtime detection

## Testing
- pytest