### PR TITLE
Add brief live smoke report summary

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -135,6 +135,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
 - `passivbot tool monitor-web`
 - `passivbot tool monitor-tui`
 - `passivbot tool monitor-dev`
+- `passivbot tool live-smoke-report` summarizes local live monitor events and text logs for
+  operator smoke-test evidence. Use `--summary` for bounded event groups and log matches, or
+  `--brief` for top-level counters suitable for repeated VPS smoke loops.
 
 ## Exchange Helpers
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -2298,3 +2298,121 @@ def summarize_live_smoke_report(
         ),
         "risk_events": _summary_limited_groups(risk_events, limit=max_groups),
     }
+
+
+def _count_value(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _brief_remote_call_health(summary: Any) -> dict[str, Any]:
+    if not isinstance(summary, dict):
+        summary = {}
+    return {
+        key: value
+        for key, value in {
+            "total": _count_value(summary.get("total")),
+            "succeeded": _count_value(summary.get("succeeded")),
+            "failed": _count_value(summary.get("failed")),
+            "throttled": _count_value(summary.get("throttled")),
+            "failure_pct": summary.get("failure_pct"),
+            "throttled_pct": summary.get("throttled_pct"),
+        }.items()
+        if value is not None
+    }
+
+
+def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
+    """Project a full smoke report into top-level smoke-loop counters."""
+
+    logs = report.get("logs") if isinstance(report.get("logs"), dict) else {}
+    processes = (
+        report.get("processes") if isinstance(report.get("processes"), dict) else {}
+    )
+    repository = (
+        report.get("repository") if isinstance(report.get("repository"), dict) else {}
+    )
+    monitor = report.get("monitor") if isinstance(report.get("monitor"), dict) else {}
+    risk_events = (
+        report.get("risk_events") if isinstance(report.get("risk_events"), dict) else {}
+    )
+    event_window = (
+        report.get("event_window") if isinstance(report.get("event_window"), dict) else {}
+    )
+    return {
+        "ok": bool(report.get("ok")),
+        "attention": bool(report.get("attention")),
+        "hard_failures": _count_value(report.get("hard_failures")),
+        "attention_count": _count_value(report.get("attention_count")),
+        "repository": {
+            key: repository.get(key)
+            for key in ("branch", "head", "dirty", "tracked_changes")
+            if key in repository
+        },
+        "monitor": {
+            key: monitor.get(key)
+            for key in (
+                "files_scanned",
+                "records_total",
+                "live_events",
+                "legacy_events",
+                "error_count",
+                "warning_count",
+            )
+            if key in monitor
+        },
+        "event_window": {
+            key: event_window.get(key)
+            for key in (
+                "since_ms",
+                "until_ms",
+                "events_considered",
+                "events_skipped_before",
+                "events_skipped_after",
+                "invalid_window_ts",
+            )
+            if key in event_window
+        },
+        "processes": {
+            key: processes.get(key)
+            for key in (
+                "enabled",
+                "ok",
+                "hard_failures",
+                "expected_total",
+                "matched_expected",
+                "running_live_total",
+                "scan_error",
+            )
+            if key in processes
+        }
+        | {
+            "missing_expected_count": len(processes.get("missing_expected") or []),
+            "unexpected_running_count": len(processes.get("unexpected_running") or []),
+        },
+        "logs": {
+            "files_scanned": _count_value(logs.get("files_scanned")),
+            "hard_matches": _count_value(logs.get("hard_matches")),
+            "attention_matches": _count_value(logs.get("attention_matches")),
+            "dropped_unparsed_attention_matches": _count_value(
+                logs.get("dropped_unparsed_attention_matches")
+            ),
+            "dropped_unparsed_hard_matches": _count_value(
+                logs.get("dropped_unparsed_hard_matches")
+            ),
+        },
+        "problem_events": {
+            "total": _count_value(report.get("problem_event_count")),
+            "hard": _count_value(report.get("hard_problem_event_count")),
+        },
+        "remote_calls": _brief_remote_call_health(report.get("remote_call_health")),
+        "account_critical_remote_calls": _brief_remote_call_health(
+            report.get("account_critical_remote_call_health")
+        ),
+        "risk_events": {
+            "total": _count_value(risk_events.get("total")),
+            "event_types": risk_events.get("event_types") or {},
+        },
+    }

--- a/src/tools/live_smoke_report.py
+++ b/src/tools/live_smoke_report.py
@@ -16,6 +16,7 @@ from live.smoke_report import (  # noqa: E402
     build_live_smoke_report,
     default_logs_root_for_monitor,
     summarize_live_smoke_report,
+    summarize_live_smoke_report_brief,
 )
 
 
@@ -140,6 +141,14 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Emit concise smoke-test summary JSON instead of the full report.",
     )
+    parser.add_argument(
+        "--brief",
+        action="store_true",
+        help=(
+            "Emit top-level smoke-test counters without event groups or log "
+            "matches. Implies --summary."
+        ),
+    )
     return parser
 
 
@@ -177,7 +186,12 @@ def main(argv: list[str] | None = None) -> int:
         max_log_matches=int(args.max_log_matches),
         log_window_unparsed_policy=str(args.log_window_unparsed_policy),
     )
