### PR TITLE
Emit EMA bundle started events

### DIFF
--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -31,6 +31,7 @@ class EventTypes:
     PLANNING_SYMBOL_STATE = "planning.symbol_state"
     FORAGER_SELECTION = "forager.selection"
     FORAGER_FEATURE_UNAVAILABLE = "forager.feature_unavailable"
+    EMA_BUNDLE_STARTED = "ema.bundle.started"
     EMA_BUNDLE_COMPLETED = "ema.bundle.completed"
     EMA_FALLBACK_USED = "ema.fallback_used"
     EMA_UNAVAILABLE = "ema.unavailable"
@@ -82,6 +83,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.PLANNING_SYMBOL_STATE,
     EventTypes.FORAGER_SELECTION,
     EventTypes.FORAGER_FEATURE_UNAVAILABLE,
+    EventTypes.EMA_BUNDLE_STARTED,
     EventTypes.EMA_BUNDLE_COMPLETED,
     EventTypes.EMA_FALLBACK_USED,
     EventTypes.EMA_UNAVAILABLE,
@@ -364,6 +366,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.PLANNING_SYMBOL_STATE: EventRoute(console=False, text=False),
     EventTypes.FORAGER_SELECTION: EventRoute(console=False, text=False),
     EventTypes.FORAGER_FEATURE_UNAVAILABLE: EventRoute(console=False, text=False),
+    EventTypes.EMA_BUNDLE_STARTED: EventRoute(console=False, text=False),
     EventTypes.EMA_BUNDLE_COMPLETED: EventRoute(console=False, text=False),
     EventTypes.EMA_FALLBACK_USED: EventRoute(console=False, text=False),
     EventTypes.EMA_UNAVAILABLE: EventRoute(console=False, text=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -983,6 +983,53 @@ def emit_forager_selection_event(bot: Any, *args: Any, **kwargs: Any) -> None:
         )
 
 
+def _mode_counts(modes: dict[str, dict[str, str]] | None) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for symbol_modes in (modes or {}).values():
+        if not isinstance(symbol_modes, dict):
+            continue
+        for mode in symbol_modes.values():
+            key = str(mode or "")
+            if not key:
+                continue
+            counts[key] = counts.get(key, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _emit_ema_bundle_started_event_unchecked(
+    bot: Any,
+    *,
+    symbols: list[str] | tuple[str, ...],
+    modes: dict[str, dict[str, str]] | None = None,
+) -> None:
+    _safe_emit(
+        bot,
+        EventTypes.EMA_BUNDLE_STARTED,
+        level="debug",
+        component="ema.bundle",
+        tags=("ema", "bundle"),
+        cycle_id=current_live_event_cycle_id(bot),
+        status="started",
+        reason_code="orchestrator_ema_bundle",
+        data={
+            "symbol_count": len(symbols or []),
+            "symbols": _symbol_sample(symbols or ()),
+            "mode_counts": _mode_counts(modes),
+        },
+    )
+
+
+def emit_ema_bundle_started_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    try:
+        _emit_ema_bundle_started_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.EMA_BUNDLE_STARTED,
+            exc,
+        )
+
+
 def _emit_ema_bundle_completed_event_unchecked(
     bot: Any,
     *,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -616,6 +616,7 @@ class Passivbot:
         live_event_emitters.emit_forager_feature_unavailable_event
     )
     _emit_forager_selection_event = live_event_emitters.emit_forager_selection_event
+    _emit_ema_bundle_started_event = live_event_emitters.emit_ema_bundle_started_event
     _emit_ema_bundle_completed_event = live_event_emitters.emit_ema_bundle_completed_event
     _emit_ema_fallback_used_event = live_event_emitters.emit_ema_fallback_used_event
     _emit_ema_unavailable_event = live_event_emitters.emit_ema_unavailable_event
