### PR TITLE
Emit min effective cost block events

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -46,6 +46,7 @@ across time.
 - `execution.create_sent`
 - `execution.create_skipped`
 - `execution.create_succeeded`
+- `entry.min_effective_cost_blocked`
 - `fill.ingested`
 - `fills.refresh_summary`
 - `forager.feature_unavailable`
@@ -145,6 +146,7 @@ across time.
 - `fill_cache_ready`
 - `length_mismatch`
 - `low_balance`
+- `min_effective_cost_blocked`
 - `new_fill`
 - `open_tail_projection`
 - `optional_ema_dropped`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -97,6 +97,7 @@ class EventTypes:
     EXECUTION_CREATE_REJECTED = "execution.create_rejected"
     EXECUTION_CREATE_DEFERRED = "execution.create_deferred"
     EXECUTION_CREATE_SKIPPED = "execution.create_skipped"
+    ENTRY_MIN_EFFECTIVE_COST_BLOCKED = "entry.min_effective_cost_blocked"
     EXECUTION_CANCEL_SENT = "execution.cancel_sent"
     EXECUTION_CANCEL_SUCCEEDED = "execution.cancel_succeeded"
     EXECUTION_CANCEL_FAILED = "execution.cancel_failed"
@@ -188,6 +189,7 @@ class ReasonCodes:
     FILL_CACHE_READY = "fill_cache_ready"
     LENGTH_MISMATCH = "length_mismatch"
     LOW_BALANCE = "low_balance"
+    MIN_EFFECTIVE_COST_BLOCKED = "min_effective_cost_blocked"
     NEW_FILL = "new_fill"
     OPEN_TAIL_PROJECTION = "open_tail_projection"
     OPTIONAL_EMA_DROPPED = "optional_ema_dropped"
@@ -321,6 +323,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.EXECUTION_CREATE_REJECTED,
     EventTypes.EXECUTION_CREATE_DEFERRED,
     EventTypes.EXECUTION_CREATE_SKIPPED,
+    EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED,
     EventTypes.EXECUTION_CANCEL_SENT,
     EventTypes.EXECUTION_CANCEL_SUCCEEDED,
     EventTypes.EXECUTION_CANCEL_FAILED,
@@ -615,6 +618,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.EXECUTION_CREATE_REJECTED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CREATE_DEFERRED: EventRoute(console=False, text=False),
     EventTypes.EXECUTION_CREATE_SKIPPED: EventRoute(console=False, text=False),
+    EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED: EventRoute(console=False, text=False),
     EventTypes.EXECUTION_CANCEL_SENT: EventRoute(console=False),
     EventTypes.EXECUTION_CANCEL_SUCCEEDED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CANCEL_FAILED: EventRoute(console=True, text=True),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -3032,6 +3032,46 @@ def emit_realized_loss_gate_blocked_event(
         )
 
 
