### PR TITLE
Add Lighter exchange support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -392,3 +392,6 @@ Cargo.lock
 
 # Git worktrees
 .worktrees/
+
+# Monitor
+monitor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable user-facing changes will be documented in this file.
 - **Monitor web wrapper** - Added `passivbot tool monitor-web` to reuse or launch the local relay and keep the browser dashboard available from one command.
 - **Terminal monitor TUI** - Added a local `monitor-tui` tool consuming the relay for current-state panels, live recent activity, focus cycling, pause/resume, and screen dumps.
 - **Monitor dev wrapper** - Added a `monitor-dev` helper that reuses or launches the local relay and opens the terminal monitor with the newest bot log tailed by default.
+- **Lighter exchange support** - New `LighterBot` adapter for the Lighter zero-fee DEX (USDC quote, one-way mode) with native WebSocket order watching and a direct signer bypass for margin/leverage updates (CCXT's `load_account`-based path is broken for this endpoint). Configure via `private_key`, `api_key_index`, `account_index`, and `library_path` in `api-keys.json`; `library_path` points at Lighter's platform-specific native signer binary.
 
 ### Changed
 - **Optimizer scoring now has explicit min/max goals** - `optimize.scoring` is normalized to `{metric, goal}` entries, optimizer engines receive minimization-space values internally, and user-facing logging/Pareto tools now show raw metric values with named objectives instead of signed `w_i` fields. Legacy string-list scoring configs and legacy Pareto result files remain readable.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Passivbot](docs/images/pbot_logo_full.svg)
 
-# Trading bot running on Bybit, OKX, Bitget, GateIO, Binance, Kucoin and Hyperliquid
+# Trading bot running on Bybit, OKX, Bitget, GateIO, Binance, Kucoin, Hyperliquid and Lighter
 
 :warning: **Used at one's own risk** :warning:
 
@@ -188,6 +188,7 @@ For more detailed information about Passivbot, see documentation files here: [do
 Useful entry points:
 
 - [Installation](docs/installation.md)
+- [Lighter exchange guide](docs/lighter_guide.md)
 - [Troubleshooting](docs/troubleshooting.md)
 - [Backtesting](docs/backtesting.md)
 - [Optimizing](docs/optimizing.md)

--- a/api-keys.json.example
+++ b/api-keys.json.example
@@ -67,5 +67,13 @@
         "provider": "alpaca",
         "api_key": "your_alpaca_api_key",
         "api_secret": "your_alpaca_api_secret"
+    },
+    "_comment_lighter": "Lighter requires a platform-specific native binary (v1.0.4). Download from: https://github.com/elliottech/lighter-python/tree/b7fc10b2/lighter/signers — newer binaries have breaking ABI changes not yet supported by CCXT.",
+    "lighter_01": {
+        "exchange": "lighter",
+        "private_key": "0x_api_key_private_key_hex",
+        "api_key_index": 0,
+        "account_index": 0,
+        "library_path": "/path/to/lighter-binary"
     }
 }

--- a/docs/ai/exchange_api_quirks.md
+++ b/docs/ai/exchange_api_quirks.md
@@ -43,6 +43,67 @@ Handling:
 1. Overlap boundaries by 1 candle.
 2. Back up initial `since` by one candle on pagination start.
 
+## Lighter
+
+### Native signer binary with pinned ABI
+
+Problem:
+
+1. CCXT's Lighter client signs transactions through a Go-compiled shared library
+   loaded via `ctypes`. CCXT ships the Python `ctypes` wrapper
+   (`ccxt.static_dependencies.lighter_client.signer`) but **not** the binary.
+2. The upstream binary has had breaking ABI changes (e.g. `CreateOrderTxReq`
+   field layout) since CCXT's wrapper was generated. Newer releases segfault or
+   produce invalid signatures.
+
+Handling in Passivbot:
+
+1. Users must download `elliottech/lighter-python@b7fc10b2` / v1.0.4 binaries
+   and point `api-keys.json:library_path` at the result.
+2. `LighterBot.create_ccxt_sessions` calls `load_lighter_library(library_path)`
+   and stores the signer on both `cca.options["signer"]` and `self._signer`.
+3. Do not bump the pinned commit in user-facing docs without verifying the
+   ctypes wrapper in the bundled `ccxt` version still matches.
+
+Primary reference: `src/exchanges/lighter.py` (`LighterBot.create_ccxt_sessions`).
+
+### Leverage/margin updates bypass CCXT
+
+Problem: CCXT's Lighter adapter routes `set_leverage` / `set_margin_mode`
+through a `load_account`-based path that is broken against the current Lighter
+endpoint.
+
+Handling in Passivbot:
+
+1. `LighterBot.update_exchange_config_by_symbols` calls
+   `self._signer.SignUpdateLeverage` directly, decodes the tx with
+   `decode_tx_info`, and submits via `self.cca.publicPostSendTx`.
+2. "already"/"no change" errors are swallowed as no-ops. Any other exception
+   propagates so the orchestrator's per-symbol retry/backoff loop can react.
+
+Primary reference: `src/exchanges/lighter.py` (`LighterBot.update_exchange_config_by_symbols`).
+
+### No all-symbols `fetch_open_orders`
+
+Problem: Lighter's REST API requires a per-symbol query for open orders.
+
+Handling: `LighterBot.fetch_open_orders(symbol=None)` fans out across tracked
+symbols (union of `open_orders` keys, symbols with positions, and
+`active_symbols`) and merges the results. Scales with active symbol count.
+
+Primary reference: `src/exchanges/lighter.py` (`LighterBot.fetch_open_orders`).
+
+### Native WebSocket (not CCXT `watch_orders`)
+
+`LighterBot` overrides `can_watch_orders` to `True` and implements its own
+connection to `wss://mainnet.zklighter.elliot.ai/stream`, subscribing to
+`account_all/{account_index}`. Order updates arrive through `_do_watch_orders`
+and are normalized by `_normalize_order_update`. If changing the WebSocket
+layer, remember that Lighter's channel payloads use `client_order_id`,
+`reduce_only`, and `status` string set mapped in `_normalize_status`.
+
+Primary reference: `src/exchanges/lighter.py` (`LighterBot._ws_connect`, `_ws_receive`, `_normalize_order_update`).
+
 ## General Guidance
 
 1. Check raw exchange payloads when CCXT abstraction is insufficient.

--- a/docs/lighter_guide.md
+++ b/docs/lighter_guide.md
@@ -1,0 +1,113 @@
+## Quick Guide for Passivbot on Lighter
+
+Lighter is a zero-fee, order-book-based decentralized perpetuals DEX (zkSync-based,
+`mainnet.zklighter.elliot.ai`). Passivbot's `LighterBot` adapter uses USDC as the
+quote currency and runs in one-way (non-hedge) mode only.
+
+Unlike every other exchange Passivbot supports, Lighter requires a **platform-specific
+native signing binary** in addition to the usual API credentials. This guide walks
+through the extra step.
+
+### Obtain Lighter API credentials
+
+Follow the CCXT FAQ for creating an API key on Lighter and locating your account
+index:
+
+https://github.com/ccxt/ccxt/wiki/FAQ#how-to-use-the-lighter-exchange-in-ccxt
+
+From that procedure you should end up with three values:
+
+- `private_key` — the API key private key (hex, `0x`-prefixed). **Not** your
+  wallet private key.
+- `api_key_index` — the integer index (0–254) Lighter assigns to the API key.
+- `account_index` — your Lighter account/sub-account index.
+
+### Download the Lighter signer binary
+
+Passivbot signs Lighter transactions through a compiled Go library that is loaded
+at runtime via `ctypes`. CCXT ships the Python ctypes wrapper
+(`ccxt.static_dependencies.lighter_client.signer`) but **not** the binary itself,
+and the wrapper is pinned to a specific ABI. You must download a matching binary
+and point Passivbot at it via `library_path`.
+
+> **Use exactly the v1.0.4 / commit `b7fc10b2` binaries.**
+> Newer releases of `elliottech/lighter-python` change the ctypes field layouts
+> (for example `CreateOrderTxReq`) and CCXT's bundled Python wrapper has not been
+> updated to match. Grabbing the latest release will break transaction signing.
+
+1. Open the pinned directory in the upstream repo:
+   https://github.com/elliottech/lighter-python/tree/b7fc10b2/lighter/signers
+2. Download the file that matches your host platform (Linux/macOS/Windows,
+   x86_64 or arm64). The repo ships one binary per platform in that directory.
+3. Save the file somewhere persistent (for example
+   `~/passivbot/lib/lighter-signer.so`). No `chmod +x` is needed — the file is
+   loaded as a shared library, not executed.
+4. If you run on Linux inside a minimal container and see
+   `OSError: ... cannot open shared object file`, install `libc6` / `glibc` —
+   the Go binary depends on it.
+
+Only one binary needs to be loaded per Python process. If you run multiple
+Lighter accounts in the same `passivbot` process, they will share the binary
+that the first one loads.
+
+### Passivbot setup
+
+1. If not already installed, install Passivbot. Otherwise, pull the latest master
+   branch and refresh dependencies:
+   ```bash
+   git pull
+   python3 -m pip install -e .
+   ```
+2. Add a Lighter entry to `api-keys.json`:
+   ```json
+   "lighter_01": {
+       "exchange": "lighter",
+       "private_key": "0x_api_key_private_key_hex",
+       "api_key_index": 0,
+       "account_index": 0,
+       "library_path": "/absolute/path/to/lighter-signer.so"
+   }
+   ```
+   `library_path` should be an absolute path to the downloaded signer binary.
+   A relative path works but is resolved against the process cwd at startup,
+   so an absolute path is less error-prone.
+3. Start the bot as usual:
+   ```bash
+   passivbot live -u lighter_01
+   ```
+
+### Operational notes
+
+- **Quote currency is USDC.** Passivbot hardcodes this for Lighter; it will not
+  trade USDT pairs there.
+- **One-way mode only.** Lighter does not support hedge mode, so Passivbot runs
+  with `hedge_mode = False`. Long and short positions on the same symbol cannot
+  coexist — opening the opposite side will net against the existing position.
+- **Native WebSocket.** `LighterBot` opens its own WebSocket to
+  `wss://mainnet.zklighter.elliot.ai/stream` and subscribes to
+  `account_all/{account_index}`, so order updates arrive via push rather than
+  REST polling.
+- **Per-symbol `fetch_open_orders`.** Lighter's REST API does not return
+  all-symbols open orders in one call, so Passivbot fans out across tracked
+  symbols and merges. This is handled automatically but means open-order
+  refreshes scale with the number of active symbols.
+- **Leverage/margin updates bypass CCXT.** `update_exchange_config_by_symbols`
+  calls the signer's `SignUpdateLeverage` directly and submits via
+  `publicPostSendTx`, because CCXT's own Lighter `load_account` path is broken
+  against the current endpoint. If the exchange reports "no change" / "already",
+  Passivbot treats it as a no-op and continues. Any other error is propagated
+  so the orchestrator's per-symbol retry/backoff loop can handle it.
+- **Startup failure modes.** If `library_path` is missing, unreadable, or wrong
+  architecture, the bot fails loudly in `create_ccxt_sessions()` with
+  `OSError` from `ctypes.CDLL`. If the signer loads but rejects your
+  credentials, `CreateClient` returns an error string and Passivbot raises
+  `lighter: CreateClient failed: ...` before any orders are placed.
+
+### Troubleshooting
+
+| Symptom | Likely cause |
+|---------|--------------|
+| `OSError: ... cannot open shared object file` at startup | Wrong path, wrong architecture, or missing glibc in the runtime image. |
+| `lighter: CreateClient failed: ...` | Wrong `private_key`, `api_key_index`, or `account_index`. Re-check them against the CCXT FAQ procedure linked above. |
+| Transactions fail with signature/ABI errors | Binary is not the pinned v1.0.4 / `b7fc10b2` version. Re-download from the URL above. |
+| Leverage/margin updates log "unchanged" forever | Expected when the symbol is already at the target leverage and margin mode; not an error. |

--- a/requirements-live.txt
+++ b/requirements-live.txt
@@ -3,7 +3,7 @@ python-dateutil==2.9.0.post0
 numba==0.59.1
 pandas==2.2.2
 numpy==1.26.4
-ccxt==4.5.22
+ccxt==4.5.47
 hjson==3.0.2
 prettytable==3.11.0
 sortedcontainers==2.4.0

--- a/src/exchanges/binance.py
+++ b/src/exchanges/binance.py
@@ -75,10 +75,6 @@ class BinanceBot(CCXTBot):
 
     # ═══════════════════ HOOK OVERRIDES ═══════════════════
 
-    def _get_position_side_for_order(self, order: dict) -> str:
-        """Binance provides ps (positionSide) in info."""
-        return order.get("info", {}).get("ps", "long").lower()
-
     async def _do_fetch_positions(self) -> list:
         """Binance: Use fapiprivatev3_get_positionrisk endpoint."""
         return await self.cca.fapiprivatev3_get_positionrisk()
@@ -225,27 +221,6 @@ class BinanceBot(CCXTBot):
             )
             start_time = fetched[-1]["timestamp"]
         return sorted(all_fetched.values(), key=lambda x: x["timestamp"])
