### PR TITLE
Record EMA readiness smoke progress

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-27.
 
 Current `origin/v8` logging-overhaul head:
 
-- `0f1afc49` merge of PR #753, `Add exchange surface health to ticker probe`.
+- `5d9f3a5` merge of PR #755, `Summarize EMA readiness in live smoke reports`.
 
 Current review gate:
 
@@ -1625,6 +1625,31 @@ VPS5 deployment status:
   failed remote calls, no failed account-critical remote calls, and clean
   tracked repository state.
 
+### PR #755: Live Smoke EMA Readiness Health
+
+- Branch: `codex/v8-smoke-ema-readiness-health`.
+- Scope: read-only smoke-report tooling.
+- Result: `passivbot tool live-smoke-report` now derives bounded
+  `ema_readiness_health` full/summary groups and brief `ema_readiness`
+  counters from existing `ema.unavailable` events. The new projection reports
+  event count, affected bot count, latest candidate/unavailable totals, bounded
+  reason counts, error-type counts, latest cycle IDs, and compact allowlisted
+  EMA event data without changing smoke verdict logic.
+- Review evidence: Claude and Hermes approved; CI was green; focused
+  smoke-report tests, compileall, `git diff --check`, and local real-data
+  summary/brief smoke checks passed before merge.
+- VPS5 evidence: deployed without bot restart because the slice is read-only
+  smoke-report tooling. The first 10-minute smoke after deploy caught a real
+  Binance `InvalidNonce`/timestamp-window recovery in authoritative positions
+  and the related text-log warning; later authoritative calls succeeded. A
+  settled 2-minute brief smoke at `5d9f3a5f` reported all five expected bots
+  running, no hard failures, no log hard/attention matches, no failed remote
+  calls, no failed account-critical remote calls, and clean tracked repository
+  state. The new `ema_readiness` counters reported `total=11`, `bots=4`,
+  `latest_candidate_unavailable_total=31`, and `latest_unavailable_total=112`,
+  making persistent non-hard EMA readiness degradation visible without full
+  problem-event inspection.
+
 ## Current Next Steps
 
 1. Continue Phase 5/6 by adding the next high-value event producer or debug
@@ -1642,10 +1667,11 @@ VPS5 deployment status:
    `exchange_surface_health` notes over the existing endpoint outcomes.
    Remaining useful slices should be driven by a concrete live exchange gap
    rather than broad probe expansion.
-3. Use the persistent non-hard EMA readiness / staged-execution degradation
-   visible in VPS5 smokes as the next candidate for targeted readiness
-   diagnostics or a narrow fix. PRs #679 and #682 made the problem groups easier
-   to inspect by surfacing bounded latest event data and aggregate groups.
+3. Use the persistent non-hard staged-execution degradation visible in VPS5
+   smokes as the next candidate for targeted readiness diagnostics or a narrow
+   fix. PRs #679/#682 made generic problem groups inspectable, and PR #755 made
+   EMA readiness directly visible; staged `completed_candles` target changes are
+   now the larger remaining readiness signal.
 4. Start the live restart/smoke automation slice if operational workflow speed
    becomes the higher leverage next step.
 5. Continue cache-doctor refinements in separate adjacent PRs: deeper metadata

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -71,11 +71,14 @@ Related detailed plans:
    `--summary` projection for operator smoke checks. It also has a `--brief`
    projection for top-level smoke-loop counters without event groups or log
    matches. It also summarizes existing structured shutdown lifecycle events as
-   `shutdown_events` in full, summary, and brief reports. The smoke report now also
-   redacts common user/home prefixes from `repository.root` for shareable
-   reports and surfaces explicit dropped-unparsed attention/hard counters when
-   the opt-in log-window drop policy suppresses contextless hard-looking log
-   fragments. The safe restart orchestration contract is not implemented.
+   `shutdown_events` in full, summary, and brief reports, and existing
+   `ema.unavailable` events as `ema_readiness_health`/`ema_readiness` with
+   latest candidate/unavailable counts and bounded reason/error evidence. The
+   smoke report now also redacts common user/home prefixes from
+   `repository.root` for shareable reports and surfaces explicit
+   dropped-unparsed attention/hard counters when the opt-in log-window drop
+   policy suppresses contextless hard-looking log fragments. The safe restart
+   orchestration contract is not implemented.
 
    Formalize the repeated VPS smoke routine: pull a branch, stop configured
    bots, measure shutdown time per bot, reload from `/root/bots_vps5.yaml`,
@@ -474,6 +477,7 @@ Related detailed plans:
 | 2026-06-27 | #6 Exchange health and contract probes | PR #749 / `16c25149` | Added opt-in bounded first-symbol `fetch_my_trades` pagination sampling to `ticker-endpoint-probe`, keeping default one-call behavior; VPS5 authenticated Binance probe validated pages=2/limit=2 request shape, short-page stop, call_count=1, and rate-limit accounting | Basic endpoint latency and deeper exchange-specific coverage checks |
 | 2026-06-27 | #6 Exchange health and contract probes | PR #751 / `4eef3572` | Added `ticker-endpoint-probe` `endpoint_latency_health` summaries from existing probe outcomes, including open-orders fallback attempts and fill-history pages; VPS5 Binance probe validated endpoint_count=11, total=12, slowest=load_markets, and expected Binance open-orders all-symbol warning classification | Deeper exchange-specific coverage checks |
 | 2026-06-27 | #6 Exchange health and contract probes | PR #753 / `0f1afc49` | Added `ticker-endpoint-probe` `exchange_surface_health` notes from existing open-orders, time-sync, fill-history, and OHLCV-tail outcomes; VPS5 Binance probe validated open-orders symbol fallback and fill-history short-page notes | Further probe expansion should be driven by concrete exchange gaps |
+| 2026-06-27 | #3 Live restart/smoke automation | PR #755 / `5d9f3a5f` | Added `live-smoke-report` EMA readiness health summaries from existing `ema.unavailable` events; settled VPS5 smoke reported all five bots matched, no hard failures, no failed remote/account-critical calls, and `ema_readiness.total=11`, `bots=4`, `latest_candidate_unavailable_total=31`, `latest_unavailable_total=112` | Safe pull/stop/start orchestration still open; staged readiness diagnostics remain a useful next slice |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |


### PR DESCRIPTION
## Summary
- update live logging progress head to PR #755 / 5d9f3a5
- record VPS5 deploy/smoke evidence for the EMA readiness smoke-report slice
- update the live ops backlog with the completed EMA readiness summary and remaining staged-readiness target

## Validation
- git diff --check
- docs-only change