### PR TITLE
Update live logging progress after cache doctor

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,12 +19,12 @@ Last updated: 2026-06-25.
 
 Current `origin/v8` logging-overhaul head:
 
-- `ff493541` merge of PR #654, `Add live event cycle trace view`.
+- `e65597c3` merge of PR #656, `Add local cache integrity doctor`.
 
 VPS5 deployment status:
 
 - Deployed through PR #642 at `ad36d8ea`.
-- PRs #643-#654 are merged to `v8`; VPS5 pull/restart and live smoke are next
+- PRs #643-#656 are merged to `v8`; VPS5 pull/restart and live smoke are next
   when explicitly authorized.
 
 ## Phase Checklist
@@ -39,7 +39,7 @@ VPS5 deployment status:
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
 | Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, `live-smoke-report` startup baselines, incident bundle, ID filters | Incident-bundle integration and cross-bot workflow |
-| Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup | Continue separate reviewed PRs for shutdown/warmup improvements |
+| Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup; PR #656 cache integrity smoke doctor | Continue separate reviewed PRs for shutdown/warmup/cache proof improvements |
 
 ## Merged Slices
 
@@ -290,14 +290,33 @@ VPS5 deployment status:
   aggregate trace summaries, and nested order traces using the existing order
   lifecycle reconstruction.
 
+### PR #655: Cycle Trace Progress Update
+
+- Branch: `codex/v8-progress-after-cycle-trace`.
+- Scope: process tracking.
+- Result: updated this progress ledger and the live operations backlog after
+  PRs #652-#654 merged.
+
+### PR #656: Local Cache Integrity Doctor
+
+- Branch: `codex/v8-cache-integrity-doctor-slice`.
+- Scope: adjacent operations tooling.
+- Result: added `passivbot tool cache-integrity-doctor`, a read-only local
+  cache smoke report for root presence, aggregate file/size counts, empty
+  files, and corrupt JSON/NDJSON/NPY artifacts. This is an initial cache-doctor
+  slice; it does not yet prove warm-cache coverage or HSL/fill metadata
+  compatibility.
+
 ## Current Next Steps
 
 1. Pull merged `v8` on VPS5 and restart bots, if explicitly authorized, so PRs
-   #643-#654 are exercised by live processes.
+   #643-#656 are exercised by live processes.
 2. Verify `health.summary` includes resource pressure and event-pipeline fields,
    verify event-projected console summaries stay readable, and verify
    `live-smoke-report` shows startup timing baselines and `live-event-query
    --order-trace`/`--cycle-trace` reconstruct recent order waves and cycles.
+   Also run `cache-integrity-doctor` on local cache roots as a read-only smoke
+   when live/VPS access is explicitly authorized.
 3. Continue Phase 5 by migrating one high-value stdlib text log family to
    structured-event projection, or add incident-bundle integration if live smoke
    shows that query tooling is still the sharper need.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -166,12 +166,21 @@ Related detailed plans:
     issue.
 
 13. [ ] Cache integrity doctor.
-    Status: open.
+    Status: partial. Initial read-only local cache smoke doctor merged.
 
     Add a read-only doctor for candle/fill/HSL caches that reports coverage,
     metadata compatibility, corrupted shards, suspicious gaps, synthetic/no-trade
     assumptions, and whether a short restart can safely use a warm-cache path.
     This supports the separate warm-cache restart work.
+
+    Work log:
+    - 2026-06-25: Added `passivbot tool cache-integrity-doctor`, which reports
+      local cache root presence, aggregate file/size counts, and empty/corrupt
+      JSON, NDJSON, and NPY artifacts without writing or touching live behavior.
+
+    Remaining refinements: add cache-family awareness, candle/fill/HSL metadata
+    compatibility checks, coverage windows, suspicious gap summaries, and
+    warm-cache reuse readiness without making trading decisions.
 
 14. [ ] Supervisor/process model.
     Status: open.
@@ -205,6 +214,7 @@ Related detailed plans:
 | 2026-06-25 | #9 Reason-code registry | PR #645 / `31263bb9` | Added shared `EventTags` and `ReasonCodes` registries and migrated representative live event emitters without changing emitted strings | Continue migrating stable literals as nearby event surfaces are touched |
 | 2026-06-25 | #9 Reason-code registry | PR #653 / `f0a0f744` | Added focused AI docs for live event tags/reason codes and a doc drift test against the code registry | Continue migrating stable literals as nearby event surfaces are touched |
 | 2026-06-25 | #10 Operator console redesign from events | PR #646 / `521832cc` | Improved event-projected console/text summaries for already-routed execution events without changing routes or console event volume | Migrate high-value stdlib text logs to structured-event projections |
+| 2026-06-25 | #13 Cache integrity doctor | PR #656 / `e65597c3` | Added read-only `cache-integrity-doctor` for local cache root presence, file counts/sizes, and corrupt JSON/NDJSON/NPY artifacts | Cache-family metadata, coverage windows, suspicious gaps, and warm-cache readiness |
 | 2026-06-24 | Operational restart goals | PR #619 / `e71c4f6c` | Improved shutdown progress and bounded shutdown cancel grace coverage | Broader interruptible shutdown contract remains separate work |
 | 2026-06-24 | Operational restart goals | PR #622 / `29eba387` | Improved live startup warm-cache reuse | Deeper cache doctor and budget tracking remain open |
 


### PR DESCRIPTION
## Summary
- record merged PR #656 in the logging progress ledger
- mark cache integrity doctor backlog item as partial with first read-only slice merged
- keep remaining cache-doctor work scoped to cache-family metadata, coverage windows, suspicious gaps, and warm-cache readiness

## Validation
- `git diff --check`

Docs/progress-only; no trading behavior, event emission, or runtime code changes.
