### PR TITLE
Emit HSL raw red pending diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added structured `hsl.raw_red_pending` diagnostics when HSL raw drawdown is
+  already beyond red but EMA-confirmed drawdown has not crossed yet, helping
+  operators spot pending RED risk without changing trading behavior.
 - `passivbot tool live-smoke-report --processes` now performs a read-only
   local config check for running/expected live commands and reports a hard
   smoke failure when account-level HSL (`unified`/`pside`) is combined with an

--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -57,6 +57,7 @@ across time.
 - `market.snapshot_diagnostic_skipped`
 - `hsl.cooldown_ended`
 - `hsl.cooldown_started`
+- `hsl.raw_red_pending`
 - `hsl.red_triggered`
 - `hsl.replay.completed`
 - `hsl.replay.failed`
@@ -155,6 +156,7 @@ across time.
 - `fill_cache_ready`
 - `fill_cache_rebuild_started`
 - `hsl_balance_override_account_level_replay_unsafe`
+- `hsl_raw_red_pending_ema_confirmation`
 - `initial_entry_distance_gate`
 - `length_mismatch`
 - `limit_order_create_market_distance`

--- a/docs/plans/live_logging_overhaul_plan.md
+++ b/docs/plans/live_logging_overhaul_plan.md
@@ -167,6 +167,7 @@ stable names:
 - `hsl.replay.progress`
 - `hsl.replay.completed`
 - `hsl.replay.failed`
+- `hsl.raw_red_pending`
 - `hsl.transition`
 - `risk.mode_changed`
 - `rust_orchestrator.called`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -116,6 +116,7 @@ class EventTypes:
     RISK_MODE_CHANGED = "risk.mode_changed"
     HSL_TRANSITION = "hsl.transition"
     HSL_STATUS = "hsl.status"
+    HSL_RAW_RED_PENDING = "hsl.raw_red_pending"
     HSL_REPLAY_STARTED = "hsl.replay.started"
     HSL_REPLAY_PROGRESS = "hsl.replay.progress"
     HSL_REPLAY_COMPLETED = "hsl.replay.completed"
@@ -221,6 +222,7 @@ class ReasonCodes:
     HSL_BALANCE_OVERRIDE_ACCOUNT_LEVEL_REPLAY_UNSAFE = (
         "hsl_balance_override_account_level_replay_unsafe"
     )
+    HSL_RAW_RED_PENDING_EMA_CONFIRMATION = "hsl_raw_red_pending_ema_confirmation"
     RUST_OUTPUT_ACTIONS = "rust_output_actions"
     SINK_PIPELINE_CLOSING = "pipeline_closing"
     SNAPSHOT_SYMBOL_STATE = "snapshot_symbol_state"
@@ -667,6 +669,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.RISK_MODE_CHANGED: EventRoute(console=False, text=False),
     EventTypes.HSL_TRANSITION: EventRoute(console=False, text=False),
     EventTypes.HSL_STATUS: EventRoute(console=False, text=False),
+    EventTypes.HSL_RAW_RED_PENDING: EventRoute(console=False, text=False),
     EventTypes.HSL_REPLAY_STARTED: EventRoute(console=False, text=False),
     EventTypes.HSL_REPLAY_PROGRESS: EventRoute(console=False, text=False),
     EventTypes.HSL_REPLAY_COMPLETED: EventRoute(console=False, text=False),

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -2688,6 +2688,9 @@ class Passivbot:
     _equity_hard_stop_apply_sample = pb_hsl._equity_hard_stop_apply_sample
     _equity_hard_stop_apply_coin_sample = pb_hsl._equity_hard_stop_apply_coin_sample
     _equity_hard_stop_log_transition = pb_hsl._equity_hard_stop_log_transition
+    _equity_hard_stop_maybe_emit_raw_red_pending = (
+        pb_hsl._equity_hard_stop_maybe_emit_raw_red_pending
+    )
     _equity_hard_stop_format_remaining_time = staticmethod(
         pb_hsl._equity_hard_stop_format_remaining_time
     )

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -328,6 +328,7 @@ def _equity_hard_stop_make_state(self) -> dict[str, Any]:
         "pending_stop_event": None,
         "last_stop_event": None,
         "red_trigger_event_emitted": False,
+        "last_raw_red_pending_event_ms": 0,
         "last_status_log_ms": 0,
         "last_cooldown_log_ms": 0,
         "cooldown_intervention_active": False,
@@ -745,6 +746,7 @@ def _equity_hard_stop_reset_state(self) -> None:
         state["pending_stop_event"] = None
         state["last_stop_event"] = None
         state["red_trigger_event_emitted"] = False
