### PR TITLE
Summarize cache families in cache doctor

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -107,7 +107,7 @@ passivbot tool iterative-history-plot backtests/.../fills.csv
 - `passivbot tool pad-historical-daily` – Ensures daily OHLCV shards are present for the downloader when new coins are added.
 - `passivbot tool verify-hlcvs-data` – Validates prepared HLCV datasets and coverage metadata before long optimizations/backtests.
 - `passivbot tool streamline-json` – Normalizes/compacts JSON configs (`passivbot tool streamline-json configs/examples/default_trailing_martingale_long_npos4.json`).
-- `passivbot tool cache-integrity-doctor` – Read-only local cache smoke report for missing roots, file counts/sizes, and empty or corrupt JSON/NDJSON/NPY artifacts.
+- `passivbot tool cache-integrity-doctor` – Read-only local cache smoke report for missing roots, file counts/sizes, cache-family summaries, and empty or corrupt JSON/NDJSON/NPY artifacts.
 - `passivbot tool candle-doctor` – Audits legacy `caches/ohlcv/...` shards for corruption, stale index entries, and legacy-format issues; add `--fix` to apply automatic repairs before importing into the v2 store.
 - `passivbot tool migrate-historical-data` – Converts legacy `historical_data/ohlcvs_<exchange>/...` shards into the current `caches/ohlcv/...` layout.
 

--- a/src/tools/cache_integrity_doctor.py
+++ b/src/tools/cache_integrity_doctor.py
@@ -11,16 +11,26 @@ NUMPY_CACHE_SUFFIXES = {".npy"}
 DEFAULT_ROOTS = ("caches",)
 
 
