### PR TITLE
Emit structured health summary events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added structured `health.summary` live events for periodic health and
+  resource summaries without adding console noise.
 - Added `passivbot tool live-smoke-report` for local smoke-test summaries from
   monitor event NDJSON and recent text logs.
 - Added `passivbot tool live-event-query` filters for order wave id, remote

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -34,6 +34,7 @@ class EventTypes:
     BOT_STOPPING = "bot.stopping"
     BOT_SHUTDOWN_STAGE = "bot.shutdown.stage"
     BOT_STOPPED = "bot.stopped"
+    HEALTH_SUMMARY = "health.summary"
     CYCLE_STARTED = "cycle.started"
     CYCLE_COMPLETED = "cycle.completed"
     CYCLE_DEGRADED = "cycle.degraded"
@@ -97,6 +98,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.BOT_STOPPING,
     EventTypes.BOT_SHUTDOWN_STAGE,
     EventTypes.BOT_STOPPED,
+    EventTypes.HEALTH_SUMMARY,
     EventTypes.CYCLE_STARTED,
     EventTypes.CYCLE_COMPLETED,
     EventTypes.CYCLE_DEGRADED,
@@ -376,6 +378,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.BOT_STOPPING: EventRoute(console=True, text=True),
     EventTypes.BOT_SHUTDOWN_STAGE: EventRoute(console=True, text=True),
     EventTypes.BOT_STOPPED: EventRoute(console=True, text=True),
+    EventTypes.HEALTH_SUMMARY: EventRoute(console=False, text=False),
     EventTypes.CYCLE_STARTED: EventRoute(
         console=True, text=True, throttle_interval_ms=60_000
     ),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -733,6 +733,31 @@ def emit_startup_timing_event(bot: Any, *args: Any, **kwargs: Any) -> None:
         )
 
 
+def _emit_health_summary_event_unchecked(
+    bot: Any,
+    payload: dict[str, Any],
+) -> None:
+    data = dict(payload or {})
+    _safe_emit(
+        bot,
+        EventTypes.HEALTH_SUMMARY,
+        level="debug",
+        component="bot.health",
+        tags=("health", "resource"),
+        cycle_id=current_live_event_cycle_id(bot),
+        status="succeeded",
+        reason_code="periodic_health_summary",
+        data=data,
+    )
+
+
+def emit_health_summary_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    try:
+        _emit_health_summary_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug("[event] failed to emit health summary event: %s", exc)
+
+
 def _symbol_sample(symbols: Any, *, limit: int = 12) -> dict[str, Any]:
     if symbols is None:
         values = []

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -659,6 +659,7 @@ class Passivbot:
         live_event_emitters.emit_planning_symbol_state_event
     )
     _emit_position_changed_event = live_event_emitters.emit_position_changed_event
+    _emit_health_summary_event = live_event_emitters.emit_health_summary_event
     _handle_candle_remote_fetch_event = live_event_emitters.emit_candle_remote_fetch_event
     _next_live_event_remote_call_id = live_event_emitters.next_live_event_remote_call_id
     _set_live_event_context_ids = live_event_emitters.set_live_event_context_ids
@@ -3062,6 +3063,12 @@ class Passivbot:
             self._health_rate_limits,
             f"{slow_phase_str}{f' | {mem_str}' if mem_str else ''}",
         )
+        emit_health_summary = getattr(self, "_emit_health_summary_event", None)
+        if callable(emit_health_summary):
+            try:
+                emit_health_summary(self._build_health_summary_payload(now_ms=now_ms))
+            except Exception as exc:
+                logging.debug("[event] failed preparing health summary event: %s", exc)
         self._maybe_log_candle_health_summary()
 
     def _unstuck_loss_allowance_pct_overrides_for_logging(self, pside: str) -> dict[str, float]:

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -148,6 +148,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.CACHE_WARMUP_DECISION,
         EventTypes.FILLS_REFRESH_SUMMARY,
         EventTypes.BOT_STARTUP_TIMING,
+        EventTypes.HEALTH_SUMMARY,
         EventTypes.PLANNING_DEFER_SUMMARY,
         EventTypes.PLANNING_SYMBOL_STATE,
         EventTypes.RISK_MODE_CHANGED,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -659,6 +659,139 @@ def test_rust_orchestrator_emitters_are_best_effort(caplog):
     assert sum(EventTypes.RUST_ORCHESTRATOR_RETURNED in msg for msg in messages) == 2
 
 
