### PR TITLE
Add ticker probe candle freshness health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added no-extra-call 1m candle freshness health summaries to
+  `passivbot tool ticker-endpoint-probe`, derived from the existing OHLCV tail
+  probe results.
 - Added read-only `fetch_time` clock-skew health summaries to
   `passivbot tool ticker-endpoint-probe`, with `--skip-time-sync` for operators
   who want to omit the extra time-sync call.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -161,12 +161,14 @@ Related detailed plans:
    Binance probe validated `account_critical_health` success for all three
    account-critical surfaces. PR #741 added read-only `fetch_time`
    `time_sync_health` summaries and `--skip-time-sync`, counting unsupported
-   exchanges separately from actual failures.
+   exchanges separately from actual failures. PR #743 added
+   `candle_freshness_health`, derived from the existing OHLCV tail probe
+   results without adding exchange calls.
 
    Add/refine explicit read-only probes for each configured exchange/account
-   before or during smoke: rate-limit behavior, fill pagination coverage,
-   candle freshness, and basic endpoint latency. The passive smoke report now
-   also exposes top-level remote-call health
+   before or during smoke: rate-limit behavior, fill pagination coverage, and
+   basic endpoint latency. The passive smoke report now also exposes top-level
+   remote-call health
    success/failure/throttle totals and a filtered
    `account_critical_remote_call_health` summary for a quick operator scan.
 
@@ -455,7 +457,8 @@ Related detailed plans:
 | 2026-06-27 | #4 Startup phase budget tracking | PR #735 / `6f415777` | Added report-only startup budget projections to `live-smoke-report` phase summaries using prior local p95 baselines from existing monitor events; VPS5 deploy kept all five bots running and the settled smoke returned `ok=true` after unrelated transient HSL/EMA events aged out | Explicit durable budget config/events |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #701 / `fcda70f5` | Added `ticker-endpoint-probe` `account_critical_health` summaries for read-only balance/positions/open-orders outcomes; VPS5 Binance probe validated the summary and exposed an open-orders shape follow-up | Lower-impact/account-only mode, exchange-aware open-orders probing, clock skew/rate-limit/fill/candle probes |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #703 / `8fefce4b` | Added `ticker-endpoint-probe --account-only`, `--skip-my-trades`, and open-orders symbol fallback; VPS5 Binance account-only probe returned account-critical total=3, succeeded=3, and smoke stayed green | Clock skew/rate-limit/fill-pagination/candle-freshness probes |
-| 2026-06-27 | #6 Exchange health and contract probes | PR #741 / pending | Added `ticker-endpoint-probe` read-only `fetch_time` clock-skew evidence and collection-level `time_sync_health`, with unsupported exchanges separated from failures and `--skip-time-sync` as an operator escape hatch | Rate-limit/fill-pagination/candle-freshness probes |
+| 2026-06-27 | #6 Exchange health and contract probes | PR #741 / `d4c28058` | Added `ticker-endpoint-probe` read-only `fetch_time` clock-skew evidence and collection-level `time_sync_health`, with unsupported exchanges separated from failures and `--skip-time-sync` as an operator escape hatch | Rate-limit/fill-pagination/candle-freshness probes |
+| 2026-06-27 | #6 Exchange health and contract probes | PR #743 / pending | Added `ticker-endpoint-probe` `candle_freshness_health` summaries from existing 1m OHLCV tail results, including worst-symbol age and current-incomplete counts without extra exchange calls | Rate-limit/fill-pagination probes |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -180,7 +180,9 @@ Ticker probes inspect CCXT ticker support and latency without placing orders:
   which still loads markets to resolve an open-orders fallback symbol, or `--skip-my-trades` to
   omit the fill-history endpoint. The probe also includes `time_sync_health` from read-only
   `fetch_time` clock-skew checks when the exchange supports it; use `--skip-time-sync` to omit that
