### PR TITLE
Add HSL live-event debug profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable user-facing changes will be documented in this file.
 - Added a `fills` live-event debug profile with bounded fill refresh and fill
   ingestion shape metadata, without raw fill/source payloads or default console
   changes.
+- Added an `hsl` live-event debug profile with bounded HSL event key, metric
+  key, and latch/cooldown state-shape metadata, without changing default HSL
+  events, console output, or trading behavior.
 - Added v2 candle coverage windows and suspicious interior gap samples to
   `passivbot tool cache-integrity-doctor`, derived only from local `.valid.npy`
   cache artifacts.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -1277,6 +1277,15 @@ VPS5 deployment status:
   bots matched, clean tracked repository state, no failed remote calls, and no
   failed account-critical remote calls.
 
+### Pending PR: HSL Debug Profile
+
+- Branch: `codex/v8-hsl-debug-profile`.
+- Scope: Phase 5/6 opt-in structured debug enrichment.
+- Result: in progress. Add `hsl` debug-profile enrichment to existing HSL
+  status, transition, replay, red-trigger, and cooldown events with bounded
+  event key, metric key, and HSL latch/cooldown state-shape metadata. Default
+  HSL events and console output remain unchanged.
+
 ## Current Next Steps
 
 1. Continue Phase 5/6 by adding the next high-value event producer or debug

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -255,8 +255,8 @@ Related detailed plans:
     surfaces are touched.
 
 12. [ ] Debug profile toggles.
-    Status: partial. Rust, EMA readiness, remote-call, and candle profile
-    slices are merged; a fills profile slice is merged.
+    Status: partial. Rust, EMA readiness, remote-call, candle, and fills
+    profile slices are merged; an HSL profile slice is in progress.
 
     Add narrow runtime/debug profiles that increase event detail for one domain:
     candles, fills, HSL, Rust payloads, order execution, or exchange calls. This
@@ -283,9 +283,12 @@ Related detailed plans:
     - 2026-06-27: Added a `fills` debug-profile slice for existing fill
       refresh and fill ingestion events, exposing bounded count, coverage, and
       key-shape metadata without raw source IDs or payload values.
+    - 2026-06-27: Started an `hsl` debug-profile slice for existing HSL
+      status, transition, replay, red-trigger, and cooldown events, exposing
+      bounded event key, metric key, and latch/cooldown state-shape metadata.
 
-    Remaining refinements: add targeted profiles for HSL and execution as those
-    diagnostics need deeper live evidence.
+    Remaining refinements: add targeted execution profiles as those diagnostics
+    need deeper live evidence.
 
 13. [ ] Cache integrity doctor.
     Status: partial. Initial read-only local cache smoke doctor, cache-family
@@ -388,6 +391,7 @@ Related detailed plans:
 | 2026-06-26 | #3/#14 Supervisor/process diagnostics | PR #712 / `51ba92a3` | Extended `live-smoke-report --supervisor-config` to classify expected matches, missing expected commands, duplicate configured-command process matches, and extra/orphan-like `passivbot live` processes with bounded per-process metadata; VPS5 smoke showed all five configured bots matched with zero duplicate or extra live process matches; documented the read-only command-match limitation and shutdown escalation ladder as policy only | Safe pull/stop/start orchestration remains open |
 | 2026-06-26 | #12 Debug profile toggles | pending PR | Added opt-in live-event debug profiles via config/env and initial Rust orchestrator structured-event enrichment with bounded input-symbol and output-order samples | Add remote-call, candle/EMA, HSL, fills, and execution profiles as needed |
 | 2026-06-27 | #12 Debug profile toggles | PR #728 / `5714d36d` | Added opt-in `fills` debug-profile enrichment to existing fill refresh and ingestion events with bounded count, coverage, and key-shape metadata | HSL and execution profiles remain open |
+| 2026-06-27 | #12 Debug profile toggles | pending PR | Add opt-in `hsl` debug-profile enrichment to existing HSL event surfaces with bounded event key, metric key, and latch/cooldown state-shape metadata | Execution profile remains open |
 | 2026-06-26 | #7 Live config preflight/linter | PR #714 / `564dc0a8` | Added `passivbot tool live-config-preflight`, a local-only JSON report for one config's risk-relevant live facts with bounded coin samples and malformed-structure errors; VPS5 preflight smoke returned `ok=true` with one expected missing short-side warning | Config diffing, deeper cache compatibility checks, and live startup enforcement remain open |
 | 2026-06-26 | #3 Live restart/smoke automation | PR #715 / `7b12d4b2` | Added passive `shutdown_events` summaries to full, summary, and brief `live-smoke-report` output for existing bot stopping/stage/stopped events; VPS5 no-restart smoke showed `shutdown_events.total=0`, all five bots matched, and no hard failures | Safe pull/stop/start orchestration remains open |
 | 2026-06-27 | #13 Cache integrity doctor | PR #722 / `3b7e6306` | Added read-only v2 candle coverage windows and suspicious interior gap samples from local `.valid.npy` artifacts | Fill/HSL coverage/readiness and deeper metadata compatibility |

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -22,8 +22,113 @@ from config.coerce import (
 )
 from config.pnl_lookback import parse_pnls_max_lookback_days
 from fill_events_manager import signed_fee_paid_from_payload
