### PR TITLE
Add smoke-report supervisor process diagnostics

### DIFF
--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -89,7 +89,10 @@ Related detailed plans:
    Binance but Kucoin, GateIO, OKX, and Hyperliquid remained as orphaned live
    processes after two Ctrl+C rounds and required SIGTERM before reload. This
    reinforces that restart orchestration needs per-bot shutdown timing, orphan
-   detection, and an explicit escalation ladder.
+   detection, and an explicit escalation ladder. The smoke-report supervisor
+   process diagnostics now make duplicate configured-command matches and
+   extra/orphan-like `passivbot live` processes visible from the local process
+   table before any restart orchestration.
 
 4. [ ] Startup phase budget tracking.
    Status: partial. Startup timing and warmup cache decision events exist, and
@@ -257,7 +260,10 @@ Related detailed plans:
 14. [ ] Supervisor/process model.
     Status: partial. `live-smoke-report --supervisor-config` now reports
     expected/matched/missing `passivbot live` processes from a tmuxp-style
-    config, and incident bundles can include that smoke snapshot.
+    config, duplicate configured-command matches, and extra/orphan-like live
+    processes from local command matching. Incident bundles can include that
+    smoke snapshot. The process classification is explicitly not tmux pane
+    ownership.
 
     The tmux/tmuxp setup is workable, but repeated live smoke showed room for a
     stricter supervisor contract: clear per-bot status, bounded stop/restart,
@@ -306,6 +312,7 @@ Related detailed plans:
 | 2026-06-26 | #3 Live restart/smoke automation | PR #698 / `7c7368f3` | Redacted common user/home prefixes from smoke-report `repository.root` while preserving real git cwd use; incident-bundle `smoke_report.json` inherits the safer display field | Safe pull/stop/start orchestration still open |
 | 2026-06-26 | #3 Live restart/smoke automation | PR #699 / `4e2fcee7` | Surfaced dropped contextless unparsed attention/hard counters under `--log-window-unparsed-policy drop`; dropped attention now makes smoke `attention=true` without making stale tail fragments hard failures; VPS5 settled smoke on `d5639813` returned `ok=true`, no hard failures, all five bots matched | Safe pull/stop/start orchestration still open |
 | 2026-06-26 | #3 Live restart/smoke automation | PR #709 / `71479c61` deploy evidence | VPS5 restart smoke after the fill-cache event slice returned `ok=true`, no hard failures, all five bots matched; the restart exposed four orphaned live processes after two Ctrl+C rounds, cleared by SIGTERM before reload | Safe pull/stop/start orchestration should include shutdown timing, orphan detection, and escalation policy |
+| 2026-06-26 | #3/#14 Supervisor/process diagnostics | pending PR | Extended `live-smoke-report --supervisor-config` to classify expected matches, missing expected commands, duplicate configured-command process matches, and extra/orphan-like `passivbot live` processes with bounded per-process metadata; documented the read-only command-match limitation and shutdown escalation ladder as policy only | Safe pull/stop/start orchestration remains open |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #701 / `fcda70f5` | Added `ticker-endpoint-probe` `account_critical_health` summaries for read-only balance/positions/open-orders outcomes; VPS5 Binance probe validated the summary and exposed an open-orders shape follow-up | Lower-impact/account-only mode, exchange-aware open-orders probing, clock skew/rate-limit/fill/candle probes |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #703 / `8fefce4b` | Added `ticker-endpoint-probe --account-only`, `--skip-my-trades`, and open-orders symbol fallback; VPS5 Binance account-only probe returned account-critical total=3, succeeded=3, and smoke stayed green | Clock skew/rate-limit/fill-pagination/candle-freshness probes |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -138,6 +138,14 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
 - `passivbot tool live-smoke-report` summarizes local live monitor events and text logs for
   operator smoke-test evidence. Use `--summary` for bounded event groups and log matches, or
   `--brief` for top-level counters suitable for repeated VPS smoke loops.
