### PR TITLE
Add local cache integrity doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool cache-integrity-doctor` for read-only local cache smoke
+  reports covering root presence, file counts/sizes, and empty or corrupt
+  JSON/NDJSON/NPY artifacts.
 - Added `passivbot tool live-event-query --cycle-trace` for offline cycle
   reconstruction grouped by cycle id, including bounded timeline samples,
   aggregate event summaries, and nested order traces.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -107,6 +107,7 @@ passivbot tool iterative-history-plot backtests/.../fills.csv
 - `passivbot tool pad-historical-daily` – Ensures daily OHLCV shards are present for the downloader when new coins are added.
 - `passivbot tool verify-hlcvs-data` – Validates prepared HLCV datasets and coverage metadata before long optimizations/backtests.
 - `passivbot tool streamline-json` – Normalizes/compacts JSON configs (`passivbot tool streamline-json configs/examples/default_trailing_martingale_long_npos4.json`).
+- `passivbot tool cache-integrity-doctor` – Read-only local cache smoke report for missing roots, file counts/sizes, and empty or corrupt JSON/NDJSON/NPY artifacts.
 - `passivbot tool candle-doctor` – Audits legacy `caches/ohlcv/...` shards for corruption, stale index entries, and legacy-format issues; add `--fix` to apply automatic repairs before importing into the v2 store.
 - `passivbot tool migrate-historical-data` – Converts legacy `historical_data/ohlcvs_<exchange>/...` shards into the current `caches/ohlcv/...` layout.
 

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -46,6 +46,11 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "audit candle caches (requires full install)",
         requires_full=True,
     ),
+    "cache-integrity-doctor": CommandSpec(
+        "tools.cache_integrity_doctor",
+        "read-only local cache integrity smoke report (requires full install)",
+        requires_full=True,
+    ),
     "crash-finder": CommandSpec(
         "tools.crash_finder",
         "scan local OHLCV cache for crash-window suite scenarios (requires full install)",

--- a/src/tools/cache_integrity_doctor.py
+++ b/src/tools/cache_integrity_doctor.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+
+NUMPY_CACHE_SUFFIXES = {".npy"}
+DEFAULT_ROOTS = ("caches",)
+
+
+def _issue(severity: str, code: str, path: Path, message: str) -> dict[str, str]:
+    return {
+        "severity": severity,
+        "code": code,
+        "path": str(path),
+        "message": message,
+    }
+
+
+def _empty_file_issue(path: Path) -> dict[str, str] | None:
+    try:
+        if path.stat().st_size == 0:
+            return _issue("warning", "empty_file", path, "cache file is empty")
+    except OSError as exc:
+        return _issue("error", "stat_failed", path, f"could not stat file: {exc}")
+    return None
+
+
+def _inspect_json_file(path: Path) -> list[dict[str, str]]:
+    empty = _empty_file_issue(path)
+    if empty is not None:
+        return [empty]
+    try:
+        json.loads(path.read_text(encoding="utf-8"))
+    except UnicodeDecodeError as exc:
+        return [_issue("error", "json_decode_failed", path, f"invalid UTF-8: {exc}")]
+    except json.JSONDecodeError as exc:
+        return [
+            _issue(
+                "error",
+                "json_decode_failed",
+                path,
+                f"invalid JSON at line {exc.lineno} column {exc.colno}: {exc.msg}",
+            )
+        ]
+    except OSError as exc:
+        return [_issue("error", "read_failed", path, f"could not read file: {exc}")]
+    return []
+
+
+def _inspect_ndjson_file(path: Path) -> list[dict[str, str]]:
+    empty = _empty_file_issue(path)
+    if empty is not None:
+        return [empty]
+    issues: list[dict[str, str]] = []
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line_no, line in enumerate(handle, start=1):
+                raw = line.strip()
+                if not raw:
+                    continue
+                try:
+                    json.loads(raw)
+                except json.JSONDecodeError as exc:
+                    issues.append(
+                        _issue(
+                            "error",
+                            "ndjson_decode_failed",
+                            path,
+                            f"invalid NDJSON at line {line_no} column {exc.colno}: {exc.msg}",
+                        )
+                    )
+                    break
+    except UnicodeDecodeError as exc:
+        return [_issue("error", "ndjson_decode_failed", path, f"invalid UTF-8: {exc}")]
+    except OSError as exc:
+        return [_issue("error", "read_failed", path, f"could not read file: {exc}")]
+    return issues
+
+
+def _inspect_npy_file(path: Path) -> list[dict[str, str]]:
+    empty = _empty_file_issue(path)
+    if empty is not None:
+        return [empty]
+    try:
+        import numpy as np
+    except ImportError as exc:
+        return [
+            _issue(
+                "warning",
+                "npy_check_unavailable",
+                path,
+                f"numpy unavailable; skipped NPY validation: {exc}",
+            )
+        ]
+    try:
+        arr = np.load(path, mmap_mode="r", allow_pickle=False)
+        _ = arr.shape
+        _ = str(arr.dtype)
+    except (OSError, ValueError, EOFError, AttributeError, TypeError) as exc:
+        return [_issue("error", "npy_load_failed", path, f"could not load NPY: {exc}")]
+    return []
+
+
+def _inspect_file(path: Path) -> list[dict[str, str]]:
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return _inspect_json_file(path)
+    if suffix == ".ndjson":
+        return _inspect_ndjson_file(path)
+    if suffix in NUMPY_CACHE_SUFFIXES:
+        return _inspect_npy_file(path)
+    return []
+
+
+def _scan_root(root: Path) -> tuple[dict[str, Any], list[dict[str, str]]]:
+    summary: dict[str, Any] = {
+        "path": str(root),
+        "exists": root.exists(),
+        "is_dir": root.is_dir(),
+        "file_count": 0,
+        "dir_count": 0,
+        "total_bytes": 0,
+        "by_extension": {},
+    }
+    issues: list[dict[str, str]] = []
+    if not root.exists():
+        issues.append(
+            _issue("warning", "root_missing", root, "cache root does not exist")
+        )
+        return summary, issues
+    if not root.is_dir():
+        issues.append(
+            _issue("error", "root_not_directory", root, "cache root is not a directory")
+        )
+        return summary, issues
+    try:
+        entries = list(root.rglob("*"))
+    except OSError as exc:
+        issues.append(
+            _issue("error", "root_scan_failed", root, f"could not scan root: {exc}")
+        )
+        return summary, issues
+
+    by_extension: Counter[str] = Counter()
+    for entry in entries:
+        if entry.is_dir():
+            summary["dir_count"] += 1
+            continue
+        if not entry.is_file():
+            continue
+        summary["file_count"] += 1
+        suffix = entry.suffix.lower() or "<none>"
+        by_extension[suffix] += 1
+        try:
+            summary["total_bytes"] += entry.stat().st_size
+        except OSError as exc:
+            issues.append(
+                _issue("error", "stat_failed", entry, f"could not stat file: {exc}")
+            )
+            continue
+        issues.extend(_inspect_file(entry))
+    summary["by_extension"] = dict(sorted(by_extension.items()))
+    return summary, issues
+
+
+def build_cache_integrity_report(roots: Iterable[str | Path]) -> dict[str, Any]:
+    root_paths = [Path(root).expanduser() for root in roots]
+    root_reports: list[dict[str, Any]] = []
+    issues: list[dict[str, str]] = []
+    for root in root_paths:
+        root_report, root_issues = _scan_root(root)
+        root_reports.append(root_report)
+        issues.extend(root_issues)
+    by_severity: Counter[str] = Counter()
+    for item in issues:
+        by_severity[item["severity"]] += 1
+    summary = {
+        "root_count": len(root_reports),
+        "file_count": sum(int(root["file_count"]) for root in root_reports),
+        "dir_count": sum(int(root["dir_count"]) for root in root_reports),
+        "total_bytes": sum(int(root["total_bytes"]) for root in root_reports),
+        "issue_count": len(issues),
+        "by_severity": dict(sorted(by_severity.items())),
+    }
+    return {
+        "ok": "error" not in by_severity,
+        "summary": summary,
+        "roots": root_reports,
+        "issues": issues,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="passivbot tool cache-integrity-doctor",
+        description=(
+            "Read-only local cache integrity smoke report for JSON, NDJSON, and NPY files."
+        ),
+    )
+    parser.add_argument(
+        "roots",
+        nargs="*",
+        default=list(DEFAULT_ROOTS),
+        help="Cache root directories to scan. Defaults to caches.",
+    )
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="Emit compact single-line JSON.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    report = build_cache_integrity_report(args.roots)
+    print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cache_integrity_doctor.py
+++ b/tests/test_cache_integrity_doctor.py
@@ -1,0 +1,83 @@
+import json
+import os
+import sys
+
+import numpy as np
+
+import passivbot_cli.main as cli_main
+from tools.cache_integrity_doctor import build_cache_integrity_report, main
+
+
+def test_cache_integrity_report_counts_files_and_flags_corrupt_artifacts(tmp_path):
+    root = tmp_path / "caches"
+    root.mkdir()
+    (root / "markets.json").write_text(json.dumps({"BTC": {}}), encoding="utf-8")
+    (root / "bad.json").write_text("{bad json", encoding="utf-8")
+    (root / "events.ndjson").write_text(
+        json.dumps({"ok": True}) + "\n{bad ndjson\n",
+        encoding="utf-8",
+    )
+    (root / "empty.ndjson").write_text("", encoding="utf-8")
+    np.save(root / "prices.npy", np.array([1.0, 2.0]))
+    (root / "corrupt.npy").write_bytes(b"not a numpy file")
+
+    report = build_cache_integrity_report([root])
+
+    assert report["ok"] is False
+    assert report["summary"]["file_count"] == 6
+    assert report["roots"][0]["by_extension"] == {
+        ".json": 2,
+        ".ndjson": 2,
+        ".npy": 2,
+    }
+    issues = {(issue["code"], issue["path"]) for issue in report["issues"]}
+    assert ("json_decode_failed", str(root / "bad.json")) in issues
+    assert ("ndjson_decode_failed", str(root / "events.ndjson")) in issues
+    assert ("empty_file", str(root / "empty.ndjson")) in issues
+    assert ("npy_load_failed", str(root / "corrupt.npy")) in issues
+
+
+def test_cache_integrity_report_marks_missing_root_as_warning(tmp_path):
+    missing = tmp_path / "missing"
+
+    report = build_cache_integrity_report([missing])
+
+    assert report["ok"] is True
+    assert report["summary"]["by_severity"] == {"warning": 1}
+    assert report["issues"][0]["code"] == "root_missing"
+
+
+def test_cache_integrity_doctor_cli_emits_json(tmp_path, capsys):
+    root = tmp_path / "caches"
+    root.mkdir()
+    (root / "cache_meta.json").write_text(json.dumps({"ok": True}), encoding="utf-8")
+
+    rc = main([str(root), "--compact"])
+
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["ok"] is True
+    assert report["summary"]["file_count"] == 1
+
+
+def test_cache_integrity_doctor_tool_dispatch_forwards_module_and_prog(monkeypatch):
+    captured = {}
+
+    def fake_invoke_module_main(module_name):
+        captured["module_name"] = module_name
+        captured["argv"] = sys.argv[:]
+        captured["prog_env"] = os.environ["PASSIVBOT_CLI_PROG"]
+        return True, 0
+
+    monkeypatch.setattr(cli_main, "_invoke_module_main", fake_invoke_module_main)
+    monkeypatch.setattr(cli_main, "_missing_full_install_markers", lambda: [])
+
+    assert cli_main.main(["tool", "cache-integrity-doctor", "caches", "--compact"]) == 0
+
+    assert captured["module_name"] == "tools.cache_integrity_doctor"
+    assert captured["argv"] == [
+        "passivbot tool cache-integrity-doctor",
+        "caches",
+        "--compact",
+    ]
+    assert captured["prog_env"] == "passivbot tool cache-integrity-doctor"


### PR DESCRIPTION
## Summary
- add read-only passivbot tool cache-integrity-doctor for local cache smoke reports
- report cache root presence, file/dir counts, total bytes, extension counts, and empty/corrupt JSON/NDJSON/NPY artifacts
- document the tool and add focused scanner/CLI tests

## Validation
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_cache_integrity_doctor.py -q
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/tools/cache_integrity_doctor.py tests/test_cache_integrity_doctor.py
- git diff --check
- rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])\)" src/tools/cache_integrity_doctor.py tests/test_cache_integrity_doctor.py

No ssh, tmux, screen, VPS/live-bot, passivbot live, process kill/restart, deploy, remote probe, or exchange-facing commands were run.