### PR TITLE
fix: decouple warmup cache hash and enforce current warmup map on cache hits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable user-facing changes will be documented in this file.
 - **Config template/format preservation** - Added `live.enable_archive_candle_fetch` to the template defaults and ensured `backtest.market_settings_sources` is preserved during config formatting.
 - **Live no-fill minute EMA continuity** - When finalized 1m candles are missing because no trades occurred, live runtime now materializes synthetic zero-candles in memory (not on disk), preventing avoidable `MissingEma` loop errors on illiquid symbols. If real candles arrive later, they overwrite synthetic runtime candles and invalidate EMA cache automatically.
 
+### Fixed
+- **Backtest HLCV cache reuse across configs** - Configs that differ only in trading parameters (EMA spans, warmup ratio) now share the same HLCV cache slot. Previously, different EMA spans produced different `warmup_minutes`, which was included in the cache hash, causing unnecessary re-downloads. The cache now uses a ratchet-up strategy: warmup sufficiency is checked at load time, and the cache is overwritten only when a larger warmup is needed.
+
 ## v7.8.2 - 2026-02-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable user-facing changes will be documented in this file.
 
 ### Fixed
 - **Backtest HLCV cache reuse across configs** - Configs that differ only in trading parameters (EMA spans, warmup ratio) now share the same HLCV cache slot. Previously, different EMA spans produced different `warmup_minutes`, which was included in the cache hash, causing unnecessary re-downloads. The cache now uses a ratchet-up strategy: warmup sufficiency is checked at load time, and the cache is overwritten only when a larger warmup is needed.
+- **Backtest cache warmup downgrade guard** - Cache saves now keep the highest recorded `warmup_minutes` for a cache slot and skip writes that would downgrade it, reducing refetch churn when multiple runs touch the same cache concurrently.
 
 ## v7.8.2 - 2026-02-09
 

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -815,18 +815,33 @@ def get_cache_hash(config, exchange):
         "gap_tolerance_ohlcvs_minutes": require_config_value(
             config, "backtest.gap_tolerance_ohlcvs_minutes"
         ),
-        "warmup_minutes": compute_backtest_warmup_minutes(config),
         "coin_sources": coin_sources_sorted,
         "market_settings_sources": market_settings_sources_sorted,
     }
     return calc_hash(to_hash)
 
 
-def load_coins_hlcvs_from_cache(config, exchange):
+def load_coins_hlcvs_from_cache(config, exchange, warmup_minutes=0):
     cache_hash = get_cache_hash(config, exchange)
     cache_dir = Path("caches") / "hlcvs_data" / cache_hash[:16]
     compress_cache = bool(require_config_value(config, "backtest.compress_cache"))
     if os.path.exists(cache_dir):
+        # Check warmup sufficiency: cached data must cover at least the needed warmup
+        meta_path = cache_dir / "cache_meta.json"
+        if meta_path.exists():
+            try:
+                cache_meta = json.load(open(meta_path))
+                cached_warmup = int(cache_meta.get("warmup_minutes", 0))
+            except Exception:
+                cached_warmup = 0
+        else:
+            cached_warmup = 0
+        if cached_warmup < warmup_minutes:
+            logging.info(
+                f"{exchange} cache warmup insufficient: cached={cached_warmup} min, "
+                f"needed={warmup_minutes} min. Will re-fetch."
+            )
+            return None
         coins = json.load(open(cache_dir / "coins.json"))
         mss = json.load(open(cache_dir / "market_specific_settings.json"))
         if compress_cache:
@@ -890,20 +905,12 @@ def save_coins_hlcvs_to_cache(
     mss,
     btc_usd_prices,
     timestamps=None,
+    warmup_minutes=0,
 ):
     cache_hash = get_cache_hash(config, exchange)
     cache_dir = Path("caches") / "hlcvs_data" / cache_hash[:16]
     cache_dir.mkdir(parents=True, exist_ok=True)
     is_compressed = bool(require_config_value(config, "backtest.compress_cache"))
