### PR TITLE
Update logging progress after smoke tooling merges

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,24 +15,27 @@ merge, live smoke evidence changes, or new gaps are discovered.
 
 ## Current Status
 
-Last updated: 2026-06-25.
+Last updated: 2026-06-26.
 
 Current `origin/v8` logging-overhaul head:
 
-- `45b0cf9e` merge of PR #663, `Summarize remote call failures in smoke report`.
+- `734c2de0` merge of PR #668, `Summarize cache families in cache doctor`.
 
 VPS5 deployment status:
 
-- Repository pulled through PR #663 at `45b0cf9e`.
-- Bots were left running after the pull; PR #663 was a read-only tooling slice
-  and did not require bot restart.
-- VPS5 process-status smoke with `/root/bots_vps5.yaml` reported
-  `expected_total=5`, `matched_expected=5`, `missing_expected=[]`,
-  and `scan_error=null`.
-- Overall smoke still returned attention/hard failure because current monitor
-  events include Kucoin authoritative state `RequestTimeout` failures. The new
-  `remote_call_failures` summary grouped them as positions=9,
-  open_orders=7, and balance=7. The process-status check itself was green.
+- Repository pulled through PR #668 at `734c2de0`.
+- Bots were restarted from `/root/bots_vps5.yaml` and left running. Four bots
+  exited promptly after Ctrl-C; Kucoin took about 105 seconds before the old
+  process disappeared.
+- `tmuxp load` returned a nonzero attach error because SSH had no terminal, but
+  it created the `passivbot` session and all five configured bot processes.
+- VPS5 post-restart smoke with text logs disabled and
+  `--recent-minutes 2 --supervisor-config /root/bots_vps5.yaml` reported
+  `ok=true`, `hard_failures=0`, `hard_problem_event_count=0`,
+  `expected_total=5`, `matched_expected=5`, and `missing_expected=[]`.
+- A wider post-restart smoke saw a real GateIO HSL ZEC long RED finalization
+  during startup/replay and one non-hard Kucoin candle `RequestTimeout`; the
+  narrower settled-window smoke confirmed no continuing hard failures.
 
 ## Phase Checklist
 
@@ -45,8 +48,8 @@ VPS5 deployment status:
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
-| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, `live-smoke-report` startup baselines, process liveness, and remote-call failure summaries, incident bundle trace/process reports, ID filters | Cross-bot incident workflow and safe restart orchestration |
-| Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup; PR #656 cache integrity smoke doctor | Continue separate reviewed PRs for shutdown/warmup/cache proof improvements |
+| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, `live-smoke-report` startup baselines/process liveness/remote-call failures/time windows, incident bundle trace/process/time-window reports, ID filters | Cross-bot incident workflow and safe restart orchestration |
+| Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup; PR #656/#668 cache integrity smoke doctor | Continue separate reviewed PRs for shutdown/warmup/cache proof improvements |
 
 ## Merged Slices
 
@@ -363,6 +366,44 @@ VPS5 deployment status:
   `/root/bots_vps5.yaml` still matched all five expected bots and now exposed
   Kucoin authoritative endpoint timeouts directly in the smoke output:
   positions=9, open_orders=7, balance=7.
+
+### PR #665: Live Smoke Report Time Window
+
+- Branch: `codex/v8-smoke-report-time-window`.
+- Scope: operator smoke tooling.
+- Result: `passivbot tool live-smoke-report` can scope structured monitor
+  events with `--since-ms`, `--until-ms`, or `--recent-minutes`, and reports
+  explicit event-window counters. Incident bundles pass the same window into
+  embedded smoke reports. Text-log scanning remains intentionally unchanged.
+
+### PR #666: Create Filter/Defer Events
+
+- Branch: `codex/v8-execution-defer-events`.
+- Scope: execution/order lifecycle observability.
+- Result: create-order pre-exchange filter/defer decisions now emit bounded
+  structured events after the existing gates decide. The execution gates remain
+  authoritative, event emission is best-effort, and the new routes stay off the
+  default console/text projection.
+
+### PR #667: Live Event Query Time Window
+
+- Branch: `codex/v8-event-query-time-window`.
+- Scope: operator query tooling.
+- Result: `passivbot tool live-event-query` can scope matched structured events
+  with `--since-ms`, `--until-ms`, or `--recent-minutes`. The same scoped event
+  set feeds query output, timeline, trace summary, order trace, and cycle trace
+  views, with explicit event-window counters.
+
+### PR #668: Cache Doctor Family Summary
+
+- Branch: `codex/v8-cache-doctor-family-summary`.
+- Scope: adjacent operations tooling.
+- Result: `passivbot tool cache-integrity-doctor` now includes per-root and
+  aggregate cache-family summaries plus family tags on reported issues. This is
+  still read-only diagnostics and does not decide whether live trading may reuse
+  a warm cache.
+- VPS5 evidence: deployed to VPS5 at `734c2de0`. A settled 2-minute smoke after
+  restart reported all five configured bots running and no hard problem events.
 
 ## Current Next Steps
 

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -45,8 +45,9 @@ Related detailed plans:
    now supports event discovery, compact JSON output, current-vs-rotated segment
    selection, terse timeline rendering, and filters for event type/kind, cycle
    id, order wave id, remote call id/group id, bot id, snapshot id, plan id,
-   action id, symbol, pside, reason code, and status. It also supports
-   aggregate trace summaries over matched events and order waves, plus a
+   action id, symbol, pside, reason code, status, and event time window. It
+   also supports aggregate trace summaries over matched events and order waves,
+   plus a
    dedicated order-trace reconstruction view for order waves/actions and a
    cycle-trace reconstruction view with nested order traces. Incident bundles
    now embed the existing trace-summary/order-trace reports and cycle traces
