### PR TITLE
Add time windows to live event query

### DIFF
--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -140,10 +140,16 @@ def _filter_report(
     psides: set[str],
     reason_codes: set[str],
     statuses: set[str],
+    since_ms: int | None = None,
+    until_ms: int | None = None,
 ) -> dict[str, Any]:
     filters: dict[str, Any] = {}
     if cycle_id is not None:
         filters["cycle_id"] = str(cycle_id)
+    if since_ms is not None:
+        filters["since_ms"] = int(since_ms)
+    if until_ms is not None:
+        filters["until_ms"] = int(until_ms)
     if event_types:
         filters["event_types"] = sorted(event_types)
     if bot_ids:
@@ -800,6 +806,8 @@ def build_event_report(
     pside: str | Iterable[str] | None = None,
     reason_code: str | Iterable[str] | None = None,
     status: str | Iterable[str] | None = None,
+    since_ms: int | None = None,
+    until_ms: int | None = None,
     limit: int = 200,
     include_data: bool = False,
     include_rotated: bool = False,
@@ -808,6 +816,19 @@ def build_event_report(
     order_trace: bool = False,
     cycle_trace: bool = False,
 ) -> dict[str, Any]:
+    since_filter = int(since_ms) if since_ms is not None else None
+    until_filter = int(until_ms) if until_ms is not None else None
+    if (
+        since_filter is not None
+        and until_filter is not None
+        and since_filter > until_filter
+    ):
+        raise ValueError("since_ms must be <= until_ms")
+    window_enabled = since_filter is not None or until_filter is not None
+    window_considered = 0
+    window_skipped_before = 0
+    window_skipped_after = 0
+    window_invalid_ts = 0
     issues: list[EventIssue] = []
     try:
         files = discover_event_files(root, include_rotated=include_rotated)
@@ -878,9 +899,10 @@ def build_event_report(
             status_filter,
         )
     )
