### PR TITLE
Fix Bybit entry-grid price-limit rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Fixed Bybit live entry-grid creation so buy orders below Bybit's dynamic
+  lower price band are skipped before submission and logged with throttled
+  skipped counts plus planned prices, avoiding repeated `110003` invalid-price
+  rejects.
 - Fixed Bitget UTA / Elite close-order placement by omitting the one-way-only
   `reduceOnly` flag from hedge-mode v3 orders that already send `posSide`.
 - Fixed Bitget UTA / Elite open-order normalization so hedge-mode close orders

--- a/src/exchanges/bybit.py
+++ b/src/exchanges/bybit.py
@@ -3,6 +3,7 @@ from passivbot import logging, clip_by_timestamp
 from uuid import uuid4
 import asyncio
 import ccxt
+import math
 from copy import deepcopy
 from collections import defaultdict
 from utils import symbol_to_coin, ts_to_date, utc_ms
@@ -33,6 +34,130 @@ class BybitBot(CCXTBot):
     def _get_position_side_for_order(self, order: dict) -> str:
         """Bybit: Use determine_pos_side_ccxt helper."""
         return determine_pos_side_ccxt(order)
+
+    async def _filter_exchange_price_limit_creations(
+        self, to_cancel: list[dict], to_create: list[dict]
+    ) -> tuple[list[dict], list[dict], int]:
+        """Skip Bybit entry-grid buy creates below its dynamic lower price band."""
+
+        def num(value):
+            try:
+                value = float(value)
+            except (TypeError, ValueError):
+                return None
+            return value if math.isfinite(value) and value > 0.0 else None
+
+        candidates = [
+            order
+            for order in to_create
+            if not self._is_market_execution_order(order)
+            and str(order.get("side") or "").lower() == "buy"
+            and not (order.get("reduce_only") or order.get("reduceOnly"))
+            and self._resolve_pb_order_type(order).lower().startswith("entry_grid_")
+        ]
+        if not candidates:
+            return to_cancel, to_create, 0
+
+        symbols = set()
+        for order in candidates:
+            symbol = str(order.get("symbol") or "")
+            if not symbol:
+                raise ValueError("missing symbol for Bybit price-limit guard")
+            symbols.add(symbol)
+        last_prices = await self._get_live_last_prices(
+            symbols,
+            max_age_ms=10_000,
+            context="bybit_price_limit_guard",
+            allow_completed_candle_fallback=True,
+        )
+
+        blocked_create_ids = set()
+        blocked_summary = defaultdict(
+            lambda: {"prices": [], "market": 0.0, "min_buy": 0.0, "ratio": 0.0}
+        )
+        for order in candidates:
+            symbol = str(order["symbol"])
+            try:
+                price_limit_ratio_x = self.markets_dict[symbol]["info"][
+                    "riskParameters"
+                ]["priceLimitRatioX"]
+            except KeyError as exc:
+                raise ValueError(
+                    f"{symbol}: missing Bybit priceLimitRatioX for price-limit guard"
+                ) from exc
+            ratio = num(price_limit_ratio_x)
+            if symbol not in last_prices:
+                raise ValueError(
+                    f"{symbol}: missing live price for Bybit price-limit guard"
+                )
+            last_price = num(last_prices[symbol])
+            if "price" not in order:
+                raise ValueError(
+                    f"{symbol}: missing order price for Bybit price-limit guard"
+                )
+            order_price = num(order["price"])
+            if ratio is None or ratio >= 1.0:
+                raise ValueError(
+                    f"{symbol}: invalid Bybit priceLimitRatioX for price-limit guard: "
+                    f"{price_limit_ratio_x!r}"
+                )
+            if last_price is None or order_price is None:
+                raise ValueError(
+                    f"{symbol}: invalid price-limit guard input last={last_price!r} "
+                    f"order={order_price!r}"
+                )
+            min_buy = last_price * ratio
+            if order_price >= min_buy:
+                continue
+
+            blocked_create_ids.add(id(order))
+            coin = symbol_to_coin(symbol, verbose=False) or symbol
+            pb_type = self._resolve_pb_order_type(order)
+            summary_key = (coin, str(order.get("position_side") or ""), pb_type)
+            blocked_summary[summary_key]["prices"].append(order_price)
+            blocked_summary[summary_key]["market"] = last_price
+            blocked_summary[summary_key]["min_buy"] = min_buy
+            blocked_summary[summary_key]["ratio"] = ratio
+            logging.debug(
+                "[order] bybit price-limit guard skipped create | symbol=%s "
+                "qty=%.10g price=%.10g market=%.10g min_buy=%.10g ratio=%.6g",
+                coin,
+                float(order["qty"]),
+                order_price,
+                last_price,
+                min_buy,
+                ratio,
+            )
+
+        if not blocked_create_ids:
+            return to_cancel, to_create, 0
+        if not hasattr(self, "_bybit_price_limit_guard_info_ms"):
+            self._bybit_price_limit_guard_info_ms = {}
+        now_ms = utc_ms()
+        for (coin, pside, pb_type), summary in blocked_summary.items():
+            prices = ",".join(f"{price:.10g}" for price in summary["prices"])
+            log_key = (coin, pside, pb_type, prices)
+            last_info_ms = (
+                int(self._bybit_price_limit_guard_info_ms[log_key])
+                if log_key in self._bybit_price_limit_guard_info_ms
+                else 0
+            )
+            message = (
+                f"[order] bybit price-limit guard skipped creates | symbol={coin} "
+                f"pside={pside} type={pb_type} skipped={len(summary['prices'])} "
+                f"prices={prices} market={summary['market']:.10g} "
+                f"min_buy={summary['min_buy']:.10g} ratio={summary['ratio']:.6g}"
+            )
+            if now_ms - last_info_ms >= 60 * 60 * 1000:
+                self._bybit_price_limit_guard_info_ms[log_key] = now_ms
+                logging.info(message)
+            else:
+                logging.debug(message)
+        return (
+            to_cancel,
+            [order for order in to_create if id(order) not in blocked_create_ids],
+            len(blocked_create_ids),
+        )
 
     # ═══════════════════ BYBIT-SPECIFIC METHODS ═══════════════════
 

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -810,18 +810,27 @@ async def calc_orders_to_cancel_and_create(bot):
     to_create, initial_entry_gate_skipped = (
         await bot._apply_initial_entry_distance_gate(to_create)
     )
