### PR TITLE
Redact smoke report repository roots

### DIFF
--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -117,6 +117,32 @@ def _resolve_path(path: str | Path) -> Path:
         return candidate.absolute()
 
 
+def _user_safe_display_path(path: str | Path) -> str:
+    resolved = _resolve_path(path)
+
+    def _tilde_path(tail: tuple[str, ...]) -> str:
+        return "~" if not tail else "~/" + "/".join(tail)
+
+    try:
+        home = _resolve_path(Path.home())
+        relative = resolved.relative_to(home)
+        return _tilde_path(relative.parts)
+    except (OSError, RuntimeError, ValueError):
+        pass
+
+    display_candidate = Path(path).expanduser()
+    try:
+        display_path = display_candidate.absolute()
+    except OSError:
+        display_path = resolved
+    parts = display_path.parts
+    if len(parts) >= 2 and parts[:2] == ("/", "root"):
+        return _tilde_path(tuple(parts[2:]))
+    if len(parts) >= 3 and parts[0] == "/" and parts[1] in {"home", "Users"}:
+        return _tilde_path(tuple(parts[3:]))
+    return str(resolved)
+
+
 def _open_text(path: Path):
     if path.name.endswith(".gz"):
         return gzip.open(path, "rt", encoding="utf-8", errors="replace")
@@ -1175,7 +1201,7 @@ def _build_repository_report(
 ) -> dict[str, Any]:
     root = _find_repository_root(monitor_root, repo_root=repo_root)
     report: dict[str, Any] = {
-        "root": str(root),
+        "root": _user_safe_display_path(root),
         "is_git_repo": False,
         "branch": None,
         "head": None,

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2187,6 +2187,51 @@ def test_live_smoke_report_includes_repository_metadata(tmp_path, monkeypatch):
     assert calls[-1][1] == ("status", "--porcelain", "--untracked-files=no")
 
 
+def test_live_smoke_report_repository_root_redacts_home_prefix(tmp_path, monkeypatch):
+    home = tmp_path / "home" / "operator"
+    repo_root = home / "passivbot"
+    _write_minimal_monitor_event(tmp_path / "monitor")
+    calls = []
+
+    def fake_git_output(root, args, *, timeout=2.0):
+        calls.append(root)
+        if args == ["rev-parse", "--is-inside-work-tree"]:
+            return "true", None
+        if args == ["rev-parse", "HEAD"]:
+            return "1234567890abcdef", None
+        if args == ["rev-parse", "--short", "HEAD"]:
+            return "1234567", None
+        if args == ["rev-parse", "--abbrev-ref", "HEAD"]:
+            return "v8", None
+        if args == ["status", "--porcelain", "--untracked-files=no"]:
+            return "", None
+        raise AssertionError(args)
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(smoke_report_module, "_git_output", fake_git_output)
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        repo_root=repo_root,
+    )
+
+    assert report["repository"]["root"] == "~/passivbot"
+    assert set(calls) == {repo_root.resolve()}
+
+
+def test_live_smoke_report_repository_root_redacts_common_user_dirs():
+    assert smoke_report_module._user_safe_display_path("/root/passivbot") == "~/passivbot"
+    assert (
+        smoke_report_module._user_safe_display_path("/home/deploy/passivbot")
+        == "~/passivbot"
+    )
+    assert (
+        smoke_report_module._user_safe_display_path("/Users/operator/passivbot")
+        == "~/passivbot"
+    )
+
+
 def test_live_smoke_report_discovers_repository_from_monitor_root(tmp_path, monkeypatch):
     repo_root = tmp_path / "passivbot"
     (repo_root / ".git").mkdir(parents=True)


### PR DESCRIPTION
## Summary
- redact user/home prefixes from smoke_report repository.root using ~/... for shareable reports
- keep git execution on the real resolved repository path
- cover current-home and common /root, /home/<user>, /Users/<user> path forms

## Validation
- git diff --check
- ./venv/bin/python -m compileall src/live/smoke_report.py tests/test_live_smoke_report.py
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py

## Notes
- Observability/tooling only. No live trading behavior changes.
- Addresses Claude retrospective low item from PR #686: repository.root leaked the absolute deploy/home path into smoke_report.json and incident bundles.