### PR TITLE
Log coin HSL status for active positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool live-smoke-report --brief` for top-level VPS smoke
+  counters without event groups or log match details.
+- Added periodic console status lines for coin-mode HSL positions, including
+  distance to RED, drawdown, slot budget, realized PnL peak, and unrealized PnL.
 - Added `passivbot tool live-smoke-report --summary` for concise smoke evidence
   that keeps high-signal process, log, problem-event, risk, repository, and
   remote-call health fields without emitting the full verbose report.

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -3090,6 +3090,40 @@ def _equity_hard_stop_emit_coin_status(self, pside: str, symbol: str, metrics: d
             last_red_ts = state["last_stop_event"].get("stop_event_timestamp_ms")
         if last_red_ts is None:
             last_red_ts = state["pending_red_since_ms"]
+        if self._equity_hard_stop_has_open_position_symbol(pside, symbol):
+            try:
+                logging.info(
+                    "[risk] HSL[%s:%s] status | tier=%s dist_to_red=%.6f drawdown_raw=%.6f "
+                    "drawdown_ema=%.6f drawdown_score=%.6f red_threshold=%.6f "
+                    "cooldown_remaining=%s last_red_ts=%s pending_red_since_ms=%s "
+                    "slot_budget=%.6f realized_pnl=%.6f peak_realized_pnl=%.6f upnl=%.6f",
+                    pside,
+                    symbol,
+                    metrics["tier"],
+                    dist_to_red,
+                    metrics["drawdown_raw"],
+                    metrics["drawdown_ema"],
+                    drawdown_score,
+                    red_threshold,
+                    cooldown_remaining if cooldown_remaining is not None else "none",
+                    last_red_ts if last_red_ts is not None else "none",
+                    (
+                        state["pending_red_since_ms"]
+                        if state["pending_red_since_ms"] is not None
+                        else "none"
+                    ),
+                    metrics["slot_budget"],
+                    metrics["realized_pnl"],
+                    metrics["peak_realized_pnl"],
+                    metrics["unrealized_pnl"],
+                )
+            except Exception as exc:
+                logging.debug(
+                    "[event] failed to log HSL coin status symbol=%s pside=%s: %s",
+                    symbol,
+                    pside,
+                    exc,
+                )
         _emit_hsl_event(
             self,
             "hsl.status",

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1411,6 +1411,105 @@ async def test_start_bot_treats_hsl_value_error_as_terminal_startup_failure(monk
     }
 
 
+def test_coin_hsl_status_logs_distance_only_for_open_position(caplog, monkeypatch):
+    sink = ListEventSink()
+
+    class FakeBot:
+        _emit_live_event = Passivbot._emit_live_event
+        _equity_hard_stop_emit_coin_status = Passivbot._equity_hard_stop_emit_coin_status
+        _hsl_coin_state = Passivbot._hsl_coin_state
+
+        def __init__(self, *, has_position: bool):
+            self.exchange = "bybit"
+            self.user = "bybit_01"
+            self.bot_id = "bot_coin_hsl"
+            self._live_event_current_cycle_id = "cy_hsl_coin"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+            self.has_position = has_position
+            self._equity_hard_stop_coin = {
+                "long": {
+                    "NEAR/USDT:USDT": {
+                        "last_status_log_ms": 0,
+                        "cooldown_until_ms": None,
+                        "last_stop_event": None,
+                        "pending_red_since_ms": None,
+                    }
+                },
+                "short": {},
+            }
+
+        def _equity_hard_stop_has_open_position_symbol(self, pside, symbol):
+            return self.has_position
+
+    metrics = {
+        "timestamp_ms": 10_000,
+        "tier": "yellow",
+        "red_threshold": 0.10,
+        "drawdown_score": 0.06,
+        "drawdown_raw": 0.05,
+        "drawdown_ema": 0.06,
+        "slot_budget": 500.0,
+        "realized_pnl": -10.0,
+        "peak_realized_pnl": 20.0,
+        "unrealized_pnl": -15.0,
+    }
+    bot = FakeBot(has_position=True)
+
+    with caplog.at_level(logging.INFO):
+        bot._equity_hard_stop_emit_coin_status("long", "NEAR/USDT:USDT", metrics)
+
+    messages = [record.message for record in caplog.records]
+    assert any("[risk] HSL[long:NEAR/USDT:USDT] status" in msg for msg in messages)
+    assert any("dist_to_red=0.040000" in msg for msg in messages)
+    assert any("slot_budget=500.000000" in msg for msg in messages)
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[-1]
+    assert event.event_type == EventTypes.HSL_STATUS
+    assert event.symbol == "NEAR/USDT:USDT"
+    assert event.pside == "long"
+    assert event.data["dist_to_red"] == pytest.approx(0.04)
+
+    caplog.clear()
+    sink.events.clear()
+    flat_bot = FakeBot(has_position=False)
+    with caplog.at_level(logging.INFO):
+        flat_bot._equity_hard_stop_emit_coin_status(
+            "long",
+            "NEAR/USDT:USDT",
+            metrics | {"timestamp_ms": 20_000},
+        )
+
+    assert not [
+        record
+        for record in caplog.records
+        if "[risk] HSL[long:NEAR/USDT:USDT] status" in record.message
+    ]
+    assert flat_bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert sink.events[-1].event_type == EventTypes.HSL_STATUS
+
+    import passivbot_hsl as hsl_mod
+
+    def fail_info(*args, **kwargs):
+        raise RuntimeError("logging failed")
+
+    caplog.clear()
+    sink.events.clear()
+    monkeypatch.setattr(hsl_mod.logging, "info", fail_info)
+    failing_log_bot = FakeBot(has_position=True)
+    failing_log_bot._equity_hard_stop_emit_coin_status(
+        "long",
+        "NEAR/USDT:USDT",
+        metrics | {"timestamp_ms": 30_000},
+    )
+
+    assert failing_log_bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert sink.events[-1].event_type == EventTypes.HSL_STATUS
+    assert sink.events[-1].data["dist_to_red"] == pytest.approx(0.04)
+
+
 def test_startup_timing_marks_log_once(monkeypatch, caplog):
     bot = Passivbot.__new__(Passivbot)
     now_ms = [1_000]


### PR DESCRIPTION
Adds the missing console projection for coin-mode HSL status when a coin/side has an open position. The existing structured hsl.status event remains unchanged, and flat historical coins still do not emit periodic console status lines.\n\nValidation:\n- ./venv/bin/python -m compileall src/passivbot_hsl.py tests/test_passivbot_balance_split.py\n- ./venv/bin/python -m pytest tests/test_passivbot_balance_split.py::test_coin_hsl_status_logs_distance_only_for_open_position\n- ./venv/bin/python -m pytest tests/test_passivbot_balance_split.py::test_start_bot_treats_hsl_value_error_as_terminal_startup_failure tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_recent_risk_events\n- git diff --check