### PR TITLE
Fix Hyperliquid rate limit errors (429) for multi-bot setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,21 @@ All notable user-facing changes will be documented in this file.
 
 ### Changed
 - **Dual balance routing (raw vs hysteresis-snapped)** - Live and orchestrator flows now carry both `balance_raw` (raw wallet balance) and `balance` (hysteresis-snapped balance). Sizing/order-shaping paths use snapped balance, while risk/accounting paths use raw balance (including realized-loss gate peak/floor checks, TWEL entry/auto-reduce gating, and auto-unstuck allowance calculations). This applies consistently across live and backtest via Rust orchestrator input.
+- **Bulk price fetch for Hyperliquid** - `calc_ideal_orders` now uses a single `allMids` API call to get prices for all symbols instead of individual `get_current_close` calls per symbol (1 call vs ~70). Falls back to per-symbol fetches for non-Hyperliquid exchanges or on error.
+- **Sequential margin mode setting for Hyperliquid** - Margin mode and leverage API calls are now sequential with a small delay instead of being fired in parallel, reducing API burst on coin changes.
 
 ### Fixed
 - **Balance peak drift in wrong direction under hysteresis** - Peak reconstruction (`balance + (pnl_cumsum_max - pnl_cumsum_last)`) previously used hysteresis-snapped balance in some paths. Since snapped balance can stay stale while `pnl_cumsum_last` changes fill-by-fill, this made reconstructed peak drift down after profits and up after losses. Peak/PnL-accuracy-sensitive paths now use raw balance (`balance_raw`) consistently.
 - **Pytest Rust-module bootstrap fallback** - Test bootstrap now tries the project venv `passivbot_rust` package before falling back to the lightweight stub when tests are launched outside the venv, reducing false failures from missing/incorrect Rust module resolution.
+- **`max_ohlcv_fetches_per_minute` ignored when forager slots open** - The rate limit config was only applied when all position slots were full. With open slots (the common case), all candidate symbols were fetched without rate limiting, causing 429 errors on Hyperliquid.
+- **Hyperliquid positions+balance double fetch** - `fetch_positions` and `fetch_balance` now share a single API call via a dedup lock instead of making two identical `clearinghouseState` requests per execution cycle.
+- **Thundering herd on minute boundary** - `get_candles` no longer force-refreshes all symbols simultaneously when a new minute boundary crosses. A 1-candle staleness tolerance prevents the TTL override that caused all symbols to fetch at once.
+- **Candle refresh TTLs aligned to 1-minute finalization** - Active candle refresh TTL raised from 10s to 60s and EMA close TTL from 30s to 60s, matching the actual 1-minute candle finalization interval.
+- **Boot stagger for multi-bot setups** - Added `boot_stagger_seconds` config (default 30s for Hyperliquid) to randomize startup delay, preventing simultaneous API bursts when multiple bots share the same IP.
+- **Warmup and refresh fetch pacing** - Added configurable `warmup_fetch_delay_ms` (default 200ms for Hyperliquid) with delays between individual symbol fetches during warmup, forager refresh, and active candle refresh loops.
+- **Exponential backoff on 429 errors** - WebSocket `watch_orders` uses exponential backoff (up to 30s) on rate limit errors. Execution loop backs off 5s on `RateLimitExceeded`. Hourly `init_markets` catches rate limits with 10s recovery.
+- **Fill events pagination abort on repeated rate limits** - `HyperliquidFetcher` now aborts after 5 consecutive rate limit retries with exponential backoff instead of retrying indefinitely.
+- **EMA bundle and active candle sweep abort on rate limit** - Both `_load_orchestrator_ema_bundle` and `update_ohlcvs_1m_for_actives` skip remaining symbols when the CandlestickManager's global rate limit backoff is active.
 
 ## v7.8.3 - 2026-02-24
 

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -5709,6 +5709,14 @@ class CandlestickManager:
         self._current_close_cache[symbol] = (float(price), int(now))
         return float(price)
 
+    def set_current_close(self, symbol: str, price: float, timestamp_ms: int) -> None:
+        """Inject a price into the current-close cache (e.g. from a bulk API call)."""
+        self._current_close_cache[symbol] = (float(price), int(timestamp_ms))
+
+    def is_rate_limited(self) -> bool:
+        """Return True if a global rate-limit backoff is active."""
+        return self._rate_limit_until > time.time()
+
     # ----- EMA helpers -----
 
     def _ema(self, values: np.ndarray, span: float) -> float:

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -44,6 +44,12 @@ class HyperliquidBot(CCXTBot):
         self._hl_fetch_lock = asyncio.Lock()
         self._hl_cache_generation = 0
 