-    expected_files = [
-        "coins.json",
-        "hlcvs.npy.gz" if is_compressed else "hlcvs.npy",
-        "btc_usd_prices.npy.gz" if is_compressed else "btc_usd_prices.npy",
-    ]
-    if timestamps is not None:
-        expected_files.append("timestamps.npy.gz" if is_compressed else "timestamps.npy")
-    if all((cache_dir / fname).exists() for fname in expected_files):
-        return
     logging.info(f"Dumping cache...")
     json.dump(coins, open(cache_dir / "coins.json", "w"))
     json.dump(mss, open(cache_dir / "market_specific_settings.json", "w"))
@@ -948,6 +955,7 @@ def save_coins_hlcvs_to_cache(
         f"{line}"
     )
     logging.info(f"Seconds to dump cache: {(utc_ms() - sts) / 1000:.4f}")
+    json.dump({"warmup_minutes": int(warmup_minutes)}, open(cache_dir / "cache_meta.json", "w"))
     return cache_dir
 
 
@@ -986,9 +994,10 @@ async def prepare_hlcvs_mss(config, exchange, *, force_refetch_gaps: bool = Fals
     results_path = oj(base_dir, exchange, "")
     warmup_map = compute_per_coin_warmup_minutes(config)
     default_warm = int(warmup_map.get("__default__", 0))
+    backtest_warmup_minutes = compute_backtest_warmup_minutes(config)
     try:
         sts = utc_ms()
-        result = load_coins_hlcvs_from_cache(config, exchange)
+        result = load_coins_hlcvs_from_cache(config, exchange, backtest_warmup_minutes)
         if result:
             logging.info(f"Seconds to load cache: {(utc_ms() - sts) / 1000:.4f}")
             cache_dir, coins, hlcvs, mss, results_path, btc_usd_prices, timestamps = result
@@ -1023,6 +1032,7 @@ async def prepare_hlcvs_mss(config, exchange, *, force_refetch_gaps: bool = Fals
             mss,
             btc_usd_prices,
             timestamps,
+            warmup_minutes=backtest_warmup_minutes,
         )
     except Exception as e:
         logging.error(f"Failed to save hlcvs to cache: {e}")

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -980,7 +980,11 @@ def ensure_valid_index_metadata(mss, hlcvs, coins, warmup_map=None):
                 last_idx = int(total_steps)
         meta["first_valid_index"] = first_idx
         meta["last_valid_index"] = last_idx
-        warm_minutes = int(meta.get("warmup_minutes", warmup_map.get(coin, default_warm)))
+        if warmup_map:
+            # Warmup from current config must override any historical cached metadata.
+            warm_minutes = int(warmup_map.get(coin, default_warm))
+        else:
+            warm_minutes = int(meta.get("warmup_minutes", 0))
         meta["warmup_minutes"] = warm_minutes
         if first_idx > last_idx:
             trade_start_idx = first_idx

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -911,6 +911,16 @@ def save_coins_hlcvs_to_cache(
     cache_dir = Path("caches") / "hlcvs_data" / cache_hash[:16]
     cache_dir.mkdir(parents=True, exist_ok=True)
     is_compressed = bool(require_config_value(config, "backtest.compress_cache"))
+    warmup_minutes = int(warmup_minutes)
+    meta_path = cache_dir / "cache_meta.json"
+    if meta_path.exists():
+        try:
+            existing_meta = json.load(open(meta_path))
+            existing_warmup = int(existing_meta.get("warmup_minutes", 0))
+            if existing_warmup >= warmup_minutes:
+                return cache_dir
+        except Exception:
+            pass
     logging.info(f"Dumping cache...")
     json.dump(coins, open(cache_dir / "coins.json", "w"))
     json.dump(mss, open(cache_dir / "market_specific_settings.json", "w"))
@@ -955,7 +965,7 @@ def save_coins_hlcvs_to_cache(
         f"{line}"
     )
     logging.info(f"Seconds to dump cache: {(utc_ms() - sts) / 1000:.4f}")
-    json.dump({"warmup_minutes": int(warmup_minutes)}, open(cache_dir / "cache_meta.json", "w"))
+    json.dump({"warmup_minutes": warmup_minutes}, open(meta_path, "w"))
     return cache_dir
 
 

--- a/tests/test_cache_warmup_reuse.py
+++ b/tests/test_cache_warmup_reuse.py
@@ -347,6 +347,29 @@ class TestSavePersistsWarmupMetadata:
         meta = json.load(open(os.path.join(str(cache_dir2), "cache_meta.json")))
         assert meta["warmup_minutes"] == 5000
 
+    def test_save_does_not_downgrade_existing_warmup(self, tmp_path, monkeypatch):
+        """Saving with smaller warmup must not downgrade cache metadata."""
+        monkeypatch.chdir(tmp_path)
+        cfg = _base_config()
+
+        coins = ["BTC"]
+        hlcvs = np.zeros((10, 1, 4), dtype=np.float64)
+        mss = {"BTC": {}}
+        btc_usd = np.ones(10, dtype=np.float64)
+        timestamps = np.arange(10, dtype=np.int64) * 60_000
+
+        cache_dir = save_coins_hlcvs_to_cache(
+            cfg, coins, hlcvs, "binance", mss, btc_usd, timestamps,
+            warmup_minutes=5000,
+        )
+        save_coins_hlcvs_to_cache(
+            cfg, coins, hlcvs, "binance", mss, btc_usd, timestamps,
+            warmup_minutes=1000,
+        )
+
+        meta = json.load(open(os.path.join(str(cache_dir), "cache_meta.json")))
+        assert meta["warmup_minutes"] == 5000
+
     def test_save_with_compression(self, tmp_path, monkeypatch):
         """cache_meta.json is written even with compressed cache."""
         monkeypatch.chdir(tmp_path)

--- a/tests/test_cache_warmup_reuse.py
+++ b/tests/test_cache_warmup_reuse.py
@@ -1,0 +1,430 @@
+"""
+Tests for backtest HLCV cache warmup decoupling.
+
+The backtest HLCV cache key no longer includes warmup_minutes. Instead,
+warmup sufficiency is checked at load time: if the cached data was
+produced with warmup >= the currently needed warmup, the cache is reused.
+This allows configs that differ only in EMA spans (and thus warmup) to
+share the same cache slot, with a ratchet-up behavior on re-fetch.
+
+Tests cover:
+- Cache hash independence from warmup_minutes
+- Warmup sufficiency gate in load_coins_hlcvs_from_cache
+- cache_meta.json persistence in save_coins_hlcvs_to_cache
+- Ratchet-up: smaller warmup reuses cache built with larger warmup
+- Legacy caches (no cache_meta.json) treated as warmup=0
+"""
+
+import copy
+import gzip
+import json
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from backtest import (
+    get_cache_hash,
+    load_coins_hlcvs_from_cache,
+    save_coins_hlcvs_to_cache,
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+def _base_config(**overrides):
+    """Minimal config sufficient for cache hash computation."""
+    cfg = {
+        "backtest": {
+            "base_dir": "backtests",
+            "compress_cache": False,
+            "end_date": "2025-06-01",
+            "start_date": "2024-01-01",
+            "exchanges": ["binance"],
+            "gap_tolerance_ohlcvs_minutes": 120,
+        },
+        "bot": {
+            "long": {
+                "ema_span_0": 1000.0,
+                "ema_span_1": 1500.0,
+                "filter_volume_ema_span": 2000.0,
+                "filter_volatility_ema_span": 100.0,
+                "entry_volatility_ema_span_hours": 1.0,
+            },
+            "short": {
+                "ema_span_0": 100.0,
+                "ema_span_1": 100.0,
+                "filter_volume_ema_span": 360.0,
+                "filter_volatility_ema_span": 10.0,
+                "entry_volatility_ema_span_hours": 1.0,
+            },
+        },
+        "live": {
+            "approved_coins": {"long": ["BTC/USDT:USDT"], "short": []},
+            "ignored_coins": {"long": [], "short": []},
+            "minimum_coin_age_days": 30,
+            "warmup_ratio": 0.3,
+            "max_warmup_minutes": 0,
+        },
+        "optimize": {"bounds": {}},
+    }
+    for k, v in overrides.items():
+        cfg[k] = v
+    return cfg
+
+
+def _write_fake_cache(cache_dir, *, compress=False, warmup_minutes=None):
+    """Write minimal valid cache files so load_coins_hlcvs_from_cache succeeds."""
+    os.makedirs(cache_dir, exist_ok=True)
+
+    coins = ["BTC"]
+    mss = {"BTC": {"first_valid_index": 0, "last_valid_index": 9}}
+
+    hlcvs = np.zeros((10, 1, 4), dtype=np.float64)
+    btc_usd = np.ones(10, dtype=np.float64) * 50000.0
+    timestamps = np.arange(10, dtype=np.int64) * 60_000
+
+    json.dump(coins, open(os.path.join(cache_dir, "coins.json"), "w"))
+    json.dump(mss, open(os.path.join(cache_dir, "market_specific_settings.json"), "w"))
+
+    if compress:
+        with gzip.open(os.path.join(cache_dir, "hlcvs.npy.gz"), "wb", compresslevel=1) as f:
+            np.save(f, hlcvs)
+        with gzip.open(os.path.join(cache_dir, "btc_usd_prices.npy.gz"), "wb", compresslevel=1) as f:
+            np.save(f, btc_usd)
+        with gzip.open(os.path.join(cache_dir, "timestamps.npy.gz"), "wb", compresslevel=1) as f:
+            np.save(f, timestamps)
+    else:
+        np.save(os.path.join(cache_dir, "hlcvs.npy"), hlcvs)
+        np.save(os.path.join(cache_dir, "btc_usd_prices.npy"), btc_usd)
+        np.save(os.path.join(cache_dir, "timestamps.npy"), timestamps)
+
+    if warmup_minutes is not None:
+        json.dump(
+            {"warmup_minutes": int(warmup_minutes)},
+            open(os.path.join(cache_dir, "cache_meta.json"), "w"),
+        )
+
+
+# ============================================================================
+# Test Class: Cache Hash Independence from Warmup
+# ============================================================================
+
+
+class TestCacheHashIndependence:
+    """Verify that warmup_minutes no longer affects the cache hash."""
+
+    def test_different_ema_spans_same_hash(self):
+        """Two configs differing only in EMA spans produce the same cache hash."""
+        cfg_a = _base_config()
+        cfg_b = copy.deepcopy(cfg_a)
+        cfg_b["bot"]["long"]["entry_volatility_ema_span_hours"] = 500.0
+
+        hash_a = get_cache_hash(cfg_a, "binance")
+        hash_b = get_cache_hash(cfg_b, "binance")
+
+        assert hash_a == hash_b
+
+    def test_different_warmup_ratio_same_hash(self):
+        """Changing warmup_ratio does not change the hash."""
+        cfg_a = _base_config()
+        cfg_b = copy.deepcopy(cfg_a)
+        cfg_b["live"]["warmup_ratio"] = 10.0
+
+        hash_a = get_cache_hash(cfg_a, "binance")
+        hash_b = get_cache_hash(cfg_b, "binance")
+
+        assert hash_a == hash_b
+
+    def test_different_coins_different_hash(self):
+        """Changing approved_coins still produces a different hash."""
+        cfg_a = _base_config()
+        cfg_b = copy.deepcopy(cfg_a)
+        cfg_b["live"]["approved_coins"]["long"] = ["ETH/USDT:USDT"]
+
+        hash_a = get_cache_hash(cfg_a, "binance")
+        hash_b = get_cache_hash(cfg_b, "binance")
+
+        assert hash_a != hash_b
+
+    def test_different_dates_different_hash(self):
+        """Changing start_date still produces a different hash."""
+        cfg_a = _base_config()
+        cfg_b = copy.deepcopy(cfg_a)
+        cfg_b["backtest"]["start_date"] = "2023-06-01"
+
+        hash_a = get_cache_hash(cfg_a, "binance")
+        hash_b = get_cache_hash(cfg_b, "binance")
+
+        assert hash_a != hash_b
+
+
+# ============================================================================
+# Test Class: Warmup Sufficiency Gate
+# ============================================================================
+
+
+class TestWarmupSufficiencyGate:
+    """Verify that load_coins_hlcvs_from_cache checks warmup sufficiency."""
+
+    def test_sufficient_warmup_returns_cache(self, tmp_path, monkeypatch):
+        """Cache with warmup >= needed returns data."""
+        cfg = _base_config()
+        cache_hash = get_cache_hash(cfg, "binance")
+        cache_dir = tmp_path / "caches" / "hlcvs_data" / cache_hash[:16]
+        _write_fake_cache(str(cache_dir), warmup_minutes=5000)
+
+        monkeypatch.chdir(tmp_path)
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=3000)
+
+        assert result is not None
+
+    def test_insufficient_warmup_returns_none(self, tmp_path, monkeypatch):
+        """Cache with warmup < needed returns None."""
+        cfg = _base_config()
+        cache_hash = get_cache_hash(cfg, "binance")
+        cache_dir = tmp_path / "caches" / "hlcvs_data" / cache_hash[:16]
+        _write_fake_cache(str(cache_dir), warmup_minutes=1000)
+
+        monkeypatch.chdir(tmp_path)
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=5000)
+
+        assert result is None
+
+    def test_exact_warmup_match_returns_cache(self, tmp_path, monkeypatch):
+        """Cache with warmup == needed returns data (boundary condition)."""
+        cfg = _base_config()
+        cache_hash = get_cache_hash(cfg, "binance")
+        cache_dir = tmp_path / "caches" / "hlcvs_data" / cache_hash[:16]
+        _write_fake_cache(str(cache_dir), warmup_minutes=5000)
+
+        monkeypatch.chdir(tmp_path)
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=5000)
+
+        assert result is not None
+
+    def test_zero_needed_warmup_always_hits(self, tmp_path, monkeypatch):
+        """When needed warmup is 0, any cache is sufficient."""
+        cfg = _base_config()
+        cache_hash = get_cache_hash(cfg, "binance")
+        cache_dir = tmp_path / "caches" / "hlcvs_data" / cache_hash[:16]
+        _write_fake_cache(str(cache_dir), warmup_minutes=0)
+
+        monkeypatch.chdir(tmp_path)
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=0)
+
+        assert result is not None
+
+    def test_default_warmup_param_is_zero(self, tmp_path, monkeypatch):
+        """Calling without warmup_minutes defaults to 0 (always hits)."""
+        cfg = _base_config()
+        cache_hash = get_cache_hash(cfg, "binance")
+        cache_dir = tmp_path / "caches" / "hlcvs_data" / cache_hash[:16]
+        _write_fake_cache(str(cache_dir), warmup_minutes=0)
+
+        monkeypatch.chdir(tmp_path)
+        result = load_coins_hlcvs_from_cache(cfg, "binance")
+
+        assert result is not None
+
+
+# ============================================================================
+# Test Class: Legacy Cache Compatibility
+# ============================================================================
+
+
+class TestLegacyCacheCompatibility:
+    """Verify behavior with pre-existing caches that lack cache_meta.json."""
+
+    def test_missing_cache_meta_treated_as_zero_warmup(self, tmp_path, monkeypatch):
+        """Legacy cache without cache_meta.json has cached_warmup=0."""
+        cfg = _base_config()
+        cache_hash = get_cache_hash(cfg, "binance")
+        cache_dir = tmp_path / "caches" / "hlcvs_data" / cache_hash[:16]
+        _write_fake_cache(str(cache_dir), warmup_minutes=None)
+
+        monkeypatch.chdir(tmp_path)
+
+        # Needed warmup > 0 → miss (legacy cache has no warmup metadata)
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=100)
+        assert result is None
+
+    def test_missing_cache_meta_hits_when_zero_needed(self, tmp_path, monkeypatch):
+        """Legacy cache still works when needed warmup is 0."""
+        cfg = _base_config()
+        cache_hash = get_cache_hash(cfg, "binance")
+        cache_dir = tmp_path / "caches" / "hlcvs_data" / cache_hash[:16]
+        _write_fake_cache(str(cache_dir), warmup_minutes=None)
+
+        monkeypatch.chdir(tmp_path)
+
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=0)
+        assert result is not None
+
+    def test_corrupt_cache_meta_treated_as_zero(self, tmp_path, monkeypatch):
+        """Corrupt cache_meta.json falls back to cached_warmup=0."""
+        cfg = _base_config()
+        cache_hash = get_cache_hash(cfg, "binance")
+        cache_dir = tmp_path / "caches" / "hlcvs_data" / cache_hash[:16]
+        _write_fake_cache(str(cache_dir), warmup_minutes=5000)
+
+        # Corrupt the meta file
+        meta_path = os.path.join(str(cache_dir), "cache_meta.json")
+        with open(meta_path, "w") as f:
+            f.write("not valid json{{{")
+
+        monkeypatch.chdir(tmp_path)
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=100)
+        assert result is None
+
+
+# ============================================================================
+# Test Class: Save Persists Warmup Metadata
+# ============================================================================
+
+
+class TestSavePersistsWarmupMetadata:
+    """Verify that save_coins_hlcvs_to_cache writes cache_meta.json."""
+
+    def test_save_writes_cache_meta(self, tmp_path, monkeypatch):
+        """save_coins_hlcvs_to_cache creates cache_meta.json with warmup_minutes."""
+        monkeypatch.chdir(tmp_path)
+        cfg = _base_config()
+
+        coins = ["BTC"]
+        hlcvs = np.zeros((10, 1, 4), dtype=np.float64)
+        mss = {"BTC": {}}
+        btc_usd = np.ones(10, dtype=np.float64)
+        timestamps = np.arange(10, dtype=np.int64) * 60_000
+
+        cache_dir = save_coins_hlcvs_to_cache(
+            cfg, coins, hlcvs, "binance", mss, btc_usd, timestamps,
+            warmup_minutes=12345,
+        )
+
+        meta_path = os.path.join(str(cache_dir), "cache_meta.json")
+        assert os.path.exists(meta_path)
+
+        meta = json.load(open(meta_path))
+        assert meta["warmup_minutes"] == 12345
+
+    def test_save_overwrites_existing_cache(self, tmp_path, monkeypatch):
+        """Saving to an existing cache dir overwrites files (ratchet-up)."""
+        monkeypatch.chdir(tmp_path)
+        cfg = _base_config()
+
+        coins = ["BTC"]
+        hlcvs = np.zeros((10, 1, 4), dtype=np.float64)
+        mss = {"BTC": {}}
+        btc_usd = np.ones(10, dtype=np.float64)
+        timestamps = np.arange(10, dtype=np.int64) * 60_000
+
+        # First save with warmup=1000
+        cache_dir = save_coins_hlcvs_to_cache(
+            cfg, coins, hlcvs, "binance", mss, btc_usd, timestamps,
+            warmup_minutes=1000,
+        )
+        meta = json.load(open(os.path.join(str(cache_dir), "cache_meta.json")))
+        assert meta["warmup_minutes"] == 1000
+
+        # Second save with warmup=5000 (ratchet up)
+        hlcvs_bigger = np.zeros((20, 1, 4), dtype=np.float64)
+        btc_bigger = np.ones(20, dtype=np.float64)
+        ts_bigger = np.arange(20, dtype=np.int64) * 60_000
+        cache_dir2 = save_coins_hlcvs_to_cache(
+            cfg, coins, hlcvs_bigger, "binance", mss, btc_bigger, ts_bigger,
+            warmup_minutes=5000,
+        )
+
+        assert str(cache_dir) == str(cache_dir2)
+        meta = json.load(open(os.path.join(str(cache_dir2), "cache_meta.json")))
+        assert meta["warmup_minutes"] == 5000
+
+    def test_save_with_compression(self, tmp_path, monkeypatch):
+        """cache_meta.json is written even with compressed cache."""
+        monkeypatch.chdir(tmp_path)
+        cfg = _base_config()
+        cfg["backtest"]["compress_cache"] = True
+
+        coins = ["BTC"]
+        hlcvs = np.zeros((10, 1, 4), dtype=np.float64)
+        mss = {"BTC": {}}
+        btc_usd = np.ones(10, dtype=np.float64)
+        timestamps = np.arange(10, dtype=np.int64) * 60_000
+
+        cache_dir = save_coins_hlcvs_to_cache(
+            cfg, coins, hlcvs, "binance", mss, btc_usd, timestamps,
+            warmup_minutes=9999,
+        )
+
+        meta_path = os.path.join(str(cache_dir), "cache_meta.json")
+        assert os.path.exists(meta_path)
+        meta = json.load(open(meta_path))
+        assert meta["warmup_minutes"] == 9999
+
+
+# ============================================================================
+# Test Class: Ratchet-Up End-to-End
+# ============================================================================
+
+
+class TestRatchetUpEndToEnd:
+    """Simulate the full ratchet-up scenario with save then load."""
+
+    def test_ratchet_scenario(self, tmp_path, monkeypatch):
+        """
+        Scenario:
+        1. Save cache with warmup=3000.
+        2. Load with warmup=3000 → hit.
+        3. Load with warmup=5000 → miss (insufficient).
+        4. Save cache with warmup=5000 (overwrite).
+        5. Load with warmup=3000 → hit (5000 >= 3000).
+        6. Load with warmup=5000 → hit (5000 >= 5000).
+        """
+        monkeypatch.chdir(tmp_path)
+        cfg = _base_config()
+
+        coins = ["BTC"]
+        hlcvs = np.zeros((10, 1, 4), dtype=np.float64)
+        mss = {"BTC": {}}
+        btc_usd = np.ones(10, dtype=np.float64)
+        timestamps = np.arange(10, dtype=np.int64) * 60_000
+
+        # Step 1: Save with warmup=3000
+        save_coins_hlcvs_to_cache(
+            cfg, coins, hlcvs, "binance", mss, btc_usd, timestamps,
+            warmup_minutes=3000,
+        )
+
+        # Step 2: Load with warmup=3000 → hit
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=3000)
+        assert result is not None
+
+        # Step 3: Load with warmup=5000 → miss
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=5000)
+        assert result is None
+
+        # Step 4: Save with warmup=5000 (overwrite same slot)
+        hlcvs_bigger = np.zeros((20, 1, 4), dtype=np.float64)
+        btc_bigger = np.ones(20, dtype=np.float64)
+        ts_bigger = np.arange(20, dtype=np.int64) * 60_000
+        save_coins_hlcvs_to_cache(
+            cfg, coins, hlcvs_bigger, "binance", mss, btc_bigger, ts_bigger,
+            warmup_minutes=5000,
+        )
+
+        # Step 5: Load with warmup=3000 → hit (ratcheted up)
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=3000)
+        assert result is not None
+
+        # Step 6: Load with warmup=5000 → hit
+        result = load_coins_hlcvs_from_cache(cfg, "binance", warmup_minutes=5000)
+        assert result is not None

