### PR TITLE
Add live smoke process status

### DIFF
--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -589,6 +589,9 @@ def build_live_incident_bundle(
     output_path: str | Path | None = None,
     logs_root: str | Path | None = None,
     config_paths: list[str | Path] | None = None,
+    include_processes: bool = False,
+    supervisor_config: str | Path | None = None,
+    process_command_match: str = "passivbot live",
     cycle_id: str | None = None,
     event_type: str | list[str] | None = None,
     order_wave_id: str | list[str] | None = None,
@@ -653,6 +656,9 @@ def build_live_incident_bundle(
     smoke_report = build_live_smoke_report(
         monitor_path,
         logs_root=logs_path,
+        include_processes=include_processes,
+        supervisor_config=supervisor_config,
+        process_command_match=process_command_match,
         include_rotated=include_rotated,
         max_problem_events=max_problem_events,
         max_log_files=max_log_files,
@@ -699,6 +705,10 @@ def build_live_incident_bundle(
                     "include_rotated": include_rotated,
                     "include_data": include_data,
                     "include_trace_report": include_trace_report,
+                    "include_processes": include_processes,
+                    "supervisor_config": str(supervisor_config)
+                    if supervisor_config is not None
+                    else None,
                 }.items()
                 if value not in (None, [], "")
             },
@@ -751,6 +761,19 @@ def build_live_incident_bundle(
             "attention": smoke_report.get("attention"),
             "hard_failures": smoke_report.get("hard_failures"),
             "attention_count": smoke_report.get("attention_count"),
+            "processes": {
+                "enabled": smoke_report.get("processes", {}).get("enabled"),
+                "ok": smoke_report.get("processes", {}).get("ok"),
+                "expected_total": smoke_report.get("processes", {}).get(
+                    "expected_total"
+                ),
+                "running_live_total": smoke_report.get("processes", {}).get(
+                    "running_live_total"
+                ),
+                "missing_expected": len(
+                    smoke_report.get("processes", {}).get("missing_expected", [])
+                ),
+            },
         },
         "config_hashes": len(config_hashes),
         "monitor_snapshots": len(metadata["monitor_snapshots"]),

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -4,6 +4,7 @@ import gzip
 import json
 import re
 import stat
+import subprocess
 from collections import Counter, defaultdict, deque
 from pathlib import Path
 from typing import Any
@@ -30,6 +31,16 @@ SENSITIVE_LOG_VALUE_PATTERN = re.compile(
 )
 AUTH_SCHEME_PATTERN = re.compile(r"(?i)\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]+")
 STARTUP_TIMING_BASELINE_WINDOW = 20
+DEFAULT_PROCESS_MATCH = "passivbot live"
+PROCESS_REPORT_FIELDS = {
+    "pid",
+    "age_s",
+    "stat",
+    "cpu_pct",
+    "mem_pct",
+    "command",
+    "command_key",
+}
 
 
 def _open_text(path: Path):
@@ -103,6 +114,260 @@ def _redact_log_text(value: str, *, max_len: int = 500) -> str:
     if len(text) > max_len:
         text = f"{text[:max_len]}...<truncated>"
     return text
+
+
+def _shell_tokens(value: str) -> list[str]:
+    try:
+        import shlex
+
+        return shlex.split(str(value))
+    except (ImportError, ValueError):
+        return str(value).split()
+
+
+def _canonical_live_command(value: str) -> str:
+    tokens = _shell_tokens(value)
+    for index, token in enumerate(tokens[:-1]):
+        if Path(token).name == "passivbot" and tokens[index + 1] == "live":
+            return " ".join([Path(tokens[index]).name, *tokens[index + 1 :]])
+    return ""
+
+
+def _parse_tmuxp_live_commands(config_path: str | Path | None) -> dict[str, Any]:
+    if config_path is None or str(config_path).strip() == "":
+        return {
+            "path": None,
+            "exists": False,
+            "error": None,
+            "expected": [],
+        }
+    path = Path(config_path).expanduser()
+    expected: list[dict[str, Any]] = []
+    if not path.exists():
+        return {
+            "path": str(path),
+            "exists": False,
+            "error": "config_not_found",
+            "expected": expected,
+        }
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:
+        return {
+            "path": str(path),
+            "exists": True,
+            "error": f"config_read_failed:{exc.__class__.__name__}",
+            "expected": expected,
+        }
+
+    current_window: str | None = None
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        window_line = stripped[2:].strip() if stripped.startswith("- ") else stripped
+        if window_line.startswith("window_name:"):
+            current_window = window_line.split(":", 1)[1].strip().strip("\"'")
+            continue
+        command = stripped
+        if command.startswith("- "):
+            command = command[2:].strip()
+        command = command.strip().strip("\"'")
+        command_key = _canonical_live_command(command)
+        if not command_key:
+            continue
+        expected.append(
+            {
+                "name": current_window,
+                "command": _redact_log_text(command, max_len=400),
+                "command_key": _redact_log_text(command_key, max_len=400),
+                "_match_key": command_key,
+            }
+        )
+    return {
+        "path": str(path),
+        "exists": True,
+        "error": None,
+        "expected": expected,
+    }
+
+
+def _ps_process_rows() -> tuple[list[str], str | None]:
+    commands = [
+        ["ps", "-eo", "pid=,ppid=,etimes=,stat=,pcpu=,pmem=,command="],
+        ["ps", "-axo", "pid=,ppid=,stat=,pcpu=,pmem=,command="],
+    ]
+    last_error: str | None = None
+    for command in commands:
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=5.0,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            last_error = f"{command[0]}_failed:{exc.__class__.__name__}"
+            continue
+        if result.returncode != 0:
+            last_error = (result.stderr or result.stdout or "ps_failed").strip()
+            continue
+        return result.stdout.splitlines(), None
+    return [], last_error or "ps_failed"
+
+
+def _float_or_none(value: str) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _int_or_none(value: str) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _process_record_from_ps_line(line: str) -> dict[str, Any] | None:
+    stripped = line.strip()
+    if not stripped:
+        return None
+    parts = stripped.split(None, 6)
+    if len(parts) == 7 and _int_or_none(parts[2]) is not None:
+        pid, ppid, etimes, stat_value, pcpu, pmem, command = parts
+        age_s = _int_or_none(etimes)
+    else:
+        parts = stripped.split(None, 5)
+        if len(parts) != 6:
+            return None
+        pid, ppid, stat_value, pcpu, pmem, command = parts
+        age_s = None
+    command_key = _canonical_live_command(command)
+    if not command_key:
+        return None
+    return {
+        "pid": _int_or_none(pid),
+        "ppid": _int_or_none(ppid),
+        "age_s": age_s,
+        "stat": stat_value,
+        "cpu_pct": _float_or_none(pcpu),
+        "mem_pct": _float_or_none(pmem),
+        "command": _redact_log_text(command, max_len=500),
+        "command_key": _redact_log_text(command_key, max_len=500),
+        "_match_key": command_key,
+    }
+
+
+def _running_live_processes(*, command_match: str) -> dict[str, Any]:
+    rows, error = _ps_process_rows()
+    processes: list[dict[str, Any]] = []
+    for row in rows:
+        record = _process_record_from_ps_line(row)
+        if record is not None:
+            match_key = str(record.get("_match_key") or "")
+            command_key = str(record.get("command_key") or "")
+            if (
+                command_match
+                and command_match not in row
+                and command_match not in match_key
+                and command_match not in command_key
+            ):
+                continue
+            processes.append(record)
+    processes.sort(
+        key=lambda item: (str(item.get("command_key") or ""), int(item.get("pid") or 0))
+    )
+    return {
+        "scan_error": error,
+        "running": processes,
+    }
+
+
+def _build_process_report(
+    *,
+    include_processes: bool,
+    supervisor_config: str | Path | None,
+    process_command_match: str,
+) -> dict[str, Any]:
+    enabled = bool(include_processes or supervisor_config)
+    if not enabled:
+        return {
+            "enabled": False,
+            "ok": True,
+            "hard_failures": 0,
+            "expected_total": 0,
+            "running_live_total": 0,
+            "missing_expected": [],
+            "unexpected_running": [],
+        }
+
+    config = _parse_tmuxp_live_commands(supervisor_config)
+    running_scan = _running_live_processes(command_match=process_command_match)
+    running = running_scan["running"]
+    expected = config["expected"]
+    missing: list[dict[str, Any]] = []
+    matched_process_indexes: set[int] = set()
+    for item in expected:
+        match_key = item.get("_match_key")
+        matches = [
+            (index, process)
+            for index, process in enumerate(running)
+            if process.get("_match_key") == match_key
+        ]
+        if matches:
+            matched_process_indexes.add(matches[0][0])
+            continue
+        missing.append(
+            {
+                "name": item.get("name"),
+                "command": item.get("command"),
+                "command_key": item.get("command_key"),
+            }
+        )
+    unexpected = [
+        {
+            key: value
+            for key, value in process.items()
+            if key in PROCESS_REPORT_FIELDS
+        }
+        for index, process in enumerate(running)
+        if expected and index not in matched_process_indexes
+    ]
+    hard_failures = len(missing)
+    if config.get("error"):
+        hard_failures += 1
+    elif supervisor_config and not expected:
+        hard_failures += 1
+        config["error"] = "no_expected_live_commands"
+    if running_scan.get("scan_error"):
+        hard_failures += 1
+    return {
+        "enabled": True,
+        "ok": hard_failures == 0,
+        "hard_failures": hard_failures,
+        "scan_error": running_scan.get("scan_error"),
+        "config": {
+            "path": config.get("path"),
+            "exists": config.get("exists"),
+            "error": config.get("error"),
+        },
+        "expected_total": len(expected),
+        "running_live_total": len(running),
+        "matched_expected": max(0, len(expected) - len(missing)),
+        "missing_expected": missing,
+        "unexpected_running": unexpected,
+        "running": [
+            {
+                key: value
+                for key, value in process.items()
+                if key in PROCESS_REPORT_FIELDS
+            }
+            for process in running
+        ],
+    }
 
 
 def _non_negative_int(value: Any) -> int | None:
@@ -471,6 +736,9 @@ def build_live_smoke_report(
     monitor_root: str | Path = "monitor",
     *,
     logs_root: str | Path | None = "logs",
+    include_processes: bool = False,
+    supervisor_config: str | Path | None = None,
+    process_command_match: str = DEFAULT_PROCESS_MATCH,
     include_rotated: bool = False,
     max_problem_events: int = 50,
     max_log_files: int = 8,
@@ -504,11 +772,17 @@ def build_live_smoke_report(
         tail_lines=log_tail_lines,
         max_matches=max_log_matches,
     )
+    process_report = _build_process_report(
+        include_processes=include_processes,
+        supervisor_config=supervisor_config,
+        process_command_match=process_command_match,
+    )
     hard_failures = (
         int(event_report["error_count"])
         + int(event_scan["invalid_rows"])
         + int(event_scan["hard_problem_event_count"])
         + int(log_scan["hard_matches"])
+        + int(process_report["hard_failures"])
     )
     attention_count = int(event_scan["problem_event_count"]) + int(
         log_scan["attention_matches"]
@@ -536,4 +810,5 @@ def build_live_smoke_report(
         "problem_events": event_scan["problem_events"],
         "hard_problem_event_count": event_scan["hard_problem_event_count"],
         "logs": log_scan,
+        "processes": process_report,
     }

--- a/src/tools/live_incident_bundle.py
+++ b/src/tools/live_incident_bundle.py
@@ -51,6 +51,23 @@ def build_parser() -> argparse.ArgumentParser:
         default=[],
         help="Config path to hash into the bundle manifest. May be repeated.",
     )
+    parser.add_argument(
+        "--processes",
+        action="store_true",
+        help="Include read-only passivbot live process liveness details in smoke_report.json.",
+    )
+    parser.add_argument(
+        "--supervisor-config",
+        help=(
+            "Optional tmuxp-style config listing expected passivbot live panes. "
+            "Implies --processes and reports missing expected bots as hard failures."
+        ),
+    )
+    parser.add_argument(
+        "--process-match",
+        default="passivbot live",
+        help="Substring used before canonicalizing passivbot live process rows.",
+    )
     parser.add_argument("--cycle-id", help="Include compact records for one cycle_id.")
     parser.add_argument(
         "--event-type",
@@ -168,6 +185,9 @@ def main(argv: list[str] | None = None) -> int:
         output_path=args.output,
         logs_root=args.logs_root,
         config_paths=list(args.config or []),
+        include_processes=bool(args.processes),
+        supervisor_config=args.supervisor_config,
+        process_command_match=str(args.process_match),
         cycle_id=args.cycle_id,
         event_type=args.event_types,
         order_wave_id=args.order_wave_id,

--- a/src/tools/live_smoke_report.py
+++ b/src/tools/live_smoke_report.py
@@ -34,6 +34,23 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--processes",
+        action="store_true",
+        help="Include read-only passivbot live process liveness details.",
+    )
+    parser.add_argument(
+        "--supervisor-config",
+        help=(
+            "Optional tmuxp-style config listing expected passivbot live panes. "
+            "Implies --processes and reports missing expected bots as hard failures."
+        ),
+    )
+    parser.add_argument(
+        "--process-match",
+        default="passivbot live",
+        help="Substring used before canonicalizing passivbot live process rows.",
+    )
+    parser.add_argument(
         "--include-rotated",
         action="store_true",
         help="Also scan rotated/compressed monitor event segments.",
@@ -80,6 +97,9 @@ def main(argv: list[str] | None = None) -> int:
     report = build_live_smoke_report(
         args.monitor_root,
         logs_root=logs_root,
+        include_processes=bool(args.processes),
+        supervisor_config=args.supervisor_config,
+        process_command_match=str(args.process_match),
         include_rotated=bool(args.include_rotated),
         max_problem_events=int(args.max_problem_events),
         max_log_files=int(args.max_log_files),

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import tarfile
 
+import live.smoke_report as smoke_report_module
 from live.incident_bundle import _redact_url_userinfo, build_live_incident_bundle
 from tools import live_incident_bundle
 
@@ -256,6 +257,75 @@ def test_live_incident_bundle_can_skip_logs_and_segments_from_cli(tmp_path, caps
     assert "order_trace" not in event_report["query"]
     assert smoke_report["logs"]["root"] is None
     assert smoke_report["logs"]["hard_matches"] == 0
+
+
+def test_live_incident_bundle_includes_process_status_when_requested(
+    tmp_path,
+    monkeypatch,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+    supervisor_config = tmp_path / "bots_vps5.yaml"
+    supervisor_config.write_text(
+        "\n".join(
+            [
+                "session_name: passivbot",
+                "windows:",
+                "  - window_name: binance_01",
+                "    panes:",
+                "      - passivbot live configs/v8.json -u binance_01",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        smoke_report_module,
+        "_ps_process_rows",
+        lambda: (
+            [
+                (
+                    "123 1 99 S 1.0 5.0 "
+                    "/root/passivbot/venv/bin/passivbot live "
+                    "configs/v8.json -u binance_01"
+                )
+            ],
+            None,
+        ),
+    )
+    output = tmp_path / "incident.tar.gz"
+
+    report = build_live_incident_bundle(
+        tmp_path / "monitor",
+        output_path=output,
+        logs_root=None,
+        supervisor_config=supervisor_config,
+        include_event_segments=False,
+    )
+
+    assert report["ok"] is True
+    assert report["smoke_report"]["processes"] == {
+        "enabled": True,
+        "ok": True,
+        "expected_total": 1,
+        "running_live_total": 1,
+        "missing_expected": 0,
+    }
+    with tarfile.open(output, "r:gz") as tar:
+        smoke_report = _read_tar_json(tar, "smoke_report.json")
+    assert smoke_report["processes"]["expected_total"] == 1
+    assert smoke_report["processes"]["matched_expected"] == 1
+    assert smoke_report["processes"]["missing_expected"] == []
 
 
 def test_live_incident_bundle_redacts_git_remote_url_userinfo():

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 
+import live.smoke_report as smoke_report_module
 from live.smoke_report import build_live_smoke_report, default_logs_root_for_monitor
 from tools import live_smoke_report
 
@@ -433,3 +434,124 @@ def test_live_smoke_report_cli_outputs_json_and_can_skip_logs(tmp_path, capsys):
     assert report["logs"]["files_scanned"] == 0
     assert report["logs"]["root"] is None
     assert report["monitor"]["live_events"] == 1
+
+
+def test_live_smoke_report_process_status_matches_supervisor_config(
+    tmp_path,
+    monkeypatch,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+    supervisor_config = tmp_path / "bots_vps5.yaml"
+    supervisor_config.write_text(
+        "\n".join(
+            [
+                "session_name: passivbot",
+                "windows:",
+                "  - window_name: binance_01",
+                "    panes:",
+                "      - passivbot live configs/forager.json -u binance_01",
+                "  - window_name: gateio_01",
+                "    panes:",
+                "      - passivbot live configs/forager.json -u gateio_01",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        smoke_report_module,
+        "_ps_process_rows",
+        lambda: (
+            [
+                (
+                    "123 1 42 S 3.5 7.0 "
+                    "/root/passivbot/venv/bin/python3 "
+                    "/root/passivbot/venv/bin/passivbot live "
+                    "configs/forager.json -u binance_01"
+                )
+            ],
+            None,
+        ),
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        supervisor_config=supervisor_config,
+    )
+
+    assert report["ok"] is False
+    assert report["hard_failures"] == 1
+    assert report["processes"]["enabled"] is True
+    assert report["processes"]["ok"] is False
+    assert report["processes"]["expected_total"] == 2
+    assert report["processes"]["matched_expected"] == 1
+    assert report["processes"]["running_live_total"] == 1
+    assert report["processes"]["missing_expected"] == [
+        {
+            "name": "gateio_01",
+            "command": "passivbot live configs/forager.json -u gateio_01",
+            "command_key": "passivbot live configs/forager.json -u gateio_01",
+        }
+    ]
+    assert report["processes"]["running"][0]["pid"] == 123
+    assert report["processes"]["running"][0]["age_s"] == 42
+
+
+def test_live_smoke_report_process_scan_without_config_is_observational(
+    tmp_path,
+    monkeypatch,
+):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        smoke_report_module,
+        "_ps_process_rows",
+        lambda: (
+            [
+                (
+                    "321 1 S 0.5 2.0 "
+                    "/root/passivbot/venv/bin/passivbot live "
+                    "configs/v8.json -u okx_faisal"
+                )
+            ],
+            None,
+        ),
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        include_processes=True,
+    )
+
+    assert report["ok"] is True
+    assert report["processes"]["enabled"] is True
+    assert report["processes"]["expected_total"] == 0
+    assert report["processes"]["running_live_total"] == 1
+    assert report["processes"]["unexpected_running"] == []
+    assert report["processes"]["running"][0]["command_key"] == (
+        "passivbot live configs/v8.json -u okx_faisal"
+    )


### PR DESCRIPTION
## Summary
- add optional read-only passivbot live process liveness capture to `live-smoke-report`
- support tmuxp-style supervisor configs so missing expected bots become hard smoke failures
- include the same process snapshot in `live-incident-bundle` smoke reports when requested

## Tests
- `./venv/bin/python -m compileall src/live/smoke_report.py src/tools/live_smoke_report.py src/live/incident_bundle.py src/tools/live_incident_bundle.py tests/test_live_smoke_report.py tests/test_live_incident_bundle.py`
- `./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py tests/test_passivbot_cli.py::test_live_smoke_report_tool_dispatch_forwards_module_and_prog tests/test_passivbot_cli.py::test_live_incident_bundle_tool_dispatch_forwards_module_and_prog`
- `git diff --check`

## Notes
- observability-only; no bot control, tmux control, exchange calls, order behavior, or restart behavior changed
- `--supervisor-config` implies process scanning and fails the smoke report if an expected bot command is missing
- `--processes` without a supervisor config is observational only