### PR TITLE
Emit candle cache load events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added structured `cache.load.completed` live events for candle disk-cache load
+  summaries.
 - Added structured `bot.startup_timing` live events for startup phase timing
   diagnostics.
 - Added structured `cache.warmup_decision` live events for candle warmup cache

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -2330,27 +2330,33 @@ class CandlestickManager:
                 except Exception:
                     loaded_start_ts = None
                     loaded_end_ts = None
-            self._emit_disk_load_observer(
-                {
-                    "symbol": symbol,
-                    "timeframe": tf_norm,
-                    "start_ts": int(start_ts),
-                    "end_ts": int(end_ts),
-                    "loaded_rows": int(merged_disk.shape[0]),
-                    "loaded_start_ts": loaded_start_ts,
-                    "loaded_end_ts": loaded_end_ts,
-                    "days": int(len(load_keys)),
-                    "primary_days": int(primary_hits),
-                    "legacy_days": int(legacy_hits),
-                    "merged_days": int(merged_hits),
-                    "source_days": {
-                        "primary": int(primary_hits),
-                        "legacy": int(legacy_hits),
-                        "merged": int(merged_hits),
-                    },
-                    "elapsed_ms": int(max(0.0, (time.monotonic() - t0) * 1000.0)),
-                }
-            )
+            try:
+                self._emit_disk_load_observer(
+                    {
+                        "symbol": symbol,
+                        "timeframe": tf_norm,
+                        "start_ts": int(start_ts),
+                        "end_ts": int(end_ts),
+                        "loaded_rows": int(merged_disk.shape[0]),
+                        "loaded_start_ts": loaded_start_ts,
+                        "loaded_end_ts": loaded_end_ts,
+                        "days": int(len(load_keys)),
+                        "primary_days": int(primary_hits),
+                        "legacy_days": int(legacy_hits),
+                        "merged_days": int(merged_hits),
+                        "source_days": {
+                            "primary": int(primary_hits),
+                            "legacy": int(legacy_hits),
+                            "merged": int(merged_hits),
+                        },
+                        "elapsed_ms": int(
+                            max(0.0, (time.monotonic() - t0) * 1000.0)
+                        ),
+                    }
+                )
+            except Exception:
+                # Disk-load telemetry must never break cache loading.
+                pass
             if tf_norm == "1m":
                 existing = self._ensure_symbol_cache(symbol)
                 merged = self._merge_overwrite(existing, merged_disk)

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -674,6 +674,7 @@ class CandlestickManager:
         self._persist_batch_observer: Optional[
             Callable[[str, str, np.ndarray], None]
         ] = None
+        self._disk_load_observer: Optional[Callable[[Dict[str, Any]], None]] = None
         # Summary tracking for strict gap warnings (logged once per 15 min instead of per-event)
         self._strict_gaps_summary: Dict[str, int] = {}  # symbol -> missing count
         self._strict_gaps_summary_last_log: float = 0.0
@@ -1522,6 +1523,22 @@ class CandlestickManager:
     ) -> None:
         self._persist_batch_observer = observer
 
+    def set_disk_load_observer(
+        self,
+        observer: Optional[Callable[[Dict[str, Any]], None]],
+    ) -> None:
+        self._disk_load_observer = observer
+
+    def _emit_disk_load_observer(self, payload: Dict[str, Any]) -> None:
+        observer = self._disk_load_observer
+        if observer is None:
+            return
+        try:
+            observer(payload)
+        except Exception:
+            # Observability hooks must never break cache loading or trading.
+            return
+
     # ----- Paths and index -----
 
     def _symbol_dir(
@@ -2303,6 +2320,36 @@ class CandlestickManager:
                 rows=int(merged_disk.shape[0]),
                 start_ts=start_ts,
                 end_ts=end_ts,
+            )
+            loaded_start_ts = None
+            loaded_end_ts = None
+            if merged_disk.size:
+                try:
+                    loaded_start_ts = int(merged_disk["ts"][0])
+                    loaded_end_ts = int(merged_disk["ts"][-1])
+                except Exception:
+                    loaded_start_ts = None
+                    loaded_end_ts = None
+            self._emit_disk_load_observer(
+                {
+                    "symbol": symbol,
+                    "timeframe": tf_norm,
+                    "start_ts": int(start_ts),
+                    "end_ts": int(end_ts),
+                    "loaded_rows": int(merged_disk.shape[0]),
+                    "loaded_start_ts": loaded_start_ts,
+                    "loaded_end_ts": loaded_end_ts,
+                    "days": int(len(load_keys)),
+                    "primary_days": int(primary_hits),
+                    "legacy_days": int(legacy_hits),
+                    "merged_days": int(merged_hits),
+                    "source_days": {
+                        "primary": int(primary_hits),
+                        "legacy": int(legacy_hits),
+                        "merged": int(merged_hits),
+                    },
+                    "elapsed_ms": int(max(0.0, (time.monotonic() - t0) * 1000.0)),
+                }
             )
             if tf_norm == "1m":
                 existing = self._ensure_symbol_cache(symbol)

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -49,6 +49,7 @@ class EventTypes:
     EMA_FALLBACK_USED = "ema.fallback_used"
     EMA_UNAVAILABLE = "ema.unavailable"
     CANDLE_TAIL_PROJECTED = "candle.tail_projected"
