### PR TITLE
Add live performance shutdown latency report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `shutdown_latency` summaries to
+  `passivbot tool live-performance-report`, projecting existing lifecycle
+  shutdown events into per-stage and total shutdown timing groups without
+  copying shutdown error text.
 - Added `resource_pressure` summaries to
   `passivbot tool live-performance-report`, projecting whitelisted
   `health.summary` process and event-pipeline fields without raw account or

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -184,7 +184,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   summarizes whitelisted process and event-pipeline health fields from existing
   `health.summary` events, including RSS, memory percent, file descriptors, load average,
   event queue depth, dropped-event counters, and sink-error counters without exposing raw
-  account or financial payloads.
+  account or financial payloads. The `shutdown_latency` section summarizes existing
+  lifecycle shutdown events, including per-stage cumulative elapsed time and final shutdown
+  duration, without copying shutdown error text.
 
 ## Exchange Helpers
 

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -54,6 +54,11 @@ _RESOURCE_PRESSURE_BOOL_FIELDS = (
     "event_pipeline_stopping",
     "event_pipeline_worker_alive",
 )
+_SHUTDOWN_EVENT_TYPES = {
+    "bot.stopping",
+    "bot.shutdown.stage",
+    "bot.stopped",
+}
 
 
 def _open_text(path: Path):
@@ -864,6 +869,61 @@ class _ResourcePressureAccumulator:
         }
 
 