+    def _hl_info_url(self) -> str:
+        """Derive the Hyperliquid /info endpoint from the CCXT session URL config."""
+        base = self.cca.urls.get("api", {}).get("public", "https://api.hyperliquid.xyz")
+        hostname = getattr(self.cca, "hostname", "hyperliquid.xyz")
+        return base.replace("{hostname}", hostname).rstrip("/") + "/info"
+
     def create_ccxt_sessions(self):
         creds = {
             "walletAddress": self.user_info["wallet_address"],
@@ -223,13 +229,21 @@ class HyperliquidBot(CCXTBot):
 
         my_gen is the caller's snapshot of _hl_cache_generation taken *before*
         acquiring the lock.  If another caller completed a fetch in the
-        meantime (cache_generation advanced), we return the cached result.
+        meantime (cache_generation advanced), we return the cached result
+        (or re-raise the cached exception if the fetch failed).
         """
         async with self._hl_fetch_lock:
             cached_gen = self._hl_cache_generation
             if cached_gen > my_gen and hasattr(self, "_hl_cached_result"):
+                if isinstance(self._hl_cached_result, Exception):
+                    raise self._hl_cached_result
                 return self._hl_cached_result
-            result = await self._fetch_positions_and_balance()
+            try:
+                result = await self._fetch_positions_and_balance()
+            except Exception as e:
+                self._hl_cached_result = e
+                self._hl_cache_generation = cached_gen + 1
+                raise
             self._hl_cached_result = result
             self._hl_cache_generation = cached_gen + 1
             return result
@@ -256,7 +270,7 @@ class HyperliquidBot(CCXTBot):
 
     async def fetch_tickers(self):
         fetched = await self.cca.fetch(
-            "https://api.hyperliquid.xyz/info",
+            self._hl_info_url(),
             method="POST",
             headers={"Content-Type": "application/json"},
             body=json.dumps({"type": "allMids"}),

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -1920,7 +1920,19 @@ class FillEventsManager:
             self.cache.save_days(day_payload)
             all_days_persisted.update(days_touched)
 
-        await self.fetcher.fetch(start_ms, end_ms, detail_cache, on_batch=handle_batch)
+        try:
+            await self.fetcher.fetch(start_ms, end_ms, detail_cache, on_batch=handle_batch)
+        except RateLimitExceeded:
+            # Preserve bounded-range failures as known gaps so retry logic can
+            # revisit them.  We still re-raise to fail loudly on critical input.
+            if start_ms is not None and end_ms is not None:
+                self.cache.add_known_gap(
+                    start_ms,
+                    end_ms,
+                    reason=GAP_REASON_FETCH_FAILED,
+                    confidence=GAP_CONFIDENCE_UNKNOWN,
+                )
+            raise
 
         self._events = sorted(updated_map.values(), key=lambda ev: ev.timestamp)
 
@@ -2643,12 +2655,13 @@ class HyperliquidFetcher(BaseFetcher):
                 trades = await self.api.fetch_my_trades(params=params)
             except RateLimitExceeded as exc:
                 rate_limit_retries += 1
-                if rate_limit_retries > max_rate_limit_retries:
-                    logger.warning(
-                        "HyperliquidFetcher.fetch: too many rate limit retries (%d), aborting pagination",
-                        rate_limit_retries,
+                if rate_limit_retries >= max_rate_limit_retries:
+                    msg = (
+                        "HyperliquidFetcher.fetch: too many consecutive rate-limit retries "
+                        f"({rate_limit_retries}/{max_rate_limit_retries}); aborting fetch"
                     )
-                    raise
+                    logger.warning("%s", msg)
+                    raise RateLimitExceeded(msg) from exc
                 logger.debug(
                     "HyperliquidFetcher.fetch: rate limit exceeded (retry %d/%d), sleeping (%s)",
                     rate_limit_retries,

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -2645,17 +2645,17 @@ class HyperliquidFetcher(BaseFetcher):
                 rate_limit_retries += 1
                 if rate_limit_retries > max_rate_limit_retries:
                     logger.warning(
-                        "HyperliquidFetcher.fetch: too many rate limit retries (%d), aborting",
+                        "HyperliquidFetcher.fetch: too many rate limit retries (%d), aborting pagination",
                         rate_limit_retries,
                     )
-                    break
+                    raise
                 logger.debug(
                     "HyperliquidFetcher.fetch: rate limit exceeded (retry %d/%d), sleeping (%s)",
                     rate_limit_retries,
                     max_rate_limit_retries,
                     exc,
                 )
-                await asyncio.sleep(2.0 * rate_limit_retries)
+                await asyncio.sleep(min(30.0, 2.0 ** rate_limit_retries))
                 # Reset prev_params so the retry is not flagged as repeated
                 prev_params = None
                 continue

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1910,6 +1910,12 @@ class Passivbot:
                     await asyncio.sleep(0.1)
             except RestartBotException:
                 raise  # Propagate restart without incrementing error count
+            except RateLimitExceeded as e:
+                self._health_errors += 1
+                self._health_rate_limits += 1
+                logging.warning("[rate] execution loop hit rate limit; backing off 5s...")
+                await self.restart_bot_on_too_many_errors()
+                await asyncio.sleep(5.0)
             except Exception as e:
                 self._health_errors += 1
                 logging.error(f"error with {get_function_name()} {e}")
@@ -5737,7 +5743,14 @@ class Passivbot:
                         )
                 # update markets dict once every hour
                 if now - self.init_markets_last_update_ms > 1000 * 60 * 60:
-                    await self.init_markets(verbose=False)
+                    try:
+                        await self.init_markets(verbose=False)
+                    except RateLimitExceeded:
+                        self._health_rate_limits += 1
+                        logging.warning(
+                            "[rate] hourly init_markets hit rate limit; will retry next cycle"
+                        )
+                        await asyncio.sleep(10)
                 await asyncio.sleep(1)
             except Exception as e:
                 logging.error(f"error with {get_function_name()} {e}")

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -2799,26 +2799,39 @@ class Passivbot:
             clip_pct = self.bot_value(pside, "filter_volume_drop_pct")
             volatility_drop = self.bot_value(pside, "filter_volatility_drop_pct")
             max_n_positions = self.get_max_n_positions(pside)
-            # Best-effort ranking when slots are full: use dynamic staleness budget.
+            # Apply max_ohlcv_fetches_per_minute in all cases (slots open or full).
+            max_calls = get_optional_live_value(self.config, "max_ohlcv_fetches_per_minute", 0)
+            try:
+                max_calls = int(max_calls) if max_calls is not None else 0
+            except Exception:
+                max_calls = 0
             if slots_open:
-                max_age_ms = 60_000
+                rate_limit_age_ms = self._forager_target_staleness_ms(len(candidates), max_calls)
+                # Respect rate limit even with open slots; floor at 60s for responsiveness.
+                max_age_ms = max(60_000, rate_limit_age_ms) if max_calls > 0 else 60_000
             else:
-                max_calls = get_optional_live_value(self.config, "max_ohlcv_fetches_per_minute", 0)
-                try:
-                    max_calls = int(max_calls) if max_calls is not None else 0
-                except Exception:
-                    max_calls = 0
                 max_age_ms = self._forager_target_staleness_ms(len(candidates), max_calls)
+            # Compute fetch budget: limits how many symbols may trigger a network
+            # request in this ranking cycle (prevents burst of 68 fetches on restart).
+            fetch_budget = (
+                self._forager_refresh_budget(max_calls) if max_calls > 0 else None
+            )
             if clip_pct > 0.0:
                 volumes, log_ranges = await self.calc_volumes_and_log_ranges(
-                    pside, symbols=candidates, max_age_ms=max_age_ms
+                    pside,
+                    symbols=candidates,
+                    max_age_ms=max_age_ms,
+                    max_network_fetches=fetch_budget,
                 )
             else:
                 volumes = {
                     symbol: float(len(candidates) - idx) for idx, symbol in enumerate(candidates)
                 }
                 log_ranges = await self.calc_log_range(
-                    pside, eligible_symbols=candidates, max_age_ms=max_age_ms
+                    pside,
+                    eligible_symbols=candidates,
+                    max_age_ms=max_age_ms,
+                    max_network_fetches=fetch_budget,
                 )
             features = [
                 {
@@ -2856,11 +2869,16 @@ class Passivbot:
         symbols: Optional[Iterable[str]] = None,
         *,
         max_age_ms: Optional[int] = 60_000,
+        max_network_fetches: Optional[int] = None,
     ) -> Tuple[Dict[str, float], Dict[str, float]]:
         """Compute 1m EMA quote volume and 1m EMA log range per symbol with one candles fetch.
 
         This uses CandlestickManager.get_latest_ema_metrics() to avoid calling get_candles() twice
         per symbol (once for volume and once for log range).
+
+        If *max_network_fetches* is set, at most that many symbols will be allowed to
+        trigger a network fetch.  The remaining symbols receive a very large TTL so they
+        return cached data (or 0.0 if nothing is cached) without hitting the API.
         """
         span_volume = int(round(self.bot_value(pside, "filter_volume_ema_span")))
         span_volatility = int(round(self.bot_value(pside, "filter_volatility_ema_span")))
@@ -2882,20 +2900,46 @@ class Passivbot:
         if symbols is None:
             symbols = self.get_symbols_approved_or_has_pos(pside)
 
+        syms = list(symbols)
+
+        # Determine per-symbol TTL: symbols allowed to fetch get the real max_age_ms,
+        # symbols over the budget get a huge TTL so they only use cached data.
+        CACHE_ONLY_TTL = 365 * 24 * 3600 * 1000  # ~1 year – effectively cache-only
+        per_sym_ttl: Dict[str, int] = {}
+        if max_network_fetches is not None and max_network_fetches >= 0 and max_age_ms is not None:
+            now = utc_ms()
+            # Sort symbols by staleness (oldest first) so the most stale get refreshed.
+            staleness = []
+            for s in syms:
+                try:
+                    last_ref = self.cm.get_last_refresh_ms(s)
+                except Exception:
+                    last_ref = 0
+                staleness.append((s, int(now - last_ref) if last_ref > 0 else now))
+            staleness.sort(key=lambda x: x[1], reverse=True)  # most stale first
+            fetch_set = set(s for s, _ in staleness[:max_network_fetches])
+            for s in syms:
+                per_sym_ttl[s] = int(max_age_ms) if s in fetch_set else CACHE_ONLY_TTL
+        else:
+            for s in syms:
+                per_sym_ttl[s] = int(max_age_ms) if max_age_ms is not None else 0
+
         async def one(symbol: str):
             try:
-                if max_age_ms is not None:
-                    ttl = int(max_age_ms)
-                else:
-                    has_pos = self.has_position(symbol)
-                    has_oo = (
-                        bool(self.open_orders.get(symbol)) if hasattr(self, "open_orders") else False
-                    )
-                    ttl = (
-                        60_000
-                        if (has_pos or has_oo)
-                        else int(getattr(self, "inactive_coin_candle_ttl_ms", 600_000))
-                    )
+                ttl = per_sym_ttl.get(symbol)
+                if ttl is None or ttl == 0:
+                    if max_age_ms is not None:
+                        ttl = int(max_age_ms)
+                    else:
+                        has_pos = self.has_position(symbol)
+                        has_oo = (
+                            bool(self.open_orders.get(symbol)) if hasattr(self, "open_orders") else False
+                        )
+                        ttl = (
+                            60_000
+                            if (has_pos or has_oo)
+                            else int(getattr(self, "inactive_coin_candle_ttl_ms", 600_000))
+                        )
                 res = await self.cm.get_latest_ema_metrics(
                     symbol,
                     {"qv": span_volume, "log_range": span_volatility},
@@ -2909,7 +2953,6 @@ class Passivbot:
             except Exception:
                 return (0.0, 0.0)
 
-        syms = list(symbols)
         tasks = {s: asyncio.create_task(one(s)) for s in syms}
         volumes: Dict[str, float] = {}
         log_ranges: Dict[str, float] = {}
@@ -5357,7 +5400,13 @@ class Passivbot:
             return
 
         if slots_open_any:
-            budget = len(all_candidates)
+            if max_calls > 0:
+                # Respect rate limit even with open slots; use token bucket budget.
+                budget = self._forager_refresh_budget(max_calls)
+                if budget <= 0:
+                    return
+            else:
+                budget = len(all_candidates)
         else:
             if max_calls <= 0:
                 return
@@ -5371,11 +5420,12 @@ class Passivbot:
         if not candidates:
             return
 
-        target_age_ms = (
-            60_000
-            if slots_open_any
-            else self._forager_target_staleness_ms(len(all_candidates), max_calls)
-        )
+        if slots_open_any:
+            rate_limit_age_ms = self._forager_target_staleness_ms(len(all_candidates), max_calls)
+            # Respect rate limit even with open slots; floor at 60s for responsiveness.
+            target_age_ms = max(60_000, rate_limit_age_ms) if max_calls > 0 else 60_000
+        else:
+            target_age_ms = self._forager_target_staleness_ms(len(all_candidates), max_calls)
         now = utc_ms()
         stale: List[Tuple[float, str]] = []
         for sym in candidates:
@@ -5588,10 +5638,14 @@ class Passivbot:
         eligible_symbols: Optional[Iterable[str]] = None,
         *,
         max_age_ms: Optional[int] = 60_000,
+        max_network_fetches: Optional[int] = None,
     ) -> Dict[str, float]:
         """Compute 1m EMA of log range per symbol: EMA(ln(high/low)).
 
         Returns mapping symbol -> ema_log_range; non-finite/failed computations yield 0.0.
+
+        If *max_network_fetches* is set, at most that many symbols will be allowed to
+        trigger a network fetch; the rest use cached data only.
         """
         if eligible_symbols is None:
             eligible_symbols = self.eligible_symbols
@@ -5611,23 +5665,47 @@ class Passivbot:
         if max_warmup_minutes > 0:
             window_candles = min(int(window_candles), int(max_warmup_minutes))
 
+        syms = list(eligible_symbols)
+
+        # Determine per-symbol TTL with optional fetch budget.
+        CACHE_ONLY_TTL = 365 * 24 * 3600 * 1000  # ~1 year – effectively cache-only
+        per_sym_ttl: Dict[str, int] = {}
+        if max_network_fetches is not None and max_network_fetches >= 0 and max_age_ms is not None:
+            now = utc_ms()
+            staleness = []
+            for s in syms:
+                try:
+                    last_ref = self.cm.get_last_refresh_ms(s)
+                except Exception:
+                    last_ref = 0
+                staleness.append((s, int(now - last_ref) if last_ref > 0 else now))
+            staleness.sort(key=lambda x: x[1], reverse=True)
+            fetch_set = set(s for s, _ in staleness[:max_network_fetches])
+            for s in syms:
+                per_sym_ttl[s] = int(max_age_ms) if s in fetch_set else CACHE_ONLY_TTL
+        else:
+            for s in syms:
+                per_sym_ttl[s] = int(max_age_ms) if max_age_ms is not None else 0
+
         # Compute EMA of log range on 1m candles: ln(high/low)
         async def one(symbol: str):
             try:
-                # If caller passes a TTL, use it; otherwise select per-symbol TTL
-                if max_age_ms is not None:
-                    ttl = int(max_age_ms)
-                else:
-                    # More generous TTL for non-traded symbols
-                    has_pos = self.has_position(symbol)
-                    has_oo = (
-                        bool(self.open_orders.get(symbol)) if hasattr(self, "open_orders") else False
-                    )
-                    ttl = (
-                        60_000
-                        if (has_pos or has_oo)
-                        else int(getattr(self, "inactive_coin_candle_ttl_ms", 600_000))
-                    )
+                ttl = per_sym_ttl.get(symbol)
+                if ttl is None or ttl == 0:
+                    # If caller passes a TTL, use it; otherwise select per-symbol TTL
+                    if max_age_ms is not None:
+                        ttl = int(max_age_ms)
+                    else:
+                        # More generous TTL for non-traded symbols
+                        has_pos = self.has_position(symbol)
+                        has_oo = (
+                            bool(self.open_orders.get(symbol)) if hasattr(self, "open_orders") else False
+                        )
+                        ttl = (
+                            60_000
+                            if (has_pos or has_oo)
+                            else int(getattr(self, "inactive_coin_candle_ttl_ms", 600_000))
+                        )
                 res = await self.cm.get_latest_ema_metrics(
                     symbol,
                     {"log_range": span},
@@ -5640,7 +5718,6 @@ class Passivbot:
             except Exception:
                 return 0.0
 
-        syms = list(eligible_symbols)
         tasks = {s: asyncio.create_task(one(s)) for s in syms}
         out = {}
         n = len(syms)

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1555,17 +1555,7 @@ class Passivbot:
             # Enable batch mode for candle replacement logs during warmup
             self.cm.start_candle_replace_batch()
 
-        # Optional per-fetch delay to reduce API pressure during warmup.
-        # Configured via warmup_fetch_delay_ms; defaults to 200ms for Hyperliquid, 0 otherwise.
-        fetch_delay_ms = get_optional_live_value(self.config, "warmup_fetch_delay_ms", None)
-        try:
-            fetch_delay_ms = float(fetch_delay_ms) if fetch_delay_ms is not None else None
-        except Exception:
-            fetch_delay_ms = None
-        if fetch_delay_ms is None:
-            exchange_lower = self.exchange.lower() if self.exchange else ""
-            fetch_delay_ms = 200.0 if exchange_lower == "hyperliquid" else 0.0
-        fetch_delay_s = max(0.0, float(fetch_delay_ms) / 1000.0)
+        fetch_delay_s = self._get_fetch_delay_seconds()
 
         async def one(sym: str):
             nonlocal completed, last_log_ms
@@ -2388,6 +2378,58 @@ class Passivbot:
             return
         apply_rest_overrides_to_ccxt(client, self.endpoint_override)
 
+    def _compute_fetch_budget_ttls(
+        self, syms: list, max_age_ms: Optional[int], max_network_fetches: Optional[int]
+    ) -> Tuple[Dict[str, int], set]:
+        """Compute per-symbol TTLs with fetch budget, return (per_sym_ttl, cache_only_never_fetched).
+
+        Symbols within the fetch budget get the real max_age_ms; symbols over the
+        budget get a huge TTL so they only use cached data.  Symbols assigned
+        cache-only TTL that have never been fetched are collected into a skip set
+        (get_candles treats last_refresh_ms==0 as "needs refresh" regardless of TTL).
+        """
+        CACHE_ONLY_TTL = 365 * 24 * 3600 * 1000  # ~1 year – effectively cache-only
+        per_sym_ttl: Dict[str, int] = {}
+        if max_network_fetches is not None and max_network_fetches >= 0 and max_age_ms is not None:
+            now = utc_ms()
+            staleness = []
+            for s in syms:
+                try:
+                    last_ref = self.cm.get_last_refresh_ms(s)
+                except Exception:
+                    last_ref = 0
+                staleness.append((s, int(now - last_ref) if last_ref > 0 else now))
+            staleness.sort(key=lambda x: x[1], reverse=True)  # most stale first
+            fetch_set = set(s for s, _ in staleness[:max_network_fetches])
+            for s in syms:
+                per_sym_ttl[s] = int(max_age_ms) if s in fetch_set else CACHE_ONLY_TTL
+        else:
+            for s in syms:
+                per_sym_ttl[s] = int(max_age_ms) if max_age_ms is not None else 0
+
+        cache_only_never_fetched: set = set()
+        for s in syms:
+            if per_sym_ttl.get(s) == CACHE_ONLY_TTL:
+                try:
+                    if self.cm.get_last_refresh_ms(s) == 0:
+                        cache_only_never_fetched.add(s)
+                except Exception:
+                    cache_only_never_fetched.add(s)
+
+        return per_sym_ttl, cache_only_never_fetched
+
+    def _get_fetch_delay_seconds(self) -> float:
+        """Return configured per-fetch delay in seconds (default 0.2s for Hyperliquid)."""
+        fetch_delay_ms = get_optional_live_value(self.config, "warmup_fetch_delay_ms", None)
+        try:
+            fetch_delay_ms = float(fetch_delay_ms) if fetch_delay_ms is not None else None
+        except Exception:
+            fetch_delay_ms = None
+        if fetch_delay_ms is None:
+            exchange_lower = self.exchange.lower() if self.exchange else ""
+            fetch_delay_ms = 200.0 if exchange_lower == "hyperliquid" else 0.0
+        return max(0.0, float(fetch_delay_ms) / 1000.0)
+
     def stop_data_maintainers(self, verbose=True):
         """Cancel background candle/orderbook tasks and log the outcome."""
         if not hasattr(self, "maintainers"):
@@ -2973,40 +3015,9 @@ class Passivbot:
 
         syms = list(symbols)
 
-        # Determine per-symbol TTL: symbols allowed to fetch get the real max_age_ms,
-        # symbols over the budget get a huge TTL so they only use cached data.
-        CACHE_ONLY_TTL = 365 * 24 * 3600 * 1000  # ~1 year – effectively cache-only
-        per_sym_ttl: Dict[str, int] = {}
-        if max_network_fetches is not None and max_network_fetches >= 0 and max_age_ms is not None:
-            now = utc_ms()
-            # Sort symbols by staleness (oldest first) so the most stale get refreshed.
-            staleness = []
-            for s in syms:
-                try:
-                    last_ref = self.cm.get_last_refresh_ms(s)
-                except Exception:
-                    last_ref = 0
-                staleness.append((s, int(now - last_ref) if last_ref > 0 else now))
-            staleness.sort(key=lambda x: x[1], reverse=True)  # most stale first
-            fetch_set = set(s for s, _ in staleness[:max_network_fetches])
-            for s in syms:
-                per_sym_ttl[s] = int(max_age_ms) if s in fetch_set else CACHE_ONLY_TTL
-        else:
-            for s in syms:
-                per_sym_ttl[s] = int(max_age_ms) if max_age_ms is not None else 0
-
-        # Identify symbols with CACHE_ONLY_TTL that have never been fetched.
-        # get_candles treats last_refresh_ms==0 as "needs refresh" regardless of
-        # TTL, which would bypass the budget.  Skip them entirely; they will be
-        # picked up by the staleness-first rotation in subsequent cycles.
-        cache_only_never_fetched: set = set()
-        for s in syms:
-            if per_sym_ttl.get(s) == CACHE_ONLY_TTL:
-                try:
-                    if self.cm.get_last_refresh_ms(s) == 0:
-                        cache_only_never_fetched.add(s)
-                except Exception:
-                    cache_only_never_fetched.add(s)
+        per_sym_ttl, cache_only_never_fetched = self._compute_fetch_budget_ttls(
+            syms, max_age_ms, max_network_fetches
+        )
 
         async def one(symbol: str):
             try:
@@ -4768,7 +4779,7 @@ class Passivbot:
                 # Call allMids directly – much cheaper than fetch_tickers which tries
                 # to map ALL coins (including unmapped HIP-3 @NNN IDs → warning spam).
                 fetched = await self.cca.fetch(
-                    "https://api.hyperliquid.xyz/info",
+                    self._hl_info_url(),
                     method="POST",
                     headers={"Content-Type": "application/json"},
                     body=json.dumps({"type": "allMids"}),
@@ -5770,17 +5781,7 @@ class Passivbot:
             max_warmup_minutes = 0
         span_buffer = 1.0 + max(0.0, warmup_ratio)
 
-        # Delay between individual candle fetches to spread API load across time.
-        # Uses the same warmup_fetch_delay_ms config; defaults to 200ms for Hyperliquid.
-        fetch_delay_ms = get_optional_live_value(self.config, "warmup_fetch_delay_ms", None)
-        try:
-            fetch_delay_ms = float(fetch_delay_ms) if fetch_delay_ms is not None else None
-        except Exception:
-            fetch_delay_ms = None
-        if fetch_delay_ms is None:
-            exchange_lower = self.exchange.lower() if self.exchange else ""
-            fetch_delay_ms = 200.0 if exchange_lower == "hyperliquid" else 0.0
-        fetch_delay_s = max(0.0, float(fetch_delay_ms) / 1000.0)
+        fetch_delay_s = self._get_fetch_delay_seconds()
 
         for sym in to_refresh:
             try:
@@ -5830,9 +5831,9 @@ class Passivbot:
                 logging.error("error refreshing forager candles for %s: %s", sym, exc, exc_info=True)
 
     async def update_ohlcvs_1m_for_actives(self):
-        """Ensure active symbols have fresh 1m candles in CandlestickManager (<=10s old).
+        """Ensure active symbols have fresh 1m candles in CandlestickManager (<=60s old).
 
-        Uses CandlestickManager.get_candles with max_age_ms=10_000 so it refreshes
+        Uses CandlestickManager.get_candles with max_age_ms=60_000 so it refreshes
         only when its internal last refresh is older than the TTL. Fetches a small
         recent window ending at the latest finalized minute.
         """
@@ -5849,16 +5850,7 @@ class Passivbot:
                 window = 120
             start_ts = end_ts - ONE_MIN_MS * window
 
-            # Per-fetch delay to spread API load (same config as warmup/forager refresh).
-            fetch_delay_ms = get_optional_live_value(self.config, "warmup_fetch_delay_ms", None)
-            try:
-                fetch_delay_ms = float(fetch_delay_ms) if fetch_delay_ms is not None else None
-            except Exception:
-                fetch_delay_ms = None
-            if fetch_delay_ms is None:
-                exchange_lower = self.exchange.lower() if self.exchange else ""
-                fetch_delay_ms = 200.0 if exchange_lower == "hyperliquid" else 0.0
-            fetch_delay_s = max(0.0, float(fetch_delay_ms) / 1000.0)
+            fetch_delay_s = self._get_fetch_delay_seconds()
 
             symbols = sorted(set(self.active_symbols))
             # Prioritize symbols with open positions (need fresh candles for
@@ -5877,12 +5869,12 @@ class Passivbot:
             )
             for sym in ordered_symbols:
                 # If a 429 triggered a global backoff in the CandlestickManager,
