### PR TITLE
Add live config preflight tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool live-config-preflight` for read-only offline summaries
+  of risk-relevant live config facts before startup.
 - Added structured `exchange.time_sync` live events for CCXT timestamp/nonce
   recovery diagnostics without changing recovery behavior or console volume.
 - Added structured `fills.refresh_summary` startup cache-ready events for fill

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -147,7 +147,12 @@ Related detailed plans:
    `account_critical_remote_call_health` summary for a quick operator scan.
 
 7. [ ] Live config preflight/linter.
-   Status: open.
+   Status: partial. `passivbot tool live-config-preflight` now emits a
+   read-only offline JSON report for one config, covering identity hints, HSL
+   side settings, HSL signal mode, approved/ignored universe counts with
+   bounded samples, forager slot/staleness settings, and cache-related live
+   settings. It does not load API keys, contact exchanges, or enforce startup
+   policy.
 
    Add a preflight that explains risk-relevant config changes before startup:
    HSL enabled/disabled changes, HSL signal-mode changes, new approved/ignored
@@ -313,6 +318,7 @@ Related detailed plans:
 | 2026-06-26 | #3 Live restart/smoke automation | PR #699 / `4e2fcee7` | Surfaced dropped contextless unparsed attention/hard counters under `--log-window-unparsed-policy drop`; dropped attention now makes smoke `attention=true` without making stale tail fragments hard failures; VPS5 settled smoke on `d5639813` returned `ok=true`, no hard failures, all five bots matched | Safe pull/stop/start orchestration still open |
 | 2026-06-26 | #3 Live restart/smoke automation | PR #709 / `71479c61` deploy evidence | VPS5 restart smoke after the fill-cache event slice returned `ok=true`, no hard failures, all five bots matched; the restart exposed four orphaned live processes after two Ctrl+C rounds, cleared by SIGTERM before reload | Safe pull/stop/start orchestration should include shutdown timing, orphan detection, and escalation policy |
 | 2026-06-26 | #3/#14 Supervisor/process diagnostics | PR #712 / `51ba92a3` | Extended `live-smoke-report --supervisor-config` to classify expected matches, missing expected commands, duplicate configured-command process matches, and extra/orphan-like `passivbot live` processes with bounded per-process metadata; VPS5 smoke showed all five configured bots matched with zero duplicate or extra live process matches; documented the read-only command-match limitation and shutdown escalation ladder as policy only | Safe pull/stop/start orchestration remains open |
+| 2026-06-26 | #7 Live config preflight/linter | pending PR | Added `passivbot tool live-config-preflight`, a local-only JSON report for one config's risk-relevant live facts with bounded coin samples and malformed-structure errors | Config diffing, deeper cache compatibility checks, and live startup enforcement remain open |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #701 / `fcda70f5` | Added `ticker-endpoint-probe` `account_critical_health` summaries for read-only balance/positions/open-orders outcomes; VPS5 Binance probe validated the summary and exposed an open-orders shape follow-up | Lower-impact/account-only mode, exchange-aware open-orders probing, clock skew/rate-limit/fill/candle probes |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #703 / `8fefce4b` | Added `ticker-endpoint-probe --account-only`, `--skip-my-trades`, and open-orders symbol fallback; VPS5 Binance account-only probe returned account-critical total=3, succeeded=3, and smoke stayed green | Clock skew/rate-limit/fill-pagination/candle-freshness probes |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -135,6 +135,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
 - `passivbot tool monitor-web`
 - `passivbot tool monitor-tui`
 - `passivbot tool monitor-dev`
+- `passivbot tool live-config-preflight` emits a read-only offline JSON report for one live
+  config, summarizing identity hints, HSL settings, universe counts, forager slots/staleness,
+  and cache-related live settings without contacting exchanges.
 - `passivbot tool live-smoke-report` summarizes local live monitor events and text logs for
   operator smoke-test evidence. Use `--summary` for bounded event groups and log matches, or
   `--brief` for top-level counters suitable for repeated VPS smoke loops.

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -106,6 +106,10 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "tools.live_incident_bundle",
         "collect local live incident evidence into a tarball",
     ),
+    "live-config-preflight": CommandSpec(
+        "tools.live_config_preflight",
+        "read-only offline live config preflight report",
+    ),
     "live-smoke-report": CommandSpec(
         "tools.live_smoke_report",
         "summarize local live monitor events and text logs",

--- a/src/tools/live_config_preflight.py
+++ b/src/tools/live_config_preflight.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_SAMPLE_SIZE = 8
+SIDES = ("long", "short")
+CACHE_LIVE_KEYS = (
+    "defer_broad_candle_warmup",
+    "enable_archive_candle_fetch",
+    "fills_confirmation_overlap_minutes",
+    "fills_recent_overlap_minutes",
+    "force_cold_startup",
+    "max_active_candle_tail_gap_minutes",
+    "max_disk_candles_per_symbol_per_tf",
+    "max_memory_candles_per_symbol",
+    "max_ohlcv_fetches_per_minute",
+    "max_warmup_minutes",
+    "pnls_max_lookback_days",
+    "warmup_concurrency",
+    "warmup_jitter_seconds",
+    "warmup_ratio",
+)
+FORAGER_LIVE_KEYS = (
+    "forager_score_hysteresis_pct",
+    "max_forager_candle_refresh_seconds",
+    "max_forager_candle_staleness_minutes",
+)
+
+
+def _issue(
+    severity: str,
+    code: str,
+    message: str,
+    *,
+    path: str | None = None,
+) -> dict[str, Any]:
+    issue = {
+        "severity": severity,
+        "code": code,
+        "message": message,
+    }
+    if path is not None:
+        issue["path"] = path
+    return issue
+
+
+def _section(value: Any, name: str, issues: list[dict[str, Any]]) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    issues.append(
+        _issue(
+            "error",
+            "required_section_invalid",
+            f"required config section {name!r} is missing or is not an object",
+            path=name,
+        )
+    )
+    return {}
+
+
+def _selected_values(section: dict[str, Any], keys: tuple[str, ...]) -> dict[str, Any]:
+    return {key: section[key] for key in keys if key in section}
+
+
+def _string_sample(values: list[Any], *, limit: int) -> list[str]:
+    sample: list[str] = []
+    for value in values[:limit]:
+        text = str(value)
+        sample.append(text[:120] + "...<truncated>" if len(text) > 120 else text)
+    return sample
+
+
+def _coin_list_summary(value: Any, *, sample_size: int) -> dict[str, Any]:
+    if value is None:
+        return {
+            "present": False,
+            "mode": "missing",
+            "count": None,
+            "sample": [],
+            "truncated": 0,
+        }
+    if isinstance(value, str):
+        if value.lower() == "all":
+            return {
+                "present": True,
+                "mode": "all",
+                "count": None,
+                "sample": [],
+                "truncated": 0,
+            }
+        return {
+            "present": True,
+            "mode": "scalar",
+            "count": 1,
+            "sample": _string_sample([value], limit=sample_size),
+            "truncated": 0,
+        }
+    if isinstance(value, list):
+        return {
+            "present": True,
+            "mode": "list",
+            "count": len(value),
+            "sample": _string_sample(value, limit=sample_size),
+            "truncated": max(0, len(value) - sample_size),
+        }
+    return {
+        "present": True,
+        "mode": "invalid",
+        "count": None,
+        "sample": [],
+        "truncated": 0,
+    }
+
+
+def _side_coin_summary(value: Any, *, sample_size: int) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return {
+            side: _coin_list_summary(
+                value[side] if side in value else None,
+                sample_size=sample_size,
+            )
+            for side in SIDES
+        }
+    summary = _coin_list_summary(value, sample_size=sample_size)
+    return {side: dict(summary) for side in SIDES}
+
+
+def _hsl_side_report(side_config: dict[str, Any]) -> dict[str, Any]:
+    hsl = side_config["hsl"] if isinstance(side_config.get("hsl"), dict) else {}
+    tier_ratios = hsl["tier_ratios"] if isinstance(hsl.get("tier_ratios"), dict) else {}
+    return {
+        "present": bool(hsl),
+        "enabled": hsl.get("enabled"),
+        "red_threshold": hsl.get("red_threshold"),
+        "cooldown_minutes_after_red": hsl.get("cooldown_minutes_after_red"),
+        "no_restart_drawdown_threshold": hsl.get("no_restart_drawdown_threshold"),
+        "ema_span_minutes": hsl.get("ema_span_minutes"),
+        "tier_ratios": {
+            key: tier_ratios[key]
+            for key in ("yellow", "orange")
+            if key in tier_ratios
+        },
+        "orange_tier_mode": hsl.get("orange_tier_mode"),
+        "panic_close_order_type": hsl.get("panic_close_order_type"),
+    }
+
+
+def _forager_side_report(side_config: dict[str, Any]) -> dict[str, Any]:
+    risk = side_config["risk"] if isinstance(side_config.get("risk"), dict) else {}
+    forager = (
+        side_config["forager"]
+        if isinstance(side_config.get("forager"), dict)
+        else {}
+    )
+    report = {
+        "n_positions": risk.get("n_positions"),
+        "forager_present": bool(forager),
+    }
+    if forager:
+        report["settings"] = {
+            key: forager[key]
+            for key in (
+                "volatility_ema_span_1m",
+                "volume_drop_pct",
+                "volume_ema_span_1m",
+            )
+            if key in forager
+        }
+    return report
+
+
+def _identity_report(config: dict[str, Any], live: dict[str, Any]) -> dict[str, Any]:
+    user = live.get("user")
+    exchange = live.get("exchange")
+    user_exchange_hint = None
+    if isinstance(user, str) and "_" in user:
+        user_exchange_hint = user.split("_", 1)[0]
+    backtest = config["backtest"] if isinstance(config.get("backtest"), dict) else {}
+    exchanges = (
+        backtest["exchanges"]
+        if isinstance(backtest.get("exchanges"), list)
+        else None
+    )
+    return {
+        "account": user,
+        "user": user,
+        "exchange": exchange,
+        "user_exchange_hint": user_exchange_hint,
+        "backtest_exchanges": exchanges,
+        "exchange_source": "live.exchange" if exchange is not None else "not_in_config",
+    }
+
+
+def _collect_shape_warnings(
+    *,
+    approved: dict[str, Any],
+    ignored: dict[str, Any],
+    issues: list[dict[str, Any]],
+) -> None:
+    for group_name, group in (("approved_coins", approved), ("ignored_coins", ignored)):
+        for side in SIDES:
+            if group[side]["mode"] == "invalid":
+                issues.append(
+                    _issue(
+                        "warning",
+                        "coin_list_shape_invalid",
+                        (
+                            f"live.{group_name}.{side} is not a list, 'all', "
+                            "scalar, or missing"
+                        ),
+                        path=f"live.{group_name}.{side}",
+                    )
+                )
+
+
+def build_live_config_preflight_report(
+    config_path: str | Path,
+    *,
+    sample_size: int = DEFAULT_SAMPLE_SIZE,
+) -> dict[str, Any]:
+    path = Path(config_path).expanduser()
+    issues: list[dict[str, Any]] = []
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {
+            "ok": False,
+            "config_path": str(path),
+            "issues": [
+                _issue(
+                    "error",
+                    "read_failed",
+                    f"could not read config: {exc}",
+                    path=str(path),
+                )
+            ],
+        }
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return {
+            "ok": False,
+            "config_path": str(path),
+            "issues": [
+                _issue(
+                    "error",
+                    "json_decode_failed",
+                    f"invalid JSON at line {exc.lineno} column {exc.colno}: {exc.msg}",
+                    path=str(path),
+                )
+            ],
+        }
+    if not isinstance(parsed, dict):
+        return {
+            "ok": False,
+            "config_path": str(path),
+            "issues": [
+                _issue("error", "config_root_invalid", "config root must be a JSON object")
+            ],
+        }
+
+    live = _section(parsed["live"] if "live" in parsed else None, "live", issues)
+    bot = _section(parsed["bot"] if "bot" in parsed else None, "bot", issues)
+    side_configs = {
+        side: bot[side] if isinstance(bot.get(side), dict) else {}
+        for side in SIDES
+    }
+    for side, side_config in side_configs.items():
+        if not side_config and bot:
+            issues.append(
+                _issue(
+                    "warning",
+                    "side_config_missing",
+                    f"bot.{side} is missing or is not an object",
+                    path=f"bot.{side}",
+                )
+            )
+
+    sample_size = max(0, int(sample_size))
+    approved = _side_coin_summary(live.get("approved_coins"), sample_size=sample_size)
+    ignored = _side_coin_summary(live.get("ignored_coins"), sample_size=sample_size)
+    _collect_shape_warnings(approved=approved, ignored=ignored, issues=issues)
+
+    forager_by_side = {
+        side: _forager_side_report(side_config)
+        for side, side_config in side_configs.items()
+    }
+    n_positions_values = [
+        value
+        for value in (forager_by_side[side]["n_positions"] for side in SIDES)
+        if isinstance(value, (int, float))
+    ]
+    severity_counts = Counter(issue["severity"] for issue in issues)
+    return {
+        "ok": "error" not in severity_counts,
+        "config_path": str(path),
+        "config_version": parsed.get("config_version"),
+        "identity": _identity_report(parsed, live),
+        "hsl": {
+            "signal_mode": live.get("hsl_signal_mode"),
+            "cooldown_position_policy": live.get("hsl_position_during_cooldown_policy"),
+            "sides": {
+                side: _hsl_side_report(side_config)
+                for side, side_config in side_configs.items()
+            },
+        },
+        "universe": {
+            "approved_coins": approved,
+            "ignored_coins": ignored,
+        },
+        "forager": {
+            "live_settings": _selected_values(live, FORAGER_LIVE_KEYS),
+            "sides": forager_by_side,
+            "total_configured_n_positions": sum(float(value) for value in n_positions_values),
+        },
+        "cache": {
+            "live_settings": _selected_values(live, CACHE_LIVE_KEYS),
+        },
+        "issues": issues,
+        "summary": {
+            "error_count": int(severity_counts["error"]),
+            "warning_count": int(severity_counts["warning"]),
+        },
+        "notes": [
+            "offline_read_only_report",
+            "does_not_load_credentials_or_contact_exchanges",
+            "does_not_enforce_live_startup_policy",
+        ],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="passivbot tool live-config-preflight",
+        description="Read-only offline preflight report for risk-relevant live config facts.",
+    )
+    parser.add_argument("config_path", help="Live config JSON file to inspect.")
+    parser.add_argument(
+        "--sample-size",
+        type=int,
+        default=DEFAULT_SAMPLE_SIZE,
+        help="Maximum approved/ignored coin sample size per side.",
+    )
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="Emit compact single-line JSON.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    report = build_live_config_preflight_report(
+        args.config_path,
+        sample_size=int(args.sample_size),
+    )
+    print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_live_config_preflight.py
+++ b/tests/test_live_config_preflight.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+from passivbot_cli import main as cli_main
+from tools import live_config_preflight
+
+
+def _write_config(path, config):
+    path.write_text(json.dumps(config, sort_keys=True), encoding="utf-8")
+
+
+def _sample_config() -> dict:
+    return {
+        "config_version": "v8.0.0",
+        "backtest": {"exchanges": ["binance"]},
+        "live": {
+            "user": "binance_01",
+            "hsl_signal_mode": "unified",
+            "hsl_position_during_cooldown_policy": "panic",
+            "approved_coins": {
+                "long": ["BTC", "ETH", "SOL", "XMR"],
+                "short": ["BTC"],
+            },
+            "ignored_coins": {"long": ["DOGE"], "short": []},
+            "max_forager_candle_staleness_minutes": 12,
+            "max_forager_candle_refresh_seconds": 45,
+            "forager_score_hysteresis_pct": 0.02,
+            "force_cold_startup": False,
+            "max_warmup_minutes": 30,
+            "pnls_max_lookback_days": 7,
+            "api_key": "super-secret-api-key",
+        },
+        "bot": {
+            "long": {
+                "risk": {"n_positions": 3},
+                "forager": {"volume_drop_pct": 0.02},
+                "hsl": {
+                    "enabled": True,
+                    "red_threshold": 0.05,
+                    "cooldown_minutes_after_red": 60,
+                    "no_restart_drawdown_threshold": 0.08,
+                    "ema_span_minutes": 120,
+                    "tier_ratios": {"yellow": 0.5, "orange": 0.75},
+                    "orange_tier_mode": "tp_only_with_active_entry_cancellation",
+                    "panic_close_order_type": "limit",
+                },
+            },
+            "short": {
+                "risk": {"n_positions": 1},
+                "hsl": {
+                    "enabled": False,
+                    "red_threshold": 0.04,
+                    "cooldown_minutes_after_red": 30,
+                },
+            },
+        },
+    }
+
+
+def test_live_config_preflight_reports_risk_relevant_shape_and_bounds_symbols(tmp_path):
+    config_path = tmp_path / "live.json"
+    _write_config(config_path, _sample_config())
+
+    report = live_config_preflight.build_live_config_preflight_report(
+        config_path,
+        sample_size=2,
+    )
+    rendered = json.dumps(report, sort_keys=True)
+
+    assert report["ok"] is True
+    assert report["identity"] == {
+        "account": "binance_01",
+        "backtest_exchanges": ["binance"],
+        "exchange": None,
+        "exchange_source": "not_in_config",
+        "user": "binance_01",
+        "user_exchange_hint": "binance",
+    }
+    assert report["hsl"]["signal_mode"] == "unified"
+    assert report["hsl"]["sides"]["long"]["enabled"] is True
+    assert report["hsl"]["sides"]["long"]["red_threshold"] == 0.05
+    assert report["hsl"]["sides"]["short"]["enabled"] is False
+    assert report["universe"]["approved_coins"]["long"] == {
+        "count": 4,
+        "mode": "list",
+        "present": True,
+        "sample": ["BTC", "ETH"],
+        "truncated": 2,
+    }
+    assert report["forager"]["sides"]["long"]["n_positions"] == 3
+    assert report["forager"]["total_configured_n_positions"] == 4.0
+    assert report["cache"]["live_settings"]["pnls_max_lookback_days"] == 7
+    assert "super-secret-api-key" not in rendered
+    assert "api_key" not in rendered
+
+
+def test_live_config_preflight_handles_all_and_invalid_coin_shapes(tmp_path):
+    config = _sample_config()
+    config["live"]["approved_coins"] = "all"
+    config["live"]["ignored_coins"] = {"long": {"BTC": True}, "short": []}
+    config_path = tmp_path / "live.json"
+    _write_config(config_path, config)
+
+    report = live_config_preflight.build_live_config_preflight_report(config_path)
+
+    assert report["ok"] is True
+    assert report["universe"]["approved_coins"]["long"]["mode"] == "all"
+    assert report["universe"]["approved_coins"]["short"]["mode"] == "all"
+    assert report["universe"]["ignored_coins"]["long"]["mode"] == "invalid"
+    assert report["summary"] == {"error_count": 0, "warning_count": 1}
+    assert report["issues"][0]["code"] == "coin_list_shape_invalid"
+
+
+def test_live_config_preflight_malformed_structure_returns_nonzero(tmp_path, capsys):
+    config_path = tmp_path / "bad.json"
+    _write_config(config_path, {"live": []})
+
+    assert live_config_preflight.main([str(config_path), "--compact"]) == 1
+    report = json.loads(capsys.readouterr().out)
+
+    assert report["ok"] is False
+    assert [issue["code"] for issue in report["issues"]] == [
+        "required_section_invalid",
+        "required_section_invalid",
+    ]
+    assert "required config section" in report["issues"][0]["message"]
+
+
+def test_live_config_preflight_invalid_json_returns_nonzero(tmp_path, capsys):
+    config_path = tmp_path / "bad.json"
+    config_path.write_text("{not-json", encoding="utf-8")
+
+    assert live_config_preflight.main([str(config_path)]) == 1
+    report = json.loads(capsys.readouterr().out)
+
+    assert report["ok"] is False
+    assert report["issues"][0]["code"] == "json_decode_failed"
+
+
+def test_live_config_preflight_rejects_negative_sample_size(tmp_path):
+    config_path = tmp_path / "live.json"
+    _write_config(config_path, _sample_config())
+
+    report = live_config_preflight.build_live_config_preflight_report(
+        config_path,
+        sample_size=-1,
+    )
+
+    assert report["universe"]["approved_coins"]["long"]["sample"] == []
+    assert report["universe"]["approved_coins"]["long"]["truncated"] == 4
+
+
+def test_live_config_preflight_help_exits_cleanly(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_config_preflight.main(["--help"])
+
+    assert exc_info.value.code == 0
+    assert "live-config-preflight" in capsys.readouterr().out
+
+
+def test_live_config_preflight_tool_dispatch_forwards_module_and_prog(monkeypatch):
+    captured = {}
+
+    def fake_invoke_module_main(module_name):
+        captured["module_name"] = module_name
+        captured["argv"] = sys.argv[:]
+        captured["prog_env"] = os.environ.get("PASSIVBOT_CLI_PROG")
+        return True, 0
+
+    monkeypatch.setattr(cli_main, "_invoke_module_main", fake_invoke_module_main)
+    monkeypatch.setattr(cli_main, "_missing_full_install_markers", lambda: [])
+
+    assert (
+        cli_main.main(
+            ["tool", "live-config-preflight", "configs/live.json", "--compact"]
+        )
+        == 0
+    )
+
+    assert captured["module_name"] == "tools.live_config_preflight"
+    assert captured["argv"] == [
+        "passivbot tool live-config-preflight",
+        "configs/live.json",
+        "--compact",
+    ]
+    assert captured["prog_env"] == "passivbot tool live-config-preflight"


### PR DESCRIPTION
## Scope
- Add passivbot tool live-config-preflight as a read-only offline JSON report for one config file.
- Report identity hints, HSL signal and per-side settings, approved/ignored universe counts with bounded samples, forager slot/staleness settings, and cache-related live settings when present.
- Return nonzero JSON errors for unreadable, invalid JSON, or malformed required top-level config structure.
- Wire the tool through passivbot tool dispatch and update backlog item #7 status/work log.

## Validation
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_config_preflight.py -q
- git diff --check
- touched-file silent-handling scan: no matches

Read-only local tooling only. No SSH, no VPS5 access, no live bot start/stop/restart, no process control, no deploys, and no exchange/account probes.