### PR TITLE
Throttle cache load events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable user-facing changes will be documented in this file.
 
 - Added structured `cache.load.completed` live events for candle disk-cache load
   summaries.
+- Throttled repeated `cache.load.completed` live events per symbol/timeframe and
+  added `suppressed_count` so warmup/HSL replay does not flood monitor storage.
 - Added structured `bot.startup_timing` live events for startup phase timing
   diagnostics.
 - Added structured `cache.warmup_decision` live events for candle warmup cache

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1102,6 +1102,7 @@ def _emit_cache_load_completed_event_unchecked(
         "legacy_days",
         "merged_days",
         "elapsed_ms",
+        "suppressed_count",
     ):
         value = _safe_int(data_in.get(key))
         if value is not None:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -644,7 +644,6 @@ class Passivbot:
     )
     _emit_position_changed_event = live_event_emitters.emit_position_changed_event
     _handle_candle_remote_fetch_event = live_event_emitters.emit_candle_remote_fetch_event
-    _handle_candle_disk_load_event = live_event_emitters.emit_cache_load_completed_event
     _next_live_event_remote_call_id = live_event_emitters.next_live_event_remote_call_id
     _set_live_event_context_ids = live_event_emitters.set_live_event_context_ids
 
@@ -6300,6 +6299,41 @@ class Passivbot:
                         traceback.format_exception(type(exc), exc, exc.__traceback__)
                     )
                 )
+
+    def _handle_candle_disk_load_event(self, payload: dict[str, Any]) -> None:
+        """Emit summarized candle disk-load events without flooding monitor storage."""
+        try:
+            data = dict(payload or {})
+            symbol = str(data.get("symbol") or "")
+            timeframe = str(data.get("timeframe") or data.get("tf") or "1m")
+            key = (symbol, timeframe)
+            now = time.monotonic()
+            try:
+                interval_s = float(
+                    getattr(self, "_cache_load_event_throttle_seconds", 60.0)
+                )
+            except Exception:
+                interval_s = 60.0
+            interval_s = max(0.0, interval_s)
+            last_by_key = getattr(self, "_cache_load_event_last_emit", None)
+            if not isinstance(last_by_key, dict):
+                last_by_key = {}
+                self._cache_load_event_last_emit = last_by_key
+            suppressed_by_key = getattr(self, "_cache_load_event_suppressed", None)
+            if not isinstance(suppressed_by_key, dict):
+                suppressed_by_key = {}
+                self._cache_load_event_suppressed = suppressed_by_key
+            last_emit = last_by_key.get(key)
+            if last_emit is not None and now - float(last_emit) < interval_s:
+                suppressed_by_key[key] = int(suppressed_by_key.get(key, 0) or 0) + 1
+                return
+            suppressed_count = int(suppressed_by_key.pop(key, 0) or 0)
+            if suppressed_count > 0:
+                data["suppressed_count"] = suppressed_count
+            last_by_key[key] = now
+            self._emit_cache_load_completed_event(data)
+        except Exception as exc:
+            logging.debug("[event] failed handling cache load event: %s", exc)
 
     def _install_live_event_pipeline(self) -> Optional[LiveEventPipeline]:
         publisher = getattr(self, "monitor_publisher", None)

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -642,6 +642,7 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
             "merged_days": 0,
             "source_days": {"primary": 1, "legacy": 0, "merged": 0},
             "elapsed_ms": 7,
+            "suppressed_count": 2,
         }
     )
     bot._emit_cache_warmup_decision_event(
@@ -706,6 +707,7 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         "legacy_days": 0,
         "merged_days": 0,
         "elapsed_ms": 7,
+        "suppressed_count": 2,
         "source_days": {"legacy": 0, "merged": 0, "primary": 1},
     }
     assert events[8].component == "cache.warmup"
@@ -721,6 +723,52 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
     }
     assert events[8].data["window_max_candles"] == 260
     assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_candle_disk_load_handler_throttles_repeated_symbol_timeframe_events():
+    import passivbot as pb_mod
+
+    class FakeBot:
+        _handle_candle_disk_load_event = (
+            pb_mod.Passivbot._handle_candle_disk_load_event
+        )
+
+        def __init__(self):
+            self._cache_load_event_throttle_seconds = 60.0
+            self.emitted = []
+
+        def _emit_cache_load_completed_event(self, payload):
+            self.emitted.append(dict(payload))
+
+    bot = FakeBot()
+    payload = {
+        "symbol": "ETH/USDT:USDT",
+        "timeframe": "1m",
+        "start_ts": 120_000,
+        "end_ts": 240_000,
+        "loaded_rows": 3,
+    }
+
+    bot._handle_candle_disk_load_event(payload)
+    bot._handle_candle_disk_load_event({**payload, "start_ts": 180_000})
+
+    assert len(bot.emitted) == 1
+    assert "suppressed_count" not in bot.emitted[0]
+    key = ("ETH/USDT:USDT", "1m")
+    assert bot._cache_load_event_suppressed[key] == 1
+
+    bot._cache_load_event_last_emit[key] -= 61.0
+    bot._handle_candle_disk_load_event({**payload, "start_ts": 240_000})
+
+    assert len(bot.emitted) == 2
+    assert bot.emitted[1]["start_ts"] == 240_000
+    assert bot.emitted[1]["suppressed_count"] == 1
+    assert key not in bot._cache_load_event_suppressed
+
+    bot._handle_candle_disk_load_event({**payload, "timeframe": "1h"})
+
+    assert len(bot.emitted) == 3
+    assert bot.emitted[2]["timeframe"] == "1h"
 
 
 def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(caplog):


### PR DESCRIPTION
## Summary
- throttle repeated cache.load.completed live events per symbol/timeframe in Passivbot
- include suppressed_count on the next emitted cache load event
- leave CandlestickManager's raw observer hook unchanged and keep cache/trading behavior untouched

## Motivation
VPS5 smoke after PR #629 showed cache.load.completed was working but high-volume during warmup/HSL replay: roughly 9.5k cache-load events in the monitor stream. This follow-up keeps the event useful while preventing it from dominating monitor storage.

## Tests
- ./venv/bin/python -m compileall src/passivbot.py src/live/event_emitters.py tests/test_passivbot_monitor.py
- ./venv/bin/python -m pytest tests/test_passivbot_monitor.py::test_forager_and_ema_summary_emitters_emit_structured_events tests/test_passivbot_monitor.py::test_candle_disk_load_handler_throttles_repeated_symbol_timeframe_events tests/test_passivbot_monitor.py::test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs tests/test_live_event_bus.py::test_route_table_keeps_data_events_off_console_by_default -q
- ./venv/bin/python -m pytest tests/test_passivbot_monitor.py tests/test_live_event_bus.py -q
- git diff --check