### PR TITLE
Add fill-history pagination sample to ticker probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added opt-in bounded fill-history pagination sampling to
+  `passivbot tool ticker-endpoint-probe` via `--fill-history-pages`, while
+  preserving the default single-call `fetch_my_trades(first symbol)` behavior.
 - Added no-extra-call rate-limit pressure estimates to
   `passivbot tool ticker-endpoint-probe`, derived from existing probe outcomes
   and CCXT rate-limit metadata.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -1556,6 +1556,19 @@ VPS5 deployment status:
   `private_call_count=5`, `concurrent_request_count=1`,
   `exchange_rate_limit_ms=50`, and `estimated_min_serial_ms=600`.
 
+### In Flight: Ticker Probe Fill Pagination Sample
+
+- Branch: `codex/v8-ticker-probe-fill-pagination-sample`.
+- Scope: read-only active exchange health probe.
+- Intended result: `passivbot tool ticker-endpoint-probe` keeps the default
+  one-call first-symbol `fetch_my_trades` sample, and adds opt-in bounded
+  pagination through `--fill-history-pages` and `--fill-history-page-limit`.
+  The probe records only page/count/timestamp/latency summaries and terminal
+  pagination reason, with no raw trade/order ids.
+- Validation target: focused ticker-probe tests, compileall, `git diff --check`,
+  touched-file silent-handling audit, reviewer approval, then a low-rate VPS5
+  authenticated probe after merge.
+
 ## Current Next Steps
 
 1. Continue Phase 5/6 by adding the next high-value event producer or debug

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -165,10 +165,12 @@ Related detailed plans:
    `candle_freshness_health`, derived from the existing OHLCV tail probe
    results without adding exchange calls. PR #745 adds `fill_history_health`,
    derived from the existing first-symbol `fetch_my_trades` sample without raw
-   trade/order ids or extra pagination calls.
+   trade/order ids or extra pagination calls. Branch
+   `codex/v8-ticker-probe-fill-pagination-sample` adds an opt-in bounded
+   `--fill-history-pages` sample while keeping the default one-call behavior.
 
    Add/refine explicit read-only probes for each configured exchange/account
-   before or during smoke: rate-limit behavior, full fill pagination coverage,
+   before or during smoke: deeper bounded fill-pagination samples,
    and basic endpoint latency. The passive smoke report now also exposes top-level
    remote-call health
    success/failure/throttle totals and a filtered

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -178,10 +178,12 @@ Ticker probes inspect CCXT ticker support and latency without placing orders:
   summary for the read-only balance, positions, and open-orders endpoints required before live
   exchange actions. Use `--account-only` for the lower-impact balance/positions/open-orders probe,
   which still loads markets to resolve an open-orders fallback symbol, or `--skip-my-trades` to
-  omit the fill-history endpoint. When the existing first-symbol `fetch_my_trades` probe is enabled,
+  omit the fill-history endpoint. When the first-symbol `fetch_my_trades` probe is enabled,
   `fill_history_health` summarizes that sample's success, latency, trade count, newest timestamp,
-  and shape without emitting raw trade/order ids; it does not perform extra pagination coverage
-  calls. `rate_limit_health` estimates request pressure from the calls the probe already made,
+  page count, terminal pagination reason, and shape without emitting raw trade/order ids. The default
+  `--fill-history-pages=1` keeps the low-impact single-call behavior; raising it performs a bounded,
+  explicit pagination sample for coverage diagnostics. `rate_limit_health` estimates request pressure
+  from the calls the probe already made,
   including public/private/concurrent call counts and CCXT `rateLimit` metadata; it is a planning
   estimate, not proof of exchange-side rate-limit consumption. The probe also includes
   `time_sync_health` from read-only `fetch_time` clock-skew checks when the exchange supports it;

--- a/src/tools/probe_ccxt_ticker_endpoints.py
+++ b/src/tools/probe_ccxt_ticker_endpoints.py
@@ -717,6 +717,18 @@ def summarize_fill_history_probe_health(probe: dict[str, Any]) -> dict[str, Any]
                 "symbol": outcome.get("symbol") if isinstance(outcome, dict) else None,
                 "elapsed_ms": elapsed_ms,
                 "error_type": error_type,
