### PR TITLE
Document live event registry

### DIFF
--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -15,7 +15,7 @@ Use this file to decide what to read for a task.
 | Exchange/API integration, pagination, data fetch | `exchange_api_quirks.md` |
 | CCXT upgrade / dependency refresh | `ccxt_upgrade_workflow.md`, `exchange_api_quirks.md` |
 | Rust/PyO3 build, extension loading, Rust test execution | `build_pitfalls.md` |
-| Logging behavior/levels/tags | `logging_guide.md` |
+| Logging behavior/levels/tags | `logging_guide.md`, `live_event_registry.md` when touching structured event tags or reason codes |
 | Order logic, risk, Python/Rust boundary | `architecture.md`, `decisions.md`, `features/strategy_runtime.md` when strategy behavior is involved |
 | Code review | `code_review_prompt.md` |
 | Common implementation mistakes | `pitfalls.md` |

--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -1,0 +1,87 @@
+# Live Event Registry
+
+This file documents the stable live event tag and reason-code registries in
+`src/live/event_bus.py`. Use these values for structured live events when the
+value is query-facing or repeated across producers.
+
+Do not add aliases for temporary branch-local spellings. Prefer adding a new
+registry value only when operators or tools should be able to filter for it
+across time.
+
+## Event Tags
+
+- `account`
+- `action`
+- `authoritative`
+- `availability`
+- `balance`
+- `bundle`
+- `cache`
+- `candle`
+- `confirmation`
+- `coverage`
+- `cycle`
+- `defer`
+- `degraded`
+- `ema`
+- `execution`
+- `fallback`
+- `fill`
+- `fills`
+- `flush`
+- `forager`
+- `gate`
+- `health`
+- `load`
+- `logging`
+- `mode`
+- `order`
+- `planning`
+- `position`
+- `refresh`
+- `remote_call`
+- `resource`
+- `risk`
+- `rust`
+- `selection`
+- `sink`
+- `snapshot`
+- `state`
+- `summary`
+- `tail`
+- `timeout`
+- `unavailable`
+- `warmup`
+- `wave`
+
+## Reason Codes
+
+- `authoritative_confirmation`
+- `authoritative_confirmation_timeout`
+- `balance_changed`
+- `candle_disk_flush_completed`
+- `candle_disk_load_completed`
+- `ema_fallback_used`
+- `exchange_acknowledged`
+- `exchange_exception`
+- `length_mismatch`
+- `new_fill`
+- `open_tail_projection`
+- `optional_ema_dropped`
+- `periodic_health_summary`
+- `queue_full`
+- `ranking_features_unavailable`
+- `remote_fetch`
+- `required_candle_disk_coverage`
+- `required_ema_unavailable`
+- `rust_output_actions`
+- `pipeline_closing`
+- `snapshot_symbol_state`
+- `startup_phase_ready`
+- `submitted_to_exchange`
+- `warmup_cache_decision`
+
+Dynamic helpers are part of the same contract:
+
+- `authoritative_reason_code(surface)` emits `authoritative_<surface>`.
+- `sink_failed_reason_code(name)` emits `<name>_sink_failed`.

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -40,7 +40,8 @@ Use stable `[tag]` prefixes, for example:
 
 Structured live event tags and reason codes must use the shared registries in
 `src/live/event_bus.py` (`EventTags`, `ReasonCodes`) when a stable value already
-exists there. Add new registry values before introducing repeated literals.
+exists there. Add new registry values before introducing repeated literals. See
+`live_event_registry.md` for the current stable values.
 
 ## Fallback Visibility
 

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -119,9 +119,12 @@ Related detailed plans:
    - 2026-06-25: Added shared `EventTags` and `ReasonCodes` registries for
      common live-event tags/reason codes, migrated representative emitters
      without changing emitted strings, and added registry contract tests.
+   - 2026-06-25: Added a focused AI doc for the live event tag/reason-code
+     registry plus a docs drift test so stable values stay discoverable.
 
    Remaining refinements: migrate additional stable literals as nearby event
-   surfaces are touched.
+   surfaces are touched, and expand the docs when new stable query-facing values
+   are added.
 
 10. [ ] Operator console redesign from events.
     Status: partial. PR #646 improved event-projected summaries for already

--- a/tests/test_live_event_registry_docs.py
+++ b/tests/test_live_event_registry_docs.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import re
+
+from live.event_bus import EventTags, ReasonCodes
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REGISTRY_DOC = REPO_ROOT / "docs" / "ai" / "live_event_registry.md"
+
+
+def _registry_values(registry: type) -> list[str]:
+    return sorted(
+        value
+        for name, value in vars(registry).items()
+        if name.isupper() and isinstance(value, str)
+    )
+
+
+def _documented_values(section: str) -> list[str]:
+    text = REGISTRY_DOC.read_text()
+    pattern = rf"^## {re.escape(section)}\n(?P<body>.*?)(?=^## |\Z)"
+    match = re.search(pattern, text, re.M | re.S)
+    assert match is not None, f"missing registry doc section: {section}"
+    return sorted(re.findall(r"^- `([^`]+)`$", match.group("body"), re.M))
+
+
+def test_live_event_tag_docs_match_registry():
+    assert _documented_values("Event Tags") == _registry_values(EventTags)
+
+
+def test_live_event_reason_code_docs_match_registry():
+    assert _documented_values("Reason Codes") == _registry_values(ReasonCodes)


### PR DESCRIPTION
## Summary
- add an AI-facing live event registry doc for stable EventTags and ReasonCodes
- link the registry doc from logging guidance and the AI docs router
- add a focused docs drift test so documented tags/reason codes match src/live/event_bus.py

## Validation
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_registry_docs.py tests/test_live_event_bus.py -q
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile tests/test_live_event_registry_docs.py
- git diff --check
- rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])\)" tests/test_live_event_registry_docs.py

No ssh, tmux, screen, VPS/live-bot, passivbot live, process kill/restart, deploy, or exchange-facing commands were run.