### PR TITLE
fix(backtest): import legacy data when persistent gap is only partially covered

### DIFF
--- a/src/backtest.py
+++ b/src/backtest.py
@@ -978,7 +978,11 @@ def check_keys(dict0, dict1):
 
 def get_cache_hash(config, exchange):
     exchanges_cfg = require_config_value(config, "backtest.exchanges")
-    approved_coins = require_live_value(config, "approved_coins")
+    approved_coins_raw = require_live_value(config, "approved_coins")
+    approved_coins = {
+        "long": sorted(approved_coins_raw.get("long", [])),
+        "short": sorted(approved_coins_raw.get("short", [])),
+    }
     minimum_coin_age = require_live_value(config, "minimum_coin_age_days")
     backtest_cfg = config.get("backtest", {}) or {}
     coin_sources = backtest_cfg.get("coin_sources") or {}

--- a/src/hlcv_preparation.py
+++ b/src/hlcv_preparation.py
@@ -1173,6 +1173,27 @@ async def _resolve_v2_store_range(
             ts_to_date(start_ts),
             ts_to_date(end_ts),
         )
+    elif plan.blocked_by_persistent_gap and plan.legacy_inspection is not None:
+        # Even when legacy data doesn't fully cover the persistent gap,
+        # import whatever is available so the valid window starts earlier.
+        imported_rows = import_legacy_range_into_store(
+            store=store,
+            legacy_root=legacy_root,
+            exchange=exchange,
+            timeframe="1m",
+            symbol=symbol,
+            start_ts=start_ts,
+            end_ts=end_ts,
+        )
+        if imported_rows > 0:
+            logging.info(
+                "[%s] imported %d partial-coverage legacy 1m rows into v2 store for %s (%s -> %s)",
+                exchange,
+                imported_rows,
+                coin,
+                ts_to_date(start_ts),
+                ts_to_date(end_ts),
+            )
     rng = store.read_range(exchange, "1m", symbol, start_ts, end_ts)
     if rng.valid.all():
         logging.info(


### PR DESCRIPTION
### Problem

Combined backtests with coins that have `pre_inception` persistent gaps (e.g., BTC on bybit before 2020-03-25) start from 2023 instead of 2020, even though legacy cache (`caches/ohlcv/`) has data from 2020.

Example: a backtest configured with `start_date: 2020-01-01` and coins `[BTC, ETH, HYPE, SOL]` across exchanges `[binance, bybit]` produced a cache starting from `2023-12-06` instead of `2020-03-25`.

### Root Cause

Two issues:

1. **Cache hash sensitive to coin order** — `get_cache_hash()` uses the raw `approved_coins` dict (with unsorted `long`/`short` lists) for hashing. Changing coin order in config produces a different hash, causing cache misses and unnecessary re-fetches.

2. **Legacy data not imported when persistent gap is only partially covered** — When `plan_local_symbol_range()` marks a symbol as `blocked_by_persistent_gap` (because legacy data doesn't 100% cover the gap period), legacy data is completely skipped. `_extract_single_valid_window()` then falls back to the v2 store's limited range (starting from 2023-12), discarding years of valid legacy data.

### Fix

1. **Sort approved_coins lists in `get_cache_hash()`** (`src/backtest.py` L981-985):
   ```python
   approved_coins_raw = require_live_value(config, "approved_coins")
   approved_coins = {
       "long": sorted(approved_coins_raw.get("long", [])),
       "short": sorted(approved_coins_raw.get("short", [])),
   }
   ```

2. **Import partial legacy data despite persistent gap** (`src/hlcv_preparation.py` L1176-1196):
   When `blocked_by_persistent_gap` but legacy data exists, still import whatever legacy data is available before extracting the valid window. This restores the effective start date to the legacy data's earliest availability.

   The persistent gap record is preserved — it still prevents unnecessary API requests for data that never existed on the exchange.

### Changed Files

- `src/backtest.py` — sort coins before hashing
- `src/hlcv_preparation.py` — import partial legacy data when blocked by persistent gap