-                # skip this symbol; CandlestickManager.get_candles would wait for
-                # the backoff anyway but there's no point spending the delay budget
-                # here.  Cached symbols still get through on next cycle; the
+                # stop the loop early; remaining symbols would all hit the same
+                # backoff.  They will be picked up on the next cycle; the
                 # position-first + shuffle ordering prevents systematic starvation.
                 if self.cm.is_rate_limited():
-                    continue
+                    logging.debug("[candle] active refresh breaking early: rate limit backoff active")
+                    break
                 try:
                     await self.cm.get_candles(
                         sym,
@@ -6004,38 +5996,9 @@ class Passivbot:
 
         syms = list(eligible_symbols)
 
-        # Determine per-symbol TTL with optional fetch budget.
-        CACHE_ONLY_TTL = 365 * 24 * 3600 * 1000  # ~1 year – effectively cache-only
-        per_sym_ttl: Dict[str, int] = {}
-        if max_network_fetches is not None and max_network_fetches >= 0 and max_age_ms is not None:
-            now = utc_ms()
-            staleness = []
-            for s in syms:
-                try:
-                    last_ref = self.cm.get_last_refresh_ms(s)
-                except Exception:
-                    last_ref = 0
-                staleness.append((s, int(now - last_ref) if last_ref > 0 else now))
-            staleness.sort(key=lambda x: x[1], reverse=True)
-            fetch_set = set(s for s, _ in staleness[:max_network_fetches])
-            for s in syms:
-                per_sym_ttl[s] = int(max_age_ms) if s in fetch_set else CACHE_ONLY_TTL
-        else:
-            for s in syms:
-                per_sym_ttl[s] = int(max_age_ms) if max_age_ms is not None else 0
-
-        # Guard: skip symbols with CACHE_ONLY_TTL that have never been fetched.
-        # get_candles treats last_refresh_ms==0 as "needs refresh" regardless
-        # of TTL, which would bypass the budget.  They will be fetched by the
-        # staleness-first rotation in subsequent cycles.
-        cache_only_never_fetched: set = set()
-        for s in syms:
-            if per_sym_ttl.get(s) == CACHE_ONLY_TTL:
-                try:
-                    if self.cm.get_last_refresh_ms(s) == 0:
-                        cache_only_never_fetched.add(s)
-                except Exception:
-                    cache_only_never_fetched.add(s)
+        per_sym_ttl, cache_only_never_fetched = self._compute_fetch_budget_ttls(
+            syms, max_age_ms, max_network_fetches
+        )
 
         # Compute EMA of log range on 1m candles: ln(high/low)
         async def one(symbol: str):

--- a/tests/test_coin_filtering.py
+++ b/tests/test_coin_filtering.py
@@ -156,3 +156,71 @@ async def test_non_forager_returns_sorted_candidates():
     )
     coins = await bot.get_filtered_coins("long")
     assert coins == ["AAA", "BBB", "CCC"]
