### PR TITLE
Emit planning defer summary events

### DIFF
--- a/docs/plans/live_logging_overhaul_plan.md
+++ b/docs/plans/live_logging_overhaul_plan.md
@@ -146,6 +146,7 @@ stable names:
 - `data_packet.updated`
 - `snapshot.built`
 - `planning.unavailable`
+- `planning.defer_summary`
 - `planning.symbol_state`
 - `forager.selection`
 - `forager.feature_unavailable`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -27,6 +27,7 @@ class EventTypes:
     DATA_PACKET_UPDATED = "data_packet.updated"
     SNAPSHOT_BUILT = "snapshot.built"
     PLANNING_UNAVAILABLE = "planning.unavailable"
+    PLANNING_DEFER_SUMMARY = "planning.defer_summary"
     FORAGER_SELECTION = "forager.selection"
     FORAGER_FEATURE_UNAVAILABLE = "forager.feature_unavailable"
     EMA_BUNDLE_COMPLETED = "ema.bundle.completed"
@@ -73,6 +74,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.DATA_PACKET_UPDATED,
     EventTypes.SNAPSHOT_BUILT,
     EventTypes.PLANNING_UNAVAILABLE,
+    EventTypes.PLANNING_DEFER_SUMMARY,
     EventTypes.FORAGER_SELECTION,
     EventTypes.FORAGER_FEATURE_UNAVAILABLE,
     EventTypes.EMA_BUNDLE_COMPLETED,
@@ -350,6 +352,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.PLANNING_UNAVAILABLE: EventRoute(
         console=True, text=True, throttle_interval_ms=60_000
     ),
