### PR TITLE
Emit warmup cache decision events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added structured `cache.warmup_decision` live events for candle warmup cache
+  reuse/cold-path summaries.
 - Added `passivbot tool live-event-query --event-type`/`--kind` filters for
   inspecting specific structured live events without grepping monitor files.
 - Added structured `candle.tail_projected` live events for open-tail EMA

--- a/docs/plans/live_logging_overhaul_plan.md
+++ b/docs/plans/live_logging_overhaul_plan.md
@@ -145,6 +145,7 @@ stable names:
 - `remote_call.throttled`
 - `cache.load.started`
 - `cache.load.completed`
+- `cache.warmup_decision`
 - `cache.flush.started`
 - `cache.flush.completed`
 - `cache.flush.degraded`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -48,6 +48,7 @@ class EventTypes:
     EMA_FALLBACK_USED = "ema.fallback_used"
     EMA_UNAVAILABLE = "ema.unavailable"
     CANDLE_TAIL_PROJECTED = "candle.tail_projected"
+    CACHE_WARMUP_DECISION = "cache.warmup_decision"
     REMOTE_CALL_STARTED = "remote_call.started"
     REMOTE_CALL_SUCCEEDED = "remote_call.succeeded"
     REMOTE_CALL_FAILED = "remote_call.failed"
@@ -104,6 +105,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.EMA_FALLBACK_USED,
     EventTypes.EMA_UNAVAILABLE,
     EventTypes.CANDLE_TAIL_PROJECTED,
+    EventTypes.CACHE_WARMUP_DECISION,
     EventTypes.REMOTE_CALL_STARTED,
     EventTypes.REMOTE_CALL_SUCCEEDED,
     EventTypes.REMOTE_CALL_FAILED,
@@ -382,6 +384,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.EMA_FALLBACK_USED: EventRoute(console=False, text=False),
     EventTypes.EMA_UNAVAILABLE: EventRoute(console=False, text=False),
     EventTypes.CANDLE_TAIL_PROJECTED: EventRoute(console=False, text=False),
+    EventTypes.CACHE_WARMUP_DECISION: EventRoute(console=False, text=False),
     EventTypes.REMOTE_CALL_STARTED: EventRoute(console=False),
     EventTypes.REMOTE_CALL_SUCCEEDED: EventRoute(console=False),
     EventTypes.REMOTE_CALL_FAILED: EventRoute(console=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1031,6 +1031,75 @@ def emit_candle_tail_projected_event(bot: Any, *args: Any, **kwargs: Any) -> Non
         )
 
 
+def _reason_counts(data: Any) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for key, value in dict(data or {}).items():
+        count = _safe_int(value)
+        if count is not None:
+            out[str(key)] = int(count)
+    return dict(sorted(out.items()))
+
+
+def _emit_cache_warmup_decision_event_unchecked(
+    bot: Any,
+    *,
+    context: str,
+    timeframe: str = "1m",
+    symbol_count: int,
+    reused_count: int,
+    cold_count: int,
+    reason_counts: dict[str, int] | None = None,
+    elapsed_ms: int | None = None,
+    concurrency: int | None = None,
+    ttl_ms: int | None = None,
+    window_min_candles: int | None = None,
+    window_max_candles: int | None = None,
+) -> None:
+    reused = max(0, int(reused_count))
+    cold = max(0, int(cold_count))
+    data: dict[str, Any] = {
+        "context": str(context),
+        "timeframe": str(timeframe or "1m"),
+        "symbol_count": max(0, int(symbol_count)),
+        "reused_count": reused,
+        "cold_count": cold,
+        "cold_path_required": cold > 0,
+        "reason_counts": _reason_counts(reason_counts),
+    }
+    for key, value in (
+        ("elapsed_ms", elapsed_ms),
+        ("concurrency", concurrency),
+        ("ttl_ms", ttl_ms),
+        ("window_min_candles", window_min_candles),
+        ("window_max_candles", window_max_candles),
+    ):
+        safe = _safe_int(value)
+        if safe is not None:
+            data[key] = safe
+    _safe_emit(
+        bot,
+        EventTypes.CACHE_WARMUP_DECISION,
+        level="debug",
+        component="cache.warmup",
+        tags=("cache", "warmup", "candle"),
+        cycle_id=current_live_event_cycle_id(bot),
+        status="succeeded",
+        reason_code="warmup_cache_decision",
+        data=data,
+    )
+
+
+def emit_cache_warmup_decision_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    try:
+        _emit_cache_warmup_decision_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.CACHE_WARMUP_DECISION,
+            exc,
+        )
+
+
 def _mode_counts(modes: dict[str, dict[str, str]] | None) -> dict[str, int]:
     counts: dict[str, int] = {}
     for symbol_modes in (modes or {}).values():

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -627,6 +627,9 @@ class Passivbot:
     _emit_candle_tail_projected_event = (
         live_event_emitters.emit_candle_tail_projected_event
     )
