### PR TITLE
Add startup readiness performance summary

### DIFF
--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -16,6 +16,21 @@ compatibility. If proof is missing, the bot should perform the smallest exact
 repair needed for the affected order class instead of falling back to broad
 blocking reconstruction.
 
+## How To Use This Checklist
+
+This document is the action list for live performance and readiness work. Each
+item should end in one of three outcomes:
+
+- a measured baseline in `passivbot tool live-performance-report`;
+- a behavior-preserving optimization with before/after timing evidence; or
+- a documented readiness contract with tests proving that fast startup does not
+  weaken trading correctness.
+
+Any optimization that changes which order classes are allowed to proceed must
+state the readiness contract explicitly. Speedups are acceptable only when they
+preserve the existing trading decision semantics or when the contract is
+deliberately changed and reviewed.
+
 ## Current Evidence
 
 Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
@@ -86,6 +101,33 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
    - These fields make the next optimization measurable, but they do not yet
      split protective readiness from full replay.
 
+## Outcome Targets
+
+- [ ] A held position should reach exact protective readiness in seconds, not
+  minutes, after process start.
+  - Initial target on the VPS5 1-vCPU profile: under `60s` for held-position
+    protective HSL readiness when required cache/fill/candle proof is present.
+  - Stretch target after optimized replay/checkpointing: under `10s` for warm
+    restart with valid proof.
+
+- [ ] A broad full-HSL replay should stop being a critical-path startup blocker.
+  - Initial target: full replay for `25-30` pairs over the configured lookback
+    completes in under `5m` on VPS5-class hardware.
+  - Stretch target: warm restart with a valid checkpoint resumes in under `60s`
+    and continues exact background repair/replay when needed.
+
+- [ ] Every performance claim should have a local/offline reproduction path.
+  - Prefer copied monitor/cache fixtures and deterministic synthetic fixtures
+    before relying on live exchange access.
+  - VPS smoke should validate integration and real endpoint behavior, not be
+    the only profiling environment.
+
+- [ ] Operators should be able to answer "what delayed this trade?" from one
+  report.
+  - The report should connect startup readiness, input staleness,
+    decision-boundary lag, Rust planning, Python filtering/gating, exchange
+    writes, confirmation, and monitor/event-pipeline overhead.
+
 ## Performance Checklist
 
 ### P0: Readiness Contract
@@ -155,6 +197,9 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
     states that have values on that row, or per-pair sparse series built once.
   - Avoid repeated nested dict scans and repeated full fill-list scans per
     symbol.
+  - Preserve current RED/green/current-drawdown semantics: a historical RED
+    crossing must not cause a panic now if current replay state is no longer in
+    the red zone.
 
 - [ ] Identify the current bottleneck with a focused profile.
   - Measure time spent in fill indexing, candle/timeline construction, pair
@@ -164,6 +209,8 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
     optimization does not require live exchange access.
   - Report rows/s and held-pair protective elapsed time before and after each
     optimization.
+  - Report whether the bottleneck is CPU-bound Python, disk/cache IO, event
+    emission, or exchange/cache backfill.
 
 - [ ] Index fill events once by `(pside, symbol)`.
   - Reuse that index for replay contracts, panic detection, position-size
@@ -190,6 +237,8 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
     minutes, on the VPS5 1-vCPU profile.
   - Full replay should be optimized enough that 25-30 pairs over 30 days is no
     longer a 20-40 minute operation.
+  - Add regression protection for rows/s or elapsed-time regressions with a
+    deterministic offline fixture.
 
 ### P1: HSL Checkpointing
 
@@ -264,6 +313,13 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
   - Group by exchange/user/bot so VPS-class regressions are visible before a
     panic incident.
 
+- [ ] Add a "slowest blockers" view.
+  - Rank operations by elapsed time and trading impact.
+  - Separate "delayed protective action", "delayed fresh entry", "delayed
+    diagnostics only", and "not on critical path".
+  - Include enough event IDs/timestamps to jump from the summary into the
+    structured event stream.
+
 ### P1: Runtime Cycle Speed
 
 - [ ] Keep normal no-op cycles lean.
