### PR TITLE
Add execution live-event debug profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable user-facing changes will be documented in this file.
 - Added an `hsl` live-event debug profile with bounded HSL event key, metric
   key, and latch/cooldown state-shape metadata, without changing default HSL
   events, console output, or trading behavior.
+- Added an `execution` live-event debug profile with bounded order-wave,
+  order-write, and confirmation key-shape metadata, without raw order payloads
+  or default console changes.
 - Added v2 candle coverage windows and suspicious interior gap samples to
   `passivbot tool cache-integrity-doctor`, derived only from local `.valid.npy`
   cache artifacts.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -1277,21 +1277,35 @@ VPS5 deployment status:
   bots matched, clean tracked repository state, no failed remote calls, and no
   failed account-critical remote calls.
 
-### Pending PR: HSL Debug Profile
+### PR #730: HSL Debug Profile
 
 - Branch: `codex/v8-hsl-debug-profile`.
 - Scope: Phase 5/6 opt-in structured debug enrichment.
-- Result: in progress. Add `hsl` debug-profile enrichment to existing HSL
+- Result: added `hsl` debug-profile enrichment to existing HSL
   status, transition, replay, red-trigger, and cooldown events with bounded
   event key, metric key, and HSL latch/cooldown state-shape metadata. Default
   HSL events and console output remain unchanged.
+- Review evidence: Hermes approved head `7cfb80ac`, CI was green, and local
+  focused tests, the broader HSL/live-event suite, compileall,
+  `git diff --check`, and touched-file silent-handling audit passed. Claude did
+  not return before merge, so this opt-in observability slice used the degraded
+  gate.
+
+### Pending PR: Execution Debug Profile
+
+- Branch: `codex/v8-execution-debug-profile`.
+- Scope: Phase 5/6 opt-in structured debug enrichment.
+- Result: in progress. Add `execution` debug-profile enrichment to existing
+  order-wave, order-write, create-filter, and confirmation events with bounded
+  key-shape/counter metadata. Default execution event payloads and console
+  output remain unchanged, and raw order payload values are not added.
 
 ## Current Next Steps
 
 1. Continue Phase 5/6 by adding the next high-value event producer or debug
    profile slice without increasing default console noise. Likely candidates
-   are HSL preview/status debug enrichment, execution debug profiles, or more
-   order/risk transition coverage.
+   are HSL preview/status debug enrichment or more order/risk transition
+   coverage.
 2. Continue active read-only exchange health probes beyond account-critical
    basics. PR #701 added account-critical health summaries and PR #703 added
    `--account-only` plus symbol fallback for open-orders. Remaining useful

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -263,8 +263,8 @@ Related detailed plans:
     surfaces are touched.
 
 12. [ ] Debug profile toggles.
-    Status: partial. Rust, EMA readiness, remote-call, candle, and fills
-    profile slices are merged; an HSL profile slice is in progress.
+    Status: partial. Rust, EMA readiness, remote-call, candle, fills, and HSL
+    profile slices are merged; an execution profile slice is in progress.
 
     Add narrow runtime/debug profiles that increase event detail for one domain:
     candles, fills, HSL, Rust payloads, order execution, or exchange calls. This
@@ -291,12 +291,15 @@ Related detailed plans:
     - 2026-06-27: Added a `fills` debug-profile slice for existing fill
       refresh and fill ingestion events, exposing bounded count, coverage, and
       key-shape metadata without raw source IDs or payload values.
-    - 2026-06-27: Started an `hsl` debug-profile slice for existing HSL
+    - 2026-06-27: Added an `hsl` debug-profile slice for existing HSL
       status, transition, replay, red-trigger, and cooldown events, exposing
       bounded event key, metric key, and latch/cooldown state-shape metadata.
+    - 2026-06-27: Started an `execution` debug-profile slice for existing
+      order-wave, order-write, create-filter, and confirmation events, exposing
+      bounded key-shape/counter metadata without raw order payload values.
 
-    Remaining refinements: add targeted execution profiles as those diagnostics
-    need deeper live evidence.
+    Remaining refinements: add new targeted profiles only as diagnostics need
+    deeper live evidence.
 
 13. [ ] Cache integrity doctor.
     Status: partial. Initial read-only local cache smoke doctor, cache-family
