### PR TITLE
Add operation duration performance summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `operation_durations` summaries to
+  `passivbot tool live-performance-report`, collating existing startup, cycle,
+  state-refresh, remote-call, HSL replay, cache, decision-boundary,
+  input-staleness, execution, and shutdown timing groups into one bounded
+  trading-impact-ranked table without adding new live events or exchange calls.
 - Added `forager_ema_readiness` summaries to
   `passivbot tool live-performance-report`, deriving bounded forager selection,
   forager feature-unavailable, EMA unavailable, and EMA fallback evidence from

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -249,6 +249,10 @@ if the final replay result is correct.
      account packet, snapshot, EMA bundle, and Rust-call events.
    - A follow-up slice added HSL coin replay pair classification, applied-row,
      elapsed, and rows-per-second fields to structured replay events.
+   - A follow-up slice added an `operation_durations` table that collates
+     existing startup, cycle, state-refresh, remote-call, HSL replay, cache,
+     decision-boundary, input-staleness, execution, and shutdown timing groups
+     into one bounded report section.
    - Missing pieces: candle close age, market price age, config age, and
      complete coverage for every order/write/shutdown stage.
 
@@ -316,6 +320,12 @@ classification when enough source events exist.
 - [ ] Cycle phases: market state, account state, Rust planning,
   reconciliation/gating, execution, confirmation, monitor flush, event
   pipeline overhead.
+  - Status: partial. The report now includes an `operation_durations` table
+    that normalizes existing duration/staleness groups from performance,
+    decision-boundary, input-staleness, execution, and shutdown sections into
+    one sortable table with operation category, timing kind, trading impact, and
+    blocking scope. Remaining work: source events for event-pipeline overhead
+    and complete stage coverage where the live loop does not yet emit timings.
 - [ ] Exchange writes: create/cancel/close/panic write latency, exchange
   response latency, ambiguous write rate, confirmation latency.
   - Status: partial. The report now derives order-wave total duration,

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -183,7 +183,10 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   The startup-readiness section summarizes latest per-bot startup phase timings and HSL
   replay state from existing lifecycle/replay events. The `slowest_blockers` section ranks
   non-diagnostic timing and staleness groups by observed duration so the largest trading-impact
-  delays are visible without scanning every timing group. The `resource_pressure` section
+  delays are visible without scanning every timing group. The `operation_durations` section
+  collates startup, cycle, state-refresh, remote-call, HSL replay, cache, decision-boundary,
+  input-staleness, execution, and shutdown timing groups into one bounded table with operation
+  category, trading-impact, blocking-scope, and timing-kind counters. The `resource_pressure` section
   summarizes whitelisted process and event-pipeline health fields from existing
   `health.summary` events, including RSS, memory percent, file descriptors, load average,
   event queue depth, dropped-event counters, and sink-error counters with count, latest,

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -2305,6 +2305,107 @@ def _slowest_blockers(
     }
 
 
