### PR TITLE
Emit create skip events for pre-create snapshots

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -160,6 +160,8 @@ across time.
 - `optional_ema_dropped`
 - `pending_exchange_config`
 - `periodic_health_summary`
+- `pre_create_market_snapshot_unavailable`
+- `pre_create_planning_snapshot_invalid`
 - `queue_full`
 - `ranking_features_unavailable`
 - `recent_execution`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -201,6 +201,10 @@ class ReasonCodes:
     OPTIONAL_EMA_DROPPED = "optional_ema_dropped"
     PENDING_EXCHANGE_CONFIG = "pending_exchange_config"
     PERIODIC_HEALTH_SUMMARY = "periodic_health_summary"
+    PRE_CREATE_MARKET_SNAPSHOT_UNAVAILABLE = (
+        "pre_create_market_snapshot_unavailable"
+    )
+    PRE_CREATE_PLANNING_SNAPSHOT_INVALID = "pre_create_planning_snapshot_invalid"
     QUEUE_FULL = "queue_full"
     RANKING_FEATURES_UNAVAILABLE = "ranking_features_unavailable"
     RECENT_EXECUTION = "recent_execution"

--- a/src/live/market_data.py
+++ b/src/live/market_data.py
@@ -28,6 +28,62 @@ def _passivbot_module():
     return module
 
 
+def _bounded_pre_create_skip_details(details: list[dict] | None) -> list[dict]:
+    bounded: list[dict] = []
+    for item in list(details or [])[:8]:
+        if not isinstance(item, dict):
+            continue
+        compact = {}
+        for key in (
+            "surface",
+            "reason",
+            "symbol",
+            "age_ms",
+            "max_age_ms",
+            "epoch",
+            "min_epoch",
+        ):
+            value = item.get(key)
+            if value is not None:
+                compact[key] = value
+        if compact:
+            bounded.append(compact)
+    return bounded
+
+
+def _emit_pre_create_skip_event(
+    bot,
+    *,
+    reason_code: str,
+    orders: list[dict],
+    symbols: list[str],
+    stage: str,
+    message: str,
+    details: list[dict] | None = None,
+    error_type: str | None = None,
+) -> None:
+    emit_filter_event = getattr(bot, "_emit_execution_create_filter_event", None)
+    if not callable(emit_filter_event):
+        return
+    details_count = len(details or [])
+    emit_filter_event(
+        event_type=EventTypes.EXECUTION_CREATE_SKIPPED,
+        status="skipped",
+        reason_code=reason_code,
+        order_count=len(orders),
+        symbols=symbols,
+        level="warning",
+        message=message,
+        data={
+            "stage": stage,
+            "details": _bounded_pre_create_skip_details(details),
+            "details_count": details_count,
+            "details_truncated": details_count > 8,
+            "error_type": error_type,
+        },
+    )
+
+
 def market_snapshot_ticker_strategy(bot) -> str:
     """Choose the cheapest safe ticker endpoint shape for market snapshots."""
     explicit = get_optional_live_value(
@@ -80,6 +136,15 @@ async def filter_fresh_market_snapshot_creations(
                 bot._log_symbols(symbols, limit=12),
                 bot._log_compact_symbol_payload(planning_snapshot_invalid[:8]),
             )
+            _emit_pre_create_skip_event(
+                bot,
+                reason_code=ReasonCodes.PRE_CREATE_PLANNING_SNAPSHOT_INVALID,
+                orders=orders,
+                symbols=symbols,
+                stage="planning_snapshot",
+                message="create orders skipped because planning snapshot is invalid before create",
+                details=planning_snapshot_invalid,
+            )
             return []
         logging.info(
             "[market] refreshing stale planning market snapshot before create | symbols=%s stale=%s",
@@ -102,12 +167,30 @@ async def filter_fresh_market_snapshot_creations(
             type(exc).__name__,
             exc,
         )
+        _emit_pre_create_skip_event(
+            bot,
+            reason_code=ReasonCodes.PRE_CREATE_MARKET_SNAPSHOT_UNAVAILABLE,
+            orders=orders,
+            symbols=symbols,
+            stage="market_snapshot_refresh",
+            message="create orders skipped because pre-create market snapshot refresh failed",
+            error_type=type(exc).__name__,
+        )
         return []
     if invalid:
         logging.warning(
             "[market] skipping order creation; stale pre-create market snapshots | symbols=%s details=%s",
             bot._log_symbols(symbols, limit=12),
             bot._log_compact_symbol_payload(invalid[:8]),
+        )
+        _emit_pre_create_skip_event(
+            bot,
+            reason_code=ReasonCodes.PRE_CREATE_MARKET_SNAPSHOT_UNAVAILABLE,
+            orders=orders,
+            symbols=symbols,
+            stage="market_snapshot_validation",
+            message="create orders skipped because pre-create market snapshots are stale",
+            details=invalid,
         )
         return []
     orders = _filter_limit_order_creations_by_market_distance(bot, orders, snapshots)

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -6405,6 +6405,11 @@ async def test_pre_create_snapshot_filter_blocks_stale_market_snapshots():
     bot.exchange = "bybit"
     bot.freshness_ledger = FreshnessLedger(now_ms=0)
     bot._authoritative_refresh_epoch = 1
+    sink = ListEventSink()
+    bot._live_event_current_cycle_id = "cy_stale_pre_create_market_snapshot"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink], monitor_sinks=[]
+    )
     symbol = "BTC/USDT:USDT"
 
     async def fake_get_snapshots(symbols, max_age_ms=None):