@@ -298,6 +354,9 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
     proves coverage.
   - Cache proof failures should be explicit and targeted, not broad blocking
     repairs by default.
+  - If the bot was down only briefly and coverage proof still matches config
+    and exchange state, startup should consume the existing cache/checkpoint
+    before scheduling broad backfill.
 
 - [ ] Add warm-restart acceptance fixtures.
   - Restart after a short downtime with complete cache proof should skip broad
@@ -323,6 +382,25 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
   - HSL coin replay over 30 days and 30 pairs.
   - EMA readiness over a high-cardinality forager universe.
   - Monitor event ingestion and smoke-report scan over large NDJSON segments.
+
+### P2: Shutdown Latency
+
+- [ ] Measure shutdown by stage.
+  - Track signal received, exit flag set, task cancellation requested, remote
+    calls cancelled or completed, monitor flush finished, and process exit.
+  - Report slowest pending tasks at shutdown without logging secrets or raw
+    exchange payloads.
+
+- [ ] Make long non-critical work interruptible.
+  - Big candle fetches, broad background replay, monitor scans, and forager
+    refresh work should observe shutdown promptly.
+  - Protective cleanup and final monitor flush may run briefly, but shutdown
+    should not wait for fresh-entry-only background work.
+
+- [ ] Add shutdown smoke expectations.
+  - Repeated Ctrl+C should not be required for the normal path.
+  - If a second interrupt is needed, the logs/events should identify the
+    blocking task and stage.
 
 ## Target State
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -177,6 +177,8 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   confirmations, and completion. It also includes an input-staleness section derived from
   existing packet, snapshot, EMA, and Rust-call events, covering account packet age at
   snapshot build plus snapshot/EMA age at the Rust call boundary when those events are present.
+  The startup-readiness section summarizes latest per-bot startup phase timings and HSL
+  replay state from existing lifecycle/replay events.
 
 ## Exchange Helpers
 

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -540,6 +540,135 @@ class _InputStalenessAccumulator:
         }
 
 
