### PR TITLE
Add live performance report summary filters

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,8 +19,7 @@ Last updated: 2026-06-27.
 
 Current `origin/v8` logging-overhaul head:
 
-- `54a909b` after PR #773, `Clarify cache doctor candle boundary gaps`, and
-  PR #774, `Emit structured unstuck live events`.
+- `fe946c6c` after PR #778, `Add live performance report tool`.
 
 Current review gate:
 
@@ -385,6 +384,17 @@ VPS5 deployment status:
   `rate_limit_health.observed_call_count=12`, `public_call_count=6`,
   `private_call_count=5`, `concurrent_request_count=1`,
   `exchange_rate_limit_ms=50`, and `estimated_min_serial_ms=600`.
+- PR #778 was merged after Claude + Hermes approval and green CI, then pulled
+  to VPS5 without bot restart because it only adds read-only performance-report
+  tooling and docs. A 5-minute summary smoke at `fe946c6c` reported
+  `ok=true`, `hard_failures=0`, `logs.hard_matches=0`,
+  `matched_expected=5`, `missing_expected=[]`,
+  `remote_calls.failed=0`, and `account_critical_remote_calls.failed=0`.
+  `passivbot tool live-performance-report --recent-minutes 180 --compact`
+  also returned `ok=true`, `issues=[]`, and redacted `~/passivbot/...` paths.
+  Its slowest groups made the current startup/HSL latency explicit:
+  OKX full-warmup about `2552s`, Binance full-warmup about `2419s`,
+  GateIO full-warmup about `2409s`, and Binance `startup.hsl` about `2017s`.
 
 ## Phase Checklist
 
@@ -397,7 +407,7 @@ VPS5 deployment status:
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events; PR #707 restores throttled coin-mode HSL position status console lines from existing `hsl.status` metrics; PR #709 mirrors fill-cache startup readiness into off-console `fills.refresh_summary` events; PR #711 mirrors CCXT timestamp/nonce recovery into off-console `exchange.time_sync` events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
-| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window reports, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries | Cross-bot incident workflow, safe restart orchestration, active probe expansion beyond current endpoint/freshness summaries |
+| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window reports, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation | Cross-bot incident workflow, safe restart orchestration, decision-boundary/input-staleness performance metrics, active probe expansion beyond current endpoint/freshness summaries |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup; PR #656/#668 cache integrity smoke doctor | Continue separate reviewed PRs for shutdown/warmup/cache proof improvements |
 
 ## Merged Slices
@@ -1904,6 +1914,27 @@ VPS5 deployment status:
   failures, no text-log hard matches, and no failed account-critical remote
   calls. Shutdown/restart events from the deployment were visible through the
   structured smoke summaries.
+
+### PR #778: Live Performance Report
+
+- Branch: `codex/v8-live-performance-report`.
+- Scope: read-only operator performance tooling and performance/readiness
+  checklist docs.
+- Result: `passivbot tool live-performance-report` now scans local monitor
+  event NDJSON and aggregates startup, cycle, state-refresh, remote-call, and
+  HSL replay timing groups with min/max/mean/median/p95, trading-impact labels,
+  bounded group output, path redaction, and no exchange calls or live behavior
+  changes.
+- Review evidence: Claude and Hermes approved after the path-redaction fix; CI
+  was green; targeted performance-report, event-query, and smoke-report tests,
+  py_compile, a local compact CLI smoke, and `git diff --check` passed.
+- VPS5 evidence: deployed at `fe946c6c` without bot restart because this is
+  read-only tooling. A 5-minute summary smoke reported `ok=true`,
+  `hard_failures=0`, no text-log hard matches, all five expected bots matched,
+  no failed remote calls, and no failed account-critical remote calls. The new
+  performance report returned `ok=true`, scanned all current monitor event
+  streams, and surfaced multi-thousand-second startup/full-warmup/HSL groups as
+  the dominant current performance gap.
 
 ### Critical Live Safety Gap: Coin-HSL Startup Replay Latency
 

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -48,15 +48,17 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
      were `balance=7121ms`, `positions=7210ms`, `open_orders=7233ms`,
      `fills=9585ms`.
 
