### PR TITLE
Emit candle coverage audit events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable user-facing changes will be documented in this file.
 - Added structured `candle.tail_projected` live events for open-tail EMA
   projection decisions, preserving per-symbol candle-tail context without
   default console noise.
+- Added structured `candle.coverage_checked` live events for required candle
+  disk-coverage audits, including bounded missing-span summaries.
 - Reduced default console/file noise for candidate-only forager EMA and
   open-tail projection diagnostics; detailed per-symbol internals remain in
   structured/debug events while active-symbol failures still fail loudly.

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -48,6 +48,7 @@ class EventTypes:
     EMA_BUNDLE_COMPLETED = "ema.bundle.completed"
     EMA_FALLBACK_USED = "ema.fallback_used"
     EMA_UNAVAILABLE = "ema.unavailable"
+    CANDLE_COVERAGE_CHECKED = "candle.coverage_checked"
     CANDLE_TAIL_PROJECTED = "candle.tail_projected"
     CACHE_LOAD_COMPLETED = "cache.load.completed"
     CACHE_FLUSH_COMPLETED = "cache.flush.completed"
@@ -109,6 +110,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.EMA_BUNDLE_COMPLETED,
     EventTypes.EMA_FALLBACK_USED,
     EventTypes.EMA_UNAVAILABLE,
+    EventTypes.CANDLE_COVERAGE_CHECKED,
     EventTypes.CANDLE_TAIL_PROJECTED,
     EventTypes.CACHE_LOAD_COMPLETED,
     EventTypes.CACHE_FLUSH_COMPLETED,
@@ -392,6 +394,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.EMA_BUNDLE_COMPLETED: EventRoute(console=False, text=False),
     EventTypes.EMA_FALLBACK_USED: EventRoute(console=False, text=False),
     EventTypes.EMA_UNAVAILABLE: EventRoute(console=False, text=False),
+    EventTypes.CANDLE_COVERAGE_CHECKED: EventRoute(console=False, text=False),
     EventTypes.CANDLE_TAIL_PROJECTED: EventRoute(console=False, text=False),
     EventTypes.CACHE_LOAD_COMPLETED: EventRoute(console=False, text=False),
     EventTypes.CACHE_FLUSH_COMPLETED: EventRoute(console=False, text=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1074,6 +1074,120 @@ def emit_candle_tail_projected_event(bot: Any, *args: Any, **kwargs: Any) -> Non
         )
 
 
