### PR TITLE
Add live performance execution timing report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `execution_timing` summaries to
+  `passivbot tool live-performance-report`, deriving bounded exchange-action
+  latency groups from existing order-wave, create/cancel, and confirmation
+  events without exposing raw order payloads.
 - Added `shutdown_latency` summaries to
   `passivbot tool live-performance-report`, projecting existing lifecycle
   shutdown events into per-stage and total shutdown timing groups without

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -47,6 +47,12 @@ Use this as a living performance scorecard:
 Snapshot source: VPS5 monitor/smoke data on 2026-06-27 after `v8` head
 `b5e08986`.
 
+Latest incident driver: Binance `hsl_signal_mode=coin` XLM panic on
+2026-06-26, with fill-event timestamp `1782492486000`. The observed startup
+path spent roughly 27 minutes in HSL history reconstruction before the
+protective close was posted. That is a safety-critical performance failure even
+if the final replay result is correct.
+
 1. HSL coin-mode startup replay is the current P0 latency gap.
    - Binance incident on 2026-06-26: coin HSL replay loaded at `16:19:33Z`
      with `symbols=24 pairs=24 rows=43201 fills=2704`, completed at
@@ -141,10 +147,31 @@ classification when enough source events exist.
   pipeline overhead.
 - [ ] Exchange writes: create/cancel/close/panic write latency, exchange
   response latency, ambiguous write rate, confirmation latency.
+  - Status: partial. The report now derives order-wave total duration,
+    create/cancel sent-to-terminal response duration, confirmation duration,
+    missing-id counts, unpaired-terminal counts, and pending-start counts from
+    existing structured events. Remaining work: distinguish close/panic
+    subclasses and tie execution delays back to exact order class once those
+    fields are consistently available in the event stream.
 - [ ] Resource pressure: CPU/load, RSS, memory percent, open FDs, event queue
   depth, dropped event counters, sink errors, loop lag where available.
 - [ ] Shutdown: signal to exit flag, cancellation request, blocking task names,
   final monitor flush, process exit.
+
+Minimum report questions the operator must be able to answer:
+
+- [ ] How long after process start could the bot safely panic-close each held
+  position?
+- [ ] How long after process start could the bot safely place fresh entries?
+- [ ] Which exact input or phase delayed the first possible protective action?
+- [ ] Which exact input or phase delayed the first possible fresh entry?
+- [ ] Was a delay caused by exchange/network IO, local cache proof, local CPU,
+  disk IO, Python replay logic, Rust planning, exchange write/confirmation, or
+  monitor/event-pipeline overhead?
+- [ ] Did any slow background task share the critical path with protective
+  actions when it should have been decoupled?
+- [ ] For each restart, did warm local cache/checkpoint proof actually reduce
+  startup time, or did the bot repeat broad reconstruction unnecessarily?
 
 Trading-impact labels:
 
@@ -275,6 +302,23 @@ Trading-impact labels:
   - Confirm whether unrelated flat pairs can delay held-pair protective
     readiness.
 
+- [ ] Prove whether coin-mode HSL needs cross-coin synchronization.
+  - If one coin's HSL state depends only on that coin's fill/PnL and candle
+    series, the held coin must not wait for unrelated coins to finish replay.
+  - If any shared state exists, document it explicitly and test the dependency.
+  - This decision should drive whether the first optimization is priority
+    scheduling, sparse per-pair replay, multiprocessing, or a single vectorized
+    pass.
+
+- [ ] Separate cache-read speed from replay-compute speed.
+  - Measure local artifact discovery, JSON/NDJSON/NPY decode, fill indexing,
+    candle/timeline materialization, and replay compute separately.
+  - A warm restart with complete local proof should not spend most startup time
+    on exchange backfill or broad artifact rescan.
+  - If disk cache reads are fast but replay is slow, optimize the replay loop.
+  - If cache proof or decode is slow, add metadata indexes/checkpoints before
+    changing trading logic.
+
 - [ ] Identify the current bottleneck with a focused profile.
   - Measure time spent in fill indexing, candle/timeline construction, pair
     iteration, EMA update, drawdown/tier update, event emission, and disk/cache
@@ -358,6 +402,18 @@ Trading-impact labels:
   - Checkpoint invalidation must be conservative: if any required proof is
     ambiguous, discard or bypass the checkpoint and emit the reason.
 
