### PR TITLE
Emit exchange time sync events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added structured `exchange.time_sync` live events for CCXT timestamp/nonce
+  recovery diagnostics without changing recovery behavior or console volume.
 - Added structured `fills.refresh_summary` startup cache-ready events for fill
   history cache load diagnostics without adding console noise.
 - Added `passivbot tool live-smoke-report --brief` for top-level VPS smoke

--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -25,6 +25,7 @@ across time.
 - `degraded`
 - `ema`
 - `execution`
+- `exchange`
 - `fallback`
 - `fill`
 - `fills`
@@ -50,6 +51,7 @@ across time.
 - `summary`
 - `tail`
 - `timeout`
+- `time_sync`
 - `unavailable`
 - `warmup`
 - `wave`
@@ -64,6 +66,8 @@ across time.
 - `ema_fallback_used`
 - `exchange_acknowledged`
 - `exchange_exception`
+- `exchange_time_sync`
+- `exchange_time_sync_unavailable`
 - `execution_loop_error_burst`
 - `fill_cache_ready`
 - `length_mismatch`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -54,6 +54,7 @@ class EventTypes:
     CACHE_LOAD_COMPLETED = "cache.load.completed"
     CACHE_FLUSH_COMPLETED = "cache.flush.completed"
     CACHE_WARMUP_DECISION = "cache.warmup_decision"
+    EXCHANGE_TIME_SYNC = "exchange.time_sync"
     REMOTE_CALL_STARTED = "remote_call.started"
     REMOTE_CALL_SUCCEEDED = "remote_call.succeeded"
     REMOTE_CALL_FAILED = "remote_call.failed"
@@ -111,6 +112,7 @@ class EventTags:
     DEGRADED = "degraded"
     EMA = "ema"
     EXECUTION = "execution"
+    EXCHANGE = "exchange"
     FALLBACK = "fallback"
     FILL = "fill"
     FILLS = "fills"
@@ -136,6 +138,7 @@ class EventTags:
     SUMMARY = "summary"
     TAIL = "tail"
     TIMEOUT = "timeout"
+    TIME_SYNC = "time_sync"
     UNAVAILABLE = "unavailable"
     WARMUP = "warmup"
     WAVE = "wave"
@@ -150,6 +153,8 @@ class ReasonCodes:
     EMA_FALLBACK_USED = "ema_fallback_used"
     EXCHANGE_ACKNOWLEDGED = "exchange_acknowledged"
     EXCHANGE_EXCEPTION = "exchange_exception"
+    EXCHANGE_TIME_SYNC = "exchange_time_sync"
+    EXCHANGE_TIME_SYNC_UNAVAILABLE = "exchange_time_sync_unavailable"
     EXECUTION_LOOP_ERROR_BURST = "execution_loop_error_burst"
     FILL_CACHE_READY = "fill_cache_ready"
     LENGTH_MISMATCH = "length_mismatch"
@@ -211,6 +216,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.CACHE_LOAD_COMPLETED,
     EventTypes.CACHE_FLUSH_COMPLETED,
     EventTypes.CACHE_WARMUP_DECISION,
+    EventTypes.EXCHANGE_TIME_SYNC,
     EventTypes.REMOTE_CALL_STARTED,
     EventTypes.REMOTE_CALL_SUCCEEDED,
     EventTypes.REMOTE_CALL_FAILED,
@@ -499,6 +505,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.CACHE_LOAD_COMPLETED: EventRoute(console=False, text=False),
     EventTypes.CACHE_FLUSH_COMPLETED: EventRoute(console=False, text=False),
     EventTypes.CACHE_WARMUP_DECISION: EventRoute(console=False, text=False),
