### PR TITLE
Update logging progress after debug profiles

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -1290,22 +1290,38 @@ VPS5 deployment status:
   `git diff --check`, and touched-file silent-handling audit passed. Claude did
   not return before merge, so this opt-in observability slice used the degraded
   gate.
+- VPS5 evidence: deployed together with PRs #731 and #732 at `9bc2c37f`.
+  Settled 5-minute smoke returned `ok=true`, no hard failures, no log hard
+  matches, all five expected bots matched, clean tracked repository state, no
+  failed remote calls, no failed account-critical remote calls, and no monitor
+  errors or warnings. Remaining attention was non-hard Hyperliquid EMA/candle
+  readiness.
 
-### Pending PR: Execution Debug Profile
+### PR #732: Execution Debug Profile
 
 - Branch: `codex/v8-execution-debug-profile`.
 - Scope: Phase 5/6 opt-in structured debug enrichment.
-- Result: in progress. Add `execution` debug-profile enrichment to existing
+- Result: added `execution` debug-profile enrichment to existing
   order-wave, order-write, create-filter, and confirmation events with bounded
   key-shape/counter metadata. Default execution event payloads and console
   output remain unchanged, and raw order payload values are not added.
+- Review evidence: Hermes found and then approved the raw-order-value leak fix
+  at `cb1f2c23`; after rebasing onto current `v8`, CI was green and focused
+  execution/live-event tests, compileall, and `git diff --check` passed. Claude
+  did not return before merge, so this opt-in observability slice used the
+  degraded gate.
+- VPS5 evidence: deployed together with PRs #730 and #731 at `9bc2c37f`.
+  Settled 5-minute smoke returned `ok=true`, no hard failures, no log hard
+  matches, all five expected bots matched, clean tracked repository state, no
+  failed remote calls, no failed account-critical remote calls, and no monitor
+  errors or warnings.
 
 ## Current Next Steps
 
 1. Continue Phase 5/6 by adding the next high-value event producer or debug
    profile slice without increasing default console noise. Likely candidates
-   are HSL preview/status debug enrichment or more order/risk transition
-   coverage.
+   are more order/risk transition coverage or focused profile refinements only
+   when live diagnostics need deeper evidence.
 2. Continue active read-only exchange health probes beyond account-critical
    basics. PR #701 added account-critical health summaries and PR #703 added
    `--account-only` plus symbol fallback for open-orders. Remaining useful

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -262,9 +262,9 @@ Related detailed plans:
     Remaining refinements: keep tightening producer coverage as nearby event
     surfaces are touched.
 
-12. [ ] Debug profile toggles.
-    Status: partial. Rust, EMA readiness, remote-call, candle, fills, and HSL
-    profile slices are merged; an execution profile slice is in progress.
+12. [x] Debug profile toggles.
+    Status: initial targeted profile set merged. Rust, EMA readiness,
+    remote-call, candle, fills, HSL, and execution profile slices are merged.
 
     Add narrow runtime/debug profiles that increase event detail for one domain:
     candles, fills, HSL, Rust payloads, order execution, or exchange calls. This
@@ -294,7 +294,7 @@ Related detailed plans:
     - 2026-06-27: Added an `hsl` debug-profile slice for existing HSL
       status, transition, replay, red-trigger, and cooldown events, exposing
       bounded event key, metric key, and latch/cooldown state-shape metadata.
-    - 2026-06-27: Started an `execution` debug-profile slice for existing
+    - 2026-06-27: Added an `execution` debug-profile slice for existing
       order-wave, order-write, create-filter, and confirmation events, exposing
       bounded key-shape/counter metadata without raw order payload values.
 
