### PR TITLE
Emit risk mode change events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable user-facing changes will be documented in this file.
   added `suppressed_count` so warmup/HSL replay does not flood monitor storage.
 - Added throttled structured `cache.flush.completed` live events for candle
   disk-cache write summaries.
+- Added structured `risk.mode_changed` live events for HSL runtime forced-mode
+  changes such as panic, graceful-stop, tp-only, and clear transitions.
 - Added structured `bot.startup_timing` live events for startup phase timing
   diagnostics.
 - Added structured `cache.warmup_decision` live events for candle warmup cache

--- a/docs/plans/live_logging_overhaul_plan.md
+++ b/docs/plans/live_logging_overhaul_plan.md
@@ -167,6 +167,7 @@ stable names:
 - `hsl.replay.progress`
 - `hsl.replay.completed`
 - `hsl.transition`
+- `risk.mode_changed`
 - `rust_orchestrator.called`
 - `rust_orchestrator.returned`
 - `action.planned`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -76,6 +76,7 @@ class EventTypes:
     FILL_INGESTED = "fill.ingested"
     POSITION_CHANGED = "position.changed"
     BALANCE_CHANGED = "balance.changed"
+    RISK_MODE_CHANGED = "risk.mode_changed"
     HSL_TRANSITION = "hsl.transition"
     HSL_STATUS = "hsl.status"
     HSL_REPLAY_STARTED = "hsl.replay.started"
@@ -136,6 +137,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.FILL_INGESTED,
     EventTypes.POSITION_CHANGED,
     EventTypes.BALANCE_CHANGED,
+    EventTypes.RISK_MODE_CHANGED,
     EventTypes.HSL_TRANSITION,
     EventTypes.HSL_STATUS,
     EventTypes.HSL_REPLAY_STARTED,
@@ -420,6 +422,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.FILL_INGESTED: EventRoute(console=False, text=False),
     EventTypes.POSITION_CHANGED: EventRoute(console=False, text=False),
     EventTypes.BALANCE_CHANGED: EventRoute(console=False, text=False),
