### PR TITLE
Add account-critical smoke health summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added account-critical remote-call health summaries to
+  `passivbot tool live-smoke-report`, isolating balance, position, and
+  open-order endpoint health from broader candle/fill traffic.
 - Added top-level success, failure, and throttle totals to remote-call health
   summaries in `passivbot tool live-smoke-report`.
 - Added remote-call health rollups to `passivbot tool live-smoke-report`,

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -47,6 +47,19 @@ REMOTE_CALL_FAILURE_GROUP_LIMIT = 20
 REMOTE_CALL_HEALTH_GROUP_LIMIT = 20
 REMOTE_CALL_TIMING_GROUP_LIMIT = 20
 REMOTE_CALL_HEALTH_VALUE_LIMIT = 8
+ACCOUNT_CRITICAL_REMOTE_CALL_KIND = "authoritative_state_fetch"
+ACCOUNT_CRITICAL_REMOTE_CALL_SURFACES = frozenset(
+    {
+        "balance",
+        "positions",
+        "open_orders",
+        # Hyperliquid state refresh splits account-critical position/balance
+        # surfaces more finely than the standard staged refresh path.
+        "positions_balance",
+        "core_positions",
+        "hip3_positions",
+    }
+)
 RISK_EVENT_GROUP_LIMIT = 20
 PROBLEM_EVENT_GROUP_LIMIT = 20
 RISK_EVENT_TYPES = {
@@ -594,6 +607,17 @@ def _summarize_remote_call_health(
         "throttled_pct": _usage_pct(total_throttled_count, total),
         "groups_truncated": len(ordered) > REMOTE_CALL_HEALTH_GROUP_LIMIT,
         "groups": compact_groups,
+    }
+
+
+def _account_critical_remote_call_health_groups(
+    groups: dict[tuple[Any, ...], dict[str, Any]]
+) -> dict[tuple[Any, ...], dict[str, Any]]:
+    return {
+        key: group
+        for key, group in groups.items()
+        if group.get("kind") == ACCOUNT_CRITICAL_REMOTE_CALL_KIND
+        and group.get("surface") in ACCOUNT_CRITICAL_REMOTE_CALL_SURFACES
     }
 
 
@@ -1712,6 +1736,9 @@ def _scan_events(
             remote_call_failure_groups
         ),
         "remote_call_health": _summarize_remote_call_health(remote_call_health_groups),
+        "account_critical_remote_call_health": _summarize_remote_call_health(
+            _account_critical_remote_call_health_groups(remote_call_health_groups)
+        ),
         "remote_call_timings": _summarize_remote_call_timings(remote_call_timing_groups),
         "risk_events": _summarize_risk_events(
             risk_event_groups,
@@ -1982,6 +2009,16 @@ def build_live_smoke_report(
                 "groups_truncated": False,
                 "groups": [],
             },
+            "account_critical_remote_call_health": {
+                "total": 0,
+                "succeeded": 0,
+                "failed": 0,
+                "throttled": 0,
+                "failure_pct": None,
+                "throttled_pct": None,
+                "groups_truncated": False,
+                "groups": [],
+            },
             "remote_call_timings": {
                 "total": 0,
                 "groups_truncated": False,
@@ -2049,6 +2086,9 @@ def build_live_smoke_report(
         "startup_timings": event_scan["startup_timings"],
         "remote_call_failures": event_scan["remote_call_failures"],
         "remote_call_health": event_scan["remote_call_health"],
+        "account_critical_remote_call_health": event_scan[
+            "account_critical_remote_call_health"
+        ],
         "remote_call_timings": event_scan["remote_call_timings"],
         "risk_events": event_scan["risk_events"],
         "event_window": event_scan["event_window"],

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -534,6 +534,119 @@ def test_live_smoke_report_remote_call_health_totals_mixed_groups(tmp_path):
     assert groups_by_surface[("ccxt_fetch_ohlcv", None)]["throttled"] == 1
 
 
+def test_live_smoke_report_account_critical_remote_call_health_subset(tmp_path):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="remote_call.failed",
+                seq=1,
+                ts=1000,
+                status="failed",
+                level="warning",
+                reason_code="authoritative_balance",
+                ids={
+                    "cycle_id": "cy_1",
+                    "remote_call_id": "rca_1",
+                    "remote_call_group_id": "cy_1:authoritative",
+                },
+                data={
+                    "kind": "authoritative_state_fetch",
+                    "surface": "balance",
+                    "elapsed_ms": 5000,
+                    "error_type": "RequestTimeout",
+                },
+            ),
+            _monitor_row(
+                event_type="remote_call.succeeded",
+                seq=2,
+                ts=2000,
+                status="succeeded",
+                level="debug",
+                reason_code="authoritative_positions",
+                ids={
+                    "cycle_id": "cy_2",
+                    "remote_call_id": "rca_2",
+                    "remote_call_group_id": "cy_2:authoritative",
+                },
+                data={
+                    "kind": "authoritative_state_fetch",
+                    "surface": "positions",
+                    "elapsed_ms": 600,
+                },
+            ),
+            _monitor_row(
+                event_type="remote_call.succeeded",
+                seq=3,
+                ts=3000,
+                status="succeeded",
+                level="debug",
+                reason_code="authoritative_open_orders",
+                ids={
+                    "cycle_id": "cy_3",
+                    "remote_call_id": "rca_3",
+                    "remote_call_group_id": "cy_3:authoritative",
+                },
+                data={
+                    "kind": "authoritative_state_fetch",
+                    "surface": "open_orders",
+                    "elapsed_ms": 300,
+                },
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                seq=4,
+                ts=4000,
+                status="failed",
+                level="warning",
+                reason_code="authoritative_fills",
+                ids={
+                    "cycle_id": "cy_4",
+                    "remote_call_id": "rca_4",
+                    "remote_call_group_id": "cy_4:authoritative",
+                },
+                data={
+                    "kind": "authoritative_state_fetch",
+                    "surface": "fills",
+                    "elapsed_ms": 1200,
+                    "error_type": "RequestTimeout",
+                },
+            ),
+            _monitor_row(
+                event_type="remote_call.throttled",
+                seq=5,
+                ts=5000,
+                status="deferred",
+                level="debug",
+                reason_code="rate_limited",
+                ids={
+                    "cycle_id": "cy_5",
+                    "remote_call_id": "rcc_5",
+                    "remote_call_group_id": "cy_5:candles",
+                },
+                data={
+                    "kind": "ccxt_fetch_ohlcv",
+                    "elapsed_ms": 250,
+                },
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    assert report["remote_call_health"]["total"] == 5
+    account_health = report["account_critical_remote_call_health"]
+    assert account_health["total"] == 3
+    assert account_health["succeeded"] == 2
+    assert account_health["failed"] == 1
+    assert account_health["throttled"] == 0
+    assert account_health["failure_pct"] == 33
+    assert account_health["throttled_pct"] == 0
+    group_surfaces = {group.get("surface") for group in account_health["groups"]}
+    assert group_surfaces == {"balance", "positions", "open_orders"}
+
+
 def test_live_smoke_report_remote_call_health_counts_throttled_events(tmp_path):
     events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- add an account_critical_remote_call_health section to live-smoke-report
- derive it from existing remote_call_health groups for authoritative balance/positions/open-orders style surfaces
- exclude broader fill/candle traffic so endpoint smoke can isolate account-critical health

## Validation
- git diff --check
- ./venv/bin/python -m compileall -q src/live/smoke_report.py tests/test_live_smoke_report.py
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py -q

Composer is retired from this loop. This is read-only smoke-report tooling; normal gate is Claude + Hermes + CI, with degraded docs/tooling gate only if Claude remains absent.