### PR TITLE
Emit execution loop error burst events

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -64,6 +64,7 @@ across time.
 - `ema_fallback_used`
 - `exchange_acknowledged`
 - `exchange_exception`
+- `execution_loop_error_burst`
 - `length_mismatch`
 - `low_balance`
 - `new_fill`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -148,6 +148,7 @@ class ReasonCodes:
     EMA_FALLBACK_USED = "ema_fallback_used"
     EXCHANGE_ACKNOWLEDGED = "exchange_acknowledged"
     EXCHANGE_EXCEPTION = "exchange_exception"
+    EXECUTION_LOOP_ERROR_BURST = "execution_loop_error_burst"
     LENGTH_MISMATCH = "length_mismatch"
     LOW_BALANCE = "low_balance"
     NEW_FILL = "new_fill"

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -771,6 +771,52 @@ def emit_health_summary_event(bot: Any, *args: Any, **kwargs: Any) -> None:
         logging.debug("[event] failed to emit health summary event: %s", exc)
 
 
+def _emit_execution_loop_error_burst_event_unchecked(
+    bot: Any,
+    *,
+    count: int,
+    window_s: int,
+    endpoints: Any,
+    latest_fields: dict[str, Any],
+) -> None:
+    try:
+        top_endpoints = [
+            {"endpoint": str(name), "count": int(n)}
+            for name, n in endpoints.most_common(5)
+        ]
+    except Exception:
+        top_endpoints = []
+    latest = dict(latest_fields or {})
+    data: dict[str, Any] = {
+        "count": max(0, int(count)),
+        "window_s": max(0, int(window_s)),
+        "top_endpoints": top_endpoints,
+        "latest_error_type": str(latest.get("error_type") or "-"),
+        "latest_status": str(latest.get("status") or "-"),
+        "latest_code": str(latest.get("code") or "-"),
+    }
+    if latest.get("error") is not None:
+        data["latest_error"] = _sanitize_remote_text(latest.get("error"), max_len=500)
+    _safe_emit(
+        bot,
+        EventTypes.HEALTH_SUMMARY,
+        level="warning",
+        component="execution_loop",
+        tags=(EventTags.HEALTH, EventTags.EXECUTION, EventTags.SUMMARY),
+        cycle_id=current_live_event_cycle_id(bot),
+        status="degraded",
+        reason_code=ReasonCodes.EXECUTION_LOOP_ERROR_BURST,
+        data=data,
+    )
+
+
+def emit_execution_loop_error_burst_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    try:
+        _emit_execution_loop_error_burst_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug("[event] failed to emit execution loop error burst event: %s", exc)
+
+
 def _symbol_sample(symbols: Any, *, limit: int = 12) -> dict[str, Any]:
     if symbols is None:
         values = []

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -663,6 +663,9 @@ class Passivbot:
     )
     _emit_position_changed_event = live_event_emitters.emit_position_changed_event
     _emit_health_summary_event = live_event_emitters.emit_health_summary_event
+    _emit_execution_loop_error_burst_event = (
+        live_event_emitters.emit_execution_loop_error_burst_event
+    )
     _handle_candle_remote_fetch_event = live_event_emitters.emit_candle_remote_fetch_event
     _next_live_event_remote_call_id = live_event_emitters.next_live_event_remote_call_id
     _set_live_event_context_ids = live_event_emitters.set_live_event_context_ids
@@ -5624,6 +5627,12 @@ class Passivbot:
         state["last_log_ms"] = now
         top = ",".join(f"{name}:{n}" for name, n in endpoints.most_common(5))
         window_s = max(1, int((now - int(state["first_ms"])) / 1000))
