### PR TITLE
Add EMA live event debug profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable user-facing changes will be documented in this file.
 - Added `logging.live_event_debug_profiles` and
   `PASSIVBOT_LIVE_EVENT_DEBUG_PROFILES` for opt-in structured live-event
   enrichment, starting with bounded Rust orchestrator input/output samples.
+- Added the `ema` live-event debug profile, which enriches structured
+  `ema.unavailable` events with bounded parsed readiness detail without
+  changing console output or trading behavior.
 - Added `passivbot tool live-config-preflight` for read-only offline summaries
   of risk-relevant live config facts before startup.
 - Added shutdown-event summaries to `passivbot tool live-smoke-report`, including

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -255,7 +255,8 @@ Related detailed plans:
     surfaces are touched.
 
 12. [ ] Debug profile toggles.
-    Status: partial. Initial Rust live-event debug profile slice is in review.
+    Status: partial. Initial Rust live-event debug profile slice merged; EMA
+    readiness profile slice is in progress.
 
     Add narrow runtime/debug profiles that increase event detail for one domain:
     candles, fills, HSL, Rust payloads, order execution, or exchange calls. This
@@ -267,9 +268,14 @@ Related detailed plans:
       `PASSIVBOT_LIVE_EVENT_DEBUG_PROFILES`, with initial `rust` support for
       bounded Rust orchestrator input-symbol and output-order samples on
       structured events only.
+    - 2026-06-26: Added the `ema` debug profile, enriching
+      `ema.unavailable` structured events with bounded parsed EMA type, span,
+      and inner reason summaries while keeping default events compact and
+      console output unchanged.
 
