### PR TITLE
Add ticker probe time sync health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added read-only `fetch_time` clock-skew health summaries to
+  `passivbot tool ticker-endpoint-probe`, with `--skip-time-sync` for operators
+  who want to omit the extra time-sync call.
 - Added process-signal safety guidance to
   `passivbot tool live-restart-smoke-plan`, warning future restart automation
   away from broad `pkill -f`/`pgrep -f` live-bot matches and toward exact tmux

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -159,12 +159,14 @@ Related detailed plans:
    exchange-aware open-orders shape. PR #703 added `--account-only`,
    `--skip-my-trades`, and an open-orders symbol fallback; a VPS5 account-only
    Binance probe validated `account_critical_health` success for all three
-   account-critical surfaces.
+   account-critical surfaces. PR #741 added read-only `fetch_time`
+   `time_sync_health` summaries and `--skip-time-sync`, counting unsupported
+   exchanges separately from actual failures.
 
    Add/refine explicit read-only probes for each configured exchange/account
-   before or during smoke: clock skew, rate-limit behavior, fill pagination
-   coverage, candle freshness, and basic endpoint latency. The passive smoke
-   report now also exposes top-level remote-call health
+   before or during smoke: rate-limit behavior, fill pagination coverage,
+   candle freshness, and basic endpoint latency. The passive smoke report now
+   also exposes top-level remote-call health
    success/failure/throttle totals and a filtered
    `account_critical_remote_call_health` summary for a quick operator scan.
 
@@ -453,6 +455,7 @@ Related detailed plans:
 | 2026-06-27 | #4 Startup phase budget tracking | PR #735 / `6f415777` | Added report-only startup budget projections to `live-smoke-report` phase summaries using prior local p95 baselines from existing monitor events; VPS5 deploy kept all five bots running and the settled smoke returned `ok=true` after unrelated transient HSL/EMA events aged out | Explicit durable budget config/events |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #701 / `fcda70f5` | Added `ticker-endpoint-probe` `account_critical_health` summaries for read-only balance/positions/open-orders outcomes; VPS5 Binance probe validated the summary and exposed an open-orders shape follow-up | Lower-impact/account-only mode, exchange-aware open-orders probing, clock skew/rate-limit/fill/candle probes |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #703 / `8fefce4b` | Added `ticker-endpoint-probe --account-only`, `--skip-my-trades`, and open-orders symbol fallback; VPS5 Binance account-only probe returned account-critical total=3, succeeded=3, and smoke stayed green | Clock skew/rate-limit/fill-pagination/candle-freshness probes |
+| 2026-06-27 | #6 Exchange health and contract probes | PR #741 / pending | Added `ticker-endpoint-probe` read-only `fetch_time` clock-skew evidence and collection-level `time_sync_health`, with unsupported exchanges separated from failures and `--skip-time-sync` as an operator escape hatch | Rate-limit/fill-pagination/candle-freshness probes |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -178,8 +178,9 @@ Ticker probes inspect CCXT ticker support and latency without placing orders:
   summary for the read-only balance, positions, and open-orders endpoints required before live
   exchange actions. Use `--account-only` for the lower-impact balance/positions/open-orders probe,
   which still loads markets to resolve an open-orders fallback symbol, or `--skip-my-trades` to
-  omit the fill-history endpoint. Keep authenticated runs low-rate when a live bot is using the
-  same account.
+  omit the fill-history endpoint. The probe also includes `time_sync_health` from read-only
+  `fetch_time` clock-skew checks when the exchange supports it; use `--skip-time-sync` to omit that
+  call. Keep authenticated runs low-rate when a live bot is using the same account.
 
 ## Hyperliquid live probes
 

--- a/src/tools/probe_ccxt_ticker_endpoints.py
+++ b/src/tools/probe_ccxt_ticker_endpoints.py
@@ -275,6 +275,150 @@ def summarize_account_critical_probe_collection(probes: list[dict[str, Any]]) ->
     }
 
 
