### PR TITLE
Add candle live event debug profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable user-facing changes will be documented in this file.
 - Added the `remote_calls` live-event debug profile, which enriches structured
   remote-call events with bounded payload-shape and correlation details without
   adding raw payloads or console output.
+- Added the `candles` live-event debug profile enrichment for candle tail and
+  disk-coverage events, exposing bounded key-shape and timing/counter details
+  without raw candle payloads or console output.
 - Added `passivbot tool live-config-preflight` for read-only offline summaries
   of risk-relevant live config facts before startup.
 - Added shutdown-event summaries to `passivbot tool live-smoke-report`, including

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-27.
 
 Current `origin/v8` logging-overhaul head:
 
-- `27f597bec` merge of PR #720, `Add EMA live event debug profile`.
+- `09ae3773a` merge of PR #723, `Add remote-call live event debug profile`.
 
 Current review gate:
 
@@ -1163,6 +1163,53 @@ VPS5 deployment status:
   reported all five configured bots running, no hard failures, no log hard
   matches, no failed remote calls, no failed account-critical remote calls, and
   clean tracked repository state.
+
+### PR #722: Cache Doctor Candle Coverage Evidence
+
+- Branch: `codex/maxwell-cache-integrity-doctor-13a`.
+- Scope: adjacent cache/warmup diagnostics.
+- Result: `passivbot tool cache-integrity-doctor` now derives v2 candle
+  coverage windows, valid row counts, suspicious interior gap samples, and
+  non-enforcing warm-cache evidence labels from local `.valid.npy` artifacts.
+  It remains read-only and does not change cache materialization, startup, or
+  trading behavior.
+- Review evidence: Hermes approved head `43f6d17b`; CI was green; Maxwell ran
+  focused cache-doctor tests, compileall, `git diff --check`, and a touched-file
+  silent-handling audit before opening the PR. Claude did not return during the
+  merge window, so this read-only tooling slice used the degraded gate.
+- VPS5 evidence: deployed as part of the `09ae3773` pull without bot restart.
+  The 10-minute brief smoke reported all five configured bots running, clean
+  tracked repository state, no hard failures, no log hard matches, no failed
+  remote calls, and no failed account-critical remote calls.
+
+### PR #723: Remote-Call Debug Profile
+
+- Branch: `codex/v8-remote-call-debug-profile`.
+- Scope: Phase 5/6 opt-in structured debug enrichment.
+- Result: added `remote_calls` debug-profile enrichment for candle remote-fetch
+  and authoritative state-fetch events. Enrichment is bounded to key shape,
+  selected timing/correlation fields, status/surface/kind, and counts; default
+  events remain unchanged, console output is unchanged, and no raw payloads are
+  added.
+- Review evidence: Hermes approved head `e78d79b0`; CI was green; focused
+  remote-call profile tests, the broader live-event/monitor suite, compileall,
+  `git diff --check`, and touched-file silent-handling audit passed before
+  merge. Claude did not return during the merge window, so this opt-in
+  observability slice used the degraded gate.
+- VPS5 evidence: deployed to VPS5 at `09ae3773` without bot restart because the
+  profile is opt-in and no VPS config enabled it. The same 10-minute brief
+  smoke reported no hard failures, all expected bots matched, and zero failed
+  remote/account-critical calls. Remaining attention came from known non-hard
+  EMA/staged-readiness and HSL cooldown events.
+
+### Pending PR: Candle Debug Profile
+
+- Branch: `codex/v8-candle-debug-profile`.
+- Scope: Phase 5/6 opt-in structured debug enrichment.
+- Planned result: add `candles` debug-profile enrichment to existing
+  `candle.tail_projected` and `candle.coverage_checked` events, exposing bounded
+  key-shape, timeframe/window, and missing-coverage counters without raw candle
+  arrays or default console/log changes.
 
 ## Current Next Steps
 

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -255,8 +255,8 @@ Related detailed plans:
     surfaces are touched.
 
 12. [ ] Debug profile toggles.
-    Status: partial. Rust, EMA readiness, and remote-call profile slices are
-    merged or in progress.
+    Status: partial. Rust, EMA readiness, remote-call, and candle profile
+    slices are merged or in progress.
 
     Add narrow runtime/debug profiles that increase event detail for one domain:
     candles, fills, HSL, Rust payloads, order execution, or exchange calls. This
