### PR TITLE
Add cache doctor candle coverage evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added v2 candle coverage windows and suspicious interior gap samples to
+  `passivbot tool cache-integrity-doctor`, derived only from local `.valid.npy`
+  cache artifacts.
 - Added `passivbot tool live-restart-smoke-plan` for read-only dry-run restart
   smoke planning from a tmuxp-style supervisor config, with explicit
   non-execution metadata and rejected execution flags.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -292,9 +292,13 @@ Related detailed plans:
       JSON, NDJSON, and NPY artifacts without writing or touching live behavior.
     - 2026-06-26: Added per-root and aggregate cache-family summaries plus
       family tags on cache-doctor issues.
+    - 2026-06-27: Added first-slice v2 candle coverage evidence from local
+      `.valid.npy` artifacts, including coverage windows, valid row counts,
+      suspicious interior gap samples, and non-enforcing warm-cache evidence
+      labels.
 
     Remaining refinements: add candle/fill/HSL metadata compatibility checks,
-    coverage windows, suspicious gap summaries, and warm-cache reuse readiness
+    fill/HSL coverage/readiness summaries, and deeper metadata compatibility
     without making trading decisions.
 
 14. [ ] Supervisor/process model.
@@ -356,6 +360,7 @@ Related detailed plans:
 | 2026-06-26 | #12 Debug profile toggles | pending PR | Added opt-in live-event debug profiles via config/env and initial Rust orchestrator structured-event enrichment with bounded input-symbol and output-order samples | Add remote-call, candle/EMA, HSL, fills, and execution profiles as needed |
 | 2026-06-26 | #7 Live config preflight/linter | PR #714 / `564dc0a8` | Added `passivbot tool live-config-preflight`, a local-only JSON report for one config's risk-relevant live facts with bounded coin samples and malformed-structure errors; VPS5 preflight smoke returned `ok=true` with one expected missing short-side warning | Config diffing, deeper cache compatibility checks, and live startup enforcement remain open |
 | 2026-06-26 | #3 Live restart/smoke automation | PR #715 / `7b12d4b2` | Added passive `shutdown_events` summaries to full, summary, and brief `live-smoke-report` output for existing bot stopping/stage/stopped events; VPS5 no-restart smoke showed `shutdown_events.total=0`, all five bots matched, and no hard failures | Safe pull/stop/start orchestration remains open |
+| 2026-06-27 | #13 Cache integrity doctor | pending PR | Added read-only v2 candle coverage windows and suspicious interior gap samples from local `.valid.npy` artifacts | Fill/HSL coverage/readiness and deeper metadata compatibility |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #701 / `fcda70f5` | Added `ticker-endpoint-probe` `account_critical_health` summaries for read-only balance/positions/open-orders outcomes; VPS5 Binance probe validated the summary and exposed an open-orders shape follow-up | Lower-impact/account-only mode, exchange-aware open-orders probing, clock skew/rate-limit/fill/candle probes |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #703 / `8fefce4b` | Added `ticker-endpoint-probe --account-only`, `--skip-my-trades`, and open-orders symbol fallback; VPS5 Binance account-only probe returned account-critical total=3, succeeded=3, and smoke stayed green | Clock skew/rate-limit/fill-pagination/candle-freshness probes |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -107,7 +107,7 @@ passivbot tool iterative-history-plot backtests/.../fills.csv
 - `passivbot tool pad-historical-daily` – Ensures daily OHLCV shards are present for the downloader when new coins are added.
 - `passivbot tool verify-hlcvs-data` – Validates prepared HLCV datasets and coverage metadata before long optimizations/backtests.
 - `passivbot tool streamline-json` – Normalizes/compacts JSON configs (`passivbot tool streamline-json configs/examples/default_trailing_martingale_long_npos4.json`).
-- `passivbot tool cache-integrity-doctor` – Read-only local cache smoke report for missing roots, file counts/sizes, cache-family summaries, and empty or corrupt JSON/NDJSON/NPY artifacts.
+- `passivbot tool cache-integrity-doctor` – Read-only local cache smoke report for missing roots, file counts/sizes, cache-family summaries, v2 candle coverage/gap evidence, and empty or corrupt JSON/NDJSON/NPY artifacts.
 - `passivbot tool candle-doctor` – Audits legacy `caches/ohlcv/...` shards for corruption, stale index entries, and legacy-format issues; add `--fix` to apply automatic repairs before importing into the v2 store.
 - `passivbot tool migrate-historical-data` – Converts legacy `historical_data/ohlcvs_<exchange>/...` shards into the current `caches/ohlcv/...` layout.
 

