### PR TITLE
Update live logging progress after console slice

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,12 +19,13 @@ Last updated: 2026-06-25.
 
 Current `origin/v8` logging-overhaul head:
 
-- `09fd305b` merge of PR #643, `Enrich live health resource summaries`.
+- `521832cc` merge of PR #646, `Improve live event console summaries`.
 
 VPS5 deployment status:
 
 - Deployed through PR #642 at `ad36d8ea`.
-- PR #643 is merged to `v8`; VPS5 pull/restart and health-summary smoke are next.
+- PRs #643-#646 are merged to `v8`; VPS5 pull/restart and live smoke are next
+  when explicitly authorized.
 
 ## Phase Checklist
 
@@ -35,7 +36,7 @@ VPS5 deployment status:
 | Phase 2: data gatherer events | Mostly done | Account remote-call cohorts, candle tail/coverage, fill refresh summaries, cache load/flush, warmup/startup timing | Not every exchange/network call is instrumented; richer remote-call payload summaries remain incremental |
 | Phase 3: Rust planning and payload refs | Partially done | Rust orchestrator called/returned events, redacted error hardening, action/planning summaries | Full raw-ref retention/debug policy still limited |
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
-| Phase 5: migrate meaningful text logs | Not started as a dedicated phase | Some noisy EMA console output already reduced; many text logs now have event equivalents | Redesign console as a projection of structured events; migrate high-value stdlib logs first |
+| Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
 | Operator tools | In progress | `live-event-query`, `live-smoke-report`, incident bundle, ID filters | Richer cycle replay and cross-bot incident workflow |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup | Continue separate reviewed PRs for shutdown/warmup improvements |
@@ -214,12 +215,35 @@ VPS5 deployment status:
   `d34241a4`; CI green; local targeted tests passed before merge.
 - VPS5 evidence: pending pull/restart/smoke.
 
+### PR #644: Logging And Ops Progress Tracking
+
+- Branch: `codex/v8-live-logging-progress-tracker`.
+- Scope: process tracking.
+- Result: added this progress ledger and converted the live operations backlog
+  into a living checklist with per-item statuses and a merged-work log.
+
+### PR #645: Reason-Code Registry Slice
+
+- Branch: `codex/v8-reason-code-registry-slice`.
+- Scope: event taxonomy and drift prevention.
+- Result: added shared `EventTags` and `ReasonCodes` registries for common live
+  event tags/reason codes, migrated representative emitters without changing
+  emitted strings, and documented the registry rule.
+
+### PR #646: Console Event Summaries
+
+- Branch: `codex/v8-console-event-summaries`.
+- Scope: Phase 5 console/text projection.
+- Result: improved `format_console_event()` with compact operator-facing tags
+  and typed summaries for order waves, order writes, confirmation results, and
+  Rust planning returns. Routes and console event volume were unchanged.
+
 ## Current Next Steps
 
-1. Pull merged `v8` on VPS5 and restart bots so PR #643 runtime health-summary
-   fields are emitted by live processes.
-2. Verify `health.summary` includes resource pressure and event-pipeline fields
-   without increasing console noise or trading behavior.
-3. Continue Phase 5 with a small console-projection/text-log migration slice, or
-   add the next high-value operator query/replay helper if live smoke shows that
-   debugging still needs better cycle reconstruction.
+1. Pull merged `v8` on VPS5 and restart bots, if explicitly authorized, so PRs
+   #643-#646 are exercised by live processes.
+2. Verify `health.summary` includes resource pressure and event-pipeline fields,
+   and verify event-projected console summaries stay readable.
+3. Continue Phase 5 by migrating one high-value stdlib text log family to
+   structured-event projection, or add a richer cycle/order reconstruction helper
+   if live smoke shows that query tooling is still the sharper need.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -105,7 +105,7 @@ Related detailed plans:
    with changed HSL configs easier to reason about before live execution.
 
 9. [ ] Reason-code registry.
-   Status: initial registry slice in progress in PR #645.
+   Status: partial. Initial registry slice merged in PR #645.
 
    Centralize reason codes and event tags enough to prevent drift. The stream is
    much easier to search when `stale_ema`, `missing_canonical_candles`,
@@ -121,7 +121,8 @@ Related detailed plans:
    surfaces are touched.
 
 10. [ ] Operator console redesign from events.
-    Status: open.
+    Status: partial. PR #646 improved event-projected summaries for already
+    routed execution events.
 
     Continue moving console output to be a projection of structured events.
     Default console should focus on fills, positions, balance, order writes,
@@ -179,6 +180,8 @@ Related detailed plans:
 | 2026-06-25 | #2 Event query and timeline CLI extensions | PR #642 / `ad36d8ea` | Added bot/snapshot/plan/action/remote-call-group filters and shared ID-key timeline rendering; VPS5 query smoke passed | Richer reconstruction views |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |
+| 2026-06-25 | #9 Reason-code registry | PR #645 / `31263bb9` | Added shared `EventTags` and `ReasonCodes` registries and migrated representative live event emitters without changing emitted strings | Continue migrating stable literals as nearby event surfaces are touched |
+| 2026-06-25 | #10 Operator console redesign from events | PR #646 / `521832cc` | Improved event-projected console/text summaries for already-routed execution events without changing routes or console event volume | Migrate high-value stdlib text logs to structured-event projections |
 | 2026-06-24 | Operational restart goals | PR #619 / `e71c4f6c` | Improved shutdown progress and bounded shutdown cancel grace coverage | Broader interruptible shutdown contract remains separate work |
 | 2026-06-24 | Operational restart goals | PR #622 / `29eba387` | Improved live startup warm-cache reuse | Deeper cache doctor and budget tracking remain open |
 
@@ -186,10 +189,10 @@ Related detailed plans:
 
 Near-term highest leverage:
 
-1. Event query/timeline CLI.
+1. Richer cycle/order reconstruction on top of `live-event-query`.
 2. Live restart/smoke automation.
 3. Startup phase budget tracking.
-4. Resource pressure telemetry.
+4. Operator console redesign from events.
 5. HSL dry-run preview.
 
 These make every later live debugging session cheaper and provide direct


### PR DESCRIPTION
Docs-only progress update after merged PRs #645 and #646.\n\nScope:\n- Updates docs/plans/live_logging_overhaul_progress.md to current v8 head and Phase 5 status.\n- Updates docs/plans/live_ops_improvement_backlog.md for reason-code registry and console-summary progress.\n- No runtime behavior changes.\n\nValidation:\n- git diff --check\n- staged diff check before commit.