### PR TITLE
Emit confirmation timeout events

### DIFF
--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -55,6 +55,7 @@ class EventTypes:
     EXECUTION_AMBIGUOUS = "execution.ambiguous"
     EXECUTION_CONFIRMATION_REQUESTED = "execution.confirmation_requested"
     EXECUTION_CONFIRMATION_SATISFIED = "execution.confirmation_satisfied"
+    EXECUTION_CONFIRMATION_TIMEOUT = "execution.confirmation_timeout"
     FILL_INGESTED = "fill.ingested"
     POSITION_CHANGED = "position.changed"
     BALANCE_CHANGED = "balance.changed"
@@ -108,6 +109,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.EXECUTION_AMBIGUOUS,
     EventTypes.EXECUTION_CONFIRMATION_REQUESTED,
     EventTypes.EXECUTION_CONFIRMATION_SATISFIED,
+    EventTypes.EXECUTION_CONFIRMATION_TIMEOUT,
     EventTypes.FILL_INGESTED,
     EventTypes.POSITION_CHANGED,
     EventTypes.BALANCE_CHANGED,
@@ -394,6 +396,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.EXECUTION_AMBIGUOUS: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CONFIRMATION_REQUESTED: EventRoute(console=False),
     EventTypes.EXECUTION_CONFIRMATION_SATISFIED: EventRoute(console=True, text=True),
+    EventTypes.EXECUTION_CONFIRMATION_TIMEOUT: EventRoute(console=True, text=True),
     EventTypes.FILL_INGESTED: EventRoute(console=False, text=False),
     EventTypes.POSITION_CHANGED: EventRoute(console=False, text=False),
     EventTypes.BALANCE_CHANGED: EventRoute(console=False, text=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1501,6 +1501,55 @@ def emit_execution_confirmation_satisfied_event(
         logging.debug("[event] failed to emit confirmation satisfied event: %s", exc)
 
 
+def emit_execution_confirmation_timeout_event(
+    bot: Any,
+    *,
+    wave: dict,
+    confirmations: dict,
+    current_epoch: int,
+    fresh_surfaces: set[str],
+    elapsed_ms: int,
+    confirm_ms: int,
+    timeout_ms: int,
+    level: str = "warning",
+) -> None:
+    try:
+        bot._emit_live_event(
+            EventTypes.EXECUTION_CONFIRMATION_TIMEOUT,
+            level=str(level).lower(),
+            component="execution.confirmation",
+            tags=("execution", "confirmation", "timeout"),
+            cycle_id=bot._current_live_event_cycle_id(),
+            order_wave_id=str(wave.get("event_id") or f"ow_{wave.get('id', '')}"),
+            status="degraded",
+            reason_code="authoritative_confirmation_timeout",
+            data={
+                "id": int(wave.get("id", 0) or 0),
+                "elapsed_ms": int(elapsed_ms),
+                "confirm_ms": int(confirm_ms),
+                "timeout_ms": int(timeout_ms),
+                "current_epoch": int(current_epoch),
+                "confirmations": {
+                    str(surface): int(epoch)
+                    for surface, epoch in dict(confirmations or {}).items()
+                },
+                "fresh_surfaces": sorted(str(surface) for surface in fresh_surfaces),
+                "pending_surfaces": sorted(
+                    str(surface)
+                    for surface, epoch in dict(confirmations or {}).items()
+                    if surface not in fresh_surfaces or current_epoch < int(epoch)
+                ),
+                "planned_cancel": int(wave.get("planned_cancel", 0) or 0),
+                "planned_create": int(wave.get("planned_create", 0) or 0),
+                "cancel_posted": int(wave.get("cancel_posted", 0) or 0),
+                "create_posted": int(wave.get("create_posted", 0) or 0),
+                "symbols": list(wave.get("symbols") or []),
+            },
+        )
+    except Exception as exc:
+        logging.debug("[event] failed to emit confirmation timeout event: %s", exc)
+
+
 def emit_balance_changed_event(
     bot: Any,
     *,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -609,6 +609,9 @@ class Passivbot:
     _emit_execution_confirmation_satisfied_event = (
         live_event_emitters.emit_execution_confirmation_satisfied_event
     )
+    _emit_execution_confirmation_timeout_event = (
+        live_event_emitters.emit_execution_confirmation_timeout_event
+    )
     _emit_execution_order_event = live_event_emitters.emit_execution_order_event
     _emit_action_planned_event = live_event_emitters.emit_action_planned_event
     _emit_balance_changed_event = live_event_emitters.emit_balance_changed_event
@@ -3934,6 +3937,7 @@ class Passivbot:
                 "confirmations": {
                     str(surface): int(epoch) for surface, epoch in confirmations.items()
                 },
+                "timeout_emitted": False,
             }
         )
         self._pending_order_waves = pending[-8:]
@@ -3950,6 +3954,13 @@ class Passivbot:
         if not pending:
             return
         now_ms = int(utc_ms())
+        try:
+            timeout_ms = max(
+                0,
+                int(getattr(self, "_order_wave_confirmation_timeout_ms", 60_000) or 0),
+            )
+        except Exception:
+            timeout_ms = 60_000
         remaining = []
         for wave in pending:
             confirmations = dict(wave.get("confirmations") or {})
@@ -3958,6 +3969,29 @@ class Passivbot:
                 for surface, epoch in confirmations.items()
             )
             if not settled:
