### PR TITLE
Add endpoint latency health to ticker probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added no-extra-call endpoint latency health summaries to
+  `passivbot tool ticker-endpoint-probe`, derived from existing probe outcomes.
 - Added opt-in bounded fill-history pagination sampling to
   `passivbot tool ticker-endpoint-probe` via `--fill-history-pages`, while
   preserving the default single-call `fetch_my_trades(first symbol)` behavior.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -1593,6 +1593,10 @@ VPS5 deployment status:
    PR #749 added opt-in bounded fill pagination sampling. Remaining useful
    slices include basic endpoint latency and deeper exchange-specific coverage
    checks.
+   Branch `codex/v8-ticker-probe-endpoint-latency-health` adds
+   `endpoint_latency_health` summaries from existing probe outcomes, including
+   open-orders fallback attempts and fill-history pages, without adding exchange
+   calls.
 3. Use the persistent non-hard EMA readiness / staged-execution degradation
    visible in VPS5 smokes as the next candidate for targeted readiness
    diagnostics or a narrow fix. PRs #679 and #682 made the problem groups easier

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -168,11 +168,14 @@ Related detailed plans:
    trade/order ids or extra pagination calls. PR #747 added
    `rate_limit_health` request-pressure estimates. PR #749 added an opt-in
    bounded `--fill-history-pages` sample while keeping the default one-call
-   behavior.
+   behavior. Branch `codex/v8-ticker-probe-endpoint-latency-health` adds
+   endpoint latency summaries from existing probe outcomes, including
+   open-orders fallback attempts and fill-history pages, without adding exchange
+   calls.
 
    Add/refine explicit read-only probes for each configured exchange/account
-   before or during smoke: basic endpoint latency and deeper exchange-specific
-   coverage checks. The passive smoke report now also exposes top-level
+   before or during smoke: deeper exchange-specific coverage checks. The
+   passive smoke report now also exposes top-level
    remote-call health
    success/failure/throttle totals and a filtered
    `account_critical_remote_call_health` summary for a quick operator scan.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -185,7 +185,9 @@ Ticker probes inspect CCXT ticker support and latency without placing orders:
   explicit pagination sample for coverage diagnostics. `rate_limit_health` estimates request pressure
   from the calls the probe already made,
   including public/private/concurrent call counts and CCXT `rateLimit` metadata; it is a planning
-  estimate, not proof of exchange-side rate-limit consumption. The probe also includes
+  estimate, not proof of exchange-side rate-limit consumption. `endpoint_latency_health` groups
+  already-recorded endpoint attempts by endpoint, including open-orders fallback attempts and
+  fill-history pages, with success/failure counts and latency summaries. The probe also includes
   `time_sync_health` from read-only `fetch_time` clock-skew checks when the exchange supports it;
   use `--skip-time-sync` to omit that call. When OHLCV probing is enabled,
   `candle_freshness_health` summarizes the existing 1m candle tail results without making

--- a/src/tools/probe_ccxt_ticker_endpoints.py
+++ b/src/tools/probe_ccxt_ticker_endpoints.py
@@ -29,6 +29,23 @@ ACCOUNT_CRITICAL_ENDPOINTS = {
     "positions": "fetch_positions",
     "open_orders": "fetch_open_orders_all",
 }