+    _emit_cache_warmup_decision_event = (
+        live_event_emitters.emit_cache_warmup_decision_event
+    )
     _emit_order_wave_started_event = live_event_emitters.emit_order_wave_started_event
     _emit_order_wave_completed_event = live_event_emitters.emit_order_wave_completed_event
     _emit_planning_defer_summary_event = (
@@ -4684,6 +4687,20 @@ class Passivbot:
             cache_cold_1m,
             reasons,
             max(0.0, (utc_ms() - started_ms) / 1000.0),
+        )
+        Passivbot._emit_cache_warmup_decision_event(
+            self,
+            context=str(context),
+            timeframe="1m",
+            symbol_count=n,
+            reused_count=cache_reused_1m,
+            cold_count=cache_cold_1m,
+            reason_counts=cache_reason_counts,
+            elapsed_ms=max(0, int(utc_ms() - started_ms)),
+            concurrency=concurrency,
+            ttl_ms=ttl_ms,
+            window_min_candles=wmin,
+            window_max_candles=wmax,
         )
 
         # Warm 1h candles for grid log-range EMAs

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -1988,6 +1988,14 @@ async def test_warmup_candles_reuses_fresh_1m_cache(monkeypatch, caplog):
             self.rebuild_calls.append((args, kwargs))
 
     bot = FakeBot()
+    events = []
+    bot._live_event_current_cycle_id = "cy_warmup"
+
+    def emit_live_event(event_type, *args, **kwargs):
+        events.append((event_type, kwargs))
+        return object()
+
+    bot._emit_live_event = emit_live_event
     with caplog.at_level(logging.INFO):
         await pb_mod.Passivbot.warmup_candles_staggered(
             bot,
@@ -2003,6 +2011,25 @@ async def test_warmup_candles_reuses_fresh_1m_cache(monkeypatch, caplog):
         and "cold=1" in record.message
         for record in caplog.records
     )
+    warmup_events = [
+        kwargs
+        for event_type, kwargs in events
+        if event_type == EventTypes.CACHE_WARMUP_DECISION
+    ]
+    assert len(warmup_events) == 1
+    assert warmup_events[0]["cycle_id"] == "cy_warmup"
+    assert warmup_events[0]["reason_code"] == "warmup_cache_decision"
+    assert warmup_events[0]["data"]["context"] == "trading-ready warmup"
+    assert warmup_events[0]["data"]["symbol_count"] == 2
+    assert warmup_events[0]["data"]["reused_count"] == 1
+    assert warmup_events[0]["data"]["cold_count"] == 1
+    assert warmup_events[0]["data"]["cold_path_required"] is True
+    assert warmup_events[0]["data"]["reason_counts"] == {
+        "missing_coverage": 1,
+        "warm_cache_accepted": 1,
+    }
+    assert warmup_events[0]["data"]["window_min_candles"] == 12
+    assert warmup_events[0]["data"]["window_max_candles"] == 12
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -142,6 +142,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.EMA_FALLBACK_USED,
         EventTypes.EMA_UNAVAILABLE,
         EventTypes.CANDLE_TAIL_PROJECTED,
+        EventTypes.CACHE_WARMUP_DECISION,
         EventTypes.PLANNING_DEFER_SUMMARY,
         EventTypes.PLANNING_SYMBOL_STATE,
         EventTypes.HSL_TRANSITION,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -484,6 +484,9 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         _emit_candle_tail_projected_event = (
             pb_mod.Passivbot._emit_candle_tail_projected_event
         )