+
+
+def test_split_forager_budget_by_side_round_robins_remainder():
+    bot = Passivbot.__new__(Passivbot)
+    first = bot._split_forager_budget_by_side(1, ["long", "short"])
+    second = bot._split_forager_budget_by_side(1, ["long", "short"])
+    assert first in ({"long": 1, "short": 0}, {"long": 0, "short": 1})
+    assert second in ({"long": 1, "short": 0}, {"long": 0, "short": 1})
+    assert first != second
+
+
+class _CMColdCacheOnlyStub:
+    def __init__(self):
+        self.calls = 0
+
+    def get_last_refresh_ms(self, _symbol):
+        return 0
+
+    async def get_latest_ema_metrics(self, _symbol, spans_by_metric, **_kwargs):
+        self.calls += 1
+        return {k: 1.0 for k in spans_by_metric}
+
+
+@pytest.mark.asyncio
+async def test_calc_log_range_respects_cache_only_budget_for_cold_symbols():
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {}}
+    bot.cm = _CMColdCacheOnlyStub()
+    bot.open_orders = {}
+    bot.positions = {}
+    bot.bot_value = (
+        lambda _pside, key: 12.0
+        if key in ("filter_volatility_ema_span", "filter_volume_ema_span")
+        else 0.0
+    )
+    bot.has_position = lambda *_args, **_kwargs: False
+    out = await bot.calc_log_range(
+        "long",
+        eligible_symbols=["AAA", "BBB", "CCC"],
+        max_age_ms=60_000,
+        max_network_fetches=0,
+    )
+    assert out == {"AAA": 0.0, "BBB": 0.0, "CCC": 0.0}
+    assert bot.cm.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_calc_volumes_and_log_ranges_respects_cache_only_budget_for_cold_symbols():
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {}}
+    bot.cm = _CMColdCacheOnlyStub()
+    bot.open_orders = {}
+    bot.positions = {}
+    bot.bot_value = (
+        lambda _pside, key: 12.0
+        if key in ("filter_volatility_ema_span", "filter_volume_ema_span")
+        else 0.0
+    )
+    bot.has_position = lambda *_args, **_kwargs: False
+    volumes, log_ranges = await bot.calc_volumes_and_log_ranges(
+        "long",
+        symbols=["AAA", "BBB", "CCC"],
+        max_age_ms=60_000,
+        max_network_fetches=0,
+    )
+    assert volumes == {"AAA": 0.0, "BBB": 0.0, "CCC": 0.0}
+    assert log_ranges == {"AAA": 0.0, "BBB": 0.0, "CCC": 0.0}
+    assert bot.cm.calls == 0

