### PR TITLE
Add live event query helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable user-facing changes will be documented in this file.
 - Added `live.limit_order_create_max_market_dist_pct` with a default of `0.8`
   so live skips limit-order creations far outside fresh market price bands
   instead of repeatedly submitting exchange-invalid deep orders.
+- Added `passivbot tool live-event-query` to validate monitor event NDJSON and
+  reconstruct one live event chain by `cycle_id`.
 - Added staged live shutdown progress events/logs, made candle fetch-lock waits
   abort promptly once shutdown is requested, and shortened the post-cancel
   background execution-loop grace from 5s to 1s.

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -14,6 +14,17 @@ from typing import Any, Iterable, Mapping, Protocol
 
 SCHEMA_VERSION = 1
 REDACTED = "[redacted]"
+LIVE_EVENT_MONITOR_PAYLOAD_KEY = "_live_event"
+LIVE_EVENT_ID_KEYS = (
+    "bot_id",
+    "cycle_id",
+    "snapshot_id",
+    "plan_id",
+    "action_id",
+    "order_wave_id",
+    "remote_call_id",
+    "remote_call_group_id",
+)
 
 
 class EventTypes:
@@ -277,7 +288,7 @@ class LiveEvent:
 
     def to_monitor_event(self) -> tuple[str, tuple[str, ...], dict[str, Any]]:
         payload = dict(self.data)
