### PR TITLE
Add fills live event debug profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable user-facing changes will be documented in this file.
 - Hardened recent live-ops tooling and debug-profile diagnostics by redacting
   shareable path fields consistently, keeping Rust debug sample construction
   best-effort, and scoping EMA debug enrichment to the `ema` profile only.
+- Added a `fills` live-event debug profile with bounded fill refresh and fill
+  ingestion shape metadata, without raw fill/source payloads or default console
+  changes.
 - Added v2 candle coverage windows and suspicious interior gap samples to
   `passivbot tool cache-integrity-doctor`, derived only from local `.valid.npy`
   cache artifacts.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-27.
 
 Current `origin/v8` logging-overhaul head:
 
-- `09ae3773a` merge of PR #723, `Add remote-call live event debug profile`.
+- `419612662` merge of PR #726, `Address live logging reviewer follow-ups`.
 
 Current review gate:
 
@@ -1221,15 +1221,34 @@ VPS5 deployment status:
   tracked repository state, no failed remote calls, and no failed
   account-critical remote calls.
 
-### Pending PR: Reviewer Follow-Ups
+### PR #726: Reviewer Follow-Ups
 
 - Branch: `codex/v8-reviewer-followups`.
 - Scope: Claude retrospective follow-up for already-merged low-risk
   observability/tooling slices.
-- Planned result: redacts shareable live-ops path fields consistently, removes
+- Result: redacted shareable live-ops path fields consistently, removed
   shutdown event message echo from smoke summaries, scopes EMA debug enrichment
   to the `ema` profile only, and keeps Rust debug sample construction
   best-effort inside the event-emitter path.
+- Review evidence: Claude and Hermes approved head `8f4465a9`, CI was green,
+  and local focused tests plus the broader live-event/monitor/smoke/preflight
+  suite, compileall, `git diff --check`, and touched-file silent-handling audit
+  passed before merge.
+- VPS5 evidence: deployed to VPS5 at `41961266` without bot restart because the
+  slice is observability/tooling-only. A 10-minute brief smoke reported
+  `ok=true`, no hard failures, all five expected bots matched, clean tracked
+  repository state, no failed remote calls, and no failed account-critical
+  remote calls. Remaining attention came from known non-hard EMA/staged
+  readiness and HSL status/cooldown events.
+
+### Pending PR: Fills Debug Profile
+
+- Branch: `codex/v8-fills-debug-profile`.
+- Scope: Phase 5/6 opt-in structured debug enrichment.
+- Planned result: add `fills` debug-profile enrichment to existing
+  `fills.refresh_summary` and `fill.ingested` events with bounded coverage,
+  count, and key-shape metadata. Default events and console output stay
+  unchanged, and no raw fill IDs, source IDs, or payload values are emitted.
 
 ## Current Next Steps
 

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -256,7 +256,7 @@ Related detailed plans:
 
 12. [ ] Debug profile toggles.
     Status: partial. Rust, EMA readiness, remote-call, and candle profile
-    slices are merged or in progress.
+    slices are merged; a fills profile slice is in progress.
 
     Add narrow runtime/debug profiles that increase event detail for one domain:
     candles, fills, HSL, Rust payloads, order execution, or exchange calls. This
@@ -280,9 +280,12 @@ Related detailed plans:
       tail-projection and disk-coverage events, exposing bounded key-shape,
       timeframe, window, and missing-coverage counters without raw candle rows
       or console output.
+    - 2026-06-27: Started a `fills` debug-profile slice for existing fill
+      refresh and fill ingestion events, exposing bounded count, coverage, and
+      key-shape metadata without raw source IDs or payload values.
 
-    Remaining refinements: add targeted profiles for HSL, fills, and execution
-    as those diagnostics need deeper live evidence.
+    Remaining refinements: add targeted profiles for HSL and execution as those
+    diagnostics need deeper live evidence.
 
 13. [ ] Cache integrity doctor.
     Status: partial. Initial read-only local cache smoke doctor and

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -2864,6 +2864,90 @@ def _fill_coverage_summary(status: Any) -> dict[str, Any]:
     return data
 
 
