### PR TITLE
Add live incident bundle tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable user-facing changes will be documented in this file.
 
 - Added structured `health.summary` live events for periodic health and
   resource summaries without adding console noise.
+- Added `passivbot tool live-incident-bundle` for collecting local monitor
+  events, smoke summaries, redacted log excerpts, monitor snapshots, config
+  hashes, runtime metadata, and bounded event segments into a tarball.
 - Added `passivbot tool live-smoke-report` for local smoke-test summaries from
   monitor event NDJSON and recent text logs.
 - Added `passivbot tool live-event-query` filters for order wave id, remote

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -19,6 +19,12 @@ Related detailed plans:
 ## High-Value Follow-Ups
 
 1. Incident bundle generator.
+   Initial implementation: `passivbot tool live-incident-bundle` collects local
+   monitor event reports, smoke summaries, redacted log excerpts, monitor
+   snapshots, config hashes, runtime metadata, and bounded event segments into a
+   tarball. Future refinements may add supervisor/process status and richer
+   remote smoke integration.
+
    Add a local tool that collects one time window or `cycle_id` into a compact
    bundle: structured events, selected text log excerpts, monitor snapshots,
    bot config hash, git head, process uptime, resource samples, and relevant

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -17,10 +17,27 @@ from urllib.parse import urlsplit, urlunsplit
 
 from live.event_bus import LIVE_EVENT_ID_KEYS, LIVE_EVENT_MONITOR_PAYLOAD_KEY
 from live.event_query import build_event_report, discover_event_files
-from live.smoke_report import build_live_smoke_report, default_logs_root_for_monitor
+from live.smoke_report import (
+    _redact_log_text,
+    build_live_smoke_report,
+    default_logs_root_for_monitor,
+)
 
 
 BUNDLE_VERSION = 1
+MONITOR_SNAPSHOT_FILE_NAMES = frozenset({"state.latest.json", "manifest.json"})
+SNAPSHOT_SENSITIVE_KEY_FRAGMENTS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "cookie",
+    "passphrase",
+    "password",
+    "private_key",
+    "secret",
+    "signature",
+    "token",
+)
 
 
 def _utc_stamp() -> str:
@@ -328,6 +345,40 @@ def _config_hashes(paths: list[str | Path]) -> list[dict[str, Any]]:
     return out
 
 
