### PR TITLE
Emit structured create filter events

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -65,12 +65,15 @@ across time.
 - `exchange_acknowledged`
 - `exchange_exception`
 - `length_mismatch`
+- `low_balance`
 - `new_fill`
 - `open_tail_projection`
 - `optional_ema_dropped`
+- `pending_exchange_config`
 - `periodic_health_summary`
 - `queue_full`
 - `ranking_features_unavailable`
+- `recent_execution`
 - `remote_fetch`
 - `required_candle_disk_coverage`
 - `required_ema_unavailable`
@@ -78,6 +81,7 @@ across time.
 - `pipeline_closing`
 - `snapshot_symbol_state`
 - `startup_phase_ready`
+- `state_change_detected`
 - `submitted_to_exchange`
 - `warmup_cache_decision`
 

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -67,6 +67,8 @@ class EventTypes:
     EXECUTION_CREATE_SUCCEEDED = "execution.create_succeeded"
     EXECUTION_CREATE_FAILED = "execution.create_failed"
     EXECUTION_CREATE_REJECTED = "execution.create_rejected"
+    EXECUTION_CREATE_DEFERRED = "execution.create_deferred"
+    EXECUTION_CREATE_SKIPPED = "execution.create_skipped"
     EXECUTION_CANCEL_SENT = "execution.cancel_sent"
     EXECUTION_CANCEL_SUCCEEDED = "execution.cancel_succeeded"
     EXECUTION_CANCEL_FAILED = "execution.cancel_failed"
@@ -147,12 +149,15 @@ class ReasonCodes:
     EXCHANGE_ACKNOWLEDGED = "exchange_acknowledged"
     EXCHANGE_EXCEPTION = "exchange_exception"
     LENGTH_MISMATCH = "length_mismatch"
+    LOW_BALANCE = "low_balance"
     NEW_FILL = "new_fill"
     OPEN_TAIL_PROJECTION = "open_tail_projection"
     OPTIONAL_EMA_DROPPED = "optional_ema_dropped"
+    PENDING_EXCHANGE_CONFIG = "pending_exchange_config"
     PERIODIC_HEALTH_SUMMARY = "periodic_health_summary"
     QUEUE_FULL = "queue_full"
     RANKING_FEATURES_UNAVAILABLE = "ranking_features_unavailable"
+    RECENT_EXECUTION = "recent_execution"
     REMOTE_FETCH = "remote_fetch"
     REQUIRED_CANDLE_DISK_COVERAGE = "required_candle_disk_coverage"
     REQUIRED_EMA_UNAVAILABLE = "required_ema_unavailable"
@@ -160,6 +165,7 @@ class ReasonCodes:
     SINK_PIPELINE_CLOSING = "pipeline_closing"
     SNAPSHOT_SYMBOL_STATE = "snapshot_symbol_state"
     STARTUP_PHASE_READY = "startup_phase_ready"
+    STATE_CHANGE_DETECTED = "state_change_detected"
     SUBMITTED_TO_EXCHANGE = "submitted_to_exchange"
     WARMUP_CACHE_DECISION = "warmup_cache_decision"
 