+                "call_count": int(outcome.get("call_count") or 0)
+                if isinstance(outcome, dict)
+                else 0,
+                "requested_pages": int(outcome.get("requested_pages") or 0)
+                if isinstance(outcome, dict)
+                else 0,
+                "page_count": int(outcome.get("page_count") or 0)
+                if isinstance(outcome, dict)
+                else 0,
+                "terminal_reason": outcome.get("terminal_reason")
+                if isinstance(outcome, dict)
+                else None,
             }
             continue
         value = outcome.get("value")
@@ -738,6 +750,11 @@ def summarize_fill_history_probe_health(probe: dict[str, Any]) -> dict[str, Any]
             "ok": True,
             "symbol": outcome.get("symbol"),
             "elapsed_ms": elapsed_ms,
+            "call_count": int(outcome.get("call_count") or 0),
+            "requested_pages": int(outcome.get("requested_pages") or 0),
+            "page_limit": int(outcome.get("page_limit") or 0),
+            "page_count": int(outcome.get("page_count") or 0),
+            "terminal_reason": outcome.get("terminal_reason"),
             "trade_count": trade_count,
             "timestamp_count": int(value.get("timestamp_count") or 0),
             "missing_timestamp_count": int(value.get("missing_timestamp_count") or 0),
@@ -799,6 +816,9 @@ def summarize_fill_history_probe_collection(probes: list[dict[str, Any]]) -> dic
             "failure_pct": summary.get("failure_pct"),
             "latest_symbol": latest.get("symbol"),
             "latest_trade_count": int(latest.get("trade_count") or 0),
+            "latest_page_count": int(latest.get("page_count") or 0),
+            "latest_call_count": int(latest.get("call_count") or 0),
+            "latest_terminal_reason": latest.get("terminal_reason"),
             "newest_trade_timestamp": (
                 summary_newest.get("last_timestamp") if summary_newest else None
             ),
@@ -849,6 +869,9 @@ def _non_negative_float(value: Any) -> float | None:
 def _probe_outcome_call_count(outcome: Any) -> int:
     if not isinstance(outcome, dict) or bool(outcome.get("skipped")):
         return 0
+    call_count = outcome.get("call_count")
+    if isinstance(call_count, int) and not isinstance(call_count, bool) and call_count >= 0:
+        return int(call_count)
     return 1
 
 
@@ -1248,6 +1271,109 @@ async def _timed_method(exchange, method_name: str, *args, summary=None) -> dict
     return outcome
 
 
