### PR TITLE
Fix snapshot-to-Rust performance correlation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Corrected `passivbot tool live-performance-report` `snapshot_to_rust`
+  correlation so planning snapshot epochs are no longer mistaken for live
+  cycle IDs; legacy snapshot events now use the latest preceding snapshot in
+  the same bot/restart scope and expose match counters.
 - Added `operation_durations` summaries to
   `passivbot tool live-performance-report`, collating existing startup, cycle,
   state-refresh, remote-call, HSL replay, cache, decision-boundary,

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -2452,7 +2452,12 @@ VPS5 deployment status:
   `total_groups=161` across cache, cycle, decision-boundary, input-staleness,
   remote-call, and state-refresh categories. The top observed groups were
   `input_staleness.snapshot_to_rust` delays in the `delays_cycle_decision`
-  scope.
+  scope. A follow-up investigation found those multi-minute
+  `snapshot_to_rust` durations were a report correlation artifact: planning
+  snapshot epochs in `snapshot.built.data.cycle_id` were being treated as live
+  event cycle IDs. The report now uses exact envelope cycle IDs when present
+  and otherwise falls back to the latest preceding snapshot in the same
+  bot/restart scope, with match counters.
 
 ### Critical Live Safety Gap: Coin-HSL Startup Replay Latency
 

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -253,6 +253,11 @@ if the final replay result is correct.
      existing startup, cycle, state-refresh, remote-call, HSL replay, cache,
      decision-boundary, input-staleness, execution, and shutdown timing groups
      into one bounded report section.
+   - A follow-up slice corrected `snapshot_to_rust` correlation: planning
+     snapshot epochs are not live event cycle IDs, so legacy/current
+     `snapshot.built` events without envelope cycle IDs are matched to the
+     latest preceding snapshot in the same bot/restart scope and surfaced with
+     exact-vs-latest match counters.
    - Missing pieces: candle close age, market price age, config age, and
      complete coverage for every order/write/shutdown stage.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -177,6 +177,10 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   confirmations, and completion. It also includes an input-staleness section derived from
   existing packet, snapshot, EMA, and Rust-call events, covering account packet age at
   snapshot build plus snapshot/EMA age at the Rust call boundary when those events are present.
+  For `snapshot_to_rust`, the report uses exact event-envelope `cycle_id` matches when
+  available; for legacy/current `snapshot.built` events that only carry a planning snapshot
+  epoch in `data.cycle_id`, it uses the latest preceding snapshot in the same bot/restart scope
+  and exposes exact-vs-latest match counters.
   Newer `snapshot.built` events also expose bounded surface-age and market-snapshot age
   summaries, allowing the report to break down stale planning inputs without exposing market
   prices.

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -603,27 +603,20 @@ class _DecisionBoundaryAccumulator:
         }
 
 
-def _cycle_id_from_snapshot_data(data: dict[str, Any]) -> str | None:
-    cycle_id = data.get("cycle_id")
-    if cycle_id is None:
-        return None
-    text = str(cycle_id)
-    if text.startswith("cy_"):
-        return text
-    return f"cy_{text}"
-
-
 class _InputStalenessAccumulator:
     def __init__(self) -> None:
         self.groups: dict[tuple[str, str, str], _MetricGroup] = {}
         self.packet_received_ts: dict[tuple[str, int, str, str], int] = {}
         self.snapshot_ts_by_cycle: dict[tuple[str, int, str], int] = {}
+        self.latest_snapshot_ts_by_scope: dict[tuple[str, int], int] = {}
         self.ema_ts_by_cycle: dict[tuple[str, int, str], int] = {}
         self.snapshots_seen = 0
         self.snapshot_surface_age_rows = 0
         self.snapshot_market_summaries_seen = 0
         self.rust_calls_seen = 0
         self.packet_refs_missing = 0
+        self.snapshot_to_rust_exact_matches = 0
+        self.snapshot_to_rust_latest_snapshot_matches = 0
         self.rust_calls_missing_snapshot = 0
         self.rust_calls_missing_ema = 0
 
