### PR TITLE
Add live limit order distance guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `live.limit_order_create_max_market_dist_pct` with a default of `0.8`
+  so live skips limit-order creations far outside fresh market price bands
+  instead of repeatedly submitting exchange-invalid deep orders.
 - Fixed Bitget UTA / Elite close-order placement by omitting the one-way-only
   `reduceOnly` flag from hedge-mode v3 orders that already send `posSide`.
 - Fixed Bitget UTA / Elite open-order normalization so hedge-mode close orders

--- a/configs/examples/default_trailing_grid_long_npos7.json
+++ b/configs/examples/default_trailing_grid_long_npos7.json
@@ -396,6 +396,7 @@
         "minimum_coin_age_days": 365,
         "forager_score_hysteresis_pct": 0.02,
         "initial_entry_exec_max_market_dist_pct": 0.005,
+        "limit_order_create_max_market_dist_pct": 0.8,
         "order_match_tolerance_pct": 0.0002,
         "pnls_max_lookback_days": 30,
         "recv_window_ms": 10000,

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -384,6 +384,7 @@ def get_template_config():
                 "minimum_coin_age_days": 365,
                 "forager_score_hysteresis_pct": 0.02,
                 "initial_entry_exec_max_market_dist_pct": 0.005,
+                "limit_order_create_max_market_dist_pct": 0.8,
                 "order_match_tolerance_pct": 0.0002,
                 "pnls_max_lookback_days": 30,
                 "recv_window_ms": 10000,

--- a/src/config/validate.py
+++ b/src/config/validate.py
@@ -42,6 +42,23 @@ def validate_config(
             "config.live.forager_score_hysteresis_pct must be finite and >= 0.0"
         )
     try:
+        limit_order_market_dist = float(
+            config["live"]["limit_order_create_max_market_dist_pct"]
+        )
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            "config.live.limit_order_create_max_market_dist_pct must be numeric"
+        ) from exc
+    if (
+        not math.isfinite(limit_order_market_dist)
+        or limit_order_market_dist < 0.0
+        or limit_order_market_dist >= 1.0
+    ):
+        raise ValueError(
+            "config.live.limit_order_create_max_market_dist_pct must be "
+            "finite and >= 0.0 and < 1.0"
+        )
+    try:
         active_tail_gap_minutes = float(
             config["live"]["max_active_candle_tail_gap_minutes"]
         )

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -187,6 +187,11 @@ FIELD_RUNTIME_RULES = {
         "consumed_by": {"live"},
         "cli_exposed_on": {"live"},
     },
