### PR TITLE
Add live restart smoke plan tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool live-restart-smoke-plan` for read-only dry-run restart
+  smoke planning from a tmuxp-style supervisor config, with explicit
+  non-execution metadata and rejected execution flags.
 - Added `passivbot tool hsl-startup-preview` for read-only offline HSL
   startup previews from config and local monitor events, with explicit
   unavailable fields for current drawdown and panic-order prediction.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -83,6 +83,15 @@ Related detailed plans:
    event counts, startup timings, and resource usage. This should be safe,
    explicit, and produce a reviewable smoke report.
 
+   Work log:
+   - 2026-06-26: Added first-slice plan-only
+     `passivbot tool live-restart-smoke-plan`, which parses a tmuxp-style
+     supervisor config and emits a structured dry-run restart/smoke plan with
+     bot commands, stop/start/check phases, timeouts, escalation ladder, repo
+     checks, and smoke-report command wiring. It explicitly rejects execution
+     and does not signal processes, invoke tmux, SSH, pull code, start bots,
+     contact exchanges, or load credentials.
+
    Remaining refinements: safe pull/stop/start orchestration remains open.
    The concise and brief summaries are intentionally bounded; further changes
    should target missing smoke fields rather than larger chat-facing payloads.

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from live.smoke_report import parse_tmuxp_live_commands
+
+
+DEFAULT_SHUTDOWN_TIMEOUT_S = 90
+DEFAULT_STARTUP_WAIT_S = 180
+DEFAULT_SMOKE_WINDOW_MINUTES = 30
+DEFAULT_MONITOR_ROOT = "monitor"
+DEFAULT_LOGS_ROOT = "logs"
+
+
+def _positive_int(value: int, *, field: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise ValueError(f"{field} must be positive")
+    return parsed
+
+
+def _display_path(value: str | Path | None) -> str | None:
+    if value is None:
+        return None
+    return str(Path(value).expanduser())
+
+
+def _shell_join(args: list[str]) -> str:
+    import shlex
+
+    return " ".join(shlex.quote(str(arg)) for arg in args if str(arg) != "")
+
+
+def _smoke_report_command(
+    *,
+    monitor_root: str | Path,
+    logs_root: str | Path | None,
+    supervisor_config: str | Path,
+    smoke_window_minutes: int,
+    compact: bool,
+    summary: bool,
+) -> str:
+    args = [
+        "passivbot",
+        "tool",
+        "live-smoke-report",
+        str(monitor_root),
+        "--supervisor-config",
+        str(supervisor_config),
+        "--processes",
+        "--recent-minutes",
+        str(smoke_window_minutes),
+    ]
+    if logs_root is not None:
+        args.extend(["--logs-root", str(logs_root)])
+    if summary:
+        args.append("--summary")
+    if compact:
+        args.append("--compact")
+    return _shell_join(args)
+
+
+def _repo_check_commands(repo_path: str | Path | None) -> list[str]:
+    if repo_path is None:
+        return [
+            _shell_join(["git", "rev-parse", "--abbrev-ref", "HEAD"]),
+            _shell_join(["git", "rev-parse", "--short", "HEAD"]),
+            _shell_join(["git", "status", "--porcelain", "--untracked-files=no"]),
+        ]
+    repo = str(repo_path)
+    return [
+        _shell_join(["git", "-C", repo, "rev-parse", "--abbrev-ref", "HEAD"]),
+        _shell_join(["git", "-C", repo, "rev-parse", "--short", "HEAD"]),
+        _shell_join(
+            ["git", "-C", repo, "status", "--porcelain", "--untracked-files=no"]
+        ),
+    ]
+
+
+def _bot_phase_plan(
+    bot: dict[str, Any],
+    *,
+    shutdown_timeout_s: int,
+    startup_wait_s: int,
+    smoke_command: str,
+) -> list[dict[str, Any]]:
+    command = str(bot.get("command") or bot.get("command_key") or "")
+    return [
+        {
+            "name": "stop_requested",
+            "goal": "operator requests graceful stop for the configured pane/process",
+            "planned_actions": [
+                {
+                    "description": (
+                        "identify the tmux pane or process matching the configured "
+                        "command"
+                    ),
+                    "command": command,
+                    "execute": False,
+                },
+                {
+                    "description": "send graceful interrupt to the matched live bot",
+                    "command": "operator_action: graceful interrupt only",
+                    "execute": False,
+                },
+            ],
+            "timeout_s": shutdown_timeout_s,
+            "measure": "elapsed time until process exits and shutdown events settle",
+        },
+        {
+            "name": "stop_verified",
+            "goal": "confirm no duplicate, stale, or orphaned matching live processes remain",
+            "planned_actions": [
+                {
+                    "description": "compare local process table against supervisor config",
+                    "command": smoke_command,
+                    "execute": False,
+                }
+            ],
+            "timeout_s": shutdown_timeout_s,
+        },
+        {
+            "name": "start_requested",
+            "goal": "operator reloads the configured tmuxp supervisor entry",
+            "planned_actions": [
+                {
+                    "description": (
+                        "start the configured command exactly as listed by the "
+                        "supervisor config"
+                    ),
+                    "command": command,
+                    "execute": False,
+                }
+            ],
+            "timeout_s": startup_wait_s,
+        },
+        {
+            "name": "startup_smoke",
+            "goal": "wait for startup, then collect read-only smoke evidence",
+            "planned_actions": [
+                {
+                    "description": (
+                        "collect process, monitor, log, shutdown, risk, remote-call, "
+                        "and repository summaries"
+                    ),
+                    "command": smoke_command,
+                    "execute": False,
+                }
+            ],
+            "wait_s": startup_wait_s,
+        },
+    ]
+
+
+def build_live_restart_smoke_plan(
+    supervisor_config: str | Path,
+    *,
+    repo_path: str | Path | None = None,
+    monitor_root: str | Path = DEFAULT_MONITOR_ROOT,
+    logs_root: str | Path | None = DEFAULT_LOGS_ROOT,
+    shutdown_timeout_s: int = DEFAULT_SHUTDOWN_TIMEOUT_S,
+    startup_wait_s: int = DEFAULT_STARTUP_WAIT_S,
+    smoke_window_minutes: int = DEFAULT_SMOKE_WINDOW_MINUTES,
+    compact_smoke_report: bool = True,
+    summary_smoke_report: bool = True,
+    execute: bool = False,
+) -> dict[str, Any]:
+    if execute:
+        raise NotImplementedError("execution is intentionally unavailable for this tool")
+    shutdown_timeout_s = _positive_int(shutdown_timeout_s, field="shutdown_timeout_s")
+    startup_wait_s = _positive_int(startup_wait_s, field="startup_wait_s")
+    smoke_window_minutes = _positive_int(smoke_window_minutes, field="smoke_window_minutes")
+
+    supervisor = parse_tmuxp_live_commands(supervisor_config)
+    bots = list(supervisor.get("expected") or [])
+    warnings = [
+        "plan_only_no_execution",
+        "does_not_signal_processes",
+        "does_not_invoke_tmux",
+        "does_not_run_ssh",
+        "does_not_run_git_pull",
+        "does_not_start_passivbot_live",
+        "does_not_contact_exchanges",
+    ]
+    issues: list[dict[str, str]] = []
+    if supervisor.get("error"):
+        issues.append(
+            {
+                "severity": "error",
+                "code": str(supervisor["error"]),
+                "message": "Supervisor config could not be parsed into expected live commands.",
+            }
+        )
+    if supervisor_config and supervisor.get("exists") and not bots:
+        issues.append(
+            {
+                "severity": "error",
+                "code": "no_expected_live_commands",
+                "message": "Supervisor config contains no parseable passivbot live commands.",
+            }
+        )
+    if not supervisor.get("exists") and not any(
+        issue.get("code") == "config_not_found" for issue in issues
+    ):
+        issues.append(
+            {
+                "severity": "error",
+                "code": "config_not_found",
+                "message": "Supervisor config is required for a restart smoke plan.",
+            }
+        )
+
+    smoke_command = _smoke_report_command(
+        monitor_root=monitor_root,
+        logs_root=logs_root,
+        supervisor_config=supervisor_config,
+        smoke_window_minutes=smoke_window_minutes,
+        compact=compact_smoke_report,
+        summary=summary_smoke_report,
+    )
+    planned_bots = []
+    for index, bot in enumerate(bots, start=1):
+        planned_bots.append(
+            {
+                "index": index,
+                **bot,
+                "phases": _bot_phase_plan(
+                    bot,
+                    shutdown_timeout_s=shutdown_timeout_s,
+                    startup_wait_s=startup_wait_s,
+                    smoke_command=smoke_command,
+                ),
+            }
+        )
+
+    return {
+        "tool": "live-restart-smoke-plan",
+        "schema_version": 1,
+        "ok": not issues,
+        "metadata": {
+            "dry_run": True,
+            "execute": False,
+            "execution_available": False,
+            "plan_only": True,
+        },
+        "inputs": {
+            "supervisor_config": _display_path(supervisor_config),
+            "repo_path": _display_path(repo_path),
+            "monitor_root": _display_path(monitor_root),
+            "logs_root": _display_path(logs_root),
+            "shutdown_timeout_s": shutdown_timeout_s,
+            "startup_wait_s": startup_wait_s,
+            "smoke_window_minutes": smoke_window_minutes,
+        },
+        "supervisor_config": {
+            "path": supervisor.get("path"),
+            "exists": supervisor.get("exists"),
+            "error": supervisor.get("error"),
+            "expected_live_commands": len(bots),
+        },
+        "bots": planned_bots,
+        "phases": [
+            {
+                "name": "pre_restart_readiness",
+                "description": (
+                    "Confirm repo state and configured bot set before any operator "
+                    "action."
+                ),
+                "planned_commands": [
+                    {"command": command, "execute": False}
+                    for command in _repo_check_commands(repo_path)
+                ],
+            },
+            {
+                "name": "graceful_stop_all",
+                "description": (
+                    "Stop configured bots one by one and record per-bot shutdown "
+                    "elapsed time."
+                ),
+                "bot_count": len(bots),
+                "timeout_s_per_bot": shutdown_timeout_s,
+            },
+            {
+                "name": "orphan_duplicate_check",
+                "description": (
+                    "Use the smoke report process comparison to find missing, "
+                    "duplicate, or extra live processes."
+                ),
+                "planned_commands": [{"command": smoke_command, "execute": False}],
+            },
+            {
+                "name": "supervisor_reload_start",
+                "description": "Reload/start from the supervisor config exactly as configured.",
+                "bot_count": len(bots),
+                "wait_s": startup_wait_s,
+            },
+            {
+                "name": "post_start_smoke_report",
+                "description": "Collect bounded read-only startup smoke evidence.",
+                "planned_commands": [{"command": smoke_command, "execute": False}],
+            },
+        ],
+        "smoke_report": {
+            "command": smoke_command,
+            "execute": False,
+            "expected_fields": [
+                "process liveness",
+                "duplicate configured-command matches",
+                "extra passivbot live processes",
+                "repository branch/head/dirty tracked state",
+                "recent hard log matches",
+                "monitor problem-event counts",
+                "startup timings",
+                "shutdown lifecycle events",
+                "remote-call health",
+                "risk/HSL events",
+            ],
+        },
+        "timeout_escalation_ladder": [
+            {
+                "level": 0,
+                "condition": "bot exits before graceful shutdown timeout",
+                "operator_action": "record elapsed shutdown time and continue",
+                "execute": False,
+            },
+            {
+                "level": 1,
+                "condition": "bot still running after graceful shutdown timeout",
+                "operator_action": (
+                    "collect smoke report and inspect shutdown events/logs before "
+                    "escalation"
+                ),
+                "execute": False,
+            },
+            {
+                "level": 2,
+                "condition": "duplicate or extra passivbot live process remains",
+                "operator_action": (
+                    "halt reload, identify owner/pane/process, and require explicit "
+                    "human approval"
+                ),
+                "execute": False,
+            },
+            {
+                "level": 3,
+                "condition": (
+                    "post-start smoke reports hard errors, missing expected bot, or "
+                    "stale startup"
+                ),
+                "operator_action": (
+                    "stop the routine and collect an incident bundle/smoke evidence"
+                ),
+                "execute": False,
+            },
+        ],
+        "execution_policy": {
+            "execute_flag": "not_implemented",
+            "future_execution_requires_review": True,
+            "rejected_operations": [
+                "ssh",
+                "tmux signal/send-keys",
+                "process kill/signal",
+                "git pull/fetch/checkout",
+                "passivbot live",
+                "exchange/API calls",
+                "credential loading",
+            ],
+        },
+        "warnings": warnings,
+        "issues": issues,
+    }

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -1548,6 +1548,21 @@ def _public_expected_record(item: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def parse_tmuxp_live_commands(config_path: str | Path | None) -> dict[str, Any]:
+    """Return sanitized passivbot live commands from a tmuxp-style config."""
+    config = _parse_tmuxp_live_commands(config_path)
+    return {
+        "path": _user_safe_display_path(config["path"])
+        if config.get("path") is not None
+        else None,
+        "exists": bool(config.get("exists")),
+        "error": config.get("error"),
+        "expected": [
+            _public_expected_record(item) for item in config.get("expected") or []
+        ],
+    }
+
+
 def _build_process_report(
     *,
     include_processes: bool,

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -118,6 +118,10 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "tools.live_smoke_report",
         "summarize local live monitor events and text logs",
     ),
+    "live-restart-smoke-plan": CommandSpec(
+        "tools.live_restart_smoke_plan",
+        "build a read-only dry-run live restart smoke plan",
+    ),
     "inspect-ohlcvs": CommandSpec(
         "tools.inspect_ohlcvs",
         "inspect v2 OHLCV cache metadata and gaps (requires full install)",

--- a/src/tools/live_restart_smoke_plan.py
+++ b/src/tools/live_restart_smoke_plan.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[1]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from live.restart_smoke_plan import (  # noqa: E402
+    DEFAULT_LOGS_ROOT,
+    DEFAULT_MONITOR_ROOT,
+    DEFAULT_SHUTDOWN_TIMEOUT_S,
+    DEFAULT_SMOKE_WINDOW_MINUTES,
+    DEFAULT_STARTUP_WAIT_S,
+    build_live_restart_smoke_plan,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="passivbot tool live-restart-smoke-plan",
+        description=(
+            "Build a read-only dry-run plan for a live restart smoke routine. "
+            "This tool does not execute the plan."
+        ),
+    )
+    parser.add_argument("supervisor_config", help="tmuxp-style supervisor config path.")
+    parser.add_argument(
+        "--repo-path",
+        help="Repository path to include in planned git checks.",
+    )
+    parser.add_argument(
+        "--monitor-root",
+        default=DEFAULT_MONITOR_ROOT,
+        help="Monitor root for the planned smoke-report command.",
+    )
+    parser.add_argument(
+        "--logs-root",
+        default=DEFAULT_LOGS_ROOT,
+        help="Logs root for the planned smoke-report command. Use an empty string to omit.",
+    )
+    parser.add_argument(
+        "--shutdown-timeout-s",
+        type=int,
+        default=DEFAULT_SHUTDOWN_TIMEOUT_S,
+        help="Per-bot graceful shutdown timeout for the plan.",
+    )
+    parser.add_argument(
+        "--startup-wait-s",
+        type=int,
+        default=DEFAULT_STARTUP_WAIT_S,
+        help="Post-start wait duration before smoke-report collection.",
+    )
+    parser.add_argument(
+        "--smoke-window-minutes",
+        type=int,
+        default=DEFAULT_SMOKE_WINDOW_MINUTES,
+        help="Recent time window for the planned smoke-report command.",
+    )
+    parser.add_argument(
+        "--full-smoke-report",
+        action="store_true",
+        help="Plan a full live-smoke-report command instead of --summary.",
+    )
+    parser.add_argument(
+        "--pretty-smoke-report",
+        action="store_true",
+        help="Plan a pretty-printed live-smoke-report command instead of --compact.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Rejected: execution is not implemented for this plan-only tool.",
+    )
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="Emit compact single-line JSON.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.execute:
+        parser.error(
+            "--execute is not implemented; live-restart-smoke-plan is plan-only"
+        )
+    try:
+        report = build_live_restart_smoke_plan(
+            args.supervisor_config,
+            repo_path=args.repo_path,
+            monitor_root=args.monitor_root,
+            logs_root=args.logs_root if str(args.logs_root).strip() else None,
+            shutdown_timeout_s=int(args.shutdown_timeout_s),
+            startup_wait_s=int(args.startup_wait_s),
+            smoke_window_minutes=int(args.smoke_window_minutes),
+            compact_smoke_report=not bool(args.pretty_smoke_report),
+            summary_smoke_report=not bool(args.full_smoke_report),
+            execute=False,
+        )
+    except (NotImplementedError, ValueError) as exc:
+        parser.error(str(exc))
+    print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+from live.restart_smoke_plan import build_live_restart_smoke_plan
+from passivbot_cli import main as cli_main
+from tools import live_restart_smoke_plan
+
+
+def _write_supervisor(path, lines):
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_live_restart_smoke_plan_builds_plan_from_supervisor_config(tmp_path):
+    supervisor_config = tmp_path / "bots_vps5.yaml"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u binance_01",
+            "  - window_name: gateio_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u gateio_01",
+        ],
+    )
+
+    report = build_live_restart_smoke_plan(
+        supervisor_config,
+        repo_path="/srv/passivbot",
+        monitor_root="/srv/passivbot/monitor",
+        logs_root="/srv/passivbot/logs",
+        shutdown_timeout_s=45,
+        startup_wait_s=120,
+        smoke_window_minutes=15,
+    )
+
+    assert report["ok"] is True
+    assert report["metadata"] == {
+        "dry_run": True,
+        "execute": False,
+        "execution_available": False,
+        "plan_only": True,
+    }
+    assert report["supervisor_config"]["expected_live_commands"] == 2
+    assert [bot["account"] for bot in report["bots"]] == ["binance_01", "gateio_01"]
+    assert report["bots"][0]["phases"][0]["planned_actions"][1]["execute"] is False
+    assert "passivbot tool live-smoke-report" in report["smoke_report"]["command"]
+    assert "--supervisor-config" in report["smoke_report"]["command"]
+    assert "--recent-minutes 15" in report["smoke_report"]["command"]
+    assert all(
+        item["execute"] is False for item in report["timeout_escalation_ladder"]
+    )
+    assert "ssh" in report["execution_policy"]["rejected_operations"]
+    assert "does_not_start_passivbot_live" in report["warnings"]
+
+
+def test_live_restart_smoke_plan_redacts_and_bounds_configured_commands(tmp_path):
+    supervisor_config = tmp_path / "bots.yaml"
+    long_secret = "S" * 600
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            (
+                "      - passivbot live configs/forager.json -u binance_01 "
+                f"api_key=ABC123 secret={long_secret}"
+            ),
+        ],
+    )
+
+    report = build_live_restart_smoke_plan(supervisor_config)
+    command = report["bots"][0]["command"]
+    command_key = report["bots"][0]["command_key"]
+
+    assert "ABC123" not in command
+    assert long_secret not in command
+    assert "[redacted]" in command
+    assert len(command) <= len("...<truncated>") + 400
+    assert len(command_key) <= len("...<truncated>") + 400
+
+
+def test_live_restart_smoke_plan_reports_missing_supervisor_config(tmp_path):
+    report = build_live_restart_smoke_plan(tmp_path / "missing.yaml")
+
+    assert report["ok"] is False
+    assert report["metadata"]["execute"] is False
+    assert report["bots"] == []
+    assert report["supervisor_config"]["exists"] is False
+    assert {issue["code"] for issue in report["issues"]} == {"config_not_found"}
+
+
+def test_live_restart_smoke_plan_reports_malformed_supervisor_config(tmp_path):
+    supervisor_config = tmp_path / "bots.yaml"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: not_a_bot",
+            "    panes:",
+            "      - echo no live command here",
+        ],
+    )
+
+    report = build_live_restart_smoke_plan(supervisor_config)
+
+    assert report["ok"] is False
+    assert report["bots"] == []
+    assert report["supervisor_config"] == {
+        "path": str(supervisor_config),
+        "exists": True,
+        "error": None,
+        "expected_live_commands": 0,
+    }
+    assert report["issues"] == [
+        {
+            "severity": "error",
+            "code": "no_expected_live_commands",
+            "message": "Supervisor config contains no parseable passivbot live commands.",
+        }
+    ]
+
+
+def test_live_restart_smoke_plan_rejects_execution():
+    with pytest.raises(
+        NotImplementedError,
+        match="execution is intentionally unavailable",
+    ):
+        build_live_restart_smoke_plan("bots.yaml", execute=True)
+
+
+def test_live_restart_smoke_plan_cli_outputs_json(tmp_path, capsys):
+    supervisor_config = tmp_path / "bots.yaml"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u binance_01",
+        ],
+    )
+
+    assert (
+        live_restart_smoke_plan.main(
+            [str(supervisor_config), "--compact", "--shutdown-timeout-s", "30"]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["ok"] is True
+    assert report["inputs"]["shutdown_timeout_s"] == 30
+
+
+def test_live_restart_smoke_plan_cli_rejects_execute(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_restart_smoke_plan.main(["bots.yaml", "--execute"])
+
+    assert exc_info.value.code == 2
+    assert "--execute is not implemented" in capsys.readouterr().err
+
+
+def test_live_restart_smoke_plan_tool_dispatch_forwards_module_and_prog(monkeypatch):
+    captured = {}
+
+    def fake_invoke_module_main(module_name):
+        captured["module_name"] = module_name
+        captured["argv"] = sys.argv[:]
+        captured["prog_env"] = os.environ.get("PASSIVBOT_CLI_PROG")
+        return True, 0
+
+    monkeypatch.setattr(cli_main, "_invoke_module_main", fake_invoke_module_main)
+    monkeypatch.setattr(cli_main, "_missing_full_install_markers", lambda: [])
+
+    assert (
+        cli_main.main(["tool", "live-restart-smoke-plan", "bots.yaml", "--compact"])
+        == 0
+    )
+
+    assert captured["module_name"] == "tools.live_restart_smoke_plan"
+    assert captured["argv"] == [
+        "passivbot tool live-restart-smoke-plan",
+        "bots.yaml",
+        "--compact",
+    ]
+    assert captured["prog_env"] == "passivbot tool live-restart-smoke-plan"


### PR DESCRIPTION
## Summary
- add `passivbot tool live-restart-smoke-plan`, a read-only dry-run planner for the repeated live restart/smoke routine
- expose sanitized tmuxp live command parsing for reuse by the planner
- document the first restart-smoke automation slice in the backlog and changelog

## Safety / Scope
- plan-only: no SSH, no tmux invocation, no process signaling, no git pull/fetch/checkout, no `passivbot live` startup, no exchange/API calls, no credential loading
- `--execute` is explicitly rejected
- no trading behavior changes

## Validation
- `./venv/bin/python -m pytest tests/test_live_restart_smoke_plan.py tests/test_live_smoke_report.py tests/test_passivbot_cli.py` -> 85 passed, 13 warnings
- `./venv/bin/python -m compileall -q src/live/restart_smoke_plan.py src/tools/live_restart_smoke_plan.py src/live/smoke_report.py src/passivbot_cli/main.py` -> pass
- `git diff --check v8..HEAD` -> pass