### PR TITLE
Add live smoke report tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool live-smoke-report` for local smoke-test summaries from
+  monitor event NDJSON and recent text logs.
 - Added `passivbot tool live-event-query` filters for order wave id, remote
   call id, symbol, position side, reason code, and status, plus optional
   timeline rows for matched structured live events.

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import gzip
+import json
+import re
+import stat
+from collections import Counter, defaultdict, deque
+from pathlib import Path
+from typing import Any
+
+from live.event_bus import LIVE_EVENT_MONITOR_PAYLOAD_KEY
+from live.event_query import build_event_report, discover_event_files
+
+
+HARD_LOG_PATTERN = re.compile(
+    r"\bTraceback\b|(?:^|\s|\[)CRITICAL(?:\s|\]|:|$)|\blevel=critical\b|\bfatal\b|\buncaught\b",
+    re.IGNORECASE,
+)
+ATTENTION_LOG_PATTERN = re.compile(
+    r"\bTraceback\b|(?:^|\s|\[)(?:CRITICAL|ERROR)(?:\s|\]|:|$)|\blevel=(?:critical|error)\b|\bfatal\b|\buncaught\b",
+    re.IGNORECASE,
+)
+SENSITIVE_LOG_HEADER_PATTERN = re.compile(
+    r"(?i)\b(authorization|proxy-authorization|x-mbx-apikey|cookie|set-cookie)"
+    r"(\s*[:=]\s*)(?:bearer|basic)?\s*[^,\s;]+"
+)
+SENSITIVE_LOG_VALUE_PATTERN = re.compile(
+    r"(?i)\b(api[-_]?key|apikey|secret|token|signature|password|passphrase|private[-_]?key)"
+    r"([\"']?\s*(?:[:=]|\s)\s*)[\"']?[^,\s;&\"'}]+"
+)
+AUTH_SCHEME_PATTERN = re.compile(r"(?i)\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]+")
+
+
+def _open_text(path: Path):
+    if path.name.endswith(".gz"):
+        return gzip.open(path, "rt", encoding="utf-8", errors="replace")
+    return open(path, "r", encoding="utf-8", errors="replace")
+
+
+def _live_event_payload(row: dict[str, Any]) -> dict[str, Any] | None:
+    payload = row.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    live_event = payload.get(LIVE_EVENT_MONITOR_PAYLOAD_KEY)
+    return live_event if isinstance(live_event, dict) else None
+
+
+def _event_ids(live_event: dict[str, Any]) -> dict[str, Any]:
+    ids = live_event.get("ids")
+    return dict(ids) if isinstance(ids, dict) else {}
+
+
+def _bot_key(live_event: dict[str, Any], row: dict[str, Any]) -> str:
+    exchange = live_event.get("exchange") or row.get("exchange") or "unknown_exchange"
+    user = live_event.get("user") or row.get("user") or "unknown_user"
+    return f"{exchange}/{user}"
+
+
+def _compact_problem_event(
+    *,
+    path: Path,
+    line_no: int,
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+) -> dict[str, Any]:
+    ids = _event_ids(live_event)
+    return {
+        key: value
+        for key, value in {
+            "path": str(path),
+            "line": int(line_no),
+            "ts": row.get("ts"),
+            "seq": row.get("seq"),
+            "event_type": live_event.get("event_type") or row.get("kind"),
+            "level": live_event.get("level"),
+            "status": live_event.get("status"),
+            "reason_code": live_event.get("reason_code"),
+            "exchange": live_event.get("exchange") or row.get("exchange"),
+            "user": live_event.get("user") or row.get("user"),
+            "symbol": live_event.get("symbol") or row.get("symbol"),
+            "pside": live_event.get("pside") or row.get("pside"),
+            "ids": {
+                key: ids.get(key)
+                for key in (
+                    "cycle_id",
+                    "order_wave_id",
+                    "remote_call_id",
+                    "remote_call_group_id",
+                )
+                if ids.get(key) is not None
+            },
+        }.items()
+        if value not in (None, {}, [])
+    }
+
+
+def _redact_log_text(value: str, *, max_len: int = 500) -> str:
+    text = str(value)
+    text = SENSITIVE_LOG_HEADER_PATTERN.sub(r"\1\2[redacted]", text)
+    text = SENSITIVE_LOG_VALUE_PATTERN.sub(r"\1\2[redacted]", text)
+    text = AUTH_SCHEME_PATTERN.sub(r"\1 [redacted]", text)
+    if len(text) > max_len:
+        text = f"{text[:max_len]}...<truncated>"
+    return text
+
+
+def _is_problem_event(live_event: dict[str, Any]) -> bool:
+    level = str(live_event.get("level") or "").lower()
+    status = str(live_event.get("status") or "").lower()
+    event_type = str(live_event.get("event_type") or "")
+    return (
+        level in {"error", "critical"}
+        or status in {"failed", "degraded"}
+        or event_type == "sink.degraded"
+    )
+
+
+def _is_hard_problem_event(live_event: dict[str, Any]) -> bool:
+    level = str(live_event.get("level") or "").lower()
+    event_type = str(live_event.get("event_type") or "")
+    return level in {"error", "critical"} or event_type == "sink.degraded"
+
+
+def _scan_events(
+    root: str | Path,
+    *,
+    include_rotated: bool,
+    max_problem_events: int,
+) -> dict[str, Any]:
+    files = discover_event_files(root, include_rotated=include_rotated)
+    bots: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {
+            "events": 0,
+            "invalid_ts": 0,
+            "last_ts": None,
+            "event_types": Counter(),
+            "levels": Counter(),
+            "statuses": Counter(),
+            "problem_events": 0,
+            "hard_problem_events": 0,
+        }
+    )
+    problem_events: deque[dict[str, Any]] = deque(maxlen=max(0, int(max_problem_events)))
+    invalid_rows = 0
+
+    for path in files:
+        try:
+            with _open_text(path) as stream:
+                for line_no, raw_line in enumerate(stream, start=1):
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    try:
+                        row = json.loads(line)
+                    except json.JSONDecodeError:
+                        invalid_rows += 1
+                        continue
+                    if not isinstance(row, dict):
+                        invalid_rows += 1
+                        continue
+                    live_event = _live_event_payload(row)
+                    if live_event is None:
+                        continue
+                    bot_key = _bot_key(live_event, row)
+                    bot = bots[bot_key]
+                    bot["events"] += 1
+                    ts = row.get("ts")
+                    if ts is not None:
+                        try:
+                            bot["last_ts"] = max(int(bot["last_ts"] or 0), int(ts))
+                        except (TypeError, ValueError):
+                            bot["invalid_ts"] += 1
+                    event_type = live_event.get("event_type") or row.get("kind")
+                    if event_type:
+                        bot["event_types"][str(event_type)] += 1
+                    level = live_event.get("level")
+                    if level:
+                        bot["levels"][str(level).lower()] += 1
+                    status = live_event.get("status")
+                    if status:
+                        bot["statuses"][str(status).lower()] += 1
+                    if _is_problem_event(live_event):
+                        bot["problem_events"] += 1
+                        hard = _is_hard_problem_event(live_event)
+                        if hard:
+                            bot["hard_problem_events"] += 1
+                        problem_event = _compact_problem_event(
+                            path=path,
+                            line_no=line_no,
+                            row=row,
+                            live_event=live_event,
+                        )
+                        problem_event["hard"] = hard
+                        problem_events.append(
+                            problem_event
+                        )
+        except OSError:
+            invalid_rows += 1
+
+    return {
+        "invalid_rows": invalid_rows,
+        "bots": [
+            {
+                "bot": key,
+                "events": int(value["events"]),
+                "invalid_ts": int(value["invalid_ts"]),
+                "last_ts": value["last_ts"],
+                "problem_events": int(value["problem_events"]),
+                "hard_problem_events": int(value["hard_problem_events"]),
+                "event_types": dict(value["event_types"].most_common(10)),
+                "levels": dict(sorted(value["levels"].items())),
+                "statuses": dict(sorted(value["statuses"].items())),
+            }
+            for key, value in sorted(bots.items())
+        ],
+        "problem_events": list(problem_events),
+        "problem_event_count": sum(int(value["problem_events"]) for value in bots.values()),
+        "hard_problem_event_count": sum(
+            int(value["hard_problem_events"]) for value in bots.values()
+        ),
+    }
+
+
+def _recent_log_files(root: str | Path, *, max_files: int) -> list[Path]:
+    path = Path(root).expanduser()
+    if not path.exists() or not path.is_dir():
+        return []
+    files: list[tuple[float, Path]] = []
+    seen_inodes: set[tuple[int, int]] = set()
+    for candidate in path.glob("*.log*"):
+        try:
+            file_stat = candidate.stat()
+        except OSError:
+            continue
+        if not stat.S_ISREG(file_stat.st_mode):
+            continue
+        inode_key = (int(file_stat.st_dev), int(file_stat.st_ino))
+        if inode_key in seen_inodes:
+            continue
+        seen_inodes.add(inode_key)
+        files.append((float(file_stat.st_mtime), candidate))
+    return [
+        candidate
+        for _, candidate in sorted(files, key=lambda item: item[0], reverse=True)[
+            : max(0, int(max_files))
+        ]
+    ]
+
+
+def _tail_lines(path: Path, *, max_lines: int) -> list[tuple[int, str]]:
+    try:
+        with _open_text(path) as stream:
+            rows = deque(enumerate(stream, start=1), maxlen=max(0, int(max_lines)))
+    except OSError:
+        return []
+    return [(line_no, line.rstrip("\n")) for line_no, line in rows]
+
+
+def default_logs_root_for_monitor(monitor_root: str | Path) -> Path | None:
+    path = Path(monitor_root).expanduser()
+    start = path.parent if path.is_file() else path
+    for ancestor in (start, *start.parents):
+        candidate = ancestor / "logs"
+        if candidate.is_dir():
+            return candidate
+    return None
+
+
+def _scan_logs(
+    root: str | Path | None,
+    *,
+    max_files: int,
+    tail_lines: int,
+    max_matches: int,
+) -> dict[str, Any]:
+    if root is None:
+        return {
+            "root": None,
+            "files_scanned": 0,
+            "hard_matches": 0,
+            "attention_matches": 0,
+            "matches": [],
+        }
+    files = _recent_log_files(root, max_files=max_files)
+    matches: list[dict[str, Any]] = []
+    hard_matches = 0
+    attention_matches = 0
+    for path in files:
+        for line_no, line in _tail_lines(path, max_lines=tail_lines):
+            if not ATTENTION_LOG_PATTERN.search(line):
+                continue
+            attention_matches += 1
+            hard = bool(HARD_LOG_PATTERN.search(line))
+            if hard:
+                hard_matches += 1
+            if len(matches) < max(0, int(max_matches)):
+                matches.append(
+                    {
+                        "path": str(path),
+                        "line": int(line_no),
+                        "hard": hard,
+                        "text": _redact_log_text(line, max_len=500),
+                    }
+                )
+    return {
+        "root": str(Path(root).expanduser()),
+        "files_scanned": len(files),
+        "hard_matches": hard_matches,
+        "attention_matches": attention_matches,
+        "matches": matches,
+    }
+
+
+def build_live_smoke_report(
+    monitor_root: str | Path = "monitor",
+    *,
+    logs_root: str | Path | None = "logs",
+    include_rotated: bool = False,
+    max_problem_events: int = 50,
+    max_log_files: int = 8,
+    log_tail_lines: int = 300,
+    max_log_matches: int = 50,
+) -> dict[str, Any]:
+    event_report = build_event_report(
+        monitor_root,
+        include_rotated=include_rotated,
+        limit=max_problem_events,
+    )
+    event_scan: dict[str, Any]
+    if event_report.get("files_scanned"):
+        event_scan = _scan_events(
+            monitor_root,
+            include_rotated=include_rotated,
+            max_problem_events=max_problem_events,
+        )
+    else:
+        event_scan = {
+            "invalid_rows": 0,
+            "bots": [],
+            "problem_events": [],
+            "problem_event_count": 0,
+            "hard_problem_event_count": 0,
+        }
+    log_scan = _scan_logs(
+        logs_root,
+        max_files=max_log_files,
+        tail_lines=log_tail_lines,
+        max_matches=max_log_matches,
+    )
+    hard_failures = (
+        int(event_report["error_count"])
+        + int(event_scan["invalid_rows"])
+        + int(event_scan["hard_problem_event_count"])
+        + int(log_scan["hard_matches"])
+    )
+    attention_count = int(event_scan["problem_event_count"]) + int(
+        log_scan["attention_matches"]
+    )
+    return {
+        "ok": hard_failures == 0,
+        "attention": attention_count > 0,
+        "hard_failures": hard_failures,
+        "attention_count": attention_count,
+        "monitor": {
+            "root": event_report.get("root"),
+            "include_rotated": event_report.get("include_rotated"),
+            "files_scanned": event_report.get("files_scanned"),
+            "records_total": event_report.get("records_total"),
+            "live_events": event_report.get("live_events"),
+            "legacy_events": event_report.get("legacy_events"),
+            "error_count": event_report.get("error_count"),
+            "warning_count": event_report.get("warning_count"),
+            "event_types": event_report["event_types"],
+            "cycle_ids_sample": event_report["cycle_ids_sample"],
+            "issues": event_report["issues"],
+        },
+        "bots": event_scan["bots"],
+        "problem_events": event_scan["problem_events"],
+        "hard_problem_event_count": event_scan["hard_problem_event_count"],
+        "logs": log_scan,
+    }

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -95,7 +95,11 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
     ),
     "live-event-query": CommandSpec(
         "tools.live_event_query",
-        "validate monitor event NDJSON and reconstruct a live cycle",
+        "query structured live event NDJSON",
+    ),
+    "live-smoke-report": CommandSpec(
+        "tools.live_smoke_report",
+        "summarize local live monitor events and text logs",
     ),
     "inspect-ohlcvs": CommandSpec(
         "tools.inspect_ohlcvs",

--- a/src/tools/live_smoke_report.py
+++ b/src/tools/live_smoke_report.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[1]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from live.smoke_report import build_live_smoke_report, default_logs_root_for_monitor  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Summarize local live monitor events and text logs for smoke-test "
+            "evidence."
+        )
+    )
+    parser.add_argument(
+        "monitor_root",
+        nargs="?",
+        default="monitor",
+        help="Monitor root, bot root, events directory, or NDJSON segment.",
+    )
+    parser.add_argument(
+        "--logs-root",
+        default=None,
+        help=(
+            "Text log directory to scan. Defaults to a sibling logs directory "
+            "found from monitor_root; use an empty string to skip logs."
+        ),
+    )
+    parser.add_argument(
+        "--include-rotated",
+        action="store_true",
+        help="Also scan rotated/compressed monitor event segments.",
+    )
+    parser.add_argument(
+        "--max-problem-events",
+        type=int,
+        default=50,
+        help="Maximum recent problem events to include.",
+    )
+    parser.add_argument(
+        "--max-log-files",
+        type=int,
+        default=8,
+        help="Maximum recent log files to inspect.",
+    )
+    parser.add_argument(
+        "--log-tail-lines",
+        type=int,
+        default=300,
+        help="Tail this many lines from each inspected log file.",
+    )
+    parser.add_argument(
+        "--max-log-matches",
+        type=int,
+        default=50,
+        help="Maximum matching log lines to include.",
+    )
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="Emit compact single-line JSON.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.logs_root is None:
+        logs_root = default_logs_root_for_monitor(args.monitor_root)
+    else:
+        logs_root = args.logs_root if str(args.logs_root).strip() else None
+    report = build_live_smoke_report(
+        args.monitor_root,
+        logs_root=logs_root,
+        include_rotated=bool(args.include_rotated),
+        max_problem_events=int(args.max_problem_events),
+        max_log_files=int(args.max_log_files),
+        log_tail_lines=int(args.log_tail_lines),
+        max_log_matches=int(args.max_log_matches),
+    )
+    print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
+    return 0 if report.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import json
+
+from live.smoke_report import build_live_smoke_report, default_logs_root_for_monitor
+from tools import live_smoke_report
+
+
+def _monitor_row(
+    *,
+    event_type: str,
+    seq: int,
+    ts: int,
+    status: str = "succeeded",
+    level: str = "info",
+    reason_code: str = "test",
+    symbol: str | None = None,
+    ids: dict | None = None,
+) -> dict:
+    live_event = {
+        "schema_version": 1,
+        "event_id": f"evt_{seq}",
+        "event_type": event_type,
+        "level": level,
+        "source": "live",
+        "component": "test",
+        "exchange": "binance",
+        "user": "binance_01",
+        "symbol": symbol,
+        "status": status,
+        "reason_code": reason_code,
+        "data": {"seq": seq},
+        "ids": dict(ids or {}),
+    }
+    return {
+        "exchange": "binance",
+        "user": "binance_01",
+        "kind": event_type,
+        "tags": ["test"],
+        "payload": {"_live_event": live_event},
+        "seq": seq,
+        "ts": ts,
+    }
+
+
+def _write_ndjson(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def test_live_smoke_report_summarizes_monitor_events_and_log_attention(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                seq=2,
+                ts=1100,
+                status="failed",
+                level="warning",
+                reason_code="request_timeout",
+                symbol="BTC/USDT:USDT",
+                ids={"remote_call_id": "rc_1"},
+            ),
+        ],
+    )
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "bot.log").write_text(
+        "\n".join(
+            [
+                "2026-06-25T00:00:00Z INFO ok",
+                "2026-06-25T00:00:01Z ERROR exchange timeout",
+                "2026-06-25T00:00:02Z CRITICAL terminal startup failure",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=logs_dir,
+        log_tail_lines=10,
+        max_log_files=2,
+    )
+
+    assert report["ok"] is False
+    assert report["attention"] is True
+    assert report["monitor"]["files_scanned"] == 1
+    assert report["monitor"]["live_events"] == 2
+    assert report["bots"] == [
+        {
+            "bot": "binance/binance_01",
+            "events": 2,
+            "event_types": {"cycle.completed": 1, "remote_call.failed": 1},
+            "invalid_ts": 0,
+            "last_ts": 1100,
+            "levels": {"info": 1, "warning": 1},
+            "hard_problem_events": 0,
+            "problem_events": 1,
+            "statuses": {"failed": 1, "succeeded": 1},
+        }
+    ]
+    assert report["problem_events"][0]["event_type"] == "remote_call.failed"
+    assert report["problem_events"][0]["hard"] is False
+    assert report["problem_events"][0]["ids"] == {"remote_call_id": "rc_1"}
+    assert report["hard_problem_event_count"] == 0
+    assert report["logs"]["attention_matches"] == 2
+    assert report["logs"]["hard_matches"] == 1
+    assert [match["hard"] for match in report["logs"]["matches"]] == [False, True]
+
+
+def test_live_smoke_report_distinguishes_attention_and_hard_structured_events(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "bybit" / "bybit_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="remote_call.failed",
+                seq=1,
+                ts=1000,
+                status="failed",
+                level="warning",
+                reason_code="request_timeout",
+            ),
+            _monitor_row(
+                event_type="bot.stopped",
+                seq=2,
+                ts=1100,
+                status="failed",
+                level="critical",
+                reason_code="terminal_startup_failure",
+            ),
+        ],
+    )
+
+    attention_only = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        max_problem_events=1,
+    )
+
+    assert attention_only["ok"] is False
+    assert attention_only["hard_problem_event_count"] == 1
+    assert attention_only["problem_events"] == [
+        {
+            "event_type": "bot.stopped",
+            "exchange": "binance",
+            "hard": True,
+            "level": "critical",
+            "line": 2,
+            "path": str(events_dir / "current.ndjson"),
+            "reason_code": "terminal_startup_failure",
+            "seq": 2,
+            "status": "failed",
+            "ts": 1100,
+            "user": "binance_01",
+        }
+    ]
+
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="remote_call.failed",
+                seq=1,
+                ts=1000,
+                status="failed",
+                level="warning",
+                reason_code="request_timeout",
+            )
+        ],
+    )
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    assert report["ok"] is True
+    assert report["attention"] is True
+    assert report["hard_failures"] == 0
+    assert report["hard_problem_event_count"] == 0
+    assert report["problem_events"][0]["hard"] is False
+
+
+def test_live_smoke_report_log_scan_deduplicates_aliases_and_matches_levels(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    log_file = logs_dir / "timestamped.log"
+    log_file.write_text(
+        "\n".join(
+            [
+                "WARNING error=bybit should not match as log level",
+                "ERROR:root: boom",
+                "[ERROR] bracketed boom",
+                "level=error lower-case field",
+                (
+                    "ERROR api_key=AKIA123 secret=hunter2 "
+                    "Authorization: Bearer TOKEN123"
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (logs_dir / "okx_faisal.log").symlink_to(log_file)
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=logs_dir,
+        max_log_files=10,
+        log_tail_lines=10,
+    )
+
+    assert report["ok"] is True
+    assert report["logs"]["files_scanned"] == 1
+    assert report["logs"]["attention_matches"] == 4
+    assert report["logs"]["hard_matches"] == 0
+    assert [match["text"] for match in report["logs"]["matches"]] == [
+        "ERROR:root: boom",
+        "[ERROR] bracketed boom",
+        "level=error lower-case field",
+        "ERROR api_key=[redacted] secret=[redacted] Authorization: [redacted]",
+    ]
+    emitted = json.dumps(report["logs"]["matches"])
+    assert "AKIA123" not in emitted
+    assert "hunter2" not in emitted
+    assert "TOKEN123" not in emitted
+
+
+def test_live_smoke_report_default_logs_root_follows_monitor_root(tmp_path, capsys):
+    bot_root = tmp_path / "bot"
+    events_dir = bot_root / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+    logs_dir = bot_root / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "gateio_01.log").write_text(
+        "2026-06-25T00:00:00Z ERROR account fetch failed\n",
+        encoding="utf-8",
+    )
+    unrelated = tmp_path / "logs"
+    unrelated.mkdir()
+    (unrelated / "wrong.log").write_text(
+        "2026-06-25T00:00:00Z CRITICAL wrong cwd log\n",
+        encoding="utf-8",
+    )
+
+    assert default_logs_root_for_monitor(bot_root / "monitor") == logs_dir
+    assert (
+        live_smoke_report.main([str(bot_root / "monitor"), "--compact"])
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["logs"]["root"] == str(logs_dir)
+    assert report["logs"]["attention_matches"] == 1
+    assert report["logs"]["matches"][0]["path"] == str(logs_dir / "gateio_01.log")
+
+
+def test_live_smoke_report_cli_outputs_json_and_can_skip_logs(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+
+    assert (
+        live_smoke_report.main(
+            [str(tmp_path / "monitor"), "--logs-root", "", "--compact"]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["ok"] is True
+    assert report["logs"]["files_scanned"] == 0
+    assert report["logs"]["root"] is None
+    assert report["monitor"]["live_events"] == 1

--- a/tests/test_passivbot_cli.py
+++ b/tests/test_passivbot_cli.py
@@ -293,6 +293,29 @@ def test_live_event_query_tool_dispatch_forwards_module_and_prog(monkeypatch):
     assert captured["prog_env"] == "passivbot tool live-event-query"
 
 
+def test_live_smoke_report_tool_dispatch_forwards_module_and_prog(monkeypatch):
+    captured = {}
+
+    def fake_invoke_module_main(module_name):
+        captured["module_name"] = module_name
+        captured["argv"] = sys.argv[:]
+        captured["prog_env"] = os.environ.get("PASSIVBOT_CLI_PROG")
+        return True, 0
+
+    monkeypatch.setattr(cli_main, "_invoke_module_main", fake_invoke_module_main)
+    monkeypatch.setattr(cli_main, "_missing_full_install_markers", lambda: [])
+
+    assert cli_main.main(["tool", "live-smoke-report", "monitor", "--compact"]) == 0
+
+    assert captured["module_name"] == "tools.live_smoke_report"
+    assert captured["argv"] == [
+        "passivbot tool live-smoke-report",
+        "monitor",
+        "--compact",
+    ]
+    assert captured["prog_env"] == "passivbot tool live-smoke-report"
+
+
 def test_pareto_tool_dispatch_forwards_module_and_prog(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Summary
- add passivbot tool live-smoke-report for local smoke-test summaries from monitor event NDJSON and recent text logs
- summarize per-bot event counts, recent problem events, monitor validation issues, and hard/attention log matches
- keep the tool offline/read-only; no live trading path changes

## Validation
- PYTHONPATH=src ./venv/bin/python -m compileall src/live/smoke_report.py src/tools/live_smoke_report.py src/passivbot_cli/main.py tests/test_live_smoke_report.py tests/test_passivbot_cli.py
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_passivbot_cli.py::test_live_smoke_report_tool_dispatch_forwards_module_and_prog tests/test_passivbot_cli.py::test_live_event_query_tool_dispatch_forwards_module_and_prog -q
- PYTHONPATH=src ./venv/bin/python -m tools.live_smoke_report monitor --logs-root logs --max-log-files 2 --log-tail-lines 80 --max-problem-events 3 --compact
- git diff --check
- touched-file silent-handling scan: no hits