### PR TITLE
Record account-only probe progress

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-26.
 
 Current `origin/v8` logging-overhaul head:
 
-- `91d5db9fb` merge of PR #701, `Summarize account-critical probe health`.
+- `a2f93456e` merge of PR #703, `Add account-only ticker endpoint probe mode`.
 
 Current review gate:
 
@@ -192,6 +192,16 @@ VPS5 deployment status:
   and positions successful and `fetch_open_orders()` failing as `ExchangeError`.
   This validates the summary projection and exposes a follow-up for
   lower-impact/account-only probing and exchange-specific open-orders shape.
+- PR #703 was merged after Claude + Hermes approval on the code delta, green CI,
+  and a docs-only amendment that clarified `--account-only` still loads markets
+  for open-orders symbol fallback. It was pulled to VPS5 without bot restart.
+  A one-repeat authenticated `ticker-endpoint-probe --account-only` on
+  `binance_01` reported `account_critical_health.total=3`, `succeeded=3`,
+  `failed=0`; Binance `fetch_open_orders()` first failed as `ExchangeError`,
+  then succeeded through `mode=symbol_fallback`. A follow-up 2-minute smoke at
+  `a2f93456` reported `ok=true`, `hard_failures=0`, `logs.hard_matches=0`,
+  `remote_calls.failed=0`, `account_critical_remote_calls.failed=0`,
+  `matched_expected=5`, and `missing_expected=[]`.
 
 ## Phase Checklist
 
@@ -204,7 +214,7 @@ VPS5 deployment status:
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
-| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/time windows/unparseable-log policy, incident bundle trace/process/time-window reports, ID filters, `ticker-endpoint-probe` account-critical health summaries | Cross-bot incident workflow, safe restart orchestration, lower-impact active probe modes |
+| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/time windows/unparseable-log policy, incident bundle trace/process/time-window reports, ID filters, `ticker-endpoint-probe` account-critical health summaries and account-only mode | Cross-bot incident workflow, safe restart orchestration, active probe expansion beyond account-critical endpoints |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup; PR #656/#668 cache integrity smoke doctor | Continue separate reviewed PRs for shutdown/warmup/cache proof improvements |
 
 ## Merged Slices
@@ -917,11 +927,11 @@ VPS5 deployment status:
 
 1. Continue Phase 5 by migrating one high-value stdlib text log family to
    structured-event projection without increasing default console noise.
-2. Refine active read-only exchange health probes. PR #701 added
-   account-critical health summaries to `ticker-endpoint-probe`; the next useful
-   slice is a lower-impact/account-only mode and exchange-aware open-orders
-   probing after the VPS5 Binance probe showed `fetch_open_orders()` without a
-   symbol fails as `ExchangeError`.
+2. Continue active read-only exchange health probes beyond account-critical
+   basics. PR #701 added account-critical health summaries and PR #703 added
+   `--account-only` plus symbol fallback for open-orders. Remaining useful
+   slices include clock skew, rate-limit behavior, fill pagination coverage, and
+   candle freshness probes.
 3. Use the persistent non-hard EMA readiness / staged-execution degradation
    visible in VPS5 smokes as the next candidate for targeted readiness
    diagnostics or a narrow fix. PRs #679 and #682 made the problem groups easier

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -125,13 +125,16 @@ Related detailed plans:
    A VPS5 one-repeat authenticated probe on `binance_01` validated the summary
    shape and showed a follow-up: Binance `fetch_open_orders()` without a symbol
    fails as `ExchangeError`, so lower-impact/account-only probing should use
-   exchange-aware open-orders shape.
+   exchange-aware open-orders shape. PR #703 added `--account-only`,
+   `--skip-my-trades`, and an open-orders symbol fallback; a VPS5 account-only
+   Binance probe validated `account_critical_health` success for all three
+   account-critical surfaces.
 
    Add/refine explicit read-only probes for each configured exchange/account
-   before or during smoke: low-impact balance/positions/open-orders fetches,
-   clock skew, rate-limit behavior, fill pagination coverage, candle freshness,
-   and basic endpoint latency. The passive smoke report now also exposes
-   top-level remote-call health success/failure/throttle totals and a filtered
+   before or during smoke: clock skew, rate-limit behavior, fill pagination
+   coverage, candle freshness, and basic endpoint latency. The passive smoke
+   report now also exposes top-level remote-call health
+   success/failure/throttle totals and a filtered
    `account_critical_remote_call_health` summary for a quick operator scan.
 
 7. [ ] Live config preflight/linter.
@@ -289,6 +292,7 @@ Related detailed plans:
 | 2026-06-26 | #3 Live restart/smoke automation | PR #698 / `7c7368f3` | Redacted common user/home prefixes from smoke-report `repository.root` while preserving real git cwd use; incident-bundle `smoke_report.json` inherits the safer display field | Safe pull/stop/start orchestration still open |
 | 2026-06-26 | #3 Live restart/smoke automation | PR #699 / `4e2fcee7` | Surfaced dropped contextless unparsed attention/hard counters under `--log-window-unparsed-policy drop`; dropped attention now makes smoke `attention=true` without making stale tail fragments hard failures; VPS5 settled smoke on `d5639813` returned `ok=true`, no hard failures, all five bots matched | Safe pull/stop/start orchestration still open |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #701 / `fcda70f5` | Added `ticker-endpoint-probe` `account_critical_health` summaries for read-only balance/positions/open-orders outcomes; VPS5 Binance probe validated the summary and exposed an open-orders shape follow-up | Lower-impact/account-only mode, exchange-aware open-orders probing, clock skew/rate-limit/fill/candle probes |
+| 2026-06-26 | #6 Exchange health and contract probes | PR #703 / `8fefce4b` | Added `ticker-endpoint-probe --account-only`, `--skip-my-trades`, and open-orders symbol fallback; VPS5 Binance account-only probe returned account-critical total=3, succeeded=3, and smoke stayed green | Clock skew/rate-limit/fill-pagination/candle-freshness probes |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |


### PR DESCRIPTION
## Summary
- record PR #703 as the current logging-overhaul head
- document VPS5 account-only probe evidence and green post-deploy smoke
- narrow remaining exchange-probe backlog to clock skew, rate-limit, fill pagination, and candle freshness probes

## Validation
- git diff --check

Docs-only progress/backlog update; no code or trading behavior changes.