@@ -212,6 +218,8 @@ PHASE1_EVENT_TYPES = {
     EventTypes.EXECUTION_CREATE_SUCCEEDED,
     EventTypes.EXECUTION_CREATE_FAILED,
     EventTypes.EXECUTION_CREATE_REJECTED,
+    EventTypes.EXECUTION_CREATE_DEFERRED,
+    EventTypes.EXECUTION_CREATE_SKIPPED,
     EventTypes.EXECUTION_CANCEL_SENT,
     EventTypes.EXECUTION_CANCEL_SUCCEEDED,
     EventTypes.EXECUTION_CANCEL_FAILED,
@@ -500,6 +508,8 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.EXECUTION_CREATE_SUCCEEDED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CREATE_FAILED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CREATE_REJECTED: EventRoute(console=True, text=True),
+    EventTypes.EXECUTION_CREATE_DEFERRED: EventRoute(console=False, text=False),
+    EventTypes.EXECUTION_CREATE_SKIPPED: EventRoute(console=False, text=False),
     EventTypes.EXECUTION_CANCEL_SENT: EventRoute(console=False),
     EventTypes.EXECUTION_CANCEL_SUCCEEDED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CANCEL_FAILED: EventRoute(console=True, text=True),
@@ -573,6 +583,8 @@ _CONSOLE_EVENT_TAGS = {
     EventTypes.EXECUTION_CREATE_SUCCEEDED: "order",
     EventTypes.EXECUTION_CREATE_FAILED: "order",
     EventTypes.EXECUTION_CREATE_REJECTED: "order",
+    EventTypes.EXECUTION_CREATE_DEFERRED: "gate",
+    EventTypes.EXECUTION_CREATE_SKIPPED: "gate",
     EventTypes.EXECUTION_CANCEL_SUCCEEDED: "order",
     EventTypes.EXECUTION_CANCEL_FAILED: "order",
     EventTypes.EXECUTION_CANCEL_AMBIGUOUS_TERMINAL: "order",
@@ -697,6 +709,20 @@ def _console_order_summary(event: LiveEvent) -> list[str]:
     return parts
 
 
+def _console_create_filter_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    if event.order_wave_id:
+        parts.append(f"wave={event.order_wave_id}")
+    count = _data_int(data, "order_count")
+    if count is not None:
+        parts.append(f"orders={count}")
+    symbols = _compact_csv(data.get("symbols"), limit=4)
+    if symbols:
+        parts.append(f"symbols={symbols}")
+    return parts
+
+
 def _console_confirmation_summary(event: LiveEvent) -> list[str]:
     data = event.data if isinstance(event.data, Mapping) else {}
     parts: list[str] = []
@@ -735,6 +761,11 @@ def _console_rust_summary(event: LiveEvent) -> list[str]:
 def _console_data_summary(event: LiveEvent) -> list[str]:
     if event.event_type == EventTypes.ORDER_WAVE_COMPLETED:
         return _console_order_wave_summary(event)
+    if event.event_type in {
+        EventTypes.EXECUTION_CREATE_DEFERRED,
+        EventTypes.EXECUTION_CREATE_SKIPPED,
+    }:
+        return _console_create_filter_summary(event)
     if event.event_type in {
         EventTypes.EXECUTION_CREATE_SUCCEEDED,
         EventTypes.EXECUTION_CREATE_FAILED,

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1882,6 +1882,59 @@ def _execution_event_ids(
     return order_wave_id, action_id
 
 
+def emit_execution_create_filter_event(
+    bot: Any,
+    *,
+    event_type: str,
+    status: str,
+    reason_code: str,
+    order_count: int,
+    symbols: Any,
+    wave: dict | None = None,
+    level: str = "debug",
+    message: str | None = None,
+    data: dict | None = None,
+) -> None:
+    """Emit a bounded event for create orders filtered before exchange write."""
+    try:
+        order_wave_id, _action_id = _execution_event_ids(
+            wave, action="create", index=None
+        )
+        try:
+            symbol_values = sorted({str(symbol) for symbol in symbols or [] if symbol})
+        except TypeError:
+            symbol_values = [str(symbols)]
+        payload = dict(data or {})
+        payload.update(
+            {
+                "order_count": max(0, int(order_count)),
+                "symbols": symbol_values[:12],
+                "symbols_count": len(symbol_values),
+                "symbols_truncated": len(symbol_values) > 12,
+            }
+        )
+        bot._emit_live_event(
+            event_type,
+            level=level,
+            component="execution.create_filter",
+            tags=(EventTags.EXECUTION, EventTags.ORDER, EventTags.GATE, "create"),
+            cycle_id=bot._current_live_event_cycle_id(),
+            order_wave_id=order_wave_id,
+            status=status,
+            reason_code=reason_code,
+            message=message,
+            data={key: value for key, value in payload.items() if value is not None},
+        )
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit execution create filter event type=%s status=%s reason=%s: %s",
+            event_type,
+            status,
+            reason_code,
+            exc,
+        )
+
+
 def emit_execution_order_event(
     bot: Any,
     *,

--- a/src/live/executor.py
+++ b/src/live/executor.py
@@ -74,6 +74,10 @@ def _order_is_protective_create(order: dict) -> bool:
     return _order_is_reduce_only(order) or _order_is_panic(order)
 
 
+def _symbols_from_orders(orders: list[dict]) -> list[str]:
+    return sorted(str(order["symbol"]) for order in orders if order.get("symbol"))
+
+
 def _create_rejection_reason(result) -> str:
     if isinstance(result, BaseException):
         return "result_exception"
@@ -179,6 +183,24 @@ async def execute_order_plan(
             ]
             if order_wave is not None:
                 order_wave["skipped_create"] += len(blocked_creates)
+            if blocked_creates:
+                passivbot_cls._emit_execution_create_filter_event(
+                    bot,
+                    event_type=EventTypes.EXECUTION_CREATE_SKIPPED,
+                    status="skipped",
+                    reason_code=ReasonCodes.LOW_BALANCE,
+                    order_count=len(blocked_creates),
+                    symbols=_symbols_from_orders(blocked_creates),
+                    wave=order_wave,
+                    message="exposure-increasing creates skipped because balance is below threshold",
+                    data={
+                        "raw_balance": raw_balance,
+                        "balance_threshold": balance_threshold,
+                        "quote": bot.quote,
+                        "allowed_cancel": len(to_cancel),
+                        "allowed_protective_create": len(to_create),
+                    },
+                )
             logging.info(
                 "[balance] too low: %.2f %s; skipped %d exposure-increasing order creates; "
                 "allowing %d cancellations and %d protective creates",
@@ -210,12 +232,14 @@ async def execute_order_plan(
             )
     else:
         to_create_mod = []
+        recent_execution_deferred: list[tuple[dict, float]] = []
         for order in to_create:
             xf_log = (
                 f"{passivbot_cls._log_symbol(order['symbol'])} {order['side']} "
                 f"{order['position_side']} {order['qty']} @ {order['price']}"
             )
             if delay_time_ms := bot.order_was_recently_updated(order):
+                recent_execution_deferred.append((order, float(delay_time_ms)))
                 logging.info(
                     "[order] recent execution found; delaying for up to %.1f secs: %s",
                     delay_time_ms / 1000,
@@ -223,15 +247,58 @@ async def execute_order_plan(
                 )
             else:
                 to_create_mod.append(order)
+        if recent_execution_deferred:
+            passivbot_cls._emit_execution_create_filter_event(
+                bot,
+                event_type=EventTypes.EXECUTION_CREATE_DEFERRED,
+                status="deferred",
+                reason_code=ReasonCodes.RECENT_EXECUTION,
+                order_count=len(recent_execution_deferred),
+                symbols=_symbols_from_orders(
+                    [order for order, _delay in recent_execution_deferred]
+                ),
+                wave=order_wave,
+                message="create orders deferred because a matching recent execution exists",
+                data={
+                    "max_delay_ms": int(
+                        max(delay for _order, delay in recent_execution_deferred)
+                    ),
+                    "delays_sample_ms": [
+                        int(delay)
+                        for _order, delay in recent_execution_deferred[:8]
+                    ],
+                },
+            )
         if order_wave is not None:
             order_wave["deferred_create"] += max(0, len(to_create) - len(to_create_mod))
         if bot.state_change_detected_by_symbol:
+            state_filtered_orders = [
+                order
+                for order in to_create_mod
+                if order["symbol"] in bot.state_change_detected_by_symbol
+            ]
             logging.info(
                 "[order] state change detected; skipping order creation for %s until next cycle",
                 passivbot_cls._log_symbols(
                     sorted(bot.state_change_detected_by_symbol), limit=12
                 ),
             )
+            if state_filtered_orders:
+                passivbot_cls._emit_execution_create_filter_event(
+                    bot,
+                    event_type=EventTypes.EXECUTION_CREATE_SKIPPED,
+                    status="skipped",
+                    reason_code=ReasonCodes.STATE_CHANGE_DETECTED,
+                    order_count=len(state_filtered_orders),
+                    symbols=_symbols_from_orders(state_filtered_orders),
+                    wave=order_wave,
+                    message="create orders skipped until authoritative state settles",
+                    data={
+                        "blocked_symbols_count": len(
+                            bot.state_change_detected_by_symbol
+                        )
+                    },
+                )
             before_state_filter = len(to_create_mod)
             to_create_mod = [
                 order
@@ -252,10 +319,29 @@ async def execute_order_plan(
                 set(creation_symbols) - set(configured_symbols or set())
             )
             if pending_config:
+                pending_config_orders = [
+                    order for order in to_create_mod if order["symbol"] in pending_config
+                ]
                 logging.warning(
                     "[config] skipping order creation for symbols pending exchange config: %s",
                     passivbot_cls._log_symbols(pending_config, limit=12),
                 )
+                if pending_config_orders:
+                    passivbot_cls._emit_execution_create_filter_event(
+                        bot,
+                        event_type=EventTypes.EXECUTION_CREATE_SKIPPED,
+                        status="skipped",
+                        reason_code=ReasonCodes.PENDING_EXCHANGE_CONFIG,
+                        order_count=len(pending_config_orders),
+                        symbols=_symbols_from_orders(pending_config_orders),
+                        wave=order_wave,
+                        level="warning",
+                        message="create orders skipped while exchange config update is pending",
+                        data={
+                            "configured_symbols_count": len(configured_symbols or set()),
+                            "pending_symbols_count": len(pending_config),
+                        },
+                    )
                 before_config_filter = len(to_create_mod)
                 to_create_mod = [
                     order

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -614,6 +614,9 @@ class Passivbot:
         live_event_emitters.emit_execution_confirmation_timeout_event
     )
     _emit_execution_order_event = live_event_emitters.emit_execution_order_event
+    _emit_execution_create_filter_event = (
+        live_event_emitters.emit_execution_create_filter_event
+    )
     _emit_action_planned_event = live_event_emitters.emit_action_planned_event
     _emit_rust_orchestrator_called_event = (
         live_event_emitters.emit_rust_orchestrator_called_event
@@ -4048,11 +4051,13 @@ class Passivbot:
             if elapsed_ms >= 1_000 or cancel_posted or create_posted
             else logging.DEBUG
         )
-        self._emit_order_wave_completed_event(
-            wave,
-            elapsed_ms=elapsed_ms,
-            level=logging.getLevelName(log_level).lower(),
-        )
+        emit_completed = getattr(self, "_emit_order_wave_completed_event", None)
+        if callable(emit_completed):
+            emit_completed(
+                wave,
+                elapsed_ms=elapsed_ms,
+                level=logging.getLevelName(log_level).lower(),
+            )
         if log_level == logging.DEBUG and summary_key == getattr(
             self, "_order_wave_last_summary_key", None
         ):

--- a/tests/test_exchange_config_updates.py
+++ b/tests/test_exchange_config_updates.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from ccxt.base.errors import BadRequest, RateLimitExceeded
+from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
 
 
 class FreshPlanningSnapshot:
@@ -544,6 +545,13 @@ async def test_execute_to_exchange_allows_cancellations_when_balance_too_low(
     import passivbot as pb_mod
 
     class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_execution_create_filter_event = (
+            pb_mod.Passivbot._emit_execution_create_filter_event
+        )
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _shutdown_requested = pb_mod.Passivbot._shutdown_requested
+
         debug_mode = False
         balance_threshold = 1.0
         quote = "USDT"
@@ -551,6 +559,12 @@ async def test_execute_to_exchange_allows_cancellations_when_balance_too_low(
         state_change_detected_by_symbol = set()
 
         def __init__(self):
+            self._live_event_current_cycle_id = "cy_low_balance"
+            self._live_event_sink = ListEventSink()
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[self._live_event_sink],
+                monitor_sinks=[],
+            )
             self.cancel_called = False
             self.create_called = False
             self.config_called = False
@@ -593,16 +607,27 @@ async def test_execute_to_exchange_allows_cancellations_when_balance_too_low(
             self.create_called = True
             return []
 
-        _shutdown_requested = pb_mod.Passivbot._shutdown_requested
-
     bot = FakeBot()
     with caplog.at_level(logging.INFO):
         await pb_mod.Passivbot.execute_to_exchange(bot)
 
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
     assert bot.cancel_called
     assert not bot.config_called
     assert not bot.create_called
     assert bot.execution_scheduled is True
+    skipped_events = [
+        event
+        for event in bot._live_event_sink.events
+        if event.event_type == EventTypes.EXECUTION_CREATE_SKIPPED
+    ]
+    assert len(skipped_events) == 1
+    assert skipped_events[0].cycle_id == "cy_low_balance"
+    assert skipped_events[0].status == "skipped"
+    assert skipped_events[0].reason_code == ReasonCodes.LOW_BALANCE
+    assert skipped_events[0].data["order_count"] == 1
+    assert skipped_events[0].data["symbols"] == ["BTC/USDT:USDT"]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
     assert any(
         "skipped 1 exposure-increasing order creates" in record.message
         for record in caplog.records
@@ -812,6 +837,244 @@ async def test_execute_to_exchange_configures_only_symbols_with_creations():
 
 
 @pytest.mark.asyncio
+async def test_execute_to_exchange_emits_recent_execution_deferred_event():
+    import passivbot as pb_mod
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_execution_create_filter_event = (
+            pb_mod.Passivbot._emit_execution_create_filter_event
+        )
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _shutdown_requested = pb_mod.Passivbot._shutdown_requested
+
+        debug_mode = False
+        balance_threshold = 0.0
+        quote = "USDT"
+        stop_signal_received = False
+        state_change_detected_by_symbol = set()
+        config = {"live": {}, "_raw_effective": {"live": {}}}
+
+        def __init__(self):
+            self._live_event_current_cycle_id = "cy_recent_execution"
+            self._live_event_sink = ListEventSink()
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[self._live_event_sink],
+                monitor_sinks=[],
+            )
+            self.config_symbols = None
+            self.created_orders = None
+            self.execution_scheduled = False
+            self._current_planning_snapshot = FreshPlanningSnapshot()
+            self.market_snapshot_provider = FreshMarketSnapshotProvider()
+
+        async def execution_cycle(self):
+            return None
+
+        async def calc_orders_to_cancel_and_create(self):
+            return [], [
+                {
+                    "symbol": "BTC/USDT:USDT",
+                    "side": "buy",
+                    "position_side": "long",
+                    "price": 1.0,
+                    "qty": 1.0,
+                },
+                {
+                    "symbol": "ETH/USDT:USDT",
+                    "side": "buy",
+                    "position_side": "long",
+                    "price": 1.0,
+                    "qty": 1.0,
+                },
+            ]
+
+        async def execute_cancellations_parent(self, orders):
+            return []
+
+        async def update_exchange_configs(self, symbols=None):
+            self.config_symbols = symbols
+            return set(symbols or [])
+
+        def get_raw_balance(self):
+            return 1.0
+
+        def order_was_recently_updated(self, order):
+            if order["symbol"] == "BTC/USDT:USDT":
+                return 5_000
+            return 0
+
+        async def execute_orders_parent(self, orders):
+            self.created_orders = list(orders)
+            return []
+
+        def _current_planning_snapshot_invalid_for_creations(self, symbols):
+            return []
+
+        async def _get_live_market_snapshots(
+            self,
+            symbols,
+            *,
+            max_age_ms=10_000,
+            context="live",
+            allow_completed_candle_fallback=False,
+        ):
+            return await self.market_snapshot_provider.get_snapshots(
+                symbols, max_age_ms=max_age_ms
+            )
+
+        def _live_market_snapshot_max_age_ms(self):
+            return 10_000
+
+        def _record_market_snapshot_surface(self, symbols, snapshots):
+            return None
+
+        def _market_snapshot_signature_invalid(self, symbols):
+            return []
+
+        _ensure_freshness_ledger = pb_mod.Passivbot._ensure_freshness_ledger
+
+    bot = FakeBot()
+    await pb_mod.Passivbot.execute_to_exchange(bot)
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert bot.config_symbols == ["ETH/USDT:USDT"]
+    assert [order["symbol"] for order in bot.created_orders] == ["ETH/USDT:USDT"]
+    deferred_events = [
+        event
+        for event in bot._live_event_sink.events
+        if event.event_type == EventTypes.EXECUTION_CREATE_DEFERRED
+    ]
+    assert len(deferred_events) == 1
+    assert deferred_events[0].cycle_id == "cy_recent_execution"
+    assert deferred_events[0].status == "deferred"
+    assert deferred_events[0].reason_code == ReasonCodes.RECENT_EXECUTION
+    assert deferred_events[0].data["order_count"] == 1
+    assert deferred_events[0].data["symbols"] == ["BTC/USDT:USDT"]
+    assert deferred_events[0].data["max_delay_ms"] == 5_000
+    assert bot.execution_scheduled is True
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_execute_to_exchange_emits_state_change_skipped_event():
+    import passivbot as pb_mod
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_execution_create_filter_event = (
+            pb_mod.Passivbot._emit_execution_create_filter_event
+        )
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _shutdown_requested = pb_mod.Passivbot._shutdown_requested
+
+        debug_mode = False
+        balance_threshold = 0.0
+        quote = "USDT"
+        stop_signal_received = False
+        state_change_detected_by_symbol = {"BTC/USDT:USDT"}
+        config = {"live": {}, "_raw_effective": {"live": {}}}
+
+        def __init__(self):
+            self._live_event_current_cycle_id = "cy_state_change"
+            self._live_event_sink = ListEventSink()
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[self._live_event_sink],
+                monitor_sinks=[],
+            )
+            self.config_symbols = None
+            self.created_orders = None
+            self.execution_scheduled = False
+            self._current_planning_snapshot = FreshPlanningSnapshot()
+            self.market_snapshot_provider = FreshMarketSnapshotProvider()
+
+        async def execution_cycle(self):
+            return None
+
+        async def calc_orders_to_cancel_and_create(self):
+            return [], [
+                {
+                    "symbol": "BTC/USDT:USDT",
+                    "side": "buy",
+                    "position_side": "long",
+                    "price": 1.0,
+                    "qty": 1.0,
+                },
+                {
+                    "symbol": "ETH/USDT:USDT",
+                    "side": "buy",
+                    "position_side": "long",
+                    "price": 1.0,
+                    "qty": 1.0,
+                },
+            ]
+
+        async def execute_cancellations_parent(self, orders):
+            return []
+
+        async def update_exchange_configs(self, symbols=None):
+            self.config_symbols = symbols
+            return set(symbols or [])
+
+        def get_raw_balance(self):
+            return 1.0
+
+        def order_was_recently_updated(self, order):
+            return 0
+
+        async def execute_orders_parent(self, orders):
+            self.created_orders = list(orders)
+            return []
+
+        def _current_planning_snapshot_invalid_for_creations(self, symbols):
+            return []
+
+        async def _get_live_market_snapshots(
+            self,
+            symbols,
+            *,
+            max_age_ms=10_000,
+            context="live",
+            allow_completed_candle_fallback=False,
+        ):
+            return await self.market_snapshot_provider.get_snapshots(
+                symbols, max_age_ms=max_age_ms
+            )
+
+        def _live_market_snapshot_max_age_ms(self):
+            return 10_000
+
+        def _record_market_snapshot_surface(self, symbols, snapshots):
+            return None
+
+        def _market_snapshot_signature_invalid(self, symbols):
+            return []
+
+        _ensure_freshness_ledger = pb_mod.Passivbot._ensure_freshness_ledger
+
+    bot = FakeBot()
+    await pb_mod.Passivbot.execute_to_exchange(bot)
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert bot.config_symbols == ["ETH/USDT:USDT"]
+    assert [order["symbol"] for order in bot.created_orders] == ["ETH/USDT:USDT"]
+    skipped_events = [
+        event
+        for event in bot._live_event_sink.events
+        if event.event_type == EventTypes.EXECUTION_CREATE_SKIPPED
+    ]
+    assert len(skipped_events) == 1
+    assert skipped_events[0].cycle_id == "cy_state_change"
+    assert skipped_events[0].status == "skipped"
+    assert skipped_events[0].reason_code == ReasonCodes.STATE_CHANGE_DETECTED
+    assert skipped_events[0].data["order_count"] == 1
+    assert skipped_events[0].data["symbols"] == ["BTC/USDT:USDT"]
+    assert skipped_events[0].data["blocked_symbols_count"] == 1
+    assert bot.execution_scheduled is True
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
 async def test_execute_order_plan_posts_replacement_matching_cancel_same_cycle():
     import passivbot as pb_mod
 
@@ -882,7 +1145,7 @@ async def test_execute_order_plan_posts_replacement_matching_cancel_same_cycle()
             "symbol": symbol,
             "side": "sell",
             "position_side": "long",
-            "price": 100.0,
+            "price": 1.0,
             "qty": 1.0,
             "reduce_only": True,
         }
@@ -892,7 +1155,7 @@ async def test_execute_order_plan_posts_replacement_matching_cancel_same_cycle()
             "symbol": symbol,
             "side": "sell",
             "position_side": "long",
-            "price": 100.0,
+            "price": 1.0,
             "qty": 1.0,
             "reduce_only": True,
             "pb_order_type": "close_grid_long",
@@ -913,6 +1176,13 @@ async def test_execute_to_exchange_skips_creations_pending_exchange_config():
     import passivbot as pb_mod
 
     class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_execution_create_filter_event = (
+            pb_mod.Passivbot._emit_execution_create_filter_event
+        )
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _shutdown_requested = pb_mod.Passivbot._shutdown_requested
+
         debug_mode = False
         balance_threshold = 0.0
         quote = "USDT"
@@ -921,6 +1191,12 @@ async def test_execute_to_exchange_skips_creations_pending_exchange_config():
 
         def __init__(self):
             self.stop_signal_received = False
+            self._live_event_current_cycle_id = "cy_pending_config"
+            self._live_event_sink = ListEventSink()
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[self._live_event_sink],
+                monitor_sinks=[],
+            )
             self.config_symbols = None
             self.created_orders = None
             self._current_planning_snapshot = FreshPlanningSnapshot()
@@ -992,10 +1268,23 @@ async def test_execute_to_exchange_skips_creations_pending_exchange_config():
             return []
 
         _ensure_freshness_ledger = pb_mod.Passivbot._ensure_freshness_ledger
-        _shutdown_requested = pb_mod.Passivbot._shutdown_requested
 
     bot = FakeBot()
     await pb_mod.Passivbot.execute_to_exchange(bot)
 
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
     assert bot.config_symbols == ["PENDING/USDT:USDT", "READY/USDT:USDT"]
     assert [order["symbol"] for order in bot.created_orders] == ["READY/USDT:USDT"]
+    skipped_events = [
+        event
+        for event in bot._live_event_sink.events
+        if event.event_type == EventTypes.EXECUTION_CREATE_SKIPPED
+    ]
+    assert len(skipped_events) == 1
+    assert skipped_events[0].cycle_id == "cy_pending_config"
+    assert skipped_events[0].status == "skipped"
+    assert skipped_events[0].reason_code == ReasonCodes.PENDING_EXCHANGE_CONFIG
+    assert skipped_events[0].data["order_count"] == 1
+    assert skipped_events[0].data["symbols"] == ["PENDING/USDT:USDT"]
+    assert skipped_events[0].data["pending_symbols_count"] == 1
+    assert bot._live_event_pipeline.close(timeout=2.0) is True

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -199,6 +199,8 @@ def test_route_table_keeps_data_events_off_console_by_default():
         assert DEFAULT_ROUTES[event_type].text is False
     assert DEFAULT_ROUTES[EventTypes.ORDER_WAVE_COMPLETED].console is True
     assert DEFAULT_ROUTES[EventTypes.ORDER_WAVE_COMPLETED].text is True
+    assert DEFAULT_ROUTES[EventTypes.EXECUTION_CREATE_DEFERRED].console is False
+    assert DEFAULT_ROUTES[EventTypes.EXECUTION_CREATE_SKIPPED].console is False
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CONFIRMATION_TIMEOUT].console is True
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CONFIRMATION_TIMEOUT].text is True
     assert DEFAULT_ROUTES[EventTypes.BOT_SHUTDOWN_STAGE].console is True
@@ -691,6 +693,28 @@ def test_console_format_summarizes_order_write_without_raw_payload():
         "[order] succeeded cycle=cy_3 wave=ow_2 side=buy type=limit "
         "qty=1.23456789 price=88.7654321 exchange_status=open "
         "order_id=abc123 client_id=pbot_456 symbol=AAVE/USDT:USDT pside=long"
+    )
+
+
+def test_console_format_summarizes_create_filter_payload():
+    event = LiveEvent(
+        EventTypes.EXECUTION_CREATE_SKIPPED,
+        status="skipped",
+        cycle_id="cy_8",
+        order_wave_id="ow_4",
+        reason_code=ReasonCodes.PENDING_EXCHANGE_CONFIG,
+        message="create orders skipped while exchange config update is pending",
+        data={
+            "order_count": 2,
+            "symbols": ["BTC/USDT:USDT", "ETH/USDT:USDT"],
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[gate] skipped cycle=cy_8 wave=ow_4 orders=2 "
+        "symbols=BTC/USDT:USDT,ETH/USDT:USDT "
+        "reason=pending_exchange_config "
+        "create orders skipped while exchange config update is pending"
     )
 
 


### PR DESCRIPTION
## Summary
- add structured live events for create-order filters/defer decisions before exchange writes
- cover low-balance skips, recent-execution defers, authoritative state-change skips, and pending exchange-config skips with stable reason codes
- keep the new events off default console/text routes while preserving compact event-projected summaries if routed later

## Validation
- ./venv/bin/python -m compileall src/live/event_bus.py src/live/event_emitters.py src/live/executor.py src/passivbot.py tests/test_exchange_config_updates.py tests/test_live_event_bus.py tests/test_live_event_registry_docs.py tests/test_passivbot_monitor.py
- ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_live_event_registry_docs.py tests/test_exchange_config_updates.py::test_execute_to_exchange_allows_cancellations_when_balance_too_low tests/test_exchange_config_updates.py::test_execute_to_exchange_emits_recent_execution_deferred_event tests/test_exchange_config_updates.py::test_execute_to_exchange_emits_state_change_skipped_event tests/test_exchange_config_updates.py::test_execute_order_plan_posts_replacement_matching_cancel_same_cycle tests/test_exchange_config_updates.py::test_execute_to_exchange_skips_creations_pending_exchange_config -q
- ./venv/bin/python -m pytest tests/test_passivbot_monitor.py::test_order_wave_summary_emits_live_event tests/test_passivbot_monitor.py::test_execute_orders_parent_records_order_opened_event tests/test_passivbot_monitor.py::test_execute_cancellations_parent_emits_ambiguous_confirmation_events -q
- git diff --check

## Notes
- Broader ./venv/bin/python -m pytest tests/test_exchange_config_updates.py -q currently fails only in the unrelated Bitget account-mode fixture cases that already lack the newer UTA detection fake endpoint. I left that exchange test repair out of this observability-only slice.
- Silent-handling diff audit found one new except Exception, confined to best-effort structured event emission; event emission failure logs DEBUG and does not affect trading behavior.