+                confirm_ms = max(
+                    0, now_ms - int(wave.get("posted_ms", now_ms) or now_ms)
+                )
+                if timeout_ms and confirm_ms >= timeout_ms and not wave.get(
+                    "timeout_emitted"
+                ):
+                    elapsed_ms = max(
+                        0, now_ms - int(wave.get("started_ms", now_ms) or now_ms)
+                    )
+                    emit_confirmation_timeout = getattr(
+                        self, "_emit_execution_confirmation_timeout_event", None
+                    )
+                    if callable(emit_confirmation_timeout):
+                        emit_confirmation_timeout(
+                            wave=wave,
+                            confirmations=confirmations,
+                            current_epoch=current_epoch,
+                            fresh_surfaces=fresh_surfaces,
+                            elapsed_ms=elapsed_ms,
+                            confirm_ms=confirm_ms,
+                            timeout_ms=timeout_ms,
+                        )
+                    wave["timeout_emitted"] = True
                 remaining.append(wave)
                 continue
             elapsed_ms = max(0, now_ms - int(wave.get("started_ms", now_ms) or now_ms))

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -155,6 +155,8 @@ def test_route_table_keeps_data_events_off_console_by_default():
         assert DEFAULT_ROUTES[event_type].text is False
     assert DEFAULT_ROUTES[EventTypes.ORDER_WAVE_COMPLETED].console is True
     assert DEFAULT_ROUTES[EventTypes.ORDER_WAVE_COMPLETED].text is True
+    assert DEFAULT_ROUTES[EventTypes.EXECUTION_CONFIRMATION_TIMEOUT].console is True
+    assert DEFAULT_ROUTES[EventTypes.EXECUTION_CONFIRMATION_TIMEOUT].text is True
 
 
 def test_redact_payload_recurses_and_payload_hash_is_stable():
@@ -658,6 +660,7 @@ def test_cycle_events_are_reconstructable_by_cycle_id():
         EventTypes.RUST_ORCHESTRATOR_RETURNED,
         EventTypes.ACTION_PLANNED,
         EventTypes.ORDER_WAVE_COMPLETED,
+        EventTypes.EXECUTION_CONFIRMATION_TIMEOUT,
         EventTypes.CYCLE_COMPLETED,
     ):
         pipeline.emit(LiveEvent(event_type, status="succeeded"))
@@ -672,6 +675,7 @@ def test_cycle_events_are_reconstructable_by_cycle_id():
         EventTypes.RUST_ORCHESTRATOR_RETURNED,
         EventTypes.ACTION_PLANNED,
         EventTypes.ORDER_WAVE_COMPLETED,
