### PR TITLE
Add live event cycle trace view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool live-event-query --cycle-trace` for offline cycle
+  reconstruction grouped by cycle id, including bounded timeline samples,
+  aggregate event summaries, and nested order traces.
 - Added `passivbot tool live-event-query --order-trace` for offline order
   lifecycle reconstruction grouped by order wave and action ids.
 - Added startup phase timing baselines to `passivbot tool live-smoke-report`,

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -562,6 +562,103 @@ class _OrderTraceBuilder:
         }
 
 
+class _CycleTraceBuilder:
+    def __init__(self, *, event_limit: int, include_data: bool) -> None:
+        self.event_limit = max(0, int(event_limit))
+        self.include_data = bool(include_data)
+        self.matched_cycle_events = 0
+        self.missing_cycle_id_event_count = 0
+        self.missing_cycle_id_events: list[dict[str, Any]] = []
+        self.missing_cycle_id_events_truncated = False
+        self.cycles: dict[str, dict[str, Any]] = {}
+
+    def add(
+        self,
+        *,
+        path: Path,
+        line_no: int,
+        row: dict[str, Any],
+        live_event: dict[str, Any],
+        event_type: str | None,
+        ids: dict[str, Any],
+    ) -> None:
+        item = _compact_record(
+            path=path,
+            line_no=line_no,
+            row=row,
+            live_event=live_event,
+            include_data=self.include_data,
+        )
+        cycle_id = ids.get("cycle_id")
+        if cycle_id is None:
+            self.missing_cycle_id_event_count += 1
+            if len(self.missing_cycle_id_events) < self.event_limit:
+                self.missing_cycle_id_events.append(item)
+            else:
+                self.missing_cycle_id_events_truncated = True
+            return
+        self.matched_cycle_events += 1
+        cycle_key = str(cycle_id)
+        cycle = self.cycles.setdefault(
+            cycle_key,
+            {
+                "cycle_id": cycle_key,
+                "event_count": 0,
+                "events_truncated": False,
+                "timeline": [],
+                "trace_summary": _TraceSummaryBuilder(),
+                "order_trace": _OrderTraceBuilder(event_limit=self.event_limit),
+            },
+        )
+        cycle["event_count"] += 1
+        if len(cycle["timeline"]) < self.event_limit:
+            cycle["timeline"].append(item)
+        else:
+            cycle["events_truncated"] = True
+        cycle["trace_summary"].add(
+            row=row,
+            live_event=live_event,
+            event_type=event_type,
+        )
+        cycle["order_trace"].add(
+            path=path,
+            line_no=line_no,
+            row=row,
+            live_event=live_event,
+            event_type=event_type,
+            ids=ids,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        cycles = []
+        for cycle_id, summary in sorted(self.cycles.items()):
+            trace_summary = summary["trace_summary"].to_dict()
+            cycles.append(
+                {
+                    "cycle_id": cycle_id,
+                    "event_count": int(summary["event_count"]),
+                    "events_truncated": bool(summary["events_truncated"]),
+                    "first_ts": trace_summary.get("first_ts"),
+                    "last_ts": trace_summary.get("last_ts"),
+                    "trace_summary": trace_summary,
+                    "order_trace": summary["order_trace"].to_dict(),
+                    "timeline": summary["timeline"],
+                }
+            )
+        out: dict[str, Any] = {
+            "matched_cycle_events": int(self.matched_cycle_events),
+            "cycle_count": len(self.cycles),
+            "cycles": cycles,
+            "missing_cycle_id_event_count": int(self.missing_cycle_id_event_count),
+        }
+        if self.missing_cycle_id_events or self.missing_cycle_id_events_truncated:
+            out["missing_cycle_id_events"] = self.missing_cycle_id_events
+            out["missing_cycle_id_events_truncated"] = bool(
+                self.missing_cycle_id_events_truncated
+            )
+        return out
+
+
 class _TraceSummaryBuilder:
     def __init__(self) -> None:
         self.events = 0
@@ -709,6 +806,7 @@ def build_event_report(
     timeline: bool = False,
     trace_summary: bool = False,
     order_trace: bool = False,
+    cycle_trace: bool = False,
 ) -> dict[str, Any]:
     issues: list[EventIssue] = []
     try:
@@ -740,10 +838,18 @@ def build_event_report(
     query_events: list[dict[str, Any]] = []
     query_match_count = 0
     query_trace = _TraceSummaryBuilder()
-    cycle_trace = _TraceSummaryBuilder()
+    cycle_trace_summary = _TraceSummaryBuilder()
     max_events = max(0, int(limit))
     query_order_trace = _OrderTraceBuilder(event_limit=max_events)
     cycle_order_trace = _OrderTraceBuilder(event_limit=max_events)
+    query_cycle_trace = _CycleTraceBuilder(
+        event_limit=max_events,
+        include_data=include_data,
+    )
+    cycle_cycle_trace = _CycleTraceBuilder(
+        event_limit=max_events,
+        include_data=include_data,
+    )
     event_type_filter = _normalize_filter_values(event_type)
     bot_filter = _normalize_filter_values(bot_id)
     snapshot_filter = _normalize_filter_values(snapshot_id)
@@ -773,7 +879,7 @@ def build_event_report(
         )
     )
     has_query_filter = has_non_cycle_filter or bool(
-        (timeline or trace_summary or order_trace) and cycle_id is None
+        (timeline or trace_summary or order_trace or cycle_trace) and cycle_id is None
     )
 
     for path in files:
@@ -924,6 +1030,15 @@ def build_event_report(
                                 event_type=record_event_type,
                                 ids=ids,
                             )
+                        if cycle_trace:
+                            query_cycle_trace.add(
+                                path=path,
+                                line_no=line_no,
+                                row=row,
+                                live_event=live_event,
+                                event_type=record_event_type,
+                                ids=ids,
+                            )
                         if len(query_events) < max_events:
                             query_events.append(
                                 _compact_record(
@@ -937,13 +1052,22 @@ def build_event_report(
                     if cycle_id is not None and query_matches:
                         cycle_match_count += 1
                         if trace_summary:
-                            cycle_trace.add(
+                            cycle_trace_summary.add(
                                 row=row,
                                 live_event=live_event,
                                 event_type=record_event_type,
                             )
                         if order_trace:
                             cycle_order_trace.add(
+                                path=path,
+                                line_no=line_no,
+                                row=row,
+                                live_event=live_event,
+                                event_type=record_event_type,
+                                ids=ids,
+                            )
+                        if cycle_trace:
+                            cycle_cycle_trace.add(
                                 path=path,
                                 line_no=line_no,
                                 row=row,
@@ -1017,6 +1141,8 @@ def build_event_report(
             report["query"]["trace_summary"] = query_trace.to_dict()
         if order_trace:
             report["query"]["order_trace"] = query_order_trace.to_dict()
+        if cycle_trace:
+            report["query"]["cycle_trace"] = query_cycle_trace.to_dict()
     if cycle_id is not None:
         cycle_filters = _filter_report(
             cycle_id=cycle_id,
@@ -1046,9 +1172,11 @@ def build_event_report(
                 _timeline_line(event) for event in cycle_events
             ]
         if trace_summary:
-            report["cycle"]["trace_summary"] = cycle_trace.to_dict()
+            report["cycle"]["trace_summary"] = cycle_trace_summary.to_dict()
         if order_trace:
             report["cycle"]["order_trace"] = cycle_order_trace.to_dict()
+        if cycle_trace:
+            report["cycle"]["cycle_trace"] = cycle_cycle_trace.to_dict()
         if not event_type_filter:
             report["cycle"].pop("event_types", None)
     return report

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -164,6 +164,15 @@ def build_parser() -> argparse.ArgumentParser:
             "wave and action ids. Event samples are bounded by --limit."
         ),
     )
+    parser.add_argument(
+        "--cycle-trace",
+        action="store_true",
+        help=(
+            "Include a cycle reconstruction view grouped by cycle_id, with "
+            "bounded timeline samples, aggregate summaries, and nested order "
+            "trace details. Event samples are bounded by --limit."
+        ),
+    )
     return parser
 
 
@@ -191,6 +200,7 @@ def main(argv: list[str] | None = None) -> int:
         timeline=bool(args.timeline),
         trace_summary=bool(args.trace_summary),
         order_trace=bool(args.order_trace),
+        cycle_trace=bool(args.cycle_trace),
     )
     print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
     return 0 if report.get("ok") else 1

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -190,6 +190,7 @@ def test_event_query_current_only_skips_rotated_segments(tmp_path):
     assert report["include_rotated"] is False
     assert report["files"] == [str(events_dir / "current.ndjson")]
     assert report["files_scanned"] == 1
+    assert "query" not in report
     assert report["cycle_ids_sample"] == [{"cycle_id": "cy_current", "events": 1}]
 
 
@@ -1015,6 +1016,139 @@ def test_event_query_order_trace_reconstructs_wave_actions_beyond_limit(tmp_path
     assert cancel["order_ids_short"] == ["cancel123"]
 
 
+def test_event_query_cycle_trace_reconstructs_cycle_with_nested_order_trace(tmp_path):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.started",
+                cycle_id="cy_9",
+                seq=1,
+                ts=1000,
+                status="started",
+            ),
+            _monitor_row(
+                event_type="rust_orchestrator.called",
+                cycle_id="cy_9",
+                seq=2,
+                ts=1100,
+                status="started",
+                ids={"snapshot_id": "snap_9", "plan_id": "plan_9"},
+            ),
+            _monitor_row(
+                event_type="execution.create_sent",
+                cycle_id="cy_9",
+                seq=3,
+                ts=1200,
+                symbol="ETH/USDT:USDT",
+                pside="long",
+                side="buy",
+                status="started",
+                reason_code="submitted_to_exchange",
+                ids={
+                    "order_wave_id": "ow_9",
+                    "action_id": "ow_9:create:0",
+                    "plan_id": "plan_9",
+                },
+                data={"qty": 0.12, "price": 2500.0},
+            ),
+            _monitor_row(
+                event_type="execution.create_failed",
+                cycle_id="cy_9",
+                seq=4,
+                ts=1300,
+                symbol="ETH/USDT:USDT",
+                pside="long",
+                side="buy",
+                status="failed",
+                reason_code="exchange_exception",
+                ids={
+                    "order_wave_id": "ow_9",
+                    "action_id": "ow_9:create:0",
+                    "plan_id": "plan_9",
+                },
+            ),
+            _monitor_row(
+                event_type="remote_call.succeeded",
+                cycle_id="cy_9",
+                seq=5,
+                ts=1400,
+                status="succeeded",
+                reason_code="authoritative_refresh",
+                ids={
+                    "remote_call_id": "rc_9",
+                    "remote_call_group_id": "cy_9:authoritative",
+                },
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                cycle_id="cy_9",
+                seq=6,
+                ts=1500,
+                status="succeeded",
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                cycle_id="cy_10",
+                seq=7,
+                ts=1600,
+                status="succeeded",
+            ),
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        cycle_id="cy_9",
+        cycle_trace=True,
+        include_data=True,
+        limit=2,
+    )
+
+    assert report["cycle"]["matched_events"] == 6
+    trace = report["cycle"]["cycle_trace"]
+    assert trace["matched_cycle_events"] == 6
+    assert trace["cycle_count"] == 1
+    assert trace["missing_cycle_id_event_count"] == 0
+    cycle = trace["cycles"][0]
+    assert cycle["cycle_id"] == "cy_9"
+    assert cycle["event_count"] == 6
+    assert cycle["events_truncated"] is True
+    assert cycle["first_ts"] == 1000
+    assert cycle["last_ts"] == 1500
+    assert [event["event_type"] for event in cycle["timeline"]] == [
+        "cycle.started",
+        "rust_orchestrator.called",
+    ]
+    assert cycle["timeline"][1]["data"] == {"seq": 2}
+
+    summary = cycle["trace_summary"]
+    assert summary["matched_events"] == 6
+    assert summary["statuses"] == {"failed": 1, "started": 3, "succeeded": 2}
+    assert summary["reason_codes"] == {
+        "authoritative_refresh": 1,
+        "exchange_exception": 1,
+        "submitted_to_exchange": 1,
+        "test": 3,
+    }
+    assert summary["ids"]["cycle_id"] == [{"id": "cy_9", "events": 6}]
+    assert summary["ids"]["order_wave_id"] == [{"id": "ow_9", "events": 2}]
+    assert summary["ids"]["plan_id"] == [{"id": "plan_9", "events": 3}]
+    assert summary["ids"]["remote_call_group_id"] == [
+        {"id": "cy_9:authoritative", "events": 1}
+    ]
+
+    order_trace = cycle["order_trace"]
+    assert order_trace["matched_order_events"] == 2
+    assert order_trace["order_wave_count"] == 1
+    wave = order_trace["order_waves"][0]
+    assert wave["order_wave_id"] == "ow_9"
+    assert wave["event_count"] == 2
+    assert wave["actions"][0]["action_id"] == "ow_9:create:0"
+    assert wave["actions"][0]["latest_status"] == "failed"
+
+
 def test_live_event_query_cli_accepts_trace_summary(tmp_path, capsys):
     events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
     _write_ndjson(
@@ -1101,6 +1235,63 @@ def test_live_event_query_cli_accepts_order_trace(tmp_path, capsys):
     trace = report["query"]["order_trace"]
     assert trace["matched_order_events"] == 2
     assert trace["order_waves"][0]["actions"][0]["latest_status"] == "failed"
+
+
+def test_live_event_query_cli_accepts_cycle_trace(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.started",
+                cycle_id="cy_7",
+                seq=1,
+                ts=1000,
+                status="started",
+            ),
+            _monitor_row(
+                event_type="execution.create_sent",
+                cycle_id="cy_7",
+                seq=2,
+                ts=1100,
+                status="started",
+                ids={"order_wave_id": "ow_7", "action_id": "ow_7:create:0"},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                cycle_id="cy_8",
+                seq=3,
+                ts=1200,
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                cycle_id=None,
+                seq=4,
+                ts=1300,
+                status="failed",
+                ids={"remote_call_id": "rc_unscoped"},
+            ),
+        ],
+    )
+
+    assert (
+        live_event_query.main(
+            [str(tmp_path / "monitor"), "--cycle-trace", "--limit", "1"]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    trace = report["query"]["cycle_trace"]
+    assert trace["matched_cycle_events"] == 3
+    assert trace["cycle_count"] == 2
+    assert trace["missing_cycle_id_event_count"] == 1
+    assert trace["missing_cycle_id_events"][0]["event_type"] == "remote_call.failed"
+    cycles = {item["cycle_id"]: item for item in trace["cycles"]}
+    assert cycles["cy_7"]["event_count"] == 2
+    assert cycles["cy_7"]["events_truncated"] is True
+    assert cycles["cy_7"]["order_trace"]["matched_order_events"] == 1
+    assert cycles["cy_8"]["event_count"] == 1
 
 
 def test_live_event_query_cli_defaults_to_current_only_for_directory_scans(


### PR DESCRIPTION
## Summary
- add `passivbot tool live-event-query --cycle-trace`
- group matched live events by `cycle_id` with bounded timeline samples
- embed aggregate trace summaries and nested order traces per cycle
- keep this as offline operator tooling over existing monitor events; no live event emission or trading behavior changes

## Validation
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_query.py -q`
- `PYTHONPATH=src ./venv/bin/python -m compileall src/live/event_query.py src/tools/live_event_query.py tests/test_live_event_query.py`
- `git diff --check`
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_query.py tests/test_passivbot_cli.py -q`
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_query.py tests/test_live_incident_bundle.py tests/test_live_smoke_report.py -q`
- silent-handling scan on touched Python files
- `PYTHONPATH=src ./venv/bin/python -m tools.live_event_query --help`