@@ -399,13 +402,14 @@ Related detailed plans:
 | 2026-06-26 | #3/#14 Supervisor/process diagnostics | PR #712 / `51ba92a3` | Extended `live-smoke-report --supervisor-config` to classify expected matches, missing expected commands, duplicate configured-command process matches, and extra/orphan-like `passivbot live` processes with bounded per-process metadata; VPS5 smoke showed all five configured bots matched with zero duplicate or extra live process matches; documented the read-only command-match limitation and shutdown escalation ladder as policy only | Safe pull/stop/start orchestration remains open |
 | 2026-06-26 | #12 Debug profile toggles | pending PR | Added opt-in live-event debug profiles via config/env and initial Rust orchestrator structured-event enrichment with bounded input-symbol and output-order samples | Add remote-call, candle/EMA, HSL, fills, and execution profiles as needed |
 | 2026-06-27 | #12 Debug profile toggles | PR #728 / `5714d36d` | Added opt-in `fills` debug-profile enrichment to existing fill refresh and ingestion events with bounded count, coverage, and key-shape metadata | HSL and execution profiles remain open |
-| 2026-06-27 | #12 Debug profile toggles | pending PR | Add opt-in `hsl` debug-profile enrichment to existing HSL event surfaces with bounded event key, metric key, and latch/cooldown state-shape metadata | Execution profile remains open |
+| 2026-06-27 | #12 Debug profile toggles | PR #730 / `1334982c` | Added opt-in `hsl` debug-profile enrichment to existing HSL event surfaces with bounded event key, metric key, and latch/cooldown state-shape metadata | Execution profile remains open |
+| 2026-06-27 | #12 Debug profile toggles | pending PR | Add opt-in `execution` debug-profile enrichment to existing order-wave, order-write, create-filter, and confirmation events with bounded key-shape/counter metadata | Review/deploy after merge |
 | 2026-06-26 | #7 Live config preflight/linter | PR #714 / `564dc0a8` | Added `passivbot tool live-config-preflight`, a local-only JSON report for one config's risk-relevant live facts with bounded coin samples and malformed-structure errors; VPS5 preflight smoke returned `ok=true` with one expected missing short-side warning | Config diffing, deeper cache compatibility checks, and live startup enforcement remain open |
 | 2026-06-26 | #3 Live restart/smoke automation | PR #715 / `7b12d4b2` | Added passive `shutdown_events` summaries to full, summary, and brief `live-smoke-report` output for existing bot stopping/stage/stopped events; VPS5 no-restart smoke showed `shutdown_events.total=0`, all five bots matched, and no hard failures | Safe pull/stop/start orchestration remains open |
 | 2026-06-27 | #13 Cache integrity doctor | PR #722 / `3b7e6306` | Added read-only v2 candle coverage windows and suspicious interior gap samples from local `.valid.npy` artifacts | Fill/HSL coverage/readiness and deeper metadata compatibility |
 | 2026-06-27 | #13 Cache integrity doctor | PR #725 / `1ed9c466` | Added read-only fill/HSL metadata summaries from local JSON/NDJSON artifacts | Deeper metadata compatibility, synthetic/no-trade assumptions, and warm-cache readiness |
 | 2026-06-27 | #13 Cache integrity doctor | PR #727 / `d8dd7246` | Added report-only warm-cache readiness evidence from already-scanned candle/fill/HSL cache metadata | Deeper metadata compatibility and synthetic/no-trade assumptions |
-| 2026-06-27 | #7 Live config preflight/linter | pending PR | Added optional read-only `--compare` diff reporting for local two-config preflights, including HSL signal/enabled changes, universe deltas, forager slots/staleness, identity hints, and cache live settings | Deeper cache compatibility checks and live startup enforcement remain open |
+| 2026-06-27 | #7 Live config preflight/linter | PR #731 / `3cc2d229` | Added optional read-only `--compare` diff reporting for local two-config preflights, including HSL signal/enabled changes, universe deltas, forager slots/staleness, identity hints, and cache live settings | Deeper cache compatibility checks and live startup enforcement remain open |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #701 / `fcda70f5` | Added `ticker-endpoint-probe` `account_critical_health` summaries for read-only balance/positions/open-orders outcomes; VPS5 Binance probe validated the summary and exposed an open-orders shape follow-up | Lower-impact/account-only mode, exchange-aware open-orders probing, clock skew/rate-limit/fill/candle probes |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #703 / `8fefce4b` | Added `ticker-endpoint-probe --account-only`, `--skip-my-trades`, and open-orders symbol fallback; VPS5 Binance account-only probe returned account-critical total=3, succeeded=3, and smoke stayed green | Clock skew/rate-limit/fill-pagination/candle-freshness probes |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -243,9 +243,6 @@ def _execution_debug_payload(
             order.get("custom_id") or order.get("clientOrderId")
         )
         debug["has_exchange_order_id"] = bool(order.get("id") or order.get("order_id"))
