### PR TITLE
Filter live event query by event type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool live-event-query --event-type`/`--kind` filters for
+  inspecting specific structured live events without grepping monitor files.
 - Added structured `candle.tail_projected` live events for open-tail EMA
   projection decisions, preserving per-symbol candle-tail context without
   default console noise.

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -73,6 +73,22 @@ def _event_ids(live_event: dict[str, Any]) -> dict[str, Any]:
     return dict(ids) if isinstance(ids, dict) else {}
 
 
+def _normalize_filter_values(values: str | Iterable[str] | None) -> set[str]:
+    if values is None:
+        return set()
+    if isinstance(values, str):
+        raw_values = [values]
+    else:
+        raw_values = list(values)
+    out: set[str] = set()
+    for value in raw_values:
+        for part in str(value).split(","):
+            cleaned = part.strip()
+            if cleaned:
+                out.add(cleaned)
+    return out
+
+
 def _compact_record(
     *,
     path: Path,
@@ -108,6 +124,7 @@ def build_event_report(
     root: str | Path,
     *,
     cycle_id: str | None = None,
+    event_type: str | Iterable[str] | None = None,
     limit: int = 200,
     include_data: bool = False,
     include_rotated: bool = False,
@@ -133,7 +150,11 @@ def build_event_report(
     missing_cycle_id = 0
     cycle_events: list[dict[str, Any]] = []
     cycle_match_count = 0
+    query_events: list[dict[str, Any]] = []
+    query_match_count = 0
     max_events = max(0, int(limit))
+    event_type_filter = _normalize_filter_values(event_type)
+    has_query_filter = bool(event_type_filter)
 
     for path in files:
         try:
@@ -174,8 +195,8 @@ def build_event_report(
                         continue
                     live_events += 1
 
-                    event_type = live_event.get("event_type") or row.get("kind")
-                    if not event_type:
+                    record_event_type = live_event.get("event_type") or row.get("kind")
+                    if not record_event_type:
                         issues.append(
                             EventIssue(
                                 str(path),
@@ -186,16 +207,16 @@ def build_event_report(
                             )
                         )
                     else:
-                        event_type = str(event_type)
-                        event_type_counts[event_type] += 1
-                        if row.get("kind") and str(row.get("kind")) != event_type:
+                        record_event_type = str(record_event_type)
+                        event_type_counts[record_event_type] += 1
+                        if row.get("kind") and str(row.get("kind")) != record_event_type:
                             issues.append(
                                 EventIssue(
                                     str(path),
                                     line_no,
                                     "warning",
                                     "kind_event_type_mismatch",
-                                    f"kind={row.get('kind')} event_type={event_type}",
+                                    f"kind={row.get('kind')} event_type={record_event_type}",
                                 )
                             )
 
@@ -218,7 +239,30 @@ def build_event_report(
                     else:
                         record_cycle_id = str(record_cycle_id)
                         cycle_counts[record_cycle_id] += 1
-                    if cycle_id is not None and record_cycle_id == str(cycle_id):
+
+                    event_type_matches = (
+                        not event_type_filter
+                        or (
+                            record_event_type is not None
+                            and str(record_event_type) in event_type_filter
+                        )
+                    )
+                    cycle_matches = cycle_id is None or record_cycle_id == str(cycle_id)
+                    query_matches = event_type_matches and cycle_matches
+
+                    if has_query_filter and query_matches:
+                        query_match_count += 1
+                        if len(query_events) < max_events:
+                            query_events.append(
+                                _compact_record(
+                                    path=path,
+                                    line_no=line_no,
+                                    row=row,
+                                    live_event=live_event,
+                                    include_data=include_data,
+                                )
+                            )
+                    if cycle_id is not None and query_matches:
                         cycle_match_count += 1
                         if len(cycle_events) < max_events:
                             cycle_events.append(
@@ -256,11 +300,24 @@ def build_event_report(
             for key, value in cycle_counts.most_common(20)
         ],
     }
+    if has_query_filter:
+        report["query"] = {
+            "filters": {
+                "event_types": sorted(event_type_filter),
+                **({"cycle_id": str(cycle_id)} if cycle_id is not None else {}),
+            },
+            "matched_events": query_match_count,
+            "events_truncated": query_match_count > len(query_events),
+            "events": query_events,
+        }
     if cycle_id is not None:
         report["cycle"] = {
             "cycle_id": str(cycle_id),
+            "event_types": sorted(event_type_filter) if event_type_filter else None,
             "matched_events": cycle_match_count,
             "events_truncated": cycle_match_count > len(cycle_events),
             "events": cycle_events,
         }
+        if not event_type_filter:
+            report["cycle"].pop("event_types", None)
     return report

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -24,6 +24,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--cycle-id", help="Return compact records for one cycle_id.")
     parser.add_argument(
+        "--event-type",
+        "--kind",
+        dest="event_types",
+        action="append",
+        help=(
+            "Return compact records matching one event type. May be repeated or "
+            "comma-separated; --kind is accepted as an alias for monitor terminology."
+        ),
+    )
+    parser.add_argument(
         "--limit",
         type=int,
         default=200,
@@ -56,6 +66,7 @@ def main(argv: list[str] | None = None) -> int:
     report = build_event_report(
         args.path,
         cycle_id=args.cycle_id,
+        event_type=args.event_types,
         limit=args.limit,
         include_data=bool(args.include_data),
         include_rotated=bool(args.include_rotated),

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -177,6 +177,107 @@ def test_event_query_current_only_skips_rotated_segments(tmp_path):
     assert report["cycle_ids_sample"] == [{"cycle_id": "cy_current", "events": 1}]
 
 
+def test_event_query_filters_by_event_type_without_changing_summary_counts(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="candle.tail_projected",
+                cycle_id="cy_1",
+                seq=1,
+                ts=1000,
+                symbol="BTC/USDT:USDT",
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                cycle_id="cy_1",
+                seq=2,
+                ts=1100,
+                symbol="ETH/USDT:USDT",
+            ),
+            _monitor_row(
+                event_type="candle.tail_projected",
+                cycle_id="cy_2",
+                seq=3,
+                ts=1200,
+                symbol="SOL/USDT:USDT",
+            ),
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        event_type="candle.tail_projected",
+        include_data=True,
+    )
+
+    assert report["ok"] is True
+    assert report["event_types"] == {
+        "candle.tail_projected": 2,
+        "remote_call.failed": 1,
+    }
+    assert report["query"]["filters"] == {
+        "event_types": ["candle.tail_projected"],
+    }
+    assert report["query"]["matched_events"] == 2
+    assert report["query"]["events_truncated"] is False
+    assert [event["symbol"] for event in report["query"]["events"]] == [
+        "BTC/USDT:USDT",
+        "SOL/USDT:USDT",
+    ]
+    assert report["query"]["events"][0]["data"] == {"seq": 1}
+
+
+def test_event_query_combines_cycle_and_event_type_filters(tmp_path):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="candle.tail_projected",
+                cycle_id="cy_7",
+                seq=1,
+                ts=1000,
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                cycle_id="cy_7",
+                seq=2,
+                ts=1100,
+            ),
+            _monitor_row(
+                event_type="candle.tail_projected",
+                cycle_id="cy_8",
+                seq=3,
+                ts=1200,
+            ),
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        cycle_id="cy_7",
+        event_type=["candle.tail_projected,remote_call.failed"],
+    )
+
+    assert report["query"]["filters"] == {
+        "cycle_id": "cy_7",
+        "event_types": ["candle.tail_projected", "remote_call.failed"],
+    }
+    assert report["query"]["matched_events"] == 2
+    assert report["cycle"]["cycle_id"] == "cy_7"
+    assert report["cycle"]["event_types"] == [
+        "candle.tail_projected",
+        "remote_call.failed",
+    ]
+    assert report["cycle"]["matched_events"] == 2
+    assert [event["event_type"] for event in report["cycle"]["events"]] == [
+        "candle.tail_projected",
+        "remote_call.failed",
+    ]
+
+
 def test_live_event_query_cli_outputs_json_and_status(tmp_path, capsys):
     events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
     _write_ndjson(
@@ -196,6 +297,51 @@ def test_live_event_query_cli_outputs_json_and_status(tmp_path, capsys):
     report = json.loads(capsys.readouterr().out)
     assert report["cycle"]["cycle_id"] == "cy_7"
     assert report["cycle"]["matched_events"] == 1
+
+
+def test_live_event_query_cli_accepts_event_type_and_kind_alias(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="candle.tail_projected",
+                cycle_id="cy_7",
+                seq=1,
+                ts=1000,
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                cycle_id="cy_8",
+                seq=2,
+                ts=1100,
+            ),
+        ],
+    )
+
+    assert (
+        live_event_query.main(
+            [
+                str(tmp_path / "monitor"),
+                "--event-type",
+                "candle.tail_projected",
+                "--kind",
+                "remote_call.failed",
+                "--limit",
+                "1",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["query"]["filters"]["event_types"] == [
+        "candle.tail_projected",
+        "remote_call.failed",
+    ]
+    assert report["query"]["matched_events"] == 2
+    assert report["query"]["events_truncated"] is True
+    assert len(report["query"]["events"]) == 1
 
 
 def test_live_event_query_cli_defaults_to_current_only_for_directory_scans(


### PR DESCRIPTION
Summary:
- add --event-type/--kind filters to passivbot tool live-event-query
- keep existing aggregate summary counts intact while adding a query section with matched compact records
- support repeated or comma-separated event types, and combined cycle_id + event-type filtering

Tests:
- ./venv/bin/python -m compileall src/live/event_query.py src/tools/live_event_query.py tests/test_live_event_query.py
- ./venv/bin/python -m pytest tests/test_live_event_query.py -q
- git diff --check