### PR TITLE
Treat depleted backtest balance as liquidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Fixed v8 backtests/optimizer runs so candidates with depleted raw wallet
+  balance terminate through the normal liquidation path and emit incomplete
+  `backtest_completion_ratio` metrics instead of crashing coin-HSL slot-budget
+  evaluation.
 - Implemented the v8 TWEL policy contract: TWEL entry gating is now controlled
   separately from TWEL auto-reduce, entry gating uses the capped thresholded
   portfolio cap, and TWEL auto-reduce supports `reduce_overweight` and

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -2367,11 +2367,14 @@ impl<'a> Backtest<'a> {
             return false;
         };
         let floor_usd = self.liquidation_equity_floor_usd();
-        let liquidated = if floor_usd > 0.0 {
-            equity_usd <= floor_usd
-        } else {
-            equity_usd <= 0.0
-        };
+        let raw_balance_depleted =
+            self.balance.usd_total_balance.is_finite() && self.balance.usd_total_balance <= 0.0;
+        let liquidated = raw_balance_depleted
+            || if floor_usd > 0.0 {
+                equity_usd <= floor_usd
+            } else {
+                equity_usd <= 0.0
+            };
         if !liquidated {
             return false;
         }
@@ -9002,6 +9005,141 @@ mod tests {
         assert!(bt.check_and_apply_liquidation(0));
         assert!((bt.equities.usd_total_equity[0] - 50.0).abs() < 1e-12);
         assert!((bt.equities.btc_total_equity[0] - 0.0025).abs() < 1e-12);
+    }
+
+    #[test]
+    fn nonpositive_raw_balance_liquidates_even_when_equity_is_above_floor() {
+        for raw_balance in [0.0, -1.0] {
+            let hlcvs = Array3::from_shape_vec((2, 1, 4), vec![1.0; 2 * 1 * 4]).unwrap();
+            let btc_usd_prices = Array1::from_vec(vec![20_000.0, 20_000.0]);
+
+            let mut bp_pair = BotParamsPair::default();
+            bp_pair.long.n_positions = 1;
+            bp_pair.long.ema_span_0 = 10.0;
+            bp_pair.long.ema_span_1 = 20.0;
+
+            let backtest_params = BacktestParams {
+                starting_balance: 1000.0,
+                maker_fee: 0.0,
+                taker_fee: 0.00055,
+                coins: vec!["TEST".to_string()],
+                active_coin_indices: None,
+                first_timestamp_ms: 0,
+                requested_start_timestamp_ms: 0,
+                first_valid_indices: vec![0],
+                last_valid_indices: vec![1],
+                warmup_minutes: vec![0],
+                trade_start_indices: vec![0],
+                global_warmup_bars: 0,
+                btc_collateral_cap: 0.0,
+                btc_collateral_ltv_cap: None,
+                metrics_only: true,
+                skip_btc_analysis: false,
+                filter_by_min_effective_cost: false,
+                dynamic_wel_by_tradability: true,
+                hedge_mode: true,
+                max_realized_loss_pct: 1.0,
+                pnls_max_lookback_days: 30.0,
+                liquidation_threshold: 0.05,
+                equity_hard_stop_loss: EquityHardStopLossConfig::default(),
+                market_orders_allowed: false,
+                market_order_near_touch_threshold: 0.001,
+                market_order_slippage_pct: 0.0005,
+                forager_score_hysteresis_pct: 0.0,
+                candle_interval_minutes: 1,
+            };
+
+            let mut bt = Backtest::new(
+                hlcvs.view(),
+                btc_usd_prices.view(),
+                vec![bp_pair],
+                vec![ExchangeParams::default()],
+                &backtest_params,
+            );
+
+            bt.balance.usd_total_balance = raw_balance;
+            bt.equities.timestamps_ms.push(0);
+            bt.equities.usd_total_equity.push(100.0);
+            bt.equities.btc_total_equity.push(0.005);
+
+            assert!(bt.check_and_apply_liquidation(0));
+            assert!(bt.liquidated());
+            assert!((bt.equities.usd_total_equity[0] - 50.0).abs() < 1e-12);
+            assert!((bt.equities.btc_total_equity[0] - 0.0025).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn depleted_raw_balance_preempts_coin_hsl_slot_budget_error() {
+        let hlcvs = Array3::from_shape_vec((2, 1, 4), vec![100.0; 2 * 1 * 4]).unwrap();
+        let btc_usd_prices = Array1::from_vec(vec![20_000.0, 20_000.0]);
+
+        let mut bp_pair = BotParamsPair::default();
+        bp_pair.long.n_positions = 1;
+        bp_pair.long.total_wallet_exposure_limit = 1.5;
+        bp_pair.long.wallet_exposure_limit = 1.5;
+        bp_pair.long.ema_span_0 = 10.0;
+        bp_pair.long.ema_span_1 = 20.0;
+        bp_pair.long.hsl_enabled = true;
+        bp_pair.long.hsl_red_threshold = 0.5;
+        bp_pair.long.hsl_ema_span_minutes = 1.0;
+        bp_pair.long.hsl_tier_ratio_yellow = 0.5;
+        bp_pair.long.hsl_tier_ratio_orange = 0.75;
+
+        let mut hs = EquityHardStopLossConfig::default();
+        hs.enabled = true;
+        hs.signal_mode = "coin".to_string();
+        hs.red_threshold = 0.5;
+        hs.ema_span_minutes = 1.0;
+
+        let backtest_params = BacktestParams {
+            starting_balance: 100.0,
+            maker_fee: 0.0,
+            taker_fee: 0.00055,
+            coins: vec!["TEST".to_string()],
+            active_coin_indices: None,
+            first_timestamp_ms: 0,
+            requested_start_timestamp_ms: 0,
+            first_valid_indices: vec![0],
+            last_valid_indices: vec![1],
+            warmup_minutes: vec![0],
+            trade_start_indices: vec![0],
+            global_warmup_bars: 0,
+            btc_collateral_cap: 0.0,
+            btc_collateral_ltv_cap: None,
+            metrics_only: true,
+            skip_btc_analysis: false,
+            filter_by_min_effective_cost: false,
+            dynamic_wel_by_tradability: true,
+            hedge_mode: true,
+            max_realized_loss_pct: 1.0,
+            pnls_max_lookback_days: 30.0,
+            liquidation_threshold: 0.05,
+            equity_hard_stop_loss: hs,
+            market_orders_allowed: false,
+            market_order_near_touch_threshold: 0.001,
+            market_order_slippage_pct: 0.0005,
+            forager_score_hysteresis_pct: 0.0,
+            candle_interval_minutes: 1,
+        };
+
+        let mut bt = Backtest::new(
+            hlcvs.view(),
+            btc_usd_prices.view(),
+            vec![bp_pair],
+            vec![ExchangeParams::default()],
+            &backtest_params,
+        );
+
+        bt.balance.usd_total_balance = -1.0;
+        bt.equities.timestamps_ms.push(0);
+        bt.equities.usd_total_equity.push(100.0);
+        bt.equities.btc_total_equity.push(0.005);
+
+        assert!(bt.check_and_apply_liquidation(0));
+        assert!(bt.liquidated());
+        assert!(bt.hard_stop_coin[LONG][0].state.is_none());
+        assert!(bt.hard_stop_drawdown_samples_pside[LONG].is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Treat finite non-positive raw USD balance as a backtest liquidation before HSL/risk metrics run.
- Preserve fail-loud coin-HSL slot/TWEL validation for non-liquidation states while letting depleted candidates terminate through normal incomplete-run analysis.
- Add Rust regressions for raw-balance liquidation and coin-HSL slot-budget preemption, plus a changelog entry.

## Tests
- git diff --check
- cargo fmt --check
- cargo test --no-default-features --lib
- cargo check --tests
- VIRTUAL_ENV=/Users/eiriknarjord/repos/passivbot-5/venv PATH=/Users/eiriknarjord/repos/passivbot-5/venv/bin:$PATH maturin develop --release
- MPLCONFIGDIR=/private/tmp/passivbot_mpl PYTHONPATH=src ./venv/bin/python -m pytest tests/test_backtest_analysis.py::test_calc_backtest_completion_ratio_detects_early_stop tests/test_backtest_analysis.py::test_execute_backtest_metrics_only_keeps_completion_ratio tests/test_analysis_visibility.py::test_validate_visible_metrics_config_accepts_fill_activity_metrics tests/test_config_scoring.py::test_default_objective_goal_recognizes_fill_activity_metrics tests/optimization/test_optimize.py::TestResolveCliLimitsOverride::test_limits_payload_replaces_existing_config_limits_before_appending -q

Note: the focused Python pytest run used a local venv-only ABI3 symlink/restamp to satisfy current v8 rust_utils extension-path verification after maturin installed passivbot_rust.abi3.so.