-
-    async def gather_fill_events(self, start_time=None, end_time=None, limit=None):
-        """Return canonical fill events for Binance."""
-        events = []
-        fills = await self.fetch_pnls(start_time=start_time, end_time=end_time, limit=limit)
-        for fill in fills:
-            events.append(
-                {
-                    "id": fill.get("id") or fill.get("tradeId"),
-                    "timestamp": fill.get("timestamp"),
-                    "symbol": fill.get("symbol"),
-                    "side": fill.get("side"),
-                    "position_side": fill.get("position_side", fill.get("pside")),
-                    "qty": fill.get("qty") or fill.get("amount"),
-                    "price": fill.get("price"),
-                    "pnl": fill.get("pnl"),
-                    "fee": fill.get("fee"),
-                    "info": fill.get("info"),
-                }
-            )
-        return events
 
     async def fetch_fills_sub(self, symbol, start_time=None, end_time=None, limit=None):
         if symbol not in self.markets_dict:

--- a/src/exchanges/bitget.py
+++ b/src/exchanges/bitget.py
@@ -7,9 +7,6 @@ from typing import Dict, List, Tuple
 from utils import utc_ms, ts_to_date
 from config.access import require_live_value
 from pure_funcs import calc_hash
-import passivbot_rust as pbr
-
-calc_order_price_diff = pbr.calc_order_price_diff
 
 
 def deduce_side_pside(fill: dict) -> tuple[str, str]:
@@ -90,10 +87,6 @@ class BitgetBot(CCXTBot):
         self.custom_id_max_length = 64
 
     # ═══════════════════ HOOK OVERRIDES ═══════════════════
-
-    def _get_position_side_for_order(self, order: dict) -> str:
-        """Bitget provides posSide in info."""
-        return order.get("info", {}).get("posSide", "long").lower()
 
     def get_symbol_id(self, symbol):
         """Return the exchange-native identifier for `symbol`, caching defaults."""
@@ -576,28 +569,8 @@ class BitgetBot(CCXTBot):
                 logging.info(f"{symbol}: {to_print}")
 
     async def calc_ideal_orders(self):
-        # Bitget returns max 100 open orders per fetch_open_orders.
-        # Only create 100 open orders.
-        # Drop orders whose pprice diff is greatest.
         ideal_orders = await super().calc_ideal_orders()
-        ideal_orders_tmp = []
-        for s in ideal_orders:
-            for x in ideal_orders[s]:
-                ideal_orders_tmp.append(
-                    (
-                        calc_order_price_diff(
-                            x["side"],
-                            x["price"],
-                            await self.cm.get_current_close(s, max_age_ms=10_000),
-                        ),
-                        {**x, **{"symbol": s}},
-                    )
-                )
-        ideal_orders_tmp = [x[1] for x in sorted(ideal_orders_tmp, key=lambda item: item[0])][:100]
-        ideal_orders = {symbol: [] for symbol in self.active_symbols}
-        for x in ideal_orders_tmp:
-            ideal_orders[x["symbol"]].append(x)
-        return ideal_orders
+        return await self._trim_orders_by_price_proximity(ideal_orders, 100)
 
     async def update_exchange_config(self):
         res = None

--- a/src/exchanges/bybit.py
+++ b/src/exchanges/bybit.py
@@ -1,5 +1,5 @@
 from exchanges.ccxt_bot import CCXTBot, format_exchange_config_response
-from passivbot import logging, clip_by_timestamp
+from passivbot import logging
 from uuid import uuid4
 import asyncio
 import ccxt
@@ -9,7 +9,6 @@ from config.access import require_live_value
 from pure_funcs import (
     floatify,
     calc_hash,
-    determine_pos_side_ccxt,
     flatten,
 )
 
@@ -19,10 +18,6 @@ class BybitBot(CCXTBot):
         super().__init__(config)
 
     # ═══════════════════ HOOK OVERRIDES ═══════════════════
-
-    def _get_position_side_for_order(self, order: dict) -> str:
-        """Bybit: Use determine_pos_side_ccxt helper."""
-        return determine_pos_side_ccxt(order)
 
     # ═══════════════════ BYBIT-SPECIFIC METHODS ═══════════════════
 
@@ -239,111 +234,6 @@ class BybitBot(CCXTBot):
                 fillsd[x["orderId"]] = [x]
         joined = {x["info"]["execId"]: x for x in flatten(fillsd.values())}
         return sorted(joined.values(), key=lambda x: x["timestamp"])
-
-    async def gather_fill_events(self, start_time=None, end_time=None, limit=None):
-        """Return canonical fill events for equity reconstruction (draft implementation)."""
-
-        def extract_fill_event_from_ph(elm):
-            event = {
-                "id": elm["info"]["orderId"],
-                "timestamp": int(float(elm.get("lastUpdateTimestamp", elm.get("timestamp", 0.0)))),
-                "symbol": elm["symbol"],
-                "side": str(elm["info"].get("side", "")).lower(),
-                "qty": float(elm.get("contracts", elm.get("qty", 0.0))),
-                "price": float(elm.get("lastPrice", elm.get("price", 0.0))),
-                "pnl": float(elm.get("realizedPnl", 0.0)),
-                "fee": None,
-                "custom_id": elm.get("info", {}).get("orderLinkId"),
-                "position_side": None,
-            }
-            if event["side"] == "buy":
-                event["position_side"] = "long" if event["pnl"] == 0.0 else "short"
-            elif event["side"] == "sell":
-                event["position_side"] = "short" if event["pnl"] == 0.0 else "long"
-            else:
-                raise Exception(f"malformed side {event['side']}")
-            return event
-
-        def extract_fill_event_from_mt(elm):
-            event = {
-                "id": elm["info"]["orderId"],
-                "timestamp": elm["timestamp"],
-                "symbol": elm["symbol"],
-                "side": elm["side"],
-                "qty": float(elm["amount"]),
-                "price": float(elm["price"]),
-                "pnl": None,
-                "fee": elm.get("fee"),
-                "custom_id": elm.get("info", {}).get("orderLinkId"),
-                "position_side": None,
-            }
-            closed_size = float(elm["info"].get("closedSize", 0.0))
-            if event["side"] == "buy":
-                event["position_side"] = "long" if closed_size == 0.0 else "short"
-                if closed_size == 0.0:
-                    event["pnl"] = 0.0
-            elif event["side"] == "sell":
-                event["position_side"] = "short" if closed_size == 0.0 else "long"
-                if closed_size == 0.0:
-                    event["pnl"] = 0.0
-            else:
-                raise Exception(f"malformed side {event['side']}")
-            return event
-
-        def is_equal(x0, x1):
-            for key in ["id", "symbol", "qty", "side", "position_side", "price"]:
-                if x0[key] != x1[key]:
-                    return False
-            return True
-
-        def merge_events(x0, x1):
-            merged_list = []
-            if is_equal(x0, x1):
-                event = {}
-                for key in x0:
-                    event[key] = x0.get(key, x1.get(key))
-                return [event]
-            else:
-                return [x0, x1]
-
-        def get_dedup_key(event):
-            return tuple(
-                [event[k] for k in ["id", "symbol", "qty", "side", "position_side", "price"]]
-            )
-
-        if end_time is None:
-            end_time = int(self.get_exchange_time() + 1000 * 60 * 60)
-        if start_time is None:
-            start_time = end_time - 1000 * 60 * 60 * 24 * 3
-
-        # fetch concurrently
-        my_trades, positions_history = await asyncio.gather(
-            self.fetch_my_trades(start_time, end_time),
-            self.fetch_positions_history(start_time, end_time),
-        )
-
-        # extract events
-        mt_events = sorted(
-            [extract_fill_event_from_mt(x) for x in my_trades], key=lambda x: x["timestamp"]
-        )
-        ph_events = sorted(
-            [extract_fill_event_from_ph(x) for x in positions_history], key=lambda x: x["timestamp"]
-        )
-        mt_events = clip_by_timestamp(mt_events, start_time, end_time)
-        ph_events = clip_by_timestamp(ph_events, start_time, end_time)
-
-        pnls = defaultdict(float)
-        for event in ph_events:
-            pnls[event["id"]] += event["pnl"]
-        unified = []
-        for event in mt_events[::-1]:
-            if event["id"] in pnls:
-                event["pnl"] = pnls.pop(event["id"])
-            unified.append(event)
-        if len(pnls) > 0:
-            logging.debug("positions_history events without corresponding my_trades")
-        unified.sort(key=lambda x: x["timestamp"])
-        return unified
 
     async def fetch_my_trades(self, start_time, end_time, limit=100):
         # wrapper for ccxt.fetch_my_trades

--- a/src/exchanges/ccxt_bot.py
+++ b/src/exchanges/ccxt_bot.py
@@ -36,7 +36,8 @@ import math
 import time
 import traceback
 
-from passivbot import Passivbot, logging, custom_id_to_snake
+from passivbot import Passivbot, logging
+import passivbot_rust as pbr
 import ccxt.pro as ccxt_pro
 import ccxt.async_support as ccxt_async
 from procedures import assert_correct_ccxt_version
@@ -130,27 +131,13 @@ class CCXTBot(Passivbot):
         return order
 
     def _get_position_side_for_order(self, order: dict) -> str:
-        """Hook: Derive position_side from order data.
-
-        Default: Use CCXT unified fields, fall back to custom_id derivation.
-        Override: Exchange-specific logic when neither source is available.
-        """
-        info = order.get("info", {})
-
-        # 1. Exchange provides positionSide directly
-        pos_side = info.get("positionSide", "")
-        if pos_side:
-            return pos_side.lower()
-
-        # 2. Derive from CCXT unified clientOrderId
-        custom_id = order.get("clientOrderId", "")
-        if custom_id:
-            order_type = custom_id_to_snake(custom_id)
-            if order_type.endswith("_long"):
-                return "long"
-            if order_type.endswith("_short"):
-                return "short"
-
+        """Derive position_side from CCXT unified side + reduceOnly."""
+        side = order.get("side", "")
+        reduce_only = order.get("reduceOnly", False)
+        if side == "buy":
+            return "short" if reduce_only else "long"
+        if side == "sell":
+            return "long" if reduce_only else "short"
         return "both"
 
     # ═══════════════════ PNL FETCHING HOOKS ═══════════════════
@@ -258,22 +245,6 @@ class CCXTBot(Passivbot):
         else:
             self.ccp = None
             logging.info(f"{self.exchange}: WebSocket disabled, using REST polling")
-
-    async def validate_websocket_support(self):
-        """Check WebSocket capabilities (informational, non-fatal).
-
-        Logs whether watchOrders is available. Does not raise.
-        Subclasses can override to set ws_orders_supported=True if
-        implementing native WebSocket.
-        """
-        if self.ccp is None:
-            logging.info(f"{self.exchange}: WebSocket client not initialized")
-            return
-
-        if self.ccp.has.get("watchOrders"):
-            logging.info(f"{self.exchange}: watchOrders support confirmed")
-        else:
-            logging.info(f"{self.exchange}: watchOrders not supported in CCXT, using REST polling")
 
     async def fetch_balance(self) -> float:
         """Template method: Fetch account balance for quote currency.
@@ -1017,6 +988,20 @@ class CCXTBot(Passivbot):
                 params["timeInForce"] = "GTC"
 
         return params
+
+    async def _trim_orders_by_price_proximity(self, ideal_orders, max_orders):
+        """Keep only the max_orders closest to current price across all symbols."""
+        flattened = []
+        for symbol, orders in ideal_orders.items():
+            market_price = await self.cm.get_current_close(symbol, max_age_ms=10_000)
+            for order in orders:
+                price_diff = pbr.calc_order_price_diff(order["side"], order["price"], market_price)
+                flattened.append((price_diff, symbol, order))
+        flattened.sort(key=lambda x: x[0])
+        result = {symbol: [] for symbol in self.active_symbols}
+        for _, symbol, order in flattened[:max_orders]:
+            result[symbol].append(order)
+        return result
 
     async def execute_orders(self, orders: list[dict]) -> list[dict]:
         """Execute order creations in parallel using asyncio.gather.

--- a/src/exchanges/defx.py
+++ b/src/exchanges/defx.py
@@ -22,29 +22,6 @@ class DefxBot(CCXTBot):
         self.quote = "USDC"
         self.hedge_mode = False
 
-    def _get_position_side_for_order(self, order: dict) -> str:
-        """Defx: Derive from position state (one-way mode)."""
-        return self.determine_pos_side(order)
-
-    def determine_pos_side(self, order):
-        # non hedge mode
-        if self.has_position("long", order["symbol"]):
-            return "long"
-        elif self.has_position("short", order["symbol"]):
-            return "short"
-        elif order["side"] == "buy":
-            return "long"
-        elif order["side"] == "sell":
-            return "short"
-        raise Exception(f"unknown side {order['side']}")
-
-    async def fetch_open_orders(self, symbol: str = None):
-        fetched = await self.cca.fetch_open_orders(symbol=symbol)
-        for order in fetched:
-            order["position_side"] = self.determine_pos_side(order)
-            order["qty"] = order["amount"]
-        return sorted(fetched, key=lambda x: x["timestamp"])
-
     async def fetch_positions(self):
         fetched_positions = await self.cca.fetch_positions()
         positions = []
@@ -95,27 +72,6 @@ class DefxBot(CCXTBot):
             else:
                 raise Exception(f"invalid side {res[i]}")
         return res