@@ -6454,6 +6459,98 @@ async def test_pre_create_snapshot_filter_blocks_stale_market_snapshots():
     ]
 
     assert await bot._filter_fresh_market_snapshot_creations(orders) == []
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.EXECUTION_CREATE_SKIPPED
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.reason_code == ReasonCodes.PRE_CREATE_MARKET_SNAPSHOT_UNAVAILABLE
+    assert event.status == "skipped"
+    assert event.level == "warning"
+    assert event.cycle_id == "cy_stale_pre_create_market_snapshot"
+    assert event.data["order_count"] == 1
+    assert event.data["symbols"] == [symbol]
+    assert event.data["stage"] == "market_snapshot_validation"
+    assert event.data["details_count"] == 1
+    assert event.data["details"][0]["symbol"] == symbol
+    assert event.data["details"][0]["reason"] == "stale"
+    assert event.data["details"][0]["age_ms"] >= 20_000
+    assert event.data["details"][0]["max_age_ms"] == 10_000
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_pre_create_snapshot_filter_emits_failed_refresh_skip_event():
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {}}
+    bot.exchange = "bybit"
+    bot.freshness_ledger = FreshnessLedger(now_ms=0)
+    bot._authoritative_refresh_epoch = 1
+    sink = ListEventSink()
+    bot._live_event_current_cycle_id = "cy_failed_pre_create_market_snapshot"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink], monitor_sinks=[]
+    )
+    symbol = "BTC/USDT:USDT"
+    now_ms = passivbot_module.utc_ms()
+    bot._current_planning_snapshot = PlanningSnapshot(
+        ts_ms=now_ms,
+        exchange="bybit",
+        user="tester",
+        epoch=1,
+        symbols=(symbol,),
+        required_surfaces=tuple(),
+        surfaces=tuple(),
+        market_snapshots=(
+            PlanningMarketSnapshot(
+                symbol=symbol,
+                bid=100.0,
+                ask=100.0,
+                last=100.0,
+                fetched_ms=now_ms,
+                source="test",
+            ),
+        ),
+        market_snapshot_max_age_ms=10_000,
+        completed_candle_signature=tuple(),
+    )
+
+    async def fail_get_snapshots(symbols, max_age_ms=None):
+        raise RuntimeError("exchange unavailable with raw detail")
+
+    bot.market_snapshot_provider = SimpleNamespace(get_snapshots=fail_get_snapshots)
+    orders = [
+        {
+            "symbol": symbol,
+            "side": "buy",
+            "position_side": "long",
+            "qty": 1.0,
+            "price": 99.0,
+        }
+    ]
+
+    assert await bot._filter_fresh_market_snapshot_creations(orders) == []
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.EXECUTION_CREATE_SKIPPED
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.reason_code == ReasonCodes.PRE_CREATE_MARKET_SNAPSHOT_UNAVAILABLE
+    assert event.status == "skipped"
+    assert event.level == "warning"
+    assert event.cycle_id == "cy_failed_pre_create_market_snapshot"
+    assert event.data["order_count"] == 1
+    assert event.data["symbols"] == [symbol]
+    assert event.data["stage"] == "market_snapshot_refresh"
+    assert event.data["error_type"] == "RuntimeError"
+    assert "exchange unavailable" not in json.dumps(event.data)
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 @pytest.mark.asyncio
@@ -6733,6 +6830,11 @@ async def test_pre_create_snapshot_filter_blocks_non_market_planning_invalidatio
     bot = Passivbot.__new__(Passivbot)
     bot.config = {"live": {}}
     bot.exchange = "bybit"
