### PR TITLE
Emit structured HSL replay failure events

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -58,6 +58,7 @@ across time.
 - `hsl.cooldown_started`
 - `hsl.red_triggered`
 - `hsl.replay.completed`
+- `hsl.replay.failed`
 - `hsl.replay.progress`
 - `hsl.replay.started`
 - `hsl.status`
@@ -148,6 +149,7 @@ across time.
 - `execution_loop_error_burst`
 - `entry_cooldown_position_delta`
 - `fill_cache_ready`
+- `hsl_balance_override_account_level_replay_unsafe`
 - `initial_entry_distance_gate`
 - `length_mismatch`
 - `low_balance`

--- a/docs/plans/live_logging_overhaul_plan.md
+++ b/docs/plans/live_logging_overhaul_plan.md
@@ -166,6 +166,7 @@ stable names:
 - `hsl.replay.started`
 - `hsl.replay.progress`
 - `hsl.replay.completed`
+- `hsl.replay.failed`
 - `hsl.transition`
 - `risk.mode_changed`
 - `rust_orchestrator.called`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -118,6 +118,7 @@ class EventTypes:
     HSL_REPLAY_STARTED = "hsl.replay.started"
     HSL_REPLAY_PROGRESS = "hsl.replay.progress"
     HSL_REPLAY_COMPLETED = "hsl.replay.completed"
+    HSL_REPLAY_FAILED = "hsl.replay.failed"
     HSL_RED_TRIGGERED = "hsl.red_triggered"
     HSL_COOLDOWN_STARTED = "hsl.cooldown_started"
     HSL_COOLDOWN_ENDED = "hsl.cooldown_ended"
@@ -206,6 +207,9 @@ class ReasonCodes:
     RISK_ENTRY_COOLDOWN_POSITION_DELTA = "entry_cooldown_position_delta"
     REQUIRED_CANDLE_DISK_COVERAGE = "required_candle_disk_coverage"
     REQUIRED_EMA_UNAVAILABLE = "required_ema_unavailable"
+    HSL_BALANCE_OVERRIDE_ACCOUNT_LEVEL_REPLAY_UNSAFE = (
+        "hsl_balance_override_account_level_replay_unsafe"
+    )
     RUST_OUTPUT_ACTIONS = "rust_output_actions"
     SINK_PIPELINE_CLOSING = "pipeline_closing"
     SNAPSHOT_SYMBOL_STATE = "snapshot_symbol_state"
@@ -349,6 +353,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.HSL_REPLAY_STARTED,
     EventTypes.HSL_REPLAY_PROGRESS,
     EventTypes.HSL_REPLAY_COMPLETED,
+    EventTypes.HSL_REPLAY_FAILED,
     EventTypes.HSL_RED_TRIGGERED,
     EventTypes.HSL_COOLDOWN_STARTED,
     EventTypes.HSL_COOLDOWN_ENDED,
@@ -651,6 +656,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.HSL_REPLAY_STARTED: EventRoute(console=False, text=False),
     EventTypes.HSL_REPLAY_PROGRESS: EventRoute(console=False, text=False),
     EventTypes.HSL_REPLAY_COMPLETED: EventRoute(console=False, text=False),
+    EventTypes.HSL_REPLAY_FAILED: EventRoute(console=False, text=False),
     EventTypes.HSL_RED_TRIGGERED: EventRoute(console=False, text=False),
     EventTypes.HSL_COOLDOWN_STARTED: EventRoute(console=False, text=False),
     EventTypes.HSL_COOLDOWN_ENDED: EventRoute(console=False, text=False),

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1304,6 +1304,8 @@ class _HslReplayProfileAccumulator:
             state["loaded"] = record
         elif event_type == "hsl.replay.completed":
             state["completed"] = record
+        elif event_type == "hsl.replay.failed":
+            state["failed"] = record
         elif event_type == "hsl.replay.progress":
             state["progress"] = record
         elif event_type == "hsl.replay.started":
@@ -1328,6 +1330,7 @@ class _HslReplayProfileAccumulator:
                 "loaded": state.get("loaded"),
                 "progress": state.get("progress"),
                 "completed": state.get("completed"),
