### PR TITLE
Emit cache flush events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable user-facing changes will be documented in this file.
   summaries.
 - Throttled repeated `cache.load.completed` live events per symbol/timeframe and
   added `suppressed_count` so warmup/HSL replay does not flood monitor storage.
+- Added throttled structured `cache.flush.completed` live events for candle
+  disk-cache write summaries.
 - Added structured `bot.startup_timing` live events for startup phase timing
   diagnostics.
 - Added structured `cache.warmup_decision` live events for candle warmup cache

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -50,6 +50,7 @@ class EventTypes:
     EMA_UNAVAILABLE = "ema.unavailable"
     CANDLE_TAIL_PROJECTED = "candle.tail_projected"
     CACHE_LOAD_COMPLETED = "cache.load.completed"
+    CACHE_FLUSH_COMPLETED = "cache.flush.completed"
     CACHE_WARMUP_DECISION = "cache.warmup_decision"
     REMOTE_CALL_STARTED = "remote_call.started"
     REMOTE_CALL_SUCCEEDED = "remote_call.succeeded"
@@ -109,6 +110,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.EMA_UNAVAILABLE,
     EventTypes.CANDLE_TAIL_PROJECTED,
     EventTypes.CACHE_LOAD_COMPLETED,
+    EventTypes.CACHE_FLUSH_COMPLETED,
     EventTypes.CACHE_WARMUP_DECISION,
     EventTypes.REMOTE_CALL_STARTED,
     EventTypes.REMOTE_CALL_SUCCEEDED,
@@ -390,6 +392,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.EMA_UNAVAILABLE: EventRoute(console=False, text=False),
     EventTypes.CANDLE_TAIL_PROJECTED: EventRoute(console=False, text=False),
     EventTypes.CACHE_LOAD_COMPLETED: EventRoute(console=False, text=False),
+    EventTypes.CACHE_FLUSH_COMPLETED: EventRoute(console=False, text=False),
     EventTypes.CACHE_WARMUP_DECISION: EventRoute(console=False, text=False),
     EventTypes.REMOTE_CALL_STARTED: EventRoute(console=False),
     EventTypes.REMOTE_CALL_SUCCEEDED: EventRoute(console=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1141,6 +1141,49 @@ def emit_cache_load_completed_event(bot: Any, *args: Any, **kwargs: Any) -> None
         )
 
 
