### PR TITLE
Fix TypeError in is_stablecoin when price fields are None

### DIFF
--- a/src/tools/generate_mcap_list.py
+++ b/src/tools/generate_mcap_list.py
@@ -14,8 +14,12 @@ def is_stablecoin(elm):
     try:
         if elm["symbol"] in ["tether", "usdb", "usdy", "tusd", "usd0", "usde"]:
             return True
+        # Check if all required price fields are not None before comparing
+        price_fields = ["high_24h", "low_24h", "current_price"]
         if (
-            all([abs(elm[k] - 1.0) < 0.01 for k in ["high_24h", "low_24h", "current_price"]])
+            all([elm.get(k) is not None for k in price_fields])
+            and all([abs(elm[k] - 1.0) < 0.01 for k in price_fields])
+            and elm.get("price_change_24h") is not None
             and abs(elm["price_change_24h"]) < 0.01
         ):
             return True


### PR DESCRIPTION
## Summary
Fixes a `TypeError` crash in `generate_mcap_list.py` when CoinGecko API returns `None` for price fields (`high_24h`, `low_24h`, `price_change_24h`).

## Problem
The `is_stablecoin()` function attempted arithmetic operations on `None` values, causing:
```
TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'
```

## Solution
Added null checks before arithmetic operations:
- Check if `high_24h`, `low_24h`, `current_price` are not `None`
- Check if `price_change_24h` is not `None`
- Only perform comparisons if all fields have valid values

## Test Plan
- [x] Verified fix handles coins with None price fields
- [x] Confirmed stablecoin detection still works correctly
- [x] Script completes without crashes