### PR TITLE
Enrich live health resource summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable user-facing changes will be documented in this file.
 
 - Added structured `health.summary` live events for periodic health and
   resource summaries without adding console noise.
+- Added process/system/event-pipeline resource-pressure fields to structured
+  `health.summary` events, including load average, open file count, queue depth,
+  event drops, and sink error counters when available.
 - Added `passivbot tool live-incident-bundle` for collecting local monitor
   events, smoke summaries, redacted log excerpts, monitor snapshots, config
   hashes, runtime metadata, and bounded event segments into a tarball.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -56,6 +56,12 @@ Related detailed plans:
    after short-downtime restarts.
 
 5. Resource pressure telemetry.
+   Initial implementation: `health.summary` events now include process RSS,
+   memory percent when available, open file descriptor count, system load
+   averages, CPU count, and live-event pipeline queue/drop/sink error counters.
+   Remaining refinements include exchange-call counts, candle-fetch concurrency,
+   loop lag, thresholded console warnings, and richer system memory/swap fields.
+
    VPS5 repeatedly showed tight memory, swap usage, and high load during
    restarts. Add low-frequency process/system resource events: RSS, open file
    count, event queue depth, event drops, exchange-call counts, candle-fetch

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -573,6 +573,40 @@ class LiveEventPipeline:
         self.context = self.context.with_ids(**kwargs)
         return self.context
 
