### PR TITLE
Upgrade to Python 3.12 and Debian Bookworm

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,6 @@ formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
+  version: "3.12"
   install:
     - requirements: requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.12-slim-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 # Skip runtime Rust compilation; extensions are prebuilt at image build time

--- a/Dockerfile_live
+++ b/Dockerfile_live
@@ -1,5 +1,5 @@
 # Stage 1: Build Rust extensions
-FROM python:3.10-slim-bullseye AS builder
+FROM python:3.12-slim-bookworm AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH="/root/.cargo/bin:${PATH}"
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir -r requirements-rust.txt \
     && maturin build --release
 
 # Stage 2: Final minimal image
-FROM python:3.10-slim-bullseye
+FROM python:3.12-slim-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV SKIP_RUST_COMPILE=true
@@ -38,6 +38,7 @@ ENV SKIP_RUST_COMPILE=true
 WORKDIR /app
 
 # Copy runtime source files
+COPY requirements-rust.txt requirements-rust.txt
 COPY requirements-live.txt requirements-live.txt
 COPY broker_codes.hjson broker_codes.hjson
 COPY src src

--- a/requirements-live.txt
+++ b/requirements-live.txt
@@ -1,11 +1,8 @@
 -r requirements-rust.txt
 python-dateutil==2.9.0.post0
-numba==0.59.1; python_version>='3.9'
-numba==0.58.1; python_version<'3.9'
-pandas==2.2.2; python_version>='3.9'
-pandas==1.5.3; python_version<'3.9'
-numpy==1.26.4; python_version>='3.9'
-numpy==1.23.5; python_version<'3.9'
+numba==0.59.1
+pandas==2.2.2
+numpy==1.26.4
 ccxt==4.5.22
 hjson==3.0.2
 prettytable==3.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 -r requirements-rust.txt
 -r requirements-live.txt
-matplotlib==3.8.4; python_version>='3.9'
-matplotlib==3.5.1; python_version<'3.9'
+matplotlib==3.8.4
 prospector==1.17.3
 colorama==0.4.6
 mkdocs==1.6.1

--- a/src/prompt_for_candlestick_manager.txt
+++ b/src/prompt_for_candlestick_manager.txt
@@ -180,7 +180,7 @@ The goal is to maintain an **up-to-date OHLCV database** with caching, lazy fetc
 
 ## Implementation Details
 
-* Python 3.8+
+* Python 3.12+
 * Dependencies: `ccxt.async_support`, `numpy`, `portalocker`, `logging`
 * Style: PEP 8
 


### PR DESCRIPTION
## Summary

This PR upgrades the Python runtime version from 3.8/3.10 to 3.12 across all Docker environments and documentation, ensuring consistency with the existing `setup.py` requirement (`python_requires=">=3.12"`).

## Changes

### Docker Infrastructure
- Updated `Dockerfile` to use `python:3.12-slim-bookworm` base image
- Updated `Dockerfile_live` (both builder and final stages) to use `python:3.12-slim-bookworm`
- Migrated from Debian Bullseye (11) to Bookworm (12) for improved Python 3.12 compatibility
- Fixed `Dockerfile_live` stage 2 to properly copy `requirements-rust.txt` (resolves build error)

### Dependencies
- Simplified version conditionals in `requirements.txt` and `requirements-live.txt`
- Removed obsolete `python_version<'3.9'` conditions for matplotlib, numpy, pandas, and numba
- Streamlined to use modern package versions compatible with Python 3.12+

### Documentation
- Updated `.readthedocs.yaml` from Python 3.8 to 3.12
- Updated `src/prompt_for_candlestick_manager.txt` documentation from Python 3.8+ to 3.12+

## Testing

All Docker images have been successfully built and tested:

- ✅ Standard `Dockerfile` builds successfully
- ✅ Production `Dockerfile_live` builds successfully (multi-stage build)
- ✅ Python 3.12.12 verified in both images
- ✅ Rust extensions (`passivbot_rust`) compile and import correctly
- ✅ All runtime dependencies install properly (numpy, pandas, ccxt, etc.)
- ✅ Main application (`src/main.py`) launches successfully

## Impact

- No breaking changes to functionality
- Maintains compatibility with existing `setup.py` requirements
- Improves consistency across development and production environments
- Ensures all environments use the same Python version (3.12)