### PR TITLE
Improve live shutdown progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ All notable user-facing changes will be documented in this file.
 - Added `live.limit_order_create_max_market_dist_pct` with a default of `0.8`
   so live skips limit-order creations far outside fresh market price bands
   instead of repeatedly submitting exchange-invalid deep orders.
-- Added staged live shutdown progress events/logs and made candle fetch-lock waits
-  abort promptly once shutdown is requested.
+- Added staged live shutdown progress events/logs, made candle fetch-lock waits
+  abort promptly once shutdown is requested, and shortened the post-cancel
+  background execution-loop grace from 5s to 1s.
 - Fixed Bitget UTA / Elite close-order placement by omitting the one-way-only
   `reduceOnly` flag from hedge-mode v3 orders that already send `posSide`.
 - Fixed Bitget UTA / Elite open-order normalization so hedge-mode close orders

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable user-facing changes will be documented in this file.
 - Added `live.limit_order_create_max_market_dist_pct` with a default of `0.8`
   so live skips limit-order creations far outside fresh market price bands
   instead of repeatedly submitting exchange-invalid deep orders.
+- Added staged live shutdown progress events/logs and made candle fetch-lock waits
+  abort promptly once shutdown is requested.
 - Fixed Bitget UTA / Elite close-order placement by omitting the one-way-only
   `reduceOnly` flag from hedge-mode v3 orders that already send `posSide`.
 - Fixed Bitget UTA / Elite open-order normalization so hedge-mode close orders

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -1817,6 +1817,7 @@ class CandlestickManager:
 
         while True:
             attempt += 1
+            self._raise_if_shutdown_requested("fetch_lock_wait")
             lock_obj = portalocker.Lock(lock_path, timeout=0, fail_when_locked=True)
             try:
                 await asyncio.to_thread(lock_obj.acquire)
@@ -1882,7 +1883,7 @@ class CandlestickManager:
                     attempt=attempt,
                     error=str(exc),
                 )
-                await asyncio.sleep(backoff)
+                await self._sleep_interruptible(backoff, stage="fetch_lock_wait")
                 backoff = min(backoff * 2.0, self._lock_backoff_max)
 
     @staticmethod

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -20,6 +20,7 @@ class EventTypes:
     BOT_STARTED = "bot.started"
     BOT_READY = "bot.ready"
     BOT_STOPPING = "bot.stopping"
+    BOT_SHUTDOWN_STAGE = "bot.shutdown.stage"
     BOT_STOPPED = "bot.stopped"
     CYCLE_STARTED = "cycle.started"
     CYCLE_COMPLETED = "cycle.completed"
@@ -74,6 +75,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.BOT_STARTED,
     EventTypes.BOT_READY,
     EventTypes.BOT_STOPPING,
+    EventTypes.BOT_SHUTDOWN_STAGE,
     EventTypes.BOT_STOPPED,
     EventTypes.CYCLE_STARTED,
     EventTypes.CYCLE_COMPLETED,
@@ -353,6 +355,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.BOT_STARTED: EventRoute(console=True, text=True),
     EventTypes.BOT_READY: EventRoute(console=True, text=True),
     EventTypes.BOT_STOPPING: EventRoute(console=True, text=True),