+def _is_sensitive_snapshot_key(key: Any) -> bool:
+    normalized = str(key).lower().replace("-", "_")
+    return any(fragment in normalized for fragment in SNAPSHOT_SENSITIVE_KEY_FRAGMENTS)
+
+
+def _redact_snapshot_value(value: Any, *, sensitive_key: bool = False) -> Any:
+    if sensitive_key and value is not None:
+        return "[redacted]"
+    if isinstance(value, str):
+        redacted = _redact_log_text(value, max_len=1_000_000)
+        return _redact_url_userinfo(redacted) or redacted
+    if isinstance(value, list):
+        return [_redact_snapshot_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            str(key): _redact_snapshot_value(
+                item,
+                sensitive_key=_is_sensitive_snapshot_key(key),
+            )
+            for key, item in value.items()
+        }
+    return value
+
+
+def _redacted_snapshot_bytes(path: Path) -> bytes:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return (_redact_log_text(text, max_len=10_000_000) + "\n").encode("utf-8")
+    redacted = _redact_snapshot_value(parsed)
+    return (json.dumps(redacted, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
 def _snapshot_files(
     monitor_root: str | Path,
     *,
@@ -342,6 +393,8 @@ def _snapshot_files(
     candidates: list[tuple[float, Path]] = []
     for path in root.rglob("*.json"):
         if any(part == "events" for part in path.parts):
+            continue
+        if path.name not in MONITOR_SNAPSHOT_FILE_NAMES:
             continue
         try:
             stat = path.stat()
@@ -381,7 +434,7 @@ def _copy_snapshot_files(
         dest = bundle_root / "monitor_snapshots" / rel
         dest.parent.mkdir(parents=True, exist_ok=True)
         try:
-            data = path.read_bytes()
+            data = _redacted_snapshot_bytes(path)
             dest.write_bytes(data)
             copied.append(
                 {
@@ -389,6 +442,7 @@ def _copy_snapshot_files(
                     "bundle_path": str(dest.relative_to(bundle_root)),
                     "size_bytes": len(data),
                     "sha256": hashlib.sha256(data).hexdigest(),
+                    "redacted": True,
                 }
             )
         except OSError as exc:

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -1,0 +1,679 @@
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import os
+import platform
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from live.event_bus import LIVE_EVENT_ID_KEYS, LIVE_EVENT_MONITOR_PAYLOAD_KEY
+from live.event_query import build_event_report, discover_event_files
+from live.smoke_report import build_live_smoke_report, default_logs_root_for_monitor
+
+
+BUNDLE_VERSION = 1
+
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _json_default(value: Any) -> str:
+    return str(value)
+
+
+def _write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(data, indent=2, sort_keys=True, default=_json_default) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _open_text(path: Path):
+    if path.name.endswith(".gz"):
+        return gzip.open(path, "rt", encoding="utf-8", errors="replace")
+    return open(path, "r", encoding="utf-8", errors="replace")
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _live_event_payload(row: dict[str, Any]) -> dict[str, Any] | None:
+    payload = row.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    live_event = payload.get(LIVE_EVENT_MONITOR_PAYLOAD_KEY)
+    return live_event if isinstance(live_event, dict) else None
+
+
+def _event_ids(live_event: dict[str, Any]) -> dict[str, Any]:
+    ids = live_event.get("ids")
+    return dict(ids) if isinstance(ids, dict) else {}
+
+
+def _compact_event(
+    *,
+    path: Path,
+    line_no: int,
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+    include_data: bool,
+) -> dict[str, Any]:
+    ids = _event_ids(live_event)
+    record = {
+        "path": str(path),
+        "line": int(line_no),
+        "ts": row.get("ts"),
+        "seq": row.get("seq"),
+        "event_type": live_event.get("event_type") or row.get("kind"),
+        "level": live_event.get("level"),
+        "status": live_event.get("status"),
+        "reason_code": live_event.get("reason_code"),
+        "component": live_event.get("component"),
+        "exchange": live_event.get("exchange") or row.get("exchange"),
+        "user": live_event.get("user") or row.get("user"),
+        "symbol": live_event.get("symbol") or row.get("symbol"),
+        "pside": live_event.get("pside") or row.get("pside"),
+        "side": live_event.get("side"),
+        "ids": {key: ids.get(key) for key in LIVE_EVENT_ID_KEYS if ids.get(key) is not None},
+    }
+    if include_data:
+        data = live_event.get("data")
+        record["data"] = dict(data) if isinstance(data, dict) else {}
+    return {key: value for key, value in record.items() if value not in (None, {}, [])}
+
+
+def _timeline_line(record: dict[str, Any]) -> str:
+    parts = [str(record.get("ts", "-"))]
+    if record.get("seq") is not None:
+        parts.append(f"seq={record['seq']}")
+    parts.append(str(record.get("event_type") or "unknown"))
+    for key in ("status", "reason_code", "symbol", "pside", "side"):
+        value = record.get(key)
+        if value is not None:
+            parts.append(f"{key}={value}")
+    ids = record.get("ids")
+    if isinstance(ids, dict) and ids:
+        id_parts = [
+            f"{key}={value}"
+            for key, value in ids.items()
+            if value is not None
+            and key
+            in {
+                "cycle_id",
+                "action_id",
+                "order_wave_id",
+                "remote_call_id",
+                "remote_call_group_id",
+            }
+        ]
+        if id_parts:
+            parts.append("ids=" + ",".join(id_parts))
+    return " ".join(parts)
+
+
+def _build_time_window_report(
+    monitor_root: str | Path,
+    *,
+    since_ms: int | None,
+    until_ms: int | None,
+    include_rotated: bool,
+    include_data: bool,
+    limit: int,
+) -> dict[str, Any]:
+    if since_ms is None and until_ms is None:
+        return {
+            "enabled": False,
+            "filters": {},
+            "matched_events": 0,
+            "events_truncated": False,
+            "events": [],
+            "timeline": [],
+            "issues": [],
+        }
+    filters = {
+        key: value
+        for key, value in {"since_ms": since_ms, "until_ms": until_ms}.items()
+        if value is not None
+    }
+    issues: list[dict[str, Any]] = []
+    events: list[dict[str, Any]] = []
+    matched_events = 0
+    max_events = max(0, int(limit))
+    try:
+        files = discover_event_files(monitor_root, include_rotated=include_rotated)
+    except FileNotFoundError as exc:
+        files = []
+        issues.append(
+            {
+                "path": str(monitor_root),
+                "line": None,
+                "severity": "error",
+                "code": "path_not_found",
+                "message": str(exc),
+            }
+        )
+
+    for path in files:
+        try:
+            with _open_text(path) as stream:
+                for line_no, raw_line in enumerate(stream, start=1):
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    try:
+                        row = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        issues.append(
+                            {
+                                "path": str(path),
+                                "line": line_no,
+                                "severity": "warning",
+                                "code": "invalid_json",
+                                "message": str(exc),
+                            }
+                        )
+                        continue
+                    if not isinstance(row, dict):
+                        continue
+                    ts_ms = _safe_int(row.get("ts"))
+                    if ts_ms is None:
+                        continue
+                    if since_ms is not None and ts_ms < int(since_ms):
+                        continue
+                    if until_ms is not None and ts_ms > int(until_ms):
+                        continue
+                    live_event = _live_event_payload(row)
+                    if live_event is None:
+                        continue
+                    matched_events += 1
+                    if len(events) < max_events:
+                        events.append(
+                            _compact_event(
+                                path=path,
+                                line_no=line_no,
+                                row=row,
+                                live_event=live_event,
+                                include_data=include_data,
+                            )
+                        )
+        except OSError as exc:
+            issues.append(
+                {
+                    "path": str(path),
+                    "line": None,
+                    "severity": "error",
+                    "code": "read_failed",
+                    "message": str(exc),
+                }
+            )
+    return {
+        "enabled": True,
+        "filters": filters,
+        "matched_events": matched_events,
+        "events_truncated": matched_events > len(events),
+        "events": events,
+        "timeline": [_timeline_line(event) for event in events],
+        "issues": issues,
+    }
+
+
+def _git_metadata(cwd: str | Path | None = None) -> dict[str, Any]:
+    root = Path(cwd or Path.cwd()).expanduser()
+
+    def run_git(args: list[str]) -> str | None:
+        try:
+            result = subprocess.run(
+                ["git", *args],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        return result.stdout.strip()
+
+    return {
+        "cwd": str(root),
+        "head": run_git(["rev-parse", "HEAD"]),
+        "branch": run_git(["branch", "--show-current"]),
+        "status_short": run_git(["status", "--short"]),
+        "remote_url": _redact_url_userinfo(run_git(["remote", "get-url", "origin"])),
+    }
+
+
+def _redact_url_userinfo(value: str | None) -> str | None:
+    if not value:
+        return value
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        return value
+    if not parts.scheme or not parts.netloc:
+        return value
+    if parts.username is None and parts.password is None:
+        return value
+    host = parts.hostname or ""
+    if parts.port is not None:
+        host = f"{host}:{parts.port}"
+    return urlunsplit(
+        (parts.scheme, f"[redacted]@{host}", parts.path, parts.query, parts.fragment)
+    )
+
+
+def _runtime_metadata() -> dict[str, Any]:
+    loadavg: tuple[float, ...] | None
+    try:
+        loadavg = tuple(float(value) for value in os.getloadavg())
+    except (AttributeError, OSError):
+        loadavg = None
+    return {
+        "created_at_ms": int(time.time() * 1000),
+        "created_at_iso": datetime.now(timezone.utc).isoformat(),
+        "python": sys.version,
+        "platform": platform.platform(),
+        "pid": os.getpid(),
+        "loadavg": loadavg,
+    }
+
+
+def _config_hashes(paths: list[str | Path]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for raw_path in paths:
+        path = Path(raw_path).expanduser()
+        item: dict[str, Any] = {"path": str(path)}
+        try:
+            stat = path.stat()
+        except OSError as exc:
+            item.update({"ok": False, "error": str(exc)})
+            out.append(item)
+            continue
+        if not path.is_file():
+            item.update({"ok": False, "error": "not a regular file"})
+            out.append(item)
+            continue
+        item.update(
+            {
+                "ok": True,
+                "size_bytes": int(stat.st_size),
+                "mtime_ms": int(stat.st_mtime * 1000),
+                "sha256": _sha256_file(path),
+            }
+        )
+        out.append(item)
+    return out
+
+
+def _snapshot_files(
+    monitor_root: str | Path,
+    *,
+    max_files: int,
+    max_file_bytes: int,
+) -> list[Path]:
+    root = Path(monitor_root).expanduser()
+    if root.is_file():
+        root = root.parent
+    if not root.exists() or not root.is_dir():
+        return []
+    candidates: list[tuple[float, Path]] = []
+    for path in root.rglob("*.json"):
+        if any(part == "events" for part in path.parts):
+            continue
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        if not path.is_file() or stat.st_size > max_file_bytes:
+            continue
+        candidates.append((float(stat.st_mtime), path))
+    return [
+        path
+        for _, path in sorted(candidates, key=lambda item: item[0], reverse=True)[
+            : max(0, int(max_files))
+        ]
+    ]
+
+
+def _copy_snapshot_files(
+    *,
+    monitor_root: str | Path,
+    bundle_root: Path,
+    max_files: int,
+    max_file_bytes: int,
+) -> list[dict[str, Any]]:
+    root = Path(monitor_root).expanduser()
+    if root.is_file():
+        root = root.parent
+    copied: list[dict[str, Any]] = []
+    for path in _snapshot_files(
+        root,
+        max_files=max_files,
+        max_file_bytes=max_file_bytes,
+    ):
+        try:
+            rel = path.relative_to(root)
+        except ValueError:
+            rel = Path(hashlib.sha256(str(path).encode()).hexdigest()[:12]) / path.name
+        dest = bundle_root / "monitor_snapshots" / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            data = path.read_bytes()
+            dest.write_bytes(data)
+            copied.append(
+                {
+                    "path": str(path),
+                    "bundle_path": str(dest.relative_to(bundle_root)),
+                    "size_bytes": len(data),
+                    "sha256": hashlib.sha256(data).hexdigest(),
+                }
+            )
+        except OSError as exc:
+            copied.append({"path": str(path), "ok": False, "error": str(exc)})
+    return copied
+
+
+def _matched_segment_paths(*reports: dict[str, Any]) -> set[str]:
+    paths: set[str] = set()
+
+    def collect_events(events: Any) -> None:
+        if not isinstance(events, list):
+            return
+        for event in events:
+            if isinstance(event, dict) and event.get("path"):
+                paths.add(str(event["path"]))
+
+    for report in reports:
+        query = report.get("query")
+        if isinstance(query, dict):
+            collect_events(query.get("events"))
+        cycle = report.get("cycle")
+        if isinstance(cycle, dict):
+            collect_events(cycle.get("events"))
+        collect_events(report.get("events"))
+    return paths
+
+
+def _copy_event_segments(
+    *,
+    monitor_root: str | Path,
+    bundle_root: Path,
+    event_report: dict[str, Any],
+    window_report: dict[str, Any],
+    include_rotated: bool,
+    include_segments: bool,
+    max_total_bytes: int,
+) -> dict[str, Any]:
+    try:
+        discovered = discover_event_files(monitor_root, include_rotated=include_rotated)
+    except FileNotFoundError:
+        discovered = []
+    matched_paths = _matched_segment_paths(event_report, window_report)
+    if matched_paths:
+        paths = [Path(path) for path in sorted(matched_paths)]
+    else:
+        paths = discovered
+    total_bytes = 0
+    files: list[dict[str, Any]] = []
+    for path in paths:
+        item: dict[str, Any] = {"path": str(path)}
+        try:
+            stat = path.stat()
+        except OSError as exc:
+            item.update({"included": False, "reason": str(exc)})
+            files.append(item)
+            continue
+        size = int(stat.st_size)
+        item["size_bytes"] = size
+        item["sha256"] = _sha256_file(path)
+        if not include_segments:
+            item.update({"included": False, "reason": "disabled"})
+            files.append(item)
+            continue
+        if total_bytes + size > max(0, int(max_total_bytes)):
+            item.update({"included": False, "reason": "max_total_bytes"})
+            files.append(item)
+            continue
+        digest = hashlib.sha256(str(path).encode()).hexdigest()[:12]
+        dest = bundle_root / "event_segments" / f"{digest}_{path.name}"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            dest.write_bytes(path.read_bytes())
+        except OSError as exc:
+            item.update({"included": False, "reason": str(exc)})
+            files.append(item)
+            continue
+        total_bytes += size
+        item.update(
+            {
+                "included": True,
+                "bundle_path": str(dest.relative_to(bundle_root)),
+            }
+        )
+        files.append(item)
+    return {
+        "include_segments": bool(include_segments),
+        "include_rotated": bool(include_rotated),
+        "max_total_bytes": int(max_total_bytes),
+        "total_included_bytes": total_bytes,
+        "files": files,
+    }
+
+
+def _tar_directory(source_dir: Path, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(output_path, "w:gz") as tar:
+        for path in sorted(source_dir.rglob("*")):
+            tar.add(path, arcname=str(path.relative_to(source_dir)), recursive=False)
+
+
+def build_live_incident_bundle(
+    monitor_root: str | Path = "monitor",
+    *,
+    output_path: str | Path | None = None,
+    logs_root: str | Path | None = None,
+    config_paths: list[str | Path] | None = None,
+    cycle_id: str | None = None,
+    event_type: str | list[str] | None = None,
+    order_wave_id: str | list[str] | None = None,
+    remote_call_id: str | list[str] | None = None,
+    symbol: str | list[str] | None = None,
+    pside: str | list[str] | None = None,
+    reason_code: str | list[str] | None = None,
+    status: str | list[str] | None = None,
+    since_ms: int | None = None,
+    until_ms: int | None = None,
+    include_data: bool = False,
+    include_rotated: bool = False,
+    include_event_segments: bool = True,
+    max_events: int = 500,
+    max_problem_events: int = 50,
+    max_log_files: int = 8,
+    log_tail_lines: int = 500,
+    max_log_matches: int = 100,
+    max_snapshot_files: int = 20,
+    max_snapshot_file_bytes: int = 1_000_000,
+    max_event_segment_bytes: int = 10_000_000,
+    cwd: str | Path | None = None,
+) -> dict[str, Any]:
+    monitor_path = Path(monitor_root).expanduser()
+    if logs_root is None:
+        logs_path = default_logs_root_for_monitor(monitor_path)
+    else:
+        logs_path = Path(logs_root).expanduser() if str(logs_root).strip() else None
+    out_path = (
+        Path(output_path).expanduser()
+        if output_path is not None
+        else Path(f"passivbot_incident_bundle_{_utc_stamp()}.tar.gz")
+    )
+
+    event_report = build_event_report(
+        monitor_path,
+        cycle_id=cycle_id,
+        event_type=event_type,
+        order_wave_id=order_wave_id,
+        remote_call_id=remote_call_id,
+        symbol=symbol,
+        pside=pside,
+        reason_code=reason_code,
+        status=status,
+        limit=max_events,
+        include_data=include_data,
+        include_rotated=include_rotated,
+        timeline=True,
+    )
+    window_report = _build_time_window_report(
+        monitor_path,
+        since_ms=since_ms,
+        until_ms=until_ms,
+        include_rotated=include_rotated,
+        include_data=include_data,
+        limit=max_events,
+    )
+    smoke_report = build_live_smoke_report(
+        monitor_path,
+        logs_root=logs_path,
+        include_rotated=include_rotated,
+        max_problem_events=max_problem_events,
+        max_log_files=max_log_files,
+        log_tail_lines=log_tail_lines,
+        max_log_matches=max_log_matches,
+    )
+
+    with tempfile.TemporaryDirectory(prefix="passivbot_incident_bundle_") as tmp_name:
+        bundle_root = Path(tmp_name)
+        config_hashes = _config_hashes(list(config_paths or []))
+        snapshots = _copy_snapshot_files(
+            monitor_root=monitor_path,
+            bundle_root=bundle_root,
+            max_files=max_snapshot_files,
+            max_file_bytes=max_snapshot_file_bytes,
+        )
+        segment_manifest = _copy_event_segments(
+            monitor_root=monitor_path,
+            bundle_root=bundle_root,
+            event_report=event_report,
+            window_report=window_report,
+            include_rotated=include_rotated,
+            include_segments=include_event_segments,
+            max_total_bytes=max_event_segment_bytes,
+        )
+        metadata = {
+            "bundle_version": BUNDLE_VERSION,
+            "monitor_root": str(monitor_path),
+            "logs_root": str(logs_path) if logs_path is not None else None,
+            "output_path": str(out_path),
+            "filters": {
+                key: value
+                for key, value in {
+                    "cycle_id": cycle_id,
+                    "event_type": event_type,
+                    "order_wave_id": order_wave_id,
+                    "remote_call_id": remote_call_id,
+                    "symbol": symbol,
+                    "pside": pside,
+                    "reason_code": reason_code,
+                    "status": status,
+                    "since_ms": since_ms,
+                    "until_ms": until_ms,
+                    "include_rotated": include_rotated,
+                    "include_data": include_data,
+                }.items()
+                if value not in (None, [], "")
+            },
+            "runtime": _runtime_metadata(),
+            "git": _git_metadata(cwd=cwd),
+            "config_hashes": config_hashes,
+            "monitor_snapshots": snapshots,
+            "event_segments": segment_manifest,
+        }
+
+        _write_json(bundle_root / "manifest.json", metadata)
+        _write_json(bundle_root / "event_report.json", event_report)
+        _write_json(bundle_root / "time_window_report.json", window_report)
+        _write_json(bundle_root / "smoke_report.json", smoke_report)
+        timeline_lines: list[str] = []
+        for section in ("cycle", "query"):
+            value = event_report.get(section)
+            if isinstance(value, dict):
+                timeline_lines.extend(str(line) for line in value.get("timeline", []))
+        timeline_lines.extend(str(line) for line in window_report.get("timeline", []))
+        (bundle_root / "timeline.txt").write_text(
+            "\n".join(timeline_lines) + ("\n" if timeline_lines else ""),
+            encoding="utf-8",
+        )
+        _write_json(bundle_root / "config_hashes.json", config_hashes)
+        _write_json(bundle_root / "event_segments_manifest.json", segment_manifest)
+        _tar_directory(bundle_root, out_path)
+
+    hard_failures = int(smoke_report.get("hard_failures", 0)) + int(
+        event_report.get("error_count", 0)
+    )
+    hard_failures += sum(
+        1
+        for issue in window_report.get("issues", [])
+        if isinstance(issue, dict) and issue.get("severity") == "error"
+    )
+    return {
+        "ok": hard_failures == 0,
+        "bundle_path": str(out_path),
+        "bundle_version": BUNDLE_VERSION,
+        "hard_failures": hard_failures,
+        "event_report": {
+            "files_scanned": event_report.get("files_scanned"),
+            "live_events": event_report.get("live_events"),
+            "error_count": event_report.get("error_count"),
+            "warning_count": event_report.get("warning_count"),
+            "cycle_matched_events": (
+                event_report.get("cycle", {}).get("matched_events")
+                if isinstance(event_report.get("cycle"), dict)
+                else None
+            ),
+            "query_matched_events": (
+                event_report.get("query", {}).get("matched_events")
+                if isinstance(event_report.get("query"), dict)
+                else None
+            ),
+        },
+        "time_window": {
+            "enabled": window_report.get("enabled"),
+            "matched_events": window_report.get("matched_events"),
+            "events_truncated": window_report.get("events_truncated"),
+        },
+        "smoke_report": {
+            "ok": smoke_report.get("ok"),
+            "attention": smoke_report.get("attention"),
+            "hard_failures": smoke_report.get("hard_failures"),
+            "attention_count": smoke_report.get("attention_count"),
+        },
+        "config_hashes": len(config_hashes),
+        "monitor_snapshots": len(metadata["monitor_snapshots"]),
+        "event_segments": {
+            "files": len(segment_manifest["files"]),
+            "included": sum(1 for item in segment_manifest["files"] if item.get("included")),
+            "total_included_bytes": segment_manifest["total_included_bytes"],
+        },
+    }

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -97,6 +97,10 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "tools.live_event_query",
         "query structured live event NDJSON",
     ),
+    "live-incident-bundle": CommandSpec(
+        "tools.live_incident_bundle",
+        "collect local live incident evidence into a tarball",
+    ),
     "live-smoke-report": CommandSpec(
         "tools.live_smoke_report",
         "summarize local live monitor events and text logs",

--- a/src/tools/live_incident_bundle.py
+++ b/src/tools/live_incident_bundle.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[1]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from live.incident_bundle import build_live_incident_bundle  # noqa: E402
+
+
+def _parse_ms(value: str | None) -> int | None:
+    if value is None:
+        return None
+    return int(value)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create a local incident evidence bundle from monitor event NDJSON, "
+            "selected text log excerpts, monitor snapshots, config hashes, and "
+            "runtime metadata."
+        )
+    )
+    parser.add_argument(
+        "monitor_root",
+        nargs="?",
+        default="monitor",
+        help="Monitor root, bot root, events directory, or NDJSON segment.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output .tar.gz path. Defaults to passivbot_incident_bundle_<utc>.tar.gz.",
+    )
+    parser.add_argument(
+        "--logs-root",
+        default=None,
+        help=(
+            "Text log directory to scan. Defaults to a sibling logs directory "
+            "found from monitor_root; use an empty string to skip logs."
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        action="append",
+        default=[],
+        help="Config path to hash into the bundle manifest. May be repeated.",
+    )
+    parser.add_argument("--cycle-id", help="Include compact records for one cycle_id.")
+    parser.add_argument(
+        "--event-type",
+        "--kind",
+        dest="event_types",
+        action="append",
+        help="Filter compact records by event type. May be repeated or comma-separated.",
+    )
+    parser.add_argument(
+        "--order-wave-id",
+        action="append",
+        help="Filter compact records by order_wave_id. May be repeated or comma-separated.",
+    )
+    parser.add_argument(
+        "--remote-call-id",
+        action="append",
+        help="Filter compact records by remote_call_id. May be repeated or comma-separated.",
+    )
+    parser.add_argument(
+        "--symbol",
+        action="append",
+        help="Filter compact records by symbol. May be repeated or comma-separated.",
+    )
+    parser.add_argument(
+        "--pside",
+        action="append",
+        help="Filter compact records by position side. May be repeated or comma-separated.",
+    )
+    parser.add_argument(
+        "--reason-code",
+        action="append",
+        help="Filter compact records by reason_code. May be repeated or comma-separated.",
+    )
+    parser.add_argument(
+        "--status",
+        action="append",
+        help="Filter compact records by status. May be repeated or comma-separated.",
+    )
+    parser.add_argument("--since-ms", help="Include live events at or after this monitor ts.")
+    parser.add_argument("--until-ms", help="Include live events at or before this monitor ts.")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=500,
+        help="Maximum compact event records or timeline rows to include per report.",
+    )
+    parser.add_argument(
+        "--include-data",
+        action="store_true",
+        help="Include each matched event's bounded data payload in compact event reports.",
+    )
+    parser.add_argument(
+        "--include-rotated",
+        action="store_true",
+        help="Also scan rotated/compressed monitor event segments.",
+    )
+    parser.add_argument(
+        "--no-event-segments",
+        action="store_true",
+        help="Do not copy bounded event segment files into the bundle.",
+    )
+    parser.add_argument(
+        "--max-event-segment-bytes",
+        type=int,
+        default=10_000_000,
+        help="Maximum total event segment bytes copied into the bundle.",
+    )
+    parser.add_argument(
+        "--max-snapshot-files",
+        type=int,
+        default=20,
+        help="Maximum monitor snapshot JSON files copied into the bundle.",
+    )
+    parser.add_argument(
+        "--max-snapshot-file-bytes",
+        type=int,
+        default=1_000_000,
+        help="Maximum size for one monitor snapshot JSON file copied into the bundle.",
+    )
+    parser.add_argument(
+        "--max-log-files",
+        type=int,
+        default=8,
+        help="Maximum recent text log files to inspect.",
+    )
+    parser.add_argument(
+        "--log-tail-lines",
+        type=int,
+        default=500,
+        help="Tail this many lines from each inspected text log file.",
+    )
+    parser.add_argument(
+        "--max-log-matches",
+        type=int,
+        default=100,
+        help="Maximum matching log lines to include in the smoke report.",
+    )
+    parser.add_argument("--compact", action="store_true", help="Emit compact single-line JSON.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    report = build_live_incident_bundle(
+        args.monitor_root,
+        output_path=args.output,
+        logs_root=args.logs_root,
+        config_paths=list(args.config or []),
+        cycle_id=args.cycle_id,
+        event_type=args.event_types,
+        order_wave_id=args.order_wave_id,
+        remote_call_id=args.remote_call_id,
+        symbol=args.symbol,
+        pside=args.pside,
+        reason_code=args.reason_code,
+        status=args.status,
+        since_ms=_parse_ms(args.since_ms),
+        until_ms=_parse_ms(args.until_ms),
+        include_data=bool(args.include_data),
+        include_rotated=bool(args.include_rotated),
+        include_event_segments=not bool(args.no_event_segments),
+        max_events=int(args.limit),
+        max_log_files=int(args.max_log_files),
+        log_tail_lines=int(args.log_tail_lines),
+        max_log_matches=int(args.max_log_matches),
+        max_snapshot_files=int(args.max_snapshot_files),
+        max_snapshot_file_bytes=int(args.max_snapshot_file_bytes),
+        max_event_segment_bytes=int(args.max_event_segment_bytes),
+    )
+    print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
+    return 0 if report.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -82,7 +82,24 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         ],
     )
     snapshot = tmp_path / "monitor" / "binance" / "binance_01" / "state.latest.json"
-    snapshot.write_text('{"ok": true}\n', encoding="utf-8")
+    snapshot.write_text(
+        json.dumps(
+            {
+                "ok": True,
+                "api_key": "SNAPSHOT_KEY",
+                "nested": {
+                    "authorization": "Bearer SNAPSHOT_TOKEN",
+                    "url": "https://user:pass@example.com/path",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    unexpected_snapshot = (
+        tmp_path / "monitor" / "binance" / "binance_01" / "debug_dump.json"
+    )
+    unexpected_snapshot.write_text('{"secret": "do-not-copy-snapshot"}\n', encoding="utf-8")
     logs_dir = tmp_path / "logs"
     logs_dir.mkdir()
     (logs_dir / "bot.log").write_text(
@@ -126,16 +143,30 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         assert "config_hashes.json" in names
         assert "binance/binance_01/state.latest.json" not in names
         assert "monitor_snapshots/binance/binance_01/state.latest.json" in names
+        assert "monitor_snapshots/binance/binance_01/debug_dump.json" not in names
         assert any(name.startswith("event_segments/") for name in names)
 
         manifest = _read_tar_json(tar, "manifest.json")
         event_report = _read_tar_json(tar, "event_report.json")
         window_report = _read_tar_json(tar, "time_window_report.json")
         config_hashes = _read_tar_json(tar, "config_hashes.json")
+        redacted_snapshot = _read_tar_json(
+            tar,
+            "monitor_snapshots/binance/binance_01/state.latest.json",
+        )
 
     assert manifest["config_hashes"][0]["sha256"] == config_hashes[0]["sha256"]
+    assert manifest["monitor_snapshots"][0]["redacted"] is True
     assert "do-not-copy" not in json.dumps(manifest)
     assert "do-not-copy" not in json.dumps(config_hashes)
+    snapshot_dump = json.dumps(redacted_snapshot)
+    assert "SNAPSHOT_KEY" not in snapshot_dump
+    assert "SNAPSHOT_TOKEN" not in snapshot_dump
+    assert "user:pass" not in snapshot_dump
+    assert "do-not-copy-snapshot" not in snapshot_dump
+    assert redacted_snapshot["api_key"] == "[redacted]"
+    assert redacted_snapshot["nested"]["authorization"] == "[redacted]"
+    assert redacted_snapshot["nested"]["url"] == "https://[redacted]@example.com/path"
     assert event_report["cycle"]["events"][0]["seq"] == 1
     assert "data" not in event_report["cycle"]["events"][0]
     assert window_report["events"][0]["seq"] == 2

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import json
+import tarfile
+
+from live.incident_bundle import _redact_url_userinfo, build_live_incident_bundle
+from tools import live_incident_bundle
+
+
+def _monitor_row(
+    *,
+    event_type: str,
+    seq: int,
+    ts: int,
+    status: str = "succeeded",
+    level: str = "info",
+    reason_code: str = "test",
+    symbol: str | None = None,
+    ids: dict | None = None,
+) -> dict:
+    live_event = {
+        "schema_version": 1,
+        "event_id": f"evt_{seq}",
+        "event_type": event_type,
+        "level": level,
+        "source": "live",
+        "component": "test",
+        "exchange": "binance",
+        "user": "binance_01",
+        "symbol": symbol,
+        "status": status,
+        "reason_code": reason_code,
+        "data": {"seq": seq, "detail": "kept only when include_data is enabled"},
+        "ids": dict(ids or {}),
+    }
+    return {
+        "exchange": "binance",
+        "user": "binance_01",
+        "kind": event_type,
+        "tags": ["test"],
+        "payload": {"_live_event": live_event},
+        "seq": seq,
+        "ts": ts,
+    }
+
+
+def _write_ndjson(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _read_tar_json(tar, name: str):
+    member = tar.extractfile(name)
+    assert member is not None
+    return json.loads(member.read().decode())
+
+
+def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                seq=2,
+                ts=2000,
+                status="failed",
+                level="warning",
+                reason_code="request_timeout",
+                symbol="BTC/USDT:USDT",
+                ids={"cycle_id": "cy_2", "remote_call_id": "rc_1"},
+            ),
+        ],
+    )
+    snapshot = tmp_path / "monitor" / "binance" / "binance_01" / "state.latest.json"
+    snapshot.write_text('{"ok": true}\n', encoding="utf-8")
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "bot.log").write_text(
+        "2026-06-25T00:00:00Z ERROR request timeout\n",
+        encoding="utf-8",
+    )
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"api_key": "do-not-copy"}\n', encoding="utf-8")
+    output = tmp_path / "incident.tar.gz"
+
+    report = build_live_incident_bundle(
+        tmp_path / "monitor",
+        output_path=output,
+        logs_root=logs_dir,
+        config_paths=[config_path],
+        cycle_id="cy_1",
+        since_ms=1500,
+        until_ms=2500,
+        include_data=False,
+        max_event_segment_bytes=100_000,
+        cwd=tmp_path,
+    )
+
+    assert report["ok"] is True
+    assert report["bundle_path"] == str(output)
+    assert report["event_report"]["cycle_matched_events"] == 1
+    assert report["time_window"]["matched_events"] == 1
+    assert report["config_hashes"] == 1
+    assert report["monitor_snapshots"] == 1
+    assert report["event_segments"]["included"] == 1
+
+    with tarfile.open(output, "r:gz") as tar:
+        tar_names = tar.getnames()
+        names = set(tar_names)
+        assert len(tar_names) == len(names)
+        assert "manifest.json" in names
+        assert "event_report.json" in names
+        assert "time_window_report.json" in names
+        assert "smoke_report.json" in names
+        assert "timeline.txt" in names
+        assert "config_hashes.json" in names
+        assert "binance/binance_01/state.latest.json" not in names
+        assert "monitor_snapshots/binance/binance_01/state.latest.json" in names
+        assert any(name.startswith("event_segments/") for name in names)
+
+        manifest = _read_tar_json(tar, "manifest.json")
+        event_report = _read_tar_json(tar, "event_report.json")
+        window_report = _read_tar_json(tar, "time_window_report.json")
+        config_hashes = _read_tar_json(tar, "config_hashes.json")
+
+    assert manifest["config_hashes"][0]["sha256"] == config_hashes[0]["sha256"]
+    assert "do-not-copy" not in json.dumps(manifest)
+    assert "do-not-copy" not in json.dumps(config_hashes)
+    assert event_report["cycle"]["events"][0]["seq"] == 1
+    assert "data" not in event_report["cycle"]["events"][0]
+    assert window_report["events"][0]["seq"] == 2
+    assert "remote_call.failed" in window_report["timeline"][0]
+
+
+def test_live_incident_bundle_can_skip_logs_and_segments_from_cli(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "bot.log").write_text(
+        "2026-06-25T00:00:00Z CRITICAL skipped log\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "incident.tar.gz"
+
+    assert (
+        live_incident_bundle.main(
+            [
+                str(tmp_path / "monitor"),
+                "--logs-root",
+                "",
+                "--no-event-segments",
+                "--output",
+                str(output),
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["ok"] is True
+    assert report["bundle_path"] == str(output)
+    assert report["event_segments"]["included"] == 0
+    assert output.exists()
+
+    with tarfile.open(output, "r:gz") as tar:
+        tar_names = tar.getnames()
+        names = set(tar_names)
+        assert len(tar_names) == len(names)
+        assert "event_segments_manifest.json" in names
+        assert not any(name.startswith("event_segments/") for name in names)
+        smoke_report = _read_tar_json(tar, "smoke_report.json")
+    assert smoke_report["logs"]["root"] is None
+    assert smoke_report["logs"]["hard_matches"] == 0
+
+
+def test_live_incident_bundle_redacts_git_remote_url_userinfo():
+    assert (
+        _redact_url_userinfo("https://token:secret@example.com/org/repo.git")
+        == "https://[redacted]@example.com/org/repo.git"
+    )
+    assert (
+        _redact_url_userinfo("git@github.com:enarjord/passivbot.git")
+        == "git@github.com:enarjord/passivbot.git"
+    )

--- a/tests/test_passivbot_cli.py
+++ b/tests/test_passivbot_cli.py
@@ -316,6 +316,35 @@ def test_live_smoke_report_tool_dispatch_forwards_module_and_prog(monkeypatch):
     assert captured["prog_env"] == "passivbot tool live-smoke-report"
 
 
+def test_live_incident_bundle_tool_dispatch_forwards_module_and_prog(monkeypatch):
+    captured = {}
+
+    def fake_invoke_module_main(module_name):
+        captured["module_name"] = module_name
+        captured["argv"] = sys.argv[:]
+        captured["prog_env"] = os.environ.get("PASSIVBOT_CLI_PROG")
+        return True, 0
+
+    monkeypatch.setattr(cli_main, "_invoke_module_main", fake_invoke_module_main)
+    monkeypatch.setattr(cli_main, "_missing_full_install_markers", lambda: [])
+
+    assert (
+        cli_main.main(
+            ["tool", "live-incident-bundle", "monitor", "--cycle-id", "cy_1"]
+        )
+        == 0
+    )
+
+    assert captured["module_name"] == "tools.live_incident_bundle"
+    assert captured["argv"] == [
+        "passivbot tool live-incident-bundle",
+        "monitor",
+        "--cycle-id",
+        "cy_1",
+    ]
+    assert captured["prog_env"] == "passivbot tool live-incident-bundle"
+
+
 def test_pareto_tool_dispatch_forwards_module_and_prog(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
Summary:
- add passivbot tool live-incident-bundle to create local tar.gz evidence bundles from monitor event reports, smoke summaries, redacted log matches, monitor snapshots, config hashes, runtime/git metadata, and bounded event segments
- support cycle/query filters and time-window extraction without touching live processes
- update the live-ops backlog item with the initial implementation note

Validation:
- PYTHONPATH=src ./venv/bin/python -m compileall src/live/incident_bundle.py src/tools/live_incident_bundle.py src/passivbot_cli/main.py tests/test_live_incident_bundle.py tests/test_passivbot_cli.py
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_incident_bundle.py tests/test_live_smoke_report.py tests/test_live_event_query.py tests/test_passivbot_cli.py::test_live_event_query_tool_dispatch_forwards_module_and_prog tests/test_passivbot_cli.py::test_live_smoke_report_tool_dispatch_forwards_module_and_prog tests/test_passivbot_cli.py::test_live_incident_bundle_tool_dispatch_forwards_module_and_prog -q
- git diff --check
- local smoke: PYTHONPATH=src ./venv/bin/python -m tools.live_incident_bundle monitor --logs-root '' --no-event-segments --output /private/tmp/passivbot_incident_bundle_skip_logs.tar.gz --compact

Read-only/offline observability tooling; no trading behavior changes.