### PR TITLE
Add smoke report repository metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added repository branch/head metadata to `passivbot tool live-smoke-report`
+  so VPS smoke evidence records the deployed code revision without counting
+  local untracked artifacts as dirty.
 - Added grouped problem-event summaries to `passivbot tool live-smoke-report`
   so repeated structured degradation can be inspected by bot, event type,
   reason, and hard/non-hard status without reading every event sample.

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -79,6 +79,14 @@ PROCESS_REPORT_FIELDS = {
 }
 
 
+def _resolve_path(path: str | Path) -> Path:
+    candidate = Path(path).expanduser()
+    try:
+        return candidate.resolve()
+    except OSError:
+        return candidate.absolute()
+
+
 def _open_text(path: Path):
     if path.name.endswith(".gz"):
         return gzip.open(path, "rt", encoding="utf-8", errors="replace")
@@ -675,6 +683,102 @@ def _ps_process_rows() -> tuple[list[str], str | None]:
             continue
         return result.stdout.splitlines(), None
     return [], last_error or "ps_failed"
+
+
+def _find_repository_root(
+    monitor_root: str | Path,
+    *,
+    repo_root: str | Path | None,
+) -> Path:
+    if repo_root is not None:
+        return _resolve_path(repo_root)
+
+    starts: list[Path] = []
+    monitor_path = _resolve_path(monitor_root)
+    starts.append(monitor_path.parent if monitor_path.name == "monitor" else monitor_path)
+    starts.append(_resolve_path(Path.cwd()))
+
+    seen: set[Path] = set()
+    for start in starts:
+        for ancestor in (start, *start.parents):
+            if ancestor in seen:
+                continue
+            seen.add(ancestor)
+            if (ancestor / ".git").exists():
+                return ancestor
+    return starts[0]
+
+
+def _git_output(
+    repo_root: Path,
+    args: list[str],
+    *,
+    timeout: float = 2.0,
+) -> tuple[str | None, str | None]:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, f"git_failed:{exc.__class__.__name__}"
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or f"git_exit_{result.returncode}").strip()
+        return None, _redact_log_text(detail, max_len=300)
+    return result.stdout.strip(), None
+
+
+def _build_repository_report(
+    monitor_root: str | Path,
+    *,
+    repo_root: str | Path | None,
+) -> dict[str, Any]:
+    root = _find_repository_root(monitor_root, repo_root=repo_root)
+    report: dict[str, Any] = {
+        "root": str(root),
+        "is_git_repo": False,
+        "branch": None,
+        "head": None,
+        "head_full": None,
+        "dirty": None,
+        "tracked_changes": None,
+        "error": None,
+    }
+    inside_work_tree, error = _git_output(root, ["rev-parse", "--is-inside-work-tree"])
+    if error is not None or inside_work_tree != "true":
+        report["error"] = error
+        return report
+
+    report["is_git_repo"] = True
+    errors: list[str] = []
+    head_full, error = _git_output(root, ["rev-parse", "HEAD"])
+    if error is None:
+        report["head_full"] = head_full
+    else:
+        errors.append(f"head:{error}")
+    head, error = _git_output(root, ["rev-parse", "--short", "HEAD"])
+    if error is None:
+        report["head"] = head
+    else:
+        errors.append(f"head_short:{error}")
+    branch, error = _git_output(root, ["rev-parse", "--abbrev-ref", "HEAD"])
+    if error is None:
+        report["branch"] = branch
+    else:
+        errors.append(f"branch:{error}")
+    status, error = _git_output(root, ["status", "--porcelain", "--untracked-files=no"])
+    if error is None:
+        changes = [line for line in (status or "").splitlines() if line.strip()]
+        report["dirty"] = bool(changes)
+        report["tracked_changes"] = len(changes)
+    else:
+        errors.append(f"status:{error}")
+    report["error"] = ";".join(errors) or None
+    return report
 
 
 def _float_or_none(value: str) -> float | None:
