### PR TITLE
Emit forager and EMA summary events

### DIFF
--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -27,6 +27,11 @@ class EventTypes:
     DATA_PACKET_UPDATED = "data_packet.updated"
     SNAPSHOT_BUILT = "snapshot.built"
     PLANNING_UNAVAILABLE = "planning.unavailable"
+    FORAGER_SELECTION = "forager.selection"
+    FORAGER_FEATURE_UNAVAILABLE = "forager.feature_unavailable"
+    EMA_BUNDLE_COMPLETED = "ema.bundle.completed"
+    EMA_FALLBACK_USED = "ema.fallback_used"
+    EMA_UNAVAILABLE = "ema.unavailable"
     REMOTE_CALL_STARTED = "remote_call.started"
     REMOTE_CALL_SUCCEEDED = "remote_call.succeeded"
     REMOTE_CALL_FAILED = "remote_call.failed"
@@ -68,6 +73,11 @@ PHASE1_EVENT_TYPES = {
     EventTypes.DATA_PACKET_UPDATED,
     EventTypes.SNAPSHOT_BUILT,
     EventTypes.PLANNING_UNAVAILABLE,
+    EventTypes.FORAGER_SELECTION,
+    EventTypes.FORAGER_FEATURE_UNAVAILABLE,
+    EventTypes.EMA_BUNDLE_COMPLETED,
+    EventTypes.EMA_FALLBACK_USED,
+    EventTypes.EMA_UNAVAILABLE,
     EventTypes.REMOTE_CALL_STARTED,
     EventTypes.REMOTE_CALL_SUCCEEDED,
     EventTypes.REMOTE_CALL_FAILED,
@@ -340,6 +350,11 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.PLANNING_UNAVAILABLE: EventRoute(
         console=True, text=True, throttle_interval_ms=60_000
     ),
+    EventTypes.FORAGER_SELECTION: EventRoute(console=False, text=False),
+    EventTypes.FORAGER_FEATURE_UNAVAILABLE: EventRoute(console=False, text=False),
+    EventTypes.EMA_BUNDLE_COMPLETED: EventRoute(console=False, text=False),
+    EventTypes.EMA_FALLBACK_USED: EventRoute(console=False, text=False),
+    EventTypes.EMA_UNAVAILABLE: EventRoute(console=False, text=False),
     EventTypes.REMOTE_CALL_STARTED: EventRoute(console=False),
     EventTypes.REMOTE_CALL_SUCCEEDED: EventRoute(console=False),
     EventTypes.REMOTE_CALL_FAILED: EventRoute(console=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -557,6 +557,469 @@ def _safe_float(value: Any) -> float | None:
     return number if number == number else None
 
 
+def _safe_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _symbol_sample(symbols: Any, *, limit: int = 12) -> dict[str, Any]:
+    if symbols is None:
+        values = []
+    else:
+        try:
+            values = sorted({str(symbol) for symbol in symbols})
+        except TypeError:
+            values = [str(symbols)]
+    return {
+        "count": len(values),
+        "sample": values[:limit],
+        "truncated": max(0, len(values) - limit),
+    }
+
+
+def _span_sample(spans: Any, *, limit: int = 8) -> list[float]:
+    out: list[float] = []
+    values = []
+    for raw_span in spans or []:
+        span = _safe_float(raw_span)
+        if span is not None:
+            values.append(span)
+    iterable = sorted(values)
+    for span in iterable:
+        if span == span:
+            out.append(span)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _ema_map_summary(values: dict[str, dict[float, float]] | None) -> dict[str, int]:
+    mapping = values or {}
+    return {
+        "symbols": len(mapping),
+        "values": sum(len(item or {}) for item in mapping.values()),
+    }
+
+
+def _fallback_examples(
+    values: dict[str, list[tuple[Any, ...]]] | None,
+    *,
+    limit: int = 8,
+) -> list[dict[str, Any]]:
+    examples: list[dict[str, Any]] = []
+    for symbol, items in sorted((values or {}).items())[:limit]:
+        spans: list[float] = []
+        ages: list[int] = []
+        counts: list[int] = []
+        metrics: set[str] = set()
+        reason = None
+        for item in items or []:
+            if not isinstance(item, (list, tuple)):
+                continue
+            if len(item) >= 1 and isinstance(item[0], str):
+                metrics.add(str(item[0]))
+                if len(item) >= 2:
+                    span = _safe_float(item[1])
+                    if span is not None:
+                        spans.append(span)
+                if len(item) >= 3:
+                    age = _safe_int(item[2])
+                    if age is not None:
+                        ages.append(age)
+            else:
+                if len(item) >= 1:
+                    span = _safe_float(item[0])
+                    if span is not None:
+                        spans.append(span)
+                if len(item) >= 2:
+                    age = _safe_int(item[1])
+                    if age is not None:
+                        ages.append(age)
+                if len(item) >= 3:
+                    count = _safe_int(item[2])
+                    if count is not None:
+                        counts.append(count)
+                if len(item) >= 4 and item[3] is not None:
+                    reason = str(item[3])[:160]
+        example: dict[str, Any] = {
+            "symbol": str(symbol),
+            "count": len(items or []),
+            "spans": _span_sample(spans),
+        }
+        if metrics:
+            example["metrics"] = sorted(metrics)
+        if ages:
+            example["max_age_ms"] = max(ages)
+        if counts:
+            example["max_fallbacks"] = max(counts)
+        if reason:
+            example["reason"] = reason
+        examples.append(example)
+    return examples
+
+
+def _candidate_unavailable_summary(
+    values: dict[str, list[tuple[str, str, str]]] | None,
+    *,
+    limit: int = 8,
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for reason, items in sorted((values or {}).items())[:limit]:
+        symbols = sorted({str(symbol) for symbol, _error_type, _error in items or []})
+        error_types = sorted(
+            {str(error_type) for _symbol, error_type, _error in items or []}
+        )
+        example_error = next(
+            (str(error) for _symbol, _error_type, error in items or [] if error),
+            "",
+        )
+        out.append(
+            {
+                "reason": str(reason),
+                "symbols": _symbol_sample(symbols),
+                "error_types": error_types[:4],
+                "example_error": example_error[:160] if example_error else None,
+            }
+        )
+    return out
+
+
+def _reason_symbol_summary(
+    values: dict[str, list[str]] | None,
+    *,
+    limit: int = 8,
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for reason, symbols in sorted((values or {}).items())[:limit]:
+        out.append({"reason": str(reason), "symbols": _symbol_sample(symbols)})
+    return out
+
+
+def _forager_top_score_sample(
+    top_scores: list[dict[str, Any]] | tuple[dict[str, Any], ...] | None,
+    *,
+    limit: int = 8,
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for item in list(top_scores or [])[:limit]:
+        if not isinstance(item, dict):
+            continue
+        payload: dict[str, Any] = {
+            "symbol": str(item.get("symbol")) if item.get("symbol") is not None else None,
+            "rank": _safe_int(item.get("rank")),
+            "score": _safe_float(item.get("score")),
+            "selected": bool(item.get("selected")),
+            "incumbent": bool(item.get("incumbent")),
+        }
+        for key in (
+            "volume_component",
+            "ema_readiness_component",
+            "volatility_component",
+        ):
+            value = _safe_float(item.get(key))
+            if value is not None:
+                payload[key] = value
+        out.append({key: value for key, value in payload.items() if value is not None})
+    return out
+
+
+def _safe_emit(bot: Any, event_type: str, **kwargs: Any) -> Any:
+    try:
+        return bot._emit_live_event(event_type, **kwargs)
+    except Exception as exc:
+        logging.debug("[event] failed to emit %s: %s", event_type, exc)
+        return None
+
+
+def _emit_forager_feature_unavailable_event_unchecked(
+    bot: Any,
+    *,
+    pside: str,
+    symbols: list[str] | tuple[str, ...] | set[str],
+    candidate_count: int,
+    volume_count: int,
+    log_range_count: int,
+    max_age_ms: int | None,
+    fetch_budget: int | None,
+) -> None:
+    if not symbols:
+        return
+    _safe_emit(
+        bot,
+        EventTypes.FORAGER_FEATURE_UNAVAILABLE,
+        level="debug",
+        component="forager.selection",
+        tags=("forager", "selection", "ema"),
+        cycle_id=current_live_event_cycle_id(bot),
+        pside=str(pside),
+        status="skipped",
+        reason_code="ranking_features_unavailable",
+        data={
+            "candidate_count": int(candidate_count),
+            "unavailable": _symbol_sample(symbols),
+            "volume_count": int(volume_count),
+            "log_range_count": int(log_range_count),
+            "max_age_ms": int(max_age_ms) if max_age_ms is not None else None,
+            "fetch_budget": int(fetch_budget) if fetch_budget is not None else None,
+        },
+    )
+
+
+def emit_forager_feature_unavailable_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    try:
+        _emit_forager_feature_unavailable_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.FORAGER_FEATURE_UNAVAILABLE,
+            exc,
+        )
+
+
+def _emit_forager_selection_event_unchecked(
+    bot: Any,
+    *,
+    pside: str,
+    candidate_count: int,
+    eligible_count: int,
+    selected_symbols: list[str] | tuple[str, ...],
+    slots_open: bool,
+    max_n_positions: int | None,
+    clip_pct: float | None,
+    volatility_drop_pct: float | None,
+    max_age_ms: int | None,
+    fetch_budget: int | None,
+    incumbent_symbols: list[str] | tuple[str, ...] | None = None,
+    slots_to_fill: int | None = None,
+    score_hysteresis_pct: float | None = None,
+    top_scores: list[dict[str, Any]] | tuple[dict[str, Any], ...] | None = None,
+    hysteresis_event_count: int = 0,
+    source: str = "python_filter",
+    feature_unavailable_count: int = 0,
+    volatility_dropped_count: int = 0,
+    reason_code: str = "selected",
+    status: str = "succeeded",
+) -> None:
+    selected = [str(symbol) for symbol in selected_symbols or []]
+    incumbent = [str(symbol) for symbol in incumbent_symbols or []]
+    _safe_emit(
+        bot,
+        EventTypes.FORAGER_SELECTION,
+        level="debug",
+        component="forager.selection",
+        tags=("forager", "selection"),
+        cycle_id=current_live_event_cycle_id(bot),
+        pside=str(pside),
+        status=status,
+        reason_code=reason_code,
+        data={
+            "candidate_count": int(candidate_count),
+            "eligible_count": int(eligible_count),
+            "selected_count": len(selected),
+            "selected_symbols": selected[:12],
+            "incumbent_count": len(incumbent),
+            "incumbent_symbols": incumbent[:12],
+            "slots_open": bool(slots_open),
+            "max_n_positions": int(max_n_positions) if max_n_positions is not None else None,
+            "slots_to_fill": int(slots_to_fill) if slots_to_fill is not None else None,
+            "clip_pct": float(clip_pct) if clip_pct is not None else None,
+            "volatility_drop_pct": (
+                float(volatility_drop_pct)
+                if volatility_drop_pct is not None
+                else None
+            ),
+            "score_hysteresis_pct": (
+                float(score_hysteresis_pct)
+                if score_hysteresis_pct is not None
+                else None
+            ),
+            "max_age_ms": int(max_age_ms) if max_age_ms is not None else None,
+            "fetch_budget": int(fetch_budget) if fetch_budget is not None else None,
+            "source": str(source),
+            "feature_unavailable_count": int(feature_unavailable_count),
+            "volatility_dropped_count": int(volatility_dropped_count),
+            "hysteresis_event_count": int(hysteresis_event_count),
+            "top_scores": _forager_top_score_sample(top_scores),
+        },
+    )
+
+
+def emit_forager_selection_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    try:
+        _emit_forager_selection_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.FORAGER_SELECTION,
+            exc,
+        )
+
+
+def _emit_ema_bundle_completed_event_unchecked(
+    bot: Any,
+    *,
+    symbols: list[str] | tuple[str, ...],
+    m1_close_emas: dict[str, dict[float, float]],
+    m1_volume_emas: dict[str, dict[float, float]],
+    m1_log_range_emas: dict[str, dict[float, float]],
+    h1_log_range_emas: dict[str, dict[float, float]],
+    cache_only_symbols: set[str] | None = None,
+    projection_contexts: dict[str, dict] | None = None,
+) -> None:
+    _safe_emit(
+        bot,
+        EventTypes.EMA_BUNDLE_COMPLETED,
+        level="debug",
+        component="ema.bundle",
+        tags=("ema", "bundle"),
+        cycle_id=current_live_event_cycle_id(bot),
+        status="succeeded",
+        data={
+            "symbol_count": len(symbols or []),
+            "cache_only": _symbol_sample(cache_only_symbols or set()),
+            "projection_contexts": _symbol_sample((projection_contexts or {}).keys()),
+            "m1_close": _ema_map_summary(m1_close_emas),
+            "m1_volume": _ema_map_summary(m1_volume_emas),
+            "m1_log_range": _ema_map_summary(m1_log_range_emas),
+            "h1_log_range": _ema_map_summary(h1_log_range_emas),
+        },
+    )
+
+
+def emit_ema_bundle_completed_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    try:
+        _emit_ema_bundle_completed_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.EMA_BUNDLE_COMPLETED,
+            exc,
+        )
+
+
+def _emit_ema_fallback_used_event_unchecked(
+    bot: Any,
+    *,
+    close_ema_recoveries: dict[str, list[tuple[float, int]]] | None = None,
+    close_ema_fallbacks: dict[str, list[tuple[float, int, int, str]]] | None = None,
+    forager_cached_ema_fallbacks: dict[str, list[tuple[str, float, int]]] | None = None,
+) -> None:
+    recovered_count = sum(len(items) for items in (close_ema_recoveries or {}).values())
+    close_fallback_count = sum(len(items) for items in (close_ema_fallbacks or {}).values())
+    forager_count = sum(len(items) for items in (forager_cached_ema_fallbacks or {}).values())
+    if not (recovered_count or close_fallback_count or forager_count):
+        return
+    level = "warning" if close_fallback_count else "debug"
+    _safe_emit(
+        bot,
+        EventTypes.EMA_FALLBACK_USED,
+        level=level,
+        component="ema.bundle",
+        tags=("ema", "fallback"),
+        cycle_id=current_live_event_cycle_id(bot),
+        status="recovered",
+        reason_code="ema_fallback_used",
+        data={
+            "close_recovered_count": int(recovered_count),
+            "close_recovered_symbols": _symbol_sample((close_ema_recoveries or {}).keys()),
+            "close_fallback_count": int(close_fallback_count),
+            "close_fallback_symbols": _symbol_sample((close_ema_fallbacks or {}).keys()),
+            "forager_cached_fallback_count": int(forager_count),
+            "forager_cached_fallback_symbols": _symbol_sample(
+                (forager_cached_ema_fallbacks or {}).keys()
+            ),
+            "examples": {
+                "close_recovered": _fallback_examples(close_ema_recoveries),
+                "close_fallback": _fallback_examples(close_ema_fallbacks),
+                "forager_cached": _fallback_examples(forager_cached_ema_fallbacks),
+            },
+        },
+    )
+
+
+def emit_ema_fallback_used_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    try:
+        _emit_ema_fallback_used_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.EMA_FALLBACK_USED,
+            exc,
+        )
+
+
+def _emit_ema_unavailable_event_unchecked(
+    bot: Any,
+    *,
+    optional_ema_drops: dict[tuple[str, str], list[tuple[str, float]]] | None = None,
+    candidate_ema_unavailable_details: dict[str, list[tuple[str, str, str]]] | None = None,
+    ema_unavailable_reasons: dict[str, list[str]] | None = None,
+) -> None:
+    optional_count = sum(len(items) for items in (optional_ema_drops or {}).values())
+    candidate_symbols = {
+        str(symbol)
+        for items in (candidate_ema_unavailable_details or {}).values()
+        for symbol, _error_type, _error in items
+    }
+    unavailable_symbols = {
+        str(symbol)
+        for items in (ema_unavailable_reasons or {}).values()
+        for symbol in items
+    }
+    if not (optional_count or candidate_symbols or unavailable_symbols):
+        return
+    level = "warning" if candidate_symbols else "debug"
+    status = "degraded" if candidate_symbols or unavailable_symbols else "skipped"
+    reason_code = (
+        "required_ema_unavailable"
+        if candidate_symbols or unavailable_symbols
+        else "optional_ema_dropped"
+    )
+    optional_summary = []
+    for (ema_type, reason), items in sorted((optional_ema_drops or {}).items())[:8]:
+        optional_summary.append(
+            {
+                "ema_type": str(ema_type),
+                "reason": str(reason)[:160],
+                "symbols": _symbol_sample(symbol for symbol, _span in items),
+                "spans": _span_sample(span for _symbol, span in items),
+            }
+        )
+    _safe_emit(
+        bot,
+        EventTypes.EMA_UNAVAILABLE,
+        level=level,
+        component="ema.bundle",
+        tags=("ema", "unavailable"),
+        cycle_id=current_live_event_cycle_id(bot),
+        status=status,
+        reason_code=reason_code,
+        data={
+            "optional_drop_count": int(optional_count),
+            "optional_drop_groups": optional_summary,
+            "candidate_unavailable": _symbol_sample(candidate_symbols),
+            "candidate_unavailable_groups": _candidate_unavailable_summary(
+                candidate_ema_unavailable_details
+            ),
+            "unavailable": _symbol_sample(unavailable_symbols),
+            "unavailable_reasons": _reason_symbol_summary(ema_unavailable_reasons),
+        },
+    )
+
+
+def emit_ema_unavailable_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    try:
+        _emit_ema_unavailable_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.EMA_UNAVAILABLE,
+            exc,
+        )
+
+
 def _short_order_id(value: Any, *, max_len: int = 32) -> str | None:
     if value is None:
         return None

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -612,6 +612,13 @@ class Passivbot:
     _emit_execution_order_event = live_event_emitters.emit_execution_order_event
     _emit_balance_changed_event = live_event_emitters.emit_balance_changed_event
     _emit_fill_ingested_event = live_event_emitters.emit_fill_ingested_event
