### PR TITLE
Window timestamped smoke log matches

### DIFF
--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -6,6 +6,7 @@ import re
 import stat
 import subprocess
 from collections import Counter, defaultdict, deque
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -30,6 +31,9 @@ SENSITIVE_LOG_VALUE_PATTERN = re.compile(
     r"([\"']?\s*(?:[:=]|\s)\s*)[\"']?[^,\s;&\"'}]+"
 )
 AUTH_SCHEME_PATTERN = re.compile(r"(?i)\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]+")
+LOG_LINE_TS_PATTERN = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)\b"
+)
 STARTUP_TIMING_BASELINE_WINDOW = 20
 DEFAULT_PROCESS_MATCH = "passivbot live"
 REMOTE_CALL_FAILURE_GROUP_LIMIT = 20
@@ -861,6 +865,37 @@ def _tail_lines(path: Path, *, max_lines: int) -> list[tuple[int, str]]:
     return [(line_no, line.rstrip("\n")) for line_no, line in rows]
 
 
+def _parse_log_line_ts_ms(line: str) -> int | None:
+    match = LOG_LINE_TS_PATTERN.match(str(line))
+    if match is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(match.group("ts").replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return int(parsed.timestamp() * 1000)
+
+
+def _log_window_report(
+    *,
+    since_ms: int | None,
+    until_ms: int | None,
+    lines_considered: int,
+    lines_skipped_before: int,
+    lines_skipped_after: int,
+    unparsed_ts: int,
+) -> dict[str, Any]:
+    return {
+        "enabled": since_ms is not None or until_ms is not None,
+        "since_ms": since_ms,
+        "until_ms": until_ms,
+        "lines_considered": int(lines_considered),
+        "lines_skipped_before": int(lines_skipped_before),
+        "lines_skipped_after": int(lines_skipped_after),
+        "unparsed_ts": int(unparsed_ts),
+    }
+
+
 def default_logs_root_for_monitor(monitor_root: str | Path) -> Path | None:
     path = Path(monitor_root).expanduser()
     start = path.parent if path.is_file() else path
@@ -877,21 +912,49 @@ def _scan_logs(
     max_files: int,
     tail_lines: int,
     max_matches: int,
+    since_ms: int | None,
+    until_ms: int | None,
 ) -> dict[str, Any]:
+    window_enabled = since_ms is not None or until_ms is not None
+    window_report = _log_window_report(
+        since_ms=since_ms,
+        until_ms=until_ms,
+        lines_considered=0,
+        lines_skipped_before=0,
+        lines_skipped_after=0,
+        unparsed_ts=0,
+    )
     if root is None:
         return {
             "root": None,
             "files_scanned": 0,
             "hard_matches": 0,
             "attention_matches": 0,
+            "window": window_report,
             "matches": [],
         }
     files = _recent_log_files(root, max_files=max_files)
     matches: list[dict[str, Any]] = []
     hard_matches = 0
     attention_matches = 0
+    lines_considered = 0
+    lines_skipped_before = 0
+    lines_skipped_after = 0
+    unparsed_ts = 0
     for path in files:
         for line_no, line in _tail_lines(path, max_lines=tail_lines):
+            line_ts = _parse_log_line_ts_ms(line)
+            if window_enabled:
+                if line_ts is None:
+                    unparsed_ts += 1
+                else:
+                    if since_ms is not None and line_ts < since_ms:
+                        lines_skipped_before += 1
+                        continue
+                    if until_ms is not None and line_ts > until_ms:
+                        lines_skipped_after += 1
+                        continue
+            lines_considered += 1
             if not ATTENTION_LOG_PATTERN.search(line):
                 continue
             attention_matches += 1
@@ -899,19 +962,28 @@ def _scan_logs(
             if hard:
                 hard_matches += 1
             if len(matches) < max(0, int(max_matches)):
-                matches.append(
-                    {
-                        "path": str(path),
-                        "line": int(line_no),
-                        "hard": hard,
-                        "text": _redact_log_text(line, max_len=500),
-                    }
-                )
+                match = {
+                    "path": str(path),
+                    "line": int(line_no),
+                    "hard": hard,
+                    "text": _redact_log_text(line, max_len=500),
+                }
+                if line_ts is not None:
+                    match["ts"] = line_ts
+                matches.append(match)
     return {
         "root": str(Path(root).expanduser()),
         "files_scanned": len(files),
         "hard_matches": hard_matches,
         "attention_matches": attention_matches,
+        "window": _log_window_report(
+            since_ms=since_ms,
+            until_ms=until_ms,
+            lines_considered=lines_considered,
+            lines_skipped_before=lines_skipped_before,
+            lines_skipped_after=lines_skipped_after,
+            unparsed_ts=unparsed_ts,
+        ),
         "matches": matches,
     }
 
@@ -972,6 +1044,8 @@ def build_live_smoke_report(
         max_files=max_log_files,
         tail_lines=log_tail_lines,
         max_matches=max_log_matches,
+        since_ms=since_ms,
+        until_ms=until_ms,
     )
     process_report = _build_process_report(
         include_processes=include_processes,

--- a/src/tools/live_smoke_report.py
+++ b/src/tools/live_smoke_report.py
@@ -68,19 +68,26 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--since-ms",
         type=int,
-        help="Only include structured monitor events at or after this monitor ts.",
+        help=(
+            "Only include structured monitor events and timestamped text log "
+            "lines at or after this epoch-ms timestamp."
+        ),
     )
     parser.add_argument(
         "--until-ms",
         type=int,
-        help="Only include structured monitor events at or before this monitor ts.",
+        help=(
+            "Only include structured monitor events and timestamped text log "
+            "lines at or before this epoch-ms timestamp."
+        ),
     )
     parser.add_argument(
         "--recent-minutes",
         type=float,
         help=(
-            "Only include structured monitor events from the last N minutes. "
-            "Equivalent to --since-ms based on local wall-clock time."
+            "Only include structured monitor events and timestamped text log "
+            "lines from the last N minutes. Equivalent to --since-ms based on "
+            "local wall-clock time."
         ),
     )
     parser.add_argument(

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -469,6 +469,62 @@ def test_live_smoke_report_log_scan_deduplicates_aliases_and_matches_levels(
     assert "TOKEN123" not in emitted
 
 
+def test_live_smoke_report_log_window_filters_parseable_timestamps(tmp_path):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=3000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "okx_faisal.log").write_text(
+        "\n".join(
+            [
+                "1970-01-01T00:00:01Z ERROR stale before window",
+                "1970-01-01T00:00:03Z ERROR fresh in window",
+                "ERROR unparseable timestamp kept visible",
+                "1970-01-01T00:00:05Z CRITICAL future hard skipped",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=logs_dir,
+        since_ms=2000,
+        until_ms=4000,
+        log_tail_lines=10,
+    )
+
+    assert report["ok"] is True
+    assert report["logs"]["attention_matches"] == 2
+    assert report["logs"]["hard_matches"] == 0
+    assert report["logs"]["window"] == {
+        "enabled": True,
+        "since_ms": 2000,
+        "until_ms": 4000,
+        "lines_considered": 2,
+        "lines_skipped_before": 1,
+        "lines_skipped_after": 1,
+        "unparsed_ts": 1,
+    }
+    assert [match["text"] for match in report["logs"]["matches"]] == [
+        "1970-01-01T00:00:03Z ERROR fresh in window",
+        "ERROR unparseable timestamp kept visible",
+    ]
+    assert report["logs"]["matches"][0]["ts"] == 3000
+    assert "future hard skipped" not in json.dumps(report["logs"]["matches"])
+
+
 def test_live_smoke_report_default_logs_root_follows_monitor_root(tmp_path, capsys):
     bot_root = tmp_path / "bot"
     events_dir = bot_root / "monitor" / "gateio" / "gateio_01" / "events"


### PR DESCRIPTION
Summary:
- apply smoke-report since/until/recent windows to parseable ISO-UTC text log lines as well as structured events
- keep unparseable text log lines visible and count them in logs.window.unparsed_ts
- expose logs.window counters and include parsed match timestamps when available
- update live-smoke-report CLI help to describe timestamped text-log behavior

Validation:
- ./venv/bin/python -m compileall src/live/smoke_report.py src/tools/live_smoke_report.py tests/test_live_smoke_report.py
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- git diff --check
- silent-handling scan on touched files only flagged pre-existing read-only aggregation counters in smoke_report.py

Notes:
- read-only operator tooling only; no live trading/event emission changes
- motivated by VPS5 smoke after #665/#668 where structured-event windows were clean but old text-log tail matches still surfaced stale pre-window warnings