-4. Existing observability has the pieces but not yet a single performance
-   report.
+4. Existing observability now has an initial performance report, but not yet
+   all decision-boundary and input-staleness metrics.
    - Useful inputs already exist: `cycle.completed.timings_ms`,
      `state.refresh_timing`, `remote_call.* elapsed_ms`,
      `hsl.replay.* elapsed_s`, startup timing events, monitor health loop
      duration, and exchange probe endpoint latency summaries.
-   - Missing piece: one operator-facing report that aggregates min/mean/max
-     and p95 by bot, phase, endpoint, and readiness surface, then explains
-     likely trading impact.
+   - First slice added `passivbot tool live-performance-report` with timing
+     groups, trading-impact labels, summary projection, and bot/user/exchange
+     filters.
+   - Missing pieces: decision-boundary lag, input staleness at decision time,
+     and complete coverage for every order/write/shutdown stage.
 
 ## Performance Checklist
 
@@ -145,8 +147,9 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
 
 ### P1: General Live Performance Report
 
-- [ ] Add `passivbot tool live-performance-report`.
-  - It should read local monitor event streams and text logs only.
+- [x] Add `passivbot tool live-performance-report`.
+  - It reads local monitor event streams only; text-log scraping is not used
+    for structured timing metrics.
   - It should not contact exchanges, mutate caches, or depend on live bot
     availability.
   - It should support `--recent-minutes`, `--include-rotated`, `--summary`,

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -168,6 +168,11 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   escalation ladder as policy only: graceful Ctrl+C/request stop, bounded wait, a second
   graceful signal when warranted, SIGTERM, then SIGKILL. The smoke report never sends those
   signals.
+- `passivbot tool live-performance-report` summarizes local live monitor event timings for
+  operator performance analysis. It is read-only and does not contact exchanges. Use
+  `--recent-minutes` for a time window, `--summary` for a bounded operator projection, and
+  `--bot EXCHANGE/USER`, `--exchange EXCHANGE`, or `--user USER` to focus one account or
+  exchange.
 
 ## Exchange Helpers
 

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -14,6 +14,7 @@ from live.smoke_report import _user_safe_display_path
 
 
 GROUP_LIMIT = 80
+SUMMARY_GROUP_LIMIT = 12
 
 
 def _open_text(path: Path):
@@ -41,6 +42,31 @@ def _bot_key(row: dict[str, Any], live_event: dict[str, Any]) -> str:
     exchange = live_event.get("exchange") or row.get("exchange") or "-"
     user = live_event.get("user") or row.get("user") or "-"
     return f"{exchange}/{user}"
+
+
+def _string_filter(values: list[str] | tuple[str, ...] | set[str] | None) -> set[str]:
+    if not values:
+        return set()
+    return {str(value) for value in values if str(value)}
+
+
+def _matches_filters(
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+    *,
+    bot_filters: set[str],
+    exchange_filters: set[str],
+    user_filters: set[str],
+) -> bool:
+    if bot_filters and _bot_key(row, live_event) not in bot_filters:
+        return False
+    exchange = str(live_event.get("exchange") or row.get("exchange") or "")
+    if exchange_filters and exchange not in exchange_filters:
+        return False
+    user = str(live_event.get("user") or row.get("user") or "")
+    if user_filters and user not in user_filters:
+        return False
+    return True
 
 
 def _finite_float(value: Any) -> float | None:
@@ -390,6 +416,9 @@ def build_live_performance_report(
     until_ms: int | None = None,
     include_rotated: bool = False,
     group_limit: int = GROUP_LIMIT,
+    bot_filters: list[str] | tuple[str, ...] | set[str] | None = None,
+    exchange_filters: list[str] | tuple[str, ...] | set[str] | None = None,
+    user_filters: list[str] | tuple[str, ...] | set[str] | None = None,
 ) -> dict[str, Any]:
     since_filter = int(since_ms) if since_ms is not None else None
     until_filter = int(until_ms) if until_ms is not None else None
@@ -408,6 +437,16 @@ def build_live_performance_report(
         "events_skipped_before": 0,
         "events_skipped_after": 0,
         "invalid_window_ts": 0,
+    }
+    bot_filter_set = _string_filter(bot_filters)
+    exchange_filter_set = _string_filter(exchange_filters)
+    user_filter_set = _string_filter(user_filters)
+    filters = {
+        "enabled": bool(bot_filter_set or exchange_filter_set or user_filter_set),
+        "bots": sorted(bot_filter_set),
+        "exchanges": sorted(exchange_filter_set),
+        "users": sorted(user_filter_set),
+        "events_skipped": 0,
     }
     issues: list[dict[str, Any]] = []
     try:
@@ -476,6 +515,15 @@ def build_live_performance_report(
                     if live_event is None:
                         legacy_events += 1
                         continue
+                    if not _matches_filters(
+                        row,
+                        live_event,
+                        bot_filters=bot_filter_set,
+                        exchange_filters=exchange_filter_set,
+                        user_filters=user_filter_set,
+                    ):
+                        filters["events_skipped"] += 1
+                        continue
                     live_events += 1
                     if window_enabled:
                         record_ts = _record_ts(row)
@@ -531,4 +579,40 @@ def build_live_performance_report(
     }
     if window_enabled:
         report["event_window"] = event_window
+    if filters["enabled"]:
+        report["filters"] = filters
     return report
+
+
+def summarize_live_performance_report(
+    report: dict[str, Any],
+    *,
+    group_limit: int = SUMMARY_GROUP_LIMIT,
+) -> dict[str, Any]:
+    performance = report.get("performance") if isinstance(report.get("performance"), dict) else {}
+    groups = performance.get("groups") if isinstance(performance.get("groups"), list) else []
+    summary = {
+        "ok": bool(report.get("ok")),
+        "root": report.get("root"),
+        "include_rotated": bool(report.get("include_rotated")),
+        "files_scanned": int(report.get("files_scanned") or 0),
+        "records_total": int(report.get("records_total") or 0),
+        "live_events": int(report.get("live_events") or 0),
+        "legacy_events": int(report.get("legacy_events") or 0),
+        "error_count": int(report.get("error_count") or 0),
+        "warning_count": int(report.get("warning_count") or 0),
+        "bots": report.get("bots") or [],
+        "performance": {
+            "total_groups": int(performance.get("total_groups") or 0),
+            "groups_truncated": bool(performance.get("groups_truncated")),
+            "trading_impact_counts": performance.get("trading_impact_counts") or {},
+            "groups": groups[: max(0, int(group_limit))],
+        },
+    }
+    if report.get("event_window") is not None:
+        summary["event_window"] = report.get("event_window")
+    if report.get("filters") is not None:
+        summary["filters"] = report.get("filters")
+    if report.get("issues"):
+        summary["issues"] = report.get("issues")
+    return summary

--- a/src/tools/live_performance_report.py
+++ b/src/tools/live_performance_report.py
@@ -10,7 +10,10 @@ SRC_ROOT = Path(__file__).resolve().parents[1]
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
-from live.performance_report import build_live_performance_report  # noqa: E402
+from live.performance_report import (  # noqa: E402
+    build_live_performance_report,
+    summarize_live_performance_report,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -56,6 +59,29 @@ def build_parser() -> argparse.ArgumentParser:
         help="Maximum performance timing groups to include.",
     )
     parser.add_argument(
+        "--bot",
+        action="append",
+        default=[],
+        help="Only include one bot key, formatted as exchange/user. May be repeated.",
+    )
+    parser.add_argument(
+        "--exchange",
+        action="append",
+        default=[],
+        help="Only include one exchange name. May be repeated.",
+    )
+    parser.add_argument(
+        "--user",
+        action="append",
+        default=[],
+        help="Only include one user/account name. May be repeated.",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Emit a bounded operator summary instead of the full report.",
+    )
+    parser.add_argument(
         "--compact",
         action="store_true",
         help="Emit compact single-line JSON.",
@@ -83,7 +109,12 @@ def main(argv: list[str] | None = None) -> int:
         until_ms=args.until_ms,
         include_rotated=bool(args.include_rotated),
         group_limit=int(args.group_limit),
+        bot_filters=args.bot,
+        exchange_filters=args.exchange,
+        user_filters=args.user,
     )
+    if args.summary:
+        report = summarize_live_performance_report(report, group_limit=int(args.group_limit))
     print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
     return 0 if report.get("ok") else 1
 

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 import live.performance_report as performance_report_module
-from live.performance_report import build_live_performance_report
+from live.performance_report import build_live_performance_report, summarize_live_performance_report
 from tools import live_performance_report
 
 
@@ -208,6 +208,99 @@ def test_live_performance_report_time_window_and_group_limit(tmp_path):
     assert report["performance"]["groups"] == []
 
 
+def test_live_performance_report_filters_by_bot_exchange_and_user(tmp_path):
+    events_dir = tmp_path / "monitor" / "mixed" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                exchange="binance",
+                user="binance_01",
+                data={"elapsed_ms": 1000},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=2,
+                ts=2000,
+                exchange="okx",
+                user="okx_faisal",
+                data={"elapsed_ms": 2000},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=3,
+                ts=3000,
+                exchange="gateio",
+                user="gateio_01",
+                data={"elapsed_ms": 3000},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(
+        tmp_path / "monitor",
+        bot_filters=["okx/okx_faisal"],
+    )
+
+    assert report["live_events"] == 1
+    assert report["filters"] == {
+        "enabled": True,
+        "bots": ["okx/okx_faisal"],
+        "exchanges": [],
+        "users": [],
+        "events_skipped": 2,
+    }
+    assert report["bots"] == [{"bot": "okx/okx_faisal", "events": 1}]
+    groups = _groups_by_operation(report)
+    assert groups["cycle.elapsed"]["max_ms"] == 2000
+
+    exchange_user_report = build_live_performance_report(
+        tmp_path / "monitor",
+        exchange_filters=["gateio"],
+        user_filters=["gateio_01"],
+    )
+
+    assert exchange_user_report["live_events"] == 1
+    assert exchange_user_report["filters"]["events_skipped"] == 2
+    assert exchange_user_report["bots"] == [{"bot": "gateio/gateio_01", "events": 1}]
+
+
+def test_live_performance_report_summary_projection_is_bounded(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                data={
+                    "elapsed_ms": 1000,
+                    "timings_ms": {"execute": 600, "monitor_flush": 50},
+                },
+            )
+        ],
+    )
+
+    report = build_live_performance_report(
+        tmp_path / "monitor",
+        group_limit=10,
+        user_filters=["binance_01"],
+    )
+    summary = summarize_live_performance_report(report, group_limit=1)
+
+    assert summary["ok"] is True
+    assert summary["files_scanned"] == 1
+    assert summary["filters"]["users"] == ["binance_01"]
+    assert summary["performance"]["total_groups"] == 3
+    assert len(summary["performance"]["groups"]) == 1
+    assert "files" not in summary
+    assert "event_types" not in summary
+
+
 def test_live_performance_report_cli_outputs_json(tmp_path, capsys):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(
@@ -228,6 +321,51 @@ def test_live_performance_report_cli_outputs_json(tmp_path, capsys):
     out = json.loads(capsys.readouterr().out)
     assert out["ok"] is True
     assert out["performance"]["groups"][0]["operation"] == "cycle.elapsed"
+
+
+def test_live_performance_report_cli_summary_and_filters(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                exchange="binance",
+                user="binance_01",
+                data={"elapsed_ms": 1000},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=2,
+                ts=2000,
+                exchange="okx",
+                user="okx_faisal",
+                data={"elapsed_ms": 2000},
+            ),
+        ],
+    )
+
+    rc = live_performance_report.main(
+        [
+            str(tmp_path / "monitor"),
+            "--summary",
+            "--compact",
+            "--exchange",
+            "okx",
+            "--group-limit",
+            "1",
+        ]
+    )
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["live_events"] == 1
+    assert out["filters"]["exchanges"] == ["okx"]
+    assert out["filters"]["events_skipped"] == 1
+    assert len(out["performance"]["groups"]) == 1
+    assert "files" not in out
 
 
 def test_live_performance_report_redacts_missing_root_paths():


### PR DESCRIPTION
## Summary
- add bot/exchange/user filters to live-performance-report with explicit skipped-event accounting
- add --summary operator projection for bounded performance output
- update tools/progress/performance-readiness docs with PR #778 deploy evidence and current report capabilities

## Validation
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_performance_report.py tests/test_live_event_query.py tests/test_live_smoke_report.py
- PYTHONPATH=src ./venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py src/passivbot_cli/main.py
- git diff --check
- PYTHONPATH=src ./venv/bin/passivbot tool live-performance-report monitor --recent-minutes 180 --summary --compact --user bybit_01 --group-limit 3