### PR TITLE
Update live logging progress after fills debug profile

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-27.
 
 Current `origin/v8` logging-overhaul head:
 
-- `419612662` merge of PR #726, `Address live logging reviewer follow-ups`.
+- `5714d36dd` merge of PR #728, `Add fills live event debug profile`.
 
 Current review gate:
 
@@ -1182,6 +1182,19 @@ VPS5 deployment status:
   tracked repository state, no hard failures, no log hard matches, no failed
   remote calls, and no failed account-critical remote calls.
 
+### PR #727: Cache Doctor Warm-Cache Readiness Evidence
+
+- Branch: `codex/maxwell-cache-warm-readiness`.
+- Scope: adjacent cache/warmup diagnostics.
+- Result: `passivbot tool cache-integrity-doctor` now adds report-only
+  `warm_cache_readiness` summaries derived from already-scanned candle, fill,
+  and HSL/risk cache metadata. The readiness projection is explicitly
+  non-enforcing and does not change startup or trading behavior.
+- Review evidence: Claude and Hermes approved head `155e3640`; CI was green;
+  focused cache-doctor tests, compileall, `git diff --check`, and
+  touched-file silent-handling audit passed before merge. A parent-side
+  temporary-worktree validation also passed the focused test/check set.
+
 ### PR #723: Remote-Call Debug Profile
 
 - Branch: `codex/v8-remote-call-debug-profile`.
@@ -1241,21 +1254,35 @@ VPS5 deployment status:
   remote calls. Remaining attention came from known non-hard EMA/staged
   readiness and HSL status/cooldown events.
 
-### Pending PR: Fills Debug Profile
+### PR #728: Fills Debug Profile
 
 - Branch: `codex/v8-fills-debug-profile`.
 - Scope: Phase 5/6 opt-in structured debug enrichment.
-- Planned result: add `fills` debug-profile enrichment to existing
+- Result: added `fills` debug-profile enrichment to existing
   `fills.refresh_summary` and `fill.ingested` events with bounded coverage,
   count, and key-shape metadata. Default events and console output stay
   unchanged, and no raw fill IDs, source IDs, or payload values are emitted.
+- Review evidence: Claude and Hermes approved the original head `4c58a718`;
+  after PR #727 merged, the branch was rebased to `8ba083f6`, CI was green, and
+  both reviewers confirmed the rebased patch was unchanged. Local focused tests,
+  the broader live-event/monitor suite, compileall, and `git diff --check`
+  passed before merge.
+- VPS5 evidence: deployed to VPS5 at `5714d36d` without bot restart because the
+  slice is opt-in and no VPS config enabled it. The first 10-minute smoke was
+  red only because text logs contained a fresh OKX ccxt-pro websocket callback
+  traceback after a reconnect; structured monitor events had no hard failures,
+  all five expected bots matched, the repository was clean, and remote-call /
+  account-critical failures were zero. A settled 2-minute follow-up smoke
+  reported `ok=true`, no hard failures, no log hard matches, all five expected
+  bots matched, clean tracked repository state, no failed remote calls, and no
+  failed account-critical remote calls.
 
 ## Current Next Steps
 
 1. Continue Phase 5/6 by adding the next high-value event producer or debug
    profile slice without increasing default console noise. Likely candidates
-   are exchange-call debug profiles, HSL preview, or more order/risk transition
-   coverage.
+   are HSL preview/status debug enrichment, execution debug profiles, or more
+   order/risk transition coverage.
 2. Continue active read-only exchange health probes beyond account-critical
    basics. PR #701 added account-critical health summaries and PR #703 added
    `--account-only` plus symbol fallback for open-orders. Remaining useful
@@ -1267,5 +1294,5 @@ VPS5 deployment status:
    to inspect by surfacing bounded latest event data and aggregate groups.
 4. Start the live restart/smoke automation slice if operational workflow speed
    becomes the higher leverage next step.
-5. Continue cache-doctor refinements in separate adjacent PRs: cache-family
-   metadata, coverage windows, suspicious gaps, and warm-cache readiness.
+5. Continue cache-doctor refinements in separate adjacent PRs: deeper metadata
+   compatibility checks and synthetic/no-trade assumptions.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -256,7 +256,7 @@ Related detailed plans:
 
 12. [ ] Debug profile toggles.
     Status: partial. Rust, EMA readiness, remote-call, and candle profile
-    slices are merged; a fills profile slice is in progress.
+    slices are merged; a fills profile slice is merged.
 
     Add narrow runtime/debug profiles that increase event detail for one domain:
     candles, fills, HSL, Rust payloads, order execution, or exchange calls. This
@@ -280,7 +280,7 @@ Related detailed plans:
       tail-projection and disk-coverage events, exposing bounded key-shape,
       timeframe, window, and missing-coverage counters without raw candle rows
       or console output.
-    - 2026-06-27: Started a `fills` debug-profile slice for existing fill
+    - 2026-06-27: Added a `fills` debug-profile slice for existing fill
       refresh and fill ingestion events, exposing bounded count, coverage, and
       key-shape metadata without raw source IDs or payload values.
 
@@ -288,8 +288,9 @@ Related detailed plans:
     diagnostics need deeper live evidence.
 
 13. [ ] Cache integrity doctor.
-    Status: partial. Initial read-only local cache smoke doctor and
-    cache-family summaries merged.
+    Status: partial. Initial read-only local cache smoke doctor, cache-family
+    summaries, candle coverage evidence, fill/HSL metadata evidence, and
+    report-only warm-cache readiness evidence are merged.
 
     Add a read-only doctor for candle/fill/HSL caches that reports coverage,
     metadata compatibility, corrupted shards, suspicious gaps, synthetic/no-trade
