### PR TITLE
Add live performance snapshot age breakdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added snapshot surface and market-snapshot age breakdowns to
+  `passivbot tool live-performance-report`, using bounded metadata from
+  existing `snapshot.built` events without exposing market prices or raw
+  payloads.
 - Added `execution_timing` summaries to
   `passivbot tool live-performance-report`, deriving bounded exchange-action
   latency groups from existing order-wave, create/cancel, and confirmation

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -140,6 +140,10 @@ classification when enough source events exist.
 - [ ] Market data: ticker/market price age, candle close age, EMA bundle age,
   forager feature age, candle remote fetch latency, synthetic/no-trade gap
   repair counts.
+  - Status: partial. New `snapshot.built` metadata and performance-report
+    groups expose planning surface ages plus market-snapshot max/mean age at
+    snapshot build. Remaining work: candle close age, forager feature age, and
+    symbol-scoped stale-but-acceptable candidate metadata.
 - [ ] Decision boundary: whole-minute lag to cycle start, Rust input snapshot,
   Rust output, Python gate/filter, first exchange write, confirmation refresh.
 - [ ] Cycle phases: market state, account state, Rust planning,

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -177,6 +177,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   confirmations, and completion. It also includes an input-staleness section derived from
   existing packet, snapshot, EMA, and Rust-call events, covering account packet age at
   snapshot build plus snapshot/EMA age at the Rust call boundary when those events are present.
+  Newer `snapshot.built` events also expose bounded surface-age and market-snapshot age
+  summaries, allowing the report to break down stale planning inputs without exposing market
+  prices.
   The startup-readiness section summarizes latest per-bot startup phase timings and HSL
   replay state from existing lifecycle/replay events. The `slowest_blockers` section ranks
   non-diagnostic timing and staleness groups by observed duration so the largest trading-impact

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -493,6 +493,8 @@ class _InputStalenessAccumulator:
         self.snapshot_ts_by_cycle: dict[tuple[str, int, str], int] = {}
         self.ema_ts_by_cycle: dict[tuple[str, int, str], int] = {}
         self.snapshots_seen = 0
+        self.snapshot_surface_age_rows = 0
+        self.snapshot_market_summaries_seen = 0
         self.rust_calls_seen = 0
         self.packet_refs_missing = 0
         self.rust_calls_missing_snapshot = 0
@@ -551,6 +553,53 @@ class _InputStalenessAccumulator:
             cycle_id = _cycle_id_from_snapshot_data(data)
             if cycle_id:
                 self.snapshot_ts_by_cycle[(bot, int(cycle_scope), cycle_id)] = int(timestamp_ms)
+            surface_ages = data.get("surface_ages")
+            if isinstance(surface_ages, list):
+                for surface in surface_ages:
+                    if not isinstance(surface, dict):
+                        continue
+                    name = surface.get("name")
+                    age_ms = _non_negative_ms(surface.get("age_ms"))
+                    if name is None or age_ms is None:
+                        continue
+                    self.snapshot_surface_age_rows += 1
+                    surface_name = str(name)
+                    impact = (
+                        "blocks_indicator_readiness"
+                        if surface_name == "completed_candles"
+                        else "blocks_exchange_actions"
+                    )
+                    self._add_group(
+                        row=row,
+                        live_event=live_event,
+                        operation=f"input_staleness.surface.{surface_name}",
+                        value_ms=age_ms,
+                        timing_kind="age_at_snapshot",
+                        trading_impact=impact,
+                    )
+            market_summary = data.get("market_snapshot_summary")
+            if isinstance(market_summary, dict):
+                max_age_ms = _non_negative_ms(market_summary.get("max_age_ms"))
+                mean_age_ms = _non_negative_ms(market_summary.get("mean_age_ms"))
+                if max_age_ms is not None:
+                    self.snapshot_market_summaries_seen += 1
+                    self._add_group(
+                        row=row,
+                        live_event=live_event,
+                        operation="input_staleness.market_snapshot.max",
+                        value_ms=max_age_ms,
+                        timing_kind="age_at_snapshot",
+                        trading_impact="blocks_exchange_actions",
+                    )
+                if mean_age_ms is not None:
+                    self._add_group(
+                        row=row,
+                        live_event=live_event,
+                        operation="input_staleness.market_snapshot.mean",
+                        value_ms=mean_age_ms,
+                        timing_kind="age_at_snapshot",
+                        trading_impact="blocks_exchange_actions",
+                    )
             packets = data.get("data_packets")
             if not isinstance(packets, list):
                 return
