### PR TITLE
Report execution terminal outcomes

### DIFF
--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -2112,6 +2112,20 @@ class _ExecutionTimingAccumulator:
         self.starts_seen: Counter[str] = Counter()
         self.terminals_seen: Counter[str] = Counter()
         self.timing_observations: Counter[str] = Counter()
+        self.terminal_outcome_counts: Counter[str] = Counter()
+
+    def _record_terminal_outcome(self, event_type: str) -> None:
+        if event_type in _EXECUTION_CREATE_TERMINALS:
+            outcome = event_type.removeprefix("execution.create_")
+            self.terminal_outcome_counts[f"create.{outcome}"] += 1
+            return
+        if event_type in _EXECUTION_CANCEL_TERMINALS:
+            outcome = event_type.removeprefix("execution.cancel_")
+            self.terminal_outcome_counts[f"cancel.{outcome}"] += 1
+            return
+        if event_type in _EXECUTION_CONFIRMATION_TERMINALS:
+            outcome = event_type.removeprefix("execution.confirmation_")
+            self.terminal_outcome_counts[f"confirmation.{outcome}"] += 1
 
     def _add_timing(
         self,
@@ -2222,6 +2236,7 @@ class _ExecutionTimingAccumulator:
             return
 
         if event_type in _EXECUTION_CREATE_TERMINALS | _EXECUTION_CANCEL_TERMINALS:
+            self._record_terminal_outcome(event_type)
             operation = (
                 "execution.create_response"
                 if event_type in _EXECUTION_CREATE_TERMINALS
@@ -2251,6 +2266,7 @@ class _ExecutionTimingAccumulator:
             return
 
         if event_type in _EXECUTION_CONFIRMATION_TERMINALS:
+            self._record_terminal_outcome(event_type)
             operation = "execution.confirmation"
             self.terminals_seen[operation] += 1
             order_wave_id = _event_id_value(live_event, "order_wave_id")
@@ -2296,6 +2312,7 @@ class _ExecutionTimingAccumulator:
             "starts_seen": dict(sorted(self.starts_seen.items())),
             "terminals_seen": dict(sorted(self.terminals_seen.items())),
             "timing_observations": dict(sorted(self.timing_observations.items())),
+            "terminal_outcome_counts": dict(sorted(self.terminal_outcome_counts.items())),
             "missing_id_counts": dict(sorted(self.missing_id_counts.items())),
             "unpaired_terminal_counts": dict(sorted(self.unpaired_terminal_counts.items())),
             "pending_start_counts": dict(sorted(pending_starts.items())),

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1798,6 +1798,11 @@ def test_live_performance_report_execution_timing_pairs_order_events(tmp_path):
         "execution.create_response": 1,
         "order_wave.total": 1,
     }
+    assert execution["terminal_outcome_counts"] == {
+        "cancel.ambiguous_terminal": 1,
+        "confirmation.satisfied": 1,
+        "create.succeeded": 1,
+    }
     assert execution["pending_start_counts"] == {}
     assert groups["execution.create_response"]["max_ms"] == 350
     assert groups["execution.cancel_response"]["max_ms"] == 600
@@ -1844,6 +1849,7 @@ def test_live_performance_report_execution_timing_counts_missing_and_unpaired_id
     execution = report["execution_timing"]
 
     assert execution["total_events"] == 3
+    assert execution["terminal_outcome_counts"] == {"create.failed": 1}
     assert execution["missing_id_counts"] == {"execution.create_response": 1}
     assert execution["unpaired_terminal_counts"] == {"execution.create_response": 1}
     assert execution["pending_start_counts"] == {"execution.write_response": 1}


### PR DESCRIPTION
## Summary
- Add `terminal_outcome_counts` to the read-only `execution_timing` section of `passivbot tool live-performance-report`.
- Derive fixed create/cancel/confirmation terminal outcome counters from existing execution events.
- Keep values bounded by the fixed event-type registry; no raw order/exchange payloads are copied.

## Safety
- Report-only: no event producers, exchange calls, cache mutation, readiness gates, order/risk logic, console routing, monitor writes, or trading behavior changed.

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/performance_report.py tests/test_live_performance_report.py`
- `git diff --check`
- Silent-handling scan on touched files: only existing report aggregation defaults/sort helpers; no trading path touched.