### PR TITLE
Emit realized loss gate block events

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -70,6 +70,7 @@ across time.
 - `remote_call.succeeded`
 - `remote_call.throttled`
 - `risk.mode_changed`
+- `risk.realized_loss_gate_blocked`
 - `rust_orchestrator.called`
 - `rust_orchestrator.returned`
 - `sink.degraded`
@@ -153,6 +154,7 @@ across time.
 - `ranking_features_unavailable`
 - `recent_execution`
 - `remote_fetch`
+- `realized_loss_gate_blocked`
 - `required_candle_disk_coverage`
 - `required_ema_unavailable`
 - `rust_output_actions`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -120,6 +120,7 @@ class EventTypes:
     HSL_COOLDOWN_ENDED = "hsl.cooldown_ended"
     UNSTUCK_STATUS = "unstuck.status"
     UNSTUCK_SELECTION = "unstuck.selection"
+    REALIZED_LOSS_GATE_BLOCKED = "risk.realized_loss_gate_blocked"
     SINK_DEGRADED = "sink.degraded"
 
 
@@ -206,6 +207,7 @@ class ReasonCodes:
     STAGED_REFRESH_TIMING = "staged_refresh_timing"
     STATE_CHANGE_DETECTED = "state_change_detected"
     SUBMITTED_TO_EXCHANGE = "submitted_to_exchange"
+    REALIZED_LOSS_GATE_BLOCKED = "realized_loss_gate_blocked"
     UNSTUCK_SELECTION = "unstuck_selection"
     UNSTUCK_STATUS = "unstuck_status"
     WARMUP_CACHE_DECISION = "warmup_cache_decision"
@@ -342,6 +344,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.HSL_COOLDOWN_ENDED,
     EventTypes.UNSTUCK_STATUS,
     EventTypes.UNSTUCK_SELECTION,
+    EventTypes.REALIZED_LOSS_GATE_BLOCKED,
     EventTypes.SINK_DEGRADED,
 }
 
@@ -635,6 +638,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.HSL_COOLDOWN_ENDED: EventRoute(console=False, text=False),
     EventTypes.UNSTUCK_STATUS: EventRoute(console=False, text=False),
     EventTypes.UNSTUCK_SELECTION: EventRoute(console=False, text=False),
+    EventTypes.REALIZED_LOSS_GATE_BLOCKED: EventRoute(console=False, text=False),
     EventTypes.SINK_DEGRADED: EventRoute(console=True, text=True),
 }
 

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -2989,6 +2989,49 @@ def emit_risk_mode_changed_event(
         )
 
 