+    EventTypes.PLANNING_DEFER_SUMMARY: EventRoute(console=False, text=False),
     EventTypes.FORAGER_SELECTION: EventRoute(console=False, text=False),
     EventTypes.FORAGER_FEATURE_UNAVAILABLE: EventRoute(console=False, text=False),
     EventTypes.EMA_BUNDLE_COMPLETED: EventRoute(console=False, text=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -477,6 +477,43 @@ def emit_live_event(
     )
 
 
+def emit_planning_defer_summary_event(
+    bot: Any,
+    *,
+    reason_code: str,
+    count: int,
+    window_s: int,
+    symbols: list[str] | tuple[str, ...] | set[str],
+    details: dict | None = None,
+) -> None:
+    try:
+        details = dict(details or {})
+        invalid = details.get("invalid") if isinstance(details.get("invalid"), dict) else {}
+        bot._emit_live_event(
+            EventTypes.PLANNING_DEFER_SUMMARY,
+            level="info",
+            component="planning_gates",
+            tags=("planning", "gate", "defer", "summary"),
+            cycle_id=bot._current_live_event_cycle_id(),
+            status="deferred",
+            reason_code=str(reason_code),
+            message="staged planning defer summary",
+            data={
+                "count": int(count),
+                "window_s": int(window_s),
+                "symbols": sorted(str(symbol) for symbol in (symbols or []) if symbol),
+                "missing": sorted(str(item) for item in details.get("missing") or []),
+                "required": sorted(str(item) for item in details.get("required") or []),
+                "context": str(details.get("context") or "planning"),
+                "epoch": int(details.get("epoch", 0) or 0),
+                "invalid_surfaces": sorted(str(surface) for surface in invalid),
+                "will_retry": "automatic",
+            },
+        )
+    except Exception as exc:
+        logging.debug("[event] failed to emit planning defer summary event: %s", exc)
+
+
 def emit_order_wave_completed_event(
     bot: Any, wave: dict | None, *, elapsed_ms: int, level: str = "info"
 ) -> None:

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -489,6 +489,8 @@ def emit_planning_defer_summary_event(
     try:
         details = dict(details or {})
         invalid = details.get("invalid") if isinstance(details.get("invalid"), dict) else {}
+        all_symbols = sorted(str(symbol) for symbol in (symbols or []) if symbol)
+        symbol_limit = 32
         bot._emit_live_event(
             EventTypes.PLANNING_DEFER_SUMMARY,
             level="info",
@@ -501,7 +503,9 @@ def emit_planning_defer_summary_event(
             data={
                 "count": int(count),
                 "window_s": int(window_s),
-                "symbols": sorted(str(symbol) for symbol in (symbols or []) if symbol),
+                "symbols": all_symbols[:symbol_limit],
+                "symbols_count": len(all_symbols),
+                "symbols_truncated": len(all_symbols) > symbol_limit,
                 "missing": sorted(str(item) for item in details.get("missing") or []),
                 "required": sorted(str(item) for item in details.get("required") or []),
                 "context": str(details.get("context") or "planning"),

--- a/src/live/planning_gates.py
+++ b/src/live/planning_gates.py
@@ -342,6 +342,18 @@ def record_routine_completed_candle_defer(bot, details: dict) -> None:
             window_s,
             bot._log_symbols(tuple(sorted(state_symbols)), limit=8),
         )
+        emitter = getattr(bot, "_emit_planning_defer_summary_event", None)
+        if callable(emitter):
+            run_diagnostic_step(
+                "emit planning.defer_summary event",
+                lambda: emitter(
+                    reason_code="completed_candle_target_changed",
+                    count=int(state.get("count", 0) or 0),
+                    window_s=window_s,
+                    symbols=tuple(sorted(state_symbols)),
+                    details=details,
+                ),
+            )
         bot._routine_completed_candle_defer_summary = {
             "window_start_ms": now_ms,
             "last_log_ms": now_ms,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -621,6 +621,9 @@ class Passivbot:
     _emit_ema_unavailable_event = live_event_emitters.emit_ema_unavailable_event
     _emit_order_wave_started_event = live_event_emitters.emit_order_wave_started_event
     _emit_order_wave_completed_event = live_event_emitters.emit_order_wave_completed_event
+    _emit_planning_defer_summary_event = (
+        live_event_emitters.emit_planning_defer_summary_event
+    )
     _emit_position_changed_event = live_event_emitters.emit_position_changed_event
     _handle_candle_remote_fetch_event = live_event_emitters.emit_candle_remote_fetch_event
     _next_live_event_remote_call_id = live_event_emitters.next_live_event_remote_call_id

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -139,6 +139,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.EMA_BUNDLE_COMPLETED,
         EventTypes.EMA_FALLBACK_USED,
         EventTypes.EMA_UNAVAILABLE,
+        EventTypes.PLANNING_DEFER_SUMMARY,
         EventTypes.HSL_TRANSITION,
         EventTypes.HSL_STATUS,
         EventTypes.HSL_RED_TRIGGERED,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -221,9 +221,25 @@ def test_routine_planning_defer_summary_emits_live_event(monkeypatch):
         "ETH/USDT:USDT",
         "XRP/USDT:USDT",
     ]
+    assert event.data["symbols_count"] == 3
+    assert event.data["symbols_truncated"] is False
     assert event.data["missing"] == ["completed_candles"]
     assert event.data["invalid_surfaces"] == ["completed_candles"]
     assert bot._routine_completed_candle_defer_summary["count"] == 0
+
+    bot._emit_planning_defer_summary_event(
+        reason_code="completed_candle_target_changed",
+        count=40,
+        window_s=60,
+        symbols=[f"S{i:02d}/USDT:USDT" for i in range(40)],
+        details={},
+    )
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    wide_event = sink.events[-1]
+    assert wide_event.event_type == EventTypes.PLANNING_DEFER_SUMMARY
+    assert wide_event.data["symbols_count"] == 40
+    assert wide_event.data["symbols_truncated"] is True
+    assert len(wide_event.data["symbols"]) == 32
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -150,6 +150,83 @@ def test_live_event_cycle_helpers_emit_structured_events():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_routine_planning_defer_summary_emits_live_event(monkeypatch):
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _emit_planning_defer_summary_event = (
+            pb_mod.Passivbot._emit_planning_defer_summary_event
+        )
+        _record_routine_completed_candle_defer = (
+            pb_mod.Passivbot._record_routine_completed_candle_defer
+        )
+
+        def __init__(self):
+            self.exchange = "kucoin"
+            self.user = "kucoin_01"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_3"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+            self._routine_completed_candle_defer_summary = {
+                "window_start_ms": 1_000,
+                "last_log_ms": 0,
+                "count": 19,
+                "symbols": {"XRP/USDT:USDT"},
+            }
+
+        def _log_symbols(self, symbols, limit=8):
+            del limit
+            return ",".join(str(symbol) for symbol in symbols)
+
+    bot = FakeBot()
+    monkeypatch.setattr(pb_mod.planning_gates, "_utc_ms", lambda: 1_861_000)
+
+    bot._record_routine_completed_candle_defer(
+        {
+            "missing": ["completed_candles"],
+            "required": ["balance", "completed_candles", "market_snapshot"],
+            "context": "rust order calculation",
+            "epoch": 42,
+            "invalid": {
+                "completed_candles": [
+                    {
+                        "reason": "signature_mismatch",
+                        "mismatch_type": "completed_candle_target_changed",
+                        "changed_symbols": ["BTC/USDT:USDT"],
+                        "missing_symbols": ["ETH/USDT:USDT"],
+                    }
+                ]
+            },
+        }
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert len(sink.events) == 1
+    event = sink.events[0]
+    assert event.event_type == EventTypes.PLANNING_DEFER_SUMMARY
+    assert event.cycle_id == "cy_3"
+    assert event.reason_code == "completed_candle_target_changed"
+    assert event.status == "deferred"
+    assert event.data["count"] == 20
+    assert event.data["window_s"] == 1860
+    assert event.data["symbols"] == [
+        "BTC/USDT:USDT",
+        "ETH/USDT:USDT",
+        "XRP/USDT:USDT",
+    ]
+    assert event.data["missing"] == ["completed_candles"]
+    assert event.data["invalid_surfaces"] == ["completed_candles"]
+    assert bot._routine_completed_candle_defer_summary["count"] == 0
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_order_wave_summary_emits_live_event(caplog):
     import passivbot as pb_mod
 


### PR DESCRIPTION
Observability-only logging slice.\n\nAdds a structured planning.defer_summary event for the existing routine completed-candle staged-planning defer aggregation. The event is emitted at the same point the current 30-minute/count-based text summary is already logged, after suppression has accumulated count/window/symbols. No planning/defer/retry behavior changes.\n\nChanges:\n- add EventTypes.PLANNING_DEFER_SUMMARY and route it to structured/monitor only\n- add best-effort emit_planning_defer_summary_event()\n- wire record_routine_completed_candle_defer() to emit after the existing text summary\n- document the event name in the logging overhaul plan\n- add route and fake-bot regression tests\n\nLocal checks:\n- python -m compileall src/live/event_bus.py src/live/event_emitters.py src/live/planning_gates.py src/passivbot.py tests/test_live_event_bus.py tests/test_passivbot_monitor.py\n- pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py::test_routine_planning_defer_summary_emits_live_event -q\n- pytest tests/test_passivbot_monitor.py -q\n- git diff --check