+        state["last_raw_red_pending_event_ms"] = 0
         state["last_status_log_ms"] = 0
         state["last_cooldown_log_ms"] = 0
         state["cooldown_intervention_active"] = False
@@ -1461,6 +1463,71 @@ def _equity_hard_stop_log_transition(self, pside: str, metrics: dict, prev_tier:
     )
 
 
+def _equity_hard_stop_maybe_emit_raw_red_pending(
+    self,
+    pside: str,
+    metrics: dict,
+    *,
+    symbol: Optional[str] = None,
+) -> None:
+    """Emit a bounded diagnostic when raw HSL drawdown is red before EMA confirms."""
+    try:
+        red_threshold = float(metrics["red_threshold"])
+        drawdown_raw = float(metrics["drawdown_raw"])
+        drawdown_ema = float(metrics["drawdown_ema"])
+        drawdown_score = float(metrics["drawdown_score"])
+        if drawdown_raw < red_threshold or drawdown_score >= red_threshold:
+            return
+        state = self._hsl_coin_state(pside, symbol) if symbol else self._hsl_state(pside)
+        now_ms = int(metrics["timestamp_ms"])
+        last_event_ms = int(state.get("last_raw_red_pending_event_ms", 0) or 0)
+        interval_ms = int(
+            getattr(
+                self,
+                "_equity_hard_stop_status_log_interval_ms",
+                15 * 60 * 1000,
+            )
+            or 0
+        )
+        if last_event_ms and interval_ms > 0 and now_ms - last_event_ms < interval_ms:
+            return
+        state["last_raw_red_pending_event_ms"] = now_ms
+        _emit_hsl_event(
+            self,
+            EventTypes.HSL_RAW_RED_PENDING,
+            ("hsl", "risk", "red", "pending"),
+            {
+                "signal_mode": str(metrics.get("signal_mode") or ""),
+                "tier": str(metrics.get("tier") or ""),
+                "timestamp_ms": now_ms,
+                "red_threshold": red_threshold,
+                "drawdown_raw": drawdown_raw,
+                "drawdown_ema": drawdown_ema,
+                "drawdown_score": drawdown_score,
+                "dist_to_red": max(0.0, red_threshold - drawdown_score),
+                "raw_excess": max(0.0, drawdown_raw - red_threshold),
+                "ema_gap_to_red": max(0.0, red_threshold - drawdown_ema),
+                "elapsed_minutes": int(metrics.get("elapsed_minutes", 0) or 0),
+                "balance_override_active": bool(
+                    getattr(self, "balance_override", None) is not None
+                ),
+            },
+            pside=pside,
+            symbol=symbol,
+            ts=now_ms,
+            level="warning",
+            status="degraded",
+            reason_code=ReasonCodes.HSL_RAW_RED_PENDING_EMA_CONFIRMATION,
+        )
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit HSL raw-red pending event pside=%s symbol=%s: %s",
+            pside,
+            symbol,
+            exc,
+        )
+
+
 def _equity_hard_stop_build_latch_payload(
     self,
     pside: str,
@@ -1979,6 +2046,7 @@ def _equity_hard_stop_reset_after_restart(self, pside: str) -> None:
     state["cooldown_until_ms"] = None
     state["pending_stop_event"] = None
     state["red_trigger_event_emitted"] = False
+    state["last_raw_red_pending_event_ms"] = 0
     state["last_status_log_ms"] = 0
     state["last_cooldown_log_ms"] = 0
     state["cooldown_intervention_active"] = False
@@ -3179,6 +3247,7 @@ async def _equity_hard_stop_check(self) -> Optional[dict]:
         )
         if metrics["changed"]:
             self._equity_hard_stop_log_transition(pside, metrics, prev_tier)
+        self._equity_hard_stop_maybe_emit_raw_red_pending(pside, metrics)
         if metrics["tier"] == "red" and not prev_latched:
             state["pending_red_since_ms"] = int(metrics["timestamp_ms"])
             state["pending_stop_event"] = None
@@ -3416,6 +3485,9 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
             )
             if metrics["changed"]:
                 self._equity_hard_stop_log_transition(pside, metrics, prev_tier)
+            self._equity_hard_stop_maybe_emit_raw_red_pending(
+                pside, metrics, symbol=symbol
+            )
             if metrics["tier"] == "red" and not prev_latched:
                 state["pending_red_since_ms"] = int(metrics["timestamp_ms"])
                 state["pending_stop_event"] = None

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -62,6 +62,7 @@ def bind_hsl_methods(bot):
         "_calc_upnl_sum_strict",
         "_equity_hard_stop_apply_coin_sample",
         "_equity_hard_stop_apply_coin_metrics_sample",