+    CACHE_LOAD_COMPLETED = "cache.load.completed"
     CACHE_WARMUP_DECISION = "cache.warmup_decision"
     REMOTE_CALL_STARTED = "remote_call.started"
     REMOTE_CALL_SUCCEEDED = "remote_call.succeeded"
@@ -107,6 +108,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.EMA_FALLBACK_USED,
     EventTypes.EMA_UNAVAILABLE,
     EventTypes.CANDLE_TAIL_PROJECTED,
+    EventTypes.CACHE_LOAD_COMPLETED,
     EventTypes.CACHE_WARMUP_DECISION,
     EventTypes.REMOTE_CALL_STARTED,
     EventTypes.REMOTE_CALL_SUCCEEDED,
@@ -387,6 +389,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.EMA_FALLBACK_USED: EventRoute(console=False, text=False),
     EventTypes.EMA_UNAVAILABLE: EventRoute(console=False, text=False),
     EventTypes.CANDLE_TAIL_PROJECTED: EventRoute(console=False, text=False),
+    EventTypes.CACHE_LOAD_COMPLETED: EventRoute(console=False, text=False),
     EventTypes.CACHE_WARMUP_DECISION: EventRoute(console=False, text=False),
     EventTypes.REMOTE_CALL_STARTED: EventRoute(console=False),
     EventTypes.REMOTE_CALL_SUCCEEDED: EventRoute(console=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1083,6 +1083,63 @@ def _reason_counts(data: Any) -> dict[str, int]:
     return dict(sorted(out.items()))
 
 
+def _emit_cache_load_completed_event_unchecked(
+    bot: Any,
+    payload: dict[str, Any],
+) -> None:
+    data_in = dict(payload or {})
+    symbol = data_in.get("symbol")
+    timeframe = str(data_in.get("timeframe") or data_in.get("tf") or "1m")
+    data: dict[str, Any] = {"timeframe": timeframe}
+    for key in (
+        "start_ts",
+        "end_ts",
+        "loaded_rows",
+        "loaded_start_ts",
+        "loaded_end_ts",
+        "days",
+        "primary_days",
+        "legacy_days",
+        "merged_days",
+        "elapsed_ms",
+    ):
+        value = _safe_int(data_in.get(key))
+        if value is not None:
+            data[key] = value
+    source_days = data_in.get("source_days")
+    if isinstance(source_days, dict):
+        clean_source_days: dict[str, int] = {}
+        for key, value in source_days.items():
+            count = _safe_int(value)
+            if count is not None:
+                clean_source_days[str(key)] = int(count)
+        if clean_source_days:
+            data["source_days"] = dict(sorted(clean_source_days.items()))
+    _safe_emit(
+        bot,
+        EventTypes.CACHE_LOAD_COMPLETED,
+        level="debug",
+        component="cache.candles",
+        tags=("cache", "candle", "load"),
+        cycle_id=current_live_event_cycle_id(bot),
+        symbol=str(symbol) if symbol is not None else None,
+        status="succeeded",
+        reason_code="candle_disk_load_completed",
+        data=data,
+    )
+
+
+def emit_cache_load_completed_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    try:
+        _emit_cache_load_completed_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.CACHE_LOAD_COMPLETED,
+            exc,
+        )
+
+
 def _emit_cache_warmup_decision_event_unchecked(
     bot: Any,
     *,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -631,6 +631,9 @@ class Passivbot:
     _emit_cache_warmup_decision_event = (
         live_event_emitters.emit_cache_warmup_decision_event
     )
+    _emit_cache_load_completed_event = (
+        live_event_emitters.emit_cache_load_completed_event
+    )
     _emit_order_wave_started_event = live_event_emitters.emit_order_wave_started_event
     _emit_order_wave_completed_event = live_event_emitters.emit_order_wave_completed_event
     _emit_planning_defer_summary_event = (
@@ -641,6 +644,7 @@ class Passivbot:
     )
     _emit_position_changed_event = live_event_emitters.emit_position_changed_event
     _handle_candle_remote_fetch_event = live_event_emitters.emit_candle_remote_fetch_event
+    _handle_candle_disk_load_event = live_event_emitters.emit_cache_load_completed_event
     _next_live_event_remote_call_id = live_event_emitters.next_live_event_remote_call_id
     _set_live_event_context_ids = live_event_emitters.set_live_event_context_ids
 
@@ -955,6 +959,8 @@ class Passivbot:
         )
         if self.monitor_publisher is not None:
             self.cm.set_persist_batch_observer(self._monitor_handle_candlestick_persist)
