### PR TITLE
Add live performance resource pressure report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `resource_pressure` summaries to
+  `passivbot tool live-performance-report`, projecting whitelisted
+  `health.summary` process and event-pipeline fields without raw account or
+  financial payloads.
 - Improved cold `passivbot backtest` materialization by batching legacy OHLCV
   imports by month, vectorizing chunk writes, staging HLCV cache writes with
   rollback on publish failure, and honoring Ctrl+C between expensive

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -25,6 +25,7 @@ Update policy:
 Related detailed plans:
 
 - `docs/plans/live_logging_overhaul_plan.md`
+- `docs/plans/live_performance_readiness_goals.md`
 - `docs/plans/live_restart_shutdown_and_warm_cache_handoff.md`
 
 ## High-Value Follow-Ups

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -31,6 +31,17 @@ state the readiness contract explicitly. Speedups are acceptable only when they
 preserve the existing trading decision semantics or when the contract is
 deliberately changed and reviewed.
 
+Use this as a living performance scorecard:
+
+- [ ] Each observed slow path has a named owner section below.
+- [ ] Each performance PR updates this file with baseline, target, and result.
+- [ ] Each optimization proves whether it affects protective action, fresh
+  entry, diagnostics only, or no trading behavior.
+- [ ] Each live smoke leaves enough structured evidence to compare against the
+  previous baseline.
+- [ ] If an item is delegated, the delegate works from one checked subsection,
+  opens a PR, and does not touch unrelated live behavior.
+
 ## Current Evidence
 
 Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
@@ -101,6 +112,48 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
    - These fields make the next optimization measurable, but they do not yet
      split protective readiness from full replay.
 
+## Required Performance Report Matrix
+
+The live performance report should become the canonical answer to "where did
+the time go?" for a live bot. Every row below should expose `count`, `min`,
+`mean`, `p50`, `p95`, `max`, latest timestamp, bot identity, and trading-impact
+classification when enough source events exist.
+
+- [ ] Startup: process start to account-critical ready.
+- [ ] Startup: process start to held-position protective HSL ready.
+- [ ] Startup: process start to fresh-entry ready.
+- [ ] Startup: process start to first planning cycle started/completed.
+- [ ] Startup: process start to first possible exchange write.
+- [ ] HSL: fill/cache load time, replay build time, held-pair protective
+  replay time, full replay time, checkpoint load time, checkpoint write time,
+  rows/s, symbols/pairs/held pairs/cooldown pairs.
+- [ ] Cache readiness: fill cache coverage proof, candle coverage proof,
+  checkpoint compatibility decision, repair scope, repair elapsed time.
+- [ ] Account state: balance, positions, open orders, fills, state-refresh wall
+  time, surface max/sum time, retry/degraded counts.
+- [ ] Market data: ticker/market price age, candle close age, EMA bundle age,
+  forager feature age, candle remote fetch latency, synthetic/no-trade gap
+  repair counts.
+- [ ] Decision boundary: whole-minute lag to cycle start, Rust input snapshot,
+  Rust output, Python gate/filter, first exchange write, confirmation refresh.
+- [ ] Cycle phases: market state, account state, Rust planning,
+  reconciliation/gating, execution, confirmation, monitor flush, event
+  pipeline overhead.
+- [ ] Exchange writes: create/cancel/close/panic write latency, exchange
+  response latency, ambiguous write rate, confirmation latency.
+- [ ] Resource pressure: CPU/load, RSS, memory percent, open FDs, event queue
+  depth, dropped event counters, sink errors, loop lag where available.
+- [ ] Shutdown: signal to exit flag, cancellation request, blocking task names,
+  final monitor flush, process exit.
+
+Trading-impact labels:
+
+- [ ] `protective_blocker`: can delay panic/reduce-only/risk protection.
+- [ ] `entry_blocker`: can delay fresh entries but not protective actions.
+- [ ] `cycle_delay`: delays the full loop after readiness is established.
+- [ ] `diagnostics_only`: affects logs/monitor/reporting only.
+- [ ] `unknown`: missing event data; should be treated as an observability gap.
+
 ## Outcome Targets
 
 - [ ] A held position should reach exact protective readiness in seconds, not
@@ -161,6 +214,17 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
   - Full replay may continue after protective readiness, but fresh initial
     entries must remain blocked until cooldown/trading eligibility is known.
 
