### PR TITLE
Add live input staleness report

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-27.
 
 Current `origin/v8` logging-overhaul head:
 
-- `0d742a4f` after PR #779, `Add live performance report summary filters`.
+- `f70434f3` after PR #780, `Add live decision boundary lag report`.
 
 Current review gate:
 
@@ -406,6 +406,16 @@ VPS5 deployment status:
   `hard_failures=0`, `logs.hard_matches=0`, all five expected bots matched,
   no account-critical remote-call failures, and one non-hard OKX candle
   timeout visible in `remote_calls`.
+- PR #780 was merged after Claude + Hermes approval and green CI, then pulled
+  to VPS5 without bot restart because it only extends read-only
+  performance-report tooling and docs. A filtered VPS5 performance summary for
+  `--exchange binance` returned `ok=true`, `decision_boundary_lag.cycles=7`,
+  `cycles_with_write=0`, and bounded lag groups led by
+  `decision_boundary.cycle_completed` p95 about `98s`,
+  `action_planned`/`rust_returned` p95 about `93s`, and `cycle_started` p95
+  about `53s`. A 5-minute summary smoke at `f70434f3` reported `ok=true`,
+  `hard_failures=0`, `logs.hard_matches=0`, all five expected bots matched,
+  no failed remote calls, and no account-critical remote-call failures.
 
 ## Phase Checklist
 
@@ -418,7 +428,7 @@ VPS5 deployment status:
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events; PR #707 restores throttled coin-mode HSL position status console lines from existing `hsl.status` metrics; PR #709 mirrors fill-cache startup readiness into off-console `fills.refresh_summary` events; PR #711 mirrors CCXT timestamp/nonce recovery into off-console `exchange.time_sync` events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
-| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window reports, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation with summary/filter support | Cross-bot incident workflow, safe restart orchestration, input-staleness performance metrics, active probe expansion beyond current endpoint/freshness summaries |
+| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window reports, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation with summary/filter, decision-boundary, and initial input-staleness support | Cross-bot incident workflow, safe restart orchestration, richer symbol/market/config staleness performance metrics, active probe expansion beyond current endpoint/freshness summaries |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup; PR #656/#668 cache integrity smoke doctor | Continue separate reviewed PRs for shutdown/warmup/cache proof improvements |
 
 ## Merged Slices
@@ -1967,6 +1977,26 @@ VPS5 deployment status:
   5-minute summary smoke reported all five expected bots running with no hard
   failures, no text-log hard matches, and no failed account-critical remote
   calls.
+
+### PR #780: Live Decision Boundary Lag Report
+
+- Branch: `codex/v8-live-performance-decision-lag`.
+- Scope: read-only performance-report decision-boundary lag aggregation, tests,
+  and docs.
+- Result: `passivbot tool live-performance-report` now includes
+  `decision_boundary_lag`, aggregating per-bot lag from the relevant whole
+  minute boundary to cycle start, Rust call/return, action planning,
+  order-wave/write/confirmation events when present, and cycle completion. The
+  report keeps cycle ids internal and surfaces only aggregate timing groups.
+- Review evidence: Claude and Hermes approved with no findings; CI was green;
+  targeted performance-report, event-query, and smoke-report tests,
+  py_compile, `git diff --check`, and a local compact filtered CLI smoke
+  passed.
+- VPS5 evidence: deployed at `f70434f3` without bot restart because this is
+  read-only tooling. A filtered Binance performance summary returned `ok=true`
+  and showed decision-boundary lag groups directly; the same smoke pass kept
+  all five configured bots running with no hard failures and no failed
+  account-critical remote calls.
 
 ### Critical Live Safety Gap: Coin-HSL Startup Replay Latency
 

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -9,6 +9,13 @@ exchange APIs, network latency, rate limits, cache repair, order confirmation,
 and partial/stale data. The goal is to measure every gap, reduce avoidable
 latency, and make unavoidable latency explicit in the event stream.
 
+The central readiness rule is speed with proof, not speed by assumption. A
+restart may use cached data and checkpoints aggressively only when metadata
+proves coverage, freshness, config compatibility, and code/schema
+compatibility. If proof is missing, the bot should perform the smallest exact
+repair needed for the affected order class instead of falling back to broad
+blocking reconstruction.
+
 ## Current Evidence
 
 Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
@@ -59,10 +66,35 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
      filters.
    - A follow-up slice added decision-boundary lag groups from current cycle
      events.