@@ -677,7 +670,9 @@ class _InputStalenessAccumulator:
             return
         if event_type == "snapshot.built":
             self.snapshots_seen += 1
-            cycle_id = _cycle_id_from_snapshot_data(data)
+            scope_key = (bot, int(cycle_scope))
+            self.latest_snapshot_ts_by_scope[scope_key] = int(timestamp_ms)
+            cycle_id = _event_cycle_id(live_event)
             if cycle_id:
                 self.snapshot_ts_by_cycle[(bot, int(cycle_scope), cycle_id)] = int(timestamp_ms)
             surface_ages = data.get("surface_ages")
@@ -763,6 +758,13 @@ class _InputStalenessAccumulator:
             if not cycle_id:
                 return
             snapshot_ts = self.snapshot_ts_by_cycle.get((bot, int(cycle_scope), cycle_id))
+            if snapshot_ts is not None:
+                self.snapshot_to_rust_exact_matches += 1
+            else:
+                latest_snapshot_ts = self.latest_snapshot_ts_by_scope.get((bot, int(cycle_scope)))
+                if latest_snapshot_ts is not None and latest_snapshot_ts <= int(timestamp_ms):
+                    snapshot_ts = int(latest_snapshot_ts)
+                    self.snapshot_to_rust_latest_snapshot_matches += 1
             if snapshot_ts is None:
                 self.rust_calls_missing_snapshot += 1
             else:
@@ -807,6 +809,10 @@ class _InputStalenessAccumulator:
             "snapshot_market_summaries_seen": int(self.snapshot_market_summaries_seen),
             "rust_calls_seen": int(self.rust_calls_seen),
             "packet_refs_missing": int(self.packet_refs_missing),
+            "snapshot_to_rust_exact_matches": int(self.snapshot_to_rust_exact_matches),
+            "snapshot_to_rust_latest_snapshot_matches": int(
+                self.snapshot_to_rust_latest_snapshot_matches
+            ),
             "rust_calls_missing_snapshot": int(self.rust_calls_missing_snapshot),
             "rust_calls_missing_ema": int(self.rust_calls_missing_ema),
             "total_groups": len(groups),
@@ -2886,6 +2892,12 @@ def summarize_live_performance_report(
             ),
             "rust_calls_seen": int(input_staleness.get("rust_calls_seen") or 0),
             "packet_refs_missing": int(input_staleness.get("packet_refs_missing") or 0),
+            "snapshot_to_rust_exact_matches": int(
+                input_staleness.get("snapshot_to_rust_exact_matches") or 0
+            ),
+            "snapshot_to_rust_latest_snapshot_matches": int(
+                input_staleness.get("snapshot_to_rust_latest_snapshot_matches") or 0
+            ),
             "rust_calls_missing_snapshot": int(
                 input_staleness.get("rust_calls_missing_snapshot") or 0
             ),

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -661,6 +661,8 @@ def test_live_performance_report_input_staleness(tmp_path):
     assert report["input_staleness"]["snapshot_market_summaries_seen"] == 1
     assert report["input_staleness"]["rust_calls_seen"] == 1
     assert report["input_staleness"]["packet_refs_missing"] == 0
