### PR TITLE
Update progress after remote call summary

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,20 @@ Last updated: 2026-06-25.
 
 Current `origin/v8` logging-overhaul head:
 
-- `72b3d931` merge of PR #661, `Add live smoke process status`.
+- `45b0cf9e` merge of PR #663, `Summarize remote call failures in smoke report`.
 
 VPS5 deployment status:
 
-- Repository pulled through PR #661 at `72b3d931`.
-- Bots were left running after the pull; PR #661 was a read-only tooling slice
+- Repository pulled through PR #663 at `45b0cf9e`.
+- Bots were left running after the pull; PR #663 was a read-only tooling slice
   and did not require bot restart.
 - VPS5 process-status smoke with `/root/bots_vps5.yaml` reported
   `expected_total=5`, `matched_expected=5`, `missing_expected=[]`,
   and `scan_error=null`.
 - Overall smoke still returned attention/hard failure because current monitor
-  events include Kucoin authoritative balance/positions/open-orders
-  `RequestTimeout` failures. The process-status check itself was green.
+  events include Kucoin authoritative state `RequestTimeout` failures. The new
+  `remote_call_failures` summary grouped them as positions=9,
+  open_orders=7, and balance=7. The process-status check itself was green.
 
 ## Phase Checklist
 
@@ -44,7 +45,7 @@ VPS5 deployment status:
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
-| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, `live-smoke-report` startup baselines and process liveness, incident bundle trace/process reports, ID filters | Cross-bot incident workflow and safe restart orchestration |
+| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, `live-smoke-report` startup baselines, process liveness, and remote-call failure summaries, incident bundle trace/process reports, ID filters | Cross-bot incident workflow and safe restart orchestration |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup; PR #656 cache integrity smoke doctor | Continue separate reviewed PRs for shutdown/warmup/cache proof improvements |
 
 ## Merged Slices
@@ -349,13 +350,26 @@ VPS5 deployment status:
   fetches had recent `RequestTimeout` events, not because process liveness
   failed.
 
+### PR #663: Remote-Call Failure Smoke Summary
+
+- Branch: `codex/v8-smoke-remote-call-summary`.
+- Scope: operator tooling.
+- Result: `passivbot tool live-smoke-report` now includes a bounded
+  `remote_call_failures` aggregate section built from existing
+  `remote_call.failed` monitor events. Groups are keyed by
+  bot/reason/surface/error type/component and include latest redacted failure
+  context.
+- VPS5 evidence: deployed to VPS5 at `45b0cf9e`; read-only smoke using
+  `/root/bots_vps5.yaml` still matched all five expected bots and now exposed
+  Kucoin authoritative endpoint timeouts directly in the smoke output:
+  positions=9, open_orders=7, balance=7.
+
 ## Current Next Steps
 
 1. Continue Phase 5 by migrating one high-value stdlib text log family to
    structured-event projection without increasing default console noise.
-2. Add read-only exchange health probes or smoke summaries for account-critical
-   endpoint timeouts, especially after the latest Kucoin authoritative-fetch
-   timeouts on VPS5.
+2. Add read-only exchange health probes for account-critical endpoint timeouts
+   if passive event summaries are insufficient.
 3. Start the live restart/smoke automation slice if operational workflow speed
    becomes the higher leverage next step.
 4. Continue cache-doctor refinements in separate adjacent PRs: cache-family

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -88,9 +88,11 @@ Related detailed plans:
    this off console unless thresholds are crossed.
 
 6. [ ] Exchange health and contract probes.
-   Status: open. VPS5 smoke on 2026-06-25 surfaced Kucoin authoritative
-   balance/positions/open-orders `RequestTimeout` events, which reinforces the
-   value of explicit exchange endpoint health probes.
+   Status: partial. VPS5 smoke on 2026-06-25 surfaced Kucoin authoritative
+   balance/positions/open-orders `RequestTimeout` events. `live-smoke-report`
+   now passively summarizes existing `remote_call.failed` events by
+   bot/reason/surface/error type, but explicit read-only exchange endpoint
+   probes are not implemented.
 
    Add explicit read-only probes for each configured exchange/account before or
    during smoke: balance/positions/open-orders fetch, clock skew, rate-limit
@@ -220,6 +222,7 @@ Related detailed plans:
 | 2026-06-25 | #2/#11 Event query and cycle trace completeness | PR #654 / `ff493541` | Added `live-event-query --cycle-trace` reconstruction grouped by cycle id, with bounded timelines, aggregate summaries, and nested order traces | Incident-bundle integration and cross-bot workflow |
 | 2026-06-25 | #1/#2/#11 Incident bundle trace integration | PR #659 / `27931c81` | Embedded trace-summary and order-trace reports into incident bundles by default, plus cycle-trace when scoped to `--cycle-id`; VPS5 bundle smoke verified trace sections | Cross-bot incident workflow and supervisor/process context |
 | 2026-06-25 | #1/#3/#14 Smoke process status | PR #661 / `72b3d931` | Added optional read-only process liveness to `live-smoke-report` and incident bundles; VPS5 smoke matched all five `/root/bots_vps5.yaml` bots | Safe restart orchestration and richer supervisor model remain open |
+| 2026-06-25 | #6 Exchange health and contract probes | PR #663 / `45b0cf9e` | Added passive `remote_call.failed` summaries to `live-smoke-report`; VPS5 smoke grouped Kucoin timeouts by balance/positions/open_orders | Active read-only exchange endpoint probes remain open |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |


### PR DESCRIPTION
## Summary
- update the live logging progress ledger for merged PR #663 / `45b0cf9e`
- record VPS5 read-only smoke evidence for the new `remote_call_failures` summary
- mark exchange health probes as partial: passive failure summaries landed, active read-only probes remain open

## Tests
- `git diff --check`

## Notes
- docs-only progress/backlog update
- no runtime or trading behavior changes