### PR TITLE
Add cache doctor fill and HSL metadata evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added fill-cache and HSL/risk-state metadata summaries to
+  `passivbot tool cache-integrity-doctor`, including local fill
+  `pnl_contract` compatibility counts and coverage timestamps.
 - Added v2 candle coverage windows and suspicious interior gap samples to
   `passivbot tool cache-integrity-doctor`, derived only from local `.valid.npy`
   cache artifacts.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -303,10 +303,14 @@ Related detailed plans:
       `.valid.npy` artifacts, including coverage windows, valid row counts,
       suspicious interior gap samples, and non-enforcing warm-cache evidence
       labels.
+    - 2026-06-27: Added fill/HSL metadata evidence from local JSON/NDJSON
+      artifacts, including fill `pnl_contract` compatibility counts, fill
+      coverage timestamps, known-gap counts, and HSL/risk state timestamp
+      summaries without repair or enforcement.
 
-    Remaining refinements: add candle/fill/HSL metadata compatibility checks,
-    fill/HSL coverage/readiness summaries, and deeper metadata compatibility
-    without making trading decisions.
+    Remaining refinements: add deeper candle/fill/HSL metadata compatibility
+    checks, synthetic/no-trade assumptions, and warm-cache readiness without
+    making trading decisions.
 
 14. [ ] Supervisor/process model.
     Status: partial. `live-smoke-report --supervisor-config` now reports
@@ -367,7 +371,8 @@ Related detailed plans:
 | 2026-06-26 | #12 Debug profile toggles | pending PR | Added opt-in live-event debug profiles via config/env and initial Rust orchestrator structured-event enrichment with bounded input-symbol and output-order samples | Add remote-call, candle/EMA, HSL, fills, and execution profiles as needed |
 | 2026-06-26 | #7 Live config preflight/linter | PR #714 / `564dc0a8` | Added `passivbot tool live-config-preflight`, a local-only JSON report for one config's risk-relevant live facts with bounded coin samples and malformed-structure errors; VPS5 preflight smoke returned `ok=true` with one expected missing short-side warning | Config diffing, deeper cache compatibility checks, and live startup enforcement remain open |
 | 2026-06-26 | #3 Live restart/smoke automation | PR #715 / `7b12d4b2` | Added passive `shutdown_events` summaries to full, summary, and brief `live-smoke-report` output for existing bot stopping/stage/stopped events; VPS5 no-restart smoke showed `shutdown_events.total=0`, all five bots matched, and no hard failures | Safe pull/stop/start orchestration remains open |
-| 2026-06-27 | #13 Cache integrity doctor | pending PR | Added read-only v2 candle coverage windows and suspicious interior gap samples from local `.valid.npy` artifacts | Fill/HSL coverage/readiness and deeper metadata compatibility |
+| 2026-06-27 | #13 Cache integrity doctor | PR #722 / `3b7e6306` | Added read-only v2 candle coverage windows and suspicious interior gap samples from local `.valid.npy` artifacts | Fill/HSL coverage/readiness and deeper metadata compatibility |
+| 2026-06-27 | #13 Cache integrity doctor | pending PR | Added read-only fill/HSL metadata summaries from local JSON/NDJSON artifacts | Deeper metadata compatibility, synthetic/no-trade assumptions, and warm-cache readiness |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #701 / `fcda70f5` | Added `ticker-endpoint-probe` `account_critical_health` summaries for read-only balance/positions/open-orders outcomes; VPS5 Binance probe validated the summary and exposed an open-orders shape follow-up | Lower-impact/account-only mode, exchange-aware open-orders probing, clock skew/rate-limit/fill/candle probes |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #703 / `8fefce4b` | Added `ticker-endpoint-probe --account-only`, `--skip-my-trades`, and open-orders symbol fallback; VPS5 Binance account-only probe returned account-critical total=3, succeeded=3, and smoke stayed green | Clock skew/rate-limit/fill-pagination/candle-freshness probes |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -107,7 +107,7 @@ passivbot tool iterative-history-plot backtests/.../fills.csv
 - `passivbot tool pad-historical-daily` – Ensures daily OHLCV shards are present for the downloader when new coins are added.
 - `passivbot tool verify-hlcvs-data` – Validates prepared HLCV datasets and coverage metadata before long optimizations/backtests.
 - `passivbot tool streamline-json` – Normalizes/compacts JSON configs (`passivbot tool streamline-json configs/examples/default_trailing_martingale_long_npos4.json`).
-- `passivbot tool cache-integrity-doctor` – Read-only local cache smoke report for missing roots, file counts/sizes, cache-family summaries, v2 candle coverage/gap evidence, and empty or corrupt JSON/NDJSON/NPY artifacts.
+- `passivbot tool cache-integrity-doctor` – Read-only local cache smoke report for missing roots, file counts/sizes, cache-family summaries, v2 candle coverage/gap evidence, fill/HSL metadata evidence, and empty or corrupt JSON/NDJSON/NPY artifacts.
 - `passivbot tool candle-doctor` – Audits legacy `caches/ohlcv/...` shards for corruption, stale index entries, and legacy-format issues; add `--fix` to apply automatic repairs before importing into the v2 store.
 - `passivbot tool migrate-historical-data` – Converts legacy `historical_data/ohlcvs_<exchange>/...` shards into the current `caches/ohlcv/...` layout.
 

--- a/src/tools/cache_integrity_doctor.py
+++ b/src/tools/cache_integrity_doctor.py
@@ -12,6 +12,24 @@ NUMPY_CACHE_SUFFIXES = {".npy"}
 DEFAULT_ROOTS = ("caches",)
 MAX_COVERAGE_ARTIFACT_SAMPLES = 8
 MAX_COVERAGE_GAP_SAMPLES = 8