@@ -276,10 +276,13 @@ Related detailed plans:
       authoritative remote-call events, exposing bounded payload key shape,
       parameter key names, and correlation state without raw payloads or
       console output.
+    - 2026-06-27: Added `candles` debug-profile enrichment for existing candle
+      tail-projection and disk-coverage events, exposing bounded key-shape,
+      timeframe, window, and missing-coverage counters without raw candle rows
+      or console output.
 
-    Remaining refinements: add targeted profiles for candle coverage/tail
-    state, HSL, fills, and execution as those diagnostics need deeper live
-    evidence.
+    Remaining refinements: add targeted profiles for HSL, fills, and execution
+    as those diagnostics need deeper live evidence.
 
 13. [ ] Cache integrity doctor.
     Status: partial. Initial read-only local cache smoke doctor and

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -110,6 +110,47 @@ def _mapping_key_sample(value: Any, *, limit: int = 32) -> list[str]:
     return sorted(str(key) for key in value)[:limit]
 
 
+def _candle_debug_payload(
+    data: dict[str, Any],
+    *,
+    context: dict[str, Any] | None = None,
+    report: dict[str, Any] | None = None,
+    timeframe_ms: int | None = None,
+    limit: int = 32,
+) -> dict[str, Any]:
+    debug: dict[str, Any] = {"data_keys": _mapping_key_sample(data, limit=limit)}
+    if isinstance(context, dict):
+        debug["context_keys"] = _mapping_key_sample(context, limit=limit)
+    if isinstance(report, dict):
+        debug["report_keys"] = _mapping_key_sample(report, limit=limit)
+    if timeframe_ms is not None:
+        debug["timeframe_ms"] = int(max(1, int(timeframe_ms)))
+    for key in (
+        "context",
+        "timeframe",
+        "coverage_ok",
+        "missing_span_count",
+        "missing_candles",
+        "loaded_rows",
+        "tail_gap_age_ms",
+        "tail_gap_candles",
+        "max_tail_gap_ms",
+    ):
+        if key in data:
+            debug[key] = data.get(key)
+    start_ts = _safe_int(data.get("start_ts"))
+    end_ts = _safe_int(data.get("end_ts"))
+    if start_ts is not None and end_ts is not None:
+        debug["window_ms"] = int(max(0, int(end_ts) - int(start_ts)))
+    if isinstance(report, dict):
+        raw_spans = report.get("missing_spans") or []
+        try:
+            debug["raw_missing_span_count"] = len(raw_spans)
+        except TypeError:
+            debug["raw_missing_span_count"] = 0
+    return debug
+
+
 def _remote_call_debug_payload(
     data: dict[str, Any],
     *,
@@ -1730,6 +1771,9 @@ def _emit_candle_tail_projected_event_unchecked(
     reason = ctx.get("reason")
     if reason is not None:
         data["projection_reason"] = str(reason)
+    if live_event_debug_profile_enabled(bot, "candles"):
+        data["debug_profile"] = "candles"
+        data["debug"] = _candle_debug_payload(data, context=ctx)
     _safe_emit(
         bot,
         EventTypes.CANDLE_TAIL_PROJECTED,
@@ -1844,6 +1888,13 @@ def _emit_candle_coverage_checked_event_unchecked(
         safe = _safe_int(value)
         if safe is not None:
             data[key] = int(safe)
+    if live_event_debug_profile_enabled(bot, "candles"):
+        data["debug_profile"] = "candles"
+        data["debug"] = _candle_debug_payload(
+            data,
+            report=report_in,
+            timeframe_ms=tf_ms,
+        )
     _safe_emit(
         bot,
         EventTypes.CANDLE_COVERAGE_CHECKED,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1310,6 +1310,7 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
     assert events[6].reason_code == "late_open_tail_projection"
     assert events[6].data["latest_expected_ts"] == 180_000
     assert events[6].data["tail_gap_age_ms"] == 60_000
+    assert "debug" not in events[6].data
     assert events[7].component == "candle.coverage"
     assert events[7].symbol == "ETH/USDT:USDT"
     assert events[7].status == "degraded"
@@ -1320,6 +1321,7 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
     assert events[7].data["missing_spans_preview"] == [
         {"start_ts": 180_000, "end_ts": 240_000, "candles": 2}
     ]
+    assert "debug" not in events[7].data
     assert events[8].component == "cache.candles"
     assert events[8].symbol == "ETH/USDT:USDT"
     assert events[8].reason_code == "candle_disk_load_completed"
@@ -1361,6 +1363,100 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
         "warm_cache_accepted": 1,
     }
     assert events[10].data["window_max_candles"] == 260
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_candle_events_debug_profile_adds_bounded_tail_and_coverage_shape():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_candle_tail_projected_event = (
+            pb_mod.Passivbot._emit_candle_tail_projected_event
+        )
+        _emit_candle_coverage_checked_event = (
+            pb_mod.Passivbot._emit_candle_coverage_checked_event
+        )
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "okx"
+            self.user = "okx_01"
+            self.bot_id = "bot_1"
+            self.live_event_debug_profiles = ("candles",)
+            self._live_event_current_cycle_id = "cy_12"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+    bot._emit_candle_tail_projected_event(
+        symbol="NEAR/USDT:USDT",
+        context={
+            "timeframe": "1m",
+            "latest_expected_ts": 300_000,
+            "last_cached_ts": 180_000,
+            "tail_gap_age_ms": 120_000,
+            "tail_gap_candles": 2,
+            "missing_candles": 2,
+            "max_tail_gap_ms": 180_000,
+            "reason": "open_tail_gap_projection",
+            "internal_notes": "not serialized as value in debug",
+        },
+    )
+    bot._emit_candle_coverage_checked_event(
+        symbol="NEAR/USDT:USDT",
+        timeframe="1m",
+        start_ts=120_000,
+        end_ts=300_000,
+        report={
+            "ok": False,
+            "timeframe": "1m",
+            "missing_spans": [(180_000, 240_000), (300_000, 300_000)],
+            "missing_candles": 3,
+            "loaded_rows": 2,
+            "raw_rows": [1, 2, 3],
+        },
+        context="required_disk_audit",
+        required=True,
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    tail, coverage = sink.events
+    assert tail.data["debug_profile"] == "candles"
+    assert coverage.data["debug_profile"] == "candles"
+    assert tail.data["debug"]["context_keys"] == [
+        "internal_notes",
+        "last_cached_ts",
+        "latest_expected_ts",
+        "max_tail_gap_ms",
+        "missing_candles",
+        "reason",
+        "tail_gap_age_ms",
+        "tail_gap_candles",
+        "timeframe",
+    ]
+    assert tail.data["debug"]["tail_gap_age_ms"] == 120_000
+    assert tail.data["debug"]["tail_gap_candles"] == 2
+    assert "not serialized" not in str(tail.data["debug"])
+    assert coverage.data["debug"]["report_keys"] == [
+        "loaded_rows",
+        "missing_candles",
+        "missing_spans",
+        "ok",
+        "raw_rows",
+        "timeframe",
+    ]
+    assert coverage.data["debug"]["timeframe_ms"] == 60_000
+    assert coverage.data["debug"]["window_ms"] == 180_000
+    assert coverage.data["debug"]["coverage_ok"] is False
+    assert coverage.data["debug"]["missing_span_count"] == 2
+    assert coverage.data["debug"]["raw_missing_span_count"] == 2
+    assert "raw_rows" in coverage.data["debug"]["report_keys"]
+    assert "[1, 2, 3]" not in str(coverage.data["debug"])
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
## Summary
- add opt-in `candles` debug-profile enrichment for existing `candle.tail_projected` and `candle.coverage_checked` events
- expose bounded key-shape, timeframe/window, and missing-coverage counters only
- keep default events compact; no raw candle arrays, console output, or trading behavior changes
- update logging progress/backlog after #722/#723 deploy evidence

## Validation
- `./venv/bin/python -m pytest -q tests/test_passivbot_monitor.py::test_forager_and_ema_summary_emitters_emit_structured_events tests/test_passivbot_monitor.py::test_candle_events_debug_profile_adds_bounded_tail_and_coverage_shape tests/test_passivbot_monitor.py::test_ema_unavailable_event_debug_profile_adds_parsed_readiness_detail`
- `./venv/bin/python -m pytest -q tests/test_passivbot_monitor.py::test_candle_events_debug_profile_adds_bounded_tail_and_coverage_shape tests/test_live_event_bus.py tests/test_passivbot_monitor.py`
- `./venv/bin/python -m compileall -q src/live/event_emitters.py tests/test_passivbot_monitor.py`
- `git diff --check`
- touched-file silent-handling audit reviewed; remaining matches are existing best-effort event/test patterns, no trading fallback added