### PR TITLE
Emit candle tail projection events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added structured `candle.tail_projected` live events for open-tail EMA
+  projection decisions, preserving per-symbol candle-tail context without
+  default console noise.
 - Reduced default console/file noise for candidate-only forager EMA and
   open-tail projection diagnostics; detailed per-symbol internals remain in
   structured/debug events while active-symbol failures still fail loudly.

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -47,6 +47,7 @@ class EventTypes:
     EMA_BUNDLE_COMPLETED = "ema.bundle.completed"
     EMA_FALLBACK_USED = "ema.fallback_used"
     EMA_UNAVAILABLE = "ema.unavailable"
+    CANDLE_TAIL_PROJECTED = "candle.tail_projected"
     REMOTE_CALL_STARTED = "remote_call.started"
     REMOTE_CALL_SUCCEEDED = "remote_call.succeeded"
     REMOTE_CALL_FAILED = "remote_call.failed"
@@ -102,6 +103,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.EMA_BUNDLE_COMPLETED,
     EventTypes.EMA_FALLBACK_USED,
     EventTypes.EMA_UNAVAILABLE,
+    EventTypes.CANDLE_TAIL_PROJECTED,
     EventTypes.REMOTE_CALL_STARTED,
     EventTypes.REMOTE_CALL_SUCCEEDED,
     EventTypes.REMOTE_CALL_FAILED,
@@ -379,6 +381,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.EMA_BUNDLE_COMPLETED: EventRoute(console=False, text=False),
     EventTypes.EMA_FALLBACK_USED: EventRoute(console=False, text=False),
     EventTypes.EMA_UNAVAILABLE: EventRoute(console=False, text=False),
+    EventTypes.CANDLE_TAIL_PROJECTED: EventRoute(console=False, text=False),
     EventTypes.REMOTE_CALL_STARTED: EventRoute(console=False),
     EventTypes.REMOTE_CALL_SUCCEEDED: EventRoute(console=False),
     EventTypes.REMOTE_CALL_FAILED: EventRoute(console=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -983,6 +983,54 @@ def emit_forager_selection_event(bot: Any, *args: Any, **kwargs: Any) -> None:
         )
 
 
+def _emit_candle_tail_projected_event_unchecked(
+    bot: Any,
+    *,
+    symbol: str,
+    context: dict[str, Any] | None,
+    reason_code: str = "open_tail_projection",
+) -> None:
+    ctx = dict(context or {})
+    data: dict[str, Any] = {"timeframe": str(ctx.get("timeframe") or "1m")}
+    for key in (
+        "latest_expected_ts",
+        "last_cached_ts",
+        "tail_gap_age_ms",
+        "tail_gap_candles",
+        "missing_candles",
+        "max_tail_gap_ms",
+    ):
+        value = _safe_int(ctx.get(key))
+        if value is not None:
+            data[key] = value
+    reason = ctx.get("reason")
+    if reason is not None:
+        data["projection_reason"] = str(reason)
+    _safe_emit(
+        bot,
+        EventTypes.CANDLE_TAIL_PROJECTED,
+        level="debug",
+        component="candle.tail_projection",
+        tags=("candle", "tail", "ema"),
+        cycle_id=current_live_event_cycle_id(bot),
+        symbol=str(symbol),
+        status="recovered",
+        reason_code=str(reason_code),
+        data=data,
+    )
+
+
+def emit_candle_tail_projected_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    try:
+        _emit_candle_tail_projected_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.CANDLE_TAIL_PROJECTED,
+            exc,
+        )
+
+
 def _mode_counts(modes: dict[str, dict[str, str]] | None) -> dict[str, int]:
     counts: dict[str, int] = {}
     for symbol_modes in (modes or {}).values():

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -624,6 +624,9 @@ class Passivbot:
     _emit_ema_bundle_completed_event = live_event_emitters.emit_ema_bundle_completed_event
     _emit_ema_fallback_used_event = live_event_emitters.emit_ema_fallback_used_event
     _emit_ema_unavailable_event = live_event_emitters.emit_ema_unavailable_event