+    _emit_forager_feature_unavailable_event = (
+        live_event_emitters.emit_forager_feature_unavailable_event
+    )
+    _emit_forager_selection_event = live_event_emitters.emit_forager_selection_event
+    _emit_ema_bundle_completed_event = live_event_emitters.emit_ema_bundle_completed_event
+    _emit_ema_fallback_used_event = live_event_emitters.emit_ema_fallback_used_event
+    _emit_ema_unavailable_event = live_event_emitters.emit_ema_unavailable_event
     _emit_order_wave_started_event = live_event_emitters.emit_order_wave_started_event
     _emit_order_wave_completed_event = live_event_emitters.emit_order_wave_completed_event
     _emit_position_changed_event = live_event_emitters.emit_position_changed_event
@@ -7602,6 +7609,9 @@ class Passivbot:
         except Exception:
             slots_open = False
         if self.is_forager_mode(pside):
+            forager_candidate_count = len(candidates)
+            feature_unavailable_count = 0
+            volatility_dropped_count = 0
             # filter coins by relative volume and log range
             clip_pct = self.bot_value(pside, "forager_volume_drop_pct")
             if not clip_pct:
@@ -7668,6 +7678,17 @@ class Passivbot:
                 if symbol not in volumes or symbol not in log_ranges
             ]
             if feature_unavailable:
+                feature_unavailable_count = len(feature_unavailable)
+                Passivbot._emit_forager_feature_unavailable_event(
+                    self,
+                    pside=pside,
+                    symbols=feature_unavailable,
+                    candidate_count=forager_candidate_count,
+                    volume_count=len(volumes),
+                    log_range_count=len(log_ranges),
+                    max_age_ms=max_age_ms,
+                    fetch_budget=fetch_budget,
+                )
                 logging.debug(
                     "[forager] %s unavailable ranking features | unavailable=%d candidates=%d symbols=%s",
                     pside,
@@ -7681,6 +7702,23 @@ class Passivbot:
                     if symbol in volumes and symbol in log_ranges
                 ]
                 if not candidates:
+                    Passivbot._emit_forager_selection_event(
+                        self,
+                        pside=pside,
+                        candidate_count=forager_candidate_count,
+                        eligible_count=0,
+                        selected_symbols=[],
+                        slots_open=slots_open,
+                        max_n_positions=max_n_positions,
+                        clip_pct=clip_pct,
+                        volatility_drop_pct=volatility_drop,
+                        max_age_ms=max_age_ms,
+                        fetch_budget=fetch_budget,
+                        feature_unavailable_count=feature_unavailable_count,
+                        volatility_dropped_count=0,
+                        status="skipped",
+                        reason_code="all_features_unavailable",
+                    )
                     return []
             if volatility_drop > 0.0:
                 ranked = sorted(
@@ -7692,8 +7730,26 @@ class Passivbot:
                     len(ranked),
                     max(0, int(round(len(ranked) * float(volatility_drop)))),
                 )
