### PR TITLE
Harden live ops tool config reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable user-facing changes will be documented in this file.
 - Hardened recent live-ops tooling and debug-profile diagnostics by redacting
   shareable path fields consistently, keeping Rust debug sample construction
   best-effort, and scoping EMA debug enrichment to the `ema` profile only.
+- Hardened read-only live-ops tools so `live-config-preflight` and
+  `hsl-startup-preview` resolve both grouped and flat bot-side config keys, and
+  HSL preview output keeps allowlisted event details scalar-only.
 - Added a `fills` live-event debug profile with bounded fill refresh and fill
   ingestion shape metadata, without raw fill/source payloads or default console
   changes.

--- a/src/tools/hsl_startup_preview.py
+++ b/src/tools/hsl_startup_preview.py
@@ -8,8 +8,10 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
+from config.shared_bot import get_grouped_bot_value
 from live.event_bus import EventTypes, LIVE_EVENT_MONITOR_PAYLOAD_KEY
 from live.event_query import discover_event_files
+from live.smoke_report import _user_safe_display_path
 
 
 SIDES = ("long", "short")
@@ -69,12 +71,13 @@ def _load_config(config_path: str | Path) -> tuple[dict[str, Any] | None, list[d
     try:
         raw = path.read_text(encoding="utf-8")
     except OSError as exc:
+        detail = getattr(exc, "strerror", None) or type(exc).__name__
         return None, [
             _issue(
                 "error",
                 "config_read_failed",
-                f"could not read config: {exc}",
-                path=str(path),
+                f"could not read config: {detail}",
+                path=_user_safe_display_path(path),
             )
         ]
     try:
@@ -85,7 +88,7 @@ def _load_config(config_path: str | Path) -> tuple[dict[str, Any] | None, list[d
                 "error",
                 "config_json_decode_failed",
                 f"invalid JSON at line {exc.lineno} column {exc.colno}: {exc.msg}",
-                path=str(path),
+                path=_user_safe_display_path(path),
             )
         ]
     if not isinstance(parsed, dict):
@@ -102,22 +105,37 @@ def _section(value: Any) -> dict[str, Any]:
 def _hsl_side_config(config: dict[str, Any], pside: str) -> dict[str, Any]:
     bot = _section(config.get("bot"))
     side_config = _section(bot.get(pside))
-    hsl = _section(side_config.get("hsl"))
-    tier_ratios = _section(hsl.get("tier_ratios"))
+    hsl_values = {
+        key: get_grouped_bot_value(side_config, flat_key, default=None)
+        for key, flat_key in (
+            ("enabled", "hsl_enabled"),
+            ("red_threshold", "hsl_red_threshold"),
+            ("cooldown_minutes_after_red", "hsl_cooldown_minutes_after_red"),
+            ("no_restart_drawdown_threshold", "hsl_no_restart_drawdown_threshold"),
+            ("ema_span_minutes", "hsl_ema_span_minutes"),
+            ("tier_ratios", "hsl_tier_ratios"),
+            ("orange_tier_mode", "hsl_orange_tier_mode"),
+            ("panic_close_order_type", "hsl_panic_close_order_type"),
+        )
+    }
+    tier_ratios = (
+        hsl_values["tier_ratios"] if isinstance(hsl_values.get("tier_ratios"), dict) else {}
+    )
+    present = any(value is not None for value in hsl_values.values())
     return {
-        "present": bool(hsl),
-        "enabled": hsl.get("enabled"),
-        "red_threshold": hsl.get("red_threshold"),
-        "cooldown_minutes_after_red": hsl.get("cooldown_minutes_after_red"),
-        "no_restart_drawdown_threshold": hsl.get("no_restart_drawdown_threshold"),
-        "ema_span_minutes": hsl.get("ema_span_minutes"),
+        "present": present,
+        "enabled": hsl_values["enabled"],
+        "red_threshold": hsl_values["red_threshold"],
+        "cooldown_minutes_after_red": hsl_values["cooldown_minutes_after_red"],
+        "no_restart_drawdown_threshold": hsl_values["no_restart_drawdown_threshold"],
+        "ema_span_minutes": hsl_values["ema_span_minutes"],
         "tier_ratios": {
             key: tier_ratios[key]
             for key in ("yellow", "orange")
             if key in tier_ratios
         },
-        "orange_tier_mode": hsl.get("orange_tier_mode"),
-        "panic_close_order_type": hsl.get("panic_close_order_type"),
+        "orange_tier_mode": hsl_values["orange_tier_mode"],
+        "panic_close_order_type": hsl_values["panic_close_order_type"],
     }
 
 
@@ -170,7 +188,21 @@ def _bot_key(live_event: dict[str, Any], row: dict[str, Any]) -> str:
 def _bounded_hsl_data(live_event: dict[str, Any]) -> dict[str, Any]:
     data = live_event.get("data")
     payload = data if isinstance(data, dict) else {}
-    return {key: payload[key] for key in HSL_DATA_KEYS if payload.get(key) is not None}
+    out: dict[str, Any] = {}
+    for key in HSL_DATA_KEYS:
+        value = payload.get(key)
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            out[key] = value
+        elif isinstance(value, int):
+            out[key] = value
+        elif isinstance(value, float):
+            if value == value and value not in (float("inf"), float("-inf")):
+                out[key] = value
+        elif isinstance(value, str):
+            out[key] = value[:160] + "...<truncated>" if len(value) > 160 else value
+    return out
 
 
 def _target_key(record: dict[str, Any]) -> tuple[str, str, str]:
@@ -398,7 +430,7 @@ def build_hsl_startup_preview_report(
         return {
             "ok": False,
             "tool": "hsl-startup-preview",
-            "config_path": str(Path(config_path).expanduser()),
+            "config_path": _user_safe_display_path(config_path),
             "issues": config_issues,
         }
 
@@ -434,12 +466,12 @@ def build_hsl_startup_preview_report(
     return {
         "ok": not any(issue.get("severity") == "error" for issue in issues),
         "tool": "hsl-startup-preview",
-        "config_path": str(Path(config_path).expanduser()),
+        "config_path": _user_safe_display_path(config_path),
         "preview_time_ms": int(now_ms),
         "inputs": {
             "config": {
                 "available": True,
-                "path": str(Path(config_path).expanduser()),
+                "path": _user_safe_display_path(config_path),
             },
             "monitor_events": {
                 key: event_scan.get(key)

--- a/src/tools/live_config_preflight.py
+++ b/src/tools/live_config_preflight.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from config.shared_bot import BOT_GROUP_FIELD_MAP, get_grouped_bot_value
 from live.smoke_report import _user_safe_display_path
 
 
@@ -108,6 +109,14 @@ def _display_value(value: Any) -> dict[str, Any]:
 
 
 def _path_value(config: dict[str, Any], path: tuple[str, ...]) -> Any:
+    if len(path) == 4 and path[0] == "bot" and path[1] in SIDES:
+        group_name = path[2]
+        local_key = path[3]
+        flat_key = BOT_GROUP_FIELD_MAP.get(group_name, {}).get(local_key)
+        bot = config.get("bot")
+        side_config = bot.get(path[1]) if isinstance(bot, dict) else None
+        if flat_key is not None:
+            return get_grouped_bot_value(side_config, flat_key, default=_MISSING)
     value: Any = config
     for part in path:
         if not isinstance(value, dict) or part not in value:
@@ -234,45 +243,60 @@ def _side_coin_summary(value: Any, *, sample_size: int) -> dict[str, Any]:
 
 
 def _hsl_side_report(side_config: dict[str, Any]) -> dict[str, Any]:
-    hsl = side_config["hsl"] if isinstance(side_config.get("hsl"), dict) else {}
-    tier_ratios = hsl["tier_ratios"] if isinstance(hsl.get("tier_ratios"), dict) else {}
+    hsl_values = {
+        key: get_grouped_bot_value(side_config, flat_key, default=None)
+        for key, flat_key in (
+            ("enabled", "hsl_enabled"),
+            ("red_threshold", "hsl_red_threshold"),
+            ("cooldown_minutes_after_red", "hsl_cooldown_minutes_after_red"),
+            ("no_restart_drawdown_threshold", "hsl_no_restart_drawdown_threshold"),
+            ("ema_span_minutes", "hsl_ema_span_minutes"),
+            ("tier_ratios", "hsl_tier_ratios"),
+            ("orange_tier_mode", "hsl_orange_tier_mode"),
+            ("panic_close_order_type", "hsl_panic_close_order_type"),
+        )
+    }
+    tier_ratios = (
+        hsl_values["tier_ratios"] if isinstance(hsl_values.get("tier_ratios"), dict) else {}
+    )
+    present = any(value is not None for value in hsl_values.values())
     return {
-        "present": bool(hsl),
-        "enabled": hsl.get("enabled"),
-        "red_threshold": hsl.get("red_threshold"),
-        "cooldown_minutes_after_red": hsl.get("cooldown_minutes_after_red"),
-        "no_restart_drawdown_threshold": hsl.get("no_restart_drawdown_threshold"),
-        "ema_span_minutes": hsl.get("ema_span_minutes"),
+        "present": present,
+        "enabled": hsl_values["enabled"],
+        "red_threshold": hsl_values["red_threshold"],
+        "cooldown_minutes_after_red": hsl_values["cooldown_minutes_after_red"],
+        "no_restart_drawdown_threshold": hsl_values["no_restart_drawdown_threshold"],
+        "ema_span_minutes": hsl_values["ema_span_minutes"],
         "tier_ratios": {
             key: tier_ratios[key]
             for key in ("yellow", "orange")
             if key in tier_ratios
         },
-        "orange_tier_mode": hsl.get("orange_tier_mode"),
-        "panic_close_order_type": hsl.get("panic_close_order_type"),
+        "orange_tier_mode": hsl_values["orange_tier_mode"],
+        "panic_close_order_type": hsl_values["panic_close_order_type"],
     }
 
 
 def _forager_side_report(side_config: dict[str, Any]) -> dict[str, Any]:
-    risk = side_config["risk"] if isinstance(side_config.get("risk"), dict) else {}
-    forager = (
-        side_config["forager"]
-        if isinstance(side_config.get("forager"), dict)
-        else {}
-    )
-    report = {
-        "n_positions": risk.get("n_positions"),
-        "forager_present": bool(forager),
+    forager_values = {
+        key: get_grouped_bot_value(side_config, flat_key, default=None)
+        for key, flat_key in (
+            ("volatility_ema_span_1m", "forager_volatility_ema_span_1m"),
+            ("volume_drop_pct", "forager_volume_drop_pct"),
+            ("volume_ema_span_1m", "forager_volume_ema_span_1m"),
+        )
     }
-    if forager:
+    report = {
+        "n_positions": get_grouped_bot_value(
+            side_config, "n_positions", default=None
+        ),
+        "forager_present": any(value is not None for value in forager_values.values()),
+    }
+    if report["forager_present"]:
         report["settings"] = {
-            key: forager[key]
-            for key in (
-                "volatility_ema_span_1m",
-                "volume_drop_pct",
-                "volume_ema_span_1m",
-            )
-            if key in forager
+            key: value
+            for key, value in forager_values.items()
+            if value is not None
         }
     return report
 

--- a/tests/test_hsl_startup_preview.py
+++ b/tests/test_hsl_startup_preview.py
@@ -115,6 +115,7 @@ def test_hsl_startup_preview_reports_config_and_latest_local_hsl_status(tmp_path
                     "drawdown_score": 0.04,
                     "dist_to_red": 0.06,
                     "red_threshold": 0.10,
+                    "cooldown_remaining": {"secret": "nested-must-not-render"},
                     "slot_budget": 25.0,
                     "realized_pnl": -1.0,
                     "peak_realized_pnl": 2.0,
@@ -165,6 +166,56 @@ def test_hsl_startup_preview_reports_config_and_latest_local_hsl_status(tmp_path
     assert report["startup_panic_orders"]["available"] is False
     assert "super-secret-api-key" not in rendered
     assert "must-not-render" not in rendered
+    assert "nested-must-not-render" not in rendered
+
+
+def test_hsl_startup_preview_reports_flat_hsl_config(tmp_path):
+    config = _sample_config()
+    config["bot"]["long"] = {
+        "hsl_enabled": True,
+        "hsl_red_threshold": 0.10,
+        "hsl_cooldown_minutes_after_red": 45,
+        "hsl_no_restart_drawdown_threshold": 0.20,
+        "hsl_ema_span_minutes": 120,
+        "hsl_tier_ratios": {"yellow": 0.5, "orange": 0.8},
+        "hsl_orange_tier_mode": "tp_only",
+        "hsl_panic_close_order_type": "limit",
+    }
+    config_path = tmp_path / "live.json"
+    _write_config(config_path, config)
+
+    report = hsl_startup_preview.build_hsl_startup_preview_report(
+        config_path,
+        monitor_root="",
+        now_ms=62_000,
+    )
+
+    assert report["ok"] is True
+    assert report["config"]["hsl"]["sides"]["long"] == {
+        "present": True,
+        "enabled": True,
+        "red_threshold": 0.10,
+        "cooldown_minutes_after_red": 45,
+        "no_restart_drawdown_threshold": 0.20,
+        "ema_span_minutes": 120,
+        "tier_ratios": {"yellow": 0.5, "orange": 0.8},
+        "orange_tier_mode": "tp_only",
+        "panic_close_order_type": "limit",
+    }
+
+
+def test_hsl_startup_preview_missing_config_path_is_user_safe():
+    report = hsl_startup_preview.build_hsl_startup_preview_report(
+        "/root/passivbot/configs/missing.json",
+        monitor_root="",
+        now_ms=62_000,
+    )
+    rendered = json.dumps(report, sort_keys=True)
+
+    assert report["ok"] is False
+    assert report["config_path"] == "~/passivbot/configs/missing.json"
+    assert report["issues"][0]["path"] == "~/passivbot/configs/missing.json"
+    assert "/root" not in rendered
 
 
 def test_hsl_startup_preview_config_only_marks_runtime_inputs_unavailable(tmp_path):

--- a/tests/test_live_config_preflight.py
+++ b/tests/test_live_config_preflight.py
@@ -99,6 +99,40 @@ def test_live_config_preflight_reports_risk_relevant_shape_and_bounds_symbols(tm
     assert "api_key" not in rendered
 
 
+def test_live_config_preflight_reports_flat_shared_bot_keys(tmp_path):
+    config = _sample_config()
+    config["bot"]["long"] = {
+        "n_positions": 3,
+        "forager_volume_drop_pct": 0.02,
+        "hsl_enabled": True,
+        "hsl_red_threshold": 0.05,
+        "hsl_cooldown_minutes_after_red": 60,
+        "hsl_no_restart_drawdown_threshold": 0.08,
+        "hsl_ema_span_minutes": 120,
+        "hsl_tier_ratios": {"yellow": 0.5, "orange": 0.75},
+        "hsl_orange_tier_mode": "tp_only_with_active_entry_cancellation",
+        "hsl_panic_close_order_type": "limit",
+    }
+    config_path = tmp_path / "live.json"
+    _write_config(config_path, config)
+
+    report = live_config_preflight.build_live_config_preflight_report(config_path)
+
+    assert report["ok"] is True
+    assert report["hsl"]["sides"]["long"]["present"] is True
+    assert report["hsl"]["sides"]["long"]["enabled"] is True
+    assert report["hsl"]["sides"]["long"]["red_threshold"] == 0.05
+    assert report["hsl"]["sides"]["long"]["tier_ratios"] == {
+        "yellow": 0.5,
+        "orange": 0.75,
+    }
+    assert report["forager"]["sides"]["long"]["n_positions"] == 3
+    assert report["forager"]["sides"]["long"]["forager_present"] is True
+    assert report["forager"]["sides"]["long"]["settings"] == {
+        "volume_drop_pct": 0.02
+    }
+
+
 def test_live_config_preflight_compare_reports_bounded_risk_relevant_changes(tmp_path):
     baseline = _sample_config()
     target = _sample_config()
@@ -160,6 +194,43 @@ def test_live_config_preflight_compare_reports_bounded_risk_relevant_changes(tmp
     assert "super-secret-api-key" not in rendered
     assert "new-secret-api-key" not in rendered
     assert "api_key" not in rendered
+
+
+def test_live_config_preflight_compare_resolves_flat_shared_bot_keys(tmp_path):
+    baseline = _sample_config()
+    target = _sample_config()
+    target["bot"]["short"] = {
+        "n_positions": 2,
+        "hsl_enabled": True,
+    }
+    baseline_path = tmp_path / "baseline.json"
+    target_path = tmp_path / "target.json"
+    _write_config(baseline_path, baseline)
+    _write_config(target_path, target)
+
+    report = live_config_preflight.build_live_config_preflight_report(
+        target_path,
+        compare_config_path=baseline_path,
+    )
+    changes = {change["field"]: change for change in report["diff"]["changes"]}
+
+    assert report["ok"] is True
+    assert changes["bot.short.hsl.enabled"]["before"] == {
+        "present": True,
+        "value": False,
+    }
+    assert changes["bot.short.hsl.enabled"]["after"] == {
+        "present": True,
+        "value": True,
+    }
+    assert changes["bot.short.risk.n_positions"]["before"] == {
+        "present": True,
+        "value": 1,
+    }
+    assert changes["bot.short.risk.n_positions"]["after"] == {
+        "present": True,
+        "value": 2,
+    }
 
 
 def test_live_config_preflight_handles_all_and_invalid_coin_shapes(tmp_path):


### PR DESCRIPTION
## Summary
- resolve grouped and flat shared bot-side config keys in live-config-preflight reports and compare diffs
- resolve grouped and flat HSL config keys in hsl-startup-preview
- keep HSL preview allowlisted event data scalar-only and collapse user/home paths in shareable config output

## Validation
- ./venv/bin/python -m pytest -q tests/test_live_config_preflight.py tests/test_hsl_startup_preview.py
- ./venv/bin/python -m compileall -q src/tools/live_config_preflight.py src/tools/hsl_startup_preview.py tests/test_live_config_preflight.py tests/test_hsl_startup_preview.py
- git diff --check
- touched-file silent-handling audit; only benign metadata lookup default in read-only preflight tool