### PR TITLE
Filter live event queries by tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `--tag` filtering to `passivbot tool live-event-query`, so operator
+  event, timeline, trace-summary, order-trace, and cycle-trace reports can be
+  scoped by structured live-event tags.
 - Corrected `passivbot tool live-performance-report` `snapshot_to_rust`
   correlation so planning snapshot epochs are no longer mistaken for live
   cycle IDs; legacy snapshot events now use the latest preceding snapshot in

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -146,6 +146,7 @@ def _filter_report(
     psides: set[str],
     reason_codes: set[str],
     statuses: set[str],
+    tags: set[str],
     since_ms: int | None = None,
     until_ms: int | None = None,
 ) -> dict[str, Any]:
@@ -180,6 +181,8 @@ def _filter_report(
         filters["reason_codes"] = sorted(reason_codes)
     if statuses:
         filters["statuses"] = sorted(statuses)
+    if tags:
+        filters["tags"] = sorted(tags)
     return filters
 
 
@@ -838,6 +841,7 @@ def build_event_report(
     pside: str | Iterable[str] | None = None,
     reason_code: str | Iterable[str] | None = None,
     status: str | Iterable[str] | None = None,
+    tag: str | Iterable[str] | None = None,
     since_ms: int | None = None,
     until_ms: int | None = None,
     limit: int = 200,
@@ -915,6 +919,7 @@ def build_event_report(
     pside_filter = _normalize_filter_values(pside)
     reason_code_filter = _normalize_filter_values(reason_code)
     status_filter = _normalize_filter_values(status)
+    tag_filter = _normalize_filter_values(tag)
     has_non_cycle_filter = any(
         (
             event_type_filter,
@@ -929,6 +934,7 @@ def build_event_report(
             pside_filter,
             reason_code_filter,
             status_filter,
+            tag_filter,
         )
     )
     trace_without_cycle = (
@@ -1036,6 +1042,7 @@ def build_event_report(
                     record_pside = live_event.get("pside") or row.get("pside")
                     record_status = live_event.get("status")
                     record_reason_code = live_event.get("reason_code")
+                    record_tags = _event_tags(row, live_event)
                     event_type_matches = _filter_matches(
                         record_event_type, event_type_filter
                     )
@@ -1063,6 +1070,9 @@ def build_event_report(
                         record_reason_code, reason_code_filter
                     )
                     status_matches = _filter_matches(record_status, status_filter)
+                    tag_matches = not tag_filter or bool(
+                        set(record_tags).intersection(tag_filter)
+                    )
                     query_matches = (
                         event_type_matches
                         and cycle_matches
@@ -1077,6 +1087,7 @@ def build_event_report(
                         and pside_matches
                         and reason_code_matches
                         and status_matches
+                        and tag_matches
                     )
 
                     if has_query_filter and query_matches:
@@ -1192,6 +1203,7 @@ def build_event_report(
             psides=pside_filter,
             reason_codes=reason_code_filter,
             statuses=status_filter,
+            tags=tag_filter,
             since_ms=since_filter,
             until_ms=until_filter,
         )
@@ -1226,6 +1238,7 @@ def build_event_report(
             psides=pside_filter,
             reason_codes=reason_code_filter,
             statuses=status_filter,
+            tags=tag_filter,
             since_ms=since_filter,
             until_ms=until_filter,
         )

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -120,6 +120,14 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--tag",
+        action="append",
+        help=(
+            "Return compact records matching one structured event tag. May be repeated "
+            "or comma-separated."
+        ),
+    )
+    parser.add_argument(
         "--since-ms",
         type=int,
         help="Only include live events with monitor ts at or after this epoch-ms value.",
@@ -219,6 +227,7 @@ def main(argv: list[str] | None = None) -> int:
         pside=args.pside,
         reason_code=args.reason_code,
         status=args.status,
+        tag=args.tag,
         since_ms=since_ms,
         until_ms=args.until_ms,
         limit=args.limit,

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -380,6 +380,52 @@ def test_event_query_filters_by_ids_symbol_pside_reason_and_status(tmp_path):
     assert remote_report["query"]["events"][0]["event_type"] == "remote_call.failed"
 
 
+def test_event_query_filters_by_tags(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="execution.create_sent",
+                cycle_id="cy_1",
+                seq=1,
+                ts=1000,
+                tags=["execution", "order"],
+            ),
+            _monitor_row(
+                event_type="risk.hsl_status",
+                cycle_id="cy_1",
+                seq=2,
+                ts=1100,
+                tags=["risk", "summary"],
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                cycle_id="cy_2",
+                seq=3,
+                ts=1200,
+                tags=["remote_call", "exchange"],
+            ),
+        ],
+    )
+
+    report = build_event_report(tmp_path / "monitor", tag="execution,order")
+
+    assert report["ok"] is True
+    assert report["query"]["filters"] == {"tags": ["execution", "order"]}
+    assert report["query"]["matched_events"] == 1
+    assert report["query"]["events"][0]["event_type"] == "execution.create_sent"
+
+    risk_report = build_event_report(tmp_path / "monitor", cycle_id="cy_1", tag="risk")
+
+    assert risk_report["cycle"]["filters"] == {
+        "cycle_id": "cy_1",
+        "tags": ["risk"],
+    }
+    assert risk_report["cycle"]["matched_events"] == 1
+    assert risk_report["cycle"]["events"][0]["event_type"] == "risk.hsl_status"
+
+
 def test_event_query_filters_by_remaining_event_ids(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(
@@ -1410,6 +1456,8 @@ def test_live_event_query_cli_accepts_trace_summary(tmp_path, capsys):
                 str(tmp_path / "monitor"),
                 "--cycle-id",
                 "cy_7",
+                "--tag",
+                "order",
                 "--trace-summary",
             ]
         )
@@ -1417,6 +1465,7 @@ def test_live_event_query_cli_accepts_trace_summary(tmp_path, capsys):
     )
 
     report = json.loads(capsys.readouterr().out)
+    assert report["cycle"]["filters"] == {"cycle_id": "cy_7", "tags": ["order"]}
     summary = report["cycle"]["trace_summary"]
     assert summary["matched_events"] == 2
     assert summary["sources"] == {"executor": 2}


### PR DESCRIPTION
Scope: read-only live-event-query tooling slice. Adds --tag filtering to passivbot tool live-event-query and the build_event_report API so event, timeline, trace-summary, order-trace, and cycle-trace reports can be scoped by structured live-event tags. No event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, or trading behavior changed.

Validation:
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_query.py src/tools/live_event_query.py tests/test_live_event_query.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_passivbot_cli.py::test_tool_help_lists_supported_tools tests/test_passivbot_cli.py::test_live_event_query_tool_dispatch_forwards_module_and_prog -q
- git diff --check
- silent-handling scan on touched files: no matches

Note: the two passivbot CLI tests required rebuilding/stamping the shared local passivbot_rust extension for this v8-based worktree; this PR has no Rust source changes.