+    _emit_candle_tail_projected_event = (
+        live_event_emitters.emit_candle_tail_projected_event
+    )
     _emit_order_wave_started_event = live_event_emitters.emit_order_wave_started_event
     _emit_order_wave_completed_event = live_event_emitters.emit_order_wave_completed_event
     _emit_planning_defer_summary_event = (
@@ -14305,6 +14308,12 @@ class Passivbot:
                 return None
             if ctx is not None:
                 projection_contexts[sym] = ctx
+                Passivbot._emit_candle_tail_projected_event(
+                    self,
+                    symbol=sym,
+                    context=ctx,
+                    reason_code="late_open_tail_projection",
+                )
                 log_ema_issue(
                     ("late_open_tail_projection", sym),
                     logging.DEBUG,

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -2,6 +2,8 @@ import logging
 
 import pytest
 
+from live.event_bus import EventTypes
+
 
 def _forager_score_weights(volume=0.0, ema_readiness=0.0, volatility=0.0):
     return {
@@ -1011,6 +1013,14 @@ async def test_orchestrator_ema_bundle_late_projection_marks_candidate_unavailab
         _candle_staleness_ms = pb_mod.Passivbot._candle_staleness_ms
 
     bot = FakeBot()
+    events = []
+    bot._live_event_current_cycle_id = "cy_tail"
+
+    def emit_live_event(event_type, *args, **kwargs):
+        events.append((event_type, kwargs))
+        return object()
+
+    bot._emit_live_event = emit_live_event
     with caplog.at_level(logging.INFO):
         (
             m1_close_emas,
@@ -1034,6 +1044,18 @@ async def test_orchestrator_ema_bundle_late_projection_marks_candidate_unavailab
         and record.levelno >= logging.INFO
         for record in caplog.records
     )
+    tail_events = [
+        kwargs
+        for event_type, kwargs in events
+        if event_type == EventTypes.CANDLE_TAIL_PROJECTED
+    ]
+    assert len(tail_events) == 1
+    assert tail_events[0]["cycle_id"] == "cy_tail"
+    assert tail_events[0]["symbol"] == symbol
+    assert tail_events[0]["reason_code"] == "late_open_tail_projection"
+    assert tail_events[0]["data"]["latest_expected_ts"] == 1_920_000
+    assert tail_events[0]["data"]["last_cached_ts"] == 1_860_000
+    assert tail_events[0]["data"]["tail_gap_age_ms"] == 60_000
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -141,6 +141,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.EMA_BUNDLE_COMPLETED,
         EventTypes.EMA_FALLBACK_USED,
         EventTypes.EMA_UNAVAILABLE,
+        EventTypes.CANDLE_TAIL_PROJECTED,
         EventTypes.PLANNING_DEFER_SUMMARY,
         EventTypes.PLANNING_SYMBOL_STATE,
         EventTypes.HSL_TRANSITION,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -481,6 +481,9 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         )
         _emit_ema_fallback_used_event = pb_mod.Passivbot._emit_ema_fallback_used_event
         _emit_ema_unavailable_event = pb_mod.Passivbot._emit_ema_unavailable_event
+        _emit_candle_tail_projected_event = (
+            pb_mod.Passivbot._emit_candle_tail_projected_event
+        )
         _emit_forager_feature_unavailable_event = (
             pb_mod.Passivbot._emit_forager_feature_unavailable_event
         )
@@ -554,6 +557,19 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         },
         ema_unavailable_reasons={"cache_only_never_fetched": ["ADA/USDT:USDT"]},
     )
+    bot._emit_candle_tail_projected_event(
+        symbol="ETH/USDT:USDT",
+        context={
+            "timeframe": "1m",
+            "latest_expected_ts": 180_000,
+            "last_cached_ts": 120_000,
+            "tail_gap_age_ms": 60_000,
+            "tail_gap_candles": 1,
+            "missing_candles": 1,
+            "reason": "open_tail_gap_projection",
+        },
+        reason_code="late_open_tail_projection",
+    )
 
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     events = sink.events
@@ -564,6 +580,7 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         EventTypes.EMA_BUNDLE_COMPLETED,
         EventTypes.EMA_FALLBACK_USED,
         EventTypes.EMA_UNAVAILABLE,
+        EventTypes.CANDLE_TAIL_PROJECTED,
     ]
     assert {event.cycle_id for event in events} == {"cy_11"}
     assert events[0].data["unavailable"]["count"] == 2
@@ -580,6 +597,11 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
     assert events[4].data["close_fallback_count"] == 1
     assert events[5].status == "degraded"
     assert events[5].data["candidate_unavailable"]["sample"] == ["XRP/USDT:USDT"]
+    assert events[6].symbol == "ETH/USDT:USDT"
+    assert events[6].status == "recovered"
+    assert events[6].reason_code == "late_open_tail_projection"
+    assert events[6].data["latest_expected_ts"] == 180_000
+    assert events[6].data["tail_gap_age_ms"] == 60_000
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
@@ -640,6 +662,11 @@ def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(ca
                 "required_missing": [("BTC/USDT:USDT", "ValueError")]
             },
         )
+        pb_mod.Passivbot._emit_candle_tail_projected_event(
+            bot,
+            symbol=object(),
+            context=object(),
+        )
 
     messages = [record.message for record in caplog.records]
     assert any(EventTypes.FORAGER_FEATURE_UNAVAILABLE in msg for msg in messages)
@@ -649,6 +676,7 @@ def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(ca
     assert any(EventTypes.EMA_BUNDLE_COMPLETED in msg for msg in messages)
     assert any(EventTypes.EMA_FALLBACK_USED in msg for msg in messages)
     assert any(EventTypes.EMA_UNAVAILABLE in msg for msg in messages)
+    assert any(EventTypes.CANDLE_TAIL_PROJECTED in msg for msg in messages)
 
 
 def _make_remote_fetch_event_bot(sink, *, cycle_id="cy_7", map_max=None):


### PR DESCRIPTION
Summary:
- add a structured candle.tail_projected live event for open-tail EMA projection context
- keep the event off console/text routes by default so per-symbol candle-tail diagnostics stay out of normal logs
- emit the event from late open-tail projection handling with cycle_id, symbol, timestamps, gap age, and missing-candle context

Tests:
- ./venv/bin/python -m compileall src/live/event_bus.py src/live/event_emitters.py src/passivbot.py tests/test_live_event_bus.py tests/test_passivbot_monitor.py tests/test_live_candle_budget.py
- ./venv/bin/python -m pytest tests/test_live_event_bus.py::test_route_table_keeps_data_events_off_console_by_default tests/test_passivbot_monitor.py::test_forager_and_ema_summary_emitters_emit_structured_events tests/test_passivbot_monitor.py::test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs tests/test_live_candle_budget.py::test_orchestrator_ema_bundle_late_projection_marks_candidate_unavailable -q