--- a/src/tools/cache_integrity_doctor.py
+++ b/src/tools/cache_integrity_doctor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 from collections import Counter
+from datetime import datetime, timezone
 import json
 from pathlib import Path
 from typing import Any, Iterable
@@ -9,6 +10,27 @@ from typing import Any, Iterable
 
 NUMPY_CACHE_SUFFIXES = {".npy"}
 DEFAULT_ROOTS = ("caches",)
+MAX_COVERAGE_ARTIFACT_SAMPLES = 8
+MAX_COVERAGE_GAP_SAMPLES = 8
+
+
+def _timeframe_interval_ms(timeframe: str) -> int | None:
+    normalized = str(timeframe).strip().lower()
+    if normalized == "1m":
+        return 60_000
+    if normalized == "1h":
+        return 60 * 60_000
+    return None
+
+
+def _format_ms(ts_ms: int | None) -> str | None:
+    if ts_ms is None:
+        return None
+    return datetime.fromtimestamp(int(ts_ms) / 1000, tz=timezone.utc).isoformat()
+
+
+def _month_start_ms(year: int, month: int) -> int:
+    return int(datetime(int(year), int(month), 1, tzinfo=timezone.utc).timestamp() * 1000)
 
 
 def _issue(
@@ -154,24 +176,267 @@ def _cache_family(root: Path, path: Path) -> str:
     return "unknown"
 
 
+def _coverage_summary_entry() -> dict[str, Any]:
+    return {
+        "artifact_count": 0,
+        "covered_artifact_count": 0,
+        "row_count": 0,
+        "valid_row_count": 0,
+        "gap_count": 0,
+        "max_gap_rows": 0,
+        "max_gap_ms": 0,
+        "first_valid_ms": None,
+        "last_valid_ms": None,
+        "artifact_samples": [],
+        "gap_samples": [],
+    }
+
+
 def _family_summary_entry() -> dict[str, Any]:
     return {
         "file_count": 0,
         "total_bytes": 0,
         "issue_count": 0,
         "by_extension": Counter(),
+        "coverage": _coverage_summary_entry(),
+    }
+
+
+def _parse_ohlcv_valid_artifact(root: Path, path: Path) -> dict[str, Any] | None:
+    name = path.name.lower()
+    if not name.endswith(".valid.npy"):
+        return None
+    try:
+        rel_parts = path.relative_to(root).parts
+    except ValueError:
+        rel_parts = path.parts
+    parts = [part.lower() for part in rel_parts]
+    if "data" in parts:
+        data_idx = parts.index("data")
+        offset = data_idx + 1
+    else:
+        offset = len(parts) - 5
+    if offset < 0 or len(parts) < offset + 5:
+        return None
+    exchange = rel_parts[offset]
+    timeframe = rel_parts[offset + 1]
+    symbol = rel_parts[offset + 2]
+    year_raw = rel_parts[offset + 3]
+    month_raw = path.name.split(".", maxsplit=1)[0]
+    interval_ms = _timeframe_interval_ms(timeframe)
+    if interval_ms is None:
+        return None
+    try:
+        year = int(year_raw)
+        month = int(month_raw)
+    except ValueError:
+        return None
+    if not 1 <= month <= 12:
+        return None
+    return {
+        "exchange": exchange,
+        "timeframe": timeframe,
+        "symbol": symbol,
+        "year": year,
+        "month": month,
+        "interval_ms": interval_ms,
+        "month_start_ms": _month_start_ms(year, month),
+    }
+
+
+def _inspect_coverage_artifact(root: Path, path: Path, family: str) -> dict[str, Any] | None:
+    if family != "candles":
+        return None
+    metadata = _parse_ohlcv_valid_artifact(root, path)
+    if metadata is None:
+        return None
+    try:
+        import numpy as np
+    except ImportError:
+        return None
+    try:
+        valid = np.asarray(np.load(path, mmap_mode="r", allow_pickle=False), dtype=bool)
+    except (OSError, ValueError, EOFError, AttributeError, TypeError):
+        return None
+    if valid.ndim != 1:
+        return None
+    valid_indices = np.flatnonzero(valid)
+    row_count = int(valid.shape[0])
+    valid_row_count = int(valid_indices.size)
+    interval_ms = int(metadata["interval_ms"])
+    first_valid_idx: int | None = None
+    last_valid_idx: int | None = None
+    first_valid_ms: int | None = None
+    last_valid_ms: int | None = None
+    gaps: list[dict[str, Any]] = []
+    if valid_row_count:
+        first_valid_idx = int(valid_indices[0])
+        last_valid_idx = int(valid_indices[-1])
+        first_valid_ms = int(metadata["month_start_ms"]) + first_valid_idx * interval_ms
+        last_valid_ms = int(metadata["month_start_ms"]) + last_valid_idx * interval_ms
+        diffs = np.diff(valid_indices)
+        gap_positions = np.flatnonzero(diffs > 1)
+        for gap_pos in gap_positions:
+            prev_idx = int(valid_indices[int(gap_pos)])
+            next_idx = int(valid_indices[int(gap_pos) + 1])
+            gap_start_idx = prev_idx + 1
+            gap_end_idx = next_idx - 1
+            gap_rows = gap_end_idx - gap_start_idx + 1
+            gap_start_ms = int(metadata["month_start_ms"]) + gap_start_idx * interval_ms
+            gap_end_ms = int(metadata["month_start_ms"]) + gap_end_idx * interval_ms
+            gaps.append(
+                {
+                    "path": str(path),
+                    "exchange": metadata["exchange"],
+                    "timeframe": metadata["timeframe"],
+                    "symbol": metadata["symbol"],
+                    "start_ms": gap_start_ms,
+                    "end_ms": gap_end_ms,
+                    "start_date": _format_ms(gap_start_ms),
+                    "end_date": _format_ms(gap_end_ms),
+                    "rows": int(gap_rows),
+                    "duration_ms": int(gap_rows * interval_ms),
+                }
+            )
+    max_gap_rows = max((int(gap["rows"]) for gap in gaps), default=0)
+    return {
+        "path": str(path),
+        "exchange": metadata["exchange"],
+        "timeframe": metadata["timeframe"],
+        "symbol": metadata["symbol"],
+        "year": metadata["year"],
+        "month": metadata["month"],
+        "interval_ms": interval_ms,
+        "row_count": row_count,
+        "valid_row_count": valid_row_count,
+        "first_valid_ms": first_valid_ms,
+        "last_valid_ms": last_valid_ms,
+        "first_valid_date": _format_ms(first_valid_ms),
+        "last_valid_date": _format_ms(last_valid_ms),
+        "gap_count": len(gaps),
+        "max_gap_rows": max_gap_rows,
+        "max_gap_ms": int(max_gap_rows * interval_ms),
+        "gaps": gaps,
+    }
+
+
+def _add_limited_sample(samples: list[dict[str, Any]], item: dict[str, Any], limit: int) -> None:
+    if len(samples) < limit:
+        samples.append(item)
+
+
+def _add_gap_samples(samples: list[dict[str, Any]], gaps: list[dict[str, Any]]) -> None:
+    samples.extend(gaps)
+    samples.sort(key=lambda item: (int(item["rows"]), str(item["path"])), reverse=True)
+    del samples[MAX_COVERAGE_GAP_SAMPLES:]
+
+
+def _merge_coverage(summary: dict[str, Any], artifact: dict[str, Any]) -> None:
+    coverage = summary["coverage"]
+    coverage["artifact_count"] += 1
+    coverage["row_count"] += int(artifact["row_count"])
+    coverage["valid_row_count"] += int(artifact["valid_row_count"])
+    coverage["gap_count"] += int(artifact["gap_count"])
+    coverage["max_gap_rows"] = max(int(coverage["max_gap_rows"]), int(artifact["max_gap_rows"]))
+    coverage["max_gap_ms"] = max(int(coverage["max_gap_ms"]), int(artifact["max_gap_ms"]))
+    first_valid_ms = artifact["first_valid_ms"]
+    last_valid_ms = artifact["last_valid_ms"]
+    if first_valid_ms is not None:
+        coverage["covered_artifact_count"] += 1
+        if coverage["first_valid_ms"] is None or int(first_valid_ms) < int(
+            coverage["first_valid_ms"]
+        ):
+            coverage["first_valid_ms"] = int(first_valid_ms)
+        if coverage["last_valid_ms"] is None or int(last_valid_ms) > int(
+            coverage["last_valid_ms"]
+        ):
+            coverage["last_valid_ms"] = int(last_valid_ms)
+    sample = {key: value for key, value in artifact.items() if key != "gaps"}
+    _add_limited_sample(coverage["artifact_samples"], sample, MAX_COVERAGE_ARTIFACT_SAMPLES)
+    _add_gap_samples(coverage["gap_samples"], artifact["gaps"])
+
+
+def _merge_finalized_coverage(summary: dict[str, Any], coverage_report: dict[str, Any]) -> None:
+    coverage = summary["coverage"]
+    coverage["artifact_count"] += int(coverage_report["artifact_count"])
+    coverage["covered_artifact_count"] += int(coverage_report["covered_artifact_count"])
+    coverage["row_count"] += int(coverage_report["row_count"])
+    coverage["valid_row_count"] += int(coverage_report["valid_row_count"])
+    coverage["gap_count"] += int(coverage_report["gap_count"])
+    coverage["max_gap_rows"] = max(
+        int(coverage["max_gap_rows"]),
+        int(coverage_report["max_gap_rows"]),
+    )
+    coverage["max_gap_ms"] = max(
+        int(coverage["max_gap_ms"]),
+        int(coverage_report["max_gap_ms"]),
+    )
+    first_valid_ms = coverage_report["first_valid_ms"]
+    last_valid_ms = coverage_report["last_valid_ms"]
+    if first_valid_ms is not None:
+        if coverage["first_valid_ms"] is None or int(first_valid_ms) < int(
+            coverage["first_valid_ms"]
+        ):
+            coverage["first_valid_ms"] = int(first_valid_ms)
+        if coverage["last_valid_ms"] is None or int(last_valid_ms) > int(
+            coverage["last_valid_ms"]
+        ):
+            coverage["last_valid_ms"] = int(last_valid_ms)
+    for artifact in coverage_report["artifact_samples"]:
+        _add_limited_sample(
+            coverage["artifact_samples"],
+            artifact,
+            MAX_COVERAGE_ARTIFACT_SAMPLES,
+        )
+    _add_gap_samples(coverage["gap_samples"], coverage_report["gap_samples"])
+
+
+def _finalize_coverage(coverage: dict[str, Any], issue_count: int) -> dict[str, Any]:
+    artifact_count = int(coverage["artifact_count"])
+    valid_row_count = int(coverage["valid_row_count"])
+    gap_count = int(coverage["gap_count"])
+    if artifact_count == 0:
+        evidence = "no_coverage_metadata"
+    elif issue_count:
+        evidence = "issues_present"
+    elif valid_row_count == 0:
+        evidence = "no_valid_rows"
+    elif gap_count:
+        evidence = "coverage_with_gaps"
+    else:
+        evidence = "coverage_observed"
+    return {
+        "warm_cache_evidence": evidence,
+        "artifact_count": artifact_count,
+        "covered_artifact_count": int(coverage["covered_artifact_count"]),
+        "row_count": int(coverage["row_count"]),
+        "valid_row_count": valid_row_count,
+        "gap_count": gap_count,
+        "max_gap_rows": int(coverage["max_gap_rows"]),
+        "max_gap_ms": int(coverage["max_gap_ms"]),
+        "first_valid_ms": coverage["first_valid_ms"],
+        "last_valid_ms": coverage["last_valid_ms"],
+        "first_valid_date": _format_ms(coverage["first_valid_ms"]),
+        "last_valid_date": _format_ms(coverage["last_valid_ms"]),
+        "artifact_samples": list(coverage["artifact_samples"]),
+        "gap_samples": list(coverage["gap_samples"]),
     }
 
 
 def _finalize_family_summary(by_family: dict[str, dict[str, Any]]) -> dict[str, Any]:
     finalized: dict[str, Any] = {}
     for family, summary in sorted(by_family.items()):
-        finalized[family] = {
+        issue_count = int(summary["issue_count"])
+        family_report = {
             "file_count": int(summary["file_count"]),
             "total_bytes": int(summary["total_bytes"]),
-            "issue_count": int(summary["issue_count"]),
+            "issue_count": issue_count,
             "by_extension": dict(sorted(summary["by_extension"].items())),
         }
+        coverage = _finalize_coverage(summary["coverage"], issue_count)
+        if family == "candles" or int(coverage["artifact_count"]):
+            family_report["coverage"] = coverage
+        finalized[family] = family_report
     return finalized
 
 
@@ -259,6 +524,9 @@ def _scan_root(root: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
             issue.setdefault("family", family)
         family_summary["issue_count"] += len(file_issues)
         issues.extend(file_issues)
+        coverage_artifact = _inspect_coverage_artifact(root, entry, family)
+        if coverage_artifact is not None:
+            _merge_coverage(family_summary, coverage_artifact)
     summary["by_extension"] = dict(sorted(by_extension.items()))
     summary["by_family"] = _finalize_family_summary(by_family)
     return summary, issues
@@ -283,6 +551,8 @@ def build_cache_integrity_report(roots: Iterable[str | Path]) -> dict[str, Any]:
             summary["total_bytes"] += int(family_report["total_bytes"])
             summary["issue_count"] += int(family_report["issue_count"])
             summary["by_extension"].update(family_report["by_extension"])
+            if "coverage" in family_report:
+                _merge_finalized_coverage(summary, family_report["coverage"])
     summary = {
         "root_count": len(root_reports),
         "file_count": sum(int(root["file_count"]) for root in root_reports),

--- a/tests/test_cache_integrity_doctor.py
+++ b/tests/test_cache_integrity_doctor.py
@@ -66,6 +66,62 @@ def test_cache_integrity_report_summarizes_cache_families(tmp_path):
     assert issue["family"] == "candles"
 
 
+def test_cache_integrity_report_summarizes_candle_coverage_windows_and_gaps(tmp_path):
+    root = tmp_path / "caches"
+    month_dir = root / "ohlcv" / "data" / "binance" / "1m" / "BTC_USDT" / "2026"
+    month_dir.mkdir(parents=True)
+    np.save(month_dir / "01.npy", np.full((8, 4), 1.0, dtype=np.float32))
+    np.save(
+        month_dir / "01.valid.npy",
+        np.array([False, True, True, False, False, True, True, False], dtype=bool),
+    )
+
+    report = build_cache_integrity_report([root])
+
+    coverage = report["summary"]["by_family"]["candles"]["coverage"]
+    assert coverage["warm_cache_evidence"] == "coverage_with_gaps"
+    assert coverage["artifact_count"] == 1
+    assert coverage["covered_artifact_count"] == 1
+    assert coverage["row_count"] == 8
+    assert coverage["valid_row_count"] == 4
+    assert coverage["gap_count"] == 1
+    assert coverage["max_gap_rows"] == 2
+    assert coverage["first_valid_date"] == "2026-01-01T00:01:00+00:00"
+    assert coverage["last_valid_date"] == "2026-01-01T00:06:00+00:00"
+    assert coverage["artifact_samples"][0]["symbol"] == "BTC_USDT"
+    assert coverage["artifact_samples"][0]["gap_count"] == 1
+    assert coverage["gap_samples"] == [
+        {
+            "path": str(month_dir / "01.valid.npy"),
+            "exchange": "binance",
+            "timeframe": "1m",
+            "symbol": "BTC_USDT",
+            "start_ms": 1767225780000,
+            "end_ms": 1767225840000,
+            "start_date": "2026-01-01T00:03:00+00:00",
+            "end_date": "2026-01-01T00:04:00+00:00",
+            "rows": 2,
+            "duration_ms": 120000,
+        }
+    ]
+
+
+def test_cache_integrity_report_marks_empty_candle_coverage_masks(tmp_path):
+    root = tmp_path / "caches"
+    month_dir = root / "ohlcv" / "data" / "okx" / "1h" / "ETH_USDT" / "2026"
+    month_dir.mkdir(parents=True)
+    np.save(month_dir / "02.valid.npy", np.zeros(3, dtype=bool))
+
+    report = build_cache_integrity_report([root])
+
+    coverage = report["summary"]["by_family"]["candles"]["coverage"]
+    assert coverage["warm_cache_evidence"] == "no_valid_rows"
+    assert coverage["artifact_count"] == 1
+    assert coverage["covered_artifact_count"] == 0
+    assert coverage["first_valid_date"] is None
+    assert coverage["last_valid_date"] is None
+
+
 def test_cache_integrity_report_marks_missing_root_as_warning(tmp_path):
     missing = tmp_path / "missing"
 


### PR DESCRIPTION
## Summary
- add read-only v2 candle coverage windows to cache-integrity-doctor from local .valid.npy masks
- include bounded suspicious interior gap samples and warm-cache evidence labels in candle family summaries
- update cache-doctor docs/backlog/changelog for the first coverage slice

## Validation
- pytest tests/test_cache_integrity_doctor.py
- python -m compileall src/tools/cache_integrity_doctor.py tests/test_cache_integrity_doctor.py
- git diff --check
- rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])\)" src/tools/cache_integrity_doctor.py tests/test_cache_integrity_doctor.py (no matches)

## Boundaries
- local/read-only cache artifact inspection only
- no live bot control, exchange access, credentials, SSH, or trading behavior changes