### PR TITLE
Add incident bundle trace reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added live-event trace summary and order-trace sections to
+  `passivbot tool live-incident-bundle` event reports, with
+  `--no-trace-report` for compact bundles.
 - Added `passivbot tool cache-integrity-doctor` for read-only local cache smoke
   reports covering root presence, file counts/sizes, and empty or corrupt
   JSON/NDJSON/NPY artifacts.

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -471,6 +471,45 @@ def _matched_segment_paths(*reports: dict[str, Any]) -> set[str]:
     return paths
 
 
+def _event_report_result_summary(event_report: dict[str, Any]) -> dict[str, Any]:
+    cycle = event_report.get("cycle")
+    query = event_report.get("query")
+    cycle_section = cycle if isinstance(cycle, dict) else None
+    query_section = query if isinstance(query, dict) else None
+    trace_section = cycle_section or query_section or {}
+
+    trace_summary = trace_section.get("trace_summary")
+    order_trace = trace_section.get("order_trace")
+    cycle_trace = trace_section.get("cycle_trace")
+    return {
+        "files_scanned": event_report.get("files_scanned"),
+        "live_events": event_report.get("live_events"),
+        "error_count": event_report.get("error_count"),
+        "warning_count": event_report.get("warning_count"),
+        "cycle_matched_events": (
+            cycle_section.get("matched_events") if cycle_section is not None else None
+        ),
+        "query_matched_events": (
+            query_section.get("matched_events") if query_section is not None else None
+        ),
+        "trace_summary_matched_events": (
+            trace_summary.get("matched_events")
+            if isinstance(trace_summary, dict)
+            else None
+        ),
+        "order_trace_matched_events": (
+            order_trace.get("matched_order_events")
+            if isinstance(order_trace, dict)
+            else None
+        ),
+        "cycle_trace_matched_events": (
+            cycle_trace.get("matched_cycle_events")
+            if isinstance(cycle_trace, dict)
+            else None
+        ),
+    }
+
+
 def _copy_event_segments(
     *,
     monitor_root: str | Path,
@@ -561,6 +600,7 @@ def build_live_incident_bundle(
     since_ms: int | None = None,
     until_ms: int | None = None,
     include_data: bool = False,
+    include_trace_report: bool = True,
     include_rotated: bool = False,
     include_event_segments: bool = True,
     max_events: int = 500,
@@ -598,6 +638,9 @@ def build_live_incident_bundle(
         include_data=include_data,
         include_rotated=include_rotated,
         timeline=True,
+        trace_summary=include_trace_report,
+        order_trace=include_trace_report,
+        cycle_trace=include_trace_report and cycle_id is not None,
     )
     window_report = _build_time_window_report(
         monitor_path,
@@ -655,6 +698,7 @@ def build_live_incident_bundle(
                     "until_ms": until_ms,
                     "include_rotated": include_rotated,
                     "include_data": include_data,
+                    "include_trace_report": include_trace_report,
                 }.items()
                 if value not in (None, [], "")
             },
@@ -696,22 +740,7 @@ def build_live_incident_bundle(
         "bundle_path": str(out_path),
         "bundle_version": BUNDLE_VERSION,
         "hard_failures": hard_failures,
-        "event_report": {
-            "files_scanned": event_report.get("files_scanned"),
-            "live_events": event_report.get("live_events"),
-            "error_count": event_report.get("error_count"),
-            "warning_count": event_report.get("warning_count"),
-            "cycle_matched_events": (
-                event_report.get("cycle", {}).get("matched_events")
-                if isinstance(event_report.get("cycle"), dict)
-                else None
-            ),
-            "query_matched_events": (
-                event_report.get("query", {}).get("matched_events")
-                if isinstance(event_report.get("query"), dict)
-                else None
-            ),
-        },
+        "event_report": _event_report_result_summary(event_report),
         "time_window": {
             "enabled": window_report.get("enabled"),
             "matched_events": window_report.get("matched_events"),

--- a/src/tools/live_incident_bundle.py
+++ b/src/tools/live_incident_bundle.py
@@ -103,6 +103,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Include each matched event's bounded data payload in compact event reports.",
     )
     parser.add_argument(
+        "--no-trace-report",
+        action="store_true",
+        help=(
+            "Do not include live-event-query trace summary/order-trace outputs "
+            "in the bundled event report."
+        ),
+    )
+    parser.add_argument(
         "--include-rotated",
         action="store_true",
         help="Also scan rotated/compressed monitor event segments.",
@@ -171,6 +179,7 @@ def main(argv: list[str] | None = None) -> int:
         since_ms=_parse_ms(args.since_ms),
         until_ms=_parse_ms(args.until_ms),
         include_data=bool(args.include_data),
+        include_trace_report=not bool(args.no_trace_report),
         include_rotated=bool(args.include_rotated),
         include_event_segments=not bool(args.no_event_segments),
         max_events=int(args.limit),

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -70,6 +70,22 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
                 ids={"cycle_id": "cy_1"},
             ),
             _monitor_row(
+                event_type="order_wave.started",
+                seq=3,
+                ts=1100,
+                ids={"cycle_id": "cy_1", "order_wave_id": "wave_1"},
+            ),
+            _monitor_row(
+                event_type="execution.create_sent",
+                seq=4,
+                ts=1200,
+                ids={
+                    "cycle_id": "cy_1",
+                    "order_wave_id": "wave_1",
+                    "action_id": "wave_1:create:0",
+                },
+            ),
+            _monitor_row(
                 event_type="remote_call.failed",
                 seq=2,
                 ts=2000,
@@ -125,7 +141,10 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
 
     assert report["ok"] is True
     assert report["bundle_path"] == str(output)
-    assert report["event_report"]["cycle_matched_events"] == 1
+    assert report["event_report"]["cycle_matched_events"] == 3
+    assert report["event_report"]["trace_summary_matched_events"] == 3
+    assert report["event_report"]["order_trace_matched_events"] == 2
+    assert report["event_report"]["cycle_trace_matched_events"] == 3
     assert report["time_window"]["matched_events"] == 1
     assert report["config_hashes"] == 1
     assert report["monitor_snapshots"] == 1
@@ -169,6 +188,15 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     assert redacted_snapshot["nested"]["url"] == "https://[redacted]@example.com/path"
     assert event_report["cycle"]["events"][0]["seq"] == 1
     assert "data" not in event_report["cycle"]["events"][0]
+    assert event_report["cycle"]["trace_summary"]["matched_events"] == 3
+    assert event_report["cycle"]["order_trace"]["matched_order_events"] == 2
+    assert event_report["cycle"]["cycle_trace"]["matched_cycle_events"] == 3
+    assert (
+        event_report["cycle"]["cycle_trace"]["cycles"][0]["order_trace"][
+            "matched_order_events"
+        ]
+        == 2
+    )
     assert window_report["events"][0]["seq"] == 2
     assert "remote_call.failed" in window_report["timeline"][0]
 
@@ -201,6 +229,7 @@ def test_live_incident_bundle_can_skip_logs_and_segments_from_cli(tmp_path, caps
                 "--logs-root",
                 "",
                 "--no-event-segments",
+                "--no-trace-report",
                 "--output",
                 str(output),
                 "--compact",
@@ -221,7 +250,10 @@ def test_live_incident_bundle_can_skip_logs_and_segments_from_cli(tmp_path, caps
         assert len(tar_names) == len(names)
         assert "event_segments_manifest.json" in names
         assert not any(name.startswith("event_segments/") for name in names)
+        event_report = _read_tar_json(tar, "event_report.json")
         smoke_report = _read_tar_json(tar, "smoke_report.json")
+    assert "trace_summary" not in event_report["query"]
+    assert "order_trace" not in event_report["query"]
     assert smoke_report["logs"]["root"] is None
     assert smoke_report["logs"]["hard_matches"] == 0
 


### PR DESCRIPTION
## Summary
- include live-event trace summary and order-trace sections in live incident bundle event reports
- include full cycle-trace reconstruction when a bundle is scoped to --cycle-id
- add --no-trace-report for compact bundles and cover trace inclusion/opt-out in tests

## Tests
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py tests/test_live_event_query.py tests/test_passivbot_cli.py -q
- ./venv/bin/python -m compileall src/live/incident_bundle.py src/tools/live_incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check