+- [ ] Define HSL startup states explicitly.
+  - `hsl_protective_unavailable`: required held-position proof is missing or
+    invalid; protective HSL cannot be evaluated yet.
+  - `hsl_protective_ready`: held positions have exact current HSL state and
+    panic/protective decisions may proceed.
+  - `hsl_entry_cooldown_unknown`: held positions are protected, but flat-symbol
+    cooldown reconstruction is incomplete, so fresh HSL-gated entries remain
+    blocked where affected.
+  - `hsl_full_ready`: cooldown and replay state are complete for the configured
+    HSL universe.
+
 - [ ] Coin mode must not make a held coin wait behind unrelated coins.
   - A currently held `coin+pside` pair should be classified before historical
     flat pairs.
@@ -201,6 +265,16 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
     crossing must not cause a panic now if current replay state is no longer in
     the red zone.
 
+- [ ] Answer the current bottleneck question before broad rewrites.
+  - Is startup blocked on CPU-bound Python replay, disk/cache reads, exchange
+    backfill, monitor/event emission, or repeated data conversion?
+  - If all needed data is cached locally, explain why replay still takes
+    hundreds or thousands of seconds.
+  - Confirm whether coin-mode replay currently serializes independent
+    `coin+pside` pairs unnecessarily.
+  - Confirm whether unrelated flat pairs can delay held-pair protective
+    readiness.
+
 - [ ] Identify the current bottleneck with a focused profile.
   - Measure time spent in fill indexing, candle/timeline construction, pair
     iteration, EMA update, drawdown/tier update, event emission, and disk/cache
@@ -212,6 +286,14 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
   - Report whether the bottleneck is CPU-bound Python, disk/cache IO, event
     emission, or exchange/cache backfill.
 
+- [ ] Build a deterministic HSL replay benchmark fixture.
+  - Include 25-30 pairs, one or more held positions, at least one cooldown
+    candidate, 30 days of one-minute rows, and realistic fill density.
+  - Fixture should run offline and produce comparable output for current full
+    replay, optimized replay, and checkpoint resume.
+  - Output metrics: elapsed, rows/s, per-stage timings, current HSL state by
+    held pair, cooldown state by affected flat pair, and equivalence diff.
+
 - [ ] Index fill events once by `(pside, symbol)`.
   - Reuse that index for replay contracts, panic detection, position-size
     replay, realized-PnL peak/current calculations, and cooldown discovery.
@@ -222,6 +304,13 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
     proof is established first.
   - Do not allow broad flat-pair replay to block a held pair that already has
     exact protective readiness.
+
+- [ ] Prefer priority ordering before parallelism.
+  - First replay currently held positions.
+  - Then replay coins with active cooldown implications.
+  - Then replay remaining eligible flat symbols in the background.
+  - This should improve safety even on a 1-vCPU VPS where parallelism has
+    limited value.
 
 - [ ] Add structured replay timing fields.
   - Done: current full-replay events include `timeline_rows`, `pairs`,
@@ -418,6 +507,50 @@ Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
 - [ ] HSL checkpointing reduces warm-restart replay without weakening
   stateless correctness: checkpoints accelerate reconstruction only when their
   proof matches exchange/cache-derived inputs.