@@ -1393,6 +1497,7 @@ def build_live_smoke_report(
     monitor_root: str | Path = "monitor",
     *,
     logs_root: str | Path | None = "logs",
+    repo_root: str | Path | None = None,
     include_processes: bool = False,
     supervisor_config: str | Path | None = None,
     process_command_match: str = DEFAULT_PROCESS_MATCH,
@@ -1466,6 +1571,7 @@ def build_live_smoke_report(
         supervisor_config=supervisor_config,
         process_command_match=process_command_match,
     )
+    repository_report = _build_repository_report(monitor_root, repo_root=repo_root)
     hard_failures = (
         int(event_report["error_count"])
         + int(event_scan["invalid_rows"])
@@ -1505,4 +1611,5 @@ def build_live_smoke_report(
         "hard_problem_event_count": event_scan["hard_problem_event_count"],
         "logs": log_scan,
         "processes": process_report,
+        "repository": repository_report,
     }

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -57,6 +57,20 @@ def _write_ndjson(path, rows):
     )
 
 
+def _write_minimal_monitor_event(monitor_root):
+    _write_ndjson(
+        monitor_root / "binance" / "binance_01" / "events" / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+
+
 def test_live_smoke_report_summarizes_monitor_events_and_log_attention(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(
@@ -1383,3 +1397,104 @@ def test_live_smoke_report_process_scan_without_config_is_observational(
     assert report["processes"]["running"][0]["command_key"] == (
         "passivbot live configs/v8.json -u okx_faisal"
     )
+
+
+def test_live_smoke_report_includes_repository_metadata(tmp_path, monkeypatch):
+    _write_minimal_monitor_event(tmp_path / "monitor")
+    calls = []
+    responses = {
+        ("rev-parse", "--is-inside-work-tree"): ("true", None),
+        ("rev-parse", "HEAD"): ("abcdef1234567890", None),
+        ("rev-parse", "--short", "HEAD"): ("abcdef1", None),
+        ("rev-parse", "--abbrev-ref", "HEAD"): ("v8", None),
+        ("status", "--porcelain", "--untracked-files=no"): (
+            " M src/live/smoke_report.py\nM  tests/test_live_smoke_report.py",
+            None,
+        ),
+    }
+
+    def fake_git_output(repo_root, args, *, timeout=2.0):
+        calls.append((repo_root, tuple(args), timeout))
+        return responses[tuple(args)]
+
+    monkeypatch.setattr(smoke_report_module, "_git_output", fake_git_output)
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        repo_root=tmp_path,
+    )
+
+    repository = report["repository"]
+    assert report["ok"] is True
+    assert repository == {
+        "root": str(tmp_path.resolve()),
+        "is_git_repo": True,
+        "branch": "v8",
+        "head": "abcdef1",
+        "head_full": "abcdef1234567890",
+        "dirty": True,
+        "tracked_changes": 2,
+        "error": None,
+    }
+    assert calls[-1][1] == ("status", "--porcelain", "--untracked-files=no")
+
+
+def test_live_smoke_report_discovers_repository_from_monitor_root(tmp_path, monkeypatch):
+    repo_root = tmp_path / "passivbot"
+    (repo_root / ".git").mkdir(parents=True)
+    _write_minimal_monitor_event(repo_root / "monitor")
+    roots = []
+
+    def fake_git_output(repo_root, args, *, timeout=2.0):
+        roots.append(repo_root)
+        if args == ["rev-parse", "--is-inside-work-tree"]:
+            return "true", None
+        if args == ["rev-parse", "HEAD"]:
+            return "1234567890abcdef", None
+        if args == ["rev-parse", "--short", "HEAD"]:
+            return "1234567", None
+        if args == ["rev-parse", "--abbrev-ref", "HEAD"]:
+            return "v8", None
+        if args == ["status", "--porcelain", "--untracked-files=no"]:
+            return "", None
+        raise AssertionError(args)
+
+    monkeypatch.setattr(smoke_report_module, "_git_output", fake_git_output)
+
+    report = build_live_smoke_report(repo_root / "monitor", logs_root=None)
+
+    assert set(roots) == {repo_root.resolve()}
+    assert report["repository"]["root"] == str(repo_root.resolve())
+    assert report["repository"]["dirty"] is False
+
+
+def test_live_smoke_report_repository_metadata_is_observational_on_git_error(
+    tmp_path,
+    monkeypatch,
+):
+    _write_minimal_monitor_event(tmp_path / "monitor")
+    monkeypatch.setattr(
+        smoke_report_module,
+        "_git_output",
+        lambda repo_root, args, *, timeout=2.0: (None, "not_a_git_repo"),
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        repo_root=tmp_path,
+    )
+
+    assert report["ok"] is True
+    assert report["hard_failures"] == 0
+    assert report["repository"] == {
+        "root": str(tmp_path.resolve()),
+        "is_git_repo": False,
+        "branch": None,
+        "head": None,
+        "head_full": None,
+        "dirty": None,
+        "tracked_changes": None,
+        "error": "not_a_git_repo",
+    }


### PR DESCRIPTION
## Summary
- add best-effort repository metadata to passivbot tool live-smoke-report
- include branch, head/head_full, tracked-only dirty state, and tracked change count
- keep git lookup failures observational and excluded from smoke hard-failure accounting

## Validation
- git diff --check
- ./venv/bin/python -m compileall -q src/live/smoke_report.py tests/test_live_smoke_report.py
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py -q