+async def _fetch_my_trades_sample(
+    exchange,
+    symbol: str,
+    *,
+    pages: int,
+    page_limit: int,
+) -> dict[str, Any]:
+    requested_pages = max(1, int(pages))
+    limit = max(1, int(page_limit))
+    started_ms = int(utc_ms())
+    page_summaries: list[dict[str, Any]] = []
+    combined_trades: list[Any] = []
+    since: int | None = None
+    terminal_reason = "requested_pages_exhausted"
+    call_count = 0
+    for page_index in range(requested_pages):
+        outcome = await _timed_call(exchange.fetch_my_trades(symbol, since, limit))
+        call_count += 1
+        page_summary: dict[str, Any] = {
+            "page_index": page_index,
+            "since": since,
+            "limit": limit,
+            "ok": bool(outcome.get("ok")),
+            "elapsed_ms": _elapsed_ms(outcome),
+        }
+        if not outcome.get("ok"):
+            page_summary["error_type"] = str(outcome.get("error_type") or "unknown")
+            page_summaries.append(page_summary)
+            elapsed_ms = int(max(0, utc_ms() - started_ms))
+            return {
+                "ok": False,
+                "elapsed_ms": elapsed_ms,
+                "symbol": symbol,
+                "call_count": call_count,
+                "requested_pages": requested_pages,
+                "page_limit": limit,
+                "page_count": len(page_summaries),
+                "pages": page_summaries,
+                "terminal_reason": "page_failed",
+                "error_type": outcome.get("error_type"),
+                "error": outcome.get("error"),
+                "value": summarize_my_trades(combined_trades),
+            }
+        trades = outcome.get("value")
+        if not isinstance(trades, list):
+            page_summary["ok"] = False
+            page_summary["error_type"] = "ValueError"
+            page_summaries.append(page_summary)
+            elapsed_ms = int(max(0, utc_ms() - started_ms))
+            return {
+                "ok": False,
+                "elapsed_ms": elapsed_ms,
+                "symbol": symbol,
+                "call_count": call_count,
+                "requested_pages": requested_pages,
+                "page_limit": limit,
+                "page_count": len(page_summaries),
+                "pages": page_summaries,
+                "terminal_reason": "invalid_page_shape",
+                "error_type": "ValueError",
+                "error": "fetch_my_trades returned non-list page",
+                "value": summarize_my_trades(combined_trades),
+            }
+        page_value = summarize_my_trades(trades)
+        page_summary.update(
+            {
+                "trade_count": int(page_value.get("count") or 0),
+                "timestamp_count": int(page_value.get("timestamp_count") or 0),
+                "first_timestamp": page_value.get("first_timestamp"),
+                "first_datetime": page_value.get("first_datetime"),
+                "last_timestamp": page_value.get("last_timestamp"),
+                "last_datetime": page_value.get("last_datetime"),
+            }
+        )
+        page_summaries.append(page_summary)
+        combined_trades.extend(trades)
+        last_ts = _int_timestamp(page_value.get("last_timestamp"))
+        if len(trades) < limit:
+            terminal_reason = "short_page"
+            break
+        if last_ts is None:
+            terminal_reason = "missing_page_timestamp"
+            break
+        next_since = last_ts + 1
+        if since is not None and next_since <= since:
+            terminal_reason = "non_advancing_timestamp"
+            break
+        since = next_since
+    elapsed_ms = int(max(0, utc_ms() - started_ms))
+    return {
+        "ok": True,
+        "elapsed_ms": elapsed_ms,
+        "symbol": symbol,
+        "call_count": call_count,
+        "requested_pages": requested_pages,
+        "page_limit": limit,
+        "page_count": len(page_summaries),
+        "pages": page_summaries,
+        "terminal_reason": terminal_reason,
+        "value": summarize_my_trades(combined_trades),
+    }
+
+
 def _with_present_fields(out: dict[str, Any], **fields) -> dict[str, Any]:
     for key, value in fields.items():
         if value is not None:
@@ -1322,6 +1448,8 @@ async def probe_exchange_ticker_endpoints(
     include_ohlcv: bool = True,
     include_my_trades: bool = True,
     include_time_sync: bool = True,
+    fill_history_pages: int = 1,
+    fill_history_page_limit: int = 10,
     progress: bool = False,
 ) -> dict[str, Any]:
     exchange_id = getattr(exchange, "id", str(user_info.get("exchange") or ""))
