### PR TITLE
Add smoke remote-call health totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added top-level success, failure, and throttle totals to remote-call health
+  summaries in `passivbot tool live-smoke-report`.
 - Added remote-call health rollups to `passivbot tool live-smoke-report`,
   grouping successes, failures, throttles, latency, and affected symbols by
   bot/component/kind/surface.

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -502,6 +502,14 @@ def _summarize_remote_call_health(
     groups: dict[tuple[Any, ...], dict[str, Any]]
 ) -> dict[str, Any]:
     ordered = sorted(groups.values(), key=_remote_call_health_sort_key)
+    status_totals: Counter[str] = Counter()
+    for group in groups.values():
+        statuses = group.get("statuses") if isinstance(group.get("statuses"), Counter) else Counter()
+        status_totals.update(statuses)
+    total = sum(int(group.get("count", 0)) for group in groups.values())
+    total_succeeded_count = int(status_totals.get("succeeded", 0))
+    total_failed_count = int(status_totals.get("failed", 0))
+    total_throttled_count = int(status_totals.get("throttled", 0))
     compact_groups = []
     for group in ordered[:REMOTE_CALL_HEALTH_GROUP_LIMIT]:
         statuses = group.get("statuses") if isinstance(group.get("statuses"), Counter) else Counter()
@@ -520,8 +528,8 @@ def _summarize_remote_call_health(
         )
         symbols = group.get("symbols") if isinstance(group.get("symbols"), Counter) else Counter()
         count = int(group.get("count", 0))
