### PR TITLE
Add resource pressure percentiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,9 @@ All notable user-facing changes will be documented in this file.
   copying shutdown error text.
 - Added `resource_pressure` summaries to
   `passivbot tool live-performance-report`, projecting whitelisted
-  `health.summary` process and event-pipeline fields without raw account or
-  financial payloads.
+  `health.summary` process and event-pipeline fields with count, min, mean,
+  median, p95, max, and latest values without raw account or financial
+  payloads.
 - Improved cold `passivbot backtest` materialization by batching legacy OHLCV
   imports by month, vectorizing chunk writes, staging HLCV cache writes with
   rollback on publish failure, and honoring Ctrl+C between expensive

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -326,6 +326,11 @@ classification when enough source events exist.
     fields are consistently available in the event stream.
 - [ ] Resource pressure: CPU/load, RSS, memory percent, open FDs, event queue
   depth, dropped event counters, sink errors, loop lag where available.
+  - Status: partial. Existing `health.summary` events are summarized by
+    `live-performance-report` as `resource_pressure`, including whitelisted
+    process and event-pipeline fields with count, latest, min, mean, median,
+    p95, and max values where present. Remaining work: CPU percent and loop lag
+    need source event support if they are not already emitted by the active bot.
 - [ ] Shutdown: signal to exit flag, cancellation request, blocking task names,
   final monitor flush, process exit.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -186,8 +186,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   delays are visible without scanning every timing group. The `resource_pressure` section
   summarizes whitelisted process and event-pipeline health fields from existing
   `health.summary` events, including RSS, memory percent, file descriptors, load average,
-  event queue depth, dropped-event counters, and sink-error counters without exposing raw
-  account or financial payloads. The `shutdown_latency` section summarizes existing
+  event queue depth, dropped-event counters, and sink-error counters with count, latest,
+  min, mean, median, p95, and max values without exposing raw account or financial
+  payloads. The `shutdown_latency` section summarizes existing
   lifecycle shutdown events, including per-stage cumulative elapsed time and final shutdown
   duration, without copying shutdown error text. The `execution_timing` section derives
   aggregate exchange-action latency groups from existing order-wave, order create/cancel,

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1892,19 +1892,39 @@ class _ResourcePressureAccumulator:
 
     @staticmethod
     def _field_stats(values: list[float | int], latest: Any) -> dict[str, Any]:
-        numeric = [float(value) for value in values]
+        numeric = sorted(float(value) for value in values)
         if not numeric:
             return {}
+        p95_index = (len(numeric) - 1) * 0.95
+        p95_lower = int(math.floor(p95_index))
+        p95_upper = int(math.ceil(p95_index))
+        if p95_lower == p95_upper:
+            p95 = numeric[p95_lower]
+        else:
+            p95_weight = p95_index - p95_lower
+            p95 = numeric[p95_lower] * (1.0 - p95_weight) + numeric[p95_upper] * p95_weight
+
+        integral_series = all(value.is_integer() for value in numeric)
+
+        def clean(value: Any) -> float | int:
+            number = float(value)
+            if integral_series:
+                return int(round(number))
+            rounded = round(number, 3)
+            if rounded.is_integer():
+                return int(rounded)
+            return rounded
+
         out: dict[str, Any] = {
-            "latest": latest,
-            "min": min(numeric),
-            "max": max(numeric),
-            "mean": statistics.fmean(numeric),
+            "latest": clean(latest),
+            "count": len(numeric),
+            "min": clean(numeric[0]),
+            "max": clean(numeric[-1]),
+            "mean": clean(statistics.fmean(numeric)),
+            "median": clean(statistics.median(numeric)),
+            "p95": clean(p95),
         }
-        return {
-            key: int(value) if isinstance(value, float) and value.is_integer() else value
-            for key, value in out.items()
-        }
+        return out
 
     def to_dict(self, *, group_limit: int = GROUP_LIMIT) -> dict[str, Any]:
         groups = []

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1799,12 +1799,24 @@ def test_live_performance_report_resource_pressure_from_health_summary(tmp_path)
     assert group["latest_ts"] == 2000
     assert group["fields"]["rss_bytes"] == {
         "latest": 1500,
+        "count": 2,
         "min": 1000,
         "max": 1500,
         "mean": 1250,
+        "median": 1250,
+        "p95": 1475,
     }
-    assert group["fields"]["memory_percent"]["latest"] == 6.5
+    assert group["fields"]["memory_percent"] == {
+        "latest": 6.5,
+        "count": 2,
+        "min": 5.5,
+        "max": 6.5,
+        "mean": 6,
+        "median": 6,
+        "p95": 6.45,
+    }
     assert group["fields"]["event_queue_depth"]["max"] == 5
+    assert group["fields"]["event_queue_depth"]["p95"] == 5
     assert group["fields"]["event_dropped_total"]["latest"] == 4
     assert group["fields"]["event_sink_error_total"]["latest"] == 1
     assert group["fields"]["event_degraded_count"]["latest"] == 3


### PR DESCRIPTION
## Summary
- Extend `live-performance-report` `resource_pressure` field stats with count, median, and p95.
- Keep integer-only resource series integer-valued while preserving decimals for fractional fields like memory/load.
- Update tests and operator docs; report remains read-only and derived only from existing `health.summary` events.

## Validation
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_performance_report.py -q`
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_query.py tests/test_live_smoke_report.py tests/test_live_performance_report.py -q`
- `PYTHONPATH=src ./venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py tests/test_live_performance_report.py`
- `PYTHONPATH=src ./venv/bin/python -m tools.live_performance_report monitor --recent-minutes 60 --summary --compact --group-limit 1`
- `git diff --check`
- Silent-handling audit on touched report/test files; hits are existing report-local sorting/default patterns, not trading-critical fallbacks.
