### PR TITLE
Add restart plan process signal safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added process-signal safety guidance to
+  `passivbot tool live-restart-smoke-plan`, warning future restart automation
+  away from broad `pkill -f`/`pgrep -f` live-bot matches and toward exact tmux
+  panes or exact canonical process rows.
 - Added report-only startup phase budget projections to
   `passivbot tool live-smoke-report`, comparing latest startup timings with
   prior local p95 baselines from existing monitor events.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -91,6 +91,11 @@ Related detailed plans:
      checks, and smoke-report command wiring. It explicitly rejects execution
      and does not signal processes, invoke tmux, SSH, pull code, start bots,
      contact exchanges, or load credentials.
+   - 2026-06-27: Added process-signal safety guidance to the plan-only restart
+     smoke planner after a VPS5 restart shell matched its own broad
+     `passivbot live` process pattern. The planner now records that future
+     execution must use exact tmux panes or exact canonical process rows, and
+     rejects broad process-pattern kill/signal commands.
 
    Remaining refinements: safe pull/stop/start orchestration remains open.
    The concise and brief summaries are intentionally bounded; further changes

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -11,6 +11,11 @@ DEFAULT_STARTUP_WAIT_S = 180
 DEFAULT_SMOKE_WINDOW_MINUTES = 30
 DEFAULT_MONITOR_ROOT = "monitor"
 DEFAULT_LOGS_ROOT = "logs"
+UNSAFE_PROCESS_SIGNAL_PATTERNS = (
+    "pkill -f 'passivbot live'",
+    "pgrep -f 'passivbot live' | xargs kill",
+    "kill $(pgrep -f 'passivbot live')",
+)
 
 
 def _positive_int(value: int, *, field: str) -> int:
@@ -76,6 +81,25 @@ def _repo_check_commands(repo_path: str | Path | None) -> list[str]:
             ["git", "-C", repo, "status", "--porcelain", "--untracked-files=no"]
         ),
     ]
+
+
+def _process_signal_safety_contract() -> dict[str, Any]:
+    return {
+        "strategy": "exact_tmux_pane_or_exact_pid_only",
+        "forbid_broad_process_pattern_signals": True,
+        "unsafe_patterns": list(UNSAFE_PROCESS_SIGNAL_PATTERNS),
+        "why": (
+            "Broad process-pattern signals can match the controller shell or "
+            "smoke command when the pattern appears in its arguments."
+        ),
+        "required_guards": [
+            "derive candidate processes from canonical live-smoke-report process rows",
+            "match configured command keys exactly before signaling",
+            "exclude the controller process and its ancestors",
+            "signal one matched bot at a time and re-scan after each signal",
+            "halt reload when duplicate, extra, or unowned matching live processes remain",
+        ],
+    }
 
 
 def _bot_phase_plan(
@@ -317,6 +341,7 @@ def build_live_restart_smoke_plan(
                 "risk/HSL events",
             ],
         },
+        "process_signal_safety": _process_signal_safety_contract(),
         "timeout_escalation_ladder": [
             {
                 "level": 0,
@@ -361,6 +386,7 @@ def build_live_restart_smoke_plan(
                 "ssh",
                 "tmux signal/send-keys",
                 "process kill/signal",
+                "broad process-pattern kill/signal",
                 "git pull/fetch/checkout",
                 "passivbot live",
                 "exchange/API calls",

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -54,10 +54,23 @@ def test_live_restart_smoke_plan_builds_plan_from_supervisor_config(tmp_path):
     assert "passivbot tool live-smoke-report" in report["smoke_report"]["command"]
     assert "--supervisor-config" in report["smoke_report"]["command"]
     assert "--recent-minutes 15" in report["smoke_report"]["command"]
+    assert report["process_signal_safety"]["strategy"] == (
+        "exact_tmux_pane_or_exact_pid_only"
+    )
+    assert report["process_signal_safety"]["forbid_broad_process_pattern_signals"] is True
+    assert "pkill -f 'passivbot live'" in report["process_signal_safety"][
+        "unsafe_patterns"
+    ]
+    assert "exclude the controller process and its ancestors" in report[
+        "process_signal_safety"
+    ]["required_guards"]
     assert all(
         item["execute"] is False for item in report["timeout_escalation_ladder"]
     )
     assert "ssh" in report["execution_policy"]["rejected_operations"]
+    assert "broad process-pattern kill/signal" in report["execution_policy"][
+        "rejected_operations"
+    ]
     assert "does_not_start_passivbot_live" in report["warnings"]
 
 


### PR DESCRIPTION
Operator tooling slice; no live execution or trading-path changes.\n\n- adds a process_signal_safety contract to live-restart-smoke-plan\n- explicitly rejects broad process-pattern kill/signal commands in the plan policy\n- records the VPS5 self-match restart gotcha in the live ops backlog\n- updates CHANGELOG\n\nValidation:\n- ./venv/bin/python -m pytest -q tests/test_live_restart_smoke_plan.py\n- ./venv/bin/python -m compileall -q src/live/restart_smoke_plan.py tests/test_live_restart_smoke_plan.py\n- git diff --check\n- diff-only touched-file silent-handling audit