+    sink = ListEventSink()
+    bot._live_event_current_cycle_id = "cy_invalid_pre_create_planning_snapshot"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink], monitor_sinks=[]
+    )
     symbol = "BTC/USDT:USDT"
     now_ms = passivbot_module.utc_ms()
     bot._current_planning_snapshot = PlanningSnapshot(
@@ -6782,6 +6884,25 @@ async def test_pre_create_snapshot_filter_blocks_non_market_planning_invalidatio
     ]
 
     assert await bot._filter_fresh_market_snapshot_creations(orders) == []
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.EXECUTION_CREATE_SKIPPED
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.reason_code == ReasonCodes.PRE_CREATE_PLANNING_SNAPSHOT_INVALID
+    assert event.status == "skipped"
+    assert event.level == "warning"
+    assert event.cycle_id == "cy_invalid_pre_create_planning_snapshot"
+    assert event.data["order_count"] == 1
+    assert event.data["symbols"] == [symbol]
+    assert event.data["stage"] == "planning_snapshot"
+    assert event.data["details_count"] == 1
+    assert event.data["details"][0]["surface"] == "positions"
+    assert event.data["details"][0]["reason"] == "surface_epoch_too_old"
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 def _make_open_order_guardrail_bot(*, epoch: int = 3):


### PR DESCRIPTION
## Summary
- emit structured execution.create_skipped events when pre-create planning snapshot invalidation blocks creates
- emit structured execution.create_skipped events when pre-create market snapshot refresh fails or remains stale
- register the new reason codes and cover bounded/redacted payloads in tests

## Tests
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_passivbot_balance_split.py::test_pre_create_snapshot_filter_blocks_stale_market_snapshots tests/test_passivbot_balance_split.py::test_pre_create_snapshot_filter_emits_failed_refresh_skip_event tests/test_passivbot_balance_split.py::test_pre_create_snapshot_filter_refreshes_stale_planning_market_snapshot tests/test_passivbot_balance_split.py::test_pre_create_snapshot_filter_skips_far_limit_order_creations tests/test_passivbot_balance_split.py::test_pre_create_snapshot_filter_blocks_non_market_planning_invalidation tests/test_live_event_registry_docs.py tests/test_live_event_bus.py::test_live_event_reason_code_registry_values_are_unique_and_query_safe -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/live/market_data.py src/live/event_bus.py tests/test_passivbot_balance_split.py
- git diff --check
- rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])" src/live/market_data.py src/live/event_bus.py tests/test_passivbot_balance_split.py