-        payload["_live_event"] = {
+        payload[LIVE_EVENT_MONITOR_PAYLOAD_KEY] = {
             "schema_version": self.schema_version,
             "event_id": self.event_id,
             "event_type": self.event_type,
@@ -298,16 +309,7 @@ class LiveEvent:
             "data": dict(self.data),
             "raw_ref": self.raw_ref,
             "raw_hash": self.raw_hash,
-            "ids": {
-                "bot_id": self.bot_id,
-                "cycle_id": self.cycle_id,
-                "snapshot_id": self.snapshot_id,
-                "plan_id": self.plan_id,
-                "action_id": self.action_id,
-                "order_wave_id": self.order_wave_id,
-                "remote_call_id": self.remote_call_id,
-                "remote_call_group_id": self.remote_call_group_id,
-            },
+            "ids": {key: getattr(self, key) for key in LIVE_EVENT_ID_KEYS},
         }
         return self.event_type, self.tags, payload
 

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -7,16 +7,9 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
+from live.event_bus import LIVE_EVENT_ID_KEYS, LIVE_EVENT_MONITOR_PAYLOAD_KEY
 
-EVENT_ID_KEYS = (
-    "cycle_id",
-    "snapshot_id",
-    "plan_id",
-    "action_id",
-    "order_wave_id",
-    "remote_call_id",
-    "remote_call_group_id",
-)
+EVENT_ID_KEYS = LIVE_EVENT_ID_KEYS
 
 
 @dataclass(frozen=True)
@@ -70,7 +63,7 @@ def _live_event_payload(row: dict[str, Any]) -> dict[str, Any] | None:
     payload = row.get("payload")
     if not isinstance(payload, dict):
         return None
-    live_event = payload.get("_live_event")
+    live_event = payload.get(LIVE_EVENT_MONITOR_PAYLOAD_KEY)
     return live_event if isinstance(live_event, dict) else None
 
 
@@ -268,4 +261,3 @@ def build_event_report(
             "events": cycle_events,
         }
     return report
-

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import gzip
+import json
+from collections import Counter
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+EVENT_ID_KEYS = (
+    "cycle_id",
+    "snapshot_id",
+    "plan_id",
+    "action_id",
+    "order_wave_id",
+    "remote_call_id",
+    "remote_call_group_id",
+)
+
+
+@dataclass(frozen=True)
+class EventIssue:
+    path: str
+    line: int | None
+    severity: str
+    code: str
+    message: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _is_event_segment(path: Path) -> bool:
+    return path.name.endswith(".ndjson") or path.name.endswith(".ndjson.gz")
+
+
+def _event_path_sort_key(path: Path) -> tuple[str, int, str]:
+    return (str(path.parent), 1 if path.name == "current.ndjson" else 0, path.name)
+
+
+def discover_event_files(root: str | Path) -> list[Path]:
+    """Find monitor event NDJSON segments below a monitor root, bot root, or events dir."""
+    path = Path(root).expanduser()
+    if path.is_file():
+        return [path] if _is_event_segment(path) else []
+    if not path.exists():
+        raise FileNotFoundError(str(path))
+    if not path.is_dir():
+        return []
+    return sorted(
+        (
+            candidate
+            for candidate in path.rglob("*.ndjson*")
+            if candidate.is_file()
+            and candidate.parent.name == "events"
+            and _is_event_segment(candidate)
+        ),
+        key=_event_path_sort_key,
+    )
+
+
+def _open_text(path: Path):
+    if path.name.endswith(".gz"):
+        return gzip.open(path, "rt", encoding="utf-8")
+    return open(path, "r", encoding="utf-8")
+
+
+def _live_event_payload(row: dict[str, Any]) -> dict[str, Any] | None:
+    payload = row.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    live_event = payload.get("_live_event")
+    return live_event if isinstance(live_event, dict) else None
+
+
+def _event_ids(live_event: dict[str, Any]) -> dict[str, Any]:
+    ids = live_event.get("ids")
+    return dict(ids) if isinstance(ids, dict) else {}
+
+
+def _compact_record(
+    *,
+    path: Path,
+    line_no: int,
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+    include_data: bool,
+) -> dict[str, Any]:
+    ids = _event_ids(live_event)
+    compact = {
+        "path": str(path),
+        "line": int(line_no),
+        "ts": row.get("ts"),
+        "seq": row.get("seq"),
+        "event_type": live_event.get("event_type") or row.get("kind"),
+        "level": live_event.get("level"),
+        "status": live_event.get("status"),
+        "reason_code": live_event.get("reason_code"),
+        "component": live_event.get("component"),
+        "exchange": live_event.get("exchange") or row.get("exchange"),
+        "user": live_event.get("user") or row.get("user"),
+        "symbol": live_event.get("symbol") or row.get("symbol"),
+        "pside": live_event.get("pside") or row.get("pside"),
+        "side": live_event.get("side"),
+        "ids": {key: ids.get(key) for key in EVENT_ID_KEYS if ids.get(key) is not None},
+    }
+    if include_data:
+        compact["data"] = live_event.get("data") if isinstance(live_event.get("data"), dict) else {}
+    return {key: value for key, value in compact.items() if value is not None}
+
+
+def build_event_report(
+    root: str | Path,
+    *,
+    cycle_id: str | None = None,
+    limit: int = 200,
+    include_data: bool = False,
+) -> dict[str, Any]:
+    issues: list[EventIssue] = []
+    try:
+        files = discover_event_files(root)
+    except FileNotFoundError as exc:
+        files = []
+        issues.append(
+            EventIssue(str(root), None, "error", "path_not_found", str(exc))
+        )
+    if not files and not issues:
+        issues.append(
+            EventIssue(str(root), None, "error", "no_event_files", "no event NDJSON files found")
+        )
+
+    event_type_counts: Counter[str] = Counter()
+    cycle_counts: Counter[str] = Counter()
+    records_total = 0
+    live_events = 0
+    legacy_events = 0
+    missing_cycle_id = 0
+    cycle_events: list[dict[str, Any]] = []
+    cycle_match_count = 0
+    max_events = max(0, int(limit))
+
+    for path in files:
+        try:
+            with _open_text(path) as stream:
+                for line_no, raw_line in enumerate(stream, start=1):
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    records_total += 1
+                    try:
+                        row = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        issues.append(
+                            EventIssue(
+                                str(path),
+                                line_no,
+                                "error",
+                                "invalid_json",
+                                str(exc),
+                            )
+                        )
+                        continue
+                    if not isinstance(row, dict):
+                        issues.append(
+                            EventIssue(
+                                str(path),
+                                line_no,
+                                "error",
+                                "invalid_record",
+                                "event row is not a JSON object",
+                            )
+                        )
+                        continue
+
+                    live_event = _live_event_payload(row)
+                    if live_event is None:
+                        legacy_events += 1
+                        continue
+                    live_events += 1
+
+                    event_type = live_event.get("event_type") or row.get("kind")
+                    if not event_type:
+                        issues.append(
+                            EventIssue(
+                                str(path),
+                                line_no,
+                                "error",
+                                "missing_event_type",
+                                "live event is missing event_type",
+                            )
+                        )
+                    else:
+                        event_type = str(event_type)
+                        event_type_counts[event_type] += 1
+                        if row.get("kind") and str(row.get("kind")) != event_type:
+                            issues.append(
+                                EventIssue(
+                                    str(path),
+                                    line_no,
+                                    "warning",
+                                    "kind_event_type_mismatch",
+                                    f"kind={row.get('kind')} event_type={event_type}",
+                                )
+                            )
+
+                    ids = _event_ids(live_event)
+                    if live_event.get("ids") is not None and not isinstance(
+                        live_event.get("ids"), dict
+                    ):
+                        issues.append(
+                            EventIssue(
+                                str(path),
+                                line_no,
+                                "error",
+                                "invalid_ids",
+                                "live event ids field is not an object",
+                            )
+                        )
+                    record_cycle_id = ids.get("cycle_id")
+                    if record_cycle_id is None:
+                        missing_cycle_id += 1
+                    else:
+                        record_cycle_id = str(record_cycle_id)
+                        cycle_counts[record_cycle_id] += 1
+                    if cycle_id is not None and record_cycle_id == str(cycle_id):
+                        cycle_match_count += 1
+                        if len(cycle_events) < max_events:
+                            cycle_events.append(
+                                _compact_record(
+                                    path=path,
+                                    line_no=line_no,
+                                    row=row,
+                                    live_event=live_event,
+                                    include_data=include_data,
+                                )
+                            )
+        except OSError as exc:
+            issues.append(
+                EventIssue(str(path), None, "error", "read_failed", str(exc))
+            )
+
+    error_count = sum(1 for issue in issues if issue.severity == "error")
+    warning_count = sum(1 for issue in issues if issue.severity == "warning")
+    report: dict[str, Any] = {
+        "ok": error_count == 0,
+        "root": str(Path(root).expanduser()),
+        "files": [str(path) for path in files],
+        "files_scanned": len(files),
+        "records_total": records_total,
+        "live_events": live_events,
+        "legacy_events": legacy_events,
+        "missing_cycle_id": missing_cycle_id,
+        "issues": [issue.to_dict() for issue in issues],
+        "error_count": error_count,
+        "warning_count": warning_count,
+        "event_types": dict(sorted(event_type_counts.items())),
+        "cycle_ids_sample": [
+            {"cycle_id": key, "events": value}
+            for key, value in cycle_counts.most_common(20)
+        ],
+    }
+    if cycle_id is not None:
+        report["cycle"] = {
+            "cycle_id": str(cycle_id),
+            "matched_events": cycle_match_count,
+            "events_truncated": cycle_match_count > len(cycle_events),
+            "events": cycle_events,
+        }
+    return report
+

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -93,6 +93,10 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "plot iterative history files (requires full install)",
         requires_full=True,
     ),