+def _clock_skew_summary(values: list[float]) -> dict[str, Any]:
+    summary = _latency_summary(values)
+    summary["max_abs"] = (
+        round(max((abs(value) for value in values), default=0.0), 3)
+        if values
+        else None
+    )
+    return summary
+
+
+def _round_ms_value(value: Any) -> float | None:
+    if not isinstance(value, (int, float)):
+        return None
+    return round(float(value), 3)
+
+
+def summarize_time_sync_probe_health(probe: dict[str, Any]) -> dict[str, Any]:
+    """Summarize read-only exchange clock-skew probe results."""
+    include_time_sync = bool(probe.get("include_time_sync", True))
+    repeats = probe.get("repeats") if isinstance(probe.get("repeats"), list) else []
+    total = 0
+    succeeded = 0
+    failed = 0
+    unsupported = 0
+    latencies = []
+    skews = []
+    error_types: Counter[str] = Counter()
+    latest: dict[str, Any] | None = None
+    for repeat in repeats:
+        outcome = repeat.get("fetch_time") if isinstance(repeat, dict) else None
+        if outcome is None:
+            if include_time_sync:
+                unsupported += 1
+                latest = {"ok": False, "supported": False, "skipped": True}
+            continue
+        if not isinstance(outcome, dict):
+            total += 1
+            failed += 1
+            error_types["missing_outcome"] += 1
+            latest = {
+                "ok": False,
+                "elapsed_ms": None,
+                "error_type": "missing_outcome",
+            }
+            continue
+        if bool(outcome.get("skipped")) or outcome.get("supported") is False:
+            unsupported += 1
+            latest = {"ok": False, "supported": False, "skipped": True}
+            continue
+        total += 1
+        elapsed_ms = _elapsed_ms(outcome)
+        if elapsed_ms is not None:
+            latencies.append(elapsed_ms)
+        ok = bool(outcome.get("ok")) if isinstance(outcome, dict) else False
+        if ok:
+            succeeded += 1
+            skew = _round_ms_value(outcome.get("clock_skew_ms"))
+            if skew is not None:
+                skews.append(skew)
+            latest = {
+                "ok": True,
+                "elapsed_ms": elapsed_ms,
+                "clock_skew_ms": skew,
+                "abs_clock_skew_ms": round(abs(skew), 3) if skew is not None else None,
+            }
+            continue
+        failed += 1
+        error_type = (
+            str(outcome.get("error_type") or "unknown")
+            if isinstance(outcome, dict)
+            else "missing_outcome"
+        )
+        error_types[error_type] += 1
+        latest = {"ok": False, "elapsed_ms": elapsed_ms, "error_type": error_type}
+    return {
+        "enabled": include_time_sync,
+        "total": total,
+        "succeeded": succeeded,
+        "failed": failed,
+        "unsupported": unsupported,
+        "failure_pct": _pct(failed, total),
+        "latency_ms": _latency_summary(latencies),
+        "clock_skew_ms": _clock_skew_summary(skews),
+        "error_types": dict(sorted(error_types.items())),
+        "latest": latest,
+    }
+
+
+def summarize_time_sync_probe_collection(probes: list[dict[str, Any]]) -> dict[str, Any]:
+    users = []
+    total = 0
+    succeeded = 0
+    failed = 0
+    unsupported = 0
+    skews = []
+    for probe in probes:
+        summary = probe.get("time_sync_health")
+        if not isinstance(summary, dict):
+            summary = summarize_time_sync_probe_health(probe)
+        skew_summary = (
+            summary.get("clock_skew_ms") if isinstance(summary.get("clock_skew_ms"), dict) else {}
+        )
+        latest = summary.get("latest") if isinstance(summary.get("latest"), dict) else {}
+        latest_skew = _round_ms_value(latest.get("clock_skew_ms"))
+        probe_skews: list[float] = []
+        repeats = probe.get("repeats") if isinstance(probe.get("repeats"), list) else []
+        for repeat in repeats:
+            outcome = repeat.get("fetch_time") if isinstance(repeat, dict) else None
+            if isinstance(outcome, dict) and outcome.get("ok"):
+                skew = _round_ms_value(outcome.get("clock_skew_ms"))
+                if skew is not None:
+                    probe_skews.append(skew)
+        if probe_skews:
+            skews.extend(probe_skews)
+        elif latest_skew is not None:
+            skews.append(latest_skew)
+        user_summary = {
+            "user": probe.get("user"),
+            "exchange": probe.get("exchange"),
+            "enabled": bool(summary.get("enabled")),
+            "total": int(summary.get("total") or 0),
+            "succeeded": int(summary.get("succeeded") or 0),
+            "failed": int(summary.get("failed") or 0),
+            "unsupported": int(summary.get("unsupported") or 0),
+            "failure_pct": summary.get("failure_pct"),
+            "latest_clock_skew_ms": latest_skew,
+            "max_abs_clock_skew_ms": skew_summary.get("max_abs"),
+        }
+        users.append(user_summary)
+        total += user_summary["total"]
+        succeeded += user_summary["succeeded"]
+        failed += user_summary["failed"]
+        unsupported += user_summary["unsupported"]
+    return {
+        "users": users,
+        "total": total,
+        "succeeded": succeeded,
+        "failed": failed,
+        "unsupported": unsupported,
+        "failure_pct": _pct(failed, total),
+        "clock_skew_ms": _clock_skew_summary(skews),
+    }
+
+
 async def _timed_load_markets(exchange) -> tuple[dict[str, Any], dict[str, Any]]:
     outcome = await _timed_call(exchange.load_markets())
     markets = outcome["value"] if outcome["ok"] and isinstance(outcome["value"], dict) else {}
