### PR TITLE
Emit startup timing events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added structured `bot.startup_timing` live events for startup phase timing
+  diagnostics.
 - Added structured `cache.warmup_decision` live events for candle warmup cache
   reuse/cold-path summaries.
 - Added `passivbot tool live-event-query --event-type`/`--kind` filters for

--- a/docs/plans/live_logging_overhaul_plan.md
+++ b/docs/plans/live_logging_overhaul_plan.md
@@ -134,6 +134,7 @@ stable names:
 
 - `bot.started`
 - `bot.ready`
+- `bot.startup_timing`
 - `bot.stopping`
 - `bot.stopped`
 - `cycle.started`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -30,6 +30,7 @@ LIVE_EVENT_ID_KEYS = (
 class EventTypes:
     BOT_STARTED = "bot.started"
     BOT_READY = "bot.ready"
+    BOT_STARTUP_TIMING = "bot.startup_timing"
     BOT_STOPPING = "bot.stopping"
     BOT_SHUTDOWN_STAGE = "bot.shutdown.stage"
     BOT_STOPPED = "bot.stopped"
@@ -87,6 +88,7 @@ class EventTypes:
 PHASE1_EVENT_TYPES = {
     EventTypes.BOT_STARTED,
     EventTypes.BOT_READY,
+    EventTypes.BOT_STARTUP_TIMING,
     EventTypes.BOT_STOPPING,
     EventTypes.BOT_SHUTDOWN_STAGE,
     EventTypes.BOT_STOPPED,
@@ -360,6 +362,7 @@ DEFAULT_ROUTE = EventRoute(structured=True, monitor=True, console=False, text=Fa
 DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.BOT_STARTED: EventRoute(console=True, text=True),
     EventTypes.BOT_READY: EventRoute(console=True, text=True),
+    EventTypes.BOT_STARTUP_TIMING: EventRoute(console=False, text=False),
     EventTypes.BOT_STOPPING: EventRoute(console=True, text=True),
     EventTypes.BOT_SHUTDOWN_STAGE: EventRoute(console=True, text=True),
     EventTypes.BOT_STOPPED: EventRoute(console=True, text=True),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -690,6 +690,49 @@ def _safe_int(value: Any) -> int | None:
         return None
 
 
+def _emit_startup_timing_event_unchecked(
+    bot: Any,
+    *,
+    phase: str,
+    elapsed_ms: int,
+    since_previous_ms: int,
+    details: str = "",
+) -> None:
+    elapsed = _safe_int(elapsed_ms)
+    since_previous = _safe_int(since_previous_ms)
+    data: dict[str, Any] = {
+        "phase": str(phase),
+        "elapsed_ms": max(0, int(elapsed)) if elapsed is not None else 0,
+        "since_previous_ms": (
+            max(0, int(since_previous)) if since_previous is not None else 0
+        ),
+    }
+    if details:
+        data["details"] = str(details)
+    _safe_emit(
+        bot,
+        EventTypes.BOT_STARTUP_TIMING,
+        level="debug",
+        component="bot.startup",
+        tags=("bot", "startup", "timing"),
+        cycle_id=current_live_event_cycle_id(bot),
+        status="succeeded",
+        reason_code="startup_phase_ready",
+        data=data,
+    )
+
+
+def emit_startup_timing_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    try:
+        _emit_startup_timing_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.BOT_STARTUP_TIMING,
+            exc,
+        )
+
+
 def _symbol_sample(symbols: Any, *, limit: int = 12) -> dict[str, Any]:
     if symbols is None:
         values = []

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -603,6 +603,7 @@ class Passivbot:
     _emit_live_cycle_completed = live_event_emitters.emit_live_cycle_completed
     _emit_live_cycle_degraded = live_event_emitters.emit_live_cycle_degraded
     _emit_live_event = live_event_emitters.emit_live_event
+    _emit_startup_timing_event = live_event_emitters.emit_startup_timing_event
     _emit_execution_confirmation_requested_event = (
         live_event_emitters.emit_execution_confirmation_requested_event
     )
@@ -3485,6 +3486,13 @@ class Passivbot:
             elapsed_s,
             since_previous_s,
             suffix,
+        )
+        Passivbot._emit_startup_timing_event(
+            self,
+            phase=label,
+            elapsed_ms=max(0, int(now_ms - started_ms)),
+            since_previous_ms=max(0, int(now_ms - previous_ms)),
+            details=str(details or ""),
         )
 
     def _force_cold_startup(self) -> bool:

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -143,6 +143,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.EMA_UNAVAILABLE,
         EventTypes.CANDLE_TAIL_PROJECTED,
         EventTypes.CACHE_WARMUP_DECISION,
+        EventTypes.BOT_STARTUP_TIMING,
         EventTypes.PLANNING_DEFER_SUMMARY,
         EventTypes.PLANNING_SYMBOL_STATE,
         EventTypes.HSL_TRANSITION,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -150,6 +150,57 @@ def test_live_event_cycle_helpers_emit_structured_events():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_startup_timing_mark_emits_structured_event(monkeypatch, caplog):
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+    clock_values = iter([1_000, 3_500, 8_000])
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: next(clock_values))
+
+    class FakeBot:
+        _startup_timing_begin = pb_mod.Passivbot._startup_timing_begin
+        _startup_timing_mark = pb_mod.Passivbot._startup_timing_mark
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "gateio"
+            self.user = "gateio_01"
+            self.bot_id = "bot_1"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+    bot._startup_timing_begin()
+    with caplog.at_level(logging.INFO):
+        bot._startup_timing_mark("account")
+        bot._startup_timing_mark("hsl", details="mode=coin")
+
+    assert any("account-ready=2.50s" in record.message for record in caplog.records)
+    assert any("hsl-ready=7.00s" in record.message for record in caplog.records)
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = sink.events
+    assert [event.event_type for event in events] == [
+        EventTypes.BOT_STARTUP_TIMING,
+        EventTypes.BOT_STARTUP_TIMING,
+    ]
+    assert events[0].component == "bot.startup"
+    assert events[0].reason_code == "startup_phase_ready"
+    assert events[0].data == {
+        "phase": "account",
+        "elapsed_ms": 2500,
+        "since_previous_ms": 2500,
+    }
+    assert events[1].data == {
+        "phase": "hsl",
+        "elapsed_ms": 7000,
+        "since_previous_ms": 4500,
+        "details": "mode=coin",
+    }
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_routine_planning_defer_summary_emits_live_event(monkeypatch):
     import passivbot as pb_mod
 
