### PR TITLE
Update logging progress after incident traces

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,13 +19,17 @@ Last updated: 2026-06-25.
 
 Current `origin/v8` logging-overhaul head:
 
-- `e65597c3` merge of PR #656, `Add local cache integrity doctor`.
+- `27931c81` merge of PR #659, `Add incident bundle trace reports`.
 
 VPS5 deployment status:
 
-- Deployed through PR #642 at `ad36d8ea`.
-- PRs #643-#656 are merged to `v8`; VPS5 pull/restart and live smoke are next
-  when explicitly authorized.
+- Repository pulled through PR #659 at `27931c81`.
+- Bots were left running after the pull; PR #659 was a read-only tooling slice
+  and did not require bot restart.
+- VPS5 incident-bundle smoke created a bundle with `trace_summary`,
+  `order_trace`, and `cycle_trace` in `event_report.json`. The command returned
+  attention because existing live monitor state still includes GateIO HSL RED
+  and non-hard EMA readiness degradation, not because bundle generation failed.
 
 ## Phase Checklist
 
@@ -38,7 +42,7 @@ VPS5 deployment status:
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
-| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, `live-smoke-report` startup baselines, incident bundle, ID filters | Incident-bundle integration and cross-bot workflow |
+| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, `live-smoke-report` startup baselines, incident bundle trace reports, ID filters | Cross-bot incident workflow and richer supervisor/process capture |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup; PR #656 cache integrity smoke doctor | Continue separate reviewed PRs for shutdown/warmup/cache proof improvements |
 
 ## Merged Slices
@@ -307,16 +311,31 @@ VPS5 deployment status:
   slice; it does not yet prove warm-cache coverage or HSL/fill metadata
   compatibility.
 
+### PR #658: Cache Doctor Progress Update
+
+- Branch: `codex/v8-progress-after-cache-doctor`.
+- Scope: process tracking.
+- Result: updated this progress ledger and the live operations backlog after
+  PR #656 merged.
+
+### PR #659: Incident Bundle Trace Reports
+
+- Branch: `codex/v8-incident-bundle-traces`.
+- Scope: incident tooling.
+- Result: `passivbot tool live-incident-bundle` now embeds existing
+  `live-event-query` trace-summary and order-trace reports in `event_report.json`
+  by default, includes cycle-trace reconstruction when scoped to `--cycle-id`,
+  and supports `--no-trace-report` for compact bundles.
+- VPS5 evidence: deployed to VPS5 at `27931c81`; a read-only bundle smoke on
+  monitor data produced a tarball containing `trace_summary`, `order_trace`, and
+  `cycle_trace` sections. The tool returned attention because the embedded
+  smoke report saw existing GateIO HSL RED and EMA readiness degradation.
+
 ## Current Next Steps
 
-1. Pull merged `v8` on VPS5 and restart bots, if explicitly authorized, so PRs
-   #643-#656 are exercised by live processes.
-2. Verify `health.summary` includes resource pressure and event-pipeline fields,
-   verify event-projected console summaries stay readable, and verify
-   `live-smoke-report` shows startup timing baselines and `live-event-query
-   --order-trace`/`--cycle-trace` reconstruct recent order waves and cycles.
-   Also run `cache-integrity-doctor` on local cache roots as a read-only smoke
-   when live/VPS access is explicitly authorized.
-3. Continue Phase 5 by migrating one high-value stdlib text log family to
-   structured-event projection, or add incident-bundle integration if live smoke
-   shows that query tooling is still the sharper need.
+1. Continue Phase 5 by migrating one high-value stdlib text log family to
+   structured-event projection without increasing default console noise.
+2. Start the live restart/smoke automation slice if operational workflow speed
+   becomes the higher leverage next step.
+3. Continue cache-doctor refinements in separate adjacent PRs: cache-family
+   metadata, coverage windows, suspicious gaps, and warm-cache readiness.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -30,10 +30,11 @@ Related detailed plans:
 ## High-Value Follow-Ups
 
 1. [x] Incident bundle generator.
