### PR TITLE
Classify risk log matches in smoke report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added risk/HSL log-match counters to `passivbot tool live-smoke-report`, so
+  CRITICAL risk-state log lines can be distinguished from non-risk hard log
+  matches without changing smoke verdict logic.
 - Added event-pipeline health summaries to
   `passivbot tool live-smoke-report`, projecting existing `health.summary`
   queue/drop/sink-error counters into full, summary, and brief reports.

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -27,6 +27,10 @@ ATTENTION_LOG_PATTERN = re.compile(
     r"\blevel=(?:critical|error)\b|\bfatal\b|\buncaught\b",
     re.IGNORECASE,
 )
+RISK_LOG_PATTERN = re.compile(
+    r"(?:\[(?:risk|hsl|wel|twel|unstuck)\]|\bHSL\[|\b(?:risk|hsl|wel|twel|unstuck)\.)",
+    re.IGNORECASE,
+)
 SENSITIVE_LOG_HEADER_PATTERN = re.compile(
     r"(?i)\b(authorization|proxy-authorization|x-mbx-apikey|cookie|set-cookie)"
     r"(\s*[:=]\s*)(?:bearer|basic)?\s*[^,\s;]+"
@@ -2819,6 +2823,10 @@ def _scan_logs(
             "files_scanned": 0,
             "hard_matches": 0,
             "attention_matches": 0,
+            "risk_attention_matches": 0,
+            "risk_hard_matches": 0,
+            "non_risk_attention_matches": 0,
+            "non_risk_hard_matches": 0,
             "window": window_report,
             "matches": [],
             "dropped_unparsed_attention_matches": 0,
@@ -2828,6 +2836,10 @@ def _scan_logs(
     matches: list[dict[str, Any]] = []
     hard_matches = 0
     attention_matches = 0
+    risk_attention_matches = 0
+    risk_hard_matches = 0
+    non_risk_attention_matches = 0
+    non_risk_hard_matches = 0
     lines_considered = 0
     lines_skipped_before = 0
     lines_skipped_after = 0
@@ -2873,13 +2885,23 @@ def _scan_logs(
                 continue
             attention_matches += 1
             hard = bool(HARD_LOG_PATTERN.search(line))
+            risk_match = bool(RISK_LOG_PATTERN.search(line))
+            if risk_match:
+                risk_attention_matches += 1
+            else:
+                non_risk_attention_matches += 1
             if hard:
                 hard_matches += 1
+                if risk_match:
+                    risk_hard_matches += 1
+                else:
+                    non_risk_hard_matches += 1
             if len(matches) < max(0, int(max_matches)):
                 match = {
                     "path": str(path),
                     "line": int(line_no),
                     "hard": hard,
+                    "category": "risk" if risk_match else "general",
                     "text": _redact_log_text(line, max_len=500),
                 }
                 if line_ts is not None:
@@ -2890,6 +2912,10 @@ def _scan_logs(
         "files_scanned": len(files),
         "hard_matches": hard_matches,
         "attention_matches": attention_matches,
+        "risk_attention_matches": risk_attention_matches,
+        "risk_hard_matches": risk_hard_matches,
+        "non_risk_attention_matches": non_risk_attention_matches,
+        "non_risk_hard_matches": non_risk_hard_matches,
         "window": _log_window_report(
             since_ms=since_ms,
             until_ms=until_ms,
@@ -3270,6 +3296,12 @@ def summarize_live_smoke_report(
             "files_scanned": int(logs.get("files_scanned") or 0),
             "hard_matches": int(logs.get("hard_matches") or 0),
             "attention_matches": int(logs.get("attention_matches") or 0),
+            "risk_attention_matches": int(logs.get("risk_attention_matches") or 0),
+            "risk_hard_matches": int(logs.get("risk_hard_matches") or 0),
+            "non_risk_attention_matches": int(
+                logs.get("non_risk_attention_matches") or 0
+            ),
+            "non_risk_hard_matches": int(logs.get("non_risk_hard_matches") or 0),
             "dropped_unparsed_attention_matches": int(
                 logs.get("dropped_unparsed_attention_matches") or 0
             ),
@@ -3439,6 +3471,16 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             "files_scanned": _count_value(logs.get("files_scanned")),
             "hard_matches": _count_value(logs.get("hard_matches")),
             "attention_matches": _count_value(logs.get("attention_matches")),
+            "risk_attention_matches": _count_value(
+                logs.get("risk_attention_matches")
+            ),
+            "risk_hard_matches": _count_value(logs.get("risk_hard_matches")),
+            "non_risk_attention_matches": _count_value(
+                logs.get("non_risk_attention_matches")
+            ),
+            "non_risk_hard_matches": _count_value(
+                logs.get("non_risk_hard_matches")
+            ),
             "dropped_unparsed_attention_matches": _count_value(
                 logs.get("dropped_unparsed_attention_matches")
             ),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -804,6 +804,10 @@ def test_live_smoke_report_brief_summary_projects_top_level_counters(tmp_path):
         "files_scanned": 1,
         "hard_matches": 0,
         "attention_matches": 1,
+        "risk_attention_matches": 0,
+        "risk_hard_matches": 0,
+        "non_risk_attention_matches": 1,
+        "non_risk_hard_matches": 0,
         "dropped_unparsed_attention_matches": 0,
         "dropped_unparsed_hard_matches": 0,
     }
@@ -2141,6 +2145,63 @@ def test_live_smoke_report_log_scan_deduplicates_aliases_and_matches_levels(
     assert "AKIA123" not in emitted
     assert "hunter2" not in emitted
     assert "TOKEN123" not in emitted
+
+
+def test_live_smoke_report_log_scan_classifies_risk_matches(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+            )
+        ],
+    )
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "binance_01.log").write_text(
+        "\n".join(
+            [
+                (
+                    "2026-06-27T16:06:24Z CRITICAL [binance] [risk] "
+                    "HSL[long:XLM/USDT:USDT] reconstructed active coin RED cooldown"
+                ),
+                "2026-06-27T16:06:25Z CRITICAL uncaught task failure",
+                "2026-06-27T16:06:26Z ERROR [fills] temporary fetch failed",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=logs_dir,
+        log_tail_lines=10,
+    )
+    summary = summarize_live_smoke_report(report)
+    brief = summarize_live_smoke_report_brief(report)
+
+    assert report["ok"] is False
+    assert report["hard_failures"] == 2
+    assert report["logs"]["attention_matches"] == 3
+    assert report["logs"]["hard_matches"] == 2
+    assert report["logs"]["risk_attention_matches"] == 1
+    assert report["logs"]["risk_hard_matches"] == 1
+    assert report["logs"]["non_risk_attention_matches"] == 2
+    assert report["logs"]["non_risk_hard_matches"] == 1
+    assert [match["category"] for match in report["logs"]["matches"]] == [
+        "risk",
+        "general",
+        "general",
+    ]
+    assert summary["logs"]["risk_hard_matches"] == 1
+    assert summary["logs"]["non_risk_hard_matches"] == 1
+    assert brief["logs"]["risk_hard_matches"] == 1
+    assert brief["logs"]["non_risk_hard_matches"] == 1
 
 
 def test_live_smoke_report_log_window_filters_parseable_timestamps(tmp_path):


### PR DESCRIPTION
Scope
- Adds risk/HSL log-match classification to passivbot tool live-smoke-report.
- Adds risk_attention_matches, risk_hard_matches, non_risk_attention_matches, and non_risk_hard_matches to full, summary, and brief log projections.
- Adds category=risk/general to bounded log match samples.
- Does not change ok, hard_failures, attention_count, or live behavior.

Validation
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_smoke_report.py: 42 passed
- PYTHONPATH=src ./venv/bin/python -m compileall -q src/live/smoke_report.py tests/test_live_smoke_report.py: pass
- git diff --check: pass