### PR TITLE
Avoid traceback prose smoke false positives

### DIFF
--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -14,12 +14,17 @@ from live.event_bus import LIVE_EVENT_MONITOR_PAYLOAD_KEY, EventTypes
 from live.event_query import build_event_report, discover_event_files
 
 
+PYTHON_TRACEBACK_HEADER_PATTERN = r"\bTraceback\s+\(most recent call last\):"
 HARD_LOG_PATTERN = re.compile(
-    r"\bTraceback\b|(?:^|\s|\[)CRITICAL(?:\s|\]|:|$)|\blevel=critical\b|\bfatal\b|\buncaught\b",
+    rf"{PYTHON_TRACEBACK_HEADER_PATTERN}|"
+    r"(?:^|\s|\[)CRITICAL(?:\s|\]|:|$)|"
+    r"\blevel=critical\b|\bfatal\b|\buncaught\b",
     re.IGNORECASE,
 )
 ATTENTION_LOG_PATTERN = re.compile(
-    r"\bTraceback\b|(?:^|\s|\[)(?:CRITICAL|ERROR)(?:\s|\]|:|$)|\blevel=(?:critical|error)\b|\bfatal\b|\buncaught\b",
+    rf"{PYTHON_TRACEBACK_HEADER_PATTERN}|"
+    r"(?:^|\s|\[)(?:CRITICAL|ERROR)(?:\s|\]|:|$)|"
+    r"\blevel=(?:critical|error)\b|\bfatal\b|\buncaught\b",
     re.IGNORECASE,
 )
 SENSITIVE_LOG_HEADER_PATTERN = re.compile(

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -525,6 +525,50 @@ def test_live_smoke_report_log_window_filters_parseable_timestamps(tmp_path):
     assert "future hard skipped" not in json.dumps(report["logs"]["matches"])
 
 
+def test_live_smoke_report_log_scan_ignores_traceback_prose(tmp_path):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "kucoin_01.log").write_text(
+        "\n".join(
+            [
+                (
+                    "2026-06-26T02:31:46Z WARNING [kucoin] [ws] "
+                    "websocket callback ping timeout; suppressing callback "
+                    "traceback and relying on reconnect"
+                ),
+                "Traceback (most recent call last):",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=logs_dir,
+        log_tail_lines=10,
+    )
+
+    assert report["ok"] is False
+    assert report["logs"]["attention_matches"] == 1
+    assert report["logs"]["hard_matches"] == 1
+    assert [match["text"] for match in report["logs"]["matches"]] == [
+        "Traceback (most recent call last):"
+    ]
+
+
 def test_live_smoke_report_default_logs_root_follows_monitor_root(tmp_path, capsys):
     bot_root = tmp_path / "bot"
     events_dir = bot_root / "monitor" / "gateio" / "gateio_01" / "events"


### PR DESCRIPTION
Summary:
- narrow smoke-report traceback matching to real Python traceback headers: 'Traceback (most recent call last):'
- avoid treating prose like 'suppressing callback traceback' as a hard smoke log match
- add regression coverage for the Kucoin websocket warning shape observed on VPS5

Validation:
- ./venv/bin/python -m compileall src/live/smoke_report.py tests/test_live_smoke_report.py
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- git diff --check
- silent-handling scan on touched files only flagged pre-existing read-only aggregation counters in smoke_report.py

Notes:
- read-only operator tooling only; no live trading/event emission changes
- motivated by VPS5 smoke after #670, where timestamp windowing worked but current Kucoin warning lines were still hard-matched because they mentioned suppressing callback traceback