+def emit_entry_min_effective_cost_blocked_event(
+    bot: Any,
+    *,
+    symbol: str,
+    pside: str,
+    projected_initial_cost: float,
+    effective_min_cost: float,
+    balance: float,
+    effective_limit: float,
+    entry_initial_qty_pct: float,
+) -> None:
+    try:
+        bot._emit_live_event(
+            EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED,
+            level="info",
+            component="entry.min_effective_cost",
+            tags=(EventTags.ORDER, EventTags.GATE),
+            cycle_id=bot._current_live_event_cycle_id(),
+            symbol=str(symbol),
+            pside=str(pside),
+            status="skipped",
+            reason_code=ReasonCodes.MIN_EFFECTIVE_COST_BLOCKED,
+            data={
+                "projected_initial_cost": _safe_float(projected_initial_cost),
+                "effective_min_cost": _safe_float(effective_min_cost),
+                "balance": _safe_float(balance),
+                "effective_limit": _safe_float(effective_limit),
+                "entry_initial_qty_pct": _safe_float(entry_initial_qty_pct),
+                "action": "skip_create",
+            },
+        )
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit min effective cost event pside=%s symbol=%s: %s",
+            pside,
+            symbol,
+            exc,
+        )
+
+
 def _unstuck_status_side_summary(
     info: dict[str, Any],
     *,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -636,6 +636,9 @@ class Passivbot:
     _emit_realized_loss_gate_blocked_event = (
         live_event_emitters.emit_realized_loss_gate_blocked_event
     )
+    _emit_entry_min_effective_cost_blocked_event = (
+        live_event_emitters.emit_entry_min_effective_cost_blocked_event
+    )
     _emit_unstuck_status_event = live_event_emitters.emit_unstuck_status_event
     _emit_unstuck_selection_event = live_event_emitters.emit_unstuck_selection_event
     _emit_forager_feature_unavailable_event = (
@@ -11257,6 +11260,15 @@ class Passivbot:
                 effective_limit,
                 entry_initial_qty_pct,
                 pside,
+            )
+            self._emit_entry_min_effective_cost_blocked_event(
+                symbol=symbol,
+                pside=pside,
+                projected_initial_cost=projected_initial_cost,
+                effective_min_cost=effective_min_cost,
+                balance=balance,
+                effective_limit=effective_limit,
+                entry_initial_qty_pct=entry_initial_qty_pct,
             )
         if len(eligible_blocks) > detail_limit:
             examples = ",".join(

--- a/tests/test_coin_filtering.py
+++ b/tests/test_coin_filtering.py
@@ -1,6 +1,7 @@
 import pytest
 
 from passivbot import Passivbot
+from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
 
 
 class CoinFilterHarness(Passivbot):
@@ -364,6 +365,71 @@ def test_log_min_effective_cost_blocks_debug_includes_full_context(monkeypatch):
     assert "balance=51.154957" in seen[0]
     assert "live.filter_by_min_effective_cost=false" in seen[0]
     assert "override_may_create_exchange-min-sized_entries" in seen[0]
+
+
+def test_log_min_effective_cost_blocks_emits_structured_event(monkeypatch):
+    bot = Passivbot.__new__(Passivbot)
+    bot._min_effective_cost_last_log_ms = {}
+    bot._min_effective_cost_log_interval_ms = 900_000
+    bot.is_pside_enabled = lambda pside: pside == "long"
+    bot.bot_id = "bot_min_cost"
+    bot.exchange = "binance"
+    bot.user = "binance_01"
+    bot._live_event_current_cycle_id = "cy_min_cost"
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    monkeypatch.setattr(
+        "passivbot.logging.info",
+        lambda msg, *args: None,
+    )
+    monkeypatch.setattr(
+        "passivbot.logging.debug",
+        lambda msg, *args: None,
+    )
+
+    out = {
+        "diagnostics": {
+            "min_effective_cost_blocks": [
+                {
+                    "symbol_idx": 0,
+                    "pside": "long",
+                    "balance": 51.154957,
+                    "effective_limit": 1.5,
+                    "entry_initial_qty_pct": 0.0192,
+                    "projected_initial_cost": 1.4732627616,
+                    "effective_min_cost": 10.1,
+                }
+            ]
+        }
+    }
+    try:
+        bot._log_min_effective_cost_blocks(out, {0: "BTC/USDC:USDC"})
+        assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    finally:
+        assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.level == "info"
+    assert event.status == "skipped"
+    assert event.reason_code == "min_effective_cost_blocked"
+    assert event.cycle_id == "cy_min_cost"
+    assert event.symbol == "BTC/USDC:USDC"
+    assert event.pside == "long"
+    assert event.data["projected_initial_cost"] == pytest.approx(1.4732627616)
+    assert event.data["effective_min_cost"] == pytest.approx(10.1)
+    assert event.data["balance"] == pytest.approx(51.154957)
+    assert event.data["effective_limit"] == pytest.approx(1.5)
+    assert event.data["entry_initial_qty_pct"] == pytest.approx(0.0192)
+    assert event.data["action"] == "skip_create"
 
 
 def test_log_min_effective_cost_blocks_is_throttled(monkeypatch):

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -207,6 +207,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.FORAGER_SELECTION,
         EventTypes.FORAGER_FEATURE_UNAVAILABLE,
         EventTypes.ACTION_PLANNED,
+        EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED,
         EventTypes.EMA_BUNDLE_STARTED,
         EventTypes.EMA_BUNDLE_COMPLETED,
         EventTypes.EMA_FALLBACK_USED,


### PR DESCRIPTION
## Summary
- emit structured entry.min_effective_cost_blocked events beside the existing throttled min-effective-cost entry block log
- keep the event off console/text routes by default so existing operator output is unchanged
- document the event/reason code and cover the emitter + route contract with focused tests

## Behavior
Observability-only. No order construction, gating, or Rust behavior changes.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_coin_filtering.py tests/test_live_event_bus.py -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py src/live/event_emitters.py src/passivbot.py tests/test_coin_filtering.py tests/test_live_event_bus.py
- git diff --check
- silent-handling scan over touched files