### PR TITLE
Summarize event taxonomy in trace queries

### DIFF
--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import gzip
 import json
+from collections.abc import Iterable as IterableABC
 from collections import Counter, defaultdict
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -262,6 +263,16 @@ def _record_ts(row: dict[str, Any]) -> int | None:
         return int(row.get("ts"))
     except (TypeError, ValueError):
         return None
+
+
+def _event_tags(row: dict[str, Any], live_event: dict[str, Any]) -> list[str]:
+    tags: list[str] = []
+    for source in (row.get("tags"), live_event.get("tags")):
+        if isinstance(source, str):
+            tags.append(source)
+        elif isinstance(source, IterableABC):
+            tags.extend(str(item) for item in source if item is not None)
+    return sorted(set(tags))
 
 
 def _short_ref(value: Any, *, max_len: int = 32) -> str | None:
@@ -677,6 +688,11 @@ class _TraceSummaryBuilder:
         self.last_ts: Any = None
         self.event_types: Counter[str] = Counter()
         self.levels: Counter[str] = Counter()
+        self.sources: Counter[str] = Counter()
+        self.components: Counter[str] = Counter()
+        self.tags: Counter[str] = Counter()
+        self.exchanges: Counter[str] = Counter()
+        self.users: Counter[str] = Counter()
         self.statuses: Counter[str] = Counter()
         self.reason_codes: Counter[str] = Counter()
         self.symbols: set[str] = set()
@@ -713,12 +729,18 @@ class _TraceSummaryBuilder:
             self.event_types[str(event_type)] += 1
         for key, counter in (
             ("level", self.levels),
+            ("source", self.sources),
+            ("component", self.components),
+            ("exchange", self.exchanges),
+            ("user", self.users),
             ("status", self.statuses),
             ("reason_code", self.reason_codes),
         ):
             value = live_event.get(key)
             if value is not None:
                 counter[str(value)] += 1
+        for tag in _event_tags(row, live_event):
+            self.tags[tag] += 1
         symbol = live_event.get("symbol") or row.get("symbol")
         if symbol is not None:
             self.symbols.add(str(symbol))
@@ -778,6 +800,11 @@ class _TraceSummaryBuilder:
             "matched_events": int(self.events),
             "event_types": _sorted_counter(self.event_types),
             "levels": _sorted_counter(self.levels),
+            "sources": _sorted_counter(self.sources),
+            "components": _sorted_counter(self.components),
+            "tags": _sorted_counter(self.tags),
+            "exchanges": _sorted_counter(self.exchanges),
+            "users": _sorted_counter(self.users),
             "statuses": _sorted_counter(self.statuses),
             "reason_codes": _sorted_counter(self.reason_codes),
             "symbols": _sorted_values(self.symbols),

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -22,6 +22,9 @@ def _monitor_row(
     reason_code: str = "test",
     ids: dict | None = None,
     data: dict | None = None,
+    source: str = "live",
+    component: str = "test",
+    tags: list[str] | None = None,
     order_id: str | None = None,
     client_order_id: str | None = None,
 ) -> dict:
@@ -33,8 +36,8 @@ def _monitor_row(
         "event_id": f"evt_{seq}",
         "event_type": event_type,
         "level": "debug",
-        "source": "live",
-        "component": "test",
+        "source": source,
+        "component": component,
         "exchange": "binance",
         "user": "binance_01",
         "symbol": symbol,
@@ -53,7 +56,7 @@ def _monitor_row(
         "exchange": "binance",
         "user": "binance_01",
         "kind": event_type,
-        "tags": ["test"],
+        "tags": list(tags or ["test"]),
         "payload": payload,
         "seq": seq,
         "ts": ts,
@@ -1382,6 +1385,9 @@ def test_live_event_query_cli_accepts_trace_summary(tmp_path, capsys):
                 seq=1,
                 ts=1000,
                 status="started",
+                source="executor",
+                component="order_wave",
+                tags=["execution", "order", "wave"],
                 ids={"order_wave_id": "ow_7"},
             ),
             _monitor_row(
@@ -1390,6 +1396,9 @@ def test_live_event_query_cli_accepts_trace_summary(tmp_path, capsys):
                 seq=2,
                 ts=1100,
                 status="succeeded",
+                source="executor",
+                component="order_wave",
+                tags=["execution", "order", "summary"],
                 ids={"order_wave_id": "ow_7"},
             ),
         ],
@@ -1410,6 +1419,16 @@ def test_live_event_query_cli_accepts_trace_summary(tmp_path, capsys):
     report = json.loads(capsys.readouterr().out)
     summary = report["cycle"]["trace_summary"]
     assert summary["matched_events"] == 2
+    assert summary["sources"] == {"executor": 2}
+    assert summary["components"] == {"order_wave": 2}
+    assert summary["tags"] == {
+        "execution": 2,
+        "order": 2,
+        "summary": 1,
+        "wave": 1,
+    }
+    assert summary["exchanges"] == {"binance": 2}
+    assert summary["users"] == {"binance_01": 2}
     assert summary["order_waves"]["ow_7"]["event_types"] == {
         "order_wave.completed": 1,
         "order_wave.started": 1,


### PR DESCRIPTION
## Scope
Query-only logging-overhaul slice for live-event trace summaries.

## Change
- Adds source, component, tag, exchange, and user counters to live-event-query trace summaries.
- Tags are read from the monitor row and optional embedded live event tags, deduplicated per event before counting.
- Adds focused regression coverage through the existing trace-summary CLI test.

## Behavior boundary
No event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, or trading behavior changed.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_query.py src/tools/live_event_query.py tests/test_live_event_query.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py -q
- git diff --check
- silent-handling scan on touched files