+MAX_METADATA_ARTIFACT_SAMPLES = 8
+CURRENT_FILL_PNL_CONTRACT = "gross_pnl_quote_fee_best_effort_v2"
+TIMESTAMP_FIELD_SUFFIXES = ("_ms", "_ts", "_at")
+TIMESTAMP_FIELD_NAMES = {
+    "timestamp",
+    "time",
+    "event_time",
+    "event_time_ms",
+    "last_refresh_ms",
+    "oldest_event_ts",
+    "newest_event_ts",
+    "covered_start_ms",
+    "start_ts",
+    "end_ts",
+    "last_red_ts",
+    "cooldown_until_ms",
+    "pending_red_since_ms",
+}
 
 
 def _timeframe_interval_ms(timeframe: str) -> int | None:
@@ -31,6 +49,21 @@ def _format_ms(ts_ms: int | None) -> str | None:
 
 def _month_start_ms(year: int, month: int) -> int:
     return int(datetime(int(year), int(month), 1, tzinfo=timezone.utc).timestamp() * 1000)
+
+
+def _int_ms(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        candidate = int(value)
+    except (TypeError, ValueError):
+        return None
+    return candidate if candidate > 0 else None
+
+
+def _timestamp_field_name(key: str) -> bool:
+    normalized = str(key).lower()
+    return normalized in TIMESTAMP_FIELD_NAMES or normalized.endswith(TIMESTAMP_FIELD_SUFFIXES)
 
 
 def _issue(
@@ -148,6 +181,26 @@ def _inspect_file(path: Path) -> list[dict[str, Any]]:
     return []
 
 
+def _read_json_payload(path: Path) -> Any | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, OSError):
+        return None
+
+
+def _read_ndjson_payload(path: Path) -> list[Any] | None:
+    payload: list[Any] = []
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                raw = line.strip()
+                if raw:
+                    payload.append(json.loads(raw))
+    except (UnicodeDecodeError, json.JSONDecodeError, OSError):
+        return None
+    return payload
+
+
 def _cache_family(root: Path, path: Path) -> str:
     try:
         rel = path.relative_to(root)
@@ -192,6 +245,26 @@ def _coverage_summary_entry() -> dict[str, Any]:
     }
 
 
+def _metadata_summary_entry() -> dict[str, Any]:
+    return {
+        "artifact_count": 0,
+        "metadata_file_count": 0,
+        "record_count": 0,
+        "current_pnl_contract_count": 0,
+        "legacy_pnl_contract_count": 0,
+        "missing_pnl_contract_count": 0,
+        "history_scope_counts": Counter(),
+        "known_gap_count": 0,
+        "first_event_ms": None,
+        "last_event_ms": None,
+        "covered_start_ms": None,
+        "newest_event_ms": None,
+        "last_refresh_ms": None,
+        "timestamp_field_count": 0,
+        "artifact_samples": [],
+    }
+
+
 def _family_summary_entry() -> dict[str, Any]:
     return {
         "file_count": 0,
@@ -199,6 +272,7 @@ def _family_summary_entry() -> dict[str, Any]:
         "issue_count": 0,
         "by_extension": Counter(),
         "coverage": _coverage_summary_entry(),
+        "metadata": _metadata_summary_entry(),
     }
 
 