-    Remaining refinements: add targeted profiles for remote calls, candle/EMA,
-    HSL, fills, and execution as those diagnostics need deeper live evidence.
+    Remaining refinements: add targeted profiles for remote calls, candle
+    coverage/tail state, HSL, fills, and execution as those diagnostics need
+    deeper live evidence.
 
 13. [ ] Cache integrity doctor.
     Status: partial. Initial read-only local cache smoke doctor and

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -29,6 +29,7 @@ LIVE_EVENT_ID_KEYS = (
 LIVE_EVENT_DEBUG_PROFILE_ENV = "PASSIVBOT_LIVE_EVENT_DEBUG_PROFILES"
 LIVE_EVENT_DEBUG_PROFILES = (
     "candles",
+    "ema",
     "execution",
     "fills",
     "forager",
@@ -41,6 +42,9 @@ LIVE_EVENT_DEBUG_PROFILES = (
 _LIVE_EVENT_DEBUG_PROFILE_SET = frozenset(LIVE_EVENT_DEBUG_PROFILES)
 _LIVE_EVENT_DEBUG_PROFILE_ALIASES = {
     "candle": "candles",
+    "emas": "ema",
+    "ema-readiness": "ema",
+    "ema_readiness": "ema",
     "remote": "remote_calls",
     "remote_call": "remote_calls",
     "remote-call": "remote_calls",

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -14,6 +14,7 @@ from live.event_bus import (
     ReasonCodes,
     authoritative_reason_code,
     emit_event,
+    live_event_debug_profile_enabled,
     utc_ms,
 )
 
@@ -1281,6 +1282,89 @@ def _candidate_unavailable_summary(
     return out
 
 
+_EMA_TYPE_RE = re.compile(
+    r"\b(?:missing\s+required\s+)?"
+    r"(?P<ema_type>m1_close|m1_volume|m1_log_range|h1_log_range)\s+EMA\b",
+    re.IGNORECASE,
+)
+_EMA_SPAN_REASON_RE = re.compile(
+    r"\bspan=(?P<span>[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?)"
+    r"\s+reason=(?P<reason>[^;|]+)",
+    re.IGNORECASE,
+)
+
+
+def _candidate_detail_tuple(item: Any) -> tuple[str, str, str]:
+    if not isinstance(item, (list, tuple)):
+        return str(item), "", ""
+    symbol = str(item[0]) if len(item) >= 1 else ""
+    error_type = str(item[1]) if len(item) >= 2 else ""
+    error = str(item[2]) if len(item) >= 3 else ""
+    return symbol, error_type, error
+
+
+def _ema_unavailable_debug_summary(
+    candidate_values: dict[str, list[tuple[str, str, str]]] | None,
+    ema_unavailable_reasons: dict[str, list[str]] | None,
+    *,
+    limit: int = 8,
+) -> dict[str, Any]:
+    candidate_groups: list[dict[str, Any]] = []
+    for reason, raw_items in sorted((candidate_values or {}).items())[:limit]:
+        symbols: set[str] = set()
+        error_types: set[str] = set()
+        ema_type_counts: Counter[str] = Counter()
+        spans: list[float] = []
+        inner_reason_counts: Counter[str] = Counter()
+        for raw_item in raw_items or []:
+            symbol, error_type, error = _candidate_detail_tuple(raw_item)
+            if symbol:
+                symbols.add(symbol)
+            if error_type:
+                error_types.add(error_type)
+            for match in _EMA_TYPE_RE.finditer(error or ""):
+                ema_type_counts[match.group("ema_type").lower()] += 1
+            for match in _EMA_SPAN_REASON_RE.finditer(error or ""):
+                span = _safe_float(match.group("span"))
+                if span is not None:
+                    spans.append(span)
+                inner_reason = str(match.group("reason") or "").strip()
+                if inner_reason:
+                    inner_reason_counts[inner_reason[:120]] += 1
+        group: dict[str, Any] = {
+            "reason": str(reason),
+            "symbols": _symbol_sample(symbols),
+            "error_types": sorted(error_types)[:4],
+        }
+        if ema_type_counts:
+            group["ema_types"] = [
+                {"ema_type": key, "count": int(count)}
+                for key, count in sorted(ema_type_counts.items())
+            ][:limit]
+        if spans:
+            group["spans"] = _span_sample(spans)
+        if inner_reason_counts:
+            group["inner_reasons"] = [
+                {"reason": key, "count": int(count)}
+                for key, count in sorted(
+                    inner_reason_counts.items(), key=lambda kv: (-kv[1], kv[0])
+                )[:limit]
+            ]
+        candidate_groups.append(group)
+
+    unavailable_groups = [
+        {
+            "reason": str(reason),
+            "symbols": _symbol_sample(symbols or ()),
+        }
+        for reason, symbols in sorted((ema_unavailable_reasons or {}).items())[:limit]
+    ]
+    return {
+        "candidate_groups": candidate_groups,
+        "unavailable_groups": unavailable_groups,
+    }
+
+
 def _reason_symbol_summary(
     values: dict[str, list[str]] | None,
     *,
@@ -2080,6 +2164,24 @@ def _emit_ema_unavailable_event_unchecked(
                 "spans": _span_sample(span for _symbol, span in items),
             }
         )
+    data = {
+        "optional_drop_count": int(optional_count),
+        "optional_drop_groups": optional_summary,
+        "candidate_unavailable": _symbol_sample(candidate_symbols),
+        "candidate_unavailable_groups": _candidate_unavailable_summary(
+            candidate_ema_unavailable_details
+        ),
+        "unavailable": _symbol_sample(unavailable_symbols),
+        "unavailable_reasons": _reason_symbol_summary(ema_unavailable_reasons),
+    }
+    if live_event_debug_profile_enabled(bot, "ema") or live_event_debug_profile_enabled(
+        bot, "candles"
+    ):
+        data["debug_profile"] = "ema"
+        data["debug"] = _ema_unavailable_debug_summary(
+            candidate_ema_unavailable_details,
+            ema_unavailable_reasons,
+        )
     _safe_emit(
         bot,
         EventTypes.EMA_UNAVAILABLE,
@@ -2089,16 +2191,7 @@ def _emit_ema_unavailable_event_unchecked(
         cycle_id=current_live_event_cycle_id(bot),
         status=status,
         reason_code=reason_code,
-        data={
-            "optional_drop_count": int(optional_count),
-            "optional_drop_groups": optional_summary,
-            "candidate_unavailable": _symbol_sample(candidate_symbols),
-            "candidate_unavailable_groups": _candidate_unavailable_summary(
-                candidate_ema_unavailable_details
-            ),
-            "unavailable": _symbol_sample(unavailable_symbols),
-            "unavailable_reasons": _reason_symbol_summary(ema_unavailable_reasons),
-        },
+        data=data,
     )
 
 

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -91,8 +91,11 @@ def test_live_event_reason_code_registry_values_are_unique_and_query_safe():
 def test_live_event_debug_profiles_normalize_and_validate():
     assert normalize_live_event_debug_profiles(None) == ()
     assert normalize_live_event_debug_profiles("") == ()
-    assert normalize_live_event_debug_profiles("rust,remote-calls candle") == (
+    assert normalize_live_event_debug_profiles(
+        "rust,remote-calls candle EMA-readiness"
+    ) == (
         "candles",
+        "ema",
         "remote_calls",
         "rust",
     )

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1304,6 +1304,7 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
     assert events[4].data["close_fallback_count"] == 1
     assert events[5].status == "degraded"
     assert events[5].data["candidate_unavailable"]["sample"] == ["XRP/USDT:USDT"]
+    assert "debug" not in events[5].data
     assert events[6].symbol == "ETH/USDT:USDT"
     assert events[6].status == "recovered"
     assert events[6].reason_code == "late_open_tail_projection"
@@ -1360,6 +1361,72 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         "warm_cache_accepted": 1,
     }
     assert events[10].data["window_max_candles"] == 260
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_ema_unavailable_event_debug_profile_adds_parsed_readiness_detail():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_ema_unavailable_event = pb_mod.Passivbot._emit_ema_unavailable_event
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "binance"
+            self.user = "binance_01"
+            self.bot_id = "bot_1"
+            self.live_event_debug_profiles = ("ema",)
+            self._live_event_current_cycle_id = "cy_12"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+    bot._emit_ema_unavailable_event(
+        candidate_ema_unavailable_details={
+            "cache_only_fetch_failed": [
+                (
+                    "BTC/USDT:USDT",
+                    "RuntimeError",
+                    "[ema] missing required h1_log_range EMA for BTC/USDT:USDT: "
+                    "span=672 reason=non-finite h1_log_range value nan; "
+                    "span=1100 reason=non-finite h1_log_range value nan",
+                ),
+                (
+                    "ETH/USDT:USDT",
+                    "RuntimeError",
+                    "[ema] missing required m1_log_range EMA for ETH/USDT:USDT: "
+                    "span=500 reason=missing required window",
+                ),
+            ]
+        },
+        ema_unavailable_reasons={
+            "never_fetched_cache_only": ["XRP/USDT:USDT", "ZEC/USDT:USDT"]
+        },
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[0]
+    assert event.event_type == EventTypes.EMA_UNAVAILABLE
+    assert event.data["debug_profile"] == "ema"
+    debug = event.data["debug"]
+    assert debug["unavailable_groups"][0]["reason"] == "never_fetched_cache_only"
+    group = debug["candidate_groups"][0]
+    assert group["reason"] == "cache_only_fetch_failed"
+    assert group["symbols"]["sample"] == ["BTC/USDT:USDT", "ETH/USDT:USDT"]
+    assert group["ema_types"] == [
+        {"ema_type": "h1_log_range", "count": 1},
+        {"ema_type": "m1_log_range", "count": 1},
+    ]
+    assert group["spans"] == [500.0, 672.0, 1100.0]
+    assert group["inner_reasons"] == [
+        {"reason": "non-finite h1_log_range value nan", "count": 2},
+        {"reason": "missing required window", "count": 1},
+    ]
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
## Summary
- add `ema` as a live-event debug profile, including `ema-readiness` aliases
- enrich `ema.unavailable` structured events with bounded parsed EMA type/span/inner-reason detail when `ema` or `candles` debug profiles are enabled
- keep default `ema.unavailable` payloads compact and keep console/trading behavior unchanged

## Safety / Scope
- observability-only; no exchange calls, no order/risk behavior changes
- debug enrichment uses data already captured for existing `ema.unavailable` events
- no new console output and no raw payload persistence

## Validation
- `./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py` -> 86 passed, 1 warning
- `./venv/bin/python -m compileall -q src/live/event_bus.py src/live/event_emitters.py tests/test_live_event_bus.py tests/test_passivbot_monitor.py` -> pass
- `git diff --check` -> pass
- touched-file silent-handling scan reports existing best-effort event emitter/sink patterns only; no new trading-path fallback