@@ -57,7 +58,8 @@ Related detailed plans:
 3. [ ] Live restart/smoke automation.
    Status: partial. The read-only `live-smoke-report` tool exists and can now
    compare running `passivbot live` processes against a tmuxp-style supervisor
-   config, but the safe restart orchestration contract is not implemented.
+   config and scope structured monitor events to a requested time window, but
+   the safe restart orchestration contract is not implemented.
 
    Formalize the repeated VPS smoke routine: pull a branch, stop configured
    bots, measure shutdown time per bot, reload from `/root/bots_vps5.yaml`,
@@ -163,6 +165,8 @@ Related detailed plans:
       summaries, and nested order traces.
     - 2026-06-25: Added incident-bundle integration for trace-summary,
       order-trace, and cycle-trace reports.
+    - 2026-06-26: Added structured create-filter/defer events for existing
+      pre-exchange create-order gates without changing gate behavior.
 
     Remaining refinements: keep tightening producer coverage as nearby event
     surfaces are touched.
@@ -176,7 +180,8 @@ Related detailed plans:
     issue.
 
 13. [ ] Cache integrity doctor.
-    Status: partial. Initial read-only local cache smoke doctor merged.
+    Status: partial. Initial read-only local cache smoke doctor and
+    cache-family summaries merged.
 
     Add a read-only doctor for candle/fill/HSL caches that reports coverage,
     metadata compatibility, corrupted shards, suspicious gaps, synthetic/no-trade
@@ -187,10 +192,12 @@ Related detailed plans:
     - 2026-06-25: Added `passivbot tool cache-integrity-doctor`, which reports
       local cache root presence, aggregate file/size counts, and empty/corrupt
       JSON, NDJSON, and NPY artifacts without writing or touching live behavior.
+    - 2026-06-26: Added per-root and aggregate cache-family summaries plus
+      family tags on cache-doctor issues.
 
-    Remaining refinements: add cache-family awareness, candle/fill/HSL metadata
-    compatibility checks, coverage windows, suspicious gap summaries, and
-    warm-cache reuse readiness without making trading decisions.
+    Remaining refinements: add candle/fill/HSL metadata compatibility checks,
+    coverage windows, suspicious gap summaries, and warm-cache reuse readiness
+    without making trading decisions.
 
 14. [ ] Supervisor/process model.
     Status: partial. `live-smoke-report --supervisor-config` now reports
@@ -223,6 +230,10 @@ Related detailed plans:
 | 2026-06-25 | #1/#2/#11 Incident bundle trace integration | PR #659 / `27931c81` | Embedded trace-summary and order-trace reports into incident bundles by default, plus cycle-trace when scoped to `--cycle-id`; VPS5 bundle smoke verified trace sections | Cross-bot incident workflow and supervisor/process context |
 | 2026-06-25 | #1/#3/#14 Smoke process status | PR #661 / `72b3d931` | Added optional read-only process liveness to `live-smoke-report` and incident bundles; VPS5 smoke matched all five `/root/bots_vps5.yaml` bots | Safe restart orchestration and richer supervisor model remain open |
 | 2026-06-25 | #6 Exchange health and contract probes | PR #663 / `45b0cf9e` | Added passive `remote_call.failed` summaries to `live-smoke-report`; VPS5 smoke grouped Kucoin timeouts by balance/positions/open_orders | Active read-only exchange endpoint probes remain open |
+| 2026-06-26 | #3 Live restart/smoke automation | PR #665 / `37c29359` | Added structured-event time windows to `live-smoke-report` and threaded them into incident-bundle smoke reports; VPS5 smoke used the window to separate pre-deploy failures from settled post-restart behavior | Safe pull/stop/start orchestration still open |
+| 2026-06-26 | #11 Order lifecycle trace completeness | PR #666 / `fa90623d` | Added structured create-filter/defer events for pre-exchange create-order gates, best-effort and off default console | Continue producer coverage as nearby execution surfaces are touched |
+| 2026-06-26 | #2 Event query and timeline CLI extensions | PR #667 / `e5771cfa` | Added event time-window filters to `live-event-query`; query, timeline, trace-summary, order-trace, and cycle-trace views use the same scoped event set | Cross-bot incident workflow |
+| 2026-06-26 | #13 Cache integrity doctor | PR #668 / `734c2de0` | Added cache-family summaries and issue family tags to the read-only cache doctor | Coverage windows, suspicious gaps, metadata compatibility, and warm-cache readiness |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |


### PR DESCRIPTION
Summary:
- update live logging progress through PR #668 / 734c2de0
- record VPS5 deployment/restart/smoke evidence for the merged queue
- update the live ops backlog for smoke/query time windows, create-filter events, and cache-family summaries

Validation:
- git diff --check
- VPS5 deployed origin/v8 at 734c2de0
- VPS5 settled smoke: passivbot tool live-smoke-report monitor --logs-root "" --supervisor-config /root/bots_vps5.yaml --recent-minutes 2 --compact returned ok=true, hard_failures=0, matched_expected=5, missing_expected=[]

Notes:
- docs-only progress/backlog update
- known VPS observations recorded: Kucoin slow Ctrl-C shutdown (~105s), tmuxp attach warning over non-TTY SSH, GateIO ZEC HSL RED finalization during startup/replay, no continuing hard failures in settled window