### PR TITLE
Add EMA gate modes for trailing martingale entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,14 @@ All notable user-facing changes will be documented in this file.
   preventing a leading non-finite candle sample from poisoning log-range EMAs.
 - Added `strategy_eq_underwater_pct_mean` and `strategy_eq_underwater_pct_median`
   backtest metrics for average and median daily-worst strategy-equity drawdown.
+- Added `bot.<side>.strategy.trailing_martingale.entry.ema_gate_mode` with
+  `disabled`, `all`, `initial`, and `reentry` modes for controlling which entry
+  orders are EMA-gated. The fixed enum is not optimized; one-way flat
+  long-vs-short tie-breaking still requires EMA bands even when emitted entry
+  EMA gating is disabled.
+- Added `bot.<side>.unstuck.ema_gating_enabled` as a fixed auto-unstuck toggle.
+  When false, auto-unstuck skips the EMA trigger while keeping loss allowance,
+  exposure threshold, and sizing checks intact.
 - Changed the v8 default backtest candle interval to 1 minute and added
   `bot.<side>.risk.we_excess_allowance_mode`. V8 defaults to bounded excess
   allowance; migrated v7 trailing-grid configs also force v7-absent entry

--- a/docs/ai/features/strategy_runtime.md
+++ b/docs/ai/features/strategy_runtime.md
@@ -69,9 +69,31 @@ Entries and closes use threshold/retracement fields.
 Entry thresholds and retracements are multiplicative distances. Positive volatility or wallet
 exposure weights widen them.
 
+`bot.<side>.strategy.trailing_martingale.entry.ema_gate_mode` controls which entry orders are
+capped/floored by the EMA entry band:
+
+- `disabled`: no emitted entry order is capped/floored by EMA. Flat initial entries rest at current
+  best bid/ask; re-entries use normal threshold/retracement logic.
+- `all`: initial entries, partial initial entries, and re-entries are capped/floored by EMA.
+- `initial`: normal initial and partial initial entries are capped/floored by EMA. Re-entries are
+  not EMA capped/floored. This is the default and preserves the previous v8 behavior.
+- `reentry`: flat initial entries are not capped/floored by EMA; re-entries are capped/floored by
+  EMA.
+
+The value is fixed config, not an optimizer parameter. In one-way mode, if both sides are flat and
+both long and short are otherwise eligible, the long-vs-short tie-break still uses the EMA entry
+band distance even when `ema_gate_mode = "disabled"`. Candles and EMA bands are therefore required
+for that tie-break, and missing EMA inputs must fail loudly.
+
 Close thresholds are additive so they can intentionally cross through break-even or negative markup
 as wallet exposure rises. Close retracement is volatility-weighted and intentionally has no
 wallet-exposure modifier.
+
+Auto-unstuck has its own EMA trigger toggle:
+`bot.<side>.unstuck.ema_gating_enabled`. It defaults to `true`. When false, auto-unstuck skips the
+EMA trigger/readiness check but still requires `unstuck.enabled`, loss allowance, exposure
+threshold, close sizing, and valid market/exchange inputs. The toggle does not add independent
+unstuck EMA spans.
 
 ## Live/Backtest Market Slippage Boundary
 

--- a/docs/config.bot.md
+++ b/docs/config.bot.md
@@ -41,8 +41,12 @@ entry_retracement_we_term = (wel / wel_base) * entry.retracement_we_weight
 entry_retracement_multiplier = max(1, 1 + entry_retracement_vol_term + entry_retracement_we_term)
 
 initial_price(pside) =