@@ -284,6 +428,49 @@ async def _timed_load_markets(exchange) -> tuple[dict[str, Any], dict[str, Any]]
             "type": type(markets).__name__,
         }
     return outcome, markets
+
+
+async def _fetch_exchange_time_sync(exchange) -> dict[str, Any]:
+    method = getattr(exchange, "fetch_time", None)
+    has = getattr(exchange, "has", None)
+    supported = isinstance(has, dict) and has.get("fetchTime") is True
+    if method is None or not supported:
+        return {
+            "ok": False,
+            "supported": False,
+            "skipped": True,
+            "error_type": "UnsupportedEndpoint",
+            "error": "fetch_time unavailable",
+        }
+    local_before_ms = int(utc_ms())
+    outcome = await _timed_call(method())
+    local_after_ms = int(utc_ms())
+    local_midpoint_ms = int(round((local_before_ms + local_after_ms) / 2.0))
+    outcome["supported"] = True
+    outcome["local_before_ms"] = local_before_ms
+    outcome["local_after_ms"] = local_after_ms
+    outcome["local_midpoint_ms"] = local_midpoint_ms
+    if not outcome["ok"] and outcome.get("error_type") == "NotSupported":
+        outcome["supported"] = False
+        outcome["skipped"] = True
+        return outcome
+    if outcome["ok"]:
+        try:
+            exchange_time_ms = int(outcome.pop("value"))
+        except (TypeError, ValueError):
+            outcome.update(
+                {
+                    "ok": False,
+                    "error_type": "ValueError",
+                    "error": "fetch_time returned non-integer timestamp",
+                }
+            )
+        else:
+            outcome["exchange_time_ms"] = exchange_time_ms
+            outcome["exchange_datetime"] = ts_to_date(exchange_time_ms)
+            outcome["clock_skew_ms"] = int(exchange_time_ms - local_midpoint_ms)
+            outcome["abs_clock_skew_ms"] = abs(int(outcome["clock_skew_ms"]))
+    return outcome
 
 
 async def _fetch_ticker_sequential(exchange, symbols: list[str]) -> dict[str, Any]:
@@ -450,6 +637,7 @@ async def probe_exchange_ticker_endpoints(
     include_order_book: bool = True,
     include_ohlcv: bool = True,
     include_my_trades: bool = True,
+    include_time_sync: bool = True,
     progress: bool = False,
 ) -> dict[str, Any]:
     exchange_id = getattr(exchange, "id", str(user_info.get("exchange") or ""))
