### PR TITLE
Emit HSL risk events

### DIFF
--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -49,6 +49,11 @@ class EventTypes:
     FILL_INGESTED = "fill.ingested"
     POSITION_CHANGED = "position.changed"
     BALANCE_CHANGED = "balance.changed"
+    HSL_TRANSITION = "hsl.transition"
+    HSL_STATUS = "hsl.status"
+    HSL_RED_TRIGGERED = "hsl.red_triggered"
+    HSL_COOLDOWN_STARTED = "hsl.cooldown_started"
+    HSL_COOLDOWN_ENDED = "hsl.cooldown_ended"
     SINK_DEGRADED = "sink.degraded"
 
 
@@ -85,6 +90,11 @@ PHASE1_EVENT_TYPES = {
     EventTypes.FILL_INGESTED,
     EventTypes.POSITION_CHANGED,
     EventTypes.BALANCE_CHANGED,
+    EventTypes.HSL_TRANSITION,
+    EventTypes.HSL_STATUS,
+    EventTypes.HSL_RED_TRIGGERED,
+    EventTypes.HSL_COOLDOWN_STARTED,
+    EventTypes.HSL_COOLDOWN_ENDED,
     EventTypes.SINK_DEGRADED,
 }
 
@@ -354,6 +364,11 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.FILL_INGESTED: EventRoute(console=False, text=False),
     EventTypes.POSITION_CHANGED: EventRoute(console=False, text=False),
     EventTypes.BALANCE_CHANGED: EventRoute(console=False, text=False),
+    EventTypes.HSL_TRANSITION: EventRoute(console=False, text=False),
+    EventTypes.HSL_STATUS: EventRoute(console=False, text=False),
+    EventTypes.HSL_RED_TRIGGERED: EventRoute(console=False, text=False),
+    EventTypes.HSL_COOLDOWN_STARTED: EventRoute(console=False, text=False),
+    EventTypes.HSL_COOLDOWN_ENDED: EventRoute(console=False, text=False),
     EventTypes.SINK_DEGRADED: EventRoute(console=True, text=True),
 }
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -2649,6 +2649,7 @@ class Passivbot:
     _equity_hard_stop_log_coin_cooldown_status = (
         pb_hsl._equity_hard_stop_log_coin_cooldown_status
     )
+    _equity_hard_stop_emit_coin_status = pb_hsl._equity_hard_stop_emit_coin_status
     _equity_hard_stop_prime_coin_runtime_for_replay = (
         pb_hsl._equity_hard_stop_prime_coin_runtime_for_replay
     )

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -47,10 +47,12 @@ def _emit_hsl_event(
     status: str | None = None,
     reason_code: str | None = None,
 ) -> None:
+    live_event_delivered = False
     try:
         emit = getattr(self, "_emit_live_event", None)
-        if callable(emit):
-            emit(
+        pipeline = getattr(self, "_live_event_pipeline", None)
+        if callable(emit) and pipeline is not None:
+            live_event_delivered = emit(
                 event_type,
                 level=level,
                 component="risk.hsl",
@@ -61,8 +63,12 @@ def _emit_hsl_event(
                 status=status,
                 reason_code=reason_code,
                 data=data,
-            )
-            return
+            ) is not None
+    except Exception as exc:
+        logging.debug("[event] failed to emit HSL live event type=%s: %s", event_type, exc)
+    if live_event_delivered:
+        return
+    try:
         record = getattr(self, "_monitor_record_event", None)
         if callable(record):
             record(
@@ -74,7 +80,11 @@ def _emit_hsl_event(
                 ts=ts,
             )
     except Exception as exc:
-        logging.debug("[event] failed to emit HSL event type=%s: %s", event_type, exc)
+        logging.debug(
+            "[event] failed to emit HSL legacy monitor event type=%s: %s",
+            event_type,
+            exc,
+        )
 
 
 def _calc_hsl_pnl(position_side, entry_price, close_price, qty, c_mult):
@@ -1186,7 +1196,13 @@ def _equity_hard_stop_log_transition(self, pside: str, metrics: dict, prev_tier:
         self,
         "hsl.transition",
         ("hsl", "risk", "transition"),
-        _hsl_event_data(metrics, {"previous_tier": prev_tier}),
+        _hsl_event_data(
+            metrics,
+            {
+                "previous_tier": prev_tier,
+                "metrics": dict(metrics),
+            },
+        ),
         pside=pside,
         symbol=metrics.get("symbol") if metrics.get("signal_mode") == "coin" else None,
         ts=int(metrics.get("timestamp_ms", 0) or 0) or None,
@@ -2850,46 +2866,55 @@ def _equity_hard_stop_log_coin_cooldown_status(self, pside: str, symbol: str, no
 
 
 def _equity_hard_stop_emit_coin_status(self, pside: str, symbol: str, metrics: dict) -> None:
-    state = self._hsl_coin_state(pside, symbol)
-    now_ms = int(metrics["timestamp_ms"])
-    if (
-        state["last_status_log_ms"] != 0
-        and now_ms - state["last_status_log_ms"] < self._equity_hard_stop_status_log_interval_ms
-    ):
-        return
-    state["last_status_log_ms"] = now_ms
-    red_threshold = float(metrics["red_threshold"])
-    drawdown_score = float(metrics["drawdown_score"])
-    dist_to_red = max(0.0, red_threshold - drawdown_score)
-    cooldown_remaining = None
-    if state["cooldown_until_ms"] is not None:
-        cooldown_remaining = _equity_hard_stop_format_remaining_time(
-            max(0.0, (state["cooldown_until_ms"] - now_ms) / 1000.0)
+    try:
+        state = self._hsl_coin_state(pside, symbol)
+        now_ms = int(metrics["timestamp_ms"])
+        if (
+            state["last_status_log_ms"] != 0
+            and now_ms - state["last_status_log_ms"]
+            < self._equity_hard_stop_status_log_interval_ms
+        ):
+            return
+        state["last_status_log_ms"] = now_ms
+        red_threshold = float(metrics["red_threshold"])
+        drawdown_score = float(metrics["drawdown_score"])
+        dist_to_red = max(0.0, red_threshold - drawdown_score)
+        cooldown_remaining = None
+        if state["cooldown_until_ms"] is not None:
+            cooldown_remaining = _equity_hard_stop_format_remaining_time(
+                max(0.0, (state["cooldown_until_ms"] - now_ms) / 1000.0)
+            )
+        last_red_ts = None
+        if state["last_stop_event"] is not None:
+            last_red_ts = state["last_stop_event"].get("stop_event_timestamp_ms")
+        if last_red_ts is None:
+            last_red_ts = state["pending_red_since_ms"]
+        _emit_hsl_event(
+            self,
+            "hsl.status",
+            ("hsl", "risk", "status"),
+            _hsl_event_data(
+                metrics,
+                {
+                    "dist_to_red": float(dist_to_red),
+                    "cooldown_remaining": cooldown_remaining,
+                    "last_red_ts": last_red_ts,
+                    "pending_red_since_ms": state["pending_red_since_ms"],
+                },
+            ),
+            pside=pside,
+            symbol=symbol,
+            ts=now_ms,
+            status="succeeded",
+            reason_code=str(metrics["tier"]),
         )
-    last_red_ts = None
-    if state["last_stop_event"] is not None:
-        last_red_ts = state["last_stop_event"].get("stop_event_timestamp_ms")
-    if last_red_ts is None:
-        last_red_ts = state["pending_red_since_ms"]
-    _emit_hsl_event(
-        self,
-        "hsl.status",
-        ("hsl", "risk", "status"),
-        _hsl_event_data(
-            metrics,
-            {
-                "dist_to_red": float(dist_to_red),
-                "cooldown_remaining": cooldown_remaining,
-                "last_red_ts": last_red_ts,
-                "pending_red_since_ms": state["pending_red_since_ms"],
-            },
-        ),
-        pside=pside,
-        symbol=symbol,
-        ts=now_ms,
-        status="succeeded",
-        reason_code=str(metrics["tier"]),
-    )
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit HSL coin status symbol=%s pside=%s: %s",
+            symbol,
+            pside,
+            exc,
+        )
 
 
 async def _equity_hard_stop_check_coin(self) -> Optional[dict]:

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -26,6 +26,57 @@ from passivbot_exceptions import RestartBotException
 from utils import make_get_filepath
 
 
+def _hsl_event_data(metrics: dict | None = None, extra: dict | None = None) -> dict[str, Any]:
+    data = dict(metrics or {})
+    data.pop("changed", None)
+    if extra:
+        data.update(extra)
+    return data
+
+
+def _emit_hsl_event(
+    self,
+    event_type: str,
+    tags: tuple[str, ...],
+    data: dict,
+    *,
+    pside: str,
+    symbol: str | None = None,
+    ts: int | None = None,
+    level: str = "info",
+    status: str | None = None,
+    reason_code: str | None = None,
+) -> None:
+    try:
+        emit = getattr(self, "_emit_live_event", None)
+        if callable(emit):
+            emit(
+                event_type,
+                level=level,
+                component="risk.hsl",
+                tags=tags,
+                cycle_id=getattr(self, "_live_event_current_cycle_id", None),
+                symbol=symbol,
+                pside=pside,
+                status=status,
+                reason_code=reason_code,
+                data=data,
+            )
+            return
+        record = getattr(self, "_monitor_record_event", None)
+        if callable(record):
+            record(
+                event_type,
+                tags,
+                data,
+                pside=pside,
+                symbol=symbol,
+                ts=ts,
+            )
+    except Exception as exc:
+        logging.debug("[event] failed to emit HSL event type=%s: %s", event_type, exc)
+
+
 def _calc_hsl_pnl(position_side, entry_price, close_price, qty, c_mult):
     if isinstance(position_side, str):
         if position_side == "long":
@@ -1131,12 +1182,16 @@ def _equity_hard_stop_log_transition(self, pside: str, metrics: dict, prev_tier:
         float(self.hsl[pside]["tier_ratios"]["yellow"]),
         float(self.hsl[pside]["tier_ratios"]["orange"]),
     )
-    self._monitor_record_event(
+    _emit_hsl_event(
+        self,
         "hsl.transition",
         ("hsl", "risk", "transition"),
-        {"previous_tier": prev_tier, "metrics": dict(metrics)},
+        _hsl_event_data(metrics, {"previous_tier": prev_tier}),
         pside=pside,
+        symbol=metrics.get("symbol") if metrics.get("signal_mode") == "coin" else None,
         ts=int(metrics.get("timestamp_ms", 0) or 0) or None,
+        status="succeeded",
+        reason_code=f"{prev_tier}_to_{metrics['tier']}",
     )
 
 
@@ -1349,6 +1404,20 @@ def _equity_hard_stop_log_cooldown_status(self, pside: str, now_ms: int) -> None
         pside,
         _equity_hard_stop_format_remaining_time(remaining_seconds),
     )
+    _emit_hsl_event(
+        self,
+        "hsl.status",
+        ("hsl", "risk", "status"),
+        {
+            "tier": "red",
+            "cooldown_until_ms": int(cooldown_until_ms),
+            "cooldown_remaining_seconds": float(remaining_seconds),
+        },
+        pside=pside,
+        ts=now_ms,
+        status="degraded",
+        reason_code="cooldown_active",
+    )
 
 
 def _equity_hard_stop_position_symbols(self, pside: str) -> list[str]:
@@ -1407,7 +1476,8 @@ async def _equity_hard_stop_refresh_cooldown_after_repanic(self, pside: str, now
         latch_path,
     )
     if cooldown_until_ms is not None:
-        self._monitor_record_event(
+        _emit_hsl_event(
+            self,
             "hsl.cooldown_started",
             ("hsl", "risk", "cooldown"),
             {
@@ -1417,6 +1487,8 @@ async def _equity_hard_stop_refresh_cooldown_after_repanic(self, pside: str, now
             },
             pside=pside,
             ts=stop_ts_ms,
+            status="started",
+            reason_code="repanic_reset",
         )
 
 
@@ -1477,7 +1549,8 @@ async def _equity_hard_stop_refresh_coin_cooldown_after_repanic(
     )
     if cooldown_until_ms is not None:
         self._equity_hard_stop_set_coin_runtime_forced_mode(pside, symbol, "graceful_stop")
-        self._monitor_record_event(
+        _emit_hsl_event(
+            self,
             "hsl.cooldown_started",
             ("hsl", "risk", "cooldown"),
             {
@@ -1489,6 +1562,8 @@ async def _equity_hard_stop_refresh_coin_cooldown_after_repanic(
             pside=pside,
             symbol=symbol,
             ts=stop_ts_ms,
+            status="started",
+            reason_code="coin_repanic_reset",
         )
 
 
@@ -2591,6 +2666,24 @@ def _equity_hard_stop_log_status(self, pside: str, metrics: dict) -> None:
         metrics["peak_strategy_equity"],
         metrics["rolling_peak_strategy_equity"],
     )
+    _emit_hsl_event(
+        self,
+        "hsl.status",
+        ("hsl", "risk", "status"),
+        _hsl_event_data(
+            metrics,
+            {
+                "dist_to_red": float(dist_to_red),
+                "cooldown_remaining": cooldown_remaining,
+                "last_red_ts": last_red_ts,
+                "pending_red_since_ms": state["pending_red_since_ms"],
+            },
+        ),
+        pside=pside,
+        ts=now_ms,
+        status="succeeded",
+        reason_code=str(metrics["tier"]),
+    )
 
 
 async def _equity_hard_stop_check(self) -> Optional[dict]:
@@ -2636,12 +2729,15 @@ async def _equity_hard_stop_check(self) -> Optional[dict]:
                     self._equity_hard_stop_reset_after_restart(pside)
                     self._equity_hard_stop_remove_latch_file(pside)
                     logging.info("[risk] HSL[%s] RED cooldown elapsed; trading resumed", pside)
-                    self._monitor_record_event(
+                    _emit_hsl_event(
+                        self,
                         "hsl.cooldown_ended",
                         ("hsl", "risk", "cooldown"),
                         {"reason": "elapsed"},
                         pside=pside,
                         ts=ts_ms,
+                        status="succeeded",
+                        reason_code="elapsed",
                     )
                     state = self._hsl_state(pside)
                 else:
@@ -2671,6 +2767,17 @@ async def _equity_hard_stop_check(self) -> Optional[dict]:
                 metrics["rolling_peak_strategy_equity"],
                 metrics["drawdown_score"],
                 metrics["red_threshold"],
+            )
+            _emit_hsl_event(
+                self,
+                "hsl.red_triggered",
+                ("hsl", "risk", "red"),
+                _hsl_event_data(metrics),
+                pside=pside,
+                ts=int(metrics["timestamp_ms"]),
+                level="critical",
+                status="degraded",
+                reason_code="red_threshold_crossed",
             )
         elif metrics["tier"] != "red":
             state["pending_red_since_ms"] = None
@@ -2724,6 +2831,65 @@ def _equity_hard_stop_log_coin_cooldown_status(self, pside: str, symbol: str, no
         symbol,
         _equity_hard_stop_format_remaining_time((cooldown_until_ms - now_ms) / 1000.0),
     )
+    remaining_seconds = max(0.0, (cooldown_until_ms - now_ms) / 1000.0)
+    _emit_hsl_event(
+        self,
+        "hsl.status",
+        ("hsl", "risk", "status"),
+        {
+            "tier": "red",
+            "cooldown_until_ms": int(cooldown_until_ms),
+            "cooldown_remaining_seconds": float(remaining_seconds),
+        },
+        pside=pside,
+        symbol=symbol,
+        ts=now_ms,
+        status="degraded",
+        reason_code="cooldown_active",
+    )
+
+
+def _equity_hard_stop_emit_coin_status(self, pside: str, symbol: str, metrics: dict) -> None:
+    state = self._hsl_coin_state(pside, symbol)
+    now_ms = int(metrics["timestamp_ms"])
+    if (
+        state["last_status_log_ms"] != 0
+        and now_ms - state["last_status_log_ms"] < self._equity_hard_stop_status_log_interval_ms
+    ):
+        return
+    state["last_status_log_ms"] = now_ms
+    red_threshold = float(metrics["red_threshold"])
+    drawdown_score = float(metrics["drawdown_score"])
+    dist_to_red = max(0.0, red_threshold - drawdown_score)
+    cooldown_remaining = None
+    if state["cooldown_until_ms"] is not None:
+        cooldown_remaining = _equity_hard_stop_format_remaining_time(
+            max(0.0, (state["cooldown_until_ms"] - now_ms) / 1000.0)
+        )
+    last_red_ts = None
+    if state["last_stop_event"] is not None:
+        last_red_ts = state["last_stop_event"].get("stop_event_timestamp_ms")
+    if last_red_ts is None:
+        last_red_ts = state["pending_red_since_ms"]
+    _emit_hsl_event(
+        self,
+        "hsl.status",
+        ("hsl", "risk", "status"),
+        _hsl_event_data(
+            metrics,
+            {
+                "dist_to_red": float(dist_to_red),
+                "cooldown_remaining": cooldown_remaining,
+                "last_red_ts": last_red_ts,
+                "pending_red_since_ms": state["pending_red_since_ms"],
+            },
+        ),
+        pside=pside,
+        symbol=symbol,
+        ts=now_ms,
+        status="succeeded",
+        reason_code=str(metrics["tier"]),
+    )
 
 
 async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
@@ -2754,6 +2920,17 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
                             "[risk] HSL[%s:%s] RED cooldown elapsed; trading resumed",
                             pside,
                             symbol,
+                        )
+                        _emit_hsl_event(
+                            self,
+                            "hsl.cooldown_ended",
+                            ("hsl", "risk", "cooldown"),
+                            {"reason": "elapsed", "symbol": symbol},
+                            pside=pside,
+                            symbol=symbol,
+                            ts=ts_ms,
+                            status="succeeded",
+                            reason_code="elapsed",
                         )
                         state = self._hsl_coin_state(pside, symbol)
                     else:
@@ -2793,6 +2970,18 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
                     metrics["peak_realized_pnl"],
                     metrics["unrealized_pnl"],
                 )
+                _emit_hsl_event(
+                    self,
+                    "hsl.red_triggered",
+                    ("hsl", "risk", "red"),
+                    _hsl_event_data(metrics),
+                    pside=pside,
+                    symbol=symbol,
+                    ts=int(metrics["timestamp_ms"]),
+                    level="critical",
+                    status="degraded",
+                    reason_code="red_threshold_crossed",
+                )
             elif metrics["tier"] != "red":
                 state["pending_red_since_ms"] = None
                 if not state["halted"]:
@@ -2807,6 +2996,7 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
                     self._equity_hard_stop_set_coin_runtime_forced_mode(
                         pside, symbol, "tp_only_with_active_entry_cancellation"
                     )
+            self._equity_hard_stop_emit_coin_status(pside, symbol, metrics)
             out[f"{pside}:{symbol}"] = metrics
     return out if out else None
 
@@ -2979,7 +3169,8 @@ async def _equity_hard_stop_finalize_red_stop(self, pside: str, stop_event: Opti
     latch_path = self._equity_hard_stop_write_latch(pside, payload)
     self._equity_hard_stop_refresh_halted_runtime_forced_modes()
     if cooldown_until_ms is not None:
-        self._monitor_record_event(
+        _emit_hsl_event(
+            self,
             "hsl.cooldown_started",
             ("hsl", "risk", "cooldown"),
             {
@@ -2991,6 +3182,8 @@ async def _equity_hard_stop_finalize_red_stop(self, pside: str, stop_event: Opti
             },
             pside=pside,
             ts=stop_ts_ms,
+            status="started",
+            reason_code="red_stop_finalized",
         )
     if no_restart_latched or cooldown_until_ms is None:
         logging.critical(
@@ -3071,7 +3264,8 @@ async def _equity_hard_stop_finalize_coin_red_stop(
     self._equity_hard_stop_clear_coin_runtime_forced_mode(pside, symbol)
     if cooldown_until_ms is not None:
         self._equity_hard_stop_set_coin_runtime_forced_mode(pside, symbol, "graceful_stop")
-        self._monitor_record_event(
+        _emit_hsl_event(
+            self,
             "hsl.cooldown_started",
             ("hsl", "risk", "cooldown"),
             {
@@ -3084,6 +3278,8 @@ async def _equity_hard_stop_finalize_coin_red_stop(
             pside=pside,
             symbol=symbol,
             ts=stop_ts_ms,
+            status="started",
+            reason_code="coin_red_stop_finalized",
         )
     logging.critical(
         "[risk] HSL[%s:%s] RED stop finalized | stop_ts=%s drawdown_raw=%.6f cooldown_until_ms=%s no_restart_latched=%s latch=%s",

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -222,6 +222,58 @@ def test_coin_hsl_slot_budget_rejects_zero_n_positions():
         bot._equity_hard_stop_apply_coin_sample("long", "A", 60_000, 100.0, -1.0)
 
 
+def test_hsl_transition_falls_back_to_monitor_when_pipeline_absent():
+    bot = make_coin_bot()
+    captured = []
+    bot._live_event_pipeline = None
+    bot._live_event_current_cycle_id = "cy_absent_pipeline"
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+
+    def record_event(kind, tags, payload, *, pside=None, symbol=None, ts=None):
+        captured.append(
+            {
+                "kind": kind,
+                "tags": tuple(tags),
+                "payload": payload,
+                "pside": pside,
+                "symbol": symbol,
+                "ts": ts,
+            }
+        )
+
+    bot._monitor_record_event = record_event
+    metrics = {
+        "pside": "long",
+        "signal_mode": "pside",
+        "timestamp_ms": 180_000,
+        "balance": 100.0,
+        "strategy_equity": 98.0,
+        "peak_strategy_equity": 100.0,
+        "rolling_peak_strategy_equity": 100.0,
+        "drawdown_raw": 0.02,
+        "drawdown_ema": 0.01,
+        "drawdown_score": 0.01,
+        "strategy_pnl": -2.0,
+        "peak_strategy_pnl": 0.0,
+        "red_threshold": 0.5,
+        "tier": "yellow",
+        "changed": True,
+    }
+
+    bot._equity_hard_stop_log_transition("long", metrics, "green")
+
+    assert len(captured) == 1
+    event = captured[0]
+    assert event["kind"] == "hsl.transition"
+    assert event["tags"] == ("hsl", "risk", "transition")
+    assert event["pside"] == "long"
+    assert event["ts"] == 180_000
+    assert event["payload"]["previous_tier"] == "green"
+    assert event["payload"]["tier"] == "yellow"
+    assert event["payload"]["metrics"]["tier"] == "yellow"
+    assert event["payload"]["metrics"]["changed"] is True
+
+
 @pytest.mark.asyncio
 async def test_coin_hsl_check_skips_enabled_side_with_zero_budget():
     from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -82,6 +82,7 @@ def bind_hsl_methods(bot):
         "_equity_hard_stop_finalize_coin_red_stop",
         "_equity_hard_stop_latest_panic_fill_timestamp_ms",
         "_equity_hard_stop_log_coin_cooldown_status",
+        "_equity_hard_stop_emit_coin_status",
         "_equity_hard_stop_make_state",
         "_equity_hard_stop_prime_coin_runtime_for_replay",
         "_equity_hard_stop_reset_coin_after_restart",
@@ -223,10 +224,20 @@ def test_coin_hsl_slot_budget_rejects_zero_n_positions():
 
 @pytest.mark.asyncio
 async def test_coin_hsl_check_skips_enabled_side_with_zero_budget():
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+
     bot = make_coin_bot()
     symbol = "A"
     bot.hsl["short"]["enabled"] = True
     bot.positions = {symbol: {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}}
+    sink = ListEventSink()
+    bot.bot_id = "bot_1"
+    bot._live_event_current_cycle_id = "cy_coin_hsl"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
 
     def bot_value(pside, key):
         values = {
@@ -242,6 +253,15 @@ async def test_coin_hsl_check_skips_enabled_side_with_zero_budget():
     assert set(out) == {f"long:{symbol}"}
     assert symbol in bot._equity_hard_stop_coin["long"]
     assert bot._equity_hard_stop_coin["short"] == {}
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [event for event in sink.events if event.event_type == EventTypes.HSL_STATUS]
+    assert len(events) == 1
+    assert events[0].cycle_id == "cy_coin_hsl"
+    assert events[0].symbol == symbol
+    assert events[0].pside == "long"
+    assert events[0].data["signal_mode"] == "coin"
+    assert events[0].data["dist_to_red"] == pytest.approx(0.5)
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -133,6 +133,17 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.DATA_PACKET_UPDATED].structured is True
     assert DEFAULT_ROUTES[EventTypes.DATA_PACKET_UPDATED].monitor is True
     assert DEFAULT_ROUTES[EventTypes.DATA_PACKET_UPDATED].console is False
+    for event_type in (
+        EventTypes.HSL_TRANSITION,
+        EventTypes.HSL_STATUS,
+        EventTypes.HSL_RED_TRIGGERED,
+        EventTypes.HSL_COOLDOWN_STARTED,
+        EventTypes.HSL_COOLDOWN_ENDED,
+    ):
+        assert DEFAULT_ROUTES[event_type].structured is True
+        assert DEFAULT_ROUTES[event_type].monitor is True
+        assert DEFAULT_ROUTES[event_type].console is False
+        assert DEFAULT_ROUTES[event_type].text is False
     assert DEFAULT_ROUTES[EventTypes.ORDER_WAVE_COMPLETED].console is True
     assert DEFAULT_ROUTES[EventTypes.ORDER_WAVE_COMPLETED].text is True
 

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -2642,8 +2642,16 @@ async def test_hard_stop_check_defers_stop_event_until_flat_confirmation(monkeyp
 
 
 def test_hard_stop_status_logging_is_throttled(caplog):
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
+    sink = ListEventSink()
+    bot._live_event_current_cycle_id = "cy_hsl"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
     _hsl_state(bot)["last_stop_event"] = {"stop_event_timestamp_ms": 1_600_000}
     _hsl_state(bot)["last_status_log_ms"] = 0
     bot._equity_hard_stop_status_log_interval_ms = 15 * 60 * 1000
@@ -2668,6 +2676,15 @@ def test_hard_stop_status_logging_is_throttled(caplog):
     assert len(msgs) == 1
     assert "dist_to_red=0.020000" in msgs[0]
     assert "last_red_ts=1600000" in msgs[0]
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [event for event in sink.events if event.event_type == EventTypes.HSL_STATUS]
+    assert len(events) == 1
+    assert events[0].cycle_id == "cy_hsl"
+    assert events[0].pside == "long"
+    assert events[0].reason_code == "yellow"
+    assert events[0].data["dist_to_red"] == pytest.approx(0.02)
+    assert events[0].data["last_red_ts"] == 1_600_000
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

Observability-only live logging slice on top of v8. Adds structured HSL/risk events through the existing live event pipeline:

- hsl.transition
- hsl.status
- hsl.red_triggered
- hsl.cooldown_started
- hsl.cooldown_ended

Existing HSL console logs remain unchanged. HSL routes are structured/monitor only: console=false, text=false. Direct HSL monitor events are bridged through LiveEvent when available, with fallback to the legacy monitor path for fake/no-pipeline bots.

## Validation

- ./venv/bin/python -m compileall src/live/event_bus.py src/passivbot_hsl.py src/passivbot.py tests/test_live_event_bus.py tests/test_hsl_coin_mode.py tests/test_unstucking_safeguards.py
- ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_hsl_coin_mode.py -q
- ./venv/bin/python -m pytest tests/test_unstucking_safeguards.py -k "hard_stop_status or hard_stop_finalize_red_stop or hsl or HSL" -q
- git diff --check

## Review Focus

Confirm this is observability-only: no trading behavior changes, console output stable, HSL event emission failures cannot affect live behavior, coin-mode hsl.status includes dist_to_red, routes remain off console/text, and monitor compatibility is preserved.