### PR TITLE
Harden rust orchestrator event emission

### DIFF
--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -975,7 +975,7 @@ def _emit_rust_orchestrator_returned_event_unchecked(
         data.update(
             {
                 "error_type": type(err).__name__,
-                "error": str(err)[:500],
+                "error": _sanitize_remote_text(err, max_len=500),
             }
         )
     else:

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -902,6 +902,116 @@ def _safe_emit(bot: Any, event_type: str, **kwargs: Any) -> Any:
         return None
 
 
+def _emit_rust_orchestrator_called_event_unchecked(
+    bot: Any,
+    *,
+    rust_call_id: str | None,
+    input_hash: str,
+    symbol_count: int,
+    tradable_count: int,
+    ema_unavailable_count: int,
+    trailing_unavailable_count: int,
+    hedge_mode: bool,
+    strategy_kind: str | None,
+) -> None:
+    bot._emit_live_event(
+        EventTypes.RUST_ORCHESTRATOR_CALLED,
+        level="debug",
+        component="rust_orchestrator",
+        tags=("planning", "rust", "orchestrator"),
+        cycle_id=current_live_event_cycle_id(bot),
+        remote_call_id=rust_call_id,
+        status="started",
+        raw_hash=str(input_hash),
+        data={
+            "symbol_count": int(symbol_count),
+            "tradable_count": int(tradable_count),
+            "ema_unavailable_count": int(ema_unavailable_count),
+            "trailing_unavailable_count": int(trailing_unavailable_count),
+            "hedge_mode": bool(hedge_mode),
+            "strategy_kind": strategy_kind,
+            "input_hash": str(input_hash),
+        },
+    )
+
+
+def emit_rust_orchestrator_called_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    try:
+        _emit_rust_orchestrator_called_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.RUST_ORCHESTRATOR_CALLED,
+            exc,
+        )
+
+
+def _emit_rust_orchestrator_returned_event_unchecked(
+    bot: Any,
+    *,
+    rust_call_id: str | None,
+    status: str,
+    input_hash: str,
+    elapsed_ms: int,
+    output_hash: str | None = None,
+    order_count: int | None = None,
+    diagnostics: Any = None,
+    error: BaseException | None = None,
+) -> None:
+    event_status = str(status or "succeeded").lower()
+    failed = event_status == "failed" or error is not None
+    data: dict[str, Any] = {
+        "elapsed_ms": int(max(0, int(elapsed_ms))),
+        "input_hash": str(input_hash),
+    }
+    raw_hash = str(input_hash)
+    level = "error" if failed else "debug"
+    tags = ["planning", "rust", "orchestrator"]
+    reason_code = None
+    if failed:
+        err = error or RuntimeError("rust orchestrator failed")
+        tags.append("error")
+        reason_code = type(err).__name__
+        data.update(
+            {
+                "error_type": type(err).__name__,
+                "error": str(err)[:500],
+            }
+        )
+    else:
+        if output_hash is not None:
+            raw_hash = str(output_hash)
+            data["output_hash"] = str(output_hash)
+        data["order_count"] = int(order_count or 0)
+        data["diagnostic_keys"] = (
+            sorted(diagnostics) if isinstance(diagnostics, dict) else []
+        )
+
+    bot._emit_live_event(
+        EventTypes.RUST_ORCHESTRATOR_RETURNED,
+        level=level,
+        component="rust_orchestrator",
+        tags=tuple(tags),
+        cycle_id=current_live_event_cycle_id(bot),
+        remote_call_id=rust_call_id,
+        status="failed" if failed else "succeeded",
+        reason_code=reason_code,
+        raw_hash=raw_hash,
+        data=data,
+    )
+
+
+def emit_rust_orchestrator_returned_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    try:
+        _emit_rust_orchestrator_returned_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.RUST_ORCHESTRATOR_RETURNED,
+            exc,
+        )
+
+
 def _emit_forager_feature_unavailable_event_unchecked(
     bot: Any,
     *,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -615,6 +615,12 @@ class Passivbot:
     )
     _emit_execution_order_event = live_event_emitters.emit_execution_order_event
     _emit_action_planned_event = live_event_emitters.emit_action_planned_event
