### PR TITLE
Cancel HSL replay during shutdown

### DIFF
--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -2099,11 +2099,23 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
         return
     prev_phase = getattr(self, "_log_silence_watchdog_phase", "runtime")
     prev_stage = getattr(self, "_log_silence_watchdog_stage", "idle")
+    raise_if_shutdown = getattr(self, "_raise_if_shutdown_requested", None)
+
+    def check_shutdown(stage: str) -> None:
+        if callable(raise_if_shutdown):
+            raise_if_shutdown(stage)
+            return
+        if getattr(self, "stop_signal_received", False) or getattr(
+            self, "_shutdown_in_progress", False
+        ):
+            raise asyncio.CancelledError(f"shutdown requested during {stage}")
+
     if hasattr(self, "_set_log_silence_watchdog_context"):
         self._set_log_silence_watchdog_context(
             phase=prev_phase, stage="equity_hard_stop_initialize_coin_from_history"
         )
     try:
+        check_shutdown("hsl_coin_history_replay_start")
         self._equity_hard_stop_coin = {"long": {}, "short": {}}
         self._runtime_forced_modes = {"long": {}, "short": {}}
         lookback = parse_pnls_max_lookback_days(
@@ -2115,6 +2127,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             lookback.display_value,
         )
         history = await self.get_balance_equity_history(current_balance=self.get_raw_balance())
+        check_shutdown("hsl_coin_history_replay_history_loaded")
         panic_flatten_events = history["panic_flatten_events"] if "panic_flatten_events" in history else []
         if panic_flatten_events is None:
             panic_flatten_events = []
@@ -2289,6 +2302,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
 
         pair_idx = 0
         for pside in self._hsl_psides():
+            check_shutdown("hsl_coin_history_replay_pside")
             if not self._equity_hard_stop_coin_active_pside(pside):
                 continue
             cfg = self.hsl[pside]
@@ -2296,6 +2310,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             cooldown_ms = int(round(cooldown_minutes * 60_000.0)) if cooldown_minutes > 0.0 else 0
             no_restart_drawdown_threshold = float(cfg["no_restart_drawdown_threshold"])
             for symbol in sorted(symbols):
+                check_shutdown("hsl_coin_history_replay_pair")
                 pair_idx += 1
                 state = self._hsl_coin_state(pside, symbol)
                 contract = self._equity_hard_stop_infer_coin_replay_contract(
@@ -2352,6 +2367,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 for row_idx, row in enumerate(timeline_rows, start=1):
                     if row_idx % 1000 == 0:
                         await asyncio.sleep(0)
+                        check_shutdown("hsl_coin_history_replay_rows")
                         log_replay_progress(pair_idx, pside, symbol, applied_rows)
                     ts = int(row["timestamp"])
                     if replay_start_boundary_ts is not None and ts < replay_start_boundary_ts:
@@ -2616,6 +2632,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     continue
                 if applied_rows == 0:
                     self._equity_hard_stop_prime_coin_runtime_for_replay(pside, symbol, now_ms)
+                check_shutdown("hsl_coin_history_replay_current_sample")
                 current_metrics = self._equity_hard_stop_apply_coin_sample(
                     pside,
                     symbol,

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -177,6 +177,41 @@ def test_passivbot_binds_coin_hsl_replay_support_helper():
     assert hasattr(Passivbot, "_equity_hard_stop_symbol_supported_for_coin_replay")
 
 
+@pytest.mark.asyncio
+async def test_coin_hsl_replay_cancels_when_shutdown_requested_after_history_load():
+    bot = make_coin_bot()
+    bot.stop_signal_received = False
+    bot._shutdown_in_progress = False
+
+    async def fake_history(current_balance=None):
+        bot.stop_signal_received = True
+        return {
+            "timeline": [
+                {
+                    "timestamp": 60_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {},
+                    "unrealized_pnl_by_coin_pside": {},
+                }
+            ],
+            "panic_flatten_events": [],
+            "fill_events": [],
+        }
+
+    async def fail_calc_upnl(*_args, **_kwargs):
+        raise AssertionError("shutdown should cancel before live upnl fetch")
+
+    bot.get_balance_equity_history = fake_history
+    bot._calc_upnl_sum_strict = fail_calc_upnl
+
+    with pytest.raises(asyncio.CancelledError, match="hsl_coin_history_replay_history_loaded"):
+        await bot._equity_hard_stop_initialize_coin_from_history()
+
+    assert bot.stop_signal_received is True
+    assert getattr(bot, "_equity_hard_stop_coin_initialized", False) is False
+
+
 def test_calc_upnl_sum_strict_preserves_symbol_filter():
     bot = FakeHslBot()
     bind_hsl_methods(bot)


### PR DESCRIPTION
Operational shutdown fix from VPS5 live smoke.\n\nObserved on Gateio while restarting merged v8: Ctrl+C during HSL coin history replay set shutdown state and closed sessions, but the replay continued and later tried a live market snapshot fetch. Because self.cca had already been closed/set None, startup logged AttributeError/RuntimeError during shutdown.\n\nFix:\n- add best-effort shutdown checkpoints in _equity_hard_stop_initialize_coin_from_history()\n- checkpoints run at replay start, after history load, per pside/pair, at existing row-yield points, and before the final live upnl sample\n- cancellation uses the existing _raise_if_shutdown_requested contract when available and falls back to stop_signal_received/_shutdown_in_progress\n- no HSL policy/replay/drawdown/panic behavior changes\n\nValidation:\n- python -m compileall src/passivbot_hsl.py tests/test_hsl_coin_mode.py\n- pytest tests/test_hsl_coin_mode.py::test_coin_hsl_replay_cancels_when_shutdown_requested_after_history_load -q\n- pytest tests/test_hsl_coin_mode.py -q\n- git diff --check