+    EventTypes.RISK_MODE_CHANGED: EventRoute(console=False, text=False),
     EventTypes.HSL_TRANSITION: EventRoute(console=False, text=False),
     EventTypes.HSL_STATUS: EventRoute(console=False, text=False),
     EventTypes.HSL_REPLAY_STARTED: EventRoute(console=False, text=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1811,6 +1811,62 @@ def emit_execution_confirmation_timeout_event(
         logging.debug("[event] failed to emit confirmation timeout event: %s", exc)
 
 
+def emit_risk_mode_changed_event(
+    bot: Any,
+    *,
+    pside: str,
+    source: str,
+    action: str,
+    previous_mode: str | None = None,
+    mode: str | None = None,
+    symbol: str | None = None,
+    symbols: Any = None,
+    previous_modes: dict[str, str] | None = None,
+    modes: dict[str, str] | None = None,
+    reason_code: str | None = None,
+) -> None:
+    try:
+        source_name = str(source or "risk").strip().lower() or "risk"
+        action_name = str(action or "changed").strip().lower() or "changed"
+        data: dict[str, Any] = {
+            "source": source_name,
+            "action": action_name,
+        }
+        if previous_mode is not None:
+            data["previous_mode"] = str(previous_mode)
+        if mode is not None:
+            data["mode"] = str(mode)
+        if symbols is not None:
+            data["symbols"] = _symbol_sample(symbols)
+        if previous_modes is not None:
+            data["previous_mode_counts"] = dict(
+                sorted(Counter(str(value) for value in previous_modes.values()).items())
+            )
+        if modes is not None:
+            data["mode_counts"] = dict(
+                sorted(Counter(str(value) for value in modes.values()).items())
+            )
+        bot._emit_live_event(
+            EventTypes.RISK_MODE_CHANGED,
+            level="info",
+            component=f"risk.{source_name}.mode",
+            tags=("risk", "mode", source_name),
+            cycle_id=bot._current_live_event_cycle_id(),
+            symbol=symbol,
+            pside=pside,
+            status="succeeded",
+            reason_code=reason_code or f"{source_name}_{action_name}",
+            data={key: value for key, value in data.items() if value is not None},
+        )
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit risk mode changed event pside=%s symbol=%s: %s",
+            pside,
+            symbol,
+            exc,
+        )
+
+
 def emit_balance_changed_event(
     bot: Any,
     *,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -617,6 +617,7 @@ class Passivbot:
     _emit_action_planned_event = live_event_emitters.emit_action_planned_event
     _emit_balance_changed_event = live_event_emitters.emit_balance_changed_event
     _emit_fill_ingested_event = live_event_emitters.emit_fill_ingested_event
+    _emit_risk_mode_changed_event = live_event_emitters.emit_risk_mode_changed_event
     _emit_forager_feature_unavailable_event = (
         live_event_emitters.emit_forager_feature_unavailable_event
     )

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -87,6 +87,43 @@ def _emit_hsl_event(
         )
 
 
+def _emit_runtime_forced_mode_changed_event(
+    self,
+    *,
+    pside: str,
+    action: str,
+    previous_mode: str | None = None,
+    mode: str | None = None,
+    symbol: str | None = None,
+    symbols: Any = None,
+    previous_modes: dict[str, str] | None = None,
+    modes: dict[str, str] | None = None,
+    reason_code: str | None = None,
+) -> None:
+    try:
+        emit = getattr(self, "_emit_risk_mode_changed_event", None)
+        if callable(emit):
+            emit(
+                pside=pside,
+                source="hsl",
+                action=action,
+                previous_mode=previous_mode,
+                mode=mode,
+                symbol=symbol,
+                symbols=symbols,
+                previous_modes=previous_modes,
+                modes=modes,
+                reason_code=reason_code,
+            )
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit HSL runtime forced mode event pside=%s symbol=%s: %s",
+            pside,
+            symbol,
+            exc,
+        )
+
+
 def _emit_hsl_replay_event(
     self,
     event_type: str,
@@ -3172,28 +3209,88 @@ def _equity_hard_stop_coin_red_active(self) -> bool:
 
 
 def _equity_hard_stop_set_red_runtime_forced_modes(self, pside: str) -> None:
+    previous = dict(getattr(self, "_runtime_forced_modes", {}).get(pside, {}) or {})
     forced = {}
     symbols = set(self.positions.keys()) | set(self.open_orders.keys()) | set(self.active_symbols)
     for symbol in symbols:
         forced[symbol] = "panic"
     self._runtime_forced_modes[pside] = forced
+    if previous != forced:
+        _emit_runtime_forced_mode_changed_event(
+            self,
+            pside=pside,
+            action="replace",
+            symbols=forced.keys(),
+            previous_modes=previous,
+            modes=forced,
+            reason_code="hsl_red_runtime_forced_modes",
+        )
 
 
 def _equity_hard_stop_set_coin_runtime_forced_mode(
     self, pside: str, symbol: str, mode: str
 ) -> None:
-    self._runtime_forced_modes.setdefault(pside, {})[symbol] = mode
+    forced_modes = self._runtime_forced_modes.setdefault(pside, {})
+    previous = forced_modes.get(symbol)
+    forced_modes[symbol] = mode
+    if previous != mode:
+        _emit_runtime_forced_mode_changed_event(
+            self,
+            pside=pside,
+            symbol=symbol,
+            action="set",
+            previous_mode=previous,
+            mode=mode,
+            reason_code="hsl_runtime_forced_mode_set",
+        )
 
 
 def _equity_hard_stop_clear_coin_runtime_forced_mode(self, pside: str, symbol: str) -> None:
-    self._runtime_forced_modes.setdefault(pside, {}).pop(symbol, None)
+    forced_modes = self._runtime_forced_modes.setdefault(pside, {})
+    previous = forced_modes.pop(symbol, None)
+    if previous is not None:
+        _emit_runtime_forced_mode_changed_event(
+            self,
+            pside=pside,
+            symbol=symbol,
+            action="clear",
+            previous_mode=previous,
+            reason_code="hsl_runtime_forced_mode_clear",
+        )
 
 
 def _equity_hard_stop_clear_runtime_forced_modes(self, pside: Optional[str] = None) -> None:
     if pside is None:
+        previous_by_pside = {
+            side: dict(modes or {})
+            for side, modes in (getattr(self, "_runtime_forced_modes", {}) or {}).items()
+        }
         self._runtime_forced_modes = {"long": {}, "short": {}}
+        for side in self._hsl_psides():
+            previous = previous_by_pside.get(side, {})
+            if previous:
+                _emit_runtime_forced_mode_changed_event(
+                    self,
+                    pside=side,
+                    action="clear_all",
+                    symbols=previous.keys(),
+                    previous_modes=previous,
+                    modes={},
+                    reason_code="hsl_runtime_forced_modes_clear_all",
+                )
         return
+    previous = dict(getattr(self, "_runtime_forced_modes", {}).get(pside, {}) or {})
     self._runtime_forced_modes[pside] = {}
+    if previous:
+        _emit_runtime_forced_mode_changed_event(
+            self,
+            pside=pside,
+            action="clear_all",
+            symbols=previous.keys(),
+            previous_modes=previous,
+            modes={},
+            reason_code="hsl_runtime_forced_modes_clear_all",
+        )
 
 
 def _equity_hard_stop_count_open_positions(self, pside: str) -> int:

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -446,6 +446,46 @@ async def test_coin_hsl_check_skips_enabled_side_with_zero_budget():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_coin_hsl_runtime_forced_mode_changes_emit_risk_events():
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+
+    bot = make_coin_bot()
+    symbol = "A"
+    sink = ListEventSink()
+    bot.bot_id = "bot_1"
+    bot._live_event_current_cycle_id = "cy_risk_mode"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._current_live_event_cycle_id = MethodType(Passivbot._current_live_event_cycle_id, bot)
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+    bot._emit_risk_mode_changed_event = MethodType(
+        Passivbot._emit_risk_mode_changed_event,
+        bot,
+    )
+
+    bot._equity_hard_stop_set_coin_runtime_forced_mode("long", symbol, "panic")
+    bot._equity_hard_stop_set_coin_runtime_forced_mode("long", symbol, "panic")
+    bot._equity_hard_stop_clear_coin_runtime_forced_mode("long", symbol)
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [event for event in sink.events if event.event_type == EventTypes.RISK_MODE_CHANGED]
+    assert len(events) == 2
+    assert events[0].cycle_id == "cy_risk_mode"
+    assert events[0].pside == "long"
+    assert events[0].symbol == symbol
+    assert events[0].reason_code == "hsl_runtime_forced_mode_set"
+    assert events[0].data["action"] == "set"
+    assert events[0].data["mode"] == "panic"
+    assert "previous_mode" not in events[0].data
+    assert events[1].reason_code == "hsl_runtime_forced_mode_clear"
+    assert events[1].data["action"] == "clear"
+    assert events[1].data["previous_mode"] == "panic"
+    assert "mode" not in events[1].data
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 @pytest.mark.asyncio
 async def test_coin_hsl_history_replay_skips_enabled_side_with_zero_budget():
     bot = make_coin_bot()

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -148,6 +148,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.BOT_STARTUP_TIMING,
         EventTypes.PLANNING_DEFER_SUMMARY,
         EventTypes.PLANNING_SYMBOL_STATE,
+        EventTypes.RISK_MODE_CHANGED,
         EventTypes.HSL_TRANSITION,
         EventTypes.HSL_STATUS,
         EventTypes.HSL_RED_TRIGGERED,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1484,6 +1484,54 @@ async def test_handle_balance_update_records_monitor_balance_event():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_risk_mode_changed_event_emits_structured_summary():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _emit_risk_mode_changed_event = pb_mod.Passivbot._emit_risk_mode_changed_event
+
+        def __init__(self):
+            self.exchange = "gateio"
+            self.user = "gateio_01"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_risk_mode"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+
+    bot._emit_risk_mode_changed_event(
+        pside="long",
+        source="hsl",
+        action="replace",
+        symbols=["ETH/USDT:USDT", "BTC/USDT:USDT"],
+        previous_modes={"BTC/USDT:USDT": "normal"},
+        modes={"BTC/USDT:USDT": "panic", "ETH/USDT:USDT": "panic"},
+        reason_code="hsl_red_runtime_forced_modes",
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[-1]
+    assert event.event_type == EventTypes.RISK_MODE_CHANGED
+    assert event.cycle_id == "cy_risk_mode"
+    assert event.pside == "long"
+    assert event.reason_code == "hsl_red_runtime_forced_modes"
+    assert event.component == "risk.hsl.mode"
+    assert event.tags == ("risk", "mode", "hsl")
+    assert event.data["action"] == "replace"
+    assert event.data["previous_mode_counts"] == {"normal": 1}
+    assert event.data["mode_counts"] == {"panic": 2}
+    assert event.data["symbols"]["count"] == 2
+    assert event.data["symbols"]["sample"] == ["BTC/USDT:USDT", "ETH/USDT:USDT"]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_log_new_fill_events_emits_fill_ingested_event():
     import passivbot as pb_mod
 


### PR DESCRIPTION
## Summary
- add quiet structured `risk.mode_changed` live events
- emit HSL runtime forced-mode set/clear/replace transitions through the central event emitter
- keep payloads bounded with symbol samples and mode counts

## Tests
- `./venv/bin/python -m compileall src/live/event_bus.py src/live/event_emitters.py src/passivbot.py src/passivbot_hsl.py tests/test_live_event_bus.py tests/test_passivbot_monitor.py tests/test_hsl_coin_mode.py`
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py::test_risk_mode_changed_event_emits_structured_summary tests/test_hsl_coin_mode.py::test_coin_hsl_runtime_forced_mode_changes_emit_risk_events -q`
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_hsl_coin_mode.py -q`
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_passivbot_monitor.py -q`
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_unstucking_safeguards.py -k 'hard_stop or runtime_forced_modes or halted_mode' -q`\n- `git diff --check`