--- a/tests/test_coin_filtering.py
+++ b/tests/test_coin_filtering.py
@@ -68,7 +68,7 @@ class CoinFilterHarness(Passivbot):
     async def calc_volumes(self, _pside, symbols):
         return {sym: self._volumes[sym] for sym in symbols}
 
-    async def calc_log_range(self, _pside, eligible_symbols, max_age_ms=None):
+    async def calc_log_range(self, _pside, eligible_symbols, max_age_ms=None, max_network_fetches=None):
         return {sym: self._log_ranges[sym] for sym in eligible_symbols}
 
     def is_pside_enabled(self, _pside):

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -82,6 +82,8 @@ class DummyCCA:
 async def test_hyperliquid_combined_fetch_reused(stubbed_modules):
     HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
 
+    import asyncio
+
     bot = HyperliquidBot.__new__(HyperliquidBot)
     bot.quote = "USDT"
     bot.positions = {}
@@ -89,6 +91,8 @@ async def test_hyperliquid_combined_fetch_reused(stubbed_modules):
     bot.fetched_positions = []
     bot.coin_to_symbol = lambda c: "BTC/USDT:USDT" if c == "BTC" else c
     bot.cm = types.SimpleNamespace(get_current_close=lambda *args, **kwargs: 1.0)
+    bot._hl_fetch_lock = asyncio.Lock()
+    bot._hl_cache_generation = 0
     dummy = DummyCCA()
     bot.cca = dummy
 