+                "failed": state.get("failed"),
             }
             groups.append({key: value for key, value in group.items() if value not in (None, {}, [])})
         groups = sorted(

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -92,6 +92,7 @@ HSL_REPLAY_EVENT_TYPES = {
     EventTypes.HSL_REPLAY_STARTED,
     EventTypes.HSL_REPLAY_PROGRESS,
     EventTypes.HSL_REPLAY_COMPLETED,
+    EventTypes.HSL_REPLAY_FAILED,
 }
 REMOTE_CALL_TIMING_EVENT_TYPES = {
     EventTypes.REMOTE_CALL_SUCCEEDED,
@@ -1934,6 +1935,10 @@ def _merge_hsl_replay_group(
         record, group.get("completed")
     ):
         group["completed"] = record
+    elif event_type == EventTypes.HSL_REPLAY_FAILED and is_newer(
+        record, group.get("failed")
+    ):
+        group["failed"] = record
 
 
 def _public_hsl_replay_record(record: Any) -> dict[str, Any]:
@@ -1950,7 +1955,10 @@ def _hsl_replay_group_active(group: dict[str, Any]) -> bool:
     latest = group.get("latest")
     if not isinstance(latest, dict):
         return False
-    return latest.get("event_type") != EventTypes.HSL_REPLAY_COMPLETED
+    return latest.get("event_type") not in {
+        EventTypes.HSL_REPLAY_COMPLETED,
+        EventTypes.HSL_REPLAY_FAILED,
+    }
 
 
 def _summarize_hsl_replay_health(
@@ -1979,6 +1987,7 @@ def _summarize_hsl_replay_health(
         active = _hsl_replay_group_active(group)
         latest = _public_hsl_replay_record(group.get("latest"))
         completed = _public_hsl_replay_record(group.get("completed"))
+        failed = _public_hsl_replay_record(group.get("failed"))
         if active:
             active_bots += 1
         if completed:
@@ -1986,6 +1995,8 @@ def _summarize_hsl_replay_health(
                 completed_bots += 1
             elif completed.get("status") == "failed":
                 failed_bots += 1
+        elif failed:
+            failed_bots += 1
         public_group = {
             "bot": group.get("bot"),
             "active": active,
@@ -1998,6 +2009,7 @@ def _summarize_hsl_replay_health(
             "loaded": _public_hsl_replay_record(group.get("loaded")),
             "progress": _public_hsl_replay_record(group.get("progress")),
             "completed": completed,
+            "failed": failed,
         }
         compact_groups.append(
             {

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -1983,6 +1983,7 @@ def _summarize_hsl_replay_health(
     active_bots = 0
     completed_bots = 0
     failed_bots = 0
+    failed_attention_bots = 0
     for group in ordered:
         active = _hsl_replay_group_active(group)
         latest = _public_hsl_replay_record(group.get("latest"))
@@ -1997,6 +1998,8 @@ def _summarize_hsl_replay_health(
                 failed_bots += 1
         elif failed:
             failed_bots += 1
+            if failed.get("reason_code") != "shutdown_cancelled":
+                failed_attention_bots += 1
         public_group = {
             "bot": group.get("bot"),
             "active": active,
@@ -2026,6 +2029,7 @@ def _summarize_hsl_replay_health(
         "active_bots": int(active_bots),
         "completed_bots": int(completed_bots),
         "failed_bots": int(failed_bots),
+        "failed_attention_bots": int(failed_attention_bots),
         "groups": compact_groups[:HSL_REPLAY_HEALTH_GROUP_LIMIT],
     }
 
@@ -2684,6 +2688,9 @@ def _is_problem_event(live_event: dict[str, Any]) -> bool:
     level = str(live_event.get("level") or "").lower()
     status = str(live_event.get("status") or "").lower()
     event_type = str(live_event.get("event_type") or "")
+    reason_code = str(live_event.get("reason_code") or "")
+    if event_type == EventTypes.HSL_REPLAY_FAILED and reason_code == "shutdown_cancelled":
+        return False
     return (
         level in {"error", "critical"}
         or status in {"failed", "degraded"}
@@ -3371,6 +3378,7 @@ def build_live_smoke_report(
                 "active_bots": 0,
                 "completed_bots": 0,
                 "failed_bots": 0,
+                "failed_attention_bots": 0,
                 "groups": [],
             },
             "risk_events": {
@@ -3416,11 +3424,18 @@ def build_live_smoke_report(
         + int(log_scan["hard_matches"])
         + int(process_report["hard_failures"])
     )
+    hsl_replay_active_bots = int(
+        event_scan["hsl_replay_health"].get("active_bots") or 0
+    )
+    hsl_replay_failed_attention_bots = int(
+        event_scan["hsl_replay_health"].get("failed_attention_bots") or 0
+    )
     attention_count = (
         int(event_scan["problem_event_count"])
         + int(log_scan["attention_matches"])
         + int(log_scan.get("dropped_unparsed_attention_matches", 0))
-        + int(event_scan["hsl_replay_health"].get("active_bots") or 0)
+        + hsl_replay_active_bots
+        + hsl_replay_failed_attention_bots
     )
     hard_failure_sources = {
         "monitor_errors": int(event_report["error_count"]),
@@ -3430,9 +3445,6 @@ def build_live_smoke_report(
         "process_hard_failures": int(process_report["hard_failures"]),
         "total": int(hard_failures),
     }
-    hsl_replay_active_bots = int(
-        event_scan["hsl_replay_health"].get("active_bots") or 0
-    )
     attention_sources = {
         "problem_events": int(event_scan["problem_event_count"]),
         "log_attention_matches": int(log_scan["attention_matches"]),
@@ -3443,6 +3455,8 @@ def build_live_smoke_report(
     }
     if hsl_replay_active_bots:
         attention_sources["hsl_replay_active_bots"] = hsl_replay_active_bots
+    if hsl_replay_failed_attention_bots:
+        attention_sources["hsl_replay_failed_bots"] = hsl_replay_failed_attention_bots
     return {
         "ok": hard_failures == 0,
         "attention": attention_count > 0,
@@ -3511,6 +3525,7 @@ def _summary_limited_groups(
             "active_bots": summary.get("active_bots"),
             "completed_bots": summary.get("completed_bots"),
             "failed_bots": summary.get("failed_bots"),
+            "failed_attention_bots": summary.get("failed_attention_bots"),
             "latest_candidate_unavailable_total": summary.get(
                 "latest_candidate_unavailable_total"
             ),
@@ -3937,6 +3952,9 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             "active_bots": _count_value(hsl_replay_health.get("active_bots")),
             "completed_bots": _count_value(hsl_replay_health.get("completed_bots")),
             "failed_bots": _count_value(hsl_replay_health.get("failed_bots")),
+            "failed_attention_bots": _count_value(
+                hsl_replay_health.get("failed_attention_bots")
+            ),
             "event_types": hsl_replay_health.get("event_types") or {},
         },
         "risk_events": {

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -1991,7 +1991,11 @@ def _summarize_hsl_replay_health(
         failed = _public_hsl_replay_record(group.get("failed"))
         if active:
             active_bots += 1
-        if completed:
+        elif latest.get("event_type") == EventTypes.HSL_REPLAY_FAILED:
+            failed_bots += 1
+            if latest.get("reason_code") != "shutdown_cancelled":
+                failed_attention_bots += 1
+        elif latest.get("event_type") == EventTypes.HSL_REPLAY_COMPLETED:
             if completed.get("status") == "succeeded":
                 completed_bots += 1
             elif completed.get("status") == "failed":

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -2991,7 +2991,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
         )
         _emit_hsl_replay_event(
             self,
-            "hsl.replay.completed",
+            EventTypes.HSL_REPLAY_COMPLETED,
             {
                 "signal_mode": "coin",
                 "stage": "full_replay",

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -22,7 +22,7 @@ from config.coerce import (
 )
 from config.pnl_lookback import parse_pnls_max_lookback_days
 from fill_events_manager import signed_fee_paid_from_payload
-from live.event_bus import live_event_debug_profile_enabled
+from live.event_bus import EventTypes, ReasonCodes, live_event_debug_profile_enabled
 from passivbot_exceptions import RestartBotException
 from utils import make_get_filepath
 
@@ -281,17 +281,20 @@ def _emit_hsl_replay_event(
     status: str | None = None,
     reason_code: str | None = None,
 ) -> None:
-    _emit_hsl_event(
-        self,
-        event_type,
-        ("hsl", "risk", "replay"),
-        data,
-        pside=pside,
-        symbol=symbol,
-        level=level,
-        status=status,
-        reason_code=reason_code,
-    )
+    try:
+        _emit_hsl_event(
+            self,
+            event_type,
+            ("hsl", "risk", "replay"),
+            data,
+            pside=pside,
+            symbol=symbol,
+            level=level,
+            status=status,
+            reason_code=reason_code,
+        )
+    except Exception as exc:
+        logging.debug("[event] failed to emit HSL replay event type=%s: %s", event_type, exc)
 
 
 def _calc_hsl_pnl(position_side, entry_price, close_price, qty, c_mult):
@@ -485,6 +488,18 @@ def _equity_hard_stop_validate_balance_source_for_history_replay(self) -> None:
     ]
     if not enabled_psides:
         return
+    _emit_hsl_replay_event(
+        self,
+        EventTypes.HSL_REPLAY_FAILED,
+        {
+            "signal_mode": signal_mode,
+            "balance_override_active": True,
+            "enabled_psides": enabled_psides,
+        },
+        level="critical",
+        status="failed",
+        reason_code=ReasonCodes.HSL_BALANCE_OVERRIDE_ACCOUNT_LEVEL_REPLAY_UNSAFE,
+    )
     raise RuntimeError(
         "HSL equity history replay is unsafe with balance_override for "
         f"signal_mode={signal_mode!r} enabled_psides={','.join(enabled_psides)}. "
@@ -3003,7 +3018,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
     except asyncio.CancelledError:
         _emit_hsl_replay_event(
             self,
-            "hsl.replay.completed",
+            EventTypes.HSL_REPLAY_FAILED,
             {
                 "signal_mode": "coin",
                 "elapsed_s": round(time.monotonic() - replay_started_s, 3)
@@ -3017,7 +3032,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
     except Exception as exc:
         _emit_hsl_replay_event(
             self,
-            "hsl.replay.completed",
+            EventTypes.HSL_REPLAY_FAILED,
             {
                 "signal_mode": "coin",
                 "error_type": type(exc).__name__,

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -222,7 +222,7 @@ async def test_coin_hsl_replay_cancels_when_shutdown_requested_after_history_loa
     events = [event for event in sink.events if event.event_type.startswith("hsl.replay.")]
     assert [event.event_type for event in events] == [
         EventTypes.HSL_REPLAY_STARTED,
-        EventTypes.HSL_REPLAY_COMPLETED,
+        EventTypes.HSL_REPLAY_FAILED,
     ]
     assert events[0].status == "started"
     assert events[0].reason_code == "coin_history_replay"

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1201,6 +1201,20 @@ def test_live_performance_report_hsl_replay_profile(tmp_path):
                     "elapsed_s": 7.5,
                 },
             ),
+            _monitor_row(
+                event_type="hsl.replay.failed",
+                seq=5,
+                ts=5000,
+                component="risk.hsl",
+                status="failed",
+                reason_code="coin_history_replay_failed",
+                data={
+                    "signal_mode": "coin",
+                    "elapsed_s": 8.0,
+                    "error_type": "RuntimeError",
+                    "secret": "must-not-render",
+                },
+            ),
         ],
     )
 
@@ -1208,12 +1222,13 @@ def test_live_performance_report_hsl_replay_profile(tmp_path):
     profile = report["hsl_replay_profile"]
     group = profile["groups"][0]
 
-    assert profile["total_events"] == 4
+    assert profile["total_events"] == 5
     assert profile["bot_count"] == 1
     assert profile["event_types"] == {
         "hsl.replay.started": 1,
         "hsl.replay.progress": 2,
         "hsl.replay.completed": 1,
+        "hsl.replay.failed": 1,
     }
     assert group["bot"] == "binance/binance_01"
     assert group["event_types"]["hsl.replay.progress"] == 2
@@ -1226,6 +1241,10 @@ def test_live_performance_report_hsl_replay_profile(tmp_path):
     assert group["progress"]["derived"]["latest_elapsed_ms"] == 2500
     assert group["completed"]["derived"]["startup_blocking_elapsed_ms"] == 7500
     assert group["completed"]["derived"]["startup_blocking"] is True
+    assert group["failed"]["event_type"] == "hsl.replay.failed"
+    assert group["failed"]["status"] == "failed"
+    assert group["failed"]["derived"]["latest_elapsed_ms"] == 8000
+    assert "must-not-render" not in json.dumps(group, sort_keys=True)
     assert group["completed"]["derived"]["observed_work_pct"] == 75
 
 

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2270,6 +2270,57 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
     }
 
 
+def test_live_smoke_report_hsl_replay_latest_failure_overrides_stale_completion(tmp_path):
+    _write_ndjson(
+        tmp_path
+        / "monitor"
+        / "binance"
+        / "binance_01"
+        / "events"
+        / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.replay.started",
+                seq=1,
+                ts=1000,
+                reason_code="coin_history_replay",
+                level="debug",
+                status="started",
+                data={"signal_mode": "coin"},
+            ),
+            _monitor_row(
+                event_type="hsl.replay.completed",
+                seq=2,
+                ts=2000,
+                reason_code="coin_history_replay_completed",
+                level="debug",
+                status="succeeded",
+                data={"signal_mode": "coin", "stage": "full_replay"},
+            ),
+            _monitor_row(
+                event_type="hsl.replay.failed",
+                seq=3,
+                ts=4000,
+                reason_code="coin_history_replay_failed",
+                level="warning",
+                status="failed",
+                data={"signal_mode": "coin", "error_type": "RuntimeError"},
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    health = report["hsl_replay_health"]
+
+    assert health["active_bots"] == 0
+    assert health["completed_bots"] == 0
+    assert health["failed_bots"] == 1
+    assert health["failed_attention_bots"] == 1
+    assert report["attention_sources"]["hsl_replay_failed_bots"] == 1
+    assert health["groups"][0]["latest"]["event_type"] == "hsl.replay.failed"
+    assert health["groups"][0]["completed"]["event_type"] == "hsl.replay.completed"
+
+
 def test_live_smoke_report_distinguishes_attention_and_hard_structured_events(
     tmp_path,
 ):

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2159,6 +2159,41 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
             ),
         ],
     )
+    _write_ndjson(
+        tmp_path
+        / "monitor"
+        / "kucoin"
+        / "kucoin_01"
+        / "events"
+        / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.replay.started",
+                seq=8,
+                ts=8000,
+                exchange="kucoin",
+                user="kucoin_01",
+                reason_code="coin_history_replay",
+                level="debug",
+                status="started",
+                data={"signal_mode": "coin", "lookback_days": 30.0},
+            ),
+            _monitor_row(
+                event_type="hsl.replay.failed",
+                seq=9,
+                ts=9000,
+                exchange="kucoin",
+                user="kucoin_01",
+                reason_code="shutdown_cancelled",
+                level="debug",
+                status="failed",
+                data={
+                    "signal_mode": "coin",
+                    "elapsed_s": 1.0,
+                },
+            ),
+        ],
+    )
 
     report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
     summary = summarize_live_smoke_report(report)
@@ -2167,15 +2202,19 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
     assert report["ok"] is True
     assert report["attention"] is True
     assert report["hard_failures"] == 0
+    assert report["attention_sources"]["problem_events"] == 1
     assert report["attention_sources"]["hsl_replay_active_bots"] == 1
+    assert report["attention_sources"]["hsl_replay_failed_bots"] == 1
+    assert report["attention_sources"]["total"] == 3
     assert report["hsl_replay_health"]["active_bots"] == 1
     assert report["hsl_replay_health"]["completed_bots"] == 1
-    assert report["hsl_replay_health"]["failed_bots"] == 1
+    assert report["hsl_replay_health"]["failed_bots"] == 2
+    assert report["hsl_replay_health"]["failed_attention_bots"] == 1
     assert report["hsl_replay_health"]["event_types"] == {
         "hsl.replay.progress": 2,
-        "hsl.replay.started": 3,
+        "hsl.replay.started": 4,
         "hsl.replay.completed": 1,
-        "hsl.replay.failed": 1,
+        "hsl.replay.failed": 2,
     }
     active_group = report["hsl_replay_health"]["groups"][0]
     assert active_group["bot"] == "gateio/gateio_01"
@@ -2208,17 +2247,25 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
     assert failed_group["active"] is False
     assert failed_group["failed"]["event_type"] == "hsl.replay.failed"
     assert failed_group["failed"]["status"] == "failed"
+    shutdown_group = next(
+        group
+        for group in report["hsl_replay_health"]["groups"]
+        if group["bot"] == "kucoin/kucoin_01"
+    )
+    assert shutdown_group["active"] is False
+    assert shutdown_group["failed"]["reason_code"] == "shutdown_cancelled"
     assert brief["hsl_replay"] == {
-        "total": 7,
-        "bots": 3,
+        "total": 9,
+        "bots": 4,
         "active_bots": 1,
         "completed_bots": 1,
-        "failed_bots": 1,
+        "failed_bots": 2,
+        "failed_attention_bots": 1,
         "event_types": {
             "hsl.replay.progress": 2,
-            "hsl.replay.started": 3,
+            "hsl.replay.started": 4,
             "hsl.replay.completed": 1,
-            "hsl.replay.failed": 1,
+            "hsl.replay.failed": 2,
         },
     }
 

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2122,6 +2122,43 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
             ),
         ],
     )
+    _write_ndjson(
+        tmp_path
+        / "monitor"
+        / "okx"
+        / "okx_01"
+        / "events"
+        / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.replay.started",
+                seq=6,
+                ts=6000,
+                exchange="okx",
+                user="okx_01",
+                reason_code="coin_history_replay",
+                level="debug",
+                status="started",
+                data={"signal_mode": "coin", "lookback_days": 30.0},
+            ),
+            _monitor_row(
+                event_type="hsl.replay.failed",
+                seq=7,
+                ts=7000,
+                exchange="okx",
+                user="okx_01",
+                reason_code="coin_history_replay_failed",
+                level="warning",
+                status="failed",
+                data={
+                    "signal_mode": "coin",
+                    "error_type": "RuntimeError",
+                    "elapsed_s": 12.3,
+                    "secret": "must-not-render",
+                },
+            ),
+        ],
+    )
 
     report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
     summary = summarize_live_smoke_report(report)
@@ -2133,11 +2170,12 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
     assert report["attention_sources"]["hsl_replay_active_bots"] == 1
     assert report["hsl_replay_health"]["active_bots"] == 1
     assert report["hsl_replay_health"]["completed_bots"] == 1
-    assert report["hsl_replay_health"]["failed_bots"] == 0
+    assert report["hsl_replay_health"]["failed_bots"] == 1
     assert report["hsl_replay_health"]["event_types"] == {
         "hsl.replay.progress": 2,
-        "hsl.replay.started": 2,
+        "hsl.replay.started": 3,
         "hsl.replay.completed": 1,
+        "hsl.replay.failed": 1,
     }
     active_group = report["hsl_replay_health"]["groups"][0]
     assert active_group["bot"] == "gateio/gateio_01"
@@ -2162,16 +2200,25 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
     )
     assert summary["hsl_replay_health"]["active_bots"] == 1
     assert summary["hsl_replay_health"]["groups"][0]["active"] is True
+    failed_group = next(
+        group
+        for group in report["hsl_replay_health"]["groups"]
+        if group["bot"] == "okx/okx_01"
+    )
+    assert failed_group["active"] is False
+    assert failed_group["failed"]["event_type"] == "hsl.replay.failed"
+    assert failed_group["failed"]["status"] == "failed"
     assert brief["hsl_replay"] == {
-        "total": 5,
-        "bots": 2,
+        "total": 7,
+        "bots": 3,
         "active_bots": 1,
         "completed_bots": 1,
-        "failed_bots": 0,
+        "failed_bots": 1,
         "event_types": {
             "hsl.replay.progress": 2,
-            "hsl.replay.started": 2,
+            "hsl.replay.started": 3,
             "hsl.replay.completed": 1,
+            "hsl.replay.failed": 1,
         },
     }
 

--- a/tests/test_realized_loss_gate.py
+++ b/tests/test_realized_loss_gate.py
@@ -3,6 +3,7 @@
 import logging
 import types
 from copy import deepcopy
+from types import MethodType
 from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
@@ -417,6 +418,42 @@ class TestGetRealizedPnlCumsumStats:
 
         with pytest.raises(RuntimeError, match="unsafe with balance_override"):
             bot._equity_hard_stop_validate_balance_source_for_history_replay()
+
+    def test_equity_hard_stop_balance_override_guard_emits_replay_failed_event(self):
+        bot = object.__new__(Passivbot)
+        bot.config = {"live": {"hsl_signal_mode": "unified"}}
+        bot.balance_override = 1000.0
+        bot.hsl = {
+            "long": {"enabled": True},
+            "short": {"enabled": False},
+        }
+        sink = ListEventSink()
+        bot._live_event_current_cycle_id = "cy_hsl_guard"
+        bot._live_event_pipeline = LiveEventPipeline(
+            structured_sinks=[sink],
+            monitor_sinks=[],
+        )
+        bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+
+        with pytest.raises(RuntimeError, match="unsafe with balance_override"):
+            bot._equity_hard_stop_validate_balance_source_for_history_replay()
+
+        assert bot._live_event_pipeline.flush(timeout=2.0) is True
+        events = [event for event in sink.events if event.event_type.startswith("hsl.replay.")]
+        assert [event.event_type for event in events] == [EventTypes.HSL_REPLAY_FAILED]
+        assert events[0].level == "critical"
+        assert events[0].status == "failed"
+        assert (
+            events[0].reason_code
+            == "hsl_balance_override_account_level_replay_unsafe"
+        )
+        assert events[0].cycle_id == "cy_hsl_guard"
+        assert events[0].data == {
+            "signal_mode": "unified",
+            "balance_override_active": True,
+            "enabled_psides": ["long"],
+        }
+        assert bot._live_event_pipeline.close(timeout=2.0) is True
 
     def test_equity_hard_stop_allows_coin_replay_with_balance_override(self):
         bot = object.__new__(Passivbot)


### PR DESCRIPTION
## Summary
- add registered `hsl.replay.failed` event type and balance-override replay guard reason code
- emit `hsl.replay.failed` when account-level HSL replay is blocked by balance override, and for coin replay cancellation/failure
- surface failed HSL replay as terminal failed state in smoke/performance reports

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_registry_docs.py tests/test_realized_loss_gate.py::TestGetRealizedPnlCumsumStats::test_equity_hard_stop_balance_override_guard_emits_replay_failed_event tests/test_realized_loss_gate.py::TestGetRealizedPnlCumsumStats::test_equity_hard_stop_blocks_unified_replay_with_balance_override tests/test_realized_loss_gate.py::TestGetRealizedPnlCumsumStats::test_equity_hard_stop_startup_guard_runs_before_history_replay tests/test_hsl_coin_mode.py::test_coin_hsl_replay_cancels_when_shutdown_requested_after_history_load tests/test_hsl_coin_mode.py::test_coin_hsl_history_replay_emits_lifecycle_events tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_hsl_replay_health tests/test_live_performance_report.py::test_live_performance_report_hsl_replay_profile -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_registry_docs.py tests/test_hsl_coin_mode.py tests/test_live_smoke_report.py tests/test_live_performance_report.py tests/test_realized_loss_gate.py -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/passivbot_hsl.py src/live/event_bus.py src/live/smoke_report.py src/live/performance_report.py tests/test_realized_loss_gate.py tests/test_hsl_coin_mode.py tests/test_live_smoke_report.py tests/test_live_performance_report.py tests/test_live_event_registry_docs.py`
- `git diff --check`

Default console/text routes remain off for the new event. Runtime guard behavior remains fail-closed; event emission is best-effort.