-   - Missing pieces: input staleness at decision time and complete coverage for
-     every order/write/shutdown stage.
+   - A follow-up slice added initial input-staleness groups from existing
+     account packet, snapshot, EMA bundle, and Rust-call events.
+   - Missing pieces: candle close age, market price age, config age, and
+     complete coverage for every order/write/shutdown stage.
 
 ## Performance Checklist
+
+### P0: Readiness Contract
+
+- [ ] Define readiness by order class, not by global startup completion.
+  - Protective panic/reduce-only paths require fresh account-critical surfaces
+    and the exact risk state for the held `coin+pside`.
+  - Fresh entries require the broader strategy-input contract, including
+    candidate freshness, EMA readiness, market snapshot freshness, and
+    cooldown/trading eligibility.
+  - Candidate-only stale inputs must not delay protective actions for held
+    positions.
+
+- [ ] Make every unavailable readiness state explicit.
+  - Use structured events for unavailable, degraded, repairing, ready, and
+    blocked states.
+  - Include reason codes, affected symbols/psides, source coverage, age, and
+    whether the state blocks protective actions, fresh entries, or diagnostics
+    only.
+
+- [ ] Do not use neutral defaults for trading-critical readiness.
+  - Missing HSL, fill, candle, account, or EMA proof must not become zero
+    drawdown, zero volume, empty fills, or ready-by-default.
+  - Allowed fallbacks must be bounded, observable, and covered by tests.
 
 ### P0: HSL Protective Readiness
 
@@ -109,9 +141,25 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
   - Avoid repeated nested dict scans and repeated full fill-list scans per
     symbol.
 
+- [ ] Identify the current bottleneck with a focused profile.
+  - Measure time spent in fill indexing, candle/timeline construction, pair
+    iteration, EMA update, drawdown/tier update, event emission, and disk/cache
+    reads.
+  - Run the profile on a copied local monitor/cache fixture when possible so
+    optimization does not require live exchange access.
+  - Report rows/s and held-pair protective elapsed time before and after each
+    optimization.
+
 - [ ] Index fill events once by `(pside, symbol)`.
   - Reuse that index for replay contracts, panic detection, position-size
     replay, realized-PnL peak/current calculations, and cooldown discovery.
+
+- [ ] Parallelize only where correctness boundaries are independent.
+  - Coin-mode held-pair protective reconstruction may classify independent
+    `coin+pside` pairs separately, as long as shared account/fill coverage
+    proof is established first.
+  - Do not allow broad flat-pair replay to block a held pair that already has
+    exact protective readiness.
 
 - [ ] Add structured replay timing fields.
   - Required fields: `timeline_rows`, `pairs`, `held_pairs`, `cooldown_pairs`,
@@ -147,6 +195,13 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
   - Store checkpoint write timing and resume/fallback reason in structured
     events.
 
+- [ ] Keep checkpointing stateless in behavior.
+  - A checkpoint may accelerate reconstruction, but every trading decision must
+    still be reproducible from exchange state, config, cache coverage proof, and
+    replay after the checkpoint boundary.
+  - Checkpoint invalidation must be conservative: if any required proof is
+    ambiguous, discard or bypass the checkpoint and emit the reason.
+
 ### P1: General Live Performance Report
 
 - [x] Add `passivbot tool live-performance-report`.
@@ -177,9 +232,19 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
   - This is the main live-vs-backtest gap metric.
 
 - [ ] Report input staleness at decision time.
-  - Candle close age, EMA bundle age, account snapshot age, fills freshness,
-    open-order snapshot age, market price age, and config age.
+  - Initial report-derived support covers account packet age at snapshot build
+    and snapshot/EMA age at the Rust call boundary.
+  - Remaining staleness surfaces: candle close age, market price age, config
+    age, and richer symbol-scoped freshness where current events do not yet
+    carry enough timestamp proof.
   - Separate strict trading blockers from stale-but-acceptable forager inputs.
+
+- [ ] Add readiness SLA summaries.
+  - Report time from process start to account ready, held-position protective
+    ready, fresh-entry ready, first cycle started, first Rust call, first
+    exchange write eligibility, and full background replay complete.
+  - Group by exchange/user/bot so VPS-class regressions are visible before a
+    panic incident.
 
 ### P1: Runtime Cycle Speed
 
