### PR TITLE
Add cache doctor warm readiness evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added report-only warm-cache readiness evidence to
+  `passivbot tool cache-integrity-doctor`, derived from already-scanned local
+  candle, fill, and HSL/risk cache metadata.
 - Added fill-cache and HSL/risk-state metadata summaries to
   `passivbot tool cache-integrity-doctor`, including local fill
   `pnl_contract` compatibility counts and coverage timestamps.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -307,10 +307,13 @@ Related detailed plans:
       artifacts, including fill `pnl_contract` compatibility counts, fill
       coverage timestamps, known-gap counts, and HSL/risk state timestamp
       summaries without repair or enforcement.
+    - 2026-06-27: Added report-only warm-cache readiness evidence derived from
+      already-scanned candle/fill/HSL metadata, including core evidence labels,
+      reasons, missing families, suspicious gap counts, and per-family
+      timestamp context without making startup or trading decisions.
 
     Remaining refinements: add deeper candle/fill/HSL metadata compatibility
-    checks, synthetic/no-trade assumptions, and warm-cache readiness without
-    making trading decisions.
+    checks and synthetic/no-trade assumptions without making trading decisions.
 
 14. [ ] Supervisor/process model.
     Status: partial. `live-smoke-report --supervisor-config` now reports
@@ -373,6 +376,7 @@ Related detailed plans:
 | 2026-06-26 | #3 Live restart/smoke automation | PR #715 / `7b12d4b2` | Added passive `shutdown_events` summaries to full, summary, and brief `live-smoke-report` output for existing bot stopping/stage/stopped events; VPS5 no-restart smoke showed `shutdown_events.total=0`, all five bots matched, and no hard failures | Safe pull/stop/start orchestration remains open |
 | 2026-06-27 | #13 Cache integrity doctor | PR #722 / `3b7e6306` | Added read-only v2 candle coverage windows and suspicious interior gap samples from local `.valid.npy` artifacts | Fill/HSL coverage/readiness and deeper metadata compatibility |
 | 2026-06-27 | #13 Cache integrity doctor | pending PR | Added read-only fill/HSL metadata summaries from local JSON/NDJSON artifacts | Deeper metadata compatibility, synthetic/no-trade assumptions, and warm-cache readiness |
+| 2026-06-27 | #13 Cache integrity doctor | pending PR | Added report-only warm-cache readiness evidence from already-scanned candle/fill/HSL cache metadata | Deeper metadata compatibility and synthetic/no-trade assumptions |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #701 / `fcda70f5` | Added `ticker-endpoint-probe` `account_critical_health` summaries for read-only balance/positions/open-orders outcomes; VPS5 Binance probe validated the summary and exposed an open-orders shape follow-up | Lower-impact/account-only mode, exchange-aware open-orders probing, clock skew/rate-limit/fill/candle probes |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #703 / `8fefce4b` | Added `ticker-endpoint-probe --account-only`, `--skip-my-trades`, and open-orders symbol fallback; VPS5 Binance account-only probe returned account-critical total=3, succeeded=3, and smoke stayed green | Clock skew/rate-limit/fill-pagination/candle-freshness probes |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -107,7 +107,7 @@ passivbot tool iterative-history-plot backtests/.../fills.csv
 - `passivbot tool pad-historical-daily` – Ensures daily OHLCV shards are present for the downloader when new coins are added.
 - `passivbot tool verify-hlcvs-data` – Validates prepared HLCV datasets and coverage metadata before long optimizations/backtests.
 - `passivbot tool streamline-json` – Normalizes/compacts JSON configs (`passivbot tool streamline-json configs/examples/default_trailing_martingale_long_npos4.json`).
-- `passivbot tool cache-integrity-doctor` – Read-only local cache smoke report for missing roots, file counts/sizes, cache-family summaries, v2 candle coverage/gap evidence, fill/HSL metadata evidence, and empty or corrupt JSON/NDJSON/NPY artifacts.
+- `passivbot tool cache-integrity-doctor` – Read-only local cache smoke report for missing roots, file counts/sizes, cache-family summaries, report-only warm-cache readiness evidence, v2 candle coverage/gap evidence, fill/HSL metadata evidence, and empty or corrupt JSON/NDJSON/NPY artifacts.
 - `passivbot tool candle-doctor` – Audits legacy `caches/ohlcv/...` shards for corruption, stale index entries, and legacy-format issues; add `--fix` to apply automatic repairs before importing into the v2 store.
 - `passivbot tool migrate-historical-data` – Converts legacy `historical_data/ohlcvs_<exchange>/...` shards into the current `caches/ohlcv/...` layout.
 

