### PR TITLE
Record concise smoke summary progress

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-26.
 
 Current `origin/v8` logging-overhaul head:
 
-- `3299c1cac` merge of PR #694, `Add account-critical smoke health summary`.
+- `d850daf55` merge of PR #696, `Add concise live smoke summary output`.
 
 Current review gate:
 
@@ -30,7 +30,7 @@ Current review gate:
 
 VPS5 deployment status:
 
-- Repository pulled through PR #690 at `b150176f`.
+- Repository pulled through PR #696 at `d850daf5`.
 - Bots were restarted from `/root/bots_vps5.yaml` after PR #677 and left
   running. The old process set stopped after about 36 seconds before the tmuxp
   reload.
@@ -148,6 +148,16 @@ VPS5 deployment status:
   `missing_expected=[]`. The new `account_critical_remote_call_health`
   summary was present with `total=126`, `succeeded=126`, `failed=0`,
   `throttled=0`, `failure_pct=0`, and `throttled_pct=0`.
+- PR #696 was pulled to VPS5 without bot restart because it only changed
+  read-only smoke-report tooling. A 2-minute compact summary smoke with text
+  logs, `--log-window-unparsed-policy drop`, and `/root/bots_vps5.yaml`
+  process matching reported `ok=true`, `hard_failures=0`,
+  `logs.hard_matches=0`, `logs.attention_matches=0`, `matched_expected=5`,
+  `missing_expected=[]`, `remote_calls.total=169`, `remote_calls.succeeded=169`,
+  `account_critical_remote_calls.total=58`, and
+  `account_critical_remote_calls.succeeded=58`. Remaining `attention=true`
+  came from known non-hard EMA readiness / staged-execution / HSL cooldown
+  groups.
 
 ## Phase Checklist
 
@@ -790,13 +800,35 @@ VPS5 deployment status:
   `total=126`, `succeeded=126`, `failed=0`, `throttled=0`, `failure_pct=0`,
   and `throttled_pct=0`.
 
+### PR #696: Concise Live Smoke Summary
+
+- Branch: `codex/v8-smoke-report-summary`.
+- Scope: operator smoke tooling.
+- Result: `passivbot tool live-smoke-report --summary` now projects the full
+  report down to high-signal smoke fields: health booleans/counters,
+  repository state, monitor totals, event/log windows, process summary,
+  bounded problem groups, remote-call/account-critical health, and risk events.
+  `--compact` can be combined with `--summary` for short machine-readable
+  output. Full report generation and exit-code behavior are unchanged.
+- Review evidence: Hermes approved head `f1efbe45`; CI was green; focused
+  smoke-report tests, compileall, `git diff --check`, and the touched-file
+  silent-handling audit passed before merge. Claude did not return during
+  repeated polls, and Composer had been retired, so this read-only tooling
+  slice used the degraded gate.
+- VPS5 evidence: deployed to VPS5 at `d850daf5` without bot restart. A
+  2-minute compact summary smoke with text logs,
+  `--log-window-unparsed-policy drop`, and `/root/bots_vps5.yaml` process
+  matching reported all five configured bots running, no hard failures, no log
+  hard or attention matches, account-critical calls `total=58`,
+  `succeeded=58`, and all terminal remote calls `total=169`,
+  `succeeded=169`.
+
 ## Current Next Steps
 
 1. Wait for the normal Claude + Hermes + CI gate on PR #681 before merging the
    runtime staged-refresh event producer slice. CI is green on rebased head
-   `7b87d6b6d9`, and Hermes approved that head. Claude has not reviewed the
-   current runtime head. Because PR #694 moved `v8`, rebase PR #681 before
-   merge if Claude later approves.
+   `bddf5a4c2`; current-head Claude and Hermes reviews are still pending after
+   the PR #696 rebase. Composer has been retired from the gate.
 2. Continue Phase 5 by migrating one high-value stdlib text log family to
    structured-event projection without increasing default console noise.
 3. Use the persistent non-hard EMA readiness / staged-execution degradation

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -66,8 +66,10 @@ Related detailed plans:
    bounded latest problem-event
    context for selected non-hard groups such as EMA/cycle readiness
    degradation, plus aggregate problem-event groups keyed by bot/event/reason/
