### PR TITLE
fix: build_backtest_payload must not mutate mss

### DIFF
--- a/src/backtest.py
+++ b/src/backtest.py
@@ -320,7 +320,6 @@ def _build_hlcvs_bundle(
     hlcvs,
     btc_usd_prices,
     timestamps,
-    config,
     exchange,
     mss,
     coins_order,
@@ -328,7 +327,7 @@ def _build_hlcvs_bundle(
     last_valid_indices,
     warmup_minutes,
     trade_start_indices,
-    requested_start_ts,
+    bundle_meta_base: dict,
     *,
     coin_indices: list[int] | None = None,
 ) -> pbr.HlcvsBundle:
@@ -378,15 +377,6 @@ def _build_hlcvs_bundle(
         timestamps_arr = np.arange(hlcvs_arr.shape[0], dtype=np.int64)
     else:
         timestamps_arr = np.ascontiguousarray(timestamps, dtype=np.int64)
-    meta_overrides = mss.get("__meta__", {}) if isinstance(mss, dict) else {}
-    warmup_requested = int(
-        meta_overrides.get("warmup_minutes_requested", compute_backtest_warmup_minutes(config))
-    )
-    warmup_provided = int(meta_overrides.get("warmup_minutes_provided", warmup_requested))
-    requested_ts = int(meta_overrides.get("requested_start_ts", requested_start_ts))
-    effective_start_ts = int(
-        meta_overrides.get("effective_start_ts", int(timestamps_arr[0]) if len(timestamps_arr) else 0)
-    )
     coin_meta_entries = _build_coin_metadata_entries(
         coins_order,
         exchange,
@@ -396,13 +386,7 @@ def _build_hlcvs_bundle(
         warmup_minutes,
         trade_start_indices,
     )
-    bundle_meta = {
-        "requested_start_timestamp_ms": requested_ts,
-        "effective_start_timestamp_ms": effective_start_ts,
-        "warmup_minutes_requested": warmup_requested,
-        "warmup_minutes_provided": warmup_provided,
-        "coins": coin_meta_entries,
-    }
+    bundle_meta = {**bundle_meta_base, "coins": coin_meta_entries}
     rss_after = _rss_mb()
     if hasattr(logger, "trace"):
         logger.trace(
@@ -495,13 +479,6 @@ def build_backtest_payload(
             hlcvs.shape[0],
             offset_bars,
         )
-        if isinstance(mss, dict):
-            meta = mss.setdefault("__meta__", {})
-            meta["data_interval_minutes"] = int(candle_interval)
-            meta["candle_interval_offset_bars"] = int(offset_bars)
-            if timestamps is not None and len(timestamps) > 0:
-                meta["effective_start_ts"] = int(timestamps[0])
-                meta["effective_start_date"] = ts_to_date(int(timestamps[0]))
 
     # Inject first timestamp (ms) into backtest params; default to 0 if unknown
     try:
@@ -585,17 +562,35 @@ def build_backtest_payload(
     except Exception:
         requested_start_ts = int(date_to_ts(require_config_value(config, "backtest.start_date")))
     backtest_params["requested_start_timestamp_ms"] = requested_start_ts
-    if isinstance(meta, dict) and timestamps is not None and len(timestamps) > 0:
-        meta["effective_start_ts"] = int(timestamps[0])
-        meta["effective_start_date"] = ts_to_date(int(timestamps[0]))
-        warmup_provided = max(0, int(max(0, requested_start_ts - int(timestamps[0])) // 60_000))
-        meta["warmup_minutes_provided"] = warmup_provided
+
+    warmup_requested = int(
+        meta.get("warmup_minutes_requested", compute_backtest_warmup_minutes(config))
+    )
+    if "warmup_minutes_provided" in meta:
+        warmup_provided = int(meta["warmup_minutes_provided"])
+    elif timestamps is not None and len(timestamps) > 0:
+        warmup_provided = max(
+            0, (requested_start_ts - int(timestamps[0])) // 60_000
+        )
+    else:
+        warmup_provided = warmup_requested
+
+    if timestamps is not None and len(timestamps) > 0:
+        effective_start_ts = int(timestamps[0])
+    else:
+        effective_start_ts = 0
+
+    bundle_meta_base = {
+        "requested_start_timestamp_ms": requested_start_ts,
+        "effective_start_timestamp_ms": effective_start_ts,
+        "warmup_minutes_requested": warmup_requested,
+        "warmup_minutes_provided": warmup_provided,
+    }
 
     bundle = _build_hlcvs_bundle(
         hlcvs,
         btc_usd_prices,
         timestamps,
-        config,
         exchange,
         mss,
         coins_order,
@@ -603,7 +598,7 @@ def build_backtest_payload(
         last_valid_indices,
         warmup_minutes,
         trade_start_indices,
-        requested_start_ts,
+        bundle_meta_base,
         coin_indices=coin_indices,
     )
 

--- a/tests/test_build_backtest_payload_purity.py
+++ b/tests/test_build_backtest_payload_purity.py
@@ -1,0 +1,174 @@
+"""
+Tests that pin `build_backtest_payload` as a pure function over its `mss`
+argument (i.e. it must not mutate the caller's dict) and that the fix for
+the re-entrance bug documented in
+docs/plans/2026-04-11-build-backtest-payload-mss-mutation-design.md holds.
+
+Synthetic fixtures, millisecond runtime. Deliberately do NOT call
+`execute_backtest` — the Rust engine is invariant under the refactor, and
+these tests need to run in a tight loop when the refactor lands.
+"""
+
+from copy import deepcopy
+
+import numpy as np
+
+from backtest import build_backtest_payload
+from config_utils import get_template_config
+
+
+def _base_config(candle_interval_minutes: int = 1) -> dict:
+    cfg = get_template_config()
+    cfg["backtest"]["exchanges"] = ["binance"]
+    cfg["backtest"]["coins"] = {"binance": ["BTC"]}
+    cfg["backtest"]["candle_interval_minutes"] = candle_interval_minutes
+    cfg["backtest"]["filter_by_min_effective_cost"] = False
+    cfg["backtest"]["start_date"] = "2021-01-01"
+    cfg["backtest"]["end_date"] = "2021-01-02"
+    cfg["backtest"]["maker_fee_override"] = None
+    cfg["backtest"]["taker_fee_override"] = None
+    cfg["live"]["warmup_ratio"] = 0.0
+    cfg["live"]["max_warmup_minutes"] = 0
+    cfg["live"]["hedge_mode"] = False
+    return cfg
+
+
+def _base_mss(start_ts: int) -> dict:
+    return {
+        "BTC": {
+            "qty_step": 0.001,
+            "price_step": 0.1,
+            "min_qty": 0.0,
+            "min_cost": 0.0,
+            "c_mult": 1.0,
+            "maker": 0.0002,
+            "taker": 0.0005,
+            "exchange": "binance",
+        },
+        "__meta__": {
+            "requested_start_ts": int(start_ts),
+            "requested_start_date": "2021-01-01",
+            "warmup_minutes_requested": 0,
+        },
+    }
+
+
+def _synthetic_1m_hlcvs(n_minutes: int, start_ts: int):
+    """Return (hlcvs, btc_usd_prices, timestamps) for `n_minutes` of 1-min data."""
+    timestamps = np.arange(
+        start_ts, start_ts + n_minutes * 60_000, 60_000, dtype=np.int64
+    )
+    hlcvs = np.zeros((n_minutes, 1, 4), dtype=np.float64)
+    for i in range(n_minutes):
+        base = 100.0 + (i % 10) * 0.1
+        hlcvs[i, 0, 0] = base + 0.5  # high
+        hlcvs[i, 0, 1] = base - 0.5  # low
+        hlcvs[i, 0, 2] = base        # close
+        hlcvs[i, 0, 3] = 1.0         # volume
+    btc_usd_prices = np.full(n_minutes, 20_000.0, dtype=np.float64)
+    return hlcvs, btc_usd_prices, timestamps
+
+
+def test_build_backtest_payload_does_not_mutate_mss():
+    """Pin the function as a pure consumer of `mss`. Covers the root cause
+    of the re-entrance bug: callers that reuse `mss` across calls must see
+    an unchanged dict after each call."""
+    start_ts = 1609459200000  # 2021-01-01 00:00:00 UTC, aligned to 2m/5m/etc.
+    n_minutes = 60
+    config = _base_config(candle_interval_minutes=2)
+    mss = _base_mss(start_ts)
+    hlcvs, btc, timestamps = _synthetic_1m_hlcvs(n_minutes, start_ts)
+
+    snapshot = deepcopy(mss)
+    build_backtest_payload(hlcvs, mss, config, "binance", btc, timestamps)
+
+    assert mss == snapshot, (
+        "build_backtest_payload mutated its `mss` argument. "
+        "Expected no side effects on the caller's dict."
+    )
+
+
+def test_build_backtest_payload_is_reentrant_on_same_mss():
+    """Regression test for docs/plans/2026-04-11-build-backtest-payload-mss-mutation-design.md.
+
+    Before the fix: second call reads `data_interval_minutes=2` from the
+    mutated `mss`, skips the aggregation branch, and returns `n_minutes`
+    bars instead of `n_minutes / 2`. After the fix: both calls aggregate
+    identically and produce the same shape.
+    """
+    start_ts = 1609459200000
+    n_minutes = 60
+    config = _base_config(candle_interval_minutes=2)
+    mss = _base_mss(start_ts)
+    hlcvs, btc, timestamps = _synthetic_1m_hlcvs(n_minutes, start_ts)
+
+    payload1 = build_backtest_payload(hlcvs, mss, config, "binance", btc, timestamps)
+    payload2 = build_backtest_payload(hlcvs, mss, config, "binance", btc, timestamps)
+
+    # Both calls should aggregate 1-min → 2-min identically.
+    assert payload1.bundle.hlcvs.shape[0] == n_minutes // 2
+    assert payload2.bundle.hlcvs.shape[0] == n_minutes // 2
+    # And the two bundles should be bar-identical.
+    assert payload1.bundle.hlcvs.shape == payload2.bundle.hlcvs.shape
+    np.testing.assert_array_equal(
+        np.asarray(payload1.bundle.timestamps),
+        np.asarray(payload2.bundle.timestamps),
+    )
+
+
+def test_build_backtest_payload_honors_explicit_warmup_provided_override():
+    """Document the contract that a caller pre-setting `warmup_minutes_provided`
+    in `mss["__meta__"]` is honored — not silently recomputed.
+
+    Under the current (buggy) code, src/backtest.py:588-592 unconditionally
+    overwrites any pre-set value with the locally-computed one. After the
+    fix, the caller-supplied value survives into the bundle.
+    """
+    start_ts = 1609459200000
+    n_minutes = 60
+    config = _base_config(candle_interval_minutes=1)
+    mss = _base_mss(start_ts)
+    # Sentinel value. With requested_start_ts == timestamps[0], the
+    # local recomputation at src/backtest.py:591 would yield 0, so the
+    # 99 is only visible in the bundle if the override path is live.
+    mss["__meta__"]["warmup_minutes_provided"] = 99
+    hlcvs, btc, timestamps = _synthetic_1m_hlcvs(n_minutes, start_ts)
+
+    payload = build_backtest_payload(hlcvs, mss, config, "binance", btc, timestamps)
+
+    assert payload.bundle.meta["warmup_minutes_provided"] == 99
+
+
+def test_build_backtest_payload_aggregation_recomputes_effective_start_ts_over_stale_mss():
+    """Pin that `build_backtest_payload` recomputes `effective_start_timestamp_ms`
+    from the post-aggregation timestamps even when the caller pre-set a stale
+    1-minute value in `mss["__meta__"]["effective_start_ts"]`.
+
+    Upstream callers in src/hlcv_preparation.py and src/downloader.py pre-set
+    `effective_start_ts` from 1-minute timestamps. If the config uses
+    `candle_interval_minutes > 1` and the data start is not aligned to the
+    aggregation boundary, `align_and_aggregate_hlcvs` trims leading bars and
+    the post-aggregation first timestamp differs from the caller's pre-set
+    value. This test exercises that scenario by starting at 00:01:00 UTC
+    (unaligned to a 2m boundary) so `offset_bars >= 1`.
+    """
+    # 2021-01-01 00:01:00 UTC, *not* aligned to a 2m boundary.
+    start_ts = 1609459260000
+    n_minutes = 60
+    config = _base_config(candle_interval_minutes=2)
+    mss = _base_mss(start_ts)
+    # Caller pre-sets the stale, pre-aggregation 1m start. Upstream
+    # hlcv_preparation.py / downloader.py do exactly this.
+    mss["__meta__"]["effective_start_ts"] = start_ts
+    hlcvs, btc, timestamps = _synthetic_1m_hlcvs(n_minutes, start_ts)
+
+    payload = build_backtest_payload(hlcvs, mss, config, "binance", btc, timestamps)
+
+    post_agg_first_ts = int(payload.bundle.timestamps[0])
+    # Sanity: aggregation actually trimmed at least one bar — otherwise the
+    # test isn't exercising the drift scenario.
+    assert post_agg_first_ts > start_ts
+    # The bundle must reflect the post-aggregation start, not the caller's
+    # stale pre-set.
+    assert payload.bundle.meta["effective_start_timestamp_ms"] == post_agg_first_ts
+    assert payload.bundle.meta["effective_start_timestamp_ms"] != start_ts

--- a/tests/test_hlcvs_bundle.py
+++ b/tests/test_hlcvs_bundle.py
@@ -111,22 +111,22 @@ def test_build_hlcvs_bundle_applies_coin_indices():
     hlcvs = np.zeros((3, 5, 4), dtype=np.float64)
     btc = np.zeros(3, dtype=np.float64)
     timestamps = np.array([0, 60_000, 120_000], dtype=np.int64)
-    config = {
-        "backtest": {"start_date": "2021-01-01", "end_date": "2021-01-02"},
-        "live": {"warmup_ratio": 0.0, "max_warmup_minutes": 0},
-        "bot": {"long": {}, "short": {}},
-    }
     coins_order = ["COIN_A", "COIN_B", "COIN_C"]
     mss = {coin: {"symbol": f"{coin}/USDT:USDT"} for coin in coins_order}
     first_valid = [0, 0, 0]
     last_valid = [2, 2, 2]
     warmup = [0, 0, 0]
     trade_start = [0, 0, 0]
+    bundle_meta_base = {
+        "requested_start_timestamp_ms": 0,
+        "effective_start_timestamp_ms": 0,
+        "warmup_minutes_requested": 0,
+        "warmup_minutes_provided": 0,
+    }
     bundle = _build_hlcvs_bundle(
         hlcvs,
         btc,
         timestamps,
-        config,
         "binanceusdm",
         mss,
         coins_order,
@@ -134,7 +134,7 @@ def test_build_hlcvs_bundle_applies_coin_indices():
         last_valid,
         warmup,
         trade_start,
-        requested_start_ts=0,
+        bundle_meta_base,
         coin_indices=[0, 2, 4],
     )
     assert bundle.hlcvs.shape[1] == 3


### PR DESCRIPTION
## Summary

- Replaces the implicit in-band channel (`build_backtest_payload` writes values to its caller's `mss["__meta__"]`; `_build_hlcvs_bundle` reads them back) with an explicit `bundle_meta_base: dict` parameter. Drops both mss mutation sites in `src/backtest.py`.
- Fixes a latent re-entrance bug: a caller reusing the same `mss` across `build_backtest_payload` calls would see `data_interval_minutes=2` from the first call's mutation, skip aggregation on the second call, and feed 1-minute data to the Rust backtest as if it were 2-minute. No current caller is affected (CLI runs once; optimizer pre-stamps via `_maybe_aggregate_backtest_data`; suite_runner deepcopies `mss` per scenario), but the bug was ready-to-fire for any future iterative backtester, scanner, or REPL session.
- Behavior is byte-for-byte identical for all current callers. `warmup_minutes_provided` honors an explicit override from `mss["__meta__"]` (real consumers in `src/suite_runner.py:1227` and `src/optimize_suite.py:232`); `effective_start_ts` is always recomputed from `timestamps[0]` so pre-set 1-minute values from `src/hlcv_preparation.py` and `src/downloader.py` don't drift under aggregation.

## Test plan

- [x] `pytest tests/test_build_backtest_payload_purity.py -v` — 4 new purity tests pass (no-mutation invariant, reentrance regression pin, warmup override contract, aggregation recomputes `effective_start_ts` over stale mss pre-set)
- [x] `pytest tests/test_candle_interval.py tests/test_backtest_maker_fee_override.py tests/test_hlcvs_bundle.py -v` — 24 existing tests pass unchanged (`tests/test_hlcvs_bundle.py::test_build_hlcvs_bundle_applies_coin_indices` updated for the new `_build_hlcvs_bundle` signature)
- [x] Red-then-green verified: before the fix, the 3 pre-fix purity tests fail; after the fix, all 4 pass

## Notes

- Independent of and orthogonal to #585 (Bug A, `fix/optimizer-warmup-from-bounds`). The two branches touch different functions, different call sites, and different invariants; whichever merges second should rebase cleanly.