### PR TITLE
Emit planned action summaries

### DIFF
--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -41,6 +41,7 @@ class EventTypes:
     REMOTE_CALL_THROTTLED = "remote_call.throttled"
     RUST_ORCHESTRATOR_CALLED = "rust_orchestrator.called"
     RUST_ORCHESTRATOR_RETURNED = "rust_orchestrator.returned"
+    ACTION_PLANNED = "action.planned"
     ORDER_WAVE_STARTED = "order_wave.started"
     ORDER_WAVE_COMPLETED = "order_wave.completed"
     EXECUTION_CREATE_SENT = "execution.create_sent"
@@ -93,6 +94,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.REMOTE_CALL_THROTTLED,
     EventTypes.RUST_ORCHESTRATOR_CALLED,
     EventTypes.RUST_ORCHESTRATOR_RETURNED,
+    EventTypes.ACTION_PLANNED,
     EventTypes.ORDER_WAVE_STARTED,
     EventTypes.ORDER_WAVE_COMPLETED,
     EventTypes.EXECUTION_CREATE_SENT,
@@ -378,6 +380,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.RUST_ORCHESTRATOR_RETURNED: EventRoute(
         console=True, text=True, throttle_interval_ms=60_000
     ),
+    EventTypes.ACTION_PLANNED: EventRoute(console=False, text=False),
     EventTypes.ORDER_WAVE_STARTED: EventRoute(console=False),
     EventTypes.ORDER_WAVE_COMPLETED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CREATE_SENT: EventRoute(console=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1209,6 +1209,106 @@ def _event_fingerprint(value: Any) -> str | None:
     return hashlib.sha256(str(value).encode("utf-8")).hexdigest()
 
 
+def _planned_order_pside(order_type: str) -> str | None:
+    text = str(order_type or "")
+    if text.endswith("_long") or "_long_" in text:
+        return "long"
+    if text.endswith("_short") or "_short_" in text:
+        return "short"
+    return None
+
+
+def _planned_action_summary(
+    orders: Any,
+    idx_to_symbol: dict[int, str] | None,
+    *,
+    limit: int = 16,
+) -> dict[str, Any]:
+    rows = list(orders or []) if isinstance(orders, (list, tuple)) else []
+    symbols_by_idx = idx_to_symbol or {}
+    by_order_type: Counter[str] = Counter()
+    by_pside: Counter[str] = Counter()
+    by_execution_type: Counter[str] = Counter()
+    symbols: set[str] = set()
+    sample: list[dict[str, Any]] = []
+    for index, order in enumerate(rows):
+        if not isinstance(order, dict):
+            by_order_type[type(order).__name__] += 1
+            continue
+        order_type = str(order.get("order_type") or "unknown")
+        execution_type = str(order.get("execution_type") or "limit")
+        pside = _planned_order_pside(order_type)
+        by_order_type[order_type] += 1
+        by_execution_type[execution_type] += 1
+        if pside:
+            by_pside[pside] += 1
+        symbol = None
+        symbol_idx = _safe_int(order.get("symbol_idx"))
+        if symbol_idx is not None:
+            symbol = symbols_by_idx.get(symbol_idx)
+        if symbol:
+            symbols.add(str(symbol))
+        if len(sample) >= max(0, int(limit)):
+            continue
+        item: dict[str, Any] = {
+            "index": int(index),
+            "symbol": str(symbol) if symbol else None,
+            "symbol_idx": symbol_idx,
+            "pside": pside,
+            "order_type": order_type,
+            "execution_type": execution_type,
+        }
+        qty = _safe_float(order.get("qty"))
+        price = _safe_float(order.get("price"))
+        if qty is not None:
+            item["qty"] = qty
+        if price is not None:
+            item["price"] = price
+        sample.append({key: value for key, value in item.items() if value is not None})
+    return {
+        "order_count": len(rows),
+        "by_order_type": dict(sorted(by_order_type.items())),
+        "by_pside": dict(sorted(by_pside.items())),
+        "by_execution_type": dict(sorted(by_execution_type.items())),
+        "symbols": _symbol_sample(symbols),
+        "orders_sample": sample,
+        "orders_sample_count": len(sample),
+        "orders_truncated": len(rows) > len(sample),
+    }
+
+
+def emit_action_planned_event(
+    bot: Any,
+    *,
+    orders: Any,
+    idx_to_symbol: dict[int, str] | None = None,
+    output_hash: str | None = None,
+    remote_call_id: str | None = None,
+) -> None:
+    try:
+        data = _planned_action_summary(orders, idx_to_symbol)
+        if output_hash:
+            data["output_hash"] = str(output_hash)
+        bot._emit_live_event(
+            EventTypes.ACTION_PLANNED,
+            level="debug",
+            component="action_planner",
+            tags=("planning", "action", "rust"),
+            cycle_id=current_live_event_cycle_id(bot),
+            remote_call_id=remote_call_id,
+            status="succeeded",
+            reason_code="rust_output_actions",
+            raw_hash=output_hash,
+            data=data,
+        )
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.ACTION_PLANNED,
+            exc,
+        )
+
+
 def _order_event_data(order: dict | None, *, index: int | None = None) -> dict[str, Any]:
     if not isinstance(order, dict):
         return {"order_type": type(order).__name__}

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -610,6 +610,7 @@ class Passivbot:
         live_event_emitters.emit_execution_confirmation_satisfied_event
     )
     _emit_execution_order_event = live_event_emitters.emit_execution_order_event
