### PR TITLE
Document live event debug profiles

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -171,3 +171,21 @@ Dynamic helpers are part of the same contract:
 
 - `authoritative_reason_code(surface)` emits `authoritative_<surface>`.
 - `sink_failed_reason_code(name)` emits `<name>_sink_failed`.
+
+## Debug Profiles
+
+Set `PASSIVBOT_LIVE_EVENT_DEBUG_PROFILES` to one or more comma-separated values
+to add bounded, opt-in diagnostic details for selected live event families.
+`all` enables every profile. Empty, false-like, or `none` values disable debug
+profile enrichment.
+
+- `candles`
+- `ema`
+- `execution`
+- `fills`
+- `forager`
+- `hsl`
+- `remote_calls`
+- `rust`
+- `startup`
+- `state`

--- a/tests/test_live_event_registry_docs.py
+++ b/tests/test_live_event_registry_docs.py
@@ -1,7 +1,12 @@
 from pathlib import Path
 import re
 
-from live.event_bus import EventTags, EventTypes, ReasonCodes
+from live.event_bus import (
+    EventTags,
+    EventTypes,
+    LIVE_EVENT_DEBUG_PROFILES,
+    ReasonCodes,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -34,3 +39,7 @@ def test_live_event_tag_docs_match_registry():
 
 def test_live_event_reason_code_docs_match_registry():
     assert _documented_values("Reason Codes") == _registry_values(ReasonCodes)
+
+
+def test_live_event_debug_profile_docs_match_registry():
+    assert _documented_values("Debug Profiles") == sorted(LIVE_EVENT_DEBUG_PROFILES)


### PR DESCRIPTION
## Summary
- Document the supported `PASSIVBOT_LIVE_EVENT_DEBUG_PROFILES` values in `docs/ai/live_event_registry.md`.
- Extend the registry docs test so debug-profile docs stay synchronized with `LIVE_EVENT_DEBUG_PROFILES`.

## Safety
- Docs/test-only: no runtime code, event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, or trading behavior changed.

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_registry_docs.py -q`
- `git diff --check`
