### PR TITLE
Extend live event query ID filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable user-facing changes will be documented in this file.
 - Added `passivbot tool live-incident-bundle` for collecting local monitor
   events, smoke summaries, redacted log excerpts, monitor snapshots, config
   hashes, runtime metadata, and bounded event segments into a tarball.
+- Added `passivbot tool live-event-query` filters and timeline ids for bot id,
+  snapshot id, plan id, action id, and remote call group id so operators can
+  trace non-cycle live event scopes.
 - Added `passivbot tool live-smoke-report` for local smoke-test summaries from
   monitor event NDJSON and recent text logs.
 - Added `passivbot tool live-event-query` filters for order wave id, remote

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -97,8 +97,13 @@ def _filter_report(
     *,
     cycle_id: str | None,
     event_types: set[str],
+    bot_ids: set[str],
+    snapshot_ids: set[str],
+    plan_ids: set[str],
+    action_ids: set[str],
     order_wave_ids: set[str],
     remote_call_ids: set[str],
+    remote_call_group_ids: set[str],
     symbols: set[str],
     psides: set[str],
     reason_codes: set[str],
@@ -109,10 +114,20 @@ def _filter_report(
         filters["cycle_id"] = str(cycle_id)
     if event_types:
         filters["event_types"] = sorted(event_types)
+    if bot_ids:
+        filters["bot_ids"] = sorted(bot_ids)
+    if snapshot_ids:
+        filters["snapshot_ids"] = sorted(snapshot_ids)
+    if plan_ids:
+        filters["plan_ids"] = sorted(plan_ids)
+    if action_ids:
+        filters["action_ids"] = sorted(action_ids)
     if order_wave_ids:
         filters["order_wave_ids"] = sorted(order_wave_ids)
     if remote_call_ids:
         filters["remote_call_ids"] = sorted(remote_call_ids)
+    if remote_call_group_ids:
+        filters["remote_call_group_ids"] = sorted(remote_call_group_ids)
     if symbols:
         filters["symbols"] = sorted(symbols)
     if psides:
@@ -172,16 +187,8 @@ def _timeline_line(record: dict[str, Any]) -> str:
     if isinstance(ids, dict) and ids:
         id_parts = [
             f"{key}={value}"
-            for key, value in ids.items()
-            if value is not None
-            and key
-            in {
-                "cycle_id",
-                "action_id",
-                "order_wave_id",
-                "remote_call_id",
-                "remote_call_group_id",
-            }
+            for key in EVENT_ID_KEYS
+            if (value := ids.get(key)) is not None
         ]
         if id_parts:
             parts.append("ids=" + ",".join(id_parts))
@@ -193,8 +200,13 @@ def build_event_report(
     *,
     cycle_id: str | None = None,
     event_type: str | Iterable[str] | None = None,
+    bot_id: str | Iterable[str] | None = None,
+    snapshot_id: str | Iterable[str] | None = None,
+    plan_id: str | Iterable[str] | None = None,
+    action_id: str | Iterable[str] | None = None,
     order_wave_id: str | Iterable[str] | None = None,
     remote_call_id: str | Iterable[str] | None = None,
+    remote_call_group_id: str | Iterable[str] | None = None,
     symbol: str | Iterable[str] | None = None,
     pside: str | Iterable[str] | None = None,
     reason_code: str | Iterable[str] | None = None,
@@ -235,8 +247,13 @@ def build_event_report(
     query_match_count = 0
     max_events = max(0, int(limit))
     event_type_filter = _normalize_filter_values(event_type)
+    bot_filter = _normalize_filter_values(bot_id)
+    snapshot_filter = _normalize_filter_values(snapshot_id)
+    plan_filter = _normalize_filter_values(plan_id)
+    action_filter = _normalize_filter_values(action_id)
     order_wave_filter = _normalize_filter_values(order_wave_id)
     remote_call_filter = _normalize_filter_values(remote_call_id)
+    remote_call_group_filter = _normalize_filter_values(remote_call_group_id)
     symbol_filter = _normalize_filter_values(symbol)
     pside_filter = _normalize_filter_values(pside)
     reason_code_filter = _normalize_filter_values(reason_code)
@@ -244,8 +261,13 @@ def build_event_report(
     has_non_cycle_filter = any(
         (
             event_type_filter,
+            bot_filter,
+            snapshot_filter,
+            plan_filter,
+            action_filter,
             order_wave_filter,
             remote_call_filter,
+            remote_call_group_filter,
             symbol_filter,
             pside_filter,
             reason_code_filter,
@@ -346,11 +368,22 @@ def build_event_report(
                         record_event_type, event_type_filter
                     )
                     cycle_matches = cycle_id is None or record_cycle_id == str(cycle_id)
+                    bot_matches = _filter_matches(ids.get("bot_id"), bot_filter)
+                    snapshot_matches = _filter_matches(
+                        ids.get("snapshot_id"), snapshot_filter
+                    )
+                    plan_matches = _filter_matches(ids.get("plan_id"), plan_filter)
+                    action_matches = _filter_matches(
+                        ids.get("action_id"), action_filter
+                    )
                     order_wave_matches = _filter_matches(
                         ids.get("order_wave_id"), order_wave_filter
                     )
                     remote_call_matches = _filter_matches(
                         ids.get("remote_call_id"), remote_call_filter
+                    )
+                    remote_call_group_matches = _filter_matches(
+                        ids.get("remote_call_group_id"), remote_call_group_filter
                     )
                     symbol_matches = _filter_matches(record_symbol, symbol_filter)
                     pside_matches = _filter_matches(record_pside, pside_filter)
@@ -361,8 +394,13 @@ def build_event_report(
                     query_matches = (
                         event_type_matches
                         and cycle_matches
+                        and bot_matches
+                        and snapshot_matches
+                        and plan_matches
+                        and action_matches
                         and order_wave_matches
                         and remote_call_matches
+                        and remote_call_group_matches
                         and symbol_matches
                         and pside_matches
                         and reason_code_matches
@@ -423,8 +461,13 @@ def build_event_report(
         query_filters = _filter_report(
             cycle_id=cycle_id,
             event_types=event_type_filter,
+            bot_ids=bot_filter,
+            snapshot_ids=snapshot_filter,
+            plan_ids=plan_filter,
+            action_ids=action_filter,
             order_wave_ids=order_wave_filter,
             remote_call_ids=remote_call_filter,
+            remote_call_group_ids=remote_call_group_filter,
             symbols=symbol_filter,
             psides=pside_filter,
             reason_codes=reason_code_filter,
@@ -444,8 +487,13 @@ def build_event_report(
         cycle_filters = _filter_report(
             cycle_id=cycle_id,
             event_types=event_type_filter,
+            bot_ids=bot_filter,
+            snapshot_ids=snapshot_filter,
+            plan_ids=plan_filter,
+            action_ids=action_filter,
             order_wave_ids=order_wave_filter,
             remote_call_ids=remote_call_filter,
+            remote_call_group_ids=remote_call_group_filter,
             symbols=symbol_filter,
             psides=pside_filter,
             reason_codes=reason_code_filter,

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -37,6 +37,38 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--bot-id",
+        action="append",
+        help=(
+            "Return compact records matching one bot_id. May be repeated "
+            "or comma-separated."
+        ),
+    )
+    parser.add_argument(
+        "--snapshot-id",
+        action="append",
+        help=(
+            "Return compact records matching one snapshot_id. May be repeated "
+            "or comma-separated."
+        ),
+    )
+    parser.add_argument(
+        "--plan-id",
+        action="append",
+        help=(
+            "Return compact records matching one plan_id. May be repeated "
+            "or comma-separated."
+        ),
+    )
+    parser.add_argument(
+        "--action-id",
+        action="append",
+        help=(
+            "Return compact records matching one action_id. May be repeated "
+            "or comma-separated."
+        ),
+    )
+    parser.add_argument(
         "--order-wave-id",
         action="append",
         help=(
@@ -50,6 +82,14 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Return compact records matching one remote_call_id. May be repeated "
             "or comma-separated."
+        ),
+    )
+    parser.add_argument(
+        "--remote-call-group-id",
+        action="append",
+        help=(
+            "Return compact records matching one remote_call_group_id. May be "
+            "repeated or comma-separated."
         ),
     )
     parser.add_argument(
@@ -117,8 +157,13 @@ def main(argv: list[str] | None = None) -> int:
         args.path,
         cycle_id=args.cycle_id,
         event_type=args.event_types,
+        bot_id=args.bot_id,
+        snapshot_id=args.snapshot_id,
+        plan_id=args.plan_id,
+        action_id=args.action_id,
         order_wave_id=args.order_wave_id,
         remote_call_id=args.remote_call_id,
+        remote_call_group_id=args.remote_call_group_id,
         symbol=args.symbol,
         pside=args.pside,
         reason_code=args.reason_code,

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -369,6 +369,123 @@ def test_event_query_filters_by_ids_symbol_pside_reason_and_status(tmp_path):
     assert remote_report["query"]["events"][0]["event_type"] == "remote_call.failed"
 
 
+def test_event_query_filters_by_remaining_event_ids(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="rust_orchestrator.called",
+                cycle_id="cy_1",
+                seq=1,
+                ts=1000,
+                ids={
+                    "bot_id": "bot_1",
+                    "snapshot_id": "snap_1",
+                    "plan_id": "plan_1",
+                },
+            ),
+            _monitor_row(
+                event_type="execution.create_sent",
+                cycle_id="cy_1",
+                seq=2,
+                ts=1100,
+                symbol="BTC/USDT:USDT",
+                ids={
+                    "bot_id": "bot_1",
+                    "plan_id": "plan_1",
+                    "action_id": "ow_1:create:0",
+                    "order_wave_id": "ow_1",
+                },
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                cycle_id="cy_1",
+                seq=3,
+                ts=1200,
+                status="failed",
+                ids={
+                    "bot_id": "bot_1",
+                    "remote_call_id": "rc_1",
+                    "remote_call_group_id": "cy_1:candles",
+                },
+            ),
+            _monitor_row(
+                event_type="remote_call.succeeded",
+                cycle_id="cy_2",
+                seq=4,
+                ts=1300,
+                ids={
+                    "bot_id": "bot_2",
+                    "snapshot_id": "snap_2",
+                    "remote_call_id": "rc_2",
+                    "remote_call_group_id": "cy_2:authoritative",
+                },
+            ),
+        ],
+    )
+
+    bot_report = build_event_report(tmp_path / "monitor", bot_id="bot_1", timeline=True)
+
+    assert bot_report["query"]["filters"] == {"bot_ids": ["bot_1"]}
+    assert bot_report["query"]["matched_events"] == 3
+    assert [event["event_type"] for event in bot_report["query"]["events"]] == [
+        "rust_orchestrator.called",
+        "execution.create_sent",
+        "remote_call.failed",
+    ]
+    assert bot_report["query"]["timeline"][0] == (
+        "1000 seq=1 rust_orchestrator.called status=succeeded "
+        "reason_code=test ids=bot_id=bot_1,cycle_id=cy_1,"
+        "snapshot_id=snap_1,plan_id=plan_1"
+    )
+
+    snapshot_report = build_event_report(
+        tmp_path / "monitor",
+        snapshot_id="snap_1",
+    )
+
+    assert snapshot_report["query"]["filters"] == {"snapshot_ids": ["snap_1"]}
+    assert snapshot_report["query"]["matched_events"] == 1
+    assert snapshot_report["query"]["events"][0]["ids"]["snapshot_id"] == "snap_1"
+
+    plan_report = build_event_report(tmp_path / "monitor", plan_id="plan_1")
+
+    assert plan_report["query"]["filters"] == {"plan_ids": ["plan_1"]}
+    assert plan_report["query"]["matched_events"] == 2
+    assert [event["event_type"] for event in plan_report["query"]["events"]] == [
+        "rust_orchestrator.called",
+        "execution.create_sent",
+    ]
+
+    action_report = build_event_report(
+        tmp_path / "monitor",
+        action_id="ow_1:create:0",
+    )
+
+    assert action_report["query"]["filters"] == {"action_ids": ["ow_1:create:0"]}
+    assert action_report["query"]["matched_events"] == 1
+    assert action_report["query"]["events"][0]["ids"]["action_id"] == "ow_1:create:0"
+
+    remote_group_report = build_event_report(
+        tmp_path / "monitor",
+        remote_call_group_id="cy_1:candles",
+        status="failed",
+    )
+
+    assert remote_group_report["query"]["filters"] == {
+        "remote_call_group_ids": ["cy_1:candles"],
+        "statuses": ["failed"],
+    }
+    assert remote_group_report["query"]["matched_events"] == 1
+    assert remote_group_report["query"]["events"][0]["ids"] == {
+        "bot_id": "bot_1",
+        "cycle_id": "cy_1",
+        "remote_call_id": "rc_1",
+        "remote_call_group_id": "cy_1:candles",
+    }
+
+
 def test_event_query_timeline_renders_cycle_and_query_matches(tmp_path):
     events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
     _write_ndjson(
@@ -570,6 +687,80 @@ def test_live_event_query_cli_accepts_scope_filters_and_timeline(tmp_path, capsy
             "1000 seq=1 execution.cancel_failed status=failed "
             "reason_code=exchange_exception symbol=SOL/USDT:USDT pside=short "
             "ids=cycle_id=cy_9,order_wave_id=ow_9"
+        )
+    ]
+
+
+def test_live_event_query_cli_accepts_additional_id_scopes(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="execution.create_sent",
+                cycle_id="cy_9",
+                seq=1,
+                ts=1000,
+                ids={
+                    "bot_id": "bot_9",
+                    "snapshot_id": "snap_9",
+                    "plan_id": "plan_9",
+                    "action_id": "ow_9:create:0",
+                    "remote_call_group_id": "cy_9:orders",
+                },
+            ),
+            _monitor_row(
+                event_type="execution.create_sent",
+                cycle_id="cy_9",
+                seq=2,
+                ts=1100,
+                ids={
+                    "bot_id": "bot_9",
+                    "snapshot_id": "snap_10",
+                    "plan_id": "plan_9",
+                    "action_id": "ow_9:create:1",
+                    "remote_call_group_id": "cy_9:orders",
+                },
+            ),
+        ],
+    )
+
+    assert (
+        live_event_query.main(
+            [
+                str(tmp_path / "monitor"),
+                "--bot-id",
+                "bot_9",
+                "--snapshot-id",
+                "snap_9",
+                "--plan-id",
+                "plan_9",
+                "--action-id",
+                "ow_9:create:0",
+                "--remote-call-group-id",
+                "cy_9:orders",
+                "--timeline",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["query"]["filters"] == {
+        "action_ids": ["ow_9:create:0"],
+        "bot_ids": ["bot_9"],
+        "plan_ids": ["plan_9"],
+        "remote_call_group_ids": ["cy_9:orders"],
+        "snapshot_ids": ["snap_9"],
+    }
+    assert report["query"]["matched_events"] == 1
+    assert report["query"]["events"][0]["ids"]["action_id"] == "ow_9:create:0"
+    assert report["query"]["timeline"] == [
+        (
+            "1000 seq=1 execution.create_sent status=succeeded "
+            "reason_code=test ids=bot_id=bot_9,cycle_id=cy_9,"
+            "snapshot_id=snap_9,plan_id=plan_9,action_id=ow_9:create:0,"
+            "remote_call_group_id=cy_9:orders"
         )
     ]
 


### PR DESCRIPTION
Summary
- Add live-event-query filters for plan_id, action_id, and remote_call_group_id.
- Wire the filters through the Python report builder and CLI.
- Add regression coverage for API and CLI filtering, plus changelog entry.

Validation
- pytest tests/test_live_event_query.py -q
- pytest tests/test_passivbot_cli.py::test_tool_help_lists_supported_tools tests/test_passivbot_cli.py::test_live_event_query_tool_dispatch_forwards_module_and_prog -q
- git diff --check

Note
- A broader pytest tests/test_live_event_query.py tests/test_passivbot_cli.py -q run was interrupted after reaching unrelated failures in tests/test_passivbot_cli.py::test_legacy_aliases_still_work_through_real_command_modules because the loaded passivbot_rust extension lacks get_strategy_kinds and needs rebuild/restamp.