+from live.event_bus import live_event_debug_profile_enabled
 from passivbot_exceptions import RestartBotException
 from utils import make_get_filepath
+
+
+def _hsl_key_sample(value: Any, *, limit: int = 32) -> list[str]:
+    if not isinstance(value, dict):
+        return []
+    return sorted(str(key) for key in value)[: max(0, int(limit))]
+
+
+def _hsl_event_state_snapshot(
+    self,
+    *,
+    pside: str | None,
+    symbol: str | None = None,
+) -> dict[str, Any]:
+    if not pside:
+        return {}
+    state = None
+    if symbol:
+        coin_states = getattr(self, "_equity_hard_stop_coin", None)
+        if isinstance(coin_states, dict):
+            pside_states = coin_states.get(pside)
+            if isinstance(pside_states, dict):
+                state = pside_states.get(symbol)
+    if state is None:
+        states = getattr(self, "_equity_hard_stop", None)
+        if isinstance(states, dict):
+            state = states.get(pside)
+    if not isinstance(state, dict):
+        return {}
+    cooldown_until_ms = state.get("cooldown_until_ms")
+    return {
+        "halted": bool(state.get("halted")),
+        "no_restart_latched": bool(state.get("no_restart_latched")),
+        "cooldown_until_present": cooldown_until_ms is not None,
+        "pending_red": state.get("pending_red_since_ms") is not None,
+        "has_pending_stop_event": state.get("pending_stop_event") is not None,
+        "has_last_stop_event": state.get("last_stop_event") is not None,
+        "red_trigger_event_emitted": bool(state.get("red_trigger_event_emitted")),
+        "cooldown_intervention_active": bool(state.get("cooldown_intervention_active")),
+        "cooldown_repanic_reset_pending": bool(
+            state.get("cooldown_repanic_reset_pending")
+        ),
+        "cooldown_unresolved_residue": bool(state.get("cooldown_unresolved_residue")),
+        "pnl_reset_timestamp_present": state.get("pnl_reset_timestamp_ms") is not None,
+    }
+
+
+def _hsl_debug_payload(
+    self,
+    *,
+    event_type: str,
+    data: dict,
+    pside: str | None,
+    symbol: str | None = None,
+    status: str | None = None,
+    reason_code: str | None = None,
+) -> dict[str, Any]:
+    debug: dict[str, Any] = {
+        "event_type": str(event_type),
+        "data_keys": _hsl_key_sample(data),
+    }
+    if status is not None:
+        debug["status"] = str(status)
+    if reason_code is not None:
+        debug["reason_code"] = str(reason_code)
+    for key in ("signal_mode", "tier"):
+        if data.get(key) is not None:
+            debug[key] = str(data[key])
+    metrics = data.get("metrics")
+    if isinstance(metrics, dict):
+        debug["metrics_keys"] = _hsl_key_sample(metrics)
+    state_snapshot = _hsl_event_state_snapshot(self, pside=pside, symbol=symbol)
+    if state_snapshot:
+        debug["state"] = state_snapshot
+    return {key: value for key, value in debug.items() if value not in (None, [], {})}
+
+
+def _best_effort_hsl_debug_payload(
+    self,
+    *,
+    event_type: str,
+    data: dict,
+    pside: str | None,
+    symbol: str | None = None,
+    status: str | None = None,
+    reason_code: str | None = None,
+) -> dict[str, Any] | None:
+    try:
+        return _hsl_debug_payload(
+            self,
+            event_type=event_type,
+            data=data,
+            pside=pside,
+            symbol=symbol,
+            status=status,
+            reason_code=reason_code,
+        )
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to build HSL debug payload type=%s: %s",
+            event_type,
+            exc,
+        )
+        return None
 
 
 def _hsl_event_data(metrics: dict | None = None, extra: dict | None = None) -> dict[str, Any]:
@@ -48,6 +153,20 @@ def _emit_hsl_event(
     reason_code: str | None = None,
 ) -> None:
     live_event_delivered = False
+    event_data = dict(data or {})
+    if live_event_debug_profile_enabled(self, "hsl"):
+        debug = _best_effort_hsl_debug_payload(
+            self,
+            event_type=event_type,
+            data=event_data,
+            pside=pside,
+            symbol=symbol,
+            status=status,
+            reason_code=reason_code,
+        )
+        if debug:
+            event_data["debug_profile"] = "hsl"
+            event_data["debug"] = debug
     try:
         emit = getattr(self, "_emit_live_event", None)
         pipeline = getattr(self, "_live_event_pipeline", None)
