### PR TITLE
Tolerate completed candle fallback shape recovery

### DIFF
--- a/src/live/planning_gates.py
+++ b/src/live/planning_gates.py
@@ -75,7 +75,15 @@ def staged_planner_precondition_state(
             expected_symbols, now_ms=candle_check_ms
         )
         stamped_signature = ledger.surface_signature("completed_candles")
-        if candle_missing or stamped_signature != signature:
+        equivalent = (
+            bot._completed_candle_signatures_equivalent(
+                signature,
+                stamped_signature,
+            )
+            if hasattr(bot, "_completed_candle_signatures_equivalent")
+            else stamped_signature == signature
+        )
+        if candle_missing or not equivalent:
             missing.append("completed_candles")
             invalid["completed_candles"] = candle_missing or (
                 bot._completed_candle_signature_mismatch_details(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -9717,6 +9717,41 @@ class Passivbot:
             }
         ]
 
+    def _completed_candle_signatures_equivalent(
+        self,
+        expected_signature,
+        stamped_signature,
+    ) -> bool:
+        """Return true when both signatures cover the same completed targets.
+
+        A stamped target may include bounded ``tail_gap_fallback`` metadata while
+        a later cache check at the same stamp time sees normal coverage after a
+        background cache improvement. That metadata shape change must not defer
+        planning when the required symbol and completed-candle timestamp are
+        unchanged.
+        """
+
+        def _targets_by_symbol(signature) -> dict[str, tuple[str, int]]:
+            out: dict[str, tuple[str, int]] = {}
+            if not isinstance(signature, (list, tuple)):
+                return out
+            for item in signature:
+                if not isinstance(item, (list, tuple)) or len(item) < 2:
+                    continue
+                symbol = str(item[0] or "")
+                if not symbol:
+                    continue
+                try:
+                    target_ts = int(item[1])
+                except (TypeError, ValueError):
+                    continue
+                out[symbol] = (symbol, target_ts)
+            return out
+
+        return _targets_by_symbol(expected_signature) == _targets_by_symbol(
+            stamped_signature
+        )
+
     def _staged_planner_precondition_state(
         self,
         *,

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -5713,6 +5713,51 @@ def test_staged_planner_preconditions_validate_candles_at_surface_stamp_time():
     assert details["missing"] == []
 
 
+def test_staged_planner_preconditions_allow_tail_fallback_shape_recovery():
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {}}
+    bot.exchange = "bybit"
+    bot.freshness_ledger = FreshnessLedger(now_ms=0)
+    symbol = "BTC/USDT:USDT"
+    stamp_ms = 120_500
+    stamped_signature = (
+        (symbol, 120_000, "tail_gap_fallback", 60_000, 60_000),
+    )
+    bot.active_symbols = [symbol]
+    bot.positions = {symbol: {"long": {"size": 1.0}, "short": {"size": 0.0}}}
+    bot.open_orders = {}
+    bot.PB_modes = {"long": {}, "short": {}}
+    bot.cm = SimpleNamespace(
+        get_completed_candle_health=lambda _symbol, windows=None, now_ms=None: {
+            "ok": True,
+            "timeframes": {
+                "1m": {
+                    "coverage_ok": True,
+                    "latest_expected_ts": 120_000,
+                    "last_cached_ts": 120_000,
+                    "missing_candles": 0,
+                    "runtime_synthetic_count": 0,
+                }
+            },
+        }
+    )
+
+    bot._begin_authoritative_refresh_epoch()
+    for surface in ACCOUNT_SURFACES:
+        bot._record_authoritative_surface(surface, (surface, "fresh"))
+    bot.freshness_ledger.stamp(
+        "completed_candles",
+        stamped_signature,
+        now_ms=stamp_ms,
+        epoch=bot._authoritative_refresh_epoch,
+    )
+
+    ok, details = bot._staged_planner_precondition_state(include_market_snapshot=False)
+
+    assert ok is True
+    assert details["missing"] == []
+
+
 def test_build_staged_planning_snapshot_captures_exact_surface_contract():
     bot = Passivbot.__new__(Passivbot)
     bot.config = {"live": {"user": "tester"}}


### PR DESCRIPTION
## Summary
- treat completed-candle freshness signatures as equivalent when they cover the same symbol and completed-candle timestamp, even if one side carries bounded tail-gap fallback metadata
- keep timestamp changes and symbol-set changes as staged planner defers
- add a regression test for fallback-shape recovery after cache improvement

## Live evidence
- VPS5 settled smokes on current v8 were hard-green but repeatedly showed non-hard staged readiness defers with completed_candle_target_changed for Binance/Hyperliquid.
- Full smoke showed the changed surface was completed_candles while remote/account-critical calls were healthy.

## Validation
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_passivbot_balance_split.py -k staged_planner_preconditions
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_smoke_report.py -k staged_readiness
- PYTHONPATH=src ./venv/bin/python -m compileall -q src/passivbot.py src/live/planning_gates.py tests/test_passivbot_balance_split.py
- git diff --check