### PR TITLE
Add live event debug profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable user-facing changes will be documented in this file.
 - Added `passivbot tool hsl-startup-preview` for read-only offline HSL
   startup previews from config and local monitor events, with explicit
   unavailable fields for current drawdown and panic-order prediction.
+- Added `logging.live_event_debug_profiles` and
+  `PASSIVBOT_LIVE_EVENT_DEBUG_PROFILES` for opt-in structured live-event
+  enrichment, starting with bounded Rust orchestrator input/output samples.
 - Added `passivbot tool live-config-preflight` for read-only offline summaries
   of risk-relevant live config facts before startup.
 - Added shutdown-event summaries to `passivbot tool live-smoke-report`, including

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -47,6 +47,22 @@ exists there. Add new registry values before introducing repeated literals. See
 
 Fallbacks in critical paths log warnings with required context from `error_contract.md`.
 
+## Live Event Debug Profiles
+
+Use `logging.live_event_debug_profiles` or the
+`PASSIVBOT_LIVE_EVENT_DEBUG_PROFILES` environment variable to opt into narrow
+structured-event enrichment without increasing default console noise. Values may
+be a list or comma/space separated string. `all` enables every known profile.
+
+Initial supported profile behavior:
+
+1. `rust` adds bounded Rust orchestrator input-symbol and output-order samples
+   to the existing `rust_orchestrator.called` and
+   `rust_orchestrator.returned` events. Full raw Rust payload persistence remains
+   disabled; hashes stay present for correlation.
+
+Unknown profile names should fail visibly instead of being ignored silently.
+
 ## Review Heuristic
 
 1. Can INFO be tailed for long periods without noise overload?

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -246,12 +246,21 @@ Related detailed plans:
     surfaces are touched.
 
 12. [ ] Debug profile toggles.
-    Status: open.
+    Status: partial. Initial Rust live-event debug profile slice is in review.
 
     Add narrow runtime/debug profiles that increase event detail for one domain:
     candles, fills, HSL, Rust payloads, order execution, or exchange calls. This
     avoids code patches or globally noisy DEBUG logs when diagnosing a live
     issue.
+
+    Work log:
+    - 2026-06-26: Added `logging.live_event_debug_profiles` and
+      `PASSIVBOT_LIVE_EVENT_DEBUG_PROFILES`, with initial `rust` support for
+      bounded Rust orchestrator input-symbol and output-order samples on
+      structured events only.
+
+    Remaining refinements: add targeted profiles for remote calls, candle/EMA,
+    HSL, fills, and execution as those diagnostics need deeper live evidence.
 
 13. [ ] Cache integrity doctor.
     Status: partial. Initial read-only local cache smoke doctor and
@@ -329,6 +338,7 @@ Related detailed plans:
 | 2026-06-26 | #3 Live restart/smoke automation | PR #699 / `4e2fcee7` | Surfaced dropped contextless unparsed attention/hard counters under `--log-window-unparsed-policy drop`; dropped attention now makes smoke `attention=true` without making stale tail fragments hard failures; VPS5 settled smoke on `d5639813` returned `ok=true`, no hard failures, all five bots matched | Safe pull/stop/start orchestration still open |
 | 2026-06-26 | #3 Live restart/smoke automation | PR #709 / `71479c61` deploy evidence | VPS5 restart smoke after the fill-cache event slice returned `ok=true`, no hard failures, all five bots matched; the restart exposed four orphaned live processes after two Ctrl+C rounds, cleared by SIGTERM before reload | Safe pull/stop/start orchestration should include shutdown timing, orphan detection, and escalation policy |
 | 2026-06-26 | #3/#14 Supervisor/process diagnostics | PR #712 / `51ba92a3` | Extended `live-smoke-report --supervisor-config` to classify expected matches, missing expected commands, duplicate configured-command process matches, and extra/orphan-like `passivbot live` processes with bounded per-process metadata; VPS5 smoke showed all five configured bots matched with zero duplicate or extra live process matches; documented the read-only command-match limitation and shutdown escalation ladder as policy only | Safe pull/stop/start orchestration remains open |
