### PR TITLE
Add startup budget smoke projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added report-only startup phase budget projections to
+  `passivbot tool live-smoke-report`, comparing latest startup timings with
+  prior local p95 baselines from existing monitor events.
 - Added optional `--compare` diff reporting to
   `passivbot tool live-config-preflight` for local, read-only HSL, universe,
   forager, identity, and cache-setting changes between two configs.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -107,7 +107,8 @@ Related detailed plans:
 4. [ ] Startup phase budget tracking.
    Status: partial. Startup timing and warmup cache decision events exist, and
    `live-smoke-report` now summarizes latest startup phase timings with rolling
-   median/p95 baselines from local monitor events. Explicit durable phase budget
+   median/p95 baselines from local monitor events plus report-only budget
+   projections against prior p95 phase baselines. Explicit durable phase budget
    configuration/events are not implemented.
 
    Startup currently has timing events, but the next step is durable budget
@@ -115,6 +116,12 @@ Related detailed plans:
    candle readiness, forager warmup, HSL replay, Rust planning, and READY.
    Store both current timings and rolling baselines so regressions stand out
    after short-downtime restarts.
+
+   Work log:
+   - 2026-06-27: Added report-only startup budget projections to
+     `live-smoke-report` phase summaries, comparing latest elapsed/phase
+     timings against prior local p95 baselines without changing startup
+     behavior or adding new runtime events.
 
 5. [x] Resource pressure telemetry.
    Status: initial implementation merged. `health.summary` events now include
@@ -410,6 +417,7 @@ Related detailed plans:
 | 2026-06-27 | #13 Cache integrity doctor | PR #725 / `1ed9c466` | Added read-only fill/HSL metadata summaries from local JSON/NDJSON artifacts | Deeper metadata compatibility, synthetic/no-trade assumptions, and warm-cache readiness |
 | 2026-06-27 | #13 Cache integrity doctor | PR #727 / `d8dd7246` | Added report-only warm-cache readiness evidence from already-scanned candle/fill/HSL cache metadata | Deeper metadata compatibility and synthetic/no-trade assumptions |
 | 2026-06-27 | #7 Live config preflight/linter | PR #731 / `3cc2d229` | Added optional read-only `--compare` diff reporting for local two-config preflights, including HSL signal/enabled changes, universe deltas, forager slots/staleness, identity hints, and cache live settings | Deeper cache compatibility checks and live startup enforcement remain open |
+| 2026-06-27 | #4 Startup phase budget tracking | pending PR | Added report-only startup budget projections to `live-smoke-report` phase summaries using prior local p95 baselines from existing monitor events | Explicit durable budget config/events |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #701 / `fcda70f5` | Added `ticker-endpoint-probe` `account_critical_health` summaries for read-only balance/positions/open-orders outcomes; VPS5 Binance probe validated the summary and exposed an open-orders shape follow-up | Lower-impact/account-only mode, exchange-aware open-orders probing, clock skew/rate-limit/fill/candle probes |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #703 / `8fefce4b` | Added `ticker-endpoint-probe --account-only`, `--skip-my-trades`, and open-orders symbol fallback; VPS5 Binance account-only probe returned account-critical total=3, succeeded=3, and smoke stayed green | Clock skew/rate-limit/fill-pagination/candle-freshness probes |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -148,6 +148,8 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
 - `passivbot tool live-smoke-report` summarizes local live monitor events and text logs for
   operator smoke-test evidence. Use `--summary` for bounded event groups and log matches, or
   `--brief` for top-level counters suitable for repeated VPS smoke loops.
+  Startup timing summaries include report-only budget projections from prior local p95
+  phase baselines when enough monitor evidence exists.
   Existing structured shutdown events are also summarized as `shutdown_events`,
   so recent Ctrl+C/restart behavior can be inspected from the same smoke output.
   With `--supervisor-config`, the read-only process section compares configured

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -1700,6 +1700,44 @@ def _usage_pct(value: int | None, budget: int | None) -> int | None:
     return int(round(float(value) * 100.0 / float(budget)))
 
 
