### PR TITLE
Summarize shutdown events in live smoke reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable user-facing changes will be documented in this file.
 
 - Added `passivbot tool live-config-preflight` for read-only offline summaries
   of risk-relevant live config facts before startup.
+- Added shutdown-event summaries to `passivbot tool live-smoke-report`, including
+  `bot.stopping`, shutdown stage, and `bot.stopped` events in full, summary, and
+  brief reports.
 - Added structured `exchange.time_sync` live events for CCXT timestamp/nonce
   recovery diagnostics without changing recovery behavior or console volume.
 - Added structured `fills.refresh_summary` startup cache-ready events for fill

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -141,6 +141,8 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
 - `passivbot tool live-smoke-report` summarizes local live monitor events and text logs for
   operator smoke-test evidence. Use `--summary` for bounded event groups and log matches, or
   `--brief` for top-level counters suitable for repeated VPS smoke loops.
+  Existing structured shutdown events are also summarized as `shutdown_events`,
+  so recent Ctrl+C/restart behavior can be inspected from the same smoke output.
   With `--supervisor-config`, the read-only process section compares configured
   `passivbot live` commands to the local process table and reports matched, missing,
   duplicate-command, and extra/orphan-like live processes. This does not prove tmux pane

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -62,6 +62,7 @@ ACCOUNT_CRITICAL_REMOTE_CALL_SURFACES = frozenset(
     }
 )
 RISK_EVENT_GROUP_LIMIT = 20