+
+## Candidate PR Slices
+
+These slices are intentionally small enough for normal review and live smoke.
+Each slice should update this checklist with its result.
+
+1. [ ] Performance-report coverage slice.
+   - Add missing report groups for resource pressure, HSL replay/protective
+     readiness, candle/market/config age, and shutdown stages as source events
+     become available.
+   - Acceptance: `passivbot tool live-performance-report` can produce a bounded
+     summary explaining the slowest startup and cycle blockers from local
+     monitor data only.
+
+2. [ ] HSL replay benchmark/profiling slice.
+   - Add an offline deterministic benchmark or fixture path for coin-mode HSL
+     replay using realistic pair count, fill count, and row count.
+   - Acceptance: report current elapsed, rows/s, and per-stage timing without
+     contacting exchanges or changing live behavior.
+
+3. [ ] Held-position protective readiness slice.
+   - Classify currently held `coin+pside` pairs before unrelated flat pairs and
+     emit explicit `hsl_protective_*` state events.
+   - Acceptance: held-pair state matches existing full replay in tests, and a
+     held late-sorting symbol is no longer delayed by broad flat-symbol replay.
+
+4. [ ] Full replay lower-complexity slice.
+   - Replace avoidable nested scans and repeated fill/timeline work with exact
+     indexed/sparse replay.
+   - Acceptance: equivalence tests pass against the old replay contract and the
+     benchmark shows a material rows/s improvement.
+
+5. [ ] HSL checkpoint proof/resume slice.
+   - Write and resume from conservative performance checkpoints after exact
+     reconstruction.
+   - Acceptance: valid checkpoint warm restart is fast; stale/incompatible
+     checkpoint is bypassed with an observable reason; decisions remain
+     reproducible from exchange/cache-derived truth.
+
+6. [ ] Shutdown and restart latency slice.
+   - Make long non-critical startup/background work interruptible and report
+     shutdown blockers.
+   - Acceptance: repeated Ctrl+C should not be needed in the normal path, and
+     slow shutdown identifies the blocking stage.
 
 ## Suggested Implementation Order
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -180,7 +180,11 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   The startup-readiness section summarizes latest per-bot startup phase timings and HSL
   replay state from existing lifecycle/replay events. The `slowest_blockers` section ranks
   non-diagnostic timing and staleness groups by observed duration so the largest trading-impact
-  delays are visible without scanning every timing group.
+  delays are visible without scanning every timing group. The `resource_pressure` section
+  summarizes whitelisted process and event-pipeline health fields from existing
+  `health.summary` events, including RSS, memory percent, file descriptors, load average,
+  event queue depth, dropped-event counters, and sink-error counters without exposing raw
+  account or financial payloads.
 
 ## Exchange Helpers
 

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -26,6 +26,34 @@ _BLOCKING_SCOPE_BY_IMPACT = {
     "blocks_next_cycle": "delays_next_cycle",
     "exchange_io": "exchange_io",
 }
+_RESOURCE_PRESSURE_FIELDS = (
+    "rss_bytes",
+    "memory_percent",
+    "open_fds",
+    "loadavg_1m",
+    "loadavg_5m",
+    "loadavg_15m",
+    "cpu_count",
+    "uptime_ms",
+    "last_loop_duration_ms",
+    "errors_last_hour",
+    "ws_reconnects",
+    "rate_limits",
+    "event_queue_depth",
+    "event_queue_maxsize",
+    "event_queue_unfinished_tasks",
+    "event_dropped_total",
+    "event_sink_error_total",
+    "event_degraded_count",
+)
+_RESOURCE_PRESSURE_COUNTER_FIELDS = (
+    "event_drop_counts",
+    "event_sink_error_counts",
+)
+_RESOURCE_PRESSURE_BOOL_FIELDS = (
+    "event_pipeline_stopping",
+    "event_pipeline_worker_alive",
+)
 
 
 def _open_text(path: Path):
@@ -95,6 +123,26 @@ def _non_negative_ms(value: Any) -> int | None:
     if number is None or number < 0:
         return None
     return int(round(number))
+
+
+def _non_negative_number(value: Any) -> float | int | None:
+    number = _finite_float(value)
+    if number is None or number < 0:
+        return None
+    if float(number).is_integer():
+        return int(number)
+    return float(number)
+
+
+def _safe_counter_mapping(value: Any) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, int] = {}
+    for key, raw in value.items():
+        number = _finite_float(raw)
+        if number is not None and number >= 0:
+            out[str(key)] = int(number)
+    return out
 
 
 def _elapsed_s_to_ms(value: Any) -> int | None:
@@ -689,6 +737,133 @@ class _StartupReadinessAccumulator:
         }
 
 