+class _ShutdownLatencyAccumulator:
+    def __init__(self) -> None:
+        self.accumulator = _PerformanceAccumulator()
+        self.event_types: Counter[str] = Counter()
+        self.stage_counts: Counter[str] = Counter()
+        self.shutdowns_started = 0
+        self.shutdowns_completed = 0
+
+    def add(self, *, row: dict[str, Any], live_event: dict[str, Any]) -> None:
+        event_type = str(live_event.get("event_type") or row.get("kind") or "")
+        if event_type not in _SHUTDOWN_EVENT_TYPES:
+            return
+        self.event_types[event_type] += 1
+        data = live_event.get("data") if isinstance(live_event.get("data"), dict) else {}
+        if event_type == "bot.stopping":
+            self.shutdowns_started += 1
+            return
+        if event_type == "bot.shutdown.stage":
+            stage = data.get("stage") or live_event.get("reason_code") or "unknown"
+            stage = str(stage)
+            self.stage_counts[stage] += 1
+            self.accumulator.add(
+                row=row,
+                live_event=live_event,
+                operation=f"shutdown.stage.{stage}",
+                value_ms=_elapsed_s_to_ms(data.get("elapsed_s")),
+                trading_impact="observability",
+                timing_kind="cumulative",
+            )
+            return
+        if event_type == "bot.stopped":
+            self.shutdowns_completed += 1
+            self.accumulator.add(
+                row=row,
+                live_event=live_event,
+                operation="shutdown.total",
+                value_ms=_elapsed_s_to_ms(data.get("elapsed_s")),
+                trading_impact="observability",
+                timing_kind="duration",
+            )
+
+    def to_dict(self, *, group_limit: int = GROUP_LIMIT) -> dict[str, Any]:
+        timing = self.accumulator.to_dict(group_limit=group_limit)
+        return {
+            "total_events": sum(self.event_types.values()),
+            "shutdowns_started": int(self.shutdowns_started),
+            "shutdowns_completed": int(self.shutdowns_completed),
+            "event_types": dict(self.event_types.most_common()),
+            "stage_counts": dict(self.stage_counts.most_common()),
+            "total_groups": int(timing.get("total_groups") or 0),
+            "groups_truncated": bool(timing.get("groups_truncated")),
+            "groups": timing.get("groups") or [],
+        }
+
+
 def _slowest_blockers(
     *,
     performance_groups: list[dict[str, Any]],
@@ -1165,6 +1225,7 @@ def build_live_performance_report(
     input_staleness = _InputStalenessAccumulator()
     startup_readiness = _StartupReadinessAccumulator()
     resource_pressure = _ResourcePressureAccumulator()
+    shutdown_latency = _ShutdownLatencyAccumulator()
     cycle_scope_tracker = _CycleScopeTracker()
     records_total = 0
     live_events = 0
@@ -1250,6 +1311,7 @@ def build_live_performance_report(
                     )
                     startup_readiness.add(row=row, live_event=live_event)
                     resource_pressure.add(row=row, live_event=live_event)
+                    shutdown_latency.add(row=row, live_event=live_event)
         except OSError as exc:
             issues.append(
                 {
@@ -1288,6 +1350,7 @@ def build_live_performance_report(
         "input_staleness": input_staleness.to_dict(group_limit=group_limit),
         "startup_readiness": startup_readiness.to_dict(group_limit=group_limit),
         "resource_pressure": resource_pressure.to_dict(group_limit=group_limit),
+        "shutdown_latency": shutdown_latency.to_dict(group_limit=group_limit),
         "slowest_blockers": _slowest_blockers(
             performance_groups=performance_groups,
             decision_boundary_groups=decision_boundary_groups,
@@ -1382,6 +1445,17 @@ def summarize_live_performance_report(
         if len(pressure_groups) > max(0, int(group_limit)):
             resource_pressure["groups_truncated"] = True
         summary["resource_pressure"] = resource_pressure
+    if isinstance(report.get("shutdown_latency"), dict):
+        shutdown_latency = dict(report["shutdown_latency"])
+        shutdown_groups = (
+            shutdown_latency.get("groups")
+            if isinstance(shutdown_latency.get("groups"), list)
+            else []
+        )
+        shutdown_latency["groups"] = shutdown_groups[: max(0, int(group_limit))]
+        if len(shutdown_groups) > max(0, int(group_limit)):
+            shutdown_latency["groups_truncated"] = True
+        summary["shutdown_latency"] = shutdown_latency
     if isinstance(report.get("slowest_blockers"), dict):
         slowest_blockers = report["slowest_blockers"]
         blocker_groups = (

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1068,6 +1068,115 @@ def test_live_performance_report_resource_pressure_summary_is_bounded(tmp_path):
     assert summary["resource_pressure"]["groups"][0]["bot"] == "okx/okx_faisal"
 
 
+def test_live_performance_report_shutdown_latency_from_lifecycle_events(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.stopping",
+                seq=1,
+                ts=1000,
+                status="started",
+                component="lifecycle",
+                reason_code="shutdown_gracefully",
+                data={"reason": "shutdown_gracefully"},
+            ),
+            _monitor_row(
+                event_type="bot.shutdown.stage",
+                seq=2,
+                ts=2000,
+                status="succeeded",
+                component="shutdown",
+                reason_code="maintainers_stopped",
+                data={"stage": "maintainers_stopped", "elapsed_s": 2.5, "task_count": 4},
+            ),
+            _monitor_row(
+                event_type="bot.shutdown.stage",
+                seq=3,
+                ts=3000,
+                status="degraded",
+                level="warning",
+                component="shutdown",
+                reason_code="execution_loop_timeout",
+                data={
+                    "stage": "execution_loop_timeout",
+                    "elapsed_s": 6.25,
+                    "timeout_s": 5.0,
+                    "error": "api_key=AKIA123 Authorization: Bearer TOKEN123",
+                },
+            ),
+            _monitor_row(
+                event_type="bot.stopped",
+                seq=4,
+                ts=4000,
+                status="succeeded",
+                component="lifecycle",
+                reason_code="shutdown_gracefully",
+                data={"reason": "shutdown_gracefully", "elapsed_s": 7.5},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    shutdown = report["shutdown_latency"]
+    groups = {group["operation"]: group for group in shutdown["groups"]}
+    rendered = json.dumps(shutdown, sort_keys=True)
+
+    assert shutdown["total_events"] == 4
+    assert shutdown["shutdowns_started"] == 1
+    assert shutdown["shutdowns_completed"] == 1
+    assert shutdown["event_types"] == {
+        "bot.stopping": 1,
+        "bot.shutdown.stage": 2,
+        "bot.stopped": 1,
+    }
+    assert shutdown["stage_counts"] == {
+        "maintainers_stopped": 1,
+        "execution_loop_timeout": 1,
+    }
+    assert groups["shutdown.stage.execution_loop_timeout"]["max_ms"] == 6250
+    assert groups["shutdown.stage.execution_loop_timeout"]["statuses"] == {"degraded": 1}
+    assert groups["shutdown.stage.execution_loop_timeout"]["timing_kind"] == "cumulative"
+    assert groups["shutdown.total"]["max_ms"] == 7500
+    assert groups["shutdown.total"]["timing_kind"] == "duration"
+    assert "AKIA123" not in rendered
+    assert "TOKEN123" not in rendered
+    assert "api_key" not in rendered
+
+
+def test_live_performance_report_shutdown_latency_summary_is_bounded(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.shutdown.stage",
+                seq=1,
+                ts=1000,
+                component="shutdown",
+                reason_code="requested",
+                data={"stage": "requested", "elapsed_s": 0.1},
+            ),
+            _monitor_row(
+                event_type="bot.stopped",
+                seq=2,
+                ts=2000,
+                component="lifecycle",
+                data={"elapsed_s": 2.0},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    summary = summarize_live_performance_report(report, group_limit=1)
+
+    assert report["shutdown_latency"]["total_groups"] == 2
+    assert len(summary["shutdown_latency"]["groups"]) == 1
+    assert summary["shutdown_latency"]["groups_truncated"] is True
+    assert summary["shutdown_latency"]["groups"][0]["operation"] == "shutdown.total"
+
+
 def test_live_performance_report_cli_outputs_json(tmp_path, capsys):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- add `shutdown_latency` to `passivbot tool live-performance-report`, derived only from existing `bot.stopping`, `bot.shutdown.stage`, and `bot.stopped` events
- summarize per-stage cumulative shutdown elapsed time and final total shutdown duration
- keep this section report-only and separate from trading blocker rankings
- add tests for lifecycle aggregation, bounded summary output, and not copying shutdown error text

## Behavior
Read-only/report-only. No event emission changes, exchange calls, cache mutation, console changes, or trading behavior changes.

## Validation
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_performance_report.py`
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_query.py tests/test_live_smoke_report.py`
- `PYTHONPATH=src ./venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py src/passivbot_cli/main.py`
- `git diff --check`
- `rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])" src/live/performance_report.py tests/test_live_performance_report.py docs/tools.md` (matches are read-only report sorting/summary defaults, not trading-critical)
- `PYTHONPATH=src ./venv/bin/passivbot tool live-performance-report monitor --recent-minutes 180 --summary --compact --group-limit 2`
