### PR TITLE
Emit initial entry distance gate events

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -46,6 +46,8 @@ across time.
 - `execution.create_sent`
 - `execution.create_skipped`
 - `execution.create_succeeded`
+- `entry.initial_distance_gate_blocked`
+- `entry.initial_distance_gate_cleared`
 - `entry.min_effective_cost_blocked`
 - `fill.ingested`
 - `fills.refresh_summary`
@@ -144,6 +146,7 @@ across time.
 - `exchange_time_sync_unavailable`
 - `execution_loop_error_burst`
 - `fill_cache_ready`
+- `initial_entry_distance_gate`
 - `length_mismatch`
 - `low_balance`
 - `min_effective_cost_blocked`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -97,6 +97,8 @@ class EventTypes:
     EXECUTION_CREATE_REJECTED = "execution.create_rejected"
     EXECUTION_CREATE_DEFERRED = "execution.create_deferred"
     EXECUTION_CREATE_SKIPPED = "execution.create_skipped"
+    ENTRY_INITIAL_DISTANCE_GATE_BLOCKED = "entry.initial_distance_gate_blocked"
+    ENTRY_INITIAL_DISTANCE_GATE_CLEARED = "entry.initial_distance_gate_cleared"
     ENTRY_MIN_EFFECTIVE_COST_BLOCKED = "entry.min_effective_cost_blocked"
     EXECUTION_CANCEL_SENT = "execution.cancel_sent"
     EXECUTION_CANCEL_SUCCEEDED = "execution.cancel_succeeded"
@@ -187,6 +189,7 @@ class ReasonCodes:
     EXCHANGE_TIME_SYNC_UNAVAILABLE = "exchange_time_sync_unavailable"
     EXECUTION_LOOP_ERROR_BURST = "execution_loop_error_burst"
     FILL_CACHE_READY = "fill_cache_ready"
+    INITIAL_ENTRY_DISTANCE_GATE = "initial_entry_distance_gate"
     LENGTH_MISMATCH = "length_mismatch"
     LOW_BALANCE = "low_balance"
     MIN_EFFECTIVE_COST_BLOCKED = "min_effective_cost_blocked"
@@ -323,6 +326,8 @@ PHASE1_EVENT_TYPES = {
     EventTypes.EXECUTION_CREATE_REJECTED,
     EventTypes.EXECUTION_CREATE_DEFERRED,
     EventTypes.EXECUTION_CREATE_SKIPPED,
+    EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
+    EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
     EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED,
     EventTypes.EXECUTION_CANCEL_SENT,
     EventTypes.EXECUTION_CANCEL_SUCCEEDED,
@@ -618,6 +623,12 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.EXECUTION_CREATE_REJECTED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CREATE_DEFERRED: EventRoute(console=False, text=False),
     EventTypes.EXECUTION_CREATE_SKIPPED: EventRoute(console=False, text=False),
+    EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED: EventRoute(
+        console=False, text=False
+    ),
+    EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED: EventRoute(
+        console=False, text=False
+    ),
     EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED: EventRoute(console=False, text=False),
     EventTypes.EXECUTION_CANCEL_SENT: EventRoute(console=False),
     EventTypes.EXECUTION_CANCEL_SUCCEEDED: EventRoute(console=True, text=True),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -2595,6 +2595,57 @@ def emit_action_planned_event(
         )
 
 
+def emit_initial_entry_distance_gate_event(
+    bot: Any,
+    *,
+    event_type: str,
+    status: str,
+    action: str,
+    order: dict,
+    market_price: float,
+    signed_dist: float,
+    threshold: float,
+    tolerance: float | None = None,
+) -> None:
+    try:
+        symbol = str(order.get("symbol") or "")
+        pside = str(order.get("position_side") or "")
+        side = str(order.get("side") or "")
+        data = {
+            "qty": _safe_float(order.get("qty")),
+            "price": _safe_float(order.get("price")),
+            "market_price": _safe_float(market_price),
+            "distance_pct": _safe_float(float(signed_dist) * 100.0),
+            "threshold_pct": _safe_float(float(threshold) * 100.0),
+            "action": str(action),
+            "order_type": str(
+                order.get("pb_order_type") or order.get("type") or "unknown"
+            ),
+        }
+        if tolerance is not None:
+            data["tolerance_pct"] = _safe_float(float(tolerance) * 100.0)
+        bot._emit_live_event(
+            event_type,
+            level="info",
+            component="entry.initial_distance_gate",
+            tags=(EventTags.ORDER, EventTags.GATE, EventTags.ACTION),
+            cycle_id=current_live_event_cycle_id(bot),
+            symbol=symbol,
+            pside=pside,
+            side=side,
+            status=status,
+            reason_code=ReasonCodes.INITIAL_ENTRY_DISTANCE_GATE,
+            data={key: value for key, value in data.items() if value is not None},
+        )
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit initial entry distance gate event type=%s symbol=%s: %s",
+            event_type,
+            order.get("symbol") if isinstance(order, dict) else None,
+            exc,
+        )
+
+
 def _order_event_data(order: dict | None, *, index: int | None = None) -> dict[str, Any]:
     if not isinstance(order, dict):
         return {"order_type": type(order).__name__}

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -620,6 +620,9 @@ class Passivbot:
     _emit_execution_create_filter_event = (
         live_event_emitters.emit_execution_create_filter_event
     )