+class _ResourcePressureAccumulator:
+    def __init__(self) -> None:
+        self.bots: dict[str, dict[str, Any]] = {}
+        self.event_types: Counter[str] = Counter()
+
+    def add(self, *, row: dict[str, Any], live_event: dict[str, Any]) -> None:
+        event_type = str(live_event.get("event_type") or row.get("kind") or "")
+        if event_type != "health.summary":
+            return
+        data = live_event.get("data") if isinstance(live_event.get("data"), dict) else {}
+        observed_values = {}
+        for key in _RESOURCE_PRESSURE_FIELDS:
+            value = _non_negative_number(data.get(key))
+            if value is not None:
+                observed_values[key] = value
+        observed_counters = {}
+        for key in _RESOURCE_PRESSURE_COUNTER_FIELDS:
+            counters = _safe_counter_mapping(data.get(key))
+            if counters:
+                observed_counters[key] = counters
+        observed_bools = {
+            key: bool(data.get(key))
+            for key in _RESOURCE_PRESSURE_BOOL_FIELDS
+            if key in data
+        }
+        if not observed_values and not observed_counters and not observed_bools:
+            return
+        bot = _bot_key(row, live_event)
+        state = self.bots.get(bot)
+        if state is None:
+            state = {
+                "bot": bot,
+                "count": 0,
+                "latest_ts": None,
+                "values": {key: [] for key in _RESOURCE_PRESSURE_FIELDS},
+                "latest": {},
+                "latest_counters": {},
+            }
+            self.bots[bot] = state
+        state["count"] = int(state["count"]) + 1
+        ts = _record_ts(row)
+        latest_changed = ts is None or state.get("latest_ts") is None
+        if ts is not None and state.get("latest_ts") is not None:
+            latest_changed = int(ts) >= int(state["latest_ts"])
+        if ts is not None and latest_changed:
+            state["latest_ts"] = int(ts)
+        for key, value in observed_values.items():
+            state["values"][key].append(value)
+            if latest_changed:
+                state["latest"][key] = value
+        if latest_changed:
+            state["latest"].update(observed_bools)
+            state["latest_counters"] = observed_counters
+        self.event_types[event_type] += 1
+
+    @staticmethod
+    def _field_stats(values: list[float | int], latest: Any) -> dict[str, Any]:
+        numeric = [float(value) for value in values]
+        if not numeric:
+            return {}
+        out: dict[str, Any] = {
+            "latest": latest,
+            "min": min(numeric),
+            "max": max(numeric),
+            "mean": statistics.fmean(numeric),
+        }
+        return {
+            key: int(value) if isinstance(value, float) and value.is_integer() else value
+            for key, value in out.items()
+        }
+
+    def to_dict(self, *, group_limit: int = GROUP_LIMIT) -> dict[str, Any]:
+        groups = []
+        for bot, state in self.bots.items():
+            latest = state.get("latest") if isinstance(state.get("latest"), dict) else {}
+            fields = {}
+            for key in _RESOURCE_PRESSURE_FIELDS:
+                values = state["values"].get(key) if isinstance(state.get("values"), dict) else []
+                stats = self._field_stats(values or [], latest.get(key))
+                if stats:
+                    fields[key] = stats
+            latest_counters = (
+                state.get("latest_counters")
+                if isinstance(state.get("latest_counters"), dict)
+                else {}
+            )
+            group = {
+                "bot": bot,
+                "count": int(state.get("count") or 0),
+                "latest_ts": state.get("latest_ts"),
+                "fields": fields,
+                "latest_event_pipeline_stopping": latest.get("event_pipeline_stopping"),
+                "latest_event_pipeline_worker_alive": latest.get(
+                    "event_pipeline_worker_alive"
+                ),
+                "latest_event_drop_counts": latest_counters.get("event_drop_counts"),
+                "latest_event_sink_error_counts": latest_counters.get(
+                    "event_sink_error_counts"
+                ),
+            }
+            groups.append(
+                {key: value for key, value in group.items() if value not in (None, {}, [])}
+            )
+        groups = sorted(
+            groups,
+            key=lambda item: (
+                -int(item.get("fields", {}).get("event_dropped_total", {}).get("latest", 0) or 0),
+                -int(
+                    item.get("fields", {}).get("event_sink_error_total", {}).get("latest", 0)
+                    or 0
+                ),
+                -int(item.get("fields", {}).get("event_degraded_count", {}).get("latest", 0) or 0),
+                -int(item.get("fields", {}).get("event_queue_depth", {}).get("latest", 0) or 0),
+                -int(item.get("fields", {}).get("rss_bytes", {}).get("max", 0) or 0),
+                str(item.get("bot") or ""),
+            ),
+        )
+        limit = max(0, int(group_limit))
+        return {
+            "total": sum(int(group.get("count") or 0) for group in groups),
+            "bots": len(groups),
+            "event_types": dict(self.event_types.most_common()),
+            "groups_truncated": len(groups) > limit,
+            "groups": groups[:limit],
+        }
+
+
 def _slowest_blockers(
     *,
     performance_groups: list[dict[str, Any]],
@@ -989,6 +1164,7 @@ def build_live_performance_report(
     decision_boundary = _DecisionBoundaryAccumulator()
     input_staleness = _InputStalenessAccumulator()
     startup_readiness = _StartupReadinessAccumulator()
+    resource_pressure = _ResourcePressureAccumulator()
     cycle_scope_tracker = _CycleScopeTracker()
     records_total = 0
     live_events = 0
@@ -1073,6 +1249,7 @@ def build_live_performance_report(
                         cycle_scope=cycle_scope,
                     )
                     startup_readiness.add(row=row, live_event=live_event)
+                    resource_pressure.add(row=row, live_event=live_event)
         except OSError as exc:
             issues.append(
                 {
@@ -1110,6 +1287,7 @@ def build_live_performance_report(
         "decision_boundary_lag": decision_boundary.to_dict(group_limit=group_limit),
         "input_staleness": input_staleness.to_dict(group_limit=group_limit),
         "startup_readiness": startup_readiness.to_dict(group_limit=group_limit),
+        "resource_pressure": resource_pressure.to_dict(group_limit=group_limit),
         "slowest_blockers": _slowest_blockers(
             performance_groups=performance_groups,
             decision_boundary_groups=decision_boundary_groups,
@@ -1193,6 +1371,17 @@ def summarize_live_performance_report(
         if len(startup_bots) > max(0, int(group_limit)):
             startup_readiness["bots_truncated"] = True
         summary["startup_readiness"] = startup_readiness
+    if isinstance(report.get("resource_pressure"), dict):
+        resource_pressure = dict(report["resource_pressure"])
+        pressure_groups = (
+            resource_pressure.get("groups")
+            if isinstance(resource_pressure.get("groups"), list)
+            else []
+        )
+        resource_pressure["groups"] = pressure_groups[: max(0, int(group_limit))]
+        if len(pressure_groups) > max(0, int(group_limit)):
+            resource_pressure["groups_truncated"] = True
+        summary["resource_pressure"] = resource_pressure
     if isinstance(report.get("slowest_blockers"), dict):
         slowest_blockers = report["slowest_blockers"]
         blocker_groups = (

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -922,6 +922,152 @@ def test_live_performance_report_summary_includes_startup_readiness(tmp_path):
     assert summary["startup_readiness"]["ready_count"] == 1
 
 
+def test_live_performance_report_resource_pressure_from_health_summary(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="health.summary",
+                seq=1,
+                ts=1000,
+                component="monitor.health",
+                data={
+                    "rss_bytes": 1000,
+                    "memory_percent": 5.5,
+                    "open_fds": 11,
+                    "loadavg_1m": 0.25,
+                    "cpu_count": 1,
+                    "event_queue_depth": 3,
+                    "event_dropped_total": 1,
+                    "event_sink_error_total": 0,
+                    "event_degraded_count": 2,
+                    "event_drop_counts": {"queue_full": 1},
+                    "event_sink_error_counts": {"disk": 0},
+                    "event_pipeline_stopping": False,
+                    "event_pipeline_worker_alive": True,
+                },
+            ),
+            _monitor_row(
+                event_type="health.summary",
+                seq=2,
+                ts=2000,
+                component="monitor.health",
+                data={
+                    "rss_bytes": 1500,
+                    "memory_percent": 6.5,
+                    "open_fds": 13,
+                    "loadavg_1m": 0.75,
+                    "cpu_count": 1,
+                    "event_queue_depth": 5,
+                    "event_dropped_total": 4,
+                    "event_sink_error_total": 1,
+                    "event_degraded_count": 3,
+                    "event_drop_counts": {"queue_full": 4},
+                    "event_sink_error_counts": {"disk": 1},
+                    "event_pipeline_stopping": False,
+                    "event_pipeline_worker_alive": True,
+                },
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    pressure = report["resource_pressure"]
+    group = pressure["groups"][0]
+
+    assert pressure["total"] == 2
+    assert pressure["bots"] == 1
+    assert pressure["event_types"] == {"health.summary": 2}
+    assert group["bot"] == "binance/binance_01"
+    assert group["count"] == 2
+    assert group["latest_ts"] == 2000
+    assert group["fields"]["rss_bytes"] == {
+        "latest": 1500,
+        "min": 1000,
+        "max": 1500,
+        "mean": 1250,
+    }
+    assert group["fields"]["memory_percent"]["latest"] == 6.5
+    assert group["fields"]["event_queue_depth"]["max"] == 5
+    assert group["fields"]["event_dropped_total"]["latest"] == 4
+    assert group["fields"]["event_sink_error_total"]["latest"] == 1
+    assert group["fields"]["event_degraded_count"]["latest"] == 3
+    assert group["latest_event_drop_counts"] == {"queue_full": 4}
+    assert group["latest_event_sink_error_counts"] == {"disk": 1}
+    assert group["latest_event_pipeline_stopping"] is False
+    assert group["latest_event_pipeline_worker_alive"] is True
+
+
+def test_live_performance_report_resource_pressure_whitelists_health_fields(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="health.summary",
+                seq=1,
+                ts=1000,
+                component="monitor.health",
+                data={
+                    "rss_bytes": 1000,
+                    "balance_raw": {"leak_marker": "raw-balance"},
+                    "balance_snapped": {"leak_marker": "snapped-balance"},
+                    "equity": "leak-equity",
+                    "pnl": "leak-pnl",
+                    "raw_payload": {"leak_marker": "raw-payload"},
+                    "event_drop_counts": {"queue_full": 1},
+                },
+            )
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    rendered = json.dumps(report["resource_pressure"], sort_keys=True)
+
+    assert report["resource_pressure"]["groups"][0]["fields"]["rss_bytes"]["latest"] == 1000
+    assert "balance_raw" not in rendered
+    assert "balance_snapped" not in rendered
+    assert "leak-equity" not in rendered
+    assert "leak-pnl" not in rendered
+    assert "raw-balance" not in rendered
+    assert "snapped-balance" not in rendered
+    assert "raw-payload" not in rendered
+
+
+def test_live_performance_report_resource_pressure_summary_is_bounded(tmp_path):
+    events_dir = tmp_path / "monitor" / "mixed" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="health.summary",
+                seq=1,
+                ts=1000,
+                exchange="binance",
+                user="binance_01",
+                data={"rss_bytes": 1000, "event_queue_depth": 1},
+            ),
+            _monitor_row(
+                event_type="health.summary",
+                seq=2,
+                ts=2000,
+                exchange="okx",
+                user="okx_faisal",
+                data={"rss_bytes": 2000, "event_queue_depth": 2},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    summary = summarize_live_performance_report(report, group_limit=1)
+
+    assert report["resource_pressure"]["bots"] == 2
+    assert len(summary["resource_pressure"]["groups"]) == 1
+    assert summary["resource_pressure"]["groups_truncated"] is True
+    assert summary["resource_pressure"]["groups"][0]["bot"] == "okx/okx_faisal"
+
+
 def test_live_performance_report_cli_outputs_json(tmp_path, capsys):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- add `resource_pressure` to `passivbot tool live-performance-report`, derived only from existing `health.summary` events
- whitelist process/event-pipeline fields such as RSS, memory percent, open FDs, load averages, queue depth, drop counters, sink-error counters, and worker state
- add tests proving health/account financial fields are not surfaced, summary output is bounded, and aggregation works
- update the performance/readiness goals checklist with actionable performance targets and PR slices

## Behavior
Read-only/report-only. No exchange calls, cache mutation, event emission changes, console changes, or trading behavior changes.

## Validation
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_performance_report.py tests/test_live_event_query.py tests/test_live_smoke_report.py`
- `PYTHONPATH=src ./venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py src/passivbot_cli/main.py`
- `git diff --check`
- `rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])" src/live/performance_report.py tests/test_live_performance_report.py docs/tools.md docs/plans/live_performance_readiness_goals.md docs/plans/live_ops_improvement_backlog.md` (matches are read-only report sorting/summary defaults, not trading-critical)
- `PYTHONPATH=src ./venv/bin/passivbot tool live-performance-report monitor --recent-minutes 180 --summary --compact --exchange binance --group-limit 3`
