### PR TITLE
Reduce forager EMA console noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Reduced default console/file noise for candidate-only forager EMA and
+  open-tail projection diagnostics; detailed per-symbol internals remain in
+  structured/debug events while active-symbol failures still fail loudly.
 - Changed `passivbot tool live-event-query` directory scans to inspect
   `current.ndjson` segments by default; use `--include-rotated` for full
   rotated history validation.

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -14307,7 +14307,7 @@ class Passivbot:
                 projection_contexts[sym] = ctx
                 log_ema_issue(
                     ("late_open_tail_projection", sym),
-                    logging.INFO,
+                    logging.DEBUG,
                     "[candle] late open-tail EMA projection context %s tail_gap_age_ms=%s latest_expected_ts=%s last_cached_ts=%s reason=%s",
                     Passivbot._log_symbol(sym),
                     ctx.get("tail_gap_age_ms"),
@@ -14476,7 +14476,7 @@ class Passivbot:
                 mark_ema_unavailable(sym, reason)
                 log_ema_issue(
                     ("required_forager_missing", sym),
-                    logging.WARNING,
+                    logging.DEBUG,
                     "[ema] missing required forager EMA %s volume_spans=%s log_range_spans=%s action=mark_nontradable_until_fresh | %s",
                     Passivbot._log_symbol(sym),
                     ",".join(f"{span:.8g}" for span in missing_required_volume),

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -854,6 +854,7 @@ async def test_orchestrator_ema_bundle_marks_flat_forager_candidate_required_m1_
 @pytest.mark.asyncio
 async def test_orchestrator_ema_bundle_late_projection_marks_candidate_unavailable(
     monkeypatch,
+    caplog,
 ):
     import passivbot as pb_mod
 
@@ -1010,16 +1011,17 @@ async def test_orchestrator_ema_bundle_late_projection_marks_candidate_unavailab
         _candle_staleness_ms = pb_mod.Passivbot._candle_staleness_ms
 
     bot = FakeBot()
-    (
-        m1_close_emas,
-        m1_volume_emas,
-        m1_log_range_emas,
-        _h1_log_range_emas,
-        volumes_long,
-        log_ranges_long,
-    ) = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
-        bot, [symbol], modes=bot.PB_modes
-    )
+    with caplog.at_level(logging.INFO):
+        (
+            m1_close_emas,
+            m1_volume_emas,
+            m1_log_range_emas,
+            _h1_log_range_emas,
+            volumes_long,
+            log_ranges_long,
+        ) = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+            bot, [symbol], modes=bot.PB_modes
+        )
 
     assert m1_close_emas[symbol]
     assert m1_volume_emas[symbol][5.0] == pytest.approx(42.0)
@@ -1027,6 +1029,11 @@ async def test_orchestrator_ema_bundle_late_projection_marks_candidate_unavailab
     assert volumes_long[symbol] == pytest.approx(42.0)
     assert symbol not in log_ranges_long
     assert bot._orchestrator_ema_unavailable_symbols == {symbol}
+    assert not any(
+        "late open-tail EMA projection context" in record.message
+        and record.levelno >= logging.INFO
+        for record in caplog.records
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -856,6 +856,7 @@ async def test_explicit_normal_missing_required_forager_features_fails_loudly():
 async def test_candidate_only_missing_required_forager_features_marks_unavailable(caplog):
     try:
         import passivbot as pb_mod
+        from live.event_bus import EventTypes
     except ImportError:
         pytest.skip("passivbot module not importable in test environment")
 
@@ -875,6 +876,13 @@ async def test_candidate_only_missing_required_forager_features_marks_unavailabl
     bot.cm.get_last_final_ts = lambda _symbol: int(time.time() * 1000)
     bot._candle_staleness_ms = lambda _symbol, now_ms=None: 0
     _enable_forager_required_ranking(bot)
+    events = []
+
+    def emit_live_event(event_type, *args, **kwargs):
+        events.append((event_type, kwargs))
+        return object()
+
+    bot._emit_live_event = emit_live_event
 
     with caplog.at_level(logging.WARNING):
         (
@@ -894,10 +902,25 @@ async def test_candidate_only_missing_required_forager_features_marks_unavailabl
     assert symbol not in volumes_long
     assert symbol not in log_ranges_long
     assert bot._orchestrator_ema_unavailable_symbols == {symbol}
-    assert any(
+    assert not any(
         "missing required forager EMA HYPE" in record.message
         and "action=mark_nontradable_until_fresh" in record.message
+        and record.levelno >= logging.WARNING
         for record in caplog.records
+    )
+    unavailable_events = [
+        kwargs
+        for event_type, kwargs in events
+        if event_type == EventTypes.EMA_UNAVAILABLE
+    ]
+    assert len(unavailable_events) == 1
+    event_data = unavailable_events[0]["data"]
+    assert event_data["candidate_unavailable"]["count"] == 0
+    assert event_data["unavailable"]["sample"] == [symbol]
+    assert any(
+        group["reason"] == "missing_required_forager_volume+missing_required_forager_log_range"
+        and group["symbols"]["sample"] == [symbol]
+        for group in event_data["unavailable_reasons"]
     )
 
 


### PR DESCRIPTION
Observability-only console cleanup. Candidate-only forager EMA/open-tail diagnostics remain in structured/debug events, but no longer spam default WARNING/INFO text logs. Active/normal missing required forager EMA still fails loudly.\n\nValidation:\n- ./venv/bin/python -m compileall src/passivbot.py tests/test_missing_ema_fix.py tests/test_live_candle_budget.py\n- ./venv/bin/python -m pytest tests/test_missing_ema_fix.py -q\n- ./venv/bin/python -m pytest tests/test_missing_ema_fix.py::test_candidate_only_missing_required_forager_features_marks_unavailable tests/test_missing_ema_fix.py::test_explicit_normal_missing_required_forager_features_fails_loudly tests/test_live_candle_budget.py::test_orchestrator_ema_bundle_late_projection_marks_candidate_unavailable -q\n- git diff --check