@@ -216,6 +281,12 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
   - Cache proof failures should be explicit and targeted, not broad blocking
     repairs by default.
 
+- [ ] Add warm-restart acceptance fixtures.
+  - Restart after a short downtime with complete cache proof should skip broad
+    historical backfill and reach protective readiness quickly.
+  - Restart with one stale symbol should repair that symbol, not stall every
+    unrelated held position or the full forager universe.
+
 - [ ] Leave bots running after smoke/restart operations.
   - Operational automation should stop/restart only when needed and should
     verify all expected bots are running before handing control back.
@@ -251,3 +322,32 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
 - [ ] HSL checkpointing reduces warm-restart replay without weakening
   stateless correctness: checkpoints accelerate reconstruction only when their
   proof matches exchange/cache-derived inputs.
+
+## Suggested Implementation Order
+
+1. Add the missing performance/readiness metrics first, so every optimization
+   has before/after evidence.
+   - Decision-boundary lag and initial input staleness are started.
+   - Next metrics: HSL protective-ready elapsed time, full replay elapsed time,
+     cache proof decision, candle close age, market price age, and shutdown
+     blocking stage.
+
+2. Optimize HSL coin-mode protective readiness before broad full-replay speed.
+   - The highest-risk failure mode is delayed panic for a held position.
+   - Full universe replay and cooldown indexing still matter, but they should
+     not sit on the critical path for already-held positions.
+
+3. Add exact HSL replay profiling and lower-complexity replay.
+   - Profile first, then remove repeated scans and avoid pair-by-row nested
+     work where a sparse/event-driven pass is exact.
+   - Prove equivalence against current replay with fixtures before using it in
+     live.
+
+4. Add checkpoints after the exact optimized path is understood.
+   - Checkpoints should make warm restarts cheap, but they should not obscure
+     the baseline exact replay contract or make debugging harder.
+
+5. Keep the live performance report as the operator-facing scorecard.
+   - Every merged performance slice should update this checklist, add a
+     regression test where practical, and make the report more useful for the
+     next bottleneck.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -174,7 +174,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   `--bot EXCHANGE/USER`, `--exchange EXCHANGE`, or `--user USER` to focus one account or
   exchange. The report includes decision-boundary lag groups showing how far after the
   whole-minute boundary cycles reached start, Rust planning, action planning, writes,
-  confirmations, and completion.
+  confirmations, and completion. It also includes an input-staleness section derived from
+  existing packet, snapshot, EMA, and Rust-call events, covering account packet age at
+  snapshot build plus snapshot/EMA age at the Rust call boundary when those events are present.
 
 ## Exchange Helpers
 

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -248,6 +248,43 @@ def _event_cycle_id(live_event: dict[str, Any]) -> str | None:
     return str(cycle_id)
 
 
+def _cycle_number(cycle_id: str | None) -> int | None:
+    if not cycle_id:
+        return None
+    text = str(cycle_id)
+    if text.startswith("cy_"):
+        text = text[3:]
+    try:
+        return int(text)
+    except (TypeError, ValueError):
+        return None
+
+
+class _CycleScopeTracker:
+    def __init__(self) -> None:
+        self.generation_by_bot: dict[str, int] = {}
+        self.last_cycle_number_by_bot: dict[str, int] = {}
+
+    def observe(self, *, row: dict[str, Any], live_event: dict[str, Any]) -> int:
+        bot = _bot_key(row, live_event)
+        generation = int(self.generation_by_bot.get(bot, 0))
+        event_type = str(live_event.get("event_type") or row.get("kind") or "")
+        if event_type == "bot.started":
+            generation += 1
+            self.generation_by_bot[bot] = generation
+            self.last_cycle_number_by_bot.pop(bot, None)
+            return generation
+        if event_type == "cycle.started":
+            cycle_number = _cycle_number(_event_cycle_id(live_event))
+            if cycle_number is not None:
+                previous = self.last_cycle_number_by_bot.get(bot)
+                if previous is not None and cycle_number <= previous:
+                    generation += 1
+                    self.generation_by_bot[bot] = generation
+                self.last_cycle_number_by_bot[bot] = cycle_number
+        return generation
+
+
 def _minute_boundary_ms(timestamp_ms: int) -> int:
     return int(timestamp_ms) - (int(timestamp_ms) % 60_000)
 
@@ -278,12 +315,18 @@ def _decision_trading_impact(milestone: str) -> str:
 class _DecisionBoundaryAccumulator:
     def __init__(self) -> None:
         self.groups: dict[tuple[str, str], _MetricGroup] = {}