-        for key in ("symbol", "side", "position_side", "pb_order_type", "type"):
-            if order.get(key) is not None:
-                debug[f"order_{key}"] = str(order.get(key))
     if isinstance(result, dict):
         debug["result_keys"] = _mapping_key_sample(result, limit=limit)
         debug["has_result_order_id"] = bool(result.get("id") or result.get("order_id"))

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -188,6 +188,131 @@ def _remote_call_debug_payload(
     return debug
 
 
+def _bounded_str_values(value: Any, *, limit: int = 32) -> list[str]:
+    try:
+        values = sorted(str(item) for item in value)
+    except TypeError:
+        return [str(value)]
+    return values[:limit]
+
+
+def _execution_wave_counts(wave: dict[str, Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for key in (
+        "planned_cancel",
+        "planned_create",
+        "cancel_posted",
+        "create_posted",
+        "skipped_cancel",
+        "deferred_create",
+        "skipped_create",
+    ):
+        if key in wave:
+            try:
+                count = int(wave.get(key) or 0)
+            except (TypeError, ValueError):
+                continue
+            if count:
+                counts[key] = count
+    return counts
+
+
+def _execution_debug_payload(
+    data: dict[str, Any],
+    *,
+    event_type: str,
+    action: str | None = None,
+    order: dict | None = None,
+    result: dict | BaseException | None = None,
+    extra: dict | None = None,
+    wave: dict | None = None,
+    surfaces: Any = None,
+    confirmations: dict | None = None,
+    fresh_surfaces: Any = None,
+    limit: int = 32,
+) -> dict[str, Any]:
+    debug: dict[str, Any] = {
+        "event_type": str(event_type),
+        "data_keys": _mapping_key_sample(data, limit=limit),
+    }
+    if action is not None:
+        debug["action"] = str(action)
+    if isinstance(order, dict):
+        debug["order_keys"] = _mapping_key_sample(order, limit=limit)
+        debug["has_client_order_id"] = bool(
+            order.get("custom_id") or order.get("clientOrderId")
+        )
+        debug["has_exchange_order_id"] = bool(order.get("id") or order.get("order_id"))
+        for key in ("symbol", "side", "position_side", "pb_order_type", "type"):
+            if order.get(key) is not None:
+                debug[f"order_{key}"] = str(order.get(key))
+    if isinstance(result, dict):
+        debug["result_keys"] = _mapping_key_sample(result, limit=limit)
+        debug["has_result_order_id"] = bool(result.get("id") or result.get("order_id"))
+        debug["has_result_client_order_id"] = bool(
+            result.get("custom_id") or result.get("clientOrderId")
+        )
+        if result.get("status") is not None:
+            debug["result_status"] = str(result.get("status"))
+    elif isinstance(result, BaseException):
+        debug["result_error_type"] = type(result).__name__
+    if isinstance(extra, dict):
+        debug["extra_keys"] = _mapping_key_sample(extra, limit=limit)
+    if isinstance(wave, dict):
+        debug["wave_keys"] = _mapping_key_sample(wave, limit=limit)
+        counts = _execution_wave_counts(wave)
+        if counts:
+            debug["wave_counts"] = counts
+    if surfaces is not None:
+        debug["surfaces"] = _bounded_str_values(surfaces, limit=limit)
+    if isinstance(confirmations, dict):
+        debug["confirmation_surfaces"] = _mapping_key_sample(confirmations, limit=limit)
+        debug["confirmation_count"] = len(confirmations)
+    if fresh_surfaces is not None:
+        debug["fresh_surfaces"] = _bounded_str_values(fresh_surfaces, limit=limit)
+    return {key: value for key, value in debug.items() if value not in (None, [], {})}
+
+
+def _add_execution_debug_profile(
+    bot: Any,
+    data: dict[str, Any],
+    *,
+    event_type: str,
+    action: str | None = None,
+    order: dict | None = None,
+    result: dict | BaseException | None = None,
+    extra: dict | None = None,
+    wave: dict | None = None,
+    surfaces: Any = None,
+    confirmations: dict | None = None,
+    fresh_surfaces: Any = None,
+) -> None:
+    if not live_event_debug_profile_enabled(bot, "execution"):
+        return
+    try:
+        data["debug_profile"] = "execution"
+        data["debug"] = _execution_debug_payload(
+            data,
+            event_type=event_type,
+            action=action,
+            order=order,
+            result=result,
+            extra=extra,
+            wave=wave,
+            surfaces=surfaces,
+            confirmations=confirmations,
+            fresh_surfaces=fresh_surfaces,
+        )
+    except Exception as exc:
+        data.pop("debug_profile", None)
+        data.pop("debug", None)
+        logging.debug(
+            "[event] failed to build execution debug payload type=%s: %s",
+            event_type,
+            exc,
+        )
+
+
 def _remote_call_map_max(bot: Any) -> int:
     try:
         raw = getattr(bot, "_live_event_remote_call_map_max", None)
@@ -785,6 +910,27 @@ def emit_order_wave_completed_event(
     elif skipped_cancel or skipped_create:
         status = "skipped"
         reason_code = "order_filtered"
+    data = {
+        "id": int(wave.get("id", 0) or 0),
+        "elapsed_ms": int(elapsed_ms),
+        "planned_cancel": planned_cancel,
+        "planned_create": planned_create,
+        "cancel_posted": cancel_posted,
+        "create_posted": create_posted,
+        "cancel_ms": wave.get("cancel_ms"),
+        "create_ms": wave.get("create_ms"),
+        "skipped_cancel": skipped_cancel,
+        "deferred_create": deferred_create,
+        "skipped_create": skipped_create,
+        "symbols": list(wave.get("symbols") or []),
+        "requested_confirmations": dict(wave.get("requested_confirmations") or {}),
+    }
+    _add_execution_debug_profile(
+        bot,
+        data,
+        event_type=EventTypes.ORDER_WAVE_COMPLETED,
+        wave=wave,
+    )
     bot._emit_live_event(
         EventTypes.ORDER_WAVE_COMPLETED,
         level=str(level).lower(),
@@ -794,23 +940,7 @@ def emit_order_wave_completed_event(
         order_wave_id=str(wave.get("event_id") or f"ow_{wave.get('id', '')}"),
         status=status,
         reason_code=reason_code,
-        data={
-            "id": int(wave.get("id", 0) or 0),
-            "elapsed_ms": int(elapsed_ms),
-            "planned_cancel": planned_cancel,
-            "planned_create": planned_create,
-            "cancel_posted": cancel_posted,
-            "create_posted": create_posted,
-            "cancel_ms": wave.get("cancel_ms"),
-            "create_ms": wave.get("create_ms"),
-            "skipped_cancel": skipped_cancel,
-            "deferred_create": deferred_create,
-            "skipped_create": skipped_create,
-            "symbols": list(wave.get("symbols") or []),
-            "requested_confirmations": dict(
-                wave.get("requested_confirmations") or {}
-            ),
-        },
+        data=data,
     )
 
 
@@ -818,6 +948,18 @@ def emit_order_wave_started_event(bot: Any, wave: dict | None) -> None:
     if not wave:
         return
     try:
+        data = {
+            "id": int(wave.get("id", 0) or 0),
+            "planned_cancel": int(wave.get("planned_cancel", 0) or 0),
+            "planned_create": int(wave.get("planned_create", 0) or 0),
+            "symbols": list(wave.get("symbols") or []),
+        }
+        _add_execution_debug_profile(
+            bot,
+            data,
+            event_type=EventTypes.ORDER_WAVE_STARTED,
+            wave=wave,
+        )
         bot._emit_live_event(
             EventTypes.ORDER_WAVE_STARTED,
             level="debug",
@@ -826,12 +968,7 @@ def emit_order_wave_started_event(bot: Any, wave: dict | None) -> None:
             cycle_id=bot._current_live_event_cycle_id(),
             order_wave_id=str(wave.get("event_id") or f"ow_{wave.get('id', '')}"),
             status="started",
-            data={
-                "id": int(wave.get("id", 0) or 0),
-                "planned_cancel": int(wave.get("planned_cancel", 0) or 0),
-                "planned_create": int(wave.get("planned_create", 0) or 0),
-                "symbols": list(wave.get("symbols") or []),
-            },
+            data=data,
         )
     except Exception as exc:
         logging.debug("[event] failed to emit order wave started event: %s", exc)
@@ -2542,6 +2679,14 @@ def emit_execution_create_filter_event(
                 "symbols_truncated": len(symbol_values) > 12,
             }
         )
+        _add_execution_debug_profile(
+            bot,
+            payload,
+            event_type=event_type,
+            action="create_filter",
+            extra=data,
+            wave=wave,
+        )
         bot._emit_live_event(
             event_type,
             level=level,
@@ -2601,6 +2746,16 @@ def emit_execution_order_event(
             data["error"] = _sanitize_remote_text(error, max_len=500)
         if extra:
             data.update(extra)
+        _add_execution_debug_profile(
+            bot,
+            data,
+            event_type=event_type,
+            action=action,
+            order=order,
+            result=result,
+            extra=extra,
+            wave=wave,
+        )
         bot._emit_live_event(
             event_type,
             level=level,
@@ -2642,6 +2797,19 @@ def emit_execution_confirmation_requested_event(
             if isinstance(wave, dict)
             else None
         )
+        data = {
+            "surfaces": sorted(str(surface) for surface in surfaces),
+            "target_epoch": int(target_epoch),
+            "current_epoch": int(getattr(bot, "_authoritative_refresh_epoch", 0) or 0),
+            "min_epoch": int(min_epoch) if min_epoch is not None else None,
+        }
+        _add_execution_debug_profile(
+            bot,
+            data,
+            event_type=EventTypes.EXECUTION_CONFIRMATION_REQUESTED,
+            wave=wave,
+            surfaces=surfaces,
+        )
         bot._emit_live_event(
             EventTypes.EXECUTION_CONFIRMATION_REQUESTED,
             level="debug",
@@ -2651,12 +2819,7 @@ def emit_execution_confirmation_requested_event(
             order_wave_id=order_wave_id,
             status="started",
             reason_code=ReasonCodes.AUTHORITATIVE_CONFIRMATION,
-            data={
-                "surfaces": sorted(str(surface) for surface in surfaces),
-                "target_epoch": int(target_epoch),
-                "current_epoch": int(getattr(bot, "_authoritative_refresh_epoch", 0) or 0),
-                "min_epoch": int(min_epoch) if min_epoch is not None else None,
-            },
+            data=data,
         )
     except Exception as exc:
         logging.debug("[event] failed to emit confirmation requested event: %s", exc)
@@ -2675,6 +2838,31 @@ def emit_execution_confirmation_satisfied_event(
     level: str = "debug",
 ) -> None:
     try:
+        data = {
+            "id": int(wave.get("id", 0) or 0),
+            "elapsed_ms": int(elapsed_ms),
+            "confirm_ms": int(confirm_ms),
+            "current_epoch": int(current_epoch),
+            "confirmations": {
+                str(surface): int(epoch)
+                for surface, epoch in dict(confirmations or {}).items()
+            },
+            "fresh_surfaces": sorted(str(surface) for surface in fresh_surfaces),
+            "changed_surfaces": list(changed_surfaces or []),
+            "planned_cancel": int(wave.get("planned_cancel", 0) or 0),
+            "planned_create": int(wave.get("planned_create", 0) or 0),
+            "cancel_posted": int(wave.get("cancel_posted", 0) or 0),
+            "create_posted": int(wave.get("create_posted", 0) or 0),
+            "symbols": list(wave.get("symbols") or []),
+        }
+        _add_execution_debug_profile(
+            bot,
+            data,
+            event_type=EventTypes.EXECUTION_CONFIRMATION_SATISFIED,
+            wave=wave,
+            confirmations=confirmations,
+            fresh_surfaces=fresh_surfaces,
+        )
         bot._emit_live_event(
             EventTypes.EXECUTION_CONFIRMATION_SATISFIED,
             level=str(level).lower(),
@@ -2684,23 +2872,7 @@ def emit_execution_confirmation_satisfied_event(
             order_wave_id=str(wave.get("event_id") or f"ow_{wave.get('id', '')}"),
             status="succeeded",
             reason_code=ReasonCodes.AUTHORITATIVE_CONFIRMATION,
-            data={
-                "id": int(wave.get("id", 0) or 0),
-                "elapsed_ms": int(elapsed_ms),
-                "confirm_ms": int(confirm_ms),
-                "current_epoch": int(current_epoch),
-                "confirmations": {
-                    str(surface): int(epoch)
-                    for surface, epoch in dict(confirmations or {}).items()
-                },
-                "fresh_surfaces": sorted(str(surface) for surface in fresh_surfaces),
-                "changed_surfaces": list(changed_surfaces or []),
-                "planned_cancel": int(wave.get("planned_cancel", 0) or 0),
-                "planned_create": int(wave.get("planned_create", 0) or 0),
-                "cancel_posted": int(wave.get("cancel_posted", 0) or 0),
-                "create_posted": int(wave.get("create_posted", 0) or 0),
-                "symbols": list(wave.get("symbols") or []),
-            },
+            data=data,
         )
     except Exception as exc:
         logging.debug("[event] failed to emit confirmation satisfied event: %s", exc)
@@ -2719,6 +2891,36 @@ def emit_execution_confirmation_timeout_event(
     level: str = "warning",
 ) -> None:
     try:
+        data = {
+            "id": int(wave.get("id", 0) or 0),
+            "elapsed_ms": int(elapsed_ms),
+            "confirm_ms": int(confirm_ms),
+            "timeout_ms": int(timeout_ms),
+            "current_epoch": int(current_epoch),
+            "confirmations": {
+                str(surface): int(epoch)
+                for surface, epoch in dict(confirmations or {}).items()
+            },
+            "fresh_surfaces": sorted(str(surface) for surface in fresh_surfaces),
+            "pending_surfaces": sorted(
+                str(surface)
+                for surface, epoch in dict(confirmations or {}).items()
+                if surface not in fresh_surfaces or current_epoch < int(epoch)
+            ),
+            "planned_cancel": int(wave.get("planned_cancel", 0) or 0),
+            "planned_create": int(wave.get("planned_create", 0) or 0),
+            "cancel_posted": int(wave.get("cancel_posted", 0) or 0),
+            "create_posted": int(wave.get("create_posted", 0) or 0),
+            "symbols": list(wave.get("symbols") or []),
+        }
+        _add_execution_debug_profile(
+            bot,
+            data,
+            event_type=EventTypes.EXECUTION_CONFIRMATION_TIMEOUT,
+            wave=wave,
+            confirmations=confirmations,
+            fresh_surfaces=fresh_surfaces,
+        )
         bot._emit_live_event(
             EventTypes.EXECUTION_CONFIRMATION_TIMEOUT,
             level=str(level).lower(),
@@ -2728,28 +2930,7 @@ def emit_execution_confirmation_timeout_event(
             order_wave_id=str(wave.get("event_id") or f"ow_{wave.get('id', '')}"),
             status="degraded",
             reason_code=ReasonCodes.AUTHORITATIVE_CONFIRMATION_TIMEOUT,
-            data={
-                "id": int(wave.get("id", 0) or 0),
-                "elapsed_ms": int(elapsed_ms),
-                "confirm_ms": int(confirm_ms),
-                "timeout_ms": int(timeout_ms),
-                "current_epoch": int(current_epoch),
-                "confirmations": {
-                    str(surface): int(epoch)
-                    for surface, epoch in dict(confirmations or {}).items()
-                },
-                "fresh_surfaces": sorted(str(surface) for surface in fresh_surfaces),
-                "pending_surfaces": sorted(
-                    str(surface)
-                    for surface, epoch in dict(confirmations or {}).items()
-                    if surface not in fresh_surfaces or current_epoch < int(epoch)
-                ),
-                "planned_cancel": int(wave.get("planned_cancel", 0) or 0),
-                "planned_create": int(wave.get("planned_create", 0) or 0),
-                "cancel_posted": int(wave.get("cancel_posted", 0) or 0),
-                "create_posted": int(wave.get("create_posted", 0) or 0),
-                "symbols": list(wave.get("symbols") or []),
-            },
+            data=data,
         )
     except Exception as exc:
         logging.debug("[event] failed to emit confirmation timeout event: %s", exc)

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -3174,6 +3174,9 @@ def test_execution_debug_profile_adds_bounded_order_write_shape():
     assert "raw-exchange-order-id-456" not in serialized_debug
     assert "raw-result-order-id-789" not in serialized_debug
     assert "raw-result-client-order-id-999" not in serialized_debug
+    assert "BTC/USDT:USDT" not in serialized_debug
+    assert "\"buy\"" not in serialized_debug
+    assert "\"long\"" not in serialized_debug
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -441,6 +441,71 @@ def test_order_wave_summary_emits_live_event(caplog):
     assert event.data["cancel_posted"] == 1
     assert event.data["create_posted"] == 1
     assert set(event.data["symbols"]) == {"BTC/USDT:USDT", "ETH/USDT:USDT"}
+    assert "debug_profile" not in event.data
+    assert "debug" not in event.data
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_execution_debug_profile_adds_bounded_order_wave_shape():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _begin_order_wave = pb_mod.Passivbot._begin_order_wave
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _emit_order_wave_completed_event = (
+            pb_mod.Passivbot._emit_order_wave_completed_event
+        )
+        _emit_order_wave_started_event = pb_mod.Passivbot._emit_order_wave_started_event
+
+        def __init__(self):
+            self.exchange = "binance"
+            self.user = "binance_01"
+            self.bot_id = "bot_1"
+            self.live_event_debug_profiles = ("execution",)
+            self._order_wave_seq = 0
+            self._live_event_current_cycle_id = "cy_execution_debug_wave"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+    wave = bot._begin_order_wave(
+        [{"symbol": "BTC/USDT:USDT", "qty": 1, "price": 100.0}],
+        [{"symbol": "ETH/USDT:USDT", "qty": 2, "price": 200.0}],
+    )
+    wave["cancel_posted"] = 1
+    wave["create_posted"] = 1
+    wave["requested_confirmations"] = {"open_orders": 5}
+
+    bot._emit_order_wave_started_event(wave)
+    bot._emit_order_wave_completed_event(wave, elapsed_ms=42)
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    started = [
+        event for event in sink.events if event.event_type == EventTypes.ORDER_WAVE_STARTED
+    ][-1]
+    completed = [
+        event for event in sink.events if event.event_type == EventTypes.ORDER_WAVE_COMPLETED
+    ][-1]
+    assert started.event_type == EventTypes.ORDER_WAVE_STARTED
+    assert started.data["debug_profile"] == "execution"
+    assert started.data["debug"]["event_type"] == EventTypes.ORDER_WAVE_STARTED
+    assert started.data["debug"]["wave_counts"]["planned_cancel"] == 1
+    assert completed.event_type == EventTypes.ORDER_WAVE_COMPLETED
+    assert completed.data["debug_profile"] == "execution"
+    debug = completed.data["debug"]
+    assert debug["event_type"] == EventTypes.ORDER_WAVE_COMPLETED
+    assert "requested_confirmations" in debug["data_keys"]
+    assert debug["wave_counts"] == {
+        "planned_cancel": 1,
+        "planned_create": 1,
+        "cancel_posted": 1,
+        "create_posted": 1,
+    }
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
@@ -3033,6 +3098,85 @@ async def test_execute_orders_parent_records_order_opened_event():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_execution_debug_profile_adds_bounded_order_write_shape():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_execution_order_event = pb_mod.Passivbot._emit_execution_order_event
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "okx"
+            self.user = "okx_01"
+            self.bot_id = "bot_1"
+            self.live_event_debug_profiles = ("execution",)
+            self._live_event_current_cycle_id = "cy_execution_debug_order"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+    order = {
+        "symbol": "BTC/USDT:USDT",
+        "side": "buy",
+        "position_side": "long",
+        "qty": 0.01,
+        "price": 100000.0,
+        "reduce_only": False,
+        "custom_id": "raw-client-order-id-123",
+        "id": "raw-exchange-order-id-456",
+        "_delta": {"price_pct_diff": 0.001, "qty_pct_diff": 0.002},
+    }
+    result = {
+        "id": "raw-result-order-id-789",
+        "clientOrderId": "raw-result-client-order-id-999",
+        "status": "open",
+        "raw_payload": {"nested": "not emitted"},
+    }
+    extra = {"exchange_latency_ms": 123, "raw_response": {"nested": "not emitted"}}
+    wave = {"id": 17, "event_id": "ow_17", "planned_create": 1, "create_posted": 1}
+
+    bot._emit_execution_order_event(
+        event_type=EventTypes.EXECUTION_CREATE_SUCCEEDED,
+        order=order,
+        action="create",
+        status="succeeded",
+        reason_code=ReasonCodes.EXCHANGE_ACKNOWLEDGED,
+        index=0,
+        wave=wave,
+        result=result,
+        extra=extra,
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[-1]
+    assert event.event_type == EventTypes.EXECUTION_CREATE_SUCCEEDED
+    assert event.data["debug_profile"] == "execution"
+    debug = event.data["debug"]
+    assert debug["event_type"] == EventTypes.EXECUTION_CREATE_SUCCEEDED
+    assert debug["action"] == "create"
+    assert "price" in debug["data_keys"]
+    assert "custom_id" in debug["order_keys"]
+    assert "raw_payload" in debug["result_keys"]
+    assert "raw_response" in debug["extra_keys"]
+    assert debug["has_client_order_id"] is True
+    assert debug["has_exchange_order_id"] is True
+    assert debug["has_result_order_id"] is True
+    assert debug["has_result_client_order_id"] is True
+    assert debug["result_status"] == "open"
+    assert debug["wave_counts"] == {"planned_create": 1, "create_posted": 1}
+    serialized_debug = json.dumps(debug, sort_keys=True)
+    assert "raw-client-order-id-123" not in serialized_debug
+    assert "raw-exchange-order-id-456" not in serialized_debug
+    assert "raw-result-order-id-789" not in serialized_debug
+    assert "raw-result-client-order-id-999" not in serialized_debug
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 @pytest.mark.asyncio
 async def test_execute_cancellations_parent_emits_ambiguous_confirmation_events():
     import passivbot as pb_mod
@@ -3057,6 +3201,7 @@ async def test_execute_cancellations_parent_emits_ambiguous_confirmation_events(
             self.exchange = "hyperliquid"
             self.user = "hyperliquid_01"
             self.bot_id = "bot_1"
+            self.live_event_debug_profiles = ("execution",)
             self._live_event_current_cycle_id = "cy_12"
             self._authoritative_pending_confirmations = {}
             self._authoritative_refresh_epoch = 4
@@ -3134,9 +3279,18 @@ async def test_execute_cancellations_parent_emits_ambiguous_confirmation_events(
     assert ambiguous.status == "degraded"
     assert ambiguous.reason_code == "requires_full_authoritative_confirmation"
     assert ambiguous.order_wave_id == "ow_9"
+    assert ambiguous.data["debug_profile"] == "execution"
+    assert ambiguous.data["debug"]["action"] == "cancel"
     requested = sink.events[2]
     assert requested.data["target_epoch"] == 5
     assert requested.data["surfaces"] == ["balance", "fills", "open_orders", "positions"]
+    assert requested.data["debug_profile"] == "execution"
+    assert requested.data["debug"]["surfaces"] == [
+        "balance",
+        "fills",
+        "open_orders",
+        "positions",
+    ]
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
## Summary
- add opt-in execution live-event debug-profile enrichment to existing order-wave, create-filter, order-write, and confirmation events
- expose bounded key-shape/counter/correlation metadata only
- do not add raw order payload values, raw exchange responses, or default console output
- keep trading/execution behavior unchanged

## Validation
- ./venv/bin/python -m pytest -q tests/test_passivbot_monitor.py tests/test_live_event_bus.py
- ./venv/bin/python -m pytest -q tests/test_passivbot_monitor.py::test_order_wave_summary_emits_live_event tests/test_passivbot_monitor.py::test_execution_debug_profile_adds_bounded_order_wave_shape tests/test_passivbot_monitor.py::test_execution_debug_profile_adds_bounded_order_write_shape tests/test_passivbot_monitor.py::test_execute_cancellations_parent_emits_ambiguous_confirmation_events tests/test_live_event_bus.py::test_live_event_debug_profiles_normalize_and_validate
- ./venv/bin/python -m compileall -q src/live/event_emitters.py tests/test_passivbot_monitor.py
- git diff --check
- touched-file silent-handling audit reviewed: new broad catch is observability-only debug payload construction; remaining hits are existing best-effort event emitters/tests