+        if self._live_event_pipeline is not None:
+            self.cm.set_disk_load_observer(self._handle_candle_disk_load_event)
         # TTL (minutes) for EMA candles on non-traded symbols
         ttl_min = require_live_value(config, "inactive_coin_candle_ttl_minutes")
         self.inactive_coin_candle_ttl_ms = int(float(ttl_min) * 60_000)

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -550,6 +550,51 @@ def test_persist_batch_observer_receives_saved_batch(tmp_path):
     assert np.array_equal(batch, arr)
 
 
+def test_disk_load_observer_receives_summary_and_is_best_effort(tmp_path):
+    cm = CandlestickManager(exchange=None, exchange_name="ex", cache_dir=str(tmp_path / "caches"))
+    symbol = "LOAD/USDT"
+    ts0 = _floor_minute(int(time.time() * 1000)) - 5 * ONE_MIN_MS
+    ts1 = ts0 + ONE_MIN_MS
+    arr = np.array(
+        [
+            (ts0, 1.0, 2.0, 0.5, 1.5, 0.3),
+            (ts1, 1.5, 2.5, 1.0, 2.0, 0.4),
+        ],
+        dtype=CANDLE_DTYPE,
+    )
+    observed = []
+
+    def observer(payload):
+        observed.append(dict(payload))
+
+    cm._persist_batch(symbol, arr, timeframe="1m")
+    cm.set_disk_load_observer(observer)
+    loaded = cm._load_from_disk(symbol, ts0, ts1, timeframe="1m")
+
+    assert loaded is not None
+    assert loaded.shape[0] == 2
+    assert len(observed) == 1
+    payload = observed[0]
+    assert payload["symbol"] == symbol
+    assert payload["timeframe"] == "1m"
+    assert payload["start_ts"] == ts0
+    assert payload["end_ts"] == ts1
+    assert payload["loaded_rows"] == 2
+    assert payload["loaded_start_ts"] == ts0
+    assert payload["loaded_end_ts"] == ts1
+    assert payload["days"] == 1
+    assert payload["source_days"] == {"primary": 1, "legacy": 0, "merged": 0}
+    assert payload["elapsed_ms"] >= 0
+
+    def failing_observer(_payload):
+        raise RuntimeError("observer failed")
+
+    cm.set_disk_load_observer(failing_observer)
+    loaded_again = cm._load_from_disk(symbol, ts0, ts1, timeframe="1m")
+    assert loaded_again is not None
+    assert loaded_again.shape[0] == 2
+
+
 def test_rebuild_index_for_range_updates_and_prunes(tmp_path):
     cm = CandlestickManager(exchange=None, exchange_name="ex", cache_dir=str(tmp_path / "caches"))
     symbol = "REBUILD/USDT"

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -142,6 +142,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.EMA_FALLBACK_USED,
         EventTypes.EMA_UNAVAILABLE,
         EventTypes.CANDLE_TAIL_PROJECTED,
+        EventTypes.CACHE_LOAD_COMPLETED,
         EventTypes.CACHE_WARMUP_DECISION,
         EventTypes.BOT_STARTUP_TIMING,
         EventTypes.PLANNING_DEFER_SUMMARY,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -535,6 +535,9 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         _emit_candle_tail_projected_event = (
             pb_mod.Passivbot._emit_candle_tail_projected_event
         )
+        _emit_cache_load_completed_event = (
+            pb_mod.Passivbot._emit_cache_load_completed_event
+        )
         _emit_cache_warmup_decision_event = (
             pb_mod.Passivbot._emit_cache_warmup_decision_event
         )
@@ -624,6 +627,23 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         },
         reason_code="late_open_tail_projection",
     )
+    bot._emit_cache_load_completed_event(
+        {
+            "symbol": "ETH/USDT:USDT",
+            "timeframe": "1m",
+            "start_ts": 120_000,
+            "end_ts": 240_000,
+            "loaded_rows": 3,
+            "loaded_start_ts": 120_000,
+            "loaded_end_ts": 240_000,
+            "days": 1,
+            "primary_days": 1,
+            "legacy_days": 0,
+            "merged_days": 0,
+            "source_days": {"primary": 1, "legacy": 0, "merged": 0},
+            "elapsed_ms": 7,
+        }
+    )
     bot._emit_cache_warmup_decision_event(
         context="trading-ready warmup",
         timeframe="1m",
@@ -648,6 +668,7 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         EventTypes.EMA_FALLBACK_USED,
         EventTypes.EMA_UNAVAILABLE,
         EventTypes.CANDLE_TAIL_PROJECTED,
+        EventTypes.CACHE_LOAD_COMPLETED,
         EventTypes.CACHE_WARMUP_DECISION,
     ]
     assert {event.cycle_id for event in events} == {"cy_11"}
