### PR TITLE
Summarize remote call timings in smoke report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added remote-call elapsed-time summaries to `passivbot tool live-smoke-report`
+  so slow exchange/API calls can be inspected even when they eventually succeed.
 - Added repository branch/head metadata to `passivbot tool live-smoke-report`
   so VPS smoke evidence records the deployed code revision without counting
   local untracked artifacts as dirty.

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -44,6 +44,7 @@ DEFAULT_PROCESS_MATCH = "passivbot live"
 LOG_WINDOW_UNPARSED_POLICIES = {"keep", "drop"}
 DEFAULT_LOG_WINDOW_UNPARSED_POLICY = "keep"
 REMOTE_CALL_FAILURE_GROUP_LIMIT = 20
+REMOTE_CALL_TIMING_GROUP_LIMIT = 20
 RISK_EVENT_GROUP_LIMIT = 20
 PROBLEM_EVENT_GROUP_LIMIT = 20
 RISK_EVENT_TYPES = {
@@ -53,6 +54,11 @@ RISK_EVENT_TYPES = {
     EventTypes.HSL_RED_TRIGGERED,
     EventTypes.HSL_COOLDOWN_STARTED,
     EventTypes.HSL_COOLDOWN_ENDED,
+}
+REMOTE_CALL_TIMING_EVENT_TYPES = {
+    EventTypes.REMOTE_CALL_SUCCEEDED,
+    EventTypes.REMOTE_CALL_FAILED,
+    EventTypes.REMOTE_CALL_THROTTLED,
 }
 PROBLEM_EVENT_DATA_KEYS: dict[str, tuple[str, ...]] = {
     EventTypes.CYCLE_DEGRADED: ("details", "authoritative_epoch"),
@@ -327,6 +333,143 @@ def _summarize_remote_call_failures(
     return {
         "total": sum(int(group.get("count", 0)) for group in groups.values()),
         "groups_truncated": len(ordered) > REMOTE_CALL_FAILURE_GROUP_LIMIT,
+        "groups": compact_groups,
+    }
+
+
+def _remote_call_timing_group(
+    *,
+    bot_key: str,
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+    path: Path,
+    line_no: int,
+) -> dict[str, Any] | None:
+    data = live_event.get("data")
+    payload = data if isinstance(data, dict) else {}
+    elapsed_ms = _non_negative_int(payload.get("elapsed_ms"))
+    if elapsed_ms is None:
+        return None
+    ids = _event_ids(live_event)
+    return {
+        "bot": bot_key,
+        "event_type": live_event.get("event_type") or row.get("kind"),
+        "reason_code": live_event.get("reason_code"),
+        "surface": payload.get("surface"),
+        "kind": payload.get("kind"),
+        "error_type": payload.get("error_type"),
+        "component": live_event.get("component"),
+        "status": live_event.get("status"),
+        "symbol": live_event.get("symbol"),
+        "count": 1,
+        "elapsed_values": [elapsed_ms],
+        "latest_ts": row.get("ts"),
+        "latest_seq": row.get("seq"),
+        "latest_path": str(path),
+        "latest_line": int(line_no),
+        "latest_elapsed_ms": elapsed_ms,
+        "latest_ids": {
+            key: ids.get(key)
+            for key in ("cycle_id", "remote_call_id", "remote_call_group_id")
+            if ids.get(key) is not None
+        },
+    }
+
+
+def _merge_remote_call_timing_group(
+    groups: dict[tuple[Any, ...], dict[str, Any]],
+    group: dict[str, Any],
+) -> None:
+    key = (
+        group.get("bot"),
+        group.get("event_type"),
+        group.get("reason_code"),
+        group.get("surface"),
+        group.get("kind"),
+        group.get("error_type"),
+        group.get("component"),
+        group.get("status"),
+        group.get("symbol"),
+    )
+    existing = groups.get(key)
+    if existing is None:
+        groups[key] = group
+        return
+    existing["count"] = int(existing.get("count", 0)) + 1
+    existing.setdefault("elapsed_values", []).extend(group.get("elapsed_values") or [])
+    current_key = _sort_event_position_key(
+        ts=group.get("latest_ts"),
+        seq=group.get("latest_seq"),
+        path=group.get("latest_path") or "",
+        line_no=int(group.get("latest_line") or 0),
+    )
+    existing_key = _sort_event_position_key(
+        ts=existing.get("latest_ts"),
+        seq=existing.get("latest_seq"),
+        path=existing.get("latest_path") or "",
+        line_no=int(existing.get("latest_line") or 0),
+    )
+    if current_key > existing_key:
+        for field in (
+            "latest_ts",
+            "latest_seq",
+            "latest_path",
+            "latest_line",
+            "latest_elapsed_ms",
+            "latest_ids",
+        ):
+            existing[field] = group.get(field)
+
+
+def _remote_call_timing_sort_key(
+    group: dict[str, Any],
+) -> tuple[int, int, int, int, str, str]:
+    summary = _ms_summary(
+        [
+            int(value)
+            for value in (group.get("elapsed_values") or [])
+            if _non_negative_int(value) is not None
+        ]
+    )
+    return (
+        -int(summary.get("p95_ms") or 0),
+        -int(summary.get("max_ms") or 0),
+        -int(group.get("count", 0)),
+        -int(_non_negative_int(group.get("latest_ts")) or 0),
+        str(group.get("bot") or ""),
+        str(group.get("reason_code") or ""),
+    )
+
+
+def _summarize_remote_call_timings(
+    groups: dict[tuple[Any, ...], dict[str, Any]]
+) -> dict[str, Any]:
+    ordered = sorted(groups.values(), key=_remote_call_timing_sort_key)
+    compact_groups = []
+    for group in ordered[:REMOTE_CALL_TIMING_GROUP_LIMIT]:
+        compact = {
+            key: value
+            for key, value in group.items()
+            if key
+            not in {
+                "elapsed_values",
+                "latest_path",
+                "latest_line",
+                "latest_seq",
+            }
+            and value not in (None, {}, [])
+        }
+        compact["elapsed_ms"] = _ms_summary(
+            [
+                int(value)
+                for value in (group.get("elapsed_values") or [])
+                if _non_negative_int(value) is not None
+            ]
+        )
+        compact_groups.append(compact)
+    return {
+        "total": sum(int(group.get("count", 0)) for group in groups.values()),
+        "groups_truncated": len(ordered) > REMOTE_CALL_TIMING_GROUP_LIMIT,
         "groups": compact_groups,
     }
 
@@ -1145,6 +1288,7 @@ def _scan_events(
     invalid_window_ts = 0
     startup_timing_records: dict[str, list[dict[str, Any]]] = defaultdict(list)
     remote_call_failure_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
+    remote_call_timing_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     risk_event_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     risk_event_type_counts: Counter[str] = Counter()
     problem_event_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -1202,6 +1346,19 @@ def _scan_events(
                                 line_no=line_no,
                             ),
                         )
+                    if event_type in REMOTE_CALL_TIMING_EVENT_TYPES:
+                        remote_call_timing_group = _remote_call_timing_group(
+                            bot_key=bot_key,
+                            row=row,
+                            live_event=live_event,
+                            path=path,
+                            line_no=line_no,
+                        )
+                        if remote_call_timing_group is not None:
+                            _merge_remote_call_timing_group(
+                                remote_call_timing_groups,
+                                remote_call_timing_group,
+                            )
                     if event_type in RISK_EVENT_TYPES:
                         risk_event_type_counts[str(event_type)] += 1
                         _merge_risk_event_group(
@@ -1283,6 +1440,7 @@ def _scan_events(
         "remote_call_failures": _summarize_remote_call_failures(
             remote_call_failure_groups
         ),
+        "remote_call_timings": _summarize_remote_call_timings(remote_call_timing_groups),
         "risk_events": _summarize_risk_events(
             risk_event_groups,
             risk_event_type_counts,
@@ -1542,6 +1700,11 @@ def build_live_smoke_report(
                 "groups_truncated": False,
                 "groups": [],
             },
+            "remote_call_timings": {
+                "total": 0,
+                "groups_truncated": False,
+                "groups": [],
+            },
             "risk_events": {
                 "total": 0,
                 "groups_truncated": False,
@@ -1603,6 +1766,7 @@ def build_live_smoke_report(
         "bots": event_scan["bots"],
         "startup_timings": event_scan["startup_timings"],
         "remote_call_failures": event_scan["remote_call_failures"],
+        "remote_call_timings": event_scan["remote_call_timings"],
         "risk_events": event_scan["risk_events"],
         "event_window": event_scan["event_window"],
         "problem_events": event_scan["problem_events"],

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -164,10 +164,158 @@ def test_live_smoke_report_summarizes_monitor_events_and_log_attention(tmp_path)
             }
         ],
     }
+    assert report["remote_call_timings"] == {
+        "total": 1,
+        "groups_truncated": False,
+        "groups": [
+            {
+                "bot": "binance/binance_01",
+                "event_type": "remote_call.failed",
+                "reason_code": "request_timeout",
+                "surface": "balance",
+                "error_type": "RequestTimeout",
+                "component": "test",
+                "status": "failed",
+                "symbol": "BTC/USDT:USDT",
+                "count": 1,
+                "latest_ts": 1100,
+                "latest_elapsed_ms": 12345,
+                "latest_ids": {"remote_call_id": "rc_1"},
+                "elapsed_ms": {
+                    "median_ms": 12345,
+                    "p95_ms": 12345,
+                    "min_ms": 12345,
+                    "max_ms": 12345,
+                },
+            }
+        ],
+    }
     assert report["hard_problem_event_count"] == 0
     assert report["logs"]["attention_matches"] == 2
     assert report["logs"]["hard_matches"] == 1
     assert [match["hard"] for match in report["logs"]["matches"]] == [False, True]
+
+
+def test_live_smoke_report_summarizes_remote_call_timings(tmp_path):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="remote_call.succeeded",
+                seq=1,
+                ts=1000,
+                level="debug",
+                reason_code="authoritative_balance",
+                ids={
+                    "cycle_id": "cy_1",
+                    "remote_call_id": "rca_1",
+                    "remote_call_group_id": "cy_1:authoritative",
+                },
+                data={
+                    "kind": "authoritative_state_fetch",
+                    "surface": "balance",
+                    "elapsed_ms": 5000,
+                },
+            ),
+            _monitor_row(
+                event_type="remote_call.succeeded",
+                seq=2,
+                ts=2000,
+                level="debug",
+                reason_code="authoritative_balance",
+                ids={
+                    "cycle_id": "cy_2",
+                    "remote_call_id": "rca_2",
+                    "remote_call_group_id": "cy_2:authoritative",
+                },
+                data={
+                    "kind": "authoritative_state_fetch",
+                    "surface": "balance",
+                    "elapsed_ms": 15000,
+                },
+            ),
+            _monitor_row(
+                event_type="remote_call.succeeded",
+                seq=3,
+                ts=3000,
+                level="debug",
+                reason_code="authoritative_open_orders",
+                ids={
+                    "cycle_id": "cy_2",
+                    "remote_call_id": "rca_3",
+                    "remote_call_group_id": "cy_2:authoritative",
+                },
+                data={
+                    "kind": "authoritative_state_fetch",
+                    "surface": "open_orders",
+                    "elapsed_ms": 90000,
+                },
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    assert report["ok"] is True
+    assert report["attention"] is False
+    assert report["remote_call_failures"] == {
+        "total": 0,
+        "groups_truncated": False,
+        "groups": [],
+    }
+    assert report["remote_call_timings"] == {
+        "total": 3,
+        "groups_truncated": False,
+        "groups": [
+            {
+                "bot": "binance/binance_01",
+                "event_type": "remote_call.succeeded",
+                "reason_code": "authoritative_open_orders",
+                "surface": "open_orders",
+                "kind": "authoritative_state_fetch",
+                "component": "test",
+                "status": "succeeded",
+                "count": 1,
+                "latest_ts": 3000,
+                "latest_elapsed_ms": 90000,
+                "latest_ids": {
+                    "cycle_id": "cy_2",
+                    "remote_call_id": "rca_3",
+                    "remote_call_group_id": "cy_2:authoritative",
+                },
+                "elapsed_ms": {
+                    "median_ms": 90000,
+                    "p95_ms": 90000,
+                    "min_ms": 90000,
+                    "max_ms": 90000,
+                },
+            },
+            {
+                "bot": "binance/binance_01",
+                "event_type": "remote_call.succeeded",
+                "reason_code": "authoritative_balance",
+                "surface": "balance",
+                "kind": "authoritative_state_fetch",
+                "component": "test",
+                "status": "succeeded",
+                "count": 2,
+                "latest_ts": 2000,
+                "latest_elapsed_ms": 15000,
+                "latest_ids": {
+                    "cycle_id": "cy_2",
+                    "remote_call_id": "rca_2",
+                    "remote_call_group_id": "cy_2:authoritative",
+                },
+                "elapsed_ms": {
+                    "median_ms": 10000,
+                    "p95_ms": 15000,
+                    "min_ms": 5000,
+                    "max_ms": 15000,
+                },
+            },
+        ],
+    }
 
 
 def test_live_smoke_report_problem_events_include_allowlisted_ema_data(tmp_path):
@@ -768,6 +916,11 @@ def test_live_smoke_report_time_window_filters_structured_problem_events(tmp_pat
     assert report["hard_problem_event_count"] == 0
     assert report["problem_events"] == []
     assert report["remote_call_failures"] == {
+        "total": 0,
+        "groups_truncated": False,
+        "groups": [],
+    }
+    assert report["remote_call_timings"] == {
         "total": 0,
         "groups_truncated": False,
         "groups": [],


### PR DESCRIPTION
## Summary
- add a read-only remote_call_timings section to live-smoke-report
- group terminal remote-call events by bot/component/reason/surface/status and summarize elapsed min/median/p95/max
- keep the section observational only; no changes to smoke ok/attention/hard-failure accounting or live trading behavior

## Validation
- git diff --check
- ./venv/bin/python -m compileall -q src/live/smoke_report.py tests/test_live_smoke_report.py tests/test_live_incident_bundle.py
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py -q