-    has_query_filter = has_non_cycle_filter or bool(
+    trace_without_cycle = (
         (timeline or trace_summary or order_trace or cycle_trace) and cycle_id is None
     )
+    has_query_filter = has_non_cycle_filter or window_enabled or trace_without_cycle
 
     for path in files:
         try:
@@ -920,6 +942,18 @@ def build_event_report(
                         legacy_events += 1
                         continue
                     live_events += 1
+                    if window_enabled:
+                        record_ts = _record_ts(row)
+                        if record_ts is None:
+                            window_invalid_ts += 1
+                            continue
+                        if since_filter is not None and record_ts < since_filter:
+                            window_skipped_before += 1
+                            continue
+                        if until_filter is not None and record_ts > until_filter:
+                            window_skipped_after += 1
+                            continue
+                        window_considered += 1
 
                     record_event_type = live_event.get("event_type") or row.get("kind")
                     if not record_event_type:
@@ -1126,6 +1160,8 @@ def build_event_report(
             psides=pside_filter,
             reason_codes=reason_code_filter,
             statuses=status_filter,
+            since_ms=since_filter,
+            until_ms=until_filter,
         )
         report["query"] = {
             "filters": query_filters,
@@ -1158,6 +1194,8 @@ def build_event_report(
             psides=pside_filter,
             reason_codes=reason_code_filter,
             statuses=status_filter,
+            since_ms=since_filter,
+            until_ms=until_filter,
         )
         report["cycle"] = {
             "cycle_id": str(cycle_id),
@@ -1179,4 +1217,14 @@ def build_event_report(
             report["cycle"]["cycle_trace"] = cycle_cycle_trace.to_dict()
         if not event_type_filter:
             report["cycle"].pop("event_types", None)
+    if window_enabled:
+        report["event_window"] = {
+            "enabled": True,
+            "since_ms": since_filter,
+            "until_ms": until_filter,
+            "events_considered": window_considered,
+            "events_skipped_before": window_skipped_before,
+            "events_skipped_after": window_skipped_after,
+            "invalid_window_ts": window_invalid_ts,
+        }
     return report

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import time
 from pathlib import Path
 
 SRC_ROOT = Path(__file__).resolve().parents[1]
@@ -119,6 +120,21 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--since-ms",
+        type=int,
+        help="Only include live events with monitor ts at or after this epoch-ms value.",
+    )
+    parser.add_argument(
+        "--until-ms",
+        type=int,
+        help="Only include live events with monitor ts at or before this epoch-ms value.",
+    )
+    parser.add_argument(
+        "--recent-minutes",
+        type=float,
+        help="Only include live events from the last N minutes.",
+    )
+    parser.add_argument(
         "--limit",
         type=int,
         default=200,
@@ -179,6 +195,15 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    if args.since_ms is not None and args.recent_minutes is not None:
+        parser.error("--since-ms and --recent-minutes are mutually exclusive")
+    since_ms = args.since_ms
+    if args.recent_minutes is not None:
+        if args.recent_minutes <= 0:
+            parser.error("--recent-minutes must be greater than 0")
+        since_ms = int(time.time() * 1000) - int(args.recent_minutes * 60_000)
+    if since_ms is not None and args.until_ms is not None and since_ms > args.until_ms:
+        parser.error("--since-ms/--recent-minutes must be <= --until-ms")
     report = build_event_report(
         args.path,
         cycle_id=args.cycle_id,
@@ -194,6 +219,8 @@ def main(argv: list[str] | None = None) -> int:
         pside=args.pside,
         reason_code=args.reason_code,
         status=args.status,
+        since_ms=since_ms,
+        until_ms=args.until_ms,
         limit=args.limit,
         include_data=bool(args.include_data),
         include_rotated=bool(args.include_rotated),

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import gzip
 import json
 
+import pytest
+
 from live.event_query import build_event_report, discover_event_files
 from tools import live_event_query
 
@@ -492,6 +494,92 @@ def test_event_query_filters_by_remaining_event_ids(tmp_path):
     }
 
 
+def test_event_query_filters_by_inclusive_time_window(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    invalid_ts = _monitor_row(
+        event_type="cycle.completed",
+        cycle_id="cy_bad",
+        seq=6,
+        ts=2600,
+    )
+    invalid_ts["ts"] = "bad"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.started",
+                cycle_id="cy_1",
+                seq=1,
+                ts=900,
+            ),
+            _monitor_row(
+                event_type="cycle.started",
+                cycle_id="cy_2",
+                seq=2,
+                ts=1000,
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                cycle_id="cy_2",
+                seq=3,
+                ts=1500,
+                reason_code="request_timeout",
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                cycle_id="cy_3",
+                seq=4,
+                ts=2000,
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                cycle_id="cy_4",
+                seq=5,
+                ts=2500,
+            ),
+            invalid_ts,
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        since_ms=1000,
+        until_ms=2000,
+        timeline=True,
+    )
+
+    assert report["ok"] is True
+    assert report["records_total"] == 6
+    assert report["live_events"] == 6
+    assert report["event_window"] == {
+        "enabled": True,
+        "since_ms": 1000,
+        "until_ms": 2000,
+        "events_considered": 3,
+        "events_skipped_before": 1,
+        "events_skipped_after": 1,
+        "invalid_window_ts": 1,
+    }
+    assert report["event_types"] == {
+        "cycle.completed": 1,
+        "cycle.started": 1,
+        "remote_call.failed": 1,
+    }
+    assert report["query"]["filters"] == {
+        "since_ms": 1000,
+        "until_ms": 2000,
+    }
+    assert report["query"]["matched_events"] == 3
+    assert report["query"]["timeline"] == [
+        "1000 seq=2 cycle.started status=succeeded reason_code=test ids=cycle_id=cy_2",
+        (
+            "1500 seq=3 remote_call.failed status=succeeded "
+            "reason_code=request_timeout ids=cycle_id=cy_2"
+        ),
+        "2000 seq=4 cycle.completed status=succeeded reason_code=test ids=cycle_id=cy_3",
+    ]
+
+
 def test_event_query_timeline_renders_cycle_and_query_matches(tmp_path):
     events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
     _write_ndjson(
@@ -695,6 +783,95 @@ def test_live_event_query_cli_accepts_scope_filters_and_timeline(tmp_path, capsy
             "ids=cycle_id=cy_9,order_wave_id=ow_9"
         )
     ]
+
+
+def test_live_event_query_cli_accepts_time_window(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="execution.cancel_failed",
+                cycle_id="cy_9",
+                seq=1,
+                ts=1000,
+                reason_code="exchange_exception",
+            ),
+            _monitor_row(
+                event_type="execution.cancel_succeeded",
+                cycle_id="cy_9",
+                seq=2,
+                ts=1200,
+                reason_code="exchange_acknowledged",
+            ),
+        ],
+    )
+
+    assert (
+        live_event_query.main(
+            [
+                str(tmp_path / "monitor"),
+                "--since-ms",
+                "1100",
+                "--until-ms",
+                "1300",
+                "--timeline",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["event_window"]["events_considered"] == 1
+    assert report["event_window"]["events_skipped_before"] == 1
+    assert report["query"]["filters"] == {"since_ms": 1100, "until_ms": 1300}
+    assert report["query"]["matched_events"] == 1
+    assert report["query"]["events"][0]["seq"] == 2
+
+
+def test_live_event_query_cli_accepts_recent_minutes(tmp_path, capsys, monkeypatch):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    now_ms = 1_700_000_000_000
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="execution.cancel_failed",
+                cycle_id="cy_9",
+                seq=1,
+                ts=now_ms - 60_001,
+            ),
+            _monitor_row(
+                event_type="execution.cancel_succeeded",
+                cycle_id="cy_9",
+                seq=2,
+                ts=now_ms - 60_000,
+            ),
+        ],
+    )
+    monkeypatch.setattr(live_event_query.time, "time", lambda: now_ms / 1000)
+
+    assert (
+        live_event_query.main(
+            [str(tmp_path / "monitor"), "--recent-minutes", "1", "--timeline"]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["query"]["filters"] == {"since_ms": now_ms - 60_000}
+    assert report["query"]["matched_events"] == 1
+    assert report["query"]["events"][0]["seq"] == 2
+
+
+def test_live_event_query_cli_rejects_invalid_time_window(tmp_path, capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_event_query.main(
+            [str(tmp_path), "--since-ms", "20", "--until-ms", "10"]
+        )
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "must be <= --until-ms" in err
 
 
 def test_live_event_query_cli_accepts_additional_id_scopes(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- add inclusive epoch-ms time-window filtering to live-event-query reports
- expose --since-ms, --until-ms, and --recent-minutes in the CLI
- report explicit event_window counters for considered/skipped/invalid-ts live events

## Validation
- ./venv/bin/python -m compileall src/live/event_query.py src/tools/live_event_query.py tests/test_live_event_query.py
- ./venv/bin/python -m pytest tests/test_live_event_query.py tests/test_passivbot_cli.py::test_live_event_query_tool_dispatch_forwards_module_and_prog -q
- git diff --check
- silent-handling scan on touched files: no matches

## Notes
- Read-only tooling slice; no live trading behavior, event emission, routes, or sinks changed.
- Window filtering is centralized in build_event_report so query, cycle, trace-summary, order-trace, and cycle-trace views use the same scoped event set.