### PR TITLE
Record PR764 and PR765 deploy evidence

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-27.
 
 Current `origin/v8` logging-overhaul head:
 
-- `d9188b64` merge of PR #762, `Tolerate completed candle fallback shape recovery`.
+- `5275ab75` merge of PR #765, `Summarize live event pipeline health in smoke report`.
 
 Current review gate:
 
@@ -1747,13 +1747,61 @@ VPS5 deployment status:
   all five bots matched, clean repository state, no hard/log failures, no
   failed remote/account-critical calls, and `staged_readiness.total=0`.
 
+### PR #764: Cache Doctor Metadata Compatibility Evidence
+
+- Branch: `codex/v8-cache-doctor-compat`.
+- Scope: adjacent read-only cache diagnostics from the live-ops backlog.
+- Result: `passivbot tool cache-integrity-doctor` now reports deeper
+  metadata compatibility evidence for local candle/fill/HSL caches. Candle
+  `index.json` known-gap metadata is classified by no-trade vs unclassified
+  reasons, fill current-contract evidence distinguishes proven coverage from
+  current-contract-but-unproven coverage, and HSL/risk metadata reports HSL
+  artifact/timestamp compatibility fields. The final follow-up commit made
+  mixed no-trade/unclassified candle gaps explicitly partial and still
+  `candle_synthetic_no_trade_evidence_unproven`.
+- Review evidence: Claude and Hermes approved the final head; CI was green;
+  `tests/test_cache_integrity_doctor.py`, compileall, and `git diff --check`
+  passed locally for the follow-up.
+- VPS5 evidence: deployed as part of merged `v8` `5275ab75` without bot
+  restart because this is read-only local tooling.
+
+### PR #765: Live Smoke Event Pipeline Health
+
+- Branch: `codex/v8-smoke-pipeline-health`.
+- Scope: read-only smoke-report tooling.
+- Result: `passivbot tool live-smoke-report` now derives bounded
+  `event_pipeline_health` full/summary groups and brief `event_pipeline`
+  counters from existing `health.summary` event-pipeline counters. The new
+  projection reports latest queue depth, unfinished queue work, dropped event
+  counts, sink-error counts, degraded count, worker-not-alive count, and
+  stopping count without changing smoke verdict logic.
+- Review evidence: Claude and Hermes approved; CI was green; full
+  `tests/test_live_smoke_report.py`, compileall, and `git diff --check`
+  passed locally.
+- VPS5 evidence: deployed at `5275ab75` without bot restart because this is
+  read-only smoke-report tooling. A 5-minute smoke confirmed the new brief
+  `event_pipeline` field was present, but no recent matching health-summary
+  sample was in that short window. A 30-minute smoke reported
+  `event_pipeline.total=1`, `bots=1`, `latest_dropped_total=0`,
+  `latest_sink_error_total=0`, `latest_worker_not_alive_count=0`, and clean
+  tracked repository state. The same smoke was red from live risk state and
+  unrelated runtime events: HSL red/cooldown events, CRITICAL HSL text logs,
+  and an earlier Hyperliquid fill-refresh timeout. All five expected bots were
+  still running, and remote/account-critical call summaries reported no
+  failures.
+
 ## Current Next Steps
 
-1. Continue Phase 5/6 by adding the next high-value event producer or debug
+1. Inspect the current VPS5 HSL/risk smoke signal separately from the merged
+   tooling. The latest deploy smoke shows real HSL RED/cooldown activity and
+   CRITICAL risk text logs; decide whether smoke should keep treating those as
+   hard operator failures or whether risk-state criticality needs a more
+   explicit classification distinct from software crashes.
+2. Continue Phase 5/6 by adding the next high-value event producer or debug
    profile slice without increasing default console noise. Likely candidates
    are more order/risk transition coverage or focused profile refinements only
    when live diagnostics need deeper evidence.
-2. Continue active read-only exchange health probes beyond account-critical
+3. Continue active read-only exchange health probes beyond account-critical
    basics. PR #701 added account-critical health summaries and PR #703 added
    `--account-only` plus symbol fallback for open-orders. PR #741 added
    clock-skew health. PR #743 added candle freshness health. PR #745 added
@@ -1764,11 +1812,11 @@ VPS5 deployment status:
    `exchange_surface_health` notes over the existing endpoint outcomes.
    Remaining useful slices should be driven by a concrete live exchange gap
    rather than broad probe expansion.
-3. Continue monitoring staged-readiness summaries after PR #762. The first
+4. Continue monitoring staged-readiness summaries after PR #762. The first
    post-restart smokes showed `staged_readiness.total=0`; if the signal returns,
    inspect whether it is a real current-epoch account surface delay or a new
    completed-candle readiness shape.