+    "live-event-query": CommandSpec(
+        "tools.live_event_query",
+        "validate monitor event NDJSON and reconstruct a live cycle",
+    ),
     "inspect-ohlcvs": CommandSpec(
         "tools.inspect_ohlcvs",
         "inspect v2 OHLCV cache metadata and gaps (requires full install)",

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -57,4 +57,3 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[1]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from live.event_query import build_event_report  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate monitor event NDJSON and reconstruct a live cycle by cycle_id."
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default="monitor",
+        help="Monitor root, bot root, events directory, or NDJSON segment.",
+    )
+    parser.add_argument("--cycle-id", help="Return compact records for one cycle_id.")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=200,
+        help="Maximum cycle records to include in output.",
+    )
+    parser.add_argument(
+        "--include-data",
+        action="store_true",
+        help="Include each matched event's bounded data payload.",
+    )
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="Emit compact single-line JSON.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    report = build_event_report(
+        args.path,
+        cycle_id=args.cycle_id,
+        limit=args.limit,
+        include_data=bool(args.include_data),
+    )
+    print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
+    return 0 if report.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -156,4 +156,3 @@ def test_live_event_query_cli_outputs_json_and_status(tmp_path, capsys):
     report = json.loads(capsys.readouterr().out)
     assert report["cycle"]["cycle_id"] == "cy_7"
     assert report["cycle"]["matched_events"] == 1
