### PR TITLE
Guard HSL equity replay with balance override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable user-facing changes will be documented in this file.
 - Added a live HSL safety guard: `hsl_signal_mode=unified` or `pside` now
   fails before account-level equity replay when `balance_override` is active,
   preventing synthetic historical peaks from triggering false RED panic orders
-  until an explicit HSL baseline/checkpoint exists.
+  until an explicit HSL baseline/checkpoint exists. HSL history replay also
+  zero-anchors realized-PnL timeline fields at the configured lookback boundary
+  so replayed peaks match the live runtime lookback contract.
 - Added root-level `passivbot -V` and `passivbot --version` output.
 - Added `hsl_replay_health` summaries to
   `passivbot tool live-smoke-report`, so smoke reports show active,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added a live HSL safety guard: `hsl_signal_mode=unified` or `pside` now
+  fails before account-level equity replay when `balance_override` is active,
+  preventing synthetic historical peaks from triggering false RED panic orders
+  until an explicit HSL baseline/checkpoint exists.
 - Added root-level `passivbot -V` and `passivbot --version` output.
 - Added `hsl_replay_health` summaries to
   `passivbot tool live-smoke-report`, so smoke reports show active,

--- a/docs/plans/vps3_ebybitsub03_wrong_hsl_panic_report.md
+++ b/docs/plans/vps3_ebybitsub03_wrong_hsl_panic_report.md
@@ -1,6 +1,6 @@
 # VPS3 ebybitsub03 Wrong HSL Panic Incident
 
-Status: investigation report for the HSL balance-override safety guard
+Status: investigation report for HSL replay safety fixes
 Incident account: `ebybitsub03` on `vps3`
 Exchange: Bybit
 Observed command: `passivbot live -u ebybitsub03 configs/xmr_migrated.json -bo 1000`
@@ -20,9 +20,10 @@ the red thresholds:
 - short RED triggered: `2026-06-28T23:47:54Z`
 - XMR long `close_panic_long` fill: `2026-06-28T23:47:55Z`, `0.8` XMR at `311.44`
 
-The executor followed the HSL forced panic mode. The questionable decision was
+The executor followed the HSL forced panic mode. The wrong decision happened
 earlier: HSL reconstructed account-level drawdown from current balance override
-plus historical realized PnL.
+plus historical realized PnL, then combined inconsistent lookback anchors for
+the replay peak and the current sample.
 
 ## Key Evidence
 
@@ -48,9 +49,13 @@ peak_strategy_equity = baseline_balance + peak_strategy_pnl
 drawdown_raw ~= 1 - strategy_equity / peak_strategy_equity
 ```
 
-The problem is not arithmetic. The problem is that `balance=1000` came from
-`-bo 1000`, not necessarily from a real exchange balance continuous with the
-entire replayed fill-history window.
+The arithmetic explains the emitted panic, but the premise is wrong. First,
+`balance=1000` came from `-bo 1000`, not necessarily from a real exchange
+balance continuous with the replayed fill-history window. Second, follow-up
+inspection showed the replay peak used cumulative realized PnL outside the
+configured 30-day lookback while the current runtime sample used the 30-day
+realized-PnL function. That mixed-window state manufactured a peak/current
+relationship that did not represent the account's current drawdown.
 
 ## Timeline
 
@@ -71,12 +76,12 @@ crossed red:
 2026-06-28T23:47:55Z post XMR sell long 0.8@311.44 close_panic_long
 ```
 
-## Root Cause
+## Root Causes
 
-Unified/pside HSL assumes historical realized PnL can be mapped onto current
-balance by subtracting cumulative realized PnL from current balance. That is
-only safe if current balance is a real exchange balance continuous with the
-replayed fill window.
+1. Unified/pside HSL assumed historical realized PnL could be mapped onto
+   current balance by subtracting cumulative realized PnL from current balance.
+   That is only safe if current balance is a real exchange balance continuous
+   with the replayed fill window.
 
 With a balance override, that assumption can synthesize a historical peak
 unrelated to the current operator allocation. In this incident:
@@ -87,6 +92,12 @@ unrelated to the current operator allocation. In this incident:
 - reconstructed current raw drawdown: about `17.5%`
 
 That is unsafe for live panic decisions.
+
+2. Balance/equity replay used pre-lookback events to reconstruct the balance
+   path, but the HSL-facing realized-PnL timeline fields were not zero-anchored
+   at the configured lookback boundary. That let old realized PnL contribute to
+   the replayed peak while the current HSL sample used lookback-scoped realized
+   PnL. This violated the active PnL lookback contract.
 
 ## Immediate Contract
 