+    EventTypes.BOT_SHUTDOWN_STAGE: EventRoute(console=True, text=True),
     EventTypes.BOT_STOPPED: EventRoute(console=True, text=True),
     EventTypes.CYCLE_STARTED: EventRoute(
         console=True, text=True, throttle_interval_ms=60_000
@@ -446,7 +449,11 @@ class ListEventSink:
 
 
 def format_console_event(event: LiveEvent) -> str:
-    base = f"[{event.event_type}]"
+    base = (
+        "[shutdown]"
+        if event.event_type == EventTypes.BOT_SHUTDOWN_STAGE
+        else f"[{event.event_type}]"
+    )
     if event.status:
         base += f" {event.status}"
     if event.cycle_id:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -6122,11 +6122,72 @@ class Passivbot:
         finally:
             self._live_event_pipeline = None
 
+    def _shutdown_elapsed_seconds(self) -> float:
+        started = getattr(self, "_shutdown_started_monotonic", None)
+        if started is None:
+            return 0.0
+        try:
+            return max(0.0, time.monotonic() - float(started))
+        except Exception:
+            return 0.0
+
+    def _emit_shutdown_stage(
+        self,
+        stage: str,
+        *,
+        status: str = "succeeded",
+        level: str = "info",
+        message: str | None = None,
+        data: dict[str, Any] | None = None,
+    ) -> None:
+        elapsed_s = self._shutdown_elapsed_seconds()
+        payload = dict(data or {})
+        payload["stage"] = stage
+        payload["elapsed_s"] = round(elapsed_s, 3)
+        detail_parts = []
+        for key in (
+            "task_count",
+            "timeout_s",
+            "cancel_timeout_s",
+            "threshold_s",
+            "closed",
+        ):
+            if key in payload:
+                detail_parts.append(f"{key}={payload[key]}")
+        detail = f" {' '.join(detail_parts)}" if detail_parts else ""
+        text = f"{message or stage.replace('_', ' ')}{detail} elapsed={elapsed_s:.2f}s"
+        emitted = None
+        try:
+            emitted = self._emit_live_event(
+                EventTypes.BOT_SHUTDOWN_STAGE,
+                level=level,
+                component="shutdown",
+                tags=("bot", "lifecycle", "shutdown"),
+                status=status,
+                reason_code=stage,
+                message=text,
+                data=payload,
+            )
+        except Exception as exc:
+            logging.debug("[shutdown] failed emitting shutdown stage %s: %s", stage, exc)
+        if emitted is None:
+            log_level = logging.INFO
+            if level == "warning":
+                log_level = logging.WARNING
+            elif level == "error":
+                log_level = logging.ERROR
+            elif level == "critical":
+                log_level = logging.CRITICAL
+            elif level == "debug":
+                log_level = logging.DEBUG
+            logging.log(log_level, "[shutdown] %s | status=%s", text, status)
+
     async def shutdown_gracefully(self):
         if getattr(self, "_shutdown_in_progress", False):
             return
         self._shutdown_in_progress = True
         self.stop_signal_received = True
+        self._shutdown_started_monotonic = time.monotonic()
         stop_ts = utc_ms()
         self._emit_live_event(
             EventTypes.BOT_STOPPING,
@@ -6138,8 +6199,10 @@ class Passivbot:
             data={"reason": "shutdown_gracefully"},
         )
         self._monitor_emit_stop("shutdown_gracefully", ts=stop_ts)
-        logging.info(
-            "[shutdown] shutdown requested; closing background tasks and sessions"
+        self._emit_shutdown_stage(
+            "requested",
+            status="started",
+            message="shutdown requested; closing background tasks and sessions",
         )
         maintainer_tasks = []
         try:
@@ -6153,6 +6216,13 @@ class Passivbot:
                         maintainer_tasks.append(task)
         except Exception as e:
             logging.error("[shutdown] error stopping maintainers: %s", e)
+            self._emit_shutdown_stage(
+                "maintainers_stop_failed",
+                status="failed",
+                level="error",
+                message="error stopping maintainer tasks",
+                data={"error": str(e)},
+            )
         if maintainer_tasks:
             try:
                 try:
@@ -6165,14 +6235,38 @@ class Passivbot:
                 maintainer_gather = asyncio.gather(
                     *maintainer_tasks, return_exceptions=True
                 )
+                self._emit_shutdown_stage(
+                    "maintainers_stopping",
+                    status="started",
+                    message="waiting for maintainer tasks to stop",
+                    data={
+                        "task_count": len(maintainer_tasks),
+                        "timeout_s": maintainer_grace,
+                    },
+                )
                 await asyncio.wait_for(
                     asyncio.shield(maintainer_gather),
                     timeout=maintainer_grace,
+                )
+                self._emit_shutdown_stage(
+                    "maintainers_stopped",
+                    message="maintainer tasks stopped",
+                    data={"task_count": len(maintainer_tasks)},
                 )
             except asyncio.TimeoutError:
                 logging.warning(
                     "[shutdown] timed out after %.1fs waiting for maintainers; closing sessions",
                     maintainer_grace,
+                )
+                self._emit_shutdown_stage(
+                    "maintainers_timeout",
+                    status="degraded",
+                    level="warning",
+                    message="maintainer tasks still running; cancelling",
+                    data={
+                        "task_count": len(maintainer_tasks),
+                        "timeout_s": maintainer_grace,
+                    },
                 )
                 for task in maintainer_tasks:
                     if task is not None and not task.done():
@@ -6180,10 +6274,27 @@ class Passivbot:
                 try:
                     await asyncio.wait_for(maintainer_gather, timeout=1.0)
                 except (asyncio.CancelledError, asyncio.TimeoutError):
+                    self._emit_shutdown_stage(
+                        "maintainers_cancel_timeout",
+                        status="degraded",
+                        level="warning",
+                        message="maintainer tasks did not finish after cancellation",
+                        data={
+                            "task_count": len(maintainer_tasks),
+                            "cancel_timeout_s": 1.0,
+                        },
+                    )
                     pass
             except Exception as e:
                 logging.error(
                     "[shutdown] error awaiting maintainer cancellation: %s", e
+                )
+                self._emit_shutdown_stage(
+                    "maintainers_await_failed",
+                    status="failed",
+                    level="error",
+                    message="error awaiting maintainer tasks",
+                    data={"task_count": len(maintainer_tasks), "error": str(e)},
                 )
         execution_loop_stopped = getattr(self, "_execution_loop_stopped", None)
         execution_loop_task = getattr(self, "_execution_loop_task", None)
@@ -6196,6 +6307,12 @@ class Passivbot:
                 grace_seconds = 5.0
             grace_seconds = max(0.0, grace_seconds)
             try:
+                self._emit_shutdown_stage(
+                    "execution_loop_waiting",
+                    status="started",
+                    message="waiting for execution loop to stop",
+                    data={"timeout_s": grace_seconds},
+                )
                 if execution_loop_stopped is not None:
                     await asyncio.wait_for(
                         execution_loop_stopped.wait(), timeout=grace_seconds
@@ -6204,28 +6321,79 @@ class Passivbot:
                     await asyncio.wait_for(
                         asyncio.shield(execution_loop_task), timeout=grace_seconds
                     )
+                self._emit_shutdown_stage(
+                    "execution_loop_stopped",
+                    message="execution loop stopped",
+                )
             except asyncio.TimeoutError:
                 logging.debug(
                     "[shutdown] execution loop still active after %.1fs",
                     grace_seconds,
                 )
-                if not bool(getattr(self, "_execution_loop_task_is_inline", False)):
+                inline_execution_loop = bool(
+                    getattr(self, "_execution_loop_task_is_inline", False)
+                )
+                self._emit_shutdown_stage(
+                    "execution_loop_timeout",
+                    status="degraded",
+                    level="warning",
+                    message=(
+                        "execution loop still active; continuing without cancellation"
+                        if inline_execution_loop
+                        else "execution loop still active; cancelling background task"
+                    ),
+                    data={"timeout_s": grace_seconds, "inline": inline_execution_loop},
+                )
+                if not inline_execution_loop:
                     logging.debug(
                         "[shutdown] cancelling background execution loop task"
                     )
                     execution_loop_task.cancel()
                     try:
-                        await asyncio.wait_for(execution_loop_task, timeout=5.0)
+                        try:
+                            cancel_grace = float(
+                                getattr(
+                                    self,
+                                    "_shutdown_execution_cancel_grace_seconds",
+                                    1.0,
+                                )
+                            )
+                        except Exception:
+                            cancel_grace = 1.0
+                        cancel_grace = max(0.0, cancel_grace)
+                        await asyncio.wait_for(
+                            execution_loop_task, timeout=cancel_grace
+                        )
                     except asyncio.CancelledError:
                         pass
                     except asyncio.TimeoutError:
                         logging.debug(
                             "[shutdown] timed out waiting for cancelled execution loop before closing sessions"
                         )
+                        self._emit_shutdown_stage(
+                            "execution_loop_cancel_timeout",
+                            status="degraded",
+                            level="warning",
+                            message="execution loop did not finish after cancellation",
+                            data={"cancel_timeout_s": cancel_grace},
+                        )
             except asyncio.CancelledError:
                 logging.debug("[shutdown] execution loop cancelled during shutdown")
+                self._emit_shutdown_stage(
+                    "execution_loop_cancelled",
+                    status="degraded",
+                    level="warning",
+                    message="execution loop cancelled during shutdown",
+                )
             except Exception as e:
                 logging.debug("[shutdown] error waiting for execution loop: %s", e)
+                self._emit_shutdown_stage(
+                    "execution_loop_wait_failed",
+                    status="failed",
+                    level="error",
+                    message="error waiting for execution loop",
+                    data={"error": str(e)},
+                )
             finally:
                 try:
                     execution_loop_stopped.set()
@@ -6236,15 +6404,55 @@ class Passivbot:
             if getattr(self, "ccp", None) is not None:
                 await self.ccp.close()
                 self.ccp = None
+                self._emit_shutdown_stage(
+                    "private_session_closed",
+                    message="private ccxt session closed",
+                )
         except Exception as e:
             logging.error("[shutdown] error closing private ccxt session: %s", e)
+            self._emit_shutdown_stage(
+                "private_session_close_failed",
+                status="failed",
+                level="error",
+                message="error closing private ccxt session",
+                data={"error": str(e)},
+            )
         try:
             if getattr(self, "cca", None) is not None:
                 await self.cca.close()
                 self.cca = None
+                self._emit_shutdown_stage(
+                    "public_session_closed",
+                    message="public ccxt session closed",
+                )
         except Exception as e:
             logging.error("[shutdown] error closing public ccxt session: %s", e)
+            self._emit_shutdown_stage(
+                "public_session_close_failed",
+                status="failed",
+                level="error",
+                message="error closing public ccxt session",
+                data={"error": str(e)},
+            )
         await self._monitor_flush_snapshot(force=True, ts=utc_ms())
+        self._emit_shutdown_stage(
+            "monitor_snapshot_flushed",
+            message="monitor snapshot flushed",
+        )
+        try:
+            degraded_after = float(
+                getattr(self, "_shutdown_degraded_after_seconds", 15.0)
+            )
+        except Exception:
+            degraded_after = 15.0
+        if degraded_after >= 0.0 and self._shutdown_elapsed_seconds() >= degraded_after:
+            self._emit_shutdown_stage(
+                "shutdown_slow",
+                status="degraded",
+                level="warning",
+                message="shutdown exceeded degraded threshold",
+                data={"threshold_s": degraded_after},
+            )
         if not getattr(self, "_live_event_bot_stopped_emitted", False):
             self._emit_live_event(
                 EventTypes.BOT_STOPPED,
@@ -6256,10 +6464,29 @@ class Passivbot:
                 data={"reason": "shutdown_gracefully"},
             )
             self._live_event_bot_stopped_emitted = True
-        self._close_live_event_pipeline(timeout=2.0)
+        self._emit_shutdown_stage(
+            "event_pipeline_closing",
+            status="started",
+            message="closing live event pipeline",
+            data={"timeout_s": 2.0},
+        )
+        pipeline_closed = self._close_live_event_pipeline(timeout=2.0)
+        if not pipeline_closed:
+            logging.warning(
+                "[shutdown] live event pipeline did not close cleanly | elapsed=%.2fs",
+                self._shutdown_elapsed_seconds(),
+            )
         publisher = getattr(self, "monitor_publisher", None)
         if publisher is not None:
             publisher.close()
+            logging.info(
+                "[shutdown] monitor publisher closed | elapsed=%.2fs",
+                self._shutdown_elapsed_seconds(),
+            )
+        logging.info(
+            "[shutdown] shutdown complete | elapsed=%.2fs",
+            self._shutdown_elapsed_seconds(),
+        )
 
     async def update_pos_oos_pnls_ohlcvs(self) -> bool:
         """Refresh positions, open orders, realised PnL, and 1m candles."""

--- a/tests/test_candlestick_manager_locking.py
+++ b/tests/test_candlestick_manager_locking.py
@@ -126,3 +126,37 @@ async def test_fetch_lock_watchdog_logs_stale_local_holder_without_release(tmp_p
     assert any(
         "fetch_lock_hold_timeout" in record.message for record in caplog.records
     )
+
+
+@pytest.mark.asyncio
+async def test_fetch_lock_wait_aborts_when_shutdown_requested(tmp_path):
+    cache_dir = tmp_path / "caches"
+    key = ("BTC/USDC:USDC", "1m")
+    holder = CandlestickManager(
+        exchange=FakeExchange(),
+        exchange_name="hyperliquid",
+        cache_dir=str(cache_dir),
+        default_window_candles=5,
+    )
+    checks = 0
+
+    def stop_requested():
+        nonlocal checks
+        checks += 1
+        return checks >= 2
+
+    waiter = CandlestickManager(
+        exchange=FakeExchange(),
+        exchange_name="hyperliquid",
+        cache_dir=str(cache_dir),
+        default_window_candles=5,
+        stop_requested_callback=stop_requested,
+    )
+
+    async with holder._acquire_fetch_lock(*key):
+        with pytest.raises(asyncio.CancelledError):
+            async with waiter._acquire_fetch_lock(*key):
+                pass
+
+    assert checks >= 2
+    assert waiter._held_fetch_locks == {}

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -157,6 +157,8 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.ORDER_WAVE_COMPLETED].text is True
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CONFIRMATION_TIMEOUT].console is True
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CONFIRMATION_TIMEOUT].text is True
+    assert DEFAULT_ROUTES[EventTypes.BOT_SHUTDOWN_STAGE].console is True
+    assert DEFAULT_ROUTES[EventTypes.BOT_SHUTDOWN_STAGE].text is True
 
 
 def test_redact_payload_recurses_and_payload_hash_is_stable():
@@ -558,6 +560,21 @@ def test_console_format_is_compact_and_operator_facing():
         "pside=long reason=stale_ema entries deferred"
     )
     assert format_console_event(event) == expected
