### PR TITLE
Summarize HSL replay state in smoke report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `hsl_replay_health` summaries to
+  `passivbot tool live-smoke-report`, so smoke reports show active,
+  completed, and failed HSL startup replay state from existing
+  `hsl.replay.*` events.
 - Updated the canonical v8 trailing-martingale default config profile, including
   the 41-coin universe, per-coin HSL signal mode, refreshed optimizer
   scoring/limits/bounds, `bot.long.risk.n_positions = 5`, and

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -71,6 +71,7 @@ PROBLEM_EVENT_GROUP_LIMIT = 20
 EMA_READINESS_GROUP_LIMIT = 20
 STAGED_READINESS_GROUP_LIMIT = 20
 EVENT_PIPELINE_HEALTH_GROUP_LIMIT = 20
+HSL_REPLAY_HEALTH_GROUP_LIMIT = 20
 RISK_EVENT_TYPES = {
     EventTypes.RISK_MODE_CHANGED,
     EventTypes.HSL_TRANSITION,
@@ -85,6 +86,11 @@ SHUTDOWN_EVENT_TYPES = {
     EventTypes.BOT_STOPPING,
     EventTypes.BOT_SHUTDOWN_STAGE,
     EventTypes.BOT_STOPPED,
+}
+HSL_REPLAY_EVENT_TYPES = {
+    EventTypes.HSL_REPLAY_STARTED,
+    EventTypes.HSL_REPLAY_PROGRESS,
+    EventTypes.HSL_REPLAY_COMPLETED,
 }
 REMOTE_CALL_TIMING_EVENT_TYPES = {
     EventTypes.REMOTE_CALL_SUCCEEDED,
@@ -1730,6 +1736,287 @@ def _redact_log_text(value: str, *, max_len: int = 500) -> str:
     return text
 
 
+def _numeric_value(value: Any) -> int | float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return None if value != value else round(value, 6)
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed != parsed:
+        return None
+    if parsed.is_integer():
+        return int(parsed)
+    return round(parsed, 6)
+
+
+def _compact_hsl_replay_data(live_event: dict[str, Any]) -> dict[str, Any]:
+    data = live_event.get("data")
+    if not isinstance(data, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for key in ("signal_mode", "stage"):
+        value = data.get(key)
+        if isinstance(value, str) and value:
+            out[key] = _redact_log_text(value, max_len=80)
+    for key in ("is_held_pair", "is_cooldown_pair"):
+        value = data.get(key)
+        if isinstance(value, bool):
+            out[key] = value
+    for key in (
+        "lookback_days",
+        "symbols",
+        "pairs",
+        "held_pairs",
+        "cooldown_pairs",
+        "required_pairs",
+        "timeline_rows",
+        "fill_events",
+        "panic_events",
+        "skipped_unsupported_symbols",
+        "pair_idx",
+        "applied_rows",
+        "total_applied_rows",
+        "rows",
+        "skipped_pairs",
+        "rows_per_second",
+        "elapsed_s",
+        "full_elapsed_s",
+        "startup_blocking_elapsed_s",
+    ):
+        value = _numeric_value(data.get(key))
+        if value is not None:
+            out[key] = value
+    return out
+
+
+def _hsl_observed_rows(data: dict[str, Any]) -> int | None:
+    for key in ("total_applied_rows", "rows", "applied_rows"):
+        value = _non_negative_int(data.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _hsl_replay_derived(data: dict[str, Any]) -> dict[str, Any]:
+    timeline_rows = _non_negative_int(data.get("timeline_rows"))
+    pairs = _non_negative_int(data.get("pairs"))
+    observed_rows = _hsl_observed_rows(data)
+    out: dict[str, Any] = {}
+    if timeline_rows is not None and pairs is not None:
+        dense_work = int(timeline_rows) * int(pairs)
+        out["estimated_dense_pair_row_work"] = dense_work
+        if observed_rows is not None and dense_work > 0:
+            out["observed_work_pct"] = round(
+                min(100.0, max(0.0, 100.0 * float(observed_rows) / float(dense_work))),
+                3,
+            )
+    for source_key, target_key in (
+        ("elapsed_s", "latest_elapsed_ms"),
+        ("full_elapsed_s", "full_elapsed_ms"),
+        ("startup_blocking_elapsed_s", "startup_blocking_elapsed_ms"),
+    ):
+        value = data.get(source_key)
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            continue
+        if parsed == parsed and parsed >= 0.0:
+            out[target_key] = int(round(parsed * 1000.0))
+    return out
+
+
+def _hsl_replay_record(
+    *,
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+    path: Path,
+    line_no: int,
+) -> dict[str, Any]:
+    data = _compact_hsl_replay_data(live_event)
+    ids = _event_ids(live_event)
+    return {
+        key: value
+        for key, value in {
+            "event_type": live_event.get("event_type") or row.get("kind"),
+            "reason_code": live_event.get("reason_code"),
+            "status": live_event.get("status"),
+            "level": live_event.get("level"),
+            "component": live_event.get("component"),
+            "ts": row.get("ts"),
+            "seq": row.get("seq"),
+            "path": str(path),
+            "line": int(line_no),
+            "symbol": live_event.get("symbol") or row.get("symbol"),
+            "pside": live_event.get("pside") or row.get("pside"),
+            "data": data,
+            "derived": _hsl_replay_derived(data),
+            "ids": {
+                key: ids.get(key)
+                for key in ("cycle_id", "snapshot_id", "plan_id", "action_id")
+                if ids.get(key) is not None
+            },
+        }.items()
+        if value not in (None, {}, [])
+    }
+
+
+def _merge_hsl_replay_group(
+    groups: dict[str, dict[str, Any]],
+    *,
+    bot_key: str,
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+    path: Path,
+    line_no: int,
+) -> None:
+    event_type = str(live_event.get("event_type") or row.get("kind") or "")
+    record = _hsl_replay_record(
+        row=row,
+        live_event=live_event,
+        path=path,
+        line_no=line_no,
+    )
+    group = groups.get(bot_key)
+    if group is None:
+        group = {
+            "bot": bot_key,
+            "count": 0,
+            "event_types": Counter(),
+            "latest": None,
+            "started": None,
+            "loaded": None,
+            "progress": None,
+            "completed": None,
+        }
+        groups[bot_key] = group
+    group["count"] = int(group.get("count", 0)) + 1
+    group["event_types"][event_type] += 1
+
+    def is_newer(candidate: dict[str, Any], existing: dict[str, Any] | None) -> bool:
+        if existing is None:
+            return True
+        return _sort_event_position_key(
+            ts=candidate.get("ts"),
+            seq=candidate.get("seq"),
+            path=candidate.get("path") or "",
+            line_no=int(candidate.get("line") or 0),
+        ) > _sort_event_position_key(
+            ts=existing.get("ts"),
+            seq=existing.get("seq"),
+            path=existing.get("path") or "",
+            line_no=int(existing.get("line") or 0),
+        )
+
+    if is_newer(record, group.get("latest")):
+        group["latest"] = record
+    data = record.get("data") if isinstance(record.get("data"), dict) else {}
+    if event_type == EventTypes.HSL_REPLAY_STARTED and is_newer(
+        record, group.get("started")
+    ):
+        group["started"] = record
+    elif (
+        event_type == EventTypes.HSL_REPLAY_PROGRESS
+        and data.get("stage") == "loaded"
+        and is_newer(record, group.get("loaded"))
+    ):
+        group["loaded"] = record
+    elif event_type == EventTypes.HSL_REPLAY_PROGRESS and is_newer(
+        record, group.get("progress")
+    ):
+        group["progress"] = record
+    elif event_type == EventTypes.HSL_REPLAY_COMPLETED and is_newer(
+        record, group.get("completed")
+    ):
+        group["completed"] = record
+
+
+def _public_hsl_replay_record(record: Any) -> dict[str, Any]:
+    if not isinstance(record, dict):
+        return {}
+    return {
+        key: value
+        for key, value in record.items()
+        if key not in {"path", "line", "seq"} and value not in (None, {}, [])
+    }
+
+
+def _hsl_replay_group_active(group: dict[str, Any]) -> bool:
+    latest = group.get("latest")
+    if not isinstance(latest, dict):
+        return False
+    return latest.get("event_type") != EventTypes.HSL_REPLAY_COMPLETED
+
+
+def _summarize_hsl_replay_health(
+    groups: dict[str, dict[str, Any]],
+    event_type_counts: Counter[str],
+) -> dict[str, Any]:
+    ordered = sorted(
+        groups.values(),
+        key=lambda item: (
+            0 if _hsl_replay_group_active(item) else 1,
+            -int(
+                (((item.get("latest") or {}).get("derived") or {}).get(
+                    "startup_blocking_elapsed_ms"
+                ))
+                or 0
+            ),
+            -int(((item.get("latest") or {}).get("ts")) or 0),
+            str(item.get("bot") or ""),
+        ),
+    )
+    compact_groups: list[dict[str, Any]] = []
+    active_bots = 0
+    completed_bots = 0
+    failed_bots = 0
+    for group in ordered:
+        active = _hsl_replay_group_active(group)
+        latest = _public_hsl_replay_record(group.get("latest"))
+        completed = _public_hsl_replay_record(group.get("completed"))
+        if active:
+            active_bots += 1
+        if completed:
+            if completed.get("status") == "succeeded":
+                completed_bots += 1
+            elif completed.get("status") == "failed":
+                failed_bots += 1
+        public_group = {
+            "bot": group.get("bot"),
+            "active": active,
+            "count": int(group.get("count") or 0),
+            "event_types": dict(group.get("event_types").most_common())
+            if isinstance(group.get("event_types"), Counter)
+            else {},
+            "latest": latest,
+            "started": _public_hsl_replay_record(group.get("started")),
+            "loaded": _public_hsl_replay_record(group.get("loaded")),
+            "progress": _public_hsl_replay_record(group.get("progress")),
+            "completed": completed,
+        }
+        compact_groups.append(
+            {
+                key: value
+                for key, value in public_group.items()
+                if value not in (None, {}, [])
+            }
+        )
+    return {
+        "total": sum(int(group.get("count", 0)) for group in groups.values()),
+        "groups_truncated": len(ordered) > HSL_REPLAY_HEALTH_GROUP_LIMIT,
+        "event_types": dict(event_type_counts.most_common()),
+        "bots": len(groups),
+        "active_bots": int(active_bots),
+        "completed_bots": int(completed_bots),
+        "failed_bots": int(failed_bots),
+        "groups": compact_groups[:HSL_REPLAY_HEALTH_GROUP_LIMIT],
+    }
+
+
 def _shell_tokens(value: str) -> list[str]:
     try:
         import shlex
@@ -2454,6 +2741,8 @@ def _scan_events(
     staged_readiness_event_type_counts: Counter[str] = Counter()
     event_pipeline_health_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     event_pipeline_health_event_type_counts: Counter[str] = Counter()
+    hsl_replay_health_groups: dict[str, dict[str, Any]] = {}
+    hsl_replay_health_event_type_counts: Counter[str] = Counter()
     risk_event_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     risk_event_type_counts: Counter[str] = Counter()
     shutdown_event_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -2574,6 +2863,16 @@ def _scan_events(
                                 event_pipeline_health_groups,
                                 event_pipeline_health_group,
                             )
+                    if event_type in HSL_REPLAY_EVENT_TYPES:
+                        hsl_replay_health_event_type_counts[str(event_type)] += 1
+                        _merge_hsl_replay_group(
+                            hsl_replay_health_groups,
+                            bot_key=bot_key,
+                            row=row,
+                            live_event=live_event,
+                            path=path,
+                            line_no=line_no,
+                        )
                     if event_type in RISK_EVENT_TYPES:
                         risk_event_type_counts[str(event_type)] += 1
                         _merge_risk_event_group(
@@ -2683,6 +2982,10 @@ def _scan_events(
         "event_pipeline_health": _summarize_event_pipeline_health(
             event_pipeline_health_groups,
             event_pipeline_health_event_type_counts,
+        ),
+        "hsl_replay_health": _summarize_hsl_replay_health(
+            hsl_replay_health_groups,
+            hsl_replay_health_event_type_counts,
         ),
         "risk_events": _summarize_risk_events(
             risk_event_groups,
@@ -3047,6 +3350,16 @@ def build_live_smoke_report(
                 "latest_stopping_count": 0,
                 "groups": [],
             },
+            "hsl_replay_health": {
+                "total": 0,
+                "groups_truncated": False,
+                "event_types": {},
+                "bots": 0,
+                "active_bots": 0,
+                "completed_bots": 0,
+                "failed_bots": 0,
+                "groups": [],
+            },
             "risk_events": {
                 "total": 0,
                 "groups_truncated": False,
@@ -3094,6 +3407,7 @@ def build_live_smoke_report(
         int(event_scan["problem_event_count"])
         + int(log_scan["attention_matches"])
         + int(log_scan.get("dropped_unparsed_attention_matches", 0))
+        + int(event_scan["hsl_replay_health"].get("active_bots") or 0)
     )
     hard_failure_sources = {
         "monitor_errors": int(event_report["error_count"]),
@@ -3103,6 +3417,9 @@ def build_live_smoke_report(
         "process_hard_failures": int(process_report["hard_failures"]),
         "total": int(hard_failures),
     }
+    hsl_replay_active_bots = int(
+        event_scan["hsl_replay_health"].get("active_bots") or 0
+    )
     attention_sources = {
         "problem_events": int(event_scan["problem_event_count"]),
         "log_attention_matches": int(log_scan["attention_matches"]),
@@ -3111,6 +3428,8 @@ def build_live_smoke_report(
         ),
         "total": int(attention_count),
     }
+    if hsl_replay_active_bots:
+        attention_sources["hsl_replay_active_bots"] = hsl_replay_active_bots
     return {
         "ok": hard_failures == 0,
         "attention": attention_count > 0,
@@ -3142,6 +3461,7 @@ def build_live_smoke_report(
         "ema_readiness_health": event_scan["ema_readiness_health"],
         "staged_readiness_health": event_scan["staged_readiness_health"],
         "event_pipeline_health": event_scan["event_pipeline_health"],
+        "hsl_replay_health": event_scan["hsl_replay_health"],
         "risk_events": event_scan["risk_events"],
         "shutdown_events": event_scan["shutdown_events"],
         "event_window": event_scan["event_window"],
@@ -3175,6 +3495,9 @@ def _summary_limited_groups(
             "throttled_pct": summary.get("throttled_pct"),
             "event_types": summary.get("event_types"),
             "bots": summary.get("bots"),
+            "active_bots": summary.get("active_bots"),
+            "completed_bots": summary.get("completed_bots"),
+            "failed_bots": summary.get("failed_bots"),
             "latest_candidate_unavailable_total": summary.get(
                 "latest_candidate_unavailable_total"
             ),
@@ -3244,6 +3567,11 @@ def summarize_live_smoke_report(
     event_pipeline_health = (
         report.get("event_pipeline_health")
         if isinstance(report.get("event_pipeline_health"), dict)
+        else {}
+    )
+    hsl_replay_health = (
+        report.get("hsl_replay_health")
+        if isinstance(report.get("hsl_replay_health"), dict)
         else {}
     )
     shutdown_events = (
@@ -3365,6 +3693,10 @@ def summarize_live_smoke_report(
             event_pipeline_health,
             limit=max_groups,
         ),
+        "hsl_replay_health": _summary_limited_groups(
+            hsl_replay_health,
+            limit=max_groups,
+        ),
         "risk_events": _summary_limited_groups(risk_events, limit=max_groups),
         "shutdown_events": _summary_limited_groups(
             shutdown_events,
@@ -3424,6 +3756,11 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
     event_pipeline_health = (
         report.get("event_pipeline_health")
         if isinstance(report.get("event_pipeline_health"), dict)
+        else {}
+    )
+    hsl_replay_health = (
+        report.get("hsl_replay_health")
+        if isinstance(report.get("hsl_replay_health"), dict)
         else {}
     )
     shutdown_events = (
@@ -3580,6 +3917,14 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
                 event_pipeline_health.get("latest_stopping_count")
             ),
             "event_types": event_pipeline_health.get("event_types") or {},
+        },
+        "hsl_replay": {
+            "total": _count_value(hsl_replay_health.get("total")),
+            "bots": _count_value(hsl_replay_health.get("bots")),
+            "active_bots": _count_value(hsl_replay_health.get("active_bots")),
+            "completed_bots": _count_value(hsl_replay_health.get("completed_bots")),
+            "failed_bots": _count_value(hsl_replay_health.get("failed_bots")),
+            "event_types": hsl_replay_health.get("event_types") or {},
         },
         "risk_events": {
             "total": _count_value(risk_events.get("total")),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2114,6 +2114,9 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
                     "elapsed_s": 201.2,
                     "is_held_pair": True,
                     "is_cooldown_pair": False,
+                    "balance": 1234.56,
+                    "equity": 1200.0,
+                    "drawdown_score": 0.42,
                     "error": "api_key=AKIA123",
                 },
             ),
@@ -2148,6 +2151,12 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
     )
     assert "AKIA123" not in json.dumps(report["hsl_replay_health"], sort_keys=True)
     assert "must-not-render" not in json.dumps(
+        report["hsl_replay_health"],
+        sort_keys=True,
+    )
+    assert "balance" not in json.dumps(report["hsl_replay_health"], sort_keys=True)
+    assert "equity" not in json.dumps(report["hsl_replay_health"], sort_keys=True)
+    assert "drawdown_score" not in json.dumps(
         report["hsl_replay_health"],
         sort_keys=True,
     )

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2015,6 +2015,158 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
     }
 
 
+def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
+    _write_ndjson(
+        tmp_path
+        / "monitor"
+        / "binance"
+        / "binance_01"
+        / "events"
+        / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.replay.started",
+                seq=1,
+                ts=1000,
+                reason_code="coin_history_replay",
+                level="debug",
+                status="started",
+                data={"signal_mode": "coin", "lookback_days": 30.0},
+            ),
+            _monitor_row(
+                event_type="hsl.replay.progress",
+                seq=2,
+                ts=2000,
+                reason_code="history_loaded",
+                level="debug",
+                status="started",
+                data={
+                    "signal_mode": "coin",
+                    "stage": "loaded",
+                    "symbols": 26,
+                    "pairs": 26,
+                    "held_pairs": 1,
+                    "cooldown_pairs": 1,
+                    "required_pairs": 20,
+                    "timeline_rows": 43201,
+                    "fill_events": 2700,
+                    "secret": "must-not-render",
+                },
+            ),
+            _monitor_row(
+                event_type="hsl.replay.completed",
+                seq=3,
+                ts=3000,
+                reason_code="coin_history_replay_completed",
+                level="debug",
+                status="succeeded",
+                data={
+                    "signal_mode": "coin",
+                    "stage": "full_replay",
+                    "rows": 985965,
+                    "pairs": 26,
+                    "timeline_rows": 43201,
+                    "full_elapsed_s": 1623.4,
+                    "startup_blocking_elapsed_s": 1623.4,
+                },
+            ),
+        ],
+    )
+    _write_ndjson(
+        tmp_path
+        / "monitor"
+        / "gateio"
+        / "gateio_01"
+        / "events"
+        / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.replay.started",
+                seq=4,
+                ts=4000,
+                exchange="gateio",
+                user="gateio_01",
+                reason_code="coin_history_replay",
+                level="debug",
+                status="started",
+                data={"signal_mode": "coin", "lookback_days": 30.0},
+            ),
+            _monitor_row(
+                event_type="hsl.replay.progress",
+                seq=5,
+                ts=5000,
+                exchange="gateio",
+                user="gateio_01",
+                reason_code="pair_replay_progress",
+                level="debug",
+                status="started",
+                symbol="ZEC/USDT:USDT",
+                pside="long",
+                data={
+                    "signal_mode": "coin",
+                    "stage": "pair_replay",
+                    "pair_idx": 3,
+                    "pairs": 29,
+                    "timeline_rows": 43201,
+                    "applied_rows": 12000,
+                    "total_applied_rows": 64000,
+                    "rows_per_second": 318.415,
+                    "elapsed_s": 201.2,
+                    "is_held_pair": True,
+                    "is_cooldown_pair": False,
+                    "error": "api_key=AKIA123",
+                },
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    summary = summarize_live_smoke_report(report)
+    brief = summarize_live_smoke_report_brief(report)
+
+    assert report["ok"] is True
+    assert report["attention"] is True
+    assert report["hard_failures"] == 0
+    assert report["attention_sources"]["hsl_replay_active_bots"] == 1
+    assert report["hsl_replay_health"]["active_bots"] == 1
+    assert report["hsl_replay_health"]["completed_bots"] == 1
+    assert report["hsl_replay_health"]["failed_bots"] == 0
+    assert report["hsl_replay_health"]["event_types"] == {
+        "hsl.replay.progress": 2,
+        "hsl.replay.started": 2,
+        "hsl.replay.completed": 1,
+    }
+    active_group = report["hsl_replay_health"]["groups"][0]
+    assert active_group["bot"] == "gateio/gateio_01"
+    assert active_group["active"] is True
+    assert active_group["latest"]["symbol"] == "ZEC/USDT:USDT"
+    assert active_group["latest"]["derived"]["estimated_dense_pair_row_work"] == (
+        43201 * 29
+    )
+    assert active_group["latest"]["derived"]["observed_work_pct"] == pytest.approx(
+        5.108
+    )
+    assert "AKIA123" not in json.dumps(report["hsl_replay_health"], sort_keys=True)
+    assert "must-not-render" not in json.dumps(
+        report["hsl_replay_health"],
+        sort_keys=True,
+    )
+    assert summary["hsl_replay_health"]["active_bots"] == 1
+    assert summary["hsl_replay_health"]["groups"][0]["active"] is True
+    assert brief["hsl_replay"] == {
+        "total": 5,
+        "bots": 2,
+        "active_bots": 1,
+        "completed_bots": 1,
+        "failed_bots": 0,
+        "event_types": {
+            "hsl.replay.progress": 2,
+            "hsl.replay.started": 2,
+            "hsl.replay.completed": 1,
+        },
+    }
+
+
 def test_live_smoke_report_distinguishes_attention_and_hard_structured_events(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- Add read-only `hsl_replay_health` to `passivbot tool live-smoke-report`, derived from existing `hsl.replay.*` monitor events.
- Surface per-bot active/completed/failed replay state, bounded latest/started/loaded/progress/completed records, dense-work estimates, observed progress, and elapsed timing.
- Count active HSL replay as smoke attention, not a hard failure, so startup replay lag is visible without marking the bot broken.

## Behavior/Safety
- Observability-only: no live bot event producers, exchange calls, cache mutation, readiness gates, order/risk logic, or console routing changed.
- Payload is allowlisted and bounded; raw errors/secrets/unknown fields are not copied.

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_smoke_report.py -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_passivbot_cli.py::test_tool_help_lists_supported_tools tests/test_passivbot_cli.py::test_live_smoke_report_tool_dispatch_forwards_module_and_prog -q`
- `git diff --check`
- silent-handling scan on touched files: only report-code counter defaults; no trading path touched.

Motivation: the latest VPS5 restart showed smoke stayed green while HSL replay was still active and required a separate event-query to see. This makes that state visible in the standard smoke surface.