### PR TITLE
Add remote-call live event debug profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable user-facing changes will be documented in this file.
 - Added the `ema` live-event debug profile, which enriches structured
   `ema.unavailable` events with bounded parsed readiness detail without
   changing console output or trading behavior.
+- Added the `remote_calls` live-event debug profile, which enriches structured
+  remote-call events with bounded payload-shape and correlation details without
+  adding raw payloads or console output.
 - Added `passivbot tool live-config-preflight` for read-only offline summaries
   of risk-relevant live config facts before startup.
 - Added shutdown-event summaries to `passivbot tool live-smoke-report`, including

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -255,8 +255,8 @@ Related detailed plans:
     surfaces are touched.
 
 12. [ ] Debug profile toggles.
-    Status: partial. Initial Rust live-event debug profile slice merged; EMA
-    readiness profile slice is in progress.
+    Status: partial. Rust, EMA readiness, and remote-call profile slices are
+    merged or in progress.
 
     Add narrow runtime/debug profiles that increase event detail for one domain:
     candles, fills, HSL, Rust payloads, order execution, or exchange calls. This
@@ -272,10 +272,14 @@ Related detailed plans:
       `ema.unavailable` structured events with bounded parsed EMA type, span,
       and inner reason summaries while keeping default events compact and
       console output unchanged.
+    - 2026-06-26: Added `remote_calls` debug-profile enrichment for candle and
+      authoritative remote-call events, exposing bounded payload key shape,
+      parameter key names, and correlation state without raw payloads or
+      console output.
 
