### PR TITLE
Record endpoint-latency probe progress

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-27.
 
 Current `origin/v8` logging-overhaul head:
 
-- `16c25149` merge of PR #749, `Add fill-history pagination sample to ticker probe`.
+- `4eef3572` merge of PR #751, `Add endpoint latency health to ticker probe`.
 
 Current review gate:
 
@@ -1590,13 +1590,10 @@ VPS5 deployment status:
    `--account-only` plus symbol fallback for open-orders. PR #741 added
    clock-skew health. PR #743 added candle freshness health. PR #745 added
    fill-history sample health. PR #747 added rate-limit pressure estimates.
-   PR #749 added opt-in bounded fill pagination sampling. Remaining useful
-   slices include basic endpoint latency and deeper exchange-specific coverage
-   checks.
-   Branch `codex/v8-ticker-probe-endpoint-latency-health` adds
+   PR #749 added opt-in bounded fill pagination sampling. PR #751 added
    `endpoint_latency_health` summaries from existing probe outcomes, including
-   open-orders fallback attempts and fill-history pages, without adding exchange
-   calls.
+   open-orders fallback attempts and fill-history pages. Remaining useful
+   slices include deeper exchange-specific coverage checks.
 3. Use the persistent non-hard EMA readiness / staged-execution degradation
    visible in VPS5 smokes as the next candidate for targeted readiness
    diagnostics or a narrow fix. PRs #679 and #682 made the problem groups easier

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -168,7 +168,7 @@ Related detailed plans:
    trade/order ids or extra pagination calls. PR #747 added
    `rate_limit_health` request-pressure estimates. PR #749 added an opt-in
    bounded `--fill-history-pages` sample while keeping the default one-call
-   behavior. Branch `codex/v8-ticker-probe-endpoint-latency-health` adds
+   behavior. PR #751 added
    endpoint latency summaries from existing probe outcomes, including
    open-orders fallback attempts and fill-history pages, without adding exchange
    calls.
@@ -470,6 +470,7 @@ Related detailed plans:
 | 2026-06-27 | #6 Exchange health and contract probes | PR #745 / `4130155e` | Added `ticker-endpoint-probe` `fill_history_health` summaries from the existing first-symbol `fetch_my_trades` sample, including success/failure, latency, trade count, newest timestamp, and shape without raw trade/order ids or extra pagination calls; VPS5 authenticated Binance probe validated total=1, succeeded=1, failed=0 | Rate-limit/full fill-pagination coverage probes |
 | 2026-06-27 | #6 Exchange health and contract probes | PR #747 / `74270454` | Added `ticker-endpoint-probe` `rate_limit_health` request-pressure estimates from existing probe outcomes and CCXT rate-limit metadata, without adding exchange calls or enforcing throttles; VPS5 authenticated Binance probe validated observed_call_count=12, private=5, public=6, concurrent=1 | Full fill-pagination coverage probes |
 | 2026-06-27 | #6 Exchange health and contract probes | PR #749 / `16c25149` | Added opt-in bounded first-symbol `fetch_my_trades` pagination sampling to `ticker-endpoint-probe`, keeping default one-call behavior; VPS5 authenticated Binance probe validated pages=2/limit=2 request shape, short-page stop, call_count=1, and rate-limit accounting | Basic endpoint latency and deeper exchange-specific coverage checks |
+| 2026-06-27 | #6 Exchange health and contract probes | PR #751 / `4eef3572` | Added `ticker-endpoint-probe` `endpoint_latency_health` summaries from existing probe outcomes, including open-orders fallback attempts and fill-history pages; VPS5 Binance probe validated endpoint_count=11, total=12, slowest=load_markets, and expected Binance open-orders all-symbol warning classification | Deeper exchange-specific coverage checks |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |


### PR DESCRIPTION
Docs-only progress update after PR #751. Records reviewer approval, VPS5 deploy at 4eef3572, smoke evidence, and the low-rate Binance endpoint_latency_health probe result.\n\nValidation:\n- git diff --check