### PR TITLE
Drop contextless stale traceback smoke matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable user-facing changes will be documented in this file.
 - Added grouped problem-event summaries to `passivbot tool live-smoke-report`
   so repeated structured degradation can be inspected by bot, event type,
   reason, and hard/non-hard status without reading every event sample.
+- Changed `passivbot tool live-smoke-report --log-window-unparsed-policy drop`
+  to skip contextless unparsed log lines inside time-windowed scans, avoiding
+  stale traceback matches when the tail starts in the middle of an old
+  traceback.
 - Added live-event trace summary and order-trace sections to
   `passivbot tool live-incident-bundle` event reports, with
   `--no-trace-report` for compact bundles.

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -1341,7 +1341,9 @@ def _scan_logs(
                         if until_ms is not None and log_context_ts_ms > until_ms:
                             lines_skipped_after += 1
                             continue
-                    if unparsed_policy == "drop" and not attention:
+                    if unparsed_policy == "drop" and (
+                        log_context_ts_ms is None or not attention
+                    ):
                         lines_skipped_unparsed += 1
                         continue
                 else:

--- a/src/tools/live_incident_bundle.py
+++ b/src/tools/live_incident_bundle.py
@@ -185,8 +185,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
         help=(
             "When the embedded smoke-report log window is active, keep "
-            "unparseable text log lines visible by default, or drop non-signal "
-            "unparseable lines."
+            "unparseable text log lines visible by default, or drop unparseable "
+            "lines without in-window timestamp context."
         ),
     )
     parser.add_argument("--compact", action="store_true", help="Emit compact single-line JSON.")

--- a/src/tools/live_smoke_report.py
+++ b/src/tools/live_smoke_report.py
@@ -101,7 +101,8 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
         help=(
             "When a log time window is active, keep unparseable text log lines "
-            "visible by default, or drop non-signal unparseable lines."
+            "visible by default, or drop unparseable lines without in-window "
+            "timestamp context."
         ),
     )
     parser.add_argument(

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1016,6 +1016,60 @@ def test_live_smoke_report_log_window_drops_stale_traceback_with_context(tmp_pat
     }
 
 
+def test_live_smoke_report_log_window_drops_contextless_tailed_traceback(tmp_path):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=3000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "kucoin_01.log").write_text(
+        "\n".join(
+            [
+                "1970-01-01T00:00:01Z ERROR old exchange call failed",
+                "old stack line before tail",
+                "Traceback (most recent call last):",
+                "  File \"/tmp/passivbot.py\", line 1, in run",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=logs_dir,
+        since_ms=2000,
+        until_ms=4000,
+        log_tail_lines=2,
+        log_window_unparsed_policy="drop",
+    )
+
+    assert report["ok"] is True
+    assert report["logs"]["attention_matches"] == 0
+    assert report["logs"]["hard_matches"] == 0
+    assert report["logs"]["matches"] == []
+    assert report["logs"]["window"] == {
+        "enabled": True,
+        "since_ms": 2000,
+        "until_ms": 4000,
+        "lines_considered": 0,
+        "lines_skipped_before": 0,
+        "lines_skipped_after": 0,
+        "unparsed_ts": 2,
+        "unparsed_policy": "drop",
+        "lines_skipped_unparsed": 2,
+    }
+
+
 def test_live_smoke_report_log_scan_ignores_traceback_prose(tmp_path):
     events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- skip contextless unparsed log lines under live-smoke-report --log-window-unparsed-policy drop
- prevents a time-windowed smoke from hard-failing when the tailed slice starts in the middle of an old traceback
- add regression coverage matching the VPS5 Kucoin stale traceback shape

## Validation
- git diff --check
- ./venv/bin/python -m compileall -q src/live/smoke_report.py tests/test_live_smoke_report.py
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q

Tooling-only smoke-report fix; no live trading behavior changed.