### PR TITLE
Document HSL false-panic recovery follow-up

### DIFF
--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -30,6 +30,31 @@ Related detailed plans:
 
 ## High-Value Follow-Ups
 
+0a. [ ] Critical: HSL false-panic recovery and preflight.
+   Status: open. VPS3 `ebybitsub03` evidence from 2026-06-28/29 showed a wrong
+   `close_panic_long` on XMR under `hsl_signal_mode=unified` with
+   `balance_override=1000`. HSL reconstructed a synthetic account-level peak
+   near `1213` from overridden balance plus historical realized PnL, while the
+   account was not near a legitimate drawdown that should have triggered RED.
+   PR #839 added the immediate fail-loud runtime guard for
+   `balance_override` plus account-level HSL replay, but an operational gap
+   remains for recovery and prevention.
+
+   Target contract: operators need a preflight-visible warning/error before
+   starting a config that combines `balance_override` with `unified` or `pside`
+   HSL, and a carefully designed recovery path for historical panic fills that
+   are known to have been created by a bad HSL model. Recovery must not silently
+   ignore exchange-derived panic fills. Any invalid-panic override must be
+   explicit, auditable, bounded to exact fill/time/side/symbol evidence, and
+   compatible with stateless restart semantics.
+
+   Investigation directions: extend `live-config-preflight` and/or
+   `hsl-startup-preview` to flag the unsafe contract offline; add richer HSL
+   baseline-source diagnostics; design an operator-owned invalid-panic marker
+   if needed; and add tests proving that the default remains fail-loud and
+   exchange-derived cooldown evidence is ignored only when the explicit recovery
+   contract is satisfied.
+
 0. [ ] Critical: HSL startup replay latency before protective panic.
    Status: open. Binance VPS5 incident evidence from 2026-06-26 shows
    `hsl_signal_mode=coin` startup history reconstruction loaded

--- a/docs/plans/vps3_ebybitsub03_wrong_hsl_panic_report.md
+++ b/docs/plans/vps3_ebybitsub03_wrong_hsl_panic_report.md
@@ -25,6 +25,13 @@ earlier: HSL reconstructed account-level drawdown from current balance override
 plus historical realized PnL, then combined inconsistent lookback anchors for
 the replay peak and the current sample.
 
+Follow-up VPS3 inspection on `2026-06-29` confirmed the operator assessment:
+the panic was wrong. The account was not near a real account-level drawdown
+that should have triggered RED. The bot was still running the vulnerable
+`b972f022` build, remained flat after the close, and kept logging RED cooldown
+from the synthetic peak. Current `v8` contains a guard which blocks this exact
+startup contract before HSL replay can trade.
+
 ## Key Evidence
 
 The current HSL latch/cache after the incident recorded:
@@ -120,6 +127,19 @@ This aligns replay with the live runtime sample path:
 `live.pnls_max_lookback_days` window via `_pnls_lookback_start_ms()`, so replayed
 peaks and current samples must use the same realized-PnL scope.
 
+The merged short-term mitigation is intentionally fail-loud: if HSL is enabled
+and `balance_override` is active, `signal_mode=unified` and `signal_mode=pside`
+must not proceed into history replay. Operators must remove the balance
+override, switch to `hsl_signal_mode=coin`, disable HSL, or wait for an explicit
+baseline/checkpoint mechanism.
+
+This fix prevents the same false-panic calculation on new starts, but it does
+not decide how to treat historical fills that were already created by the bad
+model. In this incident the exchange history now contains a
+`close_panic_long` fill for XMR. Stateless replay can legitimately see that as
+cooldown evidence unless a future, explicit recovery contract marks the event as
+operator-invalid.
+
 ## Follow-Up Work
 
 - Add explicit HSL baseline/checkpoint support for overridden strategy
@@ -128,4 +148,10 @@ peaks and current samples must use the same realized-PnL scope.
 - Add startup diagnostics when raw drawdown is above red but EMA has not caught
   up yet.
 - Decide how to treat existing latch files or panic fills created by the unsafe
-  overridden account-level replay model.
+  overridden account-level replay model. Any ignore/recovery mechanism must be
+  explicit, auditable, config- or exchange-derived, and covered by tests because
+  silently ignoring exchange-derived panic fills would weaken the stateless HSL
+  cooldown contract.
+- Add preflight/reporting that flags `balance_override` plus account-level HSL
+  before an operator starts live, so this class of configuration cannot be
+  missed in a manual restart.


### PR DESCRIPTION
Docs-only follow-up to PR #839. Records the confirmed VPS3 false HSL panic state, clarifies that current v8 prevents recurrence by fail-loud guarding balance_override + account-level HSL replay, and adds a backlog item for explicit invalid-panic recovery/preflight design. No code or trading behavior changes.