--- a/tests/test_hlcvs_valid_ranges.py
+++ b/tests/test_hlcvs_valid_ranges.py
@@ -85,6 +85,15 @@ def test_ensure_valid_index_metadata_default_warmup_fallback():
     assert mss["fallback"]["trade_start_index"] == 4
 
 
+def test_ensure_valid_index_metadata_warmup_map_overrides_cached_warmup():
+    hlcvs = np.zeros((12, 1, 4), dtype=np.float64)
+    coins = ["coinwarm"]
+    mss = {"coinwarm": {"first_valid_index": 2, "last_valid_index": 10, "warmup_minutes": 9}}
+    ensure_valid_index_metadata(mss, hlcvs, coins, {"coinwarm": 3})
+    assert mss["coinwarm"]["warmup_minutes"] == 3
+    assert mss["coinwarm"]["trade_start_index"] == 5
+
+
 def test_compute_per_coin_warmup_minutes_handles_overrides():
     config = {
         "live": {"warmup_ratio": 0.1, "max_warmup_minutes": 0.0},


### PR DESCRIPTION
## Summary
- decouple `warmup_minutes` from backtest HLCV cache hash for better reuse
- add cache warmup sufficiency gate via `cache_meta.json`
- ensure current config warmup map overrides cached per-coin warmup metadata on load
- add regression tests for warmup cache reuse and warmup-map override behavior

## Validation
- pytest -q tests/test_cache_warmup_reuse.py
- pytest -q tests/test_hlcvs_valid_ranges.py
- pytest -q tests/test_config_coin_sources.py