+def _startup_elapsed_ms(data: dict[str, Any]) -> int | None:
+    value_ms = _non_negative_ms(data.get("elapsed_ms"))
+    if value_ms is not None:
+        return value_ms
+    return _elapsed_s_to_ms(data.get("elapsed_s"))
+
+
+class _StartupReadinessAccumulator:
+    def __init__(self) -> None:
+        self.bots: dict[str, dict[str, Any]] = {}
+
+    def _bot_state(self, *, row: dict[str, Any], live_event: dict[str, Any]) -> dict[str, Any]:
+        bot = _bot_key(row, live_event)
+        state = self.bots.get(bot)
+        if state is None:
+            state = {
+                "bot": bot,
+                "startup_phases_ms": {},
+                "latest_ts": None,
+            }
+            self.bots[bot] = state
+        ts = _record_ts(row)
+        if ts is not None and (
+            state.get("latest_ts") is None or int(ts) > int(state["latest_ts"])
+        ):
+            state["latest_ts"] = int(ts)
+        return state
+
+    def add(self, *, row: dict[str, Any], live_event: dict[str, Any]) -> None:
+        event_type = str(live_event.get("event_type") or row.get("kind") or "")
+        data = live_event.get("data") if isinstance(live_event.get("data"), dict) else {}
+        ts = _record_ts(row)
+        if event_type == "bot.started":
+            state = self._bot_state(row=row, live_event=live_event)
+            bot = str(state["bot"])
+            state.clear()
+            state.update(
+                {
+                    "bot": bot,
+                    "startup_phases_ms": {},
+                    "latest_ts": int(ts) if ts is not None else None,
+                }
+            )
+            if ts is not None:
+                state["bot_started_ts"] = int(ts)
+            state["lifecycle_status"] = "started"
+            return
+        if event_type == "bot.ready":
+            state = self._bot_state(row=row, live_event=live_event)
+            if ts is not None:
+                state["bot_ready_ts"] = int(ts)
+            state["lifecycle_status"] = "ready"
+            return
+        if event_type == "bot.startup_timing":
+            state = self._bot_state(row=row, live_event=live_event)
+            stage = data.get("stage") or data.get("phase") or "startup"
+            elapsed_ms = _startup_elapsed_ms(data)
+            if elapsed_ms is not None:
+                state["startup_phases_ms"][str(stage)] = int(elapsed_ms)
+            return
+        if event_type.startswith("hsl.replay."):
+            state = self._bot_state(row=row, live_event=live_event)
+            hsl_state = state.get("hsl_replay")
+            if not isinstance(hsl_state, dict):
+                hsl_state = {}
+                state["hsl_replay"] = hsl_state
+            if ts is not None:
+                hsl_state["latest_ts"] = int(ts)
+            hsl_state["event_type"] = event_type
+            hsl_state["status"] = live_event.get("status")
+            hsl_state["reason_code"] = live_event.get("reason_code")
+            for key in (
+                "signal_mode",
+                "stage",
+                "pairs",
+                "held_pairs",
+                "cooldown_pairs",
+                "required_pairs",
+                "timeline_rows",
+                "applied_rows",
+                "total_applied_rows",
+                "skipped_pairs",
+                "rows_per_second",
+                "elapsed_s",
+                "full_elapsed_s",
+                "startup_blocking_elapsed_s",
+            ):
+                if key in data:
+                    hsl_state[key] = data[key]
+
+    def to_dict(self, *, group_limit: int = GROUP_LIMIT) -> dict[str, Any]:
+        bot_items = []
+        ready_count = 0
+        hsl_active_count = 0
+        limit = max(0, int(group_limit))
+        for bot, state in sorted(self.bots.items()):
+            phases = dict(sorted(state.get("startup_phases_ms", {}).items()))
+            item = {
+                "bot": bot,
+                "latest_ts": state.get("latest_ts"),
+                "lifecycle_status": state.get("lifecycle_status"),
+                "startup_phases_ms": dict(list(phases.items())[:limit]),
+            }
+            if len(phases) > limit:
+                item["startup_phases_truncated"] = True
+            if state.get("bot_started_ts") is not None:
+                item["bot_started_ts"] = int(state["bot_started_ts"])
+            if state.get("bot_ready_ts") is not None:
+                item["bot_ready_ts"] = int(state["bot_ready_ts"])
+                ready_count += 1
+            if isinstance(state.get("hsl_replay"), dict):
+                hsl_state = {
+                    key: value
+                    for key, value in state["hsl_replay"].items()
+                    if value is not None
+                }
+                item["hsl_replay"] = hsl_state
+                if hsl_state.get("status") not in ("succeeded", "failed"):
+                    hsl_active_count += 1
+            bot_items.append({key: value for key, value in item.items() if value not in (None, {})})
+        return {
+            "bot_count": len(bot_items),
+            "ready_count": int(ready_count),
+            "hsl_replay_active_count": int(hsl_active_count),
+            "bots_truncated": len(bot_items) > limit,
+            "bots": bot_items[:limit],
+        }
+
+
 def _timings_map(value: Any) -> dict[str, int]:
     if not isinstance(value, dict):
         return {}