### PR DESCRIPTION
## Summary

Comprehensive fix for persistent HTTP 429 (RateLimitExceeded) errors on Hyperliquid, particularly affecting setups with multiple bots sharing the same IP address.

Tested in production on 4 concurrent Hyperliquid bots (70, 25, 23, and 1 coin configs) sharing a single IP. Before these changes: hundreds of 429 errors per hour. After: zero 429 errors since deployment.

## Changes (7 commits)

### 1. Fix forager ranking rate limit compliance
- `max_ohlcv_fetches_per_minute` was completely ignored when forager slots were open (the common case), causing all ~70 candidate symbols to be fetched without any rate limiting every execution cycle
- Added `max_network_fetches` budget parameter to `calc_volumes_and_log_ranges` and `calc_log_range` — only the N most stale symbols trigger network fetches per ranking cycle; the rest use cached data

### 2. Add boot stagger and fetch pacing for Hyperliquid
- `boot_stagger_seconds` config (default 30s for HL): random delay before `init_markets()` to spread API calls when multiple bots start simultaneously
- `warmup_fetch_delay_ms` config (default 200ms for HL): delay between individual symbol fetches during warmup, forager refresh, and active candle refresh loops
- Warmup concurrency reduced from 2 to 1 for Hyperliquid

### 3. Optimize Hyperliquid API usage
- **Positions+balance dedup**: `fetch_positions` and `fetch_balance` now share a single `clearinghouseState` API call via async lock (was: 2 identical calls per cycle due to race condition)
- **Bulk allMids pricing**: single API call for all symbol prices instead of ~70 individual `get_current_close` calls; uses `symbol_ids` reverse map to avoid HIP-3 `@NNN` warning spam
- **TTL alignment**: active candle refresh 10s→60s, EMA close 30s→60s (both match 1m candle finalization interval)
- **Thundering herd fix**: `get_candles` tolerates 1-candle staleness when TTL says fresh, preventing all symbols from refreshing simultaneously on minute boundary transitions
- **Rate limit abort**: active candle sweep and EMA bundle skip remaining symbols when CandlestickManager backoff is active
- **Sequential margin mode**: calls made one-by-one with 200ms delay instead of parallel `asyncio.create_task` burst

