### PR TITLE
fix: decouple warmup_minutes from HLCV cache hash for better reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable user-facing changes will be documented in this file.
 ### Added
 - **Hyperliquid builder codes** - Builder code attribution enabled by default (2 bps fee to fund development). Auto-approves with main wallet key; shows periodic nag banner for agent wallet users who haven't approved yet. Configurable via `broker_codes.hjson`.
 
+### Fixed
+- **Backtest HLCV cache reuse across configs** - Configs that differ only in trading parameters (EMA spans, warmup ratio) now share the same HLCV cache slot. Previously, different EMA spans produced different `warmup_minutes`, which was included in the cache hash, causing unnecessary re-downloads. The cache now uses a ratchet-up strategy: warmup sufficiency is checked at load time, and the cache is overwritten only when a larger warmup is needed.
+
 ## v7.8.2 - 2026-02-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+### Added
+- **Hyperliquid builder codes** - Builder code attribution enabled by default (2 bps fee to fund development). Auto-approves with main wallet key; shows periodic nag banner for agent wallet users who haven't approved yet. Configurable via `broker_codes.hjson`.
+
 ## v7.8.2 - 2026-02-09
 
 ### Added

--- a/api-keys.json.example
+++ b/api-keys.json.example
@@ -31,6 +31,7 @@
         "secret": "secret",
         "passphrase": "passphrase"
     },
+    "_comment_hyperliquid_builder_codes": "Passivbot uses Hyperliquid builder codes by default (see broker_codes.hjson). Approval must be signed once by main wallet. Main wallet key in private_key enables auto-approval on first run; agent key requires prior manual approval.",
     "hyperliquid_01" : {
         "exchange": "hyperliquid",
         "wallet_address": "wallet_address",

--- a/broker_codes.hjson
+++ b/broker_codes.hjson
@@ -18,4 +18,14 @@
 		}
 	}
 	gateio: "passivbot"
+	// Hyperliquid builder code: earns a small fee on each order to fund Passivbot development.
+	// CCXT attaches builder info to every order automatically when approved.
+	// Users must one-time approve via main wallet (not agent wallet).
+	// fee_int is in tenths of a basis point: 20 = 2 bps = 0.02%.
+	hyperliquid: {
+		ref: "PASSIVBOT"
+		builder: "0xTODO_PASSIVBOT_BUILDER_ADDRESS"
+		fee_rate: "0.02%"
+		fee_int: 20
+	}
 }

--- a/broker_codes.hjson
+++ b/broker_codes.hjson
@@ -24,7 +24,7 @@
 	// fee_int is in tenths of a basis point: 20 = 2 bps = 0.02%.
 	hyperliquid: {
 		ref: "PASSIVBOT"
-		builder: "0xTODO_PASSIVBOT_BUILDER_ADDRESS"
+		builder: "0x5e20A6D7e11366390Fde63EA3d0A026903359a74"
 		fee_rate: "0.02%"
 		fee_int: 20
 	}

--- a/broker_codes.hjson
+++ b/broker_codes.hjson
@@ -22,10 +22,12 @@
 	// CCXT attaches builder info to every order automatically when approved.
 	// Users must one-time approve via main wallet (not agent wallet).
 	// fee_int is in tenths of a basis point: 20 = 2 bps = 0.02%.
+	// Set builder_fee to false to disable builder codes entirely.
 	hyperliquid: {
 		ref: "PASSIVBOT"
 		builder: "0x5e20A6D7e11366390Fde63EA3d0A026903359a74"
 		fee_rate: "0.02%"
 		fee_int: 20
+		builder_fee: true
 	}
 }