+| 2026-06-26 | #12 Debug profile toggles | pending PR | Added opt-in live-event debug profiles via config/env and initial Rust orchestrator structured-event enrichment with bounded input-symbol and output-order samples | Add remote-call, candle/EMA, HSL, fills, and execution profiles as needed |
 | 2026-06-26 | #7 Live config preflight/linter | PR #714 / `564dc0a8` | Added `passivbot tool live-config-preflight`, a local-only JSON report for one config's risk-relevant live facts with bounded coin samples and malformed-structure errors; VPS5 preflight smoke returned `ok=true` with one expected missing short-side warning | Config diffing, deeper cache compatibility checks, and live startup enforcement remain open |
 | 2026-06-26 | #3 Live restart/smoke automation | PR #715 / `7b12d4b2` | Added passive `shutdown_events` summaries to full, summary, and brief `live-smoke-report` output for existing bot stopping/stage/stopped events; VPS5 no-restart smoke showed `shutdown_events.total=0`, all five bots matched, and no hard failures | Safe pull/stop/start orchestration remains open |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #701 / `fcda70f5` | Added `ticker-endpoint-probe` `account_critical_health` summaries for read-only balance/positions/open-orders outcomes; VPS5 Binance probe validated the summary and exposed an open-orders shape follow-up | Lower-impact/account-only mode, exchange-aware open-orders probing, clock skew/rate-limit/fill/candle probes |

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -426,6 +426,7 @@ def get_template_config():
                 "backup_count": 5,
                 "dir": "logs",
                 "level": 1,
+                "live_event_debug_profiles": [],
                 "max_bytes_mb": 10.0,
                 "memory_snapshot_interval_minutes": 30,
                 "persist_to_file": True,

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import queue
+import re
 import threading
 import time
 import uuid
@@ -25,6 +26,26 @@ LIVE_EVENT_ID_KEYS = (
     "remote_call_id",
     "remote_call_group_id",
 )
+LIVE_EVENT_DEBUG_PROFILE_ENV = "PASSIVBOT_LIVE_EVENT_DEBUG_PROFILES"
+LIVE_EVENT_DEBUG_PROFILES = (
+    "candles",
+    "execution",
+    "fills",
+    "forager",
+    "hsl",
+    "remote_calls",
+    "rust",
+    "startup",
+    "state",
+)
+_LIVE_EVENT_DEBUG_PROFILE_SET = frozenset(LIVE_EVENT_DEBUG_PROFILES)
+_LIVE_EVENT_DEBUG_PROFILE_ALIASES = {
+    "candle": "candles",
+    "remote": "remote_calls",
+    "remote_call": "remote_calls",
+    "remote-call": "remote_calls",
+    "remote-calls": "remote_calls",
+}
 
 
 class EventTypes:
@@ -187,6 +208,63 @@ def authoritative_reason_code(surface: object) -> str:
 
 def sink_failed_reason_code(name: object) -> str:
     return f"{name}_sink_failed"
+
+
+def _split_debug_profile_string(value: str) -> list[str]:
+    return [part for part in re.split(r"[\s,;]+", value.strip()) if part]
+
+
+def normalize_live_event_debug_profiles(value: Any) -> tuple[str, ...]:
+    """Normalize live-event debug profile config/env values.
+
+    The special profile ``all`` expands to all currently known profiles. Empty,
+    false-like, or ``none`` values disable profile enrichment.
+    """
+    if value is None or value is False:
+        return ()
+    if value is True:
+        raw_values: list[Any] = ["all"]
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped or stripped.lower() in {"0", "false", "no", "none", "off"}:
+            return ()
+        raw_values = _split_debug_profile_string(stripped)
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        raw_values = list(value)
+    else:
+        raw_values = [value]
+
+    normalized: list[str] = []
+    unknown: list[str] = []
+    for raw in raw_values:
+        item = str(raw).strip().lower().replace("-", "_")
+        if not item or item in {"0", "false", "no", "none", "off"}:
+            continue
+        if item == "all":
+            normalized.extend(LIVE_EVENT_DEBUG_PROFILES)
+            continue
+        item = _LIVE_EVENT_DEBUG_PROFILE_ALIASES.get(item, item)
+        if item not in _LIVE_EVENT_DEBUG_PROFILE_SET:
+            unknown.append(str(raw))
+            continue
+        normalized.append(item)
+    if unknown:
+        allowed = ", ".join((*LIVE_EVENT_DEBUG_PROFILES, "all"))
+        raise ValueError(
+            f"unknown live event debug profile(s): {', '.join(unknown)}; "
+            f"allowed values: {allowed}"
+        )
+    return tuple(sorted(set(normalized)))
+
+
+def live_event_debug_profile_enabled(holder: Any, profile: str) -> bool:
+    item = str(profile).strip().lower().replace("-", "_")
+    item = _LIVE_EVENT_DEBUG_PROFILE_ALIASES.get(item, item)
+    profiles = getattr(holder, "live_event_debug_profiles", None)
+    if profiles is None:
+        pipeline = getattr(holder, "_live_event_pipeline", None)
+        profiles = getattr(pipeline, "debug_profiles", ())
+    return item in set(profiles or ())
 
 
 PHASE1_EVENT_TYPES = {
@@ -854,6 +932,7 @@ class LiveEventPipeline:
         console_sink: LiveEventSink | None = None,
         text_sink: LiveEventSink | None = None,
         queue_maxsize: int = 10_000,
+        debug_profiles: Iterable[str] = (),
         start: bool = True,
     ):
         self.context = context or LiveEventContext()
@@ -864,6 +943,7 @@ class LiveEventPipeline:
         self.monitor_sinks = tuple(monitor_sinks)
         self.console_sink = console_sink
         self.text_sink = text_sink
+        self.debug_profiles = normalize_live_event_debug_profiles(debug_profiles)
         self.drop_counters: Counter[str] = Counter()
         self.sink_error_counters: Counter[str] = Counter()
         self.degraded_events: deque[LiveEvent] = deque(maxlen=1_000)

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -758,6 +758,119 @@ def _safe_int(value: Any) -> int | None:
         return None
 
 
+def _rust_symbol_name(
+    idx_to_symbol: dict[int, str] | None, symbol_idx: int | None
+) -> str | None:
+    if symbol_idx is None or not isinstance(idx_to_symbol, dict):
+        return None
+    value = idx_to_symbol.get(int(symbol_idx))
+    return str(value) if value is not None else None
+
+
+def rust_input_symbol_debug_sample(
+    input_symbols: Any,
+    *,
+    idx_to_symbol: dict[int, str] | None = None,
+    limit: int = 8,
+) -> dict[str, Any]:
+    """Return a bounded, non-raw sample of Rust orchestrator symbol inputs."""
+    symbols = (
+        list(input_symbols or []) if isinstance(input_symbols, (list, tuple)) else []
+    )
+    sample: list[dict[str, Any]] = []
+    for item in symbols[: max(0, int(limit))]:
+        if not isinstance(item, dict):
+            continue
+        symbol_idx = _safe_int(item.get("symbol_idx"))
+        order_book = (
+            item.get("order_book") if isinstance(item.get("order_book"), dict) else {}
+        )
+        emas = item.get("emas") if isinstance(item.get("emas"), dict) else {}
+        m1 = emas.get("m1") if isinstance(emas.get("m1"), dict) else {}
+        h1 = emas.get("h1") if isinstance(emas.get("h1"), dict) else {}
+        active_psides: list[str] = []
+        for pside in ("long", "short"):
+            side_cfg = item.get(pside) if isinstance(item.get(pside), dict) else {}
+            position = (
+                side_cfg.get("position")
+                if isinstance(side_cfg.get("position"), dict)
+                else {}
+            )
+            size = _safe_float(position.get("size"))
+            if size is not None and abs(size) > 0.0:
+                active_psides.append(pside)
+        payload = {
+            "symbol_idx": symbol_idx,
+            "symbol": _rust_symbol_name(idx_to_symbol, symbol_idx),
+            "tradable": bool(item.get("tradable")),
+            "has_bid": order_book.get("bid") is not None,
+            "has_ask": order_book.get("ask") is not None,
+            "effective_min_cost": _safe_float(item.get("effective_min_cost")),
+            "m1_close_ema_count": len(m1.get("close") or []),
+            "m1_log_range_ema_count": len(m1.get("log_range") or []),
+            "m1_volume_ema_count": len(m1.get("volume") or []),
+            "h1_log_range_ema_count": len(h1.get("log_range") or []),
+            "active_psides": active_psides,
+        }
+        sample.append(
+            {key: value for key, value in payload.items() if value is not None}
+        )
+    return {
+        "count": len(symbols),
+        "sample": sample,
+        "truncated": max(0, len(symbols) - len(sample)),
+    }
+
+
+def rust_output_order_debug_sample(
+    orders: Any,
+    *,
+    idx_to_symbol: dict[int, str] | None = None,
+    limit: int = 12,
+) -> dict[str, Any]:
+    """Return a bounded sample of Rust output orders for diagnostics."""
+    values = list(orders or []) if isinstance(orders, (list, tuple)) else []
+    sample: list[dict[str, Any]] = []
+    for item in values[: max(0, int(limit))]:
+        if not isinstance(item, dict):
+            continue
+        symbol_idx = _safe_int(item.get("symbol_idx"))
+        payload: dict[str, Any] = {
+            "symbol_idx": symbol_idx,
+            "symbol": _rust_symbol_name(idx_to_symbol, symbol_idx),
+            "order_type": (
+                str(item.get("order_type"))
+                if item.get("order_type") is not None
+                else None
+            ),
+            "execution_type": (
+                str(item.get("execution_type"))
+                if item.get("execution_type") is not None
+                else None
+            ),
+            "side": str(item.get("side")) if item.get("side") is not None else None,
+            "pside": (
+                str(item.get("pside") or item.get("position_side"))
+                if item.get("pside") is not None
+                or item.get("position_side") is not None
+                else None
+            ),
+            "qty": _safe_float(item.get("qty")),
+            "price": _safe_float(item.get("price")),
+            "reduce_only": bool(item.get("reduce_only"))
+            if item.get("reduce_only") is not None
+            else None,
+        }
+        sample.append(
+            {key: value for key, value in payload.items() if value is not None}
+        )
+    return {
+        "count": len(values),
+        "sample": sample,
+        "truncated": max(0, len(values) - len(sample)),
+    }
+
+
 def _emit_startup_timing_event_unchecked(
     bot: Any,
     *,
@@ -1226,7 +1339,20 @@ def _emit_rust_orchestrator_called_event_unchecked(
     trailing_unavailable_count: int,
     hedge_mode: bool,
     strategy_kind: str | None,
+    input_symbol_sample: dict[str, Any] | None = None,
 ) -> None:
+    data = {
+        "symbol_count": int(symbol_count),
+        "tradable_count": int(tradable_count),
+        "ema_unavailable_count": int(ema_unavailable_count),
+        "trailing_unavailable_count": int(trailing_unavailable_count),
+        "hedge_mode": bool(hedge_mode),
+        "strategy_kind": strategy_kind,
+        "input_hash": str(input_hash),
+    }
+    if input_symbol_sample is not None:
+        data["debug_profile"] = "rust"
+        data["input_symbol_sample"] = input_symbol_sample
     bot._emit_live_event(
         EventTypes.RUST_ORCHESTRATOR_CALLED,
         level="debug",
@@ -1236,15 +1362,7 @@ def _emit_rust_orchestrator_called_event_unchecked(
         remote_call_id=rust_call_id,
         status="started",
         raw_hash=str(input_hash),
-        data={
-            "symbol_count": int(symbol_count),
-            "tradable_count": int(tradable_count),
-            "ema_unavailable_count": int(ema_unavailable_count),
-            "trailing_unavailable_count": int(trailing_unavailable_count),
-            "hedge_mode": bool(hedge_mode),
-            "strategy_kind": strategy_kind,
-            "input_hash": str(input_hash),
-        },
+        data=data,
     )
 
 
@@ -1270,6 +1388,7 @@ def _emit_rust_orchestrator_returned_event_unchecked(
     order_count: int | None = None,
     diagnostics: Any = None,
     error: BaseException | None = None,
+    output_order_sample: dict[str, Any] | None = None,
 ) -> None:
     event_status = str(status or "succeeded").lower()
     failed = event_status == "failed" or error is not None
@@ -1299,6 +1418,9 @@ def _emit_rust_orchestrator_returned_event_unchecked(
         data["diagnostic_keys"] = (
             sorted(diagnostics) if isinstance(diagnostics, dict) else []
         )
+        if output_order_sample is not None:
+            data["debug_profile"] = "rust"
+            data["output_order_sample"] = output_order_sample
 
     bot._emit_live_event(
         EventTypes.RUST_ORCHESTRATOR_RETURNED,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -60,10 +60,13 @@ from live.freshness import ACCOUNT_SURFACES, LIVE_STATE_SURFACES, FreshnessLedge
 from live.events import DiagnosticEvent, emit_diagnostic_event, run_diagnostic_step
 from live.event_bus import (
     EventTypes,
+    LIVE_EVENT_DEBUG_PROFILE_ENV,
     LiveEventContext,
     LiveEventPipeline,
     MonitorEventSink,
     ReasonCodes,
+    live_event_debug_profile_enabled,
+    normalize_live_event_debug_profiles,
     payload_hash_raw,
 )
 import live.event_emitters as live_event_emitters
@@ -830,6 +833,14 @@ class Passivbot:
         self.ccp = None
         self.create_ccxt_sessions()
         self.debug_mode = False
+        self.live_event_debug_profiles = normalize_live_event_debug_profiles(
+            os.environ.get(
+                LIVE_EVENT_DEBUG_PROFILE_ENV,
+                get_optional_config_value(
+                    config, "logging.live_event_debug_profiles", ()
+                ),
+            )
+        )
         self.balance_threshold = (
             1.0  # don't create orders if balance is less than threshold
         )
@@ -3299,6 +3310,16 @@ class Passivbot:
         logging.info("[boot] starting bot %s...", self.exchange)
         boot_stage = "start"
         try:
+            live_event_debug_profiles = list(
+                getattr(self, "live_event_debug_profiles", ()) or ()
+            )
+            bot_started_data = {
+                "pid": os.getpid(),
+                "quote": self.quote,
+                "start_time_ms": int(self.start_time_ms),
+            }
+            if live_event_debug_profiles:
+                bot_started_data["live_event_debug_profiles"] = live_event_debug_profiles
             self._monitor_record_event(
                 "bot.start",
                 ("bot", "lifecycle", "start"),
@@ -3308,6 +3329,11 @@ class Passivbot:
                     "pid": os.getpid(),
                     "quote": self.quote,
                     "start_time_ms": int(self.start_time_ms),
+                    **(
+                        {"live_event_debug_profiles": live_event_debug_profiles}
+                        if live_event_debug_profiles
+                        else {}
+                    ),
                 },
                 ts=int(self.start_time_ms),
             )
@@ -3317,11 +3343,7 @@ class Passivbot:
                 component="lifecycle",
                 tags=("bot", "lifecycle", "start"),
                 status="started",
-                data={
-                    "pid": os.getpid(),
-                    "quote": self.quote,
-                    "start_time_ms": int(self.start_time_ms),
-                },
+                data=bot_started_data,
             )
 
             # Random boot stagger to spread API load when multiple bots start simultaneously.
@@ -3437,10 +3459,13 @@ class Passivbot:
             Passivbot._startup_timing_mark(self, "startup")
             self._bot_ready = True
             ready_ts = utc_ms()
+            ready_data = {"debug_mode": bool(self.debug_mode)}
+            if live_event_debug_profiles:
+                ready_data["live_event_debug_profiles"] = live_event_debug_profiles
             self._monitor_record_event(
                 "bot.ready",
                 ("bot", "lifecycle", "ready"),
-                {"debug_mode": bool(self.debug_mode)},
+                ready_data,
                 ts=ready_ts,
             )
             self._emit_live_event(
@@ -3449,7 +3474,7 @@ class Passivbot:
                 component="lifecycle",
                 tags=("bot", "lifecycle", "ready"),
                 status="succeeded",
-                data={"debug_mode": bool(self.debug_mode)},
+                data=ready_data,
             )
             await self._monitor_flush_snapshot(force=True, ts=ready_ts)
             if not self.debug_mode:
@@ -6515,6 +6540,7 @@ class Passivbot:
                 bot_id=getattr(self, "bot_id", None),
             ),
             monitor_sinks=[MonitorEventSink(publisher)],
+            debug_profiles=getattr(self, "live_event_debug_profiles", ()),
         )
         self._live_event_pipeline = pipeline
         return pipeline