@@ -476,6 +664,7 @@ async def probe_exchange_ticker_endpoints(
         "include_private": bool(include_private),
         "include_public": bool(include_public),
         "include_my_trades": bool(include_my_trades),
+        "include_time_sync": bool(include_time_sync),
         "market_count": len(markets) if isinstance(markets, dict) else None,
         "has": {
             "fetchBalance": bool(getattr(exchange, "has", {}).get("fetchBalance")),
@@ -485,6 +674,7 @@ async def probe_exchange_ticker_endpoints(
             "fetchOpenOrders": bool(getattr(exchange, "has", {}).get("fetchOpenOrders")),
             "fetchOrderBook": bool(getattr(exchange, "has", {}).get("fetchOrderBook")),
             "fetchPositions": bool(getattr(exchange, "has", {}).get("fetchPositions")),
+            "fetchTime": bool(getattr(exchange, "has", {}).get("fetchTime")),
             "fetchTicker": bool(getattr(exchange, "has", {}).get("fetchTicker")),
             "fetchTickers": bool(getattr(exchange, "has", {}).get("fetchTickers")),
         },
@@ -506,6 +696,14 @@ async def probe_exchange_ticker_endpoints(
             "started_at_ms": int(utc_ms()),
             "started_at": ts_to_date(utc_ms()),
         }
+
+        if include_time_sync:
+            emit_progress(f"{repeat_label} fetch_time", enabled=progress)
+            repeat["fetch_time"] = await _fetch_exchange_time_sync(exchange)
+            emit_progress(
+                f"{repeat_label} fetch_time {format_outcome(repeat['fetch_time'])}",
+                enabled=progress,
+            )
 
         if include_public:
             emit_progress(f"{repeat_label} fetch_tickers()", enabled=progress)
@@ -651,6 +849,7 @@ async def probe_exchange_ticker_endpoints(
             await asyncio.sleep(float(sleep_between_seconds))
 
     out["account_critical_health"] = summarize_account_critical_probe_health(out)
+    out["time_sync_health"] = summarize_time_sync_probe_health(out)
     return out
 
 
@@ -669,6 +868,7 @@ async def probe_user_ticker_endpoints(
     include_order_book: bool = True,
     include_ohlcv: bool = True,
     include_my_trades: bool = True,
+    include_time_sync: bool = True,
     progress: bool = False,
 ) -> dict[str, Any]:
     emit_progress(f"[{user}] loading api key config", enabled=progress)
@@ -694,6 +894,7 @@ async def probe_user_ticker_endpoints(
             include_order_book=include_order_book,
             include_ohlcv=include_ohlcv,
             include_my_trades=include_my_trades,
+            include_time_sync=include_time_sync,
             progress=progress,
         )
     finally:
@@ -735,6 +936,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="skip authenticated fetch_my_trades probe",
     )
+    parser.add_argument(
+        "--skip-time-sync",
+        action="store_true",
+        help="skip read-only fetch_time clock-skew probe",
+    )
     parser.add_argument("--quiet", action="store_true", help="suppress progress output")
     parser.add_argument("--out", help="output JSON path; default is tmp/ccxt_ticker_probe_<ts>.json")
     parser.add_argument("--json", action="store_true", help="also print JSON to stdout")
@@ -768,6 +974,7 @@ async def async_main() -> int:
         "include_order_book": not bool(args.skip_order_book) and not bool(args.account_only),
         "include_ohlcv": not bool(args.skip_ohlcv) and not bool(args.account_only),
         "include_my_trades": not bool(args.skip_my_trades) and not bool(args.account_only),
+        "include_time_sync": not bool(args.skip_time_sync),
         "probes": [],
     }
     for user in users:
@@ -787,6 +994,7 @@ async def async_main() -> int:
                 include_order_book=not bool(args.skip_order_book) and not bool(args.account_only),
                 include_ohlcv=not bool(args.skip_ohlcv) and not bool(args.account_only),
                 include_my_trades=not bool(args.skip_my_trades) and not bool(args.account_only),
+                include_time_sync=not bool(args.skip_time_sync),
                 progress=not bool(args.quiet),
             )
         )