@@ -62,7 +181,7 @@ def _emit_hsl_event(
                 pside=pside,
                 status=status,
                 reason_code=reason_code,
-                data=data,
+                data=event_data,
             ) is not None
     except Exception as exc:
         logging.debug("[event] failed to emit HSL live event type=%s: %s", event_type, exc)
@@ -74,7 +193,7 @@ def _emit_hsl_event(
             record(
                 event_type,
                 tags,
-                data,
+                event_data,
                 pside=pside,
                 symbol=symbol,
                 ts=ts,

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1479,11 +1479,12 @@ def test_coin_hsl_status_logs_distance_only_for_open_position(caplog, monkeypatc
         _equity_hard_stop_emit_coin_status = Passivbot._equity_hard_stop_emit_coin_status
         _hsl_coin_state = Passivbot._hsl_coin_state
 
-        def __init__(self, *, has_position: bool):
+        def __init__(self, *, has_position: bool, debug_profiles=()):
             self.exchange = "bybit"
             self.user = "bybit_01"
             self.bot_id = "bot_coin_hsl"
             self._live_event_current_cycle_id = "cy_hsl_coin"
+            self.live_event_debug_profiles = tuple(debug_profiles)
             self._live_event_pipeline = LiveEventPipeline(
                 structured_sinks=[sink],
                 monitor_sinks=[],
@@ -1493,9 +1494,16 @@ def test_coin_hsl_status_logs_distance_only_for_open_position(caplog, monkeypatc
                 "long": {
                     "NEAR/USDT:USDT": {
                         "last_status_log_ms": 0,
-                        "cooldown_until_ms": None,
-                        "last_stop_event": None,
-                        "pending_red_since_ms": None,
+                        "cooldown_until_ms": 90_000,
+                        "last_stop_event": {
+                            "stop_event_timestamp_ms": 7_000,
+                        },
+                        "pending_stop_event": {
+                            "stop_event_timestamp_ms": 8_000,
+                        },
+                        "pending_red_since_ms": 6_000,
+                        "red_trigger_event_emitted": True,
+                        "cooldown_intervention_active": True,
                     }
                 },
                 "short": {},
@@ -1531,6 +1539,40 @@ def test_coin_hsl_status_logs_distance_only_for_open_position(caplog, monkeypatc
     assert event.symbol == "NEAR/USDT:USDT"
     assert event.pside == "long"
     assert event.data["dist_to_red"] == pytest.approx(0.04)
+    assert "debug_profile" not in event.data
+    assert "debug" not in event.data
+
+    sink.events.clear()
+    debug_bot = FakeBot(has_position=True, debug_profiles=("hsl",))
+    debug_bot._equity_hard_stop_emit_coin_status(
+        "long",
+        "NEAR/USDT:USDT",
+        metrics | {"timestamp_ms": 40_000},
+    )
+
+    assert debug_bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[-1]
+    assert event.event_type == EventTypes.HSL_STATUS
+    assert event.data["debug_profile"] == "hsl"
+    debug = event.data["debug"]
+    assert debug["event_type"] == EventTypes.HSL_STATUS
+    assert debug["reason_code"] == "yellow"
+    assert debug["status"] == "succeeded"
+    assert debug["tier"] == "yellow"
+    assert "dist_to_red" in debug["data_keys"]
+    assert debug["state"] == {
+        "halted": False,
+        "no_restart_latched": False,
+        "cooldown_until_present": True,
+        "pending_red": True,
+        "has_pending_stop_event": True,
+        "has_last_stop_event": True,
+        "red_trigger_event_emitted": True,
+        "cooldown_intervention_active": True,
+        "cooldown_repanic_reset_pending": False,
+        "cooldown_unresolved_residue": False,
+        "pnl_reset_timestamp_present": False,
+    }
 
     caplog.clear()
     sink.events.clear()


### PR DESCRIPTION
## Summary
- add opt-in hsl live-event debug-profile enrichment to existing HSL events
- include bounded event key, metric key, and latch/cooldown state-shape metadata only
- keep default HSL event payloads, console output, and trading behavior unchanged
- update changelog and logging/backlog progress docs

## Validation
- ./venv/bin/python -m pytest -q tests/test_hsl_coin_mode.py tests/test_passivbot_balance_split.py tests/test_live_event_bus.py
- ./venv/bin/python -m compileall -q src/passivbot_hsl.py tests/test_hsl_coin_mode.py tests/test_passivbot_balance_split.py tests/test_live_event_bus.py
- git diff --check
- touched-file silent-handling audit: new broad catch is observability-only debug payload construction; remaining hits are pre-existing HSL/test patterns