### PR TITLE
Feat: Add `--resume` flag to restore exact optimizer state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ All notable user-facing changes will be documented in this file.
 - Fixed Hyperliquid `xyz:*` stock-perp backtest/optimizer startup so explicit
   `backtest.ohlcv_source_dir` data can use the direct source-dir preparation path when
   strict local v2 materialization is unavailable.
+- Added optimizer `--resume` checkpoint recovery safeguards: resume now requires a
+  readable checkpoint plus prior `all_results.bin` metadata, rejects changed optimizer
+  search domains before appending results, and exits non-zero on fatal optimizer errors.
 
 ## v7.12.0 - 2026-05-27
 

--- a/src/optimization/backends/deap_backend.py
+++ b/src/optimization/backends/deap_backend.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import logging
 import multiprocessing
+import os
+import pickle
+import random
 from copy import deepcopy
 from typing import Any, Callable
 
@@ -179,28 +182,26 @@ def run_backend(
 
         population_size = _resolve_deap_population_size(config)
         start_gen = 1
-        
+
         # Checkpoint Loading
         chk = None
-        if resume and checkpoint_path is not None:
-            import os, pickle
-            if os.path.isfile(checkpoint_path):
-                logging.info(f"Loading DEAP checkpoint from {checkpoint_path}...")
-                with open(checkpoint_path, "rb") as f:
-                    chk = pickle.load(f)
-                
-                try:
-                    import random
-                    random.setstate(chk["random_state"])
-                    np.random.set_state(chk["np_random_state"])
-                except Exception as e:
-                    logging.warning(f"Could not restore random states: {e}")
-                
-                population = chk["population"]
-                logbook = chk["logbook"]
-                hof = chk["halloffame"]
-                start_gen = chk["gen"] + 1
-                logging.info(f"Resuming DEAP evolution from generation {start_gen}...")
+        if resume:
+            if checkpoint_path is None:
+                raise ValueError("DEAP resume requested without a checkpoint path")
+            if not os.path.isfile(checkpoint_path):
+                raise FileNotFoundError(f"DEAP checkpoint not found: {checkpoint_path}")
+            logging.info(f"Loading DEAP checkpoint from {checkpoint_path}...")
+            with open(checkpoint_path, "rb") as f:
+                chk = pickle.load(f)
+
+            random.setstate(chk["random_state"])
+            np.random.set_state(chk["np_random_state"])
+
+            population = chk["population"]
+            logbook = chk["logbook"]
+            hof = chk["halloffame"]
+            start_gen = chk["gen"] + 1
+            logging.info(f"Resuming DEAP evolution from generation {start_gen}...")
 
         if chk is None:
             starting_individuals = load_starting_individuals(

--- a/src/optimization/backends/deap_backend.py
+++ b/src/optimization/backends/deap_backend.py
@@ -60,6 +60,8 @@ def run_backend(
     run_evolution: Callable[..., tuple[Any, Any]],
     build_config_fn,
     overrides_fn,
+    checkpoint_path: str | None = None,
+    resume: bool = False,
 ) -> dict[str, Any]:
     del build_config_fn
     del overrides_fn
@@ -176,73 +178,96 @@ def run_backend(
             return completed["count"]
 
         population_size = _resolve_deap_population_size(config)
-        starting_individuals = load_starting_individuals(
-            starting_configs_path=starting_configs_path,
-            population_size=population_size,
-            get_starting_configs=get_starting_configs,
-            configs_to_individuals=configs_to_individuals,
-            iter_starting_configs=iter_starting_configs,
-            configs_to_individuals_streaming=configs_to_individuals_streaming,
-            optimization_shape=optimization_shape,
-            bounds=bounds,
-            sig_digits=sig_digits,
-        )
+        start_gen = 1
+        
+        # Checkpoint Loading
+        chk = None
+        if resume and checkpoint_path is not None:
+            import os, pickle
+            if os.path.isfile(checkpoint_path):
+                logging.info(f"Loading DEAP checkpoint from {checkpoint_path}...")
+                with open(checkpoint_path, "rb") as f:
+                    chk = pickle.load(f)
+                
+                try:
+                    import random
+                    random.setstate(chk["random_state"])
+                    np.random.set_state(chk["np_random_state"])
+                except Exception as e:
+                    logging.warning(f"Could not restore random states: {e}")
+                
+                population = chk["population"]
+                logbook = chk["logbook"]
+                hof = chk["halloffame"]
+                start_gen = chk["gen"] + 1
+                logging.info(f"Resuming DEAP evolution from generation {start_gen}...")
 
-        def _make_random_individual():
-            values = [bound.random_on_grid() for bound in bounds]
-            return creator.Individual(values)
+        if chk is None:
+            starting_individuals = load_starting_individuals(
+                starting_configs_path=starting_configs_path,
+                population_size=population_size,
+                get_starting_configs=get_starting_configs,
+                configs_to_individuals=configs_to_individuals,
+                iter_starting_configs=iter_starting_configs,
+                configs_to_individuals_streaming=configs_to_individuals_streaming,
+                optimization_shape=optimization_shape,
+                bounds=bounds,
+                sig_digits=sig_digits,
+            )
 
-        population = [_make_random_individual() for _ in range(population_size)]
-        if starting_individuals:
-            log_seed_memory(
-                "deap_starting_individuals_ready",
-                count=len(starting_individuals),
-                approx_bytes=approx_object_size(starting_individuals),
-            )
-            evaluated_seeds = [creator.Individual(ind) for ind in starting_individuals]
-            log_seed_memory(
-                "deap_evaluated_seeds_allocated",
-                count=len(evaluated_seeds),
-                approx_bytes=approx_object_size(evaluated_seeds),
-            )
-            eval_count = _evaluate_initial(evaluated_seeds)
-            logging.info("Evaluated %d starting configs", eval_count)
-            log_seed_memory(
-                "deap_starting_eval_complete",
-                count=len(evaluated_seeds),
-                approx_bytes=approx_object_size(evaluated_seeds),
-            )
-            if len(evaluated_seeds) > population_size:
-                evaluated_seeds = tools.selNSGA2(evaluated_seeds, population_size)
-                logging.info(
-                    "Trimmed starting configs to population size via NSGA-II crowding (kept %d)",
-                    len(evaluated_seeds),
-                )
+            def _make_random_individual():
+                values = [bound.random_on_grid() for bound in bounds]
+                return creator.Individual(values)
+
+            population = [_make_random_individual() for _ in range(population_size)]
+            if starting_individuals:
                 log_seed_memory(
-                    "deap_starting_trim_complete",
+                    "deap_starting_individuals_ready",
+                    count=len(starting_individuals),
+                    approx_bytes=approx_object_size(starting_individuals),
+                )
+                evaluated_seeds = [creator.Individual(ind) for ind in starting_individuals]
+                log_seed_memory(
+                    "deap_evaluated_seeds_allocated",
                     count=len(evaluated_seeds),
                     approx_bytes=approx_object_size(evaluated_seeds),
                 )
-            for i, ind in enumerate(evaluated_seeds):
-                population[i] = creator.Individual(ind)
+                eval_count = _evaluate_initial(evaluated_seeds)
+                logging.info("Evaluated %d starting configs", eval_count)
+                log_seed_memory(
+                    "deap_starting_eval_complete",
+                    count=len(evaluated_seeds),
+                    approx_bytes=approx_object_size(evaluated_seeds),
+                )
+                if len(evaluated_seeds) > population_size:
+                    evaluated_seeds = tools.selNSGA2(evaluated_seeds, population_size)
+                    logging.info(
+                        "Trimmed starting configs to population size via NSGA-II crowding (kept %d)",
+                        len(evaluated_seeds),
+                    )
+                    log_seed_memory(
+                        "deap_starting_trim_complete",
+                        count=len(evaluated_seeds),
+                        approx_bytes=approx_object_size(evaluated_seeds),
+                    )
+                for i, ind in enumerate(evaluated_seeds):
+                    population[i] = creator.Individual(ind)
 
-            remaining = population_size - len(evaluated_seeds)
-            seed_pool = evaluated_seeds if evaluated_seeds else []
-            if seed_pool and remaining > 0:
-                for i in range(len(evaluated_seeds), len(evaluated_seeds) + remaining // 2):
-                    population[i] = deepcopy(seed_pool[np.random.choice(range(len(seed_pool)))])
-        for i in range(len(population)):
-            population[i][:] = enforce_bounds(population[i], bounds, sig_digits)
+                remaining = population_size - len(evaluated_seeds)
+                seed_pool = evaluated_seeds if evaluated_seeds else []
+                if seed_pool and remaining > 0:
+                    for i in range(len(evaluated_seeds), len(evaluated_seeds) + remaining // 2):
+                        population[i] = deepcopy(seed_pool[np.random.choice(range(len(seed_pool)))])
+            for i in range(len(population)):
+                population[i][:] = enforce_bounds(population[i], bounds, sig_digits)
 
-        logging.info("Initial population size: %d", len(population))
+            logbook = tools.Logbook()
+            logbook.header = "gen", "evals", "min", "max"
+            hof = tools.ParetoFront()
 
         stats = tools.Statistics(lambda ind: ind.fitness.values)
         stats.register("min", np.min, axis=0)
         stats.register("max", np.max, axis=0)
-
-        logbook = tools.Logbook()
-        logbook.header = "gen", "evals", "min", "max"
-        hof = tools.ParetoFront()
 
         logging.info("Starting optimize...")
         lambda_size = max(1, int(round(population_size * offspring_multiplier)))
@@ -263,6 +288,9 @@ def run_backend(
             pool=pool,
             duplicate_counter=duplicate_counter,
             pool_state=pool_state,
+            start_gen=start_gen,
+            logbook=logbook,
+            checkpoint_path=checkpoint_path,
         )
         logging.info("Optimization complete.")
         return {

--- a/src/optimization/backends/pymoo_backend.py
+++ b/src/optimization/backends/pymoo_backend.py
@@ -4,6 +4,8 @@ import functools
 import logging
 import math
 import multiprocessing
+import os
+import pickle
 from typing import Any
 
 import numpy as np
@@ -467,52 +469,47 @@ class PymooCheckpointCallback(Callback):
 
     def notify(self, algorithm):
         try:
-            import pickle
-            import os
-            
             # Temporarily detach unpicklable runner/pool and evaluator
             problem = getattr(algorithm, "problem", None)
             runner = getattr(problem, "elementwise_runner", None) if problem else None
             adapter = getattr(problem, "evaluator_adapter", None) if problem else None
             evaluator = getattr(adapter, "evaluator", None) if adapter else None
-            
+
             alg_evaluator = getattr(algorithm, "evaluator", None)
             alg_problem = getattr(alg_evaluator, "problem", None) if alg_evaluator else None
             alg_runner = getattr(alg_problem, "elementwise_runner", None) if alg_problem else None
             alg_adapter = getattr(alg_problem, "evaluator_adapter", None) if alg_problem else None
-            
+            alg_adapter_evaluator = getattr(alg_adapter, "evaluator", None) if alg_adapter else None
+
             try:
                 if runner is not None:
                     algorithm.problem.elementwise_runner = None
                 if evaluator is not None:
                     adapter.evaluator = None
-                    
+
                 if alg_runner is not None:
                     alg_problem.elementwise_runner = None
                 if alg_adapter is not None:
                     alg_adapter.evaluator = None
-                
+
                 tmp_path = self.path + ".tmp"
                 with open(tmp_path, "wb") as f:
                     pickle.dump(algorithm, f, protocol=pickle.HIGHEST_PROTOCOL)
                 os.replace(tmp_path, self.path)
-                
-                import gc
-                gc.collect()
             finally:
                 # Restore runner and evaluator
                 if runner is not None:
                     algorithm.problem.elementwise_runner = runner
                 if evaluator is not None:
                     adapter.evaluator = evaluator
-                    
+
                 if alg_runner is not None:
                     alg_problem.elementwise_runner = alg_runner
-                if alg_adapter is not None and evaluator is not None:
-                    alg_adapter.evaluator = evaluator
-                    
-        except Exception as e:
-            logging.warning(f"Failed to save pymoo checkpoint: {e}")
+                if alg_adapter is not None:
+                    alg_adapter.evaluator = alg_adapter_evaluator
+
+        except Exception as exc:
+            raise RuntimeError(f"Failed to save pymoo checkpoint: {self.path}") from exc
 
 
 def run_backend(
@@ -608,26 +605,28 @@ def run_backend(
             evaluator_adapter=evaluator_adapter,
             elementwise_runner=runner,
         )
-        
+
         algorithm = None
-        if resume and checkpoint_path is not None:
-            import os, pickle
-            if os.path.isfile(checkpoint_path):
-                logging.info(f"Loading PyMoo checkpoint from {checkpoint_path}...")
-                with open(checkpoint_path, "rb") as f:
-                    algorithm = pickle.load(f)
-                    algorithm.has_terminated = False
-                    
-                    # Restore the active runner (pool) and evaluator
-                    if hasattr(algorithm, "problem"):
-                        algorithm.problem.elementwise_runner = runner
-                        if hasattr(algorithm.problem, "evaluator_adapter"):
-                            algorithm.problem.evaluator_adapter.evaluator = evaluator_for_pool
-                    if hasattr(algorithm, "evaluator") and hasattr(algorithm.evaluator, "problem"):
-                        algorithm.evaluator.problem.elementwise_runner = runner
-                        if hasattr(algorithm.evaluator.problem, "evaluator_adapter"):
-                            algorithm.evaluator.problem.evaluator_adapter.evaluator = evaluator_for_pool
-                    
+        if resume:
+            if checkpoint_path is None:
+                raise ValueError("PyMoo resume requested without a checkpoint path")
+            if not os.path.isfile(checkpoint_path):
+                raise FileNotFoundError(f"PyMoo checkpoint not found: {checkpoint_path}")
+            logging.info(f"Loading PyMoo checkpoint from {checkpoint_path}...")
+            with open(checkpoint_path, "rb") as f:
+                algorithm = pickle.load(f)
+            algorithm.has_terminated = False
+
+            # Restore the active runner (pool) and evaluator
+            if hasattr(algorithm, "problem"):
+                algorithm.problem.elementwise_runner = runner
+                if hasattr(algorithm.problem, "evaluator_adapter"):
+                    algorithm.problem.evaluator_adapter.evaluator = evaluator_for_pool
+            if hasattr(algorithm, "evaluator") and hasattr(algorithm.evaluator, "problem"):
+                algorithm.evaluator.problem.elementwise_runner = runner
+                if hasattr(algorithm.evaluator.problem, "evaluator_adapter"):
+                    algorithm.evaluator.problem.evaluator_adapter.evaluator = evaluator_for_pool
+
         if algorithm is None:
             algorithm = _build_algorithm(
                 config=config,
@@ -662,7 +661,7 @@ def run_backend(
                 )
         ngen = max(1, int(config["optimize"]["iters"] / population_size))
         logging.info("Starting optimize...")
-        
+
         minimize_kwargs = {
             "seed": 1,
             "verbose": False,

--- a/src/optimization/backends/pymoo_backend.py
+++ b/src/optimization/backends/pymoo_backend.py
@@ -468,20 +468,29 @@ class PymooCheckpointCallback(Callback):
     def notify(self, algorithm):
         try:
             import pickle
+            import os
             
-            # Temporarily detach unpicklable runner/pool
+            # Temporarily detach unpicklable runner/pool and evaluator
             problem = getattr(algorithm, "problem", None)
             runner = getattr(problem, "elementwise_runner", None) if problem else None
+            adapter = getattr(problem, "evaluator_adapter", None) if problem else None
+            evaluator = getattr(adapter, "evaluator", None) if adapter else None
             
             if runner is not None:
                 algorithm.problem.elementwise_runner = None
+            if evaluator is not None:
+                adapter.evaluator = None
             
-            with open(self.path, "wb") as f:
+            tmp_path = self.path + ".tmp"
+            with open(tmp_path, "wb") as f:
                 pickle.dump(algorithm, f)
+            os.replace(tmp_path, self.path)
                 
-            # Restore runner
+            # Restore runner and evaluator
             if runner is not None:
                 algorithm.problem.elementwise_runner = runner
+            if evaluator is not None:
+                adapter.evaluator = evaluator
                 
         except Exception as e:
             logging.warning(f"Failed to save pymoo checkpoint: {e}")
@@ -590,11 +599,15 @@ def run_backend(
                     algorithm = pickle.load(f)
                     algorithm.has_terminated = False
                     
-                    # Restore the active runner (pool)
+                    # Restore the active runner (pool) and evaluator
                     if hasattr(algorithm, "problem"):
                         algorithm.problem.elementwise_runner = runner
+                        if hasattr(algorithm.problem, "evaluator_adapter"):
+                            algorithm.problem.evaluator_adapter.evaluator = evaluator_for_pool
                     if hasattr(algorithm, "evaluator") and hasattr(algorithm.evaluator, "problem"):
                         algorithm.evaluator.problem.elementwise_runner = runner
+                        if hasattr(algorithm.evaluator.problem, "evaluator_adapter"):
+                            algorithm.evaluator.problem.evaluator_adapter.evaluator = evaluator_for_pool
                     
         if algorithm is None:
             algorithm = _build_algorithm(

--- a/src/optimization/backends/pymoo_backend.py
+++ b/src/optimization/backends/pymoo_backend.py
@@ -12,6 +12,7 @@ try:
     from pymoo.algorithms.moo.nsga2 import NSGA2
     from pymoo.algorithms.moo.nsga3 import NSGA3
     from pymoo.core.population import Population
+    from pymoo.core.callback import Callback
     from pymoo.optimize import minimize as pymoo_minimize
     from pymoo.operators.crossover.sbx import SBX
     from pymoo.operators.mutation.pm import PM
@@ -21,6 +22,7 @@ except ImportError:  # pragma: no cover
     NSGA2 = None
     NSGA3 = None
     Population = None
+    Callback = object
     get_reference_directions = None
 
 from optimization.backend_shared import (
@@ -458,6 +460,20 @@ def _build_algorithm(
     )
 
 
+class PymooCheckpointCallback(Callback):
+    def __init__(self, path):
+        super().__init__()
+        self.path = path
+
+    def notify(self, algorithm):
+        try:
+            import pickle
+            with open(self.path, "wb") as f:
+                pickle.dump(algorithm, f)
+        except Exception as e:
+            logging.warning(f"Failed to save pymoo checkpoint: {e}")
+
+
 def run_backend(
     *,
     config: dict[str, Any],
@@ -478,6 +494,8 @@ def run_backend(
     run_evolution,
     build_config_fn,
     overrides_fn,
+    checkpoint_path: str | None = None,
+    resume: bool = False,
 ) -> dict[str, Any]:
     del evaluator
     del duplicate_counter
@@ -549,45 +567,63 @@ def run_backend(
             evaluator_adapter=evaluator_adapter,
             elementwise_runner=runner,
         )
-        algorithm = _build_algorithm(
-            config=config,
-            sampling=sampling,
-            bounds=bounds,
-            sig_digits=sig_digits,
-            population_plan=population_plan,
-        )
-        if starting_individuals:
-            seed_payloads = _evaluate_starting_individuals(
-                starting_individuals=starting_individuals,
+        
+        algorithm = None
+        if resume and checkpoint_path is not None:
+            import os, pickle
+            if os.path.isfile(checkpoint_path):
+                logging.info(f"Loading PyMoo checkpoint from {checkpoint_path}...")
+                with open(checkpoint_path, "rb") as f:
+                    algorithm = pickle.load(f)
+                    algorithm.has_terminated = False
+                    
+        if algorithm is None:
+            algorithm = _build_algorithm(
                 config=config,
-                evaluator=evaluator_for_pool,
-                overrides_list=overrides_list,
-                runner=runner,
-                n_obj=len(config["optimize"]["scoring"]),
-                has_constraints=evaluator_adapter.has_constraints,
-            )
-            logging.info("Evaluated %d starting configs", len(seed_payloads))
-            log_seed_memory(
-                "pymoo_starting_payloads_ready",
-                count=len(seed_payloads),
-                approx_bytes=approx_object_size(seed_payloads),
-            )
-            algorithm.initialization.sampling = _reduce_starting_population(
-                problem=problem,
-                algorithm=algorithm,
-                starting_individuals=starting_individuals,
-                payloads=seed_payloads,
-                population_size=population_size,
+                sampling=sampling,
                 bounds=bounds,
+                sig_digits=sig_digits,
+                population_plan=population_plan,
             )
+            if starting_individuals:
+                seed_payloads = _evaluate_starting_individuals(
+                    starting_individuals=starting_individuals,
+                    config=config,
+                    evaluator=evaluator_for_pool,
+                    overrides_list=overrides_list,
+                    runner=runner,
+                    n_obj=len(config["optimize"]["scoring"]),
+                    has_constraints=evaluator_adapter.has_constraints,
+                )
+                logging.info("Evaluated %d starting configs", len(seed_payloads))
+                log_seed_memory(
+                    "pymoo_starting_payloads_ready",
+                    count=len(seed_payloads),
+                    approx_bytes=approx_object_size(seed_payloads),
+                )
+                algorithm.initialization.sampling = _reduce_starting_population(
+                    problem=problem,
+                    algorithm=algorithm,
+                    starting_individuals=starting_individuals,
+                    payloads=seed_payloads,
+                    population_size=population_size,
+                    bounds=bounds,
+                )
         ngen = max(1, int(config["optimize"]["iters"] / population_size))
         logging.info("Starting optimize...")
+        
+        minimize_kwargs = {
+            "seed": 1,
+            "verbose": False,
+        }
+        if checkpoint_path is not None:
+            minimize_kwargs["callback"] = PymooCheckpointCallback(checkpoint_path)
+
         pymoo_minimize(
             problem,
             algorithm,
             get_termination("n_gen", ngen),
-            seed=1,
-            verbose=False,
+            **minimize_kwargs
         )
         logging.info("Optimization complete.")
         return {

--- a/src/optimization/backends/pymoo_backend.py
+++ b/src/optimization/backends/pymoo_backend.py
@@ -483,8 +483,11 @@ class PymooCheckpointCallback(Callback):
             
             tmp_path = self.path + ".tmp"
             with open(tmp_path, "wb") as f:
-                pickle.dump(algorithm, f)
+                pickle.dump(algorithm, f, protocol=pickle.HIGHEST_PROTOCOL)
             os.replace(tmp_path, self.path)
+            
+            import gc
+            gc.collect()
                 
             # Restore runner and evaluator
             if runner is not None:
@@ -647,6 +650,7 @@ def run_backend(
         minimize_kwargs = {
             "seed": 1,
             "verbose": False,
+            "copy_algorithm": False,
         }
         if checkpoint_path is not None:
             minimize_kwargs["callback"] = PymooCheckpointCallback(checkpoint_path)

--- a/src/optimization/backends/pymoo_backend.py
+++ b/src/optimization/backends/pymoo_backend.py
@@ -468,8 +468,21 @@ class PymooCheckpointCallback(Callback):
     def notify(self, algorithm):
         try:
             import pickle
+            
+            # Temporarily detach unpicklable runner/pool
+            problem = getattr(algorithm, "problem", None)
+            runner = getattr(problem, "elementwise_runner", None) if problem else None
+            
+            if runner is not None:
+                algorithm.problem.elementwise_runner = None
+            
             with open(self.path, "wb") as f:
                 pickle.dump(algorithm, f)
+                
+            # Restore runner
+            if runner is not None:
+                algorithm.problem.elementwise_runner = runner
+                
         except Exception as e:
             logging.warning(f"Failed to save pymoo checkpoint: {e}")
 
@@ -576,6 +589,12 @@ def run_backend(
                 with open(checkpoint_path, "rb") as f:
                     algorithm = pickle.load(f)
                     algorithm.has_terminated = False
+                    
+                    # Restore the active runner (pool)
+                    if hasattr(algorithm, "problem"):
+                        algorithm.problem.elementwise_runner = runner
+                    if hasattr(algorithm, "evaluator") and hasattr(algorithm.evaluator, "problem"):
+                        algorithm.evaluator.problem.elementwise_runner = runner
                     
         if algorithm is None:
             algorithm = _build_algorithm(

--- a/src/optimization/backends/pymoo_backend.py
+++ b/src/optimization/backends/pymoo_backend.py
@@ -476,25 +476,41 @@ class PymooCheckpointCallback(Callback):
             adapter = getattr(problem, "evaluator_adapter", None) if problem else None
             evaluator = getattr(adapter, "evaluator", None) if adapter else None
             
-            if runner is not None:
-                algorithm.problem.elementwise_runner = None
-            if evaluator is not None:
-                adapter.evaluator = None
+            alg_evaluator = getattr(algorithm, "evaluator", None)
+            alg_problem = getattr(alg_evaluator, "problem", None) if alg_evaluator else None
+            alg_runner = getattr(alg_problem, "elementwise_runner", None) if alg_problem else None
+            alg_adapter = getattr(alg_problem, "evaluator_adapter", None) if alg_problem else None
             
-            tmp_path = self.path + ".tmp"
-            with open(tmp_path, "wb") as f:
-                pickle.dump(algorithm, f, protocol=pickle.HIGHEST_PROTOCOL)
-            os.replace(tmp_path, self.path)
-            
-            import gc
-            gc.collect()
+            try:
+                if runner is not None:
+                    algorithm.problem.elementwise_runner = None
+                if evaluator is not None:
+                    adapter.evaluator = None
+                    
+                if alg_runner is not None:
+                    alg_problem.elementwise_runner = None
+                if alg_adapter is not None:
+                    alg_adapter.evaluator = None
                 
-            # Restore runner and evaluator
-            if runner is not None:
-                algorithm.problem.elementwise_runner = runner
-            if evaluator is not None:
-                adapter.evaluator = evaluator
+                tmp_path = self.path + ".tmp"
+                with open(tmp_path, "wb") as f:
+                    pickle.dump(algorithm, f, protocol=pickle.HIGHEST_PROTOCOL)
+                os.replace(tmp_path, self.path)
                 
+                import gc
+                gc.collect()
+            finally:
+                # Restore runner and evaluator
+                if runner is not None:
+                    algorithm.problem.elementwise_runner = runner
+                if evaluator is not None:
+                    adapter.evaluator = evaluator
+                    
+                if alg_runner is not None:
+                    alg_problem.elementwise_runner = alg_runner
+                if alg_adapter is not None and evaluator is not None:
+                    alg_adapter.evaluator = evaluator
+                    
         except Exception as e:
             logging.warning(f"Failed to save pymoo checkpoint: {e}")
 

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -356,6 +356,7 @@ class ResultRecorder:
         write_all_results: bool,
         pareto_max_size: int = 1000,
         bounds: Optional[Sequence[Bound]] = None,
+        starting_iters: int = 0,
     ):
         self.store = ParetoStore(
             directory=results_dir,
@@ -365,6 +366,7 @@ class ResultRecorder:
             log_name="optimizer.pareto",
             max_size=pareto_max_size,
         )
+        self.store.n_iters = starting_iters
         self.write_all = write_all_results
         self.compress = compress
         self.results_file = None
@@ -2063,6 +2065,7 @@ async def main():
                 / (1000 * 60 * 60 * 24)
             )
         )
+        previous_evals = 0
         if args.resume:
             results_dir = make_get_filepath(args.resume)
             if not os.path.isdir(results_dir):
@@ -2112,6 +2115,10 @@ async def main():
                                     f"Please restore the original config or start a fresh run.\n"
                                 )
                             break
+                            
+                        # If validation passed, count remaining entries
+                        previous_evals = 1 + sum(1 for _ in unpacker)
+                        logging.info(f"Resuming with {previous_evals} previous evaluations from all_results.bin")
                 except ValueError:
                     raise
                 except Exception as e:
@@ -2166,6 +2173,7 @@ async def main():
             write_all_results=config["optimize"].get("write_all_results", True),
             pareto_max_size=pareto_max,
             bounds=evaluator.bounds,
+            starting_iters=previous_evals,
         )
         backend_name = config["optimize"]["backend"]
         logging.info("Selected optimizer backend: %s", backend_name)

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2062,6 +2062,14 @@ async def main():
             )
         )
         if args.resume:
+            raw_end_date = str(require_config_value(config, "backtest.end_date")).strip().lower()
+            if raw_end_date == "now" or raw_end_date == "":
+                raise ValueError(
+                    "\n\nERROR: Cannot use --resume with a dynamic end_date ('now'). "
+                    "The shifting time frame would corrupt the optimization scores. "
+                    "Please hard-code the end_date in your config (e.g. '2026-06-16') "
+                    "or start a fresh run.\n"
+                )
             results_dir = make_get_filepath(args.resume)
             if not os.path.isdir(results_dir):
                 raise ValueError(f"Resume directory not found: {results_dir}")

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -752,7 +752,9 @@ def ea_mu_plus_lambda_stream(
                     "np_random_state": np.random.get_state(),
                 }
                 with open(checkpoint_path, "wb") as f:
-                    pickle.dump(chk, f)
+                    pickle.dump(chk, f, protocol=pickle.HIGHEST_PROTOCOL)
+                import gc
+                gc.collect()
             except Exception as e:
                 logging.warning(f"Failed to save checkpoint: {e}")
 

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -573,20 +573,16 @@ def _resume_config_mismatches(entry: dict, config: dict) -> list[str]:
 
     mismatches = []
     is_suite_result = entry.get("suite_metrics") is not None
-    backtest_keys = ["start_date", "end_date", "exchanges"]
+    old_bt_compare = deepcopy(old_bt)
+    new_bt_compare = deepcopy(new_bt)
     if is_suite_result:
-        backtest_keys.append("scenarios")
-        if old_bt.get("coins") is not None:
-            backtest_keys.append("coins")
-    else:
-        backtest_keys.append("coins")
-    for key in backtest_keys:
-        if old_bt.get(key) != new_bt.get(key):
-            mismatches.append(f"  - backtest.{key}: '{old_bt.get(key)}' -> '{new_bt.get(key)}'")
+        # Suite result entries omit top-level backtest.coins because the
+        # scenario list is the source of truth for per-scenario coins.
+        if old_bt_compare.get("coins") is None:
+            new_bt_compare.pop("coins", None)
+    _append_resume_section_mismatches(mismatches, "backtest", old_bt_compare, new_bt_compare)
 
-    for key in ["scoring", "passivbot_mode"]:
-        if old_opt.get(key) != new_opt.get(key):
-            mismatches.append(f"  - optimize.{key}: '{old_opt.get(key)}' -> '{new_opt.get(key)}'")
+    _append_resume_section_mismatches(mismatches, "optimize", old_opt, new_opt)
 
     for side in ["long", "short"]:
         old_en = old_bot.get(side, {}).get("enabled", True)
@@ -598,6 +594,85 @@ def _resume_config_mismatches(entry: dict, config: dict) -> list[str]:
         if old_live.get(key) != new_live.get(key):
             mismatches.append(f"  - live.{key}: changed")
     return mismatches
+
+
+def _append_resume_section_mismatches(
+    mismatches: list[str], section_name: str, old_section: dict, new_section: dict
+) -> None:
+    keys = sorted(set(old_section) | set(new_section))
+    for key in keys:
+        old_value = old_section.get(key)
+        new_value = new_section.get(key)
+        if old_value != new_value:
+            mismatches.append(f"  - {section_name}.{key}: '{old_value}' -> '{new_value}'")
+
+
+def _resolve_resume_results_dir(resume_path: str) -> str:
+    results_dir = os.path.abspath(os.path.expanduser(resume_path))
+    if not os.path.isdir(results_dir):
+        raise ValueError(f"Resume directory not found: {results_dir}")
+    return results_dir
+
+
+def _require_resume_checkpoint(results_dir: str) -> str:
+    checkpoint_path = os.path.join(results_dir, "checkpoint.pkl")
+    if not os.path.isfile(checkpoint_path):
+        raise ValueError(f"Cannot resume: checkpoint not found: {checkpoint_path}")
+    if os.path.getsize(checkpoint_path) <= 0:
+        raise ValueError(f"Cannot resume: checkpoint is empty: {checkpoint_path}")
+    try:
+        with open(checkpoint_path, "rb") as f:
+            f.read(1)
+    except OSError as exc:
+        raise ValueError(f"Cannot resume: checkpoint is not readable: {checkpoint_path}") from exc
+    return checkpoint_path
+
+
+def _validate_resume_results(results_dir: str, config: dict) -> int:
+    results_filename = os.path.join(results_dir, "all_results.bin")
+    if not os.path.isfile(results_filename):
+        raise ValueError(f"Cannot resume: all_results.bin not found: {results_filename}")
+    if os.path.getsize(results_filename) <= 0:
+        raise ValueError(f"Cannot resume: all_results.bin is empty: {results_filename}")
+
+    previous_evals = 0
+    try:
+        with open(results_filename, "rb") as f:
+            unpacker = msgpack.Unpacker(f, raw=False, max_buffer_size=1024 * 1024 * 100)
+            for entry in unpacker:
+                previous_evals += 1
+                if previous_evals == 1:
+                    if not isinstance(entry, dict):
+                        raise ValueError(
+                            f"Cannot resume: first all_results.bin entry is not a config object: "
+                            f"{results_filename}"
+                        )
+                    mismatches = _resume_config_mismatches(entry, config)
+                    if mismatches:
+                        mismatch_str = "\n".join(mismatches)
+                        raise ValueError(
+                            f"\n\nERROR: Cannot resume because critical parameters have changed!\n"
+                            f"Mismatches detected:\n{mismatch_str}\n\n"
+                            f"Resuming with a changed configuration would corrupt optimization scores.\n"
+                            f"Please restore the original config or start a fresh run.\n"
+                        )
+    except msgpack.exceptions.UnpackException as exc:
+        raise ValueError(f"Cannot resume: failed to read all_results.bin: {results_filename}") from exc
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError(f"Cannot resume: failed to read all_results.bin: {results_filename}") from exc
+
+    if previous_evals <= 0:
+        raise ValueError(f"Cannot resume: all_results.bin contains no entries: {results_filename}")
+    logging.info("Resuming with %d previous evaluations from all_results.bin", previous_evals)
+    return previous_evals
+
+
+def _optimizer_exit_code(interrupted: bool, fatal_error: bool) -> int:
+    if interrupted:
+        return 130
+    return 1 if fatal_error else 0
 
 
 def ea_mu_plus_lambda_stream(
@@ -781,23 +856,23 @@ def ea_mu_plus_lambda_stream(
         log_generation(gen, nevals, record)
         
         if checkpoint_path is not None:
+            import random
+
+            chk = {
+                "population": population,
+                "logbook": logbook,
+                "gen": gen,
+                "halloffame": halloffame,
+                "random_state": random.getstate(),
+                "np_random_state": np.random.get_state(),
+            }
+            tmp_path = f"{checkpoint_path}.tmp"
             try:
-                import random
-                import numpy as np
-                chk = {
-                    "population": population,
-                    "logbook": logbook,
-                    "gen": gen,
-                    "halloffame": halloffame,
-                    "random_state": random.getstate(),
-                    "np_random_state": np.random.get_state(),
-                }
-                with open(checkpoint_path, "wb") as f:
+                with open(tmp_path, "wb") as f:
                     pickle.dump(chk, f, protocol=pickle.HIGHEST_PROTOCOL)
-                import gc
-                gc.collect()
-            except Exception as e:
-                logging.warning(f"Failed to save checkpoint: {e}")
+                os.replace(tmp_path, checkpoint_path)
+            except Exception as exc:
+                raise RuntimeError(f"Failed to save checkpoint: {checkpoint_path}") from exc
 
     logging.info(
         "Optimization summary | generations=%d | total_evals=%d | front=%d | duration=%.1fs",
@@ -1965,6 +2040,7 @@ async def main():
     backtest_exchanges = require_config_value(config, "backtest.exchanges")
     await format_approved_ignored_coins(config, backtest_exchanges)
     interrupted = False
+    fatal_error = False
     pool = None
     manager = None
     pool_terminated = False
@@ -2105,46 +2181,22 @@ async def main():
             )
         )
         previous_evals = 0
+        checkpoint_path = None
         if args.resume:
-            results_dir = make_get_filepath(args.resume)
-            if not os.path.isdir(results_dir):
-                raise ValueError(f"Resume directory not found: {results_dir}")
-                
-            results_filename_check = os.path.join(results_dir, "all_results.bin")
-            if os.path.isfile(results_filename_check):
-                try:
-                    import msgpack
-                    with open(results_filename_check, "rb") as f:
-                        unpacker = msgpack.Unpacker(f, max_buffer_size=1024*1024*100)
-                        for entry in unpacker:
-                            mismatches = _resume_config_mismatches(entry, config)
-                            if mismatches:
-                                mismatch_str = "\n".join(mismatches)
-                                raise ValueError(
-                                    f"\n\nERROR: Cannot resume because critical parameters have changed!\n"
-                                    f"Mismatches detected:\n{mismatch_str}\n\n"
-                                    f"Resuming with a changed configuration would corrupt optimization scores.\n"
-                                    f"Please restore the original config or start a fresh run.\n"
-                                )
-                            break
-                            
-                        # If validation passed, count remaining entries
-                        previous_evals = 1 + sum(1 for _ in unpacker)
-                        logging.info(f"Resuming with {previous_evals} previous evaluations from all_results.bin")
-                except ValueError:
-                    raise
-                except Exception as e:
-                    logging.warning(f"Could not verify previous config from all_results.bin: {e}")
+            results_dir = _resolve_resume_results_dir(args.resume)
+            checkpoint_path = _require_resume_checkpoint(results_dir)
+            previous_evals = _validate_resume_results(results_dir, config)
         else:
             results_dir = make_get_filepath(
                 f"optimize_results/{date_fname}_{exchanges_fname}_{n_days}days_{coins_fname}_{hash_snippet}/"
             )
             os.makedirs(results_dir, exist_ok=True)
-            
+
         config["results_dir"] = results_dir
         results_filename = os.path.join(results_dir, "all_results.bin")
         config["results_filename"] = results_filename
-        checkpoint_path = os.path.join(results_dir, "checkpoint.pkl")
+        if checkpoint_path is None:
+            checkpoint_path = os.path.join(results_dir, "checkpoint.pkl")
         overrides_list = config.get("optimize", {}).get("enable_overrides", [])
 
         # Shared state used by workers for duplicate detection
@@ -2227,6 +2279,7 @@ async def main():
                 if "pool_state" in locals():
                     pool_state["terminated"] = True
     except Exception as e:
+        fatal_error = True
         logging.error(f"An error occurred: {e}")
         traceback.print_exc()
     finally:
@@ -2266,7 +2319,7 @@ async def main():
                 logging.exception("Failed to release shared memory")
 
         logging.info("Shutdown complete.")
-        sys.exit(130 if interrupted else 0)
+        sys.exit(_optimizer_exit_code(interrupted, fatal_error))
 
 
 if __name__ == "__main__":

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2062,17 +2062,44 @@ async def main():
             )
         )
         if args.resume:
-            raw_end_date = str(require_config_value(config, "backtest.end_date")).strip().lower()
-            if raw_end_date == "now" or raw_end_date == "":
-                raise ValueError(
-                    "\n\nERROR: Cannot use --resume with a dynamic end_date ('now'). "
-                    "The shifting time frame would corrupt the optimization scores. "
-                    "Please hard-code the end_date in your config (e.g. '2026-06-16') "
-                    "or start a fresh run.\n"
-                )
             results_dir = make_get_filepath(args.resume)
             if not os.path.isdir(results_dir):
                 raise ValueError(f"Resume directory not found: {results_dir}")
+                
+            results_filename_check = os.path.join(results_dir, "all_results.bin")
+            if os.path.isfile(results_filename_check):
+                try:
+                    import msgpack
+                    with open(results_filename_check, "rb") as f:
+                        unpacker = msgpack.Unpacker(f, max_buffer_size=1024*1024*100)
+                        for entry in unpacker:
+                            old_bt = entry.get("backtest", {})
+                            new_bt = config.get("backtest", {})
+                            old_opt = entry.get("optimize", {})
+                            new_opt = config.get("optimize", {})
+                            
+                            mismatches = []
+                            for key in ["start_date", "end_date", "coins", "exchanges"]:
+                                if str(old_bt.get(key, "")) != str(new_bt.get(key, "")):
+                                    mismatches.append(f"  - backtest.{key}: '{old_bt.get(key)}' -> '{new_bt.get(key)}'")
+                            
+                            for key in ["scoring"]:
+                                if str(old_opt.get(key, "")) != str(new_opt.get(key, "")):
+                                    mismatches.append(f"  - optimize.{key}: '{old_opt.get(key)}' -> '{new_opt.get(key)}'")
+                            
+                            if mismatches:
+                                mismatch_str = "\n".join(mismatches)
+                                raise ValueError(
+                                    f"\n\nERROR: Cannot resume because critical parameters have changed!\n"
+                                    f"Mismatches detected:\n{mismatch_str}\n\n"
+                                    f"Resuming with a changed configuration would corrupt optimization scores.\n"
+                                    f"Please restore the original config or start a fresh run.\n"
+                                )
+                            break
+                except ValueError:
+                    raise
+                except Exception as e:
+                    logging.warning(f"Could not verify previous config from all_results.bin: {e}")
         else:
             results_dir = make_get_filepath(
                 f"optimize_results/{date_fname}_{exchanges_fname}_{n_days}days_{coins_fname}_{hash_snippet}/"

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2084,21 +2084,21 @@ async def main():
                             
                             mismatches = []
                             for key in ["start_date", "end_date", "coins", "exchanges"]:
-                                if str(old_bt.get(key, "")) != str(new_bt.get(key, "")):
+                                if old_bt.get(key) != new_bt.get(key):
                                     mismatches.append(f"  - backtest.{key}: '{old_bt.get(key)}' -> '{new_bt.get(key)}'")
                             
                             for key in ["scoring", "passivbot_mode"]:
-                                if str(old_opt.get(key, "")) != str(new_opt.get(key, "")):
+                                if old_opt.get(key) != new_opt.get(key):
                                     mismatches.append(f"  - optimize.{key}: '{old_opt.get(key)}' -> '{new_opt.get(key)}'")
                             
                             for side in ["long", "short"]:
-                                old_en = str(old_bot.get(side, {}).get("enabled", "True")).lower()
-                                new_en = str(new_bot.get(side, {}).get("enabled", "True")).lower()
+                                old_en = old_bot.get(side, {}).get("enabled", True)
+                                new_en = new_bot.get(side, {}).get("enabled", True)
                                 if old_en != new_en:
                                     mismatches.append(f"  - {side}.enabled: '{old_en}' -> '{new_en}'")
                                     
                             for key in ["approved_coins", "ignored_coins"]:
-                                if str(old_live.get(key, "")) != str(new_live.get(key, "")):
+                                if old_live.get(key) != new_live.get(key):
                                     mismatches.append(f"  - live.{key}: changed")
                             
                             if mismatches:

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -61,7 +61,9 @@ from backtest import (
 )
 import asyncio
 import argparse
+import mmap
 import multiprocessing
+import random
 import time
 from collections import defaultdict
 from cli_utils import (
@@ -396,7 +398,7 @@ class ResultRecorder:
                 self.results_file.write(self.packer.pack(output_data))
                 self.results_file.flush()
             except Exception as exc:
-                logging.error(f"Error writing results: {exc}")
+                raise RuntimeError("Error writing all_results.bin") from exc
         metrics_block = data.get("metrics", {}) or {}
         violation = metrics_block.get("constraint_violation")
         try:
@@ -573,8 +575,31 @@ def _resume_config_mismatches(entry: dict, config: dict) -> list[str]:
 
     mismatches = []
     is_suite_result = entry.get("suite_metrics") is not None
-    old_bt_compare = deepcopy(old_bt)
-    new_bt_compare = deepcopy(new_bt)
+    old_bt_compare = _resume_subset(
+        old_bt,
+        {
+            "aggregate",
+            "balance_sample_divider",
+            "btc_collateral_cap",
+            "btc_collateral_ltv_cap",
+            "candle_interval_minutes",
+            "coins",
+            "dynamic_wel_by_tradability",
+            "end_date",
+            "exchanges",
+            "filter_by_min_effective_cost",
+            "liquidation_threshold",
+            "maker_fee_override",
+            "market_order_slippage_pct",
+            "scenarios",
+            "start_date",
+            "starting_balance",
+            "suite_enabled",
+            "taker_fee_override",
+            "volume_normalization",
+        },
+    )
+    new_bt_compare = _resume_subset(new_bt, old_bt_compare.keys())
     if is_suite_result:
         # Suite result entries omit top-level backtest.coins because the
         # scenario list is the source of truth for per-scenario coins.
@@ -582,7 +607,30 @@ def _resume_config_mismatches(entry: dict, config: dict) -> list[str]:
             new_bt_compare.pop("coins", None)
     _append_resume_section_mismatches(mismatches, "backtest", old_bt_compare, new_bt_compare)
 
-    _append_resume_section_mismatches(mismatches, "optimize", old_opt, new_opt)
+    old_opt_compare = _resume_subset(
+        old_opt,
+        {
+            "backend",
+            "bounds",
+            "compress_results_file",
+            "crossover_eta",
+            "crossover_probability",
+            "enable_overrides",
+            "fixed_params",
+            "fixed_runtime_overrides",
+            "limits",
+            "mutation_eta",
+            "mutation_indpb",
+            "mutation_probability",
+            "offspring_multiplier",
+            "population_size",
+            "pymoo",
+            "round_to_n_significant_digits",
+            "scoring",
+        },
+    )
+    new_opt_compare = _resume_subset(new_opt, old_opt_compare.keys())
+    _append_resume_section_mismatches(mismatches, "optimize", old_opt_compare, new_opt_compare)
 
     for side in ["long", "short"]:
         old_en = old_bot.get(side, {}).get("enabled", True)
@@ -594,6 +642,10 @@ def _resume_config_mismatches(entry: dict, config: dict) -> list[str]:
         if old_live.get(key) != new_live.get(key):
             mismatches.append(f"  - live.{key}: changed")
     return mismatches
+
+
+def _resume_subset(section: dict, keys) -> dict:
+    return {key: deepcopy(section.get(key)) for key in keys if key in section}
 
 
 def _append_resume_section_mismatches(
@@ -638,24 +690,29 @@ def _validate_resume_results(results_dir: str, config: dict) -> int:
     previous_evals = 0
     try:
         with open(results_filename, "rb") as f:
-            unpacker = msgpack.Unpacker(f, raw=False, max_buffer_size=1024 * 1024 * 100)
-            for entry in unpacker:
-                previous_evals += 1
-                if previous_evals == 1:
+            with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as raw:
+                for entry in _iter_strict_msgpack_objects(raw, results_filename):
+                    previous_evals += 1
                     if not isinstance(entry, dict):
+                        if previous_evals == 1:
+                            raise ValueError(
+                                f"Cannot resume: first all_results.bin entry is not a config object: "
+                                f"{results_filename}"
+                            )
                         raise ValueError(
-                            f"Cannot resume: first all_results.bin entry is not a config object: "
+                            f"Cannot resume: all_results.bin entry {previous_evals} is not a result object: "
                             f"{results_filename}"
                         )
-                    mismatches = _resume_config_mismatches(entry, config)
-                    if mismatches:
-                        mismatch_str = "\n".join(mismatches)
-                        raise ValueError(
-                            f"\n\nERROR: Cannot resume because critical parameters have changed!\n"
-                            f"Mismatches detected:\n{mismatch_str}\n\n"
-                            f"Resuming with a changed configuration would corrupt optimization scores.\n"
-                            f"Please restore the original config or start a fresh run.\n"
-                        )
+                    if previous_evals == 1:
+                        mismatches = _resume_config_mismatches(entry, config)
+                        if mismatches:
+                            mismatch_str = "\n".join(mismatches)
+                            raise ValueError(
+                                f"\n\nERROR: Cannot resume because critical parameters have changed!\n"
+                                f"Mismatches detected:\n{mismatch_str}\n\n"
+                                f"Resuming with a changed configuration would corrupt optimization scores.\n"
+                                f"Please restore the original config or start a fresh run.\n"
+                            )
     except msgpack.exceptions.UnpackException as exc:
         raise ValueError(f"Cannot resume: failed to read all_results.bin: {results_filename}") from exc
     except ValueError:
@@ -667,6 +724,116 @@ def _validate_resume_results(results_dir: str, config: dict) -> int:
         raise ValueError(f"Cannot resume: all_results.bin contains no entries: {results_filename}")
     logging.info("Resuming with %d previous evaluations from all_results.bin", previous_evals)
     return previous_evals
+
+
+def _iter_strict_msgpack_objects(raw: bytes, filename: str):
+    offset = 0
+    while offset < len(raw):
+        next_offset = _skip_msgpack_object(raw, offset, filename)
+        try:
+            yield msgpack.unpackb(raw[offset:next_offset], raw=False, strict_map_key=False)
+        except Exception as exc:
+            raise ValueError(f"Cannot resume: failed to decode all_results.bin: {filename}") from exc
+        offset = next_offset
+
+
+def _skip_msgpack_object(raw: bytes, offset: int, filename: str, depth: int = 0) -> int:
+    if depth > 512:
+        raise ValueError(f"Cannot resume: all_results.bin nesting is too deep: {filename}")
+    if offset >= len(raw):
+        raise ValueError(f"Cannot resume: all_results.bin has truncated msgpack data: {filename}")
+    marker = raw[offset]
+    offset += 1
+
+    if marker <= 0x7F or marker >= 0xE0:
+        return offset
+    if 0x80 <= marker <= 0x8F:
+        return _skip_msgpack_map(raw, offset, marker & 0x0F, filename, depth)
+    if 0x90 <= marker <= 0x9F:
+        return _skip_msgpack_array(raw, offset, marker & 0x0F, filename, depth)
+    if 0xA0 <= marker <= 0xBF:
+        return _require_msgpack_bytes(raw, offset, marker & 0x1F, filename)
+
+    fixed_size = {
+        0xC0: 0,
+        0xC2: 0,
+        0xC3: 0,
+        0xCA: 4,
+        0xCB: 8,
+        0xCC: 1,
+        0xCD: 2,
+        0xCE: 4,
+        0xCF: 8,
+        0xD0: 1,
+        0xD1: 2,
+        0xD2: 4,
+        0xD3: 8,
+        0xD4: 2,
+        0xD5: 3,
+        0xD6: 5,
+        0xD7: 9,
+        0xD8: 17,
+    }
+    if marker in fixed_size:
+        return _require_msgpack_bytes(raw, offset, fixed_size[marker], filename)
+    if marker == 0xC1:
+        raise ValueError(f"Cannot resume: all_results.bin contains invalid msgpack marker: {filename}")
+    if marker in (0xC4, 0xD9):
+        size, offset = _read_msgpack_uint(raw, offset, 1, filename)
+        return _require_msgpack_bytes(raw, offset, size, filename)
+    if marker in (0xC5, 0xDA):
+        size, offset = _read_msgpack_uint(raw, offset, 2, filename)
+        return _require_msgpack_bytes(raw, offset, size, filename)
+    if marker in (0xC6, 0xDB):
+        size, offset = _read_msgpack_uint(raw, offset, 4, filename)
+        return _require_msgpack_bytes(raw, offset, size, filename)
+    if marker == 0xC7:
+        size, offset = _read_msgpack_uint(raw, offset, 1, filename)
+        return _require_msgpack_bytes(raw, offset, size + 1, filename)
+    if marker == 0xC8:
+        size, offset = _read_msgpack_uint(raw, offset, 2, filename)
+        return _require_msgpack_bytes(raw, offset, size + 1, filename)
+    if marker == 0xC9:
+        size, offset = _read_msgpack_uint(raw, offset, 4, filename)
+        return _require_msgpack_bytes(raw, offset, size + 1, filename)
+    if marker == 0xDC:
+        size, offset = _read_msgpack_uint(raw, offset, 2, filename)
+        return _skip_msgpack_array(raw, offset, size, filename, depth)
+    if marker == 0xDD:
+        size, offset = _read_msgpack_uint(raw, offset, 4, filename)
+        return _skip_msgpack_array(raw, offset, size, filename, depth)
+    if marker == 0xDE:
+        size, offset = _read_msgpack_uint(raw, offset, 2, filename)
+        return _skip_msgpack_map(raw, offset, size, filename, depth)
+    if marker == 0xDF:
+        size, offset = _read_msgpack_uint(raw, offset, 4, filename)
+        return _skip_msgpack_map(raw, offset, size, filename, depth)
+    raise ValueError(f"Cannot resume: all_results.bin contains unknown msgpack marker: {filename}")
+
+
+def _skip_msgpack_array(raw: bytes, offset: int, size: int, filename: str, depth: int) -> int:
+    for _ in range(size):
+        offset = _skip_msgpack_object(raw, offset, filename, depth + 1)
+    return offset
+
+
+def _skip_msgpack_map(raw: bytes, offset: int, size: int, filename: str, depth: int) -> int:
+    for _ in range(size):
+        offset = _skip_msgpack_object(raw, offset, filename, depth + 1)
+        offset = _skip_msgpack_object(raw, offset, filename, depth + 1)
+    return offset
+
+
+def _read_msgpack_uint(raw: bytes, offset: int, size: int, filename: str) -> tuple[int, int]:
+    end = _require_msgpack_bytes(raw, offset, size, filename)
+    return int.from_bytes(raw[offset:end], "big"), end
+
+
+def _require_msgpack_bytes(raw: bytes, offset: int, size: int, filename: str) -> int:
+    end = offset + size
+    if end > len(raw):
+        raise ValueError(f"Cannot resume: all_results.bin has truncated msgpack data: {filename}")
+    return end
 
 
 def _optimizer_exit_code(interrupted: bool, fatal_error: bool) -> int:
@@ -854,10 +1021,8 @@ def ea_mu_plus_lambda_stream(
         record = stats.compile(population) if stats is not None else {}
         logbook.record(gen=gen, nevals=nevals, **record)
         log_generation(gen, nevals, record)
-        
-        if checkpoint_path is not None:
-            import random
 
+        if checkpoint_path is not None:
             chk = {
                 "population": population,
                 "logbook": logbook,
@@ -2183,6 +2348,8 @@ async def main():
         previous_evals = 0
         checkpoint_path = None
         if args.resume:
+            if not config["optimize"].get("write_all_results", True):
+                raise ValueError("Cannot resume with optimize.write_all_results=false")
             results_dir = _resolve_resume_results_dir(args.resume)
             checkpoint_path = _require_resume_checkpoint(results_dir)
             previous_evals = _validate_resume_results(results_dir, config)

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -561,6 +561,45 @@ def _record_individual_result(individual, evaluator_config, overrides_list, reco
     _clear_candidate_metrics(individual)
 
 
+def _resume_config_mismatches(entry: dict, config: dict) -> list[str]:
+    old_bt = entry.get("backtest") or {}
+    new_bt = config.get("backtest") or {}
+    old_opt = entry.get("optimize") or {}
+    new_opt = config.get("optimize") or {}
+    old_bot = entry.get("bot", entry) or {}
+    new_bot = config.get("bot", config) or {}
+    old_live = entry.get("live") or {}
+    new_live = config.get("live") or {}
+
+    mismatches = []
+    is_suite_result = entry.get("suite_metrics") is not None
+    backtest_keys = ["start_date", "end_date", "exchanges"]
+    if is_suite_result:
+        backtest_keys.append("scenarios")
+        if old_bt.get("coins") is not None:
+            backtest_keys.append("coins")
+    else:
+        backtest_keys.append("coins")
+    for key in backtest_keys:
+        if old_bt.get(key) != new_bt.get(key):
+            mismatches.append(f"  - backtest.{key}: '{old_bt.get(key)}' -> '{new_bt.get(key)}'")
+
+    for key in ["scoring", "passivbot_mode"]:
+        if old_opt.get(key) != new_opt.get(key):
+            mismatches.append(f"  - optimize.{key}: '{old_opt.get(key)}' -> '{new_opt.get(key)}'")
+
+    for side in ["long", "short"]:
+        old_en = old_bot.get(side, {}).get("enabled", True)
+        new_en = new_bot.get(side, {}).get("enabled", True)
+        if old_en != new_en:
+            mismatches.append(f"  - {side}.enabled: '{old_en}' -> '{new_en}'")
+
+    for key in ["approved_coins", "ignored_coins"]:
+        if old_live.get(key) != new_live.get(key):
+            mismatches.append(f"  - live.{key}: changed")
+    return mismatches
+
+
 def ea_mu_plus_lambda_stream(
     population,
     toolbox,
@@ -2078,34 +2117,7 @@ async def main():
                     with open(results_filename_check, "rb") as f:
                         unpacker = msgpack.Unpacker(f, max_buffer_size=1024*1024*100)
                         for entry in unpacker:
-                            old_bt = entry.get("backtest", {})
-                            new_bt = config.get("backtest", {})
-                            old_opt = entry.get("optimize", {})
-                            new_opt = config.get("optimize", {})
-                            old_bot = entry.get("bot", entry)
-                            new_bot = config.get("bot", config)
-                            old_live = entry.get("live", {})
-                            new_live = config.get("live", {})
-                            
-                            mismatches = []
-                            for key in ["start_date", "end_date", "coins", "exchanges"]:
-                                if old_bt.get(key) != new_bt.get(key):
-                                    mismatches.append(f"  - backtest.{key}: '{old_bt.get(key)}' -> '{new_bt.get(key)}'")
-                            
-                            for key in ["scoring", "passivbot_mode"]:
-                                if old_opt.get(key) != new_opt.get(key):
-                                    mismatches.append(f"  - optimize.{key}: '{old_opt.get(key)}' -> '{new_opt.get(key)}'")
-                            
-                            for side in ["long", "short"]:
-                                old_en = old_bot.get(side, {}).get("enabled", True)
-                                new_en = new_bot.get(side, {}).get("enabled", True)
-                                if old_en != new_en:
-                                    mismatches.append(f"  - {side}.enabled: '{old_en}' -> '{new_en}'")
-                                    
-                            for key in ["approved_coins", "ignored_coins"]:
-                                if old_live.get(key) != new_live.get(key):
-                                    mismatches.append(f"  - live.{key}: changed")
-                            
+                            mismatches = _resume_config_mismatches(entry, config)
                             if mismatches:
                                 mismatch_str = "\n".join(mismatches)
                                 raise ValueError(

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -576,9 +576,14 @@ def ea_mu_plus_lambda_stream(
     pool,
     duplicate_counter,
     pool_state,
+    start_gen=1,
+    logbook=None,
+    checkpoint_path=None,
 ):
-    logbook = tools.Logbook()
-    logbook.header = "gen", "evals", "min", "max"
+    import pickle
+    if logbook is None:
+        logbook = tools.Logbook()
+        logbook.header = "gen", "evals", "min", "max"
 
     start_time = time.time()
     total_evals = 0
@@ -720,7 +725,7 @@ def ea_mu_plus_lambda_stream(
         )
         return population, logbook
 
-    for gen in range(1, ngen + 1):
+    for gen in range(start_gen, ngen + 1):
         offspring = algorithms.varOr(population, toolbox, lambda_, cxpb, mutpb)
         invalid_ind = [ind for ind in offspring if not ind.fitness.valid]
         nevals = evaluate_and_record(invalid_ind)
@@ -733,6 +738,23 @@ def ea_mu_plus_lambda_stream(
         record = stats.compile(population) if stats is not None else {}
         logbook.record(gen=gen, nevals=nevals, **record)
         log_generation(gen, nevals, record)
+        
+        if checkpoint_path is not None:
+            try:
+                import random
+                import numpy as np
+                chk = {
+                    "population": population,
+                    "logbook": logbook,
+                    "gen": gen,
+                    "halloffame": halloffame,
+                    "random_state": random.getstate(),
+                    "np_random_state": np.random.get_state(),
+                }
+                with open(checkpoint_path, "wb") as f:
+                    pickle.dump(chk, f)
+            except Exception as e:
+                logging.warning(f"Failed to save checkpoint: {e}")
 
     logging.info(
         "Optimization summary | generations=%d | total_evals=%d | front=%d | duration=%.1fs",
@@ -1436,6 +1458,12 @@ class SuiteEvaluator:
 
 def add_extra_options(parser, *, help_all: bool):
     parser.add_argument(
+        "--resume",
+        type=str,
+        default=None,
+        help="Path to an existing optimize_results directory to resume exact optimizer state",
+    )
+    parser.add_argument(
         "-t",
         "--start",
         type=str,
@@ -2033,13 +2061,20 @@ async def main():
                 / (1000 * 60 * 60 * 24)
             )
         )
-        results_dir = make_get_filepath(
-            f"optimize_results/{date_fname}_{exchanges_fname}_{n_days}days_{coins_fname}_{hash_snippet}/"
-        )
-        os.makedirs(results_dir, exist_ok=True)
+        if args.resume:
+            results_dir = make_get_filepath(args.resume)
+            if not os.path.isdir(results_dir):
+                raise ValueError(f"Resume directory not found: {results_dir}")
+        else:
+            results_dir = make_get_filepath(
+                f"optimize_results/{date_fname}_{exchanges_fname}_{n_days}days_{coins_fname}_{hash_snippet}/"
+            )
+            os.makedirs(results_dir, exist_ok=True)
+            
         config["results_dir"] = results_dir
         results_filename = os.path.join(results_dir, "all_results.bin")
         config["results_filename"] = results_filename
+        checkpoint_path = os.path.join(results_dir, "checkpoint.pkl")
         overrides_list = config.get("optimize", {}).get("enable_overrides", [])
 
         # Shared state used by workers for duplicate detection
@@ -2092,6 +2127,8 @@ async def main():
             overrides_list=overrides_list,
             duplicate_counter=duplicate_counter,
             starting_configs_path=args.starting_configs,
+            checkpoint_path=checkpoint_path,
+            resume=bool(args.resume),
             constraint_fitness_cls=ConstraintAwareFitness,
             ignore_sigint_in_worker=ignore_sigint_in_worker,
             get_starting_configs=get_starting_configs,

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2077,15 +2077,29 @@ async def main():
                             new_bt = config.get("backtest", {})
                             old_opt = entry.get("optimize", {})
                             new_opt = config.get("optimize", {})
+                            old_bot = entry.get("bot", entry)
+                            new_bot = config.get("bot", config)
+                            old_live = entry.get("live", {})
+                            new_live = config.get("live", {})
                             
                             mismatches = []
                             for key in ["start_date", "end_date", "coins", "exchanges"]:
                                 if str(old_bt.get(key, "")) != str(new_bt.get(key, "")):
                                     mismatches.append(f"  - backtest.{key}: '{old_bt.get(key)}' -> '{new_bt.get(key)}'")
                             
-                            for key in ["scoring"]:
+                            for key in ["scoring", "passivbot_mode"]:
                                 if str(old_opt.get(key, "")) != str(new_opt.get(key, "")):
                                     mismatches.append(f"  - optimize.{key}: '{old_opt.get(key)}' -> '{new_opt.get(key)}'")
+                            
+                            for side in ["long", "short"]:
+                                old_en = str(old_bot.get(side, {}).get("enabled", "True")).lower()
+                                new_en = str(new_bot.get(side, {}).get("enabled", "True")).lower()
+                                if old_en != new_en:
+                                    mismatches.append(f"  - {side}.enabled: '{old_en}' -> '{new_en}'")
+                                    
+                            for key in ["approved_coins", "ignored_coins"]:
+                                if str(old_live.get(key, "")) != str(new_live.get(key, "")):
+                                    mismatches.append(f"  - live.{key}: changed")
                             
                             if mismatches:
                                 mismatch_str = "\n".join(mismatches)

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -2028,6 +2028,25 @@ def test_resume_config_mismatches_rejects_changed_backend():
     assert any("optimize.backend" in mismatch for mismatch in mismatches)
 
 
+def test_resume_config_mismatches_allows_machine_local_optimizer_settings():
+    entry = _resume_validation_entry()
+    entry["optimize"]["n_cpus"] = 6
+    entry["optimize"]["pareto_max_size"] = 1000
+    entry["optimize"]["write_all_results"] = True
+    entry["backtest"]["base_dir"] = "/old/backtests"
+    entry["backtest"]["ohlcv_source_dir"] = "/old/ohlcvs"
+    entry["backtest"]["visible_metrics"] = ["adg_strategy_eq"]
+    config = deepcopy(entry)
+    config["optimize"]["n_cpus"] = 8
+    config["optimize"]["pareto_max_size"] = 250
+    config["optimize"]["write_all_results"] = False
+    config["backtest"]["base_dir"] = "/new/backtests"
+    config["backtest"]["ohlcv_source_dir"] = "/new/ohlcvs"
+    config["backtest"]["visible_metrics"] = ["drawdown_worst_strategy_eq"]
+
+    assert optimize._resume_config_mismatches(entry, config) == []
+
+
 def test_resolve_resume_results_dir_does_not_create_missing_directory(tmp_path: Path):
     missing = tmp_path / "missing_resume_dir"
 
@@ -2068,7 +2087,7 @@ def test_validate_resume_results_rejects_corrupt_all_results(tmp_path: Path):
     config = _resume_validation_entry()
     (tmp_path / "all_results.bin").write_bytes(b"\xc1")
 
-    with pytest.raises(ValueError, match="failed to read all_results.bin"):
+    with pytest.raises(ValueError, match="invalid msgpack marker"):
         optimize._validate_resume_results(str(tmp_path), config)
 
 
@@ -2079,6 +2098,24 @@ def test_validate_resume_results_rejects_non_config_first_entry(tmp_path: Path):
 
     with pytest.raises(ValueError, match="first all_results.bin entry is not a config object"):
         optimize._validate_resume_results(str(tmp_path), config)
+
+
+def test_validate_resume_results_rejects_non_dict_second_entry(tmp_path: Path):
+    entry = _resume_validation_entry()
+    packer = optimize.msgpack.Packer(use_bin_type=True)
+    (tmp_path / "all_results.bin").write_bytes(packer.pack(entry) + packer.pack(1))
+
+    with pytest.raises(ValueError, match="entry 2 is not a result object"):
+        optimize._validate_resume_results(str(tmp_path), deepcopy(entry))
+
+
+def test_validate_resume_results_rejects_truncated_trailing_msgpack(tmp_path: Path):
+    entry = _resume_validation_entry()
+    packer = optimize.msgpack.Packer(use_bin_type=True)
+    (tmp_path / "all_results.bin").write_bytes(packer.pack(entry) + b"\x81\xa1x")
+
+    with pytest.raises(ValueError, match="truncated msgpack data"):
+        optimize._validate_resume_results(str(tmp_path), deepcopy(entry))
 
 
 def test_validate_resume_results_rejects_changed_search_domain(tmp_path: Path):
@@ -2101,6 +2138,31 @@ def test_validate_resume_results_counts_entries(tmp_path: Path):
 def test_optimizer_exit_code_is_nonzero_for_fatal_errors():
     assert optimize._optimizer_exit_code(interrupted=False, fatal_error=True) == 1
     assert optimize._optimizer_exit_code(interrupted=True, fatal_error=True) == 130
+
+
+def test_result_recorder_all_results_write_failure_is_fatal():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        recorder = ResultRecorder(
+            results_dir=tmpdir,
+            sig_digits=6,
+            flush_interval=60,
+            scoring_keys=["metric1"],
+            compress=False,
+            write_all_results=True,
+            bounds=[(0.0, 1.0, 0.0)] * 4,
+        )
+        recorder.results_file.close()
+
+        with pytest.raises(RuntimeError, match="Error writing all_results.bin"):
+            recorder.record(
+                {
+                    "bot": {"long": {}, "short": {}},
+                    "metrics": {
+                        "objectives": {"metric1": 0.5},
+                        "constraint_violation": 0.0,
+                    },
+                }
+            )
 
 
 def test_result_recorder_preserves_unquantized_saved_param_values():

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -1978,6 +1978,131 @@ def test_resume_config_mismatches_plain_result_still_rejects_coin_change():
     assert any("backtest.coins" in mismatch for mismatch in mismatches)
 
 
+def _resume_validation_entry():
+    return {
+        "backtest": {
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-10",
+            "exchanges": ["binance"],
+            "coins": {"binance": ["XMR"]},
+        },
+        "bot": {"long": {"enabled": True}, "short": {"enabled": False}},
+        "live": {
+            "approved_coins": {"long": ["XMR"], "short": []},
+            "ignored_coins": {"long": [], "short": []},
+        },
+        "optimize": {
+            "backend": "pymoo",
+            "bounds": {"long_close_grid_markup_range": [0.001, 0.01]},
+            "iters": 2,
+            "population_size": 2,
+            "scoring": [{"metric": "adg_strategy_eq", "goal": "max"}],
+        },
+    }
+
+
+def _write_msgpack_entries(path: Path, entries: list[dict]) -> None:
+    packer = optimize.msgpack.Packer(use_bin_type=True)
+    with open(path, "wb") as f:
+        for entry in entries:
+            f.write(packer.pack(entry))
+
+
+def test_resume_config_mismatches_rejects_changed_optimize_bounds():
+    entry = _resume_validation_entry()
+    config = deepcopy(entry)
+    config["optimize"]["bounds"]["long_close_grid_markup_range"] = [0.002, 0.02]
+
+    mismatches = optimize._resume_config_mismatches(entry, config)
+
+    assert any("optimize.bounds" in mismatch for mismatch in mismatches)
+
+
+def test_resume_config_mismatches_rejects_changed_backend():
+    entry = _resume_validation_entry()
+    config = deepcopy(entry)
+    config["optimize"]["backend"] = "deap"
+
+    mismatches = optimize._resume_config_mismatches(entry, config)
+
+    assert any("optimize.backend" in mismatch for mismatch in mismatches)
+
+
+def test_resolve_resume_results_dir_does_not_create_missing_directory(tmp_path: Path):
+    missing = tmp_path / "missing_resume_dir"
+
+    with pytest.raises(ValueError, match="Resume directory not found"):
+        optimize._resolve_resume_results_dir(str(missing))
+
+    assert not missing.exists()
+
+
+def test_require_resume_checkpoint_rejects_missing_checkpoint(tmp_path: Path):
+    with pytest.raises(ValueError, match="checkpoint not found"):
+        optimize._require_resume_checkpoint(str(tmp_path))
+
+
+def test_require_resume_checkpoint_rejects_empty_checkpoint(tmp_path: Path):
+    (tmp_path / "checkpoint.pkl").write_bytes(b"")
+
+    with pytest.raises(ValueError, match="checkpoint is empty"):
+        optimize._require_resume_checkpoint(str(tmp_path))
+
+
+def test_validate_resume_results_requires_all_results(tmp_path: Path):
+    config = _resume_validation_entry()
+
+    with pytest.raises(ValueError, match="all_results.bin not found"):
+        optimize._validate_resume_results(str(tmp_path), config)
+
+
+def test_validate_resume_results_rejects_empty_all_results(tmp_path: Path):
+    config = _resume_validation_entry()
+    (tmp_path / "all_results.bin").write_bytes(b"")
+
+    with pytest.raises(ValueError, match="all_results.bin is empty"):
+        optimize._validate_resume_results(str(tmp_path), config)
+
+
+def test_validate_resume_results_rejects_corrupt_all_results(tmp_path: Path):
+    config = _resume_validation_entry()
+    (tmp_path / "all_results.bin").write_bytes(b"\xc1")
+
+    with pytest.raises(ValueError, match="failed to read all_results.bin"):
+        optimize._validate_resume_results(str(tmp_path), config)
+
+
+def test_validate_resume_results_rejects_non_config_first_entry(tmp_path: Path):
+    config = _resume_validation_entry()
+    packer = optimize.msgpack.Packer(use_bin_type=True)
+    (tmp_path / "all_results.bin").write_bytes(packer.pack(["not", "a", "config"]))
+
+    with pytest.raises(ValueError, match="first all_results.bin entry is not a config object"):
+        optimize._validate_resume_results(str(tmp_path), config)
+
+
+def test_validate_resume_results_rejects_changed_search_domain(tmp_path: Path):
+    entry = _resume_validation_entry()
+    config = deepcopy(entry)
+    config["optimize"]["bounds"]["long_close_grid_markup_range"] = [0.002, 0.02]
+    _write_msgpack_entries(tmp_path / "all_results.bin", [entry])
+
+    with pytest.raises(ValueError, match="critical parameters have changed"):
+        optimize._validate_resume_results(str(tmp_path), config)
+
+
+def test_validate_resume_results_counts_entries(tmp_path: Path):
+    entry = _resume_validation_entry()
+    _write_msgpack_entries(tmp_path / "all_results.bin", [entry, deepcopy(entry)])
+
+    assert optimize._validate_resume_results(str(tmp_path), deepcopy(entry)) == 2
+
+
+def test_optimizer_exit_code_is_nonzero_for_fatal_errors():
+    assert optimize._optimizer_exit_code(interrupted=False, fatal_error=True) == 1
+    assert optimize._optimizer_exit_code(interrupted=True, fatal_error=True) == 130
+
+
 def test_result_recorder_preserves_unquantized_saved_param_values():
     template = load_prepared_config("configs/examples/default_trailing_grid_long_npos7.json", verbose=False)
     bounds = extract_bounds_tuple_list_from_config(template)

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -1915,6 +1915,69 @@ def test_build_pymoo_record_entry_strips_metadata():
     assert "suite_metrics" in entry
 
 
+def test_resume_config_mismatches_allows_suite_result_without_top_level_coins():
+    entry = {
+        "backtest": {
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-10",
+            "exchanges": ["binance"],
+            "scenarios": [{"label": "base", "coins": ["XMR"], "exchanges": ["binance"]}],
+        },
+        "bot": {"long": {"enabled": True}, "short": {"enabled": False}},
+        "live": {
+            "approved_coins": {"long": ["XMR"], "short": []},
+            "ignored_coins": {"long": [], "short": []},
+        },
+        "optimize": {"scoring": [{"metric": "adg_strategy_eq", "goal": "max"}]},
+        "suite_metrics": {"scenario_labels": ["base"]},
+    }
+    config = deepcopy(entry)
+    config["backtest"]["coins"] = {"binance": ["XMR"]}
+
+    assert optimize._resume_config_mismatches(entry, config) == []
+
+
+def test_resume_config_mismatches_rejects_changed_suite_scenarios():
+    entry = {
+        "backtest": {
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-10",
+            "exchanges": ["binance"],
+            "scenarios": [{"label": "base", "coins": ["XMR"], "exchanges": ["binance"]}],
+        },
+        "bot": {},
+        "live": {"approved_coins": {}, "ignored_coins": {}},
+        "optimize": {"scoring": [{"metric": "adg_strategy_eq", "goal": "max"}]},
+        "suite_metrics": {"scenario_labels": ["base"]},
+    }
+    config = deepcopy(entry)
+    config["backtest"]["scenarios"][0]["coins"] = ["ETH"]
+
+    mismatches = optimize._resume_config_mismatches(entry, config)
+
+    assert any("backtest.scenarios" in mismatch for mismatch in mismatches)
+
+
+def test_resume_config_mismatches_plain_result_still_rejects_coin_change():
+    entry = {
+        "backtest": {
+            "start_date": "2024-01-01",
+            "end_date": "2024-01-10",
+            "exchanges": ["binance"],
+            "coins": {"binance": ["XMR"]},
+        },
+        "bot": {},
+        "live": {"approved_coins": {}, "ignored_coins": {}},
+        "optimize": {},
+    }
+    config = deepcopy(entry)
+    config["backtest"]["coins"] = {"binance": ["ETH"]}
+
+    mismatches = optimize._resume_config_mismatches(entry, config)
+
+    assert any("backtest.coins" in mismatch for mismatch in mismatches)
+
+
 def test_result_recorder_preserves_unquantized_saved_param_values():
     template = load_prepared_config("configs/examples/default_trailing_grid_long_npos7.json", verbose=False)
     bounds = extract_bounds_tuple_list_from_config(template)


### PR DESCRIPTION
### Description
This PR introduces the ability to resume optimizations from the exact state where they left off, preventing the loss of progress due to sudden interruptions like power outages or crashes. 
Previously, if an optimization was stopped, all evolutionary progress was lost. Now, the optimizer continuously checkpoints its state and can be cleanly resumed.
### Key Changes
- **Checkpointing**: The optimizer now pickles its state (including `population`, `logbook`, `random` states, and PyMoo `Algorithm` state) to `checkpoint.pkl` inside the `results_dir` at the end of every generation.
- **CLI Flag**: Added a `--resume` argument to `optimize.py` which accepts the path to an existing `optimize_results/...` folder.
- **Backend Support**: Full resumption support for both the **DEAP** and **PyMoo** backends.
- **Result Appending**: Resumed optimizations will skip initial random evaluations, initialize from the checkpoint, and seamlessly append new records to the original `all_results.bin` file.
### How to use
To resume a previously interrupted optimization, run the original command and append `--resume` with the path to the interrupted results folder: