### PR TITLE
Emit HSL replay lifecycle events

### DIFF
--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -57,6 +57,9 @@ class EventTypes:
     BALANCE_CHANGED = "balance.changed"
     HSL_TRANSITION = "hsl.transition"
     HSL_STATUS = "hsl.status"
+    HSL_REPLAY_STARTED = "hsl.replay.started"
+    HSL_REPLAY_PROGRESS = "hsl.replay.progress"
+    HSL_REPLAY_COMPLETED = "hsl.replay.completed"
     HSL_RED_TRIGGERED = "hsl.red_triggered"
     HSL_COOLDOWN_STARTED = "hsl.cooldown_started"
     HSL_COOLDOWN_ENDED = "hsl.cooldown_ended"
@@ -104,6 +107,9 @@ PHASE1_EVENT_TYPES = {
     EventTypes.BALANCE_CHANGED,
     EventTypes.HSL_TRANSITION,
     EventTypes.HSL_STATUS,
+    EventTypes.HSL_REPLAY_STARTED,
+    EventTypes.HSL_REPLAY_PROGRESS,
+    EventTypes.HSL_REPLAY_COMPLETED,
     EventTypes.HSL_RED_TRIGGERED,
     EventTypes.HSL_COOLDOWN_STARTED,
     EventTypes.HSL_COOLDOWN_ENDED,
@@ -384,6 +390,9 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.BALANCE_CHANGED: EventRoute(console=False, text=False),
     EventTypes.HSL_TRANSITION: EventRoute(console=False, text=False),
     EventTypes.HSL_STATUS: EventRoute(console=False, text=False),
+    EventTypes.HSL_REPLAY_STARTED: EventRoute(console=False, text=False),
+    EventTypes.HSL_REPLAY_PROGRESS: EventRoute(console=False, text=False),
+    EventTypes.HSL_REPLAY_COMPLETED: EventRoute(console=False, text=False),
     EventTypes.HSL_RED_TRIGGERED: EventRoute(console=False, text=False),
     EventTypes.HSL_COOLDOWN_STARTED: EventRoute(console=False, text=False),
     EventTypes.HSL_COOLDOWN_ENDED: EventRoute(console=False, text=False),

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -40,7 +40,7 @@ def _emit_hsl_event(
     tags: tuple[str, ...],
     data: dict,
     *,
-    pside: str,
+    pside: str | None,
     symbol: str | None = None,
     ts: int | None = None,
     level: str = "info",
@@ -85,6 +85,30 @@ def _emit_hsl_event(
             event_type,
             exc,
         )
+
+
+def _emit_hsl_replay_event(
+    self,
+    event_type: str,
+    data: dict[str, Any],
+    *,
+    pside: str | None = None,
+    symbol: str | None = None,
+    level: str = "debug",
+    status: str | None = None,
+    reason_code: str | None = None,
+) -> None:
+    _emit_hsl_event(
+        self,
+        event_type,
+        ("hsl", "risk", "replay"),
+        data,
+        pside=pside,
+        symbol=symbol,
+        level=level,
+        status=status,
+        reason_code=reason_code,
+    )
 
 
 def _calc_hsl_pnl(position_side, entry_price, close_price, qty, c_mult):
@@ -2126,6 +2150,16 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             "[risk] HSL coin history reconstruction starting | lookback_days=%s",
             lookback.display_value,
         )
+        _emit_hsl_replay_event(
+            self,
+            "hsl.replay.started",
+            {
+                "signal_mode": "coin",
+                "lookback_days": lookback.display_value,
+            },
+            status="started",
+            reason_code="coin_history_replay",
+        )
         history = await self.get_balance_equity_history(current_balance=self.get_raw_balance())
         check_shutdown("hsl_coin_history_replay_history_loaded")
         panic_flatten_events = history["panic_flatten_events"] if "panic_flatten_events" in history else []
@@ -2275,6 +2309,22 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             len(fill_events),
             len(panic_flatten_events),
         )
+        _emit_hsl_replay_event(
+            self,
+            "hsl.replay.progress",
+            {
+                "signal_mode": "coin",
+                "stage": "loaded",
+                "symbols": len(symbols),
+                "pairs": len(active_pairs),
+                "timeline_rows": len(timeline_rows),
+                "fill_events": len(fill_events),
+                "panic_events": len(panic_flatten_events),
+                "skipped_unsupported_symbols": len(skipped_unsupported_symbols),
+            },
+            status="started",
+            reason_code="history_loaded",
+        )
 
         def log_replay_progress(
             pair_idx: int,
@@ -2298,6 +2348,23 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 applied_rows,
                 rows,
                 now_s - replay_started_s,
+            )
+            _emit_hsl_replay_event(
+                self,
+                "hsl.replay.progress",
+                {
+                    "signal_mode": "coin",
+                    "stage": "pair_replay",
+                    "pair_idx": int(pair_idx),
+                    "pairs": len(active_pairs),
+                    "applied_rows": int(applied_rows),
+                    "total_applied_rows": int(rows),
+                    "elapsed_s": round(now_s - replay_started_s, 3),
+                },
+                pside=pside,
+                symbol=symbol,
+                status="started",
+                reason_code="pair_replay_progress",
             )
 
         pair_idx = 0
@@ -2655,6 +2722,48 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             len(active_pairs),
             time.monotonic() - replay_started_s,
         )