@@ -1350,6 +1478,8 @@ async def probe_exchange_ticker_endpoints(
         "include_ohlcv": bool(include_ohlcv),
         "include_my_trades": bool(include_my_trades),
         "include_time_sync": bool(include_time_sync),
+        "fill_history_pages": max(1, int(fill_history_pages)),
+        "fill_history_page_limit": max(1, int(fill_history_page_limit)),
         "sleep_between_seconds": float(sleep_between_seconds),
         "exchange_rate_limit_ms": getattr(exchange, "rateLimit", None),
         "exchange_enable_rate_limit": getattr(exchange, "enableRateLimit", None),
@@ -1513,16 +1643,17 @@ async def probe_exchange_ticker_endpoints(
                 enabled=progress,
             )
             if include_my_trades:
-                emit_progress(f"{repeat_label} fetch_my_trades(first symbol)", enabled=progress)
-                repeat["fetch_my_trades_first_symbol"] = await _timed_method(
-                    exchange,
-                    "fetch_my_trades",
-                    resolved_symbols[0],
-                    None,
-                    10,
-                    summary=summarize_my_trades,
+                emit_progress(
+                    f"{repeat_label} fetch_my_trades(first symbol) "
+                    f"pages={max(1, int(fill_history_pages))}",
+                    enabled=progress,
                 )
-                repeat["fetch_my_trades_first_symbol"]["symbol"] = resolved_symbols[0]
+                repeat["fetch_my_trades_first_symbol"] = await _fetch_my_trades_sample(
+                    exchange,
+                    resolved_symbols[0],
+                    pages=max(1, int(fill_history_pages)),
+                    page_limit=max(1, int(fill_history_page_limit)),
+                )
                 emit_progress(
                     f"{repeat_label} fetch_my_trades(first symbol) "
                     f"{format_outcome(repeat['fetch_my_trades_first_symbol'])}",
@@ -1561,6 +1692,8 @@ async def probe_user_ticker_endpoints(
     include_ohlcv: bool = True,
     include_my_trades: bool = True,
     include_time_sync: bool = True,
+    fill_history_pages: int = 1,
+    fill_history_page_limit: int = 10,
     progress: bool = False,
 ) -> dict[str, Any]:
     emit_progress(f"[{user}] loading api key config", enabled=progress)
@@ -1587,6 +1720,8 @@ async def probe_user_ticker_endpoints(
             include_ohlcv=include_ohlcv,
             include_my_trades=include_my_trades,
             include_time_sync=include_time_sync,
+            fill_history_pages=fill_history_pages,
+            fill_history_page_limit=fill_history_page_limit,
             progress=progress,
         )
     finally:
@@ -1629,6 +1764,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="skip authenticated fetch_my_trades probe",
     )
     parser.add_argument(
+        "--fill-history-pages",
+        type=int,
+        default=1,
+        help=(
+            "bounded first-symbol fetch_my_trades page sample; default 1 preserves "
+            "the low-impact single-call probe"
+        ),
+    )
+    parser.add_argument(
+        "--fill-history-page-limit",
+        type=int,
+        default=10,
+        help="per-page fetch_my_trades limit for the bounded pagination sample",
+    )
+    parser.add_argument(
         "--skip-time-sync",
         action="store_true",
         help="skip read-only fetch_time clock-skew probe",
@@ -1667,6 +1817,8 @@ async def async_main() -> int:
         "include_ohlcv": not bool(args.skip_ohlcv) and not bool(args.account_only),
         "include_my_trades": not bool(args.skip_my_trades) and not bool(args.account_only),
         "include_time_sync": not bool(args.skip_time_sync),
+        "fill_history_pages": max(1, int(args.fill_history_pages)),
+        "fill_history_page_limit": max(1, int(args.fill_history_page_limit)),
         "probes": [],
     }
     for user in users:
@@ -1687,6 +1839,8 @@ async def async_main() -> int:
                 include_ohlcv=not bool(args.skip_ohlcv) and not bool(args.account_only),
                 include_my_trades=not bool(args.skip_my_trades) and not bool(args.account_only),
                 include_time_sync=not bool(args.skip_time_sync),
+                fill_history_pages=max(1, int(args.fill_history_pages)),
+                fill_history_page_limit=max(1, int(args.fill_history_page_limit)),
                 progress=not bool(args.quiet),
             )
         )

--- a/tests/test_ticker_probe_tool.py
+++ b/tests/test_ticker_probe_tool.py
@@ -405,6 +405,118 @@ async def test_probe_exchange_ticker_endpoints_records_all_endpoint_shapes():
     assert exchange.fetch_tickers_calls == [None, ["BTC/USDT:USDT", "ETH/USDT:USDT"]]
 
 