+    _emit_action_planned_event = live_event_emitters.emit_action_planned_event
     _emit_balance_changed_event = live_event_emitters.emit_balance_changed_event
     _emit_fill_ingested_event = live_event_emitters.emit_fill_ingested_event
     _emit_forager_feature_unavailable_event = (
@@ -14620,6 +14621,13 @@ class Passivbot:
                     sorted(diagnostics) if isinstance(diagnostics, dict) else []
                 ),
             },
+        )
+        Passivbot._emit_action_planned_event(
+            self,
+            orders=orders,
+            idx_to_symbol=idx_to_symbol,
+            output_hash=output_hash,
+            remote_call_id=rust_call_id,
         )
         self._log_realized_loss_gate_blocks(out, idx_to_symbol)
         if hasattr(self, "_log_min_effective_cost_blocks"):

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -136,6 +136,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
     for event_type in (
         EventTypes.FORAGER_SELECTION,
         EventTypes.FORAGER_FEATURE_UNAVAILABLE,
+        EventTypes.ACTION_PLANNED,
         EventTypes.EMA_BUNDLE_STARTED,
         EventTypes.EMA_BUNDLE_COMPLETED,
         EventTypes.EMA_FALLBACK_USED,
@@ -655,6 +656,7 @@ def test_cycle_events_are_reconstructable_by_cycle_id():
         EventTypes.SNAPSHOT_BUILT,
         EventTypes.RUST_ORCHESTRATOR_CALLED,
         EventTypes.RUST_ORCHESTRATOR_RETURNED,
+        EventTypes.ACTION_PLANNED,
         EventTypes.ORDER_WAVE_COMPLETED,
         EventTypes.CYCLE_COMPLETED,
     ):
@@ -668,6 +670,7 @@ def test_cycle_events_are_reconstructable_by_cycle_id():
         EventTypes.SNAPSHOT_BUILT,
         EventTypes.RUST_ORCHESTRATOR_CALLED,
         EventTypes.RUST_ORCHESTRATOR_RETURNED,
