### PR TITLE
Add live decision boundary lag report

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-27.
 
 Current `origin/v8` logging-overhaul head:
 
-- `fe946c6c` after PR #778, `Add live performance report tool`.
+- `0d742a4f` after PR #779, `Add live performance report summary filters`.
 
 Current review gate:
 
@@ -395,6 +395,17 @@ VPS5 deployment status:
   Its slowest groups made the current startup/HSL latency explicit:
   OKX full-warmup about `2552s`, Binance full-warmup about `2419s`,
   GateIO full-warmup about `2409s`, and Binance `startup.hsl` about `2017s`.
+- PR #779 was merged after Claude + Hermes approval and green CI, then pulled
+  to VPS5 without bot restart because it only extends read-only
+  performance-report tooling and docs. A filtered VPS5 performance summary for
+  `--exchange binance` returned `ok=true`, `filters.exchanges=["binance"]`,
+  `events_skipped=11699`, and bounded slowest groups led by Binance
+  `startup.full-warmup` about `2419s`, `startup.market` about `2134s`,
+  `startup.hsl` about `2017s`, and `hsl_replay.elapsed` about `1503s`.
+  A 5-minute summary smoke at `0d742a4f` reported `ok=true`,
+  `hard_failures=0`, `logs.hard_matches=0`, all five expected bots matched,
+  no account-critical remote-call failures, and one non-hard OKX candle
+  timeout visible in `remote_calls`.
 
 ## Phase Checklist
 
@@ -407,7 +418,7 @@ VPS5 deployment status:
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events; PR #707 restores throttled coin-mode HSL position status console lines from existing `hsl.status` metrics; PR #709 mirrors fill-cache startup readiness into off-console `fills.refresh_summary` events; PR #711 mirrors CCXT timestamp/nonce recovery into off-console `exchange.time_sync` events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
-| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window reports, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation | Cross-bot incident workflow, safe restart orchestration, decision-boundary/input-staleness performance metrics, active probe expansion beyond current endpoint/freshness summaries |
+| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window reports, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation with summary/filter support | Cross-bot incident workflow, safe restart orchestration, input-staleness performance metrics, active probe expansion beyond current endpoint/freshness summaries |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup; PR #656/#668 cache integrity smoke doctor | Continue separate reviewed PRs for shutdown/warmup/cache proof improvements |
 
 ## Merged Slices
@@ -1935,6 +1946,27 @@ VPS5 deployment status:
   performance report returned `ok=true`, scanned all current monitor event
   streams, and surfaced multi-thousand-second startup/full-warmup/HSL groups as
   the dominant current performance gap.
+
+### PR #779: Live Performance Report Summary Filters
+
+- Branch: `codex/v8-live-performance-report-summary`.
+- Scope: read-only performance-report filtering, summary projection, tests, and
+  docs.
+- Result: `passivbot tool live-performance-report` now supports
+  `--summary`, `--bot`, `--exchange`, and `--user`, with explicit
+  skipped-event filter accounting and bounded summary output. This keeps
+  repeated operator performance checks concise without changing event emission,
+  exchange calls, caches, or trading behavior.
+- Review evidence: Claude and Hermes approved with no findings; CI was green;
+  targeted performance-report, event-query, and smoke-report tests,
+  py_compile, `git diff --check`, and a local compact filtered CLI smoke
+  passed.
+- VPS5 evidence: deployed at `0d742a4f` without bot restart because this is
+  read-only tooling. A filtered Binance performance summary returned `ok=true`
+  and showed HSL/startup latency as the dominant Binance performance cost. A
+  5-minute summary smoke reported all five expected bots running with no hard
+  failures, no text-log hard matches, and no failed account-critical remote
+  calls.
 
 ### Critical Live Safety Gap: Coin-HSL Startup Replay Latency
 

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -57,8 +57,10 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
    - First slice added `passivbot tool live-performance-report` with timing
      groups, trading-impact labels, summary projection, and bot/user/exchange
      filters.
-   - Missing pieces: decision-boundary lag, input staleness at decision time,
-     and complete coverage for every order/write/shutdown stage.
+   - A follow-up slice added decision-boundary lag groups from current cycle
+     events.
+   - Missing pieces: input staleness at decision time and complete coverage for
+     every order/write/shutdown stage.
 
 ## Performance Checklist
 
@@ -168,10 +170,10 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
   - Mark phases that can delay panic/protective orders.
   - Mark phases that only affect diagnostics/console/dashboard.
 
-- [ ] Report decision-boundary lag.
+- [x] Report decision-boundary lag.
   - For each cycle, measure how far after the relevant whole-minute boundary
-    the bot had sufficient inputs, called Rust, produced a plan, submitted
-    writes, and confirmed exchange state.
+    the bot started the cycle, called Rust as the current planning-ready proxy,
+    produced a plan, submitted writes, and confirmed exchange state.
   - This is the main live-vs-backtest gap metric.
 
 - [ ] Report input staleness at decision time.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -172,7 +172,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   operator performance analysis. It is read-only and does not contact exchanges. Use
   `--recent-minutes` for a time window, `--summary` for a bounded operator projection, and
   `--bot EXCHANGE/USER`, `--exchange EXCHANGE`, or `--user USER` to focus one account or