+def test_health_summary_event_emitter_records_payload():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _emit_health_summary_event = pb_mod.Passivbot._emit_health_summary_event
+
+        def __init__(self):
+            self.exchange = "binance"
+            self.user = "binance_01"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_health"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+    bot._emit_health_summary_event(
+        {
+            "uptime_ms": 60000,
+            "last_loop_duration_ms": 250,
+            "positions_long": 1,
+            "positions_short": 0,
+            "rss_bytes": 123456,
+        }
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[0]
+    assert event.event_type == EventTypes.HEALTH_SUMMARY
+    assert event.level == "debug"
+    assert event.component == "bot.health"
+    assert event.tags == ("health", "resource")
+    assert event.cycle_id == "cy_health"
+    assert event.status == "succeeded"
+    assert event.reason_code == "periodic_health_summary"
+    assert event.data["rss_bytes"] == 123456
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_log_health_summary_emits_structured_event(caplog, monkeypatch):
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _emit_health_summary_event = pb_mod.Passivbot._emit_health_summary_event
+        _format_duration = pb_mod.Passivbot._format_duration
+        _log_health_summary = pb_mod.Passivbot._log_health_summary
+
+        def __init__(self):
+            self.exchange = "okx"
+            self.user = "okx_01"
+            self.bot_id = "bot_1"
+            self.quote = "USDT"
+            self.positions = {
+                "BTC/USDT:USDT": {
+                    "long": {"size": 0.01},
+                    "short": {"size": 0.0},
+                }
+            }
+            self._health_start_ms = 140000
+            self._last_loop_duration_ms = 2500
+            self._last_loop_timing_ms = {}
+            self._health_orders_placed = 2
+            self._health_orders_cancelled = 1
+            self._health_fills = 3
+            self._health_pnl = 1.25
+            self._health_ws_reconnects = 4
+            self._health_rate_limits = 5
+            self.error_counts = [190000]
+            self.candle_health_called = False
+            self.payload_now_ms = None
+            self._live_event_current_cycle_id = "cy_health"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+        def get_raw_balance(self):
+            return 1000.0
+
+        def get_hysteresis_snapped_balance(self):
+            return 999.5
+
+        def _build_health_summary_payload(self, *, now_ms=None):
+            self.payload_now_ms = now_ms
+            return {
+                "uptime_ms": 60000,
+                "last_loop_duration_ms": 2500,
+                "positions_long": 1,
+                "positions_short": 0,
+                "balance_raw": 1000.0,
+                "balance_snapped": 999.5,
+                "orders_placed": 2,
+                "orders_cancelled": 1,
+                "fills": 3,
+                "pnl": 1.25,
+                "errors_last_hour": 1,
+                "ws_reconnects": 4,
+                "rate_limits": 5,
+                "rss_bytes": 987654,
+            }
+
+        def _maybe_log_candle_health_summary(self):
+            self.candle_health_called = True
+
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: 200000)
+    bot = FakeBot()
+
+    with caplog.at_level(logging.INFO):
+        bot._log_health_summary()
+
+    assert "[health] uptime=1m0s" in caplog.text
+    assert "positions=1 long, 0 short" in caplog.text
+    assert "orders=+2/-1" in caplog.text
+    assert bot.candle_health_called is True
+    assert bot.payload_now_ms == 200000
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[0]
+    assert event.event_type == EventTypes.HEALTH_SUMMARY
+    assert event.cycle_id == "cy_health"
+    assert event.data["rss_bytes"] == 987654
+    assert event.data["errors_last_hour"] == 1
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_forager_and_ema_summary_emitters_emit_structured_events():
     import passivbot as pb_mod
 


### PR DESCRIPTION
Summary: add health.summary to the live event registry, keep it off console/text routes by default, and emit a best-effort structured event from the existing periodic health summary path. Tests cover direct emitter behavior and the log-health-summary integration path. Validation: compileall for touched files; focused pytest for route table and health-summary tests; full affected files pytest for tests/test_live_event_bus.py and tests/test_passivbot_monitor.py; git diff --check. Observability-only; no trading behavior changes.