--- a/docs/hyperliquid_guide.md
+++ b/docs/hyperliquid_guide.md
@@ -24,8 +24,27 @@
 ```
 For the `"private_key"`, use the API wallet created in the API section on Hyperliquid.
 
-Now Passivbot may be run as normal. Note that Hyperliquid has a minimum $10 order size:  
+Now Passivbot may be run as normal. Note that Hyperliquid has a minimum $10 order size:
 `initial_entry_cost = balance * (total_wallet_exposure_limit / n_positions) * entry_initial_qty_pct`
+
+### Builder Codes (Supporting Passivbot Development)
+
+Passivbot includes a Hyperliquid builder code that adds a small fee (0.02%) to each trade.
+This fee goes directly to funding Passivbot development. Builder codes are enabled by default.
+
+**If you use your main wallet private key** in `api-keys.json`, the bot will automatically
+approve the builder code on first startup. No extra action needed.
+
+**If you use an agent/API wallet** (recommended for security), you need to approve the builder
+code once from your main wallet. Choose one method:
+
+1. **Temporary key swap**: Temporarily put your main wallet private key in `api-keys.json`,
+   start the bot once (it will auto-approve), then switch back to your agent key.
+2. **CLI tool**: `python3 src/tools/approve_builder_fee.py` (prompts for main wallet key, not stored).
+3. **Hyperliquid web UI**: Approve via Settings > Approvals on app.hyperliquid.xyz.
+
+Without approval, the bot still works but will show periodic reminders. The builder code can
+be revoked at any time. To adjust the fee or disable entirely, edit `broker_codes.hjson`.
 
 #### HyperLiquid with a Vault (CopyTrading-like)
 1. In HyperLiquid, navigate to "Vaults" in the top menu and create a new vault.

--- a/docs/plans/hyperliquid-builder-codes.md
+++ b/docs/plans/hyperliquid-builder-codes.md
@@ -1,0 +1,352 @@
+# Hyperliquid Builder Codes - Research & Implementation Plan
+
+## Research Summary
+
+### What Are Builder Codes?
+
+Builder codes are an **onchain, per-order attribution mechanism** on Hyperliquid that lets
+applications earn fees on orders they route for users. Key properties:
+
+- **Per-order**: Builder info is attached to each individual order action as `{"b": "0xAddress", "f": feeInt}`
+- **Fee unit**: `f` is in **tenths of a basis point** (value `10` = 1 bps = 0.01%)
+- **Limits**: Max 10 bps (0.1%) on perps, max 100 bps (1%) on spot
+- **Revenue**: 100% goes to the builder. Over $40M paid out ecosystem-wide to date
+- **Builder requirement**: Builder wallet must hold >= 100 USDC in perps account
+
+### Approval Flow
+
+Users must **one-time approve** a builder's maximum fee rate via the `ApproveBuilderFee` action.
+
+**Critical constraint**: This approval **must be signed with the main wallet**, not an agent/API wallet.
+This is the single most important implementation detail - most passivbot users run with agent wallets,
+so they cannot auto-approve from inside the bot. They must approve externally (e.g. via Hyperliquid
+web UI, SDK script, or a separate passivbot utility).
+
+Once approved, the user can revoke at any time. The bot (even with an agent wallet) can then
+attach builder info to every order - only the initial approval requires the main wallet.
+
+### Querying Approval Status
+
+```
+POST https://api.hyperliquid.xyz/info
+{"type": "maxBuilderFee", "user": "0xUSER", "builder": "0xBUILDER"}
+```
+
+Returns the maximum fee the user has approved for the builder. If 0 or absent, not approved.
+
+### CCXT Built-in Support
+
+CCXT (>= ~4.4.80, exact version unclear) has **full built-in builder code handling** in its
+Hyperliquid module. The installed passivbot version (CCXT 4.5.22) **fully supports this**.
+
+#### How It Works in CCXT
+
+On `initialize_client()` (called automatically on first `fetch_markets`, `create_order`, etc.):
+
+1. **`set_ref()`** - Sets referral code via `setReferrer` action. Default: `'CCXT1'`
+2. **`handle_builder_fee_approval()`** - Attempts to approve builder fee. Default builder: `0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6` (CCXT's own address)
+
+On every subsequent order, if `approvedBuilderFee` is true in options, CCXT automatically
+attaches `builder: {"b": address, "f": feeInt}` to the order action.
+
+#### CCXT Options
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| `ref` | `'CCXT1'` | Referral code for `setReferrer` |
+| `builder` | `'0x6530...'` (CCXT) | Builder wallet address |
+| `feeRate` | `'0.01%'` | Max fee rate string for approval tx |
+| `feeInt` | `10` (= 1 bps) | Fee in tenths of bps, attached to orders |
+| `builderFee` | `True` | Master enable/disable toggle |
+| `approvedBuilderFee` | `False` | Set to true after successful approval |
+| `refSet` | `False` | Set to true after referral is set |
+
+#### Current State: CCXT's Builder Code Is Already Active
+
+**Important discovery**: With CCXT 4.5.22, CCXT is **already attempting** to approve its own
+builder address on every passivbot Hyperliquid session. If the user's main wallet has
+previously approved CCXT's builder (e.g. via another CCXT-based tool), CCXT charges 1 bps
+on every order. If approval fails (agent wallet), it silently disables and no builder fee
+is charged.
+
+This was confirmed by the [freqtrade issue #11986](https://github.com/freqtrade/freqtrade/issues/11986)
+where users on CCXT 4.4.94 hit "Builder fee has not been approved" errors, while CCXT 4.4.77
+did not have this behavior.
+
+### CCXT Version Compatibility
+
+| CCXT Version | Builder Fee Support |
+|---|---|
+| < 4.4.77 | No builder fee support |
+| 4.4.77-4.4.93 | Transition period (unclear) |
+| >= 4.4.94 | Full builder fee with `initialize_client()` |
+| **4.5.22** (passivbot current) | **Fully supported** |
+
+### Hyperliquid Base Fee Context
+
+To recommend a builder fee, context on Hyperliquid's base fees:
+
+| Tier | 14d Volume | Perp Taker | Perp Maker |
+|------|------------|------------|------------|
+| Base | $0 | 0.045% (4.5 bps) | 0.010% (1 bps) |
+| Tier 2 | $5M | 0.040% | 0.008% |
+| Tier 3 | $25M | 0.035% | 0.006% |
+| Tier 4 | $100M | 0.030% | 0.000% |
+
+Passivbot primarily places **maker** (post-only) orders, so users pay 0.5-1 bps in fees.
+A builder fee adds on top of these exchange fees.
+
+### Fee Level Recommendation
+
+**Recommended default: 2 bps (0.02%) = `feeInt: 20`**
+
+Rationale:
+- CCXT's own default is 1 bps (`feeInt: 10`). We should be at or above this since passivbot
+  provides significantly more value than a library wrapper.
+- Phantom wallet charges builder fees and earns ~$100k/day. PVP.trade has earned $7.2M lifetime.
+  These are consumer-facing UIs.
+- HeyAnon charges 10 bps (0.10%) on profitable position closes.
+- Passivbot is an open-source project; 2 bps is modest and fair.
+- For a typical passivbot user doing $1M monthly volume: 2 bps = ~$200/month to the project.
+- At base tier with maker orders (1 bps exchange fee), a 2 bps builder fee means the user
+  pays 3 bps total vs 1 bps without. This is still far below taker fees (4.5 bps).
+- Users can easily edit `broker_codes.hjson` to adjust if desired.
+
+Alternative considered: 1 bps (`feeInt: 10`) - matches CCXT default, but undersells passivbot's value.
+
+### Differences from GPT's Research
+
+1. **GPT suggested off by default** (`hyperliquid_builder_enabled = false`). User requirement is
+   **on by default** with a nag banner for unapproved users.
+
+2. **GPT suggested a new config key** (`live.hyperliquid_builder_enabled`). This is unnecessary -
+   the existing `broker_codes.hjson` pattern handles this cleanly, and CCXT options control the behavior.
+
+3. **GPT suggested explicitly disabling CCXT's default behavior**. This is correct in spirit -
+   we should override CCXT's default builder address with passivbot's, not add on top.
+
+4. **GPT suggested approval-status check via raw HTTP**. We can use CCXT's built-in
+   `handle_builder_fee_approval()` which does this automatically, plus we can query
+   `maxBuilderFee` for the banner logic.
+
+5. **GPT's approval flow is mostly correct** but misses that CCXT handles the signing and
+   submission automatically via `initialize_client()` -> `approve_builder_fee()`.
+
+---
+
+## Implementation Plan
+
+### Overview
+
+Use CCXT's built-in builder code infrastructure. Override CCXT's default builder address with
+passivbot's in `create_ccxt_sessions()`. Add a periodic nag banner (like Binance's
+`print_new_user_suggestion`) that checks approval status and prints a large message encouraging
+users to approve the builder code.
+
+### Prerequisites
+
+- A Hyperliquid wallet address controlled by the passivbot project, funded with >= 100 USDC
+  in the perps subaccount. This becomes the builder address in `broker_codes.hjson`.
+
+### File Changes
+
+#### 1. `broker_codes.hjson` - Add Hyperliquid builder config
+
+```hjson
+hyperliquid: {
+    ref: "PASSIVBOT"
+    builder: "0xYOUR_PASSIVBOT_BUILDER_ADDRESS"
+    feeRate: "0.02%"
+    feeInt: 20
+}
+```
+
+- `ref`: Referral code (replaces CCXT's default `CCXT1`)
+- `builder`: Passivbot's builder wallet address (replaces CCXT's default address)
+- `feeRate`: Max fee rate string for the approval transaction
+- `feeInt`: 20 = 2 bps, attached to every order
+
+#### 2. `src/exchanges/hyperliquid.py` - Wire builder codes + nag banner
+
+**In `create_ccxt_sessions()`**, after existing options setup:
+
+```python
+# Configure builder code and referral
+if isinstance(self.broker_code, dict):
+    hl_opts = {}
+    if "ref" in self.broker_code:
+        hl_opts["ref"] = self.broker_code["ref"]
+    if "builder" in self.broker_code:
+        hl_opts["builder"] = self.broker_code["builder"]
+        hl_opts["feeRate"] = self.broker_code.get("feeRate", "0.02%")
+        hl_opts["feeInt"] = self.broker_code.get("feeInt", 20)
+    for client in [c for c in [self.cca, getattr(self, 'ccp', None)] if c]:
+        client.options.update(hl_opts)
+elif self.broker_code:
+    # Simple string = referral code only
+    for client in [c for c in [self.cca, getattr(self, 'ccp', None)] if c]:
+        client.options["ref"] = self.broker_code
+```
+
+This overrides CCXT's defaults. CCXT will automatically:
+- Call `set_ref("PASSIVBOT")` on init
+- Call `approve_builder_fee("0xPASSIVBOT_ADDR", "0.02%")` on init
+- Attach `builder: {"b": "0x...", "f": 20}` to every order (if approved)
+
+**Add nag banner method** (modeled on `BinanceBot.print_new_user_suggestion`):
+
+```python
+async def print_builder_code_banner(self):
+    """Print periodic banner encouraging builder code approval."""
+    interval_ms = 1000 * 60 * 30  # every 30 minutes
+    if hasattr(self, "_builder_banner_ts"):
+        if utc_ms() - self._builder_banner_ts < interval_ms:
+            return
+    self._builder_banner_ts = utc_ms()
+
+    # Skip if no builder configured or already approved
+    if not isinstance(self.broker_code, dict) or "builder" not in self.broker_code:
+        return
+    if self.cca.options.get("approvedBuilderFee", False):
+        return
+
+    # Check approval status via info endpoint
+    try:
+        builder_addr = self.broker_code["builder"]
+        wallet_addr = self.user_info["wallet_address"]
+        res = await self.cca.fetch(
+            "https://api.hyperliquid.xyz/info",
+            method="POST",
+            headers={"Content-Type": "application/json"},
+            body=json.dumps({
+                "type": "maxBuilderFee",
+                "user": wallet_addr,
+                "builder": builder_addr,
+            }),
+        )
+        # If user has approved a sufficient fee, mark as approved and skip banner
+        max_fee = int(res) if res else 0
+        if max_fee >= self.broker_code.get("feeInt", 20):
+            self.cca.options["approvedBuilderFee"] = True
+            return
+    except Exception as e:
+        logging.debug(f"builder fee check failed: {e}")
+
+    lines = [
+        "Passivbot builder code is NOT yet approved on your Hyperliquid account.",
+        " ",
+        "Builder codes help fund Passivbot development at a small fee (0.02%).",
+        "This is added on top of Hyperliquid's base trading fees.",
+        " ",
+        "To approve (one-time, requires main wallet - not agent wallet):",
+        " ",
+        "  Option A: Run the approval script:",
+        f"    python3 tools/approve_builder_fee.py --builder {self.broker_code['builder']}",
+        " ",
+        "  Option B: Use the Hyperliquid Python SDK directly:",
+        f'    exchange.approve_builder_fee("{self.broker_code["builder"]}", "{self.broker_code.get("feeRate", "0.02%")}")',
+        " ",
+        "  Option C: Approve via a third-party Hyperliquid frontend that supports builder approval.",
+        " ",
+        "To disable this message, set builderFee to false in your CCXT options",
+        "or remove the hyperliquid entry from broker_codes.hjson.",
+    ]
+    front_pad = " " * 4 + "##"
+    back_pad = "##"
+    max_len = max(len(line) for line in lines)
+    print("\n\n")
+    print(front_pad + "#" * (max_len + 2) + back_pad)
+    for line in lines:
+        print(front_pad + " " + line + " " * (max_len - len(line) + 1) + back_pad)
+    print(front_pad + "#" * (max_len + 2) + back_pad)
+    print("\n\n")
+```
+
+**Override `execute_to_exchange()`** to trigger the banner (same pattern as Binance):
+
+```python
+async def execute_to_exchange(self):
+    res = await super().execute_to_exchange()
+    await self.print_builder_code_banner()
+    return res
+```
+
+#### 3. (Optional) `tools/approve_builder_fee.py` - Standalone approval helper
+
+A small script that users can run with their **main wallet** private key to approve
+the builder fee one time. This is a convenience since the approval cannot happen
+from an agent wallet.
+
+```python
+"""One-time Hyperliquid builder fee approval for Passivbot.
+
+Usage:
+    python3 tools/approve_builder_fee.py \
+        --wallet-address 0xYOUR_MAIN_WALLET \
+        --private-key 0xYOUR_MAIN_WALLET_PRIVATE_KEY \
+        --builder 0xPASSIVBOT_BUILDER_ADDRESS \
+        --fee-rate "0.02%"
+"""
+```
+
+Uses CCXT directly: creates a session with the main wallet credentials and calls
+`exchange.approve_builder_fee(builder, feeRate)`.
+
+#### 4. `docs/hyperliquid_guide.md` - Add builder code section
+
+Short section explaining:
+- What builder codes are and why they exist
+- One-time approval instructions (main wallet required)
+- How to adjust or disable the fee
+- Link to the approval helper script
+
+### What We Do NOT Need
+
+- **No new config keys**: `broker_codes.hjson` already handles per-exchange broker config
+- **No changes to order placement code**: CCXT attaches builder info automatically via options
+- **No changes to `_build_order_params()`**: Builder attachment happens inside CCXT's `create_order`
+- **No manual HTTP calls for order attribution**: CCXT handles everything
+- **No `live.hyperliquid_builder_enabled` config**: Unnecessary complexity
+
+### Execution Order
+
+1. Obtain/fund passivbot builder wallet on Hyperliquid (>= 100 USDC perps)
+2. Add builder config to `broker_codes.hjson`
+3. Modify `create_ccxt_sessions()` in `hyperliquid.py` to apply builder options
+4. Add `print_builder_code_banner()` and `execute_to_exchange()` override
+5. (Optional) Create `tools/approve_builder_fee.py` helper script
+6. Update `docs/hyperliquid_guide.md`
+7. Test with testnet first, then mainnet
+8. Verify attribution via Hyperliquid builder fill stats:
+   `https://stats-data.hyperliquid.xyz/Mainnet/builder_fills/{address}/{YYYYMMDD}.csv.lz4`
+
+### Testing
+
+- Verify CCXT options are correctly set in both `cca` and `ccp` sessions
+- Verify `set_ref("PASSIVBOT")` is called on first API interaction
+- Verify builder fee approval attempt happens on init (will fail with agent wallet - expected)
+- Verify banner prints every 30 minutes when builder fee is not approved
+- Verify banner stops printing once approved
+- Verify orders include builder attribution after approval
+- Verify bot continues to work normally when builder fee is not approved (no blocking)
+
+### Risk Assessment
+
+- **Low risk**: CCXT's builder code support is mature and battle-tested
+- **No breaking changes**: Builder fee is purely additive; orders work with or without it
+- **Silent failure**: If approval fails (agent wallet), CCXT disables builder fee and bot continues
+- **User control**: Users can disable via `broker_codes.hjson` edit or CCXT options override
+
+---
+
+## Sources
+
+- [Hyperliquid Builder Codes Documentation](https://hyperliquid.gitbook.io/hyperliquid-docs/trading/builder-codes)
+- [Hyperliquid Fees Documentation](https://hyperliquid.gitbook.io/hyperliquid-docs/trading/fees)
+- [Hyperliquid Builder Codes Wiki](https://hyperliquid-co.gitbook.io/wiki/guide/builder-guide/hypercore/builder-codes)
+- [Hyperliquid Python SDK - Builder Fee Example](https://github.com/hyperliquid-dex/hyperliquid-python-sdk/blob/master/examples/basic_builder_fee.py)
+- [CCXT Hyperliquid Documentation](https://docs.ccxt.com/exchanges/hyperliquid)
+- [Freqtrade Builder Code Issue #11986](https://github.com/freqtrade/freqtrade/issues/11986) - Confirms CCXT builder fee behavior and version compatibility
+- [Dwellir - Hyperliquid Builder Codes Revenue Analysis](https://www.dwellir.com/blog/hyperliquid-builder-codes)
+- [Blockworks - Hyperliquid Frontend Wars](https://blockworks.co/news/hyperliquid-the-frontend-wars)
+- [CCXT PR #24448 - Hyperliquid Features](https://github.com/ccxt/ccxt/pull/24448)

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -979,7 +979,11 @@ def ensure_valid_index_metadata(mss, hlcvs, coins, warmup_map=None):
                 last_idx = int(total_steps)
         meta["first_valid_index"] = first_idx
         meta["last_valid_index"] = last_idx
-        warm_minutes = int(meta.get("warmup_minutes", warmup_map.get(coin, default_warm)))
+        if warmup_map:
+            # Warmup from current config must override any historical cached metadata.
+            warm_minutes = int(warmup_map.get(coin, default_warm))
+        else:
+            warm_minutes = int(meta.get("warmup_minutes", 0))
         meta["warmup_minutes"] = warm_minutes
         if first_idx > last_idx:
             trade_start_idx = first_idx

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -814,18 +814,33 @@ def get_cache_hash(config, exchange):
         "gap_tolerance_ohlcvs_minutes": require_config_value(
             config, "backtest.gap_tolerance_ohlcvs_minutes"
         ),
-        "warmup_minutes": compute_backtest_warmup_minutes(config),
         "coin_sources": coin_sources_sorted,
         "market_settings_sources": market_settings_sources_sorted,
     }
     return calc_hash(to_hash)
 
 
-def load_coins_hlcvs_from_cache(config, exchange):
+def load_coins_hlcvs_from_cache(config, exchange, warmup_minutes=0):
     cache_hash = get_cache_hash(config, exchange)
     cache_dir = Path("caches") / "hlcvs_data" / cache_hash[:16]
     compress_cache = bool(require_config_value(config, "backtest.compress_cache"))
     if os.path.exists(cache_dir):
+        # Check warmup sufficiency: cached data must cover at least the needed warmup
+        meta_path = cache_dir / "cache_meta.json"
+        if meta_path.exists():
+            try:
+                cache_meta = json.load(open(meta_path))
+                cached_warmup = int(cache_meta.get("warmup_minutes", 0))
+            except Exception:
+                cached_warmup = 0
+        else:
+            cached_warmup = 0
+        if cached_warmup < warmup_minutes:
+            logging.info(
+                f"{exchange} cache warmup insufficient: cached={cached_warmup} min, "
+                f"needed={warmup_minutes} min. Will re-fetch."
+            )
+            return None
         coins = json.load(open(cache_dir / "coins.json"))
         mss = json.load(open(cache_dir / "market_specific_settings.json"))
         if compress_cache:
@@ -889,20 +904,12 @@ def save_coins_hlcvs_to_cache(
     mss,
     btc_usd_prices,
     timestamps=None,
+    warmup_minutes=0,
 ):
     cache_hash = get_cache_hash(config, exchange)
     cache_dir = Path("caches") / "hlcvs_data" / cache_hash[:16]
     cache_dir.mkdir(parents=True, exist_ok=True)
     is_compressed = bool(require_config_value(config, "backtest.compress_cache"))
-    expected_files = [
-        "coins.json",
-        "hlcvs.npy.gz" if is_compressed else "hlcvs.npy",
-        "btc_usd_prices.npy.gz" if is_compressed else "btc_usd_prices.npy",
-    ]
-    if timestamps is not None:
-        expected_files.append("timestamps.npy.gz" if is_compressed else "timestamps.npy")
-    if all((cache_dir / fname).exists() for fname in expected_files):
-        return
     logging.info(f"Dumping cache...")
     json.dump(coins, open(cache_dir / "coins.json", "w"))
     json.dump(mss, open(cache_dir / "market_specific_settings.json", "w"))
@@ -947,6 +954,7 @@ def save_coins_hlcvs_to_cache(
         f"{line}"
     )
     logging.info(f"Seconds to dump cache: {(utc_ms() - sts) / 1000:.4f}")
+    json.dump({"warmup_minutes": int(warmup_minutes)}, open(cache_dir / "cache_meta.json", "w"))
     return cache_dir
 
 
@@ -985,9 +993,10 @@ async def prepare_hlcvs_mss(config, exchange, *, force_refetch_gaps: bool = Fals
     results_path = oj(base_dir, exchange, "")
     warmup_map = compute_per_coin_warmup_minutes(config)
     default_warm = int(warmup_map.get("__default__", 0))
+    backtest_warmup_minutes = compute_backtest_warmup_minutes(config)
     try:
         sts = utc_ms()
-        result = load_coins_hlcvs_from_cache(config, exchange)
+        result = load_coins_hlcvs_from_cache(config, exchange, backtest_warmup_minutes)
         if result:
             logging.info(f"Seconds to load cache: {(utc_ms() - sts) / 1000:.4f}")
             cache_dir, coins, hlcvs, mss, results_path, btc_usd_prices, timestamps = result
@@ -1022,6 +1031,7 @@ async def prepare_hlcvs_mss(config, exchange, *, force_refetch_gaps: bool = Fals
             mss,
             btc_usd_prices,
             timestamps,
+            warmup_minutes=backtest_warmup_minutes,
         )
     except Exception as e:
         logging.error(f"Failed to save hlcvs to cache: {e}")

--- a/src/tools/approve_builder_fee.py
+++ b/src/tools/approve_builder_fee.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+Approve the Hyperliquid builder fee for a Passivbot account.
+
+Usage:
+  python3 src/tools/approve_builder_fee.py --user hyperliquid_01
+  python3 src/tools/approve_builder_fee.py --user hyperliquid_01 --api-keys path/to/api-keys.json
+
+Builder fee approval must be signed by the main wallet. If api-keys.json contains
+an agent wallet key, you will be prompted to enter your main wallet private key
+interactively (it is never stored).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import getpass
+import json
+import logging
+import sys
+from pathlib import Path
+
+# Allow running from repo root: `python3 src/tools/approve_builder_fee.py`
+# src/ modules use bare imports (e.g. `from utils import ...`), so add src/ to path
+_repo_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_repo_root / "src"))
+
+import ccxt.async_support as ccxt_async
+from procedures import load_broker_code, load_user_info
+
+
+def _is_positive_fee_value(value) -> bool:
+    """Parse various fee value formats (int, float, "0.01%", etc.)."""
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return float(value) > 0.0
+    if isinstance(value, str):
+        text = value.strip().rstrip("%")
+        try:
+            return float(text) > 0.0
+        except ValueError:
+            return False
+    return False
+
+
+def _extract_max_builder_fee(payload):
+    """Recursively extract the max builder fee from various API response shapes."""
+    if isinstance(payload, dict):
+        for key in ("maxBuilderFee", "maxFeeRate"):
+            if key in payload:
+                return _extract_max_builder_fee(payload[key])
+        for key in ("data", "response", "result"):
+            if key in payload:
+                return _extract_max_builder_fee(payload[key])
+        return None
+    if isinstance(payload, list):
+        for item in payload:
+            extracted = _extract_max_builder_fee(item)
+            if extracted is not None:
+                return extracted
+        return None
+    return payload
+
+
+def _parse_builder_config(broker_code) -> dict:
+    """Parse broker_codes.hjson hyperliquid entry into builder/feeRate."""
+    if not isinstance(broker_code, dict):
+        return {}
+    builder = broker_code.get("builder")
+    if not builder:
+        return {}
+    fee_rate = broker_code.get("fee_rate", broker_code.get("feeRate", "0.02%"))
+    return {"builder": builder, "feeRate": fee_rate}
+
+
+def _create_exchange(wallet_address: str, private_key: str) -> ccxt_async.hyperliquid:
+    return ccxt_async.hyperliquid(
+        {
+            "walletAddress": wallet_address,
+            "privateKey": private_key,
+            "enableRateLimit": True,
+        }
+    )
+
+
+async def _check_approved(exchange, wallet_address: str, builder: str) -> bool:
+    """Check if the builder fee is already approved for this wallet."""
+    try:
+        res = await exchange.fetch(
+            "https://api.hyperliquid.xyz/info",
+            method="POST",
+            headers={"Content-Type": "application/json"},
+            body=json.dumps(
+                {
+                    "type": "maxBuilderFee",
+                    "user": wallet_address,
+                    "builder": builder,
+                }
+            ),
+        )
+        max_fee = _extract_max_builder_fee(res)
+        return _is_positive_fee_value(max_fee)
+    except Exception as e:
+        logging.debug(f"fee approval check failed: {e}")
+        return False
+
+
+async def _approve(exchange, builder: str, fee_rate: str) -> None:
+    """Call CCXT approve_builder_fee."""
+    await exchange.approve_builder_fee(builder, fee_rate)
+
+
+async def main_async(user: str, api_keys_path: str) -> int:
+    user_info = load_user_info(user, api_keys_path)
+
+    if user_info.get("exchange", "").lower() != "hyperliquid":
+        print(f"Error: user '{user}' is on exchange '{user_info.get('exchange')}', not hyperliquid")
+        return 1
+
+    broker_code = load_broker_code("hyperliquid")
+    builder_cfg = _parse_builder_config(broker_code)
+    if not builder_cfg:
+        print("Error: no builder config found in broker_codes.hjson for hyperliquid")
+        print("Expected a dict with 'builder' address. Check broker_codes.hjson.")
+        return 1
+
+    builder = builder_cfg["builder"]
+    fee_rate = builder_cfg["feeRate"]
+    wallet_address = user_info.get("wallet_address", "")
+
+    if not wallet_address:
+        print("Error: no wallet_address found for this user in api-keys.json")
+        return 1
+
+    print(f"Builder address: {builder}")
+    print(f"Fee rate:        {fee_rate}")
+    print(f"Wallet address:  {wallet_address}")
+    print()
+
+    # Step 1: Check if already approved
+    private_key = user_info.get("private_key", "")
+    if not private_key:
+        print("Error: no private_key found for this user in api-keys.json")
+        return 1
+
+    exchange = _create_exchange(wallet_address, private_key)
+    try:
+        print("Checking current approval status...")
+        if await _check_approved(exchange, wallet_address, builder):
+            print("Builder fee is already approved! No action needed.")
+            return 0
+
+        # Step 2: Try approving with the key from api-keys.json
+        print("Not yet approved. Attempting approval with key from api-keys.json...")
+        try:
+            await _approve(exchange, builder, fee_rate)
+            print("Builder fee approved successfully!")
+            return 0
+        except Exception as e:
+            logging.debug(f"approval with api-keys.json key failed: {e}")
+            print(
+                "Approval failed with the key in api-keys.json (likely an agent wallet)."
+            )
+    finally:
+        await exchange.close()
+
+    # Step 3: Prompt for main wallet private key
+    print()
+    print("Builder fee approval requires a signature from the main wallet.")
+    print("Your main wallet private key will NOT be stored anywhere.")
+    print()
+    main_key = getpass.getpass("Enter main wallet private key (hidden): ").strip()
+    if not main_key:
+        print("No key entered. Aborting.")
+        return 1
+
+    exchange = _create_exchange(wallet_address, main_key)
+    try:
+        print("Attempting approval with main wallet key...")
+        await _approve(exchange, builder, fee_rate)
+        # Verify
+        if await _check_approved(exchange, wallet_address, builder):
+            print("Builder fee approved successfully!")
+            return 0
+        else:
+            print("Approval call succeeded but verification failed.")
+            print("It may take a moment to propagate. Try running this tool again.")
+            return 0
+    except Exception as e:
+        print(f"Approval failed: {e}")
+        print()
+        print("Possible causes:")
+        print("  - Incorrect private key")
+        print("  - Key does not match the wallet address")
+        print("  - Network issue")
+        return 1
+    finally:
+        await exchange.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Approve the Hyperliquid builder fee for a Passivbot account"
+    )
+    parser.add_argument("--user", required=True, help="account name in api-keys.json")
+    parser.add_argument(
+        "--api-keys",
+        default="api-keys.json",
+        help="path to api-keys.json (default: api-keys.json)",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    try:
+        rc = asyncio.run(main_async(args.user, args.api_keys))
+        sys.exit(rc)
+    except KeyboardInterrupt:
+        print("\nAborted.")
+        sys.exit(1)
+    except Exception:
+        logging.exception("Unexpected error")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cache_warmup_reuse.py
+++ b/tests/test_cache_warmup_reuse.py
@@ -1,0 +1,430 @@
+"""
+Tests for backtest HLCV cache warmup decoupling.
+
+The backtest HLCV cache key no longer includes warmup_minutes. Instead,
+warmup sufficiency is checked at load time: if the cached data was
+produced with warmup >= the currently needed warmup, the cache is reused.
+This allows configs that differ only in EMA spans (and thus warmup) to
+share the same cache slot, with a ratchet-up behavior on re-fetch.
+
+Tests cover:
+- Cache hash independence from warmup_minutes
+- Warmup sufficiency gate in load_coins_hlcvs_from_cache
+- cache_meta.json persistence in save_coins_hlcvs_to_cache
+- Ratchet-up: smaller warmup reuses cache built with larger warmup
+- Legacy caches (no cache_meta.json) treated as warmup=0
+"""
+
+import copy
+import gzip
+import json
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from backtest import (
+    get_cache_hash,
+    load_coins_hlcvs_from_cache,
+    save_coins_hlcvs_to_cache,
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+def _base_config(**overrides):
+    """Minimal config sufficient for cache hash computation."""
+    cfg = {
+        "backtest": {
+            "base_dir": "backtests",
+            "compress_cache": False,
+            "end_date": "2025-06-01",
+            "start_date": "2024-01-01",
+            "exchanges": ["binance"],
+            "gap_tolerance_ohlcvs_minutes": 120,
+        },
+        "bot": {
+            "long": {
+                "ema_span_0": 1000.0,
+                "ema_span_1": 1500.0,
+                "filter_volume_ema_span": 2000.0,
+                "filter_volatility_ema_span": 100.0,
+                "entry_volatility_ema_span_hours": 1.0,
+            },
+            "short": {
+                "ema_span_0": 100.0,
+                "ema_span_1": 100.0,
+                "filter_volume_ema_span": 360.0,
+                "filter_volatility_ema_span": 10.0,
+                "entry_volatility_ema_span_hours": 1.0,
+            },
+        },
+        "live": {
+            "approved_coins": {"long": ["BTC/USDT:USDT"], "short": []},
+            "ignored_coins": {"long": [], "short": []},
+            "minimum_coin_age_days": 30,
+            "warmup_ratio": 0.3,
+            "max_warmup_minutes": 0,
+        },
+        "optimize": {"bounds": {}},
+    }
+    for k, v in overrides.items():
+        cfg[k] = v
+    return cfg
+
+
+def _write_fake_cache(cache_dir, *, compress=False, warmup_minutes=None):
+    """Write minimal valid cache files so load_coins_hlcvs_from_cache succeeds."""
+    os.makedirs(cache_dir, exist_ok=True)
+
+    coins = ["BTC"]
+    mss = {"BTC": {"first_valid_index": 0, "last_valid_index": 9}}
+
+    hlcvs = np.zeros((10, 1, 4), dtype=np.float64)
+    btc_usd = np.ones(10, dtype=np.float64) * 50000.0
+    timestamps = np.arange(10, dtype=np.int64) * 60_000
+
+    json.dump(coins, open(os.path.join(cache_dir, "coins.json"), "w"))
+    json.dump(mss, open(os.path.join(cache_dir, "market_specific_settings.json"), "w"))
+
+    if compress:
+        with gzip.open(os.path.join(cache_dir, "hlcvs.npy.gz"), "wb", compresslevel=1) as f:
+            np.save(f, hlcvs)
+        with gzip.open(os.path.join(cache_dir, "btc_usd_prices.npy.gz"), "wb", compresslevel=1) as f:
+            np.save(f, btc_usd)
+        with gzip.open(os.path.join(cache_dir, "timestamps.npy.gz"), "wb", compresslevel=1) as f:
+            np.save(f, timestamps)
+    else:
+        np.save(os.path.join(cache_dir, "hlcvs.npy"), hlcvs)
+        np.save(os.path.join(cache_dir, "btc_usd_prices.npy"), btc_usd)
+        np.save(os.path.join(cache_dir, "timestamps.npy"), timestamps)
+
+    if warmup_minutes is not None:
+        json.dump(
+            {"warmup_minutes": int(warmup_minutes)},
+            open(os.path.join(cache_dir, "cache_meta.json"), "w"),
+        )
+
+
+# ============================================================================
+# Test Class: Cache Hash Independence from Warmup
+# ============================================================================
+
+
+class TestCacheHashIndependence:
+    """Verify that warmup_minutes no longer affects the cache hash."""
+
+    def test_different_ema_spans_same_hash(self):
+        """Two configs differing only in EMA spans produce the same cache hash."""
+        cfg_a = _base_config()
+        cfg_b = copy.deepcopy(cfg_a)
+        cfg_b["bot"]["long"]["entry_volatility_ema_span_hours"] = 500.0
+
+        hash_a = get_cache_hash(cfg_a, "binance")
+        hash_b = get_cache_hash(cfg_b, "binance")
+
+        assert hash_a == hash_b
+
+    def test_different_warmup_ratio_same_hash(self):
+        """Changing warmup_ratio does not change the hash."""
+        cfg_a = _base_config()
+        cfg_b = copy.deepcopy(cfg_a)
+        cfg_b["live"]["warmup_ratio"] = 10.0
+
+        hash_a = get_cache_hash(cfg_a, "binance")
+        hash_b = get_cache_hash(cfg_b, "binance")
+
+        assert hash_a == hash_b
+
+    def test_different_coins_different_hash(self):
+        """Changing approved_coins still produces a different hash."""
+        cfg_a = _base_config()
+        cfg_b = copy.deepcopy(cfg_a)
+        cfg_b["live"]["approved_coins"]["long"] = ["ETH/USDT:USDT"]
+
+        hash_a = get_cache_hash(cfg_a, "binance")
+        hash_b = get_cache_hash(cfg_b, "binance")
+
+        assert hash_a != hash_b
+
+    def test_different_dates_different_hash(self):
+        """Changing start_date still produces a different hash."""
+        cfg_a = _base_config()
+        cfg_b = copy.deepcopy(cfg_a)
+        cfg_b["backtest"]["start_date"] = "2023-06-01"
+
+        hash_a = get_cache_hash(cfg_a, "binance")
+        hash_b = get_cache_hash(cfg_b, "binance")
+
+        assert hash_a != hash_b
+
+
+# ============================================================================
+# Test Class: Warmup Sufficiency Gate
+# ============================================================================
+
+
+class TestWarmupSufficiencyGate:
+    """Verify that load_coins_hlcvs_from_cache checks warmup sufficiency."""
+
+    def test_sufficient_warmup_returns_cache(self, tmp_path, monkeypatch):
+        """Cache with warmup >= needed returns data."""
+        cfg = _base_config()
+        cache_hash = get_cache_hash(cfg, "binance")
+        cache_dir = tmp_path / "caches" / "hlcvs_data" / cache_hash[:16]
+        _write_fake_cache(str(cache_dir), warmup_minutes=5000)
+
+        monkeypatch.chdir(tmp_path)
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=3000)
+
+        assert result is not None
+
+    def test_insufficient_warmup_returns_none(self, tmp_path, monkeypatch):
+        """Cache with warmup < needed returns None."""
+        cfg = _base_config()
+        cache_hash = get_cache_hash(cfg, "binance")
+        cache_dir = tmp_path / "caches" / "hlcvs_data" / cache_hash[:16]
+        _write_fake_cache(str(cache_dir), warmup_minutes=1000)
+
+        monkeypatch.chdir(tmp_path)
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=5000)
+
+        assert result is None
+
+    def test_exact_warmup_match_returns_cache(self, tmp_path, monkeypatch):
+        """Cache with warmup == needed returns data (boundary condition)."""
+        cfg = _base_config()
+        cache_hash = get_cache_hash(cfg, "binance")
+        cache_dir = tmp_path / "caches" / "hlcvs_data" / cache_hash[:16]
+        _write_fake_cache(str(cache_dir), warmup_minutes=5000)
+
+        monkeypatch.chdir(tmp_path)
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=5000)
+
+        assert result is not None
+
+    def test_zero_needed_warmup_always_hits(self, tmp_path, monkeypatch):
+        """When needed warmup is 0, any cache is sufficient."""
+        cfg = _base_config()
+        cache_hash = get_cache_hash(cfg, "binance")
+        cache_dir = tmp_path / "caches" / "hlcvs_data" / cache_hash[:16]
+        _write_fake_cache(str(cache_dir), warmup_minutes=0)
+
+        monkeypatch.chdir(tmp_path)
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=0)
+
+        assert result is not None
+
+    def test_default_warmup_param_is_zero(self, tmp_path, monkeypatch):
+        """Calling without warmup_minutes defaults to 0 (always hits)."""
+        cfg = _base_config()
+        cache_hash = get_cache_hash(cfg, "binance")
+        cache_dir = tmp_path / "caches" / "hlcvs_data" / cache_hash[:16]
+        _write_fake_cache(str(cache_dir), warmup_minutes=0)
+
+        monkeypatch.chdir(tmp_path)
+        result = load_coins_hlcvs_from_cache(cfg, "binance")
+
+        assert result is not None
+
+
+# ============================================================================
+# Test Class: Legacy Cache Compatibility
+# ============================================================================
+
+
+class TestLegacyCacheCompatibility:
+    """Verify behavior with pre-existing caches that lack cache_meta.json."""
+
+    def test_missing_cache_meta_treated_as_zero_warmup(self, tmp_path, monkeypatch):
+        """Legacy cache without cache_meta.json has cached_warmup=0."""
+        cfg = _base_config()
+        cache_hash = get_cache_hash(cfg, "binance")
+        cache_dir = tmp_path / "caches" / "hlcvs_data" / cache_hash[:16]
+        _write_fake_cache(str(cache_dir), warmup_minutes=None)
+
+        monkeypatch.chdir(tmp_path)
+
+        # Needed warmup > 0 → miss (legacy cache has no warmup metadata)
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=100)
+        assert result is None
+
+    def test_missing_cache_meta_hits_when_zero_needed(self, tmp_path, monkeypatch):
+        """Legacy cache still works when needed warmup is 0."""
+        cfg = _base_config()
+        cache_hash = get_cache_hash(cfg, "binance")
+        cache_dir = tmp_path / "caches" / "hlcvs_data" / cache_hash[:16]
+        _write_fake_cache(str(cache_dir), warmup_minutes=None)
+
+        monkeypatch.chdir(tmp_path)
+
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=0)
+        assert result is not None
+
+    def test_corrupt_cache_meta_treated_as_zero(self, tmp_path, monkeypatch):
+        """Corrupt cache_meta.json falls back to cached_warmup=0."""
+        cfg = _base_config()
+        cache_hash = get_cache_hash(cfg, "binance")
+        cache_dir = tmp_path / "caches" / "hlcvs_data" / cache_hash[:16]
+        _write_fake_cache(str(cache_dir), warmup_minutes=5000)
+
+        # Corrupt the meta file
+        meta_path = os.path.join(str(cache_dir), "cache_meta.json")
+        with open(meta_path, "w") as f:
+            f.write("not valid json{{{")
+
+        monkeypatch.chdir(tmp_path)
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=100)
+        assert result is None
+
+
+# ============================================================================
+# Test Class: Save Persists Warmup Metadata
+# ============================================================================
+
+
+class TestSavePersistsWarmupMetadata:
+    """Verify that save_coins_hlcvs_to_cache writes cache_meta.json."""
+
+    def test_save_writes_cache_meta(self, tmp_path, monkeypatch):
+        """save_coins_hlcvs_to_cache creates cache_meta.json with warmup_minutes."""
+        monkeypatch.chdir(tmp_path)
+        cfg = _base_config()
+
+        coins = ["BTC"]
+        hlcvs = np.zeros((10, 1, 4), dtype=np.float64)
+        mss = {"BTC": {}}
+        btc_usd = np.ones(10, dtype=np.float64)
+        timestamps = np.arange(10, dtype=np.int64) * 60_000
+
+        cache_dir = save_coins_hlcvs_to_cache(
+            cfg, coins, hlcvs, "binance", mss, btc_usd, timestamps,
+            warmup_minutes=12345,
+        )
+
+        meta_path = os.path.join(str(cache_dir), "cache_meta.json")
+        assert os.path.exists(meta_path)
+
+        meta = json.load(open(meta_path))
+        assert meta["warmup_minutes"] == 12345
+
+    def test_save_overwrites_existing_cache(self, tmp_path, monkeypatch):
+        """Saving to an existing cache dir overwrites files (ratchet-up)."""
+        monkeypatch.chdir(tmp_path)
+        cfg = _base_config()
+
+        coins = ["BTC"]
+        hlcvs = np.zeros((10, 1, 4), dtype=np.float64)
+        mss = {"BTC": {}}
+        btc_usd = np.ones(10, dtype=np.float64)
+        timestamps = np.arange(10, dtype=np.int64) * 60_000
+
+        # First save with warmup=1000
+        cache_dir = save_coins_hlcvs_to_cache(
+            cfg, coins, hlcvs, "binance", mss, btc_usd, timestamps,
+            warmup_minutes=1000,
+        )
+        meta = json.load(open(os.path.join(str(cache_dir), "cache_meta.json")))
+        assert meta["warmup_minutes"] == 1000
+
+        # Second save with warmup=5000 (ratchet up)
+        hlcvs_bigger = np.zeros((20, 1, 4), dtype=np.float64)
+        btc_bigger = np.ones(20, dtype=np.float64)
+        ts_bigger = np.arange(20, dtype=np.int64) * 60_000
+        cache_dir2 = save_coins_hlcvs_to_cache(
+            cfg, coins, hlcvs_bigger, "binance", mss, btc_bigger, ts_bigger,
+            warmup_minutes=5000,
+        )
+
+        assert str(cache_dir) == str(cache_dir2)
+        meta = json.load(open(os.path.join(str(cache_dir2), "cache_meta.json")))
+        assert meta["warmup_minutes"] == 5000
+
+    def test_save_with_compression(self, tmp_path, monkeypatch):
+        """cache_meta.json is written even with compressed cache."""
+        monkeypatch.chdir(tmp_path)
+        cfg = _base_config()
+        cfg["backtest"]["compress_cache"] = True
+
+        coins = ["BTC"]
+        hlcvs = np.zeros((10, 1, 4), dtype=np.float64)
+        mss = {"BTC": {}}
+        btc_usd = np.ones(10, dtype=np.float64)
+        timestamps = np.arange(10, dtype=np.int64) * 60_000
+
+        cache_dir = save_coins_hlcvs_to_cache(
+            cfg, coins, hlcvs, "binance", mss, btc_usd, timestamps,
+            warmup_minutes=9999,
+        )
+
+        meta_path = os.path.join(str(cache_dir), "cache_meta.json")
+        assert os.path.exists(meta_path)
+        meta = json.load(open(meta_path))
+        assert meta["warmup_minutes"] == 9999
+
+
+# ============================================================================
+# Test Class: Ratchet-Up End-to-End
+# ============================================================================
+
+
+class TestRatchetUpEndToEnd:
+    """Simulate the full ratchet-up scenario with save then load."""
+
+    def test_ratchet_scenario(self, tmp_path, monkeypatch):
+        """
+        Scenario:
+        1. Save cache with warmup=3000.
+        2. Load with warmup=3000 → hit.
+        3. Load with warmup=5000 → miss (insufficient).
+        4. Save cache with warmup=5000 (overwrite).
+        5. Load with warmup=3000 → hit (5000 >= 3000).
+        6. Load with warmup=5000 → hit (5000 >= 5000).
+        """
+        monkeypatch.chdir(tmp_path)
+        cfg = _base_config()
+
+        coins = ["BTC"]
+        hlcvs = np.zeros((10, 1, 4), dtype=np.float64)
+        mss = {"BTC": {}}
+        btc_usd = np.ones(10, dtype=np.float64)
+        timestamps = np.arange(10, dtype=np.int64) * 60_000
+
+        # Step 1: Save with warmup=3000
+        save_coins_hlcvs_to_cache(
+            cfg, coins, hlcvs, "binance", mss, btc_usd, timestamps,
+            warmup_minutes=3000,
+        )
+
+        # Step 2: Load with warmup=3000 → hit
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=3000)
+        assert result is not None
+
+        # Step 3: Load with warmup=5000 → miss
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=5000)
+        assert result is None
+
+        # Step 4: Save with warmup=5000 (overwrite same slot)
+        hlcvs_bigger = np.zeros((20, 1, 4), dtype=np.float64)
+        btc_bigger = np.ones(20, dtype=np.float64)
+        ts_bigger = np.arange(20, dtype=np.int64) * 60_000
+        save_coins_hlcvs_to_cache(
+            cfg, coins, hlcvs_bigger, "binance", mss, btc_bigger, ts_bigger,
+            warmup_minutes=5000,
+        )
+
+        # Step 5: Load with warmup=3000 → hit (ratcheted up)
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=3000)
+        assert result is not None
+
+        # Step 6: Load with warmup=5000 → hit
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=5000)
+        assert result is not None

