### PR TITLE
Carry forward active forager EMA features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable user-facing changes will be documented in this file.
 - Added report-only startup phase budget projections to
   `passivbot tool live-smoke-report`, comparing latest startup timings with
   prior local p95 baselines from existing monitor events.
+- Hardened forager active-symbol EMA readiness by allowing required
+  qv/log-range ranking features to carry forward bounded cached real-candle EMA
+  values for active/normal symbols during fill handoff.
 - Added optional `--compare` diff reporting to
   `passivbot tool live-config-preflight` for local, read-only HSL, universe,
   forager, identity, and cache-setting changes between two configs.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -373,7 +373,10 @@ Related detailed plans:
     requiring manual log inspection.
 
 17. [ ] Forager active-symbol EMA readiness handoff.
-    Status: open.
+    Status: partial. First hardening slice allows active/normal forager symbols
+    to carry forward bounded cached real-candle qv/log-range EMA values during
+    fill handoff. Broader create-side readiness gating and fake-live coverage
+    remain open.
 
     VPS5 smoke after PR #735 caught an OKX recovery case where `AAVE` was
     selected/posted as a forager initial entry, filled, and became an active
@@ -390,6 +393,12 @@ Related detailed plans:
     carry forward bounded/stale forager feature values through the first active
     cycle with structured readiness metadata. Do not fabricate neutral
     volume/log-range values, and do not weaken protective/risk actions.
+
+    Work log:
+    - 2026-06-27: Added bounded cached qv/log-range EMA carry-forward for
+      active/normal forager symbols, reusing local real-candle EMA metrics
+      within the configured forager staleness cap. Candidate-only symbols still
+      remain unavailable instead of receiving synthetic ranking tails.
 
 ## Merged Work Log
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -14117,7 +14117,8 @@ class Passivbot:
                 return False
             return symbol in set(getattr(self, "active_symbols", []) or [])
 
-        forager_cached_max_age_by_symbol: dict[str, int] = {}
+        forager_cached_metric_max_age_by_symbol: dict[str, int] = {}
+        forager_projection_max_age_by_symbol: dict[str, int] = {}
         if is_forager_mode():
             priority_symbols = []
             secondary_symbols = []
@@ -14148,7 +14149,7 @@ class Passivbot:
                 )
             )
             for sym in priority_symbols:
-                forager_cached_max_age_by_symbol[sym] = priority_max_age_ms
+                forager_cached_metric_max_age_by_symbol[sym] = priority_max_age_ms
             if secondary_symbols:
                 secondary_max_age_ms = int(
                     Passivbot._forager_target_staleness_ms(
@@ -14160,7 +14161,10 @@ class Passivbot:
                 stale_unavailable = set()
                 for sym in secondary_symbols:
                     cache_only_symbols.add(sym)
-                    forager_cached_max_age_by_symbol[sym] = int(secondary_max_age_ms)
+                    forager_cached_metric_max_age_by_symbol[sym] = int(
+                        secondary_max_age_ms
+                    )
+                    forager_projection_max_age_by_symbol[sym] = int(secondary_max_age_ms)
                     m1_max_age_by_symbol[sym] = cache_only_ttl
                     h1_max_age_by_symbol[sym] = cache_only_ttl
                     try:
@@ -14204,12 +14208,12 @@ class Passivbot:
                     exc,
                 )
                 ctx = None
-            if ctx is None and sym in forager_cached_max_age_by_symbol:
+            if ctx is None and sym in forager_projection_max_age_by_symbol:
                 try:
                     now_ms = utc_ms()
                     latest_expected = (now_ms // ONE_MIN_MS) * ONE_MIN_MS - ONE_MIN_MS
                     last_cached = int(self.cm.get_last_final_ts(sym) or 0)
-                    max_tail_gap_ms = int(forager_cached_max_age_by_symbol[sym])
+                    max_tail_gap_ms = int(forager_projection_max_age_by_symbol[sym])
                     tail_gap_age_ms = max(0, int(latest_expected) - int(last_cached))
                     if last_cached > 0 and tail_gap_age_ms <= max_tail_gap_ms:
                         ctx = {
@@ -14261,7 +14265,7 @@ class Passivbot:
         async def fetch_cached_forager_metric(
             symbol: str, span: float, metric_key: str
         ) -> Optional[float]:
-            max_staleness_ms = forager_cached_max_age_by_symbol.get(symbol)
+            max_staleness_ms = forager_cached_metric_max_age_by_symbol.get(symbol)
             if max_staleness_ms is None:
                 return None
             cached = await Passivbot._get_forager_cached_ema_metrics(
@@ -14642,10 +14646,10 @@ class Passivbot:
                     "[ema] projected open-tail close EMA incomplete for "
                     f"{sym}: spans={','.join(f'{span:.8g}' for span in missing_close)}"
                 )
-            if candidate_only_forager_symbol(sym):
-                # For flat forager candidates, open-tail projection is valid
-                # for close EMA readiness only. Ranking qv/log-range must carry
-                # forward cached real-candle EMA values.
+            if is_forager_mode():
+                # In forager mode, open-tail projection is valid for close EMA
+                # readiness only. Quote-volume and log-range ranking inputs must
+                # use current or cached real-candle EMA values.
                 vol = None
                 lr1m = None
             else:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -14133,14 +14133,23 @@ class Passivbot:
                 else:
                     secondary_symbols.append(sym)
             cache_only_ttl = 365 * 24 * 3600 * 1000
-            if secondary_symbols:
-                max_calls = get_optional_live_value(
-                    self.config, "max_ohlcv_fetches_per_minute", 0
+            max_calls = get_optional_live_value(
+                self.config, "max_ohlcv_fetches_per_minute", 0
+            )
+            try:
+                max_calls_i = int(max_calls) if max_calls is not None else 0
+            except Exception:
+                max_calls_i = 0
+            priority_max_age_ms = int(
+                Passivbot._forager_target_staleness_ms(
+                    self,
+                    max(1, len(priority_symbols) + len(secondary_symbols)),
+                    max_calls_i,
                 )
-                try:
-                    max_calls_i = int(max_calls) if max_calls is not None else 0
-                except Exception:
-                    max_calls_i = 0
+            )
+            for sym in priority_symbols:
+                forager_cached_max_age_by_symbol[sym] = priority_max_age_ms
+            if secondary_symbols:
                 secondary_max_age_ms = int(
                     Passivbot._forager_target_staleness_ms(
                         self, len(secondary_symbols), max_calls_i

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -939,6 +939,57 @@ async def test_active_forager_required_features_use_bounded_cached_carry_forward
 
 
 @pytest.mark.asyncio
+async def test_active_forager_open_tail_uses_cached_ranking_not_projected_values():
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "AAVE/USDT:USDT"
+    span0 = 10.0
+    span1 = 20.0
+    span2 = (span0 * span1) ** 0.5
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="value",
+        project_open_tail=True,
+        projected_close_ema={span0: 101.0, span1: 102.0, span2: 103.0},
+        projected_qv_ema={10.0: 999999.0},
+        projected_log_range_ema={10.0: 0.0099},
+        qv_mode="nan",
+        lr1m_mode="nan",
+        cached_qv_ema={10.0: 250000.0},
+        cached_log_range_ema={10.0: 0.0015},
+    )
+    bot.projected_open_tail_called = False
+    _enable_forager_required_ranking(bot)
+    mode_overrides = {"long": {symbol: "normal"}, "short": {symbol: "manual"}}
+
+    (
+        m1_close_emas,
+        m1_volume_emas,
+        m1_log_range_emas,
+        _h1_log_range_emas,
+        volumes_long,
+        log_ranges_long,
+    ) = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], mode_overrides
+    )
+
+    assert bot.projected_open_tail_called is True
+    assert m1_close_emas[symbol][span0] == pytest.approx(101.0)
+    assert m1_volume_emas[symbol][10.0] == pytest.approx(250000.0)
+    assert m1_log_range_emas[symbol][10.0] == pytest.approx(0.0015)
+    assert volumes_long[symbol] == pytest.approx(250000.0)
+    assert log_ranges_long[symbol] == pytest.approx(0.0015)
+    assert volumes_long[symbol] != pytest.approx(999999.0)
+    assert log_ranges_long[symbol] != pytest.approx(0.0099)
+    assert bot._orchestrator_ema_unavailable_symbols == set()
+    assert bot._orchestrator_ema_projection_symbols == {symbol}
+    assert {call["timeframe"] for call in bot.cached_metric_calls} == {"1m"}
+
+
+@pytest.mark.asyncio
 async def test_candidate_only_missing_required_forager_features_marks_unavailable(caplog):
     try:
         import passivbot as pb_mod

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -379,6 +379,8 @@ class _BundleReproBot:
         projected_close_ema=None,
         projected_qv_ema=None,
         projected_log_range_ema=None,
+        cached_qv_ema=None,
+        cached_log_range_ema=None,
         qv_mode="value",
         lr1m_mode="value",
         project_open_tail_after_health_calls=None,
@@ -400,6 +402,11 @@ class _BundleReproBot:
         self.projected_log_range_ema = (
             None if projected_log_range_ema is None else dict(projected_log_range_ema)
         )
+        self.cached_qv_ema = None if cached_qv_ema is None else dict(cached_qv_ema)
+        self.cached_log_range_ema = (
+            None if cached_log_range_ema is None else dict(cached_log_range_ema)
+        )
+        self.cached_metric_calls = []
         self.qv_mode = qv_mode
         self.lr1m_mode = lr1m_mode
         self.project_open_tail_after_health_calls = project_open_tail_after_health_calls
@@ -528,6 +535,38 @@ class _BundleReproBot:
                     "qv": qv,
                     "log_range": log_range,
                 }
+
+            async def get_latest_cached_ema_metrics(
+                self,
+                symbol,
+                spans_by_metric,
+                *,
+                max_staleness_ms=None,
+                window_candles=None,
+                timeframe="1m",
+            ):
+                self.outer.cached_metric_calls.append(
+                    {
+                        "symbol": symbol,
+                        "spans_by_metric": dict(spans_by_metric),
+                        "max_staleness_ms": max_staleness_ms,
+                        "window_candles": window_candles,
+                        "timeframe": timeframe,
+                    }
+                )
+                out = {}
+                if self.outer.cached_qv_ema is not None and "qv" in spans_by_metric:
+                    span = float(spans_by_metric["qv"])
+                    if span in self.outer.cached_qv_ema:
+                        out["qv"] = float(self.outer.cached_qv_ema[span])
+                if (
+                    self.outer.cached_log_range_ema is not None
+                    and "log_range" in spans_by_metric
+                ):
+                    span = float(spans_by_metric["log_range"])
+                    if span in self.outer.cached_log_range_ema:
+                        out["log_range"] = float(self.outer.cached_log_range_ema[span])
+                return out
 
         self.cm = _CM(self)
 
@@ -850,6 +889,53 @@ async def test_explicit_normal_missing_required_forager_features_fails_loudly():
         await pb_mod.Passivbot._load_orchestrator_ema_bundle(
             bot, [symbol], mode_overrides
         )
+
+
+@pytest.mark.asyncio
+async def test_active_forager_required_features_use_bounded_cached_carry_forward():
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "AAVE/USDT:USDT"
+    span0 = 10.0
+    span1 = 20.0
+    span2 = (span0 * span1) ** 0.5
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="value",
+        projected_close_ema={span0: 101.0, span1: 102.0, span2: 103.0},
+        qv_mode="nan",
+        lr1m_mode="nan",
+        cached_qv_ema={10.0: 250000.0},
+        cached_log_range_ema={10.0: 0.0015},
+    )
+    _enable_forager_required_ranking(bot)
+    mode_overrides = {"long": {symbol: "normal"}, "short": {symbol: "manual"}}
+
+    (
+        _m1_close_emas,
+        m1_volume_emas,
+        m1_log_range_emas,
+        _h1_log_range_emas,
+        volumes_long,
+        log_ranges_long,
+    ) = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
+        bot, [symbol], mode_overrides
+    )
+
+    assert m1_volume_emas[symbol][10.0] == pytest.approx(250000.0)
+    assert m1_log_range_emas[symbol][10.0] == pytest.approx(0.0015)
+    assert volumes_long[symbol] == pytest.approx(250000.0)
+    assert log_ranges_long[symbol] == pytest.approx(0.0015)
+    assert bot._orchestrator_ema_unavailable_symbols == set()
+    assert bot._orchestrator_ema_projection_symbols == set()
+    assert {call["timeframe"] for call in bot.cached_metric_calls} == {"1m"}
+    assert all(
+        int(call["max_staleness_ms"]) >= 60_000
+        for call in bot.cached_metric_calls
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- allow active/normal forager symbols to use bounded cached real-candle qv/log-range EMA fallback during fill handoff
- keep candidate-only symbols unavailable rather than giving them synthetic ranking tails
- add regression coverage for the OKX/AAVE failure shape: non-finite current qv/log-range, cached real-candle values available, no open-tail projection used

## Live evidence
VPS5 OKX emitted one transient hard loop error after AAVE was selected/posted, filled, and became active while background warmup was still catching up:
`[ema] missing required forager EMA for active/normal symbol AAVE/USDT:USDT: volume_spans= log_range_spans=996`.
Settled smoke later returned ok=true, so this PR targets the transient active-symbol handoff rather than a persistent exchange failure.

## Validation
- ./venv/bin/python -m pytest -q tests/test_missing_ema_fix.py
- ./venv/bin/python -m compileall -q src/passivbot.py tests/test_missing_ema_fix.py
- git diff --check
- diff-only silent-handling audit: only moved existing config int-parse guard