+    assert report["input_staleness"]["snapshot_to_rust_exact_matches"] == 0
+    assert report["input_staleness"]["snapshot_to_rust_latest_snapshot_matches"] == 1
     assert staleness_groups["input_staleness.surface.balance"]["max_ms"] == 900
     assert staleness_groups["input_staleness.surface.completed_candles"]["max_ms"] == 1500
     assert staleness_groups["input_staleness.surface.completed_candles"][
@@ -723,8 +725,95 @@ def test_live_performance_report_input_staleness_handles_cycle_id_reuse(tmp_path
     }
 
     assert report["input_staleness"]["rust_calls_missing_snapshot"] == 1
+    assert report["input_staleness"]["snapshot_to_rust_latest_snapshot_matches"] == 0
     assert "input_staleness.snapshot_to_rust" not in staleness_groups
     assert staleness_groups["input_staleness.ema_bundle_to_rust"]["max_ms"] == 500
+
+
+def test_live_performance_report_input_staleness_prefers_envelope_cycle_id(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=1,
+                ts=2000,
+                ids={"cycle_id": "cy_9"},
+                data={
+                    "cycle_id": 1,
+                    "surface_ages": [],
+                    "market_snapshot_summary": {},
+                    "data_packets": [],
+                },
+            ),
+            _monitor_row(
+                event_type="rust_orchestrator.called",
+                seq=2,
+                ts=2600,
+                ids={"cycle_id": "cy_9"},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    staleness_groups = {
+        group["operation"]: group
+        for group in report["input_staleness"]["groups"]
+    }
+
+    assert report["input_staleness"]["snapshot_to_rust_exact_matches"] == 1
+    assert report["input_staleness"]["snapshot_to_rust_latest_snapshot_matches"] == 0
+    assert report["input_staleness"]["rust_calls_missing_snapshot"] == 0
+    assert staleness_groups["input_staleness.snapshot_to_rust"]["max_ms"] == 600
+
+
+def test_live_performance_report_input_staleness_uses_latest_legacy_snapshot(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=1,
+                ts=1000,
+                data={
+                    "cycle_id": 1,
+                    "surface_ages": [],
+                    "market_snapshot_summary": {},
+                    "data_packets": [],
+                },
+            ),
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=2,
+                ts=2400,
+                data={
+                    "cycle_id": 2,
+                    "surface_ages": [],
+                    "market_snapshot_summary": {},
+                    "data_packets": [],
+                },
+            ),
+            _monitor_row(
+                event_type="rust_orchestrator.called",
+                seq=3,
+                ts=2700,
+                ids={"cycle_id": "cy_99"},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    staleness_groups = {
+        group["operation"]: group
+        for group in report["input_staleness"]["groups"]
+    }
+
+    assert report["input_staleness"]["snapshot_to_rust_exact_matches"] == 0
+    assert report["input_staleness"]["snapshot_to_rust_latest_snapshot_matches"] == 1
+    assert report["input_staleness"]["rust_calls_missing_snapshot"] == 0
+    assert staleness_groups["input_staleness.snapshot_to_rust"]["max_ms"] == 300
 
 
 def test_live_performance_report_summary_includes_bounded_input_staleness(tmp_path):
@@ -759,6 +848,7 @@ def test_live_performance_report_summary_includes_bounded_input_staleness(tmp_pa
     assert summary["input_staleness"]["snapshot_surface_age_rows"] == 1
     assert summary["input_staleness"]["snapshot_market_summaries_seen"] == 1
     assert summary["input_staleness"]["rust_calls_seen"] == 1
+    assert summary["input_staleness"]["snapshot_to_rust_latest_snapshot_matches"] == 1
     assert summary["input_staleness"]["rust_calls_missing_ema"] == 1
     assert summary["input_staleness"]["total_groups"] == 4
     assert len(summary["input_staleness"]["groups"]) == 1


### PR DESCRIPTION
## Summary
- fix live-performance-report snapshot_to_rust correlation so planning snapshot epochs are not treated as live cycle IDs
- use exact envelope cycle_id matches when available; otherwise use the latest preceding snapshot in the same bot/restart scope
- expose exact-vs-latest match counters and document the fallback

## Validation
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_performance_report.py -q
- PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_query.py tests/test_live_smoke_report.py tests/test_live_performance_report.py -q
- PYTHONPATH=src ./venv/bin/python -m py_compile src/live/performance_report.py tests/test_live_performance_report.py
- git diff --check
- rg silent-handling scan of touched report/test files (pre-existing projection defaults only)
- local monitor report check: snapshot_to_rust count=21 min=100ms max=307ms p95=303ms with latest-snapshot matches=21 and missing_snapshot=0

Trading behavior unchanged: read-only report/tooling/docs/tests only.