--- a/src/tools/cache_integrity_doctor.py
+++ b/src/tools/cache_integrity_doctor.py
@@ -16,6 +16,8 @@ MAX_COVERAGE_ARTIFACT_SAMPLES = 8
 MAX_COVERAGE_GAP_SAMPLES = 8
 MAX_METADATA_ARTIFACT_SAMPLES = 8
 CURRENT_FILL_PNL_CONTRACT = "gross_pnl_quote_fee_best_effort_v2"
+CORE_WARM_CACHE_FAMILIES = ("candles", "fills")
+WARM_CACHE_FAMILIES = ("candles", "fills", "risk")
 TIMESTAMP_FIELD_SUFFIXES = ("_ms", "_ts", "_at")
 TIMESTAMP_FIELD_NAMES = {
     "timestamp",
@@ -889,6 +891,170 @@ def _finalize_coverage(coverage: dict[str, Any], issue_count: int) -> dict[str, 
     }
 
 
+def _family_mapping_value(families: dict[str, Any], family: str, key: str) -> Any:
+    family_report = families[family] if family in families else {}
+    return family_report[key] if isinstance(family_report, dict) and key in family_report else None
+
+
+def _warm_cache_candle_report(families: dict[str, Any]) -> dict[str, Any]:
+    coverage = _family_mapping_value(families, "candles", "coverage")
+    if not isinstance(coverage, dict) or int(coverage["artifact_count"]) == 0:
+        return {
+            "readiness": "missing",
+            "reason": "candle_coverage_missing",
+        }
+    evidence = str(coverage["warm_cache_evidence"])
+    attention = evidence != "coverage_observed"
+    reasons = [f"candle_{evidence}"]
+    gap_count = int(coverage["gap_count"])
+    length_mismatch_count = int(coverage["length_mismatch_count"])
+    if gap_count:
+        reasons.append("candle_suspicious_gaps_present")
+    if length_mismatch_count:
+        reasons.append("candle_length_mismatch_present")
+    return {
+        "readiness": "attention" if attention else "observed",
+        "reasons": reasons,
+        "evidence": evidence,
+        "artifact_count": int(coverage["artifact_count"]),
+        "covered_artifact_count": int(coverage["covered_artifact_count"]),
+        "length_mismatch_count": length_mismatch_count,
+        "valid_row_count": int(coverage["valid_row_count"]),
+        "expected_row_count": int(coverage["expected_row_count"]),
+        "first_valid_ms": coverage["first_valid_ms"],
+        "last_valid_ms": coverage["last_valid_ms"],
+        "first_valid_date": coverage["first_valid_date"],
+        "last_valid_date": coverage["last_valid_date"],
+        "suspicious_gap_count": gap_count,
+        "max_gap_rows": int(coverage["max_gap_rows"]),
+    }
+
+
+def _warm_cache_fill_report(families: dict[str, Any]) -> dict[str, Any]:
+    metadata = _family_mapping_value(families, "fills", "metadata")
+    if not isinstance(metadata, dict) or int(metadata["artifact_count"]) == 0:
+        return {
+            "readiness": "missing",
+            "reason": "fill_metadata_missing",
+        }
+    compatibility = str(metadata["compatibility"])
+    known_gap_count = int(metadata["known_gap_count"])
+    record_count = int(metadata["record_count"])
+    covered_start_ms = metadata["covered_start_ms"]
+    history_scope_counts = metadata["history_scope_counts"]
+    reasons = [f"fill_{compatibility}"]
+    if known_gap_count:
+        reasons.append("fill_known_gaps_present")
+    if covered_start_ms is None:
+        reasons.append("fill_covered_start_missing")
+    if record_count == 0:
+        reasons.append("fill_records_missing")
+    attention = (
+        compatibility != "current_pnl_contract"
+        or known_gap_count > 0
+        or covered_start_ms is None
+    )
+    return {
+        "readiness": "attention" if attention else "observed",
+        "reasons": reasons,
+        "compatibility": compatibility,
+        "artifact_count": int(metadata["artifact_count"]),
+        "metadata_file_count": int(metadata["metadata_file_count"]),
+        "record_count": record_count,
+        "current_pnl_contract_count": int(metadata["current_pnl_contract_count"]),
+        "legacy_pnl_contract_count": int(metadata["legacy_pnl_contract_count"]),
+        "missing_pnl_contract_count": int(metadata["missing_pnl_contract_count"]),
+        "history_scope_counts": dict(history_scope_counts),
+        "covered_start_ms": covered_start_ms,
+        "covered_start_date": metadata["covered_start_date"],
+        "first_event_ms": metadata["first_event_ms"],
+        "last_event_ms": metadata["last_event_ms"],
+        "first_event_date": metadata["first_event_date"],
+        "last_event_date": metadata["last_event_date"],
+        "last_refresh_ms": metadata["last_refresh_ms"],
+        "last_refresh_date": metadata["last_refresh_date"],
+        "suspicious_gap_count": known_gap_count,
+    }
+
+
+def _warm_cache_risk_report(families: dict[str, Any]) -> dict[str, Any]:
+    metadata = _family_mapping_value(families, "risk", "metadata")
+    if not isinstance(metadata, dict) or int(metadata["artifact_count"]) == 0:
+        return {
+            "readiness": "missing_optional",
+            "reason": "risk_hsl_metadata_missing_optional",
+        }
+    compatibility = str(metadata["compatibility"])
+    attention = compatibility == "issues_present"
+    return {
+        "readiness": "attention_optional" if attention else "observed_optional",
+        "reasons": [f"risk_{compatibility}"],
+        "compatibility": compatibility,
+        "artifact_count": int(metadata["artifact_count"]),
+        "record_count": int(metadata["record_count"]),
+        "timestamp_field_count": int(metadata["timestamp_field_count"]),
+        "first_event_ms": metadata["first_event_ms"],
+        "last_event_ms": metadata["last_event_ms"],
+        "first_event_date": metadata["first_event_date"],
+        "last_event_date": metadata["last_event_date"],
+    }
+
+
+def _build_warm_cache_readiness(families: dict[str, Any]) -> dict[str, Any]:
+    family_reports = {
+        "candles": _warm_cache_candle_report(families),
+        "fills": _warm_cache_fill_report(families),
+        "risk": _warm_cache_risk_report(families),
+    }
+    missing_families = [
+        family
+        for family in WARM_CACHE_FAMILIES
+        if str(family_reports[family]["readiness"]).startswith("missing")
+    ]
+    missing_core = [
+        family
+        for family in CORE_WARM_CACHE_FAMILIES
+        if str(family_reports[family]["readiness"]) == "missing"
+    ]
+    attention_families = [
+        family
+        for family, report in family_reports.items()
+        if "attention" in str(report["readiness"])
+    ]
+    reasons: list[str] = []
+    for family, report in family_reports.items():
+        if "reasons" in report:
+            reasons.extend(str(reason) for reason in report["reasons"])
+        elif "reason" in report:
+            reasons.append(str(report["reason"]))
+    suspicious_gap_count = sum(
+        int(report["suspicious_gap_count"])
+        for report in family_reports.values()
+        if "suspicious_gap_count" in report
+    )
+    if not any(
+        int(report["artifact_count"])
+        for report in family_reports.values()
+        if "artifact_count" in report
+    ):
+        readiness = "no_cache_evidence"
+    elif missing_core:
+        readiness = "insufficient_core_evidence"
+    elif attention_families:
+        readiness = "core_evidence_with_attention"
+    else:
+        readiness = "core_evidence_observed"
+    return {
+        "mode": "report_only_non_enforcing",
+        "readiness": readiness,
+        "reasons": sorted(set(reasons)),
+        "missing_families": missing_families,
+        "attention_families": attention_families,
+        "suspicious_gap_count": suspicious_gap_count,
+        "families": family_reports,
+    }
+
+
 def _finalize_family_summary(by_family: dict[str, dict[str, Any]]) -> dict[str, Any]:
     finalized: dict[str, Any] = {}
     for family, summary in sorted(by_family.items()):
@@ -1020,6 +1186,7 @@ def _scan_root(root: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
             _merge_metadata(family_summary, metadata_artifact)
     summary["by_extension"] = dict(sorted(by_extension.items()))
     summary["by_family"] = _finalize_family_summary(by_family)
+    summary["warm_cache_readiness"] = _build_warm_cache_readiness(summary["by_family"])
     return summary, issues
 
 
@@ -1046,6 +1213,7 @@ def build_cache_integrity_report(roots: Iterable[str | Path]) -> dict[str, Any]:
                 _merge_finalized_coverage(summary, family_report["coverage"])
             if "metadata" in family_report:
                 _merge_finalized_metadata(summary, family_report["metadata"])
+    aggregate_by_family = _finalize_family_summary(by_family)
     summary = {
         "root_count": len(root_reports),
         "file_count": sum(int(root["file_count"]) for root in root_reports),
@@ -1053,7 +1221,8 @@ def build_cache_integrity_report(roots: Iterable[str | Path]) -> dict[str, Any]:
         "total_bytes": sum(int(root["total_bytes"]) for root in root_reports),
         "issue_count": len(issues),
         "by_severity": dict(sorted(by_severity.items())),
-        "by_family": _finalize_family_summary(by_family),
+        "by_family": aggregate_by_family,
+        "warm_cache_readiness": _build_warm_cache_readiness(aggregate_by_family),
     }
     return {
         "ok": "error" not in by_severity,

--- a/tests/test_cache_integrity_doctor.py
+++ b/tests/test_cache_integrity_doctor.py
@@ -247,6 +247,55 @@ def test_cache_integrity_report_summarizes_hsl_state_metadata(tmp_path):
     ]
 
 
+def test_cache_integrity_report_derives_warm_cache_readiness(tmp_path):
+    root = tmp_path / "caches"
+    month_dir = root / "ohlcv" / "data" / "binance" / "1h" / "BTC_USDT" / "2026"
+    month_dir.mkdir(parents=True)
+    np.save(month_dir / "01.valid.npy", np.ones(744, dtype=bool))
+    fill_dir = root / "fill_events" / "binance" / "user_01"
+    fill_dir.mkdir(parents=True)
+    current_contract = "gross_pnl_quote_fee_best_effort_v2"
+    (fill_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "pnl_contract": current_contract,
+                "history_scope": "all",
+                "covered_start_ms": 1767225600000,
+                "oldest_event_ts": 1767312000000,
+                "newest_event_ts": 1767312000000,
+                "last_refresh_ms": 1767315600000,
+                "known_gaps": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (fill_dir / "2026-01-02.ndjson").write_text(
+        json.dumps(
+            {
+                "id": "a",
+                "timestamp": 1767312000000,
+                "pnl_contract": current_contract,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_cache_integrity_report([root])
+
+    readiness = report["summary"]["warm_cache_readiness"]
+    assert readiness["mode"] == "report_only_non_enforcing"
+    assert readiness["readiness"] == "core_evidence_observed"
+    assert readiness["missing_families"] == ["risk"]
+    assert readiness["attention_families"] == []
+    assert readiness["suspicious_gap_count"] == 0
+    assert readiness["families"]["candles"]["readiness"] == "observed"
+    assert readiness["families"]["fills"]["readiness"] == "observed"
+    assert readiness["families"]["fills"]["covered_start_date"] == "2026-01-01T00:00:00+00:00"
+    assert readiness["families"]["risk"]["readiness"] == "missing_optional"
+    assert report["roots"][0]["warm_cache_readiness"] == readiness
+
+
 def test_cache_integrity_report_marks_missing_root_as_warning(tmp_path):
     missing = tmp_path / "missing"
 
@@ -254,6 +303,12 @@ def test_cache_integrity_report_marks_missing_root_as_warning(tmp_path):
 
     assert report["ok"] is True
     assert report["summary"]["by_severity"] == {"warning": 1}
+    assert report["summary"]["warm_cache_readiness"]["readiness"] == "no_cache_evidence"
+    assert report["summary"]["warm_cache_readiness"]["missing_families"] == [
+        "candles",
+        "fills",
+        "risk",
+    ]
     assert report["issues"][0]["family"] == "root"
     assert report["issues"][0]["code"] == "root_missing"
 


### PR DESCRIPTION
## Summary
- add report-only warm-cache readiness evidence to cache-integrity-doctor at aggregate and per-root levels
- derive readiness from already-scanned candle coverage plus fill and HSL/risk metadata, including reasons, missing families, suspicious gap counts, and timestamp context
- update cache-doctor docs, backlog progress, and changelog

## Validation
- pytest tests/test_cache_integrity_doctor.py
- python -m compileall src/tools/cache_integrity_doctor.py tests/test_cache_integrity_doctor.py
- git diff --check origin/v8...HEAD
- rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])\)" src/tools/cache_integrity_doctor.py tests/test_cache_integrity_doctor.py (no matches)

## Boundaries
- local/read-only evidence projection only
- non-enforcing/report-only; does not make startup or trading decisions
- no live bot control, exchange/API access, credentials, SSH, tmux, process actions, or #726 live-smoke/preflight files