### PR TITLE
Emit HSL red events on finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable user-facing changes will be documented in this file.
   added `suppressed_count` so warmup/HSL replay does not flood monitor storage.
 - Added throttled structured `cache.flush.completed` live events for candle
   disk-cache write summaries.
+- Added structured `hsl.red_triggered` live events for HSL stop finalization
+  paths that reconstruct or finalize RED state without a fresh threshold-crossing
+  sample.
 - Added structured `bot.startup_timing` live events for startup phase timing
   diagnostics.
 - Added structured `cache.warmup_decision` live events for candle warmup cache

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -547,6 +547,7 @@ def _equity_hard_stop_reset_state(self) -> None:
         state["cooldown_until_ms"] = None
         state["pending_stop_event"] = None
         state["last_stop_event"] = None
+        state["red_trigger_event_emitted"] = False
         state["last_status_log_ms"] = 0
         state["last_cooldown_log_ms"] = 0
         state["cooldown_intervention_active"] = False
@@ -1780,6 +1781,7 @@ def _equity_hard_stop_reset_after_restart(self, pside: str) -> None:
     state["pending_red_since_ms"] = None
     state["cooldown_until_ms"] = None
     state["pending_stop_event"] = None
+    state["red_trigger_event_emitted"] = False
     state["last_status_log_ms"] = 0
     state["last_cooldown_log_ms"] = 0
     state["cooldown_intervention_active"] = False
@@ -2947,6 +2949,7 @@ async def _equity_hard_stop_check(self) -> Optional[dict]:
             )
         elif metrics["tier"] != "red":
             state["pending_red_since_ms"] = None
+            state["red_trigger_event_emitted"] = False
         self._equity_hard_stop_log_status(pside, metrics)
         out[pside] = metrics
     self._equity_hard_stop_refresh_halted_runtime_forced_modes()
@@ -3155,6 +3158,7 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
                 )
             elif metrics["tier"] != "red":
                 state["pending_red_since_ms"] = None
+                state["red_trigger_event_emitted"] = False
                 if not state["halted"]:
                     self._equity_hard_stop_clear_coin_runtime_forced_mode(pside, symbol)
             if metrics["tier"] == "orange":

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -87,6 +87,33 @@ def _emit_hsl_event(
         )
 
 
+def _emit_hsl_red_triggered_once(
+    self,
+    state: dict,
+    data: dict,
+    *,
+    pside: str,
+    symbol: str | None = None,
+    ts: int | None = None,
+    reason_code: str = "red_threshold_crossed",
+) -> None:
+    if state.get("red_trigger_event_emitted"):
+        return
+    _emit_hsl_event(
+        self,
+        "hsl.red_triggered",
+        ("hsl", "risk", "red"),
+        data,
+        pside=pside,
+        symbol=symbol,
+        ts=ts,
+        level="critical",
+        status="degraded",
+        reason_code=reason_code,
+    )
+    state["red_trigger_event_emitted"] = True
+
+
 def _emit_hsl_replay_event(
     self,
     event_type: str,
@@ -141,6 +168,7 @@ def _equity_hard_stop_make_state(self) -> dict[str, Any]:
         "cooldown_until_ms": None,
         "pending_stop_event": None,
         "last_stop_event": None,
+        "red_trigger_event_emitted": False,
         "last_status_log_ms": 0,
         "last_cooldown_log_ms": 0,
         "cooldown_intervention_active": False,
@@ -2910,16 +2938,12 @@ async def _equity_hard_stop_check(self) -> Optional[dict]:
                 metrics["drawdown_score"],
                 metrics["red_threshold"],
             )
-            _emit_hsl_event(
+            _emit_hsl_red_triggered_once(
                 self,
-                "hsl.red_triggered",
-                ("hsl", "risk", "red"),
+                state,
                 _hsl_event_data(metrics),
                 pside=pside,
                 ts=int(metrics["timestamp_ms"]),
-                level="critical",
-                status="degraded",
-                reason_code="red_threshold_crossed",
             )
         elif metrics["tier"] != "red":
             state["pending_red_since_ms"] = None
@@ -3121,17 +3145,13 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
                     metrics["peak_realized_pnl"],
                     metrics["unrealized_pnl"],
                 )
