### PR TITLE
Record fill-pagination probe progress

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-27.
 
 Current `origin/v8` logging-overhaul head:
 
-- `74270454a` merge of PR #747, `Add ticker probe rate limit health`.
+- `16c25149` merge of PR #749, `Add fill-history pagination sample to ticker probe`.
 
 Current review gate:
 
@@ -1556,18 +1556,28 @@ VPS5 deployment status:
   `private_call_count=5`, `concurrent_request_count=1`,
   `exchange_rate_limit_ms=50`, and `estimated_min_serial_ms=600`.
 
-### In Flight: Ticker Probe Fill Pagination Sample
+### PR #749: Ticker Probe Fill Pagination Sample
 
 - Branch: `codex/v8-ticker-probe-fill-pagination-sample`.
 - Scope: read-only active exchange health probe.
-- Intended result: `passivbot tool ticker-endpoint-probe` keeps the default
+- Result: `passivbot tool ticker-endpoint-probe` keeps the default
   one-call first-symbol `fetch_my_trades` sample, and adds opt-in bounded
   pagination through `--fill-history-pages` and `--fill-history-page-limit`.
   The probe records only page/count/timestamp/latency summaries and terminal
   pagination reason, with no raw trade/order ids.
-- Validation target: focused ticker-probe tests, compileall, `git diff --check`,
-  touched-file silent-handling audit, reviewer approval, then a low-rate VPS5
-  authenticated probe after merge.
+- Review evidence: Claude and Hermes approved; CI was green; focused
+  ticker-probe tests, compileall, `git diff --check`, and the touched-file
+  silent-handling audit passed before merge.
+- VPS5 evidence: deployed without bot restart because the slice is read-only
+  probe tooling. A 5-minute smoke and a settled 3-minute smoke at `16c25149`
+  reported all five expected bots running, no hard failures, no log hard
+  matches, no failed remote calls, no failed account-critical remote calls, and
+  clean tracked repository state. A one-repeat authenticated Binance probe for
+  `BTC/USDT:USDT` with `--fill-history-pages 2 --fill-history-page-limit 2`
+  validated `fill_history_health.total=1`, `succeeded=1`, `failed=0`,
+  `latest_call_count=1`, `latest_page_count=1`,
+  `latest_terminal_reason=short_page`, and
+  `rate_limit_health.endpoint_counts.fetch_my_trades_first_symbol=1`.
 
 ## Current Next Steps
 
@@ -1580,7 +1590,9 @@ VPS5 deployment status:
    `--account-only` plus symbol fallback for open-orders. PR #741 added
    clock-skew health. PR #743 added candle freshness health. PR #745 added
    fill-history sample health. PR #747 added rate-limit pressure estimates.
-   Remaining useful slices include full fill pagination coverage.
+   PR #749 added opt-in bounded fill pagination sampling. Remaining useful
+   slices include basic endpoint latency and deeper exchange-specific coverage
+   checks.
 3. Use the persistent non-hard EMA readiness / staged-execution degradation
    visible in VPS5 smokes as the next candidate for targeted readiness
    diagnostics or a narrow fix. PRs #679 and #682 made the problem groups easier

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -165,13 +165,14 @@ Related detailed plans:
    `candle_freshness_health`, derived from the existing OHLCV tail probe
    results without adding exchange calls. PR #745 adds `fill_history_health`,
    derived from the existing first-symbol `fetch_my_trades` sample without raw
-   trade/order ids or extra pagination calls. Branch
-   `codex/v8-ticker-probe-fill-pagination-sample` adds an opt-in bounded
-   `--fill-history-pages` sample while keeping the default one-call behavior.
+   trade/order ids or extra pagination calls. PR #747 added
+   `rate_limit_health` request-pressure estimates. PR #749 added an opt-in
+   bounded `--fill-history-pages` sample while keeping the default one-call
+   behavior.
 
    Add/refine explicit read-only probes for each configured exchange/account
-   before or during smoke: deeper bounded fill-pagination samples,
-   and basic endpoint latency. The passive smoke report now also exposes top-level
+   before or during smoke: basic endpoint latency and deeper exchange-specific
+   coverage checks. The passive smoke report now also exposes top-level
    remote-call health
    success/failure/throttle totals and a filtered
    `account_critical_remote_call_health` summary for a quick operator scan.
@@ -465,6 +466,7 @@ Related detailed plans:
 | 2026-06-27 | #6 Exchange health and contract probes | PR #743 / `1fe1292b` | Added `ticker-endpoint-probe` `candle_freshness_health` summaries from existing 1m OHLCV tail results, including worst-symbol age and current-incomplete counts without extra exchange calls | Rate-limit/fill-pagination probes |
 | 2026-06-27 | #6 Exchange health and contract probes | PR #745 / `4130155e` | Added `ticker-endpoint-probe` `fill_history_health` summaries from the existing first-symbol `fetch_my_trades` sample, including success/failure, latency, trade count, newest timestamp, and shape without raw trade/order ids or extra pagination calls; VPS5 authenticated Binance probe validated total=1, succeeded=1, failed=0 | Rate-limit/full fill-pagination coverage probes |
 | 2026-06-27 | #6 Exchange health and contract probes | PR #747 / `74270454` | Added `ticker-endpoint-probe` `rate_limit_health` request-pressure estimates from existing probe outcomes and CCXT rate-limit metadata, without adding exchange calls or enforcing throttles; VPS5 authenticated Binance probe validated observed_call_count=12, private=5, public=6, concurrent=1 | Full fill-pagination coverage probes |
+| 2026-06-27 | #6 Exchange health and contract probes | PR #749 / `16c25149` | Added opt-in bounded first-symbol `fetch_my_trades` pagination sampling to `ticker-endpoint-probe`, keeping default one-call behavior; VPS5 authenticated Binance probe validated pages=2/limit=2 request shape, short-page stop, call_count=1, and rate-limit accounting | Basic endpoint latency and deeper exchange-specific coverage checks |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |


### PR DESCRIPTION
Docs-only progress update after PR #749. Records Claude/Hermes approval, green CI, VPS5 deploy at 16c25149, smoke evidence, and the low-rate Binance fill-pagination probe result.\n\nValidation:\n- git diff --check