### PR TITLE
refactor: consolidate warmup helpers in warmup_utils

### DIFF
--- a/src/downloader.py
+++ b/src/downloader.py
@@ -5,7 +5,6 @@ import gzip
 import json
 import logging
 import inspect
-import math
 import os
 import shutil
 import sys
@@ -82,128 +81,6 @@ def is_valid_date(date):
 
 def get_function_name():
     return inspect.currentframe().f_back.f_code.co_name
-
-
-def _to_float(value):
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return 0.0
-
-
-def _require_max_warmup_minutes(config: dict) -> float:
-    """Return the warmup ceiling from the live config."""
-    return _to_float(require_live_value(config, "max_warmup_minutes"))
-
-
-def _iter_param_sets(config: dict):
-    bot_cfg = config.get("bot", {})
-    base_long = dict(bot_cfg.get("long", {}) or {})
-    base_short = dict(bot_cfg.get("short", {}) or {})
-    yield "__default__", base_long, base_short
-
-    coin_overrides = config.get("coin_overrides", {})
-    for coin, overrides in coin_overrides.items():
-        bot_overrides = overrides.get("bot", {})
-        long_params = dict(base_long)
-        short_params = dict(base_short)
-        long_params.update(bot_overrides.get("long", {}))
-        short_params.update(bot_overrides.get("short", {}))
-        yield coin, long_params, short_params
-
-
-def compute_backtest_warmup_minutes(config: dict) -> int:
-    """Mirror Rust warmup span calculation (see calc_warmup_bars)."""
-
-    def _extract_bound_max(bounds: dict, key: str) -> float:
-        if key not in bounds:
-            return 0.0
-        entry = bounds[key]
-        candidates = []
-        if isinstance(entry, (list, tuple)):
-            candidates = [entry]
-        else:
-            candidates = [[entry]]
-        max_val = 0.0
-        for candidate in candidates:
-            for val in candidate:
-                max_val = max(max_val, _to_float(val))
-        return max_val
-
-    max_minutes = 0.0
-    minute_fields = [
-        "ema_span_0",
-        "ema_span_1",
-        "forager_volume_ema_span",
-        "forager_volatility_ema_span",
-    ]
-
-    for _, long_params, short_params in _iter_param_sets(config):
-        for params in (long_params, short_params):
-            for field in minute_fields:
-                max_minutes = max(max_minutes, _to_float(params.get(field)))
-            log_span_minutes = _to_float(params.get("entry_volatility_ema_span_hours")) * 60.0
-            max_minutes = max(max_minutes, log_span_minutes)
-
-    bounds = config.get("optimize", {}).get("bounds", {})
-    bound_keys_minutes = [
-        "long_ema_span_0",
-        "long_ema_span_1",
-        "long_forager_volume_ema_span",
-        "long_forager_volatility_ema_span",
-        "short_ema_span_0",
-        "short_ema_span_1",
-        "short_forager_volume_ema_span",
-        "short_forager_volatility_ema_span",
-    ]
-    bound_keys_hours = [
-        "long_entry_volatility_ema_span_hours",
-        "short_entry_volatility_ema_span_hours",
-    ]
-
-    for key in bound_keys_minutes:
-        max_minutes = max(max_minutes, _extract_bound_max(bounds, key))
-    for key in bound_keys_hours:
-        max_minutes = max(max_minutes, _extract_bound_max(bounds, key) * 60.0)
-
-    warmup_ratio = float(require_config_value(config, "live.warmup_ratio"))
-    limit = _require_max_warmup_minutes(config)
-
-    if not math.isfinite(max_minutes):
-        return 0
-    warmup_minutes = max_minutes * max(0.0, warmup_ratio)
-    if limit > 0:
-        warmup_minutes = min(warmup_minutes, limit)
-    return int(math.ceil(warmup_minutes)) if warmup_minutes > 0.0 else 0
-
-
-def compute_per_coin_warmup_minutes(config: dict) -> dict:
-    warmup_ratio = float(require_config_value(config, "live.warmup_ratio"))
-    limit = _require_max_warmup_minutes(config)
-    per_coin = {}
-    minute_fields = [
-        "ema_span_0",
-        "ema_span_1",
-        "forager_volume_ema_span",
-        "forager_volatility_ema_span",
-    ]
-    for coin, long_params, short_params in _iter_param_sets(config):
-        max_minutes = 0.0
-        for params in (long_params, short_params):
-            for field in minute_fields:
-                max_minutes = max(max_minutes, _to_float(params.get(field)))
-            max_minutes = max(
-                max_minutes,
-                _to_float(params.get("entry_volatility_ema_span_hours")) * 60.0,
-            )
-        if not math.isfinite(max_minutes):
-            per_coin[coin] = 0
-            continue
-        warmup_minutes = max_minutes * max(0.0, warmup_ratio)
-        if limit > 0:
-            warmup_minutes = min(warmup_minutes, limit)
-        per_coin[coin] = int(math.ceil(warmup_minutes)) if warmup_minutes > 0.0 else 0
-    return per_coin
 
 
 def dump_ohlcv_data(data, filepath):

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -85,7 +85,7 @@ from config.scoring import (
 )
 from config.parse import load_raw_config as load_hjson_config
 from config.schema import get_template_config
