### PR TITLE
Add ticker probe fill history health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added no-extra-call fill-history sample health summaries to
+  `passivbot tool ticker-endpoint-probe`, derived from the existing
+  `fetch_my_trades(first symbol)` probe result without raw trade/order ids.
 - Added no-extra-call 1m candle freshness health summaries to
   `passivbot tool ticker-endpoint-probe`, derived from the existing OHLCV tail
   probe results.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -163,11 +163,13 @@ Related detailed plans:
    `time_sync_health` summaries and `--skip-time-sync`, counting unsupported
    exchanges separately from actual failures. PR #743 added
    `candle_freshness_health`, derived from the existing OHLCV tail probe
-   results without adding exchange calls.
+   results without adding exchange calls. PR #745 adds `fill_history_health`,
+   derived from the existing first-symbol `fetch_my_trades` sample without raw
+   trade/order ids or extra pagination calls.
 
    Add/refine explicit read-only probes for each configured exchange/account
-   before or during smoke: rate-limit behavior, fill pagination coverage, and
-   basic endpoint latency. The passive smoke report now also exposes top-level
+   before or during smoke: rate-limit behavior, full fill pagination coverage,
+   and basic endpoint latency. The passive smoke report now also exposes top-level
    remote-call health
    success/failure/throttle totals and a filtered
    `account_critical_remote_call_health` summary for a quick operator scan.
@@ -458,7 +460,8 @@ Related detailed plans:
 | 2026-06-26 | #6 Exchange health and contract probes | PR #701 / `fcda70f5` | Added `ticker-endpoint-probe` `account_critical_health` summaries for read-only balance/positions/open-orders outcomes; VPS5 Binance probe validated the summary and exposed an open-orders shape follow-up | Lower-impact/account-only mode, exchange-aware open-orders probing, clock skew/rate-limit/fill/candle probes |
 | 2026-06-26 | #6 Exchange health and contract probes | PR #703 / `8fefce4b` | Added `ticker-endpoint-probe --account-only`, `--skip-my-trades`, and open-orders symbol fallback; VPS5 Binance account-only probe returned account-critical total=3, succeeded=3, and smoke stayed green | Clock skew/rate-limit/fill-pagination/candle-freshness probes |
 | 2026-06-27 | #6 Exchange health and contract probes | PR #741 / `d4c28058` | Added `ticker-endpoint-probe` read-only `fetch_time` clock-skew evidence and collection-level `time_sync_health`, with unsupported exchanges separated from failures and `--skip-time-sync` as an operator escape hatch | Rate-limit/fill-pagination/candle-freshness probes |
-| 2026-06-27 | #6 Exchange health and contract probes | PR #743 / pending | Added `ticker-endpoint-probe` `candle_freshness_health` summaries from existing 1m OHLCV tail results, including worst-symbol age and current-incomplete counts without extra exchange calls | Rate-limit/fill-pagination probes |
+| 2026-06-27 | #6 Exchange health and contract probes | PR #743 / `1fe1292b` | Added `ticker-endpoint-probe` `candle_freshness_health` summaries from existing 1m OHLCV tail results, including worst-symbol age and current-incomplete counts without extra exchange calls | Rate-limit/fill-pagination probes |
+| 2026-06-27 | #6 Exchange health and contract probes | PR #745 / pending | Added `ticker-endpoint-probe` `fill_history_health` summaries from the existing first-symbol `fetch_my_trades` sample, including success/failure, latency, trade count, newest timestamp, and shape without raw trade/order ids or extra pagination calls | Rate-limit/full fill-pagination coverage probes |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -178,11 +178,14 @@ Ticker probes inspect CCXT ticker support and latency without placing orders:
   summary for the read-only balance, positions, and open-orders endpoints required before live
   exchange actions. Use `--account-only` for the lower-impact balance/positions/open-orders probe,
   which still loads markets to resolve an open-orders fallback symbol, or `--skip-my-trades` to
