### PR TITLE
fix: use futures-specific CCXT exchange id and fix Binance trade fetch time windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Fixed `CCXTBot.create_ccxt_sessions()` using the generic exchange name (e.g. `binance`) instead of the futures-specific CCXT id (`binanceusdm`). This caused `load_markets()` to unnecessarily fetch COIN-margined markets from `dapi.binance.com`, and a timeout on that endpoint would cascade-fail all symbol trade fetches and open order updates.
+- Fixed `BinanceFetcher._fetch_symbol_trades` sending future `endTime` (now+1h) and using a tight 7-day safety margin (0.1%), causing Binance `-4181 "Invalid start time"` errors for symbols with sparse trades. Removed the +1h extension and widened the margin to 1%.
 - `passivbot live` now persists logs to a timestamped file under `logs/` by default, using `config.logging` for the on/off switch and file-rotation settings, and also refreshes `logs/{user}.log` as a stable alias to the current run for monitor tooling. This makes the built-in live workflow self-logging without needing `run_with_logging.py`.
 - Added a canonical live-container runtime contract around `Dockerfile_live`, a thin `container/entrypoint.sh` wrapper, env-generated `api-keys.json` support, env-driven config overrides, and a documented Compose/Railway deployment path that reuses the normal `passivbot live` CLI instead of maintaining platform-specific baked configs.
 - Restored `passivbot live --user` / `-u` as the curated shorthand for `live.user`, so existing live-run workflows using `-u account_name` work again and the alias is visible in the default live help output.

--- a/src/exchanges/ccxt_bot.py
+++ b/src/exchanges/ccxt_bot.py
@@ -239,7 +239,7 @@ class CCXTBot(Passivbot):
         user_options = self.user_info.get("options", {})
 
         # REST client
-        exchange_class = getattr(ccxt_async, self.exchange)
+        exchange_class = getattr(ccxt_async, self.exchange_ccxt_id)
         self.cca = exchange_class(ccxt_config)
         self.cca.options.update(self._build_ccxt_options())
         self.cca.options.update(user_options)
@@ -248,7 +248,7 @@ class CCXTBot(Passivbot):
 
         # WebSocket client - optional, enables faster order updates
         if self.ws_enabled:
-            ws_class = getattr(ccxt_pro, self.exchange)
+            ws_class = getattr(ccxt_pro, self.exchange_ccxt_id)
             self.ccp = ws_class(ccxt_config)
             self.ccp.options.update(self._build_ccxt_options())
             self.ccp.options.update(user_options)

--- a/src/exchanges/ccxt_bot.py
+++ b/src/exchanges/ccxt_bot.py
@@ -238,8 +238,9 @@ class CCXTBot(Passivbot):
         ccxt_config = self._build_ccxt_config()
         user_options = self.user_info.get("options", {})
 
-        # REST client
-        exchange_class = getattr(ccxt_async, self.exchange_ccxt_id)
+        # REST client — prefer futures-specific id (e.g. binanceusdm) over generic name
+        ccxt_id = getattr(self, "exchange_ccxt_id", self.exchange)
+        exchange_class = getattr(ccxt_async, ccxt_id)
         self.cca = exchange_class(ccxt_config)
         self.cca.options.update(self._build_ccxt_options())
         self.cca.options.update(user_options)
@@ -248,7 +249,7 @@ class CCXTBot(Passivbot):
 
         # WebSocket client - optional, enables faster order updates
         if self.ws_enabled:
-            ws_class = getattr(ccxt_pro, self.exchange_ccxt_id)
+            ws_class = getattr(ccxt_pro, ccxt_id)
             self.ccp = ws_class(ccxt_config)
             self.ccp.options.update(self._build_ccxt_options())
             self.ccp.options.update(user_options)

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -1724,9 +1724,9 @@ class BinanceFetcher(BaseFetcher):
             if since_ms is None and until_ms is None:
                 return await self.api.fetch_my_trades(ccxt_symbol, limit=limit)
 
-            end_bound = until_ms or (self._now_func() + 60 * 60 * 1000)
+            end_bound = until_ms or self._now_func()
             start_bound = since_ms or max(0, end_bound - 7 * 24 * 60 * 60 * 1000)
