### PR TITLE
Update progress after smoke log window fixes

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,11 +19,11 @@ Last updated: 2026-06-26.
 
 Current `origin/v8` logging-overhaul head:
 
-- `734c2de0` merge of PR #668, `Summarize cache families in cache doctor`.
+- `34f63799` merge of PR #671, `Avoid traceback prose smoke false positives`.
 
 VPS5 deployment status:
 
-- Repository pulled through PR #668 at `734c2de0`.
+- Repository pulled through PR #671 at `34f63799`.
 - Bots were restarted from `/root/bots_vps5.yaml` and left running. Four bots
   exited promptly after Ctrl-C; Kucoin took about 105 seconds before the old
   process disappeared.
@@ -36,6 +36,11 @@ VPS5 deployment status:
 - A wider post-restart smoke saw a real GateIO HSL ZEC long RED finalization
   during startup/replay and one non-hard Kucoin candle `RequestTimeout`; the
   narrower settled-window smoke confirmed no continuing hard failures.
+- PRs #670 and #671 were pulled to VPS5 without bot restart because they only
+  changed read-only smoke-report tooling. A later smoke with text logs enabled
+  and `--recent-minutes 2 --supervisor-config /root/bots_vps5.yaml` reported
+  `ok=true`, `hard_failures=0`, `hard_problem_event_count=0`,
+  `logs.hard_matches=0`, `matched_expected=5`, and `missing_expected=[]`.
 
 ## Phase Checklist
 
@@ -404,6 +409,31 @@ VPS5 deployment status:
   a warm cache.
 - VPS5 evidence: deployed to VPS5 at `734c2de0`. A settled 2-minute smoke after
   restart reported all five configured bots running and no hard problem events.
+
+### PR #670: Smoke Report Timestamped Log Window
+
+- Branch: `codex/v8-smoke-report-log-window`.
+- Scope: operator smoke tooling.
+- Result: `passivbot tool live-smoke-report` applies `since_ms`/`until_ms` and
+  `--recent-minutes` windows to parseable ISO-UTC text log lines as well as
+  structured monitor events. Unparseable log lines remain visible and are
+  counted in `logs.window.unparsed_ts`.
+- VPS5 evidence: deployed to VPS5 at `b74d12be` without bot restart. Smoke
+  showed `logs.window.lines_skipped_before=2000`, proving stale parseable log
+  lines were excluded, while two current Kucoin websocket warning lines were
+  still false-classified as hard due the older traceback matcher.
+
+### PR #671: Smoke Report Traceback Prose Filter
+
+- Branch: `codex/v8-smoke-report-traceback-pattern`.
+- Scope: operator smoke tooling.
+- Result: smoke-report text-log matching now treats only real Python traceback
+  headers (`Traceback (most recent call last):`) as traceback signals, avoiding
+  hard/attention matches for operational prose such as "suppressing callback
+  traceback".
+- VPS5 evidence: deployed to VPS5 at `34f63799` without bot restart. A
+  2-minute smoke with text logs enabled reported all five configured bots
+  running, `logs.hard_matches=0`, and no hard problem events.
 
 ## Current Next Steps
 

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -58,7 +58,8 @@ Related detailed plans:
 3. [ ] Live restart/smoke automation.
    Status: partial. The read-only `live-smoke-report` tool exists and can now
    compare running `passivbot live` processes against a tmuxp-style supervisor
-   config and scope structured monitor events to a requested time window, but
+   config, scope structured monitor events and parseable timestamped text logs
+   to a requested time window, and avoid traceback-prose false positives, but
    the safe restart orchestration contract is not implemented.
 
    Formalize the repeated VPS smoke routine: pull a branch, stop configured
@@ -234,6 +235,8 @@ Related detailed plans:
 | 2026-06-26 | #11 Order lifecycle trace completeness | PR #666 / `fa90623d` | Added structured create-filter/defer events for pre-exchange create-order gates, best-effort and off default console | Continue producer coverage as nearby execution surfaces are touched |
 | 2026-06-26 | #2 Event query and timeline CLI extensions | PR #667 / `e5771cfa` | Added event time-window filters to `live-event-query`; query, timeline, trace-summary, order-trace, and cycle-trace views use the same scoped event set | Cross-bot incident workflow |
 | 2026-06-26 | #13 Cache integrity doctor | PR #668 / `734c2de0` | Added cache-family summaries and issue family tags to the read-only cache doctor | Coverage windows, suspicious gaps, metadata compatibility, and warm-cache readiness |
+| 2026-06-26 | #3 Live restart/smoke automation | PR #670 / `b74d12be` | Extended `live-smoke-report` time windows to parseable timestamped text log lines; VPS5 smoke proved stale log lines were skipped via `logs.window.lines_skipped_before` | Safe pull/stop/start orchestration still open |
+| 2026-06-26 | #3 Live restart/smoke automation | PR #671 / `34f63799` | Narrowed traceback log matching to real Python traceback headers; VPS5 smoke with logs enabled returned `ok=true`, `logs.hard_matches=0`, and all five bots matched | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |


### PR DESCRIPTION
Summary:
- update live logging progress through PR #671 / 34f63799
- record VPS5 smoke evidence for timestamped log windows and traceback-prose filtering
- update live ops backlog item #3 for text-log windowing and traceback false-positive cleanup

Validation:
- git diff --check
- VPS5 pulled origin/v8 at 34f63799 without bot restart
- VPS5 smoke with text logs enabled: passivbot tool live-smoke-report monitor --logs-root logs --supervisor-config /root/bots_vps5.yaml --recent-minutes 2 --compact returned ok=true, hard_failures=0, logs.hard_matches=0, matched_expected=5, missing_expected=[]

Notes:
- docs-only progress/backlog update
- bots remained running throughout