### PR TITLE
Add Bitget UTA / Elite (copy-trading) account support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added Bitget UTA / Elite copy-trading account support with v3 API routing for
+  balance, orders, and fill-event history while keeping classic Bitget accounts
+  on the existing v2/mix paths.
 - Fixed live `[pos]` logging so short position size increases are labeled as
   `added` and short size decreases as `reduced`, matching exposure magnitude
   instead of signed numeric ordering.

--- a/src/exchanges/bitget.py
+++ b/src/exchanges/bitget.py
@@ -861,10 +861,37 @@ class BitgetBot(CCXTBot):
         return sorted(events_map.values(), key=lambda x: x["timestamp"])
 
     async def fetch_closed_orders(self, start_time, end_time, limit=100):
+        if getattr(self, "is_uta", False):
+            return await self._fetch_fill_events_uta(start_time, end_time, limit)
+
         def extract_fill_event_from_co(elm):
             timestamp = int(elm["lastUpdateTimestamp"])
             price = float(elm["price"])
             qty = float(elm["filled"])
+            info = elm.get("info")
+            if not isinstance(info, dict):
+                raise ValueError(
+                    "bitget closed-order payload missing info; "
+                    f"context={_bitget_payload_context(elm)}"
+                )
+            if info.get("totalProfits") in (None, ""):
+                raise ValueError(
+                    "bitget closed-order payload missing info.totalProfits; "
+                    f"context={_bitget_payload_context(elm)}"
+                )
+            try:
+                pnl = float(info["totalProfits"])
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    "bitget closed-order info.totalProfits is not numeric; "
+                    f"value={info.get('totalProfits')!r} context={_bitget_payload_context(elm)}"
+                ) from exc
+            position_side = str(info.get("posSide") or "").lower()
+            if position_side not in ("long", "short"):
+                raise ValueError(
+                    "bitget closed-order payload missing valid info.posSide; "
+                    f"context={_bitget_payload_context(elm)}"
+                )
             pb_order_type = custom_id_to_snake(elm.get("clientOrderId"))
             if not pb_order_type or pb_order_type == "unknown":
                 if not hasattr(self, "pb_order_type_missing_logged"):
@@ -878,7 +905,7 @@ class BitgetBot(CCXTBot):
                         or elm.get("symbol"),
                         elm.get("clientOrderId"),
                         elm.get("side"),
-                        elm.get("info", {}).get("posSide"),
+                        position_side,
                         qty,
                         price,
                     )
@@ -891,10 +918,10 @@ class BitgetBot(CCXTBot):
                 "side": elm["side"],
                 "qty": qty,
                 "price": price,
-                "pnl": float((elm.get("info") or {}).get("totalProfits") or 0.0),
+                "pnl": pnl,
                 "fees": elm.get("fees"),
                 "pb_order_type": pb_order_type,
-                "position_side": (elm.get("info") or {}).get("posSide", "long"),
+                "position_side": position_side,
                 "client_order_id": elm.get("clientOrderId"),
             }
 

--- a/src/exchanges/bitget.py
+++ b/src/exchanges/bitget.py
@@ -89,6 +89,11 @@ class BitgetBot(CCXTBot):
     def __init__(self, config: dict):
         super().__init__(config)
         self.custom_id_max_length = 64
+        # Whether this API key drives a UTA / Elite (copy-trading) account.
+        # Auto-detected once in update_exchange_config(); classic accounts keep
+        # is_uta == False and every code path below behaves exactly as before.
+        self.is_uta = False
+        self._account_mode_detected = False
 
     def create_ccxt_sessions(self):
         """Bitget: set Passivbot channel code for broker rebate attribution."""
@@ -98,6 +103,45 @@ class BitgetBot(CCXTBot):
         for client in [self.cca, self.ccp]:
             if client is not None:
                 client.options["broker"] = self.broker_code
+                # Preserve UTA routing across ccxt session re-creation (reconnects)
+                # once the account mode has been detected.
+                if getattr(self, "is_uta", False):
+                    client.options["uta"] = True
+
+    async def _detect_account_mode(self):
+        """Detect whether this API key is a UTA / Elite (copy-trading) account
+        (Bitget v3 API) or a classic v2/mix account, and route ccxt accordingly.
+
+        Probes the v3 account-assets endpoint: it succeeds on UTA/Elite keys and
+        returns code 40084 ("Classic Account mode") on classic keys. On ANY
+        uncertainty we fall back to classic so existing classic accounts are
+        never affected (zero regression). Runs once per process."""
+        if getattr(self, "_account_mode_detected", False):
+            return
+        is_uta = False
+        try:
+            await self.cca.private_uta_get_v3_account_assets()
+            is_uta = True
+        except Exception as e:
+            msg = str(e)
+            if "40084" not in msg:
+                logging.warning(
+                    "[bitget] UTA detection inconclusive, assuming classic account: %s",
+                    msg[:200],
+                )
+            is_uta = False
+        self.is_uta = is_uta
+        for client in (getattr(self, "cca", None), getattr(self, "ccp", None)):
+            if client is not None:
+                try:
+                    client.options["uta"] = is_uta
+                except Exception:
+                    pass
+        self._account_mode_detected = True
+        logging.info(
+            "[bitget] account mode: %s",
+            "UTA / Elite copy-trading (v3)" if is_uta else "Classic (v2/mix)",
+        )
 
     # ═══════════════════ HOOK OVERRIDES ═══════════════════
 
@@ -129,6 +173,16 @@ class BitgetBot(CCXTBot):
         return order
 
     def _determine_side(self, order: dict) -> str:
+        if getattr(self, "is_uta", False):
+            # UTA orders carry posSide (long/short) and reduceOnly (yes/no) but
+            # no tradeSide. Derive the order side from those.
+            info = order.get("info", {})
+            pos_side = str(info.get("posSide", order.get("position_side", "long"))).lower()
+            reduce_raw = info.get("reduceOnly", order.get("reduceOnly", False))
+            reduce_only = str(reduce_raw).strip().lower() in ("yes", "true", "1")
+            if reduce_only:
+                return "sell" if pos_side == "long" else "buy"
+            return "buy" if pos_side == "long" else "sell"
         if "info" in order:
             if all([x in order["info"] for x in ["tradeSide", "reduceOnly", "posSide"]]):
                 if order["info"]["tradeSide"] == "close":
@@ -186,7 +240,18 @@ class BitgetBot(CCXTBot):
         return fetched
 
     def _get_balance(self, fetched: dict) -> float:
-        """Bitget override: handle union margin mode."""
+        """Bitget override: handle union margin mode (classic) and UTA/elite."""
+        if getattr(self, "is_uta", False):
+            # UTA fetch_balance returns info as a list of asset dicts keyed by
+            # 'coin' (no 'marginCoin'). Use wallet balance (excl. uPnL), which
+            # ccxt exposes as the unified 'total'.
+            try:
+                return float(fetched[self.quote]["total"])
+            except Exception:
+                for x in (fetched.get("info") or []):
+                    if isinstance(x, dict) and x.get("coin") == self.quote:
+                        return float(x.get("balance") or x.get("available") or 0.0)
+                return 0.0
         balance_info = [x for x in fetched["info"] if x["marginCoin"] == self.quote][0]
         if (
             "assetMode" in balance_info
@@ -199,6 +264,8 @@ class BitgetBot(CCXTBot):
     # ═══════════════════ BITGET-SPECIFIC METHODS ═══════════════════
 
     async def fetch_pnls(self, start_time=None, end_time=None, limit=None):
+        if getattr(self, "is_uta", False):
+            return await self._fetch_pnls_uta(start_time, end_time, limit)
         params = {"productType": "USDT-FUTURES"}
         if start_time:
             start_time = int(start_time)
@@ -238,6 +305,42 @@ class BitgetBot(CCXTBot):
             params["endTime"] = int(last_ts)
         return sorted(data_d.values(), key=lambda x: x["timestamp"])
 
+    async def _fetch_pnls_uta(self, start_time=None, end_time=None, limit=None):
+        """UTA/elite variant of fetch_pnls using v3 trade fills (execPnl)."""
+        params = {"category": "USDT-FUTURES"}
+        if start_time:
+            start_time = int(start_time)
+        if end_time:
+            params["endTime"] = int(end_time)
+        params["limit"] = str(min(100, limit) if limit else 100)
+        data_d = {}
+        while True:
+            fetched = await self.cca.private_uta_get_v3_trade_fills(params)
+            data = (fetched.get("data") or {}).get("list") or []
+            if not data:
+                break
+            with_hashes = {calc_hash(x): x for x in data}
+            if all([h in data_d for h in with_hashes]):
+                break
+            for h, x in with_hashes.items():
+                data_d[h] = x
+                data_d[h]["pnl"] = float(x.get("execPnl") or 0.0)
+                data_d[h]["price"] = float(x.get("execPrice") or 0.0)
+                data_d[h]["amount"] = float(x.get("execQty") or 0.0)
+                data_d[h]["id"] = x.get("execId") or x.get("orderId")
+                data_d[h]["timestamp"] = float(x.get("createdTime") or 0.0)
+                data_d[h]["datetime"] = ts_to_date(data_d[h]["timestamp"])
+                data_d[h]["position_side"] = str(x.get("posSide", "long")).lower()
+                data_d[h]["symbol"] = self.get_symbol_id_inv(x.get("symbol"))
+            if start_time is None:
+                break
+            last_ts = float(data[-1].get("createdTime") or 0.0)
+            if last_ts <= start_time:
+                break
+            logging.info(f"fetched {len(data)} fills until {ts_to_date(last_ts)[:19]}")
+            params["endTime"] = int(last_ts)
+        return sorted(data_d.values(), key=lambda x: x["timestamp"])
+
     async def _throttled_order_detail(self, order_id: str, symbol: str):
         """Rate limited wrapper for clientOid lookups."""
         if not hasattr(self, "_detail_fetch_timestamps"):
@@ -254,6 +357,13 @@ class BitgetBot(CCXTBot):
                 break
             await asyncio.sleep(0.1)
         logging.debug(f"fetching order detail for {symbol} {order_id}")
+        if getattr(self, "is_uta", False):
+            return await self.cca.private_uta_get_v3_trade_order_info(
+                params={
+                    "category": "USDT-FUTURES",
+                    "orderId": order_id,
+                }
+            )
         return await self.cca.private_mix_get_v2_mix_order_detail(
             params={
                 "productType": "USDT-FUTURES",
@@ -322,6 +432,8 @@ class BitgetBot(CCXTBot):
                 self._client_oid_cache[evt_id] = (cid, pb)
 
     async def fetch_fill_events(self, start_time=None, end_time=None, limit=None):
+        if getattr(self, "is_uta", False):
+            return await self._fetch_fill_events_uta(start_time, end_time, limit)
 
         def _extract_fill(elm: dict) -> dict:
             timestamp = int(elm["cTime"])
@@ -449,6 +561,70 @@ class BitgetBot(CCXTBot):
         final_result = sorted(events_map.values(), key=lambda x: x["timestamp"])
         return final_result
 
+    async def _fetch_fill_events_uta(self, start_time=None, end_time=None, limit=None):
+        """UTA/elite variant of fetch_fill_events using v3 trade fills.
+
+        v3 fills already include clientOid and execPnl, so no per-order detail
+        enrichment is needed. Deduped by execId."""
+
+        def _extract(elm: dict) -> dict:
+            ts = int(elm.get("createdTime") or 0)
+            pos_side = str(elm.get("posSide", "long")).lower()
+            side = str(elm.get("side") or ("buy" if pos_side == "long" else "sell")).lower()
+            cid = elm.get("clientOid")
+            return {
+                "id": elm.get("orderId"),
+                "timestamp": ts,
+                "datetime": ts_to_date(ts),
+                "symbol": self.get_symbol_id_inv(elm.get("symbol")),
+                "side": side,
+                "qty": float(elm.get("execQty") or 0.0),
+                "price": float(elm.get("execPrice") or 0.0),
+                "pnl": float(elm.get("execPnl") or 0.0),
+                "fees": elm.get("feeDetail"),
+                "pb_order_type": custom_id_to_snake(cid) if cid else None,
+                "position_side": pos_side,
+                "client_order_id": cid,
+                "info": elm,
+            }
+
+        limit = 100 if limit is None else min(limit, 100)
+        max_n_fetches = 200
+        buffer_step_ms = int(1000 * 60 * 60 * 24)
+        end_time = int(utc_ms() + 3600000 if end_time is None else end_time)
+        events_map: Dict[str, dict] = {}
+        params = {"category": "USDT-FUTURES", "endTime": end_time, "limit": str(limit)}
+        count = 0
+        while True:
+            count += 1
+            if count >= max_n_fetches:
+                logging.warning(f"over {count} calls to fetch_fill_events (uta). Breaking.")
+                break
+            fetched = await self.cca.private_uta_get_v3_trade_fills(params)
+            rows = (fetched.get("data") or {}).get("list") or []
+            fill_events = sorted([_extract(x) for x in rows], key=lambda x: x["timestamp"])
+            if not fill_events:
+                break
+            added = False
+            for fe, raw in zip(fill_events, sorted(rows, key=lambda r: int(r.get("createdTime") or 0))):
+                key = raw.get("execId") or f"{fe['id']}_{fe['timestamp']}"
+                if key not in events_map:
+                    events_map[key] = fe
+                    added = True
+            if not added:
+                break
+            if len(fill_events) < limit:
+                if start_time is None or params["endTime"] - start_time < buffer_step_ms:
+                    break
+                params["endTime"] = int(fill_events[0]["timestamp"] + 1)
+                continue
+            if start_time is None or fill_events[0]["timestamp"] < start_time:
+                break
+            if params["endTime"] == fill_events[0]["timestamp"]:
+                break
+            params["endTime"] = int(fill_events[0]["timestamp"])
+        return sorted(events_map.values(), key=lambda x: x["timestamp"])
+
     async def fetch_closed_orders(self, start_time, end_time, limit=100):
         def extract_fill_event_from_co(elm):
             timestamp = int(elm["lastUpdateTimestamp"])
@@ -480,10 +656,10 @@ class BitgetBot(CCXTBot):
                 "side": elm["side"],
                 "qty": qty,
                 "price": price,
-                "pnl": float(elm["info"]["totalProfits"]),
+                "pnl": float((elm.get("info") or {}).get("totalProfits") or 0.0),
                 "fees": elm.get("fees"),
                 "pb_order_type": pb_order_type,
-                "position_side": elm["info"]["posSide"],
+                "position_side": (elm.get("info") or {}).get("posSide", "long"),
                 "client_order_id": elm.get("clientOrderId"),
             }
 
@@ -558,10 +734,18 @@ class BitgetBot(CCXTBot):
         return clip_by_timestamp(deduped, start_time, end_time)
 
     def _build_order_params(self, order: dict) -> dict:
+        tif = "PO" if require_live_value(self.config, "time_in_force") == "post_only" else "GTC"
+        if getattr(self, "is_uta", False):
+            # UTA/elite hedge-mode orders use posSide; holdSide/oneWayMode are
+            # v2-only and rejected by v3 with code 25236.
+            return {
+                "timeInForce": tif,
+                "posSide": order["position_side"],
+                "reduceOnly": order["reduce_only"],
+                "clientOid": order["custom_id"],
+            }
         return {
-            "timeInForce": (
-                "PO" if require_live_value(self.config, "time_in_force") == "post_only" else "GTC"
-            ),
+            "timeInForce": tif,
             "holdSide": order["position_side"],
             "reduceOnly": order["reduce_only"],
             "oneWayMode": False,
@@ -573,15 +757,18 @@ class BitgetBot(CCXTBot):
         for symbol in symbols:
             margin_mode = self._get_margin_mode_for_symbol(symbol)
             log_symbol = symbol_to_coin(symbol, verbose=False) or symbol
-            try:
-                coros_to_call_margin_mode[symbol] = asyncio.create_task(
-                    self.cca.set_margin_mode(
-                        margin_mode,
-                        symbol=symbol,
+            # UTA/elite: ccxt has no v3 routing for set_margin_mode and the elite
+            # portfolio is cross-only, so skip it (avoids a failing v2 call).
+            if not getattr(self, "is_uta", False):
+                try:
+                    coros_to_call_margin_mode[symbol] = asyncio.create_task(
+                        self.cca.set_margin_mode(
+                            margin_mode,
+                            symbol=symbol,
+                        )
                     )
-                )
-            except Exception as e:
-                logging.error(f"{log_symbol}: error setting {margin_mode} mode {e}")
+                except Exception as e:
+                    logging.error(f"{log_symbol}: error setting {margin_mode} mode {e}")
             try:
                 coros_to_call_lev[symbol] = asyncio.create_task(
                     self.cca.set_leverage(self._calc_leverage_for_symbol(symbol), symbol=symbol)
@@ -598,13 +785,14 @@ class BitgetBot(CCXTBot):
             except Exception as e:
                 logging.error(f"{log_symbol} error setting leverage {e}")
             res = None
-            try:
-                res = await coros_to_call_margin_mode[symbol]
-                to_print += f"margin={format_exchange_config_response(res)}"
-            except Exception as e:
-                logging.error(
-                    f"{log_symbol} error setting {self._get_margin_mode_for_symbol(symbol)} mode {e}"
-                )
+            if symbol in coros_to_call_margin_mode:
+                try:
+                    res = await coros_to_call_margin_mode[symbol]
+                    to_print += f"margin={format_exchange_config_response(res)}"
+                except Exception as e:
+                    logging.error(
+                        f"{log_symbol} error setting {self._get_margin_mode_for_symbol(symbol)} mode {e}"
+                    )
             if to_print:
                 logging.info(f"{log_symbol}: {to_print}")
 
@@ -639,6 +827,8 @@ class BitgetBot(CCXTBot):
         return ideal_orders
 
     async def update_exchange_config(self):
+        # Detect classic vs UTA/elite once, before any balance/position/order call.
+        await self._detect_account_mode()
         res = None
         try:
             res = await self.cca.set_position_mode(True)

--- a/src/exchanges/bitget.py
+++ b/src/exchanges/bitget.py
@@ -3,14 +3,150 @@ from passivbot import logging, custom_id_to_snake, clip_by_timestamp
 import asyncio
 import json
 import os
+import re
 from copy import deepcopy
-from typing import Dict, List, Tuple
+from typing import Callable, Dict, List, Tuple
 from utils import symbol_to_coin, utc_ms, ts_to_date
 from config.access import require_live_value
 from pure_funcs import calc_hash
 import passivbot_rust as pbr
 
 calc_order_price_diff = pbr.calc_order_price_diff
+
+_CLASSIC_ACCOUNT_MODE_CODES = {"40084", "25245"}
+
+
+def _bitget_payload_context(payload: object) -> str:
+    if isinstance(payload, dict):
+        keys = sorted(str(key) for key in payload.keys())
+        data = payload.get("data")
+        data_keys = sorted(str(key) for key in data.keys()) if isinstance(data, dict) else []
+        code = payload.get("code")
+        msg = payload.get("msg")
+        return f"code={code!r} msg={msg!r} keys={keys!r} data_keys={data_keys!r}"
+    return f"type={type(payload).__name__}"
+
+
+def _bitget_error_code_from_exception(exc: Exception) -> str:
+    payload = getattr(exc, "response", None) or getattr(exc, "body", None)
+    if isinstance(payload, bytes):
+        payload = payload.decode(errors="replace")
+    if isinstance(payload, str):
+        try:
+            decoded = json.loads(payload)
+        except Exception:
+            decoded = None
+        if isinstance(decoded, dict) and decoded.get("code") is not None:
+            return str(decoded["code"])
+    elif isinstance(payload, dict) and payload.get("code") is not None:
+        return str(payload["code"])
+
+    msg = str(exc)
+    match = re.search(r"['\"]code['\"]\s*:\s*['\"]?(\d+)['\"]?", msg)
+    if match:
+        return match.group(1)
+    match = re.search(r"\b(40084|25245)\b", msg)
+    return match.group(1) if match else ""
+
+
+def _require_uta_field(fill: dict, field: str) -> object:
+    if field not in fill or fill[field] in (None, ""):
+        raise ValueError(
+            f"bitget UTA fill missing required field {field!r}; "
+            f"context={_bitget_payload_context(fill)}"
+        )
+    return fill[field]
+
+
+def _require_uta_float(fill: dict, field: str, *, positive: bool = False) -> float:
+    raw = _require_uta_field(fill, field)
+    try:
+        value = float(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"bitget UTA fill field {field!r} is not numeric; "
+            f"value={raw!r} context={_bitget_payload_context(fill)}"
+        ) from exc
+    if positive and value <= 0.0:
+        raise ValueError(
+            f"bitget UTA fill field {field!r} must be positive; "
+            f"value={raw!r} context={_bitget_payload_context(fill)}"
+        )
+    return value
+
+
+def _require_uta_timestamp(fill: dict) -> int:
+    raw = _require_uta_field(fill, "createdTime")
+    try:
+        timestamp = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"bitget UTA fill createdTime is not an integer millisecond timestamp; "
+            f"value={raw!r} context={_bitget_payload_context(fill)}"
+        ) from exc
+    if timestamp <= 0:
+        raise ValueError(
+            f"bitget UTA fill createdTime must be positive; "
+            f"value={raw!r} context={_bitget_payload_context(fill)}"
+        )
+    return timestamp
+
+
+def _bitget_fee_paid_from_fee(raw_fee: object) -> float:
+    fee = float(raw_fee)
+    return fee if fee < 0.0 else -abs(fee)
+
+
+def normalize_bitget_fee_detail(fee_detail: object) -> object:
+    """Normalize Bitget feeDetail rows into canonical signed fee entries."""
+    if fee_detail is None:
+        return fee_detail
+    if isinstance(fee_detail, dict):
+        entries = [fee_detail]
+    elif isinstance(fee_detail, str):
+        try:
+            decoded = json.loads(fee_detail)
+        except Exception:
+            return fee_detail
+        if isinstance(decoded, dict):
+            entries = [decoded]
+        elif isinstance(decoded, list):
+            entries = [entry for entry in decoded if isinstance(entry, dict)]
+        else:
+            return fee_detail
+    else:
+        try:
+            entries = [entry for entry in list(fee_detail) if isinstance(entry, dict)]
+        except Exception:
+            return fee_detail
+    if not entries:
+        return fee_detail
+
+    normalized: List[Dict[str, object]] = []
+    for entry in entries:
+        item = dict(entry)
+        currency = (
+            item.get("currency")
+            or item.get("feeCoin")
+            or item.get("coin")
+            or item.get("asset")
+            or item.get("feeCurrency")
+        )
+        if currency:
+            item["currency"] = str(currency).upper()
+        try:
+            if item.get("fee_paid") not in (None, ""):
+                item["fee_paid"] = float(item["fee_paid"])
+            elif item.get("totalFee") not in (None, ""):
+                item["fee_paid"] = float(item["totalFee"])
+            elif item.get("fee") not in (None, ""):
+                item["fee_paid"] = _bitget_fee_paid_from_fee(item["fee"])
+            elif item.get("totalDeductionFee") not in (None, ""):
+                item["fee_paid"] = float(item["totalDeductionFee"])
+        except (TypeError, ValueError):
+            pass
+        normalized.append(item)
+    return normalized
 
 
 def deduce_side_pside(fill: dict) -> tuple[str, str]:
@@ -105,15 +241,56 @@ def deduce_uta_side_pside(fill: dict) -> tuple[str, str]:
                 pos_side = "short"
 
     if pos_side not in ("long", "short"):
-        pos_side = "long" if raw_side != "sell" else "short"
+        raise ValueError(
+            "bitget UTA fill cannot infer position side; "
+            f"context={_bitget_payload_context(fill)}"
+        )
 
     if raw_side not in ("buy", "sell"):
         if trade_side == "close":
             raw_side = "sell" if pos_side == "long" else "buy"
-        else:
+        elif trade_side == "open":
             raw_side = "buy" if pos_side == "long" else "sell"
+    if raw_side not in ("buy", "sell"):
+        raise ValueError(
+            "bitget UTA fill cannot infer order side; "
+            f"context={_bitget_payload_context(fill)}"
+        )
 
     return raw_side, pos_side
+
+
+def normalize_uta_fill_payload(fill: dict, symbol_resolver: Callable[[str], str]) -> dict:
+    """Validate and normalize a Bitget UTA v3 fill payload."""
+
+    exec_id = str(_require_uta_field(fill, "execId"))
+    order_id = str(_require_uta_field(fill, "orderId"))
+    timestamp = _require_uta_timestamp(fill)
+    symbol_external = str(_require_uta_field(fill, "symbol"))
+    side, position_side = deduce_uta_side_pside(fill)
+    symbol = symbol_resolver(symbol_external)
+    if not symbol:
+        raise ValueError(
+            "bitget UTA fill symbol resolver returned an empty symbol; "
+            f"symbol={symbol_external!r} context={_bitget_payload_context(fill)}"
+        )
+    cid = fill.get("clientOid")
+    return {
+        "id": exec_id,
+        "order_id": order_id,
+        "timestamp": timestamp,
+        "datetime": ts_to_date(timestamp),
+        "symbol": symbol,
+        "symbol_external": symbol_external,
+        "side": side,
+        "qty": _require_uta_float(fill, "execQty", positive=True),
+        "price": _require_uta_float(fill, "execPrice", positive=True),
+        "pnl": _require_uta_float(fill, "execPnl"),
+        "fees": normalize_bitget_fee_detail(fill.get("feeDetail")),
+        "pb_order_type": custom_id_to_snake(cid) if cid else "",
+        "position_side": position_side,
+        "client_order_id": cid,
+    }
 
 
 class BitgetBot(CCXTBot):
@@ -143,31 +320,29 @@ class BitgetBot(CCXTBot):
         """Detect whether this API key is a UTA / Elite (copy-trading) account
         (Bitget v3 API) or a classic v2/mix account, and route ccxt accordingly.
 
-        Probes the v3 account-assets endpoint: it succeeds on UTA/Elite keys and
-        returns code 40084 ("Classic Account mode") on classic keys. On ANY
-        uncertainty we fall back to classic so existing classic accounts are
-        never affected (zero regression). Runs once per process."""
+        Probes the v3 account-assets endpoint: it succeeds on UTA/Elite keys.
+        Explicit classic-account responses select classic mode; any other
+        failure is inconclusive and must fail loudly so a UTA key is not routed
+        into classic v2/mix calls for the whole process lifetime."""
         if getattr(self, "_account_mode_detected", False):
             return
-        is_uta = False
         try:
             await self.cca.private_uta_get_v3_account_assets()
             is_uta = True
         except Exception as e:
-            msg = str(e)
-            if "40084" not in msg:
-                logging.warning(
-                    "[bitget] UTA detection inconclusive, assuming classic account: %s",
-                    msg[:200],
-                )
+            code = _bitget_error_code_from_exception(e)
+            if code not in _CLASSIC_ACCOUNT_MODE_CODES:
+                raise RuntimeError(
+                    "bitget: UTA account-mode detection failed inconclusively; "
+                    f"error_code={code or 'unknown'}"
+                ) from e
             is_uta = False
         self.is_uta = is_uta
         for client in (getattr(self, "cca", None), getattr(self, "ccp", None)):
             if client is not None:
-                try:
-                    client.options["uta"] = is_uta
-                except Exception:
-                    pass
+                if getattr(client, "options", None) is None:
+                    client.options = {}
+                client.options["uta"] = is_uta
         self._account_mode_detected = True
         logging.info(
             "[bitget] account mode: %s",
@@ -283,27 +458,18 @@ class BitgetBot(CCXTBot):
                 # Passivbot balance is wallet balance: equity - upnl.
                 # Bitget UTA's effEquity is discounted effective margin value,
                 # not account balance.
-                if data.get("usdtEquity") is not None:
-                    return float(data["usdtEquity"]) - float(
-                        data.get("usdtUnrealisedPnl") or 0.0
-                    )
-                if data.get("accountEquity") is not None:
-                    return float(data["accountEquity"]) - float(
-                        data.get("unrealisedPnl") or 0.0
-                    )
-                for x in data.get("assets") or []:
-                    if isinstance(x, dict) and x.get("coin") == self.quote:
-                        return float(x.get("balance") or x.get("available") or 0.0)
-            # Backwards-compatible parser for callers/tests that still pass a
-            # CCXT-parsed UTA balance. This is a quote-coin fallback only.
-            if isinstance(fetched, dict):
-                try:
-                    return float(fetched[self.quote]["total"])
-                except Exception:
-                    for x in fetched.get("info") or []:
-                        if isinstance(x, dict) and x.get("coin") == self.quote:
-                            return float(x.get("balance") or x.get("available") or 0.0)
-            raise KeyError("bitget: UTA balance response missing account equity")
+                if data.get("usdtEquity") not in (None, "") and data.get(
+                    "usdtUnrealisedPnl"
+                ) not in (None, ""):
+                    return float(data["usdtEquity"]) - float(data["usdtUnrealisedPnl"])
+                if data.get("accountEquity") not in (None, "") and data.get(
+                    "unrealisedPnl"
+                ) not in (None, ""):
+                    return float(data["accountEquity"]) - float(data["unrealisedPnl"])
+            raise ValueError(
+                "bitget: UTA balance response missing required account equity/upnl fields; "
+                f"context={_bitget_payload_context(fetched)}"
+            )
         balance_info = [x for x in fetched["info"] if x["marginCoin"] == self.quote][0]
         if (
             "assetMode" in balance_info
@@ -375,19 +541,19 @@ class BitgetBot(CCXTBot):
             if all([h in data_d for h in with_hashes]):
                 break
             for h, x in with_hashes.items():
-                _side, position_side = deduce_uta_side_pside(x)
-                data_d[h] = x
-                data_d[h]["pnl"] = float(x.get("execPnl") or 0.0)
-                data_d[h]["price"] = float(x.get("execPrice") or 0.0)
-                data_d[h]["amount"] = float(x.get("execQty") or 0.0)
-                data_d[h]["id"] = x.get("execId") or x.get("orderId")
-                data_d[h]["timestamp"] = float(x.get("createdTime") or 0.0)
-                data_d[h]["datetime"] = ts_to_date(data_d[h]["timestamp"])
-                data_d[h]["position_side"] = position_side
-                data_d[h]["symbol"] = self.get_symbol_id_inv(x.get("symbol"))
+                event = normalize_uta_fill_payload(x, self.get_symbol_id_inv)
+                data_d[h] = dict(x)
+                data_d[h]["pnl"] = event["pnl"]
+                data_d[h]["price"] = event["price"]
+                data_d[h]["amount"] = event["qty"]
+                data_d[h]["id"] = event["id"]
+                data_d[h]["timestamp"] = float(event["timestamp"])
+                data_d[h]["datetime"] = event["datetime"]
+                data_d[h]["position_side"] = event["position_side"]
+                data_d[h]["symbol"] = event["symbol"]
             if start_time is None:
                 break
-            last_ts = float(data[-1].get("createdTime") or 0.0)
+            last_ts = float(_require_uta_timestamp(data[-1]))
             if last_ts <= start_time:
                 break
             logging.info(f"fetched {len(data)} fills until {ts_to_date(last_ts)[:19]}")
@@ -621,25 +787,9 @@ class BitgetBot(CCXTBot):
         enrichment is needed. Deduped by execId."""
 
         def _extract(elm: dict) -> dict:
-            ts = int(elm.get("createdTime") or 0)
-            side, pos_side = deduce_uta_side_pside(elm)
-            cid = elm.get("clientOid")
-            return {
-                "id": elm.get("execId") or elm.get("orderId"),
-                "order_id": elm.get("orderId"),
-                "timestamp": ts,
-                "datetime": ts_to_date(ts),
-                "symbol": self.get_symbol_id_inv(elm.get("symbol")),
-                "side": side,
-                "qty": float(elm.get("execQty") or 0.0),
-                "price": float(elm.get("execPrice") or 0.0),
-                "pnl": float(elm.get("execPnl") or 0.0),
-                "fees": elm.get("feeDetail"),
-                "pb_order_type": custom_id_to_snake(cid) if cid else None,
-                "position_side": pos_side,
-                "client_order_id": cid,
-                "info": elm,
-            }
+            event = normalize_uta_fill_payload(elm, self.get_symbol_id_inv)
+            event["info"] = elm
+            return event
 
         limit = 100 if limit is None else min(limit, 100)
         max_n_fetches = 200
@@ -666,7 +816,8 @@ class BitgetBot(CCXTBot):
             fetched = await self.cca.private_uta_get_v3_trade_fills(request_params)
             data = fetched.get("data") or {}
             rows = data.get("list") or []
-            fill_events = sorted([_extract(x) for x in rows], key=lambda x: x["timestamp"])
+            fill_events = [_extract(x) for x in rows]
+            fill_events.sort(key=lambda x: x["timestamp"])
             if not fill_events:
                 if start_time is not None and window_start is not None and window_start > start_time:
                     next_end = int(window_start) - 1
@@ -677,8 +828,8 @@ class BitgetBot(CCXTBot):
                     continue
                 break
             added = False
-            for fe, raw in zip(fill_events, sorted(rows, key=lambda r: int(r.get("createdTime") or 0))):
-                key = raw.get("execId") or f"{fe['id']}_{fe['timestamp']}"
+            for fe in fill_events:
+                key = fe["id"]
                 if key not in events_map:
                     events_map[key] = fe
                     added = True
@@ -830,7 +981,7 @@ class BitgetBot(CCXTBot):
             if use_post_only:
                 params["postOnly"] = True
             else:
-                params["timeInForce"] = "GTC"
+                params["timeInForce"] = "gtc"
             return params
         tif = "PO" if use_post_only else "GTC"
         return {

--- a/src/exchanges/bitget.py
+++ b/src/exchanges/bitget.py
@@ -85,6 +85,37 @@ def deduce_side_pside(fill: dict) -> tuple[str, str]:
     return _canonical(raw_side or "buy", "long")
 
 
+def deduce_uta_side_pside(fill: dict) -> tuple[str, str]:
+    """Infer standard ``(side, pside)`` for Bitget UTA v3 fill payloads."""
+
+    raw_side = str(fill.get("side", "")).lower()
+    trade_side = str(fill.get("tradeSide", "")).lower()
+    pos_side = str(fill.get("posSide", "")).lower()
+
+    if pos_side not in ("long", "short"):
+        if trade_side == "close":
+            if raw_side == "buy":
+                pos_side = "short"
+            elif raw_side == "sell":
+                pos_side = "long"
+        elif trade_side == "open":
+            if raw_side == "buy":
+                pos_side = "long"
+            elif raw_side == "sell":
+                pos_side = "short"
+
+    if pos_side not in ("long", "short"):
+        pos_side = "long" if raw_side != "sell" else "short"
+
+    if raw_side not in ("buy", "sell"):
+        if trade_side == "close":
+            raw_side = "sell" if pos_side == "long" else "buy"
+        else:
+            raw_side = "buy" if pos_side == "long" else "sell"
+
+    return raw_side, pos_side
+
+
 class BitgetBot(CCXTBot):
     def __init__(self, config: dict):
         super().__init__(config)
@@ -239,19 +270,40 @@ class BitgetBot(CCXTBot):
                 self._record_live_margin_mode(elm["symbol"], margin_mode)
         return fetched
 
+    async def _do_fetch_balance(self) -> dict:
+        if getattr(self, "is_uta", False):
+            return await self.cca.private_uta_get_v3_account_assets()
+        return await super()._do_fetch_balance()
+
     def _get_balance(self, fetched: dict) -> float:
         """Bitget override: handle union margin mode (classic) and UTA/elite."""
         if getattr(self, "is_uta", False):
-            # UTA fetch_balance returns info as a list of asset dicts keyed by
-            # 'coin' (no 'marginCoin'). Use wallet balance (excl. uPnL), which
-            # ccxt exposes as the unified 'total'.
-            try:
-                return float(fetched[self.quote]["total"])
-            except Exception:
-                for x in (fetched.get("info") or []):
+            data = fetched.get("data") if isinstance(fetched, dict) else None
+            if isinstance(data, dict):
+                # Passivbot balance is wallet balance: equity - upnl.
+                # Bitget UTA's effEquity is discounted effective margin value,
+                # not account balance.
+                if data.get("usdtEquity") is not None:
+                    return float(data["usdtEquity"]) - float(
+                        data.get("usdtUnrealisedPnl") or 0.0
+                    )
+                if data.get("accountEquity") is not None:
+                    return float(data["accountEquity"]) - float(
+                        data.get("unrealisedPnl") or 0.0
+                    )
+                for x in data.get("assets") or []:
                     if isinstance(x, dict) and x.get("coin") == self.quote:
                         return float(x.get("balance") or x.get("available") or 0.0)
-                return 0.0
+            # Backwards-compatible parser for callers/tests that still pass a
+            # CCXT-parsed UTA balance. This is a quote-coin fallback only.
+            if isinstance(fetched, dict):
+                try:
+                    return float(fetched[self.quote]["total"])
+                except Exception:
+                    for x in fetched.get("info") or []:
+                        if isinstance(x, dict) and x.get("coin") == self.quote:
+                            return float(x.get("balance") or x.get("available") or 0.0)
+            raise KeyError("bitget: UTA balance response missing account equity")
         balance_info = [x for x in fetched["info"] if x["marginCoin"] == self.quote][0]
         if (
             "assetMode" in balance_info
@@ -323,6 +375,7 @@ class BitgetBot(CCXTBot):
             if all([h in data_d for h in with_hashes]):
                 break
             for h, x in with_hashes.items():
+                _side, position_side = deduce_uta_side_pside(x)
                 data_d[h] = x
                 data_d[h]["pnl"] = float(x.get("execPnl") or 0.0)
                 data_d[h]["price"] = float(x.get("execPrice") or 0.0)
@@ -330,7 +383,7 @@ class BitgetBot(CCXTBot):
                 data_d[h]["id"] = x.get("execId") or x.get("orderId")
                 data_d[h]["timestamp"] = float(x.get("createdTime") or 0.0)
                 data_d[h]["datetime"] = ts_to_date(data_d[h]["timestamp"])
-                data_d[h]["position_side"] = str(x.get("posSide", "long")).lower()
+                data_d[h]["position_side"] = position_side
                 data_d[h]["symbol"] = self.get_symbol_id_inv(x.get("symbol"))
             if start_time is None:
                 break
@@ -569,11 +622,11 @@ class BitgetBot(CCXTBot):
 
         def _extract(elm: dict) -> dict:
             ts = int(elm.get("createdTime") or 0)
-            pos_side = str(elm.get("posSide", "long")).lower()
-            side = str(elm.get("side") or ("buy" if pos_side == "long" else "sell")).lower()
+            side, pos_side = deduce_uta_side_pside(elm)
             cid = elm.get("clientOid")
             return {
-                "id": elm.get("orderId"),
+                "id": elm.get("execId") or elm.get("orderId"),
+                "order_id": elm.get("orderId"),
                 "timestamp": ts,
                 "datetime": ts_to_date(ts),
                 "symbol": self.get_symbol_id_inv(elm.get("symbol")),
@@ -591,19 +644,37 @@ class BitgetBot(CCXTBot):
         limit = 100 if limit is None else min(limit, 100)
         max_n_fetches = 200
         buffer_step_ms = int(1000 * 60 * 60 * 24)
+        max_window_ms = 30 * buffer_step_ms - 1
         end_time = int(utc_ms() + 3600000 if end_time is None else end_time)
         events_map: Dict[str, dict] = {}
-        params = {"category": "USDT-FUTURES", "endTime": end_time, "limit": str(limit)}
+        params = {"category": "USDT-FUTURES", "limit": str(limit)}
         count = 0
+        cursor = None
         while True:
             count += 1
             if count >= max_n_fetches:
                 logging.warning(f"over {count} calls to fetch_fill_events (uta). Breaking.")
                 break
-            fetched = await self.cca.private_uta_get_v3_trade_fills(params)
-            rows = (fetched.get("data") or {}).get("list") or []
+            request_params = dict(params)
+            request_params["endTime"] = end_time
+            window_start = None
+            if start_time is not None:
+                window_start = max(int(start_time), int(end_time) - max_window_ms)
+                request_params["startTime"] = window_start
+            if cursor:
+                request_params["cursor"] = cursor
+            fetched = await self.cca.private_uta_get_v3_trade_fills(request_params)
+            data = fetched.get("data") or {}
+            rows = data.get("list") or []
             fill_events = sorted([_extract(x) for x in rows], key=lambda x: x["timestamp"])
             if not fill_events:
+                if start_time is not None and window_start is not None and window_start > start_time:
+                    next_end = int(window_start) - 1
+                    if next_end <= start_time:
+                        break
+                    end_time = next_end
+                    cursor = None
+                    continue
                 break
             added = False
             for fe, raw in zip(fill_events, sorted(rows, key=lambda r: int(r.get("createdTime") or 0))):
@@ -613,16 +684,29 @@ class BitgetBot(CCXTBot):
                     added = True
             if not added:
                 break
+            next_cursor = data.get("cursor")
+            if len(fill_events) >= limit and next_cursor:
+                cursor = str(next_cursor)
+                continue
+            cursor = None
             if len(fill_events) < limit:
-                if start_time is None or params["endTime"] - start_time < buffer_step_ms:
+                if start_time is None:
                     break
-                params["endTime"] = int(fill_events[0]["timestamp"] + 1)
+                if window_start is not None and window_start > start_time:
+                    next_end = int(window_start) - 1
+                    if next_end <= start_time:
+                        break
+                    end_time = next_end
+                    continue
+                if end_time - start_time < buffer_step_ms:
+                    break
+                end_time = int(fill_events[0]["timestamp"] + 1)
                 continue
             if start_time is None or fill_events[0]["timestamp"] < start_time:
                 break
-            if params["endTime"] == fill_events[0]["timestamp"]:
+            if end_time == fill_events[0]["timestamp"]:
                 break
-            params["endTime"] = int(fill_events[0]["timestamp"])
+            end_time = int(fill_events[0]["timestamp"])
         return sorted(events_map.values(), key=lambda x: x["timestamp"])
 
     async def fetch_closed_orders(self, start_time, end_time, limit=100):
@@ -734,16 +818,21 @@ class BitgetBot(CCXTBot):
         return clip_by_timestamp(deduped, start_time, end_time)
 
     def _build_order_params(self, order: dict) -> dict:
-        tif = "PO" if require_live_value(self.config, "time_in_force") == "post_only" else "GTC"
+        use_post_only = require_live_value(self.config, "time_in_force") == "post_only"
         if getattr(self, "is_uta", False):
             # UTA/elite hedge-mode orders use posSide; holdSide/oneWayMode are
             # v2-only and rejected by v3 with code 25236.
-            return {
-                "timeInForce": tif,
+            params = {
                 "posSide": order["position_side"],
                 "reduceOnly": order["reduce_only"],
                 "clientOid": order["custom_id"],
             }
+            if use_post_only:
+                params["postOnly"] = True
+            else:
+                params["timeInForce"] = "GTC"
+            return params
+        tif = "PO" if use_post_only else "GTC"
         return {
             "timeInForce": tif,
             "holdSide": order["position_side"],
@@ -838,4 +927,6 @@ class BitgetBot(CCXTBot):
 
     def format_custom_id_single(self, order_type_id: int) -> str:
         formatted = super().format_custom_id_single(order_type_id)
+        if getattr(self, "is_uta", False):
+            return formatted[:32]
         return (self.broker_code + "#" + formatted)[: self.custom_id_max_length]

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -2387,6 +2387,35 @@ class BitgetFetcher(BaseFetcher):
             normalized.append(item)
         return normalized
 
+    @staticmethod
+    def _deduce_uta_side_pside(raw: Dict[str, object]) -> Tuple[str, str]:
+        side = str(raw.get("side") or "").lower()
+        trade_side = str(raw.get("tradeSide") or "").lower()
+        position_side = str(raw.get("posSide") or "").lower()
+
+        if position_side not in ("long", "short"):
+            if trade_side == "close":
+                if side == "buy":
+                    position_side = "short"
+                elif side == "sell":
+                    position_side = "long"
+            elif trade_side == "open":
+                if side == "buy":
+                    position_side = "long"
+                elif side == "sell":
+                    position_side = "short"
+
+        if position_side not in ("long", "short"):
+            position_side = "long" if side != "sell" else "short"
+
+        if side not in ("buy", "sell"):
+            if trade_side == "close":
+                side = "sell" if position_side == "long" else "buy"
+            else:
+                side = "buy" if position_side == "long" else "sell"
+
+        return side, position_side
+
     async def _fetch_uta(
         self,
         since_ms: Optional[int],
@@ -2397,24 +2426,39 @@ class BitgetFetcher(BaseFetcher):
         """UTA/Elite variant: source fills from the v3 trade/fills endpoint.
         v3 fills already carry clientOid, so no per-order detail enrichment."""
         end_time = int(until_ms) if until_ms is not None else self._now_func() + 24 * 60 * 60 * 1000
+        max_window_ms = 30 * 24 * 60 * 60 * 1000 - 1
         params: Dict[str, object] = {
             "category": self.product_type,
             "limit": self.history_limit,
-            "endTime": end_time,
         }
-        if since_ms is not None:
-            params["startTime"] = int(since_ms)
         events: Dict[str, Dict[str, object]] = {}
         max_fetches = 400
         fetch_count = 0
+        cursor: Optional[str] = None
         while True:
             if fetch_count >= max_fetches:
                 logger.warning("BitgetFetcher._fetch_uta: reached max pagination depth (%d)", max_fetches)
                 break
             fetch_count += 1
-            payload = await self.api.private_uta_get_v3_trade_fills(dict(params))
-            rows = (payload.get("data") or {}).get("list") or []
+            request_params = dict(params)
+            request_params["endTime"] = end_time
+            window_start = None
+            if since_ms is not None:
+                window_start = max(int(since_ms), int(end_time) - max_window_ms)
+                request_params["startTime"] = window_start
+            if cursor:
+                request_params["cursor"] = cursor
+            payload = await self.api.private_uta_get_v3_trade_fills(request_params)
+            data = payload.get("data") or {}
+            rows = data.get("list") or []
             if not rows:
+                if since_ms is not None and window_start is not None and window_start > since_ms:
+                    next_end = window_start - 1
+                    if next_end <= since_ms:
+                        break
+                    end_time = next_end
+                    cursor = None
+                    continue
                 break
             batch_ids: List[str] = []
             for raw in rows:
@@ -2433,14 +2477,25 @@ class BitgetFetcher(BaseFetcher):
                 if batch_events:
                     on_batch(batch_events)
             oldest = min(int(r.get("createdTime", 0) or 0) for r in rows)
+            next_cursor = data.get("cursor")
+            if len(rows) >= self.history_limit and next_cursor:
+                cursor = str(next_cursor)
+                continue
+            cursor = None
             if len(rows) < self.history_limit:
+                if since_ms is not None and window_start is not None and window_start > since_ms:
+                    next_end = window_start - 1
+                    if next_end <= since_ms:
+                        break
+                    end_time = next_end
+                    continue
                 break
             if since_ms is not None and oldest <= since_ms:
                 break
             new_end = oldest - 1
             if since_ms is not None and new_end <= since_ms:
                 break
-            params["endTime"] = new_end
+            end_time = new_end
         ordered = sorted(events.values(), key=lambda ev: ev["timestamp"])
         if since_ms is not None:
             ordered = [ev for ev in ordered if ev["timestamp"] >= since_ms]
@@ -2451,6 +2506,7 @@ class BitgetFetcher(BaseFetcher):
     def _normalize_fill_uta(self, raw: Dict[str, object]) -> Dict[str, object]:
         timestamp = int(raw.get("createdTime", 0) or 0)
         cid = raw.get("clientOid")
+        side, position_side = self._deduce_uta_side_pside(raw)
         return {
             "id": raw.get("execId") or raw.get("tradeId"),
             "order_id": raw.get("orderId"),
@@ -2458,13 +2514,13 @@ class BitgetFetcher(BaseFetcher):
             "datetime": ts_to_date(timestamp),
             "symbol": self._resolve_symbol(raw.get("symbol")),
             "symbol_external": raw.get("symbol"),
-            "side": str(raw.get("side", "")).lower(),
+            "side": side,
             "qty": float(raw.get("execQty", 0.0) or 0.0),
             "price": float(raw.get("execPrice", 0.0) or 0.0),
             "pnl": float(raw.get("execPnl", 0.0) or 0.0),
             "fees": raw.get("feeDetail"),
             "pb_order_type": custom_id_to_snake(cid) if cid else "",
-            "position_side": str(raw.get("posSide", "")).lower(),
+            "position_side": position_side,
             "client_order_id": cid,
             "raw": [{"source": "uta_fills", "data": dict(raw)}],
         }

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -7085,6 +7085,16 @@ def _instantiate_bot(config: dict):
     return bot_cls(config)
 
 
+async def _prepare_cli_fetcher_bot(bot) -> None:
+    """Prepare read-only exchange routing needed before building a CLI fetcher."""
+    exchange = str(getattr(bot, "exchange", "") or "").lower()
+    if exchange == "bitget" and hasattr(bot, "_detect_account_mode"):
+        # The standalone fill-events CLI does not run the full live startup
+        # exchange-config path. Bitget UTA detection is a read-only v3 account
+        # assets probe and is required before BitgetFetcher can choose v3 fills.
+        await bot._detect_account_mode()
+
+
 async def _run_cli(args: argparse.Namespace) -> None:
     source_config, base_config_path, raw_snapshot = load_input_config(args.config)
     config = prepare_config(
@@ -7101,6 +7111,7 @@ async def _run_cli(args: argparse.Namespace) -> None:
     bot = _instantiate_bot(config)
     try:
         bot._fill_fetcher_allow_config_symbol_fallback = True
+        await _prepare_cli_fetcher_bot(bot)
         symbol_pool = _extract_symbol_pool(config, args.symbols)
         fetcher = _build_fetcher_for_bot(bot, symbol_pool)
         cache_root = Path(args.cache_root)

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -348,6 +348,13 @@ def _fee_entry_signed_fee_paid(fee: Dict[str, object]) -> float:
     """
     if "fee_paid" in fee:
         return float(fee.get("fee_paid") or 0.0)
+    if fee.get("totalFee") not in (None, ""):
+        return float(fee.get("totalFee") or 0.0)
+    if fee.get("fee") not in (None, ""):
+        value = float(fee.get("fee") or 0.0)
+        return value if value < 0.0 else -abs(value)
+    if fee.get("totalDeductionFee") not in (None, ""):
+        return float(fee.get("totalDeductionFee") or 0.0)
     cost = float(fee.get("cost") or 0.0)
     if cost == 0.0:
         return 0.0
@@ -2363,58 +2370,11 @@ class BitgetFetcher(BaseFetcher):
     @staticmethod
     def _normalize_fee_detail(fee_detail: object) -> object:
         """Normalize Bitget feeDetail rows into canonical signed fee entries."""
-        entries = _fee_entries(fee_detail)
-        if not entries:
-            return fee_detail
-        normalized: List[Dict[str, object]] = []
-        for entry in entries:
-            item = dict(entry)
-            currency = _fee_entry_currency(item)
-            if currency:
-                item["currency"] = currency
-            fee_paid_raw = (
-                item.get("fee_paid")
-                if "fee_paid" in item
-                else item.get("totalFee")
-                if item.get("totalFee") not in (None, "")
-                else item.get("totalDeductionFee")
-            )
-            if fee_paid_raw not in (None, ""):
-                try:
-                    item["fee_paid"] = float(fee_paid_raw)
-                except (TypeError, ValueError):
-                    pass
-            normalized.append(item)
-        return normalized
+        return normalize_bitget_fee_detail(fee_detail)
 
     @staticmethod
     def _deduce_uta_side_pside(raw: Dict[str, object]) -> Tuple[str, str]:
-        side = str(raw.get("side") or "").lower()
-        trade_side = str(raw.get("tradeSide") or "").lower()
-        position_side = str(raw.get("posSide") or "").lower()
-
-        if position_side not in ("long", "short"):
-            if trade_side == "close":
-                if side == "buy":
-                    position_side = "short"
-                elif side == "sell":
-                    position_side = "long"
-            elif trade_side == "open":
-                if side == "buy":
-                    position_side = "long"
-                elif side == "sell":
-                    position_side = "short"
-
-        if position_side not in ("long", "short"):
-            position_side = "long" if side != "sell" else "short"
-
-        if side not in ("buy", "sell"):
-            if trade_side == "close":
-                side = "sell" if position_side == "long" else "buy"
-            else:
-                side = "buy" if position_side == "long" else "sell"
-
-        return side, position_side
+        return deduce_uta_side_pside(raw)
 
     async def _fetch_uta(
         self,
@@ -2476,7 +2436,7 @@ class BitgetFetcher(BaseFetcher):
                 ]
                 if batch_events:
                     on_batch(batch_events)
-            oldest = min(int(r.get("createdTime", 0) or 0) for r in rows)
+            oldest = min(int(event["timestamp"]) for event in events.values() if event["id"] in batch_ids)
             next_cursor = data.get("cursor")
             if len(rows) >= self.history_limit and next_cursor:
                 cursor = str(next_cursor)
@@ -2504,26 +2464,9 @@ class BitgetFetcher(BaseFetcher):
         return ordered
 
     def _normalize_fill_uta(self, raw: Dict[str, object]) -> Dict[str, object]:
-        timestamp = int(raw.get("createdTime", 0) or 0)
-        cid = raw.get("clientOid")
-        side, position_side = self._deduce_uta_side_pside(raw)
-        return {
-            "id": raw.get("execId") or raw.get("tradeId"),
-            "order_id": raw.get("orderId"),
-            "timestamp": timestamp,
-            "datetime": ts_to_date(timestamp),
-            "symbol": self._resolve_symbol(raw.get("symbol")),
-            "symbol_external": raw.get("symbol"),
-            "side": side,
-            "qty": float(raw.get("execQty", 0.0) or 0.0),
-            "price": float(raw.get("execPrice", 0.0) or 0.0),
-            "pnl": float(raw.get("execPnl", 0.0) or 0.0),
-            "fees": raw.get("feeDetail"),
-            "pb_order_type": custom_id_to_snake(cid) if cid else "",
-            "position_side": position_side,
-            "client_order_id": cid,
-            "raw": [{"source": "uta_fills", "data": dict(raw)}],
-        }
+        event = normalize_uta_fill_payload(raw, self._resolve_symbol)
+        event["raw"] = [{"source": "uta_fills", "data": dict(raw)}]
+        return event
 
     def _normalize_fill(self, raw: Dict[str, object]) -> Dict[str, object]:
         timestamp = int(raw["cTime"])
@@ -6924,6 +6867,29 @@ def deduce_side_pside(elm: dict) -> Tuple[str, str]:
     except Exception:
         side = str(elm.get("side", "buy")).lower()
         return side or "buy", "long"
+
+
+def deduce_uta_side_pside(elm: dict) -> Tuple[str, str]:
+    """Import UTA helper from exchanges.bitget so inference cannot diverge."""
+    from exchanges.bitget import deduce_uta_side_pside as _real
+
+    return _real(elm)
+
+
+def normalize_bitget_fee_detail(fee_detail: object) -> object:
+    """Import Bitget feeDetail normalizer from the exchange integration."""
+    from exchanges.bitget import normalize_bitget_fee_detail as _real
+
+    return _real(fee_detail)
+
+
+def normalize_uta_fill_payload(
+    elm: Dict[str, object], symbol_resolver: Callable[[str], str]
+) -> Dict[str, object]:
+    """Import Bitget UTA fill normalizer from the exchange integration."""
+    from exchanges.bitget import normalize_uta_fill_payload as _real
+
+    return _real(elm, symbol_resolver)
 
 
 # ---------------------------------------------------------------------------

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -2135,6 +2135,10 @@ class BitgetFetcher(BaseFetcher):
         detail_cache: Dict[str, Tuple[str, str]],
         on_batch: Optional[Callable[[List[Dict[str, object]]], None]] = None,
     ) -> List[Dict[str, object]]:
+        # UTA / Elite (copy-trading) accounts speak the v3 API; the classic
+        # v2 fill-history endpoint returns error 40731 for them.
+        if getattr(self.api, "options", {}).get("uta"):
+            return await self._fetch_uta(since_ms, until_ms, detail_cache, on_batch)
         buffer_step_ms = 24 * 60 * 60 * 1000
         end_time = int(until_ms) if until_ms is not None else self._now_func() + buffer_step_ms
         params: Dict[str, object] = {
@@ -2382,6 +2386,88 @@ class BitgetFetcher(BaseFetcher):
                     pass
             normalized.append(item)
         return normalized
+
+    async def _fetch_uta(
+        self,
+        since_ms: Optional[int],
+        until_ms: Optional[int],
+        detail_cache: Dict[str, Tuple[str, str]],
+        on_batch: Optional[Callable[[List[Dict[str, object]]], None]] = None,
+    ) -> List[Dict[str, object]]:
+        """UTA/Elite variant: source fills from the v3 trade/fills endpoint.
+        v3 fills already carry clientOid, so no per-order detail enrichment."""
+        end_time = int(until_ms) if until_ms is not None else self._now_func() + 24 * 60 * 60 * 1000
+        params: Dict[str, object] = {
+            "category": self.product_type,
+            "limit": self.history_limit,
+            "endTime": end_time,
+        }
+        if since_ms is not None:
+            params["startTime"] = int(since_ms)
+        events: Dict[str, Dict[str, object]] = {}
+        max_fetches = 400
+        fetch_count = 0
+        while True:
+            if fetch_count >= max_fetches:
+                logger.warning("BitgetFetcher._fetch_uta: reached max pagination depth (%d)", max_fetches)
+                break
+            fetch_count += 1
+            payload = await self.api.private_uta_get_v3_trade_fills(dict(params))
+            rows = (payload.get("data") or {}).get("list") or []
+            if not rows:
+                break
+            batch_ids: List[str] = []
+            for raw in rows:
+                event = self._normalize_fill_uta(raw)
+                event_id = event["id"]
+                if not event_id:
+                    continue
+                batch_ids.append(event_id)
+                if event.get("client_order_id"):
+                    detail_cache[event_id] = (event["client_order_id"], event.get("pb_order_type", ""))
+                events[event_id] = event
+            if on_batch:
+                batch_events = [
+                    dict(events[i]) for i in batch_ids if events[i].get("client_order_id")
+                ]
+                if batch_events:
+                    on_batch(batch_events)
+            oldest = min(int(r.get("createdTime", 0) or 0) for r in rows)
+            if len(rows) < self.history_limit:
+                break
+            if since_ms is not None and oldest <= since_ms:
+                break
+            new_end = oldest - 1
+            if since_ms is not None and new_end <= since_ms:
+                break
+            params["endTime"] = new_end
+        ordered = sorted(events.values(), key=lambda ev: ev["timestamp"])
+        if since_ms is not None:
+            ordered = [ev for ev in ordered if ev["timestamp"] >= since_ms]
+        if until_ms is not None:
+            ordered = [ev for ev in ordered if ev["timestamp"] <= until_ms]
+        return ordered
+
+    def _normalize_fill_uta(self, raw: Dict[str, object]) -> Dict[str, object]:
+        timestamp = int(raw.get("createdTime", 0) or 0)
+        cid = raw.get("clientOid")
+        return {
+            "id": raw.get("execId") or raw.get("tradeId"),
+            "order_id": raw.get("orderId"),
+            "timestamp": timestamp,
+            "datetime": ts_to_date(timestamp),
+            "symbol": self._resolve_symbol(raw.get("symbol")),
+            "symbol_external": raw.get("symbol"),
+            "side": str(raw.get("side", "")).lower(),
+            "qty": float(raw.get("execQty", 0.0) or 0.0),
+            "price": float(raw.get("execPrice", 0.0) or 0.0),
+            "pnl": float(raw.get("execPnl", 0.0) or 0.0),
+            "fees": raw.get("feeDetail"),
+            "pb_order_type": custom_id_to_snake(cid) if cid else "",
+            "position_side": str(raw.get("posSide", "")).lower(),
+            "client_order_id": cid,
+            "raw": [{"source": "uta_fills", "data": dict(raw)}],
+        }
 
     def _normalize_fill(self, raw: Dict[str, object]) -> Dict[str, object]:
         timestamp = int(raw["cTime"])

--- a/tests/ccxt_upgrade/test_order_contracts.py
+++ b/tests/ccxt_upgrade/test_order_contracts.py
@@ -474,22 +474,26 @@ async def test_bitget_account_mode_detection_sets_uta_on_v3_success():
 
 @pytest.mark.asyncio
 async def test_bitget_account_mode_detection_uses_classic_only_for_explicit_code():
-    bot = BitgetBot.__new__(BitgetBot)
-    bot.is_uta = True
-    bot._account_mode_detected = False
+    for code in ("40084", "25245"):
+        bot = BitgetBot.__new__(BitgetBot)
+        bot.is_uta = True
+        bot._account_mode_detected = False
 
-    async def private_uta_get_v3_account_assets():
-        raise Exception('bitget {"code":"40084","msg":"Classic Account mode"}')
+        async def private_uta_get_v3_account_assets(error_code=code):
+            raise Exception(f'bitget {{"code":"{error_code}","msg":"Classic Account mode"}}')
 
-    bot.cca = SimpleNamespace(options={}, private_uta_get_v3_account_assets=private_uta_get_v3_account_assets)
-    bot.ccp = SimpleNamespace(options={})
+        bot.cca = SimpleNamespace(
+            options={},
+            private_uta_get_v3_account_assets=private_uta_get_v3_account_assets,
+        )
+        bot.ccp = SimpleNamespace(options={})
 
-    await bot._detect_account_mode()
+        await bot._detect_account_mode()
 
-    assert bot.is_uta is False
-    assert bot._account_mode_detected is True
-    assert bot.cca.options["uta"] is False
-    assert bot.ccp.options["uta"] is False
+        assert bot.is_uta is False
+        assert bot._account_mode_detected is True
+        assert bot.cca.options["uta"] is False
+        assert bot.ccp.options["uta"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/ccxt_upgrade/test_order_contracts.py
+++ b/tests/ccxt_upgrade/test_order_contracts.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from ccxt_contracts import build_contract_bot
-from exchanges.bitget import BitgetBot
+from exchanges.bitget import BitgetBot, deduce_uta_side_pside
 from exchanges.binance import BinanceBot
 from exchanges.bybit import BybitBot
 from exchanges.defx import DefxBot
@@ -282,6 +282,144 @@ def test_bitget_determine_side_uses_trade_side_reduce_only_and_pos_side():
     }
     assert bot._determine_side(close_short) == "buy"
     assert bot._determine_side(open_long) == "buy"
+
+
+def test_bitget_uta_custom_id_respects_v3_client_oid_contract():
+    bot = BitgetBot.__new__(BitgetBot)
+    bot.broker_code = "p4sve"
+    bot.custom_id_max_length = 64
+    bot.is_uta = True
+
+    custom_id = bot.format_custom_id_single(0x0007)
+
+    allowed = set(".ABCDEFGHIJKLMNOPQRSTUVWXYZ:/abcdefghijklmnopqrstuvwxyz0123456789_-")
+    assert len(custom_id) <= 32
+    assert "#" not in custom_id
+    assert set(custom_id) <= allowed
+    assert custom_id_has_explicit_passivbot_marker(custom_id)
+    assert custom_id_to_snake(custom_id) != "unknown"
+
+
+def test_bitget_uta_order_params_use_ccxt_v3_safe_time_in_force():
+    bot = BitgetBot.__new__(BitgetBot)
+    bot.config = {"live": {"time_in_force": "post_only"}}
+    bot.is_uta = True
+    order = {
+        "position_side": "short",
+        "reduce_only": True,
+        "custom_id": "0x0007abcdef",
+    }
+
+    post_only_params = bot._build_order_params(order)
+
+    assert post_only_params["postOnly"] is True
+    assert "timeInForce" not in post_only_params
+    assert post_only_params["posSide"] == "short"
+    assert post_only_params["reduceOnly"] is True
+    assert post_only_params["clientOid"] == "0x0007abcdef"
+
+    bot.config = {"live": {"time_in_force": "gtc"}}
+    gtc_params = bot._build_order_params(order)
+
+    assert gtc_params["timeInForce"] == "GTC"
+    assert "postOnly" not in gtc_params
+
+
+def test_bitget_uta_balance_uses_equity_minus_upnl_not_effective_margin():
+    bot = BitgetBot.__new__(BitgetBot)
+    bot.is_uta = True
+    bot.quote = "USDT"
+
+    balance = bot._get_balance(
+        {
+            "data": {
+                "effEquity": "941.70",
+                "usdtEquity": "1945.22",
+                "accountEquity": "1943.49",
+                "usdtUnrealisedPnl": "-12.30",
+                "assets": [
+                    {"coin": "BTC", "balance": "0.015"},
+                    {"coin": "USDT", "balance": "311.51", "available": "311.51"},
+                ],
+            }
+        }
+    )
+
+    assert balance == pytest.approx(1957.52)
+
+
+@pytest.mark.asyncio
+async def test_bitget_uta_fetch_balance_uses_raw_account_assets_endpoint():
+    bot = BitgetBot.__new__(BitgetBot)
+    bot.is_uta = True
+
+    class _Api:
+        def __init__(self):
+            self.calls = []
+
+        async def private_uta_get_v3_account_assets(self):
+            self.calls.append("private_uta_get_v3_account_assets")
+            return {"data": {"effEquity": "123.45"}}
+
+        async def fetch_balance(self):
+            raise AssertionError("CCXT parsed fetch_balance should not be used for UTA")
+
+    api = _Api()
+    bot.cca = api
+
+    fetched = await bot._do_fetch_balance()
+
+    assert fetched == {"data": {"effEquity": "123.45"}}
+    assert api.calls == ["private_uta_get_v3_account_assets"]
+
+
+def test_bitget_uta_fill_side_pside_uses_trade_side_when_pos_side_absent():
+    assert deduce_uta_side_pside({"side": "sell", "tradeSide": "open"}) == ("sell", "short")
+    assert deduce_uta_side_pside({"side": "buy", "tradeSide": "close"}) == ("buy", "short")
+    assert deduce_uta_side_pside({"side": "sell", "tradeSide": "close"}) == ("sell", "long")
+    assert deduce_uta_side_pside({"side": "buy", "posSide": "long"}) == ("buy", "long")
+
+
+@pytest.mark.asyncio
+async def test_bitget_fetch_fill_events_uta_uses_exec_id_and_trade_side():
+    bot = BitgetBot.__new__(BitgetBot)
+    bot.is_uta = True
+    bot.get_symbol_id_inv = lambda symbol: "BTC/USDT:USDT" if symbol == "BTCUSDT" else symbol
+    calls = []
+
+    async def private_uta_get_v3_trade_fills(params):
+        calls.append(dict(params))
+        if len(calls) > 1:
+            return {"data": {"list": []}}
+        return {
+            "data": {
+                "list": [
+                    {
+                        "execId": "exec-close-short",
+                        "orderId": "order-close-short",
+                        "clientOid": "0x0007abcdef",
+                        "createdTime": "1000",
+                        "symbol": "BTCUSDT",
+                        "side": "buy",
+                        "tradeSide": "close",
+                        "execQty": "0.1",
+                        "execPrice": "9",
+                        "execPnl": "1",
+                    }
+                ]
+            }
+        }
+
+    bot.cca = SimpleNamespace(private_uta_get_v3_trade_fills=private_uta_get_v3_trade_fills)
+
+    events = await bot._fetch_fill_events_uta(start_time=900, end_time=2000, limit=100)
+
+    assert len(events) == 1
+    assert events[0]["id"] == "exec-close-short"
+    assert events[0]["order_id"] == "order-close-short"
+    assert events[0]["position_side"] == "short"
+    assert events[0]["side"] == "buy"
+    assert events[0]["symbol"] == "BTC/USDT:USDT"
 
 
 def test_gateio_order_side_contract_depends_on_reduce_only_flag():

--- a/tests/ccxt_upgrade/test_order_contracts.py
+++ b/tests/ccxt_upgrade/test_order_contracts.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+import ccxt
 import pytest
 
 from ccxt_contracts import build_contract_bot
@@ -321,8 +322,70 @@ def test_bitget_uta_order_params_use_ccxt_v3_safe_time_in_force():
     bot.config = {"live": {"time_in_force": "gtc"}}
     gtc_params = bot._build_order_params(order)
 
-    assert gtc_params["timeInForce"] == "GTC"
+    assert gtc_params["timeInForce"] == "gtc"
     assert "postOnly" not in gtc_params
+
+
+def test_bitget_uta_order_params_survive_ccxt_v3_request_construction():
+    bot = BitgetBot.__new__(BitgetBot)
+    bot.config = {"live": {"time_in_force": "gtc"}}
+    bot.is_uta = True
+    params = bot._build_order_params(
+        {
+            "position_side": "short",
+            "reduce_only": True,
+            "custom_id": "0x0007abcdef",
+        }
+    )
+
+    exchange = ccxt.bitget()
+    exchange.markets = {
+        "BTC/USDT:USDT": {
+            "id": "BTCUSDT",
+            "symbol": "BTC/USDT:USDT",
+            "spot": False,
+            "swap": True,
+            "linear": True,
+            "type": "swap",
+            "contract": True,
+            "settle": "USDT",
+        }
+    }
+    exchange.market = lambda symbol: exchange.markets[symbol]
+    exchange.handle_product_type_and_params = lambda market, params: ("USDT-FUTURES", params)
+    exchange.amount_to_precision = lambda symbol, amount: str(amount)
+    exchange.price_to_precision = lambda symbol, price: str(price)
+
+    request = exchange.create_uta_order_request(
+        "BTC/USDT:USDT", "limit", "buy", 0.1, 9.0, params
+    )
+
+    assert request["timeInForce"] == "gtc"
+    assert request["reduceOnly"] == "yes"
+    assert request["posSide"] == "short"
+    assert request["clientOid"] == "0x0007abcdef"
+
+
+def test_bitget_uta_broker_code_is_signed_as_v3_channel_header():
+    exchange = ccxt.bitget({"apiKey": "key", "secret": "secret", "password": "passphrase"})
+    exchange.options["broker"] = "p4sve"
+
+    signed = exchange.sign(
+        "v3/trade/place-order",
+        ["private", "uta"],
+        "POST",
+        {
+            "category": "USDT-FUTURES",
+            "symbol": "BTCUSDT",
+            "qty": "0.1",
+            "side": "buy",
+            "orderType": "limit",
+            "price": "9",
+            "timeInForce": "gtc",
+        },
+    )
+
+    assert signed["headers"]["X-CHANNEL-API-CODE"] == "p4sve"
 
 
 def test_bitget_uta_balance_uses_equity_minus_upnl_not_effective_margin():
@@ -346,6 +409,22 @@ def test_bitget_uta_balance_uses_equity_minus_upnl_not_effective_margin():
     )
 
     assert balance == pytest.approx(1957.52)
+
+
+def test_bitget_uta_balance_rejects_missing_account_equity_fields():
+    bot = BitgetBot.__new__(BitgetBot)
+    bot.is_uta = True
+    bot.quote = "USDT"
+
+    with pytest.raises(ValueError, match="account equity/upnl"):
+        bot._get_balance(
+            {
+                "data": {
+                    "effEquity": "941.70",
+                    "assets": [{"coin": "USDT", "balance": "311.51", "available": "311.51"}],
+                }
+            }
+        )
 
 
 @pytest.mark.asyncio
@@ -373,11 +452,72 @@ async def test_bitget_uta_fetch_balance_uses_raw_account_assets_endpoint():
     assert api.calls == ["private_uta_get_v3_account_assets"]
 
 
+@pytest.mark.asyncio
+async def test_bitget_account_mode_detection_sets_uta_on_v3_success():
+    bot = BitgetBot.__new__(BitgetBot)
+    bot.is_uta = False
+    bot._account_mode_detected = False
+
+    async def private_uta_get_v3_account_assets():
+        return {"data": {"usdtEquity": "10", "usdtUnrealisedPnl": "0"}}
+
+    bot.cca = SimpleNamespace(options={}, private_uta_get_v3_account_assets=private_uta_get_v3_account_assets)
+    bot.ccp = SimpleNamespace(options={})
+
+    await bot._detect_account_mode()
+
+    assert bot.is_uta is True
+    assert bot._account_mode_detected is True
+    assert bot.cca.options["uta"] is True
+    assert bot.ccp.options["uta"] is True
+
+
+@pytest.mark.asyncio
+async def test_bitget_account_mode_detection_uses_classic_only_for_explicit_code():
+    bot = BitgetBot.__new__(BitgetBot)
+    bot.is_uta = True
+    bot._account_mode_detected = False
+
+    async def private_uta_get_v3_account_assets():
+        raise Exception('bitget {"code":"40084","msg":"Classic Account mode"}')
+
+    bot.cca = SimpleNamespace(options={}, private_uta_get_v3_account_assets=private_uta_get_v3_account_assets)
+    bot.ccp = SimpleNamespace(options={})
+
+    await bot._detect_account_mode()
+
+    assert bot.is_uta is False
+    assert bot._account_mode_detected is True
+    assert bot.cca.options["uta"] is False
+    assert bot.ccp.options["uta"] is False
+
+
+@pytest.mark.asyncio
+async def test_bitget_account_mode_detection_rejects_inconclusive_errors():
+    bot = BitgetBot.__new__(BitgetBot)
+    bot.is_uta = False
+    bot._account_mode_detected = False
+
+    async def private_uta_get_v3_account_assets():
+        raise TimeoutError("temporary network failure")
+
+    bot.cca = SimpleNamespace(options={}, private_uta_get_v3_account_assets=private_uta_get_v3_account_assets)
+    bot.ccp = SimpleNamespace(options={})
+
+    with pytest.raises(RuntimeError, match="inconclusively"):
+        await bot._detect_account_mode()
+
+    assert bot._account_mode_detected is False
+    assert "uta" not in bot.cca.options
+
+
 def test_bitget_uta_fill_side_pside_uses_trade_side_when_pos_side_absent():
     assert deduce_uta_side_pside({"side": "sell", "tradeSide": "open"}) == ("sell", "short")
     assert deduce_uta_side_pside({"side": "buy", "tradeSide": "close"}) == ("buy", "short")
     assert deduce_uta_side_pside({"side": "sell", "tradeSide": "close"}) == ("sell", "long")
     assert deduce_uta_side_pside({"side": "buy", "posSide": "long"}) == ("buy", "long")
+    with pytest.raises(ValueError, match="order side"):
+        deduce_uta_side_pside({"posSide": "long"})
 
 
 @pytest.mark.asyncio
@@ -405,6 +545,7 @@ async def test_bitget_fetch_fill_events_uta_uses_exec_id_and_trade_side():
                         "execQty": "0.1",
                         "execPrice": "9",
                         "execPnl": "1",
+                        "feeDetail": [{"feeCoin": "USDT", "fee": "0.01"}],
                     }
                 ]
             }
@@ -420,6 +561,37 @@ async def test_bitget_fetch_fill_events_uta_uses_exec_id_and_trade_side():
     assert events[0]["position_side"] == "short"
     assert events[0]["side"] == "buy"
     assert events[0]["symbol"] == "BTC/USDT:USDT"
+    assert events[0]["fees"][0]["fee_paid"] == pytest.approx(-0.01)
+
+
+@pytest.mark.asyncio
+async def test_bitget_fetch_fill_events_uta_rejects_malformed_rows():
+    bot = BitgetBot.__new__(BitgetBot)
+    bot.is_uta = True
+    bot.get_symbol_id_inv = lambda symbol: symbol
+
+    async def private_uta_get_v3_trade_fills(params):
+        return {
+            "data": {
+                "list": [
+                    {
+                        "execId": "exec-bad",
+                        "orderId": "order-bad",
+                        "symbol": "BTCUSDT",
+                        "side": "buy",
+                        "tradeSide": "open",
+                        "execQty": "0.1",
+                        "execPrice": "9",
+                        "execPnl": "0",
+                    }
+                ]
+            }
+        }
+
+    bot.cca = SimpleNamespace(private_uta_get_v3_trade_fills=private_uta_get_v3_trade_fills)
+
+    with pytest.raises(ValueError, match="createdTime"):
+        await bot._fetch_fill_events_uta(start_time=900, end_time=2000, limit=100)
 
 
 def test_gateio_order_side_contract_depends_on_reduce_only_flag():

--- a/tests/ccxt_upgrade/test_order_contracts.py
+++ b/tests/ccxt_upgrade/test_order_contracts.py
@@ -598,6 +598,84 @@ async def test_bitget_fetch_fill_events_uta_rejects_malformed_rows():
         await bot._fetch_fill_events_uta(start_time=900, end_time=2000, limit=100)
 
 
+@pytest.mark.asyncio
+async def test_bitget_fetch_closed_orders_routes_uta_to_v3_fills():
+    bot = BitgetBot.__new__(BitgetBot)
+    bot.is_uta = True
+    bot.get_symbol_id_inv = lambda symbol: "BTC/USDT:USDT" if symbol == "BTCUSDT" else symbol
+    calls = []
+
+    async def private_uta_get_v3_trade_fills(params):
+        calls.append(dict(params))
+        if len(calls) > 1:
+            return {"data": {"list": []}}
+        return {
+            "data": {
+                "list": [
+                    {
+                        "execId": "exec-close-long",
+                        "orderId": "order-close-long",
+                        "createdTime": "1000",
+                        "symbol": "BTCUSDT",
+                        "side": "sell",
+                        "tradeSide": "close",
+                        "execQty": "0.1",
+                        "execPrice": "11",
+                        "execPnl": "1",
+                    }
+                ]
+            }
+        }
+
+    async def fetch_closed_orders(*args, **kwargs):
+        raise AssertionError("UTA closed-order history must use v3 trade fills")
+
+    bot.cca = SimpleNamespace(
+        private_uta_get_v3_trade_fills=private_uta_get_v3_trade_fills,
+        fetch_closed_orders=fetch_closed_orders,
+    )
+
+    events = await bot.fetch_closed_orders(start_time=900, end_time=2000, limit=100)
+
+    assert len(events) == 1
+    assert events[0]["id"] == "exec-close-long"
+    assert events[0]["pnl"] == pytest.approx(1.0)
+    assert events[0]["position_side"] == "long"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("info", "match"),
+    [
+        ({"posSide": "long"}, "totalProfits"),
+        ({"totalProfits": "1.0"}, "posSide"),
+    ],
+)
+async def test_bitget_fetch_closed_orders_requires_pnl_and_position_side(info, match):
+    bot = BitgetBot.__new__(BitgetBot)
+    bot.is_uta = False
+
+    async def fetch_closed_orders(limit=None, params=None):
+        return [
+            {
+                "id": "closed-order",
+                "lastUpdateTimestamp": "1000",
+                "timestamp": 1000,
+                "symbol": "BTC/USDT:USDT",
+                "side": "sell",
+                "price": "11",
+                "filled": "0.1",
+                "clientOrderId": "0x0007abcdef",
+                "info": info,
+            }
+        ]
+
+    bot.cca = SimpleNamespace(fetch_closed_orders=fetch_closed_orders)
+
+    with pytest.raises(ValueError, match=match):
+        await bot.fetch_closed_orders(start_time=900, end_time=2000, limit=100)
+
+
 def test_gateio_order_side_contract_depends_on_reduce_only_flag():
     bot = GateIOBot.__new__(GateIOBot)
     assert bot.determine_pos_side({"side": "buy", "reduceOnly": False}) == "long"

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -1100,6 +1100,26 @@ def test_fee_policy_uses_scalar_quote_fee():
         assert meta["fee_quality"] == fem.FEE_QUALITY_EXACT
 
 
+def test_fee_policy_uses_bitget_fee_detail_fields():
+    for raw_fee, expected in [
+        ({"feeCoin": "USDT", "fee": "0.01"}, -0.01),
+        ({"feeCoin": "USDT", "fee": "-0.02"}, -0.02),
+        ({"feeCoin": "USDT", "totalFee": "-0.03"}, -0.03),
+    ]:
+        fee_paid, meta = fem._normalize_fee_paid_from_payload(
+            {
+                "symbol": "BTC/USDT:USDT",
+                "qty": 1.0,
+                "price": 1000.0,
+                "fees": [raw_fee],
+            }
+        )
+
+        assert fee_paid == pytest.approx(expected)
+        assert meta["fee_source"] == fem.FEE_SOURCE_REPORTED_QUOTE
+        assert meta["fee_quality"] == fem.FEE_QUALITY_EXACT
+
+
 def test_fee_policy_converts_reported_non_quote_fee_to_quote():
     fee_paid, meta = fem._normalize_fee_paid_from_payload(
         {
@@ -2270,7 +2290,7 @@ async def test_bitget_uta_fetcher_derives_position_side_without_pos_side(monkeyp
                 "execQty": "0.1",
                 "execPrice": "10",
                 "execPnl": "0",
-                "feeDetail": [{"feeCoin": "USDT", "fee": "0.01"}],
+                "feeDetail": [{"feeCoin": "USDT", "fee": "0.0001"}],
             },
             {
                 "execId": "exec-close-short",
@@ -2283,7 +2303,7 @@ async def test_bitget_uta_fetcher_derives_position_side_without_pos_side(monkeyp
                 "execQty": "0.1",
                 "execPrice": "9",
                 "execPnl": "1",
-                "feeDetail": [{"feeCoin": "USDT", "fee": "0.01"}],
+                "feeDetail": [{"feeCoin": "USDT", "fee": "0.0001"}],
             },
             {
                 "execId": "exec-close-long",
@@ -2296,7 +2316,7 @@ async def test_bitget_uta_fetcher_derives_position_side_without_pos_side(monkeyp
                 "execQty": "0.1",
                 "execPrice": "11",
                 "execPnl": "1",
-                "feeDetail": [{"feeCoin": "USDT", "fee": "0.01"}],
+                "feeDetail": [{"feeCoin": "USDT", "fee": "0.0001"}],
             },
         ]
     ]
@@ -2324,9 +2344,44 @@ async def test_bitget_uta_fetcher_derives_position_side_without_pos_side(monkeyp
     assert by_id["exec-close-short"]["side"] == "buy"
     assert by_id["exec-close-long"]["position_side"] == "long"
     assert by_id["exec-close-long"]["side"] == "sell"
+    assert by_id["exec-open-short"]["fees"][0]["fee_paid"] == pytest.approx(-0.0001)
+    fee_paid, meta = fem._normalize_fee_paid_from_payload(by_id["exec-open-short"])
+    assert fee_paid == pytest.approx(-0.0001)
+    assert meta["fee_source"] == fem.FEE_SOURCE_REPORTED_QUOTE
     assert api.detail_calls == []
     assert api.history_calls[0]["category"] == "USDT-FUTURES"
     assert api.history_calls[0]["startTime"] == 900
+
+
+@pytest.mark.asyncio
+async def test_bitget_uta_fetcher_rejects_malformed_rows():
+    api = _FakeBitgetAPI(
+        [
+            [
+                {
+                    "execId": "exec-bad",
+                    "orderId": "order-bad",
+                    "createdTime": "1000",
+                    "symbol": "BTCUSDT",
+                    "side": "sell",
+                    "tradeSide": "open",
+                    "execPrice": "10",
+                    "execPnl": "0",
+                }
+            ]
+        ],
+        options={"uta": True},
+    )
+    resolver = lambda s: f"{s[:-4]}/USDT:USDT" if s and s.endswith("USDT") else s
+    fetcher = BitgetFetcher(
+        api,
+        history_limit=100,
+        now_func=lambda: 2000,
+        symbol_resolver=resolver,
+    )
+
+    with pytest.raises(ValueError, match="execQty"):
+        await fetcher.fetch(since_ms=900, until_ms=2000, detail_cache={}, on_batch=None)
 
 
 @pytest.mark.asyncio

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -1993,6 +1993,40 @@ async def test_kucoin_doctor_repair_applies_contract_multiplier(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_fill_events_cli_prepares_bitget_uta_fetcher_mode():
+    class _Bot:
+        exchange = "bitget"
+
+        def __init__(self):
+            self.cca = types.SimpleNamespace(options={})
+            self.detect_calls = 0
+
+        async def _detect_account_mode(self):
+            self.detect_calls += 1
+            self.cca.options["uta"] = True
+
+    bot = _Bot()
+
+    await fem._prepare_cli_fetcher_bot(bot)
+    fetcher = fem._build_fetcher_for_bot(bot, ["BTC"])
+
+    assert bot.detect_calls == 1
+    assert isinstance(fetcher, BitgetFetcher)
+    assert fetcher.api.options["uta"] is True
+
+
+@pytest.mark.asyncio
+async def test_fill_events_cli_prepare_skips_non_bitget_bot():
+    class _Bot:
+        exchange = "binance"
+
+        async def _detect_account_mode(self):
+            raise AssertionError("non-Bitget CLI fetchers must not probe Bitget UTA mode")
+
+    await fem._prepare_cli_fetcher_bot(_Bot())
+
+
+@pytest.mark.asyncio
 async def test_bitget_fetcher_enriches_and_deduplicates(monkeypatch):
     fills = [
         [

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -56,8 +56,14 @@ class _Clock:
 
 
 class _FakeBitgetAPI:
-    def __init__(self, batches: List[List[Dict[str, str]]]) -> None:
+    def __init__(
+        self,
+        batches: List[List[Dict[str, str]]],
+        *,
+        options: Optional[Dict[str, object]] = None,
+    ) -> None:
         self._batches = batches
+        self.options = dict(options or {})
         self.history_calls: List[Dict[str, object]] = []
         self.detail_calls: List[Dict[str, object]] = []
         self.details_by_order: Dict[str, Dict[str, object]] = {}
@@ -79,6 +85,12 @@ class _FakeBitgetAPI:
         self.detail_calls.append(dict(params))
         order_id = params["orderId"]
         return self.details_by_order.get(order_id, {"data": {"clientOid": None}})
+
+    async def private_uta_get_v3_trade_fills(self, params: Dict[str, object]):
+        self.history_calls.append(dict(params))
+        if not self._batches:
+            return {"data": {"list": []}}
+        return {"data": {"list": self._batches.pop(0)}}
 
 
 class _StaticFetcher(BaseFetcher):
@@ -2241,6 +2253,139 @@ async def test_bitget_fetcher_reuses_detail_cache(monkeypatch):
     assert events[0]["pb_order_type"] == "cached-type"
     assert len(batch_log) == 1
     assert events[0]["symbol"].endswith(":USDT")
+
+
+@pytest.mark.asyncio
+async def test_bitget_uta_fetcher_derives_position_side_without_pos_side(monkeypatch):
+    fills = [
+        [
+            {
+                "execId": "exec-open-short",
+                "orderId": "order-open-short",
+                "clientOid": "0x0001abcdef",
+                "createdTime": "1000",
+                "symbol": "BTCUSDT",
+                "side": "sell",
+                "tradeSide": "open",
+                "execQty": "0.1",
+                "execPrice": "10",
+                "execPnl": "0",
+                "feeDetail": [{"feeCoin": "USDT", "fee": "0.01"}],
+            },
+            {
+                "execId": "exec-close-short",
+                "orderId": "order-close-short",
+                "clientOid": "0x0002abcdef",
+                "createdTime": "1100",
+                "symbol": "BTCUSDT",
+                "side": "buy",
+                "tradeSide": "close",
+                "execQty": "0.1",
+                "execPrice": "9",
+                "execPnl": "1",
+                "feeDetail": [{"feeCoin": "USDT", "fee": "0.01"}],
+            },
+            {
+                "execId": "exec-close-long",
+                "orderId": "order-close-long",
+                "clientOid": "0x0003abcdef",
+                "createdTime": "1200",
+                "symbol": "BTCUSDT",
+                "side": "sell",
+                "tradeSide": "close",
+                "execQty": "0.1",
+                "execPrice": "11",
+                "execPnl": "1",
+                "feeDetail": [{"feeCoin": "USDT", "fee": "0.01"}],
+            },
+        ]
+    ]
+    api = _FakeBitgetAPI(fills, options={"uta": True})
+    resolver = lambda s: f"{s[:-4]}/USDT:USDT" if s and s.endswith("USDT") else s
+    monkeypatch.setattr("src.fill_events_manager.custom_id_to_snake", lambda value: value)
+
+    fetcher = BitgetFetcher(
+        api,
+        history_limit=100,
+        now_func=lambda: 2000,
+        symbol_resolver=resolver,
+    )
+
+    events = await fetcher.fetch(
+        since_ms=900,
+        until_ms=2000,
+        detail_cache={},
+        on_batch=None,
+    )
+
+    by_id = {event["id"]: event for event in events}
+    assert by_id["exec-open-short"]["position_side"] == "short"
+    assert by_id["exec-close-short"]["position_side"] == "short"
+    assert by_id["exec-close-short"]["side"] == "buy"
+    assert by_id["exec-close-long"]["position_side"] == "long"
+    assert by_id["exec-close-long"]["side"] == "sell"
+    assert api.detail_calls == []
+    assert api.history_calls[0]["category"] == "USDT-FUTURES"
+    assert api.history_calls[0]["startTime"] == 900
+
+
+@pytest.mark.asyncio
+async def test_bitget_uta_fetcher_splits_long_lookback_into_30_day_windows(monkeypatch):
+    day_ms = 24 * 60 * 60 * 1000
+    api = _FakeBitgetAPI(
+        [
+            [
+                {
+                    "execId": "exec-new",
+                    "orderId": "order-new",
+                    "clientOid": "0x0001abcdef",
+                    "createdTime": str(59 * day_ms),
+                    "symbol": "BTCUSDT",
+                    "side": "sell",
+                    "tradeSide": "open",
+                    "execQty": "0.1",
+                    "execPrice": "10",
+                    "execPnl": "0",
+                }
+            ],
+            [
+                {
+                    "execId": "exec-old",
+                    "orderId": "order-old",
+                    "clientOid": "0x0002abcdef",
+                    "createdTime": str(10 * day_ms),
+                    "symbol": "BTCUSDT",
+                    "side": "buy",
+                    "tradeSide": "close",
+                    "execQty": "0.1",
+                    "execPrice": "9",
+                    "execPnl": "1",
+                }
+            ],
+        ],
+        options={"uta": True},
+    )
+    resolver = lambda s: f"{s[:-4]}/USDT:USDT" if s and s.endswith("USDT") else s
+    monkeypatch.setattr("src.fill_events_manager.custom_id_to_snake", lambda value: value)
+
+    fetcher = BitgetFetcher(
+        api,
+        history_limit=100,
+        now_func=lambda: 60 * day_ms,
+        symbol_resolver=resolver,
+    )
+
+    events = await fetcher.fetch(
+        since_ms=0,
+        until_ms=60 * day_ms,
+        detail_cache={},
+        on_batch=None,
+    )
+
+    assert [event["id"] for event in events] == ["exec-old", "exec-new"]
+    assert len(api.history_calls) == 2
+    for call in api.history_calls:
+        assert int(call["endTime"]) - int(call["startTime"]) < 30 * day_ms
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds support for trading a **Bitget UTA / Elite (copy-trading) account** while leaving classic v2/mix accounts completely unchanged.

Bitget's Elite (lead) copy-trading runs on the **Unified Trading Account (UTA) v3 API**, which is mutually exclusive with the classic v2/mix API a normal Bitget key uses. The connector now **auto-detects** which kind of account the API key drives and routes ccxt accordingly, so the same setup handles both a normal account and an elite/copy-trading account.

## How it works

- Detection runs once at startup in `update_exchange_config()`, probing the v3 `account/assets` endpoint. Classic keys return code `40084` ("Classic Account mode"); on any uncertainty it falls back to classic.
- A single flag, `self.is_uta`, gates every UTA code path in the connector. For classic accounts `is_uta` stays `False` and all existing behaviour is preserved (**zero regression**).
- ccxt already supports Bitget UTA via `options['uta']`; the connector sets it once detection completes (and re-applies it on session re-creation).

## Changes

**`src/exchanges/bitget.py`** (connector):
- balance parsed from v3 `account/assets` (no `marginCoin`)
- order params use `posSide` (v3) instead of `holdSide`/`oneWayMode` (v2), which v3 rejects with code `25236`
- open-order side derived from `posSide` + `reduceOnly` (v3 has no `tradeSide`)
- `fetch_pnls` / `fetch_fill_events` sourced from v3 `trade/fills`; order detail via v3 `trade/order-info`
- `set_margin_mode` skipped under UTA (no v3 routing; elite is cross-only)
- closed-order pnl read made null-safe (no `totalProfits` in v3)

**`src/fill_events_manager.py`** (`BitgetFetcher`):
- the PnL manager's fetcher calls the v2 fill-history endpoint directly, which returns `40731` for a UTA account and crashes the bot in `update_pnls` on startup. Added a UTA branch that sources fills from v3 `trade/fills` (execPnl; clientOid already present, so no per-order detail enrichment). Guarded by `options['uta']`.

## Testing

Validated **live on a real Bitget Elite/UTA account running on a Raspberry Pi worker**, plus a classic key for regression:

- **Classic key** — detection → classic; balance, positions and order params identical to before (no behaviour change).
- **Elite / UTA key** — detection → UTA; balance from v3, positions, fills/PnL from v3 `trade/fills`, and live order placement with `posSide`. The bot initialises without the `40731` crash and runs a normal recursive-grid position (entry + DCA orders) on the elite account.