-  call. Keep authenticated runs low-rate when a live bot is using the same account.
+  call. When OHLCV probing is enabled, `candle_freshness_health` summarizes the existing 1m candle
+  tail results without making additional exchange calls. Keep authenticated runs low-rate when a
+  live bot is using the same account.
 
 ## Hyperliquid live probes
 

--- a/src/tools/probe_ccxt_ticker_endpoints.py
+++ b/src/tools/probe_ccxt_ticker_endpoints.py
@@ -81,7 +81,8 @@ def summarize_market(market: Any) -> dict[str, Any]:
 def summarize_ohlcvs(ohlcvs: Any) -> dict[str, Any]:
     if not isinstance(ohlcvs, list):
         return {"type": type(ohlcvs).__name__, "count": None, "valid": False}
-    current_minute_open = int(utc_ms() // 60_000 * 60_000)
+    observed_at_ms = int(utc_ms())
+    current_minute_open = int(observed_at_ms // 60_000 * 60_000)
     rows = []
     for row in ohlcvs[-3:]:
         if not isinstance(row, (list, tuple)) or len(row) < 6:
@@ -104,10 +105,17 @@ def summarize_ohlcvs(ohlcvs: Any) -> dict[str, Any]:
             }
         )
     last_ts = rows[-1].get("timestamp") if rows and rows[-1].get("valid", True) else None
+    last_age_ms = None
+    if last_ts is not None:
+        last_age_ms = max(0, int(observed_at_ms) - int(last_ts))
     return {
         "count": len(ohlcvs),
+        "observed_at_ms": observed_at_ms,
+        "observed_at": ts_to_date(observed_at_ms),
         "last_timestamp": last_ts,
         "last_datetime": ts_to_date(last_ts) if last_ts is not None else None,
+        "last_age_ms": last_age_ms,
+        "last_age_minutes": round(last_age_ms / 60_000.0, 3) if last_age_ms is not None else None,
         "last_is_current_incomplete_minute": last_ts == current_minute_open,
         "sample_tail": rows,
     }
@@ -419,6 +427,190 @@ def summarize_time_sync_probe_collection(probes: list[dict[str, Any]]) -> dict[s
     }
 
 