+  With `--supervisor-config`, the read-only process section compares configured
+  `passivbot live` commands to the local process table and reports matched, missing,
+  duplicate-command, and extra/orphan-like live processes. This does not prove tmux pane
+  ownership; the fields are command-match diagnostics intended to make stale process leftovers
+  obvious before any restart orchestration. Shutdown orchestration should follow an explicit
+  escalation ladder as policy only: graceful Ctrl+C/request stop, bounded wait, a second
+  graceful signal when warranted, SIGTERM, then SIGKILL. The smoke report never sends those
+  signals.
 
 ## Exchange Helpers
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -1319,7 +1319,11 @@ def _process_record_from_ps_line(line: str) -> dict[str, Any] | None:
     if not stripped:
         return None
     parts = stripped.split(None, 7)
-    if len(parts) == 8 and _int_or_none(parts[2]) is not None:
+    if (
+        len(parts) == 8
+        and _int_or_none(parts[2]) is not None
+        and _int_or_none(parts[6]) is not None
+    ):
         pid, ppid, etimes, stat_value, pcpu, pmem, rss, command = parts
         age_s = _int_or_none(etimes)
     else:

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -100,10 +100,23 @@ PROBLEM_EVENT_DATA_MAX_ITEMS = 8
 PROBLEM_EVENT_DATA_MAX_TEXT = 240
 PROCESS_REPORT_FIELDS = {
     "pid",
+    "ppid",
     "age_s",
     "stat",
     "cpu_pct",
     "mem_pct",
+    "rss_kb",
+    "account",
+    "config_path",
+    "config_key",
+    "command",
+    "command_key",
+}
+EXPECTED_PROCESS_FIELDS = {
+    "name",
+    "account",
+    "config_path",
+    "config_key",
     "command",
     "command_key",
 }
@@ -1063,6 +1076,46 @@ def _canonical_live_command(value: str) -> str:
     return ""
 
 