+def _missing_span_preview(
+    spans: Any,
+    *,
+    timeframe_ms: int,
+    limit: int = 3,
+) -> list[dict[str, int]]:
+    preview: list[dict[str, int]] = []
+    try:
+        iterable = list(spans or [])
+    except TypeError:
+        iterable = []
+    step_ms = max(1, int(timeframe_ms or 1))
+    for item in iterable[: max(0, int(limit))]:
+        try:
+            start_ts, end_ts = item
+        except Exception:
+            continue
+        start_int = _safe_int(start_ts)
+        end_int = _safe_int(end_ts)
+        if start_int is None or end_int is None:
+            continue
+        preview.append(
+            {
+                "start_ts": int(start_int),
+                "end_ts": int(end_int),
+                "candles": int(max(0, (int(end_int) - int(start_int)) // step_ms) + 1),
+            }
+        )
+    return preview
+
+
+def _timeframe_ms(timeframe: str) -> int:
+    text = str(timeframe or "1m").strip().lower()
+    try:
+        unit = text[-1]
+        value = int(float(text[:-1] or "1"))
+    except Exception:
+        return 60_000
+    if unit == "s":
+        return max(1, value * 1_000)
+    if unit == "m":
+        return max(1, value * 60_000)
+    if unit == "h":
+        return max(1, value * 3_600_000)
+    if unit == "d":
+        return max(1, value * 86_400_000)
+    return 60_000
+
+
+def _emit_candle_coverage_checked_event_unchecked(
+    bot: Any,
+    *,
+    symbol: str,
+    timeframe: str,
+    start_ts: int,
+    end_ts: int,
+    report: dict[str, Any] | None,
+    context: str = "required_disk_audit",
+    required: bool = True,
+) -> None:
+    report_in = dict(report or {})
+    tf = str(report_in.get("timeframe") or timeframe or "1m")
+    ok = bool(report_in.get("ok", False))
+    missing_spans = report_in.get("missing_spans") or []
+    try:
+        missing_span_count = len(missing_spans)
+    except Exception:
+        missing_span_count = 0
+    tf_ms = _timeframe_ms(tf)
+    data: dict[str, Any] = {
+        "context": str(context),
+        "timeframe": tf,
+        "required": bool(required),
+        "coverage_ok": ok,
+        "missing_span_count": int(missing_span_count),
+        "missing_spans_preview": _missing_span_preview(
+            missing_spans,
+            timeframe_ms=tf_ms,
+        ),
+    }
+    for key, value in (
+        ("start_ts", start_ts),
+        ("end_ts", end_ts),
+        ("missing_candles", report_in.get("missing_candles")),
+        ("loaded_rows", report_in.get("loaded_rows")),
+    ):
+        safe = _safe_int(value)
+        if safe is not None:
+            data[key] = int(safe)
+    _safe_emit(
+        bot,
+        EventTypes.CANDLE_COVERAGE_CHECKED,
+        level="debug" if ok or not required else "warning",
+        component="candle.coverage",
+        tags=("candle", "coverage", "cache"),
+        cycle_id=current_live_event_cycle_id(bot),
+        symbol=str(symbol),
+        status="succeeded" if ok else ("degraded" if required else "skipped"),
+        reason_code="required_candle_disk_coverage",
+        data=data,
+    )
+
+
+def emit_candle_coverage_checked_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    try:
+        _emit_candle_coverage_checked_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.CANDLE_COVERAGE_CHECKED,
+            exc,
+        )
+
+
 def _reason_counts(data: Any) -> dict[str, int]:
     out: dict[str, int] = {}
     for key, value in dict(data or {}).items():

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -629,6 +629,9 @@ class Passivbot:
     _emit_candle_tail_projected_event = (
         live_event_emitters.emit_candle_tail_projected_event
     )
+    _emit_candle_coverage_checked_event = (
+        live_event_emitters.emit_candle_coverage_checked_event
+    )
     _emit_cache_warmup_decision_event = (
         live_event_emitters.emit_cache_warmup_decision_event
     )
@@ -5078,23 +5081,41 @@ class Passivbot:
             if win > 0 and end_final > 0:
                 start_ts = max(0, int(end_final - win * ONE_MIN_MS))
                 log_level = "debug"
-                self.cm.check_disk_coverage(
+                report = self.cm.check_disk_coverage(
                     sym,
                     start_ts,
                     int(end_final),
                     timeframe="1m",
                     log_level=log_level,
                 )
+                self._emit_candle_coverage_checked_event(
+                    symbol=sym,
+                    timeframe="1m",
+                    start_ts=start_ts,
+                    end_ts=int(end_final),
+                    report=report,
+                    context="required_disk_audit",
+                    required=True,
+                )
             warm_hours = int(per_symbol_h1_hours.get(sym, 0) or 0)
             if warm_hours > 0 and end_final_hour > 0:
                 start_ts = max(0, int(end_final_hour - warm_hours * 60 * ONE_MIN_MS))
                 log_level = "debug"
-                self.cm.check_disk_coverage(
+                report = self.cm.check_disk_coverage(
                     sym,
                     start_ts,
                     int(end_final_hour),
                     timeframe="1h",
                     log_level=log_level,
+                )
+                self._emit_candle_coverage_checked_event(
+                    symbol=sym,
+                    timeframe="1h",
+                    start_ts=start_ts,
+                    end_ts=int(end_final_hour),
+                    report=report,
+                    context="required_disk_audit",
+                    required=True,
                 )
 
     def _required_candle_windows_by_symbol(

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -141,6 +141,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.EMA_BUNDLE_COMPLETED,
         EventTypes.EMA_FALLBACK_USED,
         EventTypes.EMA_UNAVAILABLE,
+        EventTypes.CANDLE_COVERAGE_CHECKED,
         EventTypes.CANDLE_TAIL_PROJECTED,
         EventTypes.CACHE_LOAD_COMPLETED,
         EventTypes.CACHE_FLUSH_COMPLETED,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -535,6 +535,9 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         _emit_candle_tail_projected_event = (
             pb_mod.Passivbot._emit_candle_tail_projected_event
         )
+        _emit_candle_coverage_checked_event = (
+            pb_mod.Passivbot._emit_candle_coverage_checked_event
+        )
         _emit_cache_load_completed_event = (
             pb_mod.Passivbot._emit_cache_load_completed_event
         )
@@ -630,6 +633,21 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         },
         reason_code="late_open_tail_projection",
     )
+    bot._emit_candle_coverage_checked_event(
+        symbol="ETH/USDT:USDT",
+        timeframe="1m",
+        start_ts=120_000,
+        end_ts=240_000,
+        report={
+            "ok": False,
+            "timeframe": "1m",
+            "missing_spans": [(180_000, 240_000)],
+            "missing_candles": 2,
+            "loaded_rows": 1,
+        },
+        context="required_disk_audit",
+        required=True,
+    )
     bot._emit_cache_load_completed_event(
         {
             "symbol": "ETH/USDT:USDT",
@@ -683,6 +701,7 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         EventTypes.EMA_FALLBACK_USED,
         EventTypes.EMA_UNAVAILABLE,
         EventTypes.CANDLE_TAIL_PROJECTED,
+        EventTypes.CANDLE_COVERAGE_CHECKED,
         EventTypes.CACHE_LOAD_COMPLETED,
         EventTypes.CACHE_FLUSH_COMPLETED,
         EventTypes.CACHE_WARMUP_DECISION,
@@ -707,10 +726,20 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
     assert events[6].reason_code == "late_open_tail_projection"
     assert events[6].data["latest_expected_ts"] == 180_000
     assert events[6].data["tail_gap_age_ms"] == 60_000
-    assert events[7].component == "cache.candles"
+    assert events[7].component == "candle.coverage"
     assert events[7].symbol == "ETH/USDT:USDT"
-    assert events[7].reason_code == "candle_disk_load_completed"
-    assert events[7].data == {
+    assert events[7].status == "degraded"
+    assert events[7].level == "warning"
+    assert events[7].reason_code == "required_candle_disk_coverage"
+    assert events[7].data["coverage_ok"] is False
+    assert events[7].data["missing_span_count"] == 1
+    assert events[7].data["missing_spans_preview"] == [
+        {"start_ts": 180_000, "end_ts": 240_000, "candles": 2}
+    ]
+    assert events[8].component == "cache.candles"
+    assert events[8].symbol == "ETH/USDT:USDT"
+    assert events[8].reason_code == "candle_disk_load_completed"
+    assert events[8].data == {
         "timeframe": "1m",
         "start_ts": 120_000,
         "end_ts": 240_000,
@@ -725,10 +754,10 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         "suppressed_count": 2,
         "source_days": {"legacy": 0, "merged": 0, "primary": 1},
     }
-    assert events[8].component == "cache.candles"
-    assert events[8].symbol == "ETH/USDT:USDT"
-    assert events[8].reason_code == "candle_disk_flush_completed"
-    assert events[8].data == {
+    assert events[9].component == "cache.candles"
+    assert events[9].symbol == "ETH/USDT:USDT"
+    assert events[9].reason_code == "candle_disk_flush_completed"
+    assert events[9].data == {
         "timeframe": "1m",
         "persisted_rows": 4,
         "persisted_start_ts": 300_000,
@@ -736,19 +765,136 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         "suppressed_count": 2,
         "suppressed_rows": 8,
     }
-    assert events[9].component == "cache.warmup"
-    assert events[9].reason_code == "warmup_cache_decision"
-    assert events[9].data["context"] == "trading-ready warmup"
-    assert events[9].data["symbol_count"] == 3
-    assert events[9].data["reused_count"] == 1
-    assert events[9].data["cold_count"] == 2
-    assert events[9].data["cold_path_required"] is True
-    assert events[9].data["reason_counts"] == {
+    assert events[10].component == "cache.warmup"
+    assert events[10].reason_code == "warmup_cache_decision"
+    assert events[10].data["context"] == "trading-ready warmup"
+    assert events[10].data["symbol_count"] == 3
+    assert events[10].data["reused_count"] == 1
+    assert events[10].data["cold_count"] == 2
+    assert events[10].data["cold_path_required"] is True
+    assert events[10].data["reason_counts"] == {
         "missing_coverage": 2,
         "warm_cache_accepted": 1,
     }
-    assert events[9].data["window_max_candles"] == 260
+    assert events[10].data["window_max_candles"] == 260
     assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_candle_disk_coverage_audit_emits_structured_events(monkeypatch):
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeCandleManager:
+        def __init__(self):
+            self.calls = []
+
+        def check_disk_coverage(
+            self,
+            symbol,
+            start_ts,
+            end_ts,
+            *,
+            timeframe,
+            log_level,
+        ):
+            self.calls.append(
+                {
+                    "symbol": symbol,
+                    "start_ts": start_ts,
+                    "end_ts": end_ts,
+                    "timeframe": timeframe,
+                    "log_level": log_level,
+                }
+            )
+            if timeframe == "1m":
+                return {
+                    "ok": False,
+                    "timeframe": "1m",
+                    "missing_spans": [(180_000, 240_000)],
+                    "missing_candles": 2,
+                    "loaded_rows": 1,
+                }
+            return {
+                "ok": True,
+                "timeframe": "1h",
+                "missing_spans": [],
+                "missing_candles": 0,
+                "loaded_rows": 4,
+            }
+
+    bot = pb_mod.Passivbot.__new__(pb_mod.Passivbot)
+    bot.exchange = "okx"
+    bot.user = "okx_01"
+    bot.bot_id = "bot_1"
+    bot.cm = FakeCandleManager()
+    bot.config = {"live": {}}
+    bot.active_symbols = ["BTC/USDT:USDT"]
+    bot.open_orders = {}
+    bot.positions = {}
+    bot._live_event_current_cycle_id = "cy_12"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot.get_max_n_positions = lambda pside: 1
+    bot.get_current_n_positions = lambda pside: 1 if pside == "long" else 0
+    bot.get_symbols_with_pos = (
+        lambda pside: {"BTC/USDT:USDT"} if pside == "long" else set()
+    )
+    bot.get_symbols_approved_or_has_pos = lambda pside: {"BTC/USDT:USDT"}
+    bot.is_forager_mode = lambda pside=None: False
+    bot.has_position = lambda symbol: symbol == "BTC/USDT:USDT"
+
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: 7_500_000)
+    monkeypatch.setattr(
+        pb_mod,
+        "compute_live_warmup_windows",
+        lambda *args, **kwargs: (
+            {"BTC/USDT:USDT": 2},
+            {"BTC/USDT:USDT": 1},
+            {},
+        ),
+    )
+
+    await bot.audit_required_candle_disk_coverage()
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+    assert bot.cm.calls == [
+        {
+            "symbol": "BTC/USDT:USDT",
+            "start_ts": 7_320_000,
+            "end_ts": 7_440_000,
+            "timeframe": "1m",
+            "log_level": "debug",
+        },
+        {
+            "symbol": "BTC/USDT:USDT",
+            "start_ts": 0,
+            "end_ts": 3_600_000,
+            "timeframe": "1h",
+            "log_level": "debug",
+        },
+    ]
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.CANDLE_COVERAGE_CHECKED
+    ]
+    assert [event.status for event in events] == ["degraded", "succeeded"]
+    assert [event.level for event in events] == ["warning", "debug"]
+    assert {event.cycle_id for event in events} == {"cy_12"}
+    assert events[0].symbol == "BTC/USDT:USDT"
+    assert events[0].data["timeframe"] == "1m"
+    assert events[0].data["coverage_ok"] is False
+    assert events[0].data["missing_candles"] == 2
+    assert events[0].data["missing_spans_preview"] == [
+        {"start_ts": 180_000, "end_ts": 240_000, "candles": 2}
+    ]
+    assert events[1].data["timeframe"] == "1h"
+    assert events[1].data["coverage_ok"] is True
 
 
 def test_candle_disk_load_handler_throttles_repeated_symbol_timeframe_events():


### PR DESCRIPTION
## Summary
- Add quiet structured candle.coverage_checked live events for required candle disk-coverage audits.
- Emit bounded coverage payloads from audit_required_candle_disk_coverage without changing candle fetch/readiness policy.
- Add focused route, emitter, and audit-hook tests.

## Validation
- PYTHONPATH=src ./venv/bin/python -m compileall src/live/event_bus.py src/live/event_emitters.py src/passivbot.py tests/test_live_event_bus.py tests/test_passivbot_monitor.py
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py -q
- git diff --check