@@ -670,18 +691,35 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
     assert events[6].reason_code == "late_open_tail_projection"
     assert events[6].data["latest_expected_ts"] == 180_000
     assert events[6].data["tail_gap_age_ms"] == 60_000
-    assert events[7].component == "cache.warmup"
-    assert events[7].reason_code == "warmup_cache_decision"
-    assert events[7].data["context"] == "trading-ready warmup"
-    assert events[7].data["symbol_count"] == 3
-    assert events[7].data["reused_count"] == 1
-    assert events[7].data["cold_count"] == 2
-    assert events[7].data["cold_path_required"] is True
-    assert events[7].data["reason_counts"] == {
+    assert events[7].component == "cache.candles"
+    assert events[7].symbol == "ETH/USDT:USDT"
+    assert events[7].reason_code == "candle_disk_load_completed"
+    assert events[7].data == {
+        "timeframe": "1m",
+        "start_ts": 120_000,
+        "end_ts": 240_000,
+        "loaded_rows": 3,
+        "loaded_start_ts": 120_000,
+        "loaded_end_ts": 240_000,
+        "days": 1,
+        "primary_days": 1,
+        "legacy_days": 0,
+        "merged_days": 0,
+        "elapsed_ms": 7,
+        "source_days": {"legacy": 0, "merged": 0, "primary": 1},
+    }
+    assert events[8].component == "cache.warmup"
+    assert events[8].reason_code == "warmup_cache_decision"
+    assert events[8].data["context"] == "trading-ready warmup"
+    assert events[8].data["symbol_count"] == 3
+    assert events[8].data["reused_count"] == 1
+    assert events[8].data["cold_count"] == 2
+    assert events[8].data["cold_path_required"] is True
+    assert events[8].data["reason_counts"] == {
         "missing_coverage": 2,
         "warm_cache_accepted": 1,
     }
-    assert events[7].data["window_max_candles"] == 260
+    assert events[8].data["window_max_candles"] == 260
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
@@ -747,6 +785,10 @@ def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(ca
             symbol=object(),
             context=object(),
         )
+        pb_mod.Passivbot._emit_cache_load_completed_event(
+            bot,
+            payload=object(),
+        )
         pb_mod.Passivbot._emit_cache_warmup_decision_event(
             bot,
             context=object(),
@@ -771,6 +813,7 @@ def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(ca
     assert any(EventTypes.EMA_FALLBACK_USED in msg for msg in messages)
     assert any(EventTypes.EMA_UNAVAILABLE in msg for msg in messages)
     assert any(EventTypes.CANDLE_TAIL_PROJECTED in msg for msg in messages)
+    assert any(EventTypes.CACHE_LOAD_COMPLETED in msg for msg in messages)
     assert any(EventTypes.CACHE_WARMUP_DECISION in msg for msg in messages)
     assert any(EventTypes.BOT_STARTUP_TIMING in msg for msg in messages)
 


### PR DESCRIPTION
## Summary
- add structured cache.load.completed events for successful candle disk-cache load summaries
- wire CandlestickManager disk-load observer into the live event pipeline when monitor/event bus is active
- keep events structured/monitor-only and best-effort so cache loading/trading behavior is unchanged

## Validation
- ./venv/bin/python -m compileall src/live/event_bus.py src/live/event_emitters.py src/candlestick_manager.py src/passivbot.py tests/test_live_event_bus.py tests/test_passivbot_monitor.py tests/test_candlestick_manager.py
- ./venv/bin/python -m pytest tests/test_live_event_bus.py::test_route_table_keeps_data_events_off_console_by_default tests/test_passivbot_monitor.py::test_forager_and_ema_summary_emitters_emit_structured_events tests/test_passivbot_monitor.py::test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs tests/test_candlestick_manager.py::test_disk_load_observer_receives_summary_and_is_best_effort -q
- ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py -q
- ./venv/bin/python -m pytest tests/test_candlestick_manager.py -q
- ./venv/bin/python -m pytest tests/test_live_candle_budget.py::test_warmup_candles_reuses_fresh_1m_cache tests/test_live_candle_budget.py::test_warmup_candles_force_cold_startup_fetches_cached_symbol -q
- git diff --check