### PR TITLE
Clarify cache doctor candle boundary gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ All notable user-facing changes will be documented in this file.
 - Added report-only warm-cache readiness evidence to
   `passivbot tool cache-integrity-doctor`, derived from already-scanned local
   candle, fill, and HSL/risk cache metadata.
+- Added interior/boundary candle gap summaries to
+  `passivbot tool cache-integrity-doctor` and its report-only warm-cache
+  readiness projection, clarifying leading missing rows and trailing shortfall
+  gaps without repair or startup enforcement.
 - Added fill-cache and HSL/risk-state metadata summaries to
   `passivbot tool cache-integrity-doctor`, including local fill
   `pnl_contract` compatibility counts and coverage timestamps.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -383,6 +383,10 @@ Related detailed plans:
       no-trade reason counts, fill current-contract coverage proof labels, and
       HSL artifact/timestamp compatibility fields without repair or startup
       enforcement.
+    - 2026-06-27: Added report-only candle boundary-gap clarity to
+      cache-integrity-doctor, splitting interior gaps from boundary gaps,
+      leading missing rows, and trailing shortfall rows in coverage summaries
+      and warm-cache readiness without repair or startup enforcement.
 
     Remaining refinements: add deeper candle/fill/HSL metadata compatibility
     checks and synthetic/no-trade assumptions without making trading decisions.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -107,7 +107,7 @@ passivbot tool iterative-history-plot backtests/.../fills.csv
 - `passivbot tool pad-historical-daily` – Ensures daily OHLCV shards are present for the downloader when new coins are added.
 - `passivbot tool verify-hlcvs-data` – Validates prepared HLCV datasets and coverage metadata before long optimizations/backtests.
 - `passivbot tool streamline-json` – Normalizes/compacts JSON configs (`passivbot tool streamline-json configs/examples/default_trailing_martingale_long_npos4.json`).
-- `passivbot tool cache-integrity-doctor` – Read-only local cache smoke report for missing roots, file counts/sizes, cache-family summaries, report-only warm-cache readiness evidence, v2 candle coverage/gap evidence, fill/HSL metadata evidence, and empty or corrupt JSON/NDJSON/NPY artifacts.
+- `passivbot tool cache-integrity-doctor` – Read-only local cache smoke report for missing roots, file counts/sizes, cache-family summaries, report-only warm-cache readiness evidence, v2 candle coverage/gap evidence with interior/boundary gap summaries, fill/HSL metadata evidence, and empty or corrupt JSON/NDJSON/NPY artifacts.
 - `passivbot tool candle-doctor` – Audits legacy `caches/ohlcv/...` shards for corruption, stale index entries, and legacy-format issues; add `--fix` to apply automatic repairs before importing into the v2 store.
 - `passivbot tool migrate-historical-data` – Converts legacy `historical_data/ohlcvs_<exchange>/...` shards into the current `caches/ohlcv/...` layout.
 

--- a/src/tools/cache_integrity_doctor.py
+++ b/src/tools/cache_integrity_doctor.py
@@ -229,6 +229,12 @@ def _coverage_summary_entry() -> dict[str, Any]:
         "expected_row_count": 0,
         "valid_row_count": 0,
         "gap_count": 0,
+        "interior_gap_count": 0,
+        "boundary_gap_count": 0,
+        "trailing_shortfall_gap_count": 0,
+        "leading_missing_artifact_count": 0,
+        "leading_missing_rows": 0,
+        "trailing_shortfall_rows": 0,
         "max_gap_rows": 0,
         "max_gap_ms": 0,
         "first_valid_ms": None,
@@ -399,6 +405,14 @@ def _inspect_coverage_artifact(root: Path, path: Path, family: str) -> dict[str,
             }
         )
     max_gap_rows = max((int(gap["rows"]) for gap in gaps), default=0)