-def _issue(severity: str, code: str, path: Path, message: str) -> dict[str, str]:
-    return {
+def _issue(
+    severity: str,
+    code: str,
+    path: Path,
+    message: str,
+    *,
+    family: str | None = None,
+) -> dict[str, Any]:
+    issue = {
         "severity": severity,
         "code": code,
         "path": str(path),
         "message": message,
     }
+    if family:
+        issue["family"] = family
+    return issue
 
 
-def _empty_file_issue(path: Path) -> dict[str, str] | None:
+def _empty_file_issue(path: Path) -> dict[str, Any] | None:
     try:
         if path.stat().st_size == 0:
             return _issue("warning", "empty_file", path, "cache file is empty")
@@ -29,7 +39,7 @@ def _empty_file_issue(path: Path) -> dict[str, str] | None:
     return None
 
 
-def _inspect_json_file(path: Path) -> list[dict[str, str]]:
+def _inspect_json_file(path: Path) -> list[dict[str, Any]]:
     empty = _empty_file_issue(path)
     if empty is not None:
         return [empty]
@@ -51,11 +61,11 @@ def _inspect_json_file(path: Path) -> list[dict[str, str]]:
     return []
 
 
-def _inspect_ndjson_file(path: Path) -> list[dict[str, str]]:
+def _inspect_ndjson_file(path: Path) -> list[dict[str, Any]]:
     empty = _empty_file_issue(path)
     if empty is not None:
         return [empty]
-    issues: list[dict[str, str]] = []
+    issues: list[dict[str, Any]] = []
     try:
         with path.open("r", encoding="utf-8") as handle:
             for line_no, line in enumerate(handle, start=1):
@@ -81,7 +91,7 @@ def _inspect_ndjson_file(path: Path) -> list[dict[str, str]]:
     return issues
 
 
-def _inspect_npy_file(path: Path) -> list[dict[str, str]]:
+def _inspect_npy_file(path: Path) -> list[dict[str, Any]]:
     empty = _empty_file_issue(path)
     if empty is not None:
         return [empty]
@@ -105,7 +115,7 @@ def _inspect_npy_file(path: Path) -> list[dict[str, str]]:
     return []
 
 
-def _inspect_file(path: Path) -> list[dict[str, str]]:
+def _inspect_file(path: Path) -> list[dict[str, Any]]:
     suffix = path.suffix.lower()
     if suffix == ".json":
         return _inspect_json_file(path)
@@ -116,7 +126,56 @@ def _inspect_file(path: Path) -> list[dict[str, str]]:
     return []
 
 
-def _scan_root(root: Path) -> tuple[dict[str, Any], list[dict[str, str]]]:
+def _cache_family(root: Path, path: Path) -> str:
+    try:
+        rel = path.relative_to(root)
+        parts = [part.lower() for part in rel.parts]
+    except ValueError:
+        parts = [part.lower() for part in path.parts]
+    stem = path.stem.lower()
+    suffix = path.suffix.lower()
+    joined = "/".join(parts)
+    if suffix == ".lock" or path.name.lower().endswith(".lock"):
+        return "locks"
+    if any(part.startswith("ohlcvs") for part in parts) or "ohlcv" in joined:
+        return "candles"
+    if "hlcvs_data" in parts or "hlcvs" in joined:
+        return "historical_hlcvs"
+    if any(token in joined for token in ("fills", "fill_events", "pnls", "pnl")):
+        return "fills"
+    if any(token in joined for token in ("hsl", "equity_hard_stop", "risk")):
+        return "risk"
+    if "markets" in stem or "market" in stem:
+        return "markets"
+    if any(token in joined for token in ("monitor", "events", "snapshots")):
+        return "monitor"
+    if any(token in joined for token in ("user", "api_key", "api-keys", "api_keys")):
+        return "user_config"
+    return "unknown"
+
+
+def _family_summary_entry() -> dict[str, Any]:
+    return {
+        "file_count": 0,
+        "total_bytes": 0,
+        "issue_count": 0,
+        "by_extension": Counter(),
+    }
+
+
+def _finalize_family_summary(by_family: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    finalized: dict[str, Any] = {}
+    for family, summary in sorted(by_family.items()):
+        finalized[family] = {
+            "file_count": int(summary["file_count"]),
+            "total_bytes": int(summary["total_bytes"]),
+            "issue_count": int(summary["issue_count"]),
+            "by_extension": dict(sorted(summary["by_extension"].items())),
+        }
+    return finalized
+
+
+def _scan_root(root: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     summary: dict[str, Any] = {
         "path": str(root),
         "exists": root.exists(),
@@ -125,27 +184,47 @@ def _scan_root(root: Path) -> tuple[dict[str, Any], list[dict[str, str]]]:
         "dir_count": 0,
         "total_bytes": 0,
         "by_extension": {},
+        "by_family": {},
     }
-    issues: list[dict[str, str]] = []
+    issues: list[dict[str, Any]] = []
     if not root.exists():
         issues.append(
-            _issue("warning", "root_missing", root, "cache root does not exist")
+            _issue(
+                "warning",
+                "root_missing",
+                root,
+                "cache root does not exist",
+                family="root",
+            )
         )
         return summary, issues
     if not root.is_dir():
         issues.append(
-            _issue("error", "root_not_directory", root, "cache root is not a directory")
+            _issue(
+                "error",
+                "root_not_directory",
+                root,
+                "cache root is not a directory",
+                family="root",
+            )
         )
         return summary, issues
     try:
         entries = list(root.rglob("*"))
     except OSError as exc:
         issues.append(
-            _issue("error", "root_scan_failed", root, f"could not scan root: {exc}")
+            _issue(
+                "error",
+                "root_scan_failed",
+                root,
+                f"could not scan root: {exc}",
+                family="root",
+            )
         )
         return summary, issues
 
     by_extension: Counter[str] = Counter()
+    by_family: dict[str, dict[str, Any]] = {}
     for entry in entries:
         if entry.is_dir():
             summary["dir_count"] += 1
@@ -155,29 +234,55 @@ def _scan_root(root: Path) -> tuple[dict[str, Any], list[dict[str, str]]]:
         summary["file_count"] += 1
         suffix = entry.suffix.lower() or "<none>"
         by_extension[suffix] += 1
+        family = _cache_family(root, entry)
+        family_summary = by_family.setdefault(family, _family_summary_entry())
+        family_summary["file_count"] += 1
+        family_summary["by_extension"][suffix] += 1
         try:
-            summary["total_bytes"] += entry.stat().st_size
+            file_size = entry.stat().st_size
+            summary["total_bytes"] += file_size
+            family_summary["total_bytes"] += file_size
         except OSError as exc:
+            family_summary["issue_count"] += 1
             issues.append(
-                _issue("error", "stat_failed", entry, f"could not stat file: {exc}")
+                _issue(
+                    "error",
+                    "stat_failed",
+                    entry,
+                    f"could not stat file: {exc}",
+                    family=family,
+                )
             )
             continue
-        issues.extend(_inspect_file(entry))
+        file_issues = _inspect_file(entry)
+        for issue in file_issues:
+            issue.setdefault("family", family)
+        family_summary["issue_count"] += len(file_issues)
+        issues.extend(file_issues)
     summary["by_extension"] = dict(sorted(by_extension.items()))
+    summary["by_family"] = _finalize_family_summary(by_family)
     return summary, issues
 
 
 def build_cache_integrity_report(roots: Iterable[str | Path]) -> dict[str, Any]:
     root_paths = [Path(root).expanduser() for root in roots]
     root_reports: list[dict[str, Any]] = []
-    issues: list[dict[str, str]] = []
+    issues: list[dict[str, Any]] = []
     for root in root_paths:
         root_report, root_issues = _scan_root(root)
         root_reports.append(root_report)
         issues.extend(root_issues)
     by_severity: Counter[str] = Counter()
+    by_family: dict[str, dict[str, Any]] = {}
     for item in issues:
         by_severity[item["severity"]] += 1
+    for root in root_reports:
+        for family, family_report in root["by_family"].items():
+            summary = by_family.setdefault(family, _family_summary_entry())
+            summary["file_count"] += int(family_report["file_count"])
+            summary["total_bytes"] += int(family_report["total_bytes"])
+            summary["issue_count"] += int(family_report["issue_count"])
+            summary["by_extension"].update(family_report["by_extension"])
     summary = {
         "root_count": len(root_reports),
         "file_count": sum(int(root["file_count"]) for root in root_reports),
@@ -185,6 +290,7 @@ def build_cache_integrity_report(roots: Iterable[str | Path]) -> dict[str, Any]:
         "total_bytes": sum(int(root["total_bytes"]) for root in root_reports),
         "issue_count": len(issues),
         "by_severity": dict(sorted(by_severity.items())),
+        "by_family": _finalize_family_summary(by_family),
     }
     return {
         "ok": "error" not in by_severity,

--- a/tests/test_cache_integrity_doctor.py
+++ b/tests/test_cache_integrity_doctor.py
@@ -37,6 +37,35 @@ def test_cache_integrity_report_counts_files_and_flags_corrupt_artifacts(tmp_pat
     assert ("npy_load_failed", str(root / "corrupt.npy")) in issues
 
 
+def test_cache_integrity_report_summarizes_cache_families(tmp_path):
+    root = tmp_path / "caches"
+    (root / "okx" / "ohlcvs_1m").mkdir(parents=True)
+    np.save(root / "okx" / "ohlcvs_1m" / "BTC.npy", np.array([1.0, 2.0]))
+    (root / "okx" / "ohlcvs_1m" / "ETH.npy").write_bytes(b"not numpy")
+    (root / "fills" / "binance").mkdir(parents=True)
+    (root / "fills" / "binance" / "events.ndjson").write_text(
+        json.dumps({"id": 1}) + "\n",
+        encoding="utf-8",
+    )
+    (root / "markets.json").write_text(json.dumps({"BTC": {}}), encoding="utf-8")
+    (root / "tmp.npy.lock").write_text("locked", encoding="utf-8")
+
+    report = build_cache_integrity_report([root])
+
+    families = report["summary"]["by_family"]
+    assert families["candles"]["file_count"] == 2
+    assert families["candles"]["by_extension"] == {".npy": 2}
+    assert families["candles"]["issue_count"] == 1
+    assert families["fills"]["file_count"] == 1
+    assert families["fills"]["by_extension"] == {".ndjson": 1}
+    assert families["markets"]["file_count"] == 1
+    assert families["locks"]["file_count"] == 1
+    root_families = report["roots"][0]["by_family"]
+    assert root_families == families
+    issue = next(item for item in report["issues"] if item["code"] == "npy_load_failed")
+    assert issue["family"] == "candles"
+
+
 def test_cache_integrity_report_marks_missing_root_as_warning(tmp_path):
     missing = tmp_path / "missing"
 
@@ -44,6 +73,7 @@ def test_cache_integrity_report_marks_missing_root_as_warning(tmp_path):
 
     assert report["ok"] is True
     assert report["summary"]["by_severity"] == {"warning": 1}
+    assert report["issues"][0]["family"] == "root"
     assert report["issues"][0]["code"] == "root_missing"
 
 


### PR DESCRIPTION
## Summary
- add per-root and aggregate cache-family summaries to cache-integrity-doctor output
- attach cache family metadata to file/root issues
- document the new cache-family summary output

## Validation
- ./venv/bin/python -m compileall src/tools/cache_integrity_doctor.py tests/test_cache_integrity_doctor.py
- ./venv/bin/python -m pytest tests/test_cache_integrity_doctor.py -q
- git diff --check
- silent-handling scan on touched files: no matches

## Notes
- Read-only tooling slice; no cache writes and no live trading behavior changed.
- This is a small refinement toward cache-family metadata and warm-cache diagnostics from docs/plans/live_ops_improvement_backlog.md.