### PR TITLE
Extend live event query filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool live-event-query` filters for order wave id, remote
+  call id, symbol, position side, reason code, and status, plus optional
+  timeline rows for matched structured live events.
 - Added structured `cache.load.completed` live events for candle disk-cache load
   summaries.
 - Throttled repeated `cache.load.completed` live events per symbol/timeframe and

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -89,6 +89,41 @@ def _normalize_filter_values(values: str | Iterable[str] | None) -> set[str]:
     return out
 
 
+def _filter_matches(value: Any, filter_values: set[str]) -> bool:
+    return not filter_values or (value is not None and str(value) in filter_values)
+
+
+def _filter_report(
+    *,
+    cycle_id: str | None,
+    event_types: set[str],
+    order_wave_ids: set[str],
+    remote_call_ids: set[str],
+    symbols: set[str],
+    psides: set[str],
+    reason_codes: set[str],
+    statuses: set[str],
+) -> dict[str, Any]:
+    filters: dict[str, Any] = {}
+    if cycle_id is not None:
+        filters["cycle_id"] = str(cycle_id)
+    if event_types:
+        filters["event_types"] = sorted(event_types)
+    if order_wave_ids:
+        filters["order_wave_ids"] = sorted(order_wave_ids)
+    if remote_call_ids:
+        filters["remote_call_ids"] = sorted(remote_call_ids)
+    if symbols:
+        filters["symbols"] = sorted(symbols)
+    if psides:
+        filters["psides"] = sorted(psides)
+    if reason_codes:
+        filters["reason_codes"] = sorted(reason_codes)
+    if statuses:
+        filters["statuses"] = sorted(statuses)
+    return filters
+
+
 def _compact_record(
     *,
     path: Path,
@@ -113,11 +148,44 @@ def _compact_record(
         "symbol": live_event.get("symbol") or row.get("symbol"),
         "pside": live_event.get("pside") or row.get("pside"),
         "side": live_event.get("side"),
-        "ids": {key: ids.get(key) for key in EVENT_ID_KEYS if ids.get(key) is not None},
+        "ids": {
+            key: ids.get(key) for key in EVENT_ID_KEYS if ids.get(key) is not None
+        },
     }
     if include_data:
-        compact["data"] = live_event.get("data") if isinstance(live_event.get("data"), dict) else {}
+        compact["data"] = (
+            live_event.get("data") if isinstance(live_event.get("data"), dict) else {}
+        )
     return {key: value for key, value in compact.items() if value is not None}
+
+
+def _timeline_line(record: dict[str, Any]) -> str:
+    parts = [str(record.get("ts", "-"))]
+    if record.get("seq") is not None:
+        parts.append(f"seq={record['seq']}")
+    parts.append(str(record.get("event_type") or "unknown"))
+    for key in ("status", "reason_code", "symbol", "pside", "side"):
+        value = record.get(key)
+        if value is not None:
+            parts.append(f"{key}={value}")
+    ids = record.get("ids")
+    if isinstance(ids, dict) and ids:
+        id_parts = [
+            f"{key}={value}"
+            for key, value in ids.items()
+            if value is not None
+            and key
+            in {
+                "cycle_id",
+                "action_id",
+                "order_wave_id",
+                "remote_call_id",
+                "remote_call_group_id",
+            }
+        ]
+        if id_parts:
+            parts.append("ids=" + ",".join(id_parts))
+    return " ".join(parts)
 
 
 def build_event_report(
@@ -125,9 +193,16 @@ def build_event_report(
     *,
     cycle_id: str | None = None,
     event_type: str | Iterable[str] | None = None,
+    order_wave_id: str | Iterable[str] | None = None,
+    remote_call_id: str | Iterable[str] | None = None,
+    symbol: str | Iterable[str] | None = None,
+    pside: str | Iterable[str] | None = None,
+    reason_code: str | Iterable[str] | None = None,
+    status: str | Iterable[str] | None = None,
     limit: int = 200,
     include_data: bool = False,
     include_rotated: bool = False,
+    timeline: bool = False,
 ) -> dict[str, Any]:
     issues: list[EventIssue] = []
     try:
@@ -139,7 +214,13 @@ def build_event_report(
         )
     if not files and not issues:
         issues.append(
-            EventIssue(str(root), None, "error", "no_event_files", "no event NDJSON files found")
+            EventIssue(
+                str(root),
+                None,
+                "error",
+                "no_event_files",
+                "no event NDJSON files found",
+            )
         )
 
     event_type_counts: Counter[str] = Counter()
@@ -154,7 +235,24 @@ def build_event_report(
     query_match_count = 0
     max_events = max(0, int(limit))
     event_type_filter = _normalize_filter_values(event_type)
-    has_query_filter = bool(event_type_filter)
+    order_wave_filter = _normalize_filter_values(order_wave_id)
+    remote_call_filter = _normalize_filter_values(remote_call_id)
+    symbol_filter = _normalize_filter_values(symbol)
+    pside_filter = _normalize_filter_values(pside)
+    reason_code_filter = _normalize_filter_values(reason_code)
+    status_filter = _normalize_filter_values(status)
+    has_non_cycle_filter = any(
+        (
+            event_type_filter,
+            order_wave_filter,
+            remote_call_filter,
+            symbol_filter,
+            pside_filter,
+            reason_code_filter,
+            status_filter,
+        )
+    )
+    has_query_filter = has_non_cycle_filter or bool(timeline and cycle_id is None)
 
     for path in files:
         try:
@@ -240,15 +338,36 @@ def build_event_report(
                         record_cycle_id = str(record_cycle_id)
                         cycle_counts[record_cycle_id] += 1
 
-                    event_type_matches = (
-                        not event_type_filter
-                        or (
-                            record_event_type is not None
-                            and str(record_event_type) in event_type_filter
-                        )
+                    record_symbol = live_event.get("symbol") or row.get("symbol")
+                    record_pside = live_event.get("pside") or row.get("pside")
+                    record_status = live_event.get("status")
+                    record_reason_code = live_event.get("reason_code")
+                    event_type_matches = _filter_matches(
+                        record_event_type, event_type_filter
                     )
                     cycle_matches = cycle_id is None or record_cycle_id == str(cycle_id)
-                    query_matches = event_type_matches and cycle_matches
+                    order_wave_matches = _filter_matches(
+                        ids.get("order_wave_id"), order_wave_filter
+                    )
+                    remote_call_matches = _filter_matches(
+                        ids.get("remote_call_id"), remote_call_filter
+                    )
+                    symbol_matches = _filter_matches(record_symbol, symbol_filter)
+                    pside_matches = _filter_matches(record_pside, pside_filter)
+                    reason_code_matches = _filter_matches(
+                        record_reason_code, reason_code_filter
+                    )
+                    status_matches = _filter_matches(record_status, status_filter)
+                    query_matches = (
+                        event_type_matches
+                        and cycle_matches
+                        and order_wave_matches
+                        and remote_call_matches
+                        and symbol_matches
+                        and pside_matches
+                        and reason_code_matches
+                        and status_matches
+                    )
 
                     if has_query_filter and query_matches:
                         query_match_count += 1
@@ -301,23 +420,49 @@ def build_event_report(
         ],
     }
     if has_query_filter:
+        query_filters = _filter_report(
+            cycle_id=cycle_id,
+            event_types=event_type_filter,
+            order_wave_ids=order_wave_filter,
+            remote_call_ids=remote_call_filter,
+            symbols=symbol_filter,
+            psides=pside_filter,
+            reason_codes=reason_code_filter,
+            statuses=status_filter,
+        )
         report["query"] = {
-            "filters": {
-                "event_types": sorted(event_type_filter),
-                **({"cycle_id": str(cycle_id)} if cycle_id is not None else {}),
-            },
+            "filters": query_filters,
             "matched_events": query_match_count,
             "events_truncated": query_match_count > len(query_events),
             "events": query_events,
         }
+        if timeline:
+            report["query"]["timeline"] = [
+                _timeline_line(event) for event in query_events
+            ]
     if cycle_id is not None:
+        cycle_filters = _filter_report(
+            cycle_id=cycle_id,
+            event_types=event_type_filter,
+            order_wave_ids=order_wave_filter,
+            remote_call_ids=remote_call_filter,
+            symbols=symbol_filter,
+            psides=pside_filter,
+            reason_codes=reason_code_filter,
+            statuses=status_filter,
+        )
         report["cycle"] = {
             "cycle_id": str(cycle_id),
+            "filters": cycle_filters,
             "event_types": sorted(event_type_filter) if event_type_filter else None,
             "matched_events": cycle_match_count,
             "events_truncated": cycle_match_count > len(cycle_events),
             "events": cycle_events,
         }
+        if timeline:
+            report["cycle"]["timeline"] = [
+                _timeline_line(event) for event in cycle_events
+            ]
         if not event_type_filter:
             report["cycle"].pop("event_types", None)
     return report

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -14,7 +14,10 @@ from live.event_query import build_event_report  # noqa: E402
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Validate monitor event NDJSON and reconstruct a live cycle by cycle_id."
+        description=(
+            "Validate monitor event NDJSON and query structured live events by "
+            "cycle_id, event type, and operator scopes."
+        )
     )
     parser.add_argument(
         "path",
@@ -34,10 +37,52 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--order-wave-id",
+        action="append",
+        help=(
+            "Return compact records matching one order_wave_id. May be repeated "
+            "or comma-separated."
+        ),
+    )
+    parser.add_argument(
+        "--remote-call-id",
+        action="append",
+        help=(
+            "Return compact records matching one remote_call_id. May be repeated "
+            "or comma-separated."
+        ),
+    )
+    parser.add_argument(
+        "--symbol",
+        action="append",
+        help="Return compact records matching one symbol. May be repeated or comma-separated.",
+    )
+    parser.add_argument(
+        "--pside",
+        action="append",
+        help="Return compact records matching one position side. May be repeated or comma-separated.",
+    )
+    parser.add_argument(
+        "--reason-code",
+        action="append",
+        help=(
+            "Return compact records matching one reason_code. May be repeated "
+            "or comma-separated."
+        ),
+    )
+    parser.add_argument(
+        "--status",
+        action="append",
+        help=(
+            "Return compact records matching one event status. May be repeated "
+            "or comma-separated."
+        ),
+    )
+    parser.add_argument(
         "--limit",
         type=int,
         default=200,
-        help="Maximum cycle records to include in output.",
+        help="Maximum matched records or timeline rows to include in output.",
     )
     parser.add_argument(
         "--include-data",
@@ -57,6 +102,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Emit compact single-line JSON.",
     )
+    parser.add_argument(
+        "--timeline",
+        action="store_true",
+        help="Include terse timeline strings for matched records.",
+    )
     return parser
 
 
@@ -67,9 +117,16 @@ def main(argv: list[str] | None = None) -> int:
         args.path,
         cycle_id=args.cycle_id,
         event_type=args.event_types,
+        order_wave_id=args.order_wave_id,
+        remote_call_id=args.remote_call_id,
+        symbol=args.symbol,
+        pside=args.pside,
+        reason_code=args.reason_code,
+        status=args.status,
         limit=args.limit,
         include_data=bool(args.include_data),
         include_rotated=bool(args.include_rotated),
+        timeline=bool(args.timeline),
     )
     print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
     return 0 if report.get("ok") else 1

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -14,8 +14,15 @@ def _monitor_row(
     seq: int,
     ts: int,
     symbol: str | None = None,
+    pside: str | None = None,
+    side: str | None = None,
+    status: str = "succeeded",
+    reason_code: str = "test",
+    ids: dict | None = None,
 ) -> dict:
-    ids = {"cycle_id": cycle_id} if cycle_id is not None else {}
+    event_ids = dict(ids or {})
+    if cycle_id is not None:
+        event_ids["cycle_id"] = cycle_id
     live_event = {
         "schema_version": 1,
         "event_id": f"evt_{seq}",
@@ -26,10 +33,12 @@ def _monitor_row(
         "exchange": "binance",
         "user": "binance_01",
         "symbol": symbol,
-        "status": "succeeded",
-        "reason_code": "test",
+        "pside": pside,
+        "side": side,
+        "status": status,
+        "reason_code": reason_code,
         "data": {"seq": seq},
-        "ids": ids,
+        "ids": event_ids,
     }
     payload = {"_live_event": live_event}
     payload.update(live_event["data"])
@@ -44,6 +53,8 @@ def _monitor_row(
     }
     if symbol:
         row["symbol"] = symbol
+    if pside:
+        row["pside"] = pside
     return row
 
 
@@ -267,6 +278,10 @@ def test_event_query_combines_cycle_and_event_type_filters(tmp_path):
     }
     assert report["query"]["matched_events"] == 2
     assert report["cycle"]["cycle_id"] == "cy_7"
+    assert report["cycle"]["filters"] == {
+        "cycle_id": "cy_7",
+        "event_types": ["candle.tail_projected", "remote_call.failed"],
+    }
     assert report["cycle"]["event_types"] == [
         "candle.tail_projected",
         "remote_call.failed",
@@ -275,6 +290,150 @@ def test_event_query_combines_cycle_and_event_type_filters(tmp_path):
     assert [event["event_type"] for event in report["cycle"]["events"]] == [
         "candle.tail_projected",
         "remote_call.failed",
+    ]
+
+
+def test_event_query_filters_by_ids_symbol_pside_reason_and_status(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="execution.create_sent",
+                cycle_id="cy_1",
+                seq=1,
+                ts=1000,
+                symbol="BTC/USDT:USDT",
+                pside="long",
+                status="started",
+                reason_code="submitted_to_exchange",
+                ids={"order_wave_id": "ow_1"},
+            ),
+            _monitor_row(
+                event_type="execution.create_failed",
+                cycle_id="cy_1",
+                seq=2,
+                ts=1100,
+                symbol="BTC/USDT:USDT",
+                pside="long",
+                status="failed",
+                reason_code="exchange_exception",
+                ids={"order_wave_id": "ow_1"},
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                cycle_id="cy_2",
+                seq=3,
+                ts=1200,
+                symbol="ETH/USDT:USDT",
+                pside="short",
+                status="failed",
+                reason_code="request_timeout",
+                ids={"remote_call_id": "rc_9"},
+            ),
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        order_wave_id="ow_1",
+        symbol="BTC/USDT:USDT",
+        pside="long",
+        reason_code="exchange_exception",
+        status="failed",
+    )
+
+    assert report["ok"] is True
+    assert report["query"]["filters"] == {
+        "order_wave_ids": ["ow_1"],
+        "psides": ["long"],
+        "reason_codes": ["exchange_exception"],
+        "statuses": ["failed"],
+        "symbols": ["BTC/USDT:USDT"],
+    }
+    assert report["query"]["matched_events"] == 1
+    assert report["query"]["events"][0]["event_type"] == "execution.create_failed"
+    assert report["query"]["events"][0]["ids"]["order_wave_id"] == "ow_1"
+
+    remote_report = build_event_report(
+        tmp_path / "monitor",
+        remote_call_id="rc_9",
+        status="failed",
+    )
+
+    assert remote_report["query"]["filters"] == {
+        "remote_call_ids": ["rc_9"],
+        "statuses": ["failed"],
+    }
+    assert remote_report["query"]["matched_events"] == 1
+    assert remote_report["query"]["events"][0]["event_type"] == "remote_call.failed"
+
+
+def test_event_query_timeline_renders_cycle_and_query_matches(tmp_path):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.started",
+                cycle_id="cy_1",
+                seq=1,
+                ts=1000,
+                status="started",
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                cycle_id="cy_1",
+                seq=2,
+                ts=1100,
+                symbol="ZEC/USDT:USDT",
+                status="failed",
+                reason_code="request_timeout",
+                ids={"remote_call_id": "rc_1"},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                cycle_id="cy_2",
+                seq=3,
+                ts=1200,
+            ),
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        cycle_id="cy_1",
+        status="failed",
+        timeline=True,
+    )
+
+    assert report["query"]["matched_events"] == 1
+    assert report["cycle"]["filters"] == {
+        "cycle_id": "cy_1",
+        "statuses": ["failed"],
+    }
+    assert report["query"]["timeline"] == [
+        (
+            "1100 seq=2 remote_call.failed status=failed "
+            "reason_code=request_timeout symbol=ZEC/USDT:USDT "
+            "ids=cycle_id=cy_1,remote_call_id=rc_1"
+        )
+    ]
+    assert report["cycle"]["matched_events"] == 1
+    assert report["cycle"]["timeline"] == report["query"]["timeline"]
+
+    all_report = build_event_report(tmp_path / "monitor", limit=2, timeline=True)
+
+    assert all_report["query"]["filters"] == {}
+    assert all_report["query"]["matched_events"] == 3
+    assert all_report["query"]["events_truncated"] is True
+    assert all_report["query"]["timeline"] == [
+        "1000 seq=1 cycle.started status=started reason_code=test ids=cycle_id=cy_1",
+        (
+            "1100 seq=2 remote_call.failed status=failed "
+            "reason_code=request_timeout symbol=ZEC/USDT:USDT "
+            "ids=cycle_id=cy_1,remote_call_id=rc_1"
+        ),
     ]
 
 
@@ -292,7 +451,10 @@ def test_live_event_query_cli_outputs_json_and_status(tmp_path, capsys):
         ],
     )
 
-    assert live_event_query.main([str(tmp_path / "monitor"), "--cycle-id", "cy_7"]) == 0
+    assert (
+        live_event_query.main([str(tmp_path / "monitor"), "--cycle-id", "cy_7"])
+        == 0
+    )
 
     report = json.loads(capsys.readouterr().out)
     assert report["cycle"]["cycle_id"] == "cy_7"
@@ -342,6 +504,74 @@ def test_live_event_query_cli_accepts_event_type_and_kind_alias(tmp_path, capsys
     assert report["query"]["matched_events"] == 2
     assert report["query"]["events_truncated"] is True
     assert len(report["query"]["events"]) == 1
+
+
+def test_live_event_query_cli_accepts_scope_filters_and_timeline(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="execution.cancel_failed",
+                cycle_id="cy_9",
+                seq=1,
+                ts=1000,
+                symbol="SOL/USDT:USDT",
+                pside="short",
+                status="failed",
+                reason_code="exchange_exception",
+                ids={"order_wave_id": "ow_9"},
+            ),
+            _monitor_row(
+                event_type="execution.cancel_succeeded",
+                cycle_id="cy_9",
+                seq=2,
+                ts=1100,
+                symbol="SOL/USDT:USDT",
+                pside="short",
+                status="succeeded",
+                reason_code="exchange_acknowledged",
+                ids={"order_wave_id": "ow_9"},
+            ),
+        ],
+    )
+
+    assert (
+        live_event_query.main(
+            [
+                str(tmp_path / "monitor"),
+                "--order-wave-id",
+                "ow_9",
+                "--symbol",
+                "SOL/USDT:USDT",
+                "--pside",
+                "short",
+                "--status",
+                "failed",
+                "--reason-code",
+                "exchange_exception",
+                "--timeline",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["query"]["filters"] == {
+        "order_wave_ids": ["ow_9"],
+        "psides": ["short"],
+        "reason_codes": ["exchange_exception"],
+        "statuses": ["failed"],
+        "symbols": ["SOL/USDT:USDT"],
+    }
+    assert report["query"]["matched_events"] == 1
+    assert report["query"]["timeline"] == [
+        (
+            "1000 seq=1 execution.cancel_failed status=failed "
+            "reason_code=exchange_exception symbol=SOL/USDT:USDT pside=short "
+            "ids=cycle_id=cy_9,order_wave_id=ow_9"
+        )
+    ]
 
 
 def test_live_event_query_cli_defaults_to_current_only_for_directory_scans(


### PR DESCRIPTION
## Summary
- extend passivbot tool live-event-query with filters for order_wave_id, remote_call_id, symbol, pside, reason_code, and status
- add optional timeline rows for matched structured live events
- document the user-facing CLI improvement in CHANGELOG

## Validation
- PYTHONPATH=src ./venv/bin/python -m compileall src/live/event_query.py src/tools/live_event_query.py tests/test_live_event_query.py
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_passivbot_cli.py::test_live_event_query_tool_dispatch_forwards_module_and_prog tests/test_live_event_query.py -q
- git diff --check