-            week_span = int(7 * 24 * 60 * 60 * 1000 * 0.999)
+            week_span = int(7 * 24 * 60 * 60 * 1000 * 0.99)
             params: Dict[str, object] = {}
             fetched: Dict[str, Dict[str, object]] = {}
             previous_key: Optional[Tuple[Tuple[str, object], ...]] = None

--- a/tests/exchanges/test_ccxt_bot_hooks.py
+++ b/tests/exchanges/test_ccxt_bot_hooks.py
@@ -117,6 +117,81 @@ class TestWatchOrdersTemplateMethod:
 class TestCreateCcxtSessionsWebSocketOptional:
     """Test that WebSocket is optional in create_ccxt_sessions()."""
 
+    def test_prefers_exchange_ccxt_id_when_available(self):
+        """Should instantiate CCXT clients with futures-specific id when present."""
+        from exchanges.ccxt_bot import CCXTBot
+
+        bot = CCXTBot.__new__(CCXTBot)
+        bot.user_info = {"exchange": "binance", "apiKey": "test", "options": {"user_opt": "x"}}
+        bot.exchange = "binance"
+        bot.exchange_ccxt_id = "binanceusdm"
+        bot.ws_enabled = True
+        bot.endpoint_override = None
+        bot._build_ccxt_config = MagicMock(return_value={"apiKey": "test"})
+        bot._build_ccxt_options = MagicMock(return_value={"cfg_opt": "y"})
+        bot._apply_endpoint_override = MagicMock()
+
+        import ccxt.async_support as ccxt_async
+        import ccxt.pro as ccxt_pro
+
+        rest_ctor = MagicMock()
+        rest_ctor.return_value = MagicMock()
+        rest_ctor.return_value.options = {}
+        ws_ctor = MagicMock()
+        ws_ctor.return_value = MagicMock()
+        ws_ctor.return_value.options = {}
+        generic_rest_ctor = MagicMock()
+        generic_ws_ctor = MagicMock()
+
+        with pytest.MonkeyPatch().context() as m:
+            m.setattr(ccxt_async, "binanceusdm", rest_ctor, raising=False)
+            m.setattr(ccxt_pro, "binanceusdm", ws_ctor, raising=False)
+            m.setattr(ccxt_async, "binance", generic_rest_ctor, raising=False)
+            m.setattr(ccxt_pro, "binance", generic_ws_ctor, raising=False)
+            bot.create_ccxt_sessions()
+
+        rest_ctor.assert_called_once_with({"apiKey": "test"})
+        ws_ctor.assert_called_once_with({"apiKey": "test"})
+        generic_rest_ctor.assert_not_called()
+        generic_ws_ctor.assert_not_called()
+        assert bot.cca.options["cfg_opt"] == "y"
+        assert bot.cca.options["user_opt"] == "x"
+        assert bot.cca.options["defaultType"] == "swap"
+        assert bot.ccp.options["cfg_opt"] == "y"
+        assert bot.ccp.options["user_opt"] == "x"
+        assert bot.ccp.options["defaultType"] == "swap"
+
+    def test_falls_back_to_exchange_when_exchange_ccxt_id_missing(self):
+        """Should support test-created instances without exchange_ccxt_id."""
+        from exchanges.ccxt_bot import CCXTBot
+
+        bot = CCXTBot.__new__(CCXTBot)
+        bot.user_info = {"exchange": "paradex", "apiKey": "test"}
+        bot.exchange = "paradex"
+        bot.ws_enabled = True
+        bot.endpoint_override = None
+        bot._build_ccxt_config = MagicMock(return_value={"apiKey": "test"})
+        bot._build_ccxt_options = MagicMock(return_value={})
+        bot._apply_endpoint_override = MagicMock()
+
+        import ccxt.async_support as ccxt_async
+        import ccxt.pro as ccxt_pro
+
+        rest_ctor = MagicMock()
+        rest_ctor.return_value = MagicMock()
+        rest_ctor.return_value.options = {}
+        ws_ctor = MagicMock()
+        ws_ctor.return_value = MagicMock()
+        ws_ctor.return_value.options = {}
+
+        with pytest.MonkeyPatch().context() as m:
+            m.setattr(ccxt_async, "paradex", rest_ctor, raising=False)
+            m.setattr(ccxt_pro, "paradex", ws_ctor, raising=False)
+            bot.create_ccxt_sessions()
+
+        rest_ctor.assert_called_once_with({"apiKey": "test"})
+        ws_ctor.assert_called_once_with({"apiKey": "test"})
+
     def test_sets_ccp_none_when_ws_disabled(self):
         """Should set ccp=None instead of raising when ws_enabled=False."""
         from exchanges.ccxt_bot import CCXTBot

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -165,6 +165,29 @@ class _FakeHyperliquidAPI:
         return self._batches.pop(0)
 
 
