### PR TITLE
docs: refresh v8 branch readiness notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ All notable user-facing changes will be documented in this file.
 - Final `caches/hlcvs_data/` caches now require valid manifests and old manifest-less final caches rebuild by default; explicit override datasets require valid manifests/checksums.
 - Added per-coin HLCV coverage metadata to materialized datasets, including requested range, valid start/end, leading/trailing missing minutes, internal gap counts/windows, and synthetic fill count/source.
 - Capped omega-ratio analysis metrics at a finite value when a backtest has positive returns with no losing days, and reports flat/no-movement windows as `0.0`, preventing optimizer scoring metrics from disappearing during JSON/Python aggregation.
-- `refactor/rust-strategy-runtime-plan` is versioned as the next major release, `v8.0.0`.
+- The `v8` branch is versioned as the next major release, `v8.0.0`.
 - Increased the pymoo NSGA3 auto reference-direction cap from `330` to `500`, giving 9-objective auto-population optimizer runs `495` reference directions instead of `165`.
 - Fixed v8 strategy min-effective-cost gating so live and backtest use the active strategy's initial sizing parameter instead of legacy flat `BotParams.entry_initial_qty_pct`.
 - Fixed flat shared bot keys to override grouped defaults during config canonicalization, and changed flat strategy coin overrides to fail loudly instead of being silently discarded.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 :warning: **Used at one's own risk** :warning:
 
-Current development target on `feature/v8-strategy-runtime`: `v8.0.0`
+Current development target on `v8`: `v8.0.0`
 
 
 ## Overview

--- a/docs/plans/backtester_performance_optimization_plan.md
+++ b/docs/plans/backtester_performance_optimization_plan.md
@@ -1,7 +1,7 @@
 # Backtester Performance Optimization Checklist
 
 This is the implementation checklist for speeding up the refactored Rust backtester on
-`refactor/rust-strategy-runtime-plan`.
+`v8`.
 
 It is intentionally performance-focused. Unless an explicit correctness bug is found, every pass
 must preserve backtest outputs exactly.
@@ -287,7 +287,7 @@ For each optimization commit, record:
 
 ## Current Status
 
-- Pass 0 baseline recorded on `refactor/rust-strategy-runtime-plan`
+- Pass 0 baseline recorded on the v8 runtime branch
 - Pass 1 partial (EMA slot indices complete)
 - Pass 2 not started
 - Pass 3 partial (dense backtest state complete)

--- a/docs/plans/rust_strategy_runtime_refactor.md
+++ b/docs/plans/rust_strategy_runtime_refactor.md
@@ -3,7 +3,7 @@
 ## Status
 
 This plan supersedes the earlier master-based draft and tracks the current
-`refactor/rust-strategy-runtime-plan` branch state.
+`v8` branch state.
 
 It uses the early EMA-anchor experiment only as the motivating example, not as the desired target
 architecture.

--- a/docs/plans/rust_strategy_runtime_refactor_execution_plan.md
+++ b/docs/plans/rust_strategy_runtime_refactor_execution_plan.md
@@ -41,7 +41,7 @@ Current health-gate task:
 
 ## Branch
 
-- `refactor/rust-strategy-runtime-plan`
+- `v8`
 
 ## Baseline
 

--- a/docs/plans/v8_strategy_contract_consolidation_plan.md
+++ b/docs/plans/v8_strategy_contract_consolidation_plan.md
@@ -1,6 +1,6 @@
 # V8 Strategy Contract Consolidation Plan
 
-This plan covers the highest-value follow-up work on `feature/v8-strategy-runtime`: make the v8
+This plan covers the highest-value follow-up work on `v8`: make the v8
 strategy/config/optimizer contract single-sourced, remove duplicated path-resolution logic, and add
 tests that prove the contract survives the full config and optimizer pipeline.
 

--- a/docs/plans/v8_strategy_runtime_merge_readiness_plan.md
+++ b/docs/plans/v8_strategy_runtime_merge_readiness_plan.md
@@ -1,6 +1,6 @@
 # V8 Strategy Runtime Merge Readiness Plan
 
