### PR TITLE
Record PR767 deploy evidence

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-27.
 
 Current `origin/v8` logging-overhaul head:
 
-- `5275ab75` merge of PR #765, `Summarize live event pipeline health in smoke report`.
+- `b07d5166` merge of PR #767, `Classify risk log matches in smoke report`.
 
 Current review gate:
 
@@ -1790,13 +1790,35 @@ VPS5 deployment status:
   still running, and remote/account-critical call summaries reported no
   failures.
 
+### PR #767: Live Smoke Risk Log Classification
+
+- Branch: `codex/v8-smoke-risk-log-classification`.
+- Scope: read-only smoke-report tooling.
+- Result: `passivbot tool live-smoke-report` now splits text-log attention and
+  hard matches into risk/HSL-related and non-risk buckets. Full, summary, and
+  brief reports include `risk_attention_matches`, `risk_hard_matches`,
+  `non_risk_attention_matches`, and `non_risk_hard_matches`; bounded log match
+  samples now include `category=risk|general`. Smoke verdict logic is unchanged:
+  risk/HSL CRITICAL lines still count in `hard_matches` and still make smoke
+  red.
+- Review evidence: Claude and Hermes approved; CI was green; full
+  `tests/test_live_smoke_report.py`, compileall, `git diff --check`, and the
+  touched-file silent-handling audit passed locally.
+- VPS5 evidence: deployed at `b07d5166` without bot restart because this is
+  read-only smoke-report tooling. A 5-minute brief smoke reported `ok=true`,
+  `hard_failures=0`, `logs.hard_matches=0`,
+  `logs.risk_hard_matches=0`, `logs.non_risk_hard_matches=0`, all five
+  expected bots matched, clean tracked repository state, no failed remote
+  calls, and no failed account-critical remote calls. Remaining attention was
+  non-hard EMA readiness and HSL status.
+
 ## Current Next Steps
 
-1. Inspect the current VPS5 HSL/risk smoke signal separately from the merged
-   tooling. The latest deploy smoke shows real HSL RED/cooldown activity and
-   CRITICAL risk text logs; decide whether smoke should keep treating those as
-   hard operator failures or whether risk-state criticality needs a more
-   explicit classification distinct from software crashes.
+1. Continue collecting smoke evidence with the new risk-vs-general log-match
+   counters before changing any verdict policy. If future HSL RED/cooldown
+   episodes make smoke red, the report can now show whether the red state came
+   from risk/HSL log lines, non-risk software failures, structured problem
+   events, or process/repository health.
 2. Continue Phase 5/6 by adding the next high-value event producer or debug
    profile slice without increasing default console noise. Likely candidates
    are more order/risk transition coverage or focused profile refinements only

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -274,6 +274,9 @@ Related detailed plans:
       lines for active coin-mode HSL positions, including distance to red,
       drawdown, slot budget, realized PnL peak, and unrealized PnL. The
       structured `hsl.status` event remains the durable source.
+    - 2026-06-27: Added `live-smoke-report` risk/HSL log-match counters,
+      splitting text-log attention/hard matches into risk and non-risk buckets
+      without changing smoke verdict logic.
 
 11. [x] Order lifecycle trace completeness.
     Status: initial reconstruction view merged. The order-wave/execution event
@@ -502,6 +505,7 @@ Related detailed plans:
 | 2026-06-27 | Adjacent staged readiness/runtime | PR #762 / `d9188b64` | Tolerated completed-candle fallback-to-normal signature shape recovery when symbol and target timestamp are unchanged; VPS5 restart smoke returned `ok=true`, all five bots matched, no hard/log failures, no failed remote/account-critical calls, and `staged_readiness.total=0` in both immediate and settled windows | Continue monitoring staged readiness; if it recurs, classify account-surface delays separately from completed-candle readiness shapes |
 | 2026-06-27 | #13 Cache integrity doctor | PR #764 / `7797d038` | Added report-only metadata compatibility evidence for candle known-gap no-trade reasons, fill current-contract coverage proof, and HSL artifact/timestamp compatibility; final review follow-up made mixed no-trade/unclassified gaps explicitly partial and still unproven | Further cache-doctor refinements should stay read-only and prove rather than assume coverage |
 | 2026-06-27 | #5 Resource pressure telemetry | PR #765 / `5275ab75` | Added `live-smoke-report` event-pipeline health summaries from existing `health.summary` queue/drop/sink-error counters; VPS5 30-minute smoke showed `event_pipeline.total=1`, no drops, no sink errors, and worker alive | Consider thresholded console/report warnings only after more live evidence |
+| 2026-06-27 | #10 Operator console redesign from events | PR #767 / `b07d5166` | Added `live-smoke-report` risk/HSL log-match counters and bounded `category=risk|general` match labels; VPS5 smoke after deploy was green with zero hard/risk/non-risk log matches and all five bots running | Use the split counters to collect evidence before changing smoke verdict policy for real HSL RED/cooldown episodes |
 | 2026-06-25 | #3 Live restart/smoke automation | PR #639 / `86afd3b3` | Added read-only `passivbot tool live-smoke-report` | Safe pull/stop/start orchestration still open |
 | 2026-06-25 | #4 Startup phase budget tracking | PR #649 / `7391d43b` | Added startup timing baselines to `live-smoke-report` from existing `bot.startup_timing` monitor events | Explicit durable budget config/events |
 | 2026-06-25 | #5 Resource pressure telemetry | PR #643 / `09fd305b` | Added resource pressure and event-pipeline counters to `health.summary` | VPS5 restart/smoke pending; richer resource fields still open |


### PR DESCRIPTION
Scope
- Docs-only progress update after PR #767 merged to v8.
- Records risk/HSL log-match classification review and VPS5 deploy smoke evidence.
- Updates next step to collect risk-vs-general hard-log evidence before changing smoke verdict policy.

Validation
- git diff --check: pass