### PR TITLE
Add time window to live smoke report

### DIFF
--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -660,6 +660,8 @@ def build_live_incident_bundle(
         supervisor_config=supervisor_config,
         process_command_match=process_command_match,
         include_rotated=include_rotated,
+        since_ms=since_ms,
+        until_ms=until_ms,
         max_problem_events=max_problem_events,
         max_log_files=max_log_files,
         log_tail_lines=log_tail_lines,
@@ -761,6 +763,7 @@ def build_live_incident_bundle(
             "attention": smoke_report.get("attention"),
             "hard_failures": smoke_report.get("hard_failures"),
             "attention_count": smoke_report.get("attention_count"),
+            "event_window": smoke_report.get("event_window"),
             "processes": {
                 "enabled": smoke_report.get("processes", {}).get("enabled"),
                 "ok": smoke_report.get("processes", {}).get("ok"),

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -655,11 +655,33 @@ def _is_hard_problem_event(live_event: dict[str, Any]) -> bool:
     return level in {"error", "critical"} or event_type == "sink.degraded"
 
 
+def _event_window_report(
+    *,
+    since_ms: int | None,
+    until_ms: int | None,
+    events_considered: int,
+    events_skipped_before: int,
+    events_skipped_after: int,
+    invalid_window_ts: int,
+) -> dict[str, Any]:
+    return {
+        "enabled": since_ms is not None or until_ms is not None,
+        "since_ms": since_ms,
+        "until_ms": until_ms,
+        "events_considered": int(events_considered),
+        "events_skipped_before": int(events_skipped_before),
+        "events_skipped_after": int(events_skipped_after),
+        "invalid_window_ts": int(invalid_window_ts),
+    }
+
+
 def _scan_events(
     root: str | Path,
     *,
     include_rotated: bool,
     max_problem_events: int,
+    since_ms: int | None = None,
+    until_ms: int | None = None,
 ) -> dict[str, Any]:
     files = discover_event_files(root, include_rotated=include_rotated)
     bots: dict[str, dict[str, Any]] = defaultdict(
@@ -676,6 +698,10 @@ def _scan_events(
     )
     problem_events: deque[dict[str, Any]] = deque(maxlen=max(0, int(max_problem_events)))
     invalid_rows = 0
+    events_considered = 0
+    events_skipped_before = 0
+    events_skipped_after = 0
+    invalid_window_ts = 0
     startup_timing_records: dict[str, list[dict[str, Any]]] = defaultdict(list)
     remote_call_failure_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
 
@@ -697,6 +723,18 @@ def _scan_events(
                     live_event = _live_event_payload(row)
                     if live_event is None:
                         continue
+                    row_ts = _non_negative_int(row.get("ts"))
+                    if since_ms is not None or until_ms is not None:
+                        if row_ts is None:
+                            invalid_window_ts += 1
+                            continue
+                        if since_ms is not None and row_ts < since_ms:
+                            events_skipped_before += 1
+                            continue
+                        if until_ms is not None and row_ts > until_ms:
+                            events_skipped_after += 1
+                            continue
+                    events_considered += 1
                     bot_key = _bot_key(live_event, row)
                     bot = bots[bot_key]
                     bot["events"] += 1
@@ -776,6 +814,14 @@ def _scan_events(
         "startup_timings": _summarize_startup_timings(startup_timing_records),
         "remote_call_failures": _summarize_remote_call_failures(
             remote_call_failure_groups
+        ),
+        "event_window": _event_window_report(
+            since_ms=since_ms,
+            until_ms=until_ms,
+            events_considered=events_considered,
+            events_skipped_before=events_skipped_before,
+            events_skipped_after=events_skipped_after,
+            invalid_window_ts=invalid_window_ts,
         ),
     }
 
@@ -878,6 +924,8 @@ def build_live_smoke_report(
     supervisor_config: str | Path | None = None,
     process_command_match: str = DEFAULT_PROCESS_MATCH,
     include_rotated: bool = False,
+    since_ms: int | None = None,
+    until_ms: int | None = None,
     max_problem_events: int = 50,
     max_log_files: int = 8,
     log_tail_lines: int = 300,
@@ -894,6 +942,8 @@ def build_live_smoke_report(
             monitor_root,
             include_rotated=include_rotated,
             max_problem_events=max_problem_events,
+            since_ms=since_ms,
+            until_ms=until_ms,
         )
     else:
         event_scan = {
@@ -908,6 +958,14 @@ def build_live_smoke_report(
                 "groups_truncated": False,
                 "groups": [],
             },
+            "event_window": _event_window_report(
+                since_ms=since_ms,
+                until_ms=until_ms,
+                events_considered=0,
+                events_skipped_before=0,
+                events_skipped_after=0,
+                invalid_window_ts=0,
+            ),
         }
     log_scan = _scan_logs(
         logs_root,
@@ -951,6 +1009,7 @@ def build_live_smoke_report(
         "bots": event_scan["bots"],
         "startup_timings": event_scan["startup_timings"],
         "remote_call_failures": event_scan["remote_call_failures"],
+        "event_window": event_scan["event_window"],
         "problem_events": event_scan["problem_events"],
         "hard_problem_event_count": event_scan["hard_problem_event_count"],
         "logs": log_scan,

--- a/src/tools/live_incident_bundle.py
+++ b/src/tools/live_incident_bundle.py
@@ -12,12 +12,6 @@ if str(SRC_ROOT) not in sys.path:
 from live.incident_bundle import build_live_incident_bundle  # noqa: E402
 
 
-def _parse_ms(value: str | None) -> int | None:
-    if value is None:
-        return None
-    return int(value)
-
-
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
@@ -106,8 +100,16 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         help="Filter compact records by status. May be repeated or comma-separated.",
     )
-    parser.add_argument("--since-ms", help="Include live events at or after this monitor ts.")
-    parser.add_argument("--until-ms", help="Include live events at or before this monitor ts.")
+    parser.add_argument(
+        "--since-ms",
+        type=int,
+        help="Include live events at or after this monitor ts.",
+    )
+    parser.add_argument(
+        "--until-ms",
+        type=int,
+        help="Include live events at or before this monitor ts.",
+    )
     parser.add_argument(
         "--limit",
         type=int,
@@ -196,8 +198,8 @@ def main(argv: list[str] | None = None) -> int:
         pside=args.pside,
         reason_code=args.reason_code,
         status=args.status,
-        since_ms=_parse_ms(args.since_ms),
-        until_ms=_parse_ms(args.until_ms),
+        since_ms=args.since_ms,
+        until_ms=args.until_ms,
         include_data=bool(args.include_data),
         include_trace_report=not bool(args.no_trace_report),
         include_rotated=bool(args.include_rotated),

--- a/src/tools/live_smoke_report.py
+++ b/src/tools/live_smoke_report.py
@@ -13,12 +13,6 @@ if str(SRC_ROOT) not in sys.path:
 from live.smoke_report import build_live_smoke_report, default_logs_root_for_monitor  # noqa: E402
 
 
-def _parse_ms(value: str | None) -> int | None:
-    if value is None:
-        return None
-    return int(value)
-
-
 def _since_ms_from_recent_minutes(value: float | None) -> int | None:
     if value is None:
         return None
@@ -73,10 +67,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--since-ms",
+        type=int,
         help="Only include structured monitor events at or after this monitor ts.",
     )
     parser.add_argument(
         "--until-ms",
+        type=int,
         help="Only include structured monitor events at or before this monitor ts.",
     )
     parser.add_argument(
@@ -126,7 +122,7 @@ def main(argv: list[str] | None = None) -> int:
         logs_root = default_logs_root_for_monitor(args.monitor_root)
     else:
         logs_root = args.logs_root if str(args.logs_root).strip() else None
-    since_ms = _parse_ms(args.since_ms)
+    since_ms = args.since_ms
     try:
         recent_since_ms = _since_ms_from_recent_minutes(args.recent_minutes)
     except ValueError as exc:
@@ -135,7 +131,7 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--since-ms and --recent-minutes are mutually exclusive")
     if recent_since_ms is not None:
         since_ms = recent_since_ms
-    until_ms = _parse_ms(args.until_ms)
+    until_ms = args.until_ms
     if since_ms is not None and until_ms is not None and since_ms > until_ms:
         parser.error("--since-ms must be <= --until-ms")
     report = build_live_smoke_report(

--- a/src/tools/live_smoke_report.py
+++ b/src/tools/live_smoke_report.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import time
 from pathlib import Path
 
 SRC_ROOT = Path(__file__).resolve().parents[1]
@@ -10,6 +11,21 @@ if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
 from live.smoke_report import build_live_smoke_report, default_logs_root_for_monitor  # noqa: E402
+
+
+def _parse_ms(value: str | None) -> int | None:
+    if value is None:
+        return None
+    return int(value)
+
+
+def _since_ms_from_recent_minutes(value: float | None) -> int | None:
+    if value is None:
+        return None
+    minutes = float(value)
+    if minutes <= 0:
+        raise ValueError("--recent-minutes must be positive")
+    return int(time.time() * 1000) - int(minutes * 60_000)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -56,6 +72,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="Also scan rotated/compressed monitor event segments.",
     )
     parser.add_argument(
+        "--since-ms",
+        help="Only include structured monitor events at or after this monitor ts.",
+    )
+    parser.add_argument(
+        "--until-ms",
+        help="Only include structured monitor events at or before this monitor ts.",
+    )
+    parser.add_argument(
+        "--recent-minutes",
+        type=float,
+        help=(
+            "Only include structured monitor events from the last N minutes. "
+            "Equivalent to --since-ms based on local wall-clock time."
+        ),
+    )
+    parser.add_argument(
         "--max-problem-events",
         type=int,
         default=50,
@@ -94,6 +126,18 @@ def main(argv: list[str] | None = None) -> int:
         logs_root = default_logs_root_for_monitor(args.monitor_root)
     else:
         logs_root = args.logs_root if str(args.logs_root).strip() else None
+    since_ms = _parse_ms(args.since_ms)
+    try:
+        recent_since_ms = _since_ms_from_recent_minutes(args.recent_minutes)
+    except ValueError as exc:
+        parser.error(str(exc))
+    if since_ms is not None and recent_since_ms is not None:
+        parser.error("--since-ms and --recent-minutes are mutually exclusive")
+    if recent_since_ms is not None:
+        since_ms = recent_since_ms
+    until_ms = _parse_ms(args.until_ms)
+    if since_ms is not None and until_ms is not None and since_ms > until_ms:
+        parser.error("--since-ms must be <= --until-ms")
     report = build_live_smoke_report(
         args.monitor_root,
         logs_root=logs_root,
@@ -101,6 +145,8 @@ def main(argv: list[str] | None = None) -> int:
         supervisor_config=args.supervisor_config,
         process_command_match=str(args.process_match),
         include_rotated=bool(args.include_rotated),
+        since_ms=since_ms,
+        until_ms=until_ms,
         max_problem_events=int(args.max_problem_events),
         max_log_files=int(args.max_log_files),
         log_tail_lines=int(args.log_tail_lines),

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import tarfile
 
+import pytest
+
 import live.smoke_report as smoke_report_module
 from live.incident_bundle import _redact_url_userinfo, build_live_incident_bundle
 from tools import live_incident_bundle
@@ -147,6 +149,15 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     assert report["event_report"]["order_trace_matched_events"] == 2
     assert report["event_report"]["cycle_trace_matched_events"] == 3
     assert report["time_window"]["matched_events"] == 1
+    assert report["smoke_report"]["event_window"] == {
+        "enabled": True,
+        "since_ms": 1500,
+        "until_ms": 2500,
+        "events_considered": 1,
+        "events_skipped_before": 3,
+        "events_skipped_after": 0,
+        "invalid_window_ts": 0,
+    }
     assert report["config_hashes"] == 1
     assert report["monitor_snapshots"] == 1
     assert report["event_segments"]["included"] == 1
@@ -169,6 +180,7 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         manifest = _read_tar_json(tar, "manifest.json")
         event_report = _read_tar_json(tar, "event_report.json")
         window_report = _read_tar_json(tar, "time_window_report.json")
+        smoke_report = _read_tar_json(tar, "smoke_report.json")
         config_hashes = _read_tar_json(tar, "config_hashes.json")
         redacted_snapshot = _read_tar_json(
             tar,
@@ -200,6 +212,8 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     )
     assert window_report["events"][0]["seq"] == 2
     assert "remote_call.failed" in window_report["timeline"][0]
+    assert smoke_report["event_window"] == report["smoke_report"]["event_window"]
+    assert smoke_report["remote_call_failures"]["total"] == 1
 
 
 def test_live_incident_bundle_can_skip_logs_and_segments_from_cli(tmp_path, capsys):
@@ -257,6 +271,14 @@ def test_live_incident_bundle_can_skip_logs_and_segments_from_cli(tmp_path, caps
     assert "order_trace" not in event_report["query"]
     assert smoke_report["logs"]["root"] is None
     assert smoke_report["logs"]["hard_matches"] == 0
+
+
+def test_live_incident_bundle_cli_rejects_invalid_window_timestamp(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_incident_bundle.main(["monitor", "--since-ms", "not-an-int"])
+
+    assert exc_info.value.code == 2
+    assert "invalid int value" in capsys.readouterr().err
 
 
 def test_live_incident_bundle_includes_process_status_when_requested(

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 import live.smoke_report as smoke_report_module
 from live.smoke_report import build_live_smoke_report, default_logs_root_for_monitor
 from tools import live_smoke_report
@@ -549,6 +551,14 @@ def test_live_smoke_report_cli_outputs_json_and_can_skip_logs(tmp_path, capsys):
     assert report["logs"]["files_scanned"] == 0
     assert report["logs"]["root"] is None
     assert report["monitor"]["live_events"] == 1
+
+
+def test_live_smoke_report_cli_rejects_invalid_window_timestamp(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_smoke_report.main(["monitor", "--since-ms", "not-an-int"])
+
+    assert exc_info.value.code == 2
+    assert "invalid int value" in capsys.readouterr().err
 
 
 def test_live_smoke_report_process_status_matches_supervisor_config(

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -339,6 +339,75 @@ def test_live_smoke_report_distinguishes_attention_and_hard_structured_events(
     assert report["problem_events"][0]["hard"] is False
 
 
+def test_live_smoke_report_time_window_filters_structured_problem_events(tmp_path):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.stopped",
+                seq=1,
+                ts=1000,
+                status="failed",
+                level="critical",
+                reason_code="old_terminal_failure",
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                seq=2,
+                ts=2000,
+                status="failed",
+                level="warning",
+                reason_code="old_timeout",
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=3,
+                ts=3000,
+                ids={"cycle_id": "cy_fresh"},
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        since_ms=2500,
+    )
+
+    assert report["ok"] is True
+    assert report["monitor"]["live_events"] == 3
+    assert report["event_window"] == {
+        "enabled": True,
+        "since_ms": 2500,
+        "until_ms": None,
+        "events_considered": 1,
+        "events_skipped_before": 2,
+        "events_skipped_after": 0,
+        "invalid_window_ts": 0,
+    }
+    assert report["bots"] == [
+        {
+            "bot": "binance/binance_01",
+            "events": 1,
+            "event_types": {"cycle.completed": 1},
+            "invalid_ts": 0,
+            "last_ts": 3000,
+            "levels": {"info": 1},
+            "hard_problem_events": 0,
+            "problem_events": 0,
+            "statuses": {"succeeded": 1},
+        }
+    ]
+    assert report["hard_problem_event_count"] == 0
+    assert report["problem_events"] == []
+    assert report["remote_call_failures"] == {
+        "total": 0,
+        "groups_truncated": False,
+        "groups": [],
+    }
+
+
 def test_live_smoke_report_log_scan_deduplicates_aliases_and_matches_levels(
     tmp_path,
 ):
@@ -453,13 +522,30 @@ def test_live_smoke_report_cli_outputs_json_and_can_skip_logs(tmp_path, capsys):
 
     assert (
         live_smoke_report.main(
-            [str(tmp_path / "monitor"), "--logs-root", "", "--compact"]
+            [
+                str(tmp_path / "monitor"),
+                "--logs-root",
+                "",
+                "--since-ms",
+                "1001",
+                "--compact",
+            ]
         )
         == 0
     )
 
     report = json.loads(capsys.readouterr().out)
     assert report["ok"] is True
+    assert report["event_window"] == {
+        "enabled": True,
+        "since_ms": 1001,
+        "until_ms": None,
+        "events_considered": 0,
+        "events_skipped_before": 1,
+        "events_skipped_after": 0,
+        "invalid_window_ts": 0,
+    }
+    assert report["bots"] == []
     assert report["logs"]["files_scanned"] == 0
     assert report["logs"]["root"] is None
     assert report["monitor"]["live_events"] == 1


### PR DESCRIPTION
## Summary
- add optional structured-event time windows to live-smoke-report via --since-ms, --until-ms, and --recent-minutes
- expose an event_window summary with considered/skipped/invalid timestamp counts
- keep default behavior as the existing full current-segment scan; text log scanning is unchanged

## Validation
- ./venv/bin/python -m compileall src/live/smoke_report.py src/tools/live_smoke_report.py tests/test_live_smoke_report.py
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py
- git diff --check