### PR TITLE
Emit create skip events for market-distance guard

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -152,6 +152,7 @@ across time.
 - `hsl_balance_override_account_level_replay_unsafe`
 - `initial_entry_distance_gate`
 - `length_mismatch`
+- `limit_order_create_market_distance`
 - `low_balance`
 - `min_effective_cost_blocked`
 - `new_fill`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -193,6 +193,7 @@ class ReasonCodes:
     FILL_CACHE_READY = "fill_cache_ready"
     INITIAL_ENTRY_DISTANCE_GATE = "initial_entry_distance_gate"
     LENGTH_MISMATCH = "length_mismatch"
+    LIMIT_ORDER_CREATE_MARKET_DISTANCE = "limit_order_create_market_distance"
     LOW_BALANCE = "low_balance"
     MIN_EFFECTIVE_COST_BLOCKED = "min_effective_cost_blocked"
     NEW_FILL = "new_fill"

--- a/src/live/market_data.py
+++ b/src/live/market_data.py
@@ -8,6 +8,7 @@ from collections import Counter
 from typing import Iterable
 
 from config.access import get_optional_live_value
+from live.event_bus import EventTypes, ReasonCodes
 from live.market_snapshot import MarketSnapshot
 from utils import utc_ms
 
@@ -226,6 +227,49 @@ def _log_limit_order_distance_skips(
         for (symbol, pside, side, pb_type), count in grouped.items()
     )
     log_fn = logging.info if should_info else logging.debug
+    emit_filter_event = getattr(bot, "_emit_execution_create_filter_event", None)
+    if callable(emit_filter_event):
+        grouped_sample = [
+            {
+                "symbol": symbol,
+                "pside": pside or None,
+                "side": side or None,
+                "pb_order_type": pb_type or "unknown",
+                "count": int(count),
+            }
+            for (symbol, pside, side, pb_type), count in grouped.most_common(12)
+        ]
+        order_sample = []
+        for item in skipped[:8]:
+            order = item["order"]
+            order_sample.append(
+                {
+                    "symbol": str(order.get("symbol") or ""),
+                    "pside": str(order.get("position_side") or "") or None,
+                    "side": str(order.get("side") or "") or None,
+                    "pb_order_type": str(order.get("pb_order_type") or "unknown"),
+                    "price": float(order.get("price")),
+                    "market_price": float(item["market_price"]),
+                    "distance": float(item["dist"]),
+                }
+            )
+        emit_filter_event(
+            event_type=EventTypes.EXECUTION_CREATE_SKIPPED,
+            status="skipped",
+            reason_code=ReasonCodes.LIMIT_ORDER_CREATE_MARKET_DISTANCE,
+            order_count=len(skipped),
+            symbols=skipped_symbols,
+            level="info" if should_info else "debug",
+            message="limit order creates skipped because prices are too far from live market",
+            data={
+                "threshold": float(threshold),
+                "min_multiplier": float(min_mult),
+                "max_multiplier": float(max_mult),
+                "groups": grouped_sample,
+                "sample": order_sample,
+                "suppressed_text_log": not should_info,
+            },
+        )
     log_fn(
         "[order] skipped far-from-market limit order creates | "
         "skipped=%d symbols=%s threshold=%.4f min_multiplier=%.4f "

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -6581,6 +6581,11 @@ async def test_pre_create_snapshot_filter_skips_far_limit_order_creations(
 
     symbol = "POPCAT/USDT:USDT"
     bot = _make_pre_create_distance_guard_bot(symbol)
+    sink = ListEventSink()
+    bot._live_event_current_cycle_id = "cy_distance_guard"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink], monitor_sinks=[]
+    )
     kept_buy = {
         "symbol": symbol,
         "side": "buy",
@@ -6650,6 +6655,51 @@ async def test_pre_create_snapshot_filter_skips_far_limit_order_creations(
         and "skipped=3" in rec.message
         for rec in caplog.records
     )
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.EXECUTION_CREATE_SKIPPED
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.reason_code == ReasonCodes.LIMIT_ORDER_CREATE_MARKET_DISTANCE
+    assert event.status == "skipped"
+    assert event.level == "info"
+    assert event.cycle_id == "cy_distance_guard"
+    assert event.data["order_count"] == 3
+    assert event.data["symbols"] == [symbol]
+    assert event.data["symbols_count"] == 1
+    assert event.data["threshold"] == pytest.approx(0.8)
+    assert event.data["min_multiplier"] == pytest.approx(0.2)
+    assert event.data["max_multiplier"] == pytest.approx(1.8)
+    assert event.data["suppressed_text_log"] is False
+    assert event.data["groups"] == [
+        {
+            "symbol": symbol,
+            "pside": "long",
+            "side": "buy",
+            "pb_order_type": "entry_grid_cropped_long",
+            "count": 1,
+        },
+        {
+            "symbol": symbol,
+            "pside": "short",
+            "side": "sell",
+            "pb_order_type": "entry_grid_cropped_short",
+            "count": 1,
+        },
+        {
+            "symbol": symbol,
+            "pside": "long",
+            "side": "sell",
+            "pb_order_type": "close_grid_long",
+            "count": 1,
+        },
+    ]
+    assert len(event.data["sample"]) == 3
+    assert all(item["symbol"] == symbol for item in event.data["sample"])
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- emit off-console structured execution.create_skipped events when the pre-create market-distance guard skips far-from-market limit creates
- add a stable limit_order_create_market_distance reason code and registry docs entry
- extend the existing pre-create distance guard test to verify bounded event groups/samples alongside the text log

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_passivbot_balance_split.py::test_pre_create_snapshot_filter_skips_far_limit_order_creations tests/test_live_event_registry_docs.py tests/test_live_event_bus.py::test_live_event_reason_code_registry_values_are_unique_and_query_safe -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/live/market_data.py src/live/event_bus.py tests/test_passivbot_balance_split.py
- git diff --check