--- a/tests/test_hlcvs_valid_ranges.py
+++ b/tests/test_hlcvs_valid_ranges.py
@@ -85,6 +85,15 @@ def test_ensure_valid_index_metadata_default_warmup_fallback():
     assert mss["fallback"]["trade_start_index"] == 4
 
 
+def test_ensure_valid_index_metadata_warmup_map_overrides_cached_warmup():
+    hlcvs = np.zeros((12, 1, 4), dtype=np.float64)
+    coins = ["coinwarm"]
+    mss = {"coinwarm": {"first_valid_index": 2, "last_valid_index": 10, "warmup_minutes": 9}}
+    ensure_valid_index_metadata(mss, hlcvs, coins, {"coinwarm": 3})
+    assert mss["coinwarm"]["warmup_minutes"] == 3
+    assert mss["coinwarm"]["trade_start_index"] == 5
+
+
 def test_compute_per_coin_warmup_minutes_handles_overrides():
     config = {
         "live": {"warmup_ratio": 0.1, "max_warmup_minutes": 0.0},

--- a/tests/test_hyperliquid_builder_codes.py
+++ b/tests/test_hyperliquid_builder_codes.py
@@ -1,0 +1,293 @@
+"""Tests for Hyperliquid builder code support.
+
+Follows the same minimal-stubbing pattern as test_hyperliquid_balance_cache.py:
+only stub passivbot_rust (handled by conftest), ccxt, and procedures.
+Real modules import normally via the src/ path set by conftest.py.
+"""
+
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.fixture
+def stubbed_modules(monkeypatch):
+    """Stub ccxt and procedures so exchanges.hyperliquid can be imported."""
+    # ccxt stubs (prevent real exchange connections)
+    errors_module = types.ModuleType("ccxt.base.errors")
+    errors_module.NetworkError = Exception
+    errors_module.RateLimitExceeded = Exception
+    monkeypatch.setitem(sys.modules, "ccxt.base.errors", errors_module)
+
+    ccxt_base = types.ModuleType("ccxt.base")
+    ccxt_base.errors = errors_module
+    monkeypatch.setitem(sys.modules, "ccxt.base", ccxt_base)
+
+    ccxt_async = types.ModuleType("ccxt.async_support")
+    ccxt_async.hyperliquid = None
+    monkeypatch.setitem(sys.modules, "ccxt.async_support", ccxt_async)
+
+    ccxt_pro = types.ModuleType("ccxt.pro")
+    ccxt_pro.hyperliquid = None
+    monkeypatch.setitem(sys.modules, "ccxt.pro", ccxt_pro)
+
+    ccxt_module = types.ModuleType("ccxt")
+    ccxt_module.__version__ = "4.5.22"
+    ccxt_module.base = ccxt_base
+    ccxt_module.async_support = ccxt_async
+    ccxt_module.pro = ccxt_pro
+    monkeypatch.setitem(sys.modules, "ccxt", ccxt_module)
+
+    # Stub procedures to bypass ccxt version assertion during import
+    proc_module = types.ModuleType("procedures")
+    proc_module.assert_correct_ccxt_version = lambda *args, **kwargs: None
+    proc_module.print_async_exception = lambda *args, **kwargs: None
+    proc_module.load_broker_code = lambda *args, **kwargs: {}
+    proc_module.load_user_info = lambda *args, **kwargs: {"exchange": "hyperliquid"}
+    proc_module.get_first_timestamps_unified = lambda *args, **kwargs: {}
+    monkeypatch.setitem(sys.modules, "procedures", proc_module)
+
+    yield
+
+    # Cleanup: remove cached hyperliquid module so each test gets a fresh import
+    if "exchanges.hyperliquid" in sys.modules:
+        sys.modules.pop("exchanges.hyperliquid", None)
+
+
+def _make_bot(HLBot, broker_code=None):
+    """Create a minimal HyperliquidBot instance without full __init__."""
+    bot = HLBot.__new__(HLBot)
+    bot.broker_code = broker_code or {}
+    bot.user_info = {"wallet_address": "0xabc123", "is_vault": False}
+    bot._builder_approval_last_check_ms = 0
+    bot.cca = None
+    bot.ccp = None
+    return bot
+
+
+class DummyClient:
+    """Mock CCXT client for testing."""
+
+    def __init__(self, fetch_response=None, approve_raises=None):
+        self.options = {}
+        self._fetch_response = fetch_response
+        self._approve_raises = approve_raises
+        self._approve_called = False
+
+    async def fetch(self, *args, **kwargs):
+        return self._fetch_response
+
+    async def approve_builder_fee(self, builder, fee_rate):
+        self._approve_called = True
+        if self._approve_raises:
+            raise self._approve_raises
+        return {"status": "ok"}
+
+
+# ─── Static / pure method tests ───
+
+
+def test_is_positive_fee_value(stubbed_modules):
+    HLBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    assert HLBot._is_positive_fee_value("0.01%") is True
+    assert HLBot._is_positive_fee_value("0.02%") is True
+    assert HLBot._is_positive_fee_value("0%") is False
+    assert HLBot._is_positive_fee_value("0") is False
+    assert HLBot._is_positive_fee_value(10) is True
+    assert HLBot._is_positive_fee_value(0) is False
+    assert HLBot._is_positive_fee_value(0.0) is False
+    assert HLBot._is_positive_fee_value(None) is False
+    assert HLBot._is_positive_fee_value("garbage") is False
+
+
+def test_extract_max_builder_fee_various_shapes(stubbed_modules):
+    HLBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+
+    # Direct value
+    assert HLBot._extract_max_builder_fee("0.01%") == "0.01%"
+    assert HLBot._extract_max_builder_fee(20) == 20
+
+    # Nested in dict
+    assert HLBot._extract_max_builder_fee({"maxBuilderFee": "0.02%"}) == "0.02%"
+    assert HLBot._extract_max_builder_fee({"data": {"maxBuilderFee": 10}}) == 10
+
+    # Deeply nested
+    result = HLBot._extract_max_builder_fee({"response": {"data": {"maxBuilderFee": "0.01%"}}})
+    assert result == "0.01%"
+
+    # In list
+    assert HLBot._extract_max_builder_fee([None, {"maxBuilderFee": "0.05%"}]) == "0.05%"
+
+    # Empty / missing
+    assert HLBot._extract_max_builder_fee({}) is None
+    assert HLBot._extract_max_builder_fee(None) is None
+    assert HLBot._extract_max_builder_fee([]) is None
+
+
+def test_is_builder_fee_error(stubbed_modules):
+    HLBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = _make_bot(HLBot)
+    assert bot._is_builder_fee_error(
+        Exception("Builder fee has not been approved for this user")
+    ) is True
+    assert bot._is_builder_fee_error(
+        Exception("BUILDER FEE has NOT BEEN APPROVED")
+    ) is True
+    assert bot._is_builder_fee_error(
+        Exception("Order must have minimum value of $10")
+    ) is False
+    assert bot._is_builder_fee_error(Exception("random error")) is False
+
+
+# ─── Config normalization / option application tests ───
+
+
+def test_apply_builder_code_options_dict(stubbed_modules):
+    HLBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = _make_bot(HLBot, broker_code={
+        "ref": "PASSIVBOT",
+        "builder": "0x123",
+        "fee_rate": "0.02%",
+        "fee_int": 20,
+    })
+    bot.cca = DummyClient()
+    bot.ccp = DummyClient()
+    bot._apply_builder_code_options()
+
+    assert bot.cca.options["ref"] == "PASSIVBOT"
+    assert bot.cca.options["builder"] == "0x123"
+    assert bot.cca.options["feeRate"] == "0.02%"
+    assert bot.cca.options["feeInt"] == 20
+    assert bot.cca.options["builderFee"] is False  # suppressed for our control
+    assert bot.cca.options["approvedBuilderFee"] is False
+    assert bot.ccp.options["builder"] == "0x123"
+
+
+def test_apply_builder_code_options_string(stubbed_modules):
+    HLBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = _make_bot(HLBot, broker_code="PASSIVBOT")
+    bot.cca = DummyClient()
+    bot._apply_builder_code_options()
+
+    assert bot.cca.options["ref"] == "PASSIVBOT"
+    assert "builder" not in bot.cca.options
+
+
+def test_apply_builder_code_options_invalid_fee_int(stubbed_modules):
+    HLBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = _make_bot(HLBot, broker_code={
+        "builder": "0x123",
+        "fee_int": "not_a_number",
+    })
+    bot.cca = DummyClient()
+    bot._apply_builder_code_options()
+    assert bot.cca.options["feeInt"] == 20  # falls back to default
+
+
+def test_apply_builder_code_options_disabled(stubbed_modules):
+    HLBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = _make_bot(HLBot, broker_code={
+        "builder": "0x123",
+        "builder_fee": False,
+    })
+    bot.cca = DummyClient()
+    bot._apply_builder_code_options()
+    assert "builder" not in bot.cca.options  # nothing applied
+
+
+def test_apply_builder_code_options_disabled_string(stubbed_modules):
+    HLBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = _make_bot(HLBot, broker_code={
+        "builder": "0x123",
+        "builder_fee": "false",
+    })
+    bot.cca = DummyClient()
+    bot._apply_builder_code_options()
+    assert "builder" not in bot.cca.options
+
+
+# ─── Async path tests ───
+
+
+@pytest.mark.asyncio
+async def test_path_a_already_approved(stubbed_modules):
+    """Path A: maxBuilderFee returns positive → thank-you, no approval call."""
+    HLBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = _make_bot(HLBot, broker_code={
+        "builder": "0x123",
+        "fee_rate": "0.02%",
+        "fee_int": 20,
+    })
+    bot.cca = DummyClient(fetch_response="0.02%")
+    await bot._init_builder_codes()
+
+    assert bot.cca.options.get("approvedBuilderFee") is True
+    assert bot.cca._approve_called is False
+    assert not getattr(bot, "_builder_pending_approval", False)
+
+
+@pytest.mark.asyncio
+async def test_path_b_main_wallet_auto_approve(stubbed_modules):
+    """Path B: maxBuilderFee returns 0, approve succeeds → approved."""
+    HLBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = _make_bot(HLBot, broker_code={
+        "builder": "0x123",
+        "fee_rate": "0.02%",
+        "fee_int": 20,
+    })
+    bot.cca = DummyClient(fetch_response="0")
+    await bot._init_builder_codes()
+
+    assert bot.cca.options.get("approvedBuilderFee") is True
+    assert bot.cca._approve_called is True
+    assert not getattr(bot, "_builder_pending_approval", False)
+
+
+@pytest.mark.asyncio
+async def test_path_c_agent_wallet_pending(stubbed_modules):
+    """Path C: maxBuilderFee returns 0, approve fails → force-enable + pending."""
+    HLBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = _make_bot(HLBot, broker_code={
+        "builder": "0x123",
+        "fee_rate": "0.02%",
+        "fee_int": 20,
+    })
+    bot.cca = DummyClient(
+        fetch_response="0",
+        approve_raises=Exception("only main wallet can approve"),
+    )
+    await bot._init_builder_codes()
+
+    assert bot.cca.options.get("approvedBuilderFee") is True  # force-enabled
+    assert bot.cca._approve_called is True
+    assert bot._builder_pending_approval is True
+
+
+@pytest.mark.asyncio
+async def test_check_builder_fee_approved_caching(stubbed_modules):
+    """Status check interval cache prevents rapid re-queries."""
+    HLBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = _make_bot(HLBot, broker_code={"builder": "0x123", "fee_int": 20})
+    bot.cca = DummyClient(fetch_response="0")
+
+    # First check queries the endpoint
+    result1 = await bot._check_builder_fee_approved()
+    assert result1 is False
+
+    # Second check within cache window returns cached result
+    bot.cca._fetch_response = "0.05%"
+    result2 = await bot._check_builder_fee_approved()
+    assert result2 is False  # still cached
+
+
+@pytest.mark.asyncio
+async def test_no_builder_config_skips_init(stubbed_modules):
+    """No builder config → _init_builder_codes does nothing."""
+    HLBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    bot = _make_bot(HLBot, broker_code="PASSIVBOT")  # string, no builder key
+    bot.cca = DummyClient()
+    await bot._init_builder_codes()
+    assert bot.cca._approve_called is False
+    assert not getattr(bot, "_builder_pending_approval", False)


### PR DESCRIPTION
## Summary

- Configs that differ only in trading parameters (EMA spans, warmup ratio) now share the same backtest HLCV cache slot, avoiding redundant re-downloads of candlestick data
- The cache uses a **ratchet-up strategy**: warmup sufficiency is checked at load time, and the cache is overwritten only when a larger warmup is needed
- Backward-compatible with existing caches (missing `cache_meta.json` treated as warmup=0)

## Problem

When backtesting two configs that share identical `backtest.*`, `live.approved_coins`, and exchange settings but differ in `bot.long` (e.g., different EMA spans), the HLCV data was re-downloaded from scratch. This happened because `warmup_minutes`—derived from the max EMA span—was included in the cache hash. Different EMA spans → different warmup → different hash → cache miss → full re-download.

Example with two real configs:
- **template_candidate.json**: `entry_volatility_ema_span_hours=672` → warmup=36,288 min (25.2 days)
- **template_current.json**: `entry_volatility_ema_span_hours=2490` → warmup=44,820 min (31.1 days)
- Same coins, same dates, same exchange → but produced different cache hashes

## Solution

1. **`get_cache_hash()`** — removed `warmup_minutes` from the hash. The key now depends only on data-defining parameters (coins, dates, exchange, coin age, gap tolerance, sources).

2. **`load_coins_hlcvs_from_cache()`** — new `warmup_minutes` parameter. Reads `cache_meta.json` and checks `cached_warmup >= needed_warmup`. Returns `None` if insufficient.

3. **`save_coins_hlcvs_to_cache()`** — new `warmup_minutes` parameter. Writes `cache_meta.json`. Removed the early-return guard so that re-fetches with larger warmup can overwrite the same cache slot.

4. **`prepare_hlcvs_mss()`** — threads `backtest_warmup_minutes` through to both load and save.

### Ratchet behavior

| Run | Config warmup | Cached warmup | Result |
|-----|--------------|---------------|--------|
| 1 | 36,288 | — | Miss → fetch → save (cached=36,288) |
| 2 | 36,288 | 36,288 | Hit |
| 3 | 44,820 | 36,288 | Miss (insufficient) → fetch → save (cached=44,820) |
| 4 | 36,288 | 44,820 | Hit (44,820 >= 36,288) |
| 5 | 44,820 | 44,820 | Hit |

## Test plan

- [x] 16 new tests in `tests/test_cache_warmup_reuse.py` covering:
  - Cache hash independence from EMA spans and warmup ratio
  - Non-warmup fields (coins, dates) still differentiate hashes
  - Warmup sufficiency gate (hit/miss/boundary)
  - Legacy cache compatibility (no `cache_meta.json`)
  - Corrupt `cache_meta.json` fallback
  - Save persists `cache_meta.json` (uncompressed + compressed)
  - Overwrite behavior (ratchet-up)
  - Full end-to-end ratchet scenario
- [x] Full test suite: 744 passed, 118 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)