### PR TITLE
Improve live event console summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Improved event-projected live console summaries for cycle/order execution
+  events, including compact wave, order, confirmation, and Rust planning
+  details without increasing console event volume.
 - Added structured `health.summary` live events for periodic health and
   resource summaries without adding console noise.
 - Added process/system/event-pipeline resource-pressure fields to structured

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -558,16 +558,211 @@ class ListEventSink:
         return event
 
 
-def format_console_event(event: LiveEvent) -> str:
-    base = (
-        "[shutdown]"
-        if event.event_type == EventTypes.BOT_SHUTDOWN_STAGE
-        else f"[{event.event_type}]"
+_CONSOLE_EVENT_TAGS = {
+    EventTypes.BOT_STARTED: "bot",
+    EventTypes.BOT_READY: "bot",
+    EventTypes.BOT_STOPPING: "bot",
+    EventTypes.BOT_SHUTDOWN_STAGE: "shutdown",
+    EventTypes.BOT_STOPPED: "bot",
+    EventTypes.CYCLE_STARTED: "cycle",
+    EventTypes.CYCLE_COMPLETED: "cycle",
+    EventTypes.CYCLE_DEGRADED: "cycle",
+    EventTypes.PLANNING_UNAVAILABLE: "gate",
+    EventTypes.RUST_ORCHESTRATOR_RETURNED: "rust",
+    EventTypes.ORDER_WAVE_COMPLETED: "execute",
+    EventTypes.EXECUTION_CREATE_SUCCEEDED: "order",
+    EventTypes.EXECUTION_CREATE_FAILED: "order",
+    EventTypes.EXECUTION_CREATE_REJECTED: "order",
+    EventTypes.EXECUTION_CANCEL_SUCCEEDED: "order",
+    EventTypes.EXECUTION_CANCEL_FAILED: "order",
+    EventTypes.EXECUTION_CANCEL_AMBIGUOUS_TERMINAL: "order",
+    EventTypes.EXECUTION_AMBIGUOUS: "order",
+    EventTypes.EXECUTION_CONFIRMATION_SATISFIED: "execute",
+    EventTypes.EXECUTION_CONFIRMATION_TIMEOUT: "execute",
+    EventTypes.SINK_DEGRADED: "logging",
+}
+
+
+def _console_tag(event: LiveEvent) -> str:
+    return _CONSOLE_EVENT_TAGS.get(event.event_type, event.event_type)
+
+
+def _data_int(data: Mapping[str, Any], key: str) -> int | None:
+    try:
+        value = data.get(key)
+        if value is None:
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _data_str(data: Mapping[str, Any], key: str) -> str | None:
+    value = data.get(key)
+    if value is None or value == "":
+        return None
+    return str(value)
+
+
+def _data_float(data: Mapping[str, Any], key: str) -> str | None:
+    try:
+        value = data.get(key)
+        if value is None:
+            return None
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number != number:
+        return None
+    return f"{number:.10g}"
+
+
+def _compact_csv(values: Any, *, limit: int = 4) -> str | None:
+    if not isinstance(values, (list, tuple, set)):
+        return None
+    items = [str(item) for item in values if item is not None and str(item) != ""]
+    if not items:
+        return None
+    shown = items[:limit]
+    suffix = f",+{len(items) - len(shown)}" if len(items) > len(shown) else ""
+    return ",".join(shown) + suffix
+
+
+def _count_pair(data: Mapping[str, Any], done_key: str, planned_key: str) -> str | None:
+    done = _data_int(data, done_key)
+    planned = _data_int(data, planned_key)
+    if done is None and planned is None:
+        return None
+    if planned is None:
+        return str(done or 0)
+    return f"{done or 0}/{planned}"
+
+
+def _console_order_wave_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    if event.order_wave_id:
+        parts.append(f"wave={event.order_wave_id}")
+    cancel = _count_pair(data, "cancel_posted", "planned_cancel")
+    create = _count_pair(data, "create_posted", "planned_create")
+    if cancel is not None:
+        parts.append(f"cancel={cancel}")
+    if create is not None:
+        parts.append(f"create={create}")
+    for key in ("deferred_create", "skipped_create", "skipped_cancel"):
+        value = _data_int(data, key)
+        if value:
+            parts.append(f"{key}={value}")
+    elapsed = _data_int(data, "elapsed_ms")
+    if elapsed is not None:
+        parts.append(f"elapsed={elapsed}ms")
+    symbols = _compact_csv(data.get("symbols"), limit=4)
+    if symbols:
+        parts.append(f"symbols={symbols}")
+    return parts
+
+
+def _console_order_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    if event.order_wave_id:
+        parts.append(f"wave={event.order_wave_id}")
+    if event.side:
+        parts.append(f"side={event.side}")
+    order_type = _data_str(data, "order_type")
+    if order_type:
+        parts.append(f"type={order_type}")
+    qty = _data_float(data, "qty")
+    price = _data_float(data, "price")
+    if qty:
+        parts.append(f"qty={qty}")
+    if price:
+        parts.append(f"price={price}")
+    if data.get("reduce_only") is True:
+        parts.append("reduce_only=true")
+    result_status = _data_str(data, "result_status")
+    if result_status:
+        parts.append(f"exchange_status={result_status}")
+    order_id = _data_str(data, "result_order_id_short") or _data_str(data, "order_id_short")
+    if order_id:
+        parts.append(f"order_id={order_id}")
+    client_id = _data_str(data, "result_client_order_id_short") or _data_str(
+        data, "client_order_id_short"
     )
+    if client_id:
+        parts.append(f"client_id={client_id}")
+    error_type = _data_str(data, "error_type")
+    if error_type:
+        parts.append(f"error_type={error_type}")
+    return parts
+
+
+def _console_confirmation_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    if event.order_wave_id:
+        parts.append(f"wave={event.order_wave_id}")
+    surfaces = _compact_csv(data.get("fresh_surfaces"), limit=4)
+    if surfaces:
+        parts.append(f"fresh={surfaces}")
+    pending = _compact_csv(data.get("pending_surfaces"), limit=4)
+    if pending:
+        parts.append(f"pending={pending}")
+    elapsed = _data_int(data, "elapsed_ms")
+    timeout = _data_int(data, "timeout_ms")
+    if elapsed is not None:
+        parts.append(f"elapsed={elapsed}ms")
+    if timeout is not None:
+        parts.append(f"timeout={timeout}ms")
+    return parts
+
+
+def _console_rust_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    elapsed = _data_int(data, "elapsed_ms")
+    order_count = _data_int(data, "order_count")
+    if order_count is not None:
+        parts.append(f"orders={order_count}")
+    if elapsed is not None:
+        parts.append(f"elapsed={elapsed}ms")
+    error_type = _data_str(data, "error_type")
+    if error_type:
+        parts.append(f"error_type={error_type}")
+    return parts
+
+
+def _console_data_summary(event: LiveEvent) -> list[str]:
+    if event.event_type == EventTypes.ORDER_WAVE_COMPLETED:
+        return _console_order_wave_summary(event)
+    if event.event_type in {
+        EventTypes.EXECUTION_CREATE_SUCCEEDED,
+        EventTypes.EXECUTION_CREATE_FAILED,
+        EventTypes.EXECUTION_CREATE_REJECTED,
+        EventTypes.EXECUTION_CANCEL_SUCCEEDED,
+        EventTypes.EXECUTION_CANCEL_FAILED,
+        EventTypes.EXECUTION_CANCEL_AMBIGUOUS_TERMINAL,
+        EventTypes.EXECUTION_AMBIGUOUS,
+    }:
+        return _console_order_summary(event)
+    if event.event_type in {
+        EventTypes.EXECUTION_CONFIRMATION_SATISFIED,
+        EventTypes.EXECUTION_CONFIRMATION_TIMEOUT,
+    }:
+        return _console_confirmation_summary(event)
+    if event.event_type == EventTypes.RUST_ORCHESTRATOR_RETURNED:
+        return _console_rust_summary(event)
+    return []
+
+
+def format_console_event(event: LiveEvent) -> str:
+    base = f"[{_console_tag(event)}]"
     if event.status:
         base += f" {event.status}"
     if event.cycle_id:
         base += f" cycle={event.cycle_id}"
+    for part in _console_data_summary(event):
+        base += f" {part}"
     if event.symbol:
         base += f" symbol={event.symbol}"
     if event.pside:

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -634,10 +634,97 @@ def test_console_format_is_compact_and_operator_facing():
     )
 
     expected = (
-        "[planning.unavailable] deferred cycle=cy_1 symbol=BTC/USDT:USDT "
+        "[gate] deferred cycle=cy_1 symbol=BTC/USDT:USDT "
         "pside=long reason=stale_ema entries deferred"
     )
     assert format_console_event(event) == expected