-This plan covers the next highest-value pass on `feature/v8-strategy-runtime`.
+This plan covers the next highest-value pass on `v8`.
 
 The branch already contains the high-leverage v8 strategy/config/optimizer contract consolidation:
 Rust-owned strategy metadata, Python adapters in `src/config/strategy_spec.py`, centralized path
@@ -10,7 +10,7 @@ branch clean, verifiable, and reviewable for merge. It should not start a broad 
 
 ## Goal
 
-Make `feature/v8-strategy-runtime` merge-ready by removing known hygiene failures and validating
+Make `v8` merge-ready by removing known hygiene failures and validating
 that the current Rust/Python/config/optimizer contract works from a fresh checkout state.
 
 Success means:
@@ -36,28 +36,18 @@ Success means:
 
 ## Current Known Evidence
 
-- Current branch tip reviewed: `32bf02ef Consolidate v8 strategy config contract`.
-- `HEAD` matched `origin/feature/v8-strategy-runtime` after fetch during review.
-- Targeted contract tests passed after the repo-stamped Rust rebuild:
-
-```bash
-./venv/bin/python -m pytest \
-  tests/test_config_pipeline.py \
-  tests/optimization/test_config_adapter.py \
-  tests/optimization/test_optimize.py \
-  tests/test_suite_runner.py \
-  tests/optimization/test_optimizer_warmup.py \
-  tests/test_shared_bot.py
-```
-
-- Current result from that command: `229 passed, 14 warnings`.
-- The same tests failed before rebuild because the installed `passivbot_rust` was stale and lacked
-  `get_strategy_kinds`.
-- Confirmed hygiene blocker:
-
-```text
-src/config/param_paths.py:175: new blank line at EOF.
-```
+- Current branch tip reviewed: `15ac8094 Fix v8 full suite test expectations`.
+- `HEAD` matched `origin/v8` after fetch during review.
+- `git diff --check origin/master...HEAD` passed at the current tip; the older
+  `src/config/param_paths.py` blank-EOF hygiene blocker is resolved.
+- The installed `passivbot_rust` extension must still be rebuilt for this checkout before Python
+  tests that read Rust-owned strategy metadata are meaningful.
+- Latest review smoke after rebuilding the Rust extension verified:
+  - `passivbot_rust.get_strategy_kinds()` returned `("trailing_martingale", "ema_anchor")`.
+  - `tests/test_config_pipeline.py`, `tests/test_config_utils_helpers.py`, and
+    `tests/test_passivbot_version.py` passed.
+- Before merging, re-run the primary contract suite below because the branch has advanced since the
+  earlier `229 passed, 14 warnings` contract-test snapshot.
 
 ## Pass Sequence
 
@@ -68,17 +58,17 @@ Purpose: avoid reviewing stale local state.
 Commands:
 
 ```bash
-git fetch origin feature/v8-strategy-runtime
+git fetch origin v8
 git status --short --branch
 git rev-parse HEAD
-git rev-parse origin/feature/v8-strategy-runtime
+git rev-parse origin/v8
 git log --oneline -n 10
 ```
 
 Acceptance:
 
-- Local branch is still `feature/v8-strategy-runtime`.
-- `HEAD` matches `origin/feature/v8-strategy-runtime`, or any local-only commits are intentional
+- Local branch is still `v8`.
+- `HEAD` matches `origin/v8`, or any local-only commits are intentional
   and listed in the final report.
 - Untracked files are classified as unrelated, planned, or blockers.
 
@@ -93,7 +83,7 @@ Purpose: remove the known confirmed merge blocker before spending time on heavie
 
 Tasks:
 
-1. Remove the blank trailing EOF line in `src/config/param_paths.py`.
+1. Confirm the previously reported blank trailing EOF line in `src/config/param_paths.py` remains fixed.
 2. Run the whitespace/check gate.
 3. Inspect the diff to confirm no unrelated formatting churn.
 