+    "live.limit_order_create_max_market_dist_pct": {
+        "owner": "live",
+        "consumed_by": {"live"},
+        "cli_exposed_on": {"live"},
+    },
     "live.hedge_mode": {
         "owner": "live",
         "consumed_by": {"live", "backtest", "optimize"},
@@ -883,6 +888,22 @@ RESERVED_CLI_ARGS = {
         "group": {"live": "Behavior"},
         "help": "Executor-side distance gate for initial entry creations. Set to 0 to disable. Far initial entries are logged but not posted until they are near market.",
     },
+    "live.limit_order_create_max_market_dist_pct": {
+        "visible": ["--limit-order-create-max-market-dist-pct"],
+        "hidden": [
+            "--live.limit_order_create_max_market_dist_pct",
+            "--live_limit_order_create_max_market_dist_pct",
+        ],
+        "type": float,
+        "metavar": "FLOAT",
+        "commands": {"live"},
+        "group": {"live": "Behavior"},
+        "help": (
+            "Live pre-create guard for limit orders. Set to 0 to disable. "
+            "With the default 0.8, buys below market*0.2 and sells above "
+            "market*1.8 are skipped until price action moves closer."
+        ),
+    },
     "live.filter_by_min_effective_cost": {
         "visible": ["--filter-by-min-effective-cost", "-fbmec"],
         "hidden": [
@@ -1303,6 +1324,7 @@ def _classify_live_argument(full_name: str, help_all: bool) -> Optional[str]:
         "live.market_orders_allowed",
         "live.max_realized_loss_pct",
         "live.initial_entry_exec_max_market_dist_pct",
+        "live.limit_order_create_max_market_dist_pct",
         "live.order_match_tolerance_pct",
     }
     runtime = {

--- a/src/live/market_data.py
+++ b/src/live/market_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import sys
 from collections import Counter
 from typing import Iterable
@@ -17,6 +18,13 @@ def _utc_ms() -> int:
     if callable(time_fn):
         return int(time_fn())
     return int(utc_ms())
+
+
+def _passivbot_module():
+    module = sys.modules.get("passivbot")
+    if module is None:
+        import passivbot as module  # type: ignore
+    return module
 
 
 def market_snapshot_ticker_strategy(bot) -> str:
@@ -101,7 +109,136 @@ async def filter_fresh_market_snapshot_creations(
             bot._log_compact_symbol_payload(invalid[:8]),
         )
         return []
+    orders = _filter_limit_order_creations_by_market_distance(bot, orders, snapshots)
     return orders
+
+
+def _limit_order_create_max_market_dist_pct(bot) -> float:
+    raw = get_optional_live_value(
+        bot.config, "limit_order_create_max_market_dist_pct", 0.8
+    )
+    try:
+        threshold = float(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "live.limit_order_create_max_market_dist_pct must be numeric"
+        ) from exc
+    if not math.isfinite(threshold) or threshold < 0.0 or threshold >= 1.0:
+        raise ValueError(
+            "live.limit_order_create_max_market_dist_pct must be finite and "
+            ">= 0.0 and < 1.0"
+        )
+    return threshold
+
+
+def _filter_limit_order_creations_by_market_distance(
+    bot, orders: list[dict], snapshots: dict[str, MarketSnapshot]
+) -> list[dict]:
+    threshold = _limit_order_create_max_market_dist_pct(bot)
+    if threshold <= 0.0:
+        return orders
+    order_market_diff = getattr(_passivbot_module(), "order_market_diff")
+    kept: list[dict] = []
+    skipped: list[dict] = []
+    skipped_symbols: set[str] = set()
+    min_mult = 1.0 - threshold
+    max_mult = 1.0 + threshold
+    for order in orders:
+        if str(order.get("type", "limit")).lower() == "market":
+            kept.append(order)
+            continue
+        symbol = str(order.get("symbol") or "")
+        snapshot = snapshots.get(symbol)
+        if snapshot is None or not snapshot.is_valid():
+            kept.append(order)
+            continue
+        side = str(order.get("side") or "").lower()
+        price = float(order["price"])
+        market_price = float(snapshot.last)
+        dist = float(order_market_diff(side, price, market_price))
+        if dist > threshold:
+            skipped.append(
+                {
+                    "order": order,
+                    "market_price": market_price,
+                    "dist": dist,
+                }
+            )
+            skipped_symbols.add(symbol)
+            continue
+        kept.append(order)
+    if skipped:
+        _log_limit_order_distance_skips(
+            bot,
+            skipped,
+            skipped_symbols=skipped_symbols,
+            threshold=threshold,
+            min_mult=min_mult,
+            max_mult=max_mult,
+        )
+    return kept
+
+
+def _log_limit_order_distance_skips(
+    bot,
+    skipped: list[dict],
+    *,
+    skipped_symbols: set[str],
+    threshold: float,
+    min_mult: float,
+    max_mult: float,
+) -> None:
+    grouped: Counter[tuple[str, str, str, str]] = Counter()
+    for item in skipped:
+        order = item["order"]
+        grouped[
+            (
+                str(order.get("symbol") or ""),
+                str(order.get("position_side") or ""),
+                str(order.get("side") or ""),
+                str(order.get("pb_order_type") or ""),
+            )
+        ] += 1
+    if not hasattr(bot, "_limit_order_distance_guard_log_state"):
+        bot._limit_order_distance_guard_log_state = {}
+    now_ms = _utc_ms()
+    should_info = False
+    for key in grouped:
+        last_info_ms = int(
+            bot._limit_order_distance_guard_log_state.get(key, 0) or 0
+        )
+        if now_ms - last_info_ms >= 60 * 60 * 1000:
+            should_info = True
+            bot._limit_order_distance_guard_log_state[key] = now_ms
+    samples: list[str] = []
+    for item in skipped[:8]:
+        order = item["order"]
+        samples.append(
+            (
+                f"{bot._log_symbol(order.get('symbol'))}:{order.get('side')}:"
+                f"{float(order.get('price')):.10g}/market={item['market_price']:.10g}"
+            )
+        )
+    summary = ", ".join(
+        (
+            f"{bot._log_symbol(symbol)} {side} {pside} {pb_type or 'unknown'}={count}"
+        )
+        for (symbol, pside, side, pb_type), count in grouped.items()
+    )
+    log_fn = logging.info if should_info else logging.debug
+    log_fn(
+        "[order] skipped far-from-market limit order creates | "
+        "skipped=%d symbols=%s threshold=%.4f min_multiplier=%.4f "
+        "max_multiplier=%.4f groups=%s samples=%s "
+        "reason=limit_order_create_market_distance",
+        len(skipped),
+        bot._log_symbols(sorted(skipped_symbols), limit=12),
+        threshold,
+        min_mult,
+        max_mult,
+        summary,
+        samples,
+    )
 
 
 async def get_live_market_snapshots(

--- a/tests/test_config_utils_helpers.py
+++ b/tests/test_config_utils_helpers.py
@@ -64,6 +64,23 @@ def test_validate_config_rejects_fractional_fee_conversion_max_age_ms():
             validate_config(config, verbose=False)
 
 
+def test_limit_order_create_market_distance_default_and_validation():
+    config = get_template_config()
+
+    assert config["live"]["limit_order_create_max_market_dist_pct"] == pytest.approx(0.8)
+    validate_config(config, verbose=False)
+
+    for value in (-0.01, 1.0, float("inf"), "invalid"):
+        invalid = get_template_config()
+        invalid["live"]["limit_order_create_max_market_dist_pct"] = value
+
+        with pytest.raises(
+            (TypeError, ValueError),
+            match="limit_order_create_max_market_dist_pct",
+        ):
+            validate_config(invalid, verbose=False)
+
+
 def test_prepare_config_strips_deprecated_price_distance_threshold():
     source = get_template_config()
     source["live"]["price_distance_threshold"] = 0.002

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -3912,6 +3912,170 @@ async def test_pre_create_snapshot_filter_refreshes_stale_planning_market_snapsh
     assert await bot._filter_fresh_market_snapshot_creations(orders) == orders
 
 
+def _make_pre_create_distance_guard_bot(
+    symbol: str,
+    *,
+    threshold: float = 0.8,
+    market_price: float = 100.0,
+):
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {"limit_order_create_max_market_dist_pct": threshold}}
+    bot.exchange = "bybit"
+    bot.freshness_ledger = FreshnessLedger(now_ms=0)
+    bot._authoritative_refresh_epoch = 1
+    now_ms = passivbot_module.utc_ms()
+    bot._current_planning_snapshot = PlanningSnapshot(
+        ts_ms=now_ms,
+        exchange="bybit",
+        user="tester",
+        epoch=1,
+        symbols=(symbol,),
+        required_surfaces=tuple(),
+        surfaces=tuple(),
+        market_snapshots=(
+            PlanningMarketSnapshot(
+                symbol=symbol,
+                bid=market_price,
+                ask=market_price,
+                last=market_price,
+                fetched_ms=now_ms,
+                source="test",
+            ),
+        ),
+        market_snapshot_max_age_ms=10_000,
+        completed_candle_signature=tuple(),
+    )
+
+    async def fake_get_snapshots(symbols, max_age_ms=None):
+        return {
+            s: MarketSnapshot(
+                symbol=s,
+                bid=market_price,
+                ask=market_price,
+                last=market_price,
+                fetched_ms=passivbot_module.utc_ms(),
+                source="test",
+            )
+            for s in symbols
+        }
+
+    bot.market_snapshot_provider = SimpleNamespace(get_snapshots=fake_get_snapshots)
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_pre_create_snapshot_filter_skips_far_limit_order_creations(
+    monkeypatch, caplog
+):
+    def fake_order_market_diff(side, price, market_price):
+        side = str(side).lower()
+        if side == "buy":
+            return 1.0 - float(price) / float(market_price)
+        if side == "sell":
+            return float(price) / float(market_price) - 1.0
+        raise ValueError("invalid side")
+
+    monkeypatch.setattr(passivbot_module, "order_market_diff", fake_order_market_diff)
+
+    symbol = "POPCAT/USDT:USDT"
+    bot = _make_pre_create_distance_guard_bot(symbol)
+    kept_buy = {
+        "symbol": symbol,
+        "side": "buy",
+        "position_side": "long",
+        "qty": 1.0,
+        "price": 20.0,
+        "pb_order_type": "entry_grid_normal_long",
+    }
+    skipped_buy = {
+        "symbol": symbol,
+        "side": "buy",
+        "position_side": "long",
+        "qty": 1.0,
+        "price": 19.99,
+        "pb_order_type": "entry_grid_cropped_long",
+    }
+    kept_sell = {
+        "symbol": symbol,
+        "side": "sell",
+        "position_side": "short",
+        "qty": 1.0,
+        "price": 180.0,
+        "pb_order_type": "entry_grid_normal_short",
+    }
+    skipped_sell = {
+        "symbol": symbol,
+        "side": "sell",
+        "position_side": "short",
+        "qty": 1.0,
+        "price": 180.01,
+        "pb_order_type": "entry_grid_cropped_short",
+    }
+    skipped_close = {
+        "symbol": symbol,
+        "side": "sell",
+        "position_side": "long",
+        "qty": 1.0,
+        "price": 180.02,
+        "reduce_only": True,
+        "pb_order_type": "close_grid_long",
+    }
+    market_order = {
+        "symbol": symbol,
+        "side": "buy",
+        "position_side": "long",
+        "qty": 1.0,
+        "price": 1.0,
+        "type": "market",
+        "pb_order_type": "close_panic_long",
+    }
+
+    with caplog.at_level(logging.INFO):
+        filtered = await bot._filter_fresh_market_snapshot_creations(
+            [
+                kept_buy,
+                skipped_buy,
+                kept_sell,
+                skipped_sell,
+                skipped_close,
+                market_order,
+            ]
+        )
+
+    assert filtered == [kept_buy, kept_sell, market_order]
+    assert any(
+        "reason=limit_order_create_market_distance" in rec.message
+        and "skipped=3" in rec.message
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_pre_create_snapshot_filter_disables_limit_order_distance_guard(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        passivbot_module,
+        "order_market_diff",
+        lambda side, price, market_price: 999.0,
+    )
+
+    symbol = "POPCAT/USDT:USDT"
+    bot = _make_pre_create_distance_guard_bot(symbol, threshold=0.0)
+    orders = [
+        {
+            "symbol": symbol,
+            "side": "buy",
+            "position_side": "long",
+            "qty": 1.0,
+            "price": 1.0,
+            "pb_order_type": "entry_grid_normal_long",
+        }
+    ]
+
+    assert await bot._filter_fresh_market_snapshot_creations(orders) == orders
+
+
 @pytest.mark.asyncio
 async def test_pre_create_snapshot_filter_blocks_non_market_planning_invalidation():
     bot = Passivbot.__new__(Passivbot)


### PR DESCRIPTION
## Summary

- add `live.limit_order_create_max_market_dist_pct` with default `0.8`
- skip non-market limit order creations whose price is farther than the configured side-aware market-distance band from a fresh market snapshot
- keep market orders, cancellations, and stale/malformed market-snapshot handling fail-loud

## Tests

- `./venv/bin/python -m pytest tests/test_config_utils_helpers.py tests/test_config_pipeline.py tests/test_order_orchestration.py -q`
- `./venv/bin/python -m pytest tests/test_passivbot_balance_split.py::test_pre_create_snapshot_filter_blocks_stale_market_snapshots tests/test_passivbot_balance_split.py::test_pre_create_snapshot_filter_refreshes_stale_planning_market_snapshot tests/test_passivbot_balance_split.py::test_pre_create_snapshot_filter_skips_far_limit_order_creations tests/test_passivbot_balance_split.py::test_pre_create_snapshot_filter_disables_limit_order_distance_guard tests/test_passivbot_balance_split.py::test_pre_create_snapshot_filter_blocks_non_market_planning_invalidation -q`
- `./venv/bin/python -m py_compile src/config/schema.py src/config/validate.py src/config_utils.py src/live/market_data.py`
- `git show --check --format=short HEAD`