-                _emit_hsl_event(
+                _emit_hsl_red_triggered_once(
                     self,
-                    "hsl.red_triggered",
-                    ("hsl", "risk", "red"),
+                    state,
                     _hsl_event_data(metrics),
                     pside=pside,
                     symbol=symbol,
                     ts=int(metrics["timestamp_ms"]),
-                    level="critical",
-                    status="degraded",
-                    reason_code="red_threshold_crossed",
                 )
             elif metrics["tier"] != "red":
                 state["pending_red_since_ms"] = None
@@ -3318,6 +3338,22 @@ async def _equity_hard_stop_finalize_red_stop(self, pside: str, stop_event: Opti
     state["red_flat_confirmations"] = 0
     state["pending_red_since_ms"] = None
     latch_path = self._equity_hard_stop_write_latch(pside, payload)
+    _emit_hsl_red_triggered_once(
+        self,
+        state,
+        _hsl_event_data(
+            stop_event,
+            {
+                "reason": "red_stop_finalized",
+                "cooldown_until_ms": cooldown_until_ms,
+                "no_restart_latched": bool(no_restart_latched),
+                "no_restart_drawdown_raw": float(no_restart_drawdown_raw),
+            },
+        ),
+        pside=pside,
+        ts=stop_ts_ms,
+        reason_code="red_stop_finalized",
+    )
     self._equity_hard_stop_refresh_halted_runtime_forced_modes()
     if cooldown_until_ms is not None:
         _emit_hsl_event(
@@ -3412,6 +3448,22 @@ async def _equity_hard_stop_finalize_coin_red_stop(
     state["pending_red_since_ms"] = None
     state["pnl_reset_timestamp_ms"] = int(stop_ts_ms) + 1
     latch_path = self._equity_hard_stop_write_latch(pside, payload, symbol=symbol)
+    _emit_hsl_red_triggered_once(
+        self,
+        state,
+        _hsl_event_data(
+            stop_event,
+            {
+                "reason": "coin_red_stop_finalized",
+                "cooldown_until_ms": cooldown_until_ms,
+                "no_restart_latched": bool(no_restart_latched),
+            },
+        ),
+        pside=pside,
+        symbol=symbol,
+        ts=stop_ts_ms,
+        reason_code="coin_red_stop_finalized",
+    )
     self._equity_hard_stop_clear_coin_runtime_forced_mode(pside, symbol)
     if cooldown_until_ms is not None:
         self._equity_hard_stop_set_coin_runtime_forced_mode(pside, symbol, "graceful_stop")

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -599,9 +599,19 @@ async def test_coin_hsl_check_defers_stop_event_until_flat_confirmation():
 
 @pytest.mark.asyncio
 async def test_coin_hsl_finalize_uses_latest_panic_fill_for_reset_boundary():
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+
     bot = make_coin_bot()
     symbol = "A"
     bot.get_exchange_time = lambda: 180_000
+    sink = ListEventSink()
+    bot.bot_id = "bot_1"
+    bot._live_event_current_cycle_id = "cy_coin_finalize"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
     state = bot._hsl_coin_state("long", symbol)
     state["pending_red_since_ms"] = 120_000
     bot._pnls_manager = make_fake_pnls_manager(
@@ -622,6 +632,49 @@ async def test_coin_hsl_finalize_uses_latest_panic_fill_for_reset_boundary():
     assert state["last_stop_event"]["stop_event_timestamp_ms"] == 170_000
     assert state["pnl_reset_timestamp_ms"] == 170_001
     assert state["cooldown_until_ms"] == 470_000
+    assert state["red_trigger_event_emitted"] is True
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [event for event in sink.events if event.event_type == EventTypes.HSL_RED_TRIGGERED]
+    assert len(events) == 1
+    assert events[0].cycle_id == "cy_coin_finalize"
+    assert events[0].pside == "long"
+    assert events[0].symbol == symbol
+    assert events[0].reason_code == "coin_red_stop_finalized"
+    assert events[0].data["stop_event_timestamp_ms"] == 170_000
+    assert events[0].data["cooldown_until_ms"] == 470_000
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_finalize_does_not_duplicate_prior_red_trigger_event():
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+
+    bot = make_coin_bot()
+    symbol = "A"
+    bot.get_exchange_time = lambda: 180_000
+    sink = ListEventSink()
+    bot.bot_id = "bot_1"
+    bot._live_event_current_cycle_id = "cy_coin_finalize_duplicate"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+    state = bot._hsl_coin_state("long", symbol)
+    state["pending_red_since_ms"] = 120_000
+    state["red_trigger_event_emitted"] = True
+
+    await bot._equity_hard_stop_finalize_coin_red_stop("long", symbol)
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    red_events = [event for event in sink.events if event.event_type == EventTypes.HSL_RED_TRIGGERED]
+    cooldown_events = [
+        event for event in sink.events if event.event_type == EventTypes.HSL_COOLDOWN_STARTED
+    ]
+    assert red_events == []
+    assert len(cooldown_events) == 1
+    assert cooldown_events[0].reason_code == "coin_red_stop_finalized"
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -2767,6 +2767,8 @@ async def test_hard_stop_finalize_red_stop_equal_threshold_latches_terminal(
 
 @pytest.mark.asyncio
 async def test_hard_stop_finalize_red_stop_autorestarts_after_cooldown(monkeypatch):
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     _hsl_cfg(bot)["cooldown_minutes_after_red"] = 1.0
@@ -2775,6 +2777,12 @@ async def test_hard_stop_finalize_red_stop_autorestarts_after_cooldown(monkeypat
     _hsl_state(bot)["runtime"]._red_latched = True
     _hsl_state(bot)["runtime"]._tier = "red"
     _hsl_state(bot)["runtime"]._drawdown_ema = 0.12
+    sink = ListEventSink()
+    bot._live_event_current_cycle_id = "cy_hsl_finalize"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
 
     async def fake_compute(pside, _ts):
         assert pside == "long"
@@ -2808,7 +2816,17 @@ async def test_hard_stop_finalize_red_stop_autorestarts_after_cooldown(monkeypat
         _hsl_state(bot)["cooldown_until_ms"] == captured["payload"]["cooldown_until_ms"]
     )
     assert _hsl_state(bot)["runtime"].red_latched() is True
+    assert _hsl_state(bot)["red_trigger_event_emitted"] is True
     assert captured["pside"] == "long"
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    red_events = [event for event in sink.events if event.event_type == EventTypes.HSL_RED_TRIGGERED]
+    assert len(red_events) == 1
+    assert red_events[0].cycle_id == "cy_hsl_finalize"
+    assert red_events[0].pside == "long"
+    assert red_events[0].reason_code == "red_stop_finalized"
+    assert red_events[0].data["stop_event_timestamp_ms"] == 1_700_000_000_000
+    assert red_events[0].data["cooldown_until_ms"] == captured["payload"]["cooldown_until_ms"]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -2880,10 +2880,18 @@ async def test_hard_stop_finalize_red_stop_uses_latest_panic_fill_timestamp(monk
 
 @pytest.mark.asyncio
 async def test_hard_stop_finalize_red_stop_uses_persistent_no_restart_peak(monkeypatch):
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     _hsl_cfg(bot)["cooldown_minutes_after_red"] = 1.0
     _hsl_cfg(bot)["no_restart_drawdown_threshold"] = 0.2
+    sink = ListEventSink()
+    bot._live_event_current_cycle_id = "cy_hsl_repeat_red"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
 
     stop_events = [
         {
@@ -2927,8 +2935,10 @@ async def test_hard_stop_finalize_red_stop_uses_persistent_no_restart_peak(monke
     assert captured[0][1]["no_restart_drawdown_raw"] == pytest.approx(
         1.0 - 104.0 / 110.0
     )
+    assert _hsl_state(bot)["red_trigger_event_emitted"] is True
 
     bot._equity_hard_stop_reset_after_restart("long")
+    assert _hsl_state(bot)["red_trigger_event_emitted"] is False
     await bot._equity_hard_stop_finalize_red_stop("long")
 
     assert _hsl_state(bot)["halted"] is True
@@ -2942,6 +2952,19 @@ async def test_hard_stop_finalize_red_stop_uses_persistent_no_restart_peak(monke
         1.0 - 86.0 / 110.0
     )
     assert captured[1][1]["no_restart_peak_strategy_equity"] == pytest.approx(110.0)
+    assert _hsl_state(bot)["red_trigger_event_emitted"] is True
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    red_events = [event for event in sink.events if event.event_type == EventTypes.HSL_RED_TRIGGERED]
+    assert len(red_events) == 2
+    assert [event.reason_code for event in red_events] == [
+        "red_stop_finalized",
+        "red_stop_finalized",
+    ]
+    assert [event.data["stop_event_timestamp_ms"] for event in red_events] == [
+        1_700_000_000_000,
+        1_700_000_120_000,
+    ]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- emit `hsl.red_triggered` from HSL stop finalization when no fresh threshold-crossing event was emitted
- keep normal threshold-crossing and finalization paths duplicate-safe with a per-state event flag
- cover pside and coin finalization paths, including duplicate suppression

## Tests
- `./venv/bin/python -m compileall src/passivbot_hsl.py tests/test_hsl_coin_mode.py tests/test_unstucking_safeguards.py tests/test_live_event_bus.py`
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_hsl_coin_mode.py -q`
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_bus.py -q`
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_unstucking_safeguards.py -k 'hard_stop_finalize_red_stop or hsl_status or hard_stop_log_status or equity_hard_stop_check' -q`\n- `git diff --check`