### 4. Add rate limit error recovery
- WS `watch_orders`: exponential backoff (2s..30s) on `RateLimitExceeded`
- Execution loop: 5s backoff on `RateLimitExceeded`, calls `restart_bot_on_too_many_errors()` per existing pattern
- Hourly `init_markets`: catches `RateLimitExceeded` with 10s recovery
- `HyperliquidFetcher` pagination: aborts after 5 consecutive rate limit retries with exponential backoff

### 5. Fix EMA bundle burst and candle refresh starvation
- Process EMA bundle symbols sequentially instead of all-at-once via `asyncio.create_task` (prevents API burst of N_symbols × 4 categories)
- Re-check `_rate_limit_until` inside `_net_sem` after semaphore acquisition in CandlestickManager (tasks queued during backoff now honour it)
- Use position-priority + shuffle ordering for both EMA bundle and active candle refresh to prevent alphabetic starvation
- Replace `break` with `continue` on rate-limit so later symbols still get a chance within the same cycle

### 6. Fix dedup race condition, CACHE_ONLY_TTL bypass, and KeyError
- Fix race condition in Hyperliquid position/balance dedup: pass `my_gen` as local parameter instead of shared instance attribute that could be overwritten by concurrent callers
- Add caller-side guard to skip symbols with CACHE_ONLY_TTL that were never fetched (`last_refresh_ms==0`), preventing unintended network fetches that bypass the fetch budget
- Use `.get(symbol, 0.0)` for `effective_min_cost` to prevent KeyError when symbols are dynamically added to `approved_coins`

