### PR TITLE
Add CLI version flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added root-level `passivbot -V` and `passivbot --version` output.
 - Added `hsl_replay_health` summaries to
   `passivbot tool live-smoke-report`, so smoke reports show active,
   completed, and failed HSL startup replay state from existing

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from cli_utils import help_requested
+from passivbot_version import __version__
 
 
 @dataclass(frozen=True)
@@ -246,6 +247,7 @@ FULL_INSTALL_MODULE_HINTS = {
 FULL_INSTALL_MARKER_MODULES = tuple(sorted(FULL_INSTALL_MODULE_HINTS | {"websockets"}))
 ENV_MISMATCH_IGNORE_ENV = "PASSIVBOT_IGNORE_ENV_MISMATCH"
 ENV_REEXEC_GUARD_ENV = "PASSIVBOT_ENV_REEXEC"
+VERSION_FLAGS = {"-V", "--version"}
 
 
 def _build_root_parser() -> argparse.ArgumentParser:
@@ -487,6 +489,11 @@ def main(argv: list[str] | None = None) -> int:
     parser = _build_root_parser()
     if not argv or argv[0] in {"-h", "--help"}:
         parser.print_help()
+        return 0
+    if argv[0] in VERSION_FLAGS:
+        if len(argv) > 1:
+            parser.exit(2, f"passivbot: {argv[0]} does not accept arguments\n")
+        print(f"passivbot {__version__}")
         return 0
 
     if argv[0] == "help":

--- a/tests/test_passivbot_cli.py
+++ b/tests/test_passivbot_cli.py
@@ -9,6 +9,7 @@ import pytest
 from passivbot_cli import main as cli_main
 from cli_utils import expand_help_all_argv, help_requested
 import ohlcv_download
+from passivbot_version import __version__
 
 
 def test_root_help_lists_primary_commands(capsys):
@@ -21,6 +22,15 @@ def test_root_help_lists_primary_commands(capsys):
     assert "download" in out
     assert "tool" in out
     assert 'python3 -m pip install -e ".[full]"' in out
+
+
+@pytest.mark.parametrize("flag", ["-V", "--version"])
+def test_root_version_flags_print_package_version(flag, capsys):
+    assert cli_main.main([flag]) == 0
+
+    captured = capsys.readouterr()
+    assert captured.out == f"passivbot {__version__}\n"
+    assert captured.err == ""
 
 
 def test_dispatch_core_command_forwards_module_and_prog(monkeypatch):


### PR DESCRIPTION
## Summary
- add root-level passivbot -V and passivbot --version handling
- print the package version from passivbot_version.__version__
- cover both flags in CLI regression tests

## Tests
- ./venv/bin/python -m pytest tests/test_passivbot_cli.py tests/test_passivbot_version.py
- ./venv/bin/passivbot -V
- ./venv/bin/passivbot --version