-4. Start the live restart/smoke automation slice if operational workflow speed
+5. Start the live restart/smoke automation slice if operational workflow speed
    becomes the higher leverage next step.
-5. Continue cache-doctor refinements in separate adjacent PRs: deeper metadata
+6. Continue cache-doctor refinements in separate adjacent PRs: deeper metadata
    compatibility checks and synthetic/no-trade assumptions.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -139,11 +139,18 @@ Related detailed plans:
    Status: initial implementation merged. `health.summary` events now include
    process RSS, memory percent when available, open file descriptor count,
    system load averages, CPU count, and live-event pipeline queue/drop/sink
-   error counters.
+   error counters. `live-smoke-report` now also projects those existing
+   event-pipeline counters into full, summary, and brief smoke reports.
 
    Remaining refinements: exchange-call counts, candle-fetch concurrency, loop
    lag, thresholded console warnings, and richer system memory/swap fields. Keep
    this off console unless thresholds are crossed.
+
+   Work log:
+   - 2026-06-27: Added `live-smoke-report` event-pipeline health summaries
+     from existing `health.summary` counters, exposing queue depth, unfinished
+     work, dropped events, sink errors, degraded count, worker-not-alive count,
+     and stopping count without changing smoke verdict logic.
 
 6. [ ] Exchange health and contract probes.
    Status: partial. VPS5 smoke on 2026-06-25 surfaced Kucoin authoritative
@@ -337,7 +344,9 @@ Related detailed plans:
 13. [ ] Cache integrity doctor.
     Status: partial. Initial read-only local cache smoke doctor, cache-family
     summaries, candle coverage evidence, fill/HSL metadata evidence, and
-    report-only warm-cache readiness evidence are merged.
+    report-only warm-cache readiness evidence are merged. Deeper report-only
+    metadata compatibility evidence for candle known gaps, fill coverage proof,
+    and HSL artifact/timestamp compatibility is also merged.
 
     Add a read-only doctor for candle/fill/HSL caches that reports coverage,
     metadata compatibility, corrupted shards, suspicious gaps, synthetic/no-trade
@@ -491,6 +500,8 @@ Related detailed plans:
 | 2026-06-27 | #3 Live restart/smoke automation | PR #759 / `74a52ede` | Added `live-smoke-report` staged-readiness health summaries from existing staged `cycle.degraded` events; VPS5 smoke reported all five bots matched, no hard failures, no failed remote/account-critical calls, and `staged_readiness.total=4`, `bots=1`, `latest_missing_surface_total=1`, `latest_invalid_surface_total=1` | Use the new staged readiness signal to decide whether a narrow completed-candle readiness fix is warranted |
 | 2026-06-27 | #3 Live restart/smoke automation | PR #760 / `31d42ea3` | Recorded staged-readiness deploy evidence; VPS5 pull required no restart, an initial smoke surfaced real HSL ZEC RED finalizations through logs and `risk_events`, and settled follow-up smokes returned `ok=true`, no hard/log failures, all five bots matched, no failed remote/account-critical calls, and persistent `staged_readiness` across up to four bots | Continue using `staged_readiness` summaries to decide whether completed-candle target-change fixes or diagnostics are warranted |
 | 2026-06-27 | Adjacent staged readiness/runtime | PR #762 / `d9188b64` | Tolerated completed-candle fallback-to-normal signature shape recovery when symbol and target timestamp are unchanged; VPS5 restart smoke returned `ok=true`, all five bots matched, no hard/log failures, no failed remote/account-critical calls, and `staged_readiness.total=0` in both immediate and settled windows | Continue monitoring staged readiness; if it recurs, classify account-surface delays separately from completed-candle readiness shapes |
+| 2026-06-27 | #13 Cache integrity doctor | PR #764 / `7797d038` | Added report-only metadata compatibility evidence for candle known-gap no-trade reasons, fill current-contract coverage proof, and HSL artifact/timestamp compatibility; final review follow-up made mixed no-trade/unclassified gaps explicitly partial and still unproven | Further cache-doctor refinements should stay read-only and prove rather than assume coverage |
+| 2026-06-27 | #5 Resource pressure telemetry | PR #765 / `5275ab75` | Added `live-smoke-report` event-pipeline health summaries from existing `health.summary` queue/drop/sink-error counters; VPS5 30-minute smoke showed `event_pipeline.total=1`, no drops, no sink errors, and worker alive | Consider thresholded console/report warnings only after more live evidence |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |


### PR DESCRIPTION
Scope
- Docs-only progress update after PR #764 and PR #765 merged to v8.
- Records cache-doctor metadata compatibility evidence and live-smoke event-pipeline health evidence.
- Records VPS5 deploy smoke caveat: merged tooling deployed cleanly, all expected bots stayed running, but smoke was red from live HSL/risk activity and an unrelated fill-refresh timeout.

Validation
- git diff --check: pass