### PR TITLE
Improve backtest CLI help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Improved `passivbot backtest --help-all` descriptions for high-impact
+  runtime/config overrides, including plot groups, suite aggregation,
+  HLCV dataset replay modes, HSL modes, and TWEL/WEL policy flags.
 - Added `passivbot tool live-event-query --cycle-trace` for offline cycle
   reconstruction grouped by cycle id, including bounded timeline samples,
   aggregate event summaries, and nested order traces.

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -156,6 +156,12 @@ from tools.event_loop_policy import set_windows_event_loop_policy
 
 PLOT_GROUP_SUMMARY = {"balance", "twe", "pnl", "hard_stop"}
 PLOT_GROUP_ALL = PLOT_GROUP_SUMMARY | {"coin_fills"}
+DISABLE_PLOTTING_HELP = (
+    "Disable selected plot groups. Use without a value to disable all plotting. "
+    "Allowed values: all, summary, balance, twe, pnl, hard_stop, coin_fills, "
+    "or a comma-separated combination. summary disables balance, twe, pnl, "
+    "and hard_stop; coin_fills disables per-coin fill plots only."
+)
 HLCVS_CACHE_ROOT = Path("caches") / "hlcvs_data"
 HLCVS_CACHE_HASH_LEN = 16
 HLCVS_CACHE_DIR_SEP = "__"
@@ -2618,10 +2624,7 @@ async def main():
         nargs="?",
         const="all",
         default=None,
