### PR TITLE
Record forager EMA readiness report progress

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,11 +15,11 @@ merge, live smoke evidence changes, or new gaps are discovered.
 
 ## Current Status
 
-Last updated: 2026-06-27.
+Last updated: 2026-06-28.
 
 Current `origin/v8` logging-overhaul head:
 
-- `cb034e82` after PR #799, `Add cache warmup summaries to performance report`.
+- `1fc77413` after PR #801, `Add forager EMA readiness performance report`.
 
 Current review gate:
 
@@ -30,6 +30,23 @@ Current review gate:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #801 at `1fc77413`.
+- Bots were not restarted for PR #801 because the change was read-only
+  performance-report tooling. All five configured `passivbot live` processes
+  remained running.
+- A 10-minute time-windowed smoke after the PR #801 pull reported `ok=true`,
+  `hard_failures=0`, `logs.hard_matches=0`, `matched_expected=5`,
+  `missing_expected=[]`, `processes.ok=true`, and clean tracked repository
+  state at `repository.head=1fc77413`. The same window still showed non-hard
+  EMA readiness and HSL cooldown attention plus one recovered non-hard Kucoin
+  candle timeout; account-critical remote calls had `failed=0`.
+- A focused 10-minute performance report confirmed the new
+  `forager_ema_readiness` section populated on VPS5. It reported
+  `total_events=140`, with `ema.fallback_used=41`, `ema.unavailable=56`, and
+  `forager.selection=43`, grouped across Binance, GateIO, OKX, and
+  Hyperliquid. Sample groups showed bounded forager selection counts,
+  selected-symbol samples, EMA unavailable reason counters, and EMA fallback
+  counters without raw EMA error text or account/cache payloads.
 - Repository pulled through PR #799 at `cb034e82`.
 - Bots were not restarted for PR #799 because the change was read-only
   performance-report tooling. All five configured `passivbot live` processes
@@ -2298,6 +2315,36 @@ VPS5 deployment status:
   `cache.flush.completed=140`, and `cache.warmup_decision=5`. Sample groups
   showed OKX, Binance, and GateIO warmup cold-path decisions plus bounded
   candle load/flush row counts and elapsed summaries.
+
+### PR #801: Forager EMA Readiness Performance Report
+
+- Branch: `codex/v8-live-performance-forager-ema-readiness`.
+- Scope: read-only live performance report forager/EMA readiness projection,
+  docs, and tests.
+- Result: `passivbot tool live-performance-report` now includes
+  `forager_ema_readiness`, derived only from existing `forager.selection`,
+  `forager.feature_unavailable`, `ema.unavailable`, and `ema.fallback_used`
+  events. The section summarizes bounded forager selection counts,
+  feature-unavailable counts, EMA unavailable reason/error-type counters, EMA
+  fallback counters, pside/status/reason-code counters, configured age/budget
+  fields where present, and bounded symbol samples. Trading behavior, exchange
+  calls, cache mutation, event producers, and console routing are unchanged.
+- Review evidence: CI was green. Claude and Hermes approved with no findings.
+  Both reviews verified the section is report-only, standalone, and value-safe.
+  Local validation covered performance-report, event-query, and smoke-report
+  tests, py_compile, `git diff --check`, a local compact CLI
+  performance-report smoke, and a silent-handling scan of touched report/test
+  files. Tests explicitly inject and reject raw top scores, raw EMA error text,
+  API-key markers, balance/equity fields, raw payload markers, and local paths.
+- VPS5 evidence: deployed at `1fc77413` without bot restart because this is
+  read-only report tooling. A 10-minute time-windowed smoke reported
+  `ok=true`, `hard_failures=0`, `logs.hard_matches=0`, `matched_expected=5`,
+  `missing_expected=[]`, clean tracked repository state, and
+  `account_critical_remote_calls.failed=0`. A focused 10-minute performance
+  report returned `ok=true` and showed `forager_ema_readiness` populated with
+  `total_events=140`, including `ema.fallback_used=41`, `ema.unavailable=56`,
+  and `forager.selection=43`. The section grouped current readiness evidence
+  across Binance, GateIO, OKX, and Hyperliquid.
 
 ### Critical Live Safety Gap: Coin-HSL Startup Replay Latency
 

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -42,74 +42,133 @@ Use this as a living performance scorecard:
 - [ ] If an item is delegated, the delegate works from one checked subsection,
   opens a PR, and does not touch unrelated live behavior.
 
-## Current Priority Checklist
+## Actionable Goal Checklist
 
-This is the short actionable goal list. The rest of the document explains the
-evidence, contract, and candidate implementation slices.
+This is the implementation checklist for the performance/readiness goal. The
+rest of this document gives evidence, target contracts, and candidate PR
+slices.
 