+def _live_command_context(command_key: str) -> dict[str, str]:
+    tokens = _shell_tokens(command_key)
+    if len(tokens) < 2 or tokens[0] != "passivbot" or tokens[1] != "live":
+        return {}
+    account: str | None = None
+    config_path: str | None = None
+    args = tokens[2:]
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token in {"-u", "--user"}:
+            if index + 1 < len(args):
+                account = args[index + 1]
+            index += 2
+            continue
+        if token.startswith("--user="):
+            account = token.split("=", 1)[1]
+            index += 1
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        if config_path is None:
+            config_path = token
+        index += 1
+
+    out: dict[str, str] = {}
+    if account:
+        out["account"] = _redact_log_text(account, max_len=160)
+    if config_path:
+        out["config_path"] = _redact_log_text(config_path, max_len=260)
+    if account and config_path:
+        out["config_key"] = _redact_log_text(f"{account}:{config_path}", max_len=320)
+    elif account:
+        out["config_key"] = _redact_log_text(account, max_len=160)
+    elif config_path:
+        out["config_key"] = _redact_log_text(config_path, max_len=260)
+    return out
+
+
 def _parse_tmuxp_live_commands(config_path: str | Path | None) -> dict[str, Any]:
     if config_path is None or str(config_path).strip() == "":
         return {
@@ -1106,12 +1159,14 @@ def _parse_tmuxp_live_commands(config_path: str | Path | None) -> dict[str, Any]
         command_key = _canonical_live_command(command)
         if not command_key:
             continue
+        context = _live_command_context(command_key)
         expected.append(
             {
                 "name": current_window,
                 "command": _redact_log_text(command, max_len=400),
                 "command_key": _redact_log_text(command_key, max_len=400),
                 "_match_key": command_key,
+                **context,
             }
         )
     return {
@@ -1124,6 +1179,8 @@ def _parse_tmuxp_live_commands(config_path: str | Path | None) -> dict[str, Any]
 
 def _ps_process_rows() -> tuple[list[str], str | None]:
     commands = [
+        ["ps", "-eo", "pid=,ppid=,etimes=,stat=,pcpu=,pmem=,rss=,command="],
+        ["ps", "-axo", "pid=,ppid=,stat=,pcpu=,pmem=,rss=,command="],
         ["ps", "-eo", "pid=,ppid=,etimes=,stat=,pcpu=,pmem=,command="],
         ["ps", "-axo", "pid=,ppid=,stat=,pcpu=,pmem=,command="],
     ]
@@ -1261,30 +1318,43 @@ def _process_record_from_ps_line(line: str) -> dict[str, Any] | None:
     stripped = line.strip()
     if not stripped:
         return None
-    parts = stripped.split(None, 6)
-    if len(parts) == 7 and _int_or_none(parts[2]) is not None:
-        pid, ppid, etimes, stat_value, pcpu, pmem, command = parts
+    parts = stripped.split(None, 7)
+    if len(parts) == 8 and _int_or_none(parts[2]) is not None:
+        pid, ppid, etimes, stat_value, pcpu, pmem, rss, command = parts
         age_s = _int_or_none(etimes)
     else:
-        parts = stripped.split(None, 5)
-        if len(parts) != 6:
-            return None
-        pid, ppid, stat_value, pcpu, pmem, command = parts
-        age_s = None
+        parts = stripped.split(None, 6)
+        if len(parts) == 7 and _int_or_none(parts[2]) is not None:
+            pid, ppid, etimes, stat_value, pcpu, pmem, command = parts
+            age_s = _int_or_none(etimes)
+            rss = None
+        elif len(parts) == 7 and _int_or_none(parts[5]) is not None:
+            pid, ppid, stat_value, pcpu, pmem, rss, command = parts
+            age_s = None
+        else:
+            parts = stripped.split(None, 5)
+            if len(parts) != 6:
+                return None
+            pid, ppid, stat_value, pcpu, pmem, command = parts
+            age_s = None
+            rss = None
     command_key = _canonical_live_command(command)
     if not command_key:
         return None
-    return {
+    record = {
         "pid": _int_or_none(pid),
         "ppid": _int_or_none(ppid),
         "age_s": age_s,
         "stat": stat_value,
         "cpu_pct": _float_or_none(pcpu),
         "mem_pct": _float_or_none(pmem),
+        "rss_kb": _int_or_none(rss) if rss is not None else None,
         "command": _redact_log_text(command, max_len=500),
         "command_key": _redact_log_text(command_key, max_len=500),
         "_match_key": command_key,
     }
+    record.update(_live_command_context(command_key))
+    return record
 
 
 def _running_live_processes(*, command_match: str) -> dict[str, Any]:
@@ -1312,6 +1382,22 @@ def _running_live_processes(*, command_match: str) -> dict[str, Any]:
     }
 
 
+def _public_process_record(process: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in process.items()
+        if key in PROCESS_REPORT_FIELDS and value is not None
+    }
+
+
+def _public_expected_record(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in item.items()
+        if key in EXPECTED_PROCESS_FIELDS and value is not None
+    }
+
+
 def _build_process_report(
     *,
     include_processes: bool,
@@ -1328,6 +1414,8 @@ def _build_process_report(
             "running_live_total": 0,
             "missing_expected": [],
             "unexpected_running": [],
+            "duplicate_configured_command_matches": [],
+            "extra_passivbot_live_processes": [],
         }
 
     config = _parse_tmuxp_live_commands(supervisor_config)
@@ -1335,6 +1423,8 @@ def _build_process_report(
     running = running_scan["running"]
     expected = config["expected"]
     missing: list[dict[str, Any]] = []
+    duplicate_matches: list[dict[str, Any]] = []
+    expected_status: list[dict[str, Any]] = []
     matched_process_indexes: set[int] = set()
     for item in expected:
         match_key = item.get("_match_key")
@@ -1344,25 +1434,34 @@ def _build_process_report(
             if process.get("_match_key") == match_key
         ]
         if matches:
-            matched_process_indexes.add(matches[0][0])
+            matched_process_indexes.update(index for index, _process in matches)
+            matched_processes = [
+                _public_process_record(process) for _index, process in matches
+            ]
+            expected_row = _public_expected_record(item)
+            expected_row["match_count"] = len(matches)
+            expected_row["matched_processes"] = matched_processes
+            expected_status.append(expected_row)
+            if len(matches) > 1:
+                duplicate_row = _public_expected_record(item)
+                duplicate_row["match_count"] = len(matches)
+                duplicate_row["matched_processes"] = matched_processes
+                duplicate_matches.append(duplicate_row)
             continue
-        missing.append(
-            {
-                "name": item.get("name"),
-                "command": item.get("command"),
-                "command_key": item.get("command_key"),
-            }
-        )
+        missing_row = _public_expected_record(item)
+        missing_row["match_count"] = 0
+        missing.append(missing_row)
+        expected_row = dict(missing_row)
+        expected_row["matched_processes"] = []
+        expected_status.append(expected_row)
     unexpected = [
-        {
-            key: value
-            for key, value in process.items()
-            if key in PROCESS_REPORT_FIELDS
-        }
+        _public_process_record(process)
         for index, process in enumerate(running)
         if expected and index not in matched_process_indexes
     ]
     hard_failures = len(missing)
+    if supervisor_config:
+        hard_failures += len(duplicate_matches) + len(unexpected)
     if config.get("error"):
         hard_failures += 1
     elif supervisor_config and not expected:
@@ -1383,16 +1482,14 @@ def _build_process_report(
         "expected_total": len(expected),
         "running_live_total": len(running),
         "matched_expected": max(0, len(expected) - len(missing)),
+        "classification_source": "local_process_table_command_match",
+        "tmux_pane_ownership": "not_available_from_process_table",
+        "expected": expected_status,
         "missing_expected": missing,
+        "duplicate_configured_command_matches": duplicate_matches,
+        "extra_passivbot_live_processes": unexpected,
         "unexpected_running": unexpected,
-        "running": [
-            {
-                key: value
-                for key, value in process.items()
-                if key in PROCESS_REPORT_FIELDS
-            }
-            for process in running
-        ],
+        "running": [_public_process_record(process) for process in running],
     }
 
 
@@ -2256,14 +2353,28 @@ def summarize_live_smoke_report(
                 "expected_total",
                 "matched_expected",
                 "running_live_total",
+                "classification_source",
+                "tmux_pane_ownership",
                 "scan_error",
             )
             if key in processes
         }
         | {
             "missing_expected_count": len(processes.get("missing_expected") or []),
+            "duplicate_configured_command_matches_count": len(
+                processes.get("duplicate_configured_command_matches") or []
+            ),
+            "extra_passivbot_live_processes_count": len(
+                processes.get("extra_passivbot_live_processes") or []
+            ),
             "unexpected_running_count": len(processes.get("unexpected_running") or []),
             "missing_expected": (processes.get("missing_expected") or [])[:max_groups],
+            "duplicate_configured_command_matches": (
+                processes.get("duplicate_configured_command_matches") or []
+            )[:max_groups],
+            "extra_passivbot_live_processes": (
+                processes.get("extra_passivbot_live_processes") or []
+            )[:max_groups],
             "unexpected_running": (processes.get("unexpected_running") or [])[:max_groups],
         },
         "logs": {
@@ -2384,12 +2495,20 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
                 "expected_total",
                 "matched_expected",
                 "running_live_total",
+                "classification_source",
+                "tmux_pane_ownership",
                 "scan_error",
             )
             if key in processes
         }
         | {
             "missing_expected_count": len(processes.get("missing_expected") or []),
+            "duplicate_configured_command_matches_count": len(
+                processes.get("duplicate_configured_command_matches") or []
+            ),
+            "extra_passivbot_live_processes_count": len(
+                processes.get("extra_passivbot_live_processes") or []
+            ),
             "unexpected_running_count": len(processes.get("unexpected_running") or []),
         },
         "logs": {

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2240,12 +2240,132 @@ def test_live_smoke_report_process_status_matches_supervisor_config(
     assert report["processes"]["missing_expected"] == [
         {
             "name": "gateio_01",
+            "account": "gateio_01",
+            "config_path": "configs/forager.json",
+            "config_key": "gateio_01:configs/forager.json",
             "command": "passivbot live configs/forager.json -u gateio_01",
             "command_key": "passivbot live configs/forager.json -u gateio_01",
+            "match_count": 0,
         }
     ]
     assert report["processes"]["running"][0]["pid"] == 123
     assert report["processes"]["running"][0]["age_s"] == 42
+    assert report["processes"]["running"][0]["account"] == "binance_01"
+    assert report["processes"]["running"][0]["config_path"] == "configs/forager.json"
+
+
+def test_live_smoke_report_process_status_reports_duplicates_and_extra_live_processes(
+    tmp_path,
+    monkeypatch,
+):
+    _write_minimal_monitor_event(tmp_path / "monitor")
+    supervisor_config = tmp_path / "bots.yaml"
+    supervisor_config.write_text(
+        "\n".join(
+            [
+                "session_name: passivbot",
+                "windows:",
+                "  - window_name: binance_01",
+                "    panes:",
+                "      - passivbot live configs/forager.json -u binance_01",
+                "  - window_name: gateio_01",
+                "    panes:",
+                "      - passivbot live configs/forager.json -u gateio_01",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        smoke_report_module,
+        "_ps_process_rows",
+        lambda: (
+            [
+                (
+                    "123 1 42 S 3.5 7.0 100000 "
+                    "/root/passivbot/venv/bin/passivbot live "
+                    "configs/forager.json -u binance_01"
+                ),
+                (
+                    "124 1 44 S 1.5 3.0 90000 "
+                    "/root/passivbot/venv/bin/passivbot live "
+                    "configs/forager.json -u binance_01"
+                ),
+                (
+                    "125 1 45 S 0.5 2.0 80000 "
+                    "/root/passivbot/venv/bin/passivbot live "
+                    "configs/forager.json -u gateio_01"
+                ),
+                (
+                    "126 1 46 S 0.1 1.0 70000 "
+                    "/root/passivbot/venv/bin/passivbot live "
+                    "configs/old.json -u okx_old"
+                ),
+            ],
+            None,
+        ),
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        supervisor_config=supervisor_config,
+    )
+    summary = summarize_live_smoke_report(report, max_groups=1)
+    brief = summarize_live_smoke_report_brief(report)
+
+    assert report["ok"] is False
+    assert report["processes"]["ok"] is False
+    assert report["processes"]["hard_failures"] == 2
+    assert report["processes"]["expected_total"] == 2
+    assert report["processes"]["matched_expected"] == 2
+    assert report["processes"]["missing_expected"] == []
+    assert report["processes"]["classification_source"] == (
+        "local_process_table_command_match"
+    )
+    assert report["processes"]["tmux_pane_ownership"] == (
+        "not_available_from_process_table"
+    )
+    assert report["processes"]["duplicate_configured_command_matches"][0][
+        "account"
+    ] == "binance_01"
+    assert report["processes"]["duplicate_configured_command_matches"][0][
+        "match_count"
+    ] == 2
+    assert [
+        process["pid"]
+        for process in report["processes"]["duplicate_configured_command_matches"][0][
+            "matched_processes"
+        ]
+    ] == [123, 124]
+    assert report["processes"]["running"][0]["rss_kb"] == 100000
+    assert report["processes"]["extra_passivbot_live_processes"] == [
+        {
+            "pid": 126,
+            "ppid": 1,
+            "age_s": 46,
+            "stat": "S",
+            "cpu_pct": 0.1,
+            "mem_pct": 1.0,
+            "rss_kb": 70000,
+            "account": "okx_old",
+            "config_path": "configs/old.json",
+            "config_key": "okx_old:configs/old.json",
+            "command": (
+                "/root/passivbot/venv/bin/passivbot live configs/old.json -u okx_old"
+            ),
+            "command_key": "passivbot live configs/old.json -u okx_old",
+        }
+    ]
+    assert report["processes"]["unexpected_running"] == report["processes"][
+        "extra_passivbot_live_processes"
+    ]
+    assert summary["processes"]["duplicate_configured_command_matches_count"] == 1
+    assert summary["processes"]["extra_passivbot_live_processes_count"] == 1
+    assert len(summary["processes"]["duplicate_configured_command_matches"]) == 1
+    assert len(summary["processes"]["extra_passivbot_live_processes"]) == 1
+    assert brief["processes"]["duplicate_configured_command_matches_count"] == 1
+    assert brief["processes"]["extra_passivbot_live_processes_count"] == 1
 
 
 def test_live_smoke_report_process_scan_without_config_is_observational(

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2254,6 +2254,57 @@ def test_live_smoke_report_process_status_matches_supervisor_config(
     assert report["processes"]["running"][0]["config_path"] == "configs/forager.json"
 
 
+def test_live_smoke_report_process_status_parses_no_rss_etimes_passivbot_rows(
+    tmp_path,
+    monkeypatch,
+):
+    _write_minimal_monitor_event(tmp_path / "monitor")
+    supervisor_config = tmp_path / "bots.yaml"
+    supervisor_config.write_text(
+        "\n".join(
+            [
+                "session_name: passivbot",
+                "windows:",
+                "  - window_name: binance_01",
+                "    panes:",
+                "      - passivbot live configs/forager.json -u binance_01",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        smoke_report_module,
+        "_ps_process_rows",
+        lambda: (
+            [
+                (
+                    "123 1 42 S 3.5 7.0 "
+                    "/root/passivbot/venv/bin/passivbot live "
+                    "configs/forager.json -u binance_01"
+                )
+            ],
+            None,
+        ),
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        supervisor_config=supervisor_config,
+    )
+
+    assert report["ok"] is True
+    assert report["processes"]["running_live_total"] == 1
+    assert report["processes"]["matched_expected"] == 1
+    assert report["processes"]["running"][0]["pid"] == 123
+    assert report["processes"]["running"][0]["age_s"] == 42
+    assert "rss_kb" not in report["processes"]["running"][0]
+    assert report["processes"]["running"][0]["command_key"] == (
+        "passivbot live configs/forager.json -u binance_01"
+    )
+
+
 def test_live_smoke_report_process_status_reports_duplicates_and_extra_live_processes(
     tmp_path,
     monkeypatch,


### PR DESCRIPTION
## Scope
- Extend read-only live-smoke-report --supervisor-config process modeling to classify expected matches, missing expected commands, duplicate configured-command matches, and extra/orphan-like passivbot live processes.
- Add bounded per-process metadata from local process-table parsing, including pid/ppid, age when available, stat, CPU%, memory%, RSS KB, command, account, and config key when derivable.
- Document that classification is local command matching, not tmux pane ownership, and add a policy-only shutdown escalation ladder. No executor sends signals in this PR.

## Validation
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- git diff --check
- touched-area silent-handling scan: only pre-existing matches in src/live/smoke_report.py

Read-only operator tooling only. I did not SSH, touch VPS5, run passivbot live, stop/start/kill/restart processes, deploy, or use exchange-facing commands.