+        "_equity_hard_stop_maybe_emit_raw_red_pending",
         "_equity_hard_stop_activate_coin_red_from_metrics",
         "_equity_hard_stop_coin_active_pside",
         "_equity_hard_stop_coin_realized_pnl_peak_last",
@@ -457,6 +458,78 @@ async def test_coin_hsl_check_skips_enabled_side_with_zero_budget():
     assert events[0].pside == "long"
     assert events[0].data["signal_mode"] == "coin"
     assert events[0].data["dist_to_red"] == pytest.approx(0.5)
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_check_emits_raw_red_pending_event_with_bounded_payload():
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
+
+    bot = make_coin_bot()
+    symbol = "A"
+    bot.positions = {
+        symbol: {
+            "long": {"size": 1.0, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    sink = ListEventSink()
+    bot.bot_id = "bot_1"
+    bot._live_event_current_cycle_id = "cy_coin_raw_red_pending"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+    bot._equity_hard_stop_status_log_interval_ms = 15 * 60 * 1000
+    bot.get_exchange_time = lambda: 1_000_000
+
+    def pending_metrics(_pside, _symbol, timestamp_ms, _balance, _current_upnl):
+        return {
+            "pside": "long",
+            "symbol": symbol,
+            "signal_mode": "coin",
+            "timestamp_ms": int(timestamp_ms),
+            "drawdown_raw": 0.20,
+            "drawdown_ema": 0.05,
+            "drawdown_score": 0.05,
+            "red_threshold": 0.10,
+            "tier": "orange",
+            "changed": False,
+            "elapsed_minutes": 1,
+            "slot_budget": 100.0,
+            "realized_pnl": 0.0,
+            "peak_realized_pnl": 20.0,
+            "unrealized_pnl": 0.0,
+        }
+
+    bot._equity_hard_stop_apply_coin_sample = pending_metrics
+
+    await bot._equity_hard_stop_check_coin()
+    await bot._equity_hard_stop_check_coin()
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event for event in sink.events if event.event_type == EventTypes.HSL_RAW_RED_PENDING
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.level == "warning"
+    assert event.status == "degraded"
+    assert event.reason_code == ReasonCodes.HSL_RAW_RED_PENDING_EMA_CONFIRMATION
+    assert event.cycle_id == "cy_coin_raw_red_pending"
+    assert event.symbol == symbol
+    assert event.pside == "long"
+    assert event.data["signal_mode"] == "coin"
+    assert event.data["drawdown_raw"] == pytest.approx(0.20)
+    assert event.data["drawdown_ema"] == pytest.approx(0.05)
+    assert event.data["dist_to_red"] == pytest.approx(0.05)
+    assert event.data["raw_excess"] == pytest.approx(0.10)
+    assert event.data["balance_override_active"] is False
+    assert "balance" not in event.data
+    assert "slot_budget" not in event.data
+    assert "realized_pnl" not in event.data
+    assert "peak_realized_pnl" not in event.data
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -227,6 +227,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.RISK_MODE_CHANGED,
         EventTypes.HSL_TRANSITION,
         EventTypes.HSL_STATUS,
+        EventTypes.HSL_RAW_RED_PENDING,
         EventTypes.HSL_RED_TRIGGERED,
         EventTypes.HSL_COOLDOWN_STARTED,
         EventTypes.HSL_COOLDOWN_ENDED,


### PR DESCRIPTION
Adds a structured HSL diagnostic for the state observed before the vps3 wrong-panic incident: raw HSL drawdown already beyond red while EMA-confirmed drawdown has not crossed yet.\n\nScope:\n- Adds event type hsl.raw_red_pending and reason hsl_raw_red_pending_ema_confirmation.\n- Emits from account-level and coin-mode HSL checks after metrics are computed, before existing RED handling.\n- Throttles per HSL state using the existing HSL status interval.\n- Routes off console/text by default; structured/monitor only.\n- Payload is bounded ratios/source flags only: no balance, slot budget, realized PnL, or peak PnL.\n- No Rust/order/trading decision changes. Event emission remains best-effort.\n\nValidation:\n- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py::test_route_table_keeps_data_events_off_console_by_default tests/test_live_event_bus.py::test_live_event_reason_code_registry_values_are_unique_and_query_safe tests/test_hsl_coin_mode.py::test_coin_hsl_check_emits_raw_red_pending_event_with_bounded_payload -q\n- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_hsl_coin_mode.py tests/test_live_event_bus.py -q\n- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/passivbot_hsl.py src/passivbot.py src/live/event_bus.py tests/test_hsl_coin_mode.py tests/test_live_event_bus.py\n- git diff --check