### PR TITLE
Query legacy snapshot IDs from event data

### DIFF
--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -102,7 +102,12 @@ def _live_event_payload(row: dict[str, Any]) -> dict[str, Any] | None:
 
 def _event_ids(live_event: dict[str, Any]) -> dict[str, Any]:
     ids = live_event.get("ids")
-    return dict(ids) if isinstance(ids, dict) else {}
+    out = dict(ids) if isinstance(ids, dict) else {}
+    if out.get("snapshot_id") is None:
+        data = live_event.get("data")
+        if isinstance(data, dict) and data.get("snapshot_id") is not None:
+            out["snapshot_id"] = data["snapshot_id"]
+    return out
 
 
 def _normalize_filter_values(values: str | Iterable[str] | None) -> set[str]:

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -494,6 +494,51 @@ def test_event_query_filters_by_remaining_event_ids(tmp_path):
     }
 
 
+def test_event_query_filters_legacy_snapshot_id_from_event_data(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="snapshot.built",
+                cycle_id=None,
+                seq=1,
+                ts=1000,
+                data={
+                    "snapshot_id": "snap_legacy",
+                    "cycle_id": 42,
+                    "ready_symbols": 3,
+                },
+            ),
+            _monitor_row(
+                event_type="rust_orchestrator.called",
+                cycle_id="cy_1",
+                seq=2,
+                ts=1100,
+                ids={"snapshot_id": "snap_2", "plan_id": "plan_2"},
+            ),
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        snapshot_id="snap_legacy",
+        include_data=True,
+        trace_summary=True,
+    )
+
+    assert report["query"]["filters"] == {"snapshot_ids": ["snap_legacy"]}
+    assert report["missing_cycle_id"] == 1
+    assert report["query"]["matched_events"] == 1
+    event = report["query"]["events"][0]
+    assert event["event_type"] == "snapshot.built"
+    assert event["ids"] == {"snapshot_id": "snap_legacy"}
+    assert event["data"]["cycle_id"] == 42
+    assert report["query"]["trace_summary"]["ids"]["snapshot_id"] == [
+        {"id": "snap_legacy", "events": 1}
+    ]
+
+
 def test_event_query_filters_by_inclusive_time_window(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     invalid_ts = _monitor_row(


### PR DESCRIPTION
## Summary
- Let `live.event_query` synthesize `snapshot_id` from `_live_event.data.snapshot_id` when the structured envelope ids do not contain it.
- Keep `data.cycle_id` as data only; older `snapshot.built.data.cycle_id` is a planning epoch, not a live cycle id.
- Add regression coverage for legacy `snapshot.built` rows produced before snapshot ids were promoted into the envelope.

## Validation
- `VIRTUAL_ENV=/Users/eiriknarjord/repos/passivbot-2/venv PATH=/Users/eiriknarjord/repos/passivbot-2/venv/bin:$PATH /Users/eiriknarjord/repos/passivbot-2/venv/bin/maturin develop --release`
- Runtime extension source-stamped/verified for fingerprint `cdb900c9298c5c5b071252f3f35a168fafd25e430fa34dec511e3970f9147d3d`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py tests/test_passivbot_cli.py::test_live_event_query_tool_dispatch_forwards_module_and_prog -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_query.py tests/test_live_event_query.py`
- `git diff --check`