+        _emit_hsl_replay_event(
+            self,
+            "hsl.replay.completed",
+            {
+                "signal_mode": "coin",
+                "rows": int(rows),
+                "pairs": len(active_pairs),
+                "elapsed_s": round(time.monotonic() - replay_started_s, 3),
+            },
+            status="succeeded",
+            reason_code="coin_history_replay_completed",
+        )
+    except asyncio.CancelledError:
+        _emit_hsl_replay_event(
+            self,
+            "hsl.replay.completed",
+            {
+                "signal_mode": "coin",
+                "elapsed_s": round(time.monotonic() - replay_started_s, 3)
+                if "replay_started_s" in locals()
+                else None,
+            },
+            status="failed",
+            reason_code="shutdown_cancelled",
+        )
+        raise
+    except Exception as exc:
+        _emit_hsl_replay_event(
+            self,
+            "hsl.replay.completed",
+            {
+                "signal_mode": "coin",
+                "error_type": type(exc).__name__,
+                "elapsed_s": round(time.monotonic() - replay_started_s, 3)
+                if "replay_started_s" in locals()
+                else None,
+            },
+            level="warning",
+            status="failed",
+            reason_code="coin_history_replay_failed",
+        )
+        raise
     finally:
         if hasattr(self, "_set_log_silence_watchdog_context"):
             self._set_log_silence_watchdog_context(phase=prev_phase, stage=prev_stage)

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -179,9 +179,17 @@ def test_passivbot_binds_coin_hsl_replay_support_helper():
 
 @pytest.mark.asyncio
 async def test_coin_hsl_replay_cancels_when_shutdown_requested_after_history_load():
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+
     bot = make_coin_bot()
     bot.stop_signal_received = False
     bot._shutdown_in_progress = False
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
 
     async def fake_history(current_balance=None):
         bot.stop_signal_received = True
@@ -210,6 +218,93 @@ async def test_coin_hsl_replay_cancels_when_shutdown_requested_after_history_loa
 
     assert bot.stop_signal_received is True
     assert getattr(bot, "_equity_hard_stop_coin_initialized", False) is False
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [event for event in sink.events if event.event_type.startswith("hsl.replay.")]
+    assert [event.event_type for event in events] == [
+        EventTypes.HSL_REPLAY_STARTED,
+        EventTypes.HSL_REPLAY_COMPLETED,
+    ]
+    assert events[0].status == "started"
+    assert events[0].reason_code == "coin_history_replay"
+    assert events[1].status == "failed"
+    assert events[1].reason_code == "shutdown_cancelled"
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_history_replay_emits_lifecycle_events():
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+
+    bot = make_coin_bot()
+    symbol = "A"
+    bot.positions = {
+        symbol: {
+            "long": {"size": 1.0, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    sink = ListEventSink()
+    bot._live_event_current_cycle_id = "cy_hsl_replay"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+
+    async def fake_history(current_balance=None):
+        return {
+            "timeline": [
+                {
+                    "timestamp": 60_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {
+                        symbol: {"long": 0.0, "short": 0.0}
+                    },
+                    "unrealized_pnl_by_coin_pside": {
+                        symbol: {"long": -1.0, "short": 0.0}
+                    },
+                },
+                {
+                    "timestamp": 120_000,
+                    "balance": 100.0,
+                    "realized_pnl": 1.0,
+                    "realized_pnl_by_coin_pside": {
+                        symbol: {"long": 1.0, "short": 0.0}
+                    },
+                    "unrealized_pnl_by_coin_pside": {
+                        symbol: {"long": -0.5, "short": 0.0}
+                    },
+                },
+            ],
+            "panic_flatten_events": [],
+            "fill_events": [],
+        }
+
+    bot.get_balance_equity_history = fake_history
+
+    await bot._equity_hard_stop_initialize_coin_from_history()
+
+    assert getattr(bot, "_equity_hard_stop_coin_initialized", False) is True
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [event for event in sink.events if event.event_type.startswith("hsl.replay.")]
+    assert [event.event_type for event in events] == [
+        EventTypes.HSL_REPLAY_STARTED,
+        EventTypes.HSL_REPLAY_PROGRESS,
+        EventTypes.HSL_REPLAY_COMPLETED,
+    ]
+    assert {event.cycle_id for event in events} == {"cy_hsl_replay"}
+    assert events[0].status == "started"
+    assert events[0].reason_code == "coin_history_replay"
+    assert events[1].reason_code == "history_loaded"
+    assert events[1].data["symbols"] == 1
+    assert events[1].data["pairs"] == 1
+    assert events[1].data["timeline_rows"] == 2
+    assert events[2].status == "succeeded"
+    assert events[2].reason_code == "coin_history_replay_completed"
+    assert events[2].data["rows"] == 2
+    assert events[2].data["pairs"] == 1
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 def test_calc_upnl_sum_strict_preserves_symbol_filter():


### PR DESCRIPTION
Adds structured HSL coin replay lifecycle observability without changing replay, risk, or order behavior.

Scope:
- Adds hsl.replay.started/progress/completed event types and default non-console routes.
- Emits best-effort aggregate start/loaded/completed events from coin HSL history replay.
- Emits throttled per-pair progress events only when the existing text progress logger fires.
- On shutdown cancellation or replay exception, emits a failed completed event and re-raises.

Validation:
- ./venv/bin/python -m compileall src/live/event_bus.py src/passivbot_hsl.py tests/test_hsl_coin_mode.py
- ./venv/bin/python -m pytest tests/test_hsl_coin_mode.py::test_coin_hsl_replay_cancels_when_shutdown_requested_after_history_load tests/test_hsl_coin_mode.py::test_coin_hsl_history_replay_emits_lifecycle_events -q
- ./venv/bin/python -m pytest tests/test_hsl_coin_mode.py -q
- ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py -q
- git diff --check