-

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import gzip
+import json
+
+from live.event_query import build_event_report, discover_event_files
+from tools import live_event_query
+
+
+def _monitor_row(
+    *,
+    event_type: str,
+    cycle_id: str | None,
+    seq: int,
+    ts: int,
+    symbol: str | None = None,
+) -> dict:
+    ids = {"cycle_id": cycle_id} if cycle_id is not None else {}
+    live_event = {
+        "schema_version": 1,
+        "event_id": f"evt_{seq}",
+        "event_type": event_type,
+        "level": "debug",
+        "source": "live",
+        "component": "test",
+        "exchange": "binance",
+        "user": "binance_01",
+        "symbol": symbol,
+        "status": "succeeded",
+        "reason_code": "test",
+        "data": {"seq": seq},
+        "ids": ids,
+    }
+    payload = {"_live_event": live_event}
+    payload.update(live_event["data"])
+    row = {
+        "exchange": "binance",
+        "user": "binance_01",
+        "kind": event_type,
+        "tags": ["test"],
+        "payload": payload,
+        "seq": seq,
+        "ts": ts,
+    }
+    if symbol:
+        row["symbol"] = symbol
+    return row
+
+
+def _write_ndjson(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _write_gz_ndjson(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(path, "wt", encoding="utf-8") as stream:
+        for row in rows:
+            stream.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def test_event_query_discovers_rotated_current_and_reconstructs_cycle(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    rotated = events_dir / "2026-06-25T00-00-00.ndjson.gz"
+    current = events_dir / "current.ndjson"
+    _write_gz_ndjson(
+        rotated,
+        [
+            _monitor_row(
+                event_type="cycle.started",
+                cycle_id="cy_1",
+                seq=1,
+                ts=1000,
+            )
+        ],
+    )
+    _write_ndjson(
+        current,
+        [
+            _monitor_row(
+                event_type="action.planned",
+                cycle_id="cy_1",
+                seq=2,
+                ts=1100,
+                symbol="BTC/USDT:USDT",
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                cycle_id="cy_2",
+                seq=3,
+                ts=1200,
+            ),
+            {
+                "kind": "legacy.event",
+                "payload": {"ok": True},
+                "seq": 4,
+                "ts": 1300,
+            },
+        ],
+    )
+
+    assert discover_event_files(tmp_path / "monitor" / "binance" / "binance_01") == [
+        rotated,
+        current,
+    ]
+
+    report = build_event_report(tmp_path / "monitor", cycle_id="cy_1", include_data=True)
+
+    assert report["ok"] is True
+    assert report["files_scanned"] == 2
+    assert report["records_total"] == 4
+    assert report["live_events"] == 3
+    assert report["legacy_events"] == 1
+    assert report["event_types"]["action.planned"] == 1
+    assert report["cycle"]["matched_events"] == 2
+    assert report["cycle"]["events_truncated"] is False
+    assert [event["event_type"] for event in report["cycle"]["events"]] == [
+        "cycle.started",
+        "action.planned",
+    ]
+    assert report["cycle"]["events"][1]["symbol"] == "BTC/USDT:USDT"
+    assert report["cycle"]["events"][1]["data"] == {"seq": 2}
+
+
+def test_event_query_reports_invalid_json(tmp_path):
+    events_dir = tmp_path / "monitor" / "okx" / "user01" / "events"
+    events_dir.mkdir(parents=True)
+    (events_dir / "current.ndjson").write_text("{not json}\n", encoding="utf-8")
+
+    report = build_event_report(tmp_path / "monitor")
+
+    assert report["ok"] is False
+    assert report["error_count"] == 1
+    assert report["issues"][0]["code"] == "invalid_json"
+
+
+def test_live_event_query_cli_outputs_json_and_status(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="order_wave.completed",
+                cycle_id="cy_7",
+                seq=1,
+                ts=1000,
+            )
+        ],
+    )
+
+    assert live_event_query.main([str(tmp_path / "monitor"), "--cycle-id", "cy_7"]) == 0
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["cycle"]["cycle_id"] == "cy_7"
+    assert report["cycle"]["matched_events"] == 1
+

--- a/tests/test_passivbot_cli.py
+++ b/tests/test_passivbot_cli.py
@@ -135,6 +135,7 @@ def test_tool_help_lists_supported_tools(capsys):
     assert "hyperliquid-order-margin-probe" in out
     assert "hyperliquid-position-probe" in out
     assert "inspect-ohlcvs" in out
+    assert "live-event-query" in out
     assert "merge-paretos" in out
     assert "monitor-dev" in out
     assert "monitor-relay" in out
@@ -266,6 +267,30 @@ def test_tool_dispatch_forwards_module_and_prog(monkeypatch):
         "optimize_results",
     ]
     assert captured["prog_env"] == "passivbot tool pareto-dash"
+
+
+def test_live_event_query_tool_dispatch_forwards_module_and_prog(monkeypatch):
+    captured = {}
+
+    def fake_invoke_module_main(module_name):
+        captured["module_name"] = module_name
+        captured["argv"] = sys.argv[:]
+        captured["prog_env"] = os.environ.get("PASSIVBOT_CLI_PROG")
+        return True, 0
+
+    monkeypatch.setattr(cli_main, "_invoke_module_main", fake_invoke_module_main)
+    monkeypatch.setattr(cli_main, "_missing_full_install_markers", lambda: [])
+
+    assert cli_main.main(["tool", "live-event-query", "monitor", "--cycle-id", "cy_1"]) == 0
+
+    assert captured["module_name"] == "tools.live_event_query"
+    assert captured["argv"] == [
+        "passivbot tool live-event-query",
+        "monitor",
+        "--cycle-id",
+        "cy_1",
+    ]
+    assert captured["prog_env"] == "passivbot tool live-event-query"
 
 
 def test_pareto_tool_dispatch_forwards_module_and_prog(monkeypatch):


### PR DESCRIPTION
Observability/tooling-only slice: adds passivbot tool live-event-query to validate monitor event NDJSON and reconstruct a cycle by cycle_id. Reads monitor files only; no live trading path imports it. Handles rotated .ndjson.gz/current.ndjson, reports schema/JSON issues, and can include compact event chains. Validation: compileall target files; git diff --check; focused pytest tests/test_live_event_query.py, CLI dispatch, and two live event bus reconstruction/preservation tests.