-1. [ ] Measure the slow paths with enough detail to know what is blocking
-   trading.
-   - [ ] Add/report min, mean, p50, p95, max, count, latest timestamp, bot, and
-     trading-impact label for startup, state refresh, candle/EMA readiness, HSL
-     replay, Rust planning, Python reconciliation, exchange writes,
-     confirmation, monitor flush, event-pipeline overhead, and shutdown.
-   - [ ] Split each startup delay into account-critical readiness, held-position
-     protective readiness, fresh-entry readiness, and background/full replay.
-   - [ ] Make every long operation answer whether it delayed protective action,
-     fresh entries, normal cycles, or diagnostics only.
+### Goal 1: Make The Slow Path Measurable
 
-2. [ ] Fix the P0 HSL startup safety gap.
-   - [ ] A held `coin+pside` must not wait behind unrelated flat coins before
-     its exact HSL state is known.
-   - [ ] Current drawdown state takes precedence: a historical red crossing
-     must not trigger a new panic if the exact current state is no longer red.
-   - [ ] Full historical/cooldown reconstruction may continue after held
-     positions are protectively ready, but fresh entries remain blocked for
-     symbols whose cooldown/trading eligibility is not yet known.
+- [ ] Add one reportable duration table for startup, state refresh,
+  candle/EMA readiness, HSL replay, Rust planning, Python reconciliation,
+  exchange writes, confirmation, monitor flush, event-pipeline overhead, and
+  shutdown.
+- [ ] For every duration group, report `count`, `min`, `mean`, `p50`, `p95`,
+  `max`, latest timestamp, bot identity, and trading-impact label.
+- [ ] Split startup into account-critical readiness, held-position protective
+  readiness, fresh-entry readiness, first cycle, first possible exchange write,
+  and full background replay.
+- [ ] Every long operation must answer whether it delayed protective action,
+  fresh entries, normal cycle cadence, or diagnostics only.
+- [ ] Acceptance: one `passivbot tool live-performance-report` run can explain
+  the dominant live-vs-backtest delay without SSH log archaeology.
 
-3. [ ] Prove the HSL replay bottleneck before optimizing broadly.
-   - [ ] Measure cache discovery, cache decode, fill indexing, candle/timeline
-     materialization, pair iteration, EMA/drawdown update, event emission, and
-     exchange/backfill time separately.
-   - [ ] Determine whether coin-mode replay is CPU-bound Python, disk/cache IO,
-     exchange backfill, repeated data conversion, or unnecessary serial
-     dependency between independent pairs.
-   - [ ] Add an offline deterministic fixture so rows/s and equivalence can be
-     checked without live exchange access.
+### Goal 2: Remove HSL Broad Replay From The Protective Critical Path
 
-4. [ ] Optimize exact HSL replay.
-   - [ ] Replay held positions first, cooldown-affected symbols second, and
-     remaining flat symbols last or in background.
-   - [ ] Replace avoidable `timeline_rows * pairs` work, repeated fill scans,
-     and repeated data conversions with indexed/sparse or single-pass logic
-     where exact equivalence is proven.
-   - [ ] Keep panic/order-triggering decisions equivalent to the current HSL
-     contract unless an explicit contract change is reviewed.
+- [ ] A held `coin+pside` must not wait behind unrelated flat coins before its
+  exact HSL state is known.
+- [ ] HSL startup must expose separate states for account-critical ready,
+  held-position protective ready, fresh-entry/cooldown eligibility unknown,
+  and full replay ready.
+- [ ] Current drawdown state takes precedence: a historical red crossing must
+  not trigger a new panic if the exact current state is no longer red.
+- [ ] Full historical/cooldown reconstruction may continue after held positions
+  are protectively ready, but fresh entries remain blocked for symbols whose
+  cooldown/trading eligibility is still unknown.
+- [ ] Acceptance: with 25-30 configured pairs and one held position,
+  held-position protective readiness is reached in seconds, not tens of
+  minutes, when required local/exchange proof is present.
 
-5. [ ] Add resumable HSL checkpoints after exact replay is understood.
-   - [ ] Treat checkpoints as performance caches only, never as authority.
-   - [ ] Validate exchange, user, signal mode, risk config, schema/code version,
-     fill coverage/hash, candle coverage/hash where required, market metadata,
-     and last processed timestamp before resume.
-   - [ ] On any ambiguity, bypass the checkpoint and perform exact replay with
-     a structured reason event.
+### Goal 3: Identify The HSL Replay Bottleneck
 
-6. [ ] Make warm restarts and shutdown operationally fast.
-   - [ ] Warm restart should use proven local cache/checkpoint state before
-     scheduling broad repair.
-   - [ ] Short downtime should not cause broad HSL/candle/fill reconstruction
-     when coverage proof is still valid.
-   - [ ] Ctrl+C should interrupt non-critical long work promptly and report the
-     blocking task if shutdown is slow.
+- [ ] Measure cache discovery, cache decode, fill indexing, candle/timeline
+  materialization, pair iteration, EMA/drawdown update, event emission, and
+  exchange/backfill time separately.
+- [ ] Determine whether coin-mode replay is CPU-bound Python, disk/cache IO,
+  exchange backfill, repeated data conversion, or unnecessary serial dependency
+  between independent pairs.
+- [ ] Confirm whether all needed data was already cached in the slow Binance
+  XLM incident path; if yes, explain exactly why local replay still took about
+  27 minutes.
+- [ ] Add an offline deterministic fixture so rows/s, stage timings, and
+  equivalence can be checked without live exchange access.
+- [ ] Acceptance: before optimizing, the report identifies the dominant cost
+  category and provides a repeatable local benchmark.
 