+def emit_realized_loss_gate_blocked_event(
+    bot: Any,
+    *,
+    symbol: str,
+    pside: str,
+    order_type: str,
+    qty: float,
+    price: float,
+    projected_pnl: float,
+    projected_balance: float,
+    balance_floor: float,
+    max_realized_loss_pct: float,
+) -> None:
+    try:
+        bot._emit_live_event(
+            EventTypes.REALIZED_LOSS_GATE_BLOCKED,
+            level="warning",
+            component="risk.realized_loss_gate",
+            tags=(EventTags.RISK, EventTags.ORDER, EventTags.GATE),
+            cycle_id=bot._current_live_event_cycle_id(),
+            symbol=str(symbol),
+            pside=str(pside),
+            status="deferred",
+            reason_code=ReasonCodes.REALIZED_LOSS_GATE_BLOCKED,
+            data={
+                "order_type": str(order_type),
+                "qty": _safe_float(qty),
+                "price": _safe_float(price),
+                "projected_pnl": _safe_float(projected_pnl),
+                "projected_balance_after": _safe_float(projected_balance),
+                "balance_floor": _safe_float(balance_floor),
+                "max_realized_loss_pct": _safe_float(max_realized_loss_pct),
+            },
+        )
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit realized loss gate event pside=%s symbol=%s: %s",
+            pside,
+            symbol,
+            exc,
+        )
+
+
 def _unstuck_status_side_summary(
     info: dict[str, Any],
     *,

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -120,6 +120,7 @@ _ACCOUNT_STATE_CHANGE_EVENT_TYPES = {
 }
 _RISK_ACTIVITY_EVENT_TYPES = {
     "risk.mode_changed",
+    "risk.realized_loss_gate_blocked",
     "hsl.transition",
     "hsl.status",
     "hsl.red_triggered",

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -633,6 +633,9 @@ class Passivbot:
     )
     _emit_fill_ingested_event = live_event_emitters.emit_fill_ingested_event
     _emit_risk_mode_changed_event = live_event_emitters.emit_risk_mode_changed_event
+    _emit_realized_loss_gate_blocked_event = (
+        live_event_emitters.emit_realized_loss_gate_blocked_event
+    )
     _emit_unstuck_status_event = live_event_emitters.emit_unstuck_status_event
     _emit_unstuck_selection_event = live_event_emitters.emit_unstuck_selection_event
     _emit_forager_feature_unavailable_event = (
@@ -11134,6 +11137,17 @@ class Passivbot:
                 projected_balance,
                 balance_floor,
                 max_loss_pct,
+            )
+            self._emit_realized_loss_gate_blocked_event(
+                symbol=symbol,
+                pside=pside,
+                order_type=order_type,
+                qty=qty,
+                price=price,
+                projected_pnl=projected_pnl,
+                projected_balance=projected_balance,
+                balance_floor=balance_floor,
+                max_realized_loss_pct=max_loss_pct,
             )
 
     def _log_min_effective_cost_blocks(

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -229,6 +229,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.HSL_COOLDOWN_ENDED,
         EventTypes.UNSTUCK_STATUS,
         EventTypes.UNSTUCK_SELECTION,
+        EventTypes.REALIZED_LOSS_GATE_BLOCKED,
     ):
         assert DEFAULT_ROUTES[event_type].structured is True
         assert DEFAULT_ROUTES[event_type].monitor is True

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -2075,8 +2075,25 @@ def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
                 },
             ),
             _monitor_row(
-                event_type="hsl.replay.progress",
+                event_type="risk.realized_loss_gate_blocked",
                 seq=5,
+                ts=4500,
+                component="risk.realized_loss_gate",
+                status="deferred",
+                reason_code="realized_loss_gate_blocked",
+                symbol="SOL/USDT:USDT",
+                pside="long",
+                data={
+                    "order_type": "close_auto_reduce_wel_long",
+                    "projected_pnl": -200.0,
+                    "projected_balance_after": 9800.0,
+                    "balance_floor": 9900.0,
+                    "secret_marker": "loss-gate-secret",
+                },
+            ),
+            _monitor_row(
+                event_type="hsl.replay.progress",
+                seq=6,
                 ts=5000,
                 component="risk.hsl.replay",
                 reason_code="replay_progress",
@@ -2095,11 +2112,12 @@ def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
     }
     rendered = json.dumps(risk, sort_keys=True)
 
-    assert risk["total_events"] == 4
+    assert risk["total_events"] == 5
     assert risk["event_types"] == {
         "hsl.red_triggered": 1,
         "hsl.status": 1,
         "risk.mode_changed": 1,
+        "risk.realized_loss_gate_blocked": 1,
         "unstuck.selection": 1,
     }
     assert "hsl.replay.progress" not in risk["event_types"]
@@ -2108,6 +2126,8 @@ def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
     assert groups["hsl.status"]["symbols_sample"] == ["BTC/USDT:USDT"]
     assert groups["hsl.status"]["psides"] == {"long": 1}
     assert groups["unstuck.selection"]["symbols_sample"] == ["ETH/USDT:USDT"]
+    assert groups["risk.realized_loss_gate_blocked"]["symbols_sample"] == ["SOL/USDT:USDT"]
+    assert groups["risk.realized_loss_gate_blocked"]["statuses"] == {"deferred": 1}
     assert "98765.43" not in rendered
     assert "45678.9" not in rendered
     assert "1111.22" not in rendered