+        _emit_cache_warmup_decision_event = (
+            pb_mod.Passivbot._emit_cache_warmup_decision_event
+        )
         _emit_forager_feature_unavailable_event = (
             pb_mod.Passivbot._emit_forager_feature_unavailable_event
         )
@@ -570,6 +573,19 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         },
         reason_code="late_open_tail_projection",
     )
+    bot._emit_cache_warmup_decision_event(
+        context="trading-ready warmup",
+        timeframe="1m",
+        symbol_count=3,
+        reused_count=1,
+        cold_count=2,
+        reason_counts={"missing_coverage": 2, "warm_cache_accepted": 1},
+        elapsed_ms=1234,
+        concurrency=4,
+        ttl_ms=300_000,
+        window_min_candles=120,
+        window_max_candles=260,
+    )
 
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     events = sink.events
@@ -581,6 +597,7 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         EventTypes.EMA_FALLBACK_USED,
         EventTypes.EMA_UNAVAILABLE,
         EventTypes.CANDLE_TAIL_PROJECTED,
+        EventTypes.CACHE_WARMUP_DECISION,
     ]
     assert {event.cycle_id for event in events} == {"cy_11"}
     assert events[0].data["unavailable"]["count"] == 2
@@ -602,6 +619,18 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
     assert events[6].reason_code == "late_open_tail_projection"
     assert events[6].data["latest_expected_ts"] == 180_000
     assert events[6].data["tail_gap_age_ms"] == 60_000
+    assert events[7].component == "cache.warmup"
+    assert events[7].reason_code == "warmup_cache_decision"
+    assert events[7].data["context"] == "trading-ready warmup"
+    assert events[7].data["symbol_count"] == 3
+    assert events[7].data["reused_count"] == 1
+    assert events[7].data["cold_count"] == 2
+    assert events[7].data["cold_path_required"] is True
+    assert events[7].data["reason_counts"] == {
+        "missing_coverage": 2,
+        "warm_cache_accepted": 1,
+    }
+    assert events[7].data["window_max_candles"] == 260
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
@@ -667,6 +696,14 @@ def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(ca
             symbol=object(),
             context=object(),
         )
+        pb_mod.Passivbot._emit_cache_warmup_decision_event(
+            bot,
+            context=object(),
+            symbol_count=object(),
+            reused_count=object(),
+            cold_count=object(),
+            reason_counts=object(),
+        )
 
     messages = [record.message for record in caplog.records]
     assert any(EventTypes.FORAGER_FEATURE_UNAVAILABLE in msg for msg in messages)
@@ -677,6 +714,7 @@ def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(ca
     assert any(EventTypes.EMA_FALLBACK_USED in msg for msg in messages)
     assert any(EventTypes.EMA_UNAVAILABLE in msg for msg in messages)
     assert any(EventTypes.CANDLE_TAIL_PROJECTED in msg for msg in messages)
+    assert any(EventTypes.CACHE_WARMUP_DECISION in msg for msg in messages)
 
 
 def _make_remote_fetch_event_bot(sink, *, cycle_id="cy_7", map_max=None):


### PR DESCRIPTION
Summary:
- add structured cache.warmup_decision live events for candle warmup cache reuse/cold-path summaries
- route the new event off console/text by default while preserving the existing [warmup] text summary
- include context, timeframe, symbol/reused/cold counts, reason counts, elapsed/ttl/concurrency/window metadata

Tests:
- ./venv/bin/python -m compileall src/live/event_bus.py src/live/event_emitters.py src/passivbot.py tests/test_live_event_bus.py tests/test_passivbot_monitor.py tests/test_live_candle_budget.py
- ./venv/bin/python -m pytest tests/test_live_event_bus.py::test_route_table_keeps_data_events_off_console_by_default tests/test_passivbot_monitor.py::test_forager_and_ema_summary_emitters_emit_structured_events tests/test_passivbot_monitor.py::test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs tests/test_live_candle_budget.py::test_warmup_candles_reuses_fresh_1m_cache -q
- ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py -q
- ./venv/bin/python -m pytest tests/test_live_candle_budget.py -k warmup -q
- git diff --check