### PR TITLE
Carry snapshot IDs through diagnostic events

### DIFF
--- a/src/live/events.py
+++ b/src/live/events.py
@@ -21,6 +21,8 @@ class DiagnosticEvent:
     ts_ms: int | None = None
     symbol: str | None = None
     pside: str | None = None
+    cycle_id: str | None = None
+    snapshot_id: str | None = None
 
     @classmethod
     def build(
@@ -32,6 +34,8 @@ class DiagnosticEvent:
         ts_ms: int | None = None,
         symbol: str | None = None,
         pside: str | None = None,
+        cycle_id: str | None = None,
+        snapshot_id: str | None = None,
     ) -> "DiagnosticEvent":
         return cls(
             kind=str(kind),
@@ -40,6 +44,8 @@ class DiagnosticEvent:
             ts_ms=None if ts_ms is None else int(ts_ms),
             symbol=None if symbol is None else str(symbol),
             pside=None if pside is None else str(pside),
+            cycle_id=None if cycle_id is None else str(cycle_id),
+            snapshot_id=None if snapshot_id is None else str(snapshot_id),
         )
 
     def emit(self, bot) -> Any:
@@ -86,6 +92,8 @@ class DiagnosticEvent:
             "exchange": None if exchange is None else str(exchange),
             "user": None if user is None else str(user),
             "bot_id": None if bot_id is None else str(bot_id),
+            "cycle_id": self.cycle_id,
+            "snapshot_id": self.snapshot_id,
             "symbol": self.symbol,
             "pside": self.pside,
             "data": dict(self.payload),

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -9182,6 +9182,8 @@ class Passivbot:
                     "planning_availability": availability.summary(),
                 },
                 ts_ms=snapshot.ts_ms,
+                cycle_id=self._current_live_event_cycle_id(),
+                snapshot_id=snapshot.snapshot_id,
             ),
         )
         self._emit_planning_symbol_state_event(availability, context=context)

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -605,6 +605,8 @@ def test_diagnostic_event_uses_pipeline_when_available_and_legacy_when_absent():
     assert emitted.exchange == "binance"
     assert emitted.user == "binance_01"
     assert emitted.bot_id == "bot_1"
+    assert emitted.cycle_id is None
+    assert emitted.snapshot_id is None
     assert emitted.data["apiKey"] == REDACTED
     assert emitted.data["reason"] == "stale"
     assert bot._live_event_pipeline.close(timeout=2.0) is True
@@ -624,6 +626,39 @@ def test_diagnostic_event_uses_pipeline_when_available_and_legacy_when_absent():
         ("planning",),
         {"apiKey": "secret", "reason": "stale"},
     )
+
+
+def test_diagnostic_event_carries_envelope_ids_to_pipeline():
+    class BotWithPipeline:
+        exchange = "binance"
+        bot_id = "bot_1"
+
+        def __init__(self):
+            self._live_event_pipeline = LiveEventPipeline(
+                context=LiveEventContext(user="binance_01"),
+                structured_sinks=[],
+                monitor_sinks=[],
+            )
+
+        def config_get(self, keys):
+            return "binance_01"
+
+    bot = BotWithPipeline()
+    event = DiagnosticEvent.build(
+        "snapshot.built",
+        ("diagnostic", "snapshot"),
+        {"snapshot_id": "snap_1"},
+        cycle_id="cy_7",
+        snapshot_id="snap_1",
+    )
+
+    emitted = event.emit(bot)
+
+    assert emitted.event_type == EventTypes.SNAPSHOT_BUILT
+    assert emitted.cycle_id == "cy_7"
+    assert emitted.snapshot_id == "snap_1"
+    assert emitted.data["snapshot_id"] == "snap_1"
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 def test_diagnostic_event_falls_back_to_legacy_recorder_when_pipeline_queue_is_full():

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -5827,7 +5827,7 @@ def test_build_staged_planning_snapshot_captures_exact_surface_contract():
 
 
 @pytest.mark.asyncio
-async def test_planning_snapshot_freezes_data_packet_revisions_through_cycle():
+async def test_planning_snapshot_freezes_data_packet_revisions_through_cycle(monkeypatch):
     symbol = "BTC/USDT:USDT"
     positions = [
         {
@@ -5883,6 +5883,24 @@ async def test_planning_snapshot_freezes_data_packet_revisions_through_cycle():
         )
     }
     bot._record_market_snapshot_surface([symbol], snapshots)
+    bot._live_event_current_cycle_id = "cy_snapshot"
+    bot._current_live_event_cycle_id = Passivbot._current_live_event_cycle_id.__get__(
+        bot, Passivbot
+    )
+    diagnostic_build_calls = []
+    original_diagnostic_build = passivbot_module.DiagnosticEvent.build
+
+    def recording_diagnostic_build(kind, tags, payload=None, **kwargs):
+        event = original_diagnostic_build(kind, tags, payload, **kwargs)
+        if kind == "snapshot.built":
+            diagnostic_build_calls.append((payload, kwargs, event))
+        return event
+
+    monkeypatch.setattr(
+        passivbot_module.DiagnosticEvent,
+        "build",
+        staticmethod(recording_diagnostic_build),
+    )
 
     planning_snapshot = bot._build_staged_planning_snapshot([symbol], snapshots)
     frozen_revisions = {
@@ -5899,6 +5917,8 @@ async def test_planning_snapshot_freezes_data_packet_revisions_through_cycle():
     ]
     snapshot_payload = snapshot_events[-1]["payload"]
     assert snapshot_payload["snapshot_id"] == planning_snapshot.snapshot_id
+    assert diagnostic_build_calls[-1][1]["cycle_id"] == "cy_snapshot"
+    assert diagnostic_build_calls[-1][1]["snapshot_id"] == planning_snapshot.snapshot_id
     surface_age_names = {item["name"] for item in snapshot_payload["surface_ages"]}
     assert {"balance", "positions", "open_orders", "completed_candles", "market_snapshot"} <= (
         surface_age_names


### PR DESCRIPTION
## Summary
- Add `cycle_id` and `snapshot_id` fields to `DiagnosticEvent` so legacy diagnostic producers can populate structured live-event envelope IDs.
- Pass the current live cycle ID and planning snapshot ID into `snapshot.built` diagnostics.
- Add regression coverage for direct diagnostic emission and the live planning snapshot path.

## Validation
- `VIRTUAL_ENV=/Users/eiriknarjord/repos/passivbot-2/venv PATH=/Users/eiriknarjord/repos/passivbot-2/venv/bin:$PATH /Users/eiriknarjord/repos/passivbot-2/venv/bin/maturin develop --release`
- Runtime extension source-stamped/verified for fingerprint `84781fdb2cf45cf829a06a94f09e3951a13d31b28b456d1dac0a525bbf591026`
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_bus.py::test_diagnostic_event_uses_pipeline_when_available_and_legacy_when_absent tests/test_live_event_bus.py::test_diagnostic_event_carries_envelope_ids_to_pipeline tests/test_passivbot_balance_split.py::test_planning_snapshot_freezes_data_packet_revisions_through_cycle -q`
- `PYTHONPATH=src ./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_balance_split.py tests/test_live_performance_report.py -q`
- `PYTHONPATH=src ./venv/bin/python -m py_compile src/live/events.py src/passivbot.py tests/test_live_event_bus.py tests/test_passivbot_balance_split.py`
- `git diff --check`