+                volatility_dropped_count = keep_from
                 candidates = ranked[keep_from:]
                 if not candidates:
+                    Passivbot._emit_forager_selection_event(
+                        self,
+                        pside=pside,
+                        candidate_count=forager_candidate_count,
+                        eligible_count=0,
+                        selected_symbols=[],
+                        slots_open=slots_open,
+                        max_n_positions=max_n_positions,
+                        clip_pct=clip_pct,
+                        volatility_drop_pct=volatility_drop,
+                        max_age_ms=max_age_ms,
+                        fetch_budget=fetch_budget,
+                        feature_unavailable_count=feature_unavailable_count,
+                        volatility_dropped_count=volatility_dropped_count,
+                        status="skipped",
+                        reason_code="all_candidates_dropped_by_volatility",
+                    )
                     return []
             features = [
                 {
@@ -7713,6 +7769,23 @@ class Passivbot:
                 True,
             )
             ideal_coins = [candidates[i] for i in selected]
+            Passivbot._emit_forager_selection_event(
+                self,
+                pside=pside,
+                candidate_count=forager_candidate_count,
+                eligible_count=len(candidates),
+                selected_symbols=ideal_coins,
+                slots_open=slots_open,
+                max_n_positions=max_n_positions,
+                clip_pct=clip_pct,
+                volatility_drop_pct=volatility_drop,
+                max_age_ms=max_age_ms,
+                fetch_budget=fetch_budget,
+                feature_unavailable_count=feature_unavailable_count,
+                volatility_dropped_count=volatility_dropped_count,
+                status="succeeded" if ideal_coins else "skipped",
+                reason_code="selected" if ideal_coins else "none_selected",
+            )
             if not ideal_coins and self.live_value("filter_by_min_effective_cost"):
                 if any(not flag for flag in min_cost_flags.values()):
                     self.warn_on_high_effective_min_cost(pside)
@@ -10302,6 +10375,16 @@ class Passivbot:
                 return f"idx:{idx_int}"
             return symbol_to_coin(symbol, verbose=False) or symbol
 
+        def _event_symbol(idx) -> str:
+            try:
+                idx_int = int(idx)
+            except (TypeError, ValueError):
+                return "idx:unknown"
+            symbol = idx_to_symbol.get(idx_int)
+            if symbol is None:
+                return f"idx:{idx_int}"
+            return str(symbol)
+
         def _fmt_top(items: list[dict], limit: int, *, with_components: bool) -> str:
             parts = []
             for item in items[:limit]:
@@ -10388,6 +10471,58 @@ class Passivbot:
             )
             selected_set_key = tuple(sorted(selected_symbols))
             slots_to_fill = int(selection.get("slots_to_fill", 0) or 0)