+
+
+def test_shutdown_stage_console_format_uses_shutdown_tag():
+    event = LiveEvent(
+        EventTypes.BOT_SHUTDOWN_STAGE,
+        status="started",
+        reason_code="maintainers_stopping",
+        message="waiting for maintainer tasks task_count=2 elapsed=0.01s",
+    )
+
+    assert (
+        format_console_event(event)
+        == "[shutdown] started reason=maintainers_stopping waiting for maintainer "
+        "tasks task_count=2 elapsed=0.01s"
+    )
 
 
 def test_route_throttle_applies_only_to_console_and_text_sinks():

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -660,6 +660,87 @@ async def test_shutdown_gracefully_awaits_cancelled_maintainers():
 
 
 @pytest.mark.asyncio
+async def test_shutdown_gracefully_emits_stage_events():
+    bot = Passivbot.__new__(Passivbot)
+    bot._shutdown_in_progress = False
+    bot.stop_signal_received = False
+    events = []
+
+    def emit_event(event_type, *args, **kwargs):
+        events.append((event_type, kwargs))
+        return object()
+
+    bot._emit_live_event = emit_event
+    bot._monitor_emit_stop = lambda *args, **kwargs: None
+    bot._monitor_flush_snapshot = AsyncMock()
+    bot.monitor_publisher = None
+    bot.maintainers = {}
+    bot.WS_ohlcvs_1m_tasks = {}
+    bot._execution_loop_task = None
+    bot._execution_loop_stopped = None
+    bot.ccp = None
+    bot.cca = None
+    bot._live_event_pipeline = None
+
+    await bot.shutdown_gracefully()
+
+    stages = [
+        kwargs["reason_code"]
+        for event_type, kwargs in events
+        if event_type == EventTypes.BOT_SHUTDOWN_STAGE
+    ]
+    assert stages == [
+        "requested",
+        "monitor_snapshot_flushed",
+        "event_pipeline_closing",
+    ]
+    assert events[0][0] == EventTypes.BOT_STOPPING
+    assert any(event_type == EventTypes.BOT_STOPPED for event_type, _ in events)
+    assert all(
+        "elapsed_s" in kwargs["data"]
+        for event_type, kwargs in events
+        if event_type == EventTypes.BOT_SHUTDOWN_STAGE
+    )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_gracefully_emits_slow_stage_after_threshold():
+    bot = Passivbot.__new__(Passivbot)
+    bot._shutdown_in_progress = False
+    bot.stop_signal_received = False
+    bot._shutdown_degraded_after_seconds = 0.0
+    events = []
+
+    def emit_event(event_type, *args, **kwargs):
+        events.append((event_type, kwargs))
+        return object()
+
+    bot._emit_live_event = emit_event
+    bot._monitor_emit_stop = lambda *args, **kwargs: None
+    bot._monitor_flush_snapshot = AsyncMock()
+    bot.monitor_publisher = None
+    bot.maintainers = {}
+    bot.WS_ohlcvs_1m_tasks = {}
+    bot._execution_loop_task = None
+    bot._execution_loop_stopped = None
+    bot.ccp = None
+    bot.cca = None
+    bot._live_event_pipeline = None
+
+    await bot.shutdown_gracefully()
+
+    slow_events = [
+        kwargs
+        for event_type, kwargs in events
+        if event_type == EventTypes.BOT_SHUTDOWN_STAGE
+        and kwargs["reason_code"] == "shutdown_slow"
+    ]
+    assert len(slow_events) == 1
+    assert slow_events[0]["status"] == "degraded"
+    assert slow_events[0]["data"]["threshold_s"] == 0.0
+
+
+@pytest.mark.asyncio
 async def test_shutdown_gracefully_times_out_stuck_maintainer_before_closing_sessions(
     caplog,
 ):

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -879,6 +879,65 @@ async def test_shutdown_gracefully_cancels_stuck_execution_loop_before_closing_s
 
 
 @pytest.mark.asyncio