+def _freshness_summary(values: list[float]) -> dict[str, Any]:
+    return _latency_summary(values)
+
+
+def summarize_candle_freshness_probe_health(probe: dict[str, Any]) -> dict[str, Any]:
+    """Summarize existing 1m OHLCV tail probe freshness without extra exchange calls."""
+    include_public = bool(probe.get("include_public", True))
+    include_ohlcv = bool(probe.get("include_ohlcv", True))
+    enabled = include_public and include_ohlcv
+    repeats = probe.get("repeats") if isinstance(probe.get("repeats"), list) else []
+    total_symbols = 0
+    succeeded_symbols = 0
+    failed_symbols = 0
+    missing_timestamp_symbols = 0
+    current_incomplete_symbols = 0
+    latencies = []
+    last_ages = []
+    error_types: Counter[str] = Counter()
+    worst: dict[str, Any] | None = None
+    latest: dict[str, Any] | None = None
+    for repeat in repeats:
+        outcome = repeat.get("fetch_ohlcv_1m_tail") if isinstance(repeat, dict) else None
+        if outcome is None:
+            continue
+        symbols = outcome.get("symbols") if isinstance(outcome, dict) else None
+        if not isinstance(symbols, dict):
+            total_symbols += 1
+            failed_symbols += 1
+            error_types["missing_symbols"] += 1
+            latest = {"ok": False, "error_type": "missing_symbols"}
+            continue
+        for symbol, symbol_outcome in sorted(symbols.items()):
+            total_symbols += 1
+            elapsed_ms = _elapsed_ms(symbol_outcome)
+            if elapsed_ms is not None:
+                latencies.append(elapsed_ms)
+            if not isinstance(symbol_outcome, dict) or not symbol_outcome.get("ok"):
+                failed_symbols += 1
+                error_type = (
+                    str(symbol_outcome.get("error_type") or "unknown")
+                    if isinstance(symbol_outcome, dict)
+                    else "missing_outcome"
+                )
+                error_types[error_type] += 1
+                latest = {
+                    "ok": False,
+                    "symbol": str(symbol),
+                    "elapsed_ms": elapsed_ms,
+                    "error_type": error_type,
+                }
+                continue
+            value = symbol_outcome.get("value")
+            if not isinstance(value, dict):
+                failed_symbols += 1
+                error_types["missing_value"] += 1
+                latest = {
+                    "ok": False,
+                    "symbol": str(symbol),
+                    "elapsed_ms": elapsed_ms,
+                    "error_type": "missing_value",
+                }
+                continue
+            succeeded_symbols += 1
+            last_age_ms = _round_ms_value(value.get("last_age_ms"))
+            last_ts = value.get("last_timestamp")
+            if last_ts is None:
+                missing_timestamp_symbols += 1
+            if bool(value.get("last_is_current_incomplete_minute")):
+                current_incomplete_symbols += 1
+            if last_age_ms is not None:
+                last_ages.append(last_age_ms)
+                candidate = {
+                    "symbol": str(symbol),
+                    "last_age_ms": last_age_ms,
+                    "last_datetime": value.get("last_datetime"),
+                    "last_is_current_incomplete_minute": bool(
+                        value.get("last_is_current_incomplete_minute")
+                    ),
+                }
+                if worst is None or last_age_ms > float(worst.get("last_age_ms") or -1.0):
+                    worst = candidate
+                latest = {"ok": True, **candidate}
+            else:
+                latest = {
+                    "ok": True,
+                    "symbol": str(symbol),
+                    "last_age_ms": None,
+                    "last_datetime": value.get("last_datetime"),
+                    "last_is_current_incomplete_minute": bool(
+                        value.get("last_is_current_incomplete_minute")
+                    ),
+                }
+    return {
+        "enabled": enabled,
+        "total_symbols": total_symbols,
+        "succeeded_symbols": succeeded_symbols,
+        "failed_symbols": failed_symbols,
+        "failure_pct": _pct(failed_symbols, total_symbols),
+        "missing_timestamp_symbols": missing_timestamp_symbols,
+        "current_incomplete_symbols": current_incomplete_symbols,
+        "latency_ms": _latency_summary(latencies),
+        "last_age_ms": _freshness_summary(last_ages),
+        "error_types": dict(sorted(error_types.items())),
+        "worst": worst,
+        "latest": latest,
+    }
+
+
+def summarize_candle_freshness_probe_collection(probes: list[dict[str, Any]]) -> dict[str, Any]:
+    users = []
+    total_symbols = 0
+    succeeded_symbols = 0
+    failed_symbols = 0
+    missing_timestamp_symbols = 0
+    current_incomplete_symbols = 0
+    last_ages = []
+    worst: dict[str, Any] | None = None
+    for probe in probes:
+        summary = probe.get("candle_freshness_health")
+        if not isinstance(summary, dict):
+            summary = summarize_candle_freshness_probe_health(probe)
+        summary_worst = summary.get("worst") if isinstance(summary.get("worst"), dict) else None
+        user_summary = {
+            "user": probe.get("user"),
+            "exchange": probe.get("exchange"),
+            "enabled": bool(summary.get("enabled")),
+            "total_symbols": int(summary.get("total_symbols") or 0),
+            "succeeded_symbols": int(summary.get("succeeded_symbols") or 0),
+            "failed_symbols": int(summary.get("failed_symbols") or 0),
+            "failure_pct": summary.get("failure_pct"),
+            "missing_timestamp_symbols": int(summary.get("missing_timestamp_symbols") or 0),
+            "current_incomplete_symbols": int(summary.get("current_incomplete_symbols") or 0),
+            "max_last_age_ms": (
+                summary["last_age_ms"].get("max")
+                if isinstance(summary.get("last_age_ms"), dict)
+                else None
+            ),
+            "worst_symbol": summary_worst.get("symbol") if summary_worst else None,
+        }
+        users.append(user_summary)
+        total_symbols += user_summary["total_symbols"]
+        succeeded_symbols += user_summary["succeeded_symbols"]
+        failed_symbols += user_summary["failed_symbols"]
+        missing_timestamp_symbols += user_summary["missing_timestamp_symbols"]
+        current_incomplete_symbols += user_summary["current_incomplete_symbols"]
+        repeats = probe.get("repeats") if isinstance(probe.get("repeats"), list) else []
+        for repeat in repeats:
+            outcome = repeat.get("fetch_ohlcv_1m_tail") if isinstance(repeat, dict) else None
+            symbols = outcome.get("symbols") if isinstance(outcome, dict) else None
+            if not isinstance(symbols, dict):
+                continue
+            for symbol, symbol_outcome in sorted(symbols.items()):
+                value = symbol_outcome.get("value") if isinstance(symbol_outcome, dict) else None
+                if not isinstance(value, dict):
+                    continue
+                last_age_ms = _round_ms_value(value.get("last_age_ms"))
+                if last_age_ms is None:
+                    continue
+                last_ages.append(last_age_ms)
+                candidate = {
+                    "user": probe.get("user"),
+                    "exchange": probe.get("exchange"),
+                    "symbol": str(symbol),
+                    "last_age_ms": last_age_ms,
+                    "last_datetime": value.get("last_datetime"),
+                    "last_is_current_incomplete_minute": bool(
+                        value.get("last_is_current_incomplete_minute")
+                    ),
+                }
+                if worst is None or last_age_ms > float(worst.get("last_age_ms") or -1.0):
+                    worst = candidate
+    return {
+        "users": users,
+        "total_symbols": total_symbols,
+        "succeeded_symbols": succeeded_symbols,
+        "failed_symbols": failed_symbols,
+        "failure_pct": _pct(failed_symbols, total_symbols),
+        "missing_timestamp_symbols": missing_timestamp_symbols,
+        "current_incomplete_symbols": current_incomplete_symbols,
+        "last_age_ms": _freshness_summary(last_ages),
+        "worst": worst,
+    }
+
+
 async def _timed_load_markets(exchange) -> tuple[dict[str, Any], dict[str, Any]]:
     outcome = await _timed_call(exchange.load_markets())
     markets = outcome["value"] if outcome["ok"] and isinstance(outcome["value"], dict) else {}