-    long  : min(best_bid, EMA_low * (1 - entry_initial_ema_dist))
-    short : max(best_ask, EMA_high * (1 + entry_initial_ema_dist))
+    if entry.ema_gate_mode gates initial entries:
+        long  : min(best_bid, EMA_low * (1 - entry_initial_ema_dist))
+        short : max(best_ask, EMA_high * (1 + entry_initial_ema_dist))
+    else:
+        long  : best_bid
+        short : best_ask
 
 initial_qty(balance) =
     max(min_qty,
@@ -58,6 +62,10 @@ next_entry_price(pside) =
     long  : pos.price * (1 - effective_entry_threshold)
     short : pos.price * (1 + effective_entry_threshold)
 
+if entry.ema_gate_mode gates re-entries:
+    next_entry_price(long)  = min(next_entry_price(long), EMA_low * (1 - entry_initial_ema_dist))
+    next_entry_price(short) = max(next_entry_price(short), EMA_high * (1 + entry_initial_ema_dist))
+
 next_entry_qty(last_fill_qty) =
     last_fill_qty * entry.double_down_factor
 ```
@@ -72,6 +80,11 @@ next_entry_qty(last_fill_qty) =
   order is emitted after retracement confirmation.
 * Re-entries are only normal or cropped. Near the effective exposure cap, the bot keeps the
   current order literal instead of pulling future size forward into an inflated terminal step.
+* `entry.ema_gate_mode` is fixed config, not optimized. `initial` is the default and preserves the
+  previous behavior. `disabled` gates no entries, `all` gates initial, partial-initial, and
+  re-entry orders, and `reentry` gates re-entries only.
+* In one-way mode, if both sides are flat and otherwise eligible, the long-vs-short tie-break still
+  uses EMA-band distance even when `entry.ema_gate_mode = "disabled"`. Missing EMA inputs fail.
 
 Trailing extrema are reset for the coin+pside after any fill. Passivbot tracks its own trailing
 state from 1m OHLCVs and does not use exchange-native trailing order types.
@@ -118,6 +131,10 @@ V8 strategy contract.
 
 Auto unstuck is controlled by `bot.<side>.unstuck.enabled`. When disabled, the
 unstuck thresholds remain in the config but do not create orders.
+
+`bot.<side>.unstuck.ema_gating_enabled` controls only the EMA trigger/readiness check for
+auto-unstuck. It defaults to `true`. When false, auto-unstuck may trigger without EMA bands, but it
+still requires loss allowance, exposure threshold, close sizing, and valid market/exchange inputs.
 
 When aggregated realised PnL falls below the peak by more than
 `unstuck_loss_allowance_pct * total_wallet_exposure_limit`, one position at a time is

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -267,6 +267,12 @@ Clean migrations write canonical v8 shape with `live.strategy_kind = "trailing_g
   - Long initial entry/short unstuck close prices are lower EMA band minus offset.
   - Short initial entry/long unstuck close prices are upper EMA band plus offset.
   - See `ema_span_0`/`ema_span_1`.
+- **strategy.trailing_martingale.entry.ema_gate_mode**:
+  - Fixed enum, not optimized. Allowed values are `disabled`, `all`, `initial`, and `reentry`.
+  - `initial` is the default: normal initial and partial initial entries are EMA-gated; re-entries are not.
+  - `disabled` places initial/partial-initial entries at best bid/ask and leaves re-entries to normal threshold/retracement logic.
+  - `all` gates initial, partial-initial, and re-entry orders. `reentry` gates re-entries only.
+  - In one-way mode, when both sides are flat and otherwise eligible, EMA bands are still required for the long-vs-short tie-break even if entry EMA gating is disabled.
 - **strategy.trailing_martingale.entry.initial_qty_pct**:
   - `initial_entry_cost = balance * wallet_exposure_limit * initial_qty_pct`
   - This is the initial sizing fraction used by min-effective-cost checks when
@@ -311,6 +317,9 @@ If a position is stuck, the bot uses profits from other positions to realize los
   - Distance from EMA band to place unstucking order:
     - `long_unstuck_close_price = upper_EMA_band * (1 + unstuck_ema_dist)`
     - `short_unstuck_close_price = lower_EMA_band * (1 - unstuck_ema_dist)`
+- **unstuck.ema_gating_enabled**:
+  - Fixed boolean toggle for the auto-unstuck EMA trigger. Default is `true`.
+  - When `false`, auto-unstuck skips the EMA trigger/readiness check but still requires loss allowance, exposure threshold, close sizing, and valid market/exchange inputs.
 - **unstuck_loss_allowance_pct**:
   - Weighted percentage below past peak balance to allow losses.
   - `loss_allowance = past_peak_balance * (1 - unstuck_loss_allowance_pct * total_wallet_exposure_limit)`

--- a/docs/plans/ema_entry_gate_mode_plan.md
+++ b/docs/plans/ema_entry_gate_mode_plan.md
@@ -1,0 +1,501 @@
+# EMA Entry Gate Mode Plan
+
+Branch: `v8`
+
+## Goal
+
+Make EMA entry gating configurable for `trailing_martingale` entries instead of hard-wiring it to
+initial entry orders only.
+
+Current behavior:
+
+- Long initial entries are priced at or below the lower EMA band:
+  `min(best_bid, ema_lower * (1 - entry.initial_ema_dist))`.
+- Short initial entries are priced at or above the upper EMA band:
+  `max(best_ask, ema_upper * (1 + entry.initial_ema_dist))`.
+- Long and short reentries are based on position price, threshold, retracement, wallet exposure,
+  volatility, and best bid/ask, without an EMA-band cap/floor.
+
+Target behavior: add one explicit config mode that decides which entry order classes receive that
+same EMA-band cap/floor.
+
+## Proposed Config
+
+Add this field under each side's active `trailing_martingale` entry config:
+
+```text
+bot.<side>.strategy.trailing_martingale.entry.ema_gate_mode
+```
+
+Canonical values:
+
+- `disabled`: no entry order is EMA gated.
+- `initial`: only initial entry order types are EMA gated. This is the current behavior and should
+  be the default.
+- `reentry`: initial entry order types are not EMA gated; all non-initial entry order types are EMA
+  gated.
+- `all`: every entry order type is EMA gated.
+
+Use `reentry`, not `re-entry` or `re_entry`, as the canonical value. Do not add aliases unless the
+branch explicitly decides to support them.
+
+`ema_gate_mode` is fixed config, not an optimizer parameter. This follows the v8 optimizer rule for
+categorical and boolean policy fields: enums and bools stay fixed from the base/anchor config, while
+only numeric strategy/risk fields are optimizer-bound candidates. Examples of fixed fields include
+`hsl.enabled`, `risk.position_exposure_enforcer_enabled`,
+`risk.total_exposure_enforcer_enabled`, `risk.total_exposure_enforcer_policy`,
+`risk.total_exposure_entry_gate_enabled`, `risk.we_excess_allowance_mode`, and
+`unstuck.enabled`.
+
+Default:
+
+```json
+{
+  "entry": {
+    "ema_gate_mode": "initial"
+  }
+}
+```
+
+`entry.initial_ema_dist` remains the offset used by the EMA gate. When a mode does not gate an
+order class, `initial_ema_dist` is ignored for that order class.
+
+## Order Classification
+
+Treat these as initial entry order types:
+
+- `EntryInitialNormalLong`
+- `EntryInitialPartialLong`
+- `EntryInitialNormalShort`
+- `EntryInitialPartialShort`
+
+Treat these as reentry order types:
+
+- `EntryGridNormalLong`
+- `EntryGridCroppedLong`
+- `EntryTrailingNormalLong`
+- `EntryTrailingCroppedLong`
+- `EntryGridNormalShort`
+- `EntryGridCroppedShort`
+- `EntryTrailingNormalShort`
+- `EntryTrailingCroppedShort`
+
+`initial` and `reentry` should follow order type semantics, not just `position.size == 0.0`. The
+current code can emit an `EntryInitialPartial*` order while a small position already exists; that
+order should still count as `initial`.
+
+## Pricing Rules
+
+Define side-specific EMA gate prices:
+
+```text
+long_ema_gate_price  = min(best_bid, ema_lower * (1 - entry.initial_ema_dist))
+short_ema_gate_price = max(best_ask, ema_upper * (1 + entry.initial_ema_dist))
+```
+
+After normal entry price calculation, apply the gate only if the selected mode gates that order
+class:
+
+```text
+long_final_price  = min(normal_entry_price, long_ema_gate_price)
+short_final_price = max(normal_entry_price, short_ema_gate_price)
+```
+
+This means:
+
+- `disabled`: initial longs are placed at `best_bid`; initial shorts are placed at `best_ask`.
+  Reentries keep their current non-EMA threshold/retracement prices.
+- `initial`: preserves current initial and initial-partial behavior. Reentries keep their current
+  non-EMA threshold/retracement prices.
+- `reentry`: initial and initial-partial orders are placed at touch, while grid/trailing reentries
+  are additionally capped/floored by the EMA gate.
+- `all`: initial, initial-partial, grid, and trailing entries are capped/floored by the EMA gate.
+
+Do not make the EMA gate part of the trailing trigger condition itself. Threshold and retracement
+state should still decide whether a trailing reentry is eligible; the EMA gate only constrains the
+price of the emitted entry order after eligibility is known.
+
+Keep current price-step rounding direction:
+
+- Long gate target rounds down.
+- Short gate target rounds up.
+- Final recursive entry expansion still runs through the existing quantization step.
+
+## Entry Expansion Effects
+
+Recursive expansion in `calc_entries_long()` and `calc_entries_short()` should keep its existing
+stop rules:
+
+- stop on zero qty;
+- stop if a trailing order was emitted after at least one previous entry;
+- stop if two adjacent generated entries have the same price.
+
+With `all` or `reentry`, EMA gating may collapse multiple reentry candidates to the same gated
+price. That should be accepted and handled by the existing duplicate-price break rather than
+worked around with new state.
+
+## EMA Readiness Contract
+
+The mode must affect live/backtest input requirements. Do not claim EMA gating is disabled while
+still requiring EMA bands for that order class.
+
+EMA bands are required for entry generation only when the requested entry order class may be gated:
+
+| Mode | Flat initial entry | Initial partial | Reentry |
+|------|--------------------|-----------------|---------|
+| `disabled` | no | no | no |
+| `initial` | yes | yes | no |
+| `reentry` | no | no | yes |
+| `all` | yes | yes | yes |
+
+Other EMA consumers remain independent:
+
+- `unstuck` still requires EMA bands when enabled because unstuck uses `ema_band_upper/lower`.
+- One-way flat-side selection still requires candle/EMA readiness because it keeps using EMA-band
+  distance as the long-vs-short tie-breaker, even when `ema_gate_mode="disabled"` means the emitted
+  initial entry price itself is not EMA gated.
+- Any forager or other side-selection logic that ranks candidates by EMA distance must be treated
+  separately from entry-price gating and must declare its own EMA readiness requirement.
+- Do not pass fabricated EMA defaults into Rust for an order path that no longer requires EMA.
+  Either avoid deriving EMA bands for that path or make absence explicit in the Rust request shape.
+
+## One-Way Flat-Side Tie-Breaking
+
+Selected policy: keep EMA-band distance as a separate tie-break signal.
+
+In one-way mode, when both long and short are flat and both sides are otherwise eligible, Passivbot
+cannot place both initial entries at once. Today the tie-breaker uses EMA-band distance. If flat
+initial entry EMA gating is disabled, the bot should still use EMA-band distance to decide which
+side may place an initial entry.
+
+This is intentionally separate from entry-price gating:
+
+- `ema_gate_mode="disabled"` disables the EMA cap/floor on emitted initial entry prices.
+- It does not disable EMA use for one-way flat long-vs-short selection.
+- Therefore candlesticks and EMAs remain required in one-way mode when both sides are flat and both
+  sides need a tie-breaker.
+
+This must be documented in user-facing config docs to avoid the surprising interpretation that
+disabled entry EMA gating removes every candle/EMA dependency from flat initial entry selection.
+
+Alternatives considered:
+
+### 1. Explicit Fixed Side Priority
+
+Add a fixed non-optimizable policy such as `long`, `short`, or `auto_default_long` for the one-way
+flat-side tie-breaker. The default can preserve today's tie-break fallback preference for long when
+all else is equal.
+
+Pros:
+
+- Stateless and reproducible after restart.
+- Does not require EMA readiness when entry EMA gating is disabled.
+- Honest: it exposes that direction choice is policy, not a hidden signal.
+- Easy to test and reason about.
+
+Cons:
+
+- Arbitrary from a market-prediction perspective.
+- Can bias one-way mode toward one side for long periods unless the user configures it.
+
+Decision: rejected because it is convenient for implementation but creates trader-visible long/short
+bias.
+
+### 2. Keep EMA Distance As A Separate Tie-Break Signal
+
+Preserve the current EMA-distance side selection even when `ema_gate_mode` does not gate flat
+initial entries.
+
+Pros:
+
+- Keeps current directional behavior.
+- Uses an existing signal and avoids adding a new side-priority knob.
+- May choose the side closer to the strategy's existing EMA reference.
+
+Cons:
+
+- Still requires EMA readiness for flat one-way initial entries, even though entry prices are not
+  EMA gated.
+- Blurs the meaning of "EMA gating disabled" unless documented as "pricing disabled, tie-breaker
+  still EMA-based."
+- Stale/missing EMA can still block or alter one-way flat-side selection.
+
+Decision: selected. The separate candle/EMA readiness requirement is part of the contract.
+
+### 3. Risk-Capacity Tie-Break
+
+Choose the side with more available effective wallet exposure or fewer active positions under the
+current side-specific risk limits.
+
+Pros:
+
+- Uses existing risk state rather than adding a direction signal.
+- Helpful when long/short side limits differ or one side is already more constrained elsewhere.
+- Does not require EMA bands.
+
+Cons:
+
+- Often ties when both sides are flat and symmetric.
+- Not a directional signal; it chooses capacity, not expected opportunity.
+- Needs a deterministic fallback, likely option 1.
+
+### 4. Deterministic Rotation Or Hash
+
+Alternate side by candle timestamp, symbol index, or another deterministic stateless input.
+
+Pros:
+
+- Spreads entries across sides over time without random state.
+- Can be restart-reproducible if based only on exchange/config/time inputs.
+- Does not require EMA bands.
+
+Cons:
+
+- Still arbitrary and can flip desired side as time advances.
+- Timestamp-based rotation can cause confusing order churn near cycle boundaries.
+- Symbol-hash rotation is stable but not market-aware.
+
+### 5. Order-Book Microstructure Signal
+
+Choose using available market snapshot features such as spread, touch movement, or order-book
+imbalance if supplied by the exchange path.
+
+Pros:
+
+- Does not require candles or EMA bands.
+- At least attempts to use current market information.
+
+Cons:
+
+- Many existing order-book inputs are only best bid/ask, not full depth.
+- Very noisy and exchange-dependent.
+- Adds a new strategy signal with weak evidence and more live/backtest parity burden.
+
+### 6. Random Choice
+
+Randomly choose long or short when both sides tie.
+
+Pros:
+
+- Simple and avoids permanent directional bias.
+
+Cons:
+
+- Violates the stateless reproducibility requirement unless the randomness is derived from stable
+  inputs, in which case it becomes option 4.
+- Harder to debug and backtest/live-match.
+
+Recommendation: do not use random choice.
+
+## Auto-Unstuck EMA Gating
+
+Selected policy: add `bot.<side>.unstuck.ema_gating_enabled`.
+
+Current auto-unstuck behavior is independent from entry pricing but still EMA-dependent. In Rust,
+long unstuck requires current price to be at or above:
+
+```text
+ema_upper * (1 + unstuck.ema_dist)
+```
+
+Short unstuck requires current price to be at or below:
+
+```text
+ema_lower * (1 - unstuck.ema_dist)
+```
+
+The EMA bands are currently derived from the active strategy EMA spans, so changing entry
+`ema_gate_mode` must not accidentally change auto-unstuck readiness or trigger behavior.
+
+Auto-unstuck should get its own fixed boolean:
+
+```text
+bot.<side>.unstuck.ema_gating_enabled
+```
+
+Default: `true`.
+
+When `true`, preserve current behavior: auto-unstuck uses the strategy EMA bands plus
+`unstuck.ema_dist`.
+
+When `false`, auto-unstuck still requires its normal loss allowance, WEL threshold, close
+percentage, position, market price, and min-size inputs, but it does not require EMA bands and does
+not apply the EMA trigger. `unstuck.ema_dist` remains present but is moot while
+`unstuck.ema_gating_enabled=false`.
+
+This matches the broader v8 risk-config pattern: boolean fields enable or disable a policy, while
+numeric fields tune the policy when enabled.
+
+Alternatives considered:
+
+### A. Keep Current `unstuck.ema_dist` Only
+
+Users can approximate "always pass" EMA gating with a very permissive finite offset.
+
+Pros:
+
+- No new config.
+- Preserves current behavior exactly.
+- Keeps optimizer/config surface small.
+
+Cons:
+
+- Sentinel-style values are unclear and side-sensitive.
+- A value like `-1.0` is not a clean disable: for long it can make the target non-positive and skip
+  unstuck entirely, while for short it tends to make the condition permissive.
+- Operators cannot distinguish "wide EMA gate" from "EMA gate intentionally disabled."
+
+Decision: rejected as the documented disable mechanism.
+
+### B. Add `bot.<side>.unstuck.ema_gating_enabled`
+
+Add a fixed boolean, default `true`, that controls only the auto-unstuck EMA trigger. When `false`,
+auto-unstuck still requires its normal loss allowance, WEL threshold, close percentage, position,
+market price, and min-size inputs, but it does not require EMA bands for the unstuck trigger.
+
+Pros:
+
+- Clear operator intent.
+- Avoids sentinel offsets.
+- Lets live readiness skip EMA bands for unstuck when the gate is disabled.
+- Keeps entry EMA behavior and auto-unstuck behavior separate.
+
+Cons:
+
+- Adds one more fixed policy flag.
+- Needs explicit tests to prove unstuck still respects loss/risk constraints when EMA gating is off.
+
+Decision: selected.
+
+### C. Add Independent Unstuck EMA Spans
+
+Add separate unstuck EMA spans, for example under `bot.<side>.unstuck`, while keeping the existing
+strategy EMA spans for entry gating and strategy behavior.
+
+Pros:
+
+- Lets auto-unstuck use a risk-management horizon independent of entry timing.
+- Avoids forcing entry EMA tuning to also tune unstuck trigger sensitivity.
+- Conceptually clean if users want unstuck to react to slower or faster bands than entries.
+
+Cons:
+
+- Adds more numeric fields and therefore potentially more optimizer surface if allowed.
+- Requires additional EMA warmup/readiness plumbing in live and backtest.
+- Increases candle/indicator memory and parity test surface.
+- More scope than entry EMA gate mode and not needed to make `ema_gate_mode` coherent.
+
+Decision: not now. Do not include independent unstuck EMA spans in the first entry EMA gate patch.
+Consider them later only if backtests or live operations show that shared strategy EMA spans are a
+real limitation. If added later, decide explicitly whether they are optimizable numeric fields or
+fixed operational parameters.
+
+## Implementation Surfaces
+
+Rust should remain the source of truth for this behavior.
+
+Expected Rust changes:
+
+- Add an `EmaGateMode` enum, serialized as snake-case strings, near strategy parameter types in
+  `passivbot-rust/src/strategies/mod.rs`.
+- Add `ema_gate_mode: EmaGateMode` to `TrailingMartingaleEntryParams`.
+- Default missing `ema_gate_mode` to `Initial` for current-behavior preservation within v8.
+- Parse the new field in `passivbot-rust/src/python.rs::trailing_martingale_strategy_params_from_dict`.
+- Update entry price helpers in `passivbot-rust/src/entries.rs` so initial and reentry order paths
+  compute normal prices first, then apply the gate according to mode and order class.
+- Update orchestrator readiness in `passivbot-rust/src/orchestrator.rs` so EMA bands are required
+  only for modes/order classes that actually need them, plus existing non-entry EMA consumers.
+- Keep one-way flat-side EMA-distance tie-breaking as its own EMA consumer. It must still derive EMA
+  bands even when flat initial entry price gating is disabled.
+- Add `unstuck_ema_gating_enabled` to shared bot params, defaulting to true, and gate the
+  auto-unstuck EMA trigger/readiness on it.
+- Extend Rust strategy metadata in `passivbot-rust/src/strategies/spec.rs` so the config default is
+  Rust-owned. The current numeric `StrategyParameterSpec` is not enough for a string enum; add
+  non-optimizable enum/default metadata rather than reintroducing Python-owned strategy defaults.
+
+Expected Python/config changes:
+
+- Ensure formatted configs include
+  `bot.<side>.strategy.trailing_martingale.entry.ema_gate_mode`.
+- Ensure optimizer bound generation does not treat `ema_gate_mode` as a numeric optimizable
+  parameter. Keep all bool and enum policy fields fixed from the selected config/anchor.
+- Ensure optimizer bound generation does not treat `unstuck.ema_gating_enabled` as optimizable.
+- Ensure config normalization preserves the enum and rejects invalid values loudly.
+- Update example configs through the normal formatting/template path after Rust metadata exposes the
+  default.
+
+Expected docs changes:
+
+- Update `docs/ai/features/strategy_runtime.md` with the durable contract after implementation.
+- Update user-facing config docs or generated field references if this repo has a generated
+  strategy-field table for the current branch.
+- Update `CHANGELOG.md` under Unreleased because this is user-facing strategy behavior.
+
+## Testing Plan
+
+Rust unit tests:
+
+- `initial` preserves current long and short initial entry prices.
+- `disabled` places long initial at bid and short initial at ask.
+- `all` gates long grid reentry by `min(reentry_price, ema_gate_price)`.
+- `all` gates short grid reentry by `max(reentry_price, ema_gate_price)`.
+- `reentry` leaves initial entries at touch but gates grid/trailing reentries.
+- Initial partial orders follow initial-mode semantics.
+- Trailing reentry trigger eligibility is unchanged; only emitted price changes after eligibility.
+- Duplicate-price recursive expansion still terminates when EMA gating collapses adjacent reentries.
+
+Python/Rust boundary tests:
+
+- Config with `ema_gate_mode` reaches Rust as the expected enum.
+- Missing `ema_gate_mode` formats to `initial`.
+- Invalid mode raises with the full config path.
+- Strategy metadata exposes the enum default without adding a numeric optimizer bound.
+
+Integration/readiness tests:
+
+- With `disabled`, flat initial entries can be generated without EMA bands when no other requested
+  order class needs EMA.
+- With `reentry`, flat initial entries do not require EMA bands, but position reentries do.
+- With `initial` or `all`, flat initial entries still require EMA bands.
+- In one-way mode with both sides flat and otherwise eligible, `disabled` initial entry EMA gating
+  still requires EMA bands for the EMA-distance side tie-breaker.
+- The same one-way test proves EMA readiness is required for side selection but not for initial entry
+  price calculation.
+- Unstuck requires EMA bands when `unstuck.ema_gating_enabled=true`.
+- Unstuck does not require EMA bands for its own trigger when `unstuck.ema_gating_enabled=false`,
+  while still enforcing loss allowance, WEL threshold, close percentage, position, market price, and
+  min-size constraints.
+
+## Acceptance Criteria
+
+- Default formatted configs keep current behavior through `ema_gate_mode="initial"`.
+- Live and backtest order generation agree for all four modes.
+- No Python-side patch reimplements strategy pricing outside Rust.
+- No compatibility aliases are added for enum values unless explicitly approved.
+- Missing/invalid EMA inputs fail loudly only when the active order class or another active feature
+  requires EMA.
+- In one-way flat-side selection, EMA inputs are required for the side tie-breaker even when initial
+  entry price EMA gating is disabled.
+- Existing trailing_martingale configs either format with the new default or fail with an actionable
+  validation error; they do not silently change to `disabled`.
+
+## Resolved Decisions
+
+- `reentry` is the canonical spelling.
+- `ema_gate_mode` is fixed config, not optimizable.
+- All enum and boolean policy fields are fixed, including HSL, risk enforcer, risk policy, WEL
+  allowance mode, TWEL entry gate, and unstuck enabled flags.
+- `EntryInitialPartial*` counts as initial for EMA gate mode.
+- `disabled` means flat initial entries are emitted at current best bid/ask from the exchange
+  orderbook. Reentries continue to follow normal threshold/retracement trading logic.
+- One-way flat-side tie-breaking keeps using EMA-band distance, so candles/EMAs are still required
+  for that selection even when entry price EMA gating is disabled.
+- Auto-unstuck gets `bot.<side>.unstuck.ema_gating_enabled`, a fixed boolean defaulting to `true`.
+- Independent auto-unstuck EMA spans are out of scope for this patch.
+
+## Implementation Notes
+
+- Rust strategy metadata exposes `ema_gate_mode` through `fixed_parameters`, separate from numeric
+  optimizer `parameters`.
+- The one-way caveat should be worded explicitly: "entry EMA gate disabled" means emitted entry
+  pricing is not EMA capped/floored; one-way side selection may still require candles/EMAs.

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -940,6 +940,7 @@ fn test_trailing_martingale_params_value_from_flat(bot_params: &BotParams) -> se
         volatility_ema_span_1m: bot_params.entry_volatility_ema_span_1m,
         entry: crate::strategies::TrailingMartingaleEntryParams {
             double_down_factor: bot_params.entry_grid_double_down_factor,
+            ema_gate_mode: crate::strategies::EmaGateMode::Initial,
             initial_ema_dist: bot_params.entry_initial_ema_dist,
             initial_qty_pct: bot_params.entry_initial_qty_pct,
             threshold_base_pct: bot_params.entry_grid_spacing_pct,
@@ -6093,6 +6094,7 @@ mod tests {
             volatility_ema_span_1m: bot_params.entry_volatility_ema_span_1m,
             entry: TrailingMartingaleEntryParams {
                 double_down_factor: bot_params.entry_grid_double_down_factor,
+                ema_gate_mode: crate::strategies::EmaGateMode::Initial,
                 initial_ema_dist: bot_params.entry_initial_ema_dist,
                 initial_qty_pct: bot_params.entry_initial_qty_pct,
                 threshold_base_pct: bot_params.entry_grid_spacing_pct,

--- a/passivbot-rust/src/entries.rs
+++ b/passivbot-rust/src/entries.rs
@@ -127,6 +127,76 @@ fn calc_entry_retracement_multiplier(
     })
 }
 
+fn calc_initial_entry_price_bid(
+    exchange_params: &ExchangeParams,
+    state_params: &StateParams,
+    entry_params: &TrailingMartingaleEntryParams,
+) -> f64 {
+    if entry_params.ema_gate_mode.gates_initial() {
+        calc_ema_price_bid(
+            exchange_params.price_step,
+            state_params.order_book.bid,
+            state_params.ema_bands.lower,
+            entry_params.initial_ema_dist,
+        )
+    } else {
+        state_params.order_book.bid
+    }
+}
+
+fn calc_initial_entry_price_ask(
+    exchange_params: &ExchangeParams,
+    state_params: &StateParams,
+    entry_params: &TrailingMartingaleEntryParams,
+) -> f64 {
+    if entry_params.ema_gate_mode.gates_initial() {
+        calc_ema_price_ask(
+            exchange_params.price_step,
+            state_params.order_book.ask,
+            state_params.ema_bands.upper,
+            entry_params.initial_ema_dist,
+        )
+    } else {
+        state_params.order_book.ask
+    }
+}
+
+fn gate_reentry_price_bid(
+    price: f64,
+    exchange_params: &ExchangeParams,
+    state_params: &StateParams,
+    entry_params: &TrailingMartingaleEntryParams,
+) -> f64 {
+    if entry_params.ema_gate_mode.gates_reentry() {
+        price.min(calc_ema_price_bid(
+            exchange_params.price_step,
+            state_params.order_book.bid,
+            state_params.ema_bands.lower,
+            entry_params.initial_ema_dist,
+        ))
+    } else {
+        price
+    }
+}
+
+fn gate_reentry_price_ask(
+    price: f64,
+    exchange_params: &ExchangeParams,
+    state_params: &StateParams,
+    entry_params: &TrailingMartingaleEntryParams,
+) -> f64 {
+    if entry_params.ema_gate_mode.gates_reentry() {
+        price.max(calc_ema_price_ask(
+            exchange_params.price_step,
+            state_params.order_book.ask,
+            state_params.ema_bands.upper,
+            entry_params.initial_ema_dist,
+        ))
+    } else {
+        price
+    }
+}
+
 pub fn calc_cropped_reentry_qty(
     exchange_params: &ExchangeParams,
     bot_params: &BotParams,
@@ -292,12 +362,8 @@ pub fn calc_grid_entry_long(
     {
         return Order::default();
     }
-    let initial_entry_price = calc_ema_price_bid(
-        exchange_params.price_step,
-        state_params.order_book.bid,
-        state_params.ema_bands.lower,
-        entry_params.initial_ema_dist,
-    );
+    let initial_entry_price =
+        calc_initial_entry_price_bid(exchange_params, state_params, entry_params);
     if initial_entry_price <= exchange_params.price_step {
         return Order::default();
     }
@@ -355,7 +421,9 @@ pub fn calc_grid_entry_long(
         state_params.volatility_ema_1m,
         effective_wallet_exposure_limit,
     );
-    if reentry_price <= 0.0 {
+    let reentry_price =
+        gate_reentry_price_bid(reentry_price, exchange_params, state_params, entry_params);
+    if reentry_price <= exchange_params.price_step {
         return Order::default();
     }
     let reentry_qty = f64::max(
@@ -447,12 +515,8 @@ pub fn calc_trailing_entry_long(
     trailing_price_bundle: &TrailingPriceBundle,
     wallet_exposure_limit_cap: f64,
 ) -> Order {
-    let initial_entry_price = calc_ema_price_bid(
-        exchange_params.price_step,
-        state_params.order_book.bid,
-        state_params.ema_bands.lower,
-        entry_params.initial_ema_dist,
-    );
+    let initial_entry_price =
+        calc_initial_entry_price_bid(exchange_params, state_params, entry_params);
     if initial_entry_price <= exchange_params.price_step {
         return Order::default();
     }
@@ -560,6 +624,11 @@ pub fn calc_trailing_entry_long(
             order_type: OrderType::EntryTrailingNormalLong,
         };
     }
+    reentry_price =
+        gate_reentry_price_bid(reentry_price, exchange_params, state_params, entry_params);
+    if reentry_price <= exchange_params.price_step {
+        return Order::default();
+    }
     let reentry_qty = f64::max(
         calc_reentry_qty(
             reentry_price,
@@ -614,12 +683,8 @@ pub fn calc_grid_entry_short(
     {
         return Order::default();
     }
-    let initial_entry_price = calc_ema_price_ask(
-        exchange_params.price_step,
-        state_params.order_book.ask,
-        state_params.ema_bands.upper,
-        entry_params.initial_ema_dist,
-    );
+    let initial_entry_price =
+        calc_initial_entry_price_ask(exchange_params, state_params, entry_params);
     if initial_entry_price <= exchange_params.price_step {
         return Order::default();
     }
@@ -681,7 +746,9 @@ pub fn calc_grid_entry_short(
         state_params.volatility_ema_1m,
         effective_wallet_exposure_limit,
     );
-    if reentry_price <= 0.0 {
+    let reentry_price =
+        gate_reentry_price_ask(reentry_price, exchange_params, state_params, entry_params);
+    if reentry_price <= exchange_params.price_step {
         return Order::default();
     }
     let reentry_qty = f64::max(
@@ -733,12 +800,8 @@ pub fn calc_trailing_entry_short(
     trailing_price_bundle: &TrailingPriceBundle,
     wallet_exposure_limit_cap: f64,
 ) -> Order {
-    let initial_entry_price = calc_ema_price_ask(
-        exchange_params.price_step,
-        state_params.order_book.ask,
-        state_params.ema_bands.upper,
-        entry_params.initial_ema_dist,
-    );
+    let initial_entry_price =
+        calc_initial_entry_price_ask(exchange_params, state_params, entry_params);
     if initial_entry_price <= exchange_params.price_step {
         return Order::default();
     }
@@ -849,6 +912,11 @@ pub fn calc_trailing_entry_short(
             price: 0.0,
             order_type: OrderType::EntryTrailingNormalShort,
         };
+    }
+    reentry_price =
+        gate_reentry_price_ask(reentry_price, exchange_params, state_params, entry_params);
+    if reentry_price <= exchange_params.price_step {
+        return Order::default();
     }
     let reentry_qty = f64::max(
         calc_reentry_qty(
@@ -1067,6 +1135,7 @@ pub fn calc_entries_short(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::strategies::EmaGateMode;
 
     fn make_runtime_context() -> RuntimeOrderContext {
         RuntimeOrderContext {
@@ -1132,6 +1201,7 @@ mod tests {
     fn make_entry_params() -> TrailingMartingaleEntryParams {
         TrailingMartingaleEntryParams {
             double_down_factor: 1.0,
+            ema_gate_mode: EmaGateMode::Initial,
             threshold_base_pct: 0.01,
             initial_ema_dist: 0.0,
             initial_qty_pct: 0.01,

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -34,7 +34,7 @@ mod core {
     };
     use crate::constants::{LONG, SHORT};
     use crate::entries::{
-        calc_min_entry_qty, effective_we_excess_allowance_pct,
+        calc_initial_entry_qty, calc_min_entry_qty, effective_we_excess_allowance_pct,
         wallet_exposure_limit_with_allowance_from_base,
     };
     use crate::risk::{
@@ -45,12 +45,13 @@ mod core {
         generate_orders as generate_strategy_orders, parse_strategy_params, strategy_ema_spans,
         strategy_entry_volatility_span_hours, strategy_initial_entry_offset,
         strategy_initial_qty_pct, strategy_needs_log_range_1h, strategy_needs_log_range_1m,
-        strategy_offset_volatility_span_minutes, NextStepHint, PeekBehavior, StrategyKind,
-        StrategyRequest, StrategySide,
+        strategy_offset_volatility_span_minutes, EmaGateMode, NextStepHint, PeekBehavior,
+        StrategyKind, StrategyParams, StrategyRequest, StrategySide,
     };
     use crate::types::{
         BotParams, BotParamsPair, EMABands, ExchangeParams, OrderBook, OrderType, Position,
-        RuntimeBudgetState, StateParams, TrailingPriceBundle, TwelEnforcerPolicy,
+        RuntimeBudgetState, RuntimeOrderContext, StateParams, TrailingPriceBundle,
+        TwelEnforcerPolicy,
     };
     use crate::utils::{
         calc_new_psize_pprice, calc_order_price_diff_ask, calc_order_price_diff_bid, calc_pnl_long,
@@ -1893,6 +1894,62 @@ mod core {
         }
     }
 
+    fn strategy_order_generation_needs_ema_for_symbol_side(
+        params: &StrategyParams,
+        pside: PositionSide,
+        wants_entries: bool,
+        wants_closes: bool,
+        position: &Position,
+        exchange: &ExchangeParams,
+        order_book: &OrderBook,
+        bot_params: &BotParams,
+        runtime_budget: RuntimeBudgetState,
+        balance: f64,
+    ) -> bool {
+        match params {
+            StrategyParams::TrailingMartingale(params) => {
+                if !wants_entries {
+                    return false;
+                }
+                match params.entry.ema_gate_mode {
+                    EmaGateMode::Disabled => false,
+                    EmaGateMode::All => true,
+                    EmaGateMode::Initial => true,
+                    EmaGateMode::Reentry => {
+                        if position.size == 0.0 {
+                            return false;
+                        }
+                        let initial_price = match pside {
+                            PositionSide::Long => order_book.bid,
+                            PositionSide::Short => order_book.ask,
+                        };
+                        if !initial_price.is_finite() || initial_price <= exchange.price_step {
+                            return false;
+                        }
+                        let runtime_context = RuntimeOrderContext {
+                            effective_wallet_exposure_limit: runtime_budget
+                                .effective_wallet_exposure_limit,
+                        };
+                        let initial_qty = calc_initial_entry_qty(
+                            exchange,
+                            bot_params,
+                            &runtime_context,
+                            &params.entry,
+                            balance,
+                            initial_price,
+                        )
+                        .abs();
+                        !initial_qty.is_finite()
+                            || initial_qty <= 0.0
+                            || position.size.abs() >= initial_qty * 0.8
+                    }
+                }
+            }
+            StrategyParams::EmaAnchor(_) => wants_entries || wants_closes,
+            StrategyParams::TrailingGridV7(_) => wants_entries || wants_closes,
+        }
+    }
+
     fn effective_mode(mode: Option<TradingMode>, has_pos: bool) -> TradingMode {
         match mode {
             Some(TradingMode::GracefulStop) if has_pos => TradingMode::Normal,
@@ -2618,41 +2675,32 @@ mod core {
                         StrategySide::Short,
                         &s.short,
                     );
-                    let ema_bands_long = strategy_params_long.as_ref().ok().and_then(|params| {
-                        cached_ema_bands(&mut workspace.derived_long, idx, &s.emas, params).ok()
-                    });
-                    let ema_bands_short = strategy_params_short.as_ref().ok().and_then(|params| {
-                        cached_ema_bands(&mut workspace.derived_short, idx, &s.emas, params).ok()
-                    });
+                    let params_long = strategy_params_long?;
+                    let params_short = strategy_params_short?;
+                    let bands_long =
+                        cached_ema_bands(&mut workspace.derived_long, idx, &s.emas, &params_long)?;
+                    let bands_short = cached_ema_bands(
+                        &mut workspace.derived_short,
+                        idx,
+                        &s.emas,
+                        &params_short,
+                    )?;
 
-                    if let (
-                        Some(bands_long),
-                        Some(bands_short),
-                        Ok(params_long),
-                        Ok(params_short),
-                    ) = (
-                        ema_bands_long,
-                        ema_bands_short,
-                        strategy_params_long,
-                        strategy_params_short,
-                    ) {
-                        let entry_threshold_long =
-                            bands_long.lower * (1.0 - strategy_initial_entry_offset(&params_long));
-                        let entry_threshold_short = bands_short.upper
-                            * (1.0 + strategy_initial_entry_offset(&params_short));
+                    let entry_threshold_long =
+                        bands_long.lower * (1.0 - strategy_initial_entry_offset(&params_long));
+                    let entry_threshold_short =
+                        bands_short.upper * (1.0 + strategy_initial_entry_offset(&params_short));
 
-                        let dist_long = entry_threshold_long / s.order_book.bid - 1.0;
-                        let dist_short = 1.0 - entry_threshold_short / s.order_book.ask;
+                    let dist_long = entry_threshold_long / s.order_book.bid - 1.0;
+                    let dist_short = 1.0 - entry_threshold_short / s.order_book.ask;
 
-                        // Block the side that's farther from triggering (smaller distance).
-                        // Tie-break: favor long.
-                        if dist_long >= dist_short {
-                            workspace.one_way_block_initial_short[idx] = true;
-                        } else {
-                            workspace.one_way_block_initial_long[idx] = true;
-                        }
+                    // Block the side that's farther from triggering (smaller distance).
+                    // Tie-break: favor long.
+                    if dist_long >= dist_short {
+                        workspace.one_way_block_initial_short[idx] = true;
+                    } else {
+                        workspace.one_way_block_initial_long[idx] = true;
                     }
-                    // If EMA bands can't be derived, allow both (no blocking)
                 }
             }
         }
@@ -2739,12 +2787,28 @@ mod core {
                             StrategySide::Long,
                             &s.long,
                         )?;
-                        let ema_bands = cached_ema_bands(
-                            &mut workspace.derived_long,
-                            s.symbol_idx,
-                            &s.emas,
+                        let runtime_budget = workspace.runtime_budget_long[s.symbol_idx];
+                        let ema_bands = if strategy_order_generation_needs_ema_for_symbol_side(
                             &strategy_params,
-                        )?;
+                            PositionSide::Long,
+                            wants_entries,
+                            wants_closes,
+                            &s.long.position,
+                            &s.exchange,
+                            &s.order_book,
+                            &s.long.bot_params,
+                            runtime_budget,
+                            input.balance,
+                        ) {
+                            cached_ema_bands(
+                                &mut workspace.derived_long,
+                                s.symbol_idx,
+                                &s.emas,
+                                &strategy_params,
+                            )?
+                        } else {
+                            EMABands::default()
+                        };
                         let volatility_ema_1h = cached_volatility_ema_1h(
                             &mut workspace.derived_long,
                             s.symbol_idx,
@@ -2764,7 +2828,6 @@ mod core {
                             volatility_ema_1m,
                             volatility_ema_1h,
                         };
-                        let runtime_budget = workspace.runtime_budget_long[s.symbol_idx];
                         let generated = generate_strategy_orders(
                             strategy_kind_for_symbol_side(&input.global),
                             StrategySide::Long,
@@ -2889,12 +2952,28 @@ mod core {
                             StrategySide::Short,
                             &s.short,
                         )?;
-                        let ema_bands = cached_ema_bands(
-                            &mut workspace.derived_short,
-                            s.symbol_idx,
-                            &s.emas,
+                        let runtime_budget = workspace.runtime_budget_short[s.symbol_idx];
+                        let ema_bands = if strategy_order_generation_needs_ema_for_symbol_side(
                             &strategy_params,
-                        )?;
+                            PositionSide::Short,
+                            wants_entries,
+                            wants_closes,
+                            &s.short.position,
+                            &s.exchange,
+                            &s.order_book,
+                            &s.short.bot_params,
+                            runtime_budget,
+                            input.balance,
+                        ) {
+                            cached_ema_bands(
+                                &mut workspace.derived_short,
+                                s.symbol_idx,
+                                &s.emas,
+                                &strategy_params,
+                            )?
+                        } else {
+                            EMABands::default()
+                        };
                         let volatility_ema_1h = cached_volatility_ema_1h(
                             &mut workspace.derived_short,
                             s.symbol_idx,
@@ -2914,7 +2993,6 @@ mod core {
                             volatility_ema_1m,
                             volatility_ema_1h,
                         };
-                        let runtime_budget = workspace.runtime_budget_short[s.symbol_idx];
                         let generated = generate_strategy_orders(
                             strategy_kind_for_symbol_side(&input.global),
                             StrategySide::Short,
@@ -2987,19 +3065,23 @@ mod core {
             if !enabled {
                 continue;
             }
-            let strategy_params = cached_strategy_params_for_symbol_side(
-                &mut workspace.derived_long,
-                s.symbol_idx,
-                input.global.strategy_kind,
-                StrategySide::Long,
-                &sym.long,
-            )?;
-            let ema_bands = cached_ema_bands(
-                &mut workspace.derived_long,
-                s.symbol_idx,
-                &sym.emas,
-                &strategy_params,
-            )?;
+            let ema_bands = if bot.unstuck_ema_gating_enabled {
+                let strategy_params = cached_strategy_params_for_symbol_side(
+                    &mut workspace.derived_long,
+                    s.symbol_idx,
+                    input.global.strategy_kind,
+                    StrategySide::Long,
+                    &sym.long,
+                )?;
+                cached_ema_bands(
+                    &mut workspace.derived_long,
+                    s.symbol_idx,
+                    &sym.emas,
+                    &strategy_params,
+                )?
+            } else {
+                EMABands::default()
+            };
             workspace.unstuck_inputs.push(UnstuckPositionInput {
                 idx: s.symbol_idx,
                 side: LONG,
@@ -3012,6 +3094,7 @@ mod core {
                 ),
                 unstuck_threshold: bot.unstuck_threshold,
                 unstuck_close_pct: bot.unstuck_close_pct,
+                unstuck_ema_gating_enabled: bot.unstuck_ema_gating_enabled,
                 unstuck_ema_dist: bot.unstuck_ema_dist,
                 unstuck_loss_allowance_pct: bot.unstuck_loss_allowance_pct,
                 total_wallet_exposure_limit: bot.total_wallet_exposure_limit,
@@ -3039,19 +3122,23 @@ mod core {
             if !enabled {
                 continue;
             }
-            let strategy_params = cached_strategy_params_for_symbol_side(
-                &mut workspace.derived_short,
-                s.symbol_idx,
-                input.global.strategy_kind,
-                StrategySide::Short,
-                &sym.short,
-            )?;
-            let ema_bands = cached_ema_bands(
-                &mut workspace.derived_short,
-                s.symbol_idx,
-                &sym.emas,
-                &strategy_params,
-            )?;
+            let ema_bands = if bot.unstuck_ema_gating_enabled {
+                let strategy_params = cached_strategy_params_for_symbol_side(
+                    &mut workspace.derived_short,
+                    s.symbol_idx,
+                    input.global.strategy_kind,
+                    StrategySide::Short,
+                    &sym.short,
+                )?;
+                cached_ema_bands(
+                    &mut workspace.derived_short,
+                    s.symbol_idx,
+                    &sym.emas,
+                    &strategy_params,
+                )?
+            } else {
+                EMABands::default()
+            };
             workspace.unstuck_inputs.push(UnstuckPositionInput {
                 idx: s.symbol_idx,
                 side: SHORT,
@@ -3064,6 +3151,7 @@ mod core {
                 ),
                 unstuck_threshold: bot.unstuck_threshold,
                 unstuck_close_pct: bot.unstuck_close_pct,
+                unstuck_ema_gating_enabled: bot.unstuck_ema_gating_enabled,
                 unstuck_ema_dist: bot.unstuck_ema_dist,
                 unstuck_loss_allowance_pct: bot.unstuck_loss_allowance_pct,
                 total_wallet_exposure_limit: bot.total_wallet_exposure_limit,
@@ -3627,6 +3715,7 @@ mod core {
                 volatility_ema_span_1m: bot_params.entry_volatility_ema_span_1m,
                 entry: crate::strategies::TrailingMartingaleEntryParams {
                     double_down_factor: bot_params.entry_grid_double_down_factor,
+                    ema_gate_mode: crate::strategies::EmaGateMode::Initial,
                     initial_ema_dist: bot_params.entry_initial_ema_dist,
                     initial_qty_pct: bot_params.entry_initial_qty_pct,
                     threshold_base_pct: bot_params.entry_grid_spacing_pct,

--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -18,7 +18,8 @@ use crate::risk::{
 use crate::strategies::ema_anchor::calc_quote_prices as calc_ema_anchor_quote_prices;
 use crate::strategies::registry::{strategy_kind_from_name, strategy_kind_names, strategy_spec};
 use crate::strategies::{
-    EmaAnchorParams, StrategySide, TrailingMartingaleCloseParams, TrailingMartingaleEntryParams,
+    EmaAnchorParams, EmaGateMode, StrategySide, TrailingMartingaleCloseParams,
+    TrailingMartingaleEntryParams,
 };
 use crate::trailing::{
     trailing_bundle_to_tuple, tuple_to_trailing_bundle, update_trailing_bundle_sequence,
@@ -1139,6 +1140,12 @@ pub fn calc_unstucking_close_py(
             .get_item("unstuck_close_pct")?
             .ok_or_else(|| PyValueError::new_err("position missing 'unstuck_close_pct'"))?
             .extract::<f64>()?;
+        let unstuck_ema_gating_enabled =
+            if let Some(value) = dict.get_item("unstuck_ema_gating_enabled")? {
+                value.extract::<bool>()?
+            } else {
+                true
+            };
         let unstuck_ema_dist = dict
             .get_item("unstuck_ema_dist")?
             .ok_or_else(|| PyValueError::new_err("position missing 'unstuck_ema_dist'"))?
@@ -1185,6 +1192,7 @@ pub fn calc_unstucking_close_py(
             effective_we_excess_allowance_pct,
             unstuck_threshold,
             unstuck_close_pct,
+            unstuck_ema_gating_enabled,
             unstuck_ema_dist,
             unstuck_loss_allowance_pct: 0.0,
             total_wallet_exposure_limit: 0.0,
@@ -2052,6 +2060,7 @@ fn trailing_martingale_strategy_params_from_dict(dict: &PyDict) -> PyResult<Valu
         "volatility_ema_span_1m": extract_value::<f64>(dict, "volatility_ema_span_1m")?,
         "entry": {
             "double_down_factor": extract_value::<f64>(entry, "double_down_factor")?,
+            "ema_gate_mode": extract_optional_string(entry, "ema_gate_mode", "initial")?,
             "initial_ema_dist": extract_value::<f64>(entry, "initial_ema_dist")?,
             "initial_qty_pct": extract_value::<f64>(entry, "initial_qty_pct")?,
             "threshold_base_pct": extract_value::<f64>(entry, "threshold_base_pct")?,
@@ -2231,6 +2240,13 @@ fn extract_optional_bool(dict: &PyDict, key: &str, default: bool) -> PyResult<bo
     })
 }
 
+fn extract_optional_string(dict: &PyDict, key: &str, default: &str) -> PyResult<String> {
+    Ok(match dict.get_item(key)? {
+        Some(item) => item.extract::<String>()?,
+        None => default.to_string(),
+    })
+}
+
 fn extract_optional_we_excess_allowance_mode(dict: &PyDict) -> PyResult<WeExcessAllowanceMode> {
     Ok(match dict.get_item("risk_we_excess_allowance_mode")? {
         Some(item) => {
@@ -2394,6 +2410,11 @@ fn bot_params_from_dict(dict: &PyDict) -> PyResult<BotParams> {
         risk_we_excess_allowance_pct,
         risk_we_excess_allowance_mode: extract_optional_we_excess_allowance_mode(dict)?,
         unstuck_enabled: extract_optional_bool(dict, "unstuck_enabled", true)?,
+        unstuck_ema_gating_enabled: extract_optional_bool(
+            dict,
+            "unstuck_ema_gating_enabled",
+            true,
+        )?,
         unstuck_close_pct: extract_value(dict, "unstuck_close_pct")?,
         unstuck_ema_dist: extract_value(dict, "unstuck_ema_dist")?,
         unstuck_loss_allowance_pct: extract_value(dict, "unstuck_loss_allowance_pct")?,
@@ -2479,6 +2500,7 @@ fn make_trailing_martingale_entry_params(
     );
     TrailingMartingaleEntryParams {
         double_down_factor: entry_grid_double_down_factor,
+        ema_gate_mode: EmaGateMode::Initial,
         initial_ema_dist: entry_initial_ema_dist,
         initial_qty_pct: entry_initial_qty_pct,
         threshold_base_pct: entry_grid_spacing_pct,

--- a/passivbot-rust/src/risk.rs
+++ b/passivbot-rust/src/risk.rs
@@ -318,6 +318,7 @@ pub struct UnstuckPositionInput {
     pub effective_we_excess_allowance_pct: f64,
     pub unstuck_threshold: f64,
     pub unstuck_close_pct: f64,
+    pub unstuck_ema_gating_enabled: bool,
     pub unstuck_ema_dist: f64,
     pub unstuck_loss_allowance_pct: f64,
     pub total_wallet_exposure_limit: f64,
@@ -424,46 +425,50 @@ where
             0.0
         };
 
-        let ema_price = match input.side {
-            LONG => {
-                if !input.ema_band_upper.is_finite() || input.ema_band_upper <= 0.0 {
-                    continue;
+        if input.unstuck_ema_gating_enabled {
+            let ema_price = match input.side {
+                LONG => {
+                    if !input.ema_band_upper.is_finite() || input.ema_band_upper <= 0.0 {
+                        continue;
+                    }
+                    let target = input.ema_band_upper * (1.0 + input.unstuck_ema_dist);
+                    let rounded = if price_step > 0.0 {
+                        round_up(target, price_step)
+                    } else {
+                        target
+                    };
+                    if !rounded.is_finite() || rounded <= 0.0 {
+                        continue;
+                    }
+                    rounded
                 }
-                let target = input.ema_band_upper * (1.0 + input.unstuck_ema_dist);
-                let rounded = if price_step > 0.0 {
-                    round_up(target, price_step)
-                } else {
-                    target
-                };
-                if !rounded.is_finite() || rounded <= 0.0 {
-                    continue;
+                SHORT => {
+                    if !input.ema_band_lower.is_finite() || input.ema_band_lower <= 0.0 {
+                        continue;
+                    }
+                    let target = input.ema_band_lower * (1.0 - input.unstuck_ema_dist);
+                    let rounded = if price_step > 0.0 {
+                        round_dn(target, price_step)
+                    } else {
+                        target
+                    };
+                    if !rounded.is_finite() || rounded <= 0.0 {
+                        continue;
+                    }
+                    rounded
                 }
-                rounded
-            }
-            SHORT => {
-                if !input.ema_band_lower.is_finite() || input.ema_band_lower <= 0.0 {
-                    continue;
-                }
-                let target = input.ema_band_lower * (1.0 - input.unstuck_ema_dist);
-                let rounded = if price_step > 0.0 {
-                    round_dn(target, price_step)
-                } else {
-                    target
-                };
-                if !rounded.is_finite() || rounded <= 0.0 {
-                    continue;
-                }
-                rounded
-            }
-            _ => continue,
-        };
+                _ => continue,
+            };
 
-        let meets_trigger = match input.side {
-            LONG => input.current_price >= ema_price,
-            SHORT => input.current_price <= ema_price,
-            _ => false,
-        };
-        if !meets_trigger {
+            let meets_trigger = match input.side {
+                LONG => input.current_price >= ema_price,
+                SHORT => input.current_price <= ema_price,
+                _ => false,
+            };
+            if !meets_trigger {
+                continue;
+            }
+        } else if input.side != LONG && input.side != SHORT {
             continue;
         }
 

--- a/passivbot-rust/src/strategies/mod.rs
+++ b/passivbot-rust/src/strategies/mod.rs
@@ -21,6 +21,26 @@ pub enum StrategyKind {
     TrailingGridV7,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum EmaGateMode {
+    Disabled,
+    All,
+    #[default]
+    Initial,
+    Reentry,
+}
+
+impl EmaGateMode {
+    pub fn gates_initial(self) -> bool {
+        matches!(self, Self::All | Self::Initial)
+    }
+
+    pub fn gates_reentry(self) -> bool {
+        matches!(self, Self::All | Self::Reentry)
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default)]
 #[serde(default, deny_unknown_fields)]
 pub struct TrailingMartingaleParams {
@@ -36,6 +56,7 @@ pub struct TrailingMartingaleParams {
 #[serde(default, deny_unknown_fields)]
 pub struct TrailingMartingaleEntryParams {
     pub double_down_factor: f64,
+    pub ema_gate_mode: EmaGateMode,
     pub initial_ema_dist: f64,
     pub initial_qty_pct: f64,
     pub threshold_base_pct: f64,

--- a/passivbot-rust/src/strategies/spec.rs
+++ b/passivbot-rust/src/strategies/spec.rs
@@ -14,11 +14,21 @@ pub struct StrategyParameterSpec {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct StrategyFixedParameterSpec {
+    pub side: &'static str,
+    pub name: &'static str,
+    pub config_path: Vec<&'static str>,
+    pub default: &'static str,
+    pub allowed_values: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct StrategySpec {
     pub strategy_kind: &'static str,
     pub defaults: BTreeMap<&'static str, BTreeMap<&'static str, f64>>,
     pub optimize_bounds: BTreeMap<String, Vec<f64>>,
     pub parameters: Vec<StrategyParameterSpec>,
+    pub fixed_parameters: Vec<StrategyFixedParameterSpec>,
 }
 
 struct ParamSeed {
@@ -536,6 +546,7 @@ fn build_strategy_spec(
         defaults,
         optimize_bounds,
         parameters,
+        fixed_parameters: Vec::new(),
     }
 }
 
@@ -583,11 +594,23 @@ fn build_nested_strategy_spec(
         defaults,
         optimize_bounds,
         parameters,
+        fixed_parameters: Vec::new(),
     }
 }
 
 pub fn trailing_martingale_spec() -> StrategySpec {
-    build_nested_strategy_spec("trailing_martingale", TRAILING_MARTINGALE_PARAM_SEEDS)
+    let mut spec =
+        build_nested_strategy_spec("trailing_martingale", TRAILING_MARTINGALE_PARAM_SEEDS);
+    for side in ["long", "short"] {
+        spec.fixed_parameters.push(StrategyFixedParameterSpec {
+            side,
+            name: "entry_ema_gate_mode",
+            config_path: vec!["strategy", side, "entry", "ema_gate_mode"],
+            default: "initial",
+            allowed_values: vec!["disabled", "all", "initial", "reentry"],
+        });
+    }
+    spec
 }
 
 pub fn trailing_grid_v7_spec() -> StrategySpec {

--- a/passivbot-rust/src/types.rs
+++ b/passivbot-rust/src/types.rs
@@ -606,6 +606,8 @@ pub struct BotParams {
     pub risk_we_excess_allowance_mode: WeExcessAllowanceMode,
     #[serde(default = "default_true")]
     pub unstuck_enabled: bool,
+    #[serde(default = "default_true")]
+    pub unstuck_ema_gating_enabled: bool,
     pub unstuck_close_pct: f64,
     pub unstuck_ema_dist: f64,
     pub unstuck_loss_allowance_pct: f64,
@@ -663,6 +665,7 @@ impl Default for BotParams {
             risk_we_excess_allowance_pct: 0.0,
             risk_we_excess_allowance_mode: WeExcessAllowanceMode::default(),
             unstuck_enabled: true,
+            unstuck_ema_gating_enabled: true,
             unstuck_close_pct: 0.0,
             unstuck_ema_dist: 0.0,
             unstuck_loss_allowance_pct: 0.0,

--- a/src/config/bot.py
+++ b/src/config/bot.py
@@ -145,6 +145,10 @@ def validate_bot_config(result: dict) -> None:
             get_grouped_bot_value(bot_side, "unstuck_enabled"),
             path=f"bot.{pside}.unstuck.enabled",
         )
+        _validate_bool(
+            get_grouped_bot_value(bot_side, "unstuck_ema_gating_enabled"),
+            path=f"bot.{pside}.unstuck.ema_gating_enabled",
+        )
         validate_unstuck_ema_dist_value(
             get_grouped_bot_value(bot_side, "unstuck_ema_dist"),
             path=f"bot.{pside}.unstuck_ema_dist",

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -47,6 +47,7 @@ def _get_shared_bot_defaults():
             "unstuck": {
                 "close_pct": 0.089,
                 "ema_dist": -0.033,
+                "ema_gating_enabled": True,
                 "enabled": True,
                 "loss_allowance_pct": 0.0252,
                 "threshold": 0.408,
@@ -89,6 +90,7 @@ def _get_shared_bot_defaults():
             "unstuck": {
                 "close_pct": 0.05,
                 "ema_dist": -0.2,
+                "ema_gating_enabled": True,
                 "enabled": True,
                 "loss_allowance_pct": 0.005,
                 "threshold": 0.4,

--- a/src/config/shared_bot.py
+++ b/src/config/shared_bot.py
@@ -38,6 +38,7 @@ BOT_GROUP_FIELD_MAP = {
     "unstuck": {
         "close_pct": "unstuck_close_pct",
         "ema_dist": "unstuck_ema_dist",
+        "ema_gating_enabled": "unstuck_ema_gating_enabled",
         "enabled": "unstuck_enabled",
         "loss_allowance_pct": "unstuck_loss_allowance_pct",
         "threshold": "unstuck_threshold",

--- a/src/config/strategy.py
+++ b/src/config/strategy.py
@@ -45,8 +45,22 @@ TRAILING_GRID_V7_FLAT_ONLY_KEYS = {
     "entry_volatility_ema_span_hours",
 }
 
+TRAILING_MARTINGALE_EMA_GATE_MODES = frozenset({"disabled", "all", "initial", "reentry"})
+
 
 def _normalize_strategy_side_value(key: str, value, *, strategy_kind: str, pside: str):
+    if strategy_kind == DEFAULT_STRATEGY_KIND and key == "entry.ema_gate_mode":
+        if not isinstance(value, str):
+            raise TypeError(
+                f"bot.{pside}.strategy.{strategy_kind}.entry.ema_gate_mode must be a string"
+            )
+        normalized = value.strip().lower()
+        if normalized not in TRAILING_MARTINGALE_EMA_GATE_MODES:
+            allowed = ", ".join(sorted(TRAILING_MARTINGALE_EMA_GATE_MODES))
+            raise ValueError(
+                f"bot.{pside}.strategy.{strategy_kind}.entry.ema_gate_mode must be one of: {allowed}"
+            )
+        return normalized
     return value
 
 

--- a/src/config/strategy_spec.py
+++ b/src/config/strategy_spec.py
@@ -83,7 +83,7 @@ def _strategy_leaf_path(param: dict) -> tuple[str, ...] | None:
 def get_strategy_param_keys(strategy_kind: str) -> tuple[str, ...]:
     spec = get_strategy_spec(strategy_kind)
     keys: list[str] = []
-    for param in spec.get("parameters", []):
+    for param in [*spec.get("parameters", []), *spec.get("fixed_parameters", [])]:
         if not isinstance(param, dict):
             continue
         leaf_path = _strategy_leaf_path(param)
@@ -96,7 +96,7 @@ def get_strategy_defaults(strategy_kind: str) -> dict:
     normalized_kind = normalize_strategy_kind(strategy_kind)
     spec = get_strategy_spec(normalized_kind)
     result = {pside: {} for pside in BOT_POSITION_SIDES}
-    for param in spec.get("parameters", []):
+    for param in [*spec.get("parameters", []), *spec.get("fixed_parameters", [])]:
         if not isinstance(param, dict):
             continue
         pside = param.get("side")
@@ -179,7 +179,7 @@ def strategy_optimize_key_path_map(strategy_kind: str) -> dict[str, tuple[str, .
 def strategy_field_names_by_side(strategy_kind: str) -> dict[str, set[str]]:
     spec = get_strategy_spec(strategy_kind)
     fields = {pside: set() for pside in BOT_POSITION_SIDES}
-    for param in spec.get("parameters", []):
+    for param in [*spec.get("parameters", []), *spec.get("fixed_parameters", [])]:
         if not isinstance(param, dict):
             continue
         side = param.get("side")

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -12876,7 +12876,9 @@ class Passivbot:
         bool_keys = {
             "risk_wel_enforcer_enabled",
             "risk_twel_enforcer_enabled",
+            "risk_twel_entry_gate_enabled",
             "unstuck_enabled",
+            "unstuck_ema_gating_enabled",
         }
         string_keys = {
             "risk_we_excess_allowance_mode",
@@ -12934,11 +12936,13 @@ class Passivbot:
             "risk_wel_enforcer_enabled",
             "risk_wel_enforcer_threshold",
             "risk_twel_enforcer_enabled",
+            "risk_twel_entry_gate_enabled",
             "risk_twel_enforcer_threshold",
             "risk_we_excess_allowance_pct",
             "risk_we_excess_allowance_mode",
             "unstuck_enabled",
             "unstuck_close_pct",
+            "unstuck_ema_gating_enabled",
             "unstuck_ema_dist",
             "unstuck_loss_allowance_pct",
             "unstuck_threshold",

--- a/tests/test_config_pipeline.py
+++ b/tests/test_config_pipeline.py
@@ -29,7 +29,7 @@ def _set_path(mapping, path, value):
 
 def _nested_strategy_values_from_spec(spec, field):
     result = {"long": {}, "short": {}}
-    for param in spec["parameters"]:
+    for param in [*spec["parameters"], *spec.get("fixed_parameters", [])]:
         config_path = param["config_path"]
         pside = config_path[1]
         _set_path(result[pside], config_path[2:], param[field])
@@ -75,6 +75,36 @@ def test_rust_strategy_spec_matches_generated_strategy_optimize_bounds(strategy_
             flat_generated[f"{pside}_{local_key}"] = value
 
     assert flat_generated == expected
+
+
+def test_trailing_martingale_ema_gate_mode_is_fixed_config_not_optimizer_bound():
+    source = get_template_config()
+    source["bot"]["long"]["strategy"]["trailing_martingale"]["entry"]["ema_gate_mode"] = "REENTRY"
+    source["bot"]["short"]["unstuck"]["ema_gating_enabled"] = False
+
+    prepared = prepare_config(source, verbose=False, target="canonical", runtime=None)
+
+    assert (
+        prepared["bot"]["long"]["strategy"]["trailing_martingale"]["entry"]["ema_gate_mode"]
+        == "reentry"
+    )
+    assert prepared["bot"]["short"]["unstuck"]["ema_gating_enabled"] is False
+    assert "ema_gate_mode" not in json.dumps(prepared["optimize"]["bounds"])
+    spec = pbr.get_strategy_spec("trailing_martingale")
+    assert any(
+        param["config_path"] == ["strategy", "long", "entry", "ema_gate_mode"]
+        and param["default"] == "initial"
+        and param["allowed_values"] == ["disabled", "all", "initial", "reentry"]
+        for param in spec["fixed_parameters"]
+    )
+
+
+def test_prepare_config_rejects_invalid_trailing_martingale_ema_gate_mode():
+    source = get_template_config()
+    source["bot"]["long"]["strategy"]["trailing_martingale"]["entry"]["ema_gate_mode"] = "re_entry"
+
+    with pytest.raises(ValueError, match="ema_gate_mode must be one of"):
+        prepare_config(source, verbose=False, target="canonical", runtime=None)
 
 
 def _minimal_v7_trailing_grid_config():

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -76,6 +76,7 @@ def adaptive_strategy_params(**overrides):
         "volatility_ema_span_1m": 60.0,
         "entry": {
             "double_down_factor": 1.0,
+            "ema_gate_mode": "initial",
             "initial_ema_dist": 0.0,
             "initial_qty_pct": 0.1,
             "threshold_base_pct": 0.02,
@@ -132,6 +133,7 @@ def bot_params(**overrides):
         "risk_twel_enforcer_threshold": 0.0,
         "risk_we_excess_allowance_pct": 0.0,
         "risk_entry_cooldown_minutes": 0.0,
+        "unstuck_ema_gating_enabled": True,
         "unstuck_close_pct": 0.0,
         "unstuck_ema_dist": 0.0,
         "unstuck_loss_allowance_pct": 0.0,
@@ -334,6 +336,170 @@ def test_json_rejects_missing_ema():
         balance=1_000.0,
         symbols=[make_symbol(0, bid=100.0, ask=100.0, emas=ema_bundle(m1_close=[]))],
     )
+    with pytest.raises(ValueError, match="MissingEma"):
+        compute(pbr, inp)
+
+
+def test_ema_gate_mode_disabled_initial_long_uses_best_bid_without_ema():
+    import passivbot_rust as pbr
+
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=bot_params_pair(),
+        symbols=[
+            make_symbol(
+                0,
+                bid=100.0,
+                ask=101.0,
+                long_strategy=adaptive_strategy_params(
+                    entry={"ema_gate_mode": "disabled", "initial_ema_dist": -0.25}
+                ),
+                emas=ema_bundle(m1_close=[]),
+            )
+        ],
+    )
+    inp["global"]["hedge_mode"] = True
+
+    out = compute(pbr, inp)
+
+    initial = next(o for o in out["orders"] if o["order_type"] == "entry_initial_normal_long")
+    assert initial["price"] == pytest.approx(100.0)
+
+
+def test_ema_gate_mode_reentry_leaves_flat_initial_at_best_bid_without_ema():
+    import passivbot_rust as pbr
+
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=bot_params_pair(),
+        symbols=[
+            make_symbol(
+                0,
+                bid=100.0,
+                ask=101.0,
+                long_strategy=adaptive_strategy_params(
+                    entry={"ema_gate_mode": "reentry", "initial_ema_dist": -0.25}
+                ),
+                emas=ema_bundle(m1_close=[]),
+            )
+        ],
+    )
+    inp["global"]["hedge_mode"] = True
+
+    out = compute(pbr, inp)
+
+    initial = next(o for o in out["orders"] if o["order_type"] == "entry_initial_normal_long")
+    assert initial["price"] == pytest.approx(100.0)
+
+
+def test_ema_gate_mode_reentry_leaves_partial_initial_at_best_bid_without_ema():
+    import passivbot_rust as pbr
+
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=bot_params_pair(),
+        symbols=[
+            make_symbol(
+                0,
+                bid=100.0,
+                ask=101.0,
+                long_pos_size=0.5,
+                long_pos_price=100.0,
+                long_strategy=adaptive_strategy_params(
+                    entry={"ema_gate_mode": "reentry", "initial_ema_dist": -0.25}
+                ),
+                emas=ema_bundle(m1_close=[]),
+            )
+        ],
+    )
+    inp["global"]["hedge_mode"] = True
+
+    out = compute(pbr, inp)
+
+    partial = next(o for o in out["orders"] if o["order_type"] == "entry_initial_partial_long")
+    assert partial["price"] == pytest.approx(100.0)
+
+
+def test_ema_gate_mode_all_gates_long_reentry_price():
+    import passivbot_rust as pbr
+
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=bot_params_pair(),
+        symbols=[
+            make_symbol(
+                0,
+                bid=100.0,
+                ask=100.0,
+                long_pos_size=1.0,
+                long_pos_price=100.0,
+                long_strategy=adaptive_strategy_params(
+                    entry={"ema_gate_mode": "all", "threshold_base_pct": 0.02}
+                ),
+                emas=ema_bundle(
+                    m1_close=[
+                        [10.0, 95.0],
+                        [20.0, 95.0],
+                        [math.sqrt(10.0 * 20.0), 95.0],
+                    ]
+                ),
+            )
+        ],
+    )
+    inp["global"]["hedge_mode"] = True
+
+    out = compute(pbr, inp)
+
+    reentry = next(o for o in out["orders"] if o["order_type"] == "entry_grid_normal_long")
+    assert reentry["price"] == pytest.approx(95.0)
+
+
+def test_ema_gate_mode_reentry_requires_ema_for_true_reentry():
+    import passivbot_rust as pbr
+
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=bot_params_pair(),
+        symbols=[
+            make_symbol(
+                0,
+                bid=100.0,
+                ask=100.0,
+                long_pos_size=1.0,
+                long_pos_price=100.0,
+                long_strategy=adaptive_strategy_params(entry={"ema_gate_mode": "reentry"}),
+                emas=ema_bundle(m1_close=[]),
+            )
+        ],
+    )
+    inp["global"]["hedge_mode"] = True
+
+    with pytest.raises(ValueError, match="MissingEma"):
+        compute(pbr, inp)
+
+
+def test_one_way_flat_tie_break_requires_ema_even_when_entry_gate_disabled():
+    import passivbot_rust as pbr
+
+    side_enabled = {"n_positions": 1, "total_wallet_exposure_limit": 1.0}
+    disabled_strategy = adaptive_strategy_params(entry={"ema_gate_mode": "disabled"})
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=bot_params_pair(short_overrides=side_enabled),
+        symbols=[
+            make_symbol(
+                0,
+                bid=100.0,
+                ask=101.0,
+                short_bp=side_enabled,
+                long_strategy=disabled_strategy,
+                short_strategy=disabled_strategy,
+                emas=ema_bundle(m1_close=[]),
+            )
+        ],
+    )
+    inp["global"]["hedge_mode"] = False
+
     with pytest.raises(ValueError, match="MissingEma"):
         compute(pbr, inp)
 
@@ -1429,6 +1595,41 @@ def test_auto_unstuck_allowed_gate_blocks_symbol_allowance():
     out = compute(pbr, inp)
 
     assert all(o["order_type"] != "close_unstuck_long" for o in out["orders"])
+
+
+def test_unstuck_ema_gating_disabled_skips_missing_ema_requirement():
+    import passivbot_rust as pbr
+
+    long_bp = {
+        "total_wallet_exposure_limit": 1.5,
+        "wallet_exposure_limit": 1.5,
+        "unstuck_close_pct": 0.5,
+        "unstuck_ema_gating_enabled": False,
+        "unstuck_threshold": 0.001,
+        "unstuck_ema_dist": 0.0,
+        "unstuck_loss_allowance_pct": 0.005,
+    }
+    sym = make_symbol(
+        0,
+        bid=120.0,
+        ask=120.0,
+        long_pos_size=10.0,
+        long_pos_price=130.0,
+        long_bp=long_bp,
+        long_strategy=adaptive_strategy_params(entry={"ema_gate_mode": "disabled"}),
+        emas=ema_bundle(m1_close=[]),
+    )
+    inp = make_input(
+        balance=2_000.0,
+        global_bp=bot_params_pair(long_overrides=long_bp),
+        symbols=[sym],
+    )
+    inp["global"]["hedge_mode"] = True
+    inp["global"]["unstuck_allowance_long"] = 1e9
+
+    out = compute(pbr, inp)
+
+    assert any(o["order_type"] == "close_unstuck_long" for o in out["orders"])
 
 
 def test_orders_include_entries_and_closes():

--- a/tests/test_unstucking.py
+++ b/tests/test_unstucking.py
@@ -22,6 +22,7 @@ def _build_position(
     wallet_exposure_limit=1.0,
     unstuck_threshold=0.0,
     unstuck_close_pct=0.1,
+    unstuck_ema_gating_enabled=True,
     unstuck_ema_dist=0.0,
     qty_step=0.01,
     price_step=0.01,
@@ -46,6 +47,7 @@ def _build_position(
         "wallet_exposure_limit": float(wallet_exposure_limit),
         "unstuck_threshold": float(unstuck_threshold),
         "unstuck_close_pct": float(unstuck_close_pct),
+        "unstuck_ema_gating_enabled": bool(unstuck_ema_gating_enabled),
         "unstuck_ema_dist": float(unstuck_ema_dist),
         "risk_we_excess_allowance_pct": float(risk_we_excess_allowance_pct),
         "ema_band_upper": float(ema_band_upper),
@@ -122,6 +124,29 @@ def test_unstucking_skips_when_price_not_beyond_ema():
     ]
     result = pbr.calc_unstucking_close_py(1000.0, 5.0, 0.0, positions)
     assert result is None
+
+
+@pytest.mark.skipif(pbr is None or pbr_is_stub, reason="passivbot_rust extension not available")
+def test_unstucking_ema_gating_disabled_ignores_ema_trigger():
+    positions = [
+        _build_position(
+            side="long",
+            position_size=2.0,
+            position_price=100.0,
+            current_price=95.0,
+            ema_band_upper=100.0,
+            unstuck_ema_gating_enabled=False,
+        )
+    ]
+
+    result = pbr.calc_unstucking_close_py(1000.0, 5.0, 0.0, positions)
+
+    assert result is not None
+    idx, side_code, qty, price, order_type_id = result
+    assert idx == 0
+    assert qty < 0.0
+    assert price == pytest.approx(95.0)
+    assert order_type_id == pbr.order_type_snake_to_id("close_unstuck_long")
 
 
 @pytest.mark.skipif(pbr is None or pbr_is_stub, reason="passivbot_rust extension not available")


### PR DESCRIPTION
## Summary
- add fixed trailing_martingale entry ema_gate_mode values: disabled, all, initial, reentry
- gate initial/partial-initial and reentry prices in Rust according to the selected mode, including one-way EMA tie-break failure when EMA inputs are missing
- add fixed bot.<side>.unstuck.ema_gating_enabled toggle and wire it through Rust/Python config/runtime paths
- document the behavior and add docs/plans/ema_entry_gate_mode_plan.md

## Validation
- cargo check (passivbot-rust)
- VIRTUAL_ENV=/Users/eiriknarjord/repos/passivbot-4/venv PATH=/Users/eiriknarjord/repos/passivbot-4/venv/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/eiriknarjord/.local/bin:/Users/eiriknarjord/.codex/tmp/arg0/codex-arg0nJLWVT:/Users/eiriknarjord/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/eiriknarjord/.grok/bin:/opt/homebrew/opt/tcl-tk/bin:/Users/eiriknarjord/repos/autonomi/target/release/:/Users/eiriknarjord/.modular/pkg/packages.modular.com_mojo/bin:/Users/eiriknarjord/.pyenv/shims:/Users/eiriknarjord/.cargo/bin:/Applications/Codex.app/Contents/Resources maturin develop --release (passivbot-rust)
- ./venv/bin/python -m pytest tests/test_orchestrator_json_api.py tests/test_config_pipeline.py tests/test_unstucking.py tests/optimization/test_config_adapter.py

## Note
- ./venv/bin/python -m pytest tests/test_format_config.py still has an unrelated existing logging-default expectation mismatch: schema includes live_event_debug_profiles but the test expectation does not.