+            top_score_payload = []
+            for item in top_scores[:8]:
+                top_score_payload.append(
+                    {
+                        "symbol": _event_symbol(item.get("symbol_idx")),
+                        "rank": int(
+                            item.get("rank", len(top_score_payload) + 1)
+                            or len(top_score_payload) + 1
+                        ),
+                        "score": float(item.get("score") or 0.0),
+                        "volume_component": float(
+                            item.get("volume_component") or 0.0
+                        ),
+                        "ema_readiness_component": float(
+                            item.get("ema_readiness_component") or 0.0
+                        ),
+                        "volatility_component": float(
+                            item.get("volatility_component") or 0.0
+                        ),
+                        "selected": bool(item.get("selected")),
+                        "incumbent": bool(item.get("incumbent")),
+                    }
+                )
+            Passivbot._emit_forager_selection_event(
+                self,
+                pside=pside,
+                candidate_count=len(top_scores),
+                eligible_count=len(top_scores),
+                selected_symbols=tuple(
+                    _event_symbol(idx)
+                    for idx in (selection.get("selected_symbol_indices") or [])
+                ),
+                incumbent_symbols=tuple(
+                    _event_symbol(idx)
+                    for idx in (selection.get("incumbent_symbol_indices") or [])
+                ),
+                slots_open=slots_to_fill > 0,
+                max_n_positions=None,
+                slots_to_fill=slots_to_fill,
+                clip_pct=None,
+                volatility_drop_pct=None,
+                score_hysteresis_pct=float(
+                    selection.get("score_hysteresis_pct") or 0.0
+                ),
+                max_age_ms=None,
+                fetch_budget=None,
+                top_scores=top_score_payload,
+                hysteresis_event_count=len(events),
+                source="rust_orchestrator",
+                status="succeeded" if selected_symbols else "skipped",
+                reason_code="rust_orchestrator_selection",
+            )
             info_key = (selected_set_key, slots_to_fill)
             debug_key = (info_key, score_key)
             state = self._forager_selection_log_state.setdefault(pside, {})
