### PR TITLE
Bound live event query directory scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Changed `passivbot tool live-event-query` directory scans to inspect
+  `current.ndjson` segments by default; use `--include-rotated` for full
+  rotated history validation.
 - Added `live.limit_order_create_max_market_dist_pct` with a default of `0.8`
   so live skips limit-order creations far outside fresh market price bands
   instead of repeatedly submitting exchange-invalid deep orders.

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -32,7 +32,7 @@ def _event_path_sort_key(path: Path) -> tuple[str, int, str]:
     return (str(path.parent), 1 if path.name == "current.ndjson" else 0, path.name)
 
 
-def discover_event_files(root: str | Path) -> list[Path]:
+def discover_event_files(root: str | Path, *, include_rotated: bool = True) -> list[Path]:
     """Find monitor event NDJSON segments below a monitor root, bot root, or events dir."""
     path = Path(root).expanduser()
     if path.is_file():
@@ -48,6 +48,7 @@ def discover_event_files(root: str | Path) -> list[Path]:
             if candidate.is_file()
             and candidate.parent.name == "events"
             and _is_event_segment(candidate)
+            and (include_rotated or candidate.name == "current.ndjson")
         ),
         key=_event_path_sort_key,
     )
@@ -109,10 +110,11 @@ def build_event_report(
     cycle_id: str | None = None,
     limit: int = 200,
     include_data: bool = False,
+    include_rotated: bool = True,
 ) -> dict[str, Any]:
     issues: list[EventIssue] = []
     try:
-        files = discover_event_files(root)
+        files = discover_event_files(root, include_rotated=include_rotated)
     except FileNotFoundError as exc:
         files = []
         issues.append(
@@ -238,6 +240,7 @@ def build_event_report(
     report: dict[str, Any] = {
         "ok": error_count == 0,
         "root": str(Path(root).expanduser()),
+        "include_rotated": bool(include_rotated),
         "files": [str(path) for path in files],
         "files_scanned": len(files),
         "records_total": records_total,

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -32,7 +32,7 @@ def _event_path_sort_key(path: Path) -> tuple[str, int, str]:
     return (str(path.parent), 1 if path.name == "current.ndjson" else 0, path.name)
 
 
-def discover_event_files(root: str | Path, *, include_rotated: bool = True) -> list[Path]:
+def discover_event_files(root: str | Path, *, include_rotated: bool = False) -> list[Path]:
     """Find monitor event NDJSON segments below a monitor root, bot root, or events dir."""
     path = Path(root).expanduser()
     if path.is_file():
@@ -110,7 +110,7 @@ def build_event_report(
     cycle_id: str | None = None,
     limit: int = 200,
     include_data: bool = False,
-    include_rotated: bool = True,
+    include_rotated: bool = False,
 ) -> dict[str, Any]:
     issues: list[EventIssue] = []
     try:

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -35,6 +35,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Include each matched event's bounded data payload.",
     )
     parser.add_argument(
+        "--include-rotated",
+        action="store_true",
+        help=(
+            "Also scan rotated/compressed history segments. By default directory "
+            "scans read current.ndjson files only."
+        ),
+    )
+    parser.add_argument(
         "--compact",
         action="store_true",
         help="Emit compact single-line JSON.",
@@ -50,6 +58,7 @@ def main(argv: list[str] | None = None) -> int:
         cycle_id=args.cycle_id,
         limit=args.limit,
         include_data=bool(args.include_data),
+        include_rotated=bool(args.include_rotated),
     )
     print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
     return 0 if report.get("ok") else 1

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -102,14 +102,20 @@ def test_event_query_discovers_rotated_current_and_reconstructs_cycle(tmp_path):
         ],
     )
 
-    assert discover_event_files(tmp_path / "monitor" / "binance" / "binance_01") == [
-        rotated,
-        current,
-    ]
+    assert discover_event_files(
+        tmp_path / "monitor" / "binance" / "binance_01",
+        include_rotated=True,
+    ) == [rotated, current]
 