+@pytest.mark.asyncio
+async def test_probe_exchange_ticker_endpoints_opt_in_fill_history_pagination():
+    class FakeExchange:
+        id = "fake"
+        rateLimit = 100
+        enableRateLimit = True
+        has = {
+            "fetchBalance": True,
+            "fetchMyTrades": True,
+            "fetchOpenOrders": True,
+            "fetchPositions": True,
+        }
+
+        def __init__(self):
+            self.my_trades_calls = []
+
+        async def load_markets(self):
+            return {
+                "BTC/USDT:USDT": {
+                    "base": "BTC",
+                    "quote": "USDT",
+                    "active": True,
+                    "swap": True,
+                    "linear": True,
+                }
+            }
+
+        async def fetch_balance(self):
+            return {"USDT": {"total": 100.0}}
+
+        async def fetch_positions(self):
+            return []
+
+        async def fetch_open_orders(self):
+            return []
+
+        async def fetch_my_trades(self, symbol=None, since=None, limit=None):
+            self.my_trades_calls.append((symbol, since, limit))
+            if since is None:
+                return [
+                    {
+                        "id": "raw-trade-id-1",
+                        "order": "raw-order-id-1",
+                        "timestamp": 1_000,
+                        "symbol": symbol,
+                        "side": "buy",
+                    },
+                    {
+                        "id": "raw-trade-id-2",
+                        "order": "raw-order-id-2",
+                        "timestamp": 2_000,
+                        "symbol": symbol,
+                        "side": "sell",
+                    },
+                ]
+            return [
+                {
+                    "id": "raw-trade-id-3",
+                    "order": "raw-order-id-3",
+                    "timestamp": 3_000,
+                    "symbol": symbol,
+                    "side": "buy",
+                }
+            ]
+
+    exchange = FakeExchange()
+
+    out = await probe_exchange_ticker_endpoints(
+        exchange,
+        user="fake_user",
+        user_info={"quote": "USDT"},
+        symbols=[],
+        coins=[],
+        quote=None,
+        max_symbols=1,
+        repeats=1,
+        sleep_between_seconds=0.0,
+        include_public=False,
+        include_order_book=False,
+        include_ohlcv=False,
+        include_time_sync=False,
+        fill_history_pages=3,
+        fill_history_page_limit=2,
+    )
+
+    outcome = out["repeats"][0]["fetch_my_trades_first_symbol"]
+    assert exchange.my_trades_calls == [
+        ("BTC/USDT:USDT", None, 2),
+        ("BTC/USDT:USDT", 2_001, 2),
+    ]
+    assert outcome["ok"] is True
+    assert outcome["call_count"] == 2
+    assert outcome["requested_pages"] == 3
+    assert outcome["page_limit"] == 2
+    assert outcome["page_count"] == 2
+    assert outcome["terminal_reason"] == "short_page"
+    assert outcome["value"]["count"] == 3
+    assert outcome["value"]["id_present_count"] == 3
+    assert outcome["value"]["order_present_count"] == 3
+    assert out["fill_history_health"]["latest"]["call_count"] == 2
+    assert out["fill_history_health"]["latest"]["page_count"] == 2
+    assert out["fill_history_health"]["latest"]["terminal_reason"] == "short_page"
+    assert out["fill_history_health"]["latest"]["trade_count"] == 3
+    assert out["rate_limit_health"]["observed_call_count"] == 6
+    assert out["rate_limit_health"]["private_call_count"] == 5
+    assert out["rate_limit_health"]["endpoint_counts"]["fetch_my_trades_first_symbol"] == 2
+    assert "raw-trade-id" not in str(out)
+    assert "raw-order-id" not in str(out)
+    assert "raw-trade-id" not in str(out["fill_history_health"])
+    assert "raw-order-id" not in str(out["fill_history_health"])
+
+
 def test_account_critical_probe_health_summarizes_failures_without_raw_errors():
     summary = summarize_account_critical_probe_health(
         {


### PR DESCRIPTION
Adds an opt-in bounded first-symbol fetch_my_trades pagination sample to passivbot tool ticker-endpoint-probe. Defaults remain low-impact: --fill-history-pages=1 and --fill-history-page-limit=10 preserve the existing single-call behavior. Raising pages records only bounded page/count/timestamp/latency summaries and terminal pagination reason; no raw trade/order ids are emitted. rate_limit_health now counts the actual my-trades call_count for paginated samples.\n\nValidation:\n- ./venv/bin/python -m pytest -q tests/test_ticker_probe_tool.py\n- ./venv/bin/python -m compileall -q src/tools/probe_ccxt_ticker_endpoints.py tests/test_ticker_probe_tool.py\n- git diff --check\n- touched-file silent-handling scan: no matches