@@ -391,6 +465,288 @@ def _merge_finalized_coverage(summary: dict[str, Any], coverage_report: dict[str
     _add_gap_samples(coverage["gap_samples"], coverage_report["gap_samples"])
 
 
+def _update_min_max_ms(
+    metadata: dict[str, Any],
+    *,
+    first_key: str,
+    last_key: str,
+    value: Any,
+) -> None:
+    ts_ms = _int_ms(value)
+    if ts_ms is None:
+        return
+    if metadata[first_key] is None or ts_ms < int(metadata[first_key]):
+        metadata[first_key] = ts_ms
+    if metadata[last_key] is None or ts_ms > int(metadata[last_key]):
+        metadata[last_key] = ts_ms
+
+
+def _iter_timestamp_fields(payload: Any, *, prefix: str = ""):
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            path_key = f"{prefix}.{key}" if prefix else str(key)
+            if _timestamp_field_name(str(key)):
+                ts_ms = _int_ms(value)
+                if ts_ms is not None:
+                    yield path_key, ts_ms
+            if isinstance(value, (dict, list)):
+                yield from _iter_timestamp_fields(value, prefix=path_key)
+    elif isinstance(payload, list):
+        for index, item in enumerate(payload[:MAX_METADATA_ARTIFACT_SAMPLES]):
+            if isinstance(item, (dict, list)):
+                path_key = f"{prefix}[{index}]" if prefix else f"[{index}]"
+                yield from _iter_timestamp_fields(item, prefix=path_key)
+
+
+def _fill_contract_bucket(value: Any) -> str:
+    contract = str(value or "")
+    if contract == CURRENT_FILL_PNL_CONTRACT:
+        return "current"
+    if not contract:
+        return "missing"
+    return "legacy"
+
+
+def _summarize_fill_payload(path: Path, payload: Any) -> dict[str, Any] | None:
+    out = _metadata_summary_entry()
+    out["artifact_count"] = 1
+    sample: dict[str, Any] = {"path": str(path)}
+    records: list[Any] = []
+    if path.name == "metadata.json" and isinstance(payload, dict):
+        out["metadata_file_count"] = 1
+        bucket = _fill_contract_bucket(payload.get("pnl_contract"))
+        out[f"{bucket}_pnl_contract_count"] += 1
+        scope = str(payload.get("history_scope") or "unknown")
+        out["history_scope_counts"][scope] += 1
+        known_gaps = payload.get("known_gaps")
+        if isinstance(known_gaps, list):
+            out["known_gap_count"] = len(known_gaps)
+        for key, target in (
+            ("covered_start_ms", "covered_start_ms"),
+            ("newest_event_ts", "newest_event_ms"),
+            ("last_refresh_ms", "last_refresh_ms"),
+        ):
+            ts_ms = _int_ms(payload.get(key))
+            if ts_ms is not None:
+                out[target] = ts_ms
+        for key in ("oldest_event_ts", "newest_event_ts"):
+            _update_min_max_ms(
+                out,
+                first_key="first_event_ms",
+                last_key="last_event_ms",
+                value=payload.get(key),
+            )
+        sample.update(
+            {
+                "kind": "fill_metadata",
+                "pnl_contract": payload.get("pnl_contract"),
+                "history_scope": payload.get("history_scope"),
+                "known_gap_count": out["known_gap_count"],
+                "covered_start_ms": out["covered_start_ms"],
+                "newest_event_ms": out["newest_event_ms"],
+            }
+        )
+    elif isinstance(payload, list):
+        records = [
+            item
+            for item in payload
+            if isinstance(item, dict) and ("timestamp" in item or "pnl_contract" in item)
+        ]
+        if not records:
+            return None
+        sample["kind"] = "fill_records"
+    elif isinstance(payload, dict) and ("timestamp" in payload or "pnl_contract" in payload):
+        records = [payload]
+        sample["kind"] = "fill_record"
+    else:
+        return None
+
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        out["record_count"] += 1
+        bucket = _fill_contract_bucket(record.get("pnl_contract"))
+        out[f"{bucket}_pnl_contract_count"] += 1
+        _update_min_max_ms(
+            out,
+            first_key="first_event_ms",
+            last_key="last_event_ms",
+            value=record.get("timestamp"),
+        )
+    if records:
+        sample["record_count"] = out["record_count"]
+        sample["first_event_ms"] = out["first_event_ms"]
+        sample["last_event_ms"] = out["last_event_ms"]
+    _add_limited_sample(out["artifact_samples"], sample, MAX_METADATA_ARTIFACT_SAMPLES)
+    return out
+
+
+def _summarize_risk_payload(path: Path, payload: Any) -> dict[str, Any] | None:
+    out = _metadata_summary_entry()
+    out["artifact_count"] = 1
+    sample: dict[str, Any] = {"path": str(path)}
+    if isinstance(payload, dict):
+        sample["kind"] = "risk_state"
+        sample["top_level_keys"] = sorted(str(key) for key in payload.keys())[
+            :MAX_METADATA_ARTIFACT_SAMPLES
+        ]
+        if any(token in str(path).lower() for token in ("hsl", "equity_hard_stop")):
+            sample["hsl_related"] = True
+    elif isinstance(payload, list):
+        sample["kind"] = "risk_records"
+        out["record_count"] = sum(1 for item in payload if isinstance(item, dict))
+    else:
+        return None
+
+    timestamp_fields: list[dict[str, Any]] = []
+    for key, ts_ms in _iter_timestamp_fields(payload):
+        out["timestamp_field_count"] += 1
+        _update_min_max_ms(
+            out,
+            first_key="first_event_ms",
+            last_key="last_event_ms",
+            value=ts_ms,
+        )
+        _add_limited_sample(
+            timestamp_fields,
+            {"field": key, "timestamp_ms": ts_ms, "date": _format_ms(ts_ms)},
+            MAX_METADATA_ARTIFACT_SAMPLES,
+        )
+    if timestamp_fields:
+        sample["timestamp_fields"] = timestamp_fields
+        sample["first_timestamp_ms"] = out["first_event_ms"]
+        sample["last_timestamp_ms"] = out["last_event_ms"]
+    _add_limited_sample(out["artifact_samples"], sample, MAX_METADATA_ARTIFACT_SAMPLES)
+    return out
+
+
+def _inspect_metadata_artifact(path: Path, family: str) -> dict[str, Any] | None:
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        payload = _read_json_payload(path)
+    elif suffix == ".ndjson":
+        payload = _read_ndjson_payload(path)
+    else:
+        return None
+    if payload is None:
+        return None
+    if family == "fills":
+        return _summarize_fill_payload(path, payload)
+    if family == "risk":
+        return _summarize_risk_payload(path, payload)
+    return None
+
+
+def _merge_metadata(summary: dict[str, Any], artifact: dict[str, Any]) -> None:
+    metadata = summary["metadata"]
+    for key in (
+        "artifact_count",
+        "metadata_file_count",
+        "record_count",
+        "current_pnl_contract_count",
+        "legacy_pnl_contract_count",
+        "missing_pnl_contract_count",
+        "known_gap_count",
+        "timestamp_field_count",
+    ):
+        metadata[key] += int(artifact[key])
+    metadata["history_scope_counts"].update(artifact["history_scope_counts"])
+    for key in ("first_event_ms", "covered_start_ms"):
+        value = artifact[key]
+        if value is not None and (metadata[key] is None or int(value) < int(metadata[key])):
+            metadata[key] = int(value)
+    for key in ("last_event_ms", "newest_event_ms", "last_refresh_ms"):
+        value = artifact[key]
+        if value is not None and (metadata[key] is None or int(value) > int(metadata[key])):
+            metadata[key] = int(value)
+    for sample in artifact["artifact_samples"]:
+        _add_limited_sample(
+            metadata["artifact_samples"],
+            sample,
+            MAX_METADATA_ARTIFACT_SAMPLES,
+        )
+
+
+def _merge_finalized_metadata(summary: dict[str, Any], metadata_report: dict[str, Any]) -> None:
+    metadata = summary["metadata"]
+    for key in (
+        "artifact_count",
+        "metadata_file_count",
+        "record_count",
+        "current_pnl_contract_count",
+        "legacy_pnl_contract_count",
+        "missing_pnl_contract_count",
+        "known_gap_count",
+        "timestamp_field_count",
+    ):
+        metadata[key] += int(metadata_report[key])
+    metadata["history_scope_counts"].update(metadata_report["history_scope_counts"])
+    for key in ("first_event_ms", "covered_start_ms"):
+        value = metadata_report[key]
+        if value is not None and (metadata[key] is None or int(value) < int(metadata[key])):
+            metadata[key] = int(value)
+    for key in ("last_event_ms", "newest_event_ms", "last_refresh_ms"):
+        value = metadata_report[key]
+        if value is not None and (metadata[key] is None or int(value) > int(metadata[key])):
+            metadata[key] = int(value)
+    for sample in metadata_report["artifact_samples"]:
+        _add_limited_sample(
+            metadata["artifact_samples"],
+            sample,
+            MAX_METADATA_ARTIFACT_SAMPLES,
+        )
+
+
+def _finalize_metadata(
+    metadata: dict[str, Any],
+    *,
+    family: str,
+    issue_count: int,
+) -> dict[str, Any]:
+    artifact_count = int(metadata["artifact_count"])
+    legacy_count = int(metadata["legacy_pnl_contract_count"])
+    missing_count = int(metadata["missing_pnl_contract_count"])
+    current_count = int(metadata["current_pnl_contract_count"])
+    record_count = int(metadata["record_count"])
+    if artifact_count == 0:
+        compatibility = "no_local_metadata"
+    elif issue_count:
+        compatibility = "issues_present"
+    elif family == "fills" and (legacy_count or missing_count):
+        compatibility = "legacy_or_missing_pnl_contract"
+    elif family == "fills" and current_count:
+        compatibility = "current_pnl_contract"
+    elif family == "fills":
+        compatibility = "no_pnl_contract_evidence"
+    elif int(metadata["timestamp_field_count"]):
+        compatibility = "local_state_with_timestamps"
+    else:
+        compatibility = "local_state_observed"
+    return {
+        "compatibility": compatibility,
+        "artifact_count": artifact_count,
+        "metadata_file_count": int(metadata["metadata_file_count"]),
+        "record_count": record_count,
+        "current_pnl_contract_count": current_count,
+        "legacy_pnl_contract_count": legacy_count,
+        "missing_pnl_contract_count": missing_count,
+        "history_scope_counts": dict(sorted(metadata["history_scope_counts"].items())),
+        "known_gap_count": int(metadata["known_gap_count"]),
+        "first_event_ms": metadata["first_event_ms"],
+        "last_event_ms": metadata["last_event_ms"],
+        "first_event_date": _format_ms(metadata["first_event_ms"]),
+        "last_event_date": _format_ms(metadata["last_event_ms"]),
+        "covered_start_ms": metadata["covered_start_ms"],
+        "covered_start_date": _format_ms(metadata["covered_start_ms"]),
+        "newest_event_ms": metadata["newest_event_ms"],
+        "newest_event_date": _format_ms(metadata["newest_event_ms"]),
+        "last_refresh_ms": metadata["last_refresh_ms"],
+        "last_refresh_date": _format_ms(metadata["last_refresh_ms"]),
+        "timestamp_field_count": int(metadata["timestamp_field_count"]),
+        "artifact_samples": list(metadata["artifact_samples"]),
+    }
+
+
 def _finalize_coverage(coverage: dict[str, Any], issue_count: int) -> dict[str, Any]:
     artifact_count = int(coverage["artifact_count"])
     valid_row_count = int(coverage["valid_row_count"])
@@ -436,6 +792,13 @@ def _finalize_family_summary(by_family: dict[str, dict[str, Any]]) -> dict[str, 
         coverage = _finalize_coverage(summary["coverage"], issue_count)
         if family == "candles" or int(coverage["artifact_count"]):
             family_report["coverage"] = coverage
+        metadata = _finalize_metadata(
+            summary["metadata"],
+            family=family,
+            issue_count=issue_count,
+        )
+        if family in {"fills", "risk"} or int(metadata["artifact_count"]):
+            family_report["metadata"] = metadata
         finalized[family] = family_report
     return finalized
 
@@ -527,6 +890,9 @@ def _scan_root(root: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
         coverage_artifact = _inspect_coverage_artifact(root, entry, family)
         if coverage_artifact is not None:
             _merge_coverage(family_summary, coverage_artifact)
+        metadata_artifact = _inspect_metadata_artifact(entry, family)
+        if metadata_artifact is not None:
+            _merge_metadata(family_summary, metadata_artifact)
     summary["by_extension"] = dict(sorted(by_extension.items()))
     summary["by_family"] = _finalize_family_summary(by_family)
     return summary, issues
@@ -553,6 +919,8 @@ def build_cache_integrity_report(roots: Iterable[str | Path]) -> dict[str, Any]:
             summary["by_extension"].update(family_report["by_extension"])
             if "coverage" in family_report:
                 _merge_finalized_coverage(summary, family_report["coverage"])
+            if "metadata" in family_report:
+                _merge_finalized_metadata(summary, family_report["metadata"])
     summary = {
         "root_count": len(root_reports),
         "file_count": sum(int(root["file_count"]) for root in root_reports),

--- a/src/tools/cache_integrity_doctor.py
+++ b/src/tools/cache_integrity_doctor.py
@@ -188,19 +188,6 @@ def _read_json_payload(path: Path) -> Any | None:
         return None
 
 
-def _read_ndjson_payload(path: Path) -> list[Any] | None:
-    payload: list[Any] = []
-    try:
-        with path.open("r", encoding="utf-8") as handle:
-            for line in handle:
-                raw = line.strip()
-                if raw:
-                    payload.append(json.loads(raw))
-    except (UnicodeDecodeError, json.JSONDecodeError, OSError):
-        return None
-    return payload
-
-
 def _cache_family(root: Path, path: Path) -> str:
     try:
         rel = path.relative_to(root)
@@ -507,6 +494,34 @@ def _fill_contract_bucket(value: Any) -> str:
     return "legacy"
 
 
+def _add_fill_record_metadata(out: dict[str, Any], record: dict[str, Any]) -> bool:
+    if "timestamp" not in record and "pnl_contract" not in record:
+        return False
+    out["record_count"] += 1
+    bucket = _fill_contract_bucket(record.get("pnl_contract"))
+    out[f"{bucket}_pnl_contract_count"] += 1
+    _update_min_max_ms(
+        out,
+        first_key="first_event_ms",
+        last_key="last_event_ms",
+        value=record.get("timestamp"),
+    )
+    return True
+
+
+def _finish_record_sample(
+    out: dict[str, Any],
+    sample: dict[str, Any],
+) -> dict[str, Any] | None:
+    if int(out["record_count"]) == 0:
+        return None
+    sample["record_count"] = out["record_count"]
+    sample["first_event_ms"] = out["first_event_ms"]
+    sample["last_event_ms"] = out["last_event_ms"]
+    _add_limited_sample(out["artifact_samples"], sample, MAX_METADATA_ARTIFACT_SAMPLES)
+    return out
+
+
 def _summarize_fill_payload(path: Path, payload: Any) -> dict[str, Any] | None:
     out = _metadata_summary_entry()
     out["artifact_count"] = 1
@@ -564,21 +579,51 @@ def _summarize_fill_payload(path: Path, payload: Any) -> dict[str, Any] | None:
     for record in records:
         if not isinstance(record, dict):
             continue
-        out["record_count"] += 1
-        bucket = _fill_contract_bucket(record.get("pnl_contract"))
-        out[f"{bucket}_pnl_contract_count"] += 1
-        _update_min_max_ms(
-            out,
-            first_key="first_event_ms",
-            last_key="last_event_ms",
-            value=record.get("timestamp"),
-        )
+        _add_fill_record_metadata(out, record)
     if records:
         sample["record_count"] = out["record_count"]
         sample["first_event_ms"] = out["first_event_ms"]
         sample["last_event_ms"] = out["last_event_ms"]
     _add_limited_sample(out["artifact_samples"], sample, MAX_METADATA_ARTIFACT_SAMPLES)
     return out
+
+
+def _summarize_fill_ndjson_payload(path: Path) -> dict[str, Any] | None:
+    out = _metadata_summary_entry()
+    out["artifact_count"] = 1
+    sample: dict[str, Any] = {"path": str(path), "kind": "fill_records"}
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                raw = line.strip()
+                if not raw:
+                    continue
+                record = json.loads(raw)
+                if isinstance(record, dict):
+                    _add_fill_record_metadata(out, record)
+    except (UnicodeDecodeError, json.JSONDecodeError, OSError):
+        return None
+    return _finish_record_sample(out, sample)
+
+
+def _add_risk_timestamp_metadata(
+    out: dict[str, Any],
+    payload: Any,
+    timestamp_fields: list[dict[str, Any]],
+) -> None:
+    for key, ts_ms in _iter_timestamp_fields(payload):
+        out["timestamp_field_count"] += 1
+        _update_min_max_ms(
+            out,
+            first_key="first_event_ms",
+            last_key="last_event_ms",
+            value=ts_ms,
+        )
+        _add_limited_sample(
+            timestamp_fields,
+            {"field": key, "timestamp_ms": ts_ms, "date": _format_ms(ts_ms)},
+            MAX_METADATA_ARTIFACT_SAMPLES,
+        )
 
 
 def _summarize_risk_payload(path: Path, payload: Any) -> dict[str, Any] | None:
@@ -599,19 +644,37 @@ def _summarize_risk_payload(path: Path, payload: Any) -> dict[str, Any] | None:
         return None
 
     timestamp_fields: list[dict[str, Any]] = []
-    for key, ts_ms in _iter_timestamp_fields(payload):
-        out["timestamp_field_count"] += 1
-        _update_min_max_ms(
-            out,
-            first_key="first_event_ms",
-            last_key="last_event_ms",
-            value=ts_ms,
-        )
-        _add_limited_sample(
-            timestamp_fields,
-            {"field": key, "timestamp_ms": ts_ms, "date": _format_ms(ts_ms)},
-            MAX_METADATA_ARTIFACT_SAMPLES,
-        )
+    _add_risk_timestamp_metadata(out, payload, timestamp_fields)
+    if timestamp_fields:
+        sample["timestamp_fields"] = timestamp_fields
+        sample["first_timestamp_ms"] = out["first_event_ms"]
+        sample["last_timestamp_ms"] = out["last_event_ms"]
+    _add_limited_sample(out["artifact_samples"], sample, MAX_METADATA_ARTIFACT_SAMPLES)
+    return out
+
+
+def _summarize_risk_ndjson_payload(path: Path) -> dict[str, Any] | None:
+    out = _metadata_summary_entry()
+    out["artifact_count"] = 1
+    sample: dict[str, Any] = {"path": str(path), "kind": "risk_records"}
+    if any(token in str(path).lower() for token in ("hsl", "equity_hard_stop")):
+        sample["hsl_related"] = True
+    timestamp_fields: list[dict[str, Any]] = []
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                raw = line.strip()
+                if not raw:
+                    continue
+                record = json.loads(raw)
+                if not isinstance(record, dict):
+                    continue
+                out["record_count"] += 1
+                _add_risk_timestamp_metadata(out, record, timestamp_fields)
+    except (UnicodeDecodeError, json.JSONDecodeError, OSError):
+        return None
+    if int(out["record_count"]) == 0:
+        return None
     if timestamp_fields:
         sample["timestamp_fields"] = timestamp_fields
         sample["first_timestamp_ms"] = out["first_event_ms"]
@@ -624,17 +687,21 @@ def _inspect_metadata_artifact(path: Path, family: str) -> dict[str, Any] | None
     suffix = path.suffix.lower()
     if suffix == ".json":
         payload = _read_json_payload(path)
-    elif suffix == ".ndjson":
-        payload = _read_ndjson_payload(path)
+        if payload is None:
+            return None
+        if family == "fills":
+            return _summarize_fill_payload(path, payload)
+        if family == "risk":
+            return _summarize_risk_payload(path, payload)
+        return None
+    if suffix == ".ndjson":
+        if family == "fills":
+            return _summarize_fill_ndjson_payload(path)
+        if family == "risk":
+            return _summarize_risk_ndjson_payload(path)
+        return None
     else:
         return None
-    if payload is None:
-        return None
-    if family == "fills":
-        return _summarize_fill_payload(path, payload)
-    if family == "risk":
-        return _summarize_risk_payload(path, payload)
-    return None
 
 
 def _merge_metadata(summary: dict[str, Any], artifact: dict[str, Any]) -> None:

--- a/src/tools/cache_integrity_doctor.py
+++ b/src/tools/cache_integrity_doctor.py
@@ -7,6 +7,8 @@ import json
 from pathlib import Path
 from typing import Any, Iterable
 
+from ohlcv_store import month_start_ts, rows_in_month, timeframe_to_interval_ms
+
 
 NUMPY_CACHE_SUFFIXES = {".npy"}
 DEFAULT_ROOTS = ("caches",)
@@ -33,11 +35,10 @@ TIMESTAMP_FIELD_NAMES = {
 
 
 def _timeframe_interval_ms(timeframe: str) -> int | None:
-    normalized = str(timeframe).strip().lower()
-    if normalized == "1m":
-        return 60_000
-    if normalized == "1h":
-        return 60 * 60_000
+    try:
+        return int(timeframe_to_interval_ms(str(timeframe)))
+    except ValueError:
+        return None
     return None
 
 
@@ -48,7 +49,7 @@ def _format_ms(ts_ms: int | None) -> str | None:
 
 
 def _month_start_ms(year: int, month: int) -> int:
-    return int(datetime(int(year), int(month), 1, tzinfo=timezone.utc).timestamp() * 1000)
+    return int(month_start_ts(int(year), int(month)))
 
 
 def _int_ms(value: Any) -> int | None:
@@ -220,7 +221,9 @@ def _coverage_summary_entry() -> dict[str, Any]:
     return {
         "artifact_count": 0,
         "covered_artifact_count": 0,
+        "length_mismatch_count": 0,
         "row_count": 0,
+        "expected_row_count": 0,
         "valid_row_count": 0,
         "gap_count": 0,
         "max_gap_rows": 0,
@@ -323,8 +326,16 @@ def _inspect_coverage_artifact(root: Path, path: Path, family: str) -> dict[str,
         return None
     valid_indices = np.flatnonzero(valid)
     row_count = int(valid.shape[0])
+    expected_row_count = int(
+        rows_in_month(
+            int(metadata["year"]),
+            int(metadata["month"]),
+            metadata["timeframe"],
+        )
+    )
     valid_row_count = int(valid_indices.size)
     interval_ms = int(metadata["interval_ms"])
+    length_mismatch = row_count != expected_row_count
     first_valid_idx: int | None = None
     last_valid_idx: int | None = None
     first_valid_ms: int | None = None
@@ -359,6 +370,27 @@ def _inspect_coverage_artifact(root: Path, path: Path, family: str) -> dict[str,
                     "duration_ms": int(gap_rows * interval_ms),
                 }
             )
+    if row_count < expected_row_count:
+        gap_start_idx = row_count
+        gap_end_idx = expected_row_count - 1
+        gap_rows = gap_end_idx - gap_start_idx + 1
+        gap_start_ms = int(metadata["month_start_ms"]) + gap_start_idx * interval_ms
+        gap_end_ms = int(metadata["month_start_ms"]) + gap_end_idx * interval_ms
+        gaps.append(
+            {
+                "path": str(path),
+                "exchange": metadata["exchange"],
+                "timeframe": metadata["timeframe"],
+                "symbol": metadata["symbol"],
+                "start_ms": gap_start_ms,
+                "end_ms": gap_end_ms,
+                "start_date": _format_ms(gap_start_ms),
+                "end_date": _format_ms(gap_end_ms),
+                "rows": int(gap_rows),
+                "duration_ms": int(gap_rows * interval_ms),
+                "boundary": "trailing_shortfall",
+            }
+        )
     max_gap_rows = max((int(gap["rows"]) for gap in gaps), default=0)
     return {
         "path": str(path),
@@ -369,6 +401,8 @@ def _inspect_coverage_artifact(root: Path, path: Path, family: str) -> dict[str,
         "month": metadata["month"],
         "interval_ms": interval_ms,
         "row_count": row_count,
+        "expected_row_count": expected_row_count,
+        "length_mismatch": length_mismatch,
         "valid_row_count": valid_row_count,
         "first_valid_ms": first_valid_ms,
         "last_valid_ms": last_valid_ms,
@@ -396,6 +430,8 @@ def _merge_coverage(summary: dict[str, Any], artifact: dict[str, Any]) -> None:
     coverage = summary["coverage"]
     coverage["artifact_count"] += 1
     coverage["row_count"] += int(artifact["row_count"])
+    coverage["expected_row_count"] += int(artifact["expected_row_count"])
+    coverage["length_mismatch_count"] += int(bool(artifact["length_mismatch"]))
     coverage["valid_row_count"] += int(artifact["valid_row_count"])
     coverage["gap_count"] += int(artifact["gap_count"])
     coverage["max_gap_rows"] = max(int(coverage["max_gap_rows"]), int(artifact["max_gap_rows"]))
@@ -421,7 +457,9 @@ def _merge_finalized_coverage(summary: dict[str, Any], coverage_report: dict[str
     coverage = summary["coverage"]
     coverage["artifact_count"] += int(coverage_report["artifact_count"])
     coverage["covered_artifact_count"] += int(coverage_report["covered_artifact_count"])
+    coverage["length_mismatch_count"] += int(coverage_report["length_mismatch_count"])
     coverage["row_count"] += int(coverage_report["row_count"])
+    coverage["expected_row_count"] += int(coverage_report["expected_row_count"])
     coverage["valid_row_count"] += int(coverage_report["valid_row_count"])
     coverage["gap_count"] += int(coverage_report["gap_count"])
     coverage["max_gap_rows"] = max(
@@ -818,8 +856,11 @@ def _finalize_coverage(coverage: dict[str, Any], issue_count: int) -> dict[str, 
     artifact_count = int(coverage["artifact_count"])
     valid_row_count = int(coverage["valid_row_count"])
     gap_count = int(coverage["gap_count"])
+    length_mismatch_count = int(coverage["length_mismatch_count"])
     if artifact_count == 0:
         evidence = "no_coverage_metadata"
+    elif length_mismatch_count:
+        evidence = "coverage_length_mismatch"
     elif issue_count:
         evidence = "issues_present"
     elif valid_row_count == 0:
@@ -832,7 +873,9 @@ def _finalize_coverage(coverage: dict[str, Any], issue_count: int) -> dict[str, 
         "warm_cache_evidence": evidence,
         "artifact_count": artifact_count,
         "covered_artifact_count": int(coverage["covered_artifact_count"]),
+        "length_mismatch_count": length_mismatch_count,
         "row_count": int(coverage["row_count"]),
+        "expected_row_count": int(coverage["expected_row_count"]),
         "valid_row_count": valid_row_count,
         "gap_count": gap_count,
         "max_gap_rows": int(coverage["max_gap_rows"]),
@@ -957,6 +1000,21 @@ def _scan_root(root: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
         coverage_artifact = _inspect_coverage_artifact(root, entry, family)
         if coverage_artifact is not None:
             _merge_coverage(family_summary, coverage_artifact)
+            if coverage_artifact["length_mismatch"]:
+                family_summary["issue_count"] += 1
+                issues.append(
+                    _issue(
+                        "warning",
+                        "coverage_length_mismatch",
+                        entry,
+                        (
+                            "candle valid mask length does not match canonical "
+                            f"month rows: actual={coverage_artifact['row_count']} "
+                            f"expected={coverage_artifact['expected_row_count']}"
+                        ),
+                        family=family,
+                    )
+                )
         metadata_artifact = _inspect_metadata_artifact(entry, family)
         if metadata_artifact is not None:
             _merge_metadata(family_summary, metadata_artifact)

--- a/tests/test_cache_integrity_doctor.py
+++ b/tests/test_cache_integrity_doctor.py
@@ -70,11 +70,11 @@ def test_cache_integrity_report_summarizes_candle_coverage_windows_and_gaps(tmp_
     root = tmp_path / "caches"
     month_dir = root / "ohlcv" / "data" / "binance" / "1m" / "BTC_USDT" / "2026"
     month_dir.mkdir(parents=True)
-    np.save(month_dir / "01.npy", np.full((8, 4), 1.0, dtype=np.float32))
-    np.save(
-        month_dir / "01.valid.npy",
-        np.array([False, True, True, False, False, True, True, False], dtype=bool),
-    )
+    expected_rows = 44_640
+    valid = np.zeros(expected_rows, dtype=bool)
+    valid[[1, 2, 5, 6]] = True
+    np.save(month_dir / "01.npy", np.full((expected_rows, 4), 1.0, dtype=np.float32))
+    np.save(month_dir / "01.valid.npy", valid)
 
     report = build_cache_integrity_report([root])
 
@@ -82,7 +82,9 @@ def test_cache_integrity_report_summarizes_candle_coverage_windows_and_gaps(tmp_
     assert coverage["warm_cache_evidence"] == "coverage_with_gaps"
     assert coverage["artifact_count"] == 1
     assert coverage["covered_artifact_count"] == 1
-    assert coverage["row_count"] == 8
+    assert coverage["length_mismatch_count"] == 0
+    assert coverage["row_count"] == expected_rows
+    assert coverage["expected_row_count"] == expected_rows
     assert coverage["valid_row_count"] == 4
     assert coverage["gap_count"] == 1
     assert coverage["max_gap_rows"] == 2
@@ -110,7 +112,8 @@ def test_cache_integrity_report_marks_empty_candle_coverage_masks(tmp_path):
     root = tmp_path / "caches"
     month_dir = root / "ohlcv" / "data" / "okx" / "1h" / "ETH_USDT" / "2026"
     month_dir.mkdir(parents=True)
-    np.save(month_dir / "02.valid.npy", np.zeros(3, dtype=bool))
+    expected_rows = 672
+    np.save(month_dir / "02.valid.npy", np.zeros(expected_rows, dtype=bool))
 
     report = build_cache_integrity_report([root])
 
@@ -118,8 +121,35 @@ def test_cache_integrity_report_marks_empty_candle_coverage_masks(tmp_path):
     assert coverage["warm_cache_evidence"] == "no_valid_rows"
     assert coverage["artifact_count"] == 1
     assert coverage["covered_artifact_count"] == 0
+    assert coverage["length_mismatch_count"] == 0
+    assert coverage["row_count"] == expected_rows
+    assert coverage["expected_row_count"] == expected_rows
     assert coverage["first_valid_date"] is None
     assert coverage["last_valid_date"] is None
+
+
+def test_cache_integrity_report_flags_truncated_candle_coverage_masks(tmp_path):
+    root = tmp_path / "caches"
+    month_dir = root / "ohlcv" / "data" / "binance" / "1m" / "BTC_USDT" / "2026"
+    month_dir.mkdir(parents=True)
+    np.save(month_dir / "01.valid.npy", np.ones(8, dtype=bool))
+
+    report = build_cache_integrity_report([root])
+
+    coverage = report["summary"]["by_family"]["candles"]["coverage"]
+    assert report["ok"] is True
+    assert coverage["warm_cache_evidence"] == "coverage_length_mismatch"
+    assert coverage["length_mismatch_count"] == 1
+    assert coverage["row_count"] == 8
+    assert coverage["expected_row_count"] == 44_640
+    assert coverage["gap_count"] == 1
+    assert coverage["gap_samples"][0]["boundary"] == "trailing_shortfall"
+    assert coverage["gap_samples"][0]["rows"] == 44_632
+    assert coverage["artifact_samples"][0]["length_mismatch"] is True
+    issue = report["issues"][0]
+    assert issue["severity"] == "warning"
+    assert issue["code"] == "coverage_length_mismatch"
+    assert issue["family"] == "candles"
 
 
 def test_cache_integrity_report_summarizes_fill_cache_metadata_contract_and_coverage(tmp_path):

--- a/tests/test_cache_integrity_doctor.py
+++ b/tests/test_cache_integrity_doctor.py
@@ -122,6 +122,99 @@ def test_cache_integrity_report_marks_empty_candle_coverage_masks(tmp_path):
     assert coverage["last_valid_date"] is None
 
 
+def test_cache_integrity_report_summarizes_fill_cache_metadata_contract_and_coverage(tmp_path):
+    root = tmp_path / "caches"
+    fill_dir = root / "fill_events" / "binance" / "user_01"
+    fill_dir.mkdir(parents=True)
+    current_contract = "gross_pnl_quote_fee_best_effort_v2"
+    (fill_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "pnl_contract": current_contract,
+                "history_scope": "all",
+                "covered_start_ms": 1767225600000,
+                "oldest_event_ts": 1767312000000,
+                "newest_event_ts": 1767398400000,
+                "last_refresh_ms": 1767484800000,
+                "known_gaps": [{"start_ts": 1767355200000, "end_ts": 1767358800000}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (fill_dir / "2026-01-02.json").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "a",
+                    "timestamp": 1767312000000,
+                    "pnl_contract": current_contract,
+                },
+                {"id": "b", "timestamp": 1767315600000},
+                {
+                    "id": "c",
+                    "timestamp": 1767319200000,
+                    "pnl_contract": "legacy_contract",
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    report = build_cache_integrity_report([root])
+
+    metadata = report["summary"]["by_family"]["fills"]["metadata"]
+    assert metadata["compatibility"] == "legacy_or_missing_pnl_contract"
+    assert metadata["artifact_count"] == 2
+    assert metadata["metadata_file_count"] == 1
+    assert metadata["record_count"] == 3
+    assert metadata["current_pnl_contract_count"] == 2
+    assert metadata["legacy_pnl_contract_count"] == 1
+    assert metadata["missing_pnl_contract_count"] == 1
+    assert metadata["history_scope_counts"] == {"all": 1}
+    assert metadata["known_gap_count"] == 1
+    assert metadata["covered_start_date"] == "2026-01-01T00:00:00+00:00"
+    assert metadata["first_event_date"] == "2026-01-02T00:00:00+00:00"
+    assert metadata["last_event_date"] == "2026-01-03T00:00:00+00:00"
+    assert metadata["newest_event_date"] == "2026-01-03T00:00:00+00:00"
+    assert metadata["last_refresh_date"] == "2026-01-04T00:00:00+00:00"
+
+
+def test_cache_integrity_report_summarizes_hsl_state_metadata(tmp_path):
+    root = tmp_path / "caches"
+    hsl_dir = root / "equity_hard_stop" / "binance"
+    hsl_dir.mkdir(parents=True)
+    (hsl_dir / "user_01.json").write_text(
+        json.dumps(
+            {
+                "pside": "long",
+                "symbol": "BTCUSDT",
+                "tier": "red",
+                "last_red_ts": 1767312000000,
+                "cooldown_until_ms": 1767315600000,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = build_cache_integrity_report([root])
+
+    metadata = report["summary"]["by_family"]["risk"]["metadata"]
+    assert metadata["compatibility"] == "local_state_with_timestamps"
+    assert metadata["artifact_count"] == 1
+    assert metadata["timestamp_field_count"] == 2
+    assert metadata["first_event_date"] == "2026-01-02T00:00:00+00:00"
+    assert metadata["last_event_date"] == "2026-01-02T01:00:00+00:00"
+    sample = metadata["artifact_samples"][0]
+    assert sample["hsl_related"] is True
+    assert sample["top_level_keys"] == [
+        "cooldown_until_ms",
+        "last_red_ts",
+        "pside",
+        "symbol",
+        "tier",
+    ]
+
+
 def test_cache_integrity_report_marks_missing_root_as_warning(tmp_path):
     missing = tmp_path / "missing"
 

--- a/tests/test_cache_integrity_doctor.py
+++ b/tests/test_cache_integrity_doctor.py
@@ -141,9 +141,10 @@ def test_cache_integrity_report_summarizes_fill_cache_metadata_contract_and_cove
         ),
         encoding="utf-8",
     )
-    (fill_dir / "2026-01-02.json").write_text(
-        json.dumps(
-            [
+    (fill_dir / "2026-01-02.ndjson").write_text(
+        "\n".join(
+            json.dumps(row)
+            for row in [
                 {
                     "id": "a",
                     "timestamp": 1767312000000,
@@ -156,7 +157,8 @@ def test_cache_integrity_report_summarizes_fill_cache_metadata_contract_and_cove
                     "pnl_contract": "legacy_contract",
                 },
             ]
-        ),
+        )
+        + "\n",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Summary
- add read-only fill cache metadata summaries to cache-integrity-doctor, including local pnl_contract compatibility counts, history scope counts, known gaps, and coverage timestamps
- add local HSL/risk-state JSON metadata summaries with bounded timestamp-field samples
- update cache-doctor docs, backlog progress, and changelog

## Validation
- pytest tests/test_cache_integrity_doctor.py
- python -m compileall src/tools/cache_integrity_doctor.py tests/test_cache_integrity_doctor.py
- git diff --check
- rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])\)" src/tools/cache_integrity_doctor.py tests/test_cache_integrity_doctor.py (no matches)

## Boundaries
- local/read-only JSON/NDJSON artifact inspection only
- no repair, enforcement, live bot control, exchange access, credentials, SSH, tmux, or trading behavior changes