### PR TITLE
Add concise live smoke summary output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool live-smoke-report --summary` for concise smoke evidence
+  that keeps high-signal process, log, problem-event, risk, repository, and
+  remote-call health fields without emitting the full verbose report.
 - Added account-critical remote-call health summaries to
   `passivbot tool live-smoke-report`, isolating balance, position, and
   open-order endpoint health from broader candle/fill traffic.

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -47,6 +47,7 @@ REMOTE_CALL_FAILURE_GROUP_LIMIT = 20
 REMOTE_CALL_HEALTH_GROUP_LIMIT = 20
 REMOTE_CALL_TIMING_GROUP_LIMIT = 20
 REMOTE_CALL_HEALTH_VALUE_LIMIT = 8
+SMOKE_REPORT_SUMMARY_GROUP_LIMIT = 8
 ACCOUNT_CRITICAL_REMOTE_CALL_KIND = "authoritative_state_fetch"
 ACCOUNT_CRITICAL_REMOTE_CALL_SURFACES = frozenset(
     {
@@ -2099,4 +2100,139 @@ def build_live_smoke_report(
         "logs": log_scan,
         "processes": process_report,
         "repository": repository_report,
+    }
+
+
+def _summary_limited_groups(
+    summary: dict[str, Any],
+    *,
+    limit: int,
+) -> dict[str, Any]:
+    groups = summary.get("groups")
+    if not isinstance(groups, list):
+        groups = []
+    limit = max(0, int(limit))
+    return {
+        key: value
+        for key, value in {
+            "total": summary.get("total"),
+            "succeeded": summary.get("succeeded"),
+            "failed": summary.get("failed"),
+            "throttled": summary.get("throttled"),
+            "failure_pct": summary.get("failure_pct"),
+            "throttled_pct": summary.get("throttled_pct"),
+            "event_types": summary.get("event_types"),
+            "groups_truncated": bool(summary.get("groups_truncated"))
+            or len(groups) > limit,
+            "groups": groups[:limit],
+        }.items()
+        if value is not None
+    }
+
+
+def summarize_live_smoke_report(
+    report: dict[str, Any],
+    *,
+    max_groups: int = SMOKE_REPORT_SUMMARY_GROUP_LIMIT,
+) -> dict[str, Any]:
+    """Project a full smoke report into concise operator/debugging evidence."""
+
+    max_groups = max(0, int(max_groups))
+    logs = report.get("logs") if isinstance(report.get("logs"), dict) else {}
+    matches = logs.get("matches") if isinstance(logs.get("matches"), list) else []
+    processes = (
+        report.get("processes") if isinstance(report.get("processes"), dict) else {}
+    )
+    repository = (
+        report.get("repository") if isinstance(report.get("repository"), dict) else {}
+    )
+    monitor = report.get("monitor") if isinstance(report.get("monitor"), dict) else {}
+    problem_groups = (
+        report.get("problem_event_groups")
+        if isinstance(report.get("problem_event_groups"), dict)
+        else {}
+    )
+    problem_group_rows = (
+        problem_groups.get("groups")
+        if isinstance(problem_groups.get("groups"), list)
+        else []
+    )
+    risk_events = (
+        report.get("risk_events") if isinstance(report.get("risk_events"), dict) else {}
+    )
+
+    return {
+        "ok": bool(report.get("ok", False)),
+        "attention": bool(report.get("attention", False)),
+        "hard_failures": int(report.get("hard_failures") or 0),
+        "attention_count": int(report.get("attention_count") or 0),
+        "repository": {
+            key: repository.get(key)
+            for key in (
+                "branch",
+                "head",
+                "dirty",
+                "tracked_changes",
+                "error",
+            )
+            if key in repository
+        },
+        "monitor": {
+            key: monitor.get(key)
+            for key in (
+                "root",
+                "files_scanned",
+                "records_total",
+                "live_events",
+                "legacy_events",
+                "error_count",
+                "warning_count",
+            )
+            if key in monitor
+        },
+        "event_window": report.get("event_window"),
+        "processes": {
+            key: processes.get(key)
+            for key in (
+                "enabled",
+                "ok",
+                "hard_failures",
+                "expected_total",
+                "matched_expected",
+                "running_live_total",
+                "scan_error",
+            )
+            if key in processes
+        }
+        | {
+            "missing_expected_count": len(processes.get("missing_expected") or []),
+            "unexpected_running_count": len(processes.get("unexpected_running") or []),
+            "missing_expected": (processes.get("missing_expected") or [])[:max_groups],
+            "unexpected_running": (processes.get("unexpected_running") or [])[:max_groups],
+        },
+        "logs": {
+            "root": logs.get("root"),
+            "files_scanned": int(logs.get("files_scanned") or 0),
+            "hard_matches": int(logs.get("hard_matches") or 0),
+            "attention_matches": int(logs.get("attention_matches") or 0),
+            "matches_truncated": len(matches) > max_groups,
+            "matches": matches[:max_groups],
+            "window": logs.get("window"),
+        },
+        "problem_events": {
+            "total": int(report.get("problem_event_count") or 0),
+            "hard": int(report.get("hard_problem_event_count") or 0),
+            "groups_truncated": bool(problem_groups.get("groups_truncated"))
+            or len(problem_group_rows) > max_groups,
+            "groups": problem_group_rows[:max_groups],
+        },
+        "remote_calls": _summary_limited_groups(
+            report.get("remote_call_health") or {},
+            limit=max_groups,
+        ),
+        "account_critical_remote_calls": _summary_limited_groups(
+            report.get("account_critical_remote_call_health") or {},
+            limit=max_groups,
+        ),
+        "risk_events": _summary_limited_groups(risk_events, limit=max_groups),
     }

--- a/src/tools/live_smoke_report.py
+++ b/src/tools/live_smoke_report.py
@@ -15,6 +15,7 @@ from live.smoke_report import (  # noqa: E402
     LOG_WINDOW_UNPARSED_POLICIES,
     build_live_smoke_report,
     default_logs_root_for_monitor,
+    summarize_live_smoke_report,
 )
 
 
@@ -134,6 +135,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Emit compact single-line JSON.",
     )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Emit concise smoke-test summary JSON instead of the full report.",
+    )
     return parser
 
 
@@ -171,7 +177,8 @@ def main(argv: list[str] | None = None) -> int:
         max_log_matches=int(args.max_log_matches),
         log_window_unparsed_policy=str(args.log_window_unparsed_policy),
     )
-    print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
+    output = summarize_live_smoke_report(report) if args.summary else report
+    print(json.dumps(output, indent=None if args.compact else 2, sort_keys=True))
     return 0 if report.get("ok") else 1
 
 

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -5,7 +5,11 @@ import json
 import pytest
 
 import live.smoke_report as smoke_report_module
-from live.smoke_report import build_live_smoke_report, default_logs_root_for_monitor
+from live.smoke_report import (
+    build_live_smoke_report,
+    default_logs_root_for_monitor,
+    summarize_live_smoke_report,
+)
 from tools import live_smoke_report
 
 
@@ -645,6 +649,90 @@ def test_live_smoke_report_account_critical_remote_call_health_subset(tmp_path):
     assert account_health["throttled_pct"] == 0
     group_surfaces = {group.get("surface") for group in account_health["groups"]}
     assert group_surfaces == {"balance", "positions", "open_orders"}
+
+
+def test_live_smoke_report_summary_projects_high_signal_fields(tmp_path):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="remote_call.failed",
+                seq=1,
+                ts=1000,
+                status="failed",
+                level="warning",
+                reason_code="authoritative_balance",
+                ids={
+                    "cycle_id": "cy_1",
+                    "remote_call_id": "rca_1",
+                    "remote_call_group_id": "cy_1:authoritative",
+                },
+                data={
+                    "kind": "authoritative_state_fetch",
+                    "surface": "balance",
+                    "elapsed_ms": 5000,
+                    "error_type": "RequestTimeout",
+                },
+            ),
+            _monitor_row(
+                event_type="ema.unavailable",
+                seq=2,
+                ts=2000,
+                status="degraded",
+                level="warning",
+                reason_code="required_ema_unavailable",
+                ids={"cycle_id": "cy_2"},
+                data={
+                    "candidate_unavailable": {
+                        "count": 1,
+                        "sample": ["ZEC/USDT:USDT"],
+                        "truncated": 0,
+                    },
+                    "unavailable": {
+                        "count": 1,
+                        "sample": ["ZEC/USDT:USDT"],
+                        "truncated": 0,
+                    },
+                },
+            ),
+        ],
+    )
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "kucoin_01.log").write_text(
+        "2026-06-25T00:00:00Z ERROR exchange timeout\n",
+        encoding="utf-8",
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=logs_dir,
+        log_tail_lines=10,
+    )
+    summary = summarize_live_smoke_report(report, max_groups=1)
+
+    assert summary["ok"] is True
+    assert summary["attention"] is True
+    assert summary["hard_failures"] == 0
+    assert summary["attention_count"] == 3
+    assert summary["monitor"]["live_events"] == 2
+    assert summary["logs"]["attention_matches"] == 1
+    assert summary["logs"]["matches_truncated"] is False
+    assert len(summary["logs"]["matches"]) == 1
+    assert summary["problem_events"]["total"] == 2
+    assert summary["problem_events"]["hard"] == 0
+    assert summary["problem_events"]["groups_truncated"] is True
+    assert len(summary["problem_events"]["groups"]) == 1
+    assert summary["problem_events"]["groups"][0]["event_type"] in {
+        "ema.unavailable",
+        "remote_call.failed",
+    }
+    assert summary["account_critical_remote_calls"]["total"] == 1
+    assert summary["account_critical_remote_calls"]["failed"] == 1
+    assert summary["remote_calls"]["groups"][0]["surface"] == "balance"
+    assert "bots" not in summary
+    assert "problem_event_groups" not in summary
 
 
 def test_live_smoke_report_remote_call_health_counts_throttled_events(tmp_path):
@@ -1780,6 +1868,52 @@ def test_live_smoke_report_cli_outputs_json_and_can_skip_logs(tmp_path, capsys):
     assert report["logs"]["files_scanned"] == 0
     assert report["logs"]["root"] is None
     assert report["monitor"]["live_events"] == 1
+
+
+def test_live_smoke_report_cli_can_emit_concise_summary(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "okx_faisal.log").write_text(
+        "2026-06-25T00:00:00Z ERROR exchange timeout\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        live_smoke_report.main(
+            [
+                str(tmp_path / "monitor"),
+                "--logs-root",
+                str(logs_dir),
+                "--log-tail-lines",
+                "10",
+                "--summary",
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["ok"] is True
+    assert summary["attention"] is True
+    assert summary["logs"]["attention_matches"] == 1
+    assert summary["monitor"]["live_events"] == 1
+    assert "remote_calls" in summary
+    assert "account_critical_remote_calls" in summary
+    assert "bots" not in summary
+    assert "problem_events" in summary
 
 
 def test_live_smoke_report_cli_can_drop_unparseable_window_log_lines(


### PR DESCRIPTION
## Summary
- add `passivbot tool live-smoke-report --summary` to emit a concise projection of the existing full smoke report
- include high-signal process, log, problem-event, risk, repository, remote-call, and account-critical remote-call health fields
- keep the full report and exit-code behavior unchanged

## Scope
Tooling-only observability slice. No live runtime producers, exchange calls, order/risk logic, or trading behavior changed.

## Validation
- `git diff --check`
- `./venv/bin/python -m compileall -q src/live/smoke_report.py src/tools/live_smoke_report.py tests/test_live_smoke_report.py`
- `./venv/bin/python -m pytest tests/test_live_smoke_report.py -q` -> 29 passed
- touched-file silent-handling scan reviewed; matches are read-only aggregation defaults in smoke-report tooling, not trading-critical paths