+def _startup_budget_projection(
+    *,
+    latest_ms: int | None,
+    baseline_values: list[int],
+) -> dict[str, int | str | None]:
+    if latest_ms is None:
+        return {
+            "status": "unavailable",
+            "latest_ms": None,
+            "budget_ms": None,
+            "baseline_samples": len(baseline_values),
+            "usage_pct": None,
+            "over_budget_by_ms": None,
+            "source": "prior_p95_ms",
+        }
+    if not baseline_values:
+        return {
+            "status": "no_baseline",
+            "latest_ms": latest_ms,
+            "budget_ms": None,
+            "baseline_samples": 0,
+            "usage_pct": None,
+            "over_budget_by_ms": None,
+            "source": "prior_p95_ms",
+        }
+    budget_ms = _nearest_rank(baseline_values, 95.0)
+    over_budget_by_ms = max(0, latest_ms - budget_ms)
+    return {
+        "status": "over_budget" if over_budget_by_ms > 0 else "within_budget",
+        "latest_ms": latest_ms,
+        "budget_ms": budget_ms,
+        "baseline_samples": len(baseline_values),
+        "usage_pct": _usage_pct(latest_ms, budget_ms),
+        "over_budget_by_ms": over_budget_by_ms,
+        "source": "prior_p95_ms",
+    }
+
+
 def _startup_timing_record(
     *,
     row: dict[str, Any],
@@ -1768,6 +1806,12 @@ def _summarize_startup_timings(
             phase_summary = _ms_summary(phase_values)
             latest_elapsed = latest.get("elapsed_ms")
             latest_phase = latest.get("since_previous_ms")
+            elapsed_budget_values = (
+                elapsed_values[:-1] if latest_elapsed is not None else elapsed_values
+            )
+            phase_budget_values = (
+                phase_values[:-1] if latest_phase is not None else phase_values
+            )
             phase_summaries[phase] = {
                 "samples": len(window),
                 "latest_ts": latest.get("ts"),
@@ -1775,6 +1819,14 @@ def _summarize_startup_timings(
                 "latest_since_previous_ms": latest_phase,
                 "elapsed_baseline": elapsed_summary,
                 "phase_baseline": phase_summary,
+                "elapsed_budget": _startup_budget_projection(
+                    latest_ms=latest_elapsed,
+                    baseline_values=elapsed_budget_values,
+                ),
+                "phase_budget": _startup_budget_projection(
+                    latest_ms=latest_phase,
+                    baseline_values=phase_budget_values,
+                ),
                 "latest_elapsed_vs_p95_pct": _usage_pct(
                     latest_elapsed, elapsed_summary["p95_ms"]
                 ),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1132,6 +1132,24 @@ def test_live_smoke_report_summarizes_startup_phase_baselines(tmp_path):
                         "min_ms": 2000,
                         "max_ms": 3000,
                     },
+                    "elapsed_budget": {
+                        "status": "over_budget",
+                        "latest_ms": 3000,
+                        "budget_ms": 2000,
+                        "baseline_samples": 1,
+                        "usage_pct": 150,
+                        "over_budget_by_ms": 1000,
+                        "source": "prior_p95_ms",
+                    },
+                    "phase_budget": {
+                        "status": "over_budget",
+                        "latest_ms": 3000,
+                        "budget_ms": 2000,
+                        "baseline_samples": 1,
+                        "usage_pct": 150,
+                        "over_budget_by_ms": 1000,
+                        "source": "prior_p95_ms",
+                    },
                     "latest_elapsed_vs_p95_pct": 100,
                     "latest_phase_vs_p95_pct": 100,
                 },
@@ -1152,6 +1170,24 @@ def test_live_smoke_report_summarizes_startup_phase_baselines(tmp_path):
                         "min_ms": 6000,
                         "max_ms": 7000,
                     },
+                    "elapsed_budget": {
+                        "status": "over_budget",
+                        "latest_ms": 10000,
+                        "budget_ms": 8000,
+                        "baseline_samples": 1,
+                        "usage_pct": 125,
+                        "over_budget_by_ms": 2000,
+                        "source": "prior_p95_ms",
+                    },
+                    "phase_budget": {
+                        "status": "over_budget",
+                        "latest_ms": 7000,
+                        "budget_ms": 6000,
+                        "baseline_samples": 1,
+                        "usage_pct": 117,
+                        "over_budget_by_ms": 1000,
+                        "source": "prior_p95_ms",
+                    },
                     "latest_elapsed_vs_p95_pct": 100,
                     "latest_phase_vs_p95_pct": 100,
                     "latest_details": (
@@ -1164,6 +1200,41 @@ def test_live_smoke_report_summarizes_startup_phase_baselines(tmp_path):
     latest_details = report["startup_timings"][0]["phases"]["startup"]["latest_details"]
     assert "AKIA123" not in latest_details
     assert "TOKEN123" not in latest_details
+
+
+def test_live_smoke_report_startup_budget_no_baseline(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=1,
+                ts=1000,
+                level="debug",
+                reason_code="startup_phase_ready",
+                data={
+                    "phase": "account",
+                    "elapsed_ms": 2000,
+                    "since_previous_ms": 2000,
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    phase = report["startup_timings"][0]["phases"]["account"]
+
+    assert phase["elapsed_budget"] == {
+        "status": "no_baseline",
+        "latest_ms": 2000,
+        "budget_ms": None,
+        "baseline_samples": 0,
+        "usage_pct": None,
+        "over_budget_by_ms": None,
+        "source": "prior_p95_ms",
+    }
+    assert phase["phase_budget"]["status"] == "no_baseline"
 
 
 def test_live_smoke_report_summarizes_shutdown_events(tmp_path):


### PR DESCRIPTION
## Summary
- add report-only startup phase budget projections to `live-smoke-report` using prior local p95 baselines from existing `bot.startup_timing` events
- expose `elapsed_budget` and `phase_budget` status fields without changing startup behavior or adding runtime events
- update tools docs, changelog, and backlog item #4 work log

## Validation
- `python -m pytest tests/test_live_smoke_report.py`
- `python -m compileall src/live/smoke_report.py tests/test_live_smoke_report.py`
- `git diff --check`
- touched-file silent-handling audit: existing report aggregation defaults are present in `src/live/smoke_report.py`; diff-only audit added no new matches: `git diff -U0 -- src/live/smoke_report.py tests/test_live_smoke_report.py | rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])\)"`