@@ -663,6 +855,7 @@ async def probe_exchange_ticker_endpoints(
         "symbols": resolved_symbols,
         "include_private": bool(include_private),
         "include_public": bool(include_public),
+        "include_ohlcv": bool(include_ohlcv),
         "include_my_trades": bool(include_my_trades),
         "include_time_sync": bool(include_time_sync),
         "market_count": len(markets) if isinstance(markets, dict) else None,
@@ -850,6 +1043,7 @@ async def probe_exchange_ticker_endpoints(
 
     out["account_critical_health"] = summarize_account_critical_probe_health(out)
     out["time_sync_health"] = summarize_time_sync_probe_health(out)
+    out["candle_freshness_health"] = summarize_candle_freshness_probe_health(out)
     return out
 
 
@@ -1004,6 +1198,9 @@ async def async_main() -> int:
         result["probes"]
     )
     result["time_sync_health"] = summarize_time_sync_probe_collection(result["probes"])
+    result["candle_freshness_health"] = summarize_candle_freshness_probe_collection(
+        result["probes"]
+    )
     out_path = Path(args.out) if args.out else Path("tmp") / f"ccxt_ticker_probe_{started_ms}.json"
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(result, indent=2, sort_keys=True, default=str) + "\n")

--- a/tests/test_ticker_probe_tool.py
+++ b/tests/test_ticker_probe_tool.py
@@ -1,5 +1,6 @@
 import pytest
 