+def _fill_refresh_debug_payload(
+    *,
+    coverage_before: Any = None,
+    coverage_after: Any = None,
+    event_count_before: int | None = None,
+    event_count_after: int | None = None,
+    new_count: int | None = None,
+    enriched_count: int | None = None,
+    pending_pnl_count: int | None = None,
+) -> dict[str, Any]:
+    before_count = _safe_int(event_count_before)
+    after_count = _safe_int(event_count_after)
+    new_value = _safe_int(new_count)
+    enriched_value = _safe_int(enriched_count)
+    pending_value = _safe_int(pending_pnl_count)
+    data: dict[str, Any] = {
+        "coverage_before_keys": _mapping_key_sample(coverage_before),
+        "coverage_after_keys": _mapping_key_sample(coverage_after),
+        "event_count_before": before_count,
+        "event_count_after": after_count,
+        "new_count": new_value,
+        "enriched_count": enriched_value,
+        "pending_pnl_count": pending_value,
+    }
+    if before_count is not None and after_count is not None:
+        data["event_count_delta"] = int(after_count) - int(before_count)
+    if isinstance(coverage_before, dict):
+        data["coverage_before_ready"] = bool(coverage_before.get("ready", False))
+        reason = coverage_before.get("reason")
+        if reason is not None:
+            data["coverage_before_reason"] = str(reason)[:160]
+    if isinstance(coverage_after, dict):
+        data["coverage_after_ready"] = bool(coverage_after.get("ready", False))
+        reason = coverage_after.get("reason")
+        if reason is not None:
+            data["coverage_after_reason"] = str(reason)[:160]
+    if isinstance(coverage_before, dict) and isinstance(coverage_after, dict):
+        before_ready = bool(coverage_before.get("ready", False))
+        after_ready = bool(coverage_after.get("ready", False))
+        if before_ready != after_ready:
+            data["coverage_ready_transition"] = f"{before_ready}->{after_ready}"
+    return {key: value for key, value in data.items() if value not in (None, [], {})}
+
+
+def _best_effort_fill_refresh_debug_payload(**kwargs: Any) -> dict[str, Any] | None:
+    try:
+        return _fill_refresh_debug_payload(**kwargs)
+    except Exception as exc:
+        logging.debug("[event] failed to build fill refresh debug payload: %s", exc)
+        return None
+
+
+def _fill_ingested_debug_payload(
+    event: Any,
+    *,
+    payload: dict | None = None,
+) -> dict[str, Any]:
+    fill_payload = payload if isinstance(payload, dict) else {}
+    source_ids = list(getattr(event, "source_ids", []) or [])
+    data: dict[str, Any] = {
+        "payload_keys": _mapping_key_sample(fill_payload),
+        "payload_key_count": len(fill_payload),
+        "source_ids_count": len(source_ids),
+        "has_client_order_id": bool(getattr(event, "client_order_id", None)),
+        "has_fee": getattr(event, "fee", None) is not None,
+        "has_fee_paid": getattr(event, "fee_paid", None) is not None,
+        "has_pnl": getattr(event, "pnl", None) is not None,
+        "pnl_status": str(getattr(event, "pnl_status", "") or "")[:80] or None,
+    }
+    return {key: value for key, value in data.items() if value not in (None, [], {})}
+
+
+def _best_effort_fill_ingested_debug_payload(
+    event: Any,
+    *,
+    payload: dict | None = None,
+) -> dict[str, Any] | None:
+    try:
+        return _fill_ingested_debug_payload(event, payload=payload)
+    except Exception as exc:
+        logging.debug("[event] failed to build fill ingested debug payload: %s", exc)
+        return None
+
+
 def _emit_fills_refresh_summary_event_unchecked(
     bot: Any,
     *,
@@ -2925,6 +3009,19 @@ def _emit_fills_refresh_summary_event_unchecked(
     if error is not None:
         data["error_type"] = type(error).__name__
         data["error"] = _sanitize_remote_text(error, max_len=500)
+    if live_event_debug_profile_enabled(bot, "fills"):
+        debug = _best_effort_fill_refresh_debug_payload(
+            coverage_before=coverage_before,
+            coverage_after=coverage_after,
+            event_count_before=event_count_before,
+            event_count_after=event_count_after,
+            new_count=new_count,
+            enriched_count=enriched_count,
+            pending_pnl_count=pending_pnl_count,
+        )
+        if debug:
+            data["debug_profile"] = "fills"
+            data["debug"] = debug
     _safe_emit(
         bot,
         EventTypes.FILLS_REFRESH_SUMMARY,
@@ -2965,6 +3062,11 @@ def emit_fill_ingested_event(bot: Any, event: Any, *, payload: dict | None = Non
         for key in ("qty", "price", "pnl", "fee", "pb_order_type", "timestamp"):
             if key in fill_payload and data.get(key) is None:
                 data[key] = fill_payload.get(key)
+        if live_event_debug_profile_enabled(bot, "fills"):
+            debug = _best_effort_fill_ingested_debug_payload(event, payload=fill_payload)
+            if debug:
+                data["debug_profile"] = "fills"
+                data["debug"] = debug
         bot._emit_live_event(
             EventTypes.FILL_INGESTED,
             level="info",

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1,5 +1,6 @@
 import asyncio
 import hashlib
+import json
 import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -2720,6 +2721,76 @@ def test_log_new_fill_events_emits_fill_ingested_event():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_fill_ingested_debug_profile_adds_bounded_shape_without_source_id_leak():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_fill_ingested_event = pb_mod.Passivbot._emit_fill_ingested_event
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "bybit"
+            self.user = "bybit_01"
+            self.bot_id = "bot_1"
+            self.live_event_debug_profiles = ("fills",)
+            self._live_event_current_cycle_id = "cy_fill_debug"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    source_ids = ["trade-secret-a", "trade-secret-b"]
+    event = SimpleNamespace(
+        id="+".join(source_ids),
+        timestamp=1_782_271_234_000,
+        symbol="ETH/USDT:USDT",
+        side="sell",
+        position_side="long",
+        qty=0.5,
+        price=2500.0,
+        pnl=12.0,
+        fee=-0.5,
+        fee_paid=-0.5,
+        pb_order_type="close_grid_normal_long",
+        client_order_id="client-abcdef123456",
+        source_ids=source_ids,
+        pnl_status="complete",
+    )
+    payload = {
+        "symbol": "ETH/USDT:USDT",
+        "side": "sell",
+        "source_id": "trade-secret-a",
+        "raw_secret": "apiKey=secret",
+    }
+    bot = FakeBot()
+
+    bot._emit_fill_ingested_event(event, payload=payload)
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    live_event = sink.events[-1]
+    assert live_event.event_type == EventTypes.FILL_INGESTED
+    assert live_event.data["debug_profile"] == "fills"
+    assert live_event.data["debug"]["payload_keys"] == [
+        "raw_secret",
+        "side",
+        "source_id",
+        "symbol",
+    ]
+    assert live_event.data["debug"]["payload_key_count"] == 4
+    assert live_event.data["debug"]["source_ids_count"] == 2
+    assert live_event.data["debug"]["has_client_order_id"] is True
+    assert live_event.data["debug"]["has_fee_paid"] is True
+    assert live_event.data["debug"]["pnl_status"] == "complete"
+    rendered = json.dumps(live_event.data, sort_keys=True)
+    assert "trade-secret-a" not in rendered
+    assert "trade-secret-b" not in rendered
+    assert "apiKey=secret" not in rendered
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_emit_fills_refresh_summary_event_sanitizes_error_and_stays_off_console():
     import passivbot as pb_mod
 
@@ -2782,6 +2853,92 @@ def test_emit_fills_refresh_summary_event_sanitizes_error_and_stays_off_console(
     assert event.data["error_type"] == "RuntimeError"
     assert "secret-token" not in event.data["error"]
     assert "[redacted]" in event.data["error"]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_fills_refresh_debug_profile_adds_bounded_coverage_shape():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _emit_fills_refresh_summary_event = (
+            pb_mod.Passivbot._emit_fills_refresh_summary_event
+        )
+
+        def __init__(self):
+            self.exchange = "bybit"
+            self.user = "bybit_01"
+            self.bot_id = "bot_1"
+            self.live_event_debug_profiles = ("fills",)
+            self._live_event_current_cycle_id = "cy_fills_debug"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+    bot._emit_fills_refresh_summary_event(
+        source="staged_blocking",
+        refresh_mode="lookback_bootstrap",
+        status="succeeded",
+        reason_code="fills_refresh_succeeded",
+        elapsed_ms=321,
+        lookback=30.0,
+        history_scope="window",
+        event_count_before=3,
+        event_count_after=7,
+        new_count=2,
+        enriched_count=1,
+        pending_pnl_count=0,
+        coverage_before={
+            "ready": False,
+            "reason": "window_coverage_not_proven",
+            "history_scope": "window",
+            "covered_start_ms": 100,
+        },
+        coverage_after={
+            "ready": True,
+            "reason": "window_covered",
+            "history_scope": "window",
+            "covered_start_ms": 50,
+            "oldest_event_ts": 40,
+        },
+        level="debug",
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[-1]
+    assert event.event_type == EventTypes.FILLS_REFRESH_SUMMARY
+    assert event.data["debug_profile"] == "fills"
+    assert event.data["debug"] == {
+        "coverage_before_keys": [
+            "covered_start_ms",
+            "history_scope",
+            "ready",
+            "reason",
+        ],
+        "coverage_after_keys": [
+            "covered_start_ms",
+            "history_scope",
+            "oldest_event_ts",
+            "ready",
+            "reason",
+        ],
+        "event_count_before": 3,
+        "event_count_after": 7,
+        "new_count": 2,
+        "enriched_count": 1,
+        "pending_pnl_count": 0,
+        "event_count_delta": 4,
+        "coverage_before_ready": False,
+        "coverage_before_reason": "window_coverage_not_proven",
+        "coverage_after_ready": True,
+        "coverage_after_reason": "window_covered",
+        "coverage_ready_transition": "False->True",
+    }
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
## Summary
- add opt-in `fills` debug-profile enrichment for `fills.refresh_summary` events
- add opt-in `fills` debug-profile enrichment for `fill.ingested` events
- keep default event payloads and console output unchanged
- update the logging progress and live-ops backlog ledgers

## Safety / Scope
Observability-only. The new debug data is bounded to coverage/count/key-shape metadata. It does not emit raw fill IDs, source IDs, or payload values, and debug payload construction is best-effort inside the event emitter path. No trading/order/risk behavior is changed.

## Validation
- `./venv/bin/python -m pytest -q tests/test_passivbot_monitor.py::test_log_new_fill_events_emits_fill_ingested_event tests/test_passivbot_monitor.py::test_fill_ingested_debug_profile_adds_bounded_shape_without_source_id_leak tests/test_passivbot_monitor.py::test_emit_fills_refresh_summary_event_sanitizes_error_and_stays_off_console tests/test_passivbot_monitor.py::test_fills_refresh_debug_profile_adds_bounded_coverage_shape`
- `./venv/bin/python -m pytest -q tests/test_live_event_bus.py tests/test_passivbot_monitor.py`
- `./venv/bin/python -m compileall -q src/live/event_emitters.py tests/test_passivbot_monitor.py`
- `git diff --check`
- touched-file silent-handling audit reviewed; new broad catches are limited to best-effort debug payload construction