+ENDPOINT_LATENCY_CATEGORIES = {
+    "load_markets": "market_metadata",
+    "fetch_time": "time_sync",
+    "fetch_tickers_all": "public",
+    "fetch_tickers_symbols": "public",
+    "fetch_ticker_sequential": "public",
+    "fetch_ticker_concurrent": "public",
+    "fetch_bids_asks_all": "public",
+    "fetch_bids_asks_symbols": "public",
+    "fetch_order_book_sequential": "public",
+    "fetch_order_book_concurrent": "public",
+    "fetch_ohlcv_1m_tail": "public",
+    "fetch_balance": "private",
+    "fetch_positions": "private",
+    "fetch_open_orders": "private",
+    "fetch_my_trades_first_symbol": "private",
+}
 
 
 def select_default_symbols(
@@ -1126,6 +1143,288 @@ def summarize_rate_limit_probe_collection(probes: list[dict[str, Any]]) -> dict[
     }
 
 
+def _endpoint_latency_entry(endpoint: str, category: str | None = None) -> dict[str, Any]:
+    return {
+        "category": category or ENDPOINT_LATENCY_CATEGORIES.get(endpoint, "unknown"),
+        "total": 0,
+        "succeeded": 0,
+        "failed": 0,
+        "latencies": [],
+        "error_types": Counter(),
+        "latest": None,
+    }
+
+
+def _record_endpoint_latency(
+    endpoints: dict[str, dict[str, Any]],
+    *,
+    endpoint: str,
+    outcome: Any,
+    category: str | None = None,
+) -> None:
+    if not isinstance(outcome, dict) or bool(outcome.get("skipped")):
+        return
+    elapsed = _elapsed_ms(outcome)
+    entry = endpoints.setdefault(
+        endpoint,
+        _endpoint_latency_entry(endpoint, category=category),
+    )
+    entry["total"] += 1
+    if elapsed is not None:
+        entry["latencies"].append(elapsed)
+    ok = bool(outcome.get("ok"))
+    if ok:
+        entry["succeeded"] += 1
+        entry["latest"] = {"ok": True, "elapsed_ms": elapsed}
+        return
+    entry["failed"] += 1
+    error_type = str(outcome.get("error_type") or "unknown")
+    entry["error_types"][error_type] += 1
+    entry["latest"] = {
+        "ok": False,
+        "elapsed_ms": elapsed,
+        "error_type": error_type,
+    }
+
+
+def _record_symbol_endpoint_latencies(
+    endpoints: dict[str, dict[str, Any]],
+    *,
+    endpoint: str,
+    outcome: Any,
+    category: str | None = None,
+) -> None:
+    if not isinstance(outcome, dict) or bool(outcome.get("skipped")):
+        return
+    symbols = outcome.get("symbols")
+    if not isinstance(symbols, dict):
+        _record_endpoint_latency(
+            endpoints,
+            endpoint=endpoint,
+            outcome=outcome,
+            category=category,
+        )
+        return
+    for symbol_outcome in symbols.values():
+        _record_endpoint_latency(
+            endpoints,
+            endpoint=endpoint,
+            outcome=symbol_outcome,
+            category=category,
+        )
+
+
+def _record_open_orders_endpoint_latencies(
+    endpoints: dict[str, dict[str, Any]],
+    outcome: Any,
+) -> None:
+    if not isinstance(outcome, dict) or bool(outcome.get("skipped")):
+        return
+    attempts = outcome.get("attempts")
+    if not isinstance(attempts, dict):
+        _record_endpoint_latency(
+            endpoints,
+            endpoint="fetch_open_orders",
+            outcome=outcome,
+            category="private",
+        )
+        return
+    if isinstance(attempts.get("all_symbols"), dict):
+        _record_endpoint_latency(
+            endpoints,
+            endpoint="fetch_open_orders",
+            outcome=attempts["all_symbols"],
+            category="private",
+        )
+    symbol_attempt = attempts.get("symbol")
+    if isinstance(symbol_attempt, dict) and isinstance(symbol_attempt.get("outcome"), dict):
+        _record_endpoint_latency(
+            endpoints,
+            endpoint="fetch_open_orders",
+            outcome=symbol_attempt["outcome"],
+            category="private",
+        )
+
+
+def _record_my_trades_endpoint_latencies(
+    endpoints: dict[str, dict[str, Any]],
+    outcome: Any,
+) -> None:
+    if not isinstance(outcome, dict) or bool(outcome.get("skipped")):
+        return
+    pages = outcome.get("pages")
+    if not isinstance(pages, list):
+        _record_endpoint_latency(
+            endpoints,
+            endpoint="fetch_my_trades_first_symbol",
+            outcome=outcome,
+            category="private",
+        )
+        return
+    for page in pages:
+        _record_endpoint_latency(
+            endpoints,
+            endpoint="fetch_my_trades_first_symbol",
+            outcome=page,
+            category="private",
+        )
+
+
+def _finalize_endpoint_latency_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    total = int(entry["total"])
+    failed = int(entry["failed"])
+    return {
+        "category": entry["category"],
+        "total": total,
+        "succeeded": int(entry["succeeded"]),
+        "failed": failed,
+        "failure_pct": _pct(failed, total),
+        "latency_ms": _latency_summary(list(entry["latencies"])),
+        "error_types": dict(sorted(entry["error_types"].items())),
+        "latest": entry["latest"],
+    }
+
+
+def _record_probe_endpoint_latencies(
+    endpoints: dict[str, dict[str, Any]],
+    probe: dict[str, Any],
+) -> None:
+    _record_endpoint_latency(
+        endpoints,
+        endpoint="load_markets",
+        outcome=probe.get("load_markets"),
+        category="market_metadata",
+    )
+    repeats = probe.get("repeats") if isinstance(probe.get("repeats"), list) else []
+    for repeat in repeats:
+        if not isinstance(repeat, dict):
+            continue
+        for endpoint in (
+            "fetch_time",
+            "fetch_tickers_all",
+            "fetch_tickers_symbols",
+            "fetch_bids_asks_all",
+            "fetch_bids_asks_symbols",
+            "fetch_balance",
+            "fetch_positions",
+        ):
+            _record_endpoint_latency(
+                endpoints,
+                endpoint=endpoint,
+                outcome=repeat.get(endpoint),
+            )
+        for endpoint in (
+            "fetch_ticker_sequential",
+            "fetch_ticker_concurrent",
+            "fetch_order_book_sequential",
+            "fetch_order_book_concurrent",
+            "fetch_ohlcv_1m_tail",
+        ):
+            _record_symbol_endpoint_latencies(
+                endpoints,
+                endpoint=endpoint,
+                outcome=repeat.get(endpoint),
+            )
+        _record_open_orders_endpoint_latencies(
+            endpoints,
+            repeat.get("fetch_open_orders_all"),
+        )
+        _record_my_trades_endpoint_latencies(
+            endpoints,
+            repeat.get("fetch_my_trades_first_symbol"),
+        )
+
+
+def summarize_endpoint_latency_probe_health(probe: dict[str, Any]) -> dict[str, Any]:
+    """Summarize endpoint latency from already-recorded probe outcomes."""
+    endpoints: dict[str, dict[str, Any]] = {}
+    _record_probe_endpoint_latencies(endpoints, probe)
+    finalized = {
+        endpoint: _finalize_endpoint_latency_entry(entry)
+        for endpoint, entry in sorted(endpoints.items())
+        if int(entry.get("total") or 0) > 0
+    }
+    total = sum(int(entry["total"]) for entry in finalized.values())
+    succeeded = sum(int(entry["succeeded"]) for entry in finalized.values())
+    failed = sum(int(entry["failed"]) for entry in finalized.values())
+    slowest = None
+    for endpoint, entry in finalized.items():
+        latency = entry.get("latency_ms") if isinstance(entry.get("latency_ms"), dict) else {}
+        max_latency = _round_ms_value(latency.get("max"))
+        if max_latency is None:
+            continue
+        candidate = {
+            "endpoint": endpoint,
+            "category": entry.get("category"),
+            "max_latency_ms": max_latency,
+        }
+        if slowest is None or max_latency > float(slowest.get("max_latency_ms") or -1.0):
+            slowest = candidate
+    return {
+        "total": total,
+        "succeeded": succeeded,
+        "failed": failed,
+        "failure_pct": _pct(failed, total),
+        "endpoint_count": len(finalized),
+        "slowest": slowest,
+        "endpoints": finalized,
+    }
+
+
+def summarize_endpoint_latency_probe_collection(probes: list[dict[str, Any]]) -> dict[str, Any]:
+    users = []
+    endpoint_totals: dict[str, dict[str, Any]] = {}
+    for probe in probes:
+        summary = probe.get("endpoint_latency_health")
+        if not isinstance(summary, dict):
+            summary = summarize_endpoint_latency_probe_health(probe)
+        slowest = summary.get("slowest") if isinstance(summary.get("slowest"), dict) else {}
+        users.append(
+            {
+                "user": probe.get("user"),
+                "exchange": probe.get("exchange"),
+                "total": int(summary.get("total") or 0),
+                "succeeded": int(summary.get("succeeded") or 0),
+                "failed": int(summary.get("failed") or 0),
+                "failure_pct": summary.get("failure_pct"),
+                "slowest_endpoint": slowest.get("endpoint"),
+                "slowest_max_latency_ms": slowest.get("max_latency_ms"),
+            }
+        )
+        _record_probe_endpoint_latencies(endpoint_totals, probe)
+    finalized = {
+        endpoint: _finalize_endpoint_latency_entry(entry)
+        for endpoint, entry in sorted(endpoint_totals.items())
+        if int(entry.get("total") or 0) > 0
+    }
+    total = sum(user["total"] for user in users)
+    succeeded = sum(user["succeeded"] for user in users)
+    failed = sum(user["failed"] for user in users)
+    slowest = None
+    for endpoint, entry in finalized.items():
+        latency = entry.get("latency_ms") if isinstance(entry.get("latency_ms"), dict) else {}
+        max_latency = _round_ms_value(latency.get("max"))
+        if max_latency is None:
+            continue
+        candidate = {
+            "endpoint": endpoint,
+            "category": entry.get("category"),
+            "max_latency_ms": max_latency,
+        }
+        if slowest is None or max_latency > float(slowest.get("max_latency_ms") or -1.0):
+            slowest = candidate
+    return {
+        "users": users,
+        "total": total,
+        "succeeded": succeeded,
+        "failed": failed,
+        "failure_pct": _pct(failed, total),
+        "endpoint_count": len(finalized),
+        "slowest": slowest,
+        "endpoints": finalized,
+    }
+
+
 async def _timed_load_markets(exchange) -> tuple[dict[str, Any], dict[str, Any]]:
     outcome = await _timed_call(exchange.load_markets())
     markets = outcome["value"] if outcome["ok"] and isinstance(outcome["value"], dict) else {}
@@ -1673,6 +1972,7 @@ async def probe_exchange_ticker_endpoints(
     out["candle_freshness_health"] = summarize_candle_freshness_probe_health(out)
     out["fill_history_health"] = summarize_fill_history_probe_health(out)
     out["rate_limit_health"] = summarize_rate_limit_probe_health(out)
+    out["endpoint_latency_health"] = summarize_endpoint_latency_probe_health(out)
     return out
 
 
@@ -1857,6 +2157,9 @@ async def async_main() -> int:
         result["probes"]
     )
     result["rate_limit_health"] = summarize_rate_limit_probe_collection(
+        result["probes"]
+    )
+    result["endpoint_latency_health"] = summarize_endpoint_latency_probe_collection(
         result["probes"]
     )
     out_path = Path(args.out) if args.out else Path("tmp") / f"ccxt_ticker_probe_{started_ms}.json"

--- a/tests/test_ticker_probe_tool.py
+++ b/tests/test_ticker_probe_tool.py
@@ -14,6 +14,8 @@ from tools.probe_ccxt_ticker_endpoints import (
     select_default_symbols,
     summarize_candle_freshness_probe_collection,
     summarize_candle_freshness_probe_health,
+    summarize_endpoint_latency_probe_collection,
+    summarize_endpoint_latency_probe_health,
     summarize_fill_history_probe_collection,
     summarize_fill_history_probe_health,
     summarize_my_trades,
@@ -402,6 +404,13 @@ async def test_probe_exchange_ticker_endpoints_records_all_endpoint_shapes():
         "contains_concurrent_batches",
         "contains_authenticated_calls",
     ]
+    assert out["endpoint_latency_health"]["total"] == 20
+    assert out["endpoint_latency_health"]["failed"] == 0
+    assert out["endpoint_latency_health"]["endpoint_count"] == 15
+    assert out["endpoint_latency_health"]["endpoints"]["fetch_ticker_concurrent"]["total"] == 2
+    assert out["endpoint_latency_health"]["endpoints"]["fetch_open_orders"]["total"] == 1
+    assert out["endpoint_latency_health"]["endpoints"]["fetch_my_trades_first_symbol"]["total"] == 1
+    assert out["endpoint_latency_health"]["slowest"]["endpoint"] in out["endpoint_latency_health"]["endpoints"]
     assert exchange.fetch_tickers_calls == [None, ["BTC/USDT:USDT", "ETH/USDT:USDT"]]
 
 
@@ -511,6 +520,9 @@ async def test_probe_exchange_ticker_endpoints_opt_in_fill_history_pagination():
     assert out["rate_limit_health"]["observed_call_count"] == 6
     assert out["rate_limit_health"]["private_call_count"] == 5
     assert out["rate_limit_health"]["endpoint_counts"]["fetch_my_trades_first_symbol"] == 2
+    assert out["endpoint_latency_health"]["total"] == 6
+    assert out["endpoint_latency_health"]["endpoints"]["fetch_my_trades_first_symbol"]["total"] == 2
+    assert out["endpoint_latency_health"]["endpoints"]["fetch_my_trades_first_symbol"]["failed"] == 0
     assert "raw-trade-id" not in str(out)
     assert "raw-order-id" not in str(out)
     assert "raw-trade-id" not in str(out["fill_history_health"])
@@ -554,6 +566,103 @@ def test_account_critical_probe_health_summarizes_failures_without_raw_errors():
     assert summary["surfaces"]["open_orders"]["latest"]["error_type"] == "RuntimeError"
     assert "secret=leak" not in str(summary)
     assert "raw payload" not in str(summary)
+
+
+def test_endpoint_latency_probe_health_summarizes_existing_outcomes_only():
+    summary = summarize_endpoint_latency_probe_health(
+        {
+            "load_markets": {"ok": True, "elapsed_ms": 10.0},
+            "repeats": [
+                {
+                    "fetch_tickers_all": {"ok": True, "elapsed_ms": 20.0},
+                    "fetch_ticker_concurrent": {
+                        "symbols": {
+                            "BTC/USDT:USDT": {"ok": True, "elapsed_ms": 30.0},
+                            "ETH/USDT:USDT": {
+                                "ok": False,
+                                "elapsed_ms": 40.0,
+                                "error_type": "RequestTimeout",
+                                "error": "raw exchange error should not appear",
+                            },
+                        }
+                    },
+                    "fetch_open_orders_all": {
+                        "attempts": {
+                            "all_symbols": {
+                                "ok": False,
+                                "elapsed_ms": 0.5,
+                                "error_type": "ExchangeError",
+                                "error": "raw warning should not appear",
+                            },
+                            "symbol": {
+                                "symbol": "BTC/USDT:USDT",
+                                "outcome": {"ok": True, "elapsed_ms": 12.5},
+                            },
+                        }
+                    },
+                    "fetch_my_trades_first_symbol": {
+                        "pages": [
+                            {"ok": True, "elapsed_ms": 5.0, "trade_count": 2},
+                            {"ok": True, "elapsed_ms": 6.0, "trade_count": 1},
+                        ]
+                    },
+                }
+            ],
+        }
+    )
+
+    assert summary["total"] == 8
+    assert summary["succeeded"] == 6
+    assert summary["failed"] == 2
+    assert summary["failure_pct"] == pytest.approx(25.0)
+    assert summary["endpoints"]["fetch_ticker_concurrent"]["total"] == 2
+    assert summary["endpoints"]["fetch_ticker_concurrent"]["failed"] == 1
+    assert summary["endpoints"]["fetch_ticker_concurrent"]["error_types"] == {
+        "RequestTimeout": 1
+    }
+    assert summary["endpoints"]["fetch_open_orders"]["total"] == 2
+    assert summary["endpoints"]["fetch_my_trades_first_symbol"]["total"] == 2
+    assert summary["slowest"]["endpoint"] == "fetch_ticker_concurrent"
+    assert "raw exchange error" not in str(summary)
+    assert "raw warning" not in str(summary)
+
+
+def test_endpoint_latency_probe_collection_aggregates_raw_probe_latencies():
+    collection = summarize_endpoint_latency_probe_collection(
+        [
+            {
+                "user": "binance_01",
+                "exchange": "binance",
+                "load_markets": {"ok": True, "elapsed_ms": 10.0},
+                "repeats": [{"fetch_balance": {"ok": True, "elapsed_ms": 20.0}}],
+            },
+            {
+                "user": "kucoin_01",
+                "exchange": "kucoinfutures",
+                "load_markets": {"ok": True, "elapsed_ms": 30.0},
+                "repeats": [
+                    {
+                        "fetch_balance": {
+                            "ok": False,
+                            "elapsed_ms": 40.0,
+                            "error_type": "RequestTimeout",
+                        }
+                    }
+                ],
+            },
+        ]
+    )
+
+    assert collection["total"] == 4
+    assert collection["succeeded"] == 3
+    assert collection["failed"] == 1
+    assert collection["users"][0]["user"] == "binance_01"
+    assert collection["endpoints"]["load_markets"]["total"] == 2
+    assert collection["endpoints"]["fetch_balance"]["total"] == 2
+    assert collection["endpoints"]["fetch_balance"]["failed"] == 1
+    assert collection["endpoints"]["fetch_balance"]["error_types"] == {
+        "RequestTimeout": 1
+    }
 
 
 def test_account_critical_probe_collection_aggregates_user_summaries():


### PR DESCRIPTION
Adds endpoint_latency_health to passivbot tool ticker-endpoint-probe. It derives success/failure counts and latency summaries from existing probe outcomes only; no new exchange calls are added. Open-orders symbol fallback attempts and fill-history pages are counted as endpoint attempts, so the latency view aligns with rate-limit pressure evidence.\n\nValidation:\n- ./venv/bin/python -m pytest -q tests/test_ticker_probe_tool.py\n- ./venv/bin/python -m compileall -q src/tools/probe_ccxt_ticker_endpoints.py tests/test_ticker_probe_tool.py\n- git diff --check\n- touched-file silent-handling scan: no matches