-from downloader import compute_backtest_warmup_minutes, compute_per_coin_warmup_minutes
+from warmup_utils import compute_backtest_warmup_minutes, compute_per_coin_warmup_minutes
 from config_utils import (
     format_bot_config,
     add_config_arguments,

--- a/src/optimize_suite.py
+++ b/src/optimize_suite.py
@@ -16,7 +16,7 @@ from config import load_prepared_config
 from config.access import require_config_value, require_live_value
 from config.overrides import parse_overrides
 from config_utils import format_config
-from downloader import compute_backtest_warmup_minutes, compute_per_coin_warmup_minutes
+from warmup_utils import compute_backtest_warmup_minutes, compute_per_coin_warmup_minutes
 from shared_arrays import attach_shared_array
 from suite_runner import (
     SuiteScenario,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -105,7 +105,7 @@ from procedures import (
     print_async_exception,
 )
 from utils import get_file_mod_ms
-from downloader import compute_per_coin_warmup_minutes
+from warmup_utils import compute_per_coin_warmup_minutes
 import re
 
 NetworkError = ccxt_errors.NetworkError

--- a/src/suite_runner.py
+++ b/src/suite_runner.py
@@ -32,7 +32,7 @@ from utils import (
     utc_ms,
     date_to_ts,
 )
-from downloader import compute_backtest_warmup_minutes, compute_per_coin_warmup_minutes
+from warmup_utils import compute_backtest_warmup_minutes, compute_per_coin_warmup_minutes
 from ohlcv_utils import align_and_aggregate_hlcvs
 from shared_arrays import SharedArraySpec
 from metrics_schema import flatten_metric_stats, merge_suite_payload

--- a/tests/test_hlcvs_valid_ranges.py
+++ b/tests/test_hlcvs_valid_ranges.py
@@ -7,7 +7,7 @@ import numpy as np
 sys.modules.setdefault("passivbot_rust", types.SimpleNamespace())
 
 from backtest import ensure_valid_index_metadata
-from downloader import compute_per_coin_warmup_minutes
+from warmup_utils import compute_per_coin_warmup_minutes
 
 
 def test_ensure_valid_index_metadata_infers_ranges_for_each_coin():


### PR DESCRIPTION
## Summary

- `src/downloader.py` carried a near-verbatim copy of `_to_float`, `_require_max_warmup_minutes`, `_iter_param_sets`, `compute_backtest_warmup_minutes`, and `compute_per_coin_warmup_minutes` that already existed in `src/warmup_utils.py`. The two copies had begun to drift — `warmup_utils._iter_param_sets` guards `bot_overrides.get("long", {}) or {}` against an explicit `None`, the downloader copy did not. Duplication was a bug magnet.
- Delete the downloader-local copies (and the now-orphaned `import math`) and migrate the 5 call-sites that had been importing from `downloader` — `src/optimize.py`, `src/optimize_suite.py`, `src/suite_runner.py`, `src/passivbot.py`, `tests/test_hlcvs_valid_ranges.py` — to import from `warmup_utils` directly. No shim or re-export; `warmup_utils` is now the single import path.
- **Latent effect worth noting:** callers previously routed through `downloader` silently inherit the `None`-guard in `_iter_param_sets`. They would have crashed on an explicit `coin_overrides[coin]["bot"]["long"] = None`; they now coerce to an empty dict like the `backtest` / `hlcv_preparation` path already did. This is an intrinsic consequence of picking `warmup_utils` as the survivor, not a deliberate behavioural change.

Net diff: 6 files changed, 5 insertions(+), 128 deletions(-).

## Test plan

- [x] `python -m pytest tests/test_warmup_utils.py tests/test_hlcvs_valid_ranges.py -x` — 27 passed
- [x] Import smoke test: `downloader`, `optimize`, `optimize_suite`, `suite_runner`, `passivbot`, `backtest`, `hlcv_preparation`, `warmup_utils` all import cleanly
- [x] `grep -rn "from downloader import compute_" src/ tests/` returns zero hits
- [x] Confirmed `downloader` module no longer exposes `math`, `compute_backtest_warmup_minutes`, or `compute_per_coin_warmup_minutes` as attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)