### PR TITLE
Surface smoke problem event context

### DIFF
--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -53,6 +53,20 @@ RISK_EVENT_TYPES = {
     EventTypes.HSL_COOLDOWN_STARTED,
     EventTypes.HSL_COOLDOWN_ENDED,
 }
+PROBLEM_EVENT_DATA_KEYS: dict[str, tuple[str, ...]] = {
+    EventTypes.CYCLE_DEGRADED: ("details", "authoritative_epoch"),
+    EventTypes.EMA_UNAVAILABLE: (
+        "optional_drop_count",
+        "optional_drop_groups",
+        "candidate_unavailable",
+        "candidate_unavailable_groups",
+        "unavailable",
+        "unavailable_reasons",
+    ),
+}
+PROBLEM_EVENT_DATA_MAX_DEPTH = 4
+PROBLEM_EVENT_DATA_MAX_ITEMS = 8
+PROBLEM_EVENT_DATA_MAX_TEXT = 240
 PROCESS_REPORT_FIELDS = {
     "pid",
     "age_s",
@@ -89,6 +103,64 @@ def _bot_key(live_event: dict[str, Any], row: dict[str, Any]) -> str:
     return f"{exchange}/{user}"
 
 
+def _compact_problem_event_data_value(value: Any, *, depth: int = 0) -> Any:
+    if value in (None, "", [], {}, ()):
+        return None
+    if isinstance(value, bool) or isinstance(value, int) or isinstance(value, float):
+        return value
+    if isinstance(value, str):
+        text = _redact_log_text(value)
+        if len(text) > PROBLEM_EVENT_DATA_MAX_TEXT:
+            text = text[:PROBLEM_EVENT_DATA_MAX_TEXT] + "..."
+        return text
+    if depth >= PROBLEM_EVENT_DATA_MAX_DEPTH:
+        return _compact_problem_event_data_value(str(value), depth=depth)
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for key in sorted(value, key=str)[:PROBLEM_EVENT_DATA_MAX_ITEMS]:
+            compact = _compact_problem_event_data_value(
+                value.get(key),
+                depth=depth + 1,
+            )
+            if compact not in (None, "", [], {}):
+                out[str(key)] = compact
+        truncated = max(0, len(value) - PROBLEM_EVENT_DATA_MAX_ITEMS)
+        if truncated:
+            out["truncated"] = truncated
+        return out or None
+    if isinstance(value, (list, tuple, set)):
+        values = list(value)
+        out = [
+            compact
+            for item in values[:PROBLEM_EVENT_DATA_MAX_ITEMS]
+            if (compact := _compact_problem_event_data_value(item, depth=depth + 1))
+            not in (None, "", [], {})
+        ]
+        truncated = max(0, len(values) - PROBLEM_EVENT_DATA_MAX_ITEMS)
+        if truncated:
+            out.append({"truncated": truncated})
+        return out or None
+    return _compact_problem_event_data_value(str(value), depth=depth)
+
+
+def _compact_problem_event_data(live_event: dict[str, Any]) -> dict[str, Any]:
+    event_type = str(live_event.get("event_type") or "")
+    keys = PROBLEM_EVENT_DATA_KEYS.get(event_type)
+    if not keys:
+        return {}
+    data = live_event.get("data")
+    if not isinstance(data, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for key in keys:
+        if key not in data:
+            continue
+        compact = _compact_problem_event_data_value(data.get(key))
+        if compact not in (None, "", [], {}):
+            out[key] = compact
+    return out
+
+
 def _compact_problem_event(
     *,
     path: Path,
@@ -122,6 +194,7 @@ def _compact_problem_event(
                 )
                 if ids.get(key) is not None
             },
+            "latest_data": _compact_problem_event_data(live_event),
         }.items()
         if value not in (None, {}, [])
     }