+    boundary_gap_count = sum(1 for gap in gaps if gap.get("boundary"))
+    trailing_shortfall_gap_count = sum(
+        1 for gap in gaps if gap.get("boundary") == "trailing_shortfall"
+    )
+    trailing_shortfall_rows = sum(
+        int(gap["rows"]) for gap in gaps if gap.get("boundary") == "trailing_shortfall"
+    )
+    leading_missing_rows = int(first_valid_idx or 0) if valid_row_count else 0
     return {
         "path": str(path),
         "exchange": metadata["exchange"],
@@ -416,6 +430,11 @@ def _inspect_coverage_artifact(root: Path, path: Path, family: str) -> dict[str,
         "first_valid_date": _format_ms(first_valid_ms),
         "last_valid_date": _format_ms(last_valid_ms),
         "gap_count": len(gaps),
+        "interior_gap_count": len(gaps) - boundary_gap_count,
+        "boundary_gap_count": boundary_gap_count,
+        "trailing_shortfall_gap_count": trailing_shortfall_gap_count,
+        "leading_missing_rows": leading_missing_rows,
+        "trailing_shortfall_rows": trailing_shortfall_rows,
         "max_gap_rows": max_gap_rows,
         "max_gap_ms": int(max_gap_rows * interval_ms),
         "gaps": gaps,
@@ -441,6 +460,13 @@ def _merge_coverage(summary: dict[str, Any], artifact: dict[str, Any]) -> None:
     coverage["length_mismatch_count"] += int(bool(artifact["length_mismatch"]))
     coverage["valid_row_count"] += int(artifact["valid_row_count"])
     coverage["gap_count"] += int(artifact["gap_count"])
+    coverage["interior_gap_count"] += int(artifact["interior_gap_count"])
+    coverage["boundary_gap_count"] += int(artifact["boundary_gap_count"])
+    coverage["trailing_shortfall_gap_count"] += int(artifact["trailing_shortfall_gap_count"])
+    if int(artifact["leading_missing_rows"]):
+        coverage["leading_missing_artifact_count"] += 1
+        coverage["leading_missing_rows"] += int(artifact["leading_missing_rows"])
+    coverage["trailing_shortfall_rows"] += int(artifact["trailing_shortfall_rows"])
     coverage["max_gap_rows"] = max(int(coverage["max_gap_rows"]), int(artifact["max_gap_rows"]))
     coverage["max_gap_ms"] = max(int(coverage["max_gap_ms"]), int(artifact["max_gap_ms"]))
     first_valid_ms = artifact["first_valid_ms"]
@@ -469,6 +495,16 @@ def _merge_finalized_coverage(summary: dict[str, Any], coverage_report: dict[str
     coverage["expected_row_count"] += int(coverage_report["expected_row_count"])
     coverage["valid_row_count"] += int(coverage_report["valid_row_count"])
     coverage["gap_count"] += int(coverage_report["gap_count"])
+    coverage["interior_gap_count"] += int(coverage_report["interior_gap_count"])
+    coverage["boundary_gap_count"] += int(coverage_report["boundary_gap_count"])
+    coverage["trailing_shortfall_gap_count"] += int(
+        coverage_report["trailing_shortfall_gap_count"]
+    )
+    coverage["leading_missing_artifact_count"] += int(
+        coverage_report["leading_missing_artifact_count"]
+    )
+    coverage["leading_missing_rows"] += int(coverage_report["leading_missing_rows"])
+    coverage["trailing_shortfall_rows"] += int(coverage_report["trailing_shortfall_rows"])
     coverage["max_gap_rows"] = max(
         int(coverage["max_gap_rows"]),
         int(coverage_report["max_gap_rows"]),
@@ -1000,6 +1036,12 @@ def _finalize_coverage(coverage: dict[str, Any], issue_count: int) -> dict[str, 
         "expected_row_count": int(coverage["expected_row_count"]),
         "valid_row_count": valid_row_count,
         "gap_count": gap_count,
+        "interior_gap_count": int(coverage["interior_gap_count"]),
+        "boundary_gap_count": int(coverage["boundary_gap_count"]),
+        "trailing_shortfall_gap_count": int(coverage["trailing_shortfall_gap_count"]),
+        "leading_missing_artifact_count": int(coverage["leading_missing_artifact_count"]),
+        "leading_missing_rows": int(coverage["leading_missing_rows"]),
+        "trailing_shortfall_rows": int(coverage["trailing_shortfall_rows"]),
         "max_gap_rows": int(coverage["max_gap_rows"]),
         "max_gap_ms": int(coverage["max_gap_ms"]),
         "first_valid_ms": coverage["first_valid_ms"],
@@ -1029,6 +1071,10 @@ def _warm_cache_candle_report(families: dict[str, Any]) -> dict[str, Any]:
     attention = evidence != "coverage_observed"
     reasons = [f"candle_{evidence}"]
     gap_count = int(coverage["gap_count"])
+    interior_gap_count = int(coverage["interior_gap_count"])
+    boundary_gap_count = int(coverage["boundary_gap_count"])
+    leading_missing_rows = int(coverage["leading_missing_rows"])
+    trailing_shortfall_rows = int(coverage["trailing_shortfall_rows"])
     length_mismatch_count = int(coverage["length_mismatch_count"])
     known_gap_count = int(metadata.get("known_gap_count") or 0)
     no_trade_known_gap_count = int(metadata.get("no_trade_known_gap_count") or 0)
@@ -1049,8 +1095,14 @@ def _warm_cache_candle_report(families: dict[str, Any]) -> dict[str, Any]:
         no_trade_gap_evidence = "no_local_no_trade_gap_evidence"
     if gap_count:
         reasons.append("candle_suspicious_gaps_present")
+        if interior_gap_count:
+            reasons.append("candle_interior_gaps_present")
+        if boundary_gap_count:
+            reasons.append("candle_boundary_gaps_present")
         if not no_trade_known_gap_count or no_trade_known_gap_count != known_gap_count:
             reasons.append("candle_synthetic_no_trade_evidence_unproven")
+    if leading_missing_rows:
+        reasons.append("candle_leading_missing_rows_present")
     if length_mismatch_count:
         reasons.append("candle_length_mismatch_present")
     return {
@@ -1067,6 +1119,12 @@ def _warm_cache_candle_report(families: dict[str, Any]) -> dict[str, Any]:
         "first_valid_date": coverage["first_valid_date"],
         "last_valid_date": coverage["last_valid_date"],
         "suspicious_gap_count": gap_count,
+        "interior_gap_count": interior_gap_count,
+        "boundary_gap_count": boundary_gap_count,
+        "trailing_shortfall_gap_count": int(coverage["trailing_shortfall_gap_count"]),
+        "leading_missing_artifact_count": int(coverage["leading_missing_artifact_count"]),
+        "leading_missing_rows": leading_missing_rows,
+        "trailing_shortfall_rows": trailing_shortfall_rows,
         "max_gap_rows": int(coverage["max_gap_rows"]),
         "no_trade_gap_evidence": no_trade_gap_evidence,
         "known_gap_count": known_gap_count,

--- a/src/tools/cache_integrity_doctor.py
+++ b/src/tools/cache_integrity_doctor.py
@@ -404,6 +404,27 @@ def _inspect_coverage_artifact(root: Path, path: Path, family: str) -> dict[str,
                 "boundary": "trailing_shortfall",
             }
         )
+    leading_missing_rows = int(first_valid_idx or 0) if valid_row_count else 0
+    if leading_missing_rows:
+        gap_start_idx = 0
+        gap_end_idx = int(first_valid_idx) - 1
+        gap_start_ms = int(metadata["month_start_ms"])
+        gap_end_ms = int(metadata["month_start_ms"]) + gap_end_idx * interval_ms
+        gaps.append(
+            {
+                "path": str(path),
+                "exchange": metadata["exchange"],
+                "timeframe": metadata["timeframe"],
+                "symbol": metadata["symbol"],
+                "start_ms": gap_start_ms,
+                "end_ms": gap_end_ms,
+                "start_date": _format_ms(gap_start_ms),
+                "end_date": _format_ms(gap_end_ms),
+                "rows": int(leading_missing_rows),
+                "duration_ms": int(leading_missing_rows * interval_ms),
+                "boundary": "leading_missing",
+            }
+        )
     max_gap_rows = max((int(gap["rows"]) for gap in gaps), default=0)
     boundary_gap_count = sum(1 for gap in gaps if gap.get("boundary"))
     trailing_shortfall_gap_count = sum(
@@ -412,7 +433,6 @@ def _inspect_coverage_artifact(root: Path, path: Path, family: str) -> dict[str,
     trailing_shortfall_rows = sum(
         int(gap["rows"]) for gap in gaps if gap.get("boundary") == "trailing_shortfall"
     )
-    leading_missing_rows = int(first_valid_idx or 0) if valid_row_count else 0
     return {
         "path": str(path),
         "exchange": metadata["exchange"],

--- a/tests/test_cache_integrity_doctor.py
+++ b/tests/test_cache_integrity_doctor.py
@@ -86,9 +86,9 @@ def test_cache_integrity_report_summarizes_candle_coverage_windows_and_gaps(tmp_
     assert coverage["row_count"] == expected_rows
     assert coverage["expected_row_count"] == expected_rows
     assert coverage["valid_row_count"] == 4
-    assert coverage["gap_count"] == 1
+    assert coverage["gap_count"] == 2
     assert coverage["interior_gap_count"] == 1
-    assert coverage["boundary_gap_count"] == 0
+    assert coverage["boundary_gap_count"] == 1
     assert coverage["leading_missing_artifact_count"] == 1
     assert coverage["leading_missing_rows"] == 1
     assert coverage["trailing_shortfall_rows"] == 0
@@ -96,7 +96,7 @@ def test_cache_integrity_report_summarizes_candle_coverage_windows_and_gaps(tmp_
     assert coverage["first_valid_date"] == "2026-01-01T00:01:00+00:00"
     assert coverage["last_valid_date"] == "2026-01-01T00:06:00+00:00"
     assert coverage["artifact_samples"][0]["symbol"] == "BTC_USDT"
-    assert coverage["artifact_samples"][0]["gap_count"] == 1
+    assert coverage["artifact_samples"][0]["gap_count"] == 2
     assert coverage["artifact_samples"][0]["interior_gap_count"] == 1
     assert coverage["artifact_samples"][0]["leading_missing_rows"] == 1
     assert coverage["gap_samples"] == [
@@ -111,7 +111,20 @@ def test_cache_integrity_report_summarizes_candle_coverage_windows_and_gaps(tmp_
             "end_date": "2026-01-01T00:04:00+00:00",
             "rows": 2,
             "duration_ms": 120000,
-        }
+        },
+        {
+            "path": str(month_dir / "01.valid.npy"),
+            "exchange": "binance",
+            "timeframe": "1m",
+            "symbol": "BTC_USDT",
+            "start_ms": 1767225600000,
+            "end_ms": 1767225600000,
+            "start_date": "2026-01-01T00:00:00+00:00",
+            "end_date": "2026-01-01T00:00:00+00:00",
+            "rows": 1,
+            "duration_ms": 60000,
+            "boundary": "leading_missing",
+        },
     ]
 
 
@@ -184,6 +197,50 @@ def test_cache_integrity_report_marks_candle_gaps_without_no_trade_evidence(tmp_
     assert readiness["readiness"] == "attention"
     assert readiness["no_trade_gap_evidence"] == "no_local_no_trade_gap_evidence"
     assert "candle_synthetic_no_trade_evidence_unproven" in readiness["reasons"]
+
+
+def test_cache_integrity_report_marks_leading_only_candle_gaps(tmp_path):
+    root = tmp_path / "caches"
+    month_dir = root / "ohlcv" / "data" / "binance" / "1m" / "BTC_USDT" / "2026"
+    month_dir.mkdir(parents=True)
+    expected_rows = 44_640
+    valid = np.ones(expected_rows, dtype=bool)
+    valid[:10] = False
+    np.save(month_dir / "01.valid.npy", valid)
+
+    report = build_cache_integrity_report([root])
+
+    coverage = report["summary"]["by_family"]["candles"]["coverage"]
+    assert coverage["warm_cache_evidence"] == "coverage_with_gaps"
+    assert coverage["gap_count"] == 1
+    assert coverage["interior_gap_count"] == 0
+    assert coverage["boundary_gap_count"] == 1
+    assert coverage["leading_missing_artifact_count"] == 1
+    assert coverage["leading_missing_rows"] == 10
+    assert coverage["max_gap_rows"] == 10
+    assert coverage["gap_samples"] == [
+        {
+            "path": str(month_dir / "01.valid.npy"),
+            "exchange": "binance",
+            "timeframe": "1m",
+            "symbol": "BTC_USDT",
+            "start_ms": 1767225600000,
+            "end_ms": 1767226140000,
+            "start_date": "2026-01-01T00:00:00+00:00",
+            "end_date": "2026-01-01T00:09:00+00:00",
+            "rows": 10,
+            "duration_ms": 600000,
+            "boundary": "leading_missing",
+        }
+    ]
+    readiness = report["summary"]["warm_cache_readiness"]["families"]["candles"]
+    assert readiness["readiness"] == "attention"
+    assert readiness["evidence"] == "coverage_with_gaps"
+    assert readiness["boundary_gap_count"] == 1
+    assert readiness["leading_missing_rows"] == 10
+    assert "candle_boundary_gaps_present" in readiness["reasons"]
+    assert "candle_leading_missing_rows_present" in readiness["reasons"]
+    assert "candles" in report["summary"]["warm_cache_readiness"]["attention_families"]
 
 
 def test_cache_integrity_report_marks_empty_candle_coverage_masks(tmp_path):

--- a/tests/test_cache_integrity_doctor.py
+++ b/tests/test_cache_integrity_doctor.py
@@ -87,11 +87,18 @@ def test_cache_integrity_report_summarizes_candle_coverage_windows_and_gaps(tmp_
     assert coverage["expected_row_count"] == expected_rows
     assert coverage["valid_row_count"] == 4
     assert coverage["gap_count"] == 1
+    assert coverage["interior_gap_count"] == 1
+    assert coverage["boundary_gap_count"] == 0
+    assert coverage["leading_missing_artifact_count"] == 1
+    assert coverage["leading_missing_rows"] == 1
+    assert coverage["trailing_shortfall_rows"] == 0
     assert coverage["max_gap_rows"] == 2
     assert coverage["first_valid_date"] == "2026-01-01T00:01:00+00:00"
     assert coverage["last_valid_date"] == "2026-01-01T00:06:00+00:00"
     assert coverage["artifact_samples"][0]["symbol"] == "BTC_USDT"
     assert coverage["artifact_samples"][0]["gap_count"] == 1
+    assert coverage["artifact_samples"][0]["interior_gap_count"] == 1
+    assert coverage["artifact_samples"][0]["leading_missing_rows"] == 1
     assert coverage["gap_samples"] == [
         {
             "path": str(month_dir / "01.valid.npy"),
@@ -214,6 +221,11 @@ def test_cache_integrity_report_flags_truncated_candle_coverage_masks(tmp_path):
     assert coverage["row_count"] == 8
     assert coverage["expected_row_count"] == 44_640
     assert coverage["gap_count"] == 1
+    assert coverage["interior_gap_count"] == 0
+    assert coverage["boundary_gap_count"] == 1
+    assert coverage["trailing_shortfall_gap_count"] == 1
+    assert coverage["leading_missing_rows"] == 0
+    assert coverage["trailing_shortfall_rows"] == 44_632
     assert coverage["gap_samples"][0]["boundary"] == "trailing_shortfall"
     assert coverage["gap_samples"][0]["rows"] == 44_632
     assert coverage["artifact_samples"][0]["length_mismatch"] is True
@@ -221,6 +233,10 @@ def test_cache_integrity_report_flags_truncated_candle_coverage_masks(tmp_path):
     assert issue["severity"] == "warning"
     assert issue["code"] == "coverage_length_mismatch"
     assert issue["family"] == "candles"
+    readiness = report["summary"]["warm_cache_readiness"]["families"]["candles"]
+    assert readiness["boundary_gap_count"] == 1
+    assert readiness["trailing_shortfall_rows"] == 44_632
+    assert "candle_boundary_gaps_present" in readiness["reasons"]
 
 
 def test_cache_integrity_report_summarizes_fill_cache_metadata_contract_and_coverage(tmp_path):
@@ -393,6 +409,10 @@ def test_cache_integrity_report_derives_warm_cache_readiness(tmp_path):
     assert readiness["attention_families"] == []
     assert readiness["suspicious_gap_count"] == 0
     assert readiness["families"]["candles"]["readiness"] == "observed"
+    assert readiness["families"]["candles"]["interior_gap_count"] == 0
+    assert readiness["families"]["candles"]["boundary_gap_count"] == 0
+    assert readiness["families"]["candles"]["leading_missing_rows"] == 0
+    assert readiness["families"]["candles"]["trailing_shortfall_rows"] == 0
     assert readiness["families"]["fills"]["readiness"] == "observed"
     assert readiness["families"]["fills"]["covered_start_date"] == "2026-01-01T00:00:00+00:00"
     assert readiness["families"]["risk"]["readiness"] == "missing_optional"


### PR DESCRIPTION
## Summary
- add interior/boundary candle gap counters to cache-integrity-doctor coverage summaries
- project leading missing rows, trailing shortfall rows, and boundary-gap reasons into report-only warm-cache readiness
- update tests, tools docs, changelog, and live-ops backlog for the read-only item #13 slice

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_cache_integrity_doctor.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/tools/cache_integrity_doctor.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall -q src/tools/cache_integrity_doctor.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m tools.cache_integrity_doctor /private/tmp/nonexistent-cache-root --compact
- git diff --check