@@ -778,6 +907,7 @@ def build_live_performance_report(
     accumulator = _PerformanceAccumulator()
     decision_boundary = _DecisionBoundaryAccumulator()
     input_staleness = _InputStalenessAccumulator()
+    startup_readiness = _StartupReadinessAccumulator()
     cycle_scope_tracker = _CycleScopeTracker()
     records_total = 0
     live_events = 0
@@ -861,6 +991,7 @@ def build_live_performance_report(
                         live_event=live_event,
                         cycle_scope=cycle_scope,
                     )
+                    startup_readiness.add(row=row, live_event=live_event)
         except OSError as exc:
             issues.append(
                 {
@@ -894,6 +1025,7 @@ def build_live_performance_report(
         "performance": accumulator.to_dict(group_limit=group_limit),
         "decision_boundary_lag": decision_boundary.to_dict(group_limit=group_limit),
         "input_staleness": input_staleness.to_dict(group_limit=group_limit),
+        "startup_readiness": startup_readiness.to_dict(group_limit=group_limit),
     }
     if window_enabled:
         report["event_window"] = event_window
@@ -960,6 +1092,17 @@ def summarize_live_performance_report(
             "groups_truncated": bool(input_staleness.get("groups_truncated")),
             "groups": staleness_groups[: max(0, int(group_limit))],
         }
+    if isinstance(report.get("startup_readiness"), dict):
+        startup_readiness = dict(report["startup_readiness"])
+        startup_bots = (
+            startup_readiness.get("bots")
+            if isinstance(startup_readiness.get("bots"), list)
+            else []
+        )
+        startup_readiness["bots"] = startup_bots[: max(0, int(group_limit))]
+        if len(startup_bots) > max(0, int(group_limit)):
+            startup_readiness["bots_truncated"] = True
+        summary["startup_readiness"] = startup_readiness
     if report.get("event_window") is not None:
         summary["event_window"] = report.get("event_window")
     if report.get("filters") is not None:

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -608,6 +608,232 @@ def test_live_performance_report_summary_includes_bounded_input_staleness(tmp_pa
     assert len(summary["input_staleness"]["groups"]) == 1
 
 
+def test_live_performance_report_startup_readiness_summary(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=2,
+                ts=2000,
+                component="bot.startup",
+                data={"stage": "account", "elapsed_ms": 900},
+            ),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=3,
+                ts=3000,
+                component="bot.startup",
+                data={"stage": "hsl", "elapsed_s": 2.5},
+            ),
+            _monitor_row(
+                event_type="hsl.replay.progress",
+                seq=4,
+                ts=4000,
+                component="risk.hsl",
+                status="started",
+                data={
+                    "signal_mode": "coin",
+                    "stage": "pair_replay",
+                    "pairs": 26,
+                    "held_pairs": 1,
+                    "cooldown_pairs": 1,
+                    "required_pairs": 20,
+                    "timeline_rows": 43201,
+                    "applied_rows": 3000,
+                    "total_applied_rows": 4425,
+                    "rows_per_second": 289.4,
+                    "elapsed_s": 15.2,
+                },
+            ),
+            _monitor_row(event_type="bot.ready", seq=5, ts=5000),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    startup = report["startup_readiness"]
+
+    assert startup["bot_count"] == 1
+    assert startup["ready_count"] == 1
+    assert startup["hsl_replay_active_count"] == 1
+    bot = startup["bots"][0]
+    assert bot["bot"] == "binance/binance_01"
+    assert bot["lifecycle_status"] == "ready"
+    assert bot["bot_started_ts"] == 1000
+    assert bot["bot_ready_ts"] == 5000
+    assert bot["startup_phases_ms"] == {"account": 900, "hsl": 2500}
+    assert bot["hsl_replay"]["stage"] == "pair_replay"
+    assert bot["hsl_replay"]["pairs"] == 26
+    assert bot["hsl_replay"]["held_pairs"] == 1
+    assert bot["hsl_replay"]["rows_per_second"] == 289.4
+
+
+def test_live_performance_report_startup_readiness_completed_hsl_not_active(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="hsl.replay.completed",
+                seq=2,
+                ts=2000,
+                component="risk.hsl",
+                status="succeeded",
+                reason_code="coin_history_replay_completed",
+                data={
+                    "signal_mode": "coin",
+                    "stage": "full_replay",
+                    "pairs": 2,
+                    "skipped_pairs": 1,
+                    "full_elapsed_s": 12.3,
+                    "startup_blocking_elapsed_s": 12.3,
+                },
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    startup = report["startup_readiness"]
+
+    assert startup["ready_count"] == 0
+    assert startup["hsl_replay_active_count"] == 0
+    assert startup["bots"][0]["hsl_replay"]["status"] == "succeeded"
+    assert startup["bots"][0]["hsl_replay"]["skipped_pairs"] == 1
+
+
+def test_live_performance_report_startup_readiness_resets_on_restart(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=2,
+                ts=1100,
+                data={"stage": "account", "elapsed_ms": 300},
+            ),
+            _monitor_row(
+                event_type="hsl.replay.completed",
+                seq=3,
+                ts=1200,
+                status="succeeded",
+                data={"stage": "full_replay", "pairs": 2, "full_elapsed_s": 1.5},
+            ),
+            _monitor_row(event_type="bot.ready", seq=4, ts=1300),
+            _monitor_row(event_type="bot.started", seq=5, ts=2000),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    startup = report["startup_readiness"]
+
+    assert startup["ready_count"] == 0
+    assert startup["hsl_replay_active_count"] == 0
+    bot = startup["bots"][0]
+    assert bot["lifecycle_status"] == "started"
+    assert bot["bot_started_ts"] == 2000
+    assert "bot_ready_ts" not in bot
+    assert "startup_phases_ms" not in bot
+    assert "hsl_replay" not in bot
+
+
+def test_live_performance_report_startup_readiness_is_bounded(tmp_path):
+    for index in range(3):
+        events_dir = tmp_path / "monitor" / "binance" / f"user_{index}" / "events"
+        _write_ndjson(
+            events_dir / "current.ndjson",
+            [
+                _monitor_row(
+                    event_type="bot.started",
+                    seq=index + 1,
+                    ts=1000 + index,
+                    user=f"user_{index}",
+                ),
+                _monitor_row(
+                    event_type="bot.startup_timing",
+                    seq=index + 10,
+                    ts=1100 + index,
+                    user=f"user_{index}",
+                    data={"stage": "account", "elapsed_ms": 100},
+                ),
+                _monitor_row(
+                    event_type="bot.startup_timing",
+                    seq=index + 20,
+                    ts=1200 + index,
+                    user=f"user_{index}",
+                    data={"stage": "hsl", "elapsed_ms": 200},
+                ),
+            ],
+        )
+
+    report = build_live_performance_report(tmp_path / "monitor", group_limit=1)
+    startup = report["startup_readiness"]
+
+    assert startup["bot_count"] == 3
+    assert startup["bots_truncated"] is True
+    assert len(startup["bots"]) == 1
+    assert startup["bots"][0]["startup_phases_truncated"] is True
+    assert list(startup["bots"][0]["startup_phases_ms"]) == ["account"]
+
+
+def test_live_performance_report_startup_readiness_hsl_whitelist(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="hsl.replay.progress",
+                seq=2,
+                ts=2000,
+                status="started",
+                data={
+                    "stage": "pair_replay",
+                    "pairs": 1,
+                    "equity": 12345.0,
+                    "balance": 6789.0,
+                    "raw_payload": {"secret": "nope"},
+                    "price": 42.0,
+                    "drawdown": 0.12,
+                },
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    hsl_replay = report["startup_readiness"]["bots"][0]["hsl_replay"]
+
+    assert hsl_replay == {
+        "latest_ts": 2000,
+        "event_type": "hsl.replay.progress",
+        "status": "started",
+        "reason_code": "test",
+        "stage": "pair_replay",
+        "pairs": 1,
+    }
+
+
+def test_live_performance_report_summary_includes_startup_readiness(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(event_type="bot.ready", seq=2, ts=2000),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    summary = summarize_live_performance_report(report)
+
+    assert summary["startup_readiness"]["bot_count"] == 1
+    assert summary["startup_readiness"]["ready_count"] == 1
+
+
 def test_live_performance_report_cli_outputs_json(tmp_path, capsys):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- add startup_readiness to live-performance-report, derived only from existing bot lifecycle/startup timing/HSL replay events
- expose latest per-bot startup phase timings and HSL replay status in full and summary report output
- update tool docs and the live performance/readiness checklist with concrete speed/readiness goals

## Behavior
- read-only report/tooling/docs/tests only
- no exchange calls, no cache mutation, no trading behavior changes
- no raw payloads, symbols, balances, prices, or cycle IDs added to this summary

## Validation
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_performance_report.py tests/test_live_event_query.py tests/test_live_smoke_report.py
- PYTHONPATH=src ./venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py src/passivbot_cli/main.py
- git diff --check origin/v8...HEAD
- PYTHONPATH=src ./venv/bin/passivbot tool live-performance-report monitor --recent-minutes 180 --summary --compact --exchange binance --group-limit 2