@@ -107,7 +97,7 @@ git diff -- src/config/param_paths.py
 Acceptance:
 
 - `git diff --check origin/master...HEAD` exits cleanly.
-- The only code edit in this step is the EOF hygiene fix unless new hygiene failures are found.
+- No code edit is needed if the EOF hygiene issue remains fixed; otherwise fix only mechanical hygiene failures.
 
 Stop conditions:
 
@@ -316,7 +306,7 @@ At the end of the pass, provide:
 
 The pass is complete when:
 
-- The known `param_paths.py` EOF issue is fixed.
+- The previously reported `param_paths.py` EOF issue remains fixed.
 - All selected commands above are run or explicitly marked blocked with exact blocker evidence.
 - No validation step relies on a stale Rust extension.
 - The final report can say either "merge-ready" or "not merge-ready because ..." with concrete

--- a/docs/plans/v8_strategy_runtime_merge_readiness_plan.md
+++ b/docs/plans/v8_strategy_runtime_merge_readiness_plan.md
@@ -34,20 +34,22 @@ Success means:
 - Do not treat broad `pytest` success as sufficient if the Rust extension freshness check or
   backtest smoke path has not been exercised.
 
-## Current Known Evidence
+## Historical Known Evidence
 
-- Current branch tip reviewed: `15ac8094 Fix v8 full suite test expectations`.
-- `HEAD` matched `origin/v8` after fetch during review.
-- `git diff --check origin/master...HEAD` passed at the current tip; the older
-  `src/config/param_paths.py` blank-EOF hygiene blocker is resolved.
+- Previous reviewed branch tip: `15ac8094 Fix v8 full suite test expectations`.
+- At that review point, `HEAD` matched `origin/v8` after fetch.
+- `git diff --check origin/master...HEAD` passed at that reviewed tip; the older
+  `src/config/param_paths.py` blank-EOF hygiene blocker was resolved there.
 - The installed `passivbot_rust` extension must still be rebuilt for this checkout before Python
   tests that read Rust-owned strategy metadata are meaningful.
 - Latest review smoke after rebuilding the Rust extension verified:
   - `passivbot_rust.get_strategy_kinds()` returned `("trailing_martingale", "ema_anchor")`.
   - `tests/test_config_pipeline.py`, `tests/test_config_utils_helpers.py`, and
     `tests/test_passivbot_version.py` passed.
-- Before merging, re-run the primary contract suite below because the branch has advanced since the
-  earlier `229 passed, 14 warnings` contract-test snapshot.
+- This section is historical evidence, not a current merge-readiness certification. Before merging,
+  refresh `origin/v8` and re-run the primary contract suite below because the branch may have
+  advanced since both the `15ac8094` smoke and the earlier `229 passed, 14 warnings`
+  contract-test snapshot.
 
 ## Pass Sequence
 

--- a/docs/plans/v8_trading_logic_cleanup.md
+++ b/docs/plans/v8_trading_logic_cleanup.md
@@ -1,6 +1,6 @@
 # V8 Trading Logic Cleanup Checklist
 
-Working target for `refactor/rust-strategy-runtime-plan`.
+Working target for `v8`.
 
 ## Core behavior
 


### PR DESCRIPTION
## Summary
- update v8 docs and README/CHANGELOG to reference the current `v8` branch instead of stale branch names
- refresh `docs/plans/v8_strategy_runtime_merge_readiness_plan.md` with the latest reviewed tip and resolved hygiene status
- keep the merge-readiness checklist focused on re-validating current `v8` rather than an old feature branch

## Checks
- `git diff --check HEAD~1..HEAD`
- `git diff --check origin/master...HEAD`
- stale branch reference grep for `feature/v8-strategy-runtime|refactor/rust-strategy-runtime-plan` across changed files returned 0 matches

## Notes
- Docs-only cleanup; no trading/runtime code changed.
