### PR TITLE
Update logging progress after HSL timing

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-27.
 
 Current `origin/v8` logging-overhaul head:
 
-- `f70434f3` after PR #780, `Add live decision boundary lag report`.
+- `b5e08986` after PR #782, `Add HSL replay timing fields`.
 
 Current review gate:
 
@@ -416,6 +416,28 @@ VPS5 deployment status:
   about `53s`. A 5-minute summary smoke at `f70434f3` reported `ok=true`,
   `hard_failures=0`, `logs.hard_matches=0`, all five expected bots matched,
   no failed remote calls, and no account-critical remote-call failures.
+- PR #781 was merged after Claude + Hermes approval and green CI, then pulled
+  to VPS5 without bot restart because it only extends read-only
+  performance-report tooling and docs. The new `input_staleness` section was
+  present in a filtered Binance report and showed high snapshot-to-Rust age
+  directly: `snapshot_to_rust` p95 about `192s`, account packet age at snapshot
+  p95 about `38-42s`, and EMA-bundle age p95 about `5s`. The first smoke after
+  deploy caught a real transient GateIO authoritative positions
+  `RequestTimeout`; a later settled 2-minute smoke at `cdb2f381` reported
+  `ok=true`, `hard_failures=0`, all five expected bots matched, no text-log
+  hard matches, no failed remote calls, and no failed account-critical remote
+  calls.
+- PR #782 was merged after Claude + Hermes approval and green CI, then pulled
+  to VPS5 with a bot restart because it changes live HSL replay event
+  producers. Shutdown was bounded but Kucoin/GateIO required a second Ctrl+C;
+  the session was reloaded from `/root/bots_vps5.yaml` and all five expected
+  bots were left running. Immediate and settled smokes at `b5e08986` reported
+  `ok=true`, `hard_failures=0`, no text-log hard matches, no failed remote
+  calls, and no failed account-critical remote calls. A direct
+  `live-event-query` confirmed new `hsl.replay.progress` fields on VPS5,
+  including `held_pairs`, `cooldown_pairs`, `required_pairs`,
+  `timeline_rows`, `applied_rows`, `total_applied_rows`, `rows_per_second`,
+  `is_held_pair`, and `is_cooldown_pair`.
 
 ## Phase Checklist
 
@@ -428,7 +450,7 @@ VPS5 deployment status:
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events; PR #707 restores throttled coin-mode HSL position status console lines from existing `hsl.status` metrics; PR #709 mirrors fill-cache startup readiness into off-console `fills.refresh_summary` events; PR #711 mirrors CCXT timestamp/nonce recovery into off-console `exchange.time_sync` events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
-| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window reports, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation with summary/filter, decision-boundary, and initial input-staleness support | Cross-bot incident workflow, safe restart orchestration, richer symbol/market/config staleness performance metrics, active probe expansion beyond current endpoint/freshness summaries |
+| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window reports, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation with summary/filter, decision-boundary, and initial input-staleness support, plus HSL replay pair/rate fields | Cross-bot incident workflow, safe restart orchestration, richer symbol/market/config staleness performance metrics, active probe expansion beyond current endpoint/freshness summaries |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup; PR #656/#668 cache integrity smoke doctor | Continue separate reviewed PRs for shutdown/warmup/cache proof improvements |
 
 ## Merged Slices
@@ -1997,6 +2019,45 @@ VPS5 deployment status:
   and showed decision-boundary lag groups directly; the same smoke pass kept
   all five configured bots running with no hard failures and no failed
   account-critical remote calls.