-        self.cycle_boundaries: dict[tuple[str, str], int] = {}
-        self.cycles_seen: set[tuple[str, str]] = set()
-        self.cycles_with_write: set[tuple[str, str]] = set()
+        self.cycle_boundaries: dict[tuple[str, int, str], int] = {}
+        self.cycles_seen: set[tuple[str, int, str]] = set()
+        self.cycles_with_write: set[tuple[str, int, str]] = set()
         self.events_without_cycle_id = 0
 
-    def add(self, *, row: dict[str, Any], live_event: dict[str, Any]) -> None:
+    def add(
+        self,
+        *,
+        row: dict[str, Any],
+        live_event: dict[str, Any],
+        cycle_scope: int,
+    ) -> None:
         event_type = str(live_event.get("event_type") or row.get("kind") or "")
         milestone = _decision_milestone(event_type)
         if milestone is None:
@@ -296,7 +339,7 @@ class _DecisionBoundaryAccumulator:
             self.events_without_cycle_id += 1
             return
         bot = _bot_key(row, live_event)
-        cycle_key = (bot, cycle_id)
+        cycle_key = (bot, int(cycle_scope), cycle_id)
         self.cycles_seen.add(cycle_key)
         if milestone == "cycle_started" or cycle_key not in self.cycle_boundaries:
             self.cycle_boundaries[cycle_key] = _minute_boundary_ms(timestamp_ms)
@@ -333,6 +376,164 @@ class _DecisionBoundaryAccumulator:
             "cycles": len(self.cycles_seen),
             "cycles_with_write": len(self.cycles_with_write),
             "events_without_cycle_id": int(self.events_without_cycle_id),
