### PR TITLE
Update live logging progress after order trace

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,13 +19,12 @@ Last updated: 2026-06-25.
 
 Current `origin/v8` logging-overhaul head:
 
-- `7391d43b` merge of PR #649, `Summarize startup timing baselines in smoke
-  report`.
+- `b9f42ebd` merge of PR #651, `Add live event order trace view`.
 
 VPS5 deployment status:
 
 - Deployed through PR #642 at `ad36d8ea`.
-- PRs #643-#649 are merged to `v8`; VPS5 pull/restart and live smoke are next
+- PRs #643-#651 are merged to `v8`; VPS5 pull/restart and live smoke are next
   when explicitly authorized.
 
 ## Phase Checklist
@@ -39,7 +38,7 @@ VPS5 deployment status:
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
-| Operator tools | In progress | `live-event-query`, trace summaries, `live-smoke-report` startup baselines, incident bundle, ID filters | Richer cycle replay and cross-bot incident workflow |
+| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, `live-smoke-report` startup baselines, incident bundle, ID filters | Richer cycle replay and cross-bot incident workflow |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup | Continue separate reviewed PRs for shutdown/warmup improvements |
 
 ## Merged Slices
@@ -257,13 +256,24 @@ VPS5 deployment status:
   median/p95/min/max baselines. Latest details are redacted before smoke-report
   or incident-bundle output.
 
+### PR #651: Live Event Order Trace View
+
+- Branch: `codex/v8-live-event-order-trace`.
+- Scope: operator query tooling.
+- Result: added `passivbot tool live-event-query --order-trace` to reconstruct
+  order-wave/action lifecycles from existing structured execution events. The
+  view groups by `order_wave_id` and `action_id`, reports event/status/reason
+  counts, confirmation events, symbol/pside/side sets, and bounded event
+  samples with shortened order/client-order references.
+
 ## Current Next Steps
 
 1. Pull merged `v8` on VPS5 and restart bots, if explicitly authorized, so PRs
-   #643-#649 are exercised by live processes.
+   #643-#651 are exercised by live processes.
 2. Verify `health.summary` includes resource pressure and event-pipeline fields,
    verify event-projected console summaries stay readable, and verify
-   `live-smoke-report` shows startup timing baselines.
+   `live-smoke-report` shows startup timing baselines and `live-event-query
+   --order-trace` reconstructs recent order waves.
 3. Continue Phase 5 by migrating one high-value stdlib text log family to
-   structured-event projection, or add a richer cycle/order reconstruction helper
-   if live smoke shows that query tooling is still the sharper need.
+   structured-event projection, or add richer cycle reconstruction if live smoke
+   shows that query tooling is still the sharper need.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -44,9 +44,10 @@ Related detailed plans:
    selection, terse timeline rendering, and filters for event type/kind, cycle
    id, order wave id, remote call id/group id, bot id, snapshot id, plan id,
    action id, symbol, pside, reason code, and status. It also supports
-   aggregate trace summaries over matched events and order waves.
+   aggregate trace summaries over matched events and order waves, plus a
+   dedicated order-trace reconstruction view for order waves/actions.
 
-   Remaining refinements: richer cycle/order reconstruction and incident-bundle
+   Remaining refinements: richer cycle reconstruction and incident-bundle
    integration.
 
 3. [ ] Live restart/smoke automation.
@@ -133,17 +134,19 @@ Related detailed plans:
     summaries. EMA/candle/cache internals should stay structured DEBUG unless
     they directly explain a blocked trading action.
 
-11. [ ] Order lifecycle trace completeness.
-    Status: partial. The order-wave/execution event chain exists, and
-    `live-event-query --trace-summary` can aggregate matched event types,
-    statuses, reason codes, ID scopes, symbols, and order-wave/action coverage.
-    There is still no single reconstruction view for every
-    create/cancel/missing-order case.
+11. [x] Order lifecycle trace completeness.
+    Status: initial reconstruction view merged. The order-wave/execution event
+    chain exists, `live-event-query --trace-summary` can aggregate matched event
+    types/statuses/reason codes/ID scopes, and `live-event-query --order-trace`
+    reconstructs order-wave/action lifecycles from existing execution events.
 
     Keep tightening the end-to-end chain from Rust ideal order to executable
     order, gate decision, exchange payload, exchange response, local open-order
     refresh, confirmation, and fill. The target is that any create/cancel/missing
     order can be reconstructed from one id without reading code.
+
+    Remaining refinements: add richer cycle-level reconstruction and incident
+    bundle integration as the event stream gains more producer coverage.
 
 12. [ ] Debug profile toggles.
     Status: open.
@@ -185,6 +188,7 @@ Related detailed plans:
 | 2026-06-25 | #2 Event query and timeline CLI extensions | PR #638 / `1b15b2d5` | Added broader live event query filters | More ID scopes still needed at that point |
 | 2026-06-25 | #2 Event query and timeline CLI extensions | PR #642 / `ad36d8ea` | Added bot/snapshot/plan/action/remote-call-group filters and shared ID-key timeline rendering; VPS5 query smoke passed | Richer reconstruction views |
 | 2026-06-25 | #2/#11 Event query and order trace summaries | PR #648 / `774bcf74` | Added `live-event-query --trace-summary` aggregate counts across matched events, ID scopes, symbols, sides, and order waves | Full create/cancel/missing-order reconstruction view |
+| 2026-06-25 | #2/#11 Event query and order trace completeness | PR #651 / `b9f42ebd` | Added `live-event-query --order-trace` reconstruction grouped by order wave and action, with confirmation events and bounded samples | Richer cycle reconstruction and incident-bundle integration |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |
@@ -197,7 +201,7 @@ Related detailed plans:
 
 Near-term highest leverage:
 
-1. Richer cycle/order reconstruction on top of `live-event-query`.
+1. Richer cycle reconstruction on top of `live-event-query`.
 2. Live restart/smoke automation.
 3. Startup phase budget tracking.
 4. Operator console redesign from events.


### PR DESCRIPTION
## Summary
- record PR #651/order-trace as merged in the logging progress ledger
- mark the initial order lifecycle trace view complete in the living operations backlog
- refresh the next-step notes to point at cycle reconstruction and explicit VPS smoke authorization

## Validation
- git diff --check

Docs/progress-only; no trading behavior or live event emission changes.