-7. [ ] Keep observability and trading behavior separated.
-   - [ ] Reports, probes, and cache doctors may prove state and expose gaps, but
-     must not enforce trading decisions unless a separate behavior PR changes
-     the contract.
-   - [ ] Any readiness fallback used by live trading must be bounded,
-     observable, and covered by tests.
-   - [ ] No neutral defaults for missing HSL, fill, candle, account, EMA, or
-     market proof.
+### Goal 4: Optimize Exact HSL Replay
+
+- [ ] Replay currently held pairs first, cooldown-affected symbols second, and
+  remaining flat symbols last or in background.
+- [ ] Replace avoidable `timeline_rows * pairs` work, repeated fill scans, and
+  repeated data conversions with indexed, sparse, vectorized, or single-pass
+  logic where exact equivalence is proven.
+- [ ] Keep panic/order-triggering decisions equivalent to the current HSL
+  contract unless an explicit contract change is reviewed.
+- [ ] Add equivalence tests against the current full replay for
+  `ema_span_minutes=1` and `ema_span_minutes>1`.
+- [ ] Acceptance: full HSL replay for 25-30 pairs over the configured lookback
+  is no longer a 20-40 minute operation on VPS5-class hardware.
+
+### Goal 5: Add Conservative HSL Checkpoints
+
+- [ ] Treat checkpoints as performance caches only, never as trading authority.
+- [ ] Validate exchange, user, signal mode, risk config, schema/code version,
+  fill coverage/hash, candle coverage/hash where required, market metadata, and
+  last processed timestamp before resume.
+- [ ] Resume only from a validated checkpoint boundary; replay exact
+  exchange/cache data after that boundary.
+- [ ] On any ambiguity, bypass the checkpoint and perform exact replay with a
+  structured reason event.
+- [ ] Acceptance: warm restart with valid proof reaches held-position
+  protective readiness quickly; invalid proof falls back loudly and safely.
+
+### Goal 6: Make Warm Restart Fast But Proven
+
+- [ ] Short downtime should not cause broad HSL, candle, or fill
+  reconstruction when coverage proof is still valid.
+- [ ] Warm restart should use proven local cache/checkpoint state before
+  scheduling broad repair.
+- [ ] A stale or missing proof for one symbol should trigger targeted repair,
+  not a broad stall for every unrelated held position or forager candidate.
+- [ ] Acceptance: a quick restart after a clean shutdown reuses valid local
+  state and reaches protective readiness much faster than cold start.
+
+### Goal 7: Make Shutdown Fast And Diagnosable
+
+- [ ] Ctrl+C should set the exit flag and cancel or interrupt non-critical long
+  work promptly.
+- [ ] Big candle fetches, background HSL replay, broad forager refresh, and
+  monitor scans must not block exit unless they are inside a clearly documented
+  critical cleanup section.
+- [ ] Slow shutdown should report the blocking task, stage, and elapsed time.
+- [ ] Acceptance: repeated Ctrl+C should not be required in the normal path;
+  when it is required, the reason is visible in structured events/logs.
+
+### Goal 8: Keep Forager Readiness Fast Without Random Fresh-Subset Bias
+
+- [ ] Refresh the stalest eligible forager symbols regularly in the background.
+- [ ] Allow bounded staleness for candidate ranking without disqualifying a
+  coin merely because it was not among the freshest arbitrary subset.
+- [ ] For stale-but-within-cap candidates, close EMA readiness may use bounded
+  flat-close projection, while quote-volume and log-range ranking should carry
+  forward latest known EMA values with age/source metadata.
+- [ ] Candidates with no prior feature basis, non-finite carried values, or age
+  beyond the cap are explicitly unavailable until refreshed.
+- [ ] Acceptance: forager selection is both rate-limit friendly and
+  non-random; stale candidate state is observable and does not weaken actual
+  entry readiness.
+
+### Goal 9: Keep Speed And Correctness Boundaries Explicit
+
+- [ ] Reports, probes, and cache doctors may expose gaps, but must not enforce
+  trading decisions unless a separate behavior PR changes the contract.
+- [ ] Any readiness fallback used by live trading must be bounded, observable,
+  and covered by tests.
+- [ ] No neutral defaults for missing HSL, fill, candle, account, EMA, market,
+  or cooldown proof.
+- [ ] Acceptance: every speedup PR states whether it affects protective action,
+  fresh entries, diagnostics only, or no trading behavior.
 
 ## Definition Of Done
 


### PR DESCRIPTION
## Summary
- update the live logging overhaul progress ledger after PR #801 merged
- record Claude/Hermes/CI approval and VPS5 deployment evidence
- note current VPS5 smoke/performance-report observations for `forager_ema_readiness`

## Safety
- docs-only progress ledger update
- no code, tests, event routing, live behavior, exchange calls, cache mutation, or console changes

## Validation
- `git diff --check`