+        EventTypes.EXECUTION_CONFIRMATION_TIMEOUT,
         EventTypes.CYCLE_COMPLETED,
     ]
     assert {event.cycle_id for event in structured.events} == {"cy_1"}

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1469,6 +1469,90 @@ def test_order_wave_settlement_emits_confirmation_satisfied_event():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_order_wave_settlement_emits_confirmation_timeout_once():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_execution_confirmation_satisfied_event = (
+            pb_mod.Passivbot._emit_execution_confirmation_satisfied_event
+        )
+        _emit_execution_confirmation_timeout_event = (
+            pb_mod.Passivbot._emit_execution_confirmation_timeout_event
+        )
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _log_settled_order_waves = pb_mod.Passivbot._log_settled_order_waves
+
+        def __init__(self):
+            self.exchange = "binance"
+            self.user = "binance_01"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_14"
+            self._order_wave_confirmation_timeout_ms = 1
+            self._pending_order_waves = [
+                {
+                    "id": 4,
+                    "event_id": "ow_4",
+                    "started_ms": 1_000,
+                    "posted_ms": 2_000,
+                    "planned_cancel": 0,
+                    "planned_create": 1,
+                    "cancel_posted": 0,
+                    "create_posted": 1,
+                    "symbols": ["ETH/USDT:USDT"],
+                    "confirmations": {"open_orders": 9},
+                }
+            ]
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+
+    bot._log_settled_order_waves(
+        current_epoch=8,
+        fresh_surfaces=set(),
+        changed_surfaces=[],
+    )
+    bot._log_settled_order_waves(
+        current_epoch=8,
+        fresh_surfaces=set(),
+        changed_surfaces=[],
+    )
+
+    assert len(bot._pending_order_waves) == 1
+    assert bot._pending_order_waves[0]["timeout_emitted"] is True
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    timeout_events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.EXECUTION_CONFIRMATION_TIMEOUT
+    ]
+    assert len(timeout_events) == 1
+    timeout_event = timeout_events[0]
+    assert timeout_event.cycle_id == "cy_14"
+    assert timeout_event.order_wave_id == "ow_4"
+    assert timeout_event.status == "degraded"
+    assert timeout_event.reason_code == "authoritative_confirmation_timeout"
+    assert timeout_event.data["pending_surfaces"] == ["open_orders"]
+    assert timeout_event.data["confirmations"] == {"open_orders": 9}
+
+    bot._log_settled_order_waves(
+        current_epoch=9,
+        fresh_surfaces={"open_orders"},
+        changed_surfaces=["open_orders"],
+    )
+
+    assert bot._pending_order_waves == []
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert sink.events[-1].event_type == EventTypes.EXECUTION_CONFIRMATION_SATISFIED
+    assert sink.events[-1].order_wave_id == "ow_4"
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 @pytest.mark.asyncio
 async def test_start_bot_records_startup_error_stop_and_early_snapshot(monkeypatch):
     import passivbot as pb_mod


### PR DESCRIPTION
Observability-only logging slice.\n\nChanges:\n- Adds event type/route for execution.confirmation_timeout.\n- Emits a one-shot structured timeout event when an order wave's authoritative confirmation remains pending beyond the passive timeout window.\n- Keeps the pending wave tracked after timeout so later execution.confirmation_satisfied can still be emitted.\n- Does not alter authoritative confirmation gating, exchange writes, order construction, or risk behavior.\n\nValidation:\n- ./venv/bin/python -m compileall src/live/event_bus.py src/live/event_emitters.py src/passivbot.py tests/test_live_event_bus.py tests/test_passivbot_monitor.py\n- ./venv/bin/python -m pytest tests/test_live_event_bus.py::test_route_table_keeps_data_events_off_console_by_default tests/test_live_event_bus.py::test_cycle_events_are_reconstructable_by_cycle_id tests/test_passivbot_monitor.py::test_order_wave_settlement_emits_confirmation_satisfied_event tests/test_passivbot_monitor.py::test_order_wave_settlement_emits_confirmation_timeout_once tests/test_passivbot_monitor.py::test_execute_cancellations_parent_emits_ambiguous_confirmation_events -q\n- ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py -q\n- ./venv/bin/python -m pytest tests/test_passivbot_balance_split.py::test_order_wave_settlement_logs_authoritative_confirmation tests/test_passivbot_balance_split.py::test_order_wave_settlement_demotes_quick_open_orders_confirmation -q\n- git diff --check