### PR TITLE
Emit market snapshot diagnostic skip events

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -54,6 +54,7 @@ across time.
 - `forager.feature_unavailable`
 - `forager.selection`
 - `health.summary`
+- `market.snapshot_diagnostic_skipped`
 - `hsl.cooldown_ended`
 - `hsl.cooldown_started`
 - `hsl.red_triggered`
@@ -112,6 +113,7 @@ across time.
 - `health`
 - `load`
 - `logging`
+- `market`
 - `mode`
 - `order`
 - `planning`
@@ -157,6 +159,7 @@ across time.
 - `length_mismatch`
 - `limit_order_create_market_distance`
 - `low_balance`
+- `market_snapshot_diagnostic_skipped`
 - `min_effective_cost_blocked`
 - `new_fill`
 - `open_tail_projection`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -60,6 +60,7 @@ class EventTypes:
     BOT_SHUTDOWN_STAGE = "bot.shutdown.stage"
     BOT_STOPPED = "bot.stopped"
     HEALTH_SUMMARY = "health.summary"
+    MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED = "market.snapshot_diagnostic_skipped"
     CYCLE_STARTED = "cycle.started"
     CYCLE_COMPLETED = "cycle.completed"
     CYCLE_DEGRADED = "cycle.degraded"
@@ -155,6 +156,7 @@ class EventTags:
     HEALTH = "health"
     LOAD = "load"
     LOGGING = "logging"
+    MARKET = "market"
     MODE = "mode"
     ORDER = "order"
     PLANNING = "planning"
@@ -198,6 +200,7 @@ class ReasonCodes:
     LENGTH_MISMATCH = "length_mismatch"
     LIMIT_ORDER_CREATE_MARKET_DISTANCE = "limit_order_create_market_distance"
     LOW_BALANCE = "low_balance"
+    MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED = "market_snapshot_diagnostic_skipped"
     MIN_EFFECTIVE_COST_BLOCKED = "min_effective_cost_blocked"
     NEW_FILL = "new_fill"
     OPEN_TAIL_PROJECTION = "open_tail_projection"
@@ -596,6 +599,9 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.BOT_SHUTDOWN_STAGE: EventRoute(console=True, text=True),
     EventTypes.BOT_STOPPED: EventRoute(console=True, text=True),
     EventTypes.HEALTH_SUMMARY: EventRoute(console=False, text=False),
+    EventTypes.MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED: EventRoute(
+        console=False, text=False
+    ),
     EventTypes.CYCLE_STARTED: EventRoute(
         console=True, text=True, throttle_interval_ms=60_000
     ),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1191,6 +1191,43 @@ def emit_health_summary_event(bot: Any, *args: Any, **kwargs: Any) -> None:
         logging.debug("[event] failed to emit health summary event: %s", exc)
 
 
+def _emit_market_snapshot_diagnostic_skipped_event_unchecked(
+    bot: Any,
+    *,
+    context: str,
+    error: BaseException,
+) -> None:
+    _safe_emit(
+        bot,
+        EventTypes.MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED,
+        level="warning",
+        component="market.snapshot",
+        tags=(EventTags.MARKET, EventTags.SNAPSHOT, EventTags.DEGRADED),
+        cycle_id=current_live_event_cycle_id(bot),
+        status="skipped",
+        reason_code=ReasonCodes.MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED,
+        data={
+            "context": str(context),
+            "error_type": type(error).__name__,
+            "error": _sanitize_remote_text(error, max_len=500),
+        },
+    )
+
+
+def emit_market_snapshot_diagnostic_skipped_event(
+    bot: Any, *args: Any, **kwargs: Any
+) -> None:
+    try:
+        _emit_market_snapshot_diagnostic_skipped_event_unchecked(
+            bot, *args, **kwargs
+        )
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit market snapshot diagnostic skipped event: %s",
+            exc,
+        )
+
+
 def _safe_int_map(value: Any) -> dict[str, int]:
     if not isinstance(value, dict):
         return {}

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -680,6 +680,9 @@ class Passivbot:
     )
     _emit_position_changed_event = live_event_emitters.emit_position_changed_event
     _emit_health_summary_event = live_event_emitters.emit_health_summary_event
+    _emit_market_snapshot_diagnostic_skipped_event = (
+        live_event_emitters.emit_market_snapshot_diagnostic_skipped_event
+    )
     _emit_execution_loop_error_burst_event = (
         live_event_emitters.emit_execution_loop_error_burst_event
     )
@@ -10177,6 +10180,11 @@ class Passivbot:
     ) -> bool:
         if not self._is_market_snapshot_error(exc):
             return False
+        emit_market_snapshot_event = getattr(
+            self, "_emit_market_snapshot_diagnostic_skipped_event", None
+        )
+        if callable(emit_market_snapshot_event):
+            emit_market_snapshot_event(context=context, error=exc)
         logging.warning("[market] skipped %s | error=%s", context, exc)
         return True
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -122,6 +122,41 @@ def test_market_snapshot_ticker_strategy_respects_explicit_override():
     assert bot._market_snapshot_ticker_strategy() == "bulk"
 
 
+def test_noncritical_market_snapshot_error_emits_skipped_event():
+    sink = ListEventSink()
+    bot = Passivbot.__new__(Passivbot)
+    bot._live_event_current_cycle_id = "cy_market_diag"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    exc = RuntimeError(
+        "missing live market snapshots for upnl api_key=secret-token"
+    )
+
+    assert bot._log_noncritical_market_snapshot_error("upnl diagnostics", exc) is True
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.level == "warning"
+    assert event.component == "market.snapshot"
+    assert event.tags == ("market", "snapshot", "degraded")
+    assert event.cycle_id == "cy_market_diag"
+    assert event.status == "skipped"
+    assert event.reason_code == ReasonCodes.MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED
+    assert event.data["context"] == "upnl diagnostics"
+    assert event.data["error_type"] == "RuntimeError"
+    assert "secret-token" not in event.data["error"]
+    assert DEFAULT_ROUTES[EventTypes.MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED].console is False
+    assert DEFAULT_ROUTES[EventTypes.MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED].text is False
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 @pytest.mark.asyncio
 async def test_init_pnls_quarantines_and_rebuilds_unsupported_legacy_cache(monkeypatch):
     managers = []


### PR DESCRIPTION
Summary:
- add off-console structured market.snapshot_diagnostic_skipped events for noncritical market snapshot diagnostic skips
- keep existing warning log and helper return behavior unchanged
- include bounded sanitized context/error_type/error only, with registered event type/tag/reason code

Validation:
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_passivbot_balance_split.py::test_noncritical_market_snapshot_error_emits_skipped_event tests/test_live_event_registry_docs.py tests/test_passivbot_monitor.py::test_health_summary_event_emitter_records_payload -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/passivbot.py src/live/event_emitters.py src/live/event_bus.py tests/test_passivbot_balance_split.py
- git diff --check