@@ -14089,6 +14224,12 @@ class Passivbot:
                 "; ".join(parts[:4]),
                 interval_ms=15 * 60 * 1000,
             )
+        Passivbot._emit_ema_fallback_used_event(
+            self,
+            close_ema_recoveries=close_ema_recoveries,
+            close_ema_fallbacks=close_ema_fallbacks,
+            forager_cached_ema_fallbacks=forager_cached_ema_fallbacks,
+        )
         if errors:
             fatal = next(
                 (err for _sym, err in errors if not isinstance(err, Exception)), None
@@ -14118,6 +14259,12 @@ class Passivbot:
                 len(ema_unavailable_reasons),
                 "; ".join(parts[:4]),
             )
+        Passivbot._emit_ema_unavailable_event(
+            self,
+            optional_ema_drops=optional_ema_drops,
+            candidate_ema_unavailable_details=candidate_ema_unavailable_details,
+            ema_unavailable_reasons=ema_unavailable_reasons,
+        )
 
         # Convenience: compute the single-span values used by legacy forager logging.
         volumes_long = {
@@ -14131,6 +14278,16 @@ class Passivbot:
             if lr_span_long in m1_log_range_emas[s]
         }
         self._orchestrator_ema_unavailable_symbols = set(ema_unavailable_symbols)