+class _FakeBinanceTradeAPI:
+    def __init__(self, batches: List[List[Dict[str, Any]]]) -> None:
+        self._batches = list(batches)
+        self.calls: List[Dict[str, Any]] = []
+
+    async def fetch_my_trades(
+        self,
+        symbol: str,
+        limit: Optional[int] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ):
+        self.calls.append(
+            {
+                "symbol": symbol,
+                "limit": limit,
+                "params": dict(params or {}),
+            }
+        )
+        if not self._batches:
+            return []
+        return self._batches.pop(0)
+
+
 # ---------------------------------------------------------------------------
 # Binance fetcher tests
 # ---------------------------------------------------------------------------
@@ -241,6 +264,36 @@ async def test_binance_fetcher_merges_trade_details(monkeypatch):
     assert event["client_order_id"] == client_id
     assert event["pb_order_type"] == custom_id_to_snake(client_id)
     assert detail_cache["trade-1"][0] == client_id
+
+
+@pytest.mark.asyncio
+async def test_binance_fetch_symbol_trades_uses_now_bound_and_one_percent_margin():
+    now_ms = 1_700_000_000_000
+    seven_days_ms = 7 * 24 * 60 * 60 * 1000
+    expected_span = int(seven_days_ms * 0.99)
+    api = _FakeBinanceTradeAPI(batches=[[], []])
+    fetcher = BinanceFetcher(
+        api=api,
+        symbol_resolver=lambda sym: sym or "",
+        now_func=lambda: now_ms,
+        trade_limit=1000,
+    )
+
+    trades = await fetcher._fetch_symbol_trades(
+        "BTC/USDT:USDT",
+        since_ms=now_ms - seven_days_ms,
+        until_ms=None,
+    )
+
+    assert trades == []
+    assert len(api.calls) == 2
+    first_call = api.calls[0]["params"]
+    second_call = api.calls[1]["params"]
+    assert first_call["startTime"] == now_ms - seven_days_ms
+    assert first_call["endTime"] - first_call["startTime"] == expected_span
+    assert second_call["startTime"] == first_call["endTime"] + 1
+    assert second_call["endTime"] == now_ms
+    assert all(call["params"]["endTime"] <= now_ms for call in api.calls)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

1. **`CCXTBot.create_ccxt_sessions()`** used `self.exchange` (e.g. `"binance"`) instead of `self.exchange_ccxt_id` (`"binanceusdm"`) when instantiating REST and WebSocket CCXT clients. The generic `binance` class fetches all market types (spot + USDT-M + COIN-M) during `load_markets()`, so a timeout on `dapi.binance.com` (COIN-margined) would cascade-fail every `fetch_my_trades` and `update_open_orders` call. Switching to `exchange_ccxt_id` ensures `binanceusdm` is used, which only fetches linear markets from `fapi.binance.com`. Other exchanges are unaffected (`exchange_ccxt_id == exchange` for bybit, okx, etc.).

2. **`BinanceFetcher._fetch_symbol_trades`** set `endTime` to `now + 1h` (future timestamp) and used a 0.1% safety margin on the 7-day pagination window. For symbols with sparse trades (e.g. ICP, LINK), the last window could exceed Binance's 7-day limit, triggering repeated `-4181 "Invalid start time"` errors. Fixed by setting `end_bound = now` (no trades exist in the future) and widening the safety margin to 1%.

## Changes
- `src/exchanges/ccxt_bot.py`: `self.exchange` → `self.exchange_ccxt_id` (REST + WS clients)
- `src/fill_events_manager.py`: Remove +1h future extension, widen week_span margin 0.999 → 0.99

## Testing
- All existing pytests pass (1 pre-existing unrelated failure in `test_unstucking_cases`)
- Deployed to live VPS and verified both fixes: no more `dapi` timeouts, no more `-4181` errors