+def _emit_cache_flush_completed_event_unchecked(
+    bot: Any,
+    payload: dict[str, Any],
+) -> None:
+    data_in = dict(payload or {})
+    symbol = data_in.get("symbol")
+    timeframe = str(data_in.get("timeframe") or data_in.get("tf") or "1m")
+    data: dict[str, Any] = {"timeframe": timeframe}
+    for key in (
+        "persisted_rows",
+        "persisted_start_ts",
+        "persisted_end_ts",
+        "suppressed_count",
+        "suppressed_rows",
+    ):
+        value = _safe_int(data_in.get(key))
+        if value is not None:
+            data[key] = value
+    _safe_emit(
+        bot,
+        EventTypes.CACHE_FLUSH_COMPLETED,
+        level="debug",
+        component="cache.candles",
+        tags=("cache", "candle", "flush"),
+        cycle_id=current_live_event_cycle_id(bot),
+        symbol=str(symbol) if symbol is not None else None,
+        status="succeeded",
+        reason_code="candle_disk_flush_completed",
+        data=data,
+    )
+
+
+def emit_cache_flush_completed_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    try:
+        _emit_cache_flush_completed_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.CACHE_FLUSH_COMPLETED,
+            exc,
+        )
+
+
 def _emit_cache_warmup_decision_event_unchecked(
     bot: Any,
     *,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -634,6 +634,9 @@ class Passivbot:
     _emit_cache_load_completed_event = (
         live_event_emitters.emit_cache_load_completed_event
     )
+    _emit_cache_flush_completed_event = (
+        live_event_emitters.emit_cache_flush_completed_event
+    )
     _emit_order_wave_started_event = live_event_emitters.emit_order_wave_started_event
     _emit_order_wave_completed_event = live_event_emitters.emit_order_wave_completed_event
     _emit_planning_defer_summary_event = (
@@ -956,8 +959,8 @@ class Passivbot:
             fetch_tickers_for_symbols=getattr(self, "fetch_tickers_for_symbols", None),
             ticker_strategy=self._market_snapshot_ticker_strategy(),
         )
-        if self.monitor_publisher is not None:
-            self.cm.set_persist_batch_observer(self._monitor_handle_candlestick_persist)
+        if self.monitor_publisher is not None or self._live_event_pipeline is not None:
+            self.cm.set_persist_batch_observer(self._handle_candle_persist_event)
         if self._live_event_pipeline is not None:
             self.cm.set_disk_load_observer(self._handle_candle_disk_load_event)
         # TTL (minutes) for EMA candles on non-traded symbols
@@ -6334,6 +6337,92 @@ class Passivbot:
             self._emit_cache_load_completed_event(data)
         except Exception as exc:
             logging.debug("[event] failed handling cache load event: %s", exc)
+
+    def _handle_candle_persist_event(
+        self,
+        symbol: str,
+        timeframe: str,
+        batch: np.ndarray,
+    ) -> None:
+        try:
+            self._monitor_handle_candlestick_persist(symbol, timeframe, batch)
+        except Exception as exc:
+            logging.debug("[monitor] failed handling candlestick persist: %s", exc)
+        try:
+            self._handle_candle_cache_flush_event(symbol, timeframe, batch)
+        except Exception as exc:
+            logging.debug("[event] failed handling cache flush event: %s", exc)
+
+    def _handle_candle_cache_flush_event(
+        self,
+        symbol: str,
+        timeframe: str,
+        batch: np.ndarray,
+    ) -> None:
+        """Emit summarized candle disk-flush events without flooding monitor storage."""
+        try:
+            if not isinstance(batch, np.ndarray) or batch.size == 0:
+                return
+            tf_norm = str(timeframe or "1m")
+            sym = str(symbol or "")
+            rows = int(batch.shape[0])
+            start_ts = None
+            end_ts = None
+            try:
+                start_ts = int(batch["ts"][0])
+                end_ts = int(batch["ts"][-1])
+            except Exception:
+                start_ts = None
+                end_ts = None
+            key = (sym, tf_norm)
+            now = time.monotonic()
+            try:
+                interval_s = float(
+                    getattr(self, "_cache_flush_event_throttle_seconds", 60.0)
+                )
+            except Exception:
+                interval_s = 60.0
+            interval_s = max(0.0, interval_s)
+            last_by_key = getattr(self, "_cache_flush_event_last_emit", None)
+            if not isinstance(last_by_key, dict):
+                last_by_key = {}
+                self._cache_flush_event_last_emit = last_by_key
+            suppressed_by_key = getattr(self, "_cache_flush_event_suppressed", None)
+            if not isinstance(suppressed_by_key, dict):
+                suppressed_by_key = {}
+                self._cache_flush_event_suppressed = suppressed_by_key
+            last_emit = last_by_key.get(key)
+            if last_emit is not None and now - float(last_emit) < interval_s:
+                state = suppressed_by_key.setdefault(
+                    key, {"count": 0, "rows": 0}
+                )
+                try:
+                    state["count"] = int(state.get("count", 0) or 0) + 1
+                    state["rows"] = int(state.get("rows", 0) or 0) + rows
+                except Exception:
+                    suppressed_by_key[key] = {"count": 1, "rows": rows}
+                return
+            data: dict[str, Any] = {
+                "symbol": sym,
+                "timeframe": tf_norm,
+                "persisted_rows": rows,
+            }
+            if start_ts is not None:
+                data["persisted_start_ts"] = start_ts
+            if end_ts is not None:
+                data["persisted_end_ts"] = end_ts
+            suppressed = suppressed_by_key.pop(key, None)
+            if isinstance(suppressed, dict):
+                suppressed_count = int(suppressed.get("count", 0) or 0)
+                suppressed_rows = int(suppressed.get("rows", 0) or 0)
+                if suppressed_count > 0:
+                    data["suppressed_count"] = suppressed_count
+                if suppressed_rows > 0:
+                    data["suppressed_rows"] = suppressed_rows
+            last_by_key[key] = now
+            self._emit_cache_flush_completed_event(data)
+        except Exception as exc:
+            logging.debug("[event] failed handling cache flush event: %s", exc)
 
     def _install_live_event_pipeline(self) -> Optional[LiveEventPipeline]:
         publisher = getattr(self, "monitor_publisher", None)

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -143,6 +143,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.EMA_UNAVAILABLE,
         EventTypes.CANDLE_TAIL_PROJECTED,
         EventTypes.CACHE_LOAD_COMPLETED,
+        EventTypes.CACHE_FLUSH_COMPLETED,
         EventTypes.CACHE_WARMUP_DECISION,
         EventTypes.BOT_STARTUP_TIMING,
         EventTypes.PLANNING_DEFER_SUMMARY,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -538,6 +538,9 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         _emit_cache_load_completed_event = (
             pb_mod.Passivbot._emit_cache_load_completed_event
         )
+        _emit_cache_flush_completed_event = (
+            pb_mod.Passivbot._emit_cache_flush_completed_event
+        )
         _emit_cache_warmup_decision_event = (
             pb_mod.Passivbot._emit_cache_warmup_decision_event
         )
@@ -645,6 +648,17 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
             "suppressed_count": 2,
         }
     )
