### PR TITLE
Improve backtest materializer interrupts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Improved cold `passivbot backtest` materialization by batching legacy OHLCV
+  imports by month, vectorizing chunk writes, publishing HLCV cache directories
+  atomically, and honoring Ctrl+C between expensive materializer/cache stages.
 - Added risk/HSL log-match counters to `passivbot tool live-smoke-report`, so
   CRITICAL risk-state log lines can be distinguished from non-risk hard log
   matches without changing smoke verdict logic.

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -140,8 +140,11 @@ from plotting import (
 from collections import defaultdict
 import logging
 import gzip
+import shutil
 import traceback
+import uuid
 from logging_setup import configure_logging, resolve_log_level
+from backtest_cancellation import raise_if_backtest_cancel_requested
 from materialized_cache import release_materialized_payload
 from suite_runner import (
     extract_suite_config,
@@ -1673,7 +1676,7 @@ def save_coins_hlcvs_to_cache(
         cache_hash,
         timestamps=timestamps,
     )
-    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_dir.parent.mkdir(parents=True, exist_ok=True)
     is_compressed = bool(require_config_value(config, "backtest.compress_cache"))
     warmup_minutes = int(warmup_minutes)
     meta_path = cache_dir / "cache_meta.json"
@@ -1693,9 +1696,54 @@ def save_coins_hlcvs_to_cache(
                 cache_dir,
                 exc,
             )
+    raise_if_backtest_cancel_requested("cache save start")
     logging.info(f"Dumping cache...")
-    json.dump(coins, open(cache_dir / "coins.json", "w"))
-    json.dump(mss, open(cache_dir / "market_specific_settings.json", "w"))
+    tmp_cache_dir = cache_dir.parent / f".{cache_dir.name}.tmp-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    if tmp_cache_dir.exists():
+        shutil.rmtree(tmp_cache_dir)
+    tmp_cache_dir.mkdir(parents=True)
+    published = False
+    try:
+        json.dump(coins, open(tmp_cache_dir / "coins.json", "w"))
+        json.dump(mss, open(tmp_cache_dir / "market_specific_settings.json", "w"))
+        _save_coins_hlcvs_artifacts_to_cache_dir(
+            config=config,
+            cache_dir=tmp_cache_dir,
+            coins=coins,
+            hlcvs=hlcvs,
+            exchange=exchange,
+            mss=mss,
+            btc_usd_prices=btc_usd_prices,
+            timestamps=timestamps,
+            warmup_minutes=warmup_minutes,
+            cache_hash=cache_hash,
+            is_compressed=is_compressed,
+        )
+        raise_if_backtest_cancel_requested("cache publish")
+        if cache_dir.exists():
+            shutil.rmtree(cache_dir)
+        os.replace(tmp_cache_dir, cache_dir)
+        published = True
+    finally:
+        if not published and tmp_cache_dir.exists():
+            shutil.rmtree(tmp_cache_dir, ignore_errors=True)
+    return cache_dir
+
+
+def _save_coins_hlcvs_artifacts_to_cache_dir(
+    *,
+    config,
+    cache_dir: Path,
+    coins,
+    hlcvs,
+    exchange,
+    mss,
+    btc_usd_prices,
+    timestamps,
+    warmup_minutes: int,
+    cache_hash: str,
+    is_compressed: bool,
+) -> None:
     uncompressed_size = hlcvs.nbytes
     sts = utc_ms()
     if is_compressed:
@@ -1703,15 +1751,18 @@ def save_coins_hlcvs_to_cache(
         logging.info(f"Attempting to save hlcvs data to cache {fpath}...")
         with gzip.open(fpath, "wb", compresslevel=1) as f:
             np.save(f, hlcvs)
+        raise_if_backtest_cancel_requested("hlcvs cache artifact")
         if timestamps is not None:
             ts_fpath = cache_dir / "timestamps.npy.gz"
             logging.info(f"Attempting to save timestamps to cache {ts_fpath}...")
             with gzip.open(ts_fpath, "wb", compresslevel=1) as f:
                 np.save(f, timestamps)
+            raise_if_backtest_cancel_requested("timestamps cache artifact")
         btc_fpath = cache_dir / "btc_usd_prices.npy.gz"
         logging.info(f"Attempting to save BTC/USD prices to cache {btc_fpath}...")
         with gzip.open(btc_fpath, "wb", compresslevel=1) as f:
             np.save(f, btc_usd_prices)
+        raise_if_backtest_cancel_requested("btc cache artifact")
         compressed_size = (cache_dir / "hlcvs.npy.gz").stat().st_size
         btc_compressed_size = (cache_dir / "btc_usd_prices.npy.gz").stat().st_size
         line = (
@@ -1723,13 +1774,16 @@ def save_coins_hlcvs_to_cache(
         fpath = cache_dir / "hlcvs.npy"
         logging.info(f"Attempting to save hlcvs data to cache {fpath}...")
         np.save(fpath, hlcvs)
+        raise_if_backtest_cancel_requested("hlcvs cache artifact")
         if timestamps is not None:
             ts_fpath = cache_dir / "timestamps.npy"
             logging.info(f"Attempting to save timestamps to cache {ts_fpath}...")
             np.save(ts_fpath, timestamps)
+            raise_if_backtest_cancel_requested("timestamps cache artifact")
         btc_fpath = cache_dir / "btc_usd_prices.npy"
         logging.info(f"Attempting to save BTC/USD prices to cache {btc_fpath}...")
         np.save(btc_fpath, btc_usd_prices)
+        raise_if_backtest_cancel_requested("btc cache artifact")
         line = ""
     logging.info(
         f"Successfully dumped hlcvs cache {fpath}: "
@@ -1745,6 +1799,7 @@ def save_coins_hlcvs_to_cache(
             indent=2,
             sort_keys=True,
         )
+    raise_if_backtest_cancel_requested("cache manifest build")
     manifest = build_hlcvs_manifest(
         config=config,
         exchange=exchange,
@@ -1757,6 +1812,7 @@ def save_coins_hlcvs_to_cache(
         warmup_minutes=warmup_minutes,
         compressed=is_compressed,
     )
+    raise_if_backtest_cancel_requested("cache manifest write")
     write_hlcvs_manifest(cache_dir, manifest)
     json.dump(
         {
@@ -1764,9 +1820,8 @@ def save_coins_hlcvs_to_cache(
             "materialization_schema_version": manifest["materialization_schema_version"],
             "manifest_schema_version": manifest["schema_version"],
         },
-        open(meta_path, "w"),
+        open(cache_dir / "cache_meta.json", "w"),
     )
-    return cache_dir
 
 
 def ensure_valid_index_metadata(mss, hlcvs, coins, warmup_map=None):
@@ -1977,8 +2032,12 @@ async def prepare_hlcvs_mss(config, exchange, *, force_refetch_gaps: bool = Fals
             force_overwrite=force_refetch_gaps,
         )
     except Exception as e:
+        release_materialized_payload(hlcvs)
         logging.error(f"Failed to save hlcvs to cache: {e}")
         traceback.print_exc()
+        raise
+    except BaseException:
+        release_materialized_payload(hlcvs)
         raise
     return coins, hlcvs, mss, results_path, cache_dir, btc_usd_prices, timestamps
 
@@ -2815,6 +2874,7 @@ async def main():
                 logging.info(f"chose {ex} for {','.join(exchange_preference[ex])}")
             config["backtest"]["coins"][exchange] = coins
             config["backtest"]["cache_dir"][exchange] = str(cache_dir)
+            raise_if_backtest_cancel_requested("backtest execution")
 
             fills, equities_array, analysis, payload = run_backtest(
                 hlcvs,
@@ -2855,6 +2915,7 @@ async def main():
             try:
                 configs[exchange]["backtest"]["coins"][exchange] = coins
                 configs[exchange]["backtest"]["cache_dir"][exchange] = str(cache_dir)
+                raise_if_backtest_cancel_requested("backtest execution")
                 fills, equities_array, analysis, payload = run_backtest(
                     hlcvs,
                     mss,

--- a/src/backtest_cancellation.py
+++ b/src/backtest_cancellation.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+
+def backtest_cancel_requested() -> bool:
+    try:
+        task = asyncio.current_task()
+    except RuntimeError:
+        return False
+    return task is not None and task.cancelling() > 0
+
+
+def raise_if_backtest_cancel_requested(stage: str) -> None:
+    if not backtest_cancel_requested():
+        return
+    logging.info("[backtest] interrupt requested; aborting %s", stage)
+    raise asyncio.CancelledError(f"backtest interrupted during {stage}")

--- a/src/backtest_dataset_materializer.py
+++ b/src/backtest_dataset_materializer.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import numpy as np
 
 from materialized_cache import prepare_materialized_run, release_materialized_root
+from backtest_cancellation import raise_if_backtest_cancel_requested
 from ohlcv_store import OhlcvStore, timeframe_to_interval_ms
 
 
@@ -223,20 +224,24 @@ class BacktestDatasetMaterializer:
         timestamps = None
         btc_mm = None
         try:
+            raise_if_backtest_cancel_requested("materializer memmap allocation")
             hlcvs = np.memmap(
                 hlcvs_path, mode="w+", dtype=np.float64, shape=(n_steps, len(coins), 4)
             )
             hlcvs[:] = np.nan
+            raise_if_backtest_cancel_requested("materializer hlcvs initialization")
             timestamps = np.memmap(timestamps_path, mode="w+", dtype=np.int64, shape=(n_steps,))
             timestamps[:] = np.arange(start_ts, end_ts + interval_ms, interval_ms, dtype=np.int64)
             btc_mm = np.memmap(btc_path, mode="w+", dtype=np.float64, shape=(n_steps,))
             btc_mm[:] = btc_arr
+            raise_if_backtest_cancel_requested("materializer static arrays")
 
             enriched_mss = deepcopy(mss)
             valid_buffer = np.zeros(n_steps, dtype=np.bool_)
             symbols_by_coin = symbols_by_coin or {}
             source_windows_by_coin = source_windows_by_coin or {}
             for coin_idx, coin in enumerate(coins):
+                raise_if_backtest_cancel_requested("materializer coin loop")
                 coin_t0 = time.monotonic()
                 logging.info(
                     "[materializer] coin start %d/%d exchange=%s coin=%s",
@@ -269,6 +274,7 @@ class BacktestDatasetMaterializer:
                     coin_view[dest_start:dest_end],
                     valid_buffer[dest_start:dest_end],
                 )
+                raise_if_backtest_cancel_requested("materializer store copy")
                 source_first_valid_index, source_last_valid_index, source_valid_count = _valid_span(
                     valid_buffer
                 )
@@ -312,7 +318,9 @@ class BacktestDatasetMaterializer:
                     synthetic_gap_fill_count,
                     time.monotonic() - coin_t0,
                 )
+                raise_if_backtest_cancel_requested("materializer coin finalize")
 
+            raise_if_backtest_cancel_requested("materializer close")
             _close_memmap(hlcvs)
             _close_memmap(timestamps)
             _close_memmap(btc_mm)
@@ -391,15 +399,19 @@ def materialize_frames(
     timestamps_mm = None
     btc_mm = None
     try:
+        raise_if_backtest_cancel_requested("frame materializer memmap allocation")
         hlcvs = np.memmap(hlcvs_path, mode="w+", dtype=np.float64, shape=(n_steps, len(coins), 4))
         hlcvs[:] = np.nan
+        raise_if_backtest_cancel_requested("frame materializer hlcvs initialization")
         timestamps_mm = np.memmap(timestamps_path, mode="w+", dtype=np.int64, shape=(n_steps,))
         timestamps_mm[:] = ts_arr
         btc_mm = np.memmap(btc_path, mode="w+", dtype=np.float64, shape=(n_steps,))
         btc_mm[:] = btc_arr
+        raise_if_backtest_cancel_requested("frame materializer static arrays")
 
         enriched_mss = deepcopy(mss)
         for coin_idx, coin in enumerate(coins):
+            raise_if_backtest_cancel_requested("frame materializer coin loop")
             coin_t0 = time.monotonic()
             logging.info(
                 "[materializer] frame coin start %d/%d exchange=%s coin=%s",
@@ -414,6 +426,7 @@ def materialize_frames(
                     f"aligned_values_by_coin[{coin!r}] must have shape ({n_steps}, 4), got {aligned.shape}"
                 )
             valid_mask = ~np.isnan(aligned[:, 0])
+            raise_if_backtest_cancel_requested("frame materializer coin copy")
             source_first_valid_index, source_last_valid_index, source_valid_count = _valid_span(
                 valid_mask
             )
@@ -456,7 +469,9 @@ def materialize_frames(
                 synthetic_gap_fill_count,
                 time.monotonic() - coin_t0,
             )
+            raise_if_backtest_cancel_requested("frame materializer coin finalize")
 
+        raise_if_backtest_cancel_requested("frame materializer close")
         _close_memmap(hlcvs)
         _close_memmap(timestamps_mm)
         _close_memmap(btc_mm)

--- a/src/ohlcv_legacy_import.py
+++ b/src/ohlcv_legacy_import.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from collections import defaultdict
 
 import numpy as np
 
 from legacy_data_migrator import _sanitize_symbol
-from ohlcv_store import OhlcvStore
+from ohlcv_store import OhlcvStore, month_key_for_ts
 from ohlcv_utils import load_ohlcv_data
 
 
@@ -129,6 +130,7 @@ def import_legacy_range_into_store(
         return 0
 
     imported_rows = 0
+    month_batches: dict[tuple[int, int], list[tuple[np.ndarray, np.ndarray]]] = defaultdict(list)
     for day in _iter_utc_days(start_ts, end_ts):
         fpath = _resolve_legacy_day_path(symbol_dir, day)
         if fpath is None:
@@ -137,6 +139,17 @@ def import_legacy_range_into_store(
         mask = (ts >= int(start_ts)) & (ts <= int(end_ts))
         if not mask.any():
             continue
-        store.write_rows(exchange, timeframe, symbol, ts[mask], values[mask])
+        day_ts = ts[mask]
+        day_values = values[mask]
+        month_batches[month_key_for_ts(int(day_ts[0]))].append((day_ts, day_values))
         imported_rows += int(mask.sum())
+    for key in sorted(month_batches):
+        ts_parts, value_parts = zip(*month_batches[key])
+        store.write_rows(
+            exchange,
+            timeframe,
+            symbol,
+            np.concatenate(ts_parts),
+            np.concatenate(value_parts),
+        )
     return imported_rows

--- a/src/ohlcv_store.py
+++ b/src/ohlcv_store.py
@@ -254,10 +254,24 @@ class OhlcvStore:
                             clear_src_end = month_offset(clear_end, year, month, timeframe) + 1
                             body[clear_src_start:clear_src_end] = np.nan
                             valid[clear_src_start:clear_src_end] = False
-                    for src_idx in indices:
-                        offset = month_offset(int(ts_arr[src_idx]), year, month, timeframe)
-                        body[offset] = val_arr[src_idx]
-                        valid[offset] = True
+                    idx_arr = np.asarray(indices, dtype=np.int64)
+                    month_start = month_start_ts(year, month)
+                    offsets = ((ts_arr[idx_arr] - month_start) // interval_ms).astype(
+                        np.int64, copy=False
+                    )
+                    max_rows = rows_in_month(year, month, timeframe)
+                    if np.any(offsets < 0) or np.any(offsets >= max_rows):
+                        raise ValueError(
+                            f"timestamps out of month bounds for {year:04d}-{month:02d}"
+                        )
+                    if len(np.unique(offsets)) != len(offsets):
+                        for src_idx in indices:
+                            offset = month_offset(int(ts_arr[src_idx]), year, month, timeframe)
+                            body[offset] = val_arr[src_idx]
+                            valid[offset] = True
+                    else:
+                        body[offsets] = val_arr[idx_arr]
+                        valid[offsets] = True
                     body.flush()
                     valid.flush()
                 finally:

--- a/tests/test_cache_warmup_reuse.py
+++ b/tests/test_cache_warmup_reuse.py
@@ -16,6 +16,7 @@ Tests cover:
 """
 
 import copy
+import asyncio
 import gzip
 import json
 import os
@@ -498,6 +499,52 @@ class TestSavePersistsWarmupMetadata:
         assert float(loaded[0, 0, 0]) == 7.0
         meta = json.load(open(os.path.join(str(cache_dir), "cache_meta.json")))
         assert meta["warmup_minutes"] == 1000
+
+    def test_interrupted_save_cleans_temp_and_preserves_existing_cache(self, tmp_path, monkeypatch):
+        """A pending interrupt during artifact save must not publish partial cache data."""
+        monkeypatch.chdir(tmp_path)
+        cfg = _base_config()
+
+        coins = ["BTC"]
+        original = np.zeros((10, 1, 4), dtype=np.float64)
+        replacement = np.ones((10, 1, 4), dtype=np.float64) * 7.0
+        mss = {"BTC": {}}
+        btc_usd = np.ones(10, dtype=np.float64)
+        timestamps = np.arange(10, dtype=np.int64) * 60_000
+
+        cache_dir = save_coins_hlcvs_to_cache(
+            cfg,
+            coins,
+            original,
+            "binance",
+            mss,
+            btc_usd,
+            timestamps,
+            warmup_minutes=1000,
+        )
+
+        def interrupt_after_hlcvs(stage):
+            if stage == "hlcvs cache artifact":
+                raise asyncio.CancelledError("test interrupt")
+
+        monkeypatch.setattr("backtest.raise_if_backtest_cancel_requested", interrupt_after_hlcvs)
+
+        with pytest.raises(asyncio.CancelledError):
+            save_coins_hlcvs_to_cache(
+                cfg,
+                coins,
+                replacement,
+                "binance",
+                mss,
+                btc_usd,
+                timestamps,
+                warmup_minutes=1000,
+                force_overwrite=True,
+            )
+
+        loaded = np.load(os.path.join(str(cache_dir), "hlcvs.npy"))
+        assert float(loaded[0, 0, 0]) == 0.0
+        assert not list(Path(cache_dir).parent.glob(f".{Path(cache_dir).name}.tmp-*"))
 
     def test_save_overwrites_corrupt_manifest_cache_even_when_warmup_sufficient(
         self, tmp_path, monkeypatch

--- a/tests/test_ohlcv_legacy_import.py
+++ b/tests/test_ohlcv_legacy_import.py
@@ -93,6 +93,55 @@ def test_import_legacy_range_into_store_imports_requested_days_only(tmp_path):
     )
 
 
+def test_import_legacy_range_into_store_batches_same_month_days(tmp_path):
+    legacy_root = tmp_path / "legacy"
+    store_root = tmp_path / "new"
+    catalog = OhlcvCatalog(store_root / "catalog.sqlite")
+    store = OhlcvStore(store_root, catalog)
+
+    day1 = month_start_ts(2026, 4)
+    day2 = day1 + 24 * 60 * 60_000
+    _write_legacy_day(
+        legacy_root,
+        "binance",
+        "1m",
+        "ETH/USDT:USDT",
+        "2026-04-01",
+        [(day1, 0.0, 101.0, 99.0, 100.0, 10.0)],
+    )
+    _write_legacy_day(
+        legacy_root,
+        "binance",
+        "1m",
+        "ETH/USDT:USDT",
+        "2026-04-02",
+        [(day2, 0.0, 201.0, 199.0, 200.0, 20.0)],
+    )
+
+    calls = []
+    original_write_rows = store.write_rows
+
+    def spy_write_rows(exchange, timeframe, symbol, timestamps_ms, values, **kwargs):
+        calls.append(np.asarray(timestamps_ms).copy())
+        return original_write_rows(exchange, timeframe, symbol, timestamps_ms, values, **kwargs)
+
+    store.write_rows = spy_write_rows
+
+    imported = import_legacy_range_into_store(
+        store=store,
+        legacy_root=legacy_root,
+        exchange="binance",
+        timeframe="1m",
+        symbol="ETH/USDT:USDT",
+        start_ts=day1,
+        end_ts=day2,
+    )
+
+    assert imported == 2
+    assert len(calls) == 1
+    np.testing.assert_array_equal(calls[0], np.array([day1, day2], dtype=np.int64))
+
+
 def test_import_legacy_range_into_store_returns_zero_when_symbol_missing(tmp_path):
     store_root = tmp_path / "new"
     catalog = OhlcvCatalog(store_root / "catalog.sqlite")

--- a/tests/test_ohlcv_v2_prepare.py
+++ b/tests/test_ohlcv_v2_prepare.py
@@ -1,4 +1,5 @@
 import importlib
+import asyncio
 import json
 import sys
 from types import SimpleNamespace
@@ -2276,6 +2277,64 @@ async def test_prepare_hlcvs_mss_prefers_local_v2_before_full_prepare(monkeypatc
     np.testing.assert_array_equal(timestamps, prepared[1])
     assert mss["ETH"]["first_valid_index"] == 0
     assert mss["ETH"]["last_valid_index"] == 0
+
+
+@pytest.mark.asyncio
+async def test_prepare_hlcvs_mss_releases_payload_when_cache_save_interrupted(
+    monkeypatch, tmp_path
+):
+    import rust_utils
+
+    hlcvs = np.array([[[101.0, 99.0, 100.0, 10.0]]], dtype=np.float64)
+    prepared = (
+        {
+            "ETH": {"first_valid_index": 0, "last_valid_index": 0},
+            "__meta__": {"btc_source_exchange": "binance"},
+        },
+        np.array([month_start_ts(2026, 4)], dtype=np.int64),
+        hlcvs,
+        np.array([50_000.0], dtype=np.float64),
+    )
+    config = {
+        "backtest": {
+            "base_dir": str(tmp_path / "results"),
+            "start_date": "2026-04-01",
+            "end_date": "2026-04-01",
+            "gap_tolerance_ohlcvs_minutes": 120.0,
+        },
+        "live": {
+            "approved_coins": {"long": ["ETH"], "short": []},
+            "warmup_ratio": 0.0,
+            "max_warmup_minutes": 0.0,
+        },
+        "bot": _minimal_bot_config(),
+    }
+
+    monkeypatch.setattr(rust_utils, "check_and_maybe_compile", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        rust_utils,
+        "verify_loaded_runtime_extension",
+        lambda *args, **kwargs: {"skipped": "test"},
+    )
+    sys.modules.pop("backtest", None)
+    backtest = importlib.import_module("backtest")
+    monkeypatch.setattr(backtest, "load_coins_hlcvs_from_cache", lambda *args, **kwargs: None)
+
+    async def fake_try_prepare(*args, **kwargs):
+        return prepared
+
+    def interrupting_save(*args, **kwargs):
+        raise asyncio.CancelledError("test interrupt")
+
+    released = []
+    monkeypatch.setattr(backtest, "try_prepare_hlcvs_v2_local", fake_try_prepare)
+    monkeypatch.setattr(backtest, "save_coins_hlcvs_to_cache", interrupting_save)
+    monkeypatch.setattr(backtest, "release_materialized_payload", released.append)
+
+    with pytest.raises(asyncio.CancelledError):
+        await backtest.prepare_hlcvs_mss(config, "binance")
+
+    assert released == [hlcvs]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add backtest cancellation checkpoints between expensive materializer/cache stages so Ctrl+C stops before Rust backtest once the active artifact write returns
- publish HLCV cache directories through hidden temp dirs and clean temp output on interruption
- speed cold materialization by batching legacy OHLCV imports by month and vectorizing duplicate-free chunk writes

## Verification
- ./venv/bin/python -m pytest tests/test_cache_warmup_reuse.py tests/test_ohlcv_legacy_import.py tests/test_ohlcv_v2_foundation.py tests/test_materialized_cache.py tests/test_ohlcv_v2_prepare.py::test_prepare_hlcvs_mss_prefers_local_v2_before_full_prepare tests/test_ohlcv_v2_prepare.py::test_prepare_hlcvs_mss_releases_payload_when_cache_save_interrupted -q
- ./venv/bin/passivbot backtest tmp/private_main_candidate.json -dp -sd 2026-01-03 --suite n
- controller SIGINT run: ./venv/bin/passivbot backtest tmp/private_main_candidate.json -dp -sd 2026-01-04 --suite n, SIGINT sent at HLCV cache save start; exited rc=-2 after_sigint_s=3.397, saw_backtesting=False, saw_interrupt_log=True
- ./venv/bin/passivbot backtest tmp/private_main_candidate.json -dp -sd 2026 --suite n