+- [ ] Treat checkpoints as resumable proof, not as authority.
+  - On every startup, validate the checkpoint against config, code/schema,
+    fill coverage, candle coverage where required, market metadata, and last
+    processed timestamp before using it.
+  - Resume only from the validated boundary and replay new exchange/cache data
+    after that boundary.
+  - Emit checkpoint load/resume/bypass/write events with elapsed time and
+    reason codes.
+  - Acceptance: a warm restart with a valid checkpoint reaches held-position
+    protective readiness quickly, while an invalid checkpoint falls back to
+    exact replay loudly and safely.
+
 ### P1: General Live Performance Report
 
 - [x] Add `passivbot tool live-performance-report`.
@@ -401,6 +457,17 @@ Trading-impact labels:
     exchange write eligibility, and full background replay complete.
   - Group by exchange/user/bot so VPS-class regressions are visible before a
     panic incident.
+
+- [ ] Add a full live-operation duration table.
+  - Include startup, account refresh, fill refresh, cache proof, HSL replay,
+    candle/EMA readiness, forager feature readiness, Rust planning,
+    reconciliation/gating, order execution, confirmation refresh, monitor flush,
+    event-pipeline enqueue/write, and shutdown.
+  - Each group should include min, max, mean, p50, p95, count, latest sample,
+    bot/exchange/user, and trading-impact label.
+  - The table should be usable after a live incident to identify whether the
+    critical delay was before risk classification, before planning, before
+    exchange write, or after exchange write.
 
 - [ ] Add a "slowest blockers" view.
   - Rank operations by elapsed time and trading impact.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -186,7 +186,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   event queue depth, dropped-event counters, and sink-error counters without exposing raw
   account or financial payloads. The `shutdown_latency` section summarizes existing
   lifecycle shutdown events, including per-stage cumulative elapsed time and final shutdown
-  duration, without copying shutdown error text.
+  duration, without copying shutdown error text. The `execution_timing` section derives
+  aggregate exchange-action latency groups from existing order-wave, order create/cancel,
+  and confirmation events with missing/unpaired counters, without exposing raw order payloads.
 
 ## Exchange Helpers
 

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -59,6 +59,20 @@ _SHUTDOWN_EVENT_TYPES = {
     "bot.shutdown.stage",
     "bot.stopped",
 }
+_EXECUTION_CREATE_TERMINALS = {
+    "execution.create_succeeded",
+    "execution.create_failed",
+    "execution.create_rejected",
+}
+_EXECUTION_CANCEL_TERMINALS = {
+    "execution.cancel_succeeded",
+    "execution.cancel_failed",
+    "execution.cancel_ambiguous_terminal",
+}
+_EXECUTION_CONFIRMATION_TERMINALS = {
+    "execution.confirmation_satisfied",
+    "execution.confirmation_timeout",
+}
 
 
 def _open_text(path: Path):
@@ -313,6 +327,16 @@ def _event_cycle_id(live_event: dict[str, Any]) -> str | None:
     if cycle_id is None:
         return None
     return str(cycle_id)
+
+
+def _event_id_value(live_event: dict[str, Any], key: str) -> str | None:
+    ids = live_event.get("ids")
+    if not isinstance(ids, dict):
+        return None
+    value = ids.get(key)
+    if value is None:
+        return None
+    return str(value)
 
 
 def _cycle_number(cycle_id: str | None) -> int | None:
@@ -924,11 +948,217 @@ class _ShutdownLatencyAccumulator:
         }
 
 