+async def test_shutdown_gracefully_bounds_execution_loop_cancel_grace_before_closing_sessions():
+    bot = Passivbot.__new__(Passivbot)
+    bot._shutdown_in_progress = False
+    bot.stop_signal_received = False
+    bot._shutdown_execution_grace_seconds = 0.0
+    bot._shutdown_execution_cancel_grace_seconds = 0.01
+    bot._monitor_emit_stop = lambda *args, **kwargs: None
+    bot._monitor_flush_snapshot = AsyncMock()
+    bot.monitor_publisher = None
+
+    seen = []
+    events = []
+    execution_loop_stopped = asyncio.Event()
+
+    def emit_event(event_type, *args, **kwargs):
+        events.append((event_type, kwargs))
+        return object()
+
+    async def _stubborn_execution_loop():
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            seen.append("execution_loop_cancelled")
+            await asyncio.sleep(3600)
+
+    class _Closer:
+        def __init__(self, key):
+            self.key = key
+
+        async def close(self):
+            seen.append(self.key)
+
+    execution_task = asyncio.create_task(_stubborn_execution_loop())
+    bot._emit_live_event = emit_event
+    bot._execution_loop_task = execution_task
+    bot._execution_loop_task_is_inline = False
+    bot._execution_loop_stopped = execution_loop_stopped
+    bot.maintainers = {}
+    bot.WS_ohlcvs_1m_tasks = {}
+    bot.ccp = _Closer("ccp_closed")
+    bot.cca = _Closer("cca_closed")
+
+    await bot.shutdown_gracefully()
+
+    timeout_events = [
+        kwargs
+        for event_type, kwargs in events
+        if event_type == EventTypes.BOT_SHUTDOWN_STAGE
+        and kwargs["reason_code"] == "execution_loop_cancel_timeout"
+    ]
+    assert len(timeout_events) == 1
+    assert timeout_events[0]["status"] == "degraded"
+    assert timeout_events[0]["data"]["cancel_timeout_s"] == 0.01
+    assert execution_loop_stopped.is_set() is True
+    assert seen[-2:] == ["ccp_closed", "cca_closed"]
+    assert execution_task.done() is True
+
+
+@pytest.mark.asyncio
 async def test_shutdown_gracefully_does_not_cancel_inline_execution_task_on_timeout():
     bot = Passivbot.__new__(Passivbot)
     bot._shutdown_in_progress = False

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1880,11 +1880,12 @@ async def test_shutdown_gracefully_closes_event_pipeline_before_monitor_publishe
     await bot.shutdown_gracefully()
 
     assert order[-4:] == [
-        ("snapshot", True),
         ("event", EventTypes.BOT_STOPPED),
+        ("event", EventTypes.BOT_SHUTDOWN_STAGE),
         ("pipeline", 2.0),
         ("publisher", None),
     ]
+    assert ("snapshot", True) in order
     assert bot._live_event_pipeline is None
 
 


### PR DESCRIPTION
Summary:
- add a routed bot.shutdown.stage live event rendered as [shutdown] for operator-facing shutdown progress
- emit shutdown stage events/logs around maintainer, execution-loop, session, monitor, and event-pipeline shutdown phases
- make candle fetch-lock waits honor shutdown via the existing interruptible sleep path

Tests:
- ./venv/bin/python -m py_compile src/live/event_bus.py src/passivbot.py src/candlestick_manager.py tests/test_live_event_bus.py tests/test_passivbot_balance_split.py tests/test_passivbot_monitor.py tests/test_candlestick_manager_locking.py
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_candlestick_manager_locking.py -q
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_passivbot_balance_split.py -k shutdown_gracefully -q
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_passivbot_monitor.py -k shutdown_gracefully -q