@@ -795,6 +1003,7 @@ async def async_main() -> int:
     result["account_critical_health"] = summarize_account_critical_probe_collection(
         result["probes"]
     )
+    result["time_sync_health"] = summarize_time_sync_probe_collection(result["probes"])
     out_path = Path(args.out) if args.out else Path("tmp") / f"ccxt_ticker_probe_{started_ms}.json"
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(result, indent=2, sort_keys=True, default=str) + "\n")

--- a/tests/test_ticker_probe_tool.py
+++ b/tests/test_ticker_probe_tool.py
@@ -13,6 +13,8 @@ from tools.probe_ccxt_ticker_endpoints import (
     select_default_symbols,
     summarize_account_critical_probe_collection,
     summarize_account_critical_probe_health,
+    summarize_time_sync_probe_collection,
+    summarize_time_sync_probe_health,
 )
 
 
@@ -219,6 +221,7 @@ async def test_probe_exchange_ticker_endpoints_records_all_endpoint_shapes():
             "fetchOpenOrders": True,
             "fetchOrderBook": True,
             "fetchPositions": True,
+            "fetchTime": True,
             "fetchTicker": True,
             "fetchTickers": True,
         }
@@ -243,6 +246,9 @@ async def test_probe_exchange_ticker_endpoints_records_all_endpoint_shapes():
                     "linear": True,
                 },
             }
+
+        async def fetch_time(self):
+            return 1_767_225_600_000
 
         async def fetch_tickers(self, symbols=None):
             self.fetch_tickers_calls.append(symbols)
@@ -306,6 +312,13 @@ async def test_probe_exchange_ticker_endpoints_records_all_endpoint_shapes():
     assert repeat["fetch_positions"]["ok"] is True
     assert repeat["fetch_open_orders_all"]["ok"] is True
     assert repeat["fetch_my_trades_first_symbol"]["ok"] is True
+    assert repeat["fetch_time"]["ok"] is True
+    assert repeat["fetch_time"]["supported"] is True
+    assert isinstance(repeat["fetch_time"]["clock_skew_ms"], int)
+    assert out["time_sync_health"]["enabled"] is True
+    assert out["time_sync_health"]["total"] == 1
+    assert out["time_sync_health"]["succeeded"] == 1
+    assert out["time_sync_health"]["failed"] == 0
     assert out["account_critical_health"]["enabled"] is True
     assert out["account_critical_health"]["total"] == 3
     assert out["account_critical_health"]["succeeded"] == 3
@@ -396,6 +409,162 @@ def test_account_critical_probe_collection_aggregates_user_summaries():
         "failed": 0,
         "failure_pct": None,
     }