+            "total_groups": len(groups),
+            "groups_truncated": len(groups) > int(group_limit),
+            "groups": groups[: max(0, int(group_limit))],
+        }
+
+
+def _cycle_id_from_snapshot_data(data: dict[str, Any]) -> str | None:
+    cycle_id = data.get("cycle_id")
+    if cycle_id is None:
+        return None
+    text = str(cycle_id)
+    if text.startswith("cy_"):
+        return text
+    return f"cy_{text}"
+
+
+class _InputStalenessAccumulator:
+    def __init__(self) -> None:
+        self.groups: dict[tuple[str, str, str], _MetricGroup] = {}
+        self.packet_received_ts: dict[tuple[str, int, str, str], int] = {}
+        self.snapshot_ts_by_cycle: dict[tuple[str, int, str], int] = {}
+        self.ema_ts_by_cycle: dict[tuple[str, int, str], int] = {}
+        self.snapshots_seen = 0
+        self.rust_calls_seen = 0
+        self.packet_refs_missing = 0
+        self.rust_calls_missing_snapshot = 0
+        self.rust_calls_missing_ema = 0
+
+    def _add_group(
+        self,
+        *,
+        row: dict[str, Any],
+        live_event: dict[str, Any],
+        operation: str,
+        value_ms: int,
+        timing_kind: str,
+        trading_impact: str,
+    ) -> None:
+        bot = _bot_key(row, live_event)
+        group_key = (bot, operation, timing_kind)
+        group = self.groups.get(group_key)
+        if group is None:
+            group = _MetricGroup(
+                bot=bot,
+                operation=operation,
+                component="input_staleness",
+                event_type=str(live_event.get("event_type") or row.get("kind") or "unknown"),
+                trading_impact=trading_impact,
+                timing_kind=timing_kind,
+            )
+            self.groups[group_key] = group
+        group.add(value_ms, row=row, live_event=live_event)
+
+    def add(
+        self,
+        *,
+        row: dict[str, Any],
+        live_event: dict[str, Any],
+        cycle_scope: int,
+    ) -> None:
+        event_type = str(live_event.get("event_type") or row.get("kind") or "")
+        data = live_event.get("data") if isinstance(live_event.get("data"), dict) else {}
+        timestamp_ms = _record_ts(row)
+        if timestamp_ms is None:
+            return
+        bot = _bot_key(row, live_event)
+        if event_type == "data_packet.updated":
+            kind = data.get("kind")
+            revision = data.get("revision")
+            received_ts = _non_negative_ms(data.get("response_received_ts_ms"))
+            if kind is None or revision is None or received_ts is None:
+                return
+            self.packet_received_ts[(bot, int(cycle_scope), str(kind), str(revision))] = int(
+                received_ts
+            )
+            return
+        if event_type == "snapshot.built":
+            self.snapshots_seen += 1
+            cycle_id = _cycle_id_from_snapshot_data(data)
+            if cycle_id:
+                self.snapshot_ts_by_cycle[(bot, int(cycle_scope), cycle_id)] = int(timestamp_ms)
+            packets = data.get("data_packets")
+            if not isinstance(packets, list):
+                return
+            for packet in packets:
+                if not isinstance(packet, dict):
+                    continue
+                kind = packet.get("kind")
+                revision = packet.get("revision")
+                if kind is None or revision is None:
+                    continue
+                received_ts = self.packet_received_ts.get(
+                    (bot, int(cycle_scope), str(kind), str(revision))
+                )
+                if received_ts is None:
+                    self.packet_refs_missing += 1
+                    continue
+                self._add_group(
+                    row=row,
+                    live_event=live_event,
+                    operation=f"input_staleness.data_packet.{kind}",
+                    value_ms=max(0, int(timestamp_ms) - int(received_ts)),
+                    timing_kind="age_at_snapshot",
+                    trading_impact="blocks_exchange_actions",
+                )
+            return
+        if event_type == "ema.bundle.completed":
+            cycle_id = _event_cycle_id(live_event)
+            if cycle_id:
+                self.ema_ts_by_cycle[(bot, int(cycle_scope), cycle_id)] = int(timestamp_ms)
+            return
+        if event_type == "rust_orchestrator.called":
+            self.rust_calls_seen += 1
+            cycle_id = _event_cycle_id(live_event)
+            if not cycle_id:
+                return
+            snapshot_ts = self.snapshot_ts_by_cycle.get((bot, int(cycle_scope), cycle_id))
+            if snapshot_ts is None:
+                self.rust_calls_missing_snapshot += 1
+            else:
+                self._add_group(
+                    row=row,
+                    live_event=live_event,
+                    operation="input_staleness.snapshot_to_rust",
+                    value_ms=max(0, int(timestamp_ms) - int(snapshot_ts)),
+                    timing_kind="age_at_rust_call",
+                    trading_impact="blocks_cycle_decision",
+                )
+            ema_ts = self.ema_ts_by_cycle.get((bot, int(cycle_scope), cycle_id))
+            if ema_ts is None:
+                self.rust_calls_missing_ema += 1
+            else:
+                self._add_group(
+                    row=row,
+                    live_event=live_event,
+                    operation="input_staleness.ema_bundle_to_rust",
+                    value_ms=max(0, int(timestamp_ms) - int(ema_ts)),
+                    timing_kind="age_at_rust_call",
+                    trading_impact="blocks_indicator_readiness",
+                )
+
+    def to_dict(self, *, group_limit: int = GROUP_LIMIT) -> dict[str, Any]:
+        groups = sorted(
+            (group.to_dict() for group in self.groups.values()),
+            key=lambda item: (
+                -int(item.get("p95_ms", 0) or 0),
+                -int(item.get("max_ms", 0) or 0),
+                -int(item.get("count", 0) or 0),
+                str(item.get("bot") or ""),
+                str(item.get("operation") or ""),
+            ),
+        )
+        return {
+            "snapshots_seen": int(self.snapshots_seen),
+            "rust_calls_seen": int(self.rust_calls_seen),
+            "packet_refs_missing": int(self.packet_refs_missing),
+            "rust_calls_missing_snapshot": int(self.rust_calls_missing_snapshot),
+            "rust_calls_missing_ema": int(self.rust_calls_missing_ema),
             "total_groups": len(groups),
             "groups_truncated": len(groups) > int(group_limit),
             "groups": groups[: max(0, int(group_limit))],
@@ -576,6 +777,8 @@ def build_live_performance_report(
 
     accumulator = _PerformanceAccumulator()
     decision_boundary = _DecisionBoundaryAccumulator()
+    input_staleness = _InputStalenessAccumulator()
+    cycle_scope_tracker = _CycleScopeTracker()
     records_total = 0
     live_events = 0
     legacy_events = 0
@@ -640,6 +843,7 @@ def build_live_performance_report(
                             continue
                         event_window["events_considered"] += 1
                     event_type = str(live_event.get("event_type") or row.get("kind") or "unknown")
+                    cycle_scope = cycle_scope_tracker.observe(row=row, live_event=live_event)
                     event_types[event_type] += 1
                     bots[_bot_key(row, live_event)] += 1
                     _add_event_timings(
@@ -647,7 +851,16 @@ def build_live_performance_report(
                         row=row,
                         live_event=live_event,
                     )
-                    decision_boundary.add(row=row, live_event=live_event)
+                    decision_boundary.add(
+                        row=row,
+                        live_event=live_event,
+                        cycle_scope=cycle_scope,
+                    )
+                    input_staleness.add(
+                        row=row,
+                        live_event=live_event,
+                        cycle_scope=cycle_scope,
+                    )
         except OSError as exc:
             issues.append(
                 {
@@ -680,6 +893,7 @@ def build_live_performance_report(
         ],
         "performance": accumulator.to_dict(group_limit=group_limit),
         "decision_boundary_lag": decision_boundary.to_dict(group_limit=group_limit),
+        "input_staleness": input_staleness.to_dict(group_limit=group_limit),
     }
     if window_enabled:
         report["event_window"] = event_window
@@ -726,6 +940,25 @@ def summarize_live_performance_report(
             "total_groups": int(decision_lag.get("total_groups") or 0),
             "groups_truncated": bool(decision_lag.get("groups_truncated")),
             "groups": decision_groups[: max(0, int(group_limit))],
+        }
+    if isinstance(report.get("input_staleness"), dict):
+        input_staleness = report["input_staleness"]
+        staleness_groups = (
+            input_staleness.get("groups")
+            if isinstance(input_staleness.get("groups"), list)
+            else []
+        )
+        summary["input_staleness"] = {
+            "snapshots_seen": int(input_staleness.get("snapshots_seen") or 0),
+            "rust_calls_seen": int(input_staleness.get("rust_calls_seen") or 0),
+            "packet_refs_missing": int(input_staleness.get("packet_refs_missing") or 0),
+            "rust_calls_missing_snapshot": int(
+                input_staleness.get("rust_calls_missing_snapshot") or 0
+            ),
+            "rust_calls_missing_ema": int(input_staleness.get("rust_calls_missing_ema") or 0),
+            "total_groups": int(input_staleness.get("total_groups") or 0),
+            "groups_truncated": bool(input_staleness.get("groups_truncated")),
+            "groups": staleness_groups[: max(0, int(group_limit))],
         }
     if report.get("event_window") is not None:
         summary["event_window"] = report.get("event_window")

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -378,6 +378,52 @@ def test_live_performance_report_decision_boundary_lag(tmp_path):
     )
 
 
+def test_live_performance_report_decision_boundary_handles_cycle_id_reuse(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.started",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=2,
+                ts=2000,
+                ids={"cycle_id": "cy_1"},
+                data={"elapsed_ms": 1000},
+            ),
+            _monitor_row(event_type="bot.started", seq=3, ts=10_000),
+            _monitor_row(
+                event_type="cycle.started",
+                seq=4,
+                ts=61_000,
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=5,
+                ts=62_000,
+                ids={"cycle_id": "cy_1"},
+                data={"elapsed_ms": 1000},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+
+    assert report["decision_boundary_lag"]["cycles"] == 2
+    lag_groups = {
+        group["operation"]: group
+        for group in report["decision_boundary_lag"]["groups"]
+    }
+    assert lag_groups["decision_boundary.cycle_started"]["count"] == 2
+    assert lag_groups["decision_boundary.cycle_started"]["max_ms"] == 1000
+
+
 def test_live_performance_report_summary_includes_bounded_decision_lag(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(
@@ -404,6 +450,162 @@ def test_live_performance_report_summary_includes_bounded_decision_lag(tmp_path)
     assert summary["decision_boundary_lag"]["cycles"] == 1
     assert summary["decision_boundary_lag"]["total_groups"] == 2
     assert len(summary["decision_boundary_lag"]["groups"]) == 1
+
+
+def test_live_performance_report_input_staleness(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="data_packet.updated",
+                seq=1,
+                ts=1000,
+                data={
+                    "kind": "balance",
+                    "revision": 7,
+                    "response_received_ts_ms": 1000,
+                },
+            ),
+            _monitor_row(
+                event_type="data_packet.updated",
+                seq=2,
+                ts=1200,
+                data={
+                    "kind": "open_orders",
+                    "revision": 8,
+                    "response_received_ts_ms": 1200,
+                },
+            ),
+            _monitor_row(
+                event_type="data_packet.updated",
+                seq=3,
+                ts=1400,
+                data={
+                    "kind": "positions",
+                    "revision": 9,
+                    "response_received_ts_ms": 1400,
+                },
+            ),
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=4,
+                ts=2000,
+                data={
+                    "cycle_id": 1,
+                    "data_packets": [
+                        {"kind": "balance", "revision": 7},
+                        {"kind": "open_orders", "revision": 8},
+                        {"kind": "positions", "revision": 9},
+                    ],
+                },
+            ),
+            _monitor_row(
+                event_type="ema.bundle.completed",
+                seq=5,
+                ts=2500,
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="rust_orchestrator.called",
+                seq=6,
+                ts=3000,
+                ids={"cycle_id": "cy_1"},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    staleness_groups = {
+        group["operation"]: group
+        for group in report["input_staleness"]["groups"]
+    }
+
+    assert report["input_staleness"]["snapshots_seen"] == 1
+    assert report["input_staleness"]["rust_calls_seen"] == 1
+    assert report["input_staleness"]["packet_refs_missing"] == 0
+    assert staleness_groups["input_staleness.data_packet.balance"]["max_ms"] == 1000
+    assert staleness_groups["input_staleness.data_packet.open_orders"]["max_ms"] == 800
+    assert staleness_groups["input_staleness.data_packet.positions"]["max_ms"] == 600
+    assert staleness_groups["input_staleness.snapshot_to_rust"]["max_ms"] == 1000
+    assert staleness_groups["input_staleness.ema_bundle_to_rust"]["max_ms"] == 500
+    assert staleness_groups["input_staleness.ema_bundle_to_rust"]["trading_impact"] == (
+        "blocks_indicator_readiness"
+    )
+
+
+def test_live_performance_report_input_staleness_handles_cycle_id_reuse(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=1,
+                ts=2000,
+                data={"cycle_id": 1, "data_packets": []},
+            ),
+            _monitor_row(event_type="bot.started", seq=2, ts=10_000),
+            _monitor_row(
+                event_type="cycle.started",
+                seq=3,
+                ts=11_000,
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="ema.bundle.completed",
+                seq=4,
+                ts=11_500,
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="rust_orchestrator.called",
+                seq=5,
+                ts=12_000,
+                ids={"cycle_id": "cy_1"},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    staleness_groups = {
+        group["operation"]: group
+        for group in report["input_staleness"]["groups"]
+    }
+
+    assert report["input_staleness"]["rust_calls_missing_snapshot"] == 1
+    assert "input_staleness.snapshot_to_rust" not in staleness_groups
+    assert staleness_groups["input_staleness.ema_bundle_to_rust"]["max_ms"] == 500
+
+
+def test_live_performance_report_summary_includes_bounded_input_staleness(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=1,
+                ts=2000,
+                data={"cycle_id": 1, "data_packets": []},
+            ),
+            _monitor_row(
+                event_type="rust_orchestrator.called",
+                seq=2,
+                ts=3000,
+                ids={"cycle_id": "cy_1"},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    summary = summarize_live_performance_report(report, group_limit=1)
+
+    assert summary["input_staleness"]["snapshots_seen"] == 1
+    assert summary["input_staleness"]["rust_calls_seen"] == 1
+    assert summary["input_staleness"]["rust_calls_missing_ema"] == 1
+    assert summary["input_staleness"]["total_groups"] == 1
+    assert len(summary["input_staleness"]["groups"]) == 1
 
 
 def test_live_performance_report_cli_outputs_json(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- add input_staleness aggregation to live-performance-report using existing data_packet, snapshot, EMA bundle, and Rust-call events
- cycle-scope joins by bot generation so reused cycle ids after restarts do not cross-link old snapshots/EMA state
- update performance/readiness checklist with HSL replay speed, checkpointing, and speedy-but-correct readiness goals

## Validation
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_performance_report.py tests/test_live_event_query.py tests/test_live_smoke_report.py
- PYTHONPATH=src ./venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py src/passivbot_cli/main.py
- git diff --check
- PYTHONPATH=src ./venv/bin/passivbot tool live-performance-report monitor --recent-minutes 180 --summary --compact --user bybit_01 --group-limit 4

## Scope
Read-only reporting/docs/tests only. No exchange calls, no live trading behavior changes.