### PR TITLE
Emit fill cache ready event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added structured `fills.refresh_summary` startup cache-ready events for fill
+  history cache load diagnostics without adding console noise.
 - Added `passivbot tool live-smoke-report --brief` for top-level VPS smoke
   counters without event groups or log match details.
 - Added periodic console status lines for coin-mode HSL positions, including

--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -65,6 +65,7 @@ across time.
 - `exchange_acknowledged`
 - `exchange_exception`
 - `execution_loop_error_burst`
+- `fill_cache_ready`
 - `length_mismatch`
 - `low_balance`
 - `new_fill`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -151,6 +151,7 @@ class ReasonCodes:
     EXCHANGE_ACKNOWLEDGED = "exchange_acknowledged"
     EXCHANGE_EXCEPTION = "exchange_exception"
     EXECUTION_LOOP_ERROR_BURST = "execution_loop_error_burst"
+    FILL_CACHE_READY = "fill_cache_ready"
     LENGTH_MISMATCH = "length_mismatch"
     LOW_BALANCE = "low_balance"
     NEW_FILL = "new_fill"

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -63,6 +63,7 @@ from live.event_bus import (
     LiveEventContext,
     LiveEventPipeline,
     MonitorEventSink,
+    ReasonCodes,
     payload_hash_raw,
 )
 import live.event_emitters as live_event_emitters
@@ -10039,6 +10040,7 @@ class Passivbot:
         if self._pnls_initialized:
             return
 
+        init_started_ms = utc_ms()
         try:
             logging.debug("[fills] initializing FillEventsManager")
 
@@ -10160,6 +10162,23 @@ class Passivbot:
 
             cached_count = len(self._pnls_manager._events)
             logging.info("[fills] cache ready: %d cached events loaded", cached_count)
+            history_scope = None
+            try:
+                get_history_scope = getattr(self._pnls_manager, "get_history_scope", None)
+                if callable(get_history_scope):
+                    history_scope = get_history_scope()
+            except Exception as exc:
+                logging.debug("[event] failed to read fill-cache history scope: %s", exc)
+            self._emit_fills_refresh_summary_event(
+                source="startup",
+                refresh_mode="cache_load",
+                status="succeeded",
+                reason_code=ReasonCodes.FILL_CACHE_READY,
+                elapsed_ms=int(max(0, utc_ms() - init_started_ms)),
+                history_scope=history_scope,
+                event_count_after=cached_count,
+                level="debug",
+            )
 
             self._pnls_initialized = True
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -15,6 +15,7 @@ import numpy as np
 import pytest
 from passivbot_exceptions import FatalBotException
 from live.event_bus import (
+    DEFAULT_ROUTES,
     EventTags,
     EventTypes,
     ListEventSink,
@@ -175,6 +176,65 @@ async def test_init_pnls_quarantines_and_rebuilds_unsupported_legacy_cache(monke
     assert manager.quarantine_reason == "legacy_pnl_contract"
     assert manager.refresh_calls == [(1_700_000_000_000, None)]
     assert manager.history_scope == "window"
+
+
+@pytest.mark.asyncio
+async def test_init_pnls_emits_cache_ready_event(monkeypatch):
+    managers = []
+
+    class _Manager:
+        def __init__(self, **_kwargs):
+            self._events = [object(), object(), object()]
+            self.history_scope = "all"
+            managers.append(self)
+
+        async def ensure_loaded(self):
+            return None
+
+        def get_history_scope(self):
+            return self.history_scope
+
+    sink = ListEventSink()
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "binance"
+    bot.user = "binance_01"
+    bot.bot_id = "bot_1"
+    bot.config = {"live": {"pnls_max_lookback_days": "all"}}
+    bot._pnls_initialized = False
+    bot._live_event_current_cycle_id = "cy_init_fills"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+
+    monkeypatch.delenv("PASSIVBOT_FILL_EVENTS_DOCTOR", raising=False)
+    monkeypatch.setattr(passivbot_module, "_extract_symbol_pool", lambda *_args: [])
+    monkeypatch.setattr(passivbot_module, "_build_fetcher_for_bot", lambda *_args: object())
+    monkeypatch.setattr(passivbot_module, "FillEventsManager", _Manager)
+
+    await Passivbot.init_pnls(bot)
+
+    assert bot._pnls_initialized is True
+    assert len(managers) == 1
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.FILLS_REFRESH_SUMMARY
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.cycle_id == "cy_init_fills"
+    assert event.status == "succeeded"
+    assert event.reason_code == ReasonCodes.FILL_CACHE_READY
+    assert event.data["source"] == "startup"
+    assert event.data["refresh_mode"] == "cache_load"
+    assert event.data["event_count_after"] == 3
+    assert event.data["history_scope"] == "all"
+    route = DEFAULT_ROUTES[EventTypes.FILLS_REFRESH_SUMMARY]
+    assert route.console is False
+    assert route.text is False
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 def _counted_staged_account_refresh_bot(


### PR DESCRIPTION
## Summary
- mirror startup fill-cache readiness into the structured fills.refresh_summary event stream
- add stable fill_cache_ready reason code and registry docs
- keep existing console output unchanged and route the new event off-console

## Tests
- ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py::test_emit_fills_refresh_summary_event_sanitizes_error_and_stays_off_console tests/test_passivbot_balance_split.py::test_init_pnls_quarantines_and_rebuilds_unsupported_legacy_cache tests/test_passivbot_balance_split.py::test_init_pnls_emits_cache_ready_event tests/test_passivbot_balance_split.py::test_update_pnls_propagates_unexpected_refresh_errors tests/test_passivbot_balance_split.py::test_update_pnls_emits_summary_when_exchange_time_resync_handles_error
- ./venv/bin/python -m compileall src/passivbot.py src/live/event_bus.py tests/test_passivbot_balance_split.py tests/test_passivbot_monitor.py
- git diff --check