-        failed_count = int(statuses.get("failed", 0))
-        throttled_count = int(statuses.get("throttled", 0))
+        group_failed_count = int(statuses.get("failed", 0))
+        group_throttled_count = int(statuses.get("throttled", 0))
         compact = {
             "bot": group.get("bot"),
             "component": group.get("component"),
@@ -529,10 +537,10 @@ def _summarize_remote_call_health(
             "surface": group.get("surface"),
             "count": count,
             "succeeded": int(statuses.get("succeeded", 0)),
-            "failed": failed_count,
-            "throttled": throttled_count,
-            "failure_pct": _usage_pct(failed_count, count),
-            "throttled_pct": _usage_pct(throttled_count, count),
+            "failed": group_failed_count,
+            "throttled": group_throttled_count,
+            "failure_pct": _usage_pct(group_failed_count, count),
+            "throttled_pct": _usage_pct(group_throttled_count, count),
             "statuses": _top_counter_values(
                 statuses,
                 limit=REMOTE_CALL_HEALTH_VALUE_LIMIT,
@@ -578,7 +586,12 @@ def _summarize_remote_call_health(
             }
         )
     return {
-        "total": sum(int(group.get("count", 0)) for group in groups.values()),
+        "total": total,
+        "succeeded": total_succeeded_count,
+        "failed": total_failed_count,
+        "throttled": total_throttled_count,
+        "failure_pct": _usage_pct(total_failed_count, total),
+        "throttled_pct": _usage_pct(total_throttled_count, total),
         "groups_truncated": len(ordered) > REMOTE_CALL_HEALTH_GROUP_LIMIT,
         "groups": compact_groups,
     }
@@ -1961,6 +1974,11 @@ def build_live_smoke_report(
             },
             "remote_call_health": {
                 "total": 0,
+                "succeeded": 0,
+                "failed": 0,
+                "throttled": 0,
+                "failure_pct": None,
+                "throttled_pct": None,
                 "groups_truncated": False,
                 "groups": [],
             },

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -166,6 +166,11 @@ def test_live_smoke_report_summarizes_monitor_events_and_log_attention(tmp_path)
     }
     assert report["remote_call_health"] == {
         "total": 1,
+        "succeeded": 0,
+        "failed": 1,
+        "throttled": 0,
+        "failure_pct": 100,
+        "throttled_pct": 0,
         "groups_truncated": False,
         "groups": [
             {
@@ -304,6 +309,11 @@ def test_live_smoke_report_summarizes_remote_call_timings(tmp_path):
     }
     assert report["remote_call_health"] == {
         "total": 3,
+        "succeeded": 3,
+        "failed": 0,
+        "throttled": 0,
+        "failure_pct": 0,
+        "throttled_pct": 0,
         "groups_truncated": False,
         "groups": [
             {
@@ -420,6 +430,110 @@ def test_live_smoke_report_summarizes_remote_call_timings(tmp_path):
     }
 
 
+def test_live_smoke_report_remote_call_health_totals_mixed_groups(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="remote_call.failed",
+                seq=1,
+                ts=1000,
+                status="failed",
+                level="warning",
+                reason_code="authoritative_balance",
+                ids={
+                    "cycle_id": "cy_1",
+                    "remote_call_id": "rca_1",
+                    "remote_call_group_id": "cy_1:authoritative",
+                },
+                data={
+                    "kind": "authoritative_state_fetch",
+                    "surface": "balance",
+                    "elapsed_ms": 5000,
+                    "error_type": "RequestTimeout",
+                },
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                seq=2,
+                ts=2000,
+                status="failed",
+                level="warning",
+                reason_code="authoritative_balance",
+                ids={
+                    "cycle_id": "cy_2",
+                    "remote_call_id": "rca_2",
+                    "remote_call_group_id": "cy_2:authoritative",
+                },
+                data={
+                    "kind": "authoritative_state_fetch",
+                    "surface": "balance",
+                    "elapsed_ms": 7000,
+                    "error_type": "RequestTimeout",
+                },
+            ),
+            *[
+                _monitor_row(
+                    event_type="remote_call.succeeded",
+                    seq=3 + idx,
+                    ts=3000 + idx,
+                    level="debug",
+                    reason_code="authoritative_open_orders",
+                    ids={
+                        "cycle_id": f"cy_{3 + idx}",
+                        "remote_call_id": f"rca_{3 + idx}",
+                        "remote_call_group_id": f"cy_{3 + idx}:authoritative",
+                    },
+                    data={
+                        "kind": "authoritative_state_fetch",
+                        "surface": "open_orders",
+                        "elapsed_ms": 100 + idx,
+                    },
+                )
+                for idx in range(8)
+            ],
+            _monitor_row(
+                event_type="remote_call.throttled",
+                seq=11,
+                ts=4000,
+                status="deferred",
+                level="debug",
+                reason_code="rate_limited",
+                ids={
+                    "cycle_id": "cy_11",
+                    "remote_call_id": "rct_11",
+                    "remote_call_group_id": "cy_11:candles",
+                },
+                data={
+                    "kind": "ccxt_fetch_ohlcv",
+                    "elapsed_ms": 250,
+                },
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    health = report["remote_call_health"]
+    assert health["total"] == 11
+    assert health["succeeded"] == 8
+    assert health["failed"] == 2
+    assert health["throttled"] == 1
+    assert health["failure_pct"] == 18
+    assert health["throttled_pct"] == 9
+    groups_by_surface = {
+        (group.get("kind"), group.get("surface")): group for group in health["groups"]
+    }
+    assert groups_by_surface[
+        ("authoritative_state_fetch", "balance")
+    ]["failed"] == 2
+    assert groups_by_surface[
+        ("authoritative_state_fetch", "open_orders")
+    ]["succeeded"] == 8
+    assert groups_by_surface[("ccxt_fetch_ohlcv", None)]["throttled"] == 1
+
+
 def test_live_smoke_report_remote_call_health_counts_throttled_events(tmp_path):
     events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
     _write_ndjson(
@@ -451,6 +565,11 @@ def test_live_smoke_report_remote_call_health_counts_throttled_events(tmp_path):
     assert report["ok"] is True
     assert report["remote_call_health"] == {
         "total": 1,
+        "succeeded": 0,
+        "failed": 0,
+        "throttled": 1,
+        "failure_pct": 0,
+        "throttled_pct": 100,
         "groups_truncated": False,
         "groups": [
             {
@@ -1097,6 +1216,11 @@ def test_live_smoke_report_time_window_filters_structured_problem_events(tmp_pat
     }
     assert report["remote_call_health"] == {
         "total": 0,
+        "succeeded": 0,
+        "failed": 0,
+        "throttled": 0,
+        "failure_pct": None,
+        "throttled_pct": None,
         "groups_truncated": False,
         "groups": [],
     }


### PR DESCRIPTION
## Summary
- add top-level succeeded/failed/throttled totals and percentages to live-smoke-report remote_call_health
- keep existing grouped remote-call health details unchanged
- update changelog and focused smoke-report expectations

## Scope
- read-only smoke-report tooling only
- no live event producers changed
- no trading behavior changed
- no ok/attention semantics changed

## Validation
- git diff --check
- ./venv/bin/python -m compileall -q src/live/smoke_report.py tests/test_live_smoke_report.py
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py -q

Composer is retired for this loop; normal review gate is Claude + Hermes + CI. For this low-risk read-only tooling slice, degraded merge is acceptable only if CI is green and Hermes approves while Claude remains absent.