### PR TITLE
Address live logging reviewer follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable user-facing changes will be documented in this file.
 - Added fill-cache and HSL/risk-state metadata summaries to
   `passivbot tool cache-integrity-doctor`, including local fill
   `pnl_contract` compatibility counts and coverage timestamps.
+- Hardened recent live-ops tooling and debug-profile diagnostics by redacting
+  shareable path fields consistently, keeping Rust debug sample construction
+  best-effort, and scoping EMA debug enrichment to the `ema` profile only.
 - Added v2 candle coverage windows and suspicious interior gap samples to
   `passivbot tool cache-integrity-doctor`, derived only from local `.valid.npy`
   cache artifacts.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -1202,14 +1202,34 @@ VPS5 deployment status:
   remote/account-critical calls. Remaining attention came from known non-hard
   EMA/staged-readiness and HSL cooldown events.
 
-### Pending PR: Candle Debug Profile
+### PR #724: Candle Debug Profile
 
 - Branch: `codex/v8-candle-debug-profile`.
 - Scope: Phase 5/6 opt-in structured debug enrichment.
-- Planned result: add `candles` debug-profile enrichment to existing
+- Result: added `candles` debug-profile enrichment to existing
   `candle.tail_projected` and `candle.coverage_checked` events, exposing bounded
   key-shape, timeframe/window, and missing-coverage counters without raw candle
   arrays or default console/log changes.
+- Review evidence: Hermes approved head `4454fd09`; CI was green; focused
+  candle debug-profile tests, the broader live-event/monitor suite, compileall,
+  `git diff --check`, and touched-file silent-handling audit passed before
+  merge. Claude did not return before merge, so this opt-in observability slice
+  used the degraded gate.
+- VPS5 evidence: deployed to VPS5 at `f3969dbc` without bot restart because the
+  profile is opt-in and no VPS config enabled it. A 10-minute brief smoke
+  reported `ok=true`, no hard failures, all five expected bots matched, clean
+  tracked repository state, no failed remote calls, and no failed
+  account-critical remote calls.
+
+### Pending PR: Reviewer Follow-Ups
+
+- Branch: `codex/v8-reviewer-followups`.
+- Scope: Claude retrospective follow-up for already-merged low-risk
+  observability/tooling slices.
+- Planned result: redacts shareable live-ops path fields consistently, removes
+  shutdown event message echo from smoke summaries, scopes EMA debug enrichment
+  to the `ema` profile only, and keeps Rust debug sample construction
+  best-effort inside the event-emitter path.
 
 ## Current Next Steps
 

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -965,6 +965,30 @@ def rust_output_order_debug_sample(
     }
 
 