-  omit the fill-history endpoint. The probe also includes `time_sync_health` from read-only
-  `fetch_time` clock-skew checks when the exchange supports it; use `--skip-time-sync` to omit that
-  call. When OHLCV probing is enabled, `candle_freshness_health` summarizes the existing 1m candle
-  tail results without making additional exchange calls. Keep authenticated runs low-rate when a
-  live bot is using the same account.
+  omit the fill-history endpoint. When the existing first-symbol `fetch_my_trades` probe is enabled,
+  `fill_history_health` summarizes that sample's success, latency, trade count, newest timestamp,
+  and shape without emitting raw trade/order ids; it does not perform extra pagination coverage
+  calls. The probe also includes `time_sync_health` from read-only `fetch_time` clock-skew checks
+  when the exchange supports it; use `--skip-time-sync` to omit that call. When OHLCV probing is
+  enabled, `candle_freshness_health` summarizes the existing 1m candle tail results without making
+  additional exchange calls. Keep authenticated runs low-rate when a live bot is using the same
+  account.
 
 ## Hyperliquid live probes
 

--- a/src/tools/probe_ccxt_ticker_endpoints.py
+++ b/src/tools/probe_ccxt_ticker_endpoints.py
@@ -129,6 +129,73 @@ def summarize_collection(value: Any) -> dict[str, Any]:
     return {"type": type(value).__name__, "count": None}
 
 
+def _int_timestamp(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def summarize_my_trades(trades: Any) -> dict[str, Any]:
+    """Summarize fill-history sample shape without raw trade/order ids."""
+    if not isinstance(trades, list):
+        return {"type": type(trades).__name__, "count": None, "valid": False}
+    timestamps = []
+    symbols = set()
+    side_counts: Counter[str] = Counter()
+    id_present_count = 0
+    order_present_count = 0
+    dict_count = 0
+    for trade in trades:
+        if not isinstance(trade, dict):
+            continue
+        dict_count += 1
+        ts = _int_timestamp(trade.get("timestamp"))
+        if ts is not None:
+            timestamps.append(ts)
+        symbol = trade.get("symbol")
+        if symbol is not None:
+            symbols.add(str(symbol))
+        side = trade.get("side")
+        if side is not None:
+            side_counts[str(side)] += 1
+        if trade.get("id") is not None:
+            id_present_count += 1
+        if trade.get("order") is not None or trade.get("orderId") is not None:
+            order_present_count += 1
+    timestamps.sort()
+    first_ts = timestamps[0] if timestamps else None
+    last_ts = timestamps[-1] if timestamps else None
+    return {
+        "type": "list",
+        "count": len(trades),
+        "dict_count": dict_count,
+        "timestamp_count": len(timestamps),
+        "missing_timestamp_count": max(0, len(trades) - len(timestamps)),
+        "first_timestamp": first_ts,
+        "first_datetime": ts_to_date(first_ts) if first_ts is not None else None,
+        "last_timestamp": last_ts,
+        "last_datetime": ts_to_date(last_ts) if last_ts is not None else None,
+        "symbol_count": len(symbols),
+        "symbols_sample": sorted(symbols)[:8],
+        "symbols_truncated": max(0, len(symbols) - 8),
+        "side_counts": dict(sorted(side_counts.items())),
+        "id_present_count": id_present_count,
+        "order_present_count": order_present_count,
+        "top_level_keys_sample": sorted(
+            {
+                str(key)
+                for trade in trades
+                if isinstance(trade, dict)
+                for key in trade.keys()
+            }
+        )[:24],
+    }
+
+
 def emit_progress(message: str, *, enabled: bool) -> None:
     if enabled:
         print(message, flush=True)
@@ -611,6 +678,165 @@ def summarize_candle_freshness_probe_collection(probes: list[dict[str, Any]]) ->
     }
 
 
