### PR TITLE
Fix backtest crash when no fills are produced

### DIFF
--- a/src/backtest.py
+++ b/src/backtest.py
@@ -759,7 +759,9 @@ def process_forager_fills(
         if sample_divider > 1 and not bal_eq.empty:
             try:
                 bal_eq = bal_eq.resample(f"{sample_divider}min").last()
-            except (ValueError, TypeError):
+            except (ValueError, TypeError) as e:
+                if isinstance(e, TypeError) and "DatetimeIndex" not in str(e):
+                    raise
                 bal_eq = bal_eq.iloc[::sample_divider]
             bal_eq = bal_eq.dropna(how="all").ffill().bfill()
     bal_eq = bal_eq.round(4).astype(np.float32)

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -699,10 +699,11 @@ def process_forager_fills(
         btc_cash_series.index = pd.to_datetime(btc_cash_series.index, unit="ns")
         btc_total_balance_series.index = pd.to_datetime(btc_total_balance_series.index, unit="ns")
     else:
-        usd_cash_series = pd.Series(dtype=float, name="usd_cash_wallet")
-        usd_total_balance_series = pd.Series(dtype=float, name="usd_total_balance")
-        btc_cash_series = pd.Series(dtype=float, name="btc_cash_wallet")
-        btc_total_balance_series = pd.Series(dtype=float, name="btc_total_balance")
+        empty_dtidx = pd.DatetimeIndex([])
+        usd_cash_series = pd.Series(dtype=float, name="usd_cash_wallet", index=empty_dtidx)
+        usd_total_balance_series = pd.Series(dtype=float, name="usd_total_balance", index=empty_dtidx)
+        btc_cash_series = pd.Series(dtype=float, name="btc_cash_wallet", index=empty_dtidx)
+        btc_total_balance_series = pd.Series(dtype=float, name="btc_total_balance", index=empty_dtidx)
     equities_array = np.asarray(equities_array)
     equities_index = pd.to_datetime(equities_array[:, 0].astype(np.int64), unit="ms")
     edf = pd.Series(
@@ -758,7 +759,7 @@ def process_forager_fills(
         if sample_divider > 1 and not bal_eq.empty:
             try:
                 bal_eq = bal_eq.resample(f"{sample_divider}min").last()
-            except ValueError:
+            except (ValueError, TypeError):
                 bal_eq = bal_eq.iloc[::sample_divider]
             bal_eq = bal_eq.dropna(how="all").ffill().bfill()
     bal_eq = bal_eq.round(4).astype(np.float32)

--- a/tests/test_backtest_analysis.py
+++ b/tests/test_backtest_analysis.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 
 from backtest import expand_analysis, process_forager_fills
 
@@ -119,3 +120,39 @@ def test_process_forager_fills_handles_zero_pnl_division():
     assert analysis_appendix["loss_profit_ratio_long"] == 1.0
     assert analysis_appendix["loss_profit_ratio_short"] == 1.0
     assert analysis_appendix["pnl_ratio_long_short"] == 0.5
+
+
+def test_process_forager_fills_no_fills_does_not_crash_resample():
+    """Regression test: no fills + sample_divider > 1 must not raise TypeError.
+
+    When a backtest period produces zero fills the four balance series were
+    previously created with a plain RangeIndex.  After pd.concat with the
+    equity series (DatetimeIndex) pandas returned a generic Index, which
+    caused resample() to raise:
+        TypeError: Only valid with DatetimeIndex, TimedeltaIndex or
+        PeriodIndex, but got an instance of 'Index'
+    """
+    # Two equity data points 1 hour apart (ms timestamps)
+    t0 = 1_740_000_000_000  # some Unix ms timestamp
+    equities_array = np.array(
+        [
+            [t0, 1000.0, 0.02],
+            [t0 + 3_600_000, 1000.5, 0.02],
+        ],
+        dtype=np.float64,
+    )
+
+    # Must not raise; balance_sample_divider=60 triggers the resample path
+    fdf, analysis_appendix, bal_eq = process_forager_fills(
+        fills=[],
+        coins=[],
+        hlcvs=np.empty((0, 0), dtype=np.float64),
+        equities_array=equities_array,
+        balance_sample_divider=60,
+    )
+
+    assert fdf.empty
+    assert isinstance(bal_eq.index, pd.DatetimeIndex), (
+        f"Expected DatetimeIndex, got {type(bal_eq.index)}"
+    )
+    assert not bal_eq.empty


### PR DESCRIPTION
## Problem

When a backtest period contains no fills (e.g. the bot holds cash and
never finds an entry for the entire date range), the four balance series
inside `process_forager_fills` were created as plain `pd.Series` with
a default `RangeIndex`.

After `pd.concat` with the equity series (which carry a `DatetimeIndex`),
pandas produced a generic `Index` instead of a `DatetimeIndex`. The
subsequent `resample()` call then raised:

```
TypeError: Only valid with DatetimeIndex, TimedeltaIndex or PeriodIndex,
but got an instance of 'Index'
```

## Fix

Initialise the empty series with `pd.DatetimeIndex([])` so that the
`concat` always yields a `DatetimeIndex` regardless of whether fills
were produced or not.

Also extend the `resample` `except`-clause to catch `TypeError` as a
belt-and-suspenders guard against similar index-type mismatches in the
future.

## Reproduction

Run a backtest over a short time window (e.g. one month) where the
configured coins have prices far above the bot's entry thresholds so
that no entries are triggered. The backtest completes instantly (0.07 s)
and then crashes in `post_process`.