### PR TITLE
Update live logging progress after cycle trace

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,12 +19,12 @@ Last updated: 2026-06-25.
 
 Current `origin/v8` logging-overhaul head:
 
-- `b9f42ebd` merge of PR #651, `Add live event order trace view`.
+- `ff493541` merge of PR #654, `Add live event cycle trace view`.
 
 VPS5 deployment status:
 
 - Deployed through PR #642 at `ad36d8ea`.
-- PRs #643-#651 are merged to `v8`; VPS5 pull/restart and live smoke are next
+- PRs #643-#654 are merged to `v8`; VPS5 pull/restart and live smoke are next
   when explicitly authorized.
 
 ## Phase Checklist
@@ -38,7 +38,7 @@ VPS5 deployment status:
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
-| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, `live-smoke-report` startup baselines, incident bundle, ID filters | Richer cycle replay and cross-bot incident workflow |
+| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, `live-smoke-report` startup baselines, incident bundle, ID filters | Incident-bundle integration and cross-bot workflow |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup | Continue separate reviewed PRs for shutdown/warmup improvements |
 
 ## Merged Slices
@@ -266,14 +266,38 @@ VPS5 deployment status:
   counts, confirmation events, symbol/pside/side sets, and bounded event
   samples with shortened order/client-order references.
 
+### PR #652: Order Trace Progress Update
+
+- Branch: `codex/v8-progress-after-order-trace`.
+- Scope: process tracking.
+- Result: updated this progress ledger and the live operations backlog after
+  PR #651 merged.
+
+### PR #653: Live Event Registry Documentation
+
+- Branch: `codex/v8-reason-code-registry-docs`.
+- Scope: event taxonomy documentation and drift prevention.
+- Result: added `docs/ai/live_event_registry.md` for stable event tags and
+  reason codes, linked it from the AI docs router/logging guide, and added a
+  doc drift test that compares documented values to `EventTags`/`ReasonCodes`.
+
+### PR #654: Live Event Cycle Trace View
+
+- Branch: `codex/v8-live-event-cycle-trace`.
+- Scope: operator query tooling.
+- Result: added `passivbot tool live-event-query --cycle-trace` to reconstruct
+  matched events by `cycle_id`. Each cycle contains bounded timeline samples,
+  aggregate trace summaries, and nested order traces using the existing order
+  lifecycle reconstruction.
+
 ## Current Next Steps
 
 1. Pull merged `v8` on VPS5 and restart bots, if explicitly authorized, so PRs
-   #643-#651 are exercised by live processes.
+   #643-#654 are exercised by live processes.
 2. Verify `health.summary` includes resource pressure and event-pipeline fields,
    verify event-projected console summaries stay readable, and verify
    `live-smoke-report` shows startup timing baselines and `live-event-query
-   --order-trace` reconstructs recent order waves.
+   --order-trace`/`--cycle-trace` reconstruct recent order waves and cycles.
 3. Continue Phase 5 by migrating one high-value stdlib text log family to
-   structured-event projection, or add richer cycle reconstruction if live smoke
+   structured-event projection, or add incident-bundle integration if live smoke
    shows that query tooling is still the sharper need.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -45,10 +45,11 @@ Related detailed plans:
    id, order wave id, remote call id/group id, bot id, snapshot id, plan id,
    action id, symbol, pside, reason code, and status. It also supports
    aggregate trace summaries over matched events and order waves, plus a
-   dedicated order-trace reconstruction view for order waves/actions.
+   dedicated order-trace reconstruction view for order waves/actions and a
+   cycle-trace reconstruction view with nested order traces.
 
-   Remaining refinements: richer cycle reconstruction and incident-bundle
-   integration.
+   Remaining refinements: incident-bundle integration and cross-bot incident
+   workflow.
 
 3. [ ] Live restart/smoke automation.
    Status: partial. The read-only `live-smoke-report` tool exists, but the safe
@@ -148,8 +149,13 @@ Related detailed plans:
     refresh, confirmation, and fill. The target is that any create/cancel/missing
     order can be reconstructed from one id without reading code.
 
-    Remaining refinements: add richer cycle-level reconstruction and incident
-    bundle integration as the event stream gains more producer coverage.
+    Work log:
+    - 2026-06-25: Added `live-event-query --cycle-trace`, grouping matched
+      events by `cycle_id` with bounded timeline samples, aggregate trace
+      summaries, and nested order traces.
+
+    Remaining refinements: add incident bundle integration and keep tightening
+    producer coverage as nearby event surfaces are touched.
 
 12. [ ] Debug profile toggles.
     Status: open.
@@ -192,10 +198,12 @@ Related detailed plans:
 | 2026-06-25 | #2 Event query and timeline CLI extensions | PR #642 / `ad36d8ea` | Added bot/snapshot/plan/action/remote-call-group filters and shared ID-key timeline rendering; VPS5 query smoke passed | Richer reconstruction views |
 | 2026-06-25 | #2/#11 Event query and order trace summaries | PR #648 / `774bcf74` | Added `live-event-query --trace-summary` aggregate counts across matched events, ID scopes, symbols, sides, and order waves | Full create/cancel/missing-order reconstruction view |
 | 2026-06-25 | #2/#11 Event query and order trace completeness | PR #651 / `b9f42ebd` | Added `live-event-query --order-trace` reconstruction grouped by order wave and action, with confirmation events and bounded samples | Richer cycle reconstruction and incident-bundle integration |
+| 2026-06-25 | #2/#11 Event query and cycle trace completeness | PR #654 / `ff493541` | Added `live-event-query --cycle-trace` reconstruction grouped by cycle id, with bounded timelines, aggregate summaries, and nested order traces | Incident-bundle integration and cross-bot workflow |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |
 | 2026-06-25 | #9 Reason-code registry | PR #645 / `31263bb9` | Added shared `EventTags` and `ReasonCodes` registries and migrated representative live event emitters without changing emitted strings | Continue migrating stable literals as nearby event surfaces are touched |
+| 2026-06-25 | #9 Reason-code registry | PR #653 / `f0a0f744` | Added focused AI docs for live event tags/reason codes and a doc drift test against the code registry | Continue migrating stable literals as nearby event surfaces are touched |
 | 2026-06-25 | #10 Operator console redesign from events | PR #646 / `521832cc` | Improved event-projected console/text summaries for already-routed execution events without changing routes or console event volume | Migrate high-value stdlib text logs to structured-event projections |
 | 2026-06-24 | Operational restart goals | PR #619 / `e71c4f6c` | Improved shutdown progress and bounded shutdown cancel grace coverage | Broader interruptible shutdown contract remains separate work |
 | 2026-06-24 | Operational restart goals | PR #622 / `29eba387` | Improved live startup warm-cache reuse | Deeper cache doctor and budget tracking remain open |
@@ -204,7 +212,7 @@ Related detailed plans:
 
 Near-term highest leverage:
 
-1. Richer cycle reconstruction on top of `live-event-query`.
+1. Incident-bundle integration with `live-event-query` trace outputs.
 2. Live restart/smoke automation.
 3. Startup phase budget tracking.
 4. Operator console redesign from events.


### PR DESCRIPTION
## Summary
- record merged PRs #652, #653, and #654 in the logging progress ledger
- update the live ops backlog now that cycle trace reconstruction is merged
- refresh next-step notes toward incident-bundle trace integration and explicit VPS smoke authorization

## Validation
- `git diff --check`

Docs/progress-only; no trading behavior, event emission, or query runtime changes.