+
+### PR #781: Live Input Staleness Report
+
+- Branch: `codex/v8-live-performance-input-staleness`.
+- Scope: read-only performance-report input-staleness aggregation, tests, and
+  docs.
+- Result: `passivbot tool live-performance-report` now includes
+  `input_staleness`, aggregating account packet age at snapshot build plus
+  snapshot/EMA-bundle age at the Rust call boundary when existing monitor
+  events provide enough proof. Joins are keyed by bot plus cycle generation so
+  reused cycle IDs after restart do not cross-link old snapshot/EMA state.
+- Review evidence: Claude and Hermes approved with no findings; CI was green;
+  targeted performance-report, event-query, and smoke-report tests,
+  py_compile, `git diff --check`, and a local compact CLI smoke passed.
+- VPS5 evidence: deployed at `cdb2f381` without bot restart because this is
+  read-only tooling. A filtered Binance performance summary returned
+  `ok=true` with `input_staleness` groups visible; a settled smoke after a
+  transient GateIO timeout reported all five expected bots running with no hard
+  failures and no failed account-critical remote calls.
+
+### PR #782: HSL Replay Timing Fields
+
+- Branch: `codex/v8-hsl-replay-timing-fields`.
+- Scope: HSL coin replay structured-event payload fields and tests only.
+- Result: `hsl.replay.progress`/`completed` payloads now expose bounded replay
+  context for performance work: held/cooldown/required pair counts,
+  `timeline_rows`, `applied_rows`, `total_applied_rows`, `skipped_pairs` on
+  completion, `rows_per_second`, `full_elapsed_s`,
+  `startup_blocking_elapsed_s`, and per-pair held/cooldown booleans. The
+  current full replay remains startup-blocking; true protective elapsed timing
+  still belongs to the future protective/full replay split.
+- Review evidence: Claude and Hermes approved with no findings; CI was green;
+  focused HSL tests, py_compile, `git diff --check`, and silent-handling audit
+  of touched files passed locally.
+- VPS5 evidence: deployed at `b5e08986` with a controlled restart from
+  `/root/bots_vps5.yaml`. Immediate and settled smokes reported all five
+  expected bots running with no hard failures and no failed account-critical
+  remote calls. Direct event query showed the new HSL replay fields in live
+  Binance, GateIO, and OKX replay progress events.
 
 ### Critical Live Safety Gap: Coin-HSL Startup Replay Latency
 

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -19,7 +19,7 @@ blocking reconstruction.
 ## Current Evidence
 
 Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
-`54a909b`.
+`b5e08986`.
 
 1. HSL coin-mode startup replay is the current P0 latency gap.
    - Binance incident on 2026-06-26: coin HSL replay loaded at `16:19:33Z`
@@ -68,8 +68,23 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
      events.
    - A follow-up slice added initial input-staleness groups from existing
      account packet, snapshot, EMA bundle, and Rust-call events.
+   - A follow-up slice added HSL coin replay pair classification, applied-row,
+     elapsed, and rows-per-second fields to structured replay events.
    - Missing pieces: candle close age, market price age, config age, and
      complete coverage for every order/write/shutdown stage.
+
+5. VPS5 restart evidence after the HSL replay timing slice confirms the new
+   fields are live, while also confirming the underlying speed problem remains.
+   - Binance loaded `pairs=26`, `held_pairs=1`, `cooldown_pairs=1`,
+     `required_pairs=20`, and `timeline_rows=43201`, then progressed at roughly
+     `850-950` applied rows/s after the first minute.
+   - GateIO loaded `pairs=29`, `held_pairs=1`, `cooldown_pairs=0`,
+     `required_pairs=24`, and `timeline_rows=43201`; early progress peaked
+     above `5000` rows/s before settling lower as replay advanced.
+   - OKX loaded `pairs=27`, `held_pairs=1`, `cooldown_pairs=0`,
+     `required_pairs=21`, and `timeline_rows=43201`.
+   - These fields make the next optimization measurable, but they do not yet
+     split protective readiness from full replay.
 
 ## Performance Checklist
 
@@ -162,9 +177,12 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
     exact protective readiness.
 
 - [ ] Add structured replay timing fields.
-  - Required fields: `timeline_rows`, `pairs`, `held_pairs`, `cooldown_pairs`,
-    `applied_rows`, `skipped_pairs`, `rows_per_second`, `protective_elapsed_s`,
+  - Done: current full-replay events include `timeline_rows`, `pairs`,
+    `held_pairs`, `cooldown_pairs`, `required_pairs`, `applied_rows`,
+    `total_applied_rows`, `skipped_pairs` on completion, `rows_per_second`,
     `full_elapsed_s`, and `startup_blocking_elapsed_s`.
+  - Remaining: add true `protective_elapsed_s` once protective readiness is
+    split from full replay.
 
 - [ ] Set concrete performance acceptance targets after the first optimized
   implementation.


### PR DESCRIPTION
## Summary
- record #781 and #782 merge/deploy evidence in the logging overhaul progress ledger
- update performance/readiness goals with current v8 head and live HSL replay timing evidence
- mark HSL replay timing as partial: full/startup-blocking fields are live, true protective_elapsed_s remains pending until protective/full replay split

## Validation
- git diff --check

## Scope
Docs only. No code or behavior changes.