### PR TITLE
Record contextless traceback smoke progress

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-26.
 
 Current `origin/v8` logging-overhaul head:
 
-- `998d7c9cd` merge of PR #682, `Group smoke problem events`.
+- `dff400014` merge of PR #684, `Drop contextless stale traceback smoke matches`.
 
 Current review gate:
 
@@ -30,7 +30,7 @@ Current review gate:
 
 VPS5 deployment status:
 
-- Repository pulled through PR #682 at `998d7c9cd`.
+- Repository pulled through PR #684 at `dff40001`.
 - Bots were restarted from `/root/bots_vps5.yaml` after PR #677 and left
   running. The old process set stopped after about 36 seconds before the tmuxp
   reload.
@@ -94,6 +94,17 @@ VPS5 deployment status:
   `problem_event_groups` section grouped the remaining known non-hard
   EMA/cycle/HSL attention without requiring inspection of individual event
   samples.
+- PR #683 was pulled to VPS5 without bot restart because it only updated
+  progress docs.
+- PR #684 was pulled to VPS5 without bot restart because it only changed
+  read-only smoke-report tooling. The pre-fix smoke showed the tool could still
+  hard-fail on a stale Kucoin traceback header when the tailed log slice started
+  in the middle of an old traceback with no timestamp context. After PR #684, a
+  1-minute smoke with `--log-window-unparsed-policy drop`, text logs enabled,
+  and `/root/bots_vps5.yaml` process matching reported `ok=true`,
+  `hard_failures=0`, `hard_problem_event_count=0`, `logs.hard_matches=0`,
+  `logs.attention_matches=0`, `remote_call_failures.total=0`,
+  `matched_expected=5`, and `missing_expected=[]`.
 
 ## Phase Checklist
 
@@ -599,11 +610,41 @@ VPS5 deployment status:
   failures, and grouped the remaining known non-hard EMA/cycle/HSL attention in
   `problem_event_groups`.
 
+### PR #683: Smoke Grouping Progress Update
+
+- Branch: `codex/v8-progress-after-smoke-grouping`.
+- Scope: process tracking.
+- Result: updated this progress ledger and the live operations backlog after
+  PR #682 merged and VPS5 smoke confirmed grouped problem-event summaries.
+- Review evidence: Hermes approved head `3fa8d819`; CI was green; `git diff
+  --check` passed before merge. Claude did not return during repeated polls, and
+  Composer had been retired, so this docs-only slice used the degraded gate.
+
+### PR #684: Contextless Traceback Smoke Filter
+
+- Branch: `codex/v8-smoke-drop-contextless-traceback`.
+- Scope: operator smoke tooling.
+- Result: `passivbot tool live-smoke-report --log-window-unparsed-policy drop`
+  now skips unparseable log lines without in-window timestamp context, avoiding
+  stale hard failures when the inspected log tail begins in the middle of an old
+  traceback. The direct smoke-report and incident-bundle help text now describes
+  the context-based drop behavior.
+- Review evidence: Hermes approved original head `f01996ec` with one minor
+  help-text mismatch, then approved the fixed head `04ca717`; CI was green;
+  focused smoke-report tests, compileall, and `git diff --check` passed before
+  merge. Claude did not return during repeated polls, and Composer had been
+  retired, so this read-only tooling slice used the degraded gate.
+- VPS5 evidence: deployed to VPS5 at `dff40001` without bot restart. A
+  1-minute smoke with `--log-window-unparsed-policy drop` and
+  `/root/bots_vps5.yaml` process matching reported all five configured bots
+  running, no hard failures, no hard problem events, no log hard or attention
+  matches, and no remote-call failures.
+
 ## Current Next Steps
 
 1. Wait for the normal Claude + Hermes + CI gate on PR #681 before merging the
-   runtime staged-refresh event producer slice; Hermes and CI are already green
-   on the rebased head.
+   runtime staged-refresh event producer slice. Hermes and CI are already green
+   on rebased head `d38bfc72f`, but Claude has not reviewed that head.
 2. Continue Phase 5 by migrating one high-value stdlib text log family to
    structured-event projection without increasing default console noise.
 3. Use the persistent non-hard EMA readiness / staged-execution degradation

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -60,8 +60,10 @@ Related detailed plans:
    compare running `passivbot live` processes against a tmuxp-style supervisor
    config, scope structured monitor events and parseable timestamped text logs
    to a requested time window, apply an explicit unparseable text-log policy,
-   avoid traceback-prose false positives, and summarize recent HSL/risk events
-   from the structured stream. It also surfaces bounded latest problem-event
+   avoid traceback-prose false positives, avoid stale contextless traceback
+   false positives when a time-windowed log tail starts mid-traceback, and
+   summarize recent HSL/risk events from the structured stream. It also surfaces
+   bounded latest problem-event
    context for selected non-hard groups such as EMA/cycle readiness
    degradation, plus aggregate problem-event groups keyed by bot/event/reason/
    status/hard flag/symbol/position side. The safe restart orchestration
@@ -255,6 +257,7 @@ Related detailed plans:
 | 2026-06-26 | #10 Operator console redesign from events | PR #677 / `409f5d8e` | Mirrored existing execution-loop error burst warnings into structured `health.summary` events with `execution_loop_error_burst`, best-effort and redacted | Continue migrating high-value text logs to structured events without increasing console noise |
 | 2026-06-26 | #3 Live restart/smoke automation | PR #679 / `60c9a41` | Added bounded `problem_events.latest_data` for selected smoke problem groups and timestamp-context filtering for stale unparseable log continuations; VPS5 smoke after deploy returned `ok=true`, no hard problem events, no log hard/attention matches, and all five bots matched | Safe pull/stop/start orchestration still open |
 | 2026-06-26 | #3 Live restart/smoke automation | PR #682 / `048e8595c` | Added top-level `problem_event_count` and bounded `problem_event_groups` aggregates to `live-smoke-report`; settled VPS5 smoke after deploy returned `ok=true`, no hard problem events, no log matches, no remote-call failures, and all five bots matched | Safe pull/stop/start orchestration still open |
+| 2026-06-26 | #3 Live restart/smoke automation | PR #684 / `04ca7174` | Dropped contextless unparseable log lines under explicit `--log-window-unparsed-policy drop`, preventing stale mid-traceback tails from causing false hard smoke failures; VPS5 smoke after deploy returned `ok=true`, no hard problem events, no log hard/attention matches, no remote-call failures, and all five bots matched | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |


### PR DESCRIPTION
## Summary
- update the live logging progress ledger through PR #684 and VPS5 smoke evidence
- record the contextless traceback smoke-filter refinement in the ops backlog
- note that PR #681 still waits on the normal runtime-code gate

## Validation
- git diff --check

Docs-only progress update; no runtime behavior changed.