+    _emit_initial_entry_distance_gate_event = (
+        live_event_emitters.emit_initial_entry_distance_gate_event
+    )
     _emit_action_planned_event = live_event_emitters.emit_action_planned_event
     _emit_rust_orchestrator_called_event = (
         live_event_emitters.emit_rust_orchestrator_called_event
@@ -16011,6 +16014,18 @@ class Passivbot:
             tolerance * 100.0,
             self._resolve_pb_order_type(order),
         )
+        event_order = dict(order)
+        event_order["pb_order_type"] = self._resolve_pb_order_type(order)
+        self._emit_initial_entry_distance_gate_event(
+            event_type=EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
+            status="skipped",
+            action="skip_create",
+            order=event_order,
+            market_price=market_price,
+            signed_dist=signed_dist,
+            threshold=threshold,
+            tolerance=tolerance,
+        )
 
     def _log_initial_entry_distance_gate_cleared(
         self,
@@ -16037,6 +16052,17 @@ class Passivbot:
             signed_dist * 100.0,
             threshold * 100.0,
             self._resolve_pb_order_type(order),
+        )
+        event_order = dict(order)
+        event_order["pb_order_type"] = self._resolve_pb_order_type(order)
+        self._emit_initial_entry_distance_gate_event(
+            event_type=EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
+            status="recovered",
+            action="allow_create",
+            order=event_order,
+            market_price=market_price,
+            signed_dist=signed_dist,
+            threshold=threshold,
         )
 
     def _apply_mode_filters(

--- a/tests/test_initial_entry_distance_gate_events.py
+++ b/tests/test_initial_entry_distance_gate_events.py
@@ -1,0 +1,142 @@
+import pytest
+
+from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+from passivbot import Passivbot
+
+
+def _make_bot_with_event_sink():
+    bot = Passivbot.__new__(Passivbot)
+    bot.bot_id = "bot_distance_gate"
+    bot.exchange = "binance"
+    bot.user = "binance_01"
+    bot._live_event_current_cycle_id = "cy_distance_gate"
+    bot._initial_entry_distance_gate_log_state = {}
+    bot.open_orders = {}
+    bot.live_value = lambda key: 0.0005 if key == "order_match_tolerance_pct" else 0.0
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    return bot, sink
+
+
+def _initial_entry_order():
+    return {
+        "symbol": "BTC/USDT:USDT",
+        "side": "buy",
+        "position_side": "long",
+        "qty": 0.01,
+        "price": 95_000.0,
+        "type": "limit",
+        "pb_order_type": "entry_initial_long",
+    }
+
+
+def test_initial_entry_distance_gate_block_emits_structured_event(monkeypatch):
+    bot, sink = _make_bot_with_event_sink()
+    monkeypatch.setattr("passivbot.logging.info", lambda msg, *args: None)
+    monkeypatch.setattr("passivbot.logging.debug", lambda msg, *args: None)
+
+    try:
+        bot._log_initial_entry_distance_gate_block(
+            _initial_entry_order(),
+            market_price=100_000.0,
+            signed_dist=0.05,
+            threshold=0.01,
+        )
+        assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    finally:
+        assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.level == "info"
+    assert event.status == "skipped"
+    assert event.reason_code == "initial_entry_distance_gate"
+    assert event.cycle_id == "cy_distance_gate"
+    assert event.symbol == "BTC/USDT:USDT"
+    assert event.pside == "long"
+    assert event.side == "buy"
+    assert event.data["action"] == "skip_create"
+    assert event.data["order_type"] == "entry_initial_long"
+    assert event.data["qty"] == pytest.approx(0.01)
+    assert event.data["price"] == pytest.approx(95_000.0)
+    assert event.data["market_price"] == pytest.approx(100_000.0)
+    assert event.data["distance_pct"] == pytest.approx(5.0)
+    assert event.data["threshold_pct"] == pytest.approx(1.0)
+    assert event.data["tolerance_pct"] == pytest.approx(0.05)
+
+
+def test_initial_entry_distance_gate_event_respects_info_throttle(monkeypatch):
+    bot, sink = _make_bot_with_event_sink()
+    monkeypatch.setattr("passivbot.logging.info", lambda msg, *args: None)
+    monkeypatch.setattr("passivbot.logging.debug", lambda msg, *args: None)
+
+    try:
+        order = _initial_entry_order()
+        bot._log_initial_entry_distance_gate_block(
+            order,
+            market_price=100_000.0,
+            signed_dist=0.05,
+            threshold=0.01,
+        )
+        bot._log_initial_entry_distance_gate_block(
+            order,
+            market_price=100_000.0,
+            signed_dist=0.05,
+            threshold=0.01,
+        )
+        assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    finally:
+        assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+    assert [
+        event.event_type
+        for event in sink.events
+        if event.event_type == EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED
+    ] == [EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED]
+
+
+def test_initial_entry_distance_gate_cleared_emits_structured_event(monkeypatch):
+    bot, sink = _make_bot_with_event_sink()
+    monkeypatch.setattr("passivbot.logging.info", lambda msg, *args: None)
+    monkeypatch.setattr("passivbot.logging.debug", lambda msg, *args: None)
+    order = _initial_entry_order()
+
+    try:
+        bot._log_initial_entry_distance_gate_block(
+            order,
+            market_price=100_000.0,
+            signed_dist=0.05,
+            threshold=0.01,
+        )
+        bot._log_initial_entry_distance_gate_cleared(
+            order,
+            market_price=96_000.0,
+            signed_dist=0.005,
+            threshold=0.01,
+        )
+        assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    finally:
+        assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+    cleared = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED
+    ]
+    assert len(cleared) == 1
+    event = cleared[0]
+    assert event.status == "recovered"
+    assert event.reason_code == "initial_entry_distance_gate"
+    assert event.data["action"] == "allow_create"
+    assert event.data["market_price"] == pytest.approx(96_000.0)
+    assert event.data["distance_pct"] == pytest.approx(0.5)
+    assert event.data["threshold_pct"] == pytest.approx(1.0)
+    assert "tolerance_pct" not in event.data

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -207,6 +207,8 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.FORAGER_SELECTION,
         EventTypes.FORAGER_FEATURE_UNAVAILABLE,
         EventTypes.ACTION_PLANNED,
+        EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
+        EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
         EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED,
         EventTypes.EMA_BUNDLE_STARTED,
         EventTypes.EMA_BUNDLE_COMPLETED,


### PR DESCRIPTION
## Summary
- emit structured events beside existing initial-entry distance-gate INFO logs
- add entry.initial_distance_gate_blocked and entry.initial_distance_gate_cleared, routed off console/text by default
- preserve existing throttle semantics: suppressed debug-only repeats do not emit extra structured events
- document registry values and add focused tests

## Behavior
Observability-only. No order construction, gate decision, exchange call, Rust, or console text behavior changes.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_initial_entry_distance_gate_events.py tests/test_live_event_bus.py -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_registry_docs.py tests/test_initial_entry_distance_gate_events.py tests/test_live_event_bus.py -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py src/live/event_emitters.py src/passivbot.py tests/test_initial_entry_distance_gate_events.py tests/test_live_event_bus.py
- git diff --check
- silent-handling scan over touched files