### PR TITLE
Add smoke log unparsed window policy

### DIFF
--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -18,6 +18,7 @@ from urllib.parse import urlsplit, urlunsplit
 from live.event_bus import LIVE_EVENT_ID_KEYS, LIVE_EVENT_MONITOR_PAYLOAD_KEY
 from live.event_query import build_event_report, discover_event_files
 from live.smoke_report import (
+    DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
     _redact_log_text,
     build_live_smoke_report,
     default_logs_root_for_monitor,
@@ -611,6 +612,7 @@ def build_live_incident_bundle(
     max_log_files: int = 8,
     log_tail_lines: int = 500,
     max_log_matches: int = 100,
+    log_window_unparsed_policy: str = DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
     max_snapshot_files: int = 20,
     max_snapshot_file_bytes: int = 1_000_000,
     max_event_segment_bytes: int = 10_000_000,
@@ -666,6 +668,7 @@ def build_live_incident_bundle(
         max_log_files=max_log_files,
         log_tail_lines=log_tail_lines,
         max_log_matches=max_log_matches,
+        log_window_unparsed_policy=log_window_unparsed_policy,
     )
 
     with tempfile.TemporaryDirectory(prefix="passivbot_incident_bundle_") as tmp_name:

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -1127,10 +1127,11 @@ def _scan_logs(
     for path in files:
         for line_no, line in _tail_lines(path, max_lines=tail_lines):
             line_ts = _parse_log_line_ts_ms(line)
+            attention = bool(ATTENTION_LOG_PATTERN.search(line))
             if window_enabled:
                 if line_ts is None:
                     unparsed_ts += 1
-                    if unparsed_policy == "drop":
+                    if unparsed_policy == "drop" and not attention:
                         lines_skipped_unparsed += 1
                         continue
                 else:
@@ -1141,7 +1142,7 @@ def _scan_logs(
                         lines_skipped_after += 1
                         continue
             lines_considered += 1
-            if not ATTENTION_LOG_PATTERN.search(line):
+            if not attention:
                 continue
             attention_matches += 1
             hard = bool(HARD_LOG_PATTERN.search(line))

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -41,6 +41,8 @@ LOG_LINE_TS_PATTERN = re.compile(
 )
 STARTUP_TIMING_BASELINE_WINDOW = 20
 DEFAULT_PROCESS_MATCH = "passivbot live"
+LOG_WINDOW_UNPARSED_POLICIES = {"keep", "drop"}
+DEFAULT_LOG_WINDOW_UNPARSED_POLICY = "keep"
 REMOTE_CALL_FAILURE_GROUP_LIMIT = 20
 RISK_EVENT_GROUP_LIMIT = 20
 RISK_EVENT_TYPES = {
@@ -1038,6 +1040,16 @@ def _parse_log_line_ts_ms(line: str) -> int | None:
     return int(parsed.timestamp() * 1000)
 
 
+def _normalize_log_window_unparsed_policy(value: str | None) -> str:
+    policy = str(value or DEFAULT_LOG_WINDOW_UNPARSED_POLICY).strip().lower()
+    if policy not in LOG_WINDOW_UNPARSED_POLICIES:
+        raise ValueError(
+            "log_window_unparsed_policy must be one of "
+            f"{sorted(LOG_WINDOW_UNPARSED_POLICIES)}"
+        )
+    return policy
+
+
 def _log_window_report(
     *,
     since_ms: int | None,
@@ -1046,6 +1058,8 @@ def _log_window_report(
     lines_skipped_before: int,
     lines_skipped_after: int,
     unparsed_ts: int,
+    unparsed_policy: str,
+    lines_skipped_unparsed: int,
 ) -> dict[str, Any]:
     return {
         "enabled": since_ms is not None or until_ms is not None,
@@ -1055,6 +1069,8 @@ def _log_window_report(
         "lines_skipped_before": int(lines_skipped_before),
         "lines_skipped_after": int(lines_skipped_after),
         "unparsed_ts": int(unparsed_ts),
+        "unparsed_policy": _normalize_log_window_unparsed_policy(unparsed_policy),
+        "lines_skipped_unparsed": int(lines_skipped_unparsed),
     }
 
 
@@ -1076,8 +1092,10 @@ def _scan_logs(
     max_matches: int,
     since_ms: int | None,
     until_ms: int | None,
+    log_window_unparsed_policy: str = DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
 ) -> dict[str, Any]:
     window_enabled = since_ms is not None or until_ms is not None
+    unparsed_policy = _normalize_log_window_unparsed_policy(log_window_unparsed_policy)
     window_report = _log_window_report(
         since_ms=since_ms,
         until_ms=until_ms,
@@ -1085,6 +1103,8 @@ def _scan_logs(
         lines_skipped_before=0,
         lines_skipped_after=0,
         unparsed_ts=0,
+        unparsed_policy=unparsed_policy,
+        lines_skipped_unparsed=0,
     )
     if root is None:
         return {
@@ -1103,12 +1123,16 @@ def _scan_logs(
     lines_skipped_before = 0
     lines_skipped_after = 0
     unparsed_ts = 0
+    lines_skipped_unparsed = 0
     for path in files:
         for line_no, line in _tail_lines(path, max_lines=tail_lines):
             line_ts = _parse_log_line_ts_ms(line)
             if window_enabled:
                 if line_ts is None:
                     unparsed_ts += 1
+                    if unparsed_policy == "drop":
+                        lines_skipped_unparsed += 1
+                        continue
                 else:
                     if since_ms is not None and line_ts < since_ms:
                         lines_skipped_before += 1
@@ -1145,6 +1169,8 @@ def _scan_logs(
             lines_skipped_before=lines_skipped_before,
             lines_skipped_after=lines_skipped_after,
             unparsed_ts=unparsed_ts,
+            unparsed_policy=unparsed_policy,
+            lines_skipped_unparsed=lines_skipped_unparsed,
         ),
         "matches": matches,
     }
@@ -1164,6 +1190,7 @@ def build_live_smoke_report(
     max_log_files: int = 8,
     log_tail_lines: int = 300,
     max_log_matches: int = 50,
+    log_window_unparsed_policy: str = DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
 ) -> dict[str, Any]:
     event_report = build_event_report(
         monitor_root,
@@ -1214,6 +1241,7 @@ def build_live_smoke_report(
         max_matches=max_log_matches,
         since_ms=since_ms,
         until_ms=until_ms,
+        log_window_unparsed_policy=log_window_unparsed_policy,
     )
     process_report = _build_process_report(
         include_processes=include_processes,

--- a/src/tools/live_incident_bundle.py
+++ b/src/tools/live_incident_bundle.py
@@ -10,6 +10,10 @@ if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
 from live.incident_bundle import build_live_incident_bundle  # noqa: E402
+from live.smoke_report import (  # noqa: E402
+    DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
+    LOG_WINDOW_UNPARSED_POLICIES,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -175,6 +179,16 @@ def build_parser() -> argparse.ArgumentParser:
         default=100,
         help="Maximum matching log lines to include in the smoke report.",
     )
+    parser.add_argument(
+        "--log-window-unparsed-policy",
+        choices=sorted(LOG_WINDOW_UNPARSED_POLICIES),
+        default=DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
+        help=(
+            "When the embedded smoke-report log window is active, keep "
+            "unparseable text log lines visible by default, or drop them when "
+            "the target logs are known to be consistently timestamped."
+        ),
+    )
     parser.add_argument("--compact", action="store_true", help="Emit compact single-line JSON.")
     return parser
 
@@ -208,6 +222,7 @@ def main(argv: list[str] | None = None) -> int:
         max_log_files=int(args.max_log_files),
         log_tail_lines=int(args.log_tail_lines),
         max_log_matches=int(args.max_log_matches),
+        log_window_unparsed_policy=str(args.log_window_unparsed_policy),
         max_snapshot_files=int(args.max_snapshot_files),
         max_snapshot_file_bytes=int(args.max_snapshot_file_bytes),
         max_event_segment_bytes=int(args.max_event_segment_bytes),

--- a/src/tools/live_incident_bundle.py
+++ b/src/tools/live_incident_bundle.py
@@ -185,8 +185,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
         help=(
             "When the embedded smoke-report log window is active, keep "
-            "unparseable text log lines visible by default, or drop them when "
-            "the target logs are known to be consistently timestamped."
+            "unparseable text log lines visible by default, or drop non-signal "
+            "unparseable lines."
         ),
     )
     parser.add_argument("--compact", action="store_true", help="Emit compact single-line JSON.")

--- a/src/tools/live_smoke_report.py
+++ b/src/tools/live_smoke_report.py
@@ -101,8 +101,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
         help=(
             "When a log time window is active, keep unparseable text log lines "
-            "visible by default, or drop them when the target logs are known to "
-            "be consistently timestamped."
+            "visible by default, or drop non-signal unparseable lines."
         ),
     )
     parser.add_argument(

--- a/src/tools/live_smoke_report.py
+++ b/src/tools/live_smoke_report.py
@@ -10,7 +10,12 @@ SRC_ROOT = Path(__file__).resolve().parents[1]
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
-from live.smoke_report import build_live_smoke_report, default_logs_root_for_monitor  # noqa: E402
+from live.smoke_report import (  # noqa: E402
+    DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
+    LOG_WINDOW_UNPARSED_POLICIES,
+    build_live_smoke_report,
+    default_logs_root_for_monitor,
+)
 
 
 def _since_ms_from_recent_minutes(value: float | None) -> int | None:
@@ -91,6 +96,16 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--log-window-unparsed-policy",
+        choices=sorted(LOG_WINDOW_UNPARSED_POLICIES),
+        default=DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
+        help=(
+            "When a log time window is active, keep unparseable text log lines "
+            "visible by default, or drop them when the target logs are known to "
+            "be consistently timestamped."
+        ),
+    )
+    parser.add_argument(
         "--max-problem-events",
         type=int,
         default=50,
@@ -154,6 +169,7 @@ def main(argv: list[str] | None = None) -> int:
         max_log_files=int(args.max_log_files),
         log_tail_lines=int(args.log_tail_lines),
         max_log_matches=int(args.max_log_matches),
+        log_window_unparsed_policy=str(args.log_window_unparsed_policy),
     )
     print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
     return 0 if report.get("ok") else 1

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -273,6 +273,65 @@ def test_live_incident_bundle_can_skip_logs_and_segments_from_cli(tmp_path, caps
     assert smoke_report["logs"]["hard_matches"] == 0
 
 
+def test_live_incident_bundle_cli_passes_log_window_unparsed_policy(
+    tmp_path,
+    capsys,
+):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=3000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "okx_01.log").write_text(
+        "\n".join(
+            [
+                "1970-01-01T00:00:03Z ERROR fresh in window",
+                "ERROR old unparseable line dropped",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    output = tmp_path / "incident.tar.gz"
+
+    assert (
+        live_incident_bundle.main(
+            [
+                str(tmp_path / "monitor"),
+                "--logs-root",
+                str(logs_dir),
+                "--since-ms",
+                "2000",
+                "--until-ms",
+                "4000",
+                "--log-window-unparsed-policy",
+                "drop",
+                "--output",
+                str(output),
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["ok"] is True
+    with tarfile.open(output, "r:gz") as tar:
+        smoke_report = _read_tar_json(tar, "smoke_report.json")
+    assert smoke_report["logs"]["attention_matches"] == 1
+    assert smoke_report["logs"]["window"]["unparsed_policy"] == "drop"
+    assert smoke_report["logs"]["window"]["lines_skipped_unparsed"] == 1
+
+
 def test_live_incident_bundle_cli_rejects_invalid_window_timestamp(capsys):
     with pytest.raises(SystemExit) as exc_info:
         live_incident_bundle.main(["monitor", "--since-ms", "not-an-int"])

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -295,7 +295,7 @@ def test_live_incident_bundle_cli_passes_log_window_unparsed_policy(
         "\n".join(
             [
                 "1970-01-01T00:00:03Z ERROR fresh in window",
-                "ERROR old unparseable line dropped",
+                "old unparseable noise dropped",
             ]
         )
         + "\n",

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -643,6 +643,8 @@ def test_live_smoke_report_log_window_filters_parseable_timestamps(tmp_path):
         "lines_skipped_before": 1,
         "lines_skipped_after": 1,
         "unparsed_ts": 1,
+        "unparsed_policy": "keep",
+        "lines_skipped_unparsed": 0,
     }
     assert [match["text"] for match in report["logs"]["matches"]] == [
         "1970-01-01T00:00:03Z ERROR fresh in window",
@@ -650,6 +652,33 @@ def test_live_smoke_report_log_window_filters_parseable_timestamps(tmp_path):
     ]
     assert report["logs"]["matches"][0]["ts"] == 3000
     assert "future hard skipped" not in json.dumps(report["logs"]["matches"])
+
+    drop_report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=logs_dir,
+        since_ms=2000,
+        until_ms=4000,
+        log_tail_lines=10,
+        log_window_unparsed_policy="drop",
+    )
+
+    assert drop_report["ok"] is True
+    assert drop_report["logs"]["attention_matches"] == 1
+    assert drop_report["logs"]["hard_matches"] == 0
+    assert drop_report["logs"]["window"] == {
+        "enabled": True,
+        "since_ms": 2000,
+        "until_ms": 4000,
+        "lines_considered": 1,
+        "lines_skipped_before": 1,
+        "lines_skipped_after": 1,
+        "unparsed_ts": 1,
+        "unparsed_policy": "drop",
+        "lines_skipped_unparsed": 1,
+    }
+    assert [match["text"] for match in drop_report["logs"]["matches"]] == [
+        "1970-01-01T00:00:03Z ERROR fresh in window"
+    ]
 
 
 def test_live_smoke_report_log_scan_ignores_traceback_prose(tmp_path):
@@ -778,6 +807,64 @@ def test_live_smoke_report_cli_outputs_json_and_can_skip_logs(tmp_path, capsys):
     assert report["logs"]["files_scanned"] == 0
     assert report["logs"]["root"] is None
     assert report["monitor"]["live_events"] == 1
+
+
+def test_live_smoke_report_cli_can_drop_unparseable_window_log_lines(
+    tmp_path,
+    capsys,
+):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=3000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "okx_faisal.log").write_text(
+        "\n".join(
+            [
+                "1970-01-01T00:00:03Z ERROR fresh in window",
+                "ERROR stale unparseable line dropped",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        live_smoke_report.main(
+            [
+                str(tmp_path / "monitor"),
+                "--logs-root",
+                str(logs_dir),
+                "--since-ms",
+                "2000",
+                "--until-ms",
+                "4000",
+                "--log-tail-lines",
+                "10",
+                "--log-window-unparsed-policy",
+                "drop",
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["logs"]["attention_matches"] == 1
+    assert report["logs"]["window"]["unparsed_policy"] == "drop"
+    assert report["logs"]["window"]["lines_skipped_unparsed"] == 1
+    assert [match["text"] for match in report["logs"]["matches"]] == [
+        "1970-01-01T00:00:03Z ERROR fresh in window"
+    ]
 
 
 def test_live_smoke_report_cli_rejects_invalid_window_timestamp(capsys):

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -617,6 +617,7 @@ def test_live_smoke_report_log_window_filters_parseable_timestamps(tmp_path):
                 "1970-01-01T00:00:01Z ERROR stale before window",
                 "1970-01-01T00:00:03Z ERROR fresh in window",
                 "ERROR unparseable timestamp kept visible",
+                "unparseable timestamp noise",
                 "1970-01-01T00:00:05Z CRITICAL future hard skipped",
             ]
         )
@@ -639,10 +640,10 @@ def test_live_smoke_report_log_window_filters_parseable_timestamps(tmp_path):
         "enabled": True,
         "since_ms": 2000,
         "until_ms": 4000,
-        "lines_considered": 2,
+        "lines_considered": 3,
         "lines_skipped_before": 1,
         "lines_skipped_after": 1,
-        "unparsed_ts": 1,
+        "unparsed_ts": 2,
         "unparsed_policy": "keep",
         "lines_skipped_unparsed": 0,
     }
@@ -663,21 +664,79 @@ def test_live_smoke_report_log_window_filters_parseable_timestamps(tmp_path):
     )
 
     assert drop_report["ok"] is True
-    assert drop_report["logs"]["attention_matches"] == 1
+    assert drop_report["logs"]["attention_matches"] == 2
     assert drop_report["logs"]["hard_matches"] == 0
     assert drop_report["logs"]["window"] == {
         "enabled": True,
         "since_ms": 2000,
         "until_ms": 4000,
-        "lines_considered": 1,
+        "lines_considered": 2,
         "lines_skipped_before": 1,
         "lines_skipped_after": 1,
-        "unparsed_ts": 1,
+        "unparsed_ts": 2,
         "unparsed_policy": "drop",
         "lines_skipped_unparsed": 1,
     }
     assert [match["text"] for match in drop_report["logs"]["matches"]] == [
-        "1970-01-01T00:00:03Z ERROR fresh in window"
+        "1970-01-01T00:00:03Z ERROR fresh in window",
+        "ERROR unparseable timestamp kept visible",
+    ]
+
+
+def test_live_smoke_report_log_window_drop_preserves_unparseable_hard_signal(tmp_path):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=3000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "okx_faisal.log").write_text(
+        "\n".join(
+            [
+                "1970-01-01T00:00:03Z ERROR exchange call failed",
+                "Traceback (most recent call last):",
+                "  File \"/tmp/passivbot.py\", line 1, in run",
+                "old unparseable non-signal noise",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=logs_dir,
+        since_ms=2000,
+        until_ms=4000,
+        log_tail_lines=10,
+        log_window_unparsed_policy="drop",
+    )
+
+    assert report["ok"] is False
+    assert report["logs"]["attention_matches"] == 2
+    assert report["logs"]["hard_matches"] == 1
+    assert report["logs"]["window"] == {
+        "enabled": True,
+        "since_ms": 2000,
+        "until_ms": 4000,
+        "lines_considered": 2,
+        "lines_skipped_before": 0,
+        "lines_skipped_after": 0,
+        "unparsed_ts": 3,
+        "unparsed_policy": "drop",
+        "lines_skipped_unparsed": 2,
+    }
+    assert [match["text"] for match in report["logs"]["matches"]] == [
+        "1970-01-01T00:00:03Z ERROR exchange call failed",
+        "Traceback (most recent call last):",
     ]
 
 
@@ -831,7 +890,7 @@ def test_live_smoke_report_cli_can_drop_unparseable_window_log_lines(
         "\n".join(
             [
                 "1970-01-01T00:00:03Z ERROR fresh in window",
-                "ERROR stale unparseable line dropped",
+                "stale unparseable noise dropped",
             ]
         )
         + "\n",


### PR DESCRIPTION
## Summary
- add --log-window-unparsed-policy keep|drop to live-smoke-report
- pass the same policy through live-incident-bundle embedded smoke reports
- keep current default behavior: unparseable text log lines remain visible in time-windowed scans unless operators opt into drop
- expose unparsed_policy and lines_skipped_unparsed counters in logs.window for auditability

## Validation
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py -q
- ./venv/bin/python -m compileall src/live/smoke_report.py src/live/incident_bundle.py src/tools/live_smoke_report.py src/tools/live_incident_bundle.py tests/test_live_smoke_report.py tests/test_live_incident_bundle.py
- git diff --check
- local read-only smoke: ./venv/bin/passivbot tool live-smoke-report monitor --logs-root logs --recent-minutes 10 --log-window-unparsed-policy drop --compact