-  exchange.
+  exchange. The report includes decision-boundary lag groups showing how far after the
+  whole-minute boundary cycles reached start, Rust planning, action planning, writes,
+  confirmations, and completion.
 
 ## Exchange Helpers
 

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -238,6 +238,107 @@ class _PerformanceAccumulator:
         }
 
 
+def _event_cycle_id(live_event: dict[str, Any]) -> str | None:
+    ids = live_event.get("ids")
+    if not isinstance(ids, dict):
+        return None
+    cycle_id = ids.get("cycle_id")
+    if cycle_id is None:
+        return None
+    return str(cycle_id)
+
+
+def _minute_boundary_ms(timestamp_ms: int) -> int:
+    return int(timestamp_ms) - (int(timestamp_ms) % 60_000)
+
+
+def _decision_milestone(event_type: str) -> str | None:
+    return {
+        "cycle.started": "cycle_started",
+        "rust_orchestrator.called": "rust_called",
+        "rust_orchestrator.returned": "rust_returned",
+        "action.planned": "action_planned",
+        "order_wave.started": "order_wave_started",
+        "execution.create_sent": "first_write_sent",
+        "execution.cancel_sent": "first_write_sent",
+        "execution.confirmation_requested": "confirmation_requested",
+        "execution.confirmation_satisfied": "confirmation_satisfied",
+        "cycle.completed": "cycle_completed",
+    }.get(event_type)
+
+
+def _decision_trading_impact(milestone: str) -> str:
+    if milestone in {"first_write_sent", "confirmation_requested", "confirmation_satisfied"}:
+        return "blocks_exchange_actions"
+    if milestone == "cycle_completed":
+        return "blocks_next_cycle"
+    return "blocks_cycle_decision"
+
+
+class _DecisionBoundaryAccumulator:
+    def __init__(self) -> None:
+        self.groups: dict[tuple[str, str], _MetricGroup] = {}
+        self.cycle_boundaries: dict[tuple[str, str], int] = {}
+        self.cycles_seen: set[tuple[str, str]] = set()
+        self.cycles_with_write: set[tuple[str, str]] = set()
+        self.events_without_cycle_id = 0
+
+    def add(self, *, row: dict[str, Any], live_event: dict[str, Any]) -> None:
+        event_type = str(live_event.get("event_type") or row.get("kind") or "")
+        milestone = _decision_milestone(event_type)
+        if milestone is None:
+            return
+        timestamp_ms = _record_ts(row)
+        if timestamp_ms is None:
+            return
+        cycle_id = _event_cycle_id(live_event)
+        if not cycle_id:
+            self.events_without_cycle_id += 1
+            return
+        bot = _bot_key(row, live_event)
+        cycle_key = (bot, cycle_id)
+        self.cycles_seen.add(cycle_key)
+        if milestone == "cycle_started" or cycle_key not in self.cycle_boundaries:
+            self.cycle_boundaries[cycle_key] = _minute_boundary_ms(timestamp_ms)
+        if milestone == "first_write_sent":
+            self.cycles_with_write.add(cycle_key)
+        lag_ms = max(0, int(timestamp_ms) - int(self.cycle_boundaries[cycle_key]))
+        group_key = (bot, milestone)
+        group = self.groups.get(group_key)
+        if group is None:
+            group = _MetricGroup(
+                bot=bot,
+                operation=f"decision_boundary.{milestone}",
+                component="decision_boundary",
+                event_type=event_type,
+                trading_impact=_decision_trading_impact(milestone),
+                timing_kind="lag_from_minute_boundary",
+            )
+            self.groups[group_key] = group
+        group.add(lag_ms, row=row, live_event=live_event)
+
+    def to_dict(self, *, group_limit: int = GROUP_LIMIT) -> dict[str, Any]:
+        groups = sorted(
+            (group.to_dict() for group in self.groups.values()),
+            key=lambda item: (
+                -int(item.get("p95_ms", 0) or 0),
+                -int(item.get("max_ms", 0) or 0),
+                -int(item.get("count", 0) or 0),
+                str(item.get("bot") or ""),
+                str(item.get("operation") or ""),
+            ),
+        )
+        return {
+            "minute_ms": 60_000,
+            "cycles": len(self.cycles_seen),
+            "cycles_with_write": len(self.cycles_with_write),
+            "events_without_cycle_id": int(self.events_without_cycle_id),
+            "total_groups": len(groups),
+            "groups_truncated": len(groups) > int(group_limit),
+            "groups": groups[: max(0, int(group_limit))],
+        }
+
+
 def _timings_map(value: Any) -> dict[str, int]:
     if not isinstance(value, dict):
         return {}
@@ -474,6 +575,7 @@ def build_live_performance_report(
         )
 
     accumulator = _PerformanceAccumulator()
