### PR TITLE
Add live performance report tool

### DIFF
--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1,0 +1,533 @@
+from __future__ import annotations
+
+import gzip
+import json
+import math
+import statistics
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from live.event_bus import LIVE_EVENT_MONITOR_PAYLOAD_KEY
+from live.event_query import discover_event_files
+
+
+GROUP_LIMIT = 80
+
+
+def _open_text(path: Path):
+    if path.name.endswith(".gz"):
+        return gzip.open(path, "rt", encoding="utf-8")
+    return open(path, "r", encoding="utf-8")
+
+
+def _record_ts(row: dict[str, Any]) -> int | None:
+    try:
+        return int(row.get("ts"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _live_event_payload(row: dict[str, Any]) -> dict[str, Any] | None:
+    payload = row.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    live_event = payload.get(LIVE_EVENT_MONITOR_PAYLOAD_KEY)
+    return live_event if isinstance(live_event, dict) else None
+
+
+def _bot_key(row: dict[str, Any], live_event: dict[str, Any]) -> str:
+    exchange = live_event.get("exchange") or row.get("exchange") or "-"
+    user = live_event.get("user") or row.get("user") or "-"
+    return f"{exchange}/{user}"
+
+
+def _finite_float(value: Any) -> float | None:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number):
+        return None
+    return number
+
+
+def _non_negative_ms(value: Any) -> int | None:
+    number = _finite_float(value)
+    if number is None or number < 0:
+        return None
+    return int(round(number))
+
+
+def _elapsed_s_to_ms(value: Any) -> int | None:
+    number = _finite_float(value)
+    if number is None or number < 0:
+        return None
+    return int(round(number * 1000.0))
+
+
+def _percentile(sorted_values: list[int], pct: float) -> int | None:
+    if not sorted_values:
+        return None
+    if len(sorted_values) == 1:
+        return int(sorted_values[0])
+    rank = (len(sorted_values) - 1) * pct
+    lower = int(math.floor(rank))
+    upper = int(math.ceil(rank))
+    if lower == upper:
+        return int(sorted_values[lower])
+    weight = rank - lower
+    return int(round(sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight))
+
+
+class _MetricGroup:
+    def __init__(
+        self,
+        *,
+        bot: str,
+        operation: str,
+        component: str | None,
+        event_type: str,
+        trading_impact: str,
+        timing_kind: str,
+    ) -> None:
+        self.bot = bot
+        self.operation = operation
+        self.component = component
+        self.event_type = event_type
+        self.trading_impact = trading_impact
+        self.timing_kind = timing_kind
+        self.values: list[int] = []
+        self.statuses: Counter[str] = Counter()
+        self.reason_codes: Counter[str] = Counter()
+        self.symbols: Counter[str] = Counter()
+        self.latest_ts: int | None = None
+
+    def add(
+        self,
+        value_ms: int,
+        *,
+        row: dict[str, Any],
+        live_event: dict[str, Any],
+    ) -> None:
+        self.values.append(int(value_ms))
+        status = live_event.get("status")
+        if status is not None:
+            self.statuses[str(status)] += 1
+        reason_code = live_event.get("reason_code")
+        if reason_code is not None:
+            self.reason_codes[str(reason_code)] += 1
+        symbol = live_event.get("symbol") or row.get("symbol")
+        if symbol is not None:
+            self.symbols[str(symbol)] += 1
+        ts = _record_ts(row)
+        if ts is not None and (self.latest_ts is None or ts > self.latest_ts):
+            self.latest_ts = ts
+
+    def to_dict(self) -> dict[str, Any]:
+        values = sorted(self.values)
+        mean_value = statistics.fmean(values) if values else None
+        return {
+            key: value
+            for key, value in {
+                "bot": self.bot,
+                "operation": self.operation,
+                "component": self.component,
+                "event_type": self.event_type,
+                "trading_impact": self.trading_impact,
+                "timing_kind": self.timing_kind,
+                "count": len(values),
+                "min_ms": int(values[0]) if values else None,
+                "max_ms": int(values[-1]) if values else None,
+                "mean_ms": int(round(mean_value)) if mean_value is not None else None,
+                "median_ms": int(round(statistics.median(values))) if values else None,
+                "p95_ms": _percentile(values, 0.95),
+                "latest_ts": self.latest_ts,
+                "statuses": dict(sorted(self.statuses.items())),
+                "reason_codes": dict(sorted(self.reason_codes.items())),
+                "symbols_sample": [
+                    symbol
+                    for symbol, _count in sorted(
+                        self.symbols.items(), key=lambda item: (-item[1], item[0])
+                    )[:10]
+                ],
+            }.items()
+            if value not in (None, {}, [])
+        }
+
+
+class _PerformanceAccumulator:
+    def __init__(self) -> None:
+        self.groups: dict[tuple[str, str, str | None, str], _MetricGroup] = {}
+        self.trading_impact_counts: Counter[str] = Counter()
+
+    def add(
+        self,
+        *,
+        row: dict[str, Any],
+        live_event: dict[str, Any],
+        operation: str,
+        value_ms: int | None,
+        trading_impact: str,
+        timing_kind: str = "duration",
+    ) -> None:
+        if value_ms is None:
+            return
+        bot = _bot_key(row, live_event)
+        event_type = str(live_event.get("event_type") or row.get("kind") or "unknown")
+        component = live_event.get("component")
+        component_key = str(component) if component is not None else None
+        key = (bot, operation, component_key, timing_kind)
+        group = self.groups.get(key)
+        if group is None:
+            group = _MetricGroup(
+                bot=bot,
+                operation=operation,
+                component=component_key,
+                event_type=event_type,
+                trading_impact=trading_impact,
+                timing_kind=timing_kind,
+            )
+            self.groups[key] = group
+        group.add(value_ms, row=row, live_event=live_event)
+        self.trading_impact_counts[trading_impact] += 1
+
+    def to_dict(self, *, group_limit: int = GROUP_LIMIT) -> dict[str, Any]:
+        groups = sorted(
+            (group.to_dict() for group in self.groups.values()),
+            key=lambda item: (
+                -int(item.get("p95_ms", 0) or 0),
+                -int(item.get("max_ms", 0) or 0),
+                -int(item.get("count", 0) or 0),
+                str(item.get("bot") or ""),
+                str(item.get("operation") or ""),
+            ),
+        )
+        return {
+            "total_groups": len(groups),
+            "groups_truncated": len(groups) > int(group_limit),
+            "trading_impact_counts": dict(sorted(self.trading_impact_counts.items())),
+            "groups": groups[: max(0, int(group_limit))],
+        }
+
+
+def _timings_map(value: Any) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    out = {}
+    for key, raw in value.items():
+        duration = _non_negative_ms(raw)
+        if duration is not None:
+            out[str(key)] = duration
+    return out
+
+
+def _summary_timing_maps(value: Any) -> dict[str, dict[str, int]]:
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, dict[str, int]] = {}
+    for surface, summary in value.items():
+        if not isinstance(summary, dict):
+            continue
+        surface_summary = {}
+        for field in ("min", "mean", "max"):
+            duration = _non_negative_ms(summary.get(field))
+            if duration is not None:
+                surface_summary[field] = duration
+        if surface_summary:
+            out[str(surface)] = surface_summary
+    return out
+
+
+def _remote_call_operation(data: dict[str, Any], live_event: dict[str, Any]) -> str:
+    component = str(live_event.get("component") or "")
+    prefix = "remote_call"
+    if "authoritative" in component:
+        prefix = "remote_call.authoritative"
+    elif "candle" in component:
+        prefix = "remote_call.candle"
+    surface = data.get("surface")
+    kind = data.get("kind")
+    reason_code = live_event.get("reason_code")
+    if surface is not None:
+        return f"{prefix}.{surface}"
+    if kind is not None:
+        return f"{prefix}.{kind}"
+    if reason_code is not None:
+        return f"{prefix}.{reason_code}"
+    return prefix
+
+
+def _trading_impact_for_event(event_type: str, operation: str) -> str:
+    if event_type == "cycle.completed":
+        if operation == "cycle.phase.monitor_flush":
+            return "diagnostics_only"
+        if operation.startswith("cycle.phase."):
+            return "blocks_cycle_decision"
+        return "blocks_next_cycle"
+    if event_type == "state.refresh_timing":
+        return "blocks_exchange_actions"
+    if event_type.startswith("remote_call."):
+        if "authoritative" in operation:
+            return "blocks_exchange_actions"
+        if "ccxt_fetch_ohlcv" in operation or "candle" in operation:
+            return "blocks_indicator_readiness"
+        return "exchange_io"
+    if event_type.startswith("hsl.replay."):
+        return "blocks_or_delays_hsl_readiness"
+    if event_type == "bot.startup_timing":
+        return "blocks_startup_readiness"
+    return "observability"
+
+
+def _add_event_timings(
+    accumulator: _PerformanceAccumulator,
+    *,
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+) -> None:
+    event_type = str(live_event.get("event_type") or row.get("kind") or "")
+    data = live_event.get("data") if isinstance(live_event.get("data"), dict) else {}
+
+    if event_type == "cycle.completed":
+        elapsed_ms = _non_negative_ms(data.get("elapsed_ms"))
+        accumulator.add(
+            row=row,
+            live_event=live_event,
+            operation="cycle.elapsed",
+            value_ms=elapsed_ms,
+            trading_impact=_trading_impact_for_event(event_type, "cycle.elapsed"),
+        )
+        for phase, duration_ms in _timings_map(data.get("timings_ms")).items():
+            operation = f"cycle.phase.{phase}"
+            accumulator.add(
+                row=row,
+                live_event=live_event,
+                operation=operation,
+                value_ms=duration_ms,
+                trading_impact=_trading_impact_for_event(event_type, operation),
+            )
+        return
+
+    if event_type == "state.refresh_timing":
+        for field in ("wall_ms", "surface_max_ms", "surface_sum_ms", "residual_ms"):
+            operation = f"state_refresh.{field.removesuffix('_ms')}"
+            accumulator.add(
+                row=row,
+                live_event=live_event,
+                operation=operation,
+                value_ms=_non_negative_ms(data.get(field)),
+                trading_impact=_trading_impact_for_event(event_type, operation),
+            )
+        for surface, duration_ms in _timings_map(data.get("timings_ms")).items():
+            operation = f"state_refresh.surface.{surface}"
+            accumulator.add(
+                row=row,
+                live_event=live_event,
+                operation=operation,
+                value_ms=duration_ms,
+                trading_impact=_trading_impact_for_event(event_type, operation),
+            )
+        for surface, summary in _summary_timing_maps(data.get("surfaces_ms")).items():
+            for field, duration_ms in summary.items():
+                operation = f"state_refresh.surface.{surface}.{field}"
+                accumulator.add(
+                    row=row,
+                    live_event=live_event,
+                    operation=operation,
+                    value_ms=duration_ms,
+                    trading_impact=_trading_impact_for_event(event_type, operation),
+                    timing_kind="summary_stat",
+                )
+        return
+
+    if event_type.startswith("remote_call."):
+        operation = _remote_call_operation(data, live_event)
+        accumulator.add(
+            row=row,
+            live_event=live_event,
+            operation=operation,
+            value_ms=_non_negative_ms(data.get("elapsed_ms")),
+            trading_impact=_trading_impact_for_event(event_type, operation),
+        )
+        return
+
+    if event_type.startswith("hsl.replay."):
+        stage = data.get("stage")
+        operation = "hsl_replay.elapsed"
+        if stage is not None:
+            operation = f"hsl_replay.{stage}.elapsed"
+        accumulator.add(
+            row=row,
+            live_event=live_event,
+            operation=operation,
+            value_ms=_elapsed_s_to_ms(data.get("elapsed_s")),
+            trading_impact=_trading_impact_for_event(event_type, operation),
+            timing_kind="cumulative",
+        )
+        return
+
+    if event_type == "bot.startup_timing":
+        stage = data.get("stage") or data.get("phase") or "startup"
+        operation = f"startup.{stage}"
+        value_ms = _non_negative_ms(data.get("elapsed_ms"))
+        if value_ms is None:
+            value_ms = _elapsed_s_to_ms(data.get("elapsed_s"))
+        accumulator.add(
+            row=row,
+            live_event=live_event,
+            operation=operation,
+            value_ms=value_ms,
+            trading_impact=_trading_impact_for_event(event_type, operation),
+        )
+
+
+def build_live_performance_report(
+    root: str | Path = "monitor",
+    *,
+    since_ms: int | None = None,
+    until_ms: int | None = None,
+    include_rotated: bool = False,
+    group_limit: int = GROUP_LIMIT,
+) -> dict[str, Any]:
+    since_filter = int(since_ms) if since_ms is not None else None
+    until_filter = int(until_ms) if until_ms is not None else None
+    if (
+        since_filter is not None
+        and until_filter is not None
+        and since_filter > until_filter
+    ):
+        raise ValueError("since_ms must be <= until_ms")
+    window_enabled = since_filter is not None or until_filter is not None
+    event_window = {
+        "enabled": bool(window_enabled),
+        "since_ms": since_filter,
+        "until_ms": until_filter,
+        "events_considered": 0,
+        "events_skipped_before": 0,
+        "events_skipped_after": 0,
+        "invalid_window_ts": 0,
+    }
+    issues: list[dict[str, Any]] = []
+    try:
+        files = discover_event_files(root, include_rotated=include_rotated)
+    except FileNotFoundError as exc:
+        files = []
+        issues.append(
+            {
+                "path": str(root),
+                "line": None,
+                "severity": "error",
+                "code": "path_not_found",
+                "message": str(exc),
+            }
+        )
+    if not files and not issues:
+        issues.append(
+            {
+                "path": str(root),
+                "line": None,
+                "severity": "error",
+                "code": "no_event_files",
+                "message": "no event NDJSON files found",
+            }
+        )
+
+    accumulator = _PerformanceAccumulator()
+    records_total = 0
+    live_events = 0
+    legacy_events = 0
+    event_types: Counter[str] = Counter()
+    bots: Counter[str] = Counter()
+    for path in files:
+        try:
+            with _open_text(path) as stream:
+                for line_no, raw_line in enumerate(stream, start=1):
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    records_total += 1
+                    try:
+                        row = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        issues.append(
+                            {
+                                "path": str(path),
+                                "line": int(line_no),
+                                "severity": "error",
+                                "code": "invalid_json",
+                                "message": str(exc),
+                            }
+                        )
+                        continue
+                    if not isinstance(row, dict):
+                        issues.append(
+                            {
+                                "path": str(path),
+                                "line": int(line_no),
+                                "severity": "error",
+                                "code": "invalid_record",
+                                "message": "event row is not a JSON object",
+                            }
+                        )
+                        continue
+                    live_event = _live_event_payload(row)
+                    if live_event is None:
+                        legacy_events += 1
+                        continue
+                    live_events += 1
+                    if window_enabled:
+                        record_ts = _record_ts(row)
+                        if record_ts is None:
+                            event_window["invalid_window_ts"] += 1
+                            continue
+                        if since_filter is not None and record_ts < since_filter:
+                            event_window["events_skipped_before"] += 1
+                            continue
+                        if until_filter is not None and record_ts > until_filter:
+                            event_window["events_skipped_after"] += 1
+                            continue
+                        event_window["events_considered"] += 1
+                    event_type = str(live_event.get("event_type") or row.get("kind") or "unknown")
+                    event_types[event_type] += 1
+                    bots[_bot_key(row, live_event)] += 1
+                    _add_event_timings(
+                        accumulator,
+                        row=row,
+                        live_event=live_event,
+                    )
+        except OSError as exc:
+            issues.append(
+                {
+                    "path": str(path),
+                    "line": None,
+                    "severity": "error",
+                    "code": "read_failed",
+                    "message": str(exc),
+                }
+            )
+
+    error_count = sum(1 for issue in issues if issue.get("severity") == "error")
+    warning_count = sum(1 for issue in issues if issue.get("severity") == "warning")
+    report = {
+        "ok": error_count == 0,
+        "root": str(Path(root).expanduser()),
+        "include_rotated": bool(include_rotated),
+        "files": [str(path) for path in files],
+        "files_scanned": len(files),
+        "records_total": int(records_total),
+        "live_events": int(live_events),
+        "legacy_events": int(legacy_events),
+        "issues": issues,
+        "error_count": int(error_count),
+        "warning_count": int(warning_count),
+        "event_types": dict(sorted(event_types.items())),
+        "bots": [
+            {"bot": bot, "events": int(count)}
+            for bot, count in sorted(bots.items(), key=lambda item: (-item[1], item[0]))
+        ],
+        "performance": accumulator.to_dict(group_limit=group_limit),
+    }
+    if window_enabled:
+        report["event_window"] = event_window
+    return report

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from live.event_bus import LIVE_EVENT_MONITOR_PAYLOAD_KEY
 from live.event_query import discover_event_files
