### PR TITLE
Detect abi3 Rust extension builds

### DIFF
--- a/src/rust_utils.py
+++ b/src/rust_utils.py
@@ -28,11 +28,13 @@ _LOCK_HANDLE = None
 
 def _extension_suffixes() -> list[str]:
     # Prefer the exact interpreter suffix when available (e.g. `.cpython-312-darwin.so`),
-    # but keep broad fallbacks for non-standard environments.
+    # but keep ABI-stable and broad fallbacks for non-standard environments.
     suffix = sysconfig.get_config_var("EXT_SUFFIX")
+    suffixes: list[str] = []
     if suffix:
-        return [suffix.lstrip(".")]
-    return ["so", "pyd", "dll", "dylib", "bundle", "sl"]
+        suffixes.append(suffix.lstrip("."))
+    suffixes.extend(["abi3.so", "so", "pyd", "dll", "dylib", "bundle", "sl"])
+    return list(dict.fromkeys(suffixes))
 
 
 def _local_extension_candidates() -> list[Path]:

--- a/tests/test_rust_utils.py
+++ b/tests/test_rust_utils.py
@@ -355,6 +355,37 @@ def test_preferred_compiled_path_uses_actual_import_target_for_package_layout(
     assert preferred_compiled_path() == installed
 
 
+def test_preferred_compiled_path_accepts_abi3_package_layout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    site_packages = tmp_path / "site-packages"
+    package_dir = site_packages / "passivbot_rust"
+    package_dir.mkdir(parents=True)
+    (package_dir / "__init__.py").write_text("from .passivbot_rust import *\n")
+    installed = package_dir / "passivbot_rust.abi3.so"
+    installed.write_text("fresh-abi3-installed")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "rust_utils.sysconfig.get_config_var",
+        lambda name: ".cpython-312-x86_64-linux-gnu.so" if name == "EXT_SUFFIX" else None,
+    )
+    monkeypatch.setattr(
+        "rust_utils.sysconfig.get_paths",
+        lambda: {"platlib": str(site_packages), "purelib": str(site_packages)},
+    )
+    monkeypatch.setattr(
+        "rust_utils.importlib.util.find_spec",
+        lambda name: SimpleNamespace(
+            origin=str(package_dir / "__init__.py"),
+            submodule_search_locations=[str(package_dir)],
+        ),
+    )
+
+    assert _installed_extension_candidates() == [installed]
+    assert preferred_compiled_path() == installed
+
+
 def test_prune_shadowing_local_extensions_removes_src_copy_when_installed_exists(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):


### PR DESCRIPTION
Fix VPS startup after Python 3.14/abi3 Rust packaging change.\n\nThe Rust extension freshness guard only scanned the exact interpreter suffix when EXT_SUFFIX was present, so current maturin abi3 builds such as passivbot_rust.abi3.so were invisible. Live startup rebuilt successfully, then immediately failed because preferred_compiled_path() still returned None.\n\nChanges:\n- include abi3.so and generic shared-object fallbacks in extension suffix discovery\n- add a regression test matching the VPS package layout