@@ -1125,12 +1198,22 @@ def _scan_logs(
     unparsed_ts = 0
     lines_skipped_unparsed = 0
     for path in files:
+        log_context_ts_ms: int | None = None
         for line_no, line in _tail_lines(path, max_lines=tail_lines):
             line_ts = _parse_log_line_ts_ms(line)
+            if line_ts is not None:
+                log_context_ts_ms = line_ts
             attention = bool(ATTENTION_LOG_PATTERN.search(line))
             if window_enabled:
                 if line_ts is None:
                     unparsed_ts += 1
+                    if log_context_ts_ms is not None:
+                        if since_ms is not None and log_context_ts_ms < since_ms:
+                            lines_skipped_before += 1
+                            continue
+                        if until_ms is not None and log_context_ts_ms > until_ms:
+                            lines_skipped_after += 1
+                            continue
                     if unparsed_policy == "drop" and not attention:
                         lines_skipped_unparsed += 1
                         continue

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -156,6 +156,118 @@ def test_live_smoke_report_summarizes_monitor_events_and_log_attention(tmp_path)
     assert [match["hard"] for match in report["logs"]["matches"]] == [False, True]
 
 
+def test_live_smoke_report_problem_events_include_allowlisted_ema_data(tmp_path):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="ema.unavailable",
+                seq=1,
+                ts=1000,
+                status="degraded",
+                level="debug",
+                reason_code="required_ema_unavailable",
+                ids={"cycle_id": "cy_ema"},
+                data={
+                    "candidate_unavailable": {
+                        "count": 1,
+                        "sample": ["ZEC/USDT:USDT"],
+                        "truncated": 0,
+                    },
+                    "candidate_unavailable_groups": [
+                        {
+                            "reason": "candidate_required_ema_unavailable",
+                            "symbols": {
+                                "count": 1,
+                                "sample": ["ZEC/USDT:USDT"],
+                                "truncated": 0,
+                            },
+                            "error_types": ["MissingCloseEma"],
+                            "example_error": (
+                                "GET https://example.test/candles"
+                                "?api_key=SECRET&signature=SIG"
+                            ),
+                        }
+                    ],
+                    "unavailable_reasons": [
+                        {
+                            "reason": "candidate_required_ema_unavailable",
+                            "symbols": {
+                                "count": 1,
+                                "sample": ["ZEC/USDT:USDT"],
+                                "truncated": 0,
+                            },
+                        }
+                    ],
+                    "ignored_extra": "do not surface",
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    assert report["ok"] is True
+    event = report["problem_events"][0]
+    assert event["event_type"] == "ema.unavailable"
+    assert event["ids"] == {"cycle_id": "cy_ema"}
+    latest_data = event["latest_data"]
+    assert latest_data["candidate_unavailable"]["sample"] == ["ZEC/USDT:USDT"]
+    assert latest_data["candidate_unavailable_groups"][0]["reason"] == (
+        "candidate_required_ema_unavailable"
+    )
+    assert (
+        latest_data["candidate_unavailable_groups"][0]["example_error"]
+        == "GET https://example.test/candles?api_key=[redacted]&signature=[redacted]"
+    )
+    assert "ignored_extra" not in latest_data
+
+
+def test_live_smoke_report_problem_events_include_cycle_degraded_details(tmp_path):
+    events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.degraded",
+                seq=1,
+                ts=1000,
+                status="degraded",
+                level="debug",
+                reason_code="staged_execution_not_ready",
+                ids={"cycle_id": "cy_blocked"},
+                data={
+                    "details": {
+                        "context": "market snapshot refresh",
+                        "missing": ["completed_candles"],
+                        "required": ["positions", "balance"],
+                        "invalid": {
+                            "auth": "api_key=SECRET&signature=SIG",
+                        },
+                    },
+                    "timings_ms": {"market_state": 112},
+                    "authoritative_epoch": 9,
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    event = report["problem_events"][0]
+    assert event["event_type"] == "cycle.degraded"
+    assert event["latest_data"] == {
+        "authoritative_epoch": 9,
+        "details": {
+            "context": "market snapshot refresh",
+            "invalid": {"auth": "api_key=[redacted]&signature=[redacted]"},
+            "missing": ["completed_candles"],
+            "required": ["positions", "balance"],
+        },
+    }
+
+
 def test_live_smoke_report_summarizes_startup_phase_baselines(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(
@@ -738,6 +850,59 @@ def test_live_smoke_report_log_window_drop_preserves_unparseable_hard_signal(tmp
         "1970-01-01T00:00:03Z ERROR exchange call failed",
         "Traceback (most recent call last):",
     ]
+
+
+def test_live_smoke_report_log_window_drops_stale_traceback_with_context(tmp_path):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=3000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "kucoin_01.log").write_text(
+        "\n".join(
+            [
+                "1970-01-01T00:00:01Z ERROR old exchange call failed",
+                "Traceback (most recent call last):",
+                "1970-01-01T00:00:03Z INFO recovered",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=logs_dir,
+        since_ms=2000,
+        until_ms=4000,
+        log_tail_lines=10,
+        log_window_unparsed_policy="drop",
+    )
+
+    assert report["ok"] is True
+    assert report["logs"]["attention_matches"] == 0
+    assert report["logs"]["hard_matches"] == 0
+    assert report["logs"]["matches"] == []
+    assert report["logs"]["window"] == {
+        "enabled": True,
+        "since_ms": 2000,
+        "until_ms": 4000,
+        "lines_considered": 1,
+        "lines_skipped_before": 2,
+        "lines_skipped_after": 0,
+        "unparsed_ts": 1,
+        "unparsed_policy": "drop",
+        "lines_skipped_unparsed": 0,
+    }
 
 
 def test_live_smoke_report_log_scan_ignores_traceback_prose(tmp_path):


### PR DESCRIPTION
Observability-only smoke-report slice.

Scope:
- Add bounded allowlisted latest_data to live-smoke-report problem_events.
- Surface EMA unavailable context: candidate/unavailable symbol summaries and reason groups.
- Surface cycle.degraded details and authoritative epoch.
- Recursively bounds item count/depth/text length and redacts sensitive strings.
- Use the last parsed timestamped log line as context for unparseable log lines when a log time window is active, so stale traceback headers from an older timestamped error are skipped after recovery while current unparseable hard signals remain visible.
- Does not change live event producers, trading behavior, or smoke hard/attention policy except for more accurate time-window log filtering.

Validation:
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q (18 passed)
- ./venv/bin/python -m compileall src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check