### PR TITLE
Summarize account-critical probe health

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -148,7 +148,10 @@ passivbot tool fetch-balance --user bybit_01
 Ticker probes inspect CCXT ticker support and latency without placing orders:
 
 - `passivbot tool ticker-probe` checks ticker capability behavior for one exchange/user context.
-- `passivbot tool ticker-endpoint-probe` compares CCXT ticker endpoint latency across configured users.
+- `passivbot tool ticker-endpoint-probe` compares CCXT ticker endpoint latency across configured
+  users. When authenticated probes are enabled, its JSON includes an `account_critical_health`
+  summary for the read-only balance, positions, and open-orders endpoints required before live
+  exchange actions. Keep authenticated runs low-rate when a live bot is using the same account.
 
 ## Hyperliquid live probes
 

--- a/src/tools/probe_ccxt_ticker_endpoints.py
+++ b/src/tools/probe_ccxt_ticker_endpoints.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import math
+import statistics
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
 from procedures import load_user_info
+from live.smoke_report import _redact_log_text
 from tools.probe_ticker_capabilities import (
     create_exchange,
     is_active_linear_swap,
@@ -15,9 +19,16 @@ from tools.probe_ticker_capabilities import (
     summarize_order_book,
     summarize_ticker,
     summarize_tickers,
-    timed_call,
+    timed_call as _raw_timed_call,
 )
 from utils import ts_to_date, utc_ms
+
+
+ACCOUNT_CRITICAL_ENDPOINTS = {
+    "balance": "fetch_balance",
+    "positions": "fetch_positions",
+    "open_orders": "fetch_open_orders_all",
+}
 
 
 def select_default_symbols(
@@ -126,8 +137,146 @@ def format_outcome(outcome: dict[str, Any]) -> str:
     )
 
 
+def _redact_probe_outcome_error(outcome: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(outcome, dict):
+        return outcome
+    error = outcome.get("error")
+    if not isinstance(error, str):
+        return outcome
+    out = dict(outcome)
+    out["error"] = _redact_log_text(error, max_len=500)
+    return out
+
+
+async def _timed_call(coro) -> dict[str, Any]:
+    return _redact_probe_outcome_error(await _raw_timed_call(coro))
+
+
+def _pct(numerator: int, denominator: int) -> float | None:
+    if denominator <= 0:
+        return None
+    return round(float(numerator) * 100.0 / float(denominator), 3)
+
+
+def _elapsed_ms(outcome: Any) -> float | None:
+    if not isinstance(outcome, dict):
+        return None
+    elapsed = outcome.get("elapsed_ms")
+    if not isinstance(elapsed, (int, float)):
+        return None
+    return round(float(elapsed), 3)
+
+
+def _latency_summary(values: list[float]) -> dict[str, Any]:
+    if not values:
+        return {
+            "count": 0,
+            "min": None,
+            "median": None,
+            "p95": None,
+            "max": None,
+        }
+    ordered = sorted(values)
+    p95_index = min(len(ordered) - 1, max(0, math.ceil(len(ordered) * 0.95) - 1))
+    return {
+        "count": len(ordered),
+        "min": round(ordered[0], 3),
+        "median": round(float(statistics.median(ordered)), 3),
+        "p95": round(ordered[p95_index], 3),
+        "max": round(ordered[-1], 3),
+    }
+
+
+def summarize_account_critical_probe_health(probe: dict[str, Any]) -> dict[str, Any]:
+    """Summarize authenticated account-state endpoint health without raw payloads/errors."""
+    include_private = bool(probe.get("include_private", True))
+    repeats = probe.get("repeats") if isinstance(probe.get("repeats"), list) else []
+    surfaces: dict[str, Any] = {}
+    for surface, outcome_key in ACCOUNT_CRITICAL_ENDPOINTS.items():
+        total = 0
+        succeeded = 0
+        failed = 0
+        latencies = []
+        error_types: Counter[str] = Counter()
+        latest: dict[str, Any] | None = None
+        for repeat in repeats:
+            outcome = repeat.get(outcome_key) if isinstance(repeat, dict) else None
+            if outcome is None and not include_private:
+                continue
+            total += 1
+            elapsed_ms = _elapsed_ms(outcome)
+            if elapsed_ms is not None:
+                latencies.append(elapsed_ms)
+            ok = bool(outcome.get("ok")) if isinstance(outcome, dict) else False
+            if ok:
+                succeeded += 1
+                latest = {"ok": True, "elapsed_ms": elapsed_ms}
+                continue
+            failed += 1
+            error_type = (
+                str(outcome.get("error_type") or "unknown")
+                if isinstance(outcome, dict)
+                else "missing_outcome"
+            )
+            error_types[error_type] += 1
+            latest = {"ok": False, "elapsed_ms": elapsed_ms, "error_type": error_type}
+        surfaces[surface] = {
+            "endpoint": outcome_key,
+            "total": total,
+            "succeeded": succeeded,
+            "failed": failed,
+            "failure_pct": _pct(failed, total),
+            "latency_ms": _latency_summary(latencies),
+            "error_types": dict(sorted(error_types.items())),
+            "latest": latest,
+        }
+
+    total = sum(int(surface["total"]) for surface in surfaces.values())
+    succeeded = sum(int(surface["succeeded"]) for surface in surfaces.values())
+    failed = sum(int(surface["failed"]) for surface in surfaces.values())
+    return {
+        "enabled": include_private,
+        "total": total,
+        "succeeded": succeeded,
+        "failed": failed,
+        "failure_pct": _pct(failed, total),
+        "surfaces": surfaces,
+    }
+
+
+def summarize_account_critical_probe_collection(probes: list[dict[str, Any]]) -> dict[str, Any]:
+    users = []
+    total = 0
+    succeeded = 0
+    failed = 0
+    for probe in probes:
+        summary = probe.get("account_critical_health")
+        if not isinstance(summary, dict):
+            summary = summarize_account_critical_probe_health(probe)
+        user_summary = {
+            "user": probe.get("user"),
+            "exchange": probe.get("exchange"),
+            "enabled": bool(summary.get("enabled")),
+            "total": int(summary.get("total") or 0),
+            "succeeded": int(summary.get("succeeded") or 0),
+            "failed": int(summary.get("failed") or 0),
+            "failure_pct": summary.get("failure_pct"),
+        }
+        users.append(user_summary)
+        total += user_summary["total"]
+        succeeded += user_summary["succeeded"]
+        failed += user_summary["failed"]
+    return {
+        "users": users,
+        "total": total,
+        "succeeded": succeeded,
+        "failed": failed,
+        "failure_pct": _pct(failed, total),
+    }
+
+
 async def _timed_load_markets(exchange) -> tuple[dict[str, Any], dict[str, Any]]:
-    outcome = await timed_call(exchange.load_markets())
+    outcome = await _timed_call(exchange.load_markets())
     markets = outcome["value"] if outcome["ok"] and isinstance(outcome["value"], dict) else {}
     if outcome["ok"]:
         outcome["value"] = {
@@ -141,7 +290,7 @@ async def _fetch_ticker_sequential(exchange, symbols: list[str]) -> dict[str, An
     started_ms = utc_ms()
     results = {}
     for symbol in symbols:
-        outcome = await timed_call(exchange.fetch_ticker(symbol))
+        outcome = await _timed_call(exchange.fetch_ticker(symbol))
         if outcome["ok"]:
             outcome["value"] = summarize_ticker(outcome["value"])
         results[symbol] = outcome
@@ -155,7 +304,7 @@ async def _fetch_ticker_sequential(exchange, symbols: list[str]) -> dict[str, An
 
 async def _fetch_ticker_concurrent(exchange, symbols: list[str]) -> dict[str, Any]:
     async def _one(symbol: str) -> tuple[str, dict[str, Any]]:
-        outcome = await timed_call(exchange.fetch_ticker(symbol))
+        outcome = await _timed_call(exchange.fetch_ticker(symbol))
         if outcome["ok"]:
             outcome["value"] = summarize_ticker(outcome["value"])
         return symbol, outcome
@@ -175,7 +324,7 @@ async def _fetch_order_books_sequential(exchange, symbols: list[str]) -> dict[st
     started_ms = utc_ms()
     results = {}
     for symbol in symbols:
-        outcome = await timed_call(exchange.fetch_order_book(symbol, limit=5))
+        outcome = await _timed_call(exchange.fetch_order_book(symbol, limit=5))
         if outcome["ok"]:
             outcome["value"] = summarize_order_book(outcome["value"])
         results[symbol] = outcome
@@ -188,7 +337,7 @@ async def _fetch_order_books_sequential(exchange, symbols: list[str]) -> dict[st
 
 async def _fetch_order_books_concurrent(exchange, symbols: list[str]) -> dict[str, Any]:
     async def _one(symbol: str) -> tuple[str, dict[str, Any]]:
-        outcome = await timed_call(exchange.fetch_order_book(symbol, limit=5))
+        outcome = await _timed_call(exchange.fetch_order_book(symbol, limit=5))
         if outcome["ok"]:
             outcome["value"] = summarize_order_book(outcome["value"])
         return symbol, outcome
@@ -207,7 +356,7 @@ async def _fetch_ohlcvs(exchange, symbols: list[str]) -> dict[str, Any]:
     started_ms = utc_ms()
     results = {}
     for symbol in symbols:
-        outcome = await timed_call(exchange.fetch_ohlcv(symbol, timeframe="1m", limit=3))
+        outcome = await _timed_call(exchange.fetch_ohlcv(symbol, timeframe="1m", limit=3))
         if outcome["ok"]:
             outcome["value"] = summarize_ohlcvs(outcome["value"])
         results[symbol] = outcome
@@ -222,7 +371,7 @@ async def _timed_method(exchange, method_name: str, *args, summary=None) -> dict
     method = getattr(exchange, method_name, None)
     if method is None:
         return {"ok": False, "elapsed_ms": 0, "error_type": "AttributeError", "error": method_name}
-    outcome = await timed_call(method(*args))
+    outcome = await _timed_call(method(*args))
     if outcome["ok"] and summary is not None:
         outcome["value"] = summary(outcome["value"])
     return outcome
@@ -265,6 +414,7 @@ async def probe_exchange_ticker_endpoints(
         "exchange": exchange_id,
         "quote": quote or user_info.get("quote"),
         "symbols": resolved_symbols,
+        "include_private": bool(include_private),
         "market_count": len(markets) if isinstance(markets, dict) else None,
         "has": {
             "fetchBalance": bool(getattr(exchange, "has", {}).get("fetchBalance")),
@@ -297,7 +447,7 @@ async def probe_exchange_ticker_endpoints(
         }
 
         emit_progress(f"{repeat_label} fetch_tickers()", enabled=progress)
-        all_outcome = await timed_call(exchange.fetch_tickers())
+        all_outcome = await _timed_call(exchange.fetch_tickers())
         if all_outcome["ok"]:
             all_outcome["value"] = summarize_tickers(all_outcome["value"], resolved_symbols)
         repeat["fetch_tickers_all"] = all_outcome
@@ -307,7 +457,7 @@ async def probe_exchange_ticker_endpoints(
         )
 
         emit_progress(f"{repeat_label} fetch_tickers(symbols)", enabled=progress)
-        listed_outcome = await timed_call(exchange.fetch_tickers(resolved_symbols))
+        listed_outcome = await _timed_call(exchange.fetch_tickers(resolved_symbols))
         if listed_outcome["ok"]:
             listed_outcome["value"] = summarize_tickers(listed_outcome["value"], resolved_symbols)
         repeat["fetch_tickers_symbols"] = listed_outcome
@@ -435,6 +585,7 @@ async def probe_exchange_ticker_endpoints(
             )
             await asyncio.sleep(float(sleep_between_seconds))
 
+    out["account_critical_health"] = summarize_account_critical_probe_health(out)
     return out
 
 
@@ -555,6 +706,9 @@ async def async_main() -> int:
         )
         emit_progress(f"[{user}] probe complete", enabled=not bool(args.quiet))
 
+    result["account_critical_health"] = summarize_account_critical_probe_collection(
+        result["probes"]
+    )
     out_path = Path(args.out) if args.out else Path("tmp") / f"ccxt_ticker_probe_{started_ms}.json"
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(result, indent=2, sort_keys=True, default=str) + "\n")

--- a/tests/test_ticker_probe_tool.py
+++ b/tests/test_ticker_probe_tool.py
@@ -11,6 +11,8 @@ from tools.probe_ticker_capabilities import (
 from tools.probe_ccxt_ticker_endpoints import (
     probe_exchange_ticker_endpoints,
     select_default_symbols,
+    summarize_account_critical_probe_collection,
+    summarize_account_critical_probe_health,
 )
 
 
@@ -304,4 +306,170 @@ async def test_probe_exchange_ticker_endpoints_records_all_endpoint_shapes():
     assert repeat["fetch_positions"]["ok"] is True
     assert repeat["fetch_open_orders_all"]["ok"] is True
     assert repeat["fetch_my_trades_first_symbol"]["ok"] is True
+    assert out["account_critical_health"]["enabled"] is True
+    assert out["account_critical_health"]["total"] == 3
+    assert out["account_critical_health"]["succeeded"] == 3
+    assert out["account_critical_health"]["failed"] == 0
+    assert out["account_critical_health"]["surfaces"]["balance"]["latency_ms"]["count"] == 1
     assert exchange.fetch_tickers_calls == [None, ["BTC/USDT:USDT", "ETH/USDT:USDT"]]
+
+
+def test_account_critical_probe_health_summarizes_failures_without_raw_errors():
+    summary = summarize_account_critical_probe_health(
+        {
+            "include_private": True,
+            "repeats": [
+                {
+                    "fetch_balance": {
+                        "ok": True,
+                        "elapsed_ms": 1.25,
+                        "value": {"redacted": True},
+                    },
+                    "fetch_positions": {
+                        "ok": False,
+                        "elapsed_ms": 2.5,
+                        "error_type": "RequestTimeout",
+                        "error": "https://api.exchange.invalid/path?secret=leak",
+                    },
+                    "fetch_open_orders_all": {
+                        "ok": False,
+                        "elapsed_ms": 3.75,
+                        "error_type": "RuntimeError",
+                        "error": "raw payload should not appear",
+                    },
+                }
+            ],
+        }
+    )
+
+    assert summary["enabled"] is True
+    assert summary["total"] == 3
+    assert summary["succeeded"] == 1
+    assert summary["failed"] == 2
+    assert summary["failure_pct"] == pytest.approx(66.667)
+    assert summary["surfaces"]["positions"]["error_types"] == {"RequestTimeout": 1}
+    assert summary["surfaces"]["open_orders"]["latest"]["error_type"] == "RuntimeError"
+    assert "secret=leak" not in str(summary)
+    assert "raw payload" not in str(summary)
+
+
+def test_account_critical_probe_collection_aggregates_user_summaries():
+    probes = [
+        {
+            "user": "kucoin_01",
+            "exchange": "kucoinfutures",
+            "include_private": True,
+            "repeats": [
+                {
+                    "fetch_balance": {"ok": True, "elapsed_ms": 10.0},
+                    "fetch_positions": {"ok": True, "elapsed_ms": 20.0},
+                    "fetch_open_orders_all": {"ok": False, "error_type": "RequestTimeout"},
+                }
+            ],
+        },
+        {
+            "user": "binance_01",
+            "exchange": "binance",
+            "include_private": False,
+            "repeats": [{"fetch_tickers_all": {"ok": True}}],
+        },
+    ]
+
+    collection = summarize_account_critical_probe_collection(probes)
+
+    assert collection["total"] == 3
+    assert collection["succeeded"] == 2
+    assert collection["failed"] == 1
+    assert collection["users"][0]["user"] == "kucoin_01"
+    assert collection["users"][0]["exchange"] == "kucoinfutures"
+    assert collection["users"][0]["enabled"] is True
+    assert collection["users"][0]["total"] == 3
+    assert collection["users"][0]["succeeded"] == 2
+    assert collection["users"][0]["failed"] == 1
+    assert collection["users"][0]["failure_pct"] == pytest.approx(33.333)
+    assert collection["users"][1] == {
+        "user": "binance_01",
+        "exchange": "binance",
+        "enabled": False,
+        "total": 0,
+        "succeeded": 0,
+        "failed": 0,
+        "failure_pct": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_probe_exchange_ticker_endpoints_redacts_stored_endpoint_errors():
+    class FakeExchange:
+        id = "fake"
+        has = {
+            "fetchBalance": True,
+            "fetchBidsAsks": True,
+            "fetchMyTrades": True,
+            "fetchOpenOrders": True,
+            "fetchPositions": True,
+            "fetchTicker": True,
+            "fetchTickers": True,
+        }
+
+        async def load_markets(self):
+            return {
+                "BTC/USDT:USDT": {
+                    "base": "BTC",
+                    "quote": "USDT",
+                    "active": True,
+                    "swap": True,
+                    "linear": True,
+                }
+            }
+
+        async def fetch_tickers(self, symbols=None):
+            selected = symbols or ["BTC/USDT:USDT"]
+            return {symbol: {"symbol": symbol, "bid": 9.0, "ask": 11.0, "last": 10.0} for symbol in selected}
+
+        async def fetch_bids_asks(self, symbols=None):
+            selected = symbols or ["BTC/USDT:USDT"]
+            return {symbol: {"symbol": symbol, "bid": 9.0, "ask": 11.0, "last": 10.0} for symbol in selected}
+
+        async def fetch_ticker(self, symbol):
+            return {"symbol": symbol, "bid": 9.0, "ask": 11.0, "last": 10.0}
+
+        async def fetch_balance(self):
+            raise RuntimeError(
+                "GET https://api.exchange.invalid/account?apiKey=SECRET&signature=SIG "
+                "Authorization: Bearer TOKEN"
+            )
+
+        async def fetch_positions(self):
+            return []
+
+        async def fetch_open_orders(self):
+            return []
+
+        async def fetch_my_trades(self, symbol=None, since=None, limit=None):
+            return []
+
+    out = await probe_exchange_ticker_endpoints(
+        FakeExchange(),
+        user="fake_user",
+        user_info={"quote": "USDT"},
+        symbols=["BTC/USDT:USDT"],
+        coins=[],
+        quote=None,
+        max_symbols=1,
+        repeats=1,
+        sleep_between_seconds=0.0,
+        include_order_book=False,
+        include_ohlcv=False,
+    )
+
+    error = out["repeats"][0]["fetch_balance"]["error"]
+    assert "SECRET" not in error
+    assert "SIG" not in error
+    assert "TOKEN" not in error
+    assert "apiKey=[redacted]" in error
+    assert "signature=[redacted]" in error
+    assert "Authorization: [redacted]" in error
+    assert out["account_critical_health"]["surfaces"]["balance"]["error_types"] == {
+        "RuntimeError": 1
+    }


### PR DESCRIPTION
## Summary
- add per-user account_critical_health summaries to ticker-endpoint-probe JSON
- aggregate read-only balance/positions/open-orders health across users
- document the authenticated account-state summary in tool docs

## Validation
- ./venv/bin/python -m compileall src/tools/probe_ccxt_ticker_endpoints.py tests/test_ticker_probe_tool.py
- ./venv/bin/python -m pytest tests/test_ticker_probe_tool.py tests/test_passivbot_cli.py::test_ticker_endpoint_probe_dispatch_forwards_module_and_prog
- rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])" src/tools/probe_ccxt_ticker_endpoints.py tests/test_ticker_probe_tool.py
- git diff --check