+
+
+def test_time_sync_probe_health_summarizes_success_failure_and_unsupported():
+    summary = summarize_time_sync_probe_health(
+        {
+            "include_time_sync": True,
+            "repeats": [
+                {
+                    "fetch_time": {
+                        "ok": True,
+                        "supported": True,
+                        "elapsed_ms": 2.5,
+                        "clock_skew_ms": -125,
+                    }
+                },
+                {
+                    "fetch_time": {
+                        "ok": False,
+                        "supported": True,
+                        "elapsed_ms": 3.75,
+                        "error_type": "RequestTimeout",
+                        "error": "raw exchange error should not be summarized",
+                    }
+                },
+                {
+                    "fetch_time": {
+                        "ok": False,
+                        "supported": False,
+                        "skipped": True,
+                        "error_type": "UnsupportedEndpoint",
+                    }
+                },
+            ],
+        }
+    )
+
+    assert summary["enabled"] is True
+    assert summary["total"] == 2
+    assert summary["succeeded"] == 1
+    assert summary["failed"] == 1
+    assert summary["unsupported"] == 1
+    assert summary["failure_pct"] == pytest.approx(50.0)
+    assert summary["clock_skew_ms"]["max_abs"] == 125.0
+    assert summary["error_types"] == {"RequestTimeout": 1}
+    assert "raw exchange error" not in str(summary)
+
+
+def test_time_sync_probe_collection_aggregates_user_summaries():
+    collection = summarize_time_sync_probe_collection(
+        [
+            {
+                "user": "okx_faisal",
+                "exchange": "okx",
+                "time_sync_health": {
+                    "enabled": True,
+                    "total": 1,
+                    "succeeded": 1,
+                    "failed": 0,
+                    "unsupported": 0,
+                    "failure_pct": 0.0,
+                    "clock_skew_ms": {"max_abs": 42.0},
+                    "latest": {"ok": True, "clock_skew_ms": 42.0},
+                },
+            },
+            {
+                "user": "legacy_01",
+                "exchange": "legacy",
+                "time_sync_health": {
+                    "enabled": True,
+                    "total": 0,
+                    "succeeded": 0,
+                    "failed": 0,
+                    "unsupported": 1,
+                    "failure_pct": None,
+                    "clock_skew_ms": {"max_abs": None},
+                    "latest": {"ok": False, "supported": False, "skipped": True},
+                },
+            },
+        ]
+    )
+
+    assert collection["total"] == 1
+    assert collection["succeeded"] == 1
+    assert collection["failed"] == 0
+    assert collection["unsupported"] == 1
+    assert collection["clock_skew_ms"]["max_abs"] == 42.0
+    assert collection["users"][0]["latest_clock_skew_ms"] == 42.0
+    assert collection["users"][1]["unsupported"] == 1
+
+
+@pytest.mark.asyncio
+async def test_time_sync_probe_uses_ccxt_capability_flag_for_unsupported_method():
+    class FakeExchange:
+        id = "fake"
+        has = {
+            "fetchBalance": True,
+            "fetchBidsAsks": True,
+            "fetchMyTrades": True,
+            "fetchOpenOrders": True,
+            "fetchPositions": True,
+            "fetchTime": False,
+            "fetchTicker": True,
+            "fetchTickers": True,
+        }
+
+        def __init__(self):
+            self.fetch_time_called = False
+
+        async def load_markets(self):
+            return {
+                "BTC/USDT:USDT": {
+                    "base": "BTC",
+                    "quote": "USDT",
+                    "active": True,
+                    "swap": True,
+                    "linear": True,
+                }
+            }
+
+        async def fetch_time(self):
+            self.fetch_time_called = True
+            raise RuntimeError("should not be called when has.fetchTime is false")
+
+        async def fetch_balance(self):
+            return {"USDT": {"total": 100.0}}
+
+        async def fetch_positions(self):
+            return []
+
+        async def fetch_open_orders(self, symbol=None):
+            return []
+
+    exchange = FakeExchange()
+
+    out = await probe_exchange_ticker_endpoints(
+        exchange,
+        user="fake_user",
+        user_info={"quote": "USDT"},
+        symbols=["BTC/USDT:USDT"],
+        coins=[],
+        quote=None,
+        max_symbols=1,
+        repeats=1,
+        sleep_between_seconds=0.0,
+        include_public=False,
+        include_order_book=False,
+        include_ohlcv=False,
+        include_my_trades=False,
+    )
+
+    assert exchange.fetch_time_called is False
+    assert out["repeats"][0]["fetch_time"]["supported"] is False
+    assert out["repeats"][0]["fetch_time"]["skipped"] is True
+    assert out["time_sync_health"]["total"] == 0
+    assert out["time_sync_health"]["failed"] == 0
+    assert out["time_sync_health"]["unsupported"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add read-only fetch_time clock-skew evidence to ticker-endpoint-probe repeats
- add per-user and collection-level time_sync_health summaries, with unsupported exchanges separated from real failures
- add --skip-time-sync, docs, changelog, and backlog tracking

## Validation
- ./venv/bin/python -m pytest -q tests/test_ticker_probe_tool.py
- ./venv/bin/python -m compileall -q src/tools/probe_ccxt_ticker_endpoints.py tests/test_ticker_probe_tool.py
- git diff --check
- rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])" src/tools/probe_ccxt_ticker_endpoints.py tests/test_ticker_probe_tool.py