### PR TITLE
Emit planning symbol state events

### DIFF
--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -28,6 +28,7 @@ class EventTypes:
     SNAPSHOT_BUILT = "snapshot.built"
     PLANNING_UNAVAILABLE = "planning.unavailable"
     PLANNING_DEFER_SUMMARY = "planning.defer_summary"
+    PLANNING_SYMBOL_STATE = "planning.symbol_state"
     FORAGER_SELECTION = "forager.selection"
     FORAGER_FEATURE_UNAVAILABLE = "forager.feature_unavailable"
     EMA_BUNDLE_COMPLETED = "ema.bundle.completed"
@@ -78,6 +79,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.SNAPSHOT_BUILT,
     EventTypes.PLANNING_UNAVAILABLE,
     EventTypes.PLANNING_DEFER_SUMMARY,
+    EventTypes.PLANNING_SYMBOL_STATE,
     EventTypes.FORAGER_SELECTION,
     EventTypes.FORAGER_FEATURE_UNAVAILABLE,
     EventTypes.EMA_BUNDLE_COMPLETED,
@@ -359,6 +361,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
         console=True, text=True, throttle_interval_ms=60_000
     ),
     EventTypes.PLANNING_DEFER_SUMMARY: EventRoute(console=False, text=False),
+    EventTypes.PLANNING_SYMBOL_STATE: EventRoute(console=False, text=False),
     EventTypes.FORAGER_SELECTION: EventRoute(console=False, text=False),
     EventTypes.FORAGER_FEATURE_UNAVAILABLE: EventRoute(console=False, text=False),
     EventTypes.EMA_BUNDLE_COMPLETED: EventRoute(console=False, text=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import hashlib
 import re
+from collections import Counter
 from urllib.parse import urlsplit, urlunsplit
 from typing import Any
 
@@ -516,6 +517,90 @@ def emit_planning_defer_summary_event(
         )
     except Exception as exc:
         logging.debug("[event] failed to emit planning defer summary event: %s", exc)
+
+
+def emit_planning_symbol_state_event(
+    bot: Any,
+    availability: Any,
+    *,
+    context: str,
+    sample_limit: int = 32,
+) -> None:
+    try:
+        records = tuple(getattr(availability, "records", ()) or ())
+        summary = dict(availability.summary())
+        unavailable = [
+            record
+            for record in records
+            if str(getattr(record, "status", "")) == "unavailable"
+        ]
+        reason_counts = Counter(
+            str(getattr(record, "reason_code", "") or "unknown")
+            for record in unavailable
+        )
+        order_class_counts = Counter(
+            str(getattr(record, "order_class", "") or "unknown")
+            for record in unavailable
+        )
+        surface_counts: Counter[str] = Counter()
+        for record in unavailable:
+            surface_counts.update(
+                str(surface)
+                for surface in getattr(record, "unavailable_surfaces", ()) or ()
+            )
+        symbols = sorted(
+            {
+                str(getattr(record, "symbol", ""))
+                for record in unavailable
+                if getattr(record, "symbol", None)
+            }
+        )
+
+        samples = []
+        for record in unavailable[: max(0, int(sample_limit))]:
+            samples.append(
+                {
+                    "symbol": str(getattr(record, "symbol", "")),
+                    "pside": str(getattr(record, "position_side", "")),
+                    "order_class": str(getattr(record, "order_class", "")),
+                    "reason_code": str(getattr(record, "reason_code", "") or "unknown"),
+                    "unavailable_surfaces": [
+                        str(surface)
+                        for surface in getattr(record, "unavailable_surfaces", ()) or ()
+                    ],
+                    "required_surfaces": [
+                        str(surface)
+                        for surface in getattr(record, "required_surfaces", ()) or ()
+                    ],
+                }
+            )
+
+        bot._emit_live_event(
+            EventTypes.PLANNING_SYMBOL_STATE,
+            level="debug",
+            component="planning_availability",
+            tags=("planning", "snapshot", "availability"),
+            cycle_id=current_live_event_cycle_id(bot),
+            snapshot_id=str(getattr(availability, "snapshot_id", "") or ""),
+            status="succeeded",
+            reason_code="snapshot_symbol_state",
+            data={
+                "context": str(context),
+                "summary": summary,
+                "unavailable_count": len(unavailable),
+                "unavailable_by_reason": dict(sorted(reason_counts.items())),
+                "unavailable_by_order_class": dict(sorted(order_class_counts.items())),
+                "unavailable_by_surface": dict(sorted(surface_counts.items())),
+                "unavailable_symbols": symbols[:32],
+                "unavailable_symbols_count": len(symbols),
+                "unavailable_symbols_truncated": len(symbols) > 32,
+                "records_sample": samples,
+                "records_sample_count": len(samples),
+                "records_truncated": len(unavailable) > len(samples),
+            },
+        )
+    except Exception as exc:
+        logging.debug("[event] failed to emit planning symbol state event: %s", exc)
 
 
 def emit_order_wave_completed_event(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -624,6 +624,9 @@ class Passivbot:
     _emit_planning_defer_summary_event = (
         live_event_emitters.emit_planning_defer_summary_event
     )
+    _emit_planning_symbol_state_event = (
+        live_event_emitters.emit_planning_symbol_state_event
+    )
     _emit_position_changed_event = live_event_emitters.emit_position_changed_event
     _handle_candle_remote_fetch_event = live_event_emitters.emit_candle_remote_fetch_event
     _next_live_event_remote_call_id = live_event_emitters.next_live_event_remote_call_id
@@ -8405,6 +8408,7 @@ class Passivbot:
                 ts_ms=snapshot.ts_ms,
             ),
         )