+        self._emit_execution_loop_error_burst_event(
+            count=count,
+            window_s=window_s,
+            endpoints=endpoints,
+            latest_fields=fields,
+        )
         logging.warning(
             "[health] execution loop error burst | count=%d window=%ds top=%s latest_type=%s status=%s code=%s action=restart_backoff_continues",
             count,

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -77,6 +77,7 @@ def test_live_event_reason_code_registry_values_are_unique_and_query_safe():
 
     assert ReasonCodes.REQUIRED_EMA_UNAVAILABLE == "required_ema_unavailable"
     assert ReasonCodes.EXCHANGE_ACKNOWLEDGED == "exchange_acknowledged"
+    assert ReasonCodes.EXECUTION_LOOP_ERROR_BURST == "execution_loop_error_burst"
     assert ReasonCodes.WARMUP_CACHE_DECISION == "warmup_cache_decision"
     assert authoritative_reason_code("balance") == "authoritative_balance"
     assert sink_failed_reason_code("monitor") == "monitor_sink_failed"

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -14,7 +14,13 @@ from unittest.mock import AsyncMock, MagicMock
 import numpy as np
 import pytest
 from passivbot_exceptions import FatalBotException
-from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+from live.event_bus import (
+    EventTags,
+    EventTypes,
+    ListEventSink,
+    LiveEventPipeline,
+    ReasonCodes,
+)
 
 # Stub passivbot_rust before importing passivbot to avoid native dependency during unit test.
 sys.modules.setdefault(
@@ -7500,6 +7506,62 @@ def test_execution_loop_error_burst_summarizes_repeated_endpoints(caplog, monkey
     assert "count=3" in messages[0]
     assert "top=account-overview:3" in messages[0]
     assert "action=restart_backoff_continues" in messages[0]
+
+
+def test_execution_loop_error_burst_emits_structured_health_event(caplog, monkeypatch):
+    sink = ListEventSink()
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "kucoin"
+    bot.user = "kucoin_01"
+    bot.bot_id = "bot_1"
+    bot._live_event_current_cycle_id = "cy_error"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    now = {"value": 1_000_000}
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now["value"])
+
+    fields = {
+        "error_type": "RequestTimeout",
+        "status": "-",
+        "code": "-",
+        "error": (
+            "kucoinfutures GET https://api-futures.kucoin.com/api/v1/"
+            "account-overview?api_key=SECRET&signature=SIG"
+        ),
+    }
+
+    with caplog.at_level(logging.WARNING):
+        bot._log_execution_loop_error_burst(fields)
+        bot._log_execution_loop_error_burst(fields)
+        bot._log_execution_loop_error_burst(fields)
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = sink.events
+    assert len(events) == 1
+    event = events[0]
+    assert event.event_type == EventTypes.HEALTH_SUMMARY
+    assert event.level == "warning"
+    assert event.component == "execution_loop"
+    assert event.tags == (
+        EventTags.HEALTH,
+        EventTags.EXECUTION,
+        EventTags.SUMMARY,
+    )
+    assert event.cycle_id == "cy_error"
+    assert event.status == "degraded"
+    assert event.reason_code == ReasonCodes.EXECUTION_LOOP_ERROR_BURST
+    assert event.data["count"] == 3
+    assert event.data["window_s"] == 1
+    assert event.data["top_endpoints"] == [
+        {"endpoint": "account-overview", "count": 3}
+    ]
+    assert event.data["latest_error_type"] == "RequestTimeout"
+    assert "SECRET" not in event.data["latest_error"]
+    assert "SIG" not in event.data["latest_error"]
+    assert "[redacted]" in event.data["latest_error"]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 def test_staged_refresh_timing_summary_aggregates_routine_fast_refreshes(


### PR DESCRIPTION
## Summary
- mirror the existing throttled execution-loop error burst warning into the structured live event stream
- emit it as `health.summary` with reason code `execution_loop_error_burst`, off console/text by default
- include bounded endpoint counts and sanitized latest error fields

## Validation
- `./venv/bin/python -m pytest tests/test_live_event_bus.py::test_live_event_reason_code_registry_values_are_unique_and_query_safe tests/test_live_event_registry_docs.py tests/test_passivbot_balance_split.py::test_execution_loop_error_burst_summarizes_repeated_endpoints tests/test_passivbot_balance_split.py::test_execution_loop_error_burst_emits_structured_health_event -q`
- `./venv/bin/python -m pytest tests/test_passivbot_monitor.py::test_health_summary_event_emitter_records_payload tests/test_passivbot_monitor.py::test_log_health_summary_emits_structured_event tests/test_live_event_bus.py::test_route_table_keeps_data_events_off_console_by_default -q`
- `./venv/bin/python -m compileall src/live/event_bus.py src/live/event_emitters.py src/passivbot.py tests/test_live_event_bus.py tests/test_live_event_registry_docs.py tests/test_passivbot_balance_split.py`
- `git diff --check`
- `./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_live_event_registry_docs.py tests/test_passivbot_balance_split.py::test_execution_loop_error_burst_summarizes_repeated_endpoints tests/test_passivbot_balance_split.py::test_execution_loop_error_burst_emits_structured_health_event -q`

Observability-only; no order/risk/exchange behavior changes.