### PR TITLE
Update live logging progress after trace tooling

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,12 +19,13 @@ Last updated: 2026-06-25.
 
 Current `origin/v8` logging-overhaul head:
 
-- `521832cc` merge of PR #646, `Improve live event console summaries`.
+- `7391d43b` merge of PR #649, `Summarize startup timing baselines in smoke
+  report`.
 
 VPS5 deployment status:
 
 - Deployed through PR #642 at `ad36d8ea`.
-- PRs #643-#646 are merged to `v8`; VPS5 pull/restart and live smoke are next
+- PRs #643-#649 are merged to `v8`; VPS5 pull/restart and live smoke are next
   when explicitly authorized.
 
 ## Phase Checklist
@@ -38,7 +39,7 @@ VPS5 deployment status:
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
-| Operator tools | In progress | `live-event-query`, `live-smoke-report`, incident bundle, ID filters | Richer cycle replay and cross-bot incident workflow |
+| Operator tools | In progress | `live-event-query`, trace summaries, `live-smoke-report` startup baselines, incident bundle, ID filters | Richer cycle replay and cross-bot incident workflow |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup | Continue separate reviewed PRs for shutdown/warmup improvements |
 
 ## Merged Slices
@@ -238,12 +239,31 @@ VPS5 deployment status:
   and typed summaries for order waves, order writes, confirmation results, and
   Rust planning returns. Routes and console event volume were unchanged.
 
+### PR #648: Live Event Trace Summaries
+
+- Branch: `codex/v8-live-event-trace-summary`.
+- Scope: operator query tooling.
+- Result: added `passivbot tool live-event-query --trace-summary` to aggregate
+  matched live events by event type, level, status, reason code, ID scopes,
+  symbol/side, and order-wave/action coverage. Summary counts cover all matched
+  events even when `--limit` truncates the returned event sample.
+
+### PR #649: Startup Timing Baselines In Smoke Report
+
+- Branch: `codex/v8-startup-phase-budgets`.
+- Scope: adjacent operations observability.
+- Result: `passivbot tool live-smoke-report` now summarizes existing
+  `bot.startup_timing` monitor events into latest per-phase timings and rolling
+  median/p95/min/max baselines. Latest details are redacted before smoke-report
+  or incident-bundle output.
+
 ## Current Next Steps
 
 1. Pull merged `v8` on VPS5 and restart bots, if explicitly authorized, so PRs
-   #643-#646 are exercised by live processes.
+   #643-#649 are exercised by live processes.
 2. Verify `health.summary` includes resource pressure and event-pipeline fields,
-   and verify event-projected console summaries stay readable.
+   verify event-projected console summaries stay readable, and verify
+   `live-smoke-report` shows startup timing baselines.
 3. Continue Phase 5 by migrating one high-value stdlib text log family to
    structured-event projection, or add a richer cycle/order reconstruction helper
    if live smoke shows that query tooling is still the sharper need.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -43,7 +43,8 @@ Related detailed plans:
    now supports event discovery, compact JSON output, current-vs-rotated segment
    selection, terse timeline rendering, and filters for event type/kind, cycle
    id, order wave id, remote call id/group id, bot id, snapshot id, plan id,
-   action id, symbol, pside, reason code, and status.
+   action id, symbol, pside, reason code, and status. It also supports
+   aggregate trace summaries over matched events and order waves.
 
    Remaining refinements: richer cycle/order reconstruction and incident-bundle
    integration.
@@ -133,8 +134,11 @@ Related detailed plans:
     they directly explain a blocked trading action.
 
 11. [ ] Order lifecycle trace completeness.
-    Status: partial. The order-wave/execution event chain exists, but there is
-    no single reconstruction view for every create/cancel/missing-order case.
+    Status: partial. The order-wave/execution event chain exists, and
+    `live-event-query --trace-summary` can aggregate matched event types,
+    statuses, reason codes, ID scopes, symbols, and order-wave/action coverage.
+    There is still no single reconstruction view for every
+    create/cancel/missing-order case.
 
     Keep tightening the end-to-end chain from Rust ideal order to executable
     order, gate decision, exchange payload, exchange response, local open-order
@@ -180,7 +184,9 @@ Related detailed plans:
 | 2026-06-25 | #1 Incident bundle generator | PR #641 / `e1f99002` | Added `passivbot tool live-incident-bundle`; bundle smoke on VPS5 created an archive with redacted monitor/config evidence | Supervisor/process status and tighter remote smoke integration |
 | 2026-06-25 | #2 Event query and timeline CLI extensions | PR #638 / `1b15b2d5` | Added broader live event query filters | More ID scopes still needed at that point |
 | 2026-06-25 | #2 Event query and timeline CLI extensions | PR #642 / `ad36d8ea` | Added bot/snapshot/plan/action/remote-call-group filters and shared ID-key timeline rendering; VPS5 query smoke passed | Richer reconstruction views |
+| 2026-06-25 | #2/#11 Event query and order trace summaries | PR #648 / `774bcf74` | Added `live-event-query --trace-summary` aggregate counts across matched events, ID scopes, symbols, sides, and order waves | Full create/cancel/missing-order reconstruction view |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
+| 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |
 | 2026-06-25 | #9 Reason-code registry | PR #645 / `31263bb9` | Added shared `EventTags` and `ReasonCodes` registries and migrated representative live event emitters without changing emitted strings | Continue migrating stable literals as nearby event surfaces are touched |
 | 2026-06-25 | #10 Operator console redesign from events | PR #646 / `521832cc` | Improved event-projected console/text summaries for already-routed execution events without changing routes or console event volume | Migrate high-value stdlib text logs to structured-event projections |


### PR DESCRIPTION
## Summary
- update live logging progress ledger through merged PR #649 / `7391d43b`
- record PR #648 trace-summary tooling and PR #649 startup timing baselines
- update the live ops backlog merged-work log and remaining-work notes

## Scope
- docs/progress tracking only
- no runtime code changes
- no VPS actions performed

## Tests
- `git diff --check`