+def _operation_category(operation: Any) -> str:
+    text = str(operation or "")
+    for prefix, category in (
+        ("startup.", "startup"),
+        ("state_refresh.", "state_refresh"),
+        ("remote_call.", "remote_call"),
+        ("hsl_replay.", "hsl_replay"),
+        ("cache_", "cache"),
+        ("forager_", "forager"),
+        ("decision_boundary.", "decision_boundary"),
+        ("input_staleness.", "input_staleness"),
+        ("execution.", "execution"),
+        ("order_wave.", "execution"),
+        ("shutdown.", "shutdown"),
+        ("cycle.", "cycle"),
+    ):
+        if text.startswith(prefix):
+            return category
+    return "other"
+
+
+def _operation_duration_table(
+    *,
+    performance_groups: list[dict[str, Any]],
+    decision_boundary_groups: list[dict[str, Any]],
+    input_staleness_groups: list[dict[str, Any]],
+    execution_timing_groups: list[dict[str, Any]],
+    shutdown_latency_groups: list[dict[str, Any]],
+    group_limit: int = GROUP_LIMIT,
+) -> dict[str, Any]:
+    items: list[dict[str, Any]] = []
+    trading_impact_counts: Counter[str] = Counter()
+    blocking_scope_counts: Counter[str] = Counter()
+    operation_category_counts: Counter[str] = Counter()
+    timing_kind_counts: Counter[str] = Counter()
+    for source_section, groups in (
+        ("performance", performance_groups),
+        ("decision_boundary_lag", decision_boundary_groups),
+        ("input_staleness", input_staleness_groups),
+        ("execution_timing", execution_timing_groups),
+        ("shutdown_latency", shutdown_latency_groups),
+    ):
+        for group in groups:
+            operation = group.get("operation")
+            category = _operation_category(operation)
+            impact = str(group.get("trading_impact") or "unknown")
+            blocking_scope = _BLOCKING_SCOPE_BY_IMPACT.get(impact, impact)
+            timing_kind = str(group.get("timing_kind") or "duration")
+            item = {
+                key: group[key]
+                for key in (
+                    "bot",
+                    "operation",
+                    "component",
+                    "event_type",
+                    "trading_impact",
+                    "timing_kind",
+                    "count",
+                    "min_ms",
+                    "max_ms",
+                    "mean_ms",
+                    "median_ms",
+                    "p95_ms",
+                    "latest_ts",
+                    "statuses",
+                    "reason_codes",
+                    "symbols_sample",
+                )
+                if key in group
+            }
+            item["source_section"] = source_section
+            item["operation_category"] = category
+            item["blocking_scope"] = blocking_scope
+            items.append(item)
+            trading_impact_counts[impact] += 1
+            blocking_scope_counts[blocking_scope] += 1
+            operation_category_counts[category] += 1
+            timing_kind_counts[timing_kind] += 1
+    items = sorted(
+        items,
+        key=lambda item: (
+            -int(item.get("p95_ms", 0) or 0),
+            -int(item.get("max_ms", 0) or 0),
+            -int(item.get("count", 0) or 0),
+            str(item.get("bot") or ""),
+            str(item.get("source_section") or ""),
+            str(item.get("operation") or ""),
+        ),
+    )
+    limit = max(0, int(group_limit))
+    return {
+        "total_groups": len(items),
+        "groups_truncated": len(items) > limit,
+        "trading_impact_counts": dict(sorted(trading_impact_counts.items())),
+        "blocking_scope_counts": dict(sorted(blocking_scope_counts.items())),
+        "operation_category_counts": dict(sorted(operation_category_counts.items())),
+        "timing_kind_counts": dict(sorted(timing_kind_counts.items())),
+        "groups": items[:limit],
+    }
+
+
 def _timings_map(value: Any) -> dict[str, int]:
     if not isinstance(value, dict):
         return {}