@@ -15322,6 +15348,7 @@ class Passivbot:
         tradable_count = sum(
             1 for item in input_dict["symbols"] if bool(item.get("tradable", False))
         )
+        rust_debug_profile_enabled = live_event_debug_profile_enabled(self, "rust")
         self._emit_rust_orchestrator_called_event(
             rust_call_id=rust_call_id,
             input_hash=input_hash,
@@ -15331,6 +15358,14 @@ class Passivbot:
             trailing_unavailable_count=len(trailing_unavailable_symbols),
             hedge_mode=bool(effective_hedge_mode),
             strategy_kind=strategy_kind,
+            input_symbol_sample=(
+                live_event_emitters.rust_input_symbol_debug_sample(
+                    input_dict.get("symbols"),
+                    idx_to_symbol=idx_to_symbol,
+                )
+                if rust_debug_profile_enabled
+                else None
+            ),
         )
         try:
             out_json = pbr.compute_ideal_orders_json(input_json)
@@ -15369,6 +15404,14 @@ class Passivbot:
             elapsed_ms=int(elapsed_ms),
             order_count=len(orders),
             diagnostics=diagnostics,
+            output_order_sample=(
+                live_event_emitters.rust_output_order_debug_sample(
+                    orders,
+                    idx_to_symbol=idx_to_symbol,
+                )
+                if rust_debug_profile_enabled
+                else None
+            ),
         )
         Passivbot._emit_action_planned_event(
             self,

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -12,6 +12,7 @@ from live.event_bus import (
     EventRoute,
     EventTags,
     EventTypes,
+    LIVE_EVENT_DEBUG_PROFILES,
     ListEventSink,
     LiveEvent,
     LiveEventContext,
@@ -21,6 +22,8 @@ from live.event_bus import (
     ReasonCodes,
     authoritative_reason_code,
     format_console_event,
+    live_event_debug_profile_enabled,
+    normalize_live_event_debug_profiles,
     normalize_event_type,
     payload_hash,
     payload_hash_raw,
@@ -83,6 +86,34 @@ def test_live_event_reason_code_registry_values_are_unique_and_query_safe():
     assert sink_failed_reason_code("monitor") == "monitor_sink_failed"
     assert len(values) == len(set(values))
     assert all(re.fullmatch(r"[a-z][a-z0-9_]*", value) for value in values)
+
+
+def test_live_event_debug_profiles_normalize_and_validate():
+    assert normalize_live_event_debug_profiles(None) == ()
+    assert normalize_live_event_debug_profiles("") == ()
+    assert normalize_live_event_debug_profiles("rust,remote-calls candle") == (
+        "candles",
+        "remote_calls",
+        "rust",
+    )
+    assert normalize_live_event_debug_profiles(["rust", "rust", "off", "hsl"]) == (
+        "hsl",
+        "rust",
+    )
+    assert normalize_live_event_debug_profiles("all") == tuple(
+        sorted(LIVE_EVENT_DEBUG_PROFILES)
+    )
+    with pytest.raises(ValueError, match="unknown live event debug profile"):
+        normalize_live_event_debug_profiles("rust,unknown_profile")
+
+    class Holder:
+        live_event_debug_profiles = ("rust",)
+
+    assert live_event_debug_profile_enabled(Holder(), "rust")
+    assert live_event_debug_profile_enabled(Holder(), "remote_calls") is False
+    assert LiveEventPipeline(debug_profiles="rust", start=False).debug_profiles == (
+        "rust",
+    )
 
 
 def test_live_event_serializes_stable_envelope_and_redacts_sensitive_data():

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -8,6 +8,7 @@ import numpy as np
 
 import pytest
 
+import live.event_emitters as live_event_emitters
 from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
 
 
@@ -603,6 +604,125 @@ def test_rust_orchestrator_emitters_record_bounded_summaries():
     assert "MissingEma" in failed.data["error"]
     assert "SECRET" not in failed.data["error"]
     assert "[redacted]" in failed.data["error"]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_rust_orchestrator_debug_profile_samples_are_bounded():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _emit_rust_orchestrator_called_event = (
+            pb_mod.Passivbot._emit_rust_orchestrator_called_event
+        )
+        _emit_rust_orchestrator_returned_event = (
+            pb_mod.Passivbot._emit_rust_orchestrator_returned_event
+        )
+
+        def __init__(self):
+            self.exchange = "bybit"
+            self.user = "bybit_01"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_rust"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    idx_to_symbol = {0: "BTC/USDT:USDT", 1: "ETH/USDT:USDT"}
+    input_sample = live_event_emitters.rust_input_symbol_debug_sample(
+        [
+            {
+                "symbol_idx": 0,
+                "tradable": True,
+                "order_book": {"bid": 100.0, "ask": 101.0},
+                "effective_min_cost": 5.0,
+                "emas": {
+                    "m1": {"close": [[100.0, 1.0]], "log_range": [], "volume": []},
+                    "h1": {"log_range": [[100.0, 0.01]]},
+                },
+                "long": {"position": {"size": 0.01}},
+                "short": {"position": {"size": 0.0}},
+            },
+            {"symbol_idx": 1, "tradable": False, "emas": {}},
+        ],
+        idx_to_symbol=idx_to_symbol,
+        limit=1,
+    )
+    output_sample = live_event_emitters.rust_output_order_debug_sample(
+        [
+            {
+                "symbol_idx": 0,
+                "order_type": "entry_grid_normal_long",
+                "execution_type": "limit",
+                "side": "buy",
+                "position_side": "long",
+                "qty": 0.01,
+                "price": 100.0,
+                "reduce_only": False,
+            },
+            {"symbol_idx": 1, "order_type": "unstuck_close_short"},
+        ],
+        idx_to_symbol=idx_to_symbol,
+        limit=1,
+    )
+
+    bot = FakeBot()
+    bot._emit_rust_orchestrator_called_event(
+        rust_call_id="rust_7",
+        input_hash="input_hash",
+        symbol_count=2,
+        tradable_count=1,
+        ema_unavailable_count=0,
+        trailing_unavailable_count=0,
+        hedge_mode=True,
+        strategy_kind="recursive_grid",
+        input_symbol_sample=input_sample,
+    )
+    bot._emit_rust_orchestrator_returned_event(
+        rust_call_id="rust_7",
+        status="succeeded",
+        input_hash="input_hash",
+        output_hash="output_hash",
+        elapsed_ms=12,
+        order_count=2,
+        diagnostics={},
+        output_order_sample=output_sample,
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    called, returned = sink.events
+    assert called.data["debug_profile"] == "rust"
+    assert called.data["input_symbol_sample"]["count"] == 2
+    assert called.data["input_symbol_sample"]["truncated"] == 1
+    assert called.data["input_symbol_sample"]["sample"] == [
+        {
+            "symbol_idx": 0,
+            "symbol": "BTC/USDT:USDT",
+            "tradable": True,
+            "has_bid": True,
+            "has_ask": True,
+            "effective_min_cost": 5.0,
+            "m1_close_ema_count": 1,
+            "m1_log_range_ema_count": 0,
+            "m1_volume_ema_count": 0,
+            "h1_log_range_ema_count": 1,
+            "active_psides": ["long"],
+        }
+    ]
+    assert returned.data["debug_profile"] == "rust"
+    assert returned.data["output_order_sample"]["count"] == 2
+    assert returned.data["output_order_sample"]["truncated"] == 1
+    assert (
+        returned.data["output_order_sample"]["sample"][0]["symbol"]
+        == "BTC/USDT:USDT"
+    )
+    assert returned.data["output_order_sample"]["sample"][0]["order_type"] == (
+        "entry_grid_normal_long"
+    )
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
## Summary
- add `logging.live_event_debug_profiles` and `PASSIVBOT_LIVE_EVENT_DEBUG_PROFILES`
- add the first `rust` profile, enriching structured Rust orchestrator events with bounded input-symbol and output-order samples
- keep default behavior compact: no console routing changes, no raw Rust payload persistence, no trading behavior changes

## Validation
- `python -m compileall src/live/event_bus.py src/live/event_emitters.py src/passivbot.py src/config/schema.py`
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py -q`
- `git diff --check v8..HEAD`
- config normalization smoke for logging.live_event_debug_profiles=rust,remote-calls

## Notes
- `black` and `ruff` are not installed in this venv; formatting was checked manually plus `git diff --check`.
- This is observability-only. The profile only changes structured event data when explicitly enabled.