+from live.smoke_report import _user_safe_display_path
 
 
 GROUP_LIMIT = 80
@@ -415,17 +416,17 @@ def build_live_performance_report(
         files = []
         issues.append(
             {
-                "path": str(root),
+                "path": _user_safe_display_path(root),
                 "line": None,
                 "severity": "error",
                 "code": "path_not_found",
-                "message": str(exc),
+                "message": getattr(exc, "strerror", None) or "path not found",
             }
         )
     if not files and not issues:
         issues.append(
             {
-                "path": str(root),
+                "path": _user_safe_display_path(root),
                 "line": None,
                 "severity": "error",
                 "code": "no_event_files",
@@ -452,7 +453,7 @@ def build_live_performance_report(
                     except json.JSONDecodeError as exc:
                         issues.append(
                             {
-                                "path": str(path),
+                                "path": _user_safe_display_path(path),
                                 "line": int(line_no),
                                 "severity": "error",
                                 "code": "invalid_json",
@@ -463,7 +464,7 @@ def build_live_performance_report(
                     if not isinstance(row, dict):
                         issues.append(
                             {
-                                "path": str(path),
+                                "path": _user_safe_display_path(path),
                                 "line": int(line_no),
                                 "severity": "error",
                                 "code": "invalid_record",
@@ -499,11 +500,11 @@ def build_live_performance_report(
         except OSError as exc:
             issues.append(
                 {
-                    "path": str(path),
+                    "path": _user_safe_display_path(path),
                     "line": None,
                     "severity": "error",
                     "code": "read_failed",
-                    "message": str(exc),
+                    "message": getattr(exc, "strerror", None) or type(exc).__name__,
                 }
             )
 
@@ -511,9 +512,9 @@ def build_live_performance_report(
     warning_count = sum(1 for issue in issues if issue.get("severity") == "warning")
     report = {
         "ok": error_count == 0,
-        "root": str(Path(root).expanduser()),
+        "root": _user_safe_display_path(root),
         "include_rotated": bool(include_rotated),
-        "files": [str(path) for path in files],
+        "files": [_user_safe_display_path(path) for path in files],
         "files_scanned": len(files),
         "records_total": int(records_total),
         "live_events": int(live_events),

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -106,6 +106,10 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "tools.live_incident_bundle",
         "collect local live incident evidence into a tarball",
     ),
+    "live-performance-report": CommandSpec(
+        "tools.live_performance_report",
+        "summarize local live performance timing events",
+    ),
     "live-config-preflight": CommandSpec(
         "tools.live_config_preflight",
         "read-only offline live config preflight report",

--- a/src/tools/live_performance_report.py
+++ b/src/tools/live_performance_report.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[1]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from live.performance_report import build_live_performance_report  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Summarize local live bot performance timing from structured monitor "
+            "events. This is read-only and does not contact exchanges."
+        )
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default="monitor",
+        help="Monitor root, bot root, events directory, or NDJSON segment.",
+    )
+    parser.add_argument(
+        "--since-ms",
+        type=int,
+        help="Only include live events with monitor ts at or after this epoch-ms value.",
+    )
+    parser.add_argument(
+        "--until-ms",
+        type=int,
+        help="Only include live events with monitor ts at or before this epoch-ms value.",
+    )
+    parser.add_argument(
+        "--recent-minutes",
+        type=float,
+        help="Only include live events from the last N minutes.",
+    )
+    parser.add_argument(
+        "--include-rotated",
+        action="store_true",
+        help=(
+            "Also scan rotated/compressed history segments. By default directory "
+            "scans read current.ndjson files only."
+        ),
+    )
+    parser.add_argument(
+        "--group-limit",
+        type=int,
+        default=80,
+        help="Maximum performance timing groups to include.",
+    )
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="Emit compact single-line JSON.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.since_ms is not None and args.recent_minutes is not None:
+        parser.error("--since-ms and --recent-minutes are mutually exclusive")
+    since_ms = args.since_ms
+    if args.recent_minutes is not None:
+        if args.recent_minutes <= 0:
+            parser.error("--recent-minutes must be greater than 0")
+        since_ms = int(time.time() * 1000) - int(args.recent_minutes * 60_000)
+    if since_ms is not None and args.until_ms is not None and since_ms > args.until_ms:
+        parser.error("--since-ms/--recent-minutes must be <= --until-ms")
+    if args.group_limit < 0:
+        parser.error("--group-limit must be >= 0")
+    report = build_live_performance_report(
+        args.path,
+        since_ms=since_ms,
+        until_ms=args.until_ms,
+        include_rotated=bool(args.include_rotated),
+        group_limit=int(args.group_limit),
+    )
+    print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
+    return 0 if report.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import io
 import json
+from pathlib import Path
 
+import live.performance_report as performance_report_module
 from live.performance_report import build_live_performance_report
 from tools import live_performance_report
 
@@ -225,3 +228,69 @@ def test_live_performance_report_cli_outputs_json(tmp_path, capsys):
     out = json.loads(capsys.readouterr().out)
     assert out["ok"] is True
     assert out["performance"]["groups"][0]["operation"] == "cycle.elapsed"
+
+
+def test_live_performance_report_redacts_missing_root_paths():
+    report = build_live_performance_report("/Users/operator/passivbot/missing-monitor")
+
+    rendered = json.dumps(report, sort_keys=True)
+    assert report["root"] == "~/passivbot/missing-monitor"
+    assert report["issues"][0]["path"] == "~/passivbot/missing-monitor"
+    assert "/Users/operator" not in rendered
+
+
+def test_live_performance_report_redacts_file_paths_and_oserror_messages(monkeypatch):
+    event_path = Path("/root/passivbot/monitor/binance/binance_01/events/current.ndjson")
+
+    monkeypatch.setattr(
+        performance_report_module,
+        "discover_event_files",
+        lambda root, *, include_rotated=False: [event_path],
+    )
+
+    def fail_open(path):
+        raise OSError(13, "Permission denied", str(path))
+
+    monkeypatch.setattr(performance_report_module, "_open_text", fail_open)
+
+    report = build_live_performance_report("/root/passivbot/monitor")
+
+    rendered = json.dumps(report, sort_keys=True)
+    assert report["root"] == "~/passivbot/monitor"
+    assert report["files"] == ["~/passivbot/monitor/binance/binance_01/events/current.ndjson"]
+    assert report["issues"][0]["path"] == (
+        "~/passivbot/monitor/binance/binance_01/events/current.ndjson"
+    )
+    assert report["issues"][0]["message"] == "Permission denied"
+    assert "/root/passivbot" not in rendered
+
+
+def test_live_performance_report_redacts_file_paths_for_valid_events(monkeypatch):
+    event_path = Path("/Users/operator/passivbot/monitor/binance/binance_01/events/current.ndjson")
+    row = _monitor_row(
+        event_type="cycle.completed",
+        seq=1,
+        ts=1000,
+        data={"elapsed_ms": 1000},
+    )
+
+    monkeypatch.setattr(
+        performance_report_module,
+        "discover_event_files",
+        lambda root, *, include_rotated=False: [event_path],
+    )
+    monkeypatch.setattr(
+        performance_report_module,
+        "_open_text",
+        lambda path: io.StringIO(json.dumps(row) + "\n"),
+    )
+
+    report = build_live_performance_report("/Users/operator/passivbot/monitor")
+
+    rendered = json.dumps(report, sort_keys=True)
+    assert report["ok"] is True
+    assert report["root"] == "~/passivbot/monitor"
+    assert report["files"] == [
+        "~/passivbot/monitor/binance/binance_01/events/current.ndjson"
+    ]
+    assert "/Users/operator" not in rendered

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import json
+
+from live.performance_report import build_live_performance_report
+from tools import live_performance_report
+
+
+def _monitor_row(
+    *,
+    event_type: str,
+    seq: int,
+    ts: int,
+    exchange: str = "binance",
+    user: str = "binance_01",
+    component: str = "test",
+    status: str = "succeeded",
+    level: str = "debug",
+    reason_code: str = "test",
+    symbol: str | None = None,
+    pside: str | None = None,
+    ids: dict | None = None,
+    data: dict | None = None,
+) -> dict:
+    live_event = {
+        "schema_version": 1,
+        "event_id": f"evt_{seq}",
+        "event_type": event_type,
+        "level": level,
+        "source": "live",
+        "component": component,
+        "exchange": exchange,
+        "user": user,
+        "symbol": symbol,
+        "pside": pside,
+        "status": status,
+        "reason_code": reason_code,
+        "data": dict(data or {}),
+        "ids": dict(ids or {}),
+    }
+    row = {
+        "exchange": exchange,
+        "user": user,
+        "kind": event_type,
+        "tags": ["test"],
+        "payload": {"_live_event": live_event},
+        "seq": seq,
+        "ts": ts,
+    }
+    if symbol is not None:
+        row["symbol"] = symbol
+    if pside is not None:
+        row["pside"] = pside
+    return row
+
+
+def _write_ndjson(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _groups_by_operation(report):
+    return {
+        group["operation"]: group
+        for group in report["performance"]["groups"]
+    }
+
+
+def test_live_performance_report_aggregates_cycle_state_remote_and_hsl_timings(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                component="execution_loop",
+                ids={"cycle_id": "cy_1"},
+                data={
+                    "elapsed_ms": 1200,
+                    "timings_ms": {
+                        "authoritative": 300,
+                        "market_state": 200,
+                        "execute": 500,
+                        "monitor_flush": 100,
+                    },
+                },
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=2,
+                ts=2000,
+                component="execution_loop",
+                ids={"cycle_id": "cy_2"},
+                data={
+                    "elapsed_ms": 1800,
+                    "timings_ms": {
+                        "authoritative": 700,
+                        "market_state": 250,
+                        "execute": 600,
+                        "monitor_flush": 150,
+                    },
+                },
+            ),
+            _monitor_row(
+                event_type="state.refresh_timing",
+                seq=3,
+                ts=3000,
+                component="state.refresh",
+                data={
+                    "wall_ms": 900,
+                    "surface_max_ms": 800,
+                    "surface_sum_ms": 1700,
+                    "residual_ms": 100,
+                    "timings_ms": {"balance": 400, "open_orders": 800},
+                },
+            ),
+            _monitor_row(
+                event_type="remote_call.succeeded",
+                seq=4,
+                ts=4000,
+                component="state.authoritative_fetch",
+                reason_code="authoritative_open_orders",
+                data={"surface": "open_orders", "elapsed_ms": 850},
+            ),
+            _monitor_row(
+                event_type="remote_call.succeeded",
+                seq=5,
+                ts=5000,
+                component="candles.remote_fetch",
+                reason_code="ccxt_fetch_ohlcv",
+                symbol="BTC/USDT:USDT",
+                data={"kind": "ccxt_fetch_ohlcv", "elapsed_ms": 120},
+            ),
+            _monitor_row(
+                event_type="hsl.replay.progress",
+                seq=6,
+                ts=6000,
+                component="risk.hsl",
+                symbol="BTC/USDT:USDT",
+                pside="long",
+                data={"stage": "pair_replay", "elapsed_s": 12.5},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+
+    assert report["ok"] is True
+    assert report["files_scanned"] == 1
+    assert report["live_events"] == 6
+    groups = _groups_by_operation(report)
+    assert groups["cycle.elapsed"]["count"] == 2
+    assert groups["cycle.elapsed"]["min_ms"] == 1200
+    assert groups["cycle.elapsed"]["max_ms"] == 1800
+    assert groups["cycle.elapsed"]["mean_ms"] == 1500
+    assert groups["cycle.phase.execute"]["max_ms"] == 600
+    assert groups["cycle.phase.monitor_flush"]["trading_impact"] == "diagnostics_only"
+    assert groups["state_refresh.wall"]["max_ms"] == 900
+    assert groups["state_refresh.surface.open_orders"]["max_ms"] == 800
+    assert groups["remote_call.authoritative.open_orders"]["trading_impact"] == (
+        "blocks_exchange_actions"
+    )
+    assert groups["remote_call.candle.ccxt_fetch_ohlcv"]["trading_impact"] == (
+        "blocks_indicator_readiness"
+    )
+    assert groups["hsl_replay.pair_replay.elapsed"]["max_ms"] == 12500
+    assert groups["hsl_replay.pair_replay.elapsed"]["timing_kind"] == "cumulative"
+
+
+def test_live_performance_report_time_window_and_group_limit(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                data={"elapsed_ms": 1000},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=2,
+                ts=2000,
+                data={"elapsed_ms": 2000},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(
+        tmp_path / "monitor",
+        since_ms=1500,
+        group_limit=0,
+    )
+
+    assert report["event_window"]["events_considered"] == 1
+    assert report["event_window"]["events_skipped_before"] == 1
+    assert report["performance"]["total_groups"] == 1
+    assert report["performance"]["groups_truncated"] is True
+    assert report["performance"]["groups"] == []
+
+
+def test_live_performance_report_cli_outputs_json(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                data={"elapsed_ms": 1000},
+            )
+        ],
+    )
+
+    rc = live_performance_report.main([str(tmp_path / "monitor"), "--compact"])
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
+    assert out["performance"]["groups"][0]["operation"] == "cycle.elapsed"


### PR DESCRIPTION
## Summary
- add read-only `passivbot tool live-performance-report` over local monitor event NDJSON
- aggregate min/max/mean/median/p95 timing groups for cycles, cycle phases, state refresh, remote calls, HSL replay, and startup timing where available
- include trading-impact labels so operators can separate cycle blockers, exchange-action blockers, indicator readiness, HSL readiness, and diagnostics-only work

## Validation
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_performance_report.py tests/test_live_event_query.py tests/test_live_smoke_report.py`
- `PYTHONPATH=src ./venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py src/passivbot_cli/main.py`
- `PYTHONPATH=src ./venv/bin/passivbot tool live-performance-report monitor --recent-minutes 180 --compact --group-limit 3`
- `git diff --check`

No exchange calls or live trading behavior changes; report reads existing local monitor events only.