@@ -2678,6 +2779,7 @@ def build_live_performance_report(
     decision_boundary_groups = decision_boundary.groups_list()
     input_staleness_groups = input_staleness.groups_list()
     execution_timing_groups = execution_timing.accumulator.groups_list()
+    shutdown_latency_groups = shutdown_latency.accumulator.groups_list()
     report = {
         "ok": error_count == 0,
         "root": _user_safe_display_path(root),
@@ -2705,6 +2807,14 @@ def build_live_performance_report(
         "resource_pressure": resource_pressure.to_dict(group_limit=group_limit),
         "shutdown_latency": shutdown_latency.to_dict(group_limit=group_limit),
         "execution_timing": execution_timing.to_dict(group_limit=group_limit),
+        "operation_durations": _operation_duration_table(
+            performance_groups=performance_groups,
+            decision_boundary_groups=decision_boundary_groups,
+            input_staleness_groups=input_staleness_groups,
+            execution_timing_groups=execution_timing_groups,
+            shutdown_latency_groups=shutdown_latency_groups,
+            group_limit=group_limit,
+        ),
         "slowest_blockers": _slowest_blockers(
             performance_groups=performance_groups,
             decision_boundary_groups=decision_boundary_groups,
@@ -2872,6 +2982,25 @@ def summarize_live_performance_report(
             "total_groups": int(slowest_blockers.get("total_groups") or 0),
             "groups_truncated": bool(slowest_blockers.get("groups_truncated")),
             "groups": blocker_groups[: max(0, int(group_limit))],
+        }
+    if isinstance(report.get("operation_durations"), dict):
+        operation_durations = report["operation_durations"]
+        operation_groups = (
+            operation_durations.get("groups")
+            if isinstance(operation_durations.get("groups"), list)
+            else []
+        )
+        summary["operation_durations"] = {
+            "total_groups": int(operation_durations.get("total_groups") or 0),
+            "groups_truncated": bool(operation_durations.get("groups_truncated")),
+            "trading_impact_counts": operation_durations.get("trading_impact_counts") or {},
+            "blocking_scope_counts": operation_durations.get("blocking_scope_counts") or {},
+            "operation_category_counts": operation_durations.get(
+                "operation_category_counts"
+            )
+            or {},
+            "timing_kind_counts": operation_durations.get("timing_kind_counts") or {},
+            "groups": operation_groups[: max(0, int(group_limit))],
         }
     if report.get("event_window") is not None:
         summary["event_window"] = report.get("event_window")

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -72,6 +72,13 @@ def _groups_by_operation(report):
     }
 
 
+def _operation_duration_groups_by_operation(report):
+    return {
+        group["operation"]: group
+        for group in report["operation_durations"]["groups"]
+    }
+
+
 def test_live_performance_report_aggregates_cycle_state_remote_and_hsl_timings(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(
@@ -173,6 +180,20 @@ def test_live_performance_report_aggregates_cycle_state_remote_and_hsl_timings(t
     )
     assert groups["hsl_replay.pair_replay.elapsed"]["max_ms"] == 12500
     assert groups["hsl_replay.pair_replay.elapsed"]["timing_kind"] == "cumulative"
+
+    operation_durations = report["operation_durations"]
+    duration_groups = _operation_duration_groups_by_operation(report)
+    assert operation_durations["total_groups"] >= len(groups)
+    assert operation_durations["operation_category_counts"]["cycle"] >= 2
+    assert operation_durations["operation_category_counts"]["hsl_replay"] == 1
+    assert operation_durations["blocking_scope_counts"]["delays_protective_readiness"] == 1
+    assert duration_groups["hsl_replay.pair_replay.elapsed"]["source_section"] == "performance"
+    assert duration_groups["hsl_replay.pair_replay.elapsed"]["operation_category"] == (
+        "hsl_replay"
+    )
+    assert duration_groups["remote_call.authoritative.open_orders"]["blocking_scope"] == (
+        "delays_exchange_actions"
+    )
 
 
 def test_live_performance_report_time_window_and_group_limit(tmp_path):
@@ -297,6 +318,8 @@ def test_live_performance_report_summary_projection_is_bounded(tmp_path):
     assert summary["filters"]["users"] == ["binance_01"]
     assert summary["performance"]["total_groups"] == 3
     assert len(summary["performance"]["groups"]) == 1
+    assert summary["operation_durations"]["total_groups"] == 3
+    assert len(summary["operation_durations"]["groups"]) == 1
     assert "files" not in summary
     assert "event_types" not in summary
 
@@ -1734,6 +1757,9 @@ def test_live_performance_report_execution_timing_summary_is_bounded(tmp_path):
     assert summary["execution_timing"]["total_groups"] == 2
     assert summary["execution_timing"]["groups_truncated"] is True
     assert len(summary["execution_timing"]["groups"]) == 1
+    assert summary["operation_durations"]["total_groups"] == 2
+    assert summary["operation_durations"]["operation_category_counts"] == {"execution": 2}
+    assert summary["operation_durations"]["blocking_scope_counts"] == {"exchange_io": 2}
     assert summary["slowest_blockers"]["total_groups"] >= 2
 
 
@@ -2002,6 +2028,10 @@ def test_live_performance_report_shutdown_latency_summary_is_bounded(tmp_path):
     assert len(summary["shutdown_latency"]["groups"]) == 1
     assert summary["shutdown_latency"]["groups_truncated"] is True
     assert summary["shutdown_latency"]["groups"][0]["operation"] == "shutdown.total"
+    assert summary["operation_durations"]["total_groups"] == 2
+    assert summary["operation_durations"]["operation_category_counts"] == {"shutdown": 2}
+    assert summary["operation_durations"]["blocking_scope_counts"] == {"observability": 2}
+    assert summary["operation_durations"]["groups"][0]["operation"] == "shutdown.total"
 
 
 def test_live_performance_report_cli_outputs_json(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- add an operation_durations section to passivbot tool live-performance-report
- collate existing performance, decision-boundary, input-staleness, execution, and shutdown timing groups into one bounded table
- document the report-only surface in tools docs, changelog, and performance readiness goals

## Scope
- read-only report projection only
- no new live event producers
- no exchange calls
- no cache mutation
- no readiness gates or trading behavior changes

## Validation
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_performance_report.py -q
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_query.py tests/test_live_smoke_report.py tests/test_live_performance_report.py -q
- PYTHONPATH=src ./venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py tests/test_live_performance_report.py
- PYTHONPATH=src ./venv/bin/python -m tools.live_performance_report monitor --recent-minutes 60 --summary --compact --group-limit 1
- git diff --check