+
+
+def test_console_format_summarizes_order_wave_payload():
+    event = LiveEvent(
+        EventTypes.ORDER_WAVE_COMPLETED,
+        status="deferred",
+        cycle_id="cy_9",
+        order_wave_id="ow_7",
+        reason_code="create_deferred",
+        data={
+            "planned_cancel": 1,
+            "cancel_posted": 1,
+            "planned_create": 3,
+            "create_posted": 2,
+            "deferred_create": 1,
+            "elapsed_ms": 642,
+            "symbols": ["BTC/USDT:USDT", "ETH/USDT:USDT", "SOL/USDT:USDT"],
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[execute] deferred cycle=cy_9 wave=ow_7 cancel=1/1 create=2/3 "
+        "deferred_create=1 elapsed=642ms "
+        "symbols=BTC/USDT:USDT,ETH/USDT:USDT,SOL/USDT:USDT "
+        "reason=create_deferred"
+    )
+
+
+def test_console_format_summarizes_order_write_without_raw_payload():
+    event = LiveEvent(
+        EventTypes.EXECUTION_CREATE_SUCCEEDED,
+        status="succeeded",
+        cycle_id="cy_3",
+        order_wave_id="ow_2",
+        symbol="AAVE/USDT:USDT",
+        pside="long",
+        side="buy",
+        data={
+            "order_type": "limit",
+            "qty": 1.23456789,
+            "price": 88.7654321,
+            "reduce_only": False,
+            "result_status": "open",
+            "result_order_id_short": "abc123",
+            "result_client_order_id_short": "pbot_456",
+            "apiKey": "must_not_leak",
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[order] succeeded cycle=cy_3 wave=ow_2 side=buy type=limit "
+        "qty=1.23456789 price=88.7654321 exchange_status=open "
+        "order_id=abc123 client_id=pbot_456 symbol=AAVE/USDT:USDT pside=long"
+    )
+
+
+def test_console_format_summarizes_confirmation_timeout():
+    event = LiveEvent(
+        EventTypes.EXECUTION_CONFIRMATION_TIMEOUT,
+        status="degraded",
+        cycle_id="cy_5",
+        order_wave_id="ow_3",
+        reason_code="authoritative_confirmation_timeout",
+        data={
+            "fresh_surfaces": ["balance", "positions"],
+            "pending_surfaces": ["open_orders"],
+            "elapsed_ms": 2200,
+            "timeout_ms": 2000,
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[execute] degraded cycle=cy_5 wave=ow_3 fresh=balance,positions "
+        "pending=open_orders elapsed=2200ms timeout=2000ms "
+        "reason=authoritative_confirmation_timeout"
+    )
+
+
+def test_console_format_summarizes_rust_return():
+    event = LiveEvent(
+        EventTypes.RUST_ORCHESTRATOR_RETURNED,
+        status="succeeded",
+        cycle_id="cy_6",
+        data={"order_count": 4, "elapsed_ms": 17},
+    )
+
+    assert format_console_event(event) == "[rust] succeeded cycle=cy_6 orders=4 elapsed=17ms"
 
 
 def test_shutdown_stage_console_format_uses_shutdown_tag():


### PR DESCRIPTION
Small Phase 5 logging slice: improve the console/text projection for live events that are already routed to console.\n\nScope:\n- Adds operator-facing tags such as [gate], [execute], [order], [rust], [logging].\n- Summarizes existing event payload fields for order waves, order writes, confirmations, and Rust planning returns.\n- Does not change event routes, trading behavior, exchange calls, or console event volume.\n\nValidation:\n- git diff --check origin/v8...HEAD\n- PYTHONPATH=src ./venv/bin/python -m compileall src/live/event_bus.py tests/test_live_event_bus.py\n- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py -q