+        EventTypes.ACTION_PLANNED,
         EventTypes.ORDER_WAVE_COMPLETED,
         EventTypes.CYCLE_COMPLETED,
     ]

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -391,6 +391,81 @@ def test_order_wave_summary_emits_live_event(caplog):
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_action_planned_emitter_records_bounded_summary():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_action_planned_event = pb_mod.Passivbot._emit_action_planned_event
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "okx"
+            self.user = "okx_01"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_10"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+    orders = [
+        {
+            "symbol_idx": 0,
+            "qty": 1.5,
+            "price": 100.0,
+            "order_type": "entry_grid_normal_long",
+            "execution_type": "limit",
+        },
+        {
+            "symbol_idx": 1,
+            "qty": -2.0,
+            "price": 101.0,
+            "order_type": "close_grid_short",
+            "execution_type": "market",
+        },
+    ]
+
+    bot._emit_action_planned_event(
+        orders=orders,
+        idx_to_symbol={0: "BTC/USDT:USDT", 1: "ETH/USDT:USDT"},
+        output_hash="out_hash",
+        remote_call_id="rust_1",
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[-1]
+    assert event.event_type == EventTypes.ACTION_PLANNED
+    assert event.cycle_id == "cy_10"
+    assert event.remote_call_id == "rust_1"
+    assert event.status == "succeeded"
+    assert event.reason_code == "rust_output_actions"
+    assert event.raw_hash == "out_hash"
+    assert event.data["order_count"] == 2
+    assert event.data["by_order_type"] == {
+        "close_grid_short": 1,
+        "entry_grid_normal_long": 1,
+    }
+    assert event.data["by_pside"] == {"long": 1, "short": 1}
+    assert event.data["by_execution_type"] == {"limit": 1, "market": 1}
+    assert event.data["symbols"]["sample"] == ["BTC/USDT:USDT", "ETH/USDT:USDT"]
+    assert event.data["orders_truncated"] is False
+    assert event.data["orders_sample"][0] == {
+        "index": 0,
+        "symbol": "BTC/USDT:USDT",
+        "symbol_idx": 0,
+        "pside": "long",
+        "order_type": "entry_grid_normal_long",
+        "execution_type": "limit",
+        "qty": 1.5,
+        "price": 100.0,
+    }
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_forager_and_ema_summary_emitters_emit_structured_events():
     import passivbot as pb_mod
 
@@ -537,6 +612,11 @@ def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(ca
             max_age_ms=60_000,
             fetch_budget=1,
         )
+        pb_mod.Passivbot._emit_action_planned_event(
+            bot,
+            orders=[{"symbol_idx": 0, "order_type": "entry_grid_normal_long"}],
+            idx_to_symbol=object(),
+        )
         pb_mod.Passivbot._emit_ema_bundle_started_event(
             bot,
             symbols=object(),
@@ -564,6 +644,7 @@ def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(ca
     messages = [record.message for record in caplog.records]
     assert any(EventTypes.FORAGER_FEATURE_UNAVAILABLE in msg for msg in messages)
     assert any(EventTypes.FORAGER_SELECTION in msg for msg in messages)
+    assert any(EventTypes.ACTION_PLANNED in msg for msg in messages)
     assert any(EventTypes.EMA_BUNDLE_STARTED in msg for msg in messages)
     assert any(EventTypes.EMA_BUNDLE_COMPLETED in msg for msg in messages)
     assert any(EventTypes.EMA_FALLBACK_USED in msg for msg in messages)


### PR DESCRIPTION
Observability-only logging slice from the live event pipeline plan.

Changes:
- Add structured monitor-only action.planned event.
- Emit one bounded summary after successful Rust orchestrator return, before Python converts ideal orders to executable orders.
- Include counts by order_type/pside/execution_type, bounded symbol sample, bounded planned-order sample, output_hash/raw_hash, cycle_id, and Rust remote_call_id.
- Keep console/text routing disabled and emitter best-effort.

Behavior:
- No Rust planning, EMA/candle, order execution, risk, or trading behavior changes.

Validation:
- ./venv/bin/python -m compileall src/live/event_bus.py src/live/event_emitters.py src/passivbot.py tests/test_live_event_bus.py tests/test_passivbot_monitor.py
- ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py tests/test_missing_ema_fix.py tests/test_live_candle_budget.py -q
- ./venv/bin/python -m pytest tests/test_unstucking_safeguards.py -q
- git diff --check