+    EventTypes.EXCHANGE_TIME_SYNC: EventRoute(console=False, text=False),
     EventTypes.REMOTE_CALL_STARTED: EventRoute(console=False),
     EventTypes.REMOTE_CALL_SUCCEEDED: EventRoute(console=False),
     EventTypes.REMOTE_CALL_FAILED: EventRoute(console=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -345,6 +345,61 @@ def emit_authoritative_remote_call_event(
         return remote_call_id
 
 
+def _emit_exchange_time_sync_event_unchecked(
+    bot: Any,
+    *,
+    source: str,
+    error: BaseException,
+    synced_clients: list[str] | tuple[str, ...],
+    failed_clients: list[str] | tuple[str, ...],
+    hook_available: bool,
+) -> None:
+    synced = [str(item) for item in list(synced_clients or [])[:8]]
+    failed = [str(item) for item in list(failed_clients or [])[:8]]
+    recovered = bool(synced)
+    if not hook_available:
+        status = "skipped"
+        reason_code = ReasonCodes.EXCHANGE_TIME_SYNC_UNAVAILABLE
+        level = "warning"
+    elif recovered and not failed:
+        status = "succeeded"
+        reason_code = ReasonCodes.EXCHANGE_TIME_SYNC
+        level = "debug"
+    else:
+        status = "degraded"
+        reason_code = ReasonCodes.EXCHANGE_TIME_SYNC
+        level = "warning"
+    _safe_emit(
+        bot,
+        EventTypes.EXCHANGE_TIME_SYNC,
+        level=level,
+        component="exchange.time_sync",
+        tags=(EventTags.EXCHANGE, EventTags.TIME_SYNC),
+        cycle_id=current_live_event_cycle_id(bot),
+        status=status,
+        reason_code=reason_code,
+        data={
+            "source": str(source or "unknown"),
+            "error_type": type(error).__name__,
+            "error": _sanitize_remote_text(error, max_len=500),
+            "hook_available": bool(hook_available),
+            "recovered": recovered,
+            "synced_clients": synced,
+            "failed_clients": failed,
+            "synced_count": len(synced_clients or []),
+            "failed_count": len(failed_clients or []),
+        },
+    )
+
+
+def emit_exchange_time_sync_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    """Best-effort structured visibility for CCXT timestamp/nonce recovery."""
+    try:
+        _emit_exchange_time_sync_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug("[event] failed to emit exchange time-sync event: %s", exc)
+
+
 def begin_live_event_cycle(bot: Any, *, loop_start_ms: int) -> str:
     bot._live_event_cycle_seq = int(getattr(bot, "_live_event_cycle_seq", 0) or 0) + 1
     cycle_id = f"cy_{int(bot._live_event_cycle_seq)}"

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -667,6 +667,7 @@ class Passivbot:
     _emit_execution_loop_error_burst_event = (
         live_event_emitters.emit_execution_loop_error_burst_event
     )
+    _emit_exchange_time_sync_event = live_event_emitters.emit_exchange_time_sync_event
     _emit_state_refresh_timing_event = (
         live_event_emitters.emit_state_refresh_timing_event
     )
@@ -2890,6 +2891,13 @@ class Passivbot:
                 type(exc).__name__,
                 str(exc),
             )
+            self._emit_exchange_time_sync_event(
+                source=source,
+                error=exc,
+                synced_clients=synced_clients,
+                failed_clients=failed_clients,
+                hook_available=False,
+            )
             return False
         now_ms = utc_ms()
         last_ms = int(getattr(self, "_exchange_time_sync_last_log_ms", 0) or 0)
@@ -2903,6 +2911,13 @@ class Passivbot:
             ",".join(failed_clients) if failed_clients else "-",
             type(exc).__name__,
             str(exc),
+        )
+        self._emit_exchange_time_sync_event(
+            source=source,
+            error=exc,
+            synced_clients=synced_clients,
+            failed_clients=failed_clients,
+            hook_available=True,
         )
         return bool(synced_clients)
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -7565,6 +7565,13 @@ async def test_run_execution_loop_treats_shutdown_cancelled_error_as_clean_stop(
 async def test_exchange_time_sync_recovery_refreshes_ccxt_clients(caplog):
     bot = Passivbot.__new__(Passivbot)
     bot.exchange = "binance"
+    bot.user = "binance_01"
+    bot.bot_id = "bot_1"
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
     bot.cca = SimpleNamespace(
         options={"timeDifference": 10},
         load_time_difference=AsyncMock(
@@ -7592,6 +7599,59 @@ async def test_exchange_time_sync_recovery_refreshes_ccxt_clients(caplog):
     assert bot.cca.options["timeDifference"] == 25
     assert bot.ccp.options["timeDifference"] == 30
     assert any("[time] refreshed exchange clock offset" in r.message for r in caplog.records)
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert len(sink.events) == 1
+    event = sink.events[0]
+    assert event.event_type == EventTypes.EXCHANGE_TIME_SYNC
+    assert event.component == "exchange.time_sync"
+    assert event.tags == (EventTags.EXCHANGE, EventTags.TIME_SYNC)
+    assert event.status == "succeeded"
+    assert event.reason_code == ReasonCodes.EXCHANGE_TIME_SYNC
+    assert event.data["source"] == "test"
+    assert event.data["error_type"] == "RuntimeError"
+    assert event.data["hook_available"] is True
+    assert event.data["recovered"] is True
+    assert event.data["synced_clients"] == ["cca:10->25", "ccp:-5->30"]
+    assert event.data["failed_clients"] == []
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_exchange_time_sync_no_hook_emits_unavailable_event(caplog):
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "kucoin"
+    bot.user = "kucoin_01"
+    bot.bot_id = "bot_1"
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot.cca = SimpleNamespace(options={})
+    bot.ccp = None
+
+    exc = RuntimeError("Invalid nonce apiKey=supersecret")
+    with caplog.at_level(logging.WARNING):
+        recovered = await bot._maybe_recover_exchange_time_sync(
+            exc, source="fetch_balance"
+        )
+
+    assert recovered is False
+    assert any("no CCXT time-sync hook" in r.message for r in caplog.records)
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert len(sink.events) == 1
+    event = sink.events[0]
+    assert event.event_type == EventTypes.EXCHANGE_TIME_SYNC
+    assert event.status == "skipped"
+    assert event.reason_code == ReasonCodes.EXCHANGE_TIME_SYNC_UNAVAILABLE
+    assert event.data["source"] == "fetch_balance"
+    assert event.data["hook_available"] is False
+    assert event.data["recovered"] is False
+    assert event.data["synced_count"] == 0
+    assert event.data["failed_count"] == 0
+    assert "supersecret" not in event.data["error"]
+    assert "[redacted]" in event.data["error"]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope
- Add structured `exchange.time_sync` live events for existing CCXT timestamp/nonce recovery.
- Register stable `exchange` / `time_sync` tags and `exchange_time_sync` reason codes.
- Keep the event off default console/text routes; existing warning/debug text logs and recovery behavior are unchanged.

## Safety
- Observability-only: no trading decision, retry, exchange fetch, or order behavior changes.
- Event emission is best-effort and cannot mask the original recovery path.
- Error text is bounded and redacted through the existing live-event sanitizer.

## Tests
- `./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_live_event_registry_docs.py tests/test_passivbot_balance_split.py::test_exchange_time_sync_recovery_refreshes_ccxt_clients tests/test_passivbot_balance_split.py::test_exchange_time_sync_no_hook_emits_unavailable_event tests/test_passivbot_balance_split.py::test_run_execution_loop_recovers_timestamp_error_without_traceback` (36 passed)
- `./venv/bin/python -m compileall -q src/live/event_bus.py src/live/event_emitters.py src/passivbot.py tests/test_passivbot_balance_split.py tests/test_live_event_bus.py tests/test_live_event_registry_docs.py`
- `git diff --check`