### PR TITLE
Add HSL startup preview tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool hsl-startup-preview` for read-only offline HSL
+  startup previews from config and local monitor events, with explicit
+  unavailable fields for current drawdown and panic-order prediction.
 - Added `passivbot tool live-config-preflight` for read-only offline summaries
   of risk-relevant live config facts before startup.
 - Added shutdown-event summaries to `passivbot tool live-smoke-report`, including

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -162,12 +162,22 @@ Related detailed plans:
    trading decisions.
 
 8. [ ] HSL dry-run preview for startup.
-   Status: open.
+   Status: partial. `passivbot tool hsl-startup-preview` now emits a read-only
+   offline JSON report for one config plus optional local monitor event
+   artifacts. It reports configured HSL settings, latest observed local HSL
+   status/cooldown/drawdown-to-red fields when present, and explicitly marks
+   fresh current drawdown and startup panic-order prediction unavailable instead
+   of fabricating them.
 
    Add a non-trading preview that reconstructs current HSL state and reports
    which symbols are green/yellow/red, cooldown status, current drawdown to red,
    and whether startup would emit panic orders. This would make risky restarts
    with changed HSL configs easier to reason about before live execution.
+
+   Work log:
+   - 2026-06-26: Added first-slice local/offline `hsl-startup-preview` tool.
+     Remaining gap: safe full startup replay from local fill/account artifacts
+     without exchange access.
 
 9. [ ] Reason-code registry.
    Status: partial. Initial registry slice merged in PR #645.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -138,6 +138,11 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
 - `passivbot tool live-config-preflight` emits a read-only offline JSON report for one live
   config, summarizing identity hints, HSL settings, universe counts, forager slots/staleness,
   and cache-related live settings without contacting exchanges.
+- `passivbot tool hsl-startup-preview` emits a read-only offline JSON preview for one live
+  config plus optional local monitor events. It reports configured HSL settings and latest
+  local HSL status/cooldown observations when present, while explicitly marking current
+  drawdown and startup panic-order prediction unavailable unless a future slice adds safe
+  local replay inputs.
 - `passivbot tool live-smoke-report` summarizes local live monitor events and text logs for
   operator smoke-test evidence. Use `--summary` for bounded event groups and log matches, or
   `--brief` for top-level counters suitable for repeated VPS smoke loops.

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -110,6 +110,10 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "tools.live_config_preflight",
         "read-only offline live config preflight report",
     ),
+    "hsl-startup-preview": CommandSpec(
+        "tools.hsl_startup_preview",
+        "read-only offline HSL startup preview",
+    ),
     "live-smoke-report": CommandSpec(
         "tools.live_smoke_report",
         "summarize local live monitor events and text logs",

--- a/src/tools/hsl_startup_preview.py
+++ b/src/tools/hsl_startup_preview.py
@@ -1,0 +1,563 @@
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from live.event_bus import EventTypes, LIVE_EVENT_MONITOR_PAYLOAD_KEY
+from live.event_query import discover_event_files
+
+
+SIDES = ("long", "short")
+HSL_EVENT_TYPES = {
+    EventTypes.HSL_STATUS,
+    EventTypes.HSL_RED_TRIGGERED,
+    EventTypes.HSL_COOLDOWN_STARTED,
+    EventTypes.HSL_COOLDOWN_ENDED,
+}
+HSL_DATA_KEYS = (
+    "signal_mode",
+    "tier",
+    "previous_tier",
+    "drawdown_score",
+    "drawdown_raw",
+    "drawdown_ema",
+    "dist_to_red",
+    "red_threshold",
+    "cooldown_until_ms",
+    "cooldown_remaining",
+    "cooldown_remaining_seconds",
+    "last_red_ts",
+    "pending_red_since_ms",
+    "slot_budget",
+    "realized_pnl",
+    "peak_realized_pnl",
+    "unrealized_pnl",
+)
+
+
+def _issue(
+    severity: str,
+    code: str,
+    message: str,
+    *,
+    path: str | None = None,
+) -> dict[str, Any]:
+    issue = {
+        "severity": severity,
+        "code": code,
+        "message": message,
+    }
+    if path is not None:
+        issue["path"] = path
+    return issue
+
+
+def _unavailable(reason: str) -> dict[str, Any]:
+    return {
+        "available": False,
+        "reason": reason,
+    }
+
+
+def _load_config(config_path: str | Path) -> tuple[dict[str, Any] | None, list[dict[str, Any]]]:
+    path = Path(config_path).expanduser()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, [
+            _issue(
+                "error",
+                "config_read_failed",
+                f"could not read config: {exc}",
+                path=str(path),
+            )
+        ]
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return None, [
+            _issue(
+                "error",
+                "config_json_decode_failed",
+                f"invalid JSON at line {exc.lineno} column {exc.colno}: {exc.msg}",
+                path=str(path),
+            )
+        ]
+    if not isinstance(parsed, dict):
+        return None, [
+            _issue("error", "config_root_invalid", "config root must be a JSON object")
+        ]
+    return parsed, []
+
+
+def _section(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _hsl_side_config(config: dict[str, Any], pside: str) -> dict[str, Any]:
+    bot = _section(config.get("bot"))
+    side_config = _section(bot.get(pside))
+    hsl = _section(side_config.get("hsl"))
+    tier_ratios = _section(hsl.get("tier_ratios"))
+    return {
+        "present": bool(hsl),
+        "enabled": hsl.get("enabled"),
+        "red_threshold": hsl.get("red_threshold"),
+        "cooldown_minutes_after_red": hsl.get("cooldown_minutes_after_red"),
+        "no_restart_drawdown_threshold": hsl.get("no_restart_drawdown_threshold"),
+        "ema_span_minutes": hsl.get("ema_span_minutes"),
+        "tier_ratios": {
+            key: tier_ratios[key]
+            for key in ("yellow", "orange")
+            if key in tier_ratios
+        },
+        "orange_tier_mode": hsl.get("orange_tier_mode"),
+        "panic_close_order_type": hsl.get("panic_close_order_type"),
+    }
+
+
+def _config_report(config: dict[str, Any]) -> dict[str, Any]:
+    live = _section(config.get("live"))
+    return {
+        "config_version": config.get("config_version"),
+        "identity": {
+            "user": live.get("user"),
+            "account": live.get("user"),
+            "exchange": live.get("exchange"),
+        },
+        "hsl": {
+            "signal_mode": live.get("hsl_signal_mode"),
+            "cooldown_position_policy": live.get("hsl_position_during_cooldown_policy"),
+            "sides": {pside: _hsl_side_config(config, pside) for pside in SIDES},
+        },
+    }
+
+
+def _open_text(path: Path):
+    if path.name.endswith(".gz"):
+        return gzip.open(path, "rt", encoding="utf-8", errors="replace")
+    return open(path, "r", encoding="utf-8", errors="replace")
+
+
+def _live_event_payload(row: dict[str, Any]) -> dict[str, Any] | None:
+    payload = row.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    live_event = payload.get(LIVE_EVENT_MONITOR_PAYLOAD_KEY)
+    return live_event if isinstance(live_event, dict) else None
+
+
+def _event_sort_key(record: dict[str, Any]) -> tuple[int, int, str, int]:
+    return (
+        int(record.get("latest_ts") or -1),
+        int(record.get("latest_seq") or -1),
+        str(record.get("latest_path") or ""),
+        int(record.get("latest_line") or 0),
+    )
+
+
+def _bot_key(live_event: dict[str, Any], row: dict[str, Any]) -> str:
+    exchange = live_event.get("exchange") or row.get("exchange") or "unknown_exchange"
+    user = live_event.get("user") or row.get("user") or "unknown_user"
+    return f"{exchange}/{user}"
+
+
+def _bounded_hsl_data(live_event: dict[str, Any]) -> dict[str, Any]:
+    data = live_event.get("data")
+    payload = data if isinstance(data, dict) else {}
+    return {key: payload[key] for key in HSL_DATA_KEYS if payload.get(key) is not None}
+
+
+def _target_key(record: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(record.get("bot") or "unknown_exchange/unknown_user"),
+        str(record.get("pside") or "unknown_pside"),
+        str(record.get("symbol") or ""),
+    )
+
+
+def _status_from_event(record: dict[str, Any]) -> str:
+    data = record.get("latest_data") if isinstance(record.get("latest_data"), dict) else {}
+    tier = data.get("tier")
+    if tier not in (None, ""):
+        return str(tier)
+    reason_code = record.get("reason_code")
+    if reason_code in {"green", "yellow", "orange", "red", "cooldown_active"}:
+        return "red" if reason_code == "cooldown_active" else str(reason_code)
+    event_type = record.get("event_type")
+    if event_type in {EventTypes.HSL_RED_TRIGGERED, EventTypes.HSL_COOLDOWN_STARTED}:
+        return "red"
+    return "unknown"
+
+
+def _cooldown_preview(data: dict[str, Any], *, now_ms: int) -> dict[str, Any]:
+    cooldown_until_ms = data.get("cooldown_until_ms")
+    remaining_seconds = data.get("cooldown_remaining_seconds")
+    if cooldown_until_ms is None and remaining_seconds is None and data.get("cooldown_remaining") is None:
+        return _unavailable("no cooldown fields were present in the latest local HSL event")
+    out: dict[str, Any] = {
+        "available": True,
+        "source": "latest_local_hsl_event",
+    }
+    if cooldown_until_ms is not None:
+        try:
+            until_ms = int(cooldown_until_ms)
+            out["cooldown_until_ms"] = until_ms
+            out["remaining_seconds_at_preview"] = max(0.0, (until_ms - int(now_ms)) / 1000.0)
+            out["status_at_preview"] = "active" if int(now_ms) < until_ms else "elapsed_by_wall_clock"
+        except (TypeError, ValueError):
+            out["cooldown_until_ms"] = cooldown_until_ms
+            out["status_at_preview"] = "unknown_invalid_timestamp"
+    if remaining_seconds is not None:
+        out["last_observed_remaining_seconds"] = remaining_seconds
+    if data.get("cooldown_remaining") is not None:
+        out["last_observed_remaining"] = data.get("cooldown_remaining")
+    return out
+
+
+def _status_record_preview(record: dict[str, Any], *, now_ms: int) -> dict[str, Any]:
+    data = record.get("latest_data") if isinstance(record.get("latest_data"), dict) else {}
+    status = _status_from_event(record)
+    drawdown_to_red = (
+        {
+            "available": True,
+            "source": "latest_local_hsl_event",
+            "value": data["dist_to_red"],
+            "note": "last observed distance to red; not recomputed from current exchange state",
+        }
+        if data.get("dist_to_red") is not None
+        else _unavailable("latest local HSL event did not include dist_to_red")
+    )
+    current_drawdown = _unavailable(
+        "offline preview does not contact exchanges or replay fresh fill/account state"
+    )
+    last_observed_drawdown = {
+        key: data[key]
+        for key in ("drawdown_raw", "drawdown_ema", "drawdown_score", "red_threshold")
+        if data.get(key) is not None
+    }
+    return {
+        key: value
+        for key, value in {
+            "bot": record.get("bot"),
+            "pside": record.get("pside"),
+            "symbol": record.get("symbol"),
+            "status": status,
+            "event_type": record.get("event_type"),
+            "reason_code": record.get("reason_code"),
+            "latest_ts": record.get("latest_ts"),
+            "last_observed_drawdown": last_observed_drawdown,
+            "drawdown_to_red": drawdown_to_red,
+            "current_drawdown": current_drawdown,
+            "cooldown": _cooldown_preview(data, now_ms=now_ms),
+            "latest_data": data,
+        }.items()
+        if value not in (None, {}, [])
+    }
+
+
+def _scan_hsl_events(
+    monitor_root: str | Path,
+    *,
+    include_rotated: bool,
+    since_ms: int | None,
+    until_ms: int | None,
+) -> dict[str, Any]:
+    try:
+        files = discover_event_files(monitor_root, include_rotated=include_rotated)
+    except FileNotFoundError:
+        return {
+            "available": False,
+            "root": str(Path(monitor_root).expanduser()),
+            "files_scanned": 0,
+            "rows_scanned": 0,
+            "hsl_events_seen": 0,
+            "latest_by_target": [],
+            "issues": [
+                _issue(
+                    "warning",
+                    "monitor_root_missing",
+                    "monitor root or event segment does not exist",
+                    path=str(monitor_root),
+                )
+            ],
+        }
+
+    latest: dict[tuple[str, str, str], dict[str, Any]] = {}
+    issues: list[dict[str, Any]] = []
+    event_type_counts: Counter[str] = Counter()
+    rows_scanned = 0
+    hsl_events_seen = 0
+    for path in files:
+        try:
+            handle = _open_text(path)
+        except OSError as exc:
+            issues.append(
+                _issue(
+                    "warning",
+                    "event_file_read_failed",
+                    f"could not read event file: {exc}",
+                    path=str(path),
+                )
+            )
+            continue
+        with handle:
+            for line_no, line in enumerate(handle, start=1):
+                rows_scanned += 1
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    issues.append(
+                        _issue(
+                            "warning",
+                            "event_json_decode_failed",
+                            "skipped malformed monitor event row",
+                            path=f"{path}:{line_no}",
+                        )
+                    )
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                ts = row.get("ts")
+                try:
+                    ts_int = int(ts)
+                except (TypeError, ValueError):
+                    ts_int = None
+                if since_ms is not None and (ts_int is None or ts_int < since_ms):
+                    continue
+                if until_ms is not None and (ts_int is None or ts_int > until_ms):
+                    continue
+                live_event = _live_event_payload(row)
+                if live_event is None:
+                    continue
+                event_type = live_event.get("event_type") or row.get("kind")
+                if event_type not in HSL_EVENT_TYPES:
+                    continue
+                hsl_events_seen += 1
+                event_type_counts[str(event_type)] += 1
+                record = {
+                    "bot": _bot_key(live_event, row),
+                    "event_type": event_type,
+                    "reason_code": live_event.get("reason_code"),
+                    "status": live_event.get("status"),
+                    "level": live_event.get("level"),
+                    "exchange": live_event.get("exchange") or row.get("exchange"),
+                    "user": live_event.get("user") or row.get("user"),
+                    "symbol": live_event.get("symbol") or row.get("symbol"),
+                    "pside": live_event.get("pside") or row.get("pside"),
+                    "latest_ts": ts_int,
+                    "latest_seq": row.get("seq"),
+                    "latest_path": str(path),
+                    "latest_line": int(line_no),
+                    "latest_data": _bounded_hsl_data(live_event),
+                }
+                key = _target_key(record)
+                existing = latest.get(key)
+                if existing is None or _event_sort_key(record) > _event_sort_key(existing):
+                    latest[key] = record
+
+    latest_by_target = sorted(
+        latest.values(),
+        key=lambda item: (
+            str(item.get("bot") or ""),
+            str(item.get("pside") or ""),
+            str(item.get("symbol") or ""),
+        ),
+    )
+    return {
+        "available": bool(files),
+        "root": str(Path(monitor_root).expanduser()),
+        "include_rotated": bool(include_rotated),
+        "files_scanned": len(files),
+        "rows_scanned": rows_scanned,
+        "hsl_events_seen": hsl_events_seen,
+        "event_types": dict(event_type_counts.most_common()),
+        "latest_by_target": latest_by_target,
+        "issues": issues,
+    }
+
+
+def build_hsl_startup_preview_report(
+    config_path: str | Path,
+    *,
+    monitor_root: str | Path | None = "monitor",
+    include_rotated: bool = False,
+    since_ms: int | None = None,
+    until_ms: int | None = None,
+    now_ms: int | None = None,
+) -> dict[str, Any]:
+    if now_ms is None:
+        now_ms = int(time.time() * 1000)
+    config, config_issues = _load_config(config_path)
+    if config is None:
+        return {
+            "ok": False,
+            "tool": "hsl-startup-preview",
+            "config_path": str(Path(config_path).expanduser()),
+            "issues": config_issues,
+        }
+
+    issues = list(config_issues)
+    event_scan: dict[str, Any]
+    if monitor_root is None or str(monitor_root).strip() == "":
+        event_scan = {
+            "available": False,
+            "root": None,
+            "include_rotated": bool(include_rotated),
+            "files_scanned": 0,
+            "rows_scanned": 0,
+            "hsl_events_seen": 0,
+            "event_types": {},
+            "latest_by_target": [],
+            "issues": [],
+        }
+    else:
+        event_scan = _scan_hsl_events(
+            monitor_root,
+            include_rotated=include_rotated,
+            since_ms=since_ms,
+            until_ms=until_ms,
+        )
+    issues.extend(event_scan.get("issues") or [])
+
+    latest_by_target = event_scan["latest_by_target"]
+    statuses = [
+        _status_record_preview(record, now_ms=int(now_ms))
+        for record in latest_by_target
+    ]
+    status_counts = Counter(str(item.get("status") or "unknown") for item in statuses)
+    return {
+        "ok": not any(issue.get("severity") == "error" for issue in issues),
+        "tool": "hsl-startup-preview",
+        "config_path": str(Path(config_path).expanduser()),
+        "preview_time_ms": int(now_ms),
+        "inputs": {
+            "config": {
+                "available": True,
+                "path": str(Path(config_path).expanduser()),
+            },
+            "monitor_events": {
+                key: event_scan.get(key)
+                for key in (
+                    "available",
+                    "root",
+                    "include_rotated",
+                    "files_scanned",
+                    "rows_scanned",
+                    "hsl_events_seen",
+                    "event_types",
+                )
+            },
+            "account_state": _unavailable(
+                "not loaded; this tool is local/offline and does not contact exchanges"
+            ),
+            "fill_history": _unavailable(
+                "not replayed in this first slice; latest local HSL events are reported when present"
+            ),
+            "current_drawdown": _unavailable(
+                "requires fresh balance, positions, fills, and unrealized PnL"
+            ),
+            "startup_panic_order_prediction": _unavailable(
+                "requires live startup replay, current positions/open orders, market snapshots, and Rust planning"
+            ),
+        },
+        "config": _config_report(config),
+        "hsl_status": {
+            "available": bool(statuses),
+            "source": "latest_local_monitor_hsl_events" if statuses else None,
+            "latest_by_target": statuses,
+            "counts_by_status": dict(status_counts.most_common()),
+        },
+        "startup_panic_orders": {
+            "available": False,
+            "would_emit": None,
+            "reason": (
+                "offline first-slice preview does not predict panic orders without "
+                "current exchange/account state and order planning"
+            ),
+        },
+        "issues": issues,
+        "summary": {
+            "error_count": sum(1 for issue in issues if issue.get("severity") == "error"),
+            "warning_count": sum(1 for issue in issues if issue.get("severity") == "warning"),
+            "hsl_targets_with_local_status": len(statuses),
+            "status_counts": dict(status_counts.most_common()),
+        },
+        "notes": [
+            "offline_read_only_report",
+            "does_not_load_credentials_or_contact_exchanges",
+            "does_not_predict_current_panic_orders",
+            "latest local HSL events are observations, not fresh startup replay",
+        ],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="passivbot tool hsl-startup-preview",
+        description=(
+            "Read-only offline HSL startup preview from config and local monitor "
+            "events."
+        ),
+    )
+    parser.add_argument("config_path", help="Live config JSON file to inspect.")
+    parser.add_argument(
+        "--monitor-root",
+        default="monitor",
+        help=(
+            "Monitor root, bot root, events directory, or NDJSON segment to scan. "
+            "Use an empty string to skip local event scanning."
+        ),
+    )
+    parser.add_argument(
+        "--include-rotated",
+        action="store_true",
+        help="Also scan rotated/compressed monitor event segments.",
+    )
+    parser.add_argument(
+        "--since-ms",
+        type=int,
+        help="Only include local HSL events at or after this epoch-ms timestamp.",
+    )
+    parser.add_argument(
+        "--until-ms",
+        type=int,
+        help="Only include local HSL events at or before this epoch-ms timestamp.",
+    )
+    parser.add_argument(
+        "--now-ms",
+        type=int,
+        help="Preview wall-clock epoch-ms used for cooldown remaining calculations.",
+    )
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="Emit compact single-line JSON.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.since_ms is not None and args.until_ms is not None and args.since_ms > args.until_ms:
+        parser.error("--since-ms must be <= --until-ms")
+    report = build_hsl_startup_preview_report(
+        args.config_path,
+        monitor_root=args.monitor_root if str(args.monitor_root).strip() else None,
+        include_rotated=bool(args.include_rotated),
+        since_ms=args.since_ms,
+        until_ms=args.until_ms,
+        now_ms=args.now_ms,
+    )
+    print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_hsl_startup_preview.py
+++ b/tests/test_hsl_startup_preview.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+from passivbot_cli import main as cli_main
+from tools import hsl_startup_preview
+
+
+def _write_config(path, config):
+    path.write_text(json.dumps(config, sort_keys=True), encoding="utf-8")
+
+
+def _sample_config() -> dict:
+    return {
+        "config_version": "v8.0.0",
+        "live": {
+            "user": "binance_01",
+            "exchange": "binance",
+            "hsl_signal_mode": "coin",
+            "hsl_position_during_cooldown_policy": "panic",
+            "api_key": "super-secret-api-key",
+        },
+        "bot": {
+            "long": {
+                "hsl": {
+                    "enabled": True,
+                    "red_threshold": 0.10,
+                    "cooldown_minutes_after_red": 45,
+                    "no_restart_drawdown_threshold": 0.20,
+                    "ema_span_minutes": 120,
+                    "tier_ratios": {"yellow": 0.5, "orange": 0.8},
+                    "orange_tier_mode": "tp_only",
+                    "panic_close_order_type": "limit",
+                }
+            },
+            "short": {
+                "hsl": {
+                    "enabled": False,
+                    "red_threshold": 0.12,
+                    "cooldown_minutes_after_red": 30,
+                }
+            },
+        },
+    }
+
+
+def _monitor_row(
+    *,
+    event_type: str,
+    seq: int,
+    ts: int,
+    reason_code: str,
+    symbol: str | None,
+    pside: str,
+    data: dict,
+) -> dict:
+    live_event = {
+        "schema_version": 1,
+        "event_id": f"evt_{seq}",
+        "event_type": event_type,
+        "level": "info",
+        "source": "live",
+        "component": "risk",
+        "exchange": "binance",
+        "user": "binance_01",
+        "symbol": symbol,
+        "pside": pside,
+        "status": "succeeded",
+        "reason_code": reason_code,
+        "data": data,
+        "ids": {"cycle_id": "cy_1"},
+    }
+    return {
+        "exchange": "binance",
+        "user": "binance_01",
+        "kind": event_type,
+        "tags": ["hsl", "risk"],
+        "payload": {"_live_event": live_event},
+        "seq": seq,
+        "ts": ts,
+    }
+
+
+def _write_ndjson(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def test_hsl_startup_preview_reports_config_and_latest_local_hsl_status(tmp_path):
+    config_path = tmp_path / "live.json"
+    monitor_root = tmp_path / "monitor"
+    _write_config(config_path, _sample_config())
+    _write_ndjson(
+        monitor_root / "binance" / "binance_01" / "events" / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.status",
+                seq=1,
+                ts=1_000,
+                reason_code="yellow",
+                symbol="SOL/USDT:USDT",
+                pside="long",
+                data={
+                    "signal_mode": "coin",
+                    "tier": "yellow",
+                    "drawdown_raw": 0.03,
+                    "drawdown_ema": 0.04,
+                    "drawdown_score": 0.04,
+                    "dist_to_red": 0.06,
+                    "red_threshold": 0.10,
+                    "slot_budget": 25.0,
+                    "realized_pnl": -1.0,
+                    "peak_realized_pnl": 2.0,
+                    "unrealized_pnl": -0.5,
+                    "secret": "must-not-render",
+                },
+            ),
+            _monitor_row(
+                event_type="hsl.status",
+                seq=2,
+                ts=2_000,
+                reason_code="red",
+                symbol="SOL/USDT:USDT",
+                pside="long",
+                data={
+                    "signal_mode": "coin",
+                    "tier": "red",
+                    "drawdown_raw": 0.11,
+                    "drawdown_ema": 0.09,
+                    "drawdown_score": 0.09,
+                    "dist_to_red": 0.01,
+                    "red_threshold": 0.10,
+                    "cooldown_until_ms": 122_000,
+                    "cooldown_remaining_seconds": 120.0,
+                },
+            ),
+        ],
+    )
+
+    report = hsl_startup_preview.build_hsl_startup_preview_report(
+        config_path,
+        monitor_root=monitor_root,
+        now_ms=62_000,
+    )
+    rendered = json.dumps(report, sort_keys=True)
+
+    assert report["ok"] is True
+    assert report["config"]["hsl"]["signal_mode"] == "coin"
+    assert report["config"]["hsl"]["sides"]["long"]["enabled"] is True
+    assert report["inputs"]["monitor_events"]["hsl_events_seen"] == 2
+    assert report["hsl_status"]["counts_by_status"] == {"red": 1}
+    latest = report["hsl_status"]["latest_by_target"][0]
+    assert latest["symbol"] == "SOL/USDT:USDT"
+    assert latest["status"] == "red"
+    assert latest["drawdown_to_red"]["value"] == 0.01
+    assert latest["current_drawdown"]["available"] is False
+    assert latest["cooldown"]["remaining_seconds_at_preview"] == pytest.approx(60.0)
+    assert report["startup_panic_orders"]["available"] is False
+    assert "super-secret-api-key" not in rendered
+    assert "must-not-render" not in rendered
+
+
+def test_hsl_startup_preview_config_only_marks_runtime_inputs_unavailable(tmp_path):
+    config_path = tmp_path / "live.json"
+    _write_config(config_path, _sample_config())
+
+    report = hsl_startup_preview.build_hsl_startup_preview_report(
+        config_path,
+        monitor_root="",
+        now_ms=62_000,
+    )
+
+    assert report["ok"] is True
+    assert report["inputs"]["monitor_events"]["available"] is False
+    assert report["hsl_status"]["available"] is False
+    assert report["inputs"]["current_drawdown"]["available"] is False
+    assert report["inputs"]["startup_panic_order_prediction"]["available"] is False
+    assert report["summary"]["hsl_targets_with_local_status"] == 0
+
+
+def test_hsl_startup_preview_invalid_json_returns_nonzero(tmp_path, capsys):
+    config_path = tmp_path / "bad.json"
+    config_path.write_text("{bad-json", encoding="utf-8")
+
+    assert hsl_startup_preview.main([str(config_path), "--compact"]) == 1
+    report = json.loads(capsys.readouterr().out)
+
+    assert report["ok"] is False
+    assert report["issues"][0]["code"] == "config_json_decode_failed"
+
+
+def test_hsl_startup_preview_help_exits_cleanly(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        hsl_startup_preview.main(["--help"])
+
+    assert exc_info.value.code == 0
+    assert "hsl-startup-preview" in capsys.readouterr().out
+
+
+def test_hsl_startup_preview_tool_dispatch_forwards_module_and_prog(monkeypatch):
+    captured = {}
+
+    def fake_invoke_module_main(module_name):
+        captured["module_name"] = module_name
+        captured["argv"] = sys.argv[:]
+        captured["prog_env"] = os.environ.get("PASSIVBOT_CLI_PROG")
+        return True, 0
+
+    monkeypatch.setattr(cli_main, "_invoke_module_main", fake_invoke_module_main)
+    monkeypatch.setattr(cli_main, "_missing_full_install_markers", lambda: [])
+
+    assert (
+        cli_main.main(
+            ["tool", "hsl-startup-preview", "configs/live.json", "--compact"]
+        )
+        == 0
+    )
+
+    assert captured["module_name"] == "tools.hsl_startup_preview"
+    assert captured["argv"] == [
+        "passivbot tool hsl-startup-preview",
+        "configs/live.json",
+        "--compact",
+    ]
+    assert captured["prog_env"] == "passivbot tool hsl-startup-preview"


### PR DESCRIPTION
## Summary
- add read-only `passivbot tool hsl-startup-preview` for config plus local monitor HSL event previews
- report latest observed HSL status/cooldown/drawdown-to-red from bounded event fields without leaking raw payloads
- explicitly mark current drawdown and startup panic-order prediction unavailable in this first offline slice
- document the tool and update backlog item #8 status/work log

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_hsl_startup_preview.py`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall -q src/tools/hsl_startup_preview.py src/passivbot_cli/main.py tests/test_hsl_startup_preview.py`
- `git diff --check`
- `git diff --cached --check`

## Limitations
- does not contact exchanges, load credentials, run live trading, or predict actual startup panic orders
- local monitor HSL fields are last observed event artifacts, not a fresh stateless startup replay