-    report = build_event_report(tmp_path / "monitor", cycle_id="cy_1", include_data=True)
+    report = build_event_report(
+        tmp_path / "monitor",
+        cycle_id="cy_1",
+        include_data=True,
+        include_rotated=True,
+    )
 
     assert report["ok"] is True
+    assert report["include_rotated"] is True
     assert report["files_scanned"] == 2
     assert report["records_total"] == 4
     assert report["live_events"] == 3

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -137,6 +137,40 @@ def test_event_query_reports_invalid_json(tmp_path):
     assert report["issues"][0]["code"] == "invalid_json"
 
 
+def test_event_query_current_only_skips_rotated_segments(tmp_path):
+    events_dir = tmp_path / "monitor" / "okx" / "user01" / "events"
+    _write_gz_ndjson(
+        events_dir / "2026-06-25T00-00-00.ndjson.gz",
+        [
+            _monitor_row(
+                event_type="cycle.started",
+                cycle_id="cy_old",
+                seq=1,
+                ts=1000,
+            )
+        ],
+    )
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                cycle_id="cy_current",
+                seq=2,
+                ts=2000,
+            )
+        ],
+    )
+
+    report = build_event_report(tmp_path / "monitor", include_rotated=False)
+
+    assert report["ok"] is True
+    assert report["include_rotated"] is False
+    assert report["files"] == [str(events_dir / "current.ndjson")]
+    assert report["files_scanned"] == 1
+    assert report["cycle_ids_sample"] == [{"cycle_id": "cy_current", "events": 1}]
+
+
 def test_live_event_query_cli_outputs_json_and_status(tmp_path, capsys):
     events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
     _write_ndjson(
@@ -156,3 +190,51 @@ def test_live_event_query_cli_outputs_json_and_status(tmp_path, capsys):
     report = json.loads(capsys.readouterr().out)
     assert report["cycle"]["cycle_id"] == "cy_7"
     assert report["cycle"]["matched_events"] == 1
+
+
+def test_live_event_query_cli_defaults_to_current_only_for_directory_scans(
+    tmp_path, capsys
+):
+    events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        events_dir / "2026-06-25T00-00-00.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.started",
+                cycle_id="cy_old",
+                seq=1,
+                ts=1000,
+            )
+        ],
+    )
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                cycle_id="cy_current",
+                seq=2,
+                ts=2000,
+            )
+        ],
+    )
+
+    assert live_event_query.main([str(tmp_path / "monitor")]) == 0
+    current_only_report = json.loads(capsys.readouterr().out)
+    assert current_only_report["include_rotated"] is False
+    assert current_only_report["files"] == [str(events_dir / "current.ndjson")]
+    assert current_only_report["cycle_ids_sample"] == [
+        {"cycle_id": "cy_current", "events": 1}
+    ]
+
+    assert live_event_query.main([str(tmp_path / "monitor"), "--include-rotated"]) == 0
+    full_report = json.loads(capsys.readouterr().out)
+    assert full_report["include_rotated"] is True
+    assert full_report["files"] == [
+        str(events_dir / "2026-06-25T00-00-00.ndjson"),
+        str(events_dir / "current.ndjson"),
+    ]
+    assert full_report["cycle_ids_sample"] == [
+        {"cycle_id": "cy_old", "events": 1},
+        {"cycle_id": "cy_current", "events": 1},
+    ]


### PR DESCRIPTION
Observability/tooling-only follow-up from VPS5 smoke: passivbot tool live-event-query monitor was too slow when scanning the whole monitor tree. This changes CLI directory scans to read current.ndjson files by default, while keeping full rotated-history validation available via --include-rotated. Library defaults remain full-history for explicit programmatic validation. No live trading path imports this tool. Validation: compileall target files; git diff --check; pytest tests/test_live_event_query.py and live-event-query CLI dispatch test.