+    exchange_price_limit_skipped = 0
+    exchange_price_limit_hook = getattr(
+        bot, "_filter_exchange_price_limit_creations", None
+    )
+    if callable(exchange_price_limit_hook):
+        to_cancel, to_create, exchange_price_limit_skipped = (
+            await exchange_price_limit_hook(to_cancel, to_create)
+        )
     to_cancel = await bot._sort_orders_by_market_diff(to_cancel, "to_cancel")
     to_create = await bot._sort_orders_by_market_diff(to_create, "to_create")
     to_create, freshness_skipped = bot._apply_freshness_creation_guardrails(to_create)
     if plan_summaries:
         total_pre_cancel = sum(p[1] for p in plan_summaries)
-        total_cancel = sum(p[2] for p in plan_summaries)
+        total_cancel = len(to_cancel)
         total_pre_create = sum(p[3] for p in plan_summaries)
         total_create = len(to_create)
         total_skipped = (
             sum(p[5] for p in plan_summaries)
             + freshness_skipped
             + initial_entry_gate_skipped
+            + exchange_price_limit_skipped
         )
         detail_parts = []
         untouched_cancel = total_pre_cancel - total_cancel

--- a/tests/exchanges/test_ccxt_bot_hooks.py
+++ b/tests/exchanges/test_ccxt_bot_hooks.py
@@ -1,5 +1,6 @@
 """Tests for CCXTBot Template Method hooks."""
 
+import logging
 import pytest
 from unittest.mock import MagicMock, AsyncMock
 
@@ -433,6 +434,64 @@ class TestBybitCreateCcxtSessions:
         )
 
         assert signed["headers"]["Referer"] == "passivbotbybit"
+
+    @pytest.mark.asyncio
+    async def test_price_limit_guard_skips_only_too_deep_entry_grid_buys(self, caplog):
+        """Bybit guard should remove invalid creates without touching cancels."""
+        from exchanges.bybit import BybitBot
+
+        symbol = "POPCAT/USDT:USDT"
+        bot = BybitBot.__new__(BybitBot)
+        bot.markets_dict = {
+            symbol: {"info": {"riskParameters": {"priceLimitRatioX": "0.1"}}}
+        }
+        bot._is_market_execution_order = lambda order: str(
+            order.get("type", "limit")
+        ).lower() == "market"
+        bot._resolve_pb_order_type = lambda order: order.get("pb_order_type", "")
+
+        async def fake_last_prices(symbols, **_kwargs):
+            return {symbol: 0.0465 for symbol in symbols}
+
+        bot._get_live_last_prices = fake_last_prices
+        to_cancel = [
+            {
+                "symbol": symbol,
+                "side": "buy",
+                "position_side": "long",
+                "qty": 15363.0,
+                "price": 0.00538,
+                "reduce_only": False,
+            }
+        ]
+        too_deep = {
+            "symbol": symbol,
+            "side": "buy",
+            "position_side": "long",
+            "qty": 17687.0,
+            "price": 0.0033,
+            "reduce_only": False,
+            "type": "limit",
+            "pb_order_type": "entry_grid_normal_long",
+        }
+        allowed = {**too_deep, "price": 0.0047}
+
+        with caplog.at_level(logging.INFO):
+            cancels, creates, skipped = await bot._filter_exchange_price_limit_creations(
+                to_cancel, [too_deep, allowed]
+            )
+            await bot._filter_exchange_price_limit_creations(to_cancel, [too_deep])
+
+        assert cancels == to_cancel
+        assert creates == [allowed]
+        assert skipped == 1
+        messages = [rec.message for rec in caplog.records]
+        info_messages = [msg for msg in messages if "bybit price-limit guard" in msg]
+        assert len(info_messages) == 1
+        log_msg = info_messages[0]
+        assert "skipped=1" in log_msg
+        assert "prices=0.0033" in log_msg
+        assert "min_buy=0.00465" in log_msg
 
 
 class TestBitgetCreateCcxtSessions:


### PR DESCRIPTION
## Summary
- Add a Bybit-specific reconciler hook to skip live entry-grid limit buy creates below Bybit's dynamic lower price band before submission.
- Keep cancels untouched and fail loudly if required Bybit risk or live-price inputs are missing or invalid.
- Log skipped creates with throttled INFO summaries and DEBUG details.

## Tests
- `/home/mani/software/venv_pb7/bin/python -m pytest tests/exchanges/test_ccxt_bot_hooks.py::TestBybitCreateCcxtSessions::test_price_limit_guard_skips_only_too_deep_entry_grid_buys`
- `/home/mani/software/venv_pb7/bin/python -m pytest tests/exchanges/test_ccxt_bot_hooks.py`

## Live verification
- Smoke-tested on `manibot56` with `bybit_CPTV7HR`; POPCAT invalid creates were skipped by the guard and no new `110003` rejects appeared during the checked window.