+class _ExecutionTimingAccumulator:
+    def __init__(self) -> None:
+        self.accumulator = _PerformanceAccumulator()
+        self.action_starts: dict[tuple[str, int, str], int] = {}
+        self.confirmation_starts: dict[tuple[str, int, str], int] = {}
+        self.wave_starts: dict[tuple[str, int, str], int] = {}
+        self.event_types: Counter[str] = Counter()
+        self.missing_id_counts: Counter[str] = Counter()
+        self.unpaired_terminal_counts: Counter[str] = Counter()
+        self.starts_seen: Counter[str] = Counter()
+        self.terminals_seen: Counter[str] = Counter()
+        self.timing_observations: Counter[str] = Counter()
+
+    def _add_timing(
+        self,
+        *,
+        row: dict[str, Any],
+        live_event: dict[str, Any],
+        operation: str,
+        value_ms: int | None,
+        timing_kind: str = "duration",
+    ) -> None:
+        self.accumulator.add(
+            row=row,
+            live_event=live_event,
+            operation=operation,
+            value_ms=value_ms,
+            trading_impact="exchange_io",
+            timing_kind=timing_kind,
+        )
+        if value_ms is not None:
+            self.timing_observations[operation] += 1
+
+    def _pair_elapsed(
+        self,
+        *,
+        starts: dict[tuple[str, int, str], int],
+        key: tuple[str, int, str],
+        row: dict[str, Any],
+        live_event: dict[str, Any],
+        operation: str,
+    ) -> None:
+        start_ts = starts.pop(key, None)
+        end_ts = _record_ts(row)
+        if start_ts is None or end_ts is None:
+            self.unpaired_terminal_counts[operation] += 1
+            return
+        self._add_timing(
+            row=row,
+            live_event=live_event,
+            operation=operation,
+            value_ms=max(0, int(end_ts) - int(start_ts)),
+        )
+
+    def add(
+        self,
+        *,
+        row: dict[str, Any],
+        live_event: dict[str, Any],
+        cycle_scope: int,
+    ) -> None:
+        event_type = str(live_event.get("event_type") or row.get("kind") or "")
+        if not (
+            event_type.startswith("execution.")
+            or event_type.startswith("order_wave.")
+        ):
+            return
+        self.event_types[event_type] += 1
+        bot = _bot_key(row, live_event)
+        timestamp_ms = _record_ts(row)
+        data = live_event.get("data") if isinstance(live_event.get("data"), dict) else {}
+
+        if event_type == "order_wave.started":
+            order_wave_id = _event_id_value(live_event, "order_wave_id")
+            self.starts_seen["order_wave.total"] += 1
+            if order_wave_id is None or timestamp_ms is None:
+                self.missing_id_counts["order_wave.total"] += 1
+                return
+            self.wave_starts[(bot, int(cycle_scope), order_wave_id)] = int(timestamp_ms)
+            return
+
+        if event_type == "order_wave.completed":
+            self.terminals_seen["order_wave.total"] += 1
+            order_wave_id = _event_id_value(live_event, "order_wave_id")
+            emitted_elapsed = _non_negative_ms(data.get("elapsed_ms"))
+            if emitted_elapsed is not None:
+                if order_wave_id is not None:
+                    self.wave_starts.pop((bot, int(cycle_scope), order_wave_id), None)
+                self._add_timing(
+                    row=row,
+                    live_event=live_event,
+                    operation="order_wave.total",
+                    value_ms=emitted_elapsed,
+                )
+                return
+            if order_wave_id is None:
+                self.missing_id_counts["order_wave.total"] += 1
+                return
+            self._pair_elapsed(
+                starts=self.wave_starts,
+                key=(bot, int(cycle_scope), order_wave_id),
+                row=row,
+                live_event=live_event,
+                operation="order_wave.total",
+            )
+            return
+
+        if event_type in {"execution.create_sent", "execution.cancel_sent"}:
+            operation = (
+                "execution.create_response"
+                if event_type == "execution.create_sent"
+                else "execution.cancel_response"
+            )
+            action_id = _event_id_value(live_event, "action_id")
+            self.starts_seen[operation] += 1
+            if action_id is None or timestamp_ms is None:
+                self.missing_id_counts[operation] += 1
+                return
+            self.action_starts[(bot, int(cycle_scope), action_id)] = int(timestamp_ms)
+            return
+
+        if event_type in _EXECUTION_CREATE_TERMINALS | _EXECUTION_CANCEL_TERMINALS:
+            operation = (
+                "execution.create_response"
+                if event_type in _EXECUTION_CREATE_TERMINALS
+                else "execution.cancel_response"
+            )
+            self.terminals_seen[operation] += 1
+            action_id = _event_id_value(live_event, "action_id")
+            if action_id is None:
+                self.missing_id_counts[operation] += 1
+                return
+            self._pair_elapsed(
+                starts=self.action_starts,
+                key=(bot, int(cycle_scope), action_id),
+                row=row,
+                live_event=live_event,
+                operation=operation,
+            )
+            return
+
+        if event_type == "execution.confirmation_requested":
+            order_wave_id = _event_id_value(live_event, "order_wave_id")
+            self.starts_seen["execution.confirmation"] += 1
+            if order_wave_id is None or timestamp_ms is None:
+                self.missing_id_counts["execution.confirmation"] += 1
+                return
+            self.confirmation_starts[(bot, int(cycle_scope), order_wave_id)] = int(timestamp_ms)
+            return
+
+        if event_type in _EXECUTION_CONFIRMATION_TERMINALS:
+            operation = "execution.confirmation"
+            self.terminals_seen[operation] += 1
+            order_wave_id = _event_id_value(live_event, "order_wave_id")
+            emitted_elapsed = _non_negative_ms(data.get("confirm_ms"))
+            if emitted_elapsed is None:
+                emitted_elapsed = _non_negative_ms(data.get("elapsed_ms"))
+            if emitted_elapsed is not None:
+                if order_wave_id is not None:
+                    self.confirmation_starts.pop(
+                        (bot, int(cycle_scope), order_wave_id),
+                        None,
+                    )
+                self._add_timing(
+                    row=row,
+                    live_event=live_event,
+                    operation=operation,
+                    value_ms=emitted_elapsed,
+                )
+                return
+            if order_wave_id is None:
+                self.missing_id_counts[operation] += 1
+                return
+            self._pair_elapsed(
+                starts=self.confirmation_starts,
+                key=(bot, int(cycle_scope), order_wave_id),
+                row=row,
+                live_event=live_event,
+                operation=operation,
+            )
+
+    def to_dict(self, *, group_limit: int = GROUP_LIMIT) -> dict[str, Any]:
+        timing = self.accumulator.to_dict(group_limit=group_limit)
+        pending_starts = Counter()
+        for _key in self.action_starts:
+            pending_starts["execution.write_response"] += 1
+        for _key in self.confirmation_starts:
+            pending_starts["execution.confirmation"] += 1
+        for _key in self.wave_starts:
+            pending_starts["order_wave.total"] += 1
+        return {
+            "total_events": sum(self.event_types.values()),
+            "event_types": dict(self.event_types.most_common()),
+            "starts_seen": dict(sorted(self.starts_seen.items())),
+            "terminals_seen": dict(sorted(self.terminals_seen.items())),
+            "timing_observations": dict(sorted(self.timing_observations.items())),
+            "missing_id_counts": dict(sorted(self.missing_id_counts.items())),
+            "unpaired_terminal_counts": dict(sorted(self.unpaired_terminal_counts.items())),
+            "pending_start_counts": dict(sorted(pending_starts.items())),
+            "total_groups": int(timing.get("total_groups") or 0),
+            "groups_truncated": bool(timing.get("groups_truncated")),
+            "groups": timing.get("groups") or [],
+        }
+
+
 def _slowest_blockers(
     *,
     performance_groups: list[dict[str, Any]],
     decision_boundary_groups: list[dict[str, Any]],
     input_staleness_groups: list[dict[str, Any]],
+    execution_timing_groups: list[dict[str, Any]],
     group_limit: int = GROUP_LIMIT,
 ) -> dict[str, Any]:
     items: list[dict[str, Any]] = []