+        Passivbot._emit_ema_bundle_completed_event(
+            self,
+            symbols=symbols,
+            m1_close_emas=m1_close_emas,
+            m1_volume_emas=m1_volume_emas,
+            m1_log_range_emas=m1_log_range_emas,
+            h1_log_range_emas=h1_log_range_emas,
+            cache_only_symbols=cache_only_symbols,
+            projection_contexts=projection_contexts,
+        )
 
         return (
             m1_close_emas,

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -134,6 +134,11 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.DATA_PACKET_UPDATED].monitor is True
     assert DEFAULT_ROUTES[EventTypes.DATA_PACKET_UPDATED].console is False
     for event_type in (
+        EventTypes.FORAGER_SELECTION,
+        EventTypes.FORAGER_FEATURE_UNAVAILABLE,
+        EventTypes.EMA_BUNDLE_COMPLETED,
+        EventTypes.EMA_FALLBACK_USED,
+        EventTypes.EMA_UNAVAILABLE,
         EventTypes.HSL_TRANSITION,
         EventTypes.HSL_STATUS,
         EventTypes.HSL_RED_TRIGGERED,

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1860,6 +1860,15 @@ def test_min_effective_cost_blocks_are_aggregated(caplog):
 
 def test_forager_selection_diagnostics_log_scores_and_hysteresis(caplog):
     bot = Passivbot.__new__(Passivbot)
+    sink = ListEventSink()
+    bot.exchange = "binance"
+    bot.user = "binance_01"
+    bot.bot_id = "bot_1"
+    bot._live_event_current_cycle_id = "cy_forager"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
     out = {
         "diagnostics": {
             "forager_selections": [
@@ -1924,6 +1933,20 @@ def test_forager_selection_diagnostics_log_scores_and_hysteresis(caplog):
     assert not any("DOGE/USDT:USDT" in msg for msg in messages)
     assert any("[forager] long score detail" in msg for msg in messages)
     assert any("vol=0.400" in msg for msg in messages)
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.FORAGER_SELECTION
+    ]
+    assert len(events) == 2
+    assert events[0].cycle_id == "cy_forager"
+    assert events[0].data["source"] == "rust_orchestrator"
+    assert events[0].data["selected_symbols"] == ["DOGE/USDT:USDT"]
+    assert events[0].data["incumbent_symbols"] == ["DOGE/USDT:USDT"]
+    assert events[0].data["hysteresis_event_count"] == 1
+    assert events[0].data["top_scores"][0]["symbol"] == "SOL/USDT:USDT"
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 def test_forager_selection_diagnostics_demotes_rank_only_changes(caplog):

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -200,6 +200,161 @@ def test_order_wave_summary_emits_live_event(caplog):
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_forager_and_ema_summary_emitters_emit_structured_events():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_ema_bundle_completed_event = (
+            pb_mod.Passivbot._emit_ema_bundle_completed_event
+        )
+        _emit_ema_fallback_used_event = pb_mod.Passivbot._emit_ema_fallback_used_event
+        _emit_ema_unavailable_event = pb_mod.Passivbot._emit_ema_unavailable_event
+        _emit_forager_feature_unavailable_event = (
+            pb_mod.Passivbot._emit_forager_feature_unavailable_event
+        )
+        _emit_forager_selection_event = pb_mod.Passivbot._emit_forager_selection_event
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "gateio"
+            self.user = "gateio_01"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_11"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+
+    bot._emit_forager_feature_unavailable_event(
+        pside="long",
+        symbols=["ETH/USDT:USDT", "BTC/USDT:USDT"],
+        candidate_count=4,
+        volume_count=3,
+        log_range_count=2,
+        max_age_ms=300_000,
+        fetch_budget=1,
+    )
+    bot._emit_forager_selection_event(
+        pside="long",
+        candidate_count=4,
+        eligible_count=2,
+        selected_symbols=["BTC/USDT:USDT"],
+        slots_open=True,
+        max_n_positions=3,
+        clip_pct=0.1,
+        volatility_drop_pct=0.25,
+        max_age_ms=300_000,
+        fetch_budget=1,
+        feature_unavailable_count=2,
+        volatility_dropped_count=1,
+    )
+    bot._emit_ema_bundle_completed_event(
+        symbols=["BTC/USDT:USDT", "ETH/USDT:USDT"],
+        m1_close_emas={"BTC/USDT:USDT": {100.0: 50_000.0}},
+        m1_volume_emas={"BTC/USDT:USDT": {60.0: 123.0}},
+        m1_log_range_emas={"BTC/USDT:USDT": {60.0: 0.01}},
+        h1_log_range_emas={},
+        cache_only_symbols={"ETH/USDT:USDT"},
+        projection_contexts={"ETH/USDT:USDT": {"tail_gap_age_ms": 120_000}},
+    )
+    bot._emit_ema_fallback_used_event(
+        close_ema_recoveries={"BTC/USDT:USDT": [(100.0, 1)]},
+        close_ema_fallbacks={"ETH/USDT:USDT": [(100.0, 120_000, 2, "stale")]},
+        forager_cached_ema_fallbacks={
+            "DOGE/USDT:USDT": [("qv", 60.0, 180_000)]
+        },
+    )
+    bot._emit_ema_unavailable_event(
+        optional_ema_drops={
+            ("h1_log_range", "missing_optional"): [("SOL/USDT:USDT", 24.0)]
+        },
+        candidate_ema_unavailable_details={
+            "required_missing": [("XRP/USDT:USDT", "ValueError", "missing")]
+        },
+        ema_unavailable_reasons={"cache_only_never_fetched": ["ADA/USDT:USDT"]},
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = sink.events
+    assert [event.event_type for event in events] == [
+        EventTypes.FORAGER_FEATURE_UNAVAILABLE,
+        EventTypes.FORAGER_SELECTION,
+        EventTypes.EMA_BUNDLE_COMPLETED,
+        EventTypes.EMA_FALLBACK_USED,
+        EventTypes.EMA_UNAVAILABLE,
+    ]
+    assert {event.cycle_id for event in events} == {"cy_11"}
+    assert events[0].data["unavailable"]["count"] == 2
+    assert events[1].data["selected_symbols"] == ["BTC/USDT:USDT"]
+    assert events[2].data["cache_only"]["sample"] == ["ETH/USDT:USDT"]
+    assert events[3].level == "warning"
+    assert events[3].data["close_fallback_count"] == 1
+    assert events[4].status == "degraded"
+    assert events[4].data["candidate_unavailable"]["sample"] == ["XRP/USDT:USDT"]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(caplog):
+    import passivbot as pb_mod
+
+    bot = object()
+
+    with caplog.at_level(logging.DEBUG):
+        pb_mod.Passivbot._emit_forager_feature_unavailable_event(
+            bot,
+            pside="long",
+            symbols=["BTC/USDT:USDT"],
+            candidate_count="not-an-int",
+            volume_count=1,
+            log_range_count=1,
+            max_age_ms=60_000,
+            fetch_budget=1,
+        )
+        pb_mod.Passivbot._emit_forager_selection_event(
+            bot,
+            pside="long",
+            candidate_count="not-an-int",
+            eligible_count=1,
+            selected_symbols=["BTC/USDT:USDT"],
+            slots_open=True,
+            max_n_positions=1,
+            clip_pct=0.0,
+            volatility_drop_pct=0.0,
+            max_age_ms=60_000,
+            fetch_budget=1,
+        )
+        pb_mod.Passivbot._emit_ema_bundle_completed_event(
+            bot,
+            symbols=["BTC/USDT:USDT"],
+            m1_close_emas={"BTC/USDT:USDT": object()},
+            m1_volume_emas={},
+            m1_log_range_emas={},
+            h1_log_range_emas={},
+        )
+        pb_mod.Passivbot._emit_ema_fallback_used_event(
+            bot,
+            close_ema_fallbacks={"BTC/USDT:USDT": object()},
+        )
+        pb_mod.Passivbot._emit_ema_unavailable_event(
+            bot,
+            candidate_ema_unavailable_details={
+                "required_missing": [("BTC/USDT:USDT", "ValueError")]
+            },
+        )
+
+    messages = [record.message for record in caplog.records]
+    assert any(EventTypes.FORAGER_FEATURE_UNAVAILABLE in msg for msg in messages)
+    assert any(EventTypes.FORAGER_SELECTION in msg for msg in messages)
+    assert any(EventTypes.EMA_BUNDLE_COMPLETED in msg for msg in messages)
+    assert any(EventTypes.EMA_FALLBACK_USED in msg for msg in messages)
+    assert any(EventTypes.EMA_UNAVAILABLE in msg for msg in messages)
+
+
 def _make_remote_fetch_event_bot(sink, *, cycle_id="cy_7", map_max=None):
     import passivbot as pb_mod
 


### PR DESCRIPTION
Observability-only logging slice from updated v8.

Scope:
- add structured event types for forager selection, forager feature unavailability, EMA bundle completion, EMA fallback use, and EMA unavailable summaries
- route those events to structured/monitor sinks only; console/text remain disabled by default
- emit bounded summaries from existing get_filtered_coins and orchestrator EMA bundle paths
- reuse already-computed counts/samples; no extra exchange calls and no trading-decision changes

Tests:
- python -m compileall src/live/event_bus.py src/live/event_emitters.py src/passivbot.py tests/test_live_event_bus.py tests/test_passivbot_monitor.py
- pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py tests/test_coin_filtering.py tests/test_live_candle_budget.py tests/test_missing_ema_fix.py -q
- git diff --check

Review focus:
- event emission must stay best-effort and behavior-neutral
- payloads must stay bounded and free of raw exchange/account payloads
- console/text defaults should remain quiet for EMA/forager internals