### PR TITLE
Report stale market snapshot age excess

### DIFF
--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -613,6 +613,7 @@ class _InputStalenessAccumulator:
         self.snapshots_seen = 0
         self.snapshot_surface_age_rows = 0
         self.snapshot_market_summaries_seen = 0
+        self.snapshot_market_stale_count = 0
         self.rust_calls_seen = 0
         self.packet_refs_missing = 0
         self.snapshot_to_rust_exact_matches = 0
@@ -703,6 +704,9 @@ class _InputStalenessAccumulator:
             if isinstance(market_summary, dict):
                 max_age_ms = _non_negative_ms(market_summary.get("max_age_ms"))
                 mean_age_ms = _non_negative_ms(market_summary.get("mean_age_ms"))
+                configured_max_age_ms = _non_negative_ms(
+                    market_summary.get("configured_max_age_ms")
+                )
                 if max_age_ms is not None:
                     self.snapshot_market_summaries_seen += 1
                     self._add_group(
@@ -713,6 +717,19 @@ class _InputStalenessAccumulator:
                         timing_kind="age_at_snapshot",
                         trading_impact="blocks_exchange_actions",
                     )
+                    if (
+                        configured_max_age_ms is not None
+                        and max_age_ms > configured_max_age_ms
+                    ):
+                        self.snapshot_market_stale_count += 1
+                        self._add_group(
+                            row=row,
+                            live_event=live_event,
+                            operation="input_staleness.market_snapshot.configured_excess",
+                            value_ms=max_age_ms - configured_max_age_ms,
+                            timing_kind="configured_age_excess",
+                            trading_impact="blocks_exchange_actions",
+                        )
                 if mean_age_ms is not None:
                     self._add_group(
                         row=row,
@@ -807,6 +824,7 @@ class _InputStalenessAccumulator:
             "snapshots_seen": int(self.snapshots_seen),
             "snapshot_surface_age_rows": int(self.snapshot_surface_age_rows),
             "snapshot_market_summaries_seen": int(self.snapshot_market_summaries_seen),
+            "snapshot_market_stale_count": int(self.snapshot_market_stale_count),
             "rust_calls_seen": int(self.rust_calls_seen),
             "packet_refs_missing": int(self.packet_refs_missing),
             "snapshot_to_rust_exact_matches": int(self.snapshot_to_rust_exact_matches),
@@ -2889,6 +2907,9 @@ def summarize_live_performance_report(
             ),
             "snapshot_market_summaries_seen": int(
                 input_staleness.get("snapshot_market_summaries_seen") or 0
+            ),
+            "snapshot_market_stale_count": int(
+                input_staleness.get("snapshot_market_stale_count") or 0
             ),
             "rust_calls_seen": int(input_staleness.get("rust_calls_seen") or 0),
             "packet_refs_missing": int(input_staleness.get("packet_refs_missing") or 0),

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -624,7 +624,7 @@ def test_live_performance_report_input_staleness(tmp_path):
                         "missing_count": 0,
                         "max_age_ms": 700,
                         "mean_age_ms": 450,
-                        "configured_max_age_ms": 10_000,
+                        "configured_max_age_ms": 600,
                         "sources": ["ticker"],
                         "sources_count": 1,
                     },
@@ -659,6 +659,7 @@ def test_live_performance_report_input_staleness(tmp_path):
     assert report["input_staleness"]["snapshots_seen"] == 1
     assert report["input_staleness"]["snapshot_surface_age_rows"] == 2
     assert report["input_staleness"]["snapshot_market_summaries_seen"] == 1
+    assert report["input_staleness"]["snapshot_market_stale_count"] == 1
     assert report["input_staleness"]["rust_calls_seen"] == 1
     assert report["input_staleness"]["packet_refs_missing"] == 0
     assert report["input_staleness"]["snapshot_to_rust_exact_matches"] == 0
@@ -670,6 +671,12 @@ def test_live_performance_report_input_staleness(tmp_path):
     ] == "blocks_indicator_readiness"
     assert staleness_groups["input_staleness.market_snapshot.max"]["max_ms"] == 700
     assert staleness_groups["input_staleness.market_snapshot.mean"]["max_ms"] == 450
+    assert staleness_groups["input_staleness.market_snapshot.configured_excess"][
+        "max_ms"
+    ] == 100
+    assert staleness_groups["input_staleness.market_snapshot.configured_excess"][
+        "timing_kind"
+    ] == "configured_age_excess"
     assert staleness_groups["input_staleness.data_packet.balance"]["max_ms"] == 1000
     assert staleness_groups["input_staleness.data_packet.open_orders"]["max_ms"] == 800
     assert staleness_groups["input_staleness.data_packet.positions"]["max_ms"] == 600
@@ -828,7 +835,11 @@ def test_live_performance_report_summary_includes_bounded_input_staleness(tmp_pa
                 data={
                     "cycle_id": 1,
                     "surface_ages": [{"name": "balance", "age_ms": 500}],
-                    "market_snapshot_summary": {"max_age_ms": 250, "mean_age_ms": 125},
+                    "market_snapshot_summary": {
+                        "max_age_ms": 250,
+                        "mean_age_ms": 125,
+                        "configured_max_age_ms": 200,
+                    },
                     "data_packets": [],
                 },
             ),
@@ -847,10 +858,11 @@ def test_live_performance_report_summary_includes_bounded_input_staleness(tmp_pa
     assert summary["input_staleness"]["snapshots_seen"] == 1
     assert summary["input_staleness"]["snapshot_surface_age_rows"] == 1
     assert summary["input_staleness"]["snapshot_market_summaries_seen"] == 1
+    assert summary["input_staleness"]["snapshot_market_stale_count"] == 1
     assert summary["input_staleness"]["rust_calls_seen"] == 1
     assert summary["input_staleness"]["snapshot_to_rust_latest_snapshot_matches"] == 1
     assert summary["input_staleness"]["rust_calls_missing_ema"] == 1
-    assert summary["input_staleness"]["total_groups"] == 4
+    assert summary["input_staleness"]["total_groups"] == 5
     assert len(summary["input_staleness"]["groups"]) == 1
 
 


### PR DESCRIPTION
Read-only live performance-report slice.

Scope:
- Derive `input_staleness.snapshot_market_stale_count` from existing `snapshot.built.data.market_snapshot_summary` fields.
- Add `input_staleness.market_snapshot.configured_excess` timing group when `max_age_ms` exceeds `configured_max_age_ms`.
- Include the new counter in bounded summary output.

No event producers, exchange calls, cache mutation, readiness gates, console routing, or trading behavior changed.

Validation:
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/performance_report.py tests/test_live_performance_report.py`
- `git diff --check`
- silent-handling scan on touched files; hits are pre-existing report summary/sort defaults, no new critical-path fallback.