@@ -99,6 +110,16 @@ before replay starts.
 PnL cumsum semantics and does not reconstruct account-level historical equity
 from `balance - realized_pnl_total`.
 
+Separately, balance/equity replay may still use pre-lookback fills to reconstruct
+open positions and absolute balance continuity, but all HSL-facing realized-PnL
+fields in recorded timeline rows must be zero-anchored at the configured
+lookback boundary.
+
+This aligns replay with the live runtime sample path:
+`_equity_hard_stop_realized_pnl_now()` consumes the same active
+`live.pnls_max_lookback_days` window via `_pnls_lookback_start_ms()`, so replayed
+peaks and current samples must use the same realized-PnL scope.
+
 ## Follow-Up Work
 
 - Add explicit HSL baseline/checkpoint support for overridden strategy
@@ -106,5 +127,5 @@ from `balance - realized_pnl_total`.
 - Include baseline source in HSL metrics/latch payloads.
 - Add startup diagnostics when raw drawdown is above red but EMA has not caught
   up yet.
-- Decide how to treat existing latch files created by the unsafe overridden
-  account-level replay model.
+- Decide how to treat existing latch files or panic fills created by the unsafe
+  overridden account-level replay model.

--- a/docs/plans/vps3_ebybitsub03_wrong_hsl_panic_report.md
+++ b/docs/plans/vps3_ebybitsub03_wrong_hsl_panic_report.md
@@ -1,0 +1,110 @@
+# VPS3 ebybitsub03 Wrong HSL Panic Incident
+
+Status: investigation report for the HSL balance-override safety guard
+Incident account: `ebybitsub03` on `vps3`
+Exchange: Bybit
+Observed command: `passivbot live -u ebybitsub03 configs/xmr_migrated.json -bo 1000`
+Observed VPS3 head: `v8` at `b972f0221fb5121330a7ee3a41b99c761317544c`
+
+## Summary
+
+The XMR panic close was emitted because HSL `signal_mode=unified` reconstructed
+a strategy-equity peak around `1213.127` USDT while current strategy equity was
+around `1000.5` USDT. That made the bot see about `17.5%` raw drawdown. With
+the configured EMA span of `563` minutes, drawdown EMA climbed until it crossed
+the red thresholds:
+
+- long red threshold: `0.067`
+- short red threshold: `0.072`
+- long RED triggered: `2026-06-28T23:23:02Z`
+- short RED triggered: `2026-06-28T23:47:54Z`
+- XMR long `close_panic_long` fill: `2026-06-28T23:47:55Z`, `0.8` XMR at `311.44`
+
+The executor followed the HSL forced panic mode. The questionable decision was
+earlier: HSL reconstructed account-level drawdown from current balance override
+plus historical realized PnL.
+
+## Key Evidence
+
+The current HSL latch/cache after the incident recorded:
+
+```text
+balance                  1000.000000
+realized_pnl_total        201.801644
+baseline_balance          798.198356
+peak_strategy_pnl         414.928620
+peak_strategy_equity     1213.126976
+strategy_equity          1000.499700
+drawdown_raw                0.175272
+drawdown_ema                0.075951
+signal_mode              unified
+```
+
+These values are internally consistent with the current formula:
+
+```text
+baseline_balance = balance - realized_pnl_total
+peak_strategy_equity = baseline_balance + peak_strategy_pnl
+drawdown_raw ~= 1 - strategy_equity / peak_strategy_equity
+```
+
+The problem is not arithmetic. The problem is that `balance=1000` came from
+`-bo 1000`, not necessarily from a real exchange balance continuous with the
+entire replayed fill-history window.
+
+## Timeline
+
+Startup already showed the false raw drawdown:
+
+```text
+2026-06-28T21:10:47Z Using balance override: 1000.000000
+2026-06-28T21:11:03Z HSL[long] status tier=green drawdown_raw=0.176071 drawdown_ema=0.002097 peak_strategy_equity=1213.260375
+2026-06-28T21:11:03Z HSL[short] status tier=green drawdown_raw=0.176071 drawdown_ema=0.002097 peak_strategy_equity=1213.260375
+```
+
+The bot did not panic immediately because drawdown EMA was still low. It later
+crossed red:
+
+```text
+2026-06-28T23:23:02Z HSL[long] RED triggered strategy_equity=1000.035700 peak_strategy_equity=1213.126976 drawdown_score=0.067112 red_threshold=0.067000
+2026-06-28T23:47:54Z HSL[short] RED triggered strategy_equity=1000.499700 peak_strategy_equity=1213.126976 drawdown_score=0.075951 red_threshold=0.072000
+2026-06-28T23:47:55Z post XMR sell long 0.8@311.44 close_panic_long
+```
+
+## Root Cause
+
+Unified/pside HSL assumes historical realized PnL can be mapped onto current
+balance by subtracting cumulative realized PnL from current balance. That is
+only safe if current balance is a real exchange balance continuous with the
+replayed fill window.
+
+With a balance override, that assumption can synthesize a historical peak
+unrelated to the current operator allocation. In this incident:
+
+- current overridden allocation: `1000`
+- reconstructed baseline: `798.198`
+- reconstructed peak: `1213.127`
+- reconstructed current raw drawdown: about `17.5%`
+
+That is unsafe for live panic decisions.
+
+## Immediate Contract
+
+Until an explicit HSL baseline/checkpoint mechanism exists, live HSL must not
+run account-level equity replay (`signal_mode=unified` or `signal_mode=pside`)
+with `balance_override` active. The safe short-term behavior is to fail loudly
+before replay starts.
+
+`signal_mode=coin` is not blocked by this guard because it uses per-coin realized
+PnL cumsum semantics and does not reconstruct account-level historical equity
+from `balance - realized_pnl_total`.
+
+## Follow-Up Work
+
+- Add explicit HSL baseline/checkpoint support for overridden strategy
+  allocations.
+- Include baseline source in HSL metrics/latch payloads.
+- Add startup diagnostics when raw drawdown is above red but EMA has not caught
+  up yet.
+- Decide how to treat existing latch files created by the unsafe overridden
+  account-level replay model.

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -2638,6 +2638,12 @@ class Passivbot:
     _parse_hsl_config = pb_hsl._parse_hsl_config
     _equity_hard_stop_enabled = pb_hsl._equity_hard_stop_enabled
     _equity_hard_stop_signal_mode = pb_hsl._equity_hard_stop_signal_mode