+def _best_effort_rust_input_symbol_debug_sample(
+    input_symbols: Any,
+    *,
+    idx_to_symbol: dict[int, str] | None = None,
+) -> dict[str, Any] | None:
+    try:
+        return rust_input_symbol_debug_sample(input_symbols, idx_to_symbol=idx_to_symbol)
+    except Exception as exc:
+        logging.debug("[event] failed to build rust input debug sample: %s", exc)
+        return None
+
+
+def _best_effort_rust_output_order_debug_sample(
+    orders: Any,
+    *,
+    idx_to_symbol: dict[int, str] | None = None,
+) -> dict[str, Any] | None:
+    try:
+        return rust_output_order_debug_sample(orders, idx_to_symbol=idx_to_symbol)
+    except Exception as exc:
+        logging.debug("[event] failed to build rust output debug sample: %s", exc)
+        return None
+
+
 def _emit_startup_timing_event_unchecked(
     bot: Any,
     *,
@@ -1517,6 +1541,8 @@ def _emit_rust_orchestrator_called_event_unchecked(
     hedge_mode: bool,
     strategy_kind: str | None,
     input_symbol_sample: dict[str, Any] | None = None,
+    input_symbols: Any = None,
+    idx_to_symbol: dict[int, str] | None = None,
 ) -> None:
     data = {
         "symbol_count": int(symbol_count),
@@ -1527,6 +1553,11 @@ def _emit_rust_orchestrator_called_event_unchecked(
         "strategy_kind": strategy_kind,
         "input_hash": str(input_hash),
     }
+    if input_symbol_sample is None and live_event_debug_profile_enabled(bot, "rust"):
+        input_symbol_sample = _best_effort_rust_input_symbol_debug_sample(
+            input_symbols,
+            idx_to_symbol=idx_to_symbol,
+        )
     if input_symbol_sample is not None:
         data["debug_profile"] = "rust"
         data["input_symbol_sample"] = input_symbol_sample
@@ -1566,6 +1597,8 @@ def _emit_rust_orchestrator_returned_event_unchecked(
     diagnostics: Any = None,
     error: BaseException | None = None,
     output_order_sample: dict[str, Any] | None = None,
+    orders: Any = None,
+    idx_to_symbol: dict[int, str] | None = None,
 ) -> None:
     event_status = str(status or "succeeded").lower()
     failed = event_status == "failed" or error is not None
@@ -1595,6 +1628,11 @@ def _emit_rust_orchestrator_returned_event_unchecked(
         data["diagnostic_keys"] = (
             sorted(diagnostics) if isinstance(diagnostics, dict) else []
         )
+        if output_order_sample is None and live_event_debug_profile_enabled(bot, "rust"):
+            output_order_sample = _best_effort_rust_output_order_debug_sample(
+                orders,
+                idx_to_symbol=idx_to_symbol,
+            )
         if output_order_sample is not None:
             data["debug_profile"] = "rust"
             data["output_order_sample"] = output_order_sample
@@ -2277,9 +2315,7 @@ def _emit_ema_unavailable_event_unchecked(
         "unavailable": _symbol_sample(unavailable_symbols),
         "unavailable_reasons": _reason_symbol_summary(ema_unavailable_reasons),
     }
-    if live_event_debug_profile_enabled(bot, "ema") or live_event_debug_profile_enabled(
-        bot, "candles"
-    ):
+    if live_event_debug_profile_enabled(bot, "ema"):
         data["debug_profile"] = "ema"
         data["debug"] = _ema_unavailable_debug_summary(
             candidate_ema_unavailable_details,

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from live.smoke_report import parse_tmuxp_live_commands
+from live.smoke_report import parse_tmuxp_live_commands, _user_safe_display_path
 
 
 DEFAULT_SHUTDOWN_TIMEOUT_S = 90
@@ -23,7 +23,7 @@ def _positive_int(value: int, *, field: str) -> int:
 def _display_path(value: str | Path | None) -> str | None:
     if value is None:
         return None
-    return str(Path(value).expanduser())
+    return _user_safe_display_path(value)
 
 
 def _shell_join(args: list[str]) -> str:
@@ -254,7 +254,7 @@ def build_live_restart_smoke_plan(
             "smoke_window_minutes": smoke_window_minutes,
         },
         "supervisor_config": {
-            "path": supervisor.get("path"),
+            "path": _display_path(supervisor.get("path")),
             "exists": supervisor.get("exists"),
             "error": supervisor.get("error"),
             "expected_live_commands": len(bots),

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -1095,7 +1095,6 @@ def _shutdown_event_group(
     line_no: int,
 ) -> dict[str, Any]:
     ids = _event_ids(live_event)
-    message = live_event.get("message")
     return {
         "bot": bot_key,
         "event_type": live_event.get("event_type") or row.get("kind"),
@@ -1108,11 +1107,6 @@ def _shutdown_event_group(
         "latest_seq": row.get("seq"),
         "latest_path": str(path),
         "latest_line": int(line_no),
-        "latest_message": (
-            _redact_log_text(str(message), max_len=240)
-            if message not in (None, "")
-            else None
-        ),
         "latest_data": _compact_shutdown_event_data(live_event),
         "latest_ids": {
             key: ids.get(key)

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -65,7 +65,6 @@ from live.event_bus import (
     LiveEventPipeline,
     MonitorEventSink,
     ReasonCodes,
-    live_event_debug_profile_enabled,
     normalize_live_event_debug_profiles,
     payload_hash_raw,
 )
@@ -15348,7 +15347,6 @@ class Passivbot:
         tradable_count = sum(
             1 for item in input_dict["symbols"] if bool(item.get("tradable", False))
         )
-        rust_debug_profile_enabled = live_event_debug_profile_enabled(self, "rust")
         self._emit_rust_orchestrator_called_event(
             rust_call_id=rust_call_id,
             input_hash=input_hash,
@@ -15358,14 +15356,8 @@ class Passivbot:
             trailing_unavailable_count=len(trailing_unavailable_symbols),
             hedge_mode=bool(effective_hedge_mode),
             strategy_kind=strategy_kind,
-            input_symbol_sample=(
-                live_event_emitters.rust_input_symbol_debug_sample(
-                    input_dict.get("symbols"),
-                    idx_to_symbol=idx_to_symbol,
-                )
-                if rust_debug_profile_enabled
-                else None
-            ),
+            input_symbols=input_dict.get("symbols"),
+            idx_to_symbol=idx_to_symbol,
         )
         try:
             out_json = pbr.compute_ideal_orders_json(input_json)
@@ -15404,14 +15396,8 @@ class Passivbot:
             elapsed_ms=int(elapsed_ms),
             order_count=len(orders),
             diagnostics=diagnostics,
-            output_order_sample=(
-                live_event_emitters.rust_output_order_debug_sample(
-                    orders,
-                    idx_to_symbol=idx_to_symbol,
-                )
-                if rust_debug_profile_enabled
-                else None
-            ),
+            orders=orders,
+            idx_to_symbol=idx_to_symbol,
         )
         Passivbot._emit_action_planned_event(
             self,

--- a/src/tools/live_config_preflight.py
+++ b/src/tools/live_config_preflight.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from live.smoke_report import _user_safe_display_path
+
 
 DEFAULT_SAMPLE_SIZE = 8
 SIDES = ("long", "short")
@@ -224,19 +226,21 @@ def build_live_config_preflight_report(
     sample_size: int = DEFAULT_SAMPLE_SIZE,
 ) -> dict[str, Any]:
     path = Path(config_path).expanduser()
+    display_path = _user_safe_display_path(path)
     issues: list[dict[str, Any]] = []
     try:
         raw = path.read_text(encoding="utf-8")
     except OSError as exc:
+        detail = getattr(exc, "strerror", None) or type(exc).__name__
         return {
             "ok": False,
-            "config_path": str(path),
+            "config_path": display_path,
             "issues": [
                 _issue(
                     "error",
                     "read_failed",
-                    f"could not read config: {exc}",
-                    path=str(path),
+                    f"could not read config {display_path}: {detail}",
+                    path=display_path,
                 )
             ],
         }
@@ -245,20 +249,20 @@ def build_live_config_preflight_report(
     except json.JSONDecodeError as exc:
         return {
             "ok": False,
-            "config_path": str(path),
+            "config_path": display_path,
             "issues": [
                 _issue(
                     "error",
                     "json_decode_failed",
                     f"invalid JSON at line {exc.lineno} column {exc.colno}: {exc.msg}",
-                    path=str(path),
+                    path=display_path,
                 )
             ],
         }
     if not isinstance(parsed, dict):
         return {
             "ok": False,
-            "config_path": str(path),
+            "config_path": display_path,
             "issues": [
                 _issue("error", "config_root_invalid", "config root must be a JSON object")
             ],
@@ -298,7 +302,7 @@ def build_live_config_preflight_report(
     severity_counts = Counter(issue["severity"] for issue in issues)
     return {
         "ok": "error" not in severity_counts,
-        "config_path": str(path),
+        "config_path": display_path,
         "config_version": parsed.get("config_version"),
         "identity": _identity_report(parsed, live),
         "hsl": {

--- a/tests/test_live_config_preflight.py
+++ b/tests/test_live_config_preflight.py
@@ -142,6 +142,18 @@ def test_live_config_preflight_invalid_json_returns_nonzero(tmp_path, capsys):
     assert report["issues"][0]["code"] == "json_decode_failed"
 
 
+def test_live_config_preflight_missing_config_path_is_user_safe():
+    report = live_config_preflight.build_live_config_preflight_report(
+        "/root/passivbot/configs/missing.json"
+    )
+
+    assert report["ok"] is False
+    assert report["config_path"] == "~/passivbot/configs/missing.json"
+    assert report["issues"][0]["path"] == "~/passivbot/configs/missing.json"
+    rendered = json.dumps(report, sort_keys=True)
+    assert "/root" not in rendered
+
+
 def test_live_config_preflight_rejects_negative_sample_size(tmp_path):
     config_path = tmp_path / "live.json"
     _write_config(config_path, _sample_config())

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -6,7 +6,7 @@ import sys
 
 import pytest
 
-from live.restart_smoke_plan import build_live_restart_smoke_plan
+from live.restart_smoke_plan import _display_path, build_live_restart_smoke_plan
 from passivbot_cli import main as cli_main
 from tools import live_restart_smoke_plan
 
@@ -89,6 +89,12 @@ def test_live_restart_smoke_plan_redacts_and_bounds_configured_commands(tmp_path
     assert len(command_key) <= len("...<truncated>") + 400
 
 
+def test_live_restart_smoke_plan_display_path_collapses_user_prefixes():
+    assert _display_path("/root/bots_vps5.yaml") == "~/bots_vps5.yaml"
+    assert _display_path("/Users/alice/passivbot/monitor") == "~/passivbot/monitor"
+    assert _display_path(None) is None
+
+
 def test_live_restart_smoke_plan_reports_missing_supervisor_config(tmp_path):
     report = build_live_restart_smoke_plan(tmp_path / "missing.yaml")
 
@@ -117,7 +123,7 @@ def test_live_restart_smoke_plan_reports_malformed_supervisor_config(tmp_path):
     assert report["ok"] is False
     assert report["bots"] == []
     assert report["supervisor_config"] == {
-        "path": str(supervisor_config),
+        "path": report["inputs"]["supervisor_config"],
         "exists": True,
         "error": None,
         "expected_live_commands": 0,

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -26,6 +26,7 @@ def _monitor_row(
     pside: str | None = None,
     ids: dict | None = None,
     data: dict | None = None,
+    message: str | None = None,
 ) -> dict:
     live_event = {
         "schema_version": 1,
@@ -43,6 +44,8 @@ def _monitor_row(
         "data": dict(data or {"seq": seq}),
         "ids": dict(ids or {}),
     }
+    if message is not None:
+        live_event["message"] = message
     return {
         "exchange": "binance",
         "user": "binance_01",
@@ -1183,6 +1186,7 @@ def test_live_smoke_report_summarizes_shutdown_events(tmp_path):
                 status="degraded",
                 level="warning",
                 reason_code="maintainers_timeout",
+                message="shutdown delayed in /Users/alice/passivbot for alice_01",
                 data={
                     "stage": "maintainers_timeout",
                     "elapsed_s": 6.25,
@@ -1226,6 +1230,8 @@ def test_live_smoke_report_summarizes_shutdown_events(tmp_path):
     assert stage_group["latest_data"]["task_count"] == 4
     assert "AKIA123" not in stage_group["latest_data"]["error"]
     assert "TOKEN123" not in stage_group["latest_data"]["error"]
+    assert "latest_message" not in stage_group
+    assert "alice" not in json.dumps(report["shutdown_events"], sort_keys=True)
     assert summary["shutdown_events"]["total"] == 3
     assert summary["shutdown_events"]["groups_truncated"] is True
     assert len(summary["shutdown_events"]["groups"]) == 2

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -726,6 +726,85 @@ def test_rust_orchestrator_debug_profile_samples_are_bounded():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_rust_debug_sample_failures_do_not_suppress_base_events(monkeypatch):
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _emit_rust_orchestrator_called_event = (
+            pb_mod.Passivbot._emit_rust_orchestrator_called_event
+        )
+        _emit_rust_orchestrator_returned_event = (
+            pb_mod.Passivbot._emit_rust_orchestrator_returned_event
+        )
+
+        def __init__(self):
+            self.exchange = "bybit"
+            self.user = "bybit_01"
+            self.bot_id = "bot_1"
+            self.live_event_debug_profiles = ("rust",)
+            self._live_event_current_cycle_id = "cy_rust"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    def fail_input_sample(*_args, **_kwargs):
+        raise RuntimeError("input sample failed")
+
+    def fail_output_sample(*_args, **_kwargs):
+        raise RuntimeError("output sample failed")
+
+    monkeypatch.setattr(
+        live_event_emitters,
+        "rust_input_symbol_debug_sample",
+        fail_input_sample,
+    )
+    monkeypatch.setattr(
+        live_event_emitters,
+        "rust_output_order_debug_sample",
+        fail_output_sample,
+    )
+
+    bot = FakeBot()
+    bot._emit_rust_orchestrator_called_event(
+        rust_call_id="rust_8",
+        input_hash="input_hash",
+        symbol_count=1,
+        tradable_count=1,
+        ema_unavailable_count=0,
+        trailing_unavailable_count=0,
+        hedge_mode=True,
+        strategy_kind="recursive_grid",
+        input_symbols=[{"symbol_idx": 0, "tradable": True}],
+        idx_to_symbol={0: "BTC/USDT:USDT"},
+    )
+    bot._emit_rust_orchestrator_returned_event(
+        rust_call_id="rust_8",
+        status="succeeded",
+        input_hash="input_hash",
+        output_hash="output_hash",
+        elapsed_ms=12,
+        order_count=1,
+        diagnostics={},
+        orders=[{"symbol_idx": 0, "order_type": "entry_grid_normal_long"}],
+        idx_to_symbol={0: "BTC/USDT:USDT"},
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    called, returned = sink.events
+    assert called.event_type == EventTypes.RUST_ORCHESTRATOR_CALLED
+    assert returned.event_type == EventTypes.RUST_ORCHESTRATOR_RETURNED
+    assert "debug_profile" not in called.data
+    assert "input_symbol_sample" not in called.data
+    assert "debug_profile" not in returned.data
+    assert "output_order_sample" not in returned.data
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_rust_orchestrator_emitters_are_best_effort(caplog):
     import passivbot as pb_mod
 
@@ -1523,6 +1602,48 @@ def test_ema_unavailable_event_debug_profile_adds_parsed_readiness_detail():
         {"reason": "non-finite h1_log_range value nan", "count": 2},
         {"reason": "missing required window", "count": 1},
     ]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_ema_unavailable_event_debug_profile_not_enabled_by_candles_profile():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_ema_unavailable_event = pb_mod.Passivbot._emit_ema_unavailable_event
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "binance"
+            self.user = "binance_01"
+            self.bot_id = "bot_1"
+            self.live_event_debug_profiles = ("candles",)
+            self._live_event_current_cycle_id = "cy_13"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+    bot._emit_ema_unavailable_event(
+        candidate_ema_unavailable_details={
+            "cache_only_fetch_failed": [
+                (
+                    "BTC/USDT:USDT",
+                    "RuntimeError",
+                    "[ema] missing required h1_log_range EMA for BTC/USDT:USDT",
+                )
+            ]
+        }
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[0]
+    assert event.event_type == EventTypes.EMA_UNAVAILABLE
+    assert "debug_profile" not in event.data
+    assert "debug" not in event.data
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
## Summary
- redact/share-safe live-ops path display fields in restart smoke plans and config preflight reports
- remove free-form shutdown event message echo from smoke report summaries
- keep Rust debug sample construction best-effort inside event emitters so debug-profile failures cannot suppress base events
- scope EMA unavailable debug enrichment to the `ema` profile only, not `candles`

## Context
Follow-up to Claude retrospective findings posted on PR #723 for already-merged low-risk logging/tooling slices. Observability/tooling only; no trading-path behavior change intended.

## Validation
- `./venv/bin/python -m pytest -q tests/test_live_restart_smoke_plan.py tests/test_live_config_preflight.py tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_shutdown_events tests/test_passivbot_monitor.py::test_ema_unavailable_event_debug_profile_not_enabled_by_candles_profile tests/test_passivbot_monitor.py::test_rust_orchestrator_debug_profile_samples_are_bounded tests/test_passivbot_monitor.py::test_rust_debug_sample_failures_do_not_suppress_base_events`
- `./venv/bin/python -m pytest -q tests/test_live_event_bus.py tests/test_passivbot_monitor.py tests/test_live_smoke_report.py tests/test_live_restart_smoke_plan.py tests/test_live_config_preflight.py`
- `./venv/bin/python -m compileall -q src/live/restart_smoke_plan.py src/live/smoke_report.py src/tools/live_config_preflight.py src/live/event_emitters.py src/passivbot.py tests/test_live_restart_smoke_plan.py tests/test_live_config_preflight.py tests/test_live_smoke_report.py tests/test_passivbot_monitor.py`
- `git diff --check origin/v8..HEAD`
- touched-file silent-handling audit reviewed; new broad catches are limited to best-effort debug sample construction