-   status/hard flag/symbol/position side. The safe restart orchestration
-   contract is not implemented.
+   status/hard flag/symbol/position side, passive remote-call health summaries,
+   account-critical remote-call summaries, repository state, and a concise
+   `--summary` projection for operator smoke checks. The safe restart
+   orchestration contract is not implemented.
 
    Formalize the repeated VPS smoke routine: pull a branch, stop configured
    bots, measure shutdown time per bot, reload from `/root/bots_vps5.yaml`,
@@ -76,6 +78,9 @@ Related detailed plans:
    explicit, and produce a reviewable smoke report.
 
    Remaining refinements: safe pull/stop/start orchestration remains open.
+   The concise summary is still intentionally bounded but can be tightened
+   further with row limits or a brief mode if chat-facing smoke output remains
+   too large.
 
 4. [ ] Startup phase budget tracking.
    Status: partial. Startup timing and warmup cache decision events exist, and
@@ -273,6 +278,7 @@ Related detailed plans:
 | 2026-06-26 | #3/#6 Live restart/smoke automation and exchange probes | PR #690 / `dc99378a` | Added `remote_call_health` groups to `live-smoke-report`, rolling up terminal remote-call successes/failures/throttles, latency, reason/error counts, and affected symbols by bot/component/kind/surface; VPS5 smoke on `b150176f` returned `ok=true`, no hard failures, all five bots matched, and summarized 445 terminal remote calls | Explicit exchange endpoint probes and safe pull/stop/start orchestration remain open |
 | 2026-06-26 | #3/#6 Live restart/smoke automation and exchange probes | PR #692 / `ac4afe3f` | Added top-level `remote_call_health` success/failure/throttle totals and percentages to `live-smoke-report`; VPS5 smoke on `c8ce4880` returned `ok=true`, no hard failures, all five bots matched, and reported total=390, succeeded=389, failed=1, throttled=0 | Explicit exchange endpoint probes and safe pull/stop/start orchestration remain open |
 | 2026-06-26 | #3/#6 Live restart/smoke automation and exchange probes | PR #694 / `bebbb3f6` | Added `account_critical_remote_call_health` to `live-smoke-report`, isolating authoritative balance/positions/open-orders style endpoint health from candle/fill traffic; VPS5 smoke on `3299c1ca` returned `ok=true`, no hard failures, all five bots matched, and reported account-critical total=126, succeeded=126, failed=0, throttled=0 | Explicit exchange endpoint probes and safe pull/stop/start orchestration remain open |
+| 2026-06-26 | #3 Live restart/smoke automation | PR #696 / `f1efbe45` | Added `live-smoke-report --summary`, a concise high-signal projection of smoke health, process/repository state, problem groups, remote-call/account-critical health, and risk events; VPS5 compact summary smoke on `d850daf5` returned `ok=true`, no hard failures, all five bots matched, and account-critical total=58, succeeded=58 | Safe pull/stop/start orchestration remains open; optional row-limit/brief summary mode could reduce chat-facing output further |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |


### PR DESCRIPTION
Docs-only progress bookkeeping after PR #696.\n\nScope:\n- update live logging progress ledger to current v8 head d850daf55 / PR #696\n- record VPS5 compact summary smoke evidence for the concise smoke summary tooling\n- update the live ops backlog with the new live-smoke-report --summary capability\n\nValidation:\n- git diff --check\n\nNo runtime code, tests, or trading behavior changed. Composer is retired from the gate; this is suitable for the degraded docs/tooling-only review path if Hermes + CI are clean.