+    def health_snapshot(self) -> dict[str, Any]:
+        """Return best-effort operational counters for periodic health events."""
+        try:
+            queue_depth = int(self._queue.qsize())
+        except (AttributeError, NotImplementedError, TypeError, ValueError):
+            queue_depth = None
+        try:
+            unfinished_tasks = int(self._queue.unfinished_tasks)
+        except (AttributeError, TypeError, ValueError):
+            unfinished_tasks = None
+        try:
+            queue_maxsize = int(getattr(self._queue, "maxsize", 0) or 0)
+        except (TypeError, ValueError):
+            queue_maxsize = None
+        with self._state_lock:
+            drop_counts = dict(self.drop_counters)
+            sink_error_counts = dict(self.sink_error_counters)
+            degraded_count = len(self.degraded_events)
+        snapshot: dict[str, Any] = {
+            "event_queue_depth": queue_depth,
+            "event_queue_maxsize": queue_maxsize,
+            "event_queue_unfinished_tasks": unfinished_tasks,
+            "event_dropped_total": int(sum(drop_counts.values())),
+            "event_drop_counts": drop_counts,
+            "event_sink_error_total": int(sum(sink_error_counts.values())),
+            "event_sink_error_counts": sink_error_counts,
+            "event_degraded_count": int(degraded_count),
+            "event_pipeline_stopping": bool(self._stop.is_set()),
+            "event_pipeline_worker_alive": bool(
+                self._worker is not None and self._worker.is_alive()
+            ),
+        }
+        return {key: value for key, value in snapshot.items() if value is not None}
+
     def emit(
         self,
         event: LiveEvent | Mapping[str, Any],

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -53,6 +53,55 @@ def _get_process_rss_bytes() -> Optional[int]:
     return None
 
 
+def _get_process_memory_percent() -> Optional[float]:
+    """Return current process memory percentage when psutil is available."""
+    try:
+        if psutil is not None:
+            return float(psutil.Process(os.getpid()).memory_percent())
+    except Exception as exc:
+        logging.debug("[monitor] memory percent probe unavailable: %s", exc)
+    return None
+
+
+def _get_open_fd_count() -> Optional[int]:
+    """Return current open file descriptor count when the platform exposes it."""
+    try:
+        if psutil is not None:
+            process = psutil.Process(os.getpid())
+            num_fds = getattr(process, "num_fds", None)
+            if callable(num_fds):
+                return int(num_fds())
+    except Exception as exc:
+        logging.debug("[monitor] psutil fd-count probe unavailable: %s", exc)
+    proc_fd = "/proc/self/fd"
+    try:
+        if os.path.isdir(proc_fd):
+            return int(len(os.listdir(proc_fd)))
+    except Exception as exc:
+        logging.debug("[monitor] proc fd-count probe unavailable: %s", exc)
+    return None
+
+
+def _get_loadavg_payload() -> dict[str, Any]:
+    """Return system load averages and CPU count when available."""
+    payload: dict[str, Any] = {}
+    try:
+        one, five, fifteen = os.getloadavg()
+        payload.update(
+            {
+                "loadavg_1m": float(one),
+                "loadavg_5m": float(five),
+                "loadavg_15m": float(fifteen),
+            }
+        )
+    except (AttributeError, OSError):
+        pass
+    cpu_count = os.cpu_count()
+    if cpu_count is not None:
+        payload["cpu_count"] = int(cpu_count)
+    return payload
+
+
 def _calc_monitor_pnl(position_side, entry_price, close_price, qty, c_mult):
     """Calculate trade PnL using the same Rust helpers as the live bot."""
     try:
@@ -335,6 +384,23 @@ def _build_health_summary_payload(self, *, now_ms: Optional[int] = None) -> dict
     rss = _get_process_rss_bytes()
     if rss is not None:
         payload["rss_bytes"] = int(rss)
+    mem_pct = _get_process_memory_percent()
+    if mem_pct is not None and math.isfinite(mem_pct):
+        payload["memory_percent"] = float(mem_pct)
+    open_fds = _get_open_fd_count()
+    if open_fds is not None:
+        payload["open_fds"] = int(open_fds)
+    payload.update(_get_loadavg_payload())
+    pipeline = getattr(self, "_live_event_pipeline", None)
+    health_snapshot = getattr(pipeline, "health_snapshot", None)
+    if callable(health_snapshot):
+        try:
+            pipeline_payload = health_snapshot()
+        except Exception as exc:
+            logging.debug("[monitor] event pipeline health snapshot unavailable: %s", exc)
+            pipeline_payload = {}
+        if isinstance(pipeline_payload, dict):
+            payload.update(pipeline_payload)
     return payload
 
 

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -241,6 +241,40 @@ def test_pipeline_queue_overflow_is_observable_without_raising():
     assert pipeline.degraded_events[-1].reason_code == "queue_full"
 
 
+def test_pipeline_health_snapshot_reports_queue_and_degraded_counters():
+    pipeline = LiveEventPipeline(
+        queue_maxsize=1,
+        start=False,
+        routes={
+            EventTypes.DATA_PACKET_UPDATED: EventRoute(
+                structured=True, monitor=False, console=False
+            )
+        },
+    )
+
+    assert pipeline.emit(LiveEvent(EventTypes.DATA_PACKET_UPDATED)) is not None
+    assert (
+        pipeline.emit(LiveEvent(EventTypes.DATA_PACKET_UPDATED), require_enqueue=True)
+        is None
+    )
+
+    snapshot = pipeline.health_snapshot()
+
+    assert snapshot["event_queue_depth"] == 1
+    assert snapshot["event_queue_maxsize"] == 1
+    assert snapshot["event_queue_unfinished_tasks"] == 1
+    assert snapshot["event_dropped_total"] == 1
+    assert snapshot["event_drop_counts"] == {EventTypes.DATA_PACKET_UPDATED: 1}
+    assert snapshot["event_sink_error_total"] == 0
+    assert snapshot["event_sink_error_counts"] == {}
+    assert snapshot["event_degraded_count"] == 1
+    assert snapshot["event_pipeline_stopping"] is False
+    assert snapshot["event_pipeline_worker_alive"] is False
+
+    pipeline._queue.get_nowait()
+    pipeline._queue.task_done()
+
+
 def test_pipeline_queue_overflow_is_logged_and_monitor_visible(caplog):
     monitor = ListEventSink()
     pipeline = LiveEventPipeline(

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -703,6 +703,90 @@ def test_health_summary_event_emitter_records_payload():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
+    import passivbot as pb_mod
+
+    class FakePipeline:
+        def health_snapshot(self):
+            return {
+                "event_queue_depth": 3,
+                "event_queue_maxsize": 100,
+                "event_dropped_total": 2,
+                "event_drop_counts": {"remote_call.started": 2},
+                "event_sink_error_total": 1,
+                "event_sink_error_counts": {"monitor": 1},
+                "event_degraded_count": 4,
+                "event_pipeline_worker_alive": True,
+            }
+
+    class FakeBot:
+        _build_health_summary_payload = pb_mod.Passivbot._build_health_summary_payload
+
+        def __init__(self):
+            self.positions = {
+                "BTC/USDT:USDT": {
+                    "long": {"size": 0.01},
+                    "short": {"size": 0.0},
+                },
+                "ETH/USDT:USDT": {
+                    "long": {"size": 0.0},
+                    "short": {"size": -0.02},
+                },
+            }
+            self._health_start_ms = 100_000
+            self._last_loop_duration_ms = 1234
+            self._monitor_last_equity = 1001.0
+            self._health_orders_placed = 5
+            self._health_orders_cancelled = 2
+            self._health_fills = 7
+            self._health_pnl = 8.5
+            self._health_ws_reconnects = 1
+            self._health_rate_limits = 2
+            self.error_counts = [159_000, 10_000]
+            self._live_event_pipeline = FakePipeline()
+
+        def get_raw_balance(self):
+            return 1000.0
+
+        def get_hysteresis_snapped_balance(self):
+            return 999.0
+
+    monkeypatch.setattr(pb_mod.pb_monitor, "_get_process_rss_bytes", lambda: 123456)
+    monkeypatch.setattr(pb_mod.pb_monitor, "_get_process_memory_percent", lambda: 12.5)
+    monkeypatch.setattr(pb_mod.pb_monitor, "_get_open_fd_count", lambda: 42)
+    monkeypatch.setattr(
+        pb_mod.pb_monitor,
+        "_get_loadavg_payload",
+        lambda: {
+            "loadavg_1m": 1.5,
+            "loadavg_5m": 1.25,
+            "loadavg_15m": 1.0,
+            "cpu_count": 1,
+        },
+    )
+
+    payload = FakeBot()._build_health_summary_payload(now_ms=160_000)
+
+    assert payload["uptime_ms"] == 60_000
+    assert payload["positions_long"] == 1
+    assert payload["positions_short"] == 1
+    assert payload["rss_bytes"] == 123456
+    assert payload["memory_percent"] == 12.5
+    assert payload["open_fds"] == 42
+    assert payload["loadavg_1m"] == 1.5
+    assert payload["loadavg_5m"] == 1.25
+    assert payload["loadavg_15m"] == 1.0
+    assert payload["cpu_count"] == 1
+    assert payload["event_queue_depth"] == 3
+    assert payload["event_queue_maxsize"] == 100
+    assert payload["event_dropped_total"] == 2
+    assert payload["event_drop_counts"] == {"remote_call.started": 2}
+    assert payload["event_sink_error_total"] == 1
+    assert payload["event_sink_error_counts"] == {"monitor": 1}
+    assert payload["event_degraded_count"] == 4
+    assert payload["event_pipeline_worker_alive"] is True
+
+
 def test_log_health_summary_emits_structured_event(caplog, monkeypatch):
     import passivbot as pb_mod
 


### PR DESCRIPTION
## Summary
- add a best-effort LiveEventPipeline.health_snapshot() for queue/drop/sink health counters
- enrich structured health.summary payloads with resource-pressure fields: memory percent, open FDs, load averages, CPU count, and event-pipeline counters
- update the living ops backlog and changelog

## Scope
- observability-only; no trading behavior, order logic, exchange calls, or console output changes
- health summary fields are omitted when the platform/probe cannot provide them

## Tests
- PYTHONPATH=src ./venv/bin/python -m compileall src/live/event_bus.py src/passivbot_monitor.py tests/test_live_event_bus.py tests/test_passivbot_monitor.py
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py -q
- git diff --check