@@ -627,6 +676,8 @@ class _InputStalenessAccumulator:
         groups = self.groups_list()
         return {
             "snapshots_seen": int(self.snapshots_seen),
+            "snapshot_surface_age_rows": int(self.snapshot_surface_age_rows),
+            "snapshot_market_summaries_seen": int(self.snapshot_market_summaries_seen),
             "rust_calls_seen": int(self.rust_calls_seen),
             "packet_refs_missing": int(self.packet_refs_missing),
             "rust_calls_missing_snapshot": int(self.rust_calls_missing_snapshot),
@@ -1653,6 +1704,12 @@ def summarize_live_performance_report(
         )
         summary["input_staleness"] = {
             "snapshots_seen": int(input_staleness.get("snapshots_seen") or 0),
+            "snapshot_surface_age_rows": int(
+                input_staleness.get("snapshot_surface_age_rows") or 0
+            ),
+            "snapshot_market_summaries_seen": int(
+                input_staleness.get("snapshot_market_summaries_seen") or 0
+            ),
             "rust_calls_seen": int(input_staleness.get("rust_calls_seen") or 0),
             "packet_refs_missing": int(input_staleness.get("packet_refs_missing") or 0),
             "rust_calls_missing_snapshot": int(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -9113,6 +9113,44 @@ class Passivbot:
         self, snapshot: PlanningSnapshot, *, context: str
     ) -> None:
         availability = PlanningAvailability.from_snapshot(snapshot, now_ms=utc_ms())
+        surface_ages = []
+        for surface in snapshot.surfaces:
+            try:
+                age_ms = max(0, int(snapshot.ts_ms) - int(surface.updated_ms))
+            except (TypeError, ValueError):
+                continue
+            surface_ages.append(
+                {
+                    "name": str(surface.name),
+                    "age_ms": int(age_ms),
+                    "epoch": int(surface.epoch),
+                    "min_epoch": int(surface.min_epoch),
+                }
+            )
+        market_snapshot_ages = []
+        market_snapshot_sources = set()
+        for row in snapshot.market_snapshots:
+            try:
+                age_ms = max(0, int(snapshot.ts_ms) - int(row.fetched_ms))
+            except (TypeError, ValueError):
+                continue
+            market_snapshot_ages.append(int(age_ms))
+            market_snapshot_sources.add(str(row.source))
+        market_snapshot_summary = {
+            "count": len(snapshot.market_snapshots),
+            "symbol_count": len(snapshot.symbols),
+            "missing_count": max(0, len(snapshot.symbols) - len(snapshot.market_snapshots)),
+            "max_age_ms": max(market_snapshot_ages) if market_snapshot_ages else None,
+            "min_age_ms": min(market_snapshot_ages) if market_snapshot_ages else None,
+            "mean_age_ms": (
+                int(round(sum(market_snapshot_ages) / len(market_snapshot_ages)))
+                if market_snapshot_ages
+                else None
+            ),
+            "configured_max_age_ms": int(snapshot.market_snapshot_max_age_ms),
+            "sources": sorted(market_snapshot_sources)[:8],
+            "sources_count": len(market_snapshot_sources),
+        }
         emit_diagnostic_event(
             self,
             DiagnosticEvent.build(
@@ -9124,6 +9162,12 @@ class Passivbot:
                     "context": str(context),
                     "symbols": list(snapshot.symbols),
                     "required_surfaces": list(snapshot.required_surfaces),
+                    "surface_ages": surface_ages,
+                    "market_snapshot_summary": {
+                        key: value
+                        for key, value in market_snapshot_summary.items()
+                        if value is not None
+                    },
                     "data_packets": [
                         {
                             "kind": packet.kind,

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -581,6 +581,30 @@ def test_live_performance_report_input_staleness(tmp_path):
                 ts=2000,
                 data={
                     "cycle_id": 1,
+                    "surface_ages": [
+                        {
+                            "name": "balance",
+                            "age_ms": 900,
+                            "epoch": 3,
+                            "min_epoch": 3,
+                        },
+                        {
+                            "name": "completed_candles",
+                            "age_ms": 1500,
+                            "epoch": 2,
+                            "min_epoch": 2,
+                        },
+                    ],
+                    "market_snapshot_summary": {
+                        "count": 2,
+                        "symbol_count": 2,
+                        "missing_count": 0,
+                        "max_age_ms": 700,
+                        "mean_age_ms": 450,
+                        "configured_max_age_ms": 10_000,
+                        "sources": ["ticker"],
+                        "sources_count": 1,
+                    },
                     "data_packets": [
                         {"kind": "balance", "revision": 7},
                         {"kind": "open_orders", "revision": 8},
@@ -610,8 +634,17 @@ def test_live_performance_report_input_staleness(tmp_path):
     }
 
     assert report["input_staleness"]["snapshots_seen"] == 1
+    assert report["input_staleness"]["snapshot_surface_age_rows"] == 2
+    assert report["input_staleness"]["snapshot_market_summaries_seen"] == 1
     assert report["input_staleness"]["rust_calls_seen"] == 1
     assert report["input_staleness"]["packet_refs_missing"] == 0
+    assert staleness_groups["input_staleness.surface.balance"]["max_ms"] == 900
+    assert staleness_groups["input_staleness.surface.completed_candles"]["max_ms"] == 1500
+    assert staleness_groups["input_staleness.surface.completed_candles"][
+        "trading_impact"
+    ] == "blocks_indicator_readiness"
+    assert staleness_groups["input_staleness.market_snapshot.max"]["max_ms"] == 700
+    assert staleness_groups["input_staleness.market_snapshot.mean"]["max_ms"] == 450
     assert staleness_groups["input_staleness.data_packet.balance"]["max_ms"] == 1000
     assert staleness_groups["input_staleness.data_packet.open_orders"]["max_ms"] == 800
     assert staleness_groups["input_staleness.data_packet.positions"]["max_ms"] == 600
@@ -631,7 +664,12 @@ def test_live_performance_report_input_staleness_handles_cycle_id_reuse(tmp_path
                 event_type="snapshot.built",
                 seq=1,
                 ts=2000,
-                data={"cycle_id": 1, "data_packets": []},
+                data={
+                    "cycle_id": 1,
+                    "surface_ages": [{"name": "balance", "age_ms": 500}],
+                    "market_snapshot_summary": {"max_age_ms": 250, "mean_age_ms": 125},
+                    "data_packets": [],
+                },
             ),
             _monitor_row(event_type="bot.started", seq=2, ts=10_000),
             _monitor_row(
@@ -675,7 +713,12 @@ def test_live_performance_report_summary_includes_bounded_input_staleness(tmp_pa
                 event_type="snapshot.built",
                 seq=1,
                 ts=2000,
-                data={"cycle_id": 1, "data_packets": []},
+                data={
+                    "cycle_id": 1,
+                    "surface_ages": [{"name": "balance", "age_ms": 500}],
+                    "market_snapshot_summary": {"max_age_ms": 250, "mean_age_ms": 125},
+                    "data_packets": [],
+                },
             ),
             _monitor_row(
                 event_type="rust_orchestrator.called",
@@ -690,9 +733,11 @@ def test_live_performance_report_summary_includes_bounded_input_staleness(tmp_pa
     summary = summarize_live_performance_report(report, group_limit=1)
 
     assert summary["input_staleness"]["snapshots_seen"] == 1
+    assert summary["input_staleness"]["snapshot_surface_age_rows"] == 1
+    assert summary["input_staleness"]["snapshot_market_summaries_seen"] == 1
     assert summary["input_staleness"]["rust_calls_seen"] == 1
     assert summary["input_staleness"]["rust_calls_missing_ema"] == 1
-    assert summary["input_staleness"]["total_groups"] == 1
+    assert summary["input_staleness"]["total_groups"] == 4
     assert len(summary["input_staleness"]["groups"]) == 1
 
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -5897,8 +5897,23 @@ async def test_planning_snapshot_freezes_data_packet_revisions_through_cycle():
     snapshot_events = [
         event for event in events if event["kind"] == "snapshot.built"
     ]
-    assert snapshot_events[-1]["payload"]["snapshot_id"] == planning_snapshot.snapshot_id
-    availability = snapshot_events[-1]["payload"]["planning_availability"]
+    snapshot_payload = snapshot_events[-1]["payload"]
+    assert snapshot_payload["snapshot_id"] == planning_snapshot.snapshot_id
+    surface_age_names = {item["name"] for item in snapshot_payload["surface_ages"]}
+    assert {"balance", "positions", "open_orders", "completed_candles", "market_snapshot"} <= (
+        surface_age_names
+    )
+    market_summary = snapshot_payload["market_snapshot_summary"]
+    assert market_summary["count"] == 1
+    assert market_summary["symbol_count"] == 1
+    assert market_summary["missing_count"] == 0
+    assert market_summary["configured_max_age_ms"] == 10_000
+    assert market_summary["sources"] == ["test"]
+    rendered_snapshot = json.dumps(snapshot_payload, sort_keys=True)
+    assert "\"last\"" not in rendered_snapshot
+    assert "\"bid\"" not in rendered_snapshot
+    assert "\"ask\"" not in rendered_snapshot
+    availability = snapshot_payload["planning_availability"]
     assert availability["snapshot_id"] == planning_snapshot.snapshot_id
     assert availability["record_count"] == 18
     assert availability["status_counts"] == {"available": 18}


### PR DESCRIPTION
## Summary
- add bounded surface-age and market-snapshot age summaries to existing snapshot.built diagnostics
- project those fields in live-performance-report input_staleness groups and slowest_blockers
- document the partial market-data age coverage in tools/readiness docs

## Safety
- observability-only producer/report change
- no planning, exchange, cache, order, or risk behavior changes
- snapshot diagnostic still omits market prices; tests assert bid/ask/last are not surfaced

## Validation
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_performance_report.py
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_passivbot_balance_split.py::test_planning_snapshot_freezes_data_packet_revisions_through_cycle tests/test_passivbot_balance_split.py::test_build_staged_planning_snapshot_captures_exact_surface_contract tests/test_passivbot_balance_split.py::test_build_staged_planning_snapshot_survives_diagnostic_failures
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_query.py tests/test_live_smoke_report.py
- PYTHONPATH=src ./venv/bin/python -m py_compile src/passivbot.py src/live/performance_report.py src/tools/live_performance_report.py tests/test_live_performance_report.py tests/test_passivbot_balance_split.py
- git diff --check
- local synthetic CLI smoke for tools.live_performance_report --summary