### PR TITLE
Report risk event activity

### DIFF
--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -118,6 +118,16 @@ _ACCOUNT_STATE_CHANGE_EVENT_TYPES = {
     "position.changed",
     "balance.changed",
 }
+_RISK_ACTIVITY_EVENT_TYPES = {
+    "risk.mode_changed",
+    "hsl.transition",
+    "hsl.status",
+    "hsl.red_triggered",
+    "hsl.cooldown_started",
+    "hsl.cooldown_ended",
+    "unstuck.status",
+    "unstuck.selection",
+}
 _CACHE_STRING_FIELDS = (
     "context",
     "timeframe",
@@ -2449,6 +2459,123 @@ class _AccountStateChangeAccumulator:
         }
 
 
+class _RiskActivityGroup:
+    def __init__(self, *, bot: str, event_type: str) -> None:
+        self.bot = bot
+        self.event_type = event_type
+        self.count = 0
+        self.statuses: Counter[str] = Counter()
+        self.reason_codes: Counter[str] = Counter()
+        self.symbols: Counter[str] = Counter()
+        self.psides: Counter[str] = Counter()
+        self.components: Counter[str] = Counter()
+        self.latest_ts: int | None = None
+
+    def add(self, *, row: dict[str, Any], live_event: dict[str, Any]) -> None:
+        self.count += 1
+        status = live_event.get("status")
+        if status is not None:
+            self.statuses[str(status)] += 1
+        reason_code = live_event.get("reason_code")
+        if reason_code is not None:
+            self.reason_codes[str(reason_code)] += 1
+        symbol = live_event.get("symbol") or row.get("symbol")
+        if symbol is not None:
+            self.symbols[str(symbol)] += 1
+        pside = live_event.get("pside") or row.get("pside")
+        if pside is not None:
+            self.psides[str(pside)] += 1
+        component = live_event.get("component")
+        if component is not None:
+            self.components[str(component)] += 1
+        ts = _record_ts(row)
+        if ts is not None and (self.latest_ts is None or ts > self.latest_ts):
+            self.latest_ts = ts
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in {
+                "bot": self.bot,
+                "event_type": self.event_type,
+                "count": int(self.count),
+                "latest_ts": self.latest_ts,
+                "statuses": dict(sorted(self.statuses.items())),
+                "reason_codes": dict(sorted(self.reason_codes.items())),
+                "psides": dict(sorted(self.psides.items())),
+                "components": dict(sorted(self.components.items())),
+                "symbols_sample": [
+                    symbol
+                    for symbol, _count in sorted(
+                        self.symbols.items(), key=lambda item: (-item[1], item[0])
+                    )[:10]
+                ],
+                "symbols_count": len(self.symbols),
+            }.items()
+            if value not in (None, {}, [])
+        }
+
+
+class _RiskActivityAccumulator:
+    def __init__(self) -> None:
+        self.groups: dict[tuple[str, str], _RiskActivityGroup] = {}
+        self.event_types: Counter[str] = Counter()
+        self.statuses: Counter[str] = Counter()
+        self.reason_codes: Counter[str] = Counter()
+        self.bot_counts: Counter[str] = Counter()
+
+    def add(self, *, row: dict[str, Any], live_event: dict[str, Any]) -> None:
+        event_type = str(live_event.get("event_type") or row.get("kind") or "")
+        if event_type not in _RISK_ACTIVITY_EVENT_TYPES:
+            return
+        bot = _bot_key(row, live_event)
+        self.event_types[event_type] += 1
+        self.bot_counts[bot] += 1
+        status = live_event.get("status")
+        if status is not None:
+            self.statuses[str(status)] += 1
+        reason_code = live_event.get("reason_code")
+        if reason_code is not None:
+            self.reason_codes[str(reason_code)] += 1
+        key = (bot, event_type)
+        group = self.groups.get(key)
+        if group is None:
+            group = _RiskActivityGroup(bot=bot, event_type=event_type)
+            self.groups[key] = group
+        group.add(row=row, live_event=live_event)
+
+    def groups_list(self) -> list[dict[str, Any]]:
+        return sorted(
+            (group.to_dict() for group in self.groups.values()),
+            key=lambda item: (
+                -int(item.get("count", 0) or 0),
+                -int(item.get("latest_ts", 0) or 0),
+                str(item.get("bot") or ""),
+                str(item.get("event_type") or ""),
+            ),
+        )
+
+    def to_dict(self, *, group_limit: int = GROUP_LIMIT) -> dict[str, Any]:
+        groups = self.groups_list()
+        return {
+            "total_events": sum(self.event_types.values()),
+            "event_types": dict(sorted(self.event_types.items())),
+            "statuses": dict(sorted(self.statuses.items())),
+            "reason_codes": dict(sorted(self.reason_codes.items())),
+            "bot_count": len(self.bot_counts),
+            "bots": [
+                {"bot": bot, "events": int(count)}
+                for bot, count in sorted(
+                    self.bot_counts.items(), key=lambda item: (-item[1], item[0])
+                )[: max(0, int(group_limit))]
+            ],
+            "bots_truncated": len(self.bot_counts) > int(group_limit),
+            "total_groups": len(groups),
+            "groups_truncated": len(groups) > int(group_limit),
+            "groups": groups[: max(0, int(group_limit))],
+        }
+
+
 def _slowest_blockers(
     *,
     performance_groups: list[dict[str, Any]],
@@ -2876,6 +3003,7 @@ def build_live_performance_report(
     shutdown_latency = _ShutdownLatencyAccumulator()
     execution_timing = _ExecutionTimingAccumulator()
     account_state_changes = _AccountStateChangeAccumulator()
+    risk_activity = _RiskActivityAccumulator()
     cycle_scope_tracker = _CycleScopeTracker()
     records_total = 0
     live_events = 0
@@ -2971,6 +3099,7 @@ def build_live_performance_report(
                         cycle_scope=cycle_scope,
                     )
                     account_state_changes.add(row=row, live_event=live_event)
+                    risk_activity.add(row=row, live_event=live_event)
         except OSError as exc:
             issues.append(
                 {
@@ -3017,6 +3146,7 @@ def build_live_performance_report(
         "shutdown_latency": shutdown_latency.to_dict(group_limit=group_limit),
         "execution_timing": execution_timing.to_dict(group_limit=group_limit),
         "account_state_changes": account_state_changes.to_dict(group_limit=group_limit),
+        "risk_activity": risk_activity.to_dict(group_limit=group_limit),
         "operation_durations": _operation_duration_table(
             performance_groups=performance_groups,
             decision_boundary_groups=decision_boundary_groups,
@@ -3209,6 +3339,25 @@ def summarize_live_performance_report(
         if len(state_bots) > max(0, int(group_limit)):
             account_state_changes["bots_truncated"] = True
         summary["account_state_changes"] = account_state_changes
+    if isinstance(report.get("risk_activity"), dict):
+        risk_activity = dict(report["risk_activity"])
+        risk_groups = (
+            risk_activity.get("groups")
+            if isinstance(risk_activity.get("groups"), list)
+            else []
+        )
+        risk_bots = (
+            risk_activity.get("bots")
+            if isinstance(risk_activity.get("bots"), list)
+            else []
+        )
+        risk_activity["groups"] = risk_groups[: max(0, int(group_limit))]
+        risk_activity["bots"] = risk_bots[: max(0, int(group_limit))]
+        if len(risk_groups) > max(0, int(group_limit)):
+            risk_activity["groups_truncated"] = True
+        if len(risk_bots) > max(0, int(group_limit)):
+            risk_activity["bots_truncated"] = True
+        summary["risk_activity"] = risk_activity
     if isinstance(report.get("slowest_blockers"), dict):
         slowest_blockers = report["slowest_blockers"]
         blocker_groups = (

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -2009,6 +2009,145 @@ def test_live_performance_report_account_state_changes_summary_is_bounded(tmp_pa
     assert summary["account_state_changes"]["bots_truncated"] is True
 
 
+def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.status",
+                seq=1,
+                ts=1000,
+                component="risk.hsl.status",
+                status="degraded",
+                reason_code="cooldown_active",
+                symbol="BTC/USDT:USDT",
+                pside="long",
+                data={
+                    "tier": "red",
+                    "drawdown_score": 0.1234,
+                    "strategy_equity": 98765.43,
+                    "unrealized_pnl": -12.34,
+                    "secret_marker": "hsl-secret",
+                },
+            ),
+            _monitor_row(
+                event_type="hsl.red_triggered",
+                seq=2,
+                ts=2000,
+                component="risk.hsl",
+                status="degraded",
+                reason_code="red_threshold_crossed",
+                symbol="BTC/USDT:USDT",
+                pside="long",
+                data={
+                    "balance": 12345.67,
+                    "peak_strategy_equity": 45678.9,
+                    "raw_payload": {"secret_marker": "red-secret"},
+                },
+            ),
+            _monitor_row(
+                event_type="risk.mode_changed",
+                seq=3,
+                ts=3000,
+                component="risk.hsl.mode",
+                reason_code="hsl_halted",
+                pside="long",
+                data={
+                    "mode": "halted",
+                    "symbols": ["BTC/USDT:USDT"],
+                    "secret_marker": "mode-secret",
+                },
+            ),
+            _monitor_row(
+                event_type="unstuck.selection",
+                seq=4,
+                ts=4000,
+                component="risk.unstuck.selection",
+                reason_code="unstuck_selection",
+                symbol="ETH/USDT:USDT",
+                pside="short",
+                data={
+                    "entry_price": 1111.22,
+                    "current_price": 999.88,
+                    "allowance": -0.123,
+                    "secret_marker": "unstuck-secret",
+                },
+            ),
+            _monitor_row(
+                event_type="hsl.replay.progress",
+                seq=5,
+                ts=5000,
+                component="risk.hsl.replay",
+                reason_code="replay_progress",
+                symbol="XRP/USDT:USDT",
+                pside="long",
+                data={"rows": 100, "secret_marker": "replay-secret"},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    risk = report["risk_activity"]
+    groups = {
+        group["event_type"]: group
+        for group in risk["groups"]
+    }
+    rendered = json.dumps(risk, sort_keys=True)
+
+    assert risk["total_events"] == 4
+    assert risk["event_types"] == {
+        "hsl.red_triggered": 1,
+        "hsl.status": 1,
+        "risk.mode_changed": 1,
+        "unstuck.selection": 1,
+    }
+    assert "hsl.replay.progress" not in risk["event_types"]
+    assert groups["hsl.status"]["statuses"] == {"degraded": 1}
+    assert groups["hsl.status"]["reason_codes"] == {"cooldown_active": 1}
+    assert groups["hsl.status"]["symbols_sample"] == ["BTC/USDT:USDT"]
+    assert groups["hsl.status"]["psides"] == {"long": 1}
+    assert groups["unstuck.selection"]["symbols_sample"] == ["ETH/USDT:USDT"]
+    assert "98765.43" not in rendered
+    assert "45678.9" not in rendered
+    assert "1111.22" not in rendered
+    assert "hsl-secret" not in rendered
+    assert "red-secret" not in rendered
+    assert "mode-secret" not in rendered
+    assert "unstuck-secret" not in rendered
+    assert "replay-secret" not in rendered
+
+
+def test_live_performance_report_risk_activity_summary_is_bounded(tmp_path):
+    for index in range(2):
+        events_dir = tmp_path / "monitor" / "binance" / f"user_{index}" / "events"
+        _write_ndjson(
+            events_dir / "current.ndjson",
+            [
+                _monitor_row(
+                    event_type="hsl.status",
+                    seq=index + 1,
+                    ts=1000 + index,
+                    user=f"user_{index}",
+                    component="risk.hsl.status",
+                    status="degraded",
+                    reason_code="cooldown_active",
+                    symbol=f"COIN{index}/USDT:USDT",
+                    pside="long",
+                ),
+            ],
+        )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    summary = summarize_live_performance_report(report, group_limit=1)
+
+    assert report["risk_activity"]["bot_count"] == 2
+    assert len(summary["risk_activity"]["groups"]) == 1
+    assert len(summary["risk_activity"]["bots"]) == 1
+    assert summary["risk_activity"]["groups_truncated"] is True
+    assert summary["risk_activity"]["bots_truncated"] is True
+
+
 def test_live_performance_report_resource_pressure_from_health_summary(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- Add a `risk_activity` section to the read-only `passivbot tool live-performance-report` output.
- Summarize existing `risk.mode_changed`, `hsl.status`, `hsl.transition`, `hsl.red_triggered`, `hsl.cooldown_started`, `hsl.cooldown_ended`, `unstuck.status`, and `unstuck.selection` events by bot/event type.
- Include bounded status, reason, symbol, pside, and component counters in full and `--summary` output.

## Safety
- Report-only: no event producers, exchange calls, cache mutation, readiness gates, order/risk logic, console routing, monitor writes, or trading behavior changed.
- Value-safe: the new section ignores event data payloads and does not surface HSL drawdown/equity/PnL values, balances, prices, allowances, raw payloads, ids, or other financial metrics.
- HSL replay events remain handled by the existing dedicated `hsl_replay_profile`; this slice excludes `hsl.replay.*` from `risk_activity`.

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/performance_report.py tests/test_live_performance_report.py`
- `git diff --check`
- Silent-handling scan on touched files: only existing report aggregation defaults/sort helpers; no trading path touched.