-    Remaining refinements: add targeted profiles for remote calls, candle
-    coverage/tail state, HSL, fills, and execution as those diagnostics need
-    deeper live evidence.
+    Remaining refinements: add targeted profiles for candle coverage/tail
+    state, HSL, fills, and execution as those diagnostics need deeper live
+    evidence.
 
 13. [ ] Cache integrity doctor.
     Status: partial. Initial read-only local cache smoke doctor and

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -104,6 +104,49 @@ def _remote_fetch_payload_key(payload: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
+def _mapping_key_sample(value: Any, *, limit: int = 32) -> list[str]:
+    if not isinstance(value, dict):
+        return []
+    return sorted(str(key) for key in value)[:limit]
+
+
+def _remote_call_debug_payload(
+    data: dict[str, Any],
+    *,
+    matched_start: bool | None = None,
+    limit: int = 32,
+) -> dict[str, Any]:
+    debug: dict[str, Any] = {
+        "data_keys": _mapping_key_sample(data, limit=limit),
+    }
+    if isinstance(data.get("params"), dict):
+        debug["param_keys"] = _mapping_key_sample(data.get("params"), limit=limit)
+    if matched_start is not None:
+        debug["matched_start"] = bool(matched_start)
+    for key in (
+        "kind",
+        "surface",
+        "stage",
+        "tf",
+        "timeframe",
+        "since_ts",
+        "end_ts",
+        "limit",
+        "rows",
+        "first_ts",
+        "last_ts",
+        "elapsed_ms",
+        "state_epoch",
+        "url_hash",
+        "error_type",
+    ):
+        if key in data:
+            debug[key] = data.get(key)
+    if isinstance(data.get("pending_confirmations"), list):
+        debug["pending_confirmation_count"] = len(data["pending_confirmations"])
+    return debug
+
+
 def _remote_call_map_max(bot: Any) -> int:
     try:
         raw = getattr(bot, "_live_event_remote_call_map_max", None)
@@ -198,6 +241,12 @@ def emit_candle_remote_fetch_event(bot: Any, payload: dict[str, Any]) -> Any:
     data = _sanitize_remote_fetch_payload(payload)
     if stage != "start" and not matched_start:
         data["orphan_result"] = True
+    if live_event_debug_profile_enabled(bot, "remote_calls"):
+        data["debug_profile"] = "remote_calls"
+        data["debug"] = _remote_call_debug_payload(
+            data,
+            matched_start=matched_start if stage != "start" else None,
+        )
     return bot._emit_live_event(
         event_type,
         level=level,
@@ -293,6 +342,9 @@ def _emit_authoritative_remote_call_event_unchecked(
         data["error_repr"] = _sanitize_remote_text(repr(error), max_len=500)
     elif stage != "start":
         data.update(_authoritative_result_summary(surface, result))
+    if live_event_debug_profile_enabled(bot, "remote_calls"):
+        data["debug_profile"] = "remote_calls"
+        data["debug"] = _remote_call_debug_payload(data)
     emit(
         event_type,
         level=level,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1790,7 +1790,13 @@ def test_forager_and_ema_summary_emitters_are_best_effort_on_malformed_inputs(ca
     assert any(EventTypes.BOT_STARTUP_TIMING in msg for msg in messages)
 
 
-def _make_remote_fetch_event_bot(sink, *, cycle_id="cy_7", map_max=None):
+def _make_remote_fetch_event_bot(
+    sink,
+    *,
+    cycle_id="cy_7",
+    map_max=None,
+    debug_profiles=(),
+):
     import passivbot as pb_mod
 
     class FakeBot:
@@ -1803,6 +1809,7 @@ def _make_remote_fetch_event_bot(sink, *, cycle_id="cy_7", map_max=None):
             self.exchange = "okx"
             self.user = "okx_01"
             self.bot_id = "bot_1"
+            self.live_event_debug_profiles = tuple(debug_profiles or ())
             self._live_event_current_cycle_id = cycle_id
             self._live_event_remote_call_seq = 0
             self._live_event_remote_call_ids = {}
@@ -1856,7 +1863,50 @@ def test_candle_remote_fetch_callback_emits_correlated_remote_call_events():
     assert started.symbol == "BTC/USDT:USDT"
     assert succeeded.data["rows"] == 100
     assert started.data["params"]["apiKey"] == "[redacted]"
+    assert "debug" not in started.data
+    assert "debug" not in succeeded.data
     assert bot._live_event_remote_call_seq == 1
+
+
+def test_remote_call_debug_profile_adds_bounded_candle_payload_shape():
+    sink = ListEventSink()
+    bot = _make_remote_fetch_event_bot(sink, debug_profiles=("remote_calls",))
+    base = {
+        "kind": "ccxt_fetch_ohlcv",
+        "exchange": "okx",
+        "symbol": "BTC/USDT:USDT",
+        "tf": "1m",
+        "since_ts": 123000,
+    }
+
+    bot._handle_candle_remote_fetch_event(
+        {**base, "stage": "start", "limit": 100, "params": {"apiKey": "secret"}}
+    )
+    bot._handle_candle_remote_fetch_event(
+        {
+            **base,
+            "stage": "ok",
+            "rows": 100,
+            "first_ts": 123000,
+            "last_ts": 183000,
+            "elapsed_ms": 42,
+        }
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+    started, succeeded = sink.events
+    assert started.data["debug_profile"] == "remote_calls"
+    assert succeeded.data["debug_profile"] == "remote_calls"
+    assert started.data["debug"]["param_keys"] == ["apiKey"]
+    assert started.data["debug"]["kind"] == "ccxt_fetch_ohlcv"
+    assert started.data["debug"]["tf"] == "1m"
+    assert started.data["debug"]["since_ts"] == 123000
+    assert started.data["debug"]["limit"] == 100
+    assert succeeded.data["debug"]["matched_start"] is True
+    assert succeeded.data["debug"]["rows"] == 100
+    assert succeeded.data["debug"]["elapsed_ms"] == 42
+    assert "secret" not in str(started.data["debug"]).lower()
 
 
 def test_candle_remote_fetch_error_sanitizes_and_keeps_correlation():
@@ -2073,6 +2123,58 @@ async def test_authoritative_timed_fetch_emits_correlated_remote_call_events():
     assert succeeded.data["count"] == 2
     assert succeeded.data["state_epoch"] == 17
     assert succeeded.data["pending_confirmations"] == ["open_orders"]
+    assert "debug" not in started.data
+    assert "debug" not in succeeded.data
+
+
+@pytest.mark.asyncio
+async def test_remote_call_debug_profile_adds_authoritative_payload_shape():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _timed_authoritative_fetch = pb_mod.Passivbot._timed_authoritative_fetch
+
+        def __init__(self):
+            self.exchange = "kucoin"
+            self.user = "kucoin_01"
+            self.bot_id = "bot_1"
+            self.live_event_debug_profiles = ("remote_calls",)
+            self._live_event_current_cycle_id = "cy_12"
+            self._authoritative_refresh_epoch = 21
+            self._authoritative_pending_confirmations = {"open_orders": 22}
+            self._live_event_remote_call_seq = 0
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    async def fetch_open_orders():
+        return [{"id": "a", "symbol": "BTC/USDT:USDT"}]
+
+    bot = FakeBot()
+    timings_ms = {}
+    result = await bot._timed_authoritative_fetch(
+        "open_orders", fetch_open_orders(), timings_ms
+    )
+
+    assert len(result) == 1
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+    started, succeeded = sink.events
+    assert started.data["debug_profile"] == "remote_calls"
+    assert succeeded.data["debug_profile"] == "remote_calls"
+    assert started.data["debug"]["surface"] == "open_orders"
+    assert started.data["debug"]["stage"] == "start"
+    assert started.data["debug"]["state_epoch"] == 21
+    assert started.data["debug"]["pending_confirmation_count"] == 1
+    assert succeeded.data["debug"]["surface"] == "open_orders"
+    assert succeeded.data["debug"]["stage"] == "ok"
+    assert succeeded.data["debug"]["state_epoch"] == 21
+    assert "count" in succeeded.data["debug"]["data_keys"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add opt-in `remote_calls` live-event debug profile enrichment for candle and authoritative remote-call events
- include bounded payload-shape/correlation details only: data keys, param keys, stage/surface/kind/timing IDs/counts
- keep default events unchanged and avoid raw payload values or console output

## Validation
- `./venv/bin/python -m pytest -q tests/test_passivbot_monitor.py::test_candle_remote_fetch_callback_emits_correlated_remote_call_events tests/test_passivbot_monitor.py::test_remote_call_debug_profile_adds_bounded_candle_payload_shape tests/test_passivbot_monitor.py::test_authoritative_timed_fetch_emits_correlated_remote_call_events tests/test_passivbot_monitor.py::test_remote_call_debug_profile_adds_authoritative_payload_shape`
- `./venv/bin/python -m pytest -q tests/test_live_event_bus.py tests/test_passivbot_monitor.py`
- `./venv/bin/python -m compileall -q src/live/event_emitters.py tests/test_passivbot_monitor.py`
- `git diff --check`
- touched-file silent-handling audit reviewed; matches are pre-existing best-effort event/test patterns, no trading fallback added