### PR TITLE
Summarize smoke report verdict sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added explicit hard-failure and attention source breakdowns to
+  `passivbot tool live-smoke-report`, so red or attention smokes identify
+  monitor parse errors, invalid rows, structured events, log matches, and
+  process liveness contributions without changing verdict logic.
 - Added risk/HSL log-match counters to `passivbot tool live-smoke-report`, so
   CRITICAL risk-state log lines can be distinguished from non-risk hard log
   matches without changing smoke verdict logic.

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -3089,11 +3089,29 @@ def build_live_smoke_report(
         + int(log_scan["attention_matches"])
         + int(log_scan.get("dropped_unparsed_attention_matches", 0))
     )
+    hard_failure_sources = {
+        "monitor_errors": int(event_report["error_count"]),
+        "invalid_event_rows": int(event_scan["invalid_rows"]),
+        "hard_problem_events": int(event_scan["hard_problem_event_count"]),
+        "log_hard_matches": int(log_scan["hard_matches"]),
+        "process_hard_failures": int(process_report["hard_failures"]),
+        "total": int(hard_failures),
+    }
+    attention_sources = {
+        "problem_events": int(event_scan["problem_event_count"]),
+        "log_attention_matches": int(log_scan["attention_matches"]),
+        "dropped_unparsed_attention_matches": int(
+            log_scan.get("dropped_unparsed_attention_matches", 0)
+        ),
+        "total": int(attention_count),
+    }
     return {
         "ok": hard_failures == 0,
         "attention": attention_count > 0,
         "hard_failures": hard_failures,
         "attention_count": attention_count,
+        "hard_failure_sources": hard_failure_sources,
+        "attention_sources": attention_sources,
         "monitor": {
             "root": event_report.get("root"),
             "include_rotated": event_report.get("include_rotated"),
@@ -3233,6 +3251,8 @@ def summarize_live_smoke_report(
         "attention": bool(report.get("attention", False)),
         "hard_failures": int(report.get("hard_failures") or 0),
         "attention_count": int(report.get("attention_count") or 0),
+        "hard_failure_sources": dict(report.get("hard_failure_sources") or {}),
+        "attention_sources": dict(report.get("attention_sources") or {}),
         "repository": {
             key: repository.get(key)
             for key in (
@@ -3413,6 +3433,14 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         "attention": bool(report.get("attention")),
         "hard_failures": _count_value(report.get("hard_failures")),
         "attention_count": _count_value(report.get("attention_count")),
+        "hard_failure_sources": {
+            key: _count_value(value)
+            for key, value in (report.get("hard_failure_sources") or {}).items()
+        },
+        "attention_sources": {
+            key: _count_value(value)
+            for key, value in (report.get("attention_sources") or {}).items()
+        },
         "repository": {
             key: repository.get(key)
             for key in ("branch", "head", "dirty", "tracked_changes")

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -152,6 +152,20 @@ def test_live_smoke_report_summarizes_monitor_events_and_log_attention(tmp_path)
     assert report["problem_events"][0]["event_type"] == "remote_call.failed"
     assert report["problem_events"][0]["hard"] is False
     assert report["problem_events"][0]["ids"] == {"remote_call_id": "rc_1"}
+    assert report["hard_failure_sources"] == {
+        "monitor_errors": 0,
+        "invalid_event_rows": 0,
+        "hard_problem_events": 0,
+        "log_hard_matches": 1,
+        "process_hard_failures": 0,
+        "total": 1,
+    }
+    assert report["attention_sources"] == {
+        "problem_events": 1,
+        "log_attention_matches": 2,
+        "dropped_unparsed_attention_matches": 0,
+        "total": 3,
+    }
     assert report["remote_call_failures"] == {
         "total": 1,
         "groups_truncated": False,
@@ -720,6 +734,20 @@ def test_live_smoke_report_summary_projects_high_signal_fields(tmp_path):
     assert summary["attention"] is True
     assert summary["hard_failures"] == 0
     assert summary["attention_count"] == 3
+    assert summary["hard_failure_sources"] == {
+        "monitor_errors": 0,
+        "invalid_event_rows": 0,
+        "hard_problem_events": 0,
+        "log_hard_matches": 0,
+        "process_hard_failures": 0,
+        "total": 0,
+    }
+    assert summary["attention_sources"] == {
+        "problem_events": 2,
+        "log_attention_matches": 1,
+        "dropped_unparsed_attention_matches": 0,
+        "total": 3,
+    }
     assert summary["monitor"]["live_events"] == 2
     assert summary["logs"]["attention_matches"] == 1
     assert summary["logs"]["matches_truncated"] is False
@@ -799,6 +827,20 @@ def test_live_smoke_report_brief_summary_projects_top_level_counters(tmp_path):
     assert brief["attention"] is True
     assert brief["hard_failures"] == 0
     assert brief["attention_count"] == 3
+    assert brief["hard_failure_sources"] == {
+        "monitor_errors": 0,
+        "invalid_event_rows": 0,
+        "hard_problem_events": 0,
+        "log_hard_matches": 0,
+        "process_hard_failures": 0,
+        "total": 0,
+    }
+    assert brief["attention_sources"] == {
+        "problem_events": 2,
+        "log_attention_matches": 1,
+        "dropped_unparsed_attention_matches": 0,
+        "total": 3,
+    }
     assert brief["monitor"]["live_events"] == 2
     assert brief["logs"] == {
         "files_scanned": 1,


### PR DESCRIPTION
## Summary
- add explicit hard_failure_sources and attention_sources to live-smoke-report full output
- project the same source accounting into --summary and --brief output
- keep ok/hard_failures/attention_count verdict math unchanged

## Validation
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_smoke_report.py -k "summarizes_monitor_events_and_log_attention or summary_limits_problem_event_groups or brief_summary_projects_top_level_counters"
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_smoke_report.py
- PYTHONPATH=src ./venv/bin/python -m compileall -q src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check

## Notes
Observability-only operator smoke-report projection. No trading behavior and no smoke verdict policy change.