+    _emit_rust_orchestrator_called_event = (
+        live_event_emitters.emit_rust_orchestrator_called_event
+    )
+    _emit_rust_orchestrator_returned_event = (
+        live_event_emitters.emit_rust_orchestrator_returned_event
+    )
     _emit_balance_changed_event = live_event_emitters.emit_balance_changed_event
     _emit_fills_refresh_summary_event = (
         live_event_emitters.emit_fills_refresh_summary_event
@@ -15249,33 +15255,19 @@ class Passivbot:
         rust_call_id = self._next_live_event_remote_call_id("rust")
         orchestrator_started_ms = int(utc_ms())
         input_hash = payload_hash_raw(input_json)
-        try:
-            tradable_count = sum(
-                1 for item in input_dict["symbols"] if bool(item.get("tradable", False))
-            )
-            self._emit_live_event(
-                EventTypes.RUST_ORCHESTRATOR_CALLED,
-                level="debug",
-                component="rust_orchestrator",
-                tags=("planning", "rust", "orchestrator"),
-                cycle_id=self._current_live_event_cycle_id(),
-                remote_call_id=rust_call_id,
-                status="started",
-                raw_hash=input_hash,
-                data={
-                    "symbol_count": len(input_dict["symbols"]),
-                    "tradable_count": int(tradable_count),
-                    "ema_unavailable_count": len(ema_unavailable_symbols),
-                    "trailing_unavailable_count": len(trailing_unavailable_symbols),
-                    "hedge_mode": bool(effective_hedge_mode),
-                    "strategy_kind": strategy_kind,
-                    "input_hash": input_hash,
-                },
-            )
-        except Exception as event_exc:
-            logging.debug(
-                "[event] failed preparing rust_orchestrator.called: %s", event_exc
-            )
+        tradable_count = sum(
+            1 for item in input_dict["symbols"] if bool(item.get("tradable", False))
+        )
+        self._emit_rust_orchestrator_called_event(
+            rust_call_id=rust_call_id,
+            input_hash=input_hash,
+            symbol_count=len(input_dict["symbols"]),
+            tradable_count=int(tradable_count),
+            ema_unavailable_count=len(ema_unavailable_symbols),
+            trailing_unavailable_count=len(trailing_unavailable_symbols),
+            hedge_mode=bool(effective_hedge_mode),
+            strategy_kind=strategy_kind,
+        )
         try:
             out_json = pbr.compute_ideal_orders_json(input_json)
         except Exception as e:
@@ -15292,22 +15284,12 @@ class Passivbot:
                             Passivbot._log_symbol(symbol),
                             idx,
                         )