+import tools.probe_ccxt_ticker_endpoints as ticker_endpoint_probe
 from tools.probe_ticker_capabilities import (
     create_exchange,
     probe_ticker_capabilities,
@@ -11,6 +12,9 @@ from tools.probe_ticker_capabilities import (
 from tools.probe_ccxt_ticker_endpoints import (
     probe_exchange_ticker_endpoints,
     select_default_symbols,
+    summarize_candle_freshness_probe_collection,
+    summarize_candle_freshness_probe_health,
+    summarize_ohlcvs,
     summarize_account_critical_probe_collection,
     summarize_account_critical_probe_health,
     summarize_time_sync_probe_collection,
@@ -57,6 +61,24 @@ def test_summarize_order_book_reports_top_of_book():
     assert out["has_ask"] is True
     assert out["bid"] == 99.0
     assert out["ask"] == 101.0
+
+
+def test_summarize_ohlcvs_reports_bounded_tail_freshness(monkeypatch):
+    monkeypatch.setattr(ticker_endpoint_probe, "utc_ms", lambda: 1_180_000)
+
+    out = summarize_ohlcvs(
+        [
+            [1_000_000, 9.0, 11.0, 8.0, 10.0, 100.0],
+            [1_120_000, 10.0, 12.0, 9.0, 11.0, 101.0],
+        ]
+    )
+
+    assert out["count"] == 2
+    assert out["observed_at_ms"] == 1_180_000
+    assert out["last_timestamp"] == 1_120_000
+    assert out["last_age_ms"] == 60_000
+    assert out["last_age_minutes"] == 1.0
+    assert out["last_is_current_incomplete_minute"] is False
 
 
 @pytest.mark.asyncio
@@ -319,6 +341,11 @@ async def test_probe_exchange_ticker_endpoints_records_all_endpoint_shapes():
     assert out["time_sync_health"]["total"] == 1
     assert out["time_sync_health"]["succeeded"] == 1
     assert out["time_sync_health"]["failed"] == 0
+    assert out["candle_freshness_health"]["enabled"] is True
+    assert out["candle_freshness_health"]["total_symbols"] == 2
+    assert out["candle_freshness_health"]["succeeded_symbols"] == 2
+    assert out["candle_freshness_health"]["failed_symbols"] == 0
+    assert out["candle_freshness_health"]["last_age_ms"]["count"] == 2
     assert out["account_critical_health"]["enabled"] is True
     assert out["account_critical_health"]["total"] == 3
     assert out["account_critical_health"]["succeeded"] == 3
@@ -497,6 +524,130 @@ def test_time_sync_probe_collection_aggregates_user_summaries():
     assert collection["clock_skew_ms"]["max_abs"] == 42.0
     assert collection["users"][0]["latest_clock_skew_ms"] == 42.0
     assert collection["users"][1]["unsupported"] == 1
+
+
+def test_candle_freshness_probe_health_summarizes_symbol_tail_ages():
+    summary = summarize_candle_freshness_probe_health(
+        {
+            "include_public": True,
+            "include_ohlcv": True,
+            "repeats": [
+                {
+                    "fetch_ohlcv_1m_tail": {
+                        "ok": False,
+                        "elapsed_ms": 12.0,
+                        "symbols": {
+                            "BTC/USDT:USDT": {
+                                "ok": True,
+                                "elapsed_ms": 4.5,
+                                "value": {
+                                    "last_timestamp": 1_000_000,
+                                    "last_datetime": "1970-01-01T00:16:40",
+                                    "last_age_ms": 60_000,
+                                    "last_is_current_incomplete_minute": False,
+                                },
+                            },
+                            "ETH/USDT:USDT": {
+                                "ok": True,
+                                "elapsed_ms": 5.5,
+                                "value": {
+                                    "last_timestamp": 1_060_000,
+                                    "last_datetime": "1970-01-01T00:17:40",
+                                    "last_age_ms": 10_000,
+                                    "last_is_current_incomplete_minute": True,
+                                },
+                            },
+                            "XRP/USDT:USDT": {
+                                "ok": False,
+                                "elapsed_ms": 6.5,
+                                "error_type": "RequestTimeout",
+                                "error": "raw exchange error should not appear",
+                            },
+                        },
+                    }
+                }
+            ],
+        }
+    )
+
+    assert summary["enabled"] is True
+    assert summary["total_symbols"] == 3
+    assert summary["succeeded_symbols"] == 2
+    assert summary["failed_symbols"] == 1
+    assert summary["failure_pct"] == pytest.approx(33.333)
+    assert summary["current_incomplete_symbols"] == 1
+    assert summary["missing_timestamp_symbols"] == 0
+    assert summary["last_age_ms"]["max"] == 60_000.0
+    assert summary["worst"]["symbol"] == "BTC/USDT:USDT"
+    assert summary["error_types"] == {"RequestTimeout": 1}
+    assert "raw exchange error" not in str(summary)
+
+
+def test_candle_freshness_probe_collection_aggregates_users():
+    probes = [
+        {
+            "user": "binance_01",
+            "exchange": "binance",
+            "include_public": True,
+            "include_ohlcv": True,
+            "repeats": [
+                {
+                    "fetch_ohlcv_1m_tail": {
+                        "symbols": {
+                            "BTC/USDT:USDT": {
+                                "ok": True,
+                                "value": {
+                                    "last_age_ms": 30_000,
+                                    "last_datetime": "fresh",
+                                    "last_is_current_incomplete_minute": True,
+                                },
+                            }
+                        }
+                    }
+                }
+            ],
+        },
+        {
+            "user": "okx_faisal",
+            "exchange": "okx",
+            "include_public": True,
+            "include_ohlcv": True,
+            "repeats": [
+                {
+                    "fetch_ohlcv_1m_tail": {
+                        "symbols": {
+                            "ETH/USDT:USDT": {
+                                "ok": True,
+                                "value": {
+                                    "last_age_ms": 120_000,
+                                    "last_datetime": "stale",
+                                    "last_is_current_incomplete_minute": False,
+                                },
+                            }
+                        }
+                    }
+                }
+            ],
+        },
+    ]
+
+    collection = summarize_candle_freshness_probe_collection(probes)
+
+    assert collection["total_symbols"] == 2
+    assert collection["succeeded_symbols"] == 2
+    assert collection["failed_symbols"] == 0
+    assert collection["current_incomplete_symbols"] == 1
+    assert collection["last_age_ms"]["max"] == 120_000.0
+    assert collection["worst"] == {
+        "user": "okx_faisal",
+        "exchange": "okx",
+        "symbol": "ETH/USDT:USDT",
+        "last_age_ms": 120_000.0,
+        "last_datetime": "stale",
+        "last_is_current_incomplete_minute": False,
+    }
+    assert collection["users"][0]["max_last_age_ms"] == 30_000.0
+    assert collection["users"][1]["worst_symbol"] == "ETH/USDT:USDT"
 
 
 @pytest.mark.asyncio
@@ -736,3 +887,5 @@ async def test_account_only_probe_skips_public_and_uses_open_orders_symbol_fallb
     assert exchange.my_trades_called is False
     assert out["account_critical_health"]["succeeded"] == 3
     assert out["account_critical_health"]["failed"] == 0
+    assert out["candle_freshness_health"]["enabled"] is False
+    assert out["candle_freshness_health"]["total_symbols"] == 0


### PR DESCRIPTION
## Summary
- add last-age metadata to existing 1m OHLCV tail probe summaries
- add per-user and collection-level candle_freshness_health derived from existing fetch_ohlcv results, with no additional exchange calls
- update docs, changelog, and live-ops backlog to mark candle freshness probe coverage

## Validation
- ./venv/bin/python -m pytest -q tests/test_ticker_probe_tool.py
- ./venv/bin/python -m compileall -q src/tools/probe_ccxt_ticker_endpoints.py tests/test_ticker_probe_tool.py
- git diff --check
- touched-file silent-handling scan: no matches