+        self._emit_planning_symbol_state_event(availability, context=context)
 
     def _emit_planning_unavailable_diagnostic(self, details: dict) -> None:
         emit_diagnostic_event(

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -140,6 +140,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.EMA_FALLBACK_USED,
         EventTypes.EMA_UNAVAILABLE,
         EventTypes.PLANNING_DEFER_SUMMARY,
+        EventTypes.PLANNING_SYMBOL_STATE,
         EventTypes.HSL_TRANSITION,
         EventTypes.HSL_STATUS,
         EventTypes.HSL_RED_TRIGGERED,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -243,6 +243,104 @@ def test_routine_planning_defer_summary_emits_live_event(monkeypatch):
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_planning_symbol_state_event_summarizes_and_bounds_records():
+    import passivbot as pb_mod
+    from live.planning_availability import (
+        PlanningAvailability,
+        PlanningAvailabilityRecord,
+    )
+
+    structured_sink = ListEventSink()
+    monitor_sink = ListEventSink()
+
+    class FakeBot:
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _emit_planning_symbol_state_event = (
+            pb_mod.Passivbot._emit_planning_symbol_state_event
+        )
+
+        def __init__(self):
+            self.exchange = "gateio"
+            self.user = "gateio_01"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_3"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[structured_sink],
+                monitor_sinks=[monitor_sink],
+            )
+
+    records = tuple(
+        PlanningAvailabilityRecord(
+            cycle_id=7,
+            snapshot_id="snap_7",
+            symbol=f"S{i:02d}/USDT:USDT",
+            position_side="long" if i % 2 == 0 else "short",
+            order_class="initial_entry" if i % 3 else "hsl_panic_close",
+            status="unavailable",
+            reason_code=(
+                "missing_canonical_candles" if i % 2 == 0 else "market_prices_too_old"
+            ),
+            required_surfaces=("balance", "market_prices", "canonical_candles"),
+            unavailable_surfaces=(
+                ("canonical_candles",) if i % 2 == 0 else ("market_prices",)
+            ),
+            packet_revisions=(("balance", 1),),
+            surface_epochs=(("completed_candles", 1, 2),),
+        )
+        for i in range(40)
+    )
+    availability = PlanningAvailability(
+        cycle_id=7,
+        snapshot_id="snap_7",
+        records=records,
+    )
+    bot = FakeBot()
+
+    bot._emit_planning_symbol_state_event(
+        availability,
+        context="rust order calculation",
+        sample_limit=5,
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert len(structured_sink.events) == 1
+    assert monitor_sink.events == structured_sink.events
+    event = structured_sink.events[0]
+    assert event.event_type == EventTypes.PLANNING_SYMBOL_STATE
+    assert event.level == "debug"
+    assert event.cycle_id == "cy_3"
+    assert event.snapshot_id == "snap_7"
+    assert event.status == "succeeded"
+    assert event.reason_code == "snapshot_symbol_state"
+    assert event.data["context"] == "rust order calculation"
+    assert event.data["summary"]["cycle_id"] == 7
+    assert event.data["summary"]["record_count"] == 40
+    assert event.data["summary"]["status_counts"] == {"unavailable": 40}
+    assert event.data["unavailable_count"] == 40
+    assert event.data["unavailable_by_reason"] == {
+        "market_prices_too_old": 20,
+        "missing_canonical_candles": 20,
+    }
+    assert event.data["unavailable_by_surface"] == {
+        "canonical_candles": 20,
+        "market_prices": 20,
+    }
+    assert event.data["unavailable_symbols_count"] == 40
+    assert event.data["unavailable_symbols_truncated"] is True
+    assert len(event.data["unavailable_symbols"]) == 32
+    assert event.data["records_sample_count"] == 5
+    assert event.data["records_truncated"] is True
+    assert event.data["records_sample"][0] == {
+        "symbol": "S00/USDT:USDT",
+        "pside": "long",
+        "order_class": "hsl_panic_close",
+        "reason_code": "missing_canonical_candles",
+        "unavailable_surfaces": ["canonical_candles"],
+        "required_surfaces": ["balance", "market_prices", "canonical_candles"],
+    }
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_order_wave_summary_emits_live_event(caplog):
     import passivbot as pb_mod
 


### PR DESCRIPTION
Observability-only logging slice. Adds structured/monitor-only planning.symbol_state events from the existing PlanningAvailability snapshot summary. Payload is bounded: grouped unavailable counts by reason/order class/surface, truncated unavailable symbols, and a small unavailable-record sample. No planning gates, Rust inputs, orders, or risk behavior changed.\n\nValidation:\n- ./venv/bin/python -m compileall src/live/event_bus.py src/live/event_emitters.py src/passivbot.py tests/test_live_event_bus.py tests/test_passivbot_monitor.py\n- ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py -q\n- ./venv/bin/python -m pytest tests/test_passivbot_balance_split.py -k 'planning_availability or snapshot' -q\n- git diff --check