-            self._emit_live_event(
-                EventTypes.RUST_ORCHESTRATOR_RETURNED,
-                level="error",
-                component="rust_orchestrator",
-                tags=("planning", "rust", "orchestrator", "error"),
-                cycle_id=self._current_live_event_cycle_id(),
-                remote_call_id=rust_call_id,
+            self._emit_rust_orchestrator_returned_event(
+                rust_call_id=rust_call_id,
                 status="failed",
-                reason_code=type(e).__name__,
-                raw_hash=input_hash,
-                data={
-                    "elapsed_ms": int(elapsed_ms),
-                    "input_hash": input_hash,
-                    "error_type": type(e).__name__,
-                    "error": str(e)[:500],
-                },
+                input_hash=input_hash,
+                elapsed_ms=int(elapsed_ms),
+                error=e,
             )
             raise
         out = json.loads(out_json)
@@ -15315,24 +15297,14 @@ class Passivbot:
         output_hash = payload_hash_raw(out_json)
         orders = out.get("orders", [])
         diagnostics = out.get("diagnostics", {})
-        self._emit_live_event(
-            EventTypes.RUST_ORCHESTRATOR_RETURNED,
-            level="debug",
-            component="rust_orchestrator",
-            tags=("planning", "rust", "orchestrator"),
-            cycle_id=self._current_live_event_cycle_id(),
-            remote_call_id=rust_call_id,
+        self._emit_rust_orchestrator_returned_event(
+            rust_call_id=rust_call_id,
             status="succeeded",
-            raw_hash=output_hash,
-            data={
-                "elapsed_ms": int(elapsed_ms),
-                "input_hash": input_hash,
-                "output_hash": output_hash,
-                "order_count": len(orders),
-                "diagnostic_keys": (
-                    sorted(diagnostics) if isinstance(diagnostics, dict) else []
-                ),
-            },
+            input_hash=input_hash,
+            output_hash=output_hash,
+            elapsed_ms=int(elapsed_ms),
+            order_count=len(orders),
+            diagnostics=diagnostics,
         )
         Passivbot._emit_action_planned_event(
             self,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -517,6 +517,146 @@ def test_action_planned_emitter_records_bounded_summary():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_rust_orchestrator_emitters_record_bounded_summaries():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _emit_rust_orchestrator_called_event = (
+            pb_mod.Passivbot._emit_rust_orchestrator_called_event
+        )
+        _emit_rust_orchestrator_returned_event = (
+            pb_mod.Passivbot._emit_rust_orchestrator_returned_event
+        )
+
+        def __init__(self):
+            self.exchange = "bybit"
+            self.user = "bybit_01"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_rust"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+
+    bot._emit_rust_orchestrator_called_event(
+        rust_call_id="rust_7",
+        input_hash="input_hash",
+        symbol_count=4,
+        tradable_count=3,
+        ema_unavailable_count=1,
+        trailing_unavailable_count=2,
+        hedge_mode=True,
+        strategy_kind="recursive_grid",
+    )
+    bot._emit_rust_orchestrator_returned_event(
+        rust_call_id="rust_7",
+        status="succeeded",
+        input_hash="input_hash",
+        output_hash="output_hash",
+        elapsed_ms=12,
+        order_count=5,
+        diagnostics={"min_cost": {}, "forager": {}},
+    )
+    bot._emit_rust_orchestrator_returned_event(
+        rust_call_id="rust_8",
+        status="failed",
+        input_hash="failed_input_hash",
+        elapsed_ms=9,
+        error=ValueError("MissingEma { symbol_idx: 0 }"),
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    called, returned, failed = sink.events
+    assert called.event_type == EventTypes.RUST_ORCHESTRATOR_CALLED
+    assert called.cycle_id == "cy_rust"
+    assert called.remote_call_id == "rust_7"
+    assert called.raw_hash == "input_hash"
+    assert called.data == {
+        "symbol_count": 4,
+        "tradable_count": 3,
+        "ema_unavailable_count": 1,
+        "trailing_unavailable_count": 2,
+        "hedge_mode": True,
+        "strategy_kind": "recursive_grid",
+        "input_hash": "input_hash",
+    }
+    assert returned.event_type == EventTypes.RUST_ORCHESTRATOR_RETURNED
+    assert returned.status == "succeeded"
+    assert returned.raw_hash == "output_hash"
+    assert returned.data["elapsed_ms"] == 12
+    assert returned.data["input_hash"] == "input_hash"
+    assert returned.data["output_hash"] == "output_hash"
+    assert returned.data["order_count"] == 5
+    assert returned.data["diagnostic_keys"] == ["forager", "min_cost"]
+    assert failed.event_type == EventTypes.RUST_ORCHESTRATOR_RETURNED
+    assert failed.level == "error"
+    assert failed.status == "failed"
+    assert failed.reason_code == "ValueError"
+    assert failed.raw_hash == "failed_input_hash"
+    assert failed.data["error_type"] == "ValueError"
+    assert "MissingEma" in failed.data["error"]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_rust_orchestrator_emitters_are_best_effort(caplog):
+    import passivbot as pb_mod
+
+    class FailingBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_rust_orchestrator_called_event = (
+            pb_mod.Passivbot._emit_rust_orchestrator_called_event
+        )
+        _emit_rust_orchestrator_returned_event = (
+            pb_mod.Passivbot._emit_rust_orchestrator_returned_event
+        )
+
+        def __init__(self):
+            self._live_event_current_cycle_id = "cy_rust"
+
+        def _emit_live_event(self, *args, **kwargs):
+            raise RuntimeError("event sink failed")
+
+    bot = FailingBot()
+
+    with caplog.at_level(logging.DEBUG):
+        bot._emit_rust_orchestrator_called_event(
+            rust_call_id="rust_1",
+            input_hash="input_hash",
+            symbol_count=1,
+            tradable_count=1,
+            ema_unavailable_count=0,
+            trailing_unavailable_count=0,
+            hedge_mode=False,
+            strategy_kind="recursive_grid",
+        )
+        bot._emit_rust_orchestrator_returned_event(
+            rust_call_id="rust_1",
+            status="succeeded",
+            input_hash="input_hash",
+            output_hash="output_hash",
+            elapsed_ms=1,
+            order_count=0,
+            diagnostics={},
+        )
+        bot._emit_rust_orchestrator_returned_event(
+            rust_call_id="rust_2",
+            status="failed",
+            input_hash="failed_input_hash",
+            elapsed_ms=1,
+            error=RuntimeError("rust failed"),
+        )
+
+    messages = [record.message for record in caplog.records]
+    assert any(EventTypes.RUST_ORCHESTRATOR_CALLED in msg for msg in messages)
+    assert sum(EventTypes.RUST_ORCHESTRATOR_RETURNED in msg for msg in messages) == 2
+
+
 def test_forager_and_ema_summary_emitters_emit_structured_events():
     import passivbot as pb_mod
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -568,7 +568,7 @@ def test_rust_orchestrator_emitters_record_bounded_summaries():
         status="failed",
         input_hash="failed_input_hash",
         elapsed_ms=9,
-        error=ValueError("MissingEma { symbol_idx: 0 }"),
+        error=ValueError("MissingEma { symbol_idx: 0 } apiKey=SECRET token SECRET"),
     )
 
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
@@ -601,6 +601,8 @@ def test_rust_orchestrator_emitters_record_bounded_summaries():
     assert failed.raw_hash == "failed_input_hash"
     assert failed.data["error_type"] == "ValueError"
     assert "MissingEma" in failed.data["error"]
+    assert "SECRET" not in failed.data["error"]
+    assert "[redacted]" in failed.data["error"]
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
## Summary
- move rust_orchestrator.called/returned emission into best-effort event helpers
- preserve existing event payload shape while preventing event sink failures from interrupting planning or masking Rust errors
- add focused tests for bounded summaries and best-effort called/returned emission

## Validation
- PYTHONPATH=src ./venv/bin/python -m compileall src/live/event_emitters.py src/passivbot.py tests/test_passivbot_monitor.py
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_passivbot_monitor.py::test_rust_orchestrator_emitters_record_bounded_summaries tests/test_passivbot_monitor.py::test_rust_orchestrator_emitters_are_best_effort -q
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_passivbot_monitor.py tests/test_live_event_bus.py -q
- git diff --check