+    _equity_hard_stop_balance_override_active = (
+        pb_hsl._equity_hard_stop_balance_override_active
+    )
+    _equity_hard_stop_validate_balance_source_for_history_replay = (
+        pb_hsl._equity_hard_stop_validate_balance_source_for_history_replay
+    )
     _equity_hard_stop_cooldown_position_policy = (
         pb_hsl._equity_hard_stop_cooldown_position_policy
     )

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11789,9 +11789,11 @@ class Passivbot:
 
         if lookback_start is None:
             start_ts = ensure_millis(events[0]["timestamp"])
+            record_start_ts = int(math.floor(start_ts / ONE_MIN_MS) * ONE_MIN_MS)
             record_start_minute = int(math.floor(start_ts / ONE_MIN_MS) * ONE_MIN_MS)
         else:
             start_ts = min(ensure_millis(events[0]["timestamp"]), lookback_start)
+            record_start_ts = int(lookback_start)
             record_start_minute = int(
                 math.floor(lookback_start / ONE_MIN_MS) * ONE_MIN_MS
             )
@@ -11922,6 +11924,9 @@ class Passivbot:
         missing_price_symbols: set[str] = set()
         realized_pnl_pside_running = {"long": 0.0, "short": 0.0}
         realized_pnl_coin_pside_running: Dict[str, Dict[str, float]] = {}
+        record_start_balance: Optional[float] = None
+        record_start_realized_pnl_pside = {"long": 0.0, "short": 0.0}
+        record_start_realized_pnl_coin_pside: Dict[str, Dict[str, float]] = {}
         actual_symbol_pside_flat = {
             (sym, ps): size <= 1e-12
             for (sym, ps), (size, _price) in current_position_state.items()
@@ -11988,6 +11993,19 @@ class Passivbot:
             panic_fill_count = 0
             while event_idx < len(events) and events[event_idx]["timestamp"] < boundary:
                 evt = events[event_idx]
+                if record_start_balance is None and int(evt["timestamp"]) >= record_start_ts:
+                    record_start_balance = float(balance)
+                    record_start_realized_pnl_pside = {
+                        "long": float(realized_pnl_pside_running["long"]),
+                        "short": float(realized_pnl_pside_running["short"]),
+                    }
+                    record_start_realized_pnl_coin_pside = {
+                        sym: {
+                            "long": float(values["long"]),
+                            "short": float(values["short"]),
+                        }
+                        for sym, values in realized_pnl_coin_pside_running.items()
+                    }
                 _apply_event(evt)
                 realized_delta = evt["pnl"] + evt.get("fee", 0.0)
                 balance += realized_delta
@@ -12068,6 +12086,45 @@ class Passivbot:
                     )
                     symbol_upnl[pside] += pside_upnl
             if minute >= record_start_minute:
+                if record_start_balance is None:
+                    record_start_balance = float(balance)
+                    record_start_realized_pnl_pside = {
+                        "long": float(realized_pnl_pside_running["long"]),
+                        "short": float(realized_pnl_pside_running["short"]),
+                    }
+                    record_start_realized_pnl_coin_pside = {
+                        sym: {
+                            "long": float(values["long"]),
+                            "short": float(values["short"]),
+                        }
+                        for sym, values in realized_pnl_coin_pside_running.items()
+                    }
+                realized_pnl_window = float(balance - record_start_balance)
+                realized_pnl_pside_window = {
+                    "long": float(
+                        realized_pnl_pside_running["long"]
+                        - record_start_realized_pnl_pside.get("long", 0.0)
+                    ),
+                    "short": float(
+                        realized_pnl_pside_running["short"]
+                        - record_start_realized_pnl_pside.get("short", 0.0)
+                    ),
+                }
+                realized_pnl_coin_pside_window: Dict[str, Dict[str, float]] = {}
+                for sym in sorted(
+                    set(realized_pnl_coin_pside_running)
+                    | set(record_start_realized_pnl_coin_pside)
+                ):
+                    values = realized_pnl_coin_pside_running.get(
+                        sym, {"long": 0.0, "short": 0.0}
+                    )
+                    anchor = record_start_realized_pnl_coin_pside.get(
+                        sym, {"long": 0.0, "short": 0.0}
+                    )
+                    realized_pnl_coin_pside_window[sym] = {
+                        "long": float(values["long"] - anchor.get("long", 0.0)),
+                        "short": float(values["short"] - anchor.get("short", 0.0)),
+                    }
                 timeline_upnl_by_coin_pside = {
                     sym: {
                         "long": float(values["long"]),
@@ -12086,19 +12143,13 @@ class Passivbot:
                         "balance": balance,
                         "equity": balance + upnl,
                         "unrealized_pnl": upnl,
-                        "realized_pnl": balance - baseline_balance,
+                        "realized_pnl": realized_pnl_window,
                         "unrealized_pnl_long": upnl_by_pside["long"],
                         "unrealized_pnl_short": upnl_by_pside["short"],
-                        "realized_pnl_long": realized_pnl_pside_running["long"],
-                        "realized_pnl_short": realized_pnl_pside_running["short"],
+                        "realized_pnl_long": realized_pnl_pside_window["long"],
+                        "realized_pnl_short": realized_pnl_pside_window["short"],
                         "unrealized_pnl_by_coin_pside": timeline_upnl_by_coin_pside,
-                        "realized_pnl_by_coin_pside": {
-                            sym: {
-                                "long": float(values["long"]),
-                                "short": float(values["short"]),
-                            }
-                            for sym, values in sorted(realized_pnl_coin_pside_running.items())
-                        },
+                        "realized_pnl_by_coin_pside": realized_pnl_coin_pside_window,
                         "is_flat": len(active_symbols) == 0,
                         "is_flat_long": not any(
                             positions.get(sym, {}).get("long", {}).get("size", 0.0)

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -470,6 +470,32 @@ def _equity_hard_stop_signal_mode(self) -> str:
     return normalize_hsl_signal_mode(get_optional_live_value(config, "hsl_signal_mode", "unified"))
 
 
+def _equity_hard_stop_balance_override_active(self) -> bool:
+    return getattr(self, "balance_override", None) is not None
+
+
+def _equity_hard_stop_validate_balance_source_for_history_replay(self) -> None:
+    signal_mode = self._equity_hard_stop_signal_mode()
+    if signal_mode == "coin":
+        return
+    if not self._equity_hard_stop_balance_override_active():
+        return
+    enabled_psides = [
+        pside for pside in self._hsl_psides() if self._equity_hard_stop_enabled(pside)
+    ]
+    if not enabled_psides:
+        return
+    raise RuntimeError(
+        "HSL equity history replay is unsafe with balance_override for "
+        f"signal_mode={signal_mode!r} enabled_psides={','.join(enabled_psides)}. "
+        "Unified/pside HSL reconstructs historical drawdown from current balance "
+        "minus realized PnL; with a balance override this can create a synthetic "
+        "peak and false RED panic. Remove the balance override, use "
+        "hsl_signal_mode='coin', disable HSL, or initialize an explicit HSL "
+        "baseline/checkpoint before live trading."
+    )
+
+
 def _equity_hard_stop_cooldown_position_policy(self) -> str:
     config = getattr(self, "config", {})
     return normalize_hsl_cooldown_position_policy(
@@ -2023,6 +2049,7 @@ def _equity_hard_stop_refresh_halted_runtime_forced_modes(self) -> None:
 async def _equity_hard_stop_initialize_from_history(self) -> None:
     if not self._equity_hard_stop_enabled():
         return
+    self._equity_hard_stop_validate_balance_source_for_history_replay()
     prev_phase = getattr(self, "_log_silence_watchdog_phase", "runtime")
     prev_stage = getattr(self, "_log_silence_watchdog_stage", "idle")
     if hasattr(self, "_set_log_silence_watchdog_context"):

--- a/tests/test_realized_loss_gate.py
+++ b/tests/test_realized_loss_gate.py
@@ -381,6 +381,47 @@ class TestGetRealizedPnlCumsumStats:
         result = bot._equity_hard_stop_realized_pnl_now()
         assert result == pytest.approx(45.0)
 
+    def test_equity_hard_stop_blocks_unified_replay_with_balance_override(self):
+        bot = object.__new__(Passivbot)
+        bot.config = {"live": {"hsl_signal_mode": "unified"}}
+        bot.balance_override = 1000.0
+        bot.hsl = {
+            "long": {"enabled": True},
+            "short": {"enabled": False},
+        }
+
+        with pytest.raises(RuntimeError, match="unsafe with balance_override"):
+            bot._equity_hard_stop_validate_balance_source_for_history_replay()
+
+    def test_equity_hard_stop_allows_coin_replay_with_balance_override(self):
+        bot = object.__new__(Passivbot)
+        bot.config = {"live": {"hsl_signal_mode": "coin"}}
+        bot.balance_override = 1000.0
+        bot.hsl = {
+            "long": {"enabled": True},
+            "short": {"enabled": True},
+        }
+
+        bot._equity_hard_stop_validate_balance_source_for_history_replay()
+
+    @pytest.mark.asyncio
+    async def test_equity_hard_stop_startup_guard_runs_before_history_replay(self):
+        bot = object.__new__(Passivbot)
+        bot.config = {"live": {"hsl_signal_mode": "pside"}}
+        bot.balance_override = 1000.0
+        bot.hsl = {
+            "long": {"enabled": True},
+            "short": {"enabled": False},
+        }
+
+        async def fail_if_called(*_args, **_kwargs):
+            raise AssertionError("history replay should not start")
+
+        bot.get_balance_equity_history = fail_if_called
+
+        with pytest.raises(RuntimeError, match="false RED panic"):
+            await bot._equity_hard_stop_initialize_from_history()
+
 
 # ---------------------------------------------------------------------------
 # _log_realized_loss_gate_blocks

--- a/tests/test_realized_loss_gate.py
+++ b/tests/test_realized_loss_gate.py
@@ -3,7 +3,7 @@
 import logging
 import types
 from copy import deepcopy
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
 import pytest
@@ -115,6 +115,31 @@ def _make_bot_with_events(events, balance=10000.0, cache=_DEFAULT_RISK_CACHE):
 def _set_pnl_lookback(bot, *, lookback_days: float | str, now_ms: int) -> None:
     bot.config = {"live": {"pnls_max_lookback_days": lookback_days}}
     bot.get_exchange_time = lambda: now_ms
+
+
+def _make_replay_fill(
+    *,
+    timestamp: int,
+    pnl: float,
+    symbol: str = "BTC/USDT:USDT",
+    position_side: str = "long",
+    side: str = "sell",
+    qty: float = 1.0,
+    price: float = 100.0,
+    fee_paid: float = 0.0,
+    pb_order_type: str = "close_grid_long",
+) -> dict:
+    return {
+        "timestamp": int(timestamp),
+        "symbol": symbol,
+        "position_side": position_side,
+        "side": side,
+        "qty": qty,
+        "price": price,
+        "pnl": pnl,
+        "fee_paid": fee_paid,
+        "pb_order_type": pb_order_type,
+    }
 
 
 def _rust_effective_pnl_cumsum_reference(events, *, start_ms=None):
@@ -421,6 +446,80 @@ class TestGetRealizedPnlCumsumStats:
 
         with pytest.raises(RuntimeError, match="false RED panic"):
             await bot._equity_hard_stop_initialize_from_history()
+
+    @pytest.mark.asyncio
+    async def test_balance_equity_history_realized_pnl_is_lookback_anchored(self):
+        day_ms = 86_400_000
+        now_ms = 1_782_700_043_210
+        lookback_start_ms = now_ms - day_ms
+        bot = object.__new__(Passivbot)
+        bot.config = {"live": {"pnls_max_lookback_days": 1.0}}
+        bot.init_pnls = AsyncMock()
+        bot.get_exchange_time = lambda: now_ms
+        bot.get_raw_balance = lambda: 1000.0
+        bot.live_value = lambda key: bot.config["live"][key]
+        bot.c_mults = {"BTC/USDT:USDT": 1.0}
+        bot.positions = {}
+        bot.cm = None
+        bot.inverse = False
+        bot.exchange = "binance"
+        bot.user = "test_user"
+        bot.get_symbol_id_inv = lambda symbol: symbol
+        bot._pnls_manager = None
+
+        history = await bot.get_balance_equity_history(
+            fill_events=[
+                _make_replay_fill(timestamp=lookback_start_ms - 60_000, pnl=200.0),
+                _make_replay_fill(timestamp=lookback_start_ms + 60_000, pnl=10.0),
+            ],
+            current_balance=1000.0,
+        )
+
+        assert history["timeline"]
+        last = history["timeline"][-1]
+        assert last["balance"] == pytest.approx(1000.0)
+        assert last["realized_pnl"] == pytest.approx(10.0)
+        assert last["realized_pnl_long"] == pytest.approx(10.0)
+        assert last["realized_pnl_short"] == pytest.approx(0.0)
+        assert last["realized_pnl_by_coin_pside"]["BTC/USDT:USDT"]["long"] == pytest.approx(
+            10.0
+        )
+
+    @pytest.mark.asyncio
+    async def test_balance_equity_history_excludes_same_minute_pre_lookback_pnl(self):
+        day_ms = 86_400_000
+        now_ms = 1_782_700_043_210
+        lookback_start_ms = now_ms - day_ms
+        pre_window_ts = lookback_start_ms - 10_000
+        in_window_ts = lookback_start_ms + 10_000
+        assert pre_window_ts // 60_000 == in_window_ts // 60_000
+        bot = object.__new__(Passivbot)
+        bot.config = {"live": {"pnls_max_lookback_days": 1.0}}
+        bot.init_pnls = AsyncMock()
+        bot.get_exchange_time = lambda: now_ms
+        bot.get_raw_balance = lambda: 1000.0
+        bot.live_value = lambda key: bot.config["live"][key]
+        bot.c_mults = {"BTC/USDT:USDT": 1.0}
+        bot.positions = {}
+        bot.cm = None
+        bot.inverse = False
+        bot.exchange = "binance"
+        bot.user = "test_user"
+        bot.get_symbol_id_inv = lambda symbol: symbol
+        bot._pnls_manager = None
+
+        history = await bot.get_balance_equity_history(
+            fill_events=[
+                _make_replay_fill(timestamp=pre_window_ts, pnl=200.0),
+                _make_replay_fill(timestamp=in_window_ts, pnl=10.0),
+            ],
+            current_balance=1000.0,
+        )
+
+        last = history["timeline"][-1]
+        assert last["balance"] == pytest.approx(1000.0)
+        assert last["realized_pnl"] == pytest.approx(10.0)
+        assert last["realized_pnl_long"] == pytest.approx(10.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fail HSL unified/pside account-level equity replay before startup history reconstruction when `balance_override` is active
- leave coin-mode HSL untouched because it does not reconstruct account-level equity from `balance - realized_pnl_total`
- add VPS3 incident report documenting the false XMR panic path

## Why
VPS3 `ebybitsub03` ran Bybit XMR with `hsl_signal_mode=unified` and `-bo 1000`. HSL reconstructed `peak_strategy_equity ~= 1213` from overridden balance plus historical realized PnL, saw ~17.5% raw drawdown, and eventually emitted a panic close even though the account allocation was not actually near red drawdown.

## Tests
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_realized_loss_gate.py -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_run_fake_live.py -k hsl_replay_scenarios_run_end_to_end -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/passivbot_hsl.py src/passivbot.py tests/test_realized_loss_gate.py`
- `git diff --check`