@@ -704,6 +755,12 @@ def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(ca
             cold_count=object(),
             reason_counts=object(),
         )
+        pb_mod.Passivbot._emit_startup_timing_event(
+            bot,
+            phase=object(),
+            elapsed_ms=object(),
+            since_previous_ms=object(),
+        )
 
     messages = [record.message for record in caplog.records]
     assert any(EventTypes.FORAGER_FEATURE_UNAVAILABLE in msg for msg in messages)
@@ -715,6 +772,7 @@ def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(ca
     assert any(EventTypes.EMA_UNAVAILABLE in msg for msg in messages)
     assert any(EventTypes.CANDLE_TAIL_PROJECTED in msg for msg in messages)
     assert any(EventTypes.CACHE_WARMUP_DECISION in msg for msg in messages)
+    assert any(EventTypes.BOT_STARTUP_TIMING in msg for msg in messages)
 
 
 def _make_remote_fetch_event_bot(sink, *, cycle_id="cy_7", map_max=None):


### PR DESCRIPTION
Summary:
- add structured bot.startup_timing live events for existing startup phase timing marks
- keep the existing [boot] startup timing text logs unchanged while routing structured timing details off console/text by default
- include phase, elapsed_ms, since_previous_ms, and optional details

Tests:
- ./venv/bin/python -m compileall src/live/event_bus.py src/live/event_emitters.py src/passivbot.py tests/test_live_event_bus.py tests/test_passivbot_monitor.py
- ./venv/bin/python -m pytest tests/test_live_event_bus.py::test_route_table_keeps_data_events_off_console_by_default tests/test_passivbot_monitor.py::test_startup_timing_mark_emits_structured_event tests/test_passivbot_monitor.py::test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs -q
- ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py -q
- git diff --check