@@ -339,6 +340,17 @@ Related detailed plans:
     resync, queue overflow, slow shutdown, and exchange-call ambiguity. These
     should prove observability behavior without risking live accounts.
 
+16. [ ] Websocket reconnect diagnostics.
+    Status: open.
+
+    VPS5 smoke after PR #728 caught a fresh OKX ccxt-pro websocket callback
+    traceback after `connection lost ... RequestTimeout`; the bot continued and
+    the settled 2-minute smoke was green, but the current signal is only a raw
+    text-log traceback. Add structured websocket reconnect/callback diagnostics
+    where practical, or improve smoke classification so known dependency
+    callback races are grouped with surrounding reconnect context instead of
+    requiring manual log inspection.
+
 ## Merged Work Log
 
 | Date | Item | PR / Commit | Result | Remaining |
@@ -375,11 +387,12 @@ Related detailed plans:
 | 2026-06-26 | #3 Live restart/smoke automation | PR #709 / `71479c61` deploy evidence | VPS5 restart smoke after the fill-cache event slice returned `ok=true`, no hard failures, all five bots matched; the restart exposed four orphaned live processes after two Ctrl+C rounds, cleared by SIGTERM before reload | Safe pull/stop/start orchestration should include shutdown timing, orphan detection, and escalation policy |
 | 2026-06-26 | #3/#14 Supervisor/process diagnostics | PR #712 / `51ba92a3` | Extended `live-smoke-report --supervisor-config` to classify expected matches, missing expected commands, duplicate configured-command process matches, and extra/orphan-like `passivbot live` processes with bounded per-process metadata; VPS5 smoke showed all five configured bots matched with zero duplicate or extra live process matches; documented the read-only command-match limitation and shutdown escalation ladder as policy only | Safe pull/stop/start orchestration remains open |
 | 2026-06-26 | #12 Debug profile toggles | pending PR | Added opt-in live-event debug profiles via config/env and initial Rust orchestrator structured-event enrichment with bounded input-symbol and output-order samples | Add remote-call, candle/EMA, HSL, fills, and execution profiles as needed |
+| 2026-06-27 | #12 Debug profile toggles | PR #728 / `5714d36d` | Added opt-in `fills` debug-profile enrichment to existing fill refresh and ingestion events with bounded count, coverage, and key-shape metadata | HSL and execution profiles remain open |
 | 2026-06-26 | #7 Live config preflight/linter | PR #714 / `564dc0a8` | Added `passivbot tool live-config-preflight`, a local-only JSON report for one config's risk-relevant live facts with bounded coin samples and malformed-structure errors; VPS5 preflight smoke returned `ok=true` with one expected missing short-side warning | Config diffing, deeper cache compatibility checks, and live startup enforcement remain open |
 | 2026-06-26 | #3 Live restart/smoke automation | PR #715 / `7b12d4b2` | Added passive `shutdown_events` summaries to full, summary, and brief `live-smoke-report` output for existing bot stopping/stage/stopped events; VPS5 no-restart smoke showed `shutdown_events.total=0`, all five bots matched, and no hard failures | Safe pull/stop/start orchestration remains open |
 | 2026-06-27 | #13 Cache integrity doctor | PR #722 / `3b7e6306` | Added read-only v2 candle coverage windows and suspicious interior gap samples from local `.valid.npy` artifacts | Fill/HSL coverage/readiness and deeper metadata compatibility |
-| 2026-06-27 | #13 Cache integrity doctor | pending PR | Added read-only fill/HSL metadata summaries from local JSON/NDJSON artifacts | Deeper metadata compatibility, synthetic/no-trade assumptions, and warm-cache readiness |
-| 2026-06-27 | #13 Cache integrity doctor | pending PR | Added report-only warm-cache readiness evidence from already-scanned candle/fill/HSL cache metadata | Deeper metadata compatibility and synthetic/no-trade assumptions |
+| 2026-06-27 | #13 Cache integrity doctor | PR #725 / `1ed9c466` | Added read-only fill/HSL metadata summaries from local JSON/NDJSON artifacts | Deeper metadata compatibility, synthetic/no-trade assumptions, and warm-cache readiness |
+| 2026-06-27 | #13 Cache integrity doctor | PR #727 / `d8dd7246` | Added report-only warm-cache readiness evidence from already-scanned candle/fill/HSL cache metadata | Deeper metadata compatibility and synthetic/no-trade assumptions |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #701 / `fcda70f5` | Added `ticker-endpoint-probe` `account_critical_health` summaries for read-only balance/positions/open-orders outcomes; VPS5 Binance probe validated the summary and exposed an open-orders shape follow-up | Lower-impact/account-only mode, exchange-aware open-orders probing, clock skew/rate-limit/fill/candle probes |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #703 / `8fefce4b` | Added `ticker-endpoint-probe --account-only`, `--skip-my-trades`, and open-orders symbol fallback; VPS5 Binance account-only probe returned account-critical total=3, succeeded=3, and smoke stayed green | Clock skew/rate-limit/fill-pagination/candle-freshness probes |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |


### PR DESCRIPTION
## Summary
- mark PR #727 and PR #728 as merged in the live logging progress ledger
- record VPS5 deploy/smoke evidence for `5714d36d`
- update the live-ops backlog status for cache-doctor warm readiness and the fills debug profile
- add an open follow-up for the fresh OKX ccxt-pro websocket reconnect traceback seen during smoke

## Validation
- `git diff --check`
- docs-only change; no runtime tests run