+    bot._emit_cache_flush_completed_event(
+        {
+            "symbol": "ETH/USDT:USDT",
+            "timeframe": "1m",
+            "persisted_rows": 4,
+            "persisted_start_ts": 300_000,
+            "persisted_end_ts": 480_000,
+            "suppressed_count": 2,
+            "suppressed_rows": 8,
+        }
+    )
     bot._emit_cache_warmup_decision_event(
         context="trading-ready warmup",
         timeframe="1m",
@@ -670,6 +684,7 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         EventTypes.EMA_UNAVAILABLE,
         EventTypes.CANDLE_TAIL_PROJECTED,
         EventTypes.CACHE_LOAD_COMPLETED,
+        EventTypes.CACHE_FLUSH_COMPLETED,
         EventTypes.CACHE_WARMUP_DECISION,
     ]
     assert {event.cycle_id for event in events} == {"cy_11"}
@@ -710,18 +725,29 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         "suppressed_count": 2,
         "source_days": {"legacy": 0, "merged": 0, "primary": 1},
     }
-    assert events[8].component == "cache.warmup"
-    assert events[8].reason_code == "warmup_cache_decision"
-    assert events[8].data["context"] == "trading-ready warmup"
-    assert events[8].data["symbol_count"] == 3
-    assert events[8].data["reused_count"] == 1
-    assert events[8].data["cold_count"] == 2
-    assert events[8].data["cold_path_required"] is True
-    assert events[8].data["reason_counts"] == {
+    assert events[8].component == "cache.candles"
+    assert events[8].symbol == "ETH/USDT:USDT"
+    assert events[8].reason_code == "candle_disk_flush_completed"
+    assert events[8].data == {
+        "timeframe": "1m",
+        "persisted_rows": 4,
+        "persisted_start_ts": 300_000,
+        "persisted_end_ts": 480_000,
+        "suppressed_count": 2,
+        "suppressed_rows": 8,
+    }
+    assert events[9].component == "cache.warmup"
+    assert events[9].reason_code == "warmup_cache_decision"
+    assert events[9].data["context"] == "trading-ready warmup"
+    assert events[9].data["symbol_count"] == 3
+    assert events[9].data["reused_count"] == 1
+    assert events[9].data["cold_count"] == 2
+    assert events[9].data["cold_path_required"] is True
+    assert events[9].data["reason_counts"] == {
         "missing_coverage": 2,
         "warm_cache_accepted": 1,
     }
-    assert events[8].data["window_max_candles"] == 260
+    assert events[9].data["window_max_candles"] == 260
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
@@ -769,6 +795,103 @@ def test_candle_disk_load_handler_throttles_repeated_symbol_timeframe_events():
 
     assert len(bot.emitted) == 3
     assert bot.emitted[2]["timeframe"] == "1h"
+
+
+def test_candle_cache_flush_handler_throttles_repeated_symbol_timeframe_events():
+    import passivbot as pb_mod
+
+    class FakeBot:
+        _handle_candle_cache_flush_event = (
+            pb_mod.Passivbot._handle_candle_cache_flush_event
+        )
+
+        def __init__(self):
+            self._cache_flush_event_throttle_seconds = 60.0
+            self.emitted = []
+
+        def _emit_cache_flush_completed_event(self, payload):
+            self.emitted.append(dict(payload))
+
+    bot = FakeBot()
+    batch = np.array(
+        [
+            (60_000, 1.0, 2.0, 0.5, 1.5, 10.0),
+            (120_000, 1.5, 2.5, 1.0, 2.0, 11.0),
+        ],
+        dtype=pb_mod.CANDLE_DTYPE,
+    )
+
+    bot._handle_candle_cache_flush_event("BTC/USDT:USDT", "1m", batch)
+    bot._handle_candle_cache_flush_event("BTC/USDT:USDT", "1m", batch)
+
+    assert len(bot.emitted) == 1
+    assert bot.emitted[0] == {
+        "symbol": "BTC/USDT:USDT",
+        "timeframe": "1m",
+        "persisted_rows": 2,
+        "persisted_start_ts": 60_000,
+        "persisted_end_ts": 120_000,
+    }
+    key = ("BTC/USDT:USDT", "1m")
+    assert bot._cache_flush_event_suppressed[key] == {"count": 1, "rows": 2}
+
+    bot._cache_flush_event_last_emit[key] -= 61.0
+    bot._handle_candle_cache_flush_event("BTC/USDT:USDT", "1m", batch)
+
+    assert len(bot.emitted) == 2
+    assert bot.emitted[1]["suppressed_count"] == 1
+    assert bot.emitted[1]["suppressed_rows"] == 2
+    assert key not in bot._cache_flush_event_suppressed
+
+    bot._handle_candle_cache_flush_event("BTC/USDT:USDT", "1h", batch)
+
+    assert len(bot.emitted) == 3
+    assert bot.emitted[2]["timeframe"] == "1h"
+
+
+def test_candle_persist_handler_preserves_monitor_and_emits_flush_summary():
+    import passivbot as pb_mod
+
+    class FakeBot:
+        _monitor_handle_candlestick_persist = (
+            pb_mod.Passivbot._monitor_handle_candlestick_persist
+        )
+        _handle_candle_cache_flush_event = (
+            pb_mod.Passivbot._handle_candle_cache_flush_event
+        )
+        _handle_candle_persist_event = pb_mod.Passivbot._handle_candle_persist_event
+
+        def __init__(self):
+            self.monitor_publisher = RecorderPublisher()
+            self._bot_ready = True
+            self._cache_flush_event_throttle_seconds = 60.0
+            self.flush_events = []
+
+        def _emit_cache_flush_completed_event(self, payload):
+            self.flush_events.append(dict(payload))
+
+    bot = FakeBot()
+    batch = np.array(
+        [
+            (60_000, 1.0, 2.0, 0.5, 1.5, 10.0),
+            (120_000, 1.5, 2.5, 1.0, 2.0, 11.0),
+        ],
+        dtype=pb_mod.CANDLE_DTYPE,
+    )
+
+    bot._handle_candle_persist_event("BTC/USDT:USDT", "1m", batch)
+
+    assert len(bot.monitor_publisher.completed_candles) == 1
+    assert bot.monitor_publisher.completed_candles[0]["symbol"] == "BTC/USDT:USDT"
+    assert bot.flush_events == [
+        {
+            "symbol": "BTC/USDT:USDT",
+            "timeframe": "1m",
+            "persisted_rows": 2,
+            "persisted_start_ts": 60_000,
+            "persisted_end_ts": 120_000,
+        }
+    ]
 
 
 def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(caplog):
@@ -837,6 +960,10 @@ def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(ca
             bot,
             payload=object(),
         )
+        pb_mod.Passivbot._emit_cache_flush_completed_event(
+            bot,
+            payload=object(),
+        )
         pb_mod.Passivbot._emit_cache_warmup_decision_event(
             bot,
             context=object(),
@@ -862,6 +989,7 @@ def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(ca
     assert any(EventTypes.EMA_UNAVAILABLE in msg for msg in messages)
     assert any(EventTypes.CANDLE_TAIL_PROJECTED in msg for msg in messages)
     assert any(EventTypes.CACHE_LOAD_COMPLETED in msg for msg in messages)
+    assert any(EventTypes.CACHE_FLUSH_COMPLETED in msg for msg in messages)
     assert any(EventTypes.CACHE_WARMUP_DECISION in msg for msg in messages)
     assert any(EventTypes.BOT_STARTUP_TIMING in msg for msg in messages)
 


### PR DESCRIPTION
Summary:
- add quiet structured cache.flush.completed live events for candle disk-cache writes
- route flush events off console/text by default and throttle them per symbol/timeframe with suppressed count/row summaries
- preserve the existing monitor completed-candle persist observer while adding the flush event observer path

Tests:
- ./venv/bin/python -m compileall src/live/event_bus.py src/live/event_emitters.py src/passivbot.py tests/test_live_event_bus.py tests/test_passivbot_monitor.py
- ./venv/bin/python -m pytest tests/test_passivbot_monitor.py tests/test_live_event_bus.py -q