-        help=(
-            "Disable selected plot groups. Use without a value to disable all plotting. "
-            "Allowed values: all, summary, balance, twe, pnl, coin_fills, or a comma-separated combination."
-        ),
+        help=DISABLE_PLOTTING_HELP,
     )
     runtime_group.add_argument(
         "--cm-debug",

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -1071,7 +1071,11 @@ RESERVED_CLI_ARGS = {
             "backtest": "Backtest Runtime",
             "optimize": "Backtest Runtime",
         },
-        "help": "HSL signal mode: unified, pside, or coin.",
+        "help": (
+            "HSL signal mode. unified uses one account-level strategy signal for both "
+            "sides; pside tracks long/short independently; coin tracks each coin+side "
+            "slot and panic-closes only the affected slot."
+        ),
     },
     "live.time_in_force": {
         "visible": ["--time-in-force", "-tif"],
@@ -1162,7 +1166,11 @@ RESERVED_CLI_ARGS = {
         "commands": {"backtest"},
         "group": {"backtest": "Backtest Runtime"},
         "choices": ("intersection", "dataset"),
-        "help": "How --hlcvs-data-dir chooses coins/range: intersection or dataset.",
+        "help": (
+            "How --hlcvs-data-dir chooses coins/range. intersection keeps the current "
+            "config clipped to the verified dataset; dataset adopts the dataset's "
+            "effective coins and timestamp window for exact artifact replay."
+        ),
     },
     "backtest.maker_fee_override": {
         "visible": ["--maker-fee-override"],
@@ -1201,10 +1209,14 @@ RESERVED_CLI_ARGS = {
         "visible": ["--aggregate-default"],
         "hidden": ["--backtest.aggregate.default", "--backtest_aggregate_default"],
         "type": str,
-        "metavar": "VALUE",
+        "metavar": "MODE",
         "commands": {"backtest"},
         "group": {"backtest": "Suite"},
-        "help": "Suite-only: default aggregation to use for scenario metrics.",
+        "help": (
+            "Suite-only default aggregation for scenario metrics. Allowed modes: "
+            "mean, min, max, std, median. Metric-specific backtest.aggregate entries "
+            "override this default."
+        ),
     },
     "optimize.iters": {
         "visible": ["--iters", "-i"],
@@ -1358,7 +1370,146 @@ def _argument_metavar(type_, full_name: str, value):
     return "VALUE"
 
 
+CLI_HELP_OVERRIDES = {
+    "backtest.scenarios": (
+        "Suite scenario definitions. Use --scenarios to select labels; use "
+        "--suite-config for complex scenario files. Scenario entries support "
+        "label, start_date, end_date, coins, ignored_coins, exchanges, "
+        "coin_sources, and overrides."
+    ),
+    "backtest.balance_sample_divider": (
+        "Minutes per saved balance/equity sample. 1 keeps per-minute series; "
+        "higher values thin balance_and_equity.csv.gz and related plots."
+    ),
+    "backtest.btc_collateral_cap": (
+        "Target and ceiling share of equity held as BTC collateral. 0 keeps "
+        "USD-only; 1 targets fully BTC collateral; values >1 allow leveraged "
+        "BTC collateral."
+    ),
+    "backtest.btc_collateral_ltv_cap": (
+        "Optional USD-debt/equity cap while topping up BTC collateral. Leave "
+        "unset for no LTV cap."
+    ),
+    "backtest.compress_cache": (
+        "Compress generated backtest cache artifacts to save disk. Set n/false "
+        "for faster reloads with larger files."
+    ),
+    "backtest.dynamic_wel_by_tradability": (
+        "Backtest-only WEL denominator mode. y grows the denominator with the "
+        "max tradable coin count seen so far; n uses fixed live-style "
+        "n_positions."
+    ),
+    "backtest.filter_by_min_effective_cost": (
+        "Skip coins whose projected initial entry is below the exchange "
+        "effective min cost. y improves live parity; n allows oversized "
+        "min-cost entries."
+    ),
+    "backtest.gap_tolerance_ohlcvs_minutes": (
+        "Largest internal candle gap, in minutes, that preparation may "
+        "tolerate or repair before excluding the affected tradable window."
+    ),
+    "backtest.ohlcv_source_dir": (
+        "Import legacy OHLCV shards before remote fetches. Expected layout: "
+        "<dir>/<exchange>/1m/<coin_or_symbol>/YYYY-MM-DD.npz or .npy."
+    ),
+    "live.max_warmup_minutes": (
+        "Hard cap on calculated EMA/history warmup minutes for backtests and "
+        "live. 0 disables the cap."
+    ),
+    "backtest.base_dir": "Directory where standalone backtest results are written.",
+    "backtest.volume_normalization": (
+        "Normalize volume across exchanges for combined datasets. Leave enabled "
+        "for comparable combined-exchange backtests."
+    ),
+    "backtest.liquidation_threshold": (
+        "Early-stop equity floor as a fraction of starting balance. Must "
+        "satisfy 0 <= x < 1; 0.05 stops once equity is <= 5 percent of start."
+    ),
+    "backtest.market_order_slippage_pct": (
+        "Backtest-only simulated market-order slippage as part-per-one. Applies "
+        "to market-promoted orders and market HSL panic closes; not a live "
+        "slippage cap."
+    ),
+    "backtest.suite_enabled": (
+        "Enable suite mode from config. CLI --suite y/n overrides it for one run."
+    ),
+    "backtest.visible_metrics": (
+        "Terminal metric visibility config. null uses optimize scoring/limits; "
+        "[] shows all; a list adds named metrics. Full analysis is still saved."
+    ),
+    "config_version": "Config schema version. Canonical V8 configs use v8.0.0.",
+}
+
+for _pside in ("long", "short"):
+    CLI_HELP_OVERRIDES.update(
+        {
+            f"bot.{_pside}.hsl.enabled": f"Enable HSL for the {_pside} side.",
+            f"bot.{_pside}.hsl.red_threshold": (
+                f"RED drawdown trigger for {_pside} HSL, as part-per-one."
+            ),
+            f"bot.{_pside}.hsl.ema_span_minutes": (
+                f"EMA span, in minutes, for the {_pside} HSL drawdown signal."
+            ),
+            f"bot.{_pside}.hsl.cooldown_minutes_after_red": (
+                f"Minutes to wait after {_pside} HSL RED is flattened before "
+                "restart is allowed."
+            ),
+            f"bot.{_pside}.hsl.no_restart_drawdown_threshold": (
+                f"Terminal {_pside} HSL drawdown threshold. Values below "
+                "red_threshold are clamped up to red_threshold."
+            ),
+            f"bot.{_pside}.hsl.tier_ratios.yellow": (
+                f"Multiplier of red_threshold used for the {_pside} YELLOW HSL tier."
+            ),
+            f"bot.{_pside}.hsl.tier_ratios.orange": (
+                f"Multiplier of red_threshold used for the {_pside} ORANGE HSL tier."
+            ),
+            f"bot.{_pside}.hsl.orange_tier_mode": (
+                "Allowed values: graceful_stop or "
+                "tp_only_with_active_entry_cancellation. Controls ORANGE-tier "
+                f"behavior for the {_pside} side."
+            ),
+            f"bot.{_pside}.hsl.panic_close_order_type": (
+                "Allowed values: limit or market. market uses "
+                "backtest.market_order_slippage_pct and taker fees in backtests."
+            ),
+            f"bot.{_pside}.risk.total_exposure_entry_gate_enabled": (
+                f"Enable the {_pside} TWEL entry cap for bot-generated entries."
+            ),
+            f"bot.{_pside}.risk.total_exposure_enforcer_enabled": (
+                f"Enable {_pside} TWEL auto-reduce repair for already-over-target "
+                "same-side exposure."
+            ),
+            f"bot.{_pside}.risk.total_exposure_enforcer_policy": (
+                "Allowed values: reduce_overweight or reduce_portfolio. Controls "
+                f"which managed {_pside} positions TWEL auto-reduce may trim."
+            ),
+            f"bot.{_pside}.risk.total_exposure_enforcer_threshold": (
+                f"Fraction of {_pside} TWEL used by entry gating and TWEL "
+                "auto-reduce repair."
+            ),
+            f"bot.{_pside}.risk.we_excess_allowance_mode": (
+                "Allowed values: bounded or legacy_raw. bounded caps per-symbol "
+                "excess by side TWEL; legacy_raw preserves raw v7-style allowance."
+            ),
+            f"bot.{_pside}.risk.we_excess_allowance_pct": (
+                f"Per-symbol allowance above the configured {_pside} WEL before "
+                "position exposure trimming."
+            ),
+            f"bot.{_pside}.risk.n_positions": (
+                f"Target number of concurrent {_pside} position slots."
+            ),
+            f"bot.{_pside}.risk.total_wallet_exposure_limit": (
+                f"Total wallet exposure limit for the {_pside} side."
+            ),
+        }
+    )
+
+
 def _argument_help_text(full_name: str, appendix: str) -> str:
+    override = CLI_HELP_OVERRIDES.get(full_name)
+    if override is not None:
+        return override
     base = f"Override {full_name}."
     if appendix:
         return f"{base} {appendix}".strip()

--- a/tests/test_backtest_analysis.py
+++ b/tests/test_backtest_analysis.py
@@ -8,6 +8,7 @@ import backtest as bt
 import plotting
 from backtest import (
     BacktestPayload,
+    DISABLE_PLOTTING_HELP,
     calc_backtest_completion_ratio,
     execute_backtest,
     expand_analysis,
@@ -883,6 +884,12 @@ def test_parse_disabled_plot_groups_accepts_summary_alias_and_commas():
         "hard_stop",
         "coin_fills",
     }
+
+
+def test_disable_plotting_help_lists_every_plot_group():
+    assert "hard_stop" in DISABLE_PLOTTING_HELP
+    assert "summary disables balance, twe, pnl, and hard_stop" in DISABLE_PLOTTING_HELP
+    assert "coin_fills disables per-coin fill plots only" in DISABLE_PLOTTING_HELP
 
 
 def test_create_forager_hard_stop_drawdown_figure_returns_plot_when_enabled(monkeypatch):

--- a/tests/test_config_utils_helpers.py
+++ b/tests/test_config_utils_helpers.py
@@ -1155,6 +1155,10 @@ def _format_parser_help_with_config(command: str, config: dict, help_all: bool) 
     return parser.format_help()
 
 
+def _single_line_help(help_text: str) -> str:
+    return " ".join(help_text.split())
+
+
 def test_optimize_default_help_groups_common_flags_and_hides_bounds():
     config = get_template_config()
     help_text = _format_parser_help_with_config("optimize", config, help_all=False)
@@ -1267,8 +1271,36 @@ def test_backtest_default_help_hides_optimize_flags_and_shows_suite_controls():
     assert "--market-order-near-touch-threshold FLOAT, -montt FLOAT" in help_text
     assert "--max-realized-loss-pct FLOAT, -mrlp FLOAT" in help_text
     assert "--pnls-max-lookback-days FLOAT|all, -pmld FLOAT|all" in help_text
-    assert "--aggregate-default VALUE" in help_text
+    assert "--aggregate-default MODE" in help_text
     assert "--iters INT, -i INT" not in help_text
+
+
+def test_backtest_help_all_describes_high_value_overrides():
+    config = get_template_config()
+    help_text = _single_line_help(
+        _format_parser_help_with_config("backtest", config, help_all=True)
+    )
+
+    assert "--aggregate-default MODE" in help_text
+    assert "Allowed modes: mean, min, max, std, median" in help_text
+    assert "Suite scenario definitions" in help_text
+    assert "use --suite-config for complex scenario files" in help_text
+    assert "intersection keeps the current config clipped to the verified dataset" in help_text
+    assert "dataset adopts the dataset's effective coins and timestamp window" in help_text
+    assert "Backtest-only WEL denominator mode" in help_text
+    assert "max tradable coin count seen so far" in help_text
+    assert "Early-stop equity floor as a fraction of starting balance" in help_text
+    assert "Backtest-only simulated market-order slippage" in help_text
+    assert "not a live slippage cap" in help_text
+    assert "Terminal metric visibility config" in help_text
+    assert "[] shows all; a list adds named metrics" in help_text
+    assert "Allowed values: graceful_stop or tp_only_with_active_entry_cancellation" in help_text
+    assert "Allowed values: limit or market" in help_text
+    assert "Allowed values: reduce_overweight or reduce_portfolio" in help_text
+    assert "Allowed values: bounded or legacy_raw" in help_text
+    assert "Override bot.long.hsl.orange_tier_mode." not in help_text
+    assert "Override bot.short.risk.we_excess_allowance_mode." not in help_text
+    assert "Override backtest.dynamic_wel_by_tradability." not in help_text
 
 
 def test_live_reserved_pnls_lookback_alias_parses_short_and_long():


### PR DESCRIPTION
## Summary
- expand high-value `passivbot backtest --help-all` descriptions for plot groups, suite aggregation, HLCV dataset replay, HSL modes, and TWEL/WEL policies
- add a targeted help override registry for selected schema-derived backtest config flags
- cover the new help text with focused parser/help tests

## Tests
- `./venv/bin/python -m pytest tests/test_config_utils_helpers.py tests/test_backtest_analysis.py`
- `env MPLCONFIGDIR=/private/tmp/passivbot_mpl COLUMNS=180 ./venv/bin/python - <<'PY' ... passivbot backtest --help-all checks ... PY`