@@ -401,9 +401,9 @@ Related detailed plans:
 | 2026-06-26 | #3 Live restart/smoke automation | PR #709 / `71479c61` deploy evidence | VPS5 restart smoke after the fill-cache event slice returned `ok=true`, no hard failures, all five bots matched; the restart exposed four orphaned live processes after two Ctrl+C rounds, cleared by SIGTERM before reload | Safe pull/stop/start orchestration should include shutdown timing, orphan detection, and escalation policy |
 | 2026-06-26 | #3/#14 Supervisor/process diagnostics | PR #712 / `51ba92a3` | Extended `live-smoke-report --supervisor-config` to classify expected matches, missing expected commands, duplicate configured-command process matches, and extra/orphan-like `passivbot live` processes with bounded per-process metadata; VPS5 smoke showed all five configured bots matched with zero duplicate or extra live process matches; documented the read-only command-match limitation and shutdown escalation ladder as policy only | Safe pull/stop/start orchestration remains open |
 | 2026-06-26 | #12 Debug profile toggles | pending PR | Added opt-in live-event debug profiles via config/env and initial Rust orchestrator structured-event enrichment with bounded input-symbol and output-order samples | Add remote-call, candle/EMA, HSL, fills, and execution profiles as needed |
-| 2026-06-27 | #12 Debug profile toggles | PR #728 / `5714d36d` | Added opt-in `fills` debug-profile enrichment to existing fill refresh and ingestion events with bounded count, coverage, and key-shape metadata | HSL and execution profiles remain open |
-| 2026-06-27 | #12 Debug profile toggles | PR #730 / `1334982c` | Added opt-in `hsl` debug-profile enrichment to existing HSL event surfaces with bounded event key, metric key, and latch/cooldown state-shape metadata | Execution profile remains open |
-| 2026-06-27 | #12 Debug profile toggles | pending PR | Add opt-in `execution` debug-profile enrichment to existing order-wave, order-write, create-filter, and confirmation events with bounded key-shape/counter metadata | Review/deploy after merge |
+| 2026-06-27 | #12 Debug profile toggles | PR #728 / `5714d36d` | Added opt-in `fills` debug-profile enrichment to existing fill refresh and ingestion events with bounded count, coverage, and key-shape metadata | HSL and execution followed in #730/#732 |
+| 2026-06-27 | #12 Debug profile toggles | PR #730 / `1334982c` | Added opt-in `hsl` debug-profile enrichment to existing HSL event surfaces with bounded event key, metric key, and latch/cooldown state-shape metadata | Execution followed in #732 |
+| 2026-06-27 | #12 Debug profile toggles | PR #732 / `9bc2c37f` | Added opt-in `execution` debug-profile enrichment to existing order-wave, order-write, create-filter, and confirmation events with bounded key-shape/counter metadata | Initial targeted profile set complete; add future profiles only as diagnostics require |
 | 2026-06-26 | #7 Live config preflight/linter | PR #714 / `564dc0a8` | Added `passivbot tool live-config-preflight`, a local-only JSON report for one config's risk-relevant live facts with bounded coin samples and malformed-structure errors; VPS5 preflight smoke returned `ok=true` with one expected missing short-side warning | Config diffing, deeper cache compatibility checks, and live startup enforcement remain open |
 | 2026-06-26 | #3 Live restart/smoke automation | PR #715 / `7b12d4b2` | Added passive `shutdown_events` summaries to full, summary, and brief `live-smoke-report` output for existing bot stopping/stage/stopped events; VPS5 no-restart smoke showed `shutdown_events.total=0`, all five bots matched, and no hard failures | Safe pull/stop/start orchestration remains open |
 | 2026-06-27 | #13 Cache integrity doctor | PR #722 / `3b7e6306` | Added read-only v2 candle coverage windows and suspicious interior gap samples from local `.valid.npy` artifacts | Fill/HSL coverage/readiness and deeper metadata compatibility |


### PR DESCRIPTION
## Summary
- mark HSL and execution debug-profile work as merged and VPS-smoked
- mark the initial targeted debug-profile set complete in the live-ops backlog
- record degraded-gate review evidence and settled VPS5 smoke at v8 head 9bc2c37f

## Validation
- git diff --check

Docs-only progress update; no code or trading behavior changes.