### 7. Fix MissingEma crash: remove rate-limit early-abort from EMA fetch_map
- Removed the rate-limit early-abort check from `fetch_map` that returned `{}` for ALL symbols when CandlestickManager had a rate-limit backoff active — this prevented even cached data from being returned, starving position symbols of EMA data and causing `MissingEma` Rust panics

## Trading impact

**None.** All changes affect only data fetching, not order logic:
- Prices: still refreshed every 10s (same freshness, just 1 bulk call instead of 70)
- EMA: TTL 30s→60s is irrelevant for an average over ~1000 candles (<0.001% change)
- Active candles: TTL 10s→60s matches the actual 1m finalization interval
- Forager ranking: fetch budget limits symbols per cycle, but most stale are prioritized; all symbols are current within ~3 minutes

## Config options added (all optional, with sensible defaults)
- `boot_stagger_seconds` (default: 30 for HL, 0 otherwise)
- `warmup_fetch_delay_ms` (default: 200 for HL, 0 otherwise)

## Files changed
- `src/passivbot.py` — ranking, pricing, pacing, TTLs, error recovery, EMA bundle sequential, starvation prevention, CACHE_ONLY_TTL guard, KeyError fix
- `src/exchanges/hyperliquid.py` — WS backoff, positions dedup (race-safe), margin mode
- `src/candlestick_manager.py` — thundering herd fix, semaphore rate-limit re-check
- `src/fill_events_manager.py` — pagination abort
- `CHANGELOG.md` — updated

## Testing
- 776 tests pass (0 failures)
- Production-tested on 4 bots × 7+ days