+    decision_boundary = _DecisionBoundaryAccumulator()
     records_total = 0
     live_events = 0
     legacy_events = 0
@@ -545,6 +647,7 @@ def build_live_performance_report(
                         row=row,
                         live_event=live_event,
                     )
+                    decision_boundary.add(row=row, live_event=live_event)
         except OSError as exc:
             issues.append(
                 {
@@ -576,6 +679,7 @@ def build_live_performance_report(
             for bot, count in sorted(bots.items(), key=lambda item: (-item[1], item[0]))
         ],
         "performance": accumulator.to_dict(group_limit=group_limit),
+        "decision_boundary_lag": decision_boundary.to_dict(group_limit=group_limit),
     }
     if window_enabled:
         report["event_window"] = event_window
@@ -609,6 +713,20 @@ def summarize_live_performance_report(
             "groups": groups[: max(0, int(group_limit))],
         },
     }
+    if isinstance(report.get("decision_boundary_lag"), dict):
+        decision_lag = report["decision_boundary_lag"]
+        decision_groups = (
+            decision_lag.get("groups") if isinstance(decision_lag.get("groups"), list) else []
+        )
+        summary["decision_boundary_lag"] = {
+            "minute_ms": int(decision_lag.get("minute_ms") or 60_000),
+            "cycles": int(decision_lag.get("cycles") or 0),
+            "cycles_with_write": int(decision_lag.get("cycles_with_write") or 0),
+            "events_without_cycle_id": int(decision_lag.get("events_without_cycle_id") or 0),
+            "total_groups": int(decision_lag.get("total_groups") or 0),
+            "groups_truncated": bool(decision_lag.get("groups_truncated")),
+            "groups": decision_groups[: max(0, int(group_limit))],
+        }
     if report.get("event_window") is not None:
         summary["event_window"] = report.get("event_window")
     if report.get("filters") is not None:

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -301,6 +301,111 @@ def test_live_performance_report_summary_projection_is_bounded(tmp_path):
     assert "event_types" not in summary
 
 
+def test_live_performance_report_decision_boundary_lag(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.started",
+                seq=1,
+                ts=61_000,
+                component="execution_loop",
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="rust_orchestrator.called",
+                seq=2,
+                ts=62_500,
+                component="rust_orchestrator",
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="rust_orchestrator.returned",
+                seq=3,
+                ts=62_700,
+                component="rust_orchestrator",
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="action.planned",
+                seq=4,
+                ts=62_800,
+                component="action_planner",
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="execution.create_sent",
+                seq=5,
+                ts=63_500,
+                component="executor",
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="execution.confirmation_satisfied",
+                seq=6,
+                ts=64_000,
+                component="executor",
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=7,
+                ts=64_200,
+                component="execution_loop",
+                ids={"cycle_id": "cy_1"},
+                data={"elapsed_ms": 3200},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    lag_groups = {
+        group["operation"]: group
+        for group in report["decision_boundary_lag"]["groups"]
+    }
+
+    assert report["decision_boundary_lag"]["cycles"] == 1
+    assert report["decision_boundary_lag"]["cycles_with_write"] == 1
+    assert lag_groups["decision_boundary.cycle_started"]["max_ms"] == 1000
+    assert lag_groups["decision_boundary.rust_called"]["max_ms"] == 2500
+    assert lag_groups["decision_boundary.action_planned"]["max_ms"] == 2800
+    assert lag_groups["decision_boundary.first_write_sent"]["max_ms"] == 3500
+    assert lag_groups["decision_boundary.confirmation_satisfied"]["max_ms"] == 4000
+    assert lag_groups["decision_boundary.cycle_completed"]["max_ms"] == 4200
+    assert lag_groups["decision_boundary.first_write_sent"]["trading_impact"] == (
+        "blocks_exchange_actions"
+    )
+
+
+def test_live_performance_report_summary_includes_bounded_decision_lag(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.started",
+                seq=1,
+                ts=61_000,
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="rust_orchestrator.called",
+                seq=2,
+                ts=62_500,
+                ids={"cycle_id": "cy_1"},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    summary = summarize_live_performance_report(report, group_limit=1)
+
+    assert summary["decision_boundary_lag"]["cycles"] == 1
+    assert summary["decision_boundary_lag"]["total_groups"] == 2
+    assert len(summary["decision_boundary_lag"]["groups"]) == 1
+
+
 def test_live_performance_report_cli_outputs_json(tmp_path, capsys):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- add decision_boundary_lag groups to live-performance-report, measuring cycle milestone lag from the cycle minute boundary
- include cycle start, Rust call/return, action planning, first writes, confirmations, and cycle completion where present
- update performance/readiness docs and logging progress with PR #779 deploy evidence

## Validation
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_performance_report.py tests/test_live_event_query.py tests/test_live_smoke_report.py
- PYTHONPATH=src ./venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py src/passivbot_cli/main.py
- git diff --check
- PYTHONPATH=src ./venv/bin/passivbot tool live-performance-report monitor --recent-minutes 180 --summary --compact --user bybit_01 --group-limit 4