+def summarize_fill_history_probe_health(probe: dict[str, Any]) -> dict[str, Any]:
+    """Summarize existing fetch_my_trades probe results without raw fill payloads."""
+    enabled = bool(probe.get("include_private", True)) and bool(
+        probe.get("include_my_trades", True)
+    )
+    repeats = probe.get("repeats") if isinstance(probe.get("repeats"), list) else []
+    total = 0
+    succeeded = 0
+    failed = 0
+    latencies = []
+    trade_counts = []
+    error_types: Counter[str] = Counter()
+    latest: dict[str, Any] | None = None
+    newest_trade: dict[str, Any] | None = None
+    for repeat in repeats:
+        outcome = (
+            repeat.get("fetch_my_trades_first_symbol")
+            if isinstance(repeat, dict)
+            else None
+        )
+        if outcome is None:
+            continue
+        total += 1
+        elapsed_ms = _elapsed_ms(outcome)
+        if elapsed_ms is not None:
+            latencies.append(elapsed_ms)
+        if not isinstance(outcome, dict) or not outcome.get("ok"):
+            failed += 1
+            error_type = (
+                str(outcome.get("error_type") or "unknown")
+                if isinstance(outcome, dict)
+                else "missing_outcome"
+            )
+            error_types[error_type] += 1
+            latest = {
+                "ok": False,
+                "symbol": outcome.get("symbol") if isinstance(outcome, dict) else None,
+                "elapsed_ms": elapsed_ms,
+                "error_type": error_type,
+            }
+            continue
+        value = outcome.get("value")
+        if not isinstance(value, dict):
+            failed += 1
+            error_types["missing_value"] += 1
+            latest = {
+                "ok": False,
+                "symbol": outcome.get("symbol"),
+                "elapsed_ms": elapsed_ms,
+                "error_type": "missing_value",
+            }
+            continue
+        succeeded += 1
+        trade_count = int(value.get("count") or 0)
+        trade_counts.append(float(trade_count))
+        last_ts = _int_timestamp(value.get("last_timestamp"))
+        candidate = {
+            "ok": True,
+            "symbol": outcome.get("symbol"),
+            "elapsed_ms": elapsed_ms,
+            "trade_count": trade_count,
+            "timestamp_count": int(value.get("timestamp_count") or 0),
+            "missing_timestamp_count": int(value.get("missing_timestamp_count") or 0),
+            "first_timestamp": _int_timestamp(value.get("first_timestamp")),
+            "first_datetime": value.get("first_datetime"),
+            "last_timestamp": last_ts,
+            "last_datetime": value.get("last_datetime"),
+            "symbol_count": int(value.get("symbol_count") or 0),
+            "side_counts": (
+                value.get("side_counts") if isinstance(value.get("side_counts"), dict) else {}
+            ),
+            "id_present_count": int(value.get("id_present_count") or 0),
+            "order_present_count": int(value.get("order_present_count") or 0),
+        }
+        latest = candidate
+        if last_ts is not None and (
+            newest_trade is None
+            or last_ts > int(newest_trade.get("last_timestamp") or -1)
+        ):
+            newest_trade = candidate
+    return {
+        "enabled": enabled,
+        "total": total,
+        "succeeded": succeeded,
+        "failed": failed,
+        "failure_pct": _pct(failed, total),
+        "latency_ms": _latency_summary(latencies),
+        "trade_count": _latency_summary(trade_counts),
+        "error_types": dict(sorted(error_types.items())),
+        "latest": latest,
+        "newest_trade": newest_trade,
+    }
+
+
+def summarize_fill_history_probe_collection(probes: list[dict[str, Any]]) -> dict[str, Any]:
+    users = []
+    total = 0
+    succeeded = 0
+    failed = 0
+    trade_counts = []
+    newest_trade: dict[str, Any] | None = None
+    for probe in probes:
+        summary = probe.get("fill_history_health")
+        if not isinstance(summary, dict):
+            summary = summarize_fill_history_probe_health(probe)
+        latest = summary.get("latest") if isinstance(summary.get("latest"), dict) else {}
+        summary_newest = (
+            summary.get("newest_trade")
+            if isinstance(summary.get("newest_trade"), dict)
+            else None
+        )
+        user_summary = {
+            "user": probe.get("user"),
+            "exchange": probe.get("exchange"),
+            "enabled": bool(summary.get("enabled")),
+            "total": int(summary.get("total") or 0),
+            "succeeded": int(summary.get("succeeded") or 0),
+            "failed": int(summary.get("failed") or 0),
+            "failure_pct": summary.get("failure_pct"),
+            "latest_symbol": latest.get("symbol"),
+            "latest_trade_count": int(latest.get("trade_count") or 0),
+            "newest_trade_timestamp": (
+                summary_newest.get("last_timestamp") if summary_newest else None
+            ),
+            "newest_trade_datetime": (
+                summary_newest.get("last_datetime") if summary_newest else None
+            ),
+        }
+        users.append(user_summary)
+        total += user_summary["total"]
+        succeeded += user_summary["succeeded"]
+        failed += user_summary["failed"]
+        if user_summary["total"] > 0 and latest:
+            trade_counts.append(float(user_summary["latest_trade_count"]))
+        if summary_newest is not None:
+            ts = _int_timestamp(summary_newest.get("last_timestamp"))
+            if ts is not None and (
+                newest_trade is None
+                or ts > int(newest_trade.get("last_timestamp") or -1)
+            ):
+                newest_trade = {
+                    "user": probe.get("user"),
+                    "exchange": probe.get("exchange"),
+                    "symbol": summary_newest.get("symbol"),
+                    "last_timestamp": ts,
+                    "last_datetime": summary_newest.get("last_datetime"),
+                    "trade_count": int(summary_newest.get("trade_count") or 0),
+                }
+    return {
+        "users": users,
+        "total": total,
+        "succeeded": succeeded,
+        "failed": failed,
+        "failure_pct": _pct(failed, total),
+        "trade_count": _latency_summary(trade_counts),
+        "newest_trade": newest_trade,
+    }
+
+
 async def _timed_load_markets(exchange) -> tuple[dict[str, Any], dict[str, Any]]:
     outcome = await _timed_call(exchange.load_markets())
     markets = outcome["value"] if outcome["ok"] and isinstance(outcome["value"], dict) else {}