-    output = summarize_live_smoke_report(report) if args.summary else report
+    if args.brief:
+        output = summarize_live_smoke_report_brief(report)
+    elif args.summary:
+        output = summarize_live_smoke_report(report)
+    else:
+        output = report
     print(json.dumps(output, indent=None if args.compact else 2, sort_keys=True))
     return 0 if report.get("ok") else 1
 

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -9,6 +9,7 @@ from live.smoke_report import (
     build_live_smoke_report,
     default_logs_root_for_monitor,
     summarize_live_smoke_report,
+    summarize_live_smoke_report_brief,
 )
 from tools import live_smoke_report
 
@@ -733,6 +734,85 @@ def test_live_smoke_report_summary_projects_high_signal_fields(tmp_path):
     assert summary["remote_calls"]["groups"][0]["surface"] == "balance"
     assert "bots" not in summary
     assert "problem_event_groups" not in summary
+
+
+def test_live_smoke_report_brief_summary_projects_top_level_counters(tmp_path):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="remote_call.failed",
+                seq=1,
+                ts=1000,
+                status="failed",
+                level="warning",
+                reason_code="authoritative_balance",
+                ids={
+                    "cycle_id": "cy_1",
+                    "remote_call_id": "rca_1",
+                    "remote_call_group_id": "cy_1:authoritative",
+                },
+                data={
+                    "kind": "authoritative_state_fetch",
+                    "surface": "balance",
+                    "elapsed_ms": 5000,
+                    "error_type": "RequestTimeout",
+                },
+            ),
+            _monitor_row(
+                event_type="ema.unavailable",
+                seq=2,
+                ts=2000,
+                status="degraded",
+                level="warning",
+                reason_code="required_ema_unavailable",
+                ids={"cycle_id": "cy_2"},
+                data={
+                    "candidate_unavailable": {
+                        "count": 1,
+                        "sample": ["ZEC/USDT:USDT"],
+                        "truncated": 0,
+                    }
+                },
+            ),
+        ],
+    )
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "kucoin_01.log").write_text(
+        "2026-06-25T00:00:00Z ERROR exchange timeout\n",
+        encoding="utf-8",
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=logs_dir,
+        log_tail_lines=10,
+    )
+    brief = summarize_live_smoke_report_brief(report)
+
+    assert brief["ok"] is True
+    assert brief["attention"] is True
+    assert brief["hard_failures"] == 0
+    assert brief["attention_count"] == 3
+    assert brief["monitor"]["live_events"] == 2
+    assert brief["logs"] == {
+        "files_scanned": 1,
+        "hard_matches": 0,
+        "attention_matches": 1,
+        "dropped_unparsed_attention_matches": 0,
+        "dropped_unparsed_hard_matches": 0,
+    }
+    assert brief["problem_events"] == {"total": 2, "hard": 0}
+    assert brief["remote_calls"]["total"] == 1
+    assert brief["remote_calls"]["failed"] == 1
+    assert brief["account_critical_remote_calls"]["total"] == 1
+    assert brief["account_critical_remote_calls"]["failed"] == 1
+    assert "bots" not in brief
+    assert "matches" not in brief["logs"]
+    assert "groups" not in brief["remote_calls"]
+    assert "groups" not in brief["account_critical_remote_calls"]
 
 
 def test_live_smoke_report_remote_call_health_counts_throttled_events(tmp_path):
@@ -1971,6 +2051,61 @@ def test_live_smoke_report_cli_can_emit_concise_summary(tmp_path, capsys):
     assert "account_critical_remote_calls" in summary
     assert "bots" not in summary
     assert "problem_events" in summary
+
+
+def test_live_smoke_report_cli_can_emit_brief_summary(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="remote_call.failed",
+                seq=1,
+                ts=1000,
+                status="failed",
+                level="warning",
+                reason_code="authoritative_balance",
+                data={
+                    "kind": "authoritative_state_fetch",
+                    "surface": "balance",
+                    "error_type": "RequestTimeout",
+                },
+            )
+        ],
+    )
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "okx_faisal.log").write_text(
+        "2026-06-25T00:00:00Z ERROR exchange timeout\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        live_smoke_report.main(
+            [
+                str(tmp_path / "monitor"),
+                "--logs-root",
+                str(logs_dir),
+                "--log-tail-lines",
+                "10",
+                "--brief",
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["ok"] is True
+    assert summary["attention"] is True
+    assert summary["attention_count"] == 2
+    assert summary["logs"]["attention_matches"] == 1
+    assert summary["problem_events"] == {"hard": 0, "total": 1}
+    assert summary["account_critical_remote_calls"]["failed"] == 1
+    assert "bots" not in summary
+    assert "matches" not in summary["logs"]
+    assert "groups" not in summary["remote_calls"]
+    assert "groups" not in summary["account_critical_remote_calls"]
 
 
 def test_live_smoke_report_cli_can_drop_unparseable_window_log_lines(


### PR DESCRIPTION
Adds a --brief projection to passivbot tool live-smoke-report for repeated VPS smoke loops. It keeps existing --summary output unchanged and emits only top-level counters without event groups/log matches.\n\nValidation:\n- ./venv/bin/python -m compileall src/live/smoke_report.py src/tools/live_smoke_report.py tests/test_live_smoke_report.py\n- ./venv/bin/python -m pytest tests/test_live_smoke_report.py\n- git diff --check