@@ -936,6 +1166,7 @@ def _slowest_blockers(
         ("performance", performance_groups),
         ("decision_boundary_lag", decision_boundary_groups),
         ("input_staleness", input_staleness_groups),
+        ("execution_timing", execution_timing_groups),
     ):
         for group in groups:
             impact = str(group.get("trading_impact") or "")
@@ -1226,6 +1457,7 @@ def build_live_performance_report(
     startup_readiness = _StartupReadinessAccumulator()
     resource_pressure = _ResourcePressureAccumulator()
     shutdown_latency = _ShutdownLatencyAccumulator()
+    execution_timing = _ExecutionTimingAccumulator()
     cycle_scope_tracker = _CycleScopeTracker()
     records_total = 0
     live_events = 0
@@ -1312,6 +1544,11 @@ def build_live_performance_report(
                     startup_readiness.add(row=row, live_event=live_event)
                     resource_pressure.add(row=row, live_event=live_event)
                     shutdown_latency.add(row=row, live_event=live_event)
+                    execution_timing.add(
+                        row=row,
+                        live_event=live_event,
+                        cycle_scope=cycle_scope,
+                    )
         except OSError as exc:
             issues.append(
                 {
@@ -1328,6 +1565,7 @@ def build_live_performance_report(
     performance_groups = accumulator.groups_list()
     decision_boundary_groups = decision_boundary.groups_list()
     input_staleness_groups = input_staleness.groups_list()
+    execution_timing_groups = execution_timing.accumulator.groups_list()
     report = {
         "ok": error_count == 0,
         "root": _user_safe_display_path(root),
@@ -1351,10 +1589,12 @@ def build_live_performance_report(
         "startup_readiness": startup_readiness.to_dict(group_limit=group_limit),
         "resource_pressure": resource_pressure.to_dict(group_limit=group_limit),
         "shutdown_latency": shutdown_latency.to_dict(group_limit=group_limit),
+        "execution_timing": execution_timing.to_dict(group_limit=group_limit),
         "slowest_blockers": _slowest_blockers(
             performance_groups=performance_groups,
             decision_boundary_groups=decision_boundary_groups,
             input_staleness_groups=input_staleness_groups,
+            execution_timing_groups=execution_timing_groups,
             group_limit=group_limit,
         ),
     }
@@ -1456,6 +1696,17 @@ def summarize_live_performance_report(
         if len(shutdown_groups) > max(0, int(group_limit)):
             shutdown_latency["groups_truncated"] = True
         summary["shutdown_latency"] = shutdown_latency
+    if isinstance(report.get("execution_timing"), dict):
+        execution_timing = dict(report["execution_timing"])
+        execution_groups = (
+            execution_timing.get("groups")
+            if isinstance(execution_timing.get("groups"), list)
+            else []
+        )
+        execution_timing["groups"] = execution_groups[: max(0, int(group_limit))]
+        if len(execution_groups) > max(0, int(group_limit)):
+            execution_timing["groups_truncated"] = True
+        summary["execution_timing"] = execution_timing
     if isinstance(report.get("slowest_blockers"), dict):
         slowest_blockers = report["slowest_blockers"]
         blocker_groups = (

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -922,6 +922,209 @@ def test_live_performance_report_summary_includes_startup_readiness(tmp_path):
     assert summary["startup_readiness"]["ready_count"] == 1
 
 
+def test_live_performance_report_execution_timing_pairs_order_events(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="order_wave.started",
+                seq=1,
+                ts=1000,
+                status="started",
+                component="order_wave",
+                ids={"cycle_id": "cy_1", "order_wave_id": "ow_1"},
+                data={"planned_create": 1, "planned_cancel": 1},
+            ),
+            _monitor_row(
+                event_type="execution.create_sent",
+                seq=2,
+                ts=1100,
+                status="started",
+                component="execution.order_write",
+                ids={
+                    "cycle_id": "cy_1",
+                    "order_wave_id": "ow_1",
+                    "action_id": "ow_1:create:0",
+                },
+                symbol="BTC/USDT:USDT",
+                pside="long",
+                data={"client_order_id_short": "cid-short"},
+            ),
+            _monitor_row(
+                event_type="execution.create_succeeded",
+                seq=3,
+                ts=1450,
+                status="succeeded",
+                component="execution.order_write",
+                reason_code="exchange_acknowledged",
+                ids={
+                    "cycle_id": "cy_1",
+                    "order_wave_id": "ow_1",
+                    "action_id": "ow_1:create:0",
+                },
+                symbol="BTC/USDT:USDT",
+                pside="long",
+                data={"raw_order_payload": {"secret": "must-not-leak"}},
+            ),
+            _monitor_row(
+                event_type="execution.cancel_sent",
+                seq=4,
+                ts=1500,
+                status="started",
+                component="execution.order_write",
+                ids={
+                    "cycle_id": "cy_1",
+                    "order_wave_id": "ow_1",
+                    "action_id": "ow_1:cancel:0",
+                },
+                symbol="ETH/USDT:USDT",
+                pside="short",
+            ),
+            _monitor_row(
+                event_type="execution.cancel_ambiguous_terminal",
+                seq=5,
+                ts=2100,
+                status="degraded",
+                component="execution.order_write",
+                reason_code="requires_full_authoritative_confirmation",
+                ids={
+                    "cycle_id": "cy_1",
+                    "order_wave_id": "ow_1",
+                    "action_id": "ow_1:cancel:0",
+                },
+                symbol="ETH/USDT:USDT",
+                pside="short",
+            ),
+            _monitor_row(
+                event_type="execution.confirmation_requested",
+                seq=6,
+                ts=2200,
+                status="started",
+                component="execution.confirmation",
+                ids={"cycle_id": "cy_1", "order_wave_id": "ow_1"},
+            ),
+            _monitor_row(
+                event_type="execution.confirmation_satisfied",
+                seq=7,
+                ts=3400,
+                status="succeeded",
+                component="execution.confirmation",
+                ids={"cycle_id": "cy_1", "order_wave_id": "ow_1"},
+                data={"confirm_ms": 975, "elapsed_ms": 1200},
+            ),
+            _monitor_row(
+                event_type="order_wave.completed",
+                seq=8,
+                ts=3500,
+                status="succeeded",
+                component="order_wave",
+                ids={"cycle_id": "cy_1", "order_wave_id": "ow_1"},
+                data={"elapsed_ms": 2450},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    execution = report["execution_timing"]
+    groups = {
+        group["operation"]: group
+        for group in execution["groups"]
+    }
+    rendered = json.dumps(execution, sort_keys=True)
+
+    assert execution["total_events"] == 8
+    assert execution["timing_observations"] == {
+        "execution.cancel_response": 1,
+        "execution.confirmation": 1,
+        "execution.create_response": 1,
+        "order_wave.total": 1,
+    }
+    assert execution["pending_start_counts"] == {}
+    assert groups["execution.create_response"]["max_ms"] == 350
+    assert groups["execution.cancel_response"]["max_ms"] == 600
+    assert groups["execution.confirmation"]["max_ms"] == 975
+    assert groups["order_wave.total"]["max_ms"] == 2450
+    assert groups["execution.cancel_response"]["statuses"] == {"degraded": 1}
+    assert groups["execution.create_response"]["symbols_sample"] == ["BTC/USDT:USDT"]
+    assert "must-not-leak" not in rendered
+    assert "raw_order_payload" not in rendered
+    assert "ow_1:create:0" not in rendered
+    assert "cid-short" not in rendered
+
+
+def test_live_performance_report_execution_timing_counts_missing_and_unpaired_ids(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="execution.create_sent",
+                seq=1,
+                ts=1000,
+                status="started",
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="execution.create_failed",
+                seq=2,
+                ts=1200,
+                status="failed",
+                ids={"cycle_id": "cy_1", "action_id": "missing_start"},
+            ),
+            _monitor_row(
+                event_type="execution.cancel_sent",
+                seq=3,
+                ts=1300,
+                status="started",
+                ids={"cycle_id": "cy_1", "action_id": "pending_cancel"},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    execution = report["execution_timing"]
+
+    assert execution["total_events"] == 3
+    assert execution["missing_id_counts"] == {"execution.create_response": 1}
+    assert execution["unpaired_terminal_counts"] == {"execution.create_response": 1}
+    assert execution["pending_start_counts"] == {"execution.write_response": 1}
+    assert execution["total_groups"] == 0
+
+
+def test_live_performance_report_execution_timing_summary_is_bounded(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="order_wave.completed",
+                seq=1,
+                ts=1000,
+                component="order_wave",
+                ids={"order_wave_id": "ow_1"},
+                data={"elapsed_ms": 1000},
+            ),
+            _monitor_row(
+                event_type="execution.confirmation_satisfied",
+                seq=2,
+                ts=2000,
+                component="execution.confirmation",
+                ids={"order_wave_id": "ow_1"},
+                data={"confirm_ms": 2000},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    summary = summarize_live_performance_report(report, group_limit=1)
+
+    assert summary["execution_timing"]["total_groups"] == 2
+    assert summary["execution_timing"]["groups_truncated"] is True
+    assert len(summary["execution_timing"]["groups"]) == 1
+    assert summary["slowest_blockers"]["total_groups"] >= 2
+
+
 def test_live_performance_report_resource_pressure_from_health_summary(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- add an execution_timing section to live-performance-report from existing order-wave/write/confirmation events
- derive bounded create/cancel response, confirmation, and order-wave timing groups with missing/unpaired/pending counters
- include execution timing in slowest_blockers and document the performance-readiness checklist update

## Safety
- read-only report projection only
- no event producer, exchange call, cache, or trading behavior changes
- output uses aggregate timing/status/reason/symbol samples only; tests assert raw order payloads, action IDs, and client-order IDs do not leak

## Validation
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_performance_report.py
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_query.py tests/test_live_smoke_report.py
- PYTHONPATH=src ./venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py tests/test_live_performance_report.py
- git diff --check
- local synthetic CLI smoke for tools.live_performance_report --summary