@@ -2115,6 +2135,8 @@ def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
     assert "red-secret" not in rendered
     assert "mode-secret" not in rendered
     assert "unstuck-secret" not in rendered
+    assert "loss-gate-secret" not in rendered
+    assert "9800" not in rendered
     assert "replay-secret" not in rendered
 
 

--- a/tests/test_realized_loss_gate.py
+++ b/tests/test_realized_loss_gate.py
@@ -10,6 +10,7 @@ import pytest
 
 from passivbot import Passivbot
 from backtest import prep_backtest_args
+from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -420,6 +421,58 @@ class TestLogRealizedLossGateBlocks:
         assert "[risk] order blocked by realized-loss gate" in caplog.text
         assert " BTC long " in caplog.text
         assert "close_auto_reduce_wel_long" in caplog.text
+
+    def test_block_emits_structured_event(self, caplog):
+        bot = _make_bot_for_logging()
+        sink = ListEventSink()
+        bot.bot_id = "bot_loss_gate"
+        bot.exchange = "binance"
+        bot.user = "binance_01"
+        bot._live_event_current_cycle_id = "cy_loss_gate"
+        bot._live_event_pipeline = LiveEventPipeline(
+            structured_sinks=[sink],
+            monitor_sinks=[],
+        )
+        block = {
+            "symbol_idx": 0,
+            "pside": "long",
+            "order_type": "close_auto_reduce_wel_long",
+            "qty": -1.5,
+            "price": 80.0,
+            "projected_pnl": -200.0,
+            "projected_balance_after": 9800.0,
+            "balance_floor": 9900.0,
+            "max_realized_loss_pct": 0.01,
+        }
+        try:
+            with caplog.at_level(logging.WARNING):
+                bot._log_realized_loss_gate_blocks(
+                    {"diagnostics": {"loss_gate_blocks": [block]}},
+                    {0: "BTCUSDT"},
+                )
+            assert bot._live_event_pipeline.flush(timeout=2.0) is True
+        finally:
+            assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+        assert "[risk] order blocked by realized-loss gate" in caplog.text
+        events = [
+            event
+            for event in sink.events
+            if event.event_type == EventTypes.REALIZED_LOSS_GATE_BLOCKED
+        ]
+        assert len(events) == 1
+        event = events[0]
+        assert event.level == "warning"
+        assert event.status == "deferred"
+        assert event.reason_code == "realized_loss_gate_blocked"
+        assert event.cycle_id == "cy_loss_gate"
+        assert event.symbol == "BTCUSDT"
+        assert event.pside == "long"
+        assert event.data["order_type"] == "close_auto_reduce_wel_long"
+        assert event.data["projected_pnl"] == pytest.approx(-200.0)
+        assert event.data["projected_balance_after"] == pytest.approx(9800.0)
+        assert event.data["balance_floor"] == pytest.approx(9900.0)
+        assert event.data["max_realized_loss_pct"] == pytest.approx(0.01)
 
     def test_unknown_symbol_idx_logs_unknown(self, caplog):
         bot = _make_bot_for_logging()


### PR DESCRIPTION
Adds a structured risk.realized_loss_gate_blocked event next to the existing throttled realized-loss gate warning. No trading decision changes; emission is best-effort and routed off console/text by default. The read-only live-performance-report risk_activity summary includes the new event type using envelope labels only.\n\nValidation:\n- pytest tests/test_realized_loss_gate.py -q -> 36 passed\n- pytest tests/test_live_performance_report.py -q -> 46 passed\n- pytest tests/test_live_event_bus.py -q -> 33 passed\n- py_compile touched Python files\n- git diff --check\n\nNote: initial pytest collection hit the local stale Rust-extension guard; rebuilt/restamped the extension, then tests passed in fresh Python processes.