-   Status: initial implementation merged. `passivbot tool live-incident-bundle`
-   collects local monitor event reports, smoke summaries, redacted log excerpts,
-   monitor snapshots, config hashes, runtime metadata, and bounded event
-   segments into a tarball.
+   Status: initial implementation plus trace-report integration merged.
+   `passivbot tool live-incident-bundle` collects local monitor event reports,
+   live-event trace reports, smoke summaries, redacted log excerpts, monitor
+   snapshots, config hashes, runtime metadata, and bounded event segments into a
+   tarball.
 
    Remaining refinements: add supervisor/process status and richer remote smoke
    integration when the restart/smoke automation exists.
@@ -46,10 +47,11 @@ Related detailed plans:
    action id, symbol, pside, reason code, and status. It also supports
    aggregate trace summaries over matched events and order waves, plus a
    dedicated order-trace reconstruction view for order waves/actions and a
-   cycle-trace reconstruction view with nested order traces.
+   cycle-trace reconstruction view with nested order traces. Incident bundles
+   now embed the existing trace-summary/order-trace reports and cycle traces
+   when scoped to `--cycle-id`.
 
-   Remaining refinements: incident-bundle integration and cross-bot incident
-   workflow.
+   Remaining refinements: cross-bot incident workflow.
 
 3. [ ] Live restart/smoke automation.
    Status: partial. The read-only `live-smoke-report` tool exists, but the safe
@@ -153,9 +155,11 @@ Related detailed plans:
     - 2026-06-25: Added `live-event-query --cycle-trace`, grouping matched
       events by `cycle_id` with bounded timeline samples, aggregate trace
       summaries, and nested order traces.
+    - 2026-06-25: Added incident-bundle integration for trace-summary,
+      order-trace, and cycle-trace reports.
 
-    Remaining refinements: add incident bundle integration and keep tightening
-    producer coverage as nearby event surfaces are touched.
+    Remaining refinements: keep tightening producer coverage as nearby event
+    surfaces are touched.
 
 12. [ ] Debug profile toggles.
     Status: open.
@@ -208,6 +212,7 @@ Related detailed plans:
 | 2026-06-25 | #2/#11 Event query and order trace summaries | PR #648 / `774bcf74` | Added `live-event-query --trace-summary` aggregate counts across matched events, ID scopes, symbols, sides, and order waves | Full create/cancel/missing-order reconstruction view |
 | 2026-06-25 | #2/#11 Event query and order trace completeness | PR #651 / `b9f42ebd` | Added `live-event-query --order-trace` reconstruction grouped by order wave and action, with confirmation events and bounded samples | Richer cycle reconstruction and incident-bundle integration |
 | 2026-06-25 | #2/#11 Event query and cycle trace completeness | PR #654 / `ff493541` | Added `live-event-query --cycle-trace` reconstruction grouped by cycle id, with bounded timelines, aggregate summaries, and nested order traces | Incident-bundle integration and cross-bot workflow |
+| 2026-06-25 | #1/#2/#11 Incident bundle trace integration | PR #659 / `27931c81` | Embedded trace-summary and order-trace reports into incident bundles by default, plus cycle-trace when scoped to `--cycle-id`; VPS5 bundle smoke verified trace sections | Cross-bot incident workflow and supervisor/process context |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |
@@ -222,11 +227,11 @@ Related detailed plans:
 
 Near-term highest leverage:
 
-1. Incident-bundle integration with `live-event-query` trace outputs.
-2. Live restart/smoke automation.
+1. Live restart/smoke automation.
+2. Operator console redesign from events.
 3. Startup phase budget tracking.
-4. Operator console redesign from events.
-5. HSL dry-run preview.
+4. HSL dry-run preview.
+5. Cache integrity doctor coverage/readiness refinements.
 
 These make every later live debugging session cheaper and provide direct
 feedback on whether the event stream is actually answering operator questions.


### PR DESCRIPTION
## Summary
- update live logging progress for merged PR #659 and VPS5 incident-bundle trace smoke evidence
- mark incident-bundle trace integration complete in the live ops backlog
- refresh the suggested next priorities now that incident-bundle trace reports are merged

## Tests
- git diff --check
- docs-only