-
-    async def gather_fill_events(self, start_time=None, end_time=None, limit=None):
-        """Return canonical fill events for dYdX/DeFX adapter (draft placeholder)."""
-        events = []
-        fills = await self.fetch_pnls(start_time=start_time, end_time=end_time, limit=limit)
-        for fill in fills:
-            events.append(
-                {
-                    "id": fill.get("id"),
-                    "timestamp": fill.get("timestamp"),
-                    "symbol": fill.get("symbol"),
-                    "side": fill.get("side"),
-                    "position_side": fill.get("position_side"),
-                    "qty": fill.get("qty"),
-                    "price": fill.get("price"),
-                    "pnl": fill.get("pnl"),
-                    "fee": fill.get("fee"),
-                    "info": fill.get("info"),
-                }
-            )
-        return events
 
     def _build_order_params(self, order: dict) -> dict:
         return {

--- a/src/exchanges/gateio.py
+++ b/src/exchanges/gateio.py
@@ -29,18 +29,6 @@ class GateIOBot(CCXTBot):
 
     # ═══════════════════ HOOK OVERRIDES ═══════════════════
 
-    def _get_position_side_for_order(self, order: dict) -> str:
-        """GateIO: Derive position side from order side + reduceOnly (one-way mode)."""
-        return self.determine_pos_side(order)
-
-    def determine_pos_side(self, order):
-        """GateIO-specific logic for one-way mode position side derivation."""
-        if order["side"] == "buy":
-            return "short" if order["reduceOnly"] else "long"
-        if order["side"] == "sell":
-            return "long" if order["reduceOnly"] else "short"
-        raise Exception(f"unsupported order side {order['side']}")
-
     # ═══════════════════ GATEIO-SPECIFIC METHODS ═══════════════════
 
     async def fetch_balance(self) -> float:
@@ -92,27 +80,6 @@ class GateIOBot(CCXTBot):
             offset += limit
         return sorted(all_fetched.values(), key=lambda x: x["timestamp"])
 
-    async def gather_fill_events(self, start_time=None, end_time=None, limit=None):
-        """Return canonical fill events for Gate.io."""
-        events = []
-        fills = await self.fetch_pnls(start_time=start_time, end_time=end_time, limit=limit)
-        for fill in fills:
-            events.append(
-                {
-                    "id": fill.get("id"),
-                    "timestamp": fill.get("timestamp"),
-                    "symbol": fill.get("symbol"),
-                    "side": fill.get("side"),
-                    "position_side": fill.get("position_side"),
-                    "qty": fill.get("amount") or fill.get("filled"),
-                    "price": fill.get("price"),
-                    "pnl": fill.get("pnl"),
-                    "fee": fill.get("fee"),
-                    "info": fill.get("info"),
-                }
-            )
-        return events
-
     async def fetch_pnl(
         self,
         offset=0,
@@ -122,7 +89,7 @@ class GateIOBot(CCXTBot):
         fetched = await self.cca.fetch_closed_orders(limit=n_pnls_limit, params={"offset": offset})
         for i in range(len(fetched)):
             fetched[i]["pnl"] = float(fetched[i]["info"]["pnl"])
-            fetched[i]["position_side"] = self.determine_pos_side(fetched[i])
+            fetched[i]["position_side"] = self._get_position_side_for_order(fetched[i])
         return sorted(fetched, key=lambda x: x["timestamp"])
 
     def did_cancel_order(self, executed, order=None):

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -290,7 +290,7 @@ class HyperliquidBot(CCXTBot):
                 res = await self.ccp.watch_orders()
                 _ws_consecutive_rate_limits = 0  # reset on success
                 for i in range(len(res)):
-                    res[i]["position_side"] = self.determine_pos_side(res[i])
+                    res[i]["position_side"] = self._get_position_side_for_order(res[i])
                     res[i]["qty"] = res[i]["amount"]
                 self.handle_order_update(res)
             except RateLimitExceeded:
@@ -320,27 +320,6 @@ class HyperliquidBot(CCXTBot):
                 await asyncio.sleep(1)
                 logging.info("[ws] %s: reconnecting...", self.exchange)
 
-    def determine_pos_side(self, order):
-        # hyperliquid is not hedge mode
-        if order["symbol"] in self.positions:
-            if self.positions[order["symbol"]]["long"]["size"] != 0.0:
-                return "long"
-            elif self.positions[order["symbol"]]["short"]["size"] != 0.0:
-                return "short"
-            else:
-                return "long" if order["side"] == "buy" else "short"
-        else:
-            if "reduceOnly" in order:
-                if order["side"] == "buy":
-                    return "short" if order["reduceOnly"] else "long"
-                if order["side"] == "sell":
-                    return "long" if order["reduceOnly"] else "short"
-            return "long" if order["side"] == "buy" else "short"
-
-    def _get_position_side_for_order(self, order: dict) -> str:
-        """Hook: Derive position_side from order data for Hyperliquid (one-way mode)."""
-        return self.determine_pos_side(order)
-
     async def fetch_open_orders(self, symbol: str = None):
         fetched = []
         seen_ids = set()
@@ -369,7 +348,7 @@ class HyperliquidBot(CCXTBot):
                 fetched.append(order)
 
         for elm in fetched:
-            elm["position_side"] = self.determine_pos_side(elm)
+            elm["position_side"] = self._get_position_side_for_order(elm)
             elm["qty"] = elm["amount"]
         return sorted(fetched, key=lambda x: x["timestamp"])
 
@@ -509,27 +488,6 @@ class HyperliquidBot(CCXTBot):
             start_time = fetched[-1]["timestamp"] - 1000
             limit = 2000
         return sorted(all_fetched.values(), key=lambda x: x["timestamp"])
-
-    async def gather_fill_events(self, start_time=None, end_time=None, limit=None):
-        """Return canonical fill events for Hyperliquid (draft placeholder)."""
-        events = []
-        fills = await self.fetch_pnls(start_time=start_time, end_time=end_time, limit=limit)
-        for fill in fills:
-            events.append(
-                {
-                    "id": fill.get("id"),
-                    "timestamp": fill.get("timestamp"),
-                    "symbol": fill.get("symbol"),
-                    "side": fill.get("side"),
-                    "position_side": fill.get("position_side"),
-                    "qty": fill.get("amount"),
-                    "price": fill.get("price"),
-                    "pnl": fill.get("pnl"),
-                    "fee": fill.get("fee"),
-                    "info": fill.get("info"),
-                }
-            )
-        return events
 
     async def fetch_pnl(
         self,

--- a/src/exchanges/kucoin.py
+++ b/src/exchanges/kucoin.py
@@ -4,15 +4,12 @@ from passivbot import logging
 import ccxt.pro as ccxt_pro
 import ccxt.async_support as ccxt_async
 import asyncio
-import passivbot_rust as pbr
 from utils import ts_to_date, utc_ms
 from procedures import assert_correct_ccxt_version
 from collections import defaultdict
 import hmac
 import hashlib
 import base64
-
-calc_order_price_diff = pbr.calc_order_price_diff
 
 # ---------------------------------------------------------------------------
 # Broker mixin classes for injecting KC-BROKER-NAME on KuCoin futures requests.
@@ -167,22 +164,6 @@ class KucoinBot(CCXTBot):
         """KuCoin: No-op - OHLCV websocket not used."""
         return
 
-    def _get_position_side_for_order(self, order: dict) -> str:
-        """KuCoin: Derive position_side from position state."""
-        return self.determine_pos_side(order)
-
-    def determine_pos_side(self, order):
-        # non hedge mode
-        if self.has_position("long", order["symbol"]):
-            return "long"
-        elif self.has_position("short", order["symbol"]):
-            return "short"
-        elif order["side"] == "buy":
-            return "long"
-        elif order["side"] == "sell":
-            return "short"
-        raise Exception(f"unknown side {order['side']}")
-
     async def fetch_open_orders(self, symbol: str = None) -> list:
         """KuCoin: Fetch open orders with pagination.
 
@@ -201,7 +182,7 @@ class KucoinBot(CCXTBot):
             if not fetched:
                 break
             for order in fetched:
-                order["position_side"] = self.determine_pos_side(order)
+                order["position_side"] = self._get_position_side_for_order(order)
                 order["qty"] = order["amount"]
                 self._record_live_margin_mode_from_payload(order)
             open_orders.extend(fetched)
@@ -217,25 +198,8 @@ class KucoinBot(CCXTBot):
         return float(fetched["info"]["data"]["marginBalance"])
 
     async def calc_ideal_orders(self):
-        # KuCoin enforces a 150 open-order cap; keep only the closest price targets.
         ideal_orders = await super().calc_ideal_orders()
-        flattened = []
-        for symbol, orders in ideal_orders.items():
-            if not orders:
-                continue
-            market_price = await self.cm.get_current_close(symbol, max_age_ms=10_000)
-            for order in orders:
-                price_diff = calc_order_price_diff(order["side"], order["price"], market_price)
-                flattened.append((price_diff, symbol, order))
-        limit = getattr(self, "MAX_OPEN_ORDERS", 150)
-        flattened.sort(key=lambda x: x[0])
-        trimmed = flattened[:limit] if limit and limit > 0 else flattened
-        filtered: dict[str, list] = {symbol: [] for symbol in self.active_symbols}
-        for _, symbol, order in trimmed:
-            filtered.setdefault(symbol, []).append(order)
-        for symbol in ideal_orders:
-            filtered.setdefault(symbol, ideal_orders[symbol])
-        return filtered
+        return await self._trim_orders_by_price_proximity(ideal_orders, 150)
 
     async def fetch_fills(self, start_time=None, end_time=None, limit=None):
         if start_time is None:
@@ -389,33 +353,6 @@ class KucoinBot(CCXTBot):
 
         return sorted(deduped.values(), key=lambda x: x["timestamp"])
 
-    async def gather_fill_events(self, start_time=None, end_time=None, limit=None):
-        """Return canonical fill events for KuCoin.
-
-        Returns:
-            list: Fill events with normalized fields.
-
-        Raises:
-            Exception: On API errors (caller handles via restart_bot_on_too_many_errors).
-        """
-        fills = await self.fetch_pnls(start_time=start_time, end_time=end_time, limit=limit)
-        events = []
-        for fill in fills:
-            events.append(
-                {
-                    "id": fill.get("id") or fill.get("orderId"),
-                    "timestamp": fill.get("timestamp"),
-                    "symbol": fill.get("symbol"),
-                    "side": fill.get("side"),
-                    "position_side": fill.get("position_side"),
-                    "qty": fill.get("qty") or fill.get("amount"),
-                    "price": fill.get("price"),
-                    "pnl": fill.get("pnl"),
-                    "fee": fill.get("fee"),
-                    "info": fill.get("info"),
-                }
-            )
-        return events
 
     def _build_order_params(self, order: dict) -> dict:
         margin_mode = self._get_margin_mode_for_symbol(order["symbol"])

--- a/src/exchanges/lighter.py
+++ b/src/exchanges/lighter.py
@@ -1,0 +1,249 @@
+"""
+LighterBot: Lighter exchange adapter with native WebSocket.
+
+Lighter is a zero-fee decentralized trading platform using wallet-based auth.
+Requires a platform-specific native binary (libraryPath) for transaction signing.
+
+Auth fields (api-keys.json):
+  - private_key: API key private key (hex) from Lighter's API keys page
+  - api_key_index: integer (0-254) assigned to the API key
+  - account_index: integer from Lighter API
+  - library_path: path to platform-specific native binary
+
+WebSocket: Native connection to wss://mainnet.zklighter.elliot.ai/stream
+  - Subscribes to account_all/{account_index} for orders, positions, balance
+
+Reference: https://github.com/ccxt/ccxt/wiki/FAQ#how-to-use-the-lighter-exchange-in-ccxt
+"""
+
+import asyncio
+import json
+
+import websockets
+from websockets.exceptions import ConnectionClosed
+
+from ccxt.static_dependencies.lighter_client.signer import load_lighter_library, decode_tx_info
+from exchanges.ccxt_bot import CCXTBot
+from passivbot import logging, custom_id_to_snake
+from config.access import require_live_value
+
+
+class LighterBot(CCXTBot):
+
+    def __init__(self, config: dict):
+        super().__init__(config)
+        self.quote = "USDC"
+        self.hedge_mode = False
+        self._ws = None
+
+    def _build_ccxt_config(self) -> dict:
+        config = {"enableRateLimit": True}
+        config.setdefault("timeout", 30000)  # match CCXTBot base; CCXT default ~10s too tight on cold boot
+        config["privateKey"] = self.user_info["private_key"]
+        config["options"] = {
+            "apiKeyIndex": int(self.user_info["api_key_index"]),
+            "accountIndex": int(self.user_info["account_index"]),
+        }
+        if self.user_info.get("library_path"):
+            config["options"]["libraryPath"] = self.user_info["library_path"]
+        return config
+
+    def create_ccxt_sessions(self):
+        super().create_ccxt_sessions()
+        library_path = (
+            self.user_info.get("library_path") or self.cca.options.get("libraryPath")
+        )
+        signer = load_lighter_library(library_path)
+        url = self.cca.implode_hostname(self.cca.urls["api"]["public"])
+        api_key_index = int(self.user_info["api_key_index"])
+        account_index = int(self.user_info["account_index"])
+        res = signer.CreateClient(
+            url.encode("utf-8"),
+            self.cca.privateKey.encode("utf-8"),
+            self.cca.options["chainId"],
+            api_key_index,
+            account_index,
+        )
+        if res is not None:
+            err = res.decode("utf-8") if isinstance(res, bytes) else str(res)
+            if "error" in err.lower():
+                raise Exception(f"lighter: CreateClient failed: {err}")
+        self.cca.options["signer"] = signer
+        self._signer = signer
+
+    async def update_exchange_config_by_symbols(self, symbols):
+        """Set leverage and margin mode via direct signer call.
+
+        Bypasses CCXT's buggy load_account/lighter_sign_update_leverage
+        by calling self._signer.SignUpdateLeverage directly.
+        """
+        for symbol in symbols:
+            leverage = None
+            margin_mode = None
+            try:
+                leverage = self._calc_leverage_for_symbol(symbol)
+                margin_mode = self._get_margin_mode_for_symbol(symbol)
+                market = self.cca.market(symbol)
+                api_key_index = int(self.user_info["api_key_index"])
+                account_index = int(self.user_info["account_index"])
+                nonce = await self.cca.fetch_nonce(account_index, api_key_index)
+                tx_type, tx_info, _, error = decode_tx_info(
+                    self._signer.SignUpdateLeverage(
+                        int(market["id"]),
+                        int(10000 / leverage),
+                        0 if margin_mode == "cross" else 1,
+                        nonce,
+                        api_key_index,
+                        account_index,
+                    )
+                )
+                if error:
+                    raise Exception(error)
+                await self.cca.publicPostSendTx({
+                    "tx_type": tx_type,
+                    "tx_info": tx_info,
+                })
+                logging.info(f"{symbol}: set {margin_mode} margin, {leverage}x leverage")
+            except Exception as e:
+                err_str = str(e)
+                if "already" in err_str.lower() or "no change" in err_str.lower():
+                    logging.info(
+                        f"{symbol}: margin/leverage unchanged ({margin_mode}, {leverage}x)"
+                    )
+                else:
+                    # Propagate so the orchestrator's per-symbol retry/backoff
+                    # loop (see passivbot.py update_exchange_config) can handle it.
+                    raise
+            await asyncio.sleep(0.2)
+
+    def _build_order_params(self, order: dict) -> dict:
+        params = {
+            "reduceOnly": order["reduce_only"],
+            "clientOrderId": order["custom_id"],
+        }
+        if order.get("type") == "limit":
+            tif = require_live_value(self.config, "time_in_force")
+            if tif == "post_only":
+                params["postOnly"] = True
+            else:
+                # CCXT's Lighter adapter only maps 'gtt' and 'ioc' (not 'gtc');
+                # passing 'gtt' internally sets order_expiry=-1, giving GTC semantics.
+                params["timeInForce"] = "GTT"
+        return params
+
+    # ── REST overrides ────────────────────────────────────────
+
+    async def fetch_open_orders(self, symbol: str = None) -> list:
+        """Lighter requires per-symbol queries; gather across tracked symbols."""
+        if symbol is not None:
+            return await super().fetch_open_orders(symbol=symbol)
+        symbols_ = set()
+        symbols_.update(s for s in self.open_orders if self.open_orders[s])
+        symbols_.update(self.get_symbols_with_pos())
+        if hasattr(self, "active_symbols") and self.active_symbols:
+            symbols_.update(self.active_symbols)
+        if not symbols_:
+            return []
+        results = await asyncio.gather(
+            *[super().fetch_open_orders(symbol=s) for s in sorted(symbols_)]
+        )
+        return sorted(
+            [order for sublist in results for order in sublist],
+            key=lambda x: x["timestamp"],
+        )
+
+    # ── WebSocket support ──────────────────────────────────────
+
+    def can_watch_orders(self) -> bool:
+        """Override: Always True - we implement native WebSocket."""
+        return True
+
+    def _get_ws_url(self) -> str:
+        """Return WebSocket URL, respecting testnet setting."""
+        if self.cca.urls.get("test", {}).get("public"):
+            return "wss://testnet.zklighter.elliot.ai/stream"
+        return "wss://mainnet.zklighter.elliot.ai/stream"
+
+    async def _ws_connect(self):
+        """Establish WebSocket connection and subscribe to account channel."""
+        url = self._get_ws_url()
+        self._ws = await websockets.connect(url)
+        logging.info(f"lighter: WebSocket connected to {url}")
+
+        account_index = int(self.user_info["account_index"])
+        subscribe_msg = json.dumps({
+            "type": "subscribe",
+            "channel": f"account_all/{account_index}",
+        })
+        await self._ws.send(subscribe_msg)
+        raw = await self._ws.recv()
+        logging.info(f"lighter: subscription confirmation: {raw}")
+
+    async def _ws_receive(self) -> list:
+        """Receive and route WebSocket messages, returning order updates."""
+        while True:
+            try:
+                raw = await self._ws.recv()
+            except ConnectionClosed:
+                self._ws = None
+                raise
+
+            msg = json.loads(raw)
+
+            if msg.get("type") == "ping":
+                await self._ws.send(json.dumps({"type": "pong"}))
+                continue
+
+            if "update" not in msg.get("type", ""):
+                continue
+
+            return msg.get("orders") or []
+
+    async def _do_watch_orders(self) -> list:
+        """Hook: Connect if needed, then receive order updates."""
+        if self._ws is None or self._ws.closed:
+            await self._ws_connect()
+        return await self._ws_receive()
+
+    # ── Order normalization ────────────────────────────────────
+
+    def _normalize_order_update(self, order: dict) -> dict:
+        """Transform Lighter WS order format to passivbot format."""
+        custom_id = order.get("client_order_id") or ""
+        reduce_only = bool(order.get("reduce_only"))
+        if not reduce_only and custom_id:
+            snake = custom_id_to_snake(custom_id)
+            reduce_only = "close" in snake
+        price = float(order.get("price") or 0)
+        size = float(order.get("size") or 0)
+        normalized = {
+            "id": order.get("order_id"),
+            "symbol": order.get("symbol", ""),
+            "side": (order.get("side") or "").lower(),
+            "type": (order.get("order_type") or "limit").lower(),
+            "price": price,
+            "amount": size,
+            "qty": size,
+            "reduceOnly": reduce_only,
+            "status": self._normalize_status(order.get("status")),
+            "timestamp": order.get("timestamp"),
+            "clientOrderId": custom_id,
+            "custom_id": custom_id,
+            "info": order,
+        }
+        normalized["position_side"] = self._get_position_side_for_order(normalized)
+        return normalized
+
+    def _normalize_status(self, status: str) -> str:
+        """Map Lighter status strings to passivbot statuses."""
+        mapping = {
+            "open": "open",
+            "new": "open",
+            "partially_filled": "open",
+            "fully_filled": "closed",
+            "filled": "closed",
+            "canceled": "canceled",
+            "cancelled": "canceled",
+            "expired": "canceled",
+        }
+        return mapping.get(status, (status or "").lower())

--- a/src/exchanges/okx.py
+++ b/src/exchanges/okx.py
@@ -1,12 +1,9 @@
 from exchanges.ccxt_bot import CCXTBot, format_exchange_config_response
 from passivbot import logging
-import passivbot_rust as pbr
 
 import asyncio
 from utils import ts_to_date, utc_ms
 from config.access import require_live_value
-
-calc_order_price_diff = pbr.calc_order_price_diff
 
 
 class OKXBot(CCXTBot):
@@ -49,10 +46,6 @@ class OKXBot(CCXTBot):
             logging.warning(f"Unable to detect OKX account configuration: {e}")
 
     # ═══════════════════ HOOK OVERRIDES ═══════════════════
-
-    def _get_position_side_for_order(self, order: dict) -> str:
-        """OKX provides posSide in info."""
-        return order.get("info", {}).get("posSide", "long").lower()
 
     def _normalize_positions(self, fetched: list) -> list:
         """OKX: Preserve live positions across both cross and isolated margin modes."""
@@ -133,27 +126,6 @@ class OKXBot(CCXTBot):
             logging.debug(f"fetching income {ts_to_date(fetched[-1]['timestamp'])}")
             end_time = fetched[0]["timestamp"]
         return sorted(all_fetched.values(), key=lambda x: x["timestamp"])
-
-    async def gather_fill_events(self, start_time=None, end_time=None, limit=None):
-        """Return canonical fill events for OKX."""
-        events = []
-        fills = await self.fetch_pnls(start_time=start_time, end_time=end_time, limit=limit)
-        for fill in fills:
-            events.append(
-                {
-                    "id": fill.get("id"),
-                    "timestamp": fill.get("timestamp"),
-                    "symbol": fill.get("symbol"),
-                    "side": fill.get("side"),
-                    "position_side": fill.get("position_side"),
-                    "qty": fill.get("amount"),
-                    "price": fill.get("price"),
-                    "pnl": fill.get("pnl"),
-                    "fee": fill.get("fee"),
-                    "info": fill.get("info"),
-                }
-            )
-        return events
 
     async def fetch_pnl(
         self,
@@ -258,26 +230,8 @@ class OKXBot(CCXTBot):
                 logging.error("[config] error setting hedge mode: %s", e)
 
     async def calc_ideal_orders(self):
-        # okx has max 100 open orders. Drop orders whose pprice diff is greatest.
         ideal_orders = await super().calc_ideal_orders()
-        ideal_orders_tmp = []
-        for s in ideal_orders:
-            for x in ideal_orders[s]:
-                ideal_orders_tmp.append(
-                    (
-                        calc_order_price_diff(
-                            x["side"],
-                            x["price"],
-                            await self.cm.get_current_close(s, max_age_ms=10_000),
-                        ),
-                        {**x, **{"symbol": s}},
-                    )
-                )
-        ideal_orders_tmp = [x[1] for x in sorted(ideal_orders_tmp, key=lambda x: x[0])][:100]
-        ideal_orders = {symbol: [] for symbol in self.active_symbols}
-        for x in ideal_orders_tmp:
-            ideal_orders[x["symbol"]].append(x)
-        return ideal_orders
+        return await self._trim_orders_by_price_proximity(ideal_orders, 100)
 
     def format_custom_id_single(self, order_type_id: int) -> str:
         formatted = super().format_custom_id_single(order_type_id)

--- a/src/exchanges/paradex.py
+++ b/src/exchanges/paradex.py
@@ -15,7 +15,7 @@ import websockets
 from websockets.exceptions import ConnectionClosed
 
 from exchanges.ccxt_bot import CCXTBot
-from passivbot import logging
+from passivbot import logging, custom_id_to_snake
 
 
 class ParadexBot(CCXTBot):
@@ -153,6 +153,10 @@ class ParadexBot(CCXTBot):
     def _normalize_order_update(self, order: dict) -> dict:
         """Transform Paradex order format to passivbot format."""
         custom_id = order.get("client_id") or ""
+        reduce_only = bool(order.get("reduce_only"))
+        if not reduce_only and custom_id:
+            snake = custom_id_to_snake(custom_id)
+            reduce_only = "close" in snake
         normalized = {
             "id": order.get("id"),
             "symbol": self._paradex_market_to_symbol(order.get("market")),
@@ -161,6 +165,7 @@ class ParadexBot(CCXTBot):
             "price": float(order.get("price") or 0),
             "amount": float(order.get("size") or 0),
             "qty": float(order.get("size") or 0),
+            "reduceOnly": reduce_only,
             "status": self._normalize_status(order.get("status")),
             "timestamp": order.get("created_at"),
             "clientOrderId": custom_id,

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -3350,6 +3350,172 @@ class HyperliquidFetcher(BaseFetcher):
         }
 
 
+class LighterFetcher(BaseFetcher):
+    """Fetches fill events via ccxt.fetch_my_trades for Lighter."""
+
+    def __init__(
+        self,
+        api,
+        *,
+        trade_limit: int = 100,
+        symbol_resolver: Optional[Callable[[Optional[str]], str]] = None,
+    ) -> None:
+        self.api = api
+        self.trade_limit = max(1, trade_limit)
+        self._symbol_resolver = symbol_resolver
+
+    async def fetch(
+        self,
+        since_ms: Optional[int],
+        until_ms: Optional[int],
+        detail_cache: Dict[str, Tuple[str, str]],
+        on_batch: Optional[Callable[[List[Dict[str, object]]], None]] = None,
+    ) -> List[Dict[str, object]]:
+        params: Dict[str, object] = {"limit": self.trade_limit}
+        if since_ms is not None:
+            params["since"] = int(since_ms)
+
+        collected: Dict[str, Dict[str, object]] = {}
+        max_fetches = 200
+        fetch_count = 0
+
+        prev_params = None
+        rate_limit_retries = 0
+        max_rate_limit_retries = 5
+        while True:
+            check_params = dict(params)
+            check_params["_page"] = fetch_count
+            new_key = _check_pagination_progress(
+                prev_params,
+                check_params,
+                "LighterFetcher.fetch",
+            )
+            if new_key is None:
+                break
+            prev_params = new_key
+            try:
+                trades = await self.api.fetch_my_trades(params=params)
+            except RateLimitExceeded as exc:
+                rate_limit_retries += 1
+                if rate_limit_retries >= max_rate_limit_retries:
+                    msg = (
+                        "LighterFetcher.fetch: too many consecutive rate-limit retries "
+                        f"({rate_limit_retries}/{max_rate_limit_retries}); aborting fetch"
+                    )
+                    logger.warning("%s", msg)
+                    raise RateLimitExceeded(msg) from exc
+                logger.debug(
+                    "LighterFetcher.fetch: rate limit exceeded (retry %d/%d), sleeping (%s)",
+                    rate_limit_retries,
+                    max_rate_limit_retries,
+                    exc,
+                )
+                await asyncio.sleep(min(30.0, 2.0 ** rate_limit_retries))
+                prev_params = None
+                continue
+            rate_limit_retries = 0
+            fetch_count += 1
+            if fetch_count > 1:
+                logger.debug(
+                    "LighterFetcher.fetch: fetch #%d since=%s size=%d",
+                    fetch_count,
+                    _format_ms(params.get("since")),
+                    len(trades) if trades else 0,
+                )
+            if not trades:
+                break
+            before_count = len(collected)
+            for trade in trades:
+                event = self._normalize_trade(trade)
+                ts = event["timestamp"]
+                if since_ms is not None and ts < since_ms:
+                    continue
+                if until_ms is not None and ts > until_ms:
+                    continue
+                collected[event["id"]] = event
+            added = len(collected) - before_count
+            if len(trades) < self.trade_limit:
+                break
+            last_ts = int(
+                trades[-1].get("timestamp")
+                or trades[-1].get("info", {}).get("timestamp")
+                or 0
+            )
+            if last_ts <= 0:
+                break
+            if until_ms is not None and last_ts >= until_ms:
+                break
+            if added <= 0:
+                logger.debug(
+                    "LighterFetcher.fetch: no new trades added on page (last_ts=%s), stopping",
+                    last_ts,
+                )
+                break
+            params["since"] = last_ts
+            if fetch_count >= max_fetches:
+                logger.warning(
+                    "LighterFetcher.fetch: reached maximum pagination depth (%d)",
+                    max_fetches,
+                )
+                break
+
+        events = sorted(collected.values(), key=lambda ev: ev["timestamp"])
+        events = _coalesce_events(events)
+
+        for event in events:
+            cache_entry = detail_cache.get(event["id"])
+            if cache_entry:
+                event["client_order_id"], event["pb_order_type"] = cache_entry
+            elif event["client_order_id"]:
+                event["pb_order_type"] = custom_id_to_snake(event["client_order_id"])
+            else:
+                event["pb_order_type"] = "unknown"
+            if not event["pb_order_type"]:
+                event["pb_order_type"] = "unknown"
+
+        if on_batch and events:
+            on_batch(events)
+
+        return events
+
+    @staticmethod
+    def _normalize_trade(trade: Dict[str, object]) -> Dict[str, object]:
+        info = trade.get("info", {}) or {}
+        trade_id = str(trade.get("id") or info.get("trade_id") or "")
+        order_id = str(trade.get("order") or "")
+        timestamp = int(trade.get("timestamp") or info.get("timestamp") or 0)
+        symbol_raw = trade.get("symbol") or ""
+        side = str(trade.get("side") or "").lower()
+        qty = abs(float(trade.get("amount") or 0.0))
+        price = float(trade.get("price") or 0.0)
+        pnl = float(trade.get("pnl") or 0.0)
+        fee = trade.get("fee") or {"currency": "USDC", "cost": 0.0}
+        client_order_id = str(
+            trade.get("clientOrderId")
+            or info.get("ask_client_id")
+            or info.get("bid_client_id")
+            or ""
+        )
+        position_side = "long" if side == "buy" else "short"
+        return {
+            "id": trade_id,
+            "order_id": order_id,
+            "timestamp": timestamp,
+            "datetime": ts_to_date(timestamp) if timestamp else "",
+            "symbol": str(symbol_raw),
+            "side": side,
+            "qty": qty,
+            "price": price,
+            "pnl": pnl,
+            "fees": fee,
+            "pb_order_type": "",
+            "position_side": position_side,
+            "client_order_id": client_order_id,
+            "raw": [{"source": "fetch_my_trades", "data": trade}],
+            "c_mult": 1.0,
+        }
+
+
 class GateioFetcher(BaseFetcher):
     """Fetches fill events for Gate.io using trades + order PnL.
 
@@ -4674,6 +4840,11 @@ def _build_fetcher_for_bot(bot, symbols: List[str]) -> BaseFetcher:
         return FakeFetcher(api=bot.cca)
     if exchange == "hyperliquid":
         return HyperliquidFetcher(
+            api=bot.cca,
+            symbol_resolver=lambda value: resolver(value),
+        )
+    if exchange == "lighter":
+        return LighterFetcher(
             api=bot.cca,
             symbol_resolver=lambda value: resolver(value),
         )

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -5973,6 +5973,97 @@ class Passivbot:
         res = log_dict_changes(previous_PB_modes, self.PB_modes)
         self._log_mode_changes(res, previous_PB_modes)
 
+    def _log_inactive_symbol_reasons(
+        self,
+        diagnostics: dict,
+        idx_to_symbol: dict[int, str],
+        input_dict: dict,
+    ) -> None:
+        """Log why symbols were not activated by the orchestrator.
+
+        Checks each inactive symbol against known rejection causes (min cost,
+        one-way block, pside disabled) and emits an INFO log with specifics.
+        Throttled to once per 5 minutes per symbol/pside to avoid spam.
+        """
+        if not hasattr(self, "_inactive_reason_last_log_ms"):
+            self._inactive_reason_last_log_ms = {}
+        throttle_ms = 300_000
+        now_ms = utc_ms()
+
+        symbol_states = diagnostics.get("symbol_states", [])
+        if not symbol_states:
+            return
+
+        balance = float(input_dict.get("balance", 0.0))
+        filter_enabled = bool(
+            input_dict.get("global", {}).get("filter_by_min_effective_cost", False)
+        )
+
+        for row in symbol_states:
+            if not isinstance(row, dict):
+                continue
+            symbol_idx = int(row.get("symbol_idx", -1))
+            symbol = idx_to_symbol.get(symbol_idx)
+            if symbol is None:
+                continue
+
+            for pside in ("long", "short"):
+                if not self.is_pside_enabled(pside):
+                    continue
+                side_state = row.get(pside, {})
+                if not isinstance(side_state, dict):
+                    continue
+                if side_state.get("active", False):
+                    continue
+
+                # Symbol is inactive for this pside — diagnose why
+                throttle_key = f"{symbol}:{pside}"
+                last_ms = self._inactive_reason_last_log_ms.get(throttle_key, 0)
+                if (now_ms - last_ms) < throttle_ms:
+                    continue
+                self._inactive_reason_last_log_ms[throttle_key] = now_ms
+
+                coin = symbol.split("/")[0] if "/" in symbol else symbol
+                reasons = []
+
+                # Check effective min cost
+                if filter_enabled:
+                    emc = float(self.effective_min_cost.get(symbol, 0.0) or 0.0)
+                    if emc <= 0.0:
+                        mprice = float(
+                            input_dict.get("symbols", [{}])[symbol_idx]
+                            .get("order_book", {})
+                            .get("bid", 0.0)
+                            if symbol_idx < len(input_dict.get("symbols", []))
+                            else 0.0
+                        )
+                        if mprice > 0.0:
+                            emc = self._calc_effective_min_cost_at_price(symbol, mprice)
+                    wel = float(self.bot_value(pside, "total_wallet_exposure_limit") or 0.0)
+                    n_pos = float(self.bot_value(pside, "n_positions") or 0.0)
+                    if n_pos > 0.0:
+                        wel_per_sym = wel / n_pos
+                    else:
+                        wel_per_sym = wel
+                    qty_pct = float(self.bp(pside, "entry_initial_qty_pct", symbol))
+                    budget = balance * wel_per_sym * qty_pct
+                    if emc > 0.0 and budget < emc:
+                        reasons.append(
+                            f"min_cost: budget={budget:.2f} < effective_min_cost={emc:.2f}"
+                            f" (balance={balance:.2f} × WEL/n={wel_per_sym:.2f}"
+                            f" × qty_pct={qty_pct:.4f})"
+                        )
+
+                if not reasons:
+                    reasons.append("not selected by orchestrator (check forager scoring or EMA data)")
+
+                logging.info(
+                    "[orchestrator] %s %s inactive: %s",
+                    coin,
+                    pside,
+                    "; ".join(reasons),
+                )
+
     def _orchestrator_mode_override(self, pside: str, symbol: str) -> Optional[str]:
         if self._equity_hard_stop_enabled(pside):
             state = self._hsl_state(pside)
@@ -6717,6 +6808,11 @@ class Passivbot:
                 idx_to_symbol,
                 mode_overrides,
             )
+        self._log_inactive_symbol_reasons(
+            out.get("diagnostics", {}),
+            idx_to_symbol,
+            input_dict,
+        )
         orders = out.get("orders", [])
         if hasattr(self, "_update_monitor_runtime_hints"):
             self._update_monitor_runtime_hints(
@@ -8295,6 +8391,10 @@ def setup_bot(config):
         from exchanges.kucoin import KucoinBot
 
         bot = KucoinBot(config)
+    elif user_info["exchange"] == "lighter":
+        from exchanges.lighter import LighterBot
+
+        bot = LighterBot(config)
     elif user_info["exchange"] == "paradex":
         from exchanges.paradex import ParadexBot
 

--- a/src/pure_funcs.py
+++ b/src/pure_funcs.py
@@ -18,7 +18,6 @@ __all__ = [
     "flatten",
     "floatify",
     "shorten_custom_id",
-    "determine_pos_side_ccxt",
     "calc_hash",
     "ensure_millis",
     "multi_replace",
@@ -150,36 +149,6 @@ def shorten_custom_id(id_: str) -> str:
     for before, after in replacements:
         id_ = id_.replace(before, after)
     return id_
-
-
-def determine_pos_side_ccxt(open_order: dict) -> str:
-    info = open_order.get("info", open_order)
-    if "positionIdx" in info:
-        idx = float(info["positionIdx"])
-        if idx == 1.0:
-            return "long"
-        if idx == 2.0:
-            return "short"
-
-    keys_map = {key.lower().replace("_", ""): key for key in info}
-    for pos_key in ("posside", "positionside"):
-        if pos_key in keys_map:
-            return info[keys_map[pos_key]].lower()
-
-    if info.get("side", "").lower() == "buy":
-        if "reduceonly" in keys_map:
-            return "long" if not info[keys_map["reduceonly"]] else "short"
-        if "closedsize" in keys_map:
-            return "long" if float(info[keys_map["closedsize"]]) != 0.0 else "short"
-
-    for key in ["order_link_id", "clOrdId", "clientOid", "orderLinkId"]:
-        if key in info:
-            value = info[key].lower()
-            if "long" in value or "lng" in value:
-                return "long"
-            if "short" in value or "shrt" in value:
-                return "short"
-    return "both"
 
 
 def calc_hash(data) -> str:

--- a/tests/exchanges/test_ccxt_bot.py
+++ b/tests/exchanges/test_ccxt_bot.py
@@ -230,7 +230,7 @@ class TestCCXTBotFetchOpenOrders:
         assert orders[0]["id"] == "123"
         assert orders[0]["position_side"] == "long"
         assert orders[0]["qty"] == 0.1
-        assert orders[1]["position_side"] == "both"  # Fallback
+        assert orders[1]["position_side"] == "short"  # sell + !reduceOnly = short
         assert orders[1]["qty"] == 0.2
         # Should be sorted by timestamp
         assert orders[0]["timestamp"] < orders[1]["timestamp"]
@@ -258,12 +258,11 @@ class TestCCXTBotWatchOrders:
         async def mock_watch_orders():
             call_count[0] += 1
             if call_count[0] == 1:
-                return [{"id": "order1", "amount": 0.5, "info": {"positionSide": "LONG"}}]
+                return [{"id": "order1", "amount": 0.5, "side": "buy", "reduceOnly": False}]
             else:
                 # Stop after processing first batch
                 bot.stop_websocket = True
-                # Return order that triggers stop on next iteration
-                return [{"id": "order2", "amount": 1.0, "info": {}}]
+                return [{"id": "order2", "amount": 1.0, "side": "sell", "reduceOnly": False}]
 
         bot.ccp = MagicMock()
         bot.ccp.has = {"watchOrders": True}  # Required for can_watch_orders()
@@ -759,18 +758,3 @@ class TestCCXTBotFetchOHLCV:
         assert call_count[0] == 2  # Two paginated calls
 
 
-class TestCCXTBotValidateWebSocketSupport:
-    """Tests for validate_websocket_support."""
-
-    @pytest.mark.asyncio
-    async def test_validates_watch_orders_support(self):
-        """Test that method passes when watchOrders is supported."""
-        from exchanges.ccxt_bot import CCXTBot
-
-        bot = CCXTBot.__new__(CCXTBot)
-        bot.exchange = "testexchange"
-        bot.ccp = MagicMock()
-        bot.ccp.has = {"watchOrders": True}
-
-        # Should not raise
-        await bot.validate_websocket_support()

--- a/tests/exchanges/test_ccxt_bot_hooks.py
+++ b/tests/exchanges/test_ccxt_bot_hooks.py
@@ -40,14 +40,15 @@ class TestCanWatchOrders:
 class TestNormalizeOrderUpdate:
     """Test _normalize_order_update() hook."""
 
-    def test_adds_position_side_from_info(self):
-        """Should extract position_side from info.positionSide."""
+    def test_adds_position_side_from_side_and_reduce_only(self):
+        """Should derive position_side from side + reduceOnly."""
         from exchanges.ccxt_bot import CCXTBot
 
         bot = CCXTBot.__new__(CCXTBot)
         order = {
             "amount": 1.5,
-            "info": {"positionSide": "LONG"},
+            "side": "buy",
+            "reduceOnly": False,
         }
 
         result = bot._normalize_order_update(order)
@@ -55,12 +56,12 @@ class TestNormalizeOrderUpdate:
         assert result["position_side"] == "long"
         assert result["qty"] == 1.5
 
-    def test_defaults_position_side_to_both(self):
-        """Should default position_side to 'both' when not in info."""
+    def test_defaults_position_side_to_both_when_no_side(self):
+        """Should default position_side to 'both' when no side field."""
         from exchanges.ccxt_bot import CCXTBot
 
         bot = CCXTBot.__new__(CCXTBot)
-        order = {"amount": 2.0, "info": {}}
+        order = {"amount": 2.0}
 
         result = bot._normalize_order_update(order)
 
@@ -95,7 +96,7 @@ class TestWatchOrdersTemplateMethod:
 
         # Mock the hooks
         bot._do_watch_orders = AsyncMock(
-            return_value=[{"amount": 1.0, "info": {"positionSide": "LONG"}}]
+            return_value=[{"amount": 1.0, "side": "buy", "reduceOnly": False}]
         )
 
         # Set stop_websocket = True after first call to exit loop
@@ -216,35 +217,6 @@ class TestCreateCcxtSessionsWebSocketOptional:
             bot.create_ccxt_sessions()
 
         assert bot.ccp is None
-
-
-class TestValidateWebsocketSupport:
-    """Test validate_websocket_support() is non-fatal."""
-
-    @pytest.mark.asyncio
-    async def test_does_not_raise_when_watch_orders_not_supported(self):
-        """Should log warning instead of raising when watchOrders not supported."""
-        from exchanges.ccxt_bot import CCXTBot
-
-        bot = CCXTBot.__new__(CCXTBot)
-        bot.ccp = MagicMock()
-        bot.ccp.has = {"watchOrders": False}
-        bot.exchange = "test_exchange"
-
-        # Should not raise
-        await bot.validate_websocket_support()
-
-    @pytest.mark.asyncio
-    async def test_does_not_raise_when_ccp_is_none(self):
-        """Should handle ccp=None gracefully."""
-        from exchanges.ccxt_bot import CCXTBot
-
-        bot = CCXTBot.__new__(CCXTBot)
-        bot.ccp = None
-        bot.exchange = "test_exchange"
-
-        # Should not raise
-        await bot.validate_websocket_support()
 
 
 class TestGetPnlFromTrade:

--- a/tests/exchanges/test_ccxt_bot_position_side.py
+++ b/tests/exchanges/test_ccxt_bot_position_side.py
@@ -1,53 +1,48 @@
-"""Tests for CCXTBot._get_position_side_for_order() hook."""
+"""Tests for CCXTBot._get_position_side_for_order() — side + reduceOnly derivation."""
 
 import pytest
 
 
 class TestGetPositionSideForOrder:
-    """Test the position_side derivation hook."""
+    """Test position_side derivation from CCXT unified side + reduceOnly."""
 
-    def test_uses_position_side_from_info_when_present(self):
-        """When exchange provides positionSide in info, use it."""
+    def _make_bot(self):
         from exchanges.ccxt_bot import CCXTBot
 
-        # Create minimal instance (no real exchange connection needed)
-        bot = CCXTBot.__new__(CCXTBot)
+        return CCXTBot.__new__(CCXTBot)
 
-        order = {"info": {"positionSide": "LONG"}}
+    def test_buy_entry_is_long(self):
+        bot = self._make_bot()
+        order = {"side": "buy", "reduceOnly": False}
         assert bot._get_position_side_for_order(order) == "long"
 
-        order = {"info": {"positionSide": "SHORT"}}
+    def test_buy_reduce_only_is_short(self):
+        bot = self._make_bot()
+        order = {"side": "buy", "reduceOnly": True}
         assert bot._get_position_side_for_order(order) == "short"
 
-    def test_derives_from_client_order_id_when_no_position_side(self):
-        """When no positionSide, derive from clientOrderId order type suffix."""
-        from exchanges.ccxt_bot import CCXTBot
+    def test_sell_entry_is_short(self):
+        bot = self._make_bot()
+        order = {"side": "sell", "reduceOnly": False}
+        assert bot._get_position_side_for_order(order) == "short"
 
-        bot = CCXTBot.__new__(CCXTBot)
+    def test_sell_reduce_only_is_long(self):
+        bot = self._make_bot()
+        order = {"side": "sell", "reduceOnly": True}
+        assert bot._get_position_side_for_order(order) == "long"
 
-        # clientOrderId encodes order type - 0x0000 = entry_initial_normal_long (ID 0)
-        # The hex pattern "0x0000" decodes to type ID 0 which is "entry_initial_normal_long"
-        order = {"info": {}, "clientOrderId": "pb-0x0000-abc123"}
-        result = bot._get_position_side_for_order(order)
-        assert result == "long"
+    def test_missing_reduce_only_defaults_to_false(self):
+        bot = self._make_bot()
+        order = {"side": "buy"}
+        assert bot._get_position_side_for_order(order) == "long"
 
-        # 0x0012 = close_grid_short (ID 18)
-        order = {"info": {}, "clientOrderId": "pb-0x0012-xyz789"}
-        result = bot._get_position_side_for_order(order)
-        assert result == "short"
+        order = {"side": "sell"}
+        assert bot._get_position_side_for_order(order) == "short"
 
-    def test_returns_both_when_no_position_side_and_no_client_order_id(self):
-        """When neither positionSide nor clientOrderId available, return 'both'."""
-        from exchanges.ccxt_bot import CCXTBot
-
-        bot = CCXTBot.__new__(CCXTBot)
-
-        order = {"info": {}}
+    def test_missing_side_returns_both(self):
+        bot = self._make_bot()
+        order = {}
         assert bot._get_position_side_for_order(order) == "both"
 
-        order = {"info": {}, "clientOrderId": ""}
-        assert bot._get_position_side_for_order(order) == "both"
-
-        # Also test with invalid clientOrderId that doesn't decode to a valid type
-        order = {"info": {}, "clientOrderId": "invalid-no-hex"}
+        order = {"reduceOnly": True}
         assert bot._get_position_side_for_order(order) == "both"

--- a/tests/exchanges/test_lighter.py
+++ b/tests/exchanges/test_lighter.py
@@ -1,0 +1,596 @@
+"""Tests for LighterBot exchange adapter."""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ═══════════════════ Task 2: Skeleton tests ═══════════════════
+
+
+class TestLighterBotInit:
+    """Test LighterBot initialization and basic attributes."""
+
+    def _make_bot(self, user_info=None):
+        with patch("exchanges.lighter.CCXTBot.__init__", return_value=None):
+            from exchanges.lighter import LighterBot
+
+            bot = LighterBot.__new__(LighterBot)
+            bot.user_info = user_info or {
+                "private_key": "0xdeadbeef",
+                "api_key_index": "1",
+                "account_index": "42",
+            }
+            bot.quote = "USDC"
+            bot.hedge_mode = False
+            bot._ws = None
+            return bot
+
+    def test_quote_is_usdc(self):
+        bot = self._make_bot()
+        assert bot.quote == "USDC"
+
+    def test_hedge_mode_is_false(self):
+        bot = self._make_bot()
+        assert bot.hedge_mode is False
+
+    def test_ws_state_initialized(self):
+        bot = self._make_bot()
+        assert bot._ws is None
+
+
+class TestLighterBotCcxtConfig:
+    """Test _build_ccxt_config maps auth fields correctly."""
+
+    def _make_bot(self, user_info):
+        with patch("exchanges.lighter.CCXTBot.__init__", return_value=None):
+            from exchanges.lighter import LighterBot
+
+            bot = LighterBot.__new__(LighterBot)
+            bot.user_info = user_info
+            return bot
+
+    def test_build_ccxt_config_maps_fields(self):
+        bot = self._make_bot({
+            "private_key": "0xabc123",
+            "api_key_index": "5",
+            "account_index": "99",
+        })
+        config = bot._build_ccxt_config()
+        assert config["enableRateLimit"] is True
+        assert config["privateKey"] == "0xabc123"
+        assert config["options"]["apiKeyIndex"] == 5
+        assert config["options"]["accountIndex"] == 99
+
+    def test_build_ccxt_config_with_library_path(self):
+        bot = self._make_bot({
+            "private_key": "0xabc123",
+            "api_key_index": "5",
+            "account_index": "99",
+            "library_path": "/usr/lib/lighter.so",
+        })
+        config = bot._build_ccxt_config()
+        assert config["options"]["libraryPath"] == "/usr/lib/lighter.so"
+
+    def test_build_ccxt_config_without_library_path(self):
+        bot = self._make_bot({
+            "private_key": "0xabc123",
+            "api_key_index": "5",
+            "account_index": "99",
+        })
+        config = bot._build_ccxt_config()
+        assert "libraryPath" not in config["options"]
+
+    def test_build_ccxt_config_sets_default_timeout(self):
+        """Match CCXTBot base — CCXT's ~10s default is too tight on cold boot (see PR 576)."""
+        bot = self._make_bot({
+            "private_key": "0xabc123",
+            "api_key_index": "5",
+            "account_index": "99",
+        })
+        config = bot._build_ccxt_config()
+        assert config["timeout"] == 30000
+
+
+class TestLighterBotMarginMode:
+    """Test that LighterBot inherits base class margin mode support."""
+
+    def test_no_margin_mode_override(self):
+        """LighterBot should NOT override _should_set_margin_mode (supports both modes)."""
+        from exchanges.lighter import LighterBot
+        from exchanges.ccxt_bot import CCXTBot
+
+        # LighterBot should use the base class implementation, not override it
+        assert "_should_set_margin_mode" not in LighterBot.__dict__
+
+
+# ═══════════════════ Task 1: Signer init ═══════════════════
+
+
+class TestLighterSignerInit:
+    """Test create_ccxt_sessions loads native signer and injects it."""
+
+    def _make_bot(self, user_info=None):
+        with patch("exchanges.lighter.CCXTBot.__init__", return_value=None):
+            from exchanges.lighter import LighterBot
+
+            bot = LighterBot.__new__(LighterBot)
+            bot.user_info = user_info or {
+                "private_key": "0xdeadbeef",
+                "api_key_index": "1",
+                "account_index": "42",
+                "library_path": "/usr/lib/lighter.so",
+            }
+            bot.exchange = "lighter"
+            bot.ws_enabled = False
+            bot.cca = MagicMock()
+            bot.cca.privateKey = "0xdeadbeef"
+            bot.cca.options = {"chainId": 304}
+            bot.cca.urls = {"api": {"public": "https://mainnet.zklighter.elliot.ai"}}
+            bot.cca.implode_hostname = MagicMock(
+                return_value="https://mainnet.zklighter.elliot.ai"
+            )
+            return bot
+
+    @patch("exchanges.lighter.CCXTBot.create_ccxt_sessions")
+    @patch("exchanges.lighter.load_lighter_library")
+    def test_creates_client_and_injects_signer(self, mock_load, mock_super):
+        mock_signer = MagicMock()
+        mock_signer.CreateClient.return_value = None  # success
+        mock_load.return_value = mock_signer
+
+        bot = self._make_bot()
+        bot.create_ccxt_sessions()
+
+        mock_load.assert_called_once_with("/usr/lib/lighter.so")
+        mock_signer.CreateClient.assert_called_once_with(
+            b"https://mainnet.zklighter.elliot.ai",
+            b"0xdeadbeef",
+            304,
+            1,
+            42,
+        )
+        assert bot._signer is mock_signer
+        assert bot.cca.options["signer"] is mock_signer
+
+    @patch("exchanges.lighter.CCXTBot.create_ccxt_sessions")
+    @patch("exchanges.lighter.load_lighter_library")
+    def test_raises_on_create_client_error(self, mock_load, mock_super):
+        mock_signer = MagicMock()
+        mock_signer.CreateClient.return_value = b"error: invalid key"
+        mock_load.return_value = mock_signer
+
+        bot = self._make_bot()
+        with pytest.raises(Exception, match="CreateClient failed"):
+            bot.create_ccxt_sessions()
+
+    @patch("exchanges.lighter.CCXTBot.create_ccxt_sessions")
+    @patch("exchanges.lighter.load_lighter_library")
+    def test_falls_back_to_ccxt_library_path(self, mock_load, mock_super):
+        mock_signer = MagicMock()
+        mock_signer.CreateClient.return_value = None
+        mock_load.return_value = mock_signer
+
+        bot = self._make_bot(user_info={
+            "private_key": "0xdeadbeef",
+            "api_key_index": "1",
+            "account_index": "42",
+        })
+        bot.cca.options["libraryPath"] = "/fallback/lighter.so"
+        bot.create_ccxt_sessions()
+
+        mock_load.assert_called_once_with("/fallback/lighter.so")
+
+
+# ═══════════════════ Task 2: update_exchange_config_by_symbols ═══════════════════
+
+
+class TestLighterUpdateExchangeConfig:
+    """Test update_exchange_config_by_symbols calls signer directly."""
+
+    def _make_bot(self):
+        with patch("exchanges.lighter.CCXTBot.__init__", return_value=None):
+            from exchanges.lighter import LighterBot
+
+            bot = LighterBot.__new__(LighterBot)
+            bot.user_info = {
+                "api_key_index": "1",
+                "account_index": "42",
+            }
+            bot.config = {"live": {"TWE_long": 1.5, "TWE_short": 1.5}}
+            bot._signer = MagicMock()
+            bot.cca = MagicMock()
+            bot.cca.market.return_value = {"id": "3"}
+            bot.cca.fetch_nonce = AsyncMock(return_value=100)
+            bot.cca.publicPostSendTx = AsyncMock(return_value={})
+            return bot
+
+    @pytest.mark.asyncio
+    @patch("exchanges.lighter.decode_tx_info")
+    async def test_signs_and_submits_leverage_tx(self, mock_decode):
+        mock_decode.return_value = (7, "signed_data", "hash", None)
+        bot = self._make_bot()
+        bot._calc_leverage_for_symbol = MagicMock(return_value=5)
+        bot._get_margin_mode_for_symbol = MagicMock(return_value="cross")
+
+        await bot.update_exchange_config_by_symbols(["HYPE/USDC:USDC"])
+
+        bot._signer.SignUpdateLeverage.assert_called_once_with(3, 2000, 0, 100, 1, 42)
+        bot.cca.publicPostSendTx.assert_called_once_with({
+            "tx_type": 7,
+            "tx_info": "signed_data",
+        })
+
+    @pytest.mark.asyncio
+    @patch("exchanges.lighter.decode_tx_info")
+    async def test_isolated_margin_mode_value(self, mock_decode):
+        mock_decode.return_value = (7, "signed_data", "hash", None)
+        bot = self._make_bot()
+        bot._calc_leverage_for_symbol = MagicMock(return_value=10)
+        bot._get_margin_mode_for_symbol = MagicMock(return_value="isolated")
+
+        await bot.update_exchange_config_by_symbols(["HYPE/USDC:USDC"])
+
+        # margin_mode=1 for isolated
+        call_args = bot._signer.SignUpdateLeverage.call_args[0]
+        assert call_args[2] == 1
+        # initial_margin_fraction = 10000 / 10 = 1000
+        assert call_args[1] == 1000
+
+    @pytest.mark.asyncio
+    @patch("exchanges.lighter.decode_tx_info")
+    async def test_signer_error_propagates(self, mock_decode):
+        """Generic signer errors must raise so the orchestrator's retry/backoff
+        loop in passivbot.update_exchange_config can handle them."""
+        mock_decode.return_value = (None, None, None, "some signer error")
+        bot = self._make_bot()
+        bot._calc_leverage_for_symbol = MagicMock(return_value=5)
+        bot._get_margin_mode_for_symbol = MagicMock(return_value="cross")
+
+        with pytest.raises(Exception, match="some signer error"):
+            await bot.update_exchange_config_by_symbols(["HYPE/USDC:USDC"])
+        bot.cca.publicPostSendTx.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("exchanges.lighter.decode_tx_info")
+    async def test_already_set_is_info_not_error(self, mock_decode):
+        mock_decode.return_value = (None, None, None, "leverage already set")
+        bot = self._make_bot()
+        bot._calc_leverage_for_symbol = MagicMock(return_value=5)
+        bot._get_margin_mode_for_symbol = MagicMock(return_value="cross")
+
+        # Should not raise — "already" is expected
+        await bot.update_exchange_config_by_symbols(["HYPE/USDC:USDC"])
+
+
+# ═══════════════════ Task 3: Position side logic ═══════════════════
+
+
+class TestLighterPositionSide:
+    """Test _get_position_side_for_order one-way mode logic."""
+
+    def _make_bot(self, positions=None):
+        with patch("exchanges.lighter.CCXTBot.__init__", return_value=None):
+            from exchanges.lighter import LighterBot
+
+            bot = LighterBot.__new__(LighterBot)
+            bot.positions = positions or {}
+            return bot
+
+    def test_has_long_position_returns_long(self):
+        bot = self._make_bot({
+            "BTC/USDC:USDC": {"long": {"size": 1.0}, "short": {"size": 0.0}},
+        })
+        order = {"symbol": "BTC/USDC:USDC", "side": "sell", "reduceOnly": True}
+        assert bot._get_position_side_for_order(order) == "long"
+
+    def test_has_short_position_returns_short(self):
+        bot = self._make_bot({
+            "BTC/USDC:USDC": {"long": {"size": 0.0}, "short": {"size": -1.0}},
+        })
+        order = {"symbol": "BTC/USDC:USDC", "side": "buy", "reduceOnly": True}
+        assert bot._get_position_side_for_order(order) == "short"
+
+    def test_no_position_reduce_only_buy_returns_short(self):
+        """When symbol not in positions dict, reduceOnly buy -> short."""
+        bot = self._make_bot({})
+        order = {"symbol": "BTC/USDC:USDC", "side": "buy", "reduceOnly": True}
+        assert bot._get_position_side_for_order(order) == "short"
+
+    def test_no_position_reduce_only_sell_returns_long(self):
+        """When symbol not in positions dict, reduceOnly sell -> long."""
+        bot = self._make_bot({})
+        order = {"symbol": "BTC/USDC:USDC", "side": "sell", "reduceOnly": True}
+        assert bot._get_position_side_for_order(order) == "long"
+
+    def test_no_position_buy_returns_long(self):
+        bot = self._make_bot({
+            "BTC/USDC:USDC": {"long": {"size": 0.0}, "short": {"size": 0.0}},
+        })
+        order = {"symbol": "BTC/USDC:USDC", "side": "buy", "reduceOnly": False}
+        assert bot._get_position_side_for_order(order) == "long"
+
+    def test_no_position_sell_returns_short(self):
+        bot = self._make_bot({
+            "BTC/USDC:USDC": {"long": {"size": 0.0}, "short": {"size": 0.0}},
+        })
+        order = {"symbol": "BTC/USDC:USDC", "side": "sell", "reduceOnly": False}
+        assert bot._get_position_side_for_order(order) == "short"
+
+    def test_symbol_not_in_positions_buy_returns_long(self):
+        bot = self._make_bot({})
+        order = {"symbol": "BTC/USDC:USDC", "side": "buy"}
+        assert bot._get_position_side_for_order(order) == "long"
+
+
+# ═══════════════════ Task 4: Order params ═══════════════════
+
+
+class TestLighterOrderParams:
+    """Test _build_order_params for limit/market orders."""
+
+    def _make_bot(self, tif="post_only"):
+        with patch("exchanges.lighter.CCXTBot.__init__", return_value=None):
+            from exchanges.lighter import LighterBot
+
+            bot = LighterBot.__new__(LighterBot)
+            bot.config = {"live": {"time_in_force": tif}}
+            return bot
+
+    def test_limit_order_post_only(self):
+        bot = self._make_bot(tif="post_only")
+        order = {
+            "type": "limit",
+            "reduce_only": False,
+            "custom_id": "abc123",
+        }
+        params = bot._build_order_params(order)
+        assert params["reduceOnly"] is False
+        assert params["clientOrderId"] == "abc123"
+        assert params["postOnly"] is True
+        assert "timeInForce" not in params
+
+    def test_limit_order_gtc(self):
+        bot = self._make_bot(tif="gtc")
+        order = {
+            "type": "limit",
+            "reduce_only": True,
+            "custom_id": "def456",
+        }
+        params = bot._build_order_params(order)
+        assert params["reduceOnly"] is True
+        assert params["clientOrderId"] == "def456"
+        # Lighter uses GTT (Good Till Time with expiry=-1) for GTC-equivalent behavior
+        assert params["timeInForce"] == "GTT"
+        assert "postOnly" not in params
+
+    def test_market_order_no_tif_params(self):
+        bot = self._make_bot(tif="post_only")
+        order = {
+            "type": "market",
+            "reduce_only": True,
+            "custom_id": "ghi789",
+        }
+        params = bot._build_order_params(order)
+        assert params["reduceOnly"] is True
+        assert params["clientOrderId"] == "ghi789"
+        assert "postOnly" not in params
+        assert "timeInForce" not in params
+
+
+# ═══════════════════ Task 5: WebSocket tests ═══════════════════
+
+
+class TestLighterWebSocketUrl:
+    """Test _get_ws_url returns correct URL based on testnet config."""
+
+    def _make_bot(self, test_urls=None):
+        with patch("exchanges.lighter.CCXTBot.__init__", return_value=None):
+            from exchanges.lighter import LighterBot
+
+            bot = LighterBot.__new__(LighterBot)
+            bot.cca = MagicMock()
+            bot.cca.urls = {"test": test_urls or {}}
+            return bot
+
+    def test_mainnet_url(self):
+        bot = self._make_bot(test_urls={})
+        assert bot._get_ws_url() == "wss://mainnet.zklighter.elliot.ai/stream"
+
+    def test_testnet_url(self):
+        bot = self._make_bot(test_urls={"public": "https://testnet.zklighter.elliot.ai"})
+        assert bot._get_ws_url() == "wss://testnet.zklighter.elliot.ai/stream"
+
+
+class TestLighterCanWatchOrders:
+    """Test can_watch_orders always returns True."""
+
+    def test_can_watch_orders_returns_true(self):
+        with patch("exchanges.lighter.CCXTBot.__init__", return_value=None):
+            from exchanges.lighter import LighterBot
+
+            bot = LighterBot.__new__(LighterBot)
+            assert bot.can_watch_orders() is True
+
+
+class TestLighterWsConnect:
+    """Test _ws_connect establishes connection and subscribes."""
+
+    def _make_bot(self, account_index=42):
+        with patch("exchanges.lighter.CCXTBot.__init__", return_value=None):
+            from exchanges.lighter import LighterBot
+
+            bot = LighterBot.__new__(LighterBot)
+            bot._ws = None
+            bot.cca = MagicMock()
+            bot.cca.urls = {"test": {}}
+            bot.user_info = {"account_index": str(account_index)}
+            return bot
+
+    @pytest.mark.asyncio
+    async def test_ws_connect_subscribes_to_account_all(self):
+        bot = self._make_bot(account_index=42)
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(return_value='{"type": "subscribed"}')
+
+        with patch("exchanges.lighter.websockets.connect", new_callable=AsyncMock, return_value=mock_ws):
+            await bot._ws_connect()
+
+        mock_ws.send.assert_called_once()
+        sent = json.loads(mock_ws.send.call_args[0][0])
+        assert sent["type"] == "subscribe"
+        assert sent["channel"] == "account_all/42"
+        assert bot._ws is mock_ws
+
+
+class TestLighterWsReceive:
+    """Test _ws_receive routes messages correctly."""
+
+    def _make_bot(self):
+        with patch("exchanges.lighter.CCXTBot.__init__", return_value=None):
+            from exchanges.lighter import LighterBot
+
+            bot = LighterBot.__new__(LighterBot)
+            bot._ws = AsyncMock()
+            bot.positions = {}
+            return bot
+
+    @pytest.mark.asyncio
+    async def test_receive_order_updates(self):
+        bot = self._make_bot()
+        msg = {"type": "order_update", "orders": [{"order_id": "1"}]}
+        bot._ws.recv = AsyncMock(return_value=json.dumps(msg))
+        result = await bot._ws_receive()
+        assert result == [{"order_id": "1"}]
+
+    @pytest.mark.asyncio
+    async def test_receive_null_orders_returns_empty_list(self):
+        """Regression: msg.get('orders', []) returned None when the server sent
+        JSON null, crashing the watch loop downstream. Use `or []` as a guard."""
+        bot = self._make_bot()
+        msg = {"type": "account_update", "orders": None}
+        bot._ws.recv = AsyncMock(return_value=json.dumps(msg))
+        result = await bot._ws_receive()
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_receive_handles_ping(self):
+        bot = self._make_bot()
+        ping_msg = json.dumps({"type": "ping"})
+        real_msg = json.dumps({"type": "order_update", "orders": [{"order_id": "2"}]})
+        bot._ws.recv = AsyncMock(side_effect=[ping_msg, real_msg])
+        result = await bot._ws_receive()
+        # Should have sent pong
+        bot._ws.send.assert_called_once()
+        pong = json.loads(bot._ws.send.call_args[0][0])
+        assert pong["type"] == "pong"
+        # Should return the real message orders
+        assert result == [{"order_id": "2"}]
+
+    @pytest.mark.asyncio
+    async def test_receive_connection_closed_sets_ws_none(self):
+        from websockets.exceptions import ConnectionClosed
+        from websockets.frames import Close
+
+        bot = self._make_bot()
+        close_frame = Close(1000, "normal")
+        bot._ws.recv = AsyncMock(
+            side_effect=ConnectionClosed(close_frame, None)
+        )
+        with pytest.raises(ConnectionClosed):
+            await bot._ws_receive()
+        assert bot._ws is None
+
+
+# ═══════════════════ Task 6: Order normalization tests ═══════════════════
+
+
+class TestLighterNormalizeOrderUpdate:
+    """Test _normalize_order_update maps fields correctly."""
+
+    def _make_bot(self, positions=None):
+        with patch("exchanges.lighter.CCXTBot.__init__", return_value=None):
+            from exchanges.lighter import LighterBot
+
+            bot = LighterBot.__new__(LighterBot)
+            bot.positions = positions or {}
+            return bot
+
+    def test_normalize_order_maps_fields(self):
+        bot = self._make_bot()
+        order = {
+            "order_id": "12345",
+            "symbol": "BTC/USDC:USDC",
+            "side": "Buy",
+            "order_type": "Limit",
+            "price": "50000.0",
+            "size": "0.5",
+            "status": "open",
+            "timestamp": 1700000000,
+            "client_order_id": "custom_abc",
+        }
+        result = bot._normalize_order_update(order)
+        assert result["id"] == "12345"
+        assert result["symbol"] == "BTC/USDC:USDC"
+        assert result["side"] == "buy"
+        assert result["type"] == "limit"
+        assert result["price"] == 50000.0
+        assert result["amount"] == 0.5
+        assert result["qty"] == 0.5
+        assert result["status"] == "open"
+        assert result["timestamp"] == 1700000000
+        assert result["clientOrderId"] == "custom_abc"
+        assert result["custom_id"] == "custom_abc"
+        assert result["info"] is order
+        assert result["position_side"] == "long"
+
+    def test_normalize_order_sell_no_position_is_short(self):
+        bot = self._make_bot()
+        order = {
+            "order_id": "99",
+            "symbol": "ETH/USDC:USDC",
+            "side": "Sell",
+            "price": "3000",
+            "size": "1.0",
+            "status": "open",
+        }
+        result = bot._normalize_order_update(order)
+        assert result["position_side"] == "short"
+
+    def test_normalize_order_filled_status(self):
+        bot = self._make_bot()
+        order = {
+            "order_id": "100",
+            "symbol": "BTC/USDC:USDC",
+            "side": "Buy",
+            "price": "50000",
+            "size": "1.0",
+            "status": "fully_filled",
+        }
+        result = bot._normalize_order_update(order)
+        assert result["status"] == "closed"
+
+
+class TestLighterNormalizeStatus:
+    """Test _normalize_status maps all statuses correctly."""
+
+    def _make_bot(self):
+        with patch("exchanges.lighter.CCXTBot.__init__", return_value=None):
+            from exchanges.lighter import LighterBot
+
+            bot = LighterBot.__new__(LighterBot)
+            return bot
+
+    def test_normalize_status_mappings(self):
+        bot = self._make_bot()
+        assert bot._normalize_status("open") == "open"
+        assert bot._normalize_status("new") == "open"
+        assert bot._normalize_status("partially_filled") == "open"
+        assert bot._normalize_status("fully_filled") == "closed"
+        assert bot._normalize_status("filled") == "closed"
+        assert bot._normalize_status("canceled") == "canceled"
+        assert bot._normalize_status("cancelled") == "canceled"
+        assert bot._normalize_status("expired") == "canceled"
+        assert bot._normalize_status("some_other") == "some_other"
+
+

--- a/tests/exchanges/test_paradex_websocket.py
+++ b/tests/exchanges/test_paradex_websocket.py
@@ -390,8 +390,8 @@ class TestParadexNormalizeOrderUpdate:
             assert result["position_side"] == "long"  # NOT short!
             assert result["side"] == "sell"
 
-    def test_normalize_order_update_no_client_id_returns_both(self):
-        """Orders without client_id get position_side='both'."""
+    def test_normalize_order_update_no_client_id_sell_returns_short(self):
+        """Orders without client_id: sell + !reduceOnly = short."""
         with patch("exchanges.paradex.CCXTBot.__init__", return_value=None):
             from exchanges.paradex import ParadexBot
 
@@ -400,7 +400,7 @@ class TestParadexNormalizeOrderUpdate:
 
             result = bot._normalize_order_update({"side": "SELL", "market": "X"})
 
-            assert result["position_side"] == "both"
+            assert result["position_side"] == "short"
 
     def test_normalize_status_mappings(self):
         """Paradex statuses map to CCXT-style statuses."""

--- a/tests/test_inactive_symbol_logging.py
+++ b/tests/test_inactive_symbol_logging.py
@@ -1,0 +1,204 @@
+"""Tests for _log_inactive_symbol_reasons diagnostic logging."""
+
+import logging
+
+import pytest
+
+
+@pytest.fixture
+def make_bot():
+    """Create a minimal mock with the attributes _log_inactive_symbol_reasons needs."""
+
+    class FakeBot:
+        def __init__(self, balance, twel, n_pos, qty_pct, emc, filter_enabled=True):
+            self.effective_min_cost = {}
+            self.config = {
+                "bot": {
+                    "long": {
+                        "total_wallet_exposure_limit": twel,
+                        "n_positions": n_pos,
+                        "entry_initial_qty_pct": qty_pct,
+                    },
+                    "short": {
+                        "total_wallet_exposure_limit": 0,
+                        "n_positions": 0,
+                        "entry_initial_qty_pct": 0,
+                    },
+                },
+                "live": {},
+            }
+            self.coin_overrides = {}
+            self._filter_enabled = filter_enabled
+            self._emc = emc
+
+        def is_pside_enabled(self, pside):
+            if pside == "long":
+                twel = self.config["bot"]["long"]["total_wallet_exposure_limit"]
+                n = self.config["bot"]["long"]["n_positions"]
+                return twel > 0 and n > 0
+            return False
+
+        def bot_value(self, pside, key):
+            return self.config["bot"].get(pside, {}).get(key, 0.0)
+
+        def bp(self, pside, key, symbol=None):
+            return self.config["bot"].get(pside, {}).get(key, 0.0)
+
+        def _calc_effective_min_cost_at_price(self, symbol, price):
+            return self._emc
+
+    def _factory(balance=100.0, twel=2.0, n_pos=1, qty_pct=0.05, emc=20.0):
+        bot = FakeBot(balance, twel, n_pos, qty_pct, emc)
+        # Bind the real method
+        from passivbot import Passivbot
+
+        import types
+
+        bot._log_inactive_symbol_reasons = types.MethodType(
+            Passivbot._log_inactive_symbol_reasons, bot
+        )
+        return bot
+
+    return _factory
+
+
+class TestLogInactiveSymbolReasons:
+    def test_min_cost_too_high_logs_info(self, make_bot, caplog):
+        """When budget < effective_min_cost, an INFO log explains the numbers."""
+        bot = make_bot(balance=100.0, twel=2.0, n_pos=1, qty_pct=0.05, emc=20.0)
+        # budget = 100 * 2.0 * 0.05 = 10 < 20 → should log
+
+        diagnostics = {
+            "symbol_states": [
+                {
+                    "symbol_idx": 0,
+                    "long": {"active": False, "allow_initial": False},
+                    "short": {"active": False, "allow_initial": False},
+                }
+            ]
+        }
+        idx_to_symbol = {0: "HYPE/USDC:USDC"}
+        input_dict = {
+            "balance": 100.0,
+            "global": {"filter_by_min_effective_cost": True},
+            "symbols": [
+                {
+                    "symbol_idx": 0,
+                    "order_book": {"bid": 41.0, "ask": 41.0},
+                }
+            ],
+        }
+
+        with caplog.at_level(logging.INFO):
+            bot._log_inactive_symbol_reasons(diagnostics, idx_to_symbol, input_dict)
+
+        assert any("[orchestrator] HYPE long inactive: min_cost:" in r.message for r in caplog.records)
+        # Verify it includes the budget and emc numbers
+        msg = [r.message for r in caplog.records if "min_cost:" in r.message][0]
+        assert "budget=10.00" in msg
+        assert "effective_min_cost=20.00" in msg
+
+    def test_active_symbol_not_logged(self, make_bot, caplog):
+        """Active symbols should not produce any log."""
+        bot = make_bot()
+        diagnostics = {
+            "symbol_states": [
+                {
+                    "symbol_idx": 0,
+                    "long": {"active": True, "allow_initial": True},
+                    "short": {"active": False, "allow_initial": False},
+                }
+            ]
+        }
+        idx_to_symbol = {0: "HYPE/USDC:USDC"}
+        input_dict = {
+            "balance": 100.0,
+            "global": {"filter_by_min_effective_cost": True},
+            "symbols": [],
+        }
+
+        with caplog.at_level(logging.INFO):
+            bot._log_inactive_symbol_reasons(diagnostics, idx_to_symbol, input_dict)
+
+        assert not any("inactive" in r.message for r in caplog.records)
+
+    def test_budget_sufficient_shows_generic_reason(self, make_bot, caplog):
+        """When budget >= emc but still inactive, show generic orchestrator message."""
+        bot = make_bot(balance=1000.0, twel=2.0, n_pos=1, qty_pct=0.05, emc=5.0)
+        # budget = 1000 * 2.0 * 0.05 = 100 > 5 → min cost is not the reason
+
+        diagnostics = {
+            "symbol_states": [
+                {
+                    "symbol_idx": 0,
+                    "long": {"active": False, "allow_initial": False},
+                    "short": {"active": False, "allow_initial": False},
+                }
+            ]
+        }
+        idx_to_symbol = {0: "HYPE/USDC:USDC"}
+        input_dict = {
+            "balance": 1000.0,
+            "global": {"filter_by_min_effective_cost": True},
+            "symbols": [{"symbol_idx": 0, "order_book": {"bid": 41.0, "ask": 41.0}}],
+        }
+
+        with caplog.at_level(logging.INFO):
+            bot._log_inactive_symbol_reasons(diagnostics, idx_to_symbol, input_dict)
+
+        msg = [r.message for r in caplog.records if "inactive" in r.message][0]
+        assert "not selected by orchestrator" in msg
+
+    def test_throttle_prevents_spam(self, make_bot, caplog):
+        """Second call within 5 minutes should not log again."""
+        bot = make_bot(balance=100.0, twel=2.0, n_pos=1, qty_pct=0.05, emc=20.0)
+
+        diagnostics = {
+            "symbol_states": [
+                {
+                    "symbol_idx": 0,
+                    "long": {"active": False, "allow_initial": False},
+                    "short": {"active": False, "allow_initial": False},
+                }
+            ]
+        }
+        idx_to_symbol = {0: "HYPE/USDC:USDC"}
+        input_dict = {
+            "balance": 100.0,
+            "global": {"filter_by_min_effective_cost": True},
+            "symbols": [{"symbol_idx": 0, "order_book": {"bid": 41.0, "ask": 41.0}}],
+        }
+
+        with caplog.at_level(logging.INFO):
+            bot._log_inactive_symbol_reasons(diagnostics, idx_to_symbol, input_dict)
+            count_first = sum(1 for r in caplog.records if "inactive" in r.message)
+            bot._log_inactive_symbol_reasons(diagnostics, idx_to_symbol, input_dict)
+            count_second = sum(1 for r in caplog.records if "inactive" in r.message)
+
+        assert count_first == 1
+        assert count_second == count_first  # throttled, no new log
+
+    def test_disabled_pside_not_logged(self, make_bot, caplog):
+        """Short side disabled (twel=0) should not produce inactive log."""
+        bot = make_bot()
+        diagnostics = {
+            "symbol_states": [
+                {
+                    "symbol_idx": 0,
+                    "long": {"active": True, "allow_initial": True},
+                    "short": {"active": False, "allow_initial": False},
+                }
+            ]
+        }
+        idx_to_symbol = {0: "HYPE/USDC:USDC"}
+        input_dict = {
+            "balance": 100.0,
+            "global": {"filter_by_min_effective_cost": True},
+            "symbols": [],
+        }
+
+        with caplog.at_level(logging.INFO):
+            bot._log_inactive_symbol_reasons(diagnostics, idx_to_symbol, input_dict)
+
+        # Short is disabled (twel=0, n_positions=0), should not log
+        assert not any("short" in r.message and "inactive" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- **New `LighterBot` adapter** for the Lighter zero-fee perpetuals DEX (USDC quote, one-way mode only). Uses a native WebSocket to `wss://mainnet.zklighter.elliot.ai/stream` for order streaming, and calls the Lighter signer's `SignUpdateLeverage` directly because CCXT's own `load_account`-based leverage/margin path is broken against the current endpoint. Bumps `ccxt` to `4.5.47`.
- **Consolidated `position_side` derivation** into `CCXTBot._get_position_side_for_order` (from `side` + `reduceOnly`), removing duplicated `determine_pos_side` helpers and dead code across binance/bitget/bybit/defx/gateio/hyperliquid/kucoin/okx. Also lifts `_trim_orders_by_price_proximity` into the base class and deletes `validate_websocket_support` / `gather_fill_events` stubs that were never called from production.
- **Throttled orchestrator logging** that explains why symbols were not activated (min-cost budget, one-way blocks, forager scoring), with regression tests in `tests/test_inactive_symbol_logging.py`.
- **Docs:** new `docs/lighter_guide.md` end-user guide, README header + "Useful entry points" link updated to include Lighter, and a new Lighter section in `docs/ai/exchange_api_quirks.md` for future maintainers (pinned-ABI signer, `load_account` bypass, per-symbol `fetch_open_orders` fan-out, native WebSocket).

## How to set up Lighter

Lighter is the first Passivbot exchange that needs a **platform-specific native signing binary** in addition to API credentials, because CCXT ships the Python `ctypes` wrapper for the signer but not the compiled shared library itself.

1. **Create API credentials.** Follow the CCXT FAQ for creating an API key and locating your account index: https://github.com/ccxt/ccxt/wiki/FAQ#how-to-use-the-lighter-exchange-in-ccxt . You should end up with:
   - `private_key` — API key private key (hex, `0x`-prefixed). **Not** the wallet private key.
   - `api_key_index` — integer 0–254 Lighter assigns to the API key.
   - `account_index` — your Lighter account/sub-account index.

2. **Download the signer binary.** Use the pinned `v1.0.4` / commit `b7fc10b2` binaries from:
   https://github.com/elliottech/lighter-python/tree/b7fc10b2/lighter/signers
   Pick the file that matches your host platform (Linux/macOS/Windows, x86_64 or arm64) and save it somewhere persistent (e.g. `~/passivbot/lib/lighter-signer.so`). No `chmod +x` is needed — it is loaded as a shared library via `ctypes.CDLL`, not executed.

   > **Do not bump to a newer release.** `elliottech/lighter-python` has had breaking ABI changes to `CreateOrderTxReq` and related ctypes layouts; CCXT's bundled Python wrapper still targets the `b7fc10b2` ABI and newer binaries will segfault or produce invalid signatures.

3. **Add an `api-keys.json` entry** with a new field, `library_path`, pointing at the downloaded binary:
   ```json
   "lighter_01": {
       "exchange": "lighter",
       "private_key": "0x_api_key_private_key_hex",
       "api_key_index": 0,
       "account_index": 0,
       "library_path": "/absolute/path/to/lighter-signer.so"
   }
   ```

4. **Run the bot** as usual:
   ```bash
   passivbot live -u lighter_01
   ```

See `docs/lighter_guide.md` for the full walk-through including operational notes (USDC quote, one-way mode, native WebSocket, per-symbol open-orders fan-out) and a troubleshooting table for common failure modes (wrong architecture, missing glibc, wrong ABI version, credential rejection).

## Test plan

- [ ] `pytest tests/exchanges/test_lighter.py` — 596 lines of adapter coverage including `_build_ccxt_config` default timeout, WS receive handling null `orders`, signer error propagation, order normalization, and WebSocket connect/subscribe flow.
- [ ] `pytest tests/exchanges/test_ccxt_bot*.py` — regression coverage for the consolidated `_get_position_side_for_order` path across all migrated exchanges.
- [ ] `pytest tests/test_inactive_symbol_logging.py` — throttled inactive-symbol logging.
- [ ] Manual live smoke test against a funded Lighter sub-account with the pinned v1.0.4 binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)