@@ -12811,6 +12812,7 @@ class Passivbot:
         """
         # Gather full EMA context for the live symbol universe.
         # Python should provide the market-state bundle; Rust decides which branches use it.
+        Passivbot._emit_ema_bundle_started_event(self, symbols=symbols, modes=modes)
         need_close_spans: dict[str, set[float]] = {s: set() for s in symbols}
         need_m1_lr_spans: dict[str, set[float]] = {s: set() for s in symbols}
         need_h1_lr_spans: dict[str, set[float]] = {s: set() for s in symbols}

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -136,6 +136,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
     for event_type in (
         EventTypes.FORAGER_SELECTION,
         EventTypes.FORAGER_FEATURE_UNAVAILABLE,
+        EventTypes.EMA_BUNDLE_STARTED,
         EventTypes.EMA_BUNDLE_COMPLETED,
         EventTypes.EMA_FALLBACK_USED,
         EventTypes.EMA_UNAVAILABLE,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -398,6 +398,9 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
 
     class FakeBot:
         _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_ema_bundle_started_event = (
+            pb_mod.Passivbot._emit_ema_bundle_started_event
+        )
         _emit_ema_bundle_completed_event = (
             pb_mod.Passivbot._emit_ema_bundle_completed_event
         )
@@ -444,6 +447,13 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         feature_unavailable_count=2,
         volatility_dropped_count=1,
     )
+    bot._emit_ema_bundle_started_event(
+        symbols=["BTC/USDT:USDT", "ETH/USDT:USDT"],
+        modes={
+            "BTC/USDT:USDT": {"long": "normal", "short": ""},
+            "ETH/USDT:USDT": {"long": "forager", "short": ""},
+        },
+    )
     bot._emit_ema_bundle_completed_event(
         symbols=["BTC/USDT:USDT", "ETH/USDT:USDT"],
         m1_close_emas={"BTC/USDT:USDT": {100.0: 50_000.0}},
@@ -475,6 +485,7 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
     assert [event.event_type for event in events] == [
         EventTypes.FORAGER_FEATURE_UNAVAILABLE,
         EventTypes.FORAGER_SELECTION,
+        EventTypes.EMA_BUNDLE_STARTED,
         EventTypes.EMA_BUNDLE_COMPLETED,
         EventTypes.EMA_FALLBACK_USED,
         EventTypes.EMA_UNAVAILABLE,
@@ -482,11 +493,18 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
     assert {event.cycle_id for event in events} == {"cy_11"}
     assert events[0].data["unavailable"]["count"] == 2
     assert events[1].data["selected_symbols"] == ["BTC/USDT:USDT"]
-    assert events[2].data["cache_only"]["sample"] == ["ETH/USDT:USDT"]
-    assert events[3].level == "warning"
-    assert events[3].data["close_fallback_count"] == 1
-    assert events[4].status == "degraded"
-    assert events[4].data["candidate_unavailable"]["sample"] == ["XRP/USDT:USDT"]
+    assert events[2].status == "started"
+    assert events[2].data["symbol_count"] == 2
+    assert events[2].data["symbols"]["sample"] == [
+        "BTC/USDT:USDT",
+        "ETH/USDT:USDT",
+    ]
+    assert events[2].data["mode_counts"] == {"forager": 1, "normal": 1}
+    assert events[3].data["cache_only"]["sample"] == ["ETH/USDT:USDT"]
+    assert events[4].level == "warning"
+    assert events[4].data["close_fallback_count"] == 1
+    assert events[5].status == "degraded"
+    assert events[5].data["candidate_unavailable"]["sample"] == ["XRP/USDT:USDT"]
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
@@ -519,6 +537,11 @@ def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(ca
             max_age_ms=60_000,
             fetch_budget=1,
         )
+        pb_mod.Passivbot._emit_ema_bundle_started_event(
+            bot,
+            symbols=object(),
+            modes=object(),
+        )
         pb_mod.Passivbot._emit_ema_bundle_completed_event(
             bot,
             symbols=["BTC/USDT:USDT"],
@@ -541,6 +564,7 @@ def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(ca
     messages = [record.message for record in caplog.records]
     assert any(EventTypes.FORAGER_FEATURE_UNAVAILABLE in msg for msg in messages)
     assert any(EventTypes.FORAGER_SELECTION in msg for msg in messages)
+    assert any(EventTypes.EMA_BUNDLE_STARTED in msg for msg in messages)
     assert any(EventTypes.EMA_BUNDLE_COMPLETED in msg for msg in messages)
     assert any(EventTypes.EMA_FALLBACK_USED in msg for msg in messages)
     assert any(EventTypes.EMA_UNAVAILABLE in msg for msg in messages)


### PR DESCRIPTION
Observability-only logging slice from the live event pipeline plan.

Changes:
- Add structured monitor-only ema.bundle.started event.
- Emit it at the start of Passivbot._load_orchestrator_ema_bundle, paired with existing ema.bundle.completed.
- Include bounded symbol sample and mode_counts summary.
- Keep console/text routing disabled and emitter best-effort.

Behavior:
- No EMA readiness, candle fetching, Rust planning, order, risk, or trading behavior changes.

Validation:
- ./venv/bin/python -m compileall src/live/event_bus.py src/live/event_emitters.py src/passivbot.py tests/test_live_event_bus.py tests/test_passivbot_monitor.py
- ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py -q
- ./venv/bin/python -m pytest tests/test_missing_ema_fix.py tests/test_live_candle_budget.py -q
- ./venv/bin/python -m pytest tests/test_unstucking_safeguards.py -q
- git diff --check