### PR TITLE
Report startup debug profiles

### DIFF
--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -8,7 +8,7 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
-from live.event_bus import LIVE_EVENT_MONITOR_PAYLOAD_KEY
+from live.event_bus import LIVE_EVENT_DEBUG_PROFILES, LIVE_EVENT_MONITOR_PAYLOAD_KEY
 from live.event_query import discover_event_files
 from live.smoke_report import _user_safe_display_path
 
@@ -846,9 +846,40 @@ def _startup_elapsed_ms(data: dict[str, Any]) -> int | None:
     return _elapsed_s_to_ms(data.get("elapsed_s"))
 
 
+_LIVE_EVENT_DEBUG_PROFILE_SET = set(LIVE_EVENT_DEBUG_PROFILES)
+
+
+def _known_debug_profiles(value: Any) -> list[str]:
+    if isinstance(value, str):
+        raw_values: list[Any] = [
+            part for part in value.replace(";", ",").replace(" ", ",").split(",") if part
+        ]
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        raw_values = list(value)
+    else:
+        return []
+    profiles = {
+        str(item).strip()
+        for item in raw_values
+        if str(item).strip() in _LIVE_EVENT_DEBUG_PROFILE_SET
+    }
+    return sorted(profiles)
+
+
 class _StartupReadinessAccumulator:
     def __init__(self) -> None:
         self.bots: dict[str, dict[str, Any]] = {}
+
+    @staticmethod
+    def _update_debug_profiles(state: dict[str, Any], data: dict[str, Any]) -> None:
+        profiles = _known_debug_profiles(data.get("live_event_debug_profiles"))
+        if not profiles:
+            return
+        existing = state.get("debug_profiles")
+        if not isinstance(existing, set):
+            existing = set()
+            state["debug_profiles"] = existing
+        existing.update(profiles)
 
     def _bot_state(self, *, row: dict[str, Any], live_event: dict[str, Any]) -> dict[str, Any]:
         bot = _bot_key(row, live_event)
@@ -885,12 +916,14 @@ class _StartupReadinessAccumulator:
             if ts is not None:
                 state["bot_started_ts"] = int(ts)
             state["lifecycle_status"] = "started"
+            self._update_debug_profiles(state, data)
             return
         if event_type == "bot.ready":
             state = self._bot_state(row=row, live_event=live_event)
             if ts is not None:
                 state["bot_ready_ts"] = int(ts)
             state["lifecycle_status"] = "ready"
+            self._update_debug_profiles(state, data)
             return
         if event_type == "bot.startup_timing":
             state = self._bot_state(row=row, live_event=live_event)
@@ -933,6 +966,7 @@ class _StartupReadinessAccumulator:
         bot_items = []
         ready_count = 0
         hsl_active_count = 0
+        debug_profile_counts: Counter[str] = Counter()
         limit = max(0, int(group_limit))
         for bot, state in sorted(self.bots.items()):
             phases = dict(sorted(state.get("startup_phases_ms", {}).items()))
@@ -958,11 +992,16 @@ class _StartupReadinessAccumulator:
                 item["hsl_replay"] = hsl_state
                 if hsl_state.get("status") not in ("succeeded", "failed"):
                     hsl_active_count += 1
+            debug_profiles = sorted(state.get("debug_profiles") or [])
+            if debug_profiles:
+                item["debug_profiles"] = debug_profiles
+                debug_profile_counts.update(debug_profiles)
             bot_items.append({key: value for key, value in item.items() if value not in (None, {})})
         return {
             "bot_count": len(bot_items),
             "ready_count": int(ready_count),
             "hsl_replay_active_count": int(hsl_active_count),
+            "debug_profile_counts": dict(sorted(debug_profile_counts.items())),
             "bots_truncated": len(bot_items) > limit,
             "bots": bot_items[:limit],
         }

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -871,7 +871,18 @@ def test_live_performance_report_startup_readiness_summary(tmp_path):
     _write_ndjson(
         events_dir / "current.ndjson",
         [
-            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="bot.started",
+                seq=1,
+                ts=1000,
+                data={
+                    "live_event_debug_profiles": [
+                        "rust",
+                        "ema",
+                        "api_key=should_not_render",
+                    ]
+                },
+            ),
             _monitor_row(
                 event_type="bot.startup_timing",
                 seq=2,
@@ -921,6 +932,9 @@ def test_live_performance_report_startup_readiness_summary(tmp_path):
     assert bot["lifecycle_status"] == "ready"
     assert bot["bot_started_ts"] == 1000
     assert bot["bot_ready_ts"] == 5000
+    assert bot["debug_profiles"] == ["ema", "rust"]
+    assert startup["debug_profile_counts"] == {"ema": 1, "rust": 1}
+    assert "api_key=should_not_render" not in json.dumps(startup, sort_keys=True)
     assert bot["startup_phases_ms"] == {"account": 900, "hsl": 2500}
     assert bot["hsl_replay"]["stage"] == "pair_replay"
     assert bot["hsl_replay"]["pairs"] == 26
@@ -982,7 +996,12 @@ def test_live_performance_report_startup_readiness_resets_on_restart(tmp_path):
                 data={"stage": "full_replay", "pairs": 2, "full_elapsed_s": 1.5},
             ),
             _monitor_row(event_type="bot.ready", seq=4, ts=1300),
-            _monitor_row(event_type="bot.started", seq=5, ts=2000),
+            _monitor_row(
+                event_type="bot.started",
+                seq=5,
+                ts=2000,
+                data={"live_event_debug_profiles": ["state"]},
+            ),
         ],
     )
 
@@ -994,6 +1013,8 @@ def test_live_performance_report_startup_readiness_resets_on_restart(tmp_path):
     bot = startup["bots"][0]
     assert bot["lifecycle_status"] == "started"
     assert bot["bot_started_ts"] == 2000
+    assert bot["debug_profiles"] == ["state"]
+    assert startup["debug_profile_counts"] == {"state": 1}
     assert "bot_ready_ts" not in bot
     assert "startup_phases_ms" not in bot
     assert "hsl_replay" not in bot


### PR DESCRIPTION
## Summary
- Add `debug_profiles` and `debug_profile_counts` to the read-only `startup_readiness` section of `passivbot tool live-performance-report`.
- Derive values only from existing `bot.started` / `bot.ready` event data.
- Filter surfaced values through `LIVE_EVENT_DEBUG_PROFILES` so arbitrary event-data strings are ignored.

## Safety
- Report-only: no event producers, exchange calls, cache mutation, readiness gates, order/risk logic, console routing, monitor writes, or trading behavior changed.

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/performance_report.py tests/test_live_performance_report.py`
- `git diff --check`
- silent-handling scan on touched files: only existing report-code defaults/sort helpers; no trading path touched.