@@ -1025,8 +1251,9 @@ async def probe_exchange_ticker_endpoints(
                     resolved_symbols[0],
                     None,
                     10,
-                    summary=summarize_collection,
+                    summary=summarize_my_trades,
                 )
+                repeat["fetch_my_trades_first_symbol"]["symbol"] = resolved_symbols[0]
                 emit_progress(
                     f"{repeat_label} fetch_my_trades(first symbol) "
                     f"{format_outcome(repeat['fetch_my_trades_first_symbol'])}",
@@ -1044,6 +1271,7 @@ async def probe_exchange_ticker_endpoints(
     out["account_critical_health"] = summarize_account_critical_probe_health(out)
     out["time_sync_health"] = summarize_time_sync_probe_health(out)
     out["candle_freshness_health"] = summarize_candle_freshness_probe_health(out)
+    out["fill_history_health"] = summarize_fill_history_probe_health(out)
     return out
 
 
@@ -1199,6 +1427,9 @@ async def async_main() -> int:
     )
     result["time_sync_health"] = summarize_time_sync_probe_collection(result["probes"])
     result["candle_freshness_health"] = summarize_candle_freshness_probe_collection(
+        result["probes"]
+    )
+    result["fill_history_health"] = summarize_fill_history_probe_collection(
         result["probes"]
     )
     out_path = Path(args.out) if args.out else Path("tmp") / f"ccxt_ticker_probe_{started_ms}.json"

--- a/tests/test_ticker_probe_tool.py
+++ b/tests/test_ticker_probe_tool.py
@@ -14,6 +14,9 @@ from tools.probe_ccxt_ticker_endpoints import (
     select_default_symbols,
     summarize_candle_freshness_probe_collection,
     summarize_candle_freshness_probe_health,
+    summarize_fill_history_probe_collection,
+    summarize_fill_history_probe_health,
+    summarize_my_trades,
     summarize_ohlcvs,
     summarize_account_critical_probe_collection,
     summarize_account_critical_probe_health,
@@ -303,7 +306,22 @@ async def test_probe_exchange_ticker_endpoints_records_all_endpoint_shapes():
             return []
 
         async def fetch_my_trades(self, symbol=None, since=None, limit=None):
-            return []
+            return [
+                {
+                    "id": "raw-trade-id-1",
+                    "order": "raw-order-id-1",
+                    "timestamp": 1_767_225_540_000,
+                    "symbol": symbol,
+                    "side": "buy",
+                },
+                {
+                    "id": "raw-trade-id-2",
+                    "orderId": "raw-order-id-2",
+                    "timestamp": 1_767_225_600_000,
+                    "symbol": symbol,
+                    "side": "sell",
+                },
+            ]
 
     exchange = FakeExchange()
 
@@ -334,6 +352,10 @@ async def test_probe_exchange_ticker_endpoints_records_all_endpoint_shapes():
     assert repeat["fetch_positions"]["ok"] is True
     assert repeat["fetch_open_orders_all"]["ok"] is True
     assert repeat["fetch_my_trades_first_symbol"]["ok"] is True
+    assert repeat["fetch_my_trades_first_symbol"]["symbol"] == "BTC/USDT:USDT"
+    assert repeat["fetch_my_trades_first_symbol"]["value"]["count"] == 2
+    assert repeat["fetch_my_trades_first_symbol"]["value"]["id_present_count"] == 2
+    assert repeat["fetch_my_trades_first_symbol"]["value"]["order_present_count"] == 2
     assert repeat["fetch_time"]["ok"] is True
     assert repeat["fetch_time"]["supported"] is True
     assert isinstance(repeat["fetch_time"]["clock_skew_ms"], int)
@@ -351,6 +373,16 @@ async def test_probe_exchange_ticker_endpoints_records_all_endpoint_shapes():
     assert out["account_critical_health"]["succeeded"] == 3
     assert out["account_critical_health"]["failed"] == 0
     assert out["account_critical_health"]["surfaces"]["balance"]["latency_ms"]["count"] == 1
+    assert out["fill_history_health"]["enabled"] is True
+    assert out["fill_history_health"]["total"] == 1
+    assert out["fill_history_health"]["succeeded"] == 1
+    assert out["fill_history_health"]["failed"] == 0
+    assert out["fill_history_health"]["latest"]["symbol"] == "BTC/USDT:USDT"
+    assert out["fill_history_health"]["latest"]["trade_count"] == 2
+    assert out["fill_history_health"]["latest"]["id_present_count"] == 2
+    assert out["fill_history_health"]["latest"]["order_present_count"] == 2
+    assert "raw-trade-id" not in str(out["fill_history_health"])
+    assert "raw-order-id" not in str(out["fill_history_health"])
     assert exchange.fetch_tickers_calls == [None, ["BTC/USDT:USDT", "ETH/USDT:USDT"]]
 
 
@@ -650,6 +682,171 @@ def test_candle_freshness_probe_collection_aggregates_users():
     assert collection["users"][1]["worst_symbol"] == "ETH/USDT:USDT"
 
 
+def test_summarize_my_trades_reports_shape_without_raw_ids():
+    summary = summarize_my_trades(
+        [
+            {
+                "id": "raw-fill-id-a",
+                "order": "raw-order-id-a",
+                "timestamp": 1_000_000,
+                "symbol": "BTC/USDT:USDT",
+                "side": "buy",
+                "info": {"secret": "not emitted"},
+            },
+            {
+                "id": "raw-fill-id-b",
+                "orderId": "raw-order-id-b",
+                "timestamp": 1_060_000,
+                "symbol": "ETH/USDT:USDT",
+                "side": "sell",
+            },
+            {"symbol": "ETH/USDT:USDT"},
+        ]
+    )
+
+    assert summary["count"] == 3
+    assert summary["dict_count"] == 3
+    assert summary["timestamp_count"] == 2
+    assert summary["missing_timestamp_count"] == 1
+    assert summary["first_timestamp"] == 1_000_000
+    assert summary["last_timestamp"] == 1_060_000
+    assert summary["symbol_count"] == 2
+    assert summary["symbols_sample"] == ["BTC/USDT:USDT", "ETH/USDT:USDT"]
+    assert summary["side_counts"] == {"buy": 1, "sell": 1}
+    assert summary["id_present_count"] == 2
+    assert summary["order_present_count"] == 2
+    assert "raw-fill-id" not in str(summary)
+    assert "raw-order-id" not in str(summary)
+    assert "not emitted" not in str(summary)
+
+
+def test_fill_history_probe_health_summarizes_success_failure_without_raw_errors():
+    summary = summarize_fill_history_probe_health(
+        {
+            "include_private": True,
+            "include_my_trades": True,
+            "repeats": [
+                {
+                    "fetch_my_trades_first_symbol": {
+                        "ok": True,
+                        "symbol": "BTC/USDT:USDT",
+                        "elapsed_ms": 12.0,
+                        "value": {
+                            "count": 2,
+                            "timestamp_count": 2,
+                            "missing_timestamp_count": 0,
+                            "first_timestamp": 1_000_000,
+                            "first_datetime": "1970-01-01T00:16:40",
+                            "last_timestamp": 1_060_000,
+                            "last_datetime": "1970-01-01T00:17:40",
+                            "symbol_count": 1,
+                            "side_counts": {"buy": 1, "sell": 1},
+                            "id_present_count": 2,
+                            "order_present_count": 2,
+                        },
+                    }
+                },
+                {
+                    "fetch_my_trades_first_symbol": {
+                        "ok": False,
+                        "symbol": "ETH/USDT:USDT",
+                        "elapsed_ms": 22.0,
+                        "error_type": "RequestTimeout",
+                        "error": "raw exchange error apiKey=SECRET should not appear",
+                    }
+                },
+            ],
+        }
+    )
+
+    assert summary["enabled"] is True
+    assert summary["total"] == 2
+    assert summary["succeeded"] == 1
+    assert summary["failed"] == 1
+    assert summary["failure_pct"] == pytest.approx(50.0)
+    assert summary["latency_ms"]["count"] == 2
+    assert summary["trade_count"]["max"] == 2.0
+    assert summary["error_types"] == {"RequestTimeout": 1}
+    assert summary["latest"]["ok"] is False
+    assert summary["latest"]["error_type"] == "RequestTimeout"
+    assert summary["newest_trade"]["symbol"] == "BTC/USDT:USDT"
+    assert summary["newest_trade"]["last_timestamp"] == 1_060_000
+    assert "raw exchange error" not in str(summary)
+    assert "SECRET" not in str(summary)
+
+
+def test_fill_history_probe_collection_aggregates_users():
+    collection = summarize_fill_history_probe_collection(
+        [
+            {
+                "user": "binance_01",
+                "exchange": "binance",
+                "fill_history_health": {
+                    "enabled": True,
+                    "total": 1,
+                    "succeeded": 1,
+                    "failed": 0,
+                    "failure_pct": 0.0,
+                    "latest": {
+                        "symbol": "BTC/USDT:USDT",
+                        "trade_count": 2,
+                    },
+                    "newest_trade": {
+                        "symbol": "BTC/USDT:USDT",
+                        "last_timestamp": 1_060_000,
+                        "last_datetime": "1970-01-01T00:17:40",
+                        "trade_count": 2,
+                    },
+                },
+            },
+            {
+                "user": "okx_01",
+                "exchange": "okx",
+                "fill_history_health": {
+                    "enabled": True,
+                    "total": 1,
+                    "succeeded": 0,
+                    "failed": 1,
+                    "failure_pct": 100.0,
+                    "latest": {
+                        "symbol": "ETH/USDT:USDT",
+                        "trade_count": 0,
+                    },
+                    "newest_trade": None,
+                },
+            },
+            {
+                "user": "paper_01",
+                "exchange": "paper",
+                "fill_history_health": {
+                    "enabled": False,
+                    "total": 0,
+                    "succeeded": 0,
+                    "failed": 0,
+                    "failure_pct": None,
+                    "latest": None,
+                    "newest_trade": None,
+                },
+            },
+        ]
+    )
+
+    assert collection["total"] == 2
+    assert collection["succeeded"] == 1
+    assert collection["failed"] == 1
+    assert collection["failure_pct"] == pytest.approx(50.0)
+    assert collection["trade_count"]["count"] == 2
+    assert collection["newest_trade"] == {
+        "user": "binance_01",
+        "exchange": "binance",
+        "symbol": "BTC/USDT:USDT",
+        "last_timestamp": 1_060_000,
+        "last_datetime": "1970-01-01T00:17:40",
+        "trade_count": 2,
+    }
+    assert collection["users"][2]["enabled"] is False
+
+
 @pytest.mark.asyncio
 async def test_time_sync_probe_uses_ccxt_capability_flag_for_unsupported_method():
     class FakeExchange:
@@ -889,3 +1086,5 @@ async def test_account_only_probe_skips_public_and_uses_open_orders_symbol_fallb
     assert out["account_critical_health"]["failed"] == 0
     assert out["candle_freshness_health"]["enabled"] is False
     assert out["candle_freshness_health"]["total_symbols"] == 0
+    assert out["fill_history_health"]["enabled"] is False
+    assert out["fill_history_health"]["total"] == 0


### PR DESCRIPTION
## Summary
- add no-extra-call fill_history_health summaries to ticker-endpoint-probe from the existing first-symbol fetch_my_trades probe
- summarize sample success/failure, latency, trade counts, newest timestamp, and shape without raw trade/order ids
- document that this is sample health only, not full fill-pagination coverage, and update the live ops backlog ledger

## Validation
- ./venv/bin/python -m pytest -q tests/test_ticker_probe_tool.py
- ./venv/bin/python -m compileall -q src/tools/probe_ccxt_ticker_endpoints.py tests/test_ticker_probe_tool.py
- git diff --check
- rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])" src/tools/probe_ccxt_ticker_endpoints.py tests/test_ticker_probe_tool.py