### PR TITLE
Emit fill refresh summary events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable user-facing changes will be documented in this file.
   default console noise.
 - Added structured `candle.coverage_checked` live events for required candle
   disk-coverage audits, including bounded missing-span summaries.
+- Added structured `fills.refresh_summary` live events for fill/PnL refresh
+  timing, coverage, retry, and failure summaries without exposing raw fill ids.
 - Reduced default console/file noise for candidate-only forager EMA and
   open-tail projection diagnostics; detailed per-symbol internals remain in
   structured/debug events while active-symbol failures still fail loudly.

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -74,6 +74,7 @@ class EventTypes:
     EXECUTION_CONFIRMATION_REQUESTED = "execution.confirmation_requested"
     EXECUTION_CONFIRMATION_SATISFIED = "execution.confirmation_satisfied"
     EXECUTION_CONFIRMATION_TIMEOUT = "execution.confirmation_timeout"
+    FILLS_REFRESH_SUMMARY = "fills.refresh_summary"
     FILL_INGESTED = "fill.ingested"
     POSITION_CHANGED = "position.changed"
     BALANCE_CHANGED = "balance.changed"
@@ -136,6 +137,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.EXECUTION_CONFIRMATION_REQUESTED,
     EventTypes.EXECUTION_CONFIRMATION_SATISFIED,
     EventTypes.EXECUTION_CONFIRMATION_TIMEOUT,
+    EventTypes.FILLS_REFRESH_SUMMARY,
     EventTypes.FILL_INGESTED,
     EventTypes.POSITION_CHANGED,
     EventTypes.BALANCE_CHANGED,
@@ -422,6 +424,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.EXECUTION_CONFIRMATION_REQUESTED: EventRoute(console=False),
     EventTypes.EXECUTION_CONFIRMATION_SATISFIED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CONFIRMATION_TIMEOUT: EventRoute(console=True, text=True),
+    EventTypes.FILLS_REFRESH_SUMMARY: EventRoute(console=False, text=False),
     EventTypes.FILL_INGESTED: EventRoute(console=False, text=False),
     EventTypes.POSITION_CHANGED: EventRoute(console=False, text=False),
     EventTypes.BALANCE_CHANGED: EventRoute(console=False, text=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -2017,6 +2017,100 @@ def emit_balance_changed_event(
         logging.debug("[event] failed to emit balance changed event: %s", exc)
 
 
+def _fill_coverage_summary(status: Any) -> dict[str, Any]:
+    if not isinstance(status, dict):
+        return {}
+    data: dict[str, Any] = {}
+    if "ready" in status:
+        data["ready"] = bool(status.get("ready"))
+    for key in ("reason", "history_scope", "gap_reason"):
+        value = status.get(key)
+        if value is not None:
+            data[key] = str(value)[:160]
+    for key in ("covered_start_ms", "oldest_event_ts", "gap_start_ts", "gap_end_ts"):
+        value = _safe_int(status.get(key))
+        if value is not None:
+            data[key] = value
+    return data
+
+
+def emit_fills_refresh_summary_event(
+    bot: Any,
+    *,
+    source: str,
+    refresh_mode: str,
+    status: str,
+    reason_code: str,
+    elapsed_ms: int,
+    lookback: Any = None,
+    history_scope: str | None = None,
+    event_count_before: int | None = None,
+    event_count_after: int | None = None,
+    new_count: int | None = None,
+    enriched_count: int | None = None,
+    pending_pnl_count: int | None = None,
+    coverage_before: dict[str, Any] | None = None,
+    coverage_after: dict[str, Any] | None = None,
+    overlap_minutes: float | None = None,
+    retry_count: int | None = None,
+    next_retry_in_ms: int | None = None,
+    error: BaseException | None = None,
+    level: str = "debug",
+) -> None:
+    try:
+        coverage_before_summary = _fill_coverage_summary(coverage_before)
+        coverage_after_summary = _fill_coverage_summary(coverage_after)
+        data: dict[str, Any] = {
+            "source": str(source),
+            "refresh_mode": str(refresh_mode),
+            "elapsed_ms": max(0, int(elapsed_ms)),
+            "lookback": str(lookback) if lookback is not None else None,
+            "history_scope": str(history_scope) if history_scope is not None else None,
+            "event_count_before": _safe_int(event_count_before),
+            "event_count_after": _safe_int(event_count_after),
+            "new_count": _safe_int(new_count),
+            "enriched_count": _safe_int(enriched_count),
+            "pending_pnl_count": _safe_int(pending_pnl_count),
+        }
+        if coverage_before_summary:
+            data["coverage_before"] = coverage_before_summary
+            if "ready" in coverage_before_summary:
+                data["coverage_ready_before"] = coverage_before_summary["ready"]
+            if "reason" in coverage_before_summary:
+                data["coverage_reason_before"] = coverage_before_summary["reason"]
+        if coverage_after_summary:
+            data["coverage_after"] = coverage_after_summary
+            if "ready" in coverage_after_summary:
+                data["coverage_ready_after"] = coverage_after_summary["ready"]
+            if "reason" in coverage_after_summary:
+                data["coverage_reason_after"] = coverage_after_summary["reason"]
+        overlap = _safe_float(overlap_minutes)
+        if overlap is not None:
+            data["overlap_minutes"] = overlap
+        retry_value = _safe_int(retry_count)
+        if retry_value is not None:
+            data["retry_count"] = retry_value
+        next_retry_value = _safe_int(next_retry_in_ms)
+        if next_retry_value is not None:
+            data["next_retry_in_ms"] = max(0, next_retry_value)
+        if error is not None:
+            data["error_type"] = type(error).__name__
+            data["error"] = _sanitize_remote_text(error, max_len=500)
+        _safe_emit(
+            bot,
+            EventTypes.FILLS_REFRESH_SUMMARY,
+            level=str(level).lower(),
+            component="fills.refresh",
+            tags=("fills", "refresh", "coverage"),
+            cycle_id=current_live_event_cycle_id(bot),
+            status=str(status),
+            reason_code=str(reason_code),
+            data={key: value for key, value in data.items() if value is not None},
+        )
+    except Exception as exc:
+        logging.debug("[event] failed to emit fills refresh summary event: %s", exc)
+
+
 def emit_fill_ingested_event(bot: Any, event: Any, *, payload: dict | None = None) -> None:
     try:
         fill_payload = dict(payload or {})

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -2034,7 +2034,7 @@ def _fill_coverage_summary(status: Any) -> dict[str, Any]:
     return data
 
 
-def emit_fills_refresh_summary_event(
+def _emit_fills_refresh_summary_event_unchecked(
     bot: Any,
     *,
     source: str,
@@ -2057,56 +2057,60 @@ def emit_fills_refresh_summary_event(
     error: BaseException | None = None,
     level: str = "debug",
 ) -> None:
+    coverage_before_summary = _fill_coverage_summary(coverage_before)
+    coverage_after_summary = _fill_coverage_summary(coverage_after)
+    data: dict[str, Any] = {
+        "source": str(source),
+        "refresh_mode": str(refresh_mode),
+        "elapsed_ms": max(0, int(elapsed_ms)),
+        "lookback": str(lookback) if lookback is not None else None,
+        "history_scope": str(history_scope) if history_scope is not None else None,
+        "event_count_before": _safe_int(event_count_before),
+        "event_count_after": _safe_int(event_count_after),
+        "new_count": _safe_int(new_count),
+        "enriched_count": _safe_int(enriched_count),
+        "pending_pnl_count": _safe_int(pending_pnl_count),
+    }
+    if coverage_before_summary:
+        data["coverage_before"] = coverage_before_summary
+        if "ready" in coverage_before_summary:
+            data["coverage_ready_before"] = coverage_before_summary["ready"]
+        if "reason" in coverage_before_summary:
+            data["coverage_reason_before"] = coverage_before_summary["reason"]
+    if coverage_after_summary:
+        data["coverage_after"] = coverage_after_summary
+        if "ready" in coverage_after_summary:
+            data["coverage_ready_after"] = coverage_after_summary["ready"]
+        if "reason" in coverage_after_summary:
+            data["coverage_reason_after"] = coverage_after_summary["reason"]
+    overlap = _safe_float(overlap_minutes)
+    if overlap is not None:
+        data["overlap_minutes"] = overlap
+    retry_value = _safe_int(retry_count)
+    if retry_value is not None:
+        data["retry_count"] = retry_value
+    next_retry_value = _safe_int(next_retry_in_ms)
+    if next_retry_value is not None:
+        data["next_retry_in_ms"] = max(0, next_retry_value)
+    if error is not None:
+        data["error_type"] = type(error).__name__
+        data["error"] = _sanitize_remote_text(error, max_len=500)
+    _safe_emit(
+        bot,
+        EventTypes.FILLS_REFRESH_SUMMARY,
+        level=str(level).lower(),
+        component="fills.refresh",
+        tags=("fills", "refresh", "coverage"),
+        cycle_id=current_live_event_cycle_id(bot),
+        status=str(status),
+        reason_code=str(reason_code),
+        data={key: value for key, value in data.items() if value is not None},
+    )
+
+
+def emit_fills_refresh_summary_event(bot: Any, *args: Any, **kwargs: Any) -> None:
     try:
-        coverage_before_summary = _fill_coverage_summary(coverage_before)
-        coverage_after_summary = _fill_coverage_summary(coverage_after)
-        data: dict[str, Any] = {
-            "source": str(source),
-            "refresh_mode": str(refresh_mode),
-            "elapsed_ms": max(0, int(elapsed_ms)),
-            "lookback": str(lookback) if lookback is not None else None,
-            "history_scope": str(history_scope) if history_scope is not None else None,
-            "event_count_before": _safe_int(event_count_before),
-            "event_count_after": _safe_int(event_count_after),
-            "new_count": _safe_int(new_count),
-            "enriched_count": _safe_int(enriched_count),
-            "pending_pnl_count": _safe_int(pending_pnl_count),
-        }
-        if coverage_before_summary:
-            data["coverage_before"] = coverage_before_summary
-            if "ready" in coverage_before_summary:
-                data["coverage_ready_before"] = coverage_before_summary["ready"]
-            if "reason" in coverage_before_summary:
-                data["coverage_reason_before"] = coverage_before_summary["reason"]
-        if coverage_after_summary:
-            data["coverage_after"] = coverage_after_summary
-            if "ready" in coverage_after_summary:
-                data["coverage_ready_after"] = coverage_after_summary["ready"]
-            if "reason" in coverage_after_summary:
-                data["coverage_reason_after"] = coverage_after_summary["reason"]
-        overlap = _safe_float(overlap_minutes)
-        if overlap is not None:
-            data["overlap_minutes"] = overlap
-        retry_value = _safe_int(retry_count)
-        if retry_value is not None:
-            data["retry_count"] = retry_value
-        next_retry_value = _safe_int(next_retry_in_ms)
-        if next_retry_value is not None:
-            data["next_retry_in_ms"] = max(0, next_retry_value)
-        if error is not None:
-            data["error_type"] = type(error).__name__
-            data["error"] = _sanitize_remote_text(error, max_len=500)
-        _safe_emit(
-            bot,
-            EventTypes.FILLS_REFRESH_SUMMARY,
-            level=str(level).lower(),
-            component="fills.refresh",
-            tags=("fills", "refresh", "coverage"),
-            cycle_id=current_live_event_cycle_id(bot),
-            status=str(status),
-            reason_code=str(reason_code),
-            data={key: value for key, value in data.items() if value is not None},
-        )
+        _emit_fills_refresh_summary_event_unchecked(bot, *args, **kwargs)
     except Exception as exc:
         logging.debug("[event] failed to emit fills refresh summary event: %s", exc)
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -616,6 +616,9 @@ class Passivbot:
     _emit_execution_order_event = live_event_emitters.emit_execution_order_event
     _emit_action_planned_event = live_event_emitters.emit_action_planned_event
     _emit_balance_changed_event = live_event_emitters.emit_balance_changed_event
+    _emit_fills_refresh_summary_event = (
+        live_event_emitters.emit_fills_refresh_summary_event
+    )
     _emit_fill_ingested_event = live_event_emitters.emit_fill_ingested_event
     _emit_risk_mode_changed_event = live_event_emitters.emit_risk_mode_changed_event
     _emit_forager_feature_unavailable_event = (
@@ -10147,6 +10150,10 @@ class Passivbot:
         refresh_started_ms = utc_ms()
         refresh_mode = "unknown"
         overlap_minutes: Optional[float] = None
+        before_events_count = 0
+        coverage_status: dict[str, Any] = {}
+        post_refresh_coverage_status: dict[str, Any] = {}
+        lookback_config_value = None
         await self.init_pnls()  # will do nothing if already initiated
 
         if self._pnls_manager is None:
@@ -10154,8 +10161,9 @@ class Passivbot:
 
         try:
             # Use the same lookback window
+            lookback_config_value = self.live_value("pnls_max_lookback_days")
             lookback = parse_pnls_max_lookback_days(
-                self.live_value("pnls_max_lookback_days"),
+                lookback_config_value,
                 field_name="live.pnls_max_lookback_days",
             )
             age_limit = lookback.fill_cache_age_limit_ms(self.get_exchange_time())
@@ -10196,12 +10204,28 @@ class Passivbot:
                 if self._fill_coverage_retry_deferred(coverage_status, now_ms):
                     state = getattr(self, "_fill_coverage_retry_state", {}) or {}
                     next_retry_ms = int(state.get("next_retry_ms", 0) or 0)
+                    refresh_mode = "coverage_retry_backoff"
+                    next_retry_in_ms = max(0, next_retry_ms - now_ms)
                     logging.debug(
                         "[fills] fill-history lookback proof deferred by retry backoff | "
                         "reason=%s scope=%s next_retry_in_ms=%d",
                         str(coverage_status.get("reason", "unknown")),
                         history_scope,
-                        max(0, next_retry_ms - now_ms),
+                        next_retry_in_ms,
+                    )
+                    self._emit_fills_refresh_summary_event(
+                        source=source,
+                        refresh_mode=refresh_mode,
+                        status="deferred",
+                        reason_code="fill_history_coverage_retry_backoff",
+                        elapsed_ms=int(max(0, utc_ms() - refresh_started_ms)),
+                        lookback=lookback_config_value,
+                        history_scope=history_scope,
+                        event_count_before=before_events_count,
+                        coverage_before=coverage_status,
+                        next_retry_in_ms=next_retry_in_ms,
+                        retry_count=int(state.get("retry_count", 0) or 0),
+                        level="debug",
                     )
                     return False
             if needs_full_refresh:
@@ -10374,17 +10398,43 @@ class Passivbot:
                 before_events_count,
                 len(all_events),
                 len(new_events),
-                str(self.live_value("pnls_max_lookback_days")),
+                str(lookback_config_value),
                 self._pnls_manager.get_history_scope(),
                 coverage_ready_after,
                 str(post_refresh_coverage_status.get("reason", "unknown")),
                 (f"{overlap_minutes:.3f}" if overlap_minutes is not None else "-"),
                 len(pending_pnl_events),
             )
+            self._emit_fills_refresh_summary_event(
+                source=source,
+                refresh_mode=refresh_mode,
+                status="succeeded" if pnls_complete and coverage_ready_after else "deferred",
+                reason_code=(
+                    "fills_refresh_succeeded"
+                    if pnls_complete and coverage_ready_after
+                    else (
+                        "pending_pnl_enrichment"
+                        if not pnls_complete
+                        else "fill_history_coverage_unavailable"
+                    )
+                ),
+                elapsed_ms=elapsed_ms,
+                lookback=lookback_config_value,
+                history_scope=self._pnls_manager.get_history_scope(),
+                event_count_before=before_events_count,
+                event_count_after=len(all_events),
+                new_count=len(new_events),
+                enriched_count=len(enriched_events),
+                pending_pnl_count=len(pending_pnl_events),
+                coverage_before=coverage_status,
+                coverage_after=post_refresh_coverage_status,
+                overlap_minutes=overlap_minutes,
+                level=logging.getLevelName(log_level).lower(),
+            )
 
             return pnls_complete and coverage_ready_after
 
-        except RateLimitExceeded:
+        except RateLimitExceeded as e:
             if self._shutdown_requested():
                 logging.debug(
                     "[shutdown] fill refresh stopped during rate-limit handling"
@@ -10398,6 +10448,18 @@ class Passivbot:
             )
             logging.warning(
                 "[rate] hit rate limit while fetching fill events; retrying next cycle"
+            )
+            self._emit_fills_refresh_summary_event(
+                source=source,
+                refresh_mode=refresh_mode,
+                status="deferred",
+                reason_code="rate_limit",
+                elapsed_ms=int(max(0, utc_ms() - refresh_started_ms)),
+                lookback=lookback_config_value,
+                event_count_before=before_events_count,
+                coverage_before=coverage_status,
+                error=e,
+                level="warning",
             )
             return False
         except Exception as e:
@@ -10420,6 +10482,19 @@ class Passivbot:
                 getattr(e, "status", "-"),
                 getattr(e, "code", "-"),
                 e,
+            )
+            self._emit_fills_refresh_summary_event(
+                source=source,
+                refresh_mode=refresh_mode,
+                status="failed",
+                reason_code="fill_refresh_failed",
+                elapsed_ms=int(max(0, utc_ms() - refresh_started_ms)),
+                lookback=lookback_config_value,
+                event_count_before=before_events_count,
+                coverage_before=coverage_status,
+                coverage_after=post_refresh_coverage_status,
+                error=e,
+                level="error",
             )
             if self.logging_level >= 2:
                 traceback.print_exc()

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -10469,6 +10469,19 @@ class Passivbot:
                 )
                 return False
             if await self._maybe_recover_exchange_time_sync(e, source="update_pnls"):
+                self._emit_fills_refresh_summary_event(
+                    source=source,
+                    refresh_mode=refresh_mode,
+                    status="deferred",
+                    reason_code="exchange_time_resync",
+                    elapsed_ms=int(max(0, utc_ms() - refresh_started_ms)),
+                    lookback=lookback_config_value,
+                    event_count_before=before_events_count,
+                    coverage_before=coverage_status,
+                    coverage_after=post_refresh_coverage_status,
+                    error=e,
+                    level="warning",
+                )
                 return False
             self._monitor_record_error(
                 "error.exchange",

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -146,6 +146,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.CACHE_LOAD_COMPLETED,
         EventTypes.CACHE_FLUSH_COMPLETED,
         EventTypes.CACHE_WARMUP_DECISION,
+        EventTypes.FILLS_REFRESH_SUMMARY,
         EventTypes.BOT_STARTUP_TIMING,
         EventTypes.PLANNING_DEFER_SUMMARY,
         EventTypes.PLANNING_SYMBOL_STATE,

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2931,6 +2931,15 @@ async def test_update_pnls_window_lookback_uses_incremental_when_coverage_proven
         }
     }
     bot._authoritative_pending_confirmations = {}
+    sink = ListEventSink()
+    bot.exchange = "bybit"
+    bot.user = "bybit_01"
+    bot.bot_id = "bot_1"
+    bot._live_event_current_cycle_id = "cy_fills"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
     bot._pnls_manager = _Manager(cached_events)
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: bot.config["live"][key]
@@ -2950,6 +2959,25 @@ async def test_update_pnls_window_lookback_uses_incremental_when_coverage_proven
         overlap=20,
         last_refresh_overlap_ms=10 * 60 * 1000,
     )
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.FILLS_REFRESH_SUMMARY
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.cycle_id == "cy_fills"
+    assert event.status == "succeeded"
+    assert event.reason_code == "fills_refresh_succeeded"
+    assert event.data["refresh_mode"] == "incremental_recent"
+    assert event.data["event_count_before"] == 1
+    assert event.data["event_count_after"] == 1
+    assert event.data["coverage_ready_before"] is True
+    assert event.data["coverage_ready_after"] is True
+    assert event.data["coverage_reason_after"] == "window_covered"
+    assert event.data["pending_pnl_count"] == 0
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 @pytest.mark.asyncio
@@ -3036,6 +3064,15 @@ async def test_update_pnls_propagates_unexpected_refresh_errors():
             "pnls_max_lookback_days": "all",
         }
     }