+SHUTDOWN_EVENT_GROUP_LIMIT = 20
 PROBLEM_EVENT_GROUP_LIMIT = 20
 RISK_EVENT_TYPES = {
     EventTypes.RISK_MODE_CHANGED,
@@ -70,6 +71,11 @@ RISK_EVENT_TYPES = {
     EventTypes.HSL_RED_TRIGGERED,
     EventTypes.HSL_COOLDOWN_STARTED,
     EventTypes.HSL_COOLDOWN_ENDED,
+}
+SHUTDOWN_EVENT_TYPES = {
+    EventTypes.BOT_STOPPING,
+    EventTypes.BOT_SHUTDOWN_STAGE,
+    EventTypes.BOT_STOPPED,
 }
 REMOTE_CALL_TIMING_EVENT_TYPES = {
     EventTypes.REMOTE_CALL_SUCCEEDED,
@@ -1049,6 +1055,146 @@ def _summarize_risk_events(
     }
 
 
+def _compact_shutdown_event_data(live_event: dict[str, Any]) -> dict[str, Any]:
+    data = live_event.get("data")
+    if not isinstance(data, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for key in (
+        "reason",
+        "stage",
+        "elapsed_s",
+        "task_count",
+        "timeout_s",
+        "cancel_timeout_s",
+        "threshold_s",
+        "closed",
+        "inline",
+        "error",
+    ):
+        if key not in data or data.get(key) is None:
+            continue
+        value = data.get(key)
+        if isinstance(value, str):
+            out[key] = _redact_log_text(value, max_len=240)
+        elif isinstance(value, (bool, int, float)):
+            out[key] = value
+        else:
+            compact = _compact_problem_event_data_value(value)
+            if compact not in (None, "", [], {}):
+                out[key] = compact
+    return out
+
+
+def _shutdown_event_group(
+    *,
+    bot_key: str,
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+    path: Path,
+    line_no: int,
+) -> dict[str, Any]:
+    ids = _event_ids(live_event)
+    message = live_event.get("message")
+    return {
+        "bot": bot_key,
+        "event_type": live_event.get("event_type") or row.get("kind"),
+        "reason_code": live_event.get("reason_code"),
+        "status": live_event.get("status"),
+        "level": live_event.get("level"),
+        "component": live_event.get("component"),
+        "count": 1,
+        "latest_ts": row.get("ts"),
+        "latest_seq": row.get("seq"),
+        "latest_path": str(path),
+        "latest_line": int(line_no),
+        "latest_message": (
+            _redact_log_text(str(message), max_len=240)
+            if message not in (None, "")
+            else None
+        ),
+        "latest_data": _compact_shutdown_event_data(live_event),
+        "latest_ids": {
+            key: ids.get(key)
+            for key in ("cycle_id", "snapshot_id", "plan_id", "action_id")
+            if ids.get(key) is not None
+        },
+    }
+
+
+def _merge_shutdown_event_group(
+    groups: dict[tuple[Any, ...], dict[str, Any]],
+    group: dict[str, Any],
+) -> None:
+    key = (
+        group.get("bot"),
+        group.get("event_type"),
+        group.get("reason_code"),
+        group.get("status"),
+    )
+    existing = groups.get(key)
+    if existing is None:
+        groups[key] = group
+        return
+    existing["count"] = int(existing.get("count", 0)) + 1
+    current_key = _sort_event_position_key(
+        ts=group.get("latest_ts"),
+        seq=group.get("latest_seq"),
+        path=group.get("latest_path") or "",
+        line_no=int(group.get("latest_line") or 0),
+    )
+    existing_key = _sort_event_position_key(
+        ts=existing.get("latest_ts"),
+        seq=existing.get("latest_seq"),
+        path=existing.get("latest_path") or "",
+        line_no=int(existing.get("latest_line") or 0),
+    )
+    if current_key > existing_key:
+        for field in (
+            "level",
+            "component",
+            "latest_ts",
+            "latest_seq",
+            "latest_path",
+            "latest_line",
+            "latest_message",
+            "latest_data",
+            "latest_ids",
+        ):
+            existing[field] = group.get(field)
+
+
+def _summarize_shutdown_events(
+    groups: dict[tuple[Any, ...], dict[str, Any]],
+    event_type_counts: Counter[str],
+) -> dict[str, Any]:
+    ordered = sorted(
+        groups.values(),
+        key=lambda item: (
+            -int(_non_negative_int(item.get("latest_ts")) or 0),
+            str(item.get("bot") or ""),
+            str(item.get("event_type") or ""),
+            str(item.get("reason_code") or ""),
+            str(item.get("status") or ""),
+        ),
+    )
+    compact_groups = [
+        {
+            key: value
+            for key, value in group.items()
+            if key not in {"latest_path", "latest_line", "latest_seq"}
+            and value not in (None, {}, [])
+        }
+        for group in ordered[:SHUTDOWN_EVENT_GROUP_LIMIT]
+    ]
+    return {
+        "total": sum(int(group.get("count", 0)) for group in groups.values()),
+        "groups_truncated": len(ordered) > SHUTDOWN_EVENT_GROUP_LIMIT,
+        "event_types": dict(event_type_counts.most_common()),
+        "groups": compact_groups,
+    }
+
+
 def _redact_log_text(value: str, *, max_len: int = 500) -> str:
     text = str(value)
     text = SENSITIVE_LOG_HEADER_PATTERN.sub(r"\1\2[redacted]", text)
@@ -1712,6 +1858,8 @@ def _scan_events(
     remote_call_timing_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     risk_event_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     risk_event_type_counts: Counter[str] = Counter()
+    shutdown_event_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
+    shutdown_event_type_counts: Counter[str] = Counter()
     problem_event_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
 
     for path in files:
@@ -1802,6 +1950,18 @@ def _scan_events(
                                 line_no=line_no,
                             ),
                         )
+                    if event_type in SHUTDOWN_EVENT_TYPES:
+                        shutdown_event_type_counts[str(event_type)] += 1
+                        _merge_shutdown_event_group(
+                            shutdown_event_groups,
+                            _shutdown_event_group(
+                                bot_key=bot_key,
+                                row=row,
+                                live_event=live_event,
+                                path=path,
+                                line_no=line_no,
+                            ),
+                        )
                     level = live_event.get("level")
                     if level:
                         bot["levels"][str(level).lower()] += 1
@@ -1879,6 +2039,10 @@ def _scan_events(
         "risk_events": _summarize_risk_events(
             risk_event_groups,
             risk_event_type_counts,
+        ),
+        "shutdown_events": _summarize_shutdown_events(
+            shutdown_event_groups,
+            shutdown_event_type_counts,
         ),
         "event_window": _event_window_report(
             since_ms=since_ms,
@@ -2186,6 +2350,12 @@ def build_live_smoke_report(
                 "event_types": {},
                 "groups": [],
             },
+            "shutdown_events": {
+                "total": 0,
+                "groups_truncated": False,
+                "event_types": {},
+                "groups": [],
+            },
             "event_window": _event_window_report(
                 since_ms=since_ms,
                 until_ms=until_ms,
@@ -2249,6 +2419,7 @@ def build_live_smoke_report(
         ],
         "remote_call_timings": event_scan["remote_call_timings"],
         "risk_events": event_scan["risk_events"],
+        "shutdown_events": event_scan["shutdown_events"],
         "event_window": event_scan["event_window"],
         "problem_events": event_scan["problem_events"],
         "problem_event_groups": event_scan["problem_event_groups"],
@@ -2316,6 +2487,11 @@ def summarize_live_smoke_report(
     )
     risk_events = (
         report.get("risk_events") if isinstance(report.get("risk_events"), dict) else {}
+    )
+    shutdown_events = (
+        report.get("shutdown_events")
+        if isinstance(report.get("shutdown_events"), dict)
+        else {}
     )
 
     return {
@@ -2412,6 +2588,10 @@ def summarize_live_smoke_report(
             limit=max_groups,
         ),
         "risk_events": _summary_limited_groups(risk_events, limit=max_groups),
+        "shutdown_events": _summary_limited_groups(
+            shutdown_events,
+            limit=max_groups,
+        ),
     }
 
 
@@ -2452,6 +2632,11 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
     monitor = report.get("monitor") if isinstance(report.get("monitor"), dict) else {}
     risk_events = (
         report.get("risk_events") if isinstance(report.get("risk_events"), dict) else {}
+    )
+    shutdown_events = (
+        report.get("shutdown_events")
+        if isinstance(report.get("shutdown_events"), dict)
+        else {}
     )
     event_window = (
         report.get("event_window") if isinstance(report.get("event_window"), dict) else {}
@@ -2537,5 +2722,9 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         "risk_events": {
             "total": _count_value(risk_events.get("total")),
             "event_types": risk_events.get("event_types") or {},
+        },
+        "shutdown_events": {
+            "total": _count_value(shutdown_events.get("total")),
+            "event_types": shutdown_events.get("event_types") or {},
         },
     }

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1163,6 +1163,82 @@ def test_live_smoke_report_summarizes_startup_phase_baselines(tmp_path):
     assert "TOKEN123" not in latest_details
 
 
+def test_live_smoke_report_summarizes_shutdown_events(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.stopping",
+                seq=1,
+                ts=1000,
+                status="started",
+                reason_code="shutdown_gracefully",
+                data={"reason": "shutdown_gracefully"},
+            ),
+            _monitor_row(
+                event_type="bot.shutdown.stage",
+                seq=2,
+                ts=2000,
+                status="degraded",
+                level="warning",
+                reason_code="maintainers_timeout",
+                data={
+                    "stage": "maintainers_timeout",
+                    "elapsed_s": 6.25,
+                    "task_count": 4,
+                    "timeout_s": 5.0,
+                    "error": "api_key=AKIA123 Authorization: Bearer TOKEN123",
+                },
+            ),
+            _monitor_row(
+                event_type="bot.stopped",
+                seq=3,
+                ts=3000,
+                status="succeeded",
+                reason_code="shutdown_gracefully",
+                data={"reason": "shutdown_gracefully", "elapsed_s": 7.5},
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    summary = summarize_live_smoke_report(report, max_groups=2)
+    brief = summarize_live_smoke_report_brief(report)
+
+    assert report["ok"] is True
+    assert report["attention"] is True
+    assert report["shutdown_events"]["total"] == 3
+    assert report["shutdown_events"]["event_types"] == {
+        "bot.stopping": 1,
+        "bot.shutdown.stage": 1,
+        "bot.stopped": 1,
+    }
+    assert [group["event_type"] for group in report["shutdown_events"]["groups"]] == [
+        "bot.stopped",
+        "bot.shutdown.stage",
+        "bot.stopping",
+    ]
+    stage_group = report["shutdown_events"]["groups"][1]
+    assert stage_group["reason_code"] == "maintainers_timeout"
+    assert stage_group["status"] == "degraded"
+    assert stage_group["latest_data"]["elapsed_s"] == 6.25
+    assert stage_group["latest_data"]["task_count"] == 4
+    assert "AKIA123" not in stage_group["latest_data"]["error"]
+    assert "TOKEN123" not in stage_group["latest_data"]["error"]
+    assert summary["shutdown_events"]["total"] == 3
+    assert summary["shutdown_events"]["groups_truncated"] is True
+    assert len(summary["shutdown_events"]["groups"]) == 2
+    assert brief["shutdown_events"] == {
+        "total": 3,
+        "event_types": {
+            "bot.stopping": 1,
+            "bot.shutdown.stage": 1,
+            "bot.stopped": 1,
+        },
+    }
+
+
 def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
     events_dir = tmp_path / "monitor" / "bybit" / "bybit_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- add passive `shutdown_events` summaries to `live-smoke-report` from existing `bot.stopping`, `bot.shutdown.stage`, and `bot.stopped` live events
- include the shutdown summary in full, `--summary`, and `--brief` projections
- document the smoke-report output and changelog entry

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_smoke_report.py` — 37 passed
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_incident_bundle.py` — 6 passed
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/live/smoke_report.py` — passed
- `git diff --check` — passed

Note: an optional `tests/test_passivbot_cli.py::test_live_smoke_report_tool_has_prog` attempt was not usable in this worktree because collection hit the existing Rust extension source-stamp guard before collecting the requested test (`Loaded Rust extension does not match current Rust sources`). No Rust code was changed.