### PR TITLE
Support Python 3.14 installs

### DIFF
--- a/passivbot-rust/Cargo.toml
+++ b/passivbot-rust/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["extension-module"]
+default = ["extension-module", "abi3-py312"]
 extension-module = ["pyo3/extension-module"]
+abi3-py312 = ["pyo3/abi3-py312"]
 
 [lib]
 name = "passivbot_rust"

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -1,4 +1,5 @@
-matplotlib==3.8.4
+matplotlib==3.8.4; python_version < "3.14"
+matplotlib==3.10.9; python_version >= "3.14"
 colorama==0.4.6
 pyecharts==1.9.1
 deap==1.4.3
@@ -9,6 +10,7 @@ msgpack==1.1.0
 plotly==6.0.1
 dash==2.18.2
 dash-bootstrap-components==1.6.0
-psutil==5.9.8
+psutil==5.9.8; python_version < "3.14"
+psutil==7.2.2; python_version >= "3.14"
 requests==2.32.3
 dictdiffer==0.9.0

--- a/requirements-live.txt
+++ b/requirements-live.txt
@@ -1,8 +1,10 @@
 -r requirements-rust.txt
 python-dateutil==2.9.0.post0
-numba==0.59.1
-pandas==2.2.2
-numpy==1.26.4
+numba==0.59.1; python_version < "3.14"
+pandas==2.2.2; python_version < "3.14"
+pandas==2.3.3; python_version >= "3.14"
+numpy==1.26.4; python_version < "3.14"
+numpy==2.3.5; python_version >= "3.14"
 ccxt==4.5.48
 hjson==3.0.2
 prettytable==3.11.0


### PR DESCRIPTION
## Summary
- add Python 3.14-compatible dependency pins while preserving existing pins for older Python versions
- skip the old numba pin on Python 3.14, where it is not compatible and is not imported by the codebase
- build the existing PyO3 0.21 Rust extension with `abi3-py312` so Python 3.14 installs work without a PyO3 API migration

## Validation
- `python3.14 -m venv .venv314`
- `python -m pip install -e ".[dev]"`
- `python -m pip check`
- import smoke test for `numpy`, `pandas`, `matplotlib`, `psutil`, `passivbot_rust`
- `passivbot --help`
- `cd passivbot-rust && cargo check --tests`
- `python -m pytest -q tests/test_passivbot_cli.py tests/test_rust_utils.py tests/test_custom_endpoints.py`

## Notes
Full `pytest -q` under Python 3.14 still has unrelated failures in config/help-string tests and one monitor fake test. The install/build path succeeds.