+    sink = ListEventSink()
+    bot.exchange = "bybit"
+    bot.user = "bybit_01"
+    bot.bot_id = "bot_1"
+    bot._live_event_current_cycle_id = "cy_fills_error"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
     bot._pnls_manager = _Manager(cached_events, history_scope="all")
     bot.init_pnls = AsyncMock()
     bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
@@ -3048,6 +3085,20 @@ async def test_update_pnls_propagates_unexpected_refresh_errors():
 
     with pytest.raises(RuntimeError, match="fill refresh failed"):
         await bot.update_pnls()
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.FILLS_REFRESH_SUMMARY
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.status == "failed"
+    assert event.reason_code == "fill_refresh_failed"
+    assert event.data["error_type"] == "RuntimeError"
+    assert event.data["error"] == "fill refresh failed"
+    assert event.data["coverage_ready_before"] is True
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -3102,6 +3102,78 @@ async def test_update_pnls_propagates_unexpected_refresh_errors():
 
 
 @pytest.mark.asyncio
+async def test_update_pnls_emits_summary_when_exchange_time_resync_handles_error():
+    bot = Passivbot.__new__(Passivbot)
+    cached_events = [
+        SimpleNamespace(timestamp=1_700_000_000_000, id="fill-1", source_ids=["fill-1"])
+    ]
+
+    class _Manager:
+        def __init__(self, events, *, history_scope="unknown"):
+            self._events = list(events)
+            self.refresh = AsyncMock()
+            self.refresh_latest = AsyncMock(
+                side_effect=RuntimeError("timestamp outside recvWindow")
+            )
+            self.history_scope = history_scope
+
+        def get_events(self):
+            return list(self._events)
+
+        def get_history_scope(self):
+            return self.history_scope
+
+        def set_history_scope(self, scope):
+            self.history_scope = scope
+
+    bot.stop_signal_received = False
+    bot.config = {
+        "live": {
+            "fills_recent_overlap_minutes": 10.0,
+            "pnls_max_lookback_days": "all",
+        }
+    }
+    sink = ListEventSink()
+    bot.exchange = "binance"
+    bot.user = "binance_01"
+    bot.bot_id = "bot_1"
+    bot._live_event_current_cycle_id = "cy_fills_resync"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._pnls_manager = _Manager(cached_events, history_scope="all")
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
+    bot.get_exchange_time = lambda: 1_700_000_060_000
+    bot._log_new_fill_events = lambda new_events: None
+    bot._monitor_record_event = lambda *args, **kwargs: None
+    bot._monitor_record_error = lambda *args, **kwargs: None
+    bot._maybe_recover_exchange_time_sync = AsyncMock(return_value=True)
+    bot.logging_level = 0
+    bot._health_rate_limits = 0
+
+    result = await bot.update_pnls()
+
+    assert result is False
+    bot._maybe_recover_exchange_time_sync.assert_awaited_once()
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.FILLS_REFRESH_SUMMARY
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.status == "deferred"
+    assert event.reason_code == "exchange_time_resync"
+    assert event.data["refresh_mode"] == "incremental_recent"
+    assert event.data["error_type"] == "RuntimeError"
+    assert event.data["coverage_ready_before"] is True
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
 async def test_update_pnls_suppresses_inflight_shutdown_refresh_error(caplog):
     bot = Passivbot.__new__(Passivbot)
     cached_events = [

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1751,6 +1751,71 @@ def test_log_new_fill_events_emits_fill_ingested_event():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_emit_fills_refresh_summary_event_sanitizes_error_and_stays_off_console():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _emit_fills_refresh_summary_event = (
+            pb_mod.Passivbot._emit_fills_refresh_summary_event
+        )
+
+        def __init__(self):
+            self.exchange = "bybit"
+            self.user = "bybit_01"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_fills"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+    bot._emit_fills_refresh_summary_event(
+        source="staged_blocking",
+        refresh_mode="lookback_bootstrap",
+        status="failed",
+        reason_code="fill_refresh_failed",
+        elapsed_ms=123,
+        lookback=30.0,
+        history_scope="window",
+        event_count_before=3,
+        coverage_before={
+            "ready": False,
+            "reason": "known_gap_overlaps_lookback",
+            "history_scope": "window",
+            "covered_start_ms": 100,
+            "oldest_event_ts": 90,
+            "gap_start_ts": 120,
+            "gap_end_ts": 180,
+            "gap_reason": "fetch_failed",
+        },
+        next_retry_in_ms=45_000,
+        error=RuntimeError("apiKey=secret-token failed"),
+        level="error",
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[-1]
+    assert event.event_type == EventTypes.FILLS_REFRESH_SUMMARY
+    assert event.cycle_id == "cy_fills"
+    assert event.status == "failed"
+    assert event.reason_code == "fill_refresh_failed"
+    assert event.data["source"] == "staged_blocking"
+    assert event.data["refresh_mode"] == "lookback_bootstrap"
+    assert event.data["coverage_ready_before"] is False
+    assert event.data["coverage_reason_before"] == "known_gap_overlaps_lookback"
+    assert event.data["coverage_before"]["gap_reason"] == "fetch_failed"
+    assert event.data["next_retry_in_ms"] == 45_000
+    assert event.data["error_type"] == "RuntimeError"
+    assert "secret-token" not in event.data["error"]
+    assert "[redacted]" in event.data["error"]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 @pytest.mark.asyncio
 async def test_execute_orders_parent_records_order_opened_event():
     import passivbot as pb_mod


### PR DESCRIPTION
Summary:
- add quiet structured fills.refresh_summary live events for fill/PnL refresh timing, coverage decisions, retry-backoff defers, rate-limit defers, and failures
- wire the event around existing _update_pnls_locked decisions without changing refresh policy or return/raise behavior
- sanitize failure text and keep raw fill ids/source ids out of the summary payload

Tests:
- PYTHONPATH=src ./venv/bin/python -m compileall src/live/event_bus.py src/live/event_emitters.py src/passivbot.py tests/test_live_event_bus.py tests/test_passivbot_balance_split.py tests/test_passivbot_monitor.py
- git diff --check
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py tests/test_passivbot_balance_split.py -k 'route_table_keeps_data_events_off_console_by_default or fills_refresh_summary or update_pnls_window_lookback_uses_incremental_when_coverage_proven or update_pnls_propagates_unexpected_refresh_errors' -q
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py -q
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_passivbot_balance_split.py -k update_pnls -q

Silent-handling scan:
- full touched-file scan run; new diff hits are limited to the intentional best-effort event emitter catch and non-trading retry_count event metadata default.