### PR TITLE
Validate HSL panic markers during replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable user-facing changes will be documented in this file.
 - Added structured `hsl.raw_red_pending` diagnostics when HSL raw drawdown is
   already beyond red but EMA-confirmed drawdown has not crossed yet, helping
   operators spot pending RED risk without changing trading behavior.
+- HSL history replay now ignores historical `close_panic_*` markers that cannot
+  be confirmed as RED by reconstructed HSL metrics at the marker timestamp, so
+  an old or erroneous panic fill does not recreate RED cooldown or supervisor
+  state on restart.
 - `passivbot tool live-smoke-report --processes` now performs a read-only
   local config check for running/expected live commands and reports a hard
   smoke failure when account-level HSL (`unified`/`pside`) is combined with an

--- a/docs/plans/vps3_ebybitsub03_wrong_hsl_panic_report.md
+++ b/docs/plans/vps3_ebybitsub03_wrong_hsl_panic_report.md
@@ -143,12 +143,16 @@ must not proceed into history replay. Operators must remove the balance
 override, switch to `hsl_signal_mode=coin`, disable HSL, or wait for an explicit
 baseline/checkpoint mechanism.
 
-This fix prevents the same false-panic calculation on new starts, but it does
-not decide how to treat historical fills that were already created by the bad
-model. In this incident the exchange history now contains a
-`close_panic_long` fill for XMR. Stateless replay can legitimately see that as
-cooldown evidence unless a future, explicit recovery contract marks the event as
-operator-invalid.
+This fix prevents the same false-panic calculation on new starts. Follow-up
+inspection showed a second unsafe replay behavior: after restart without
+`-bo`, the latest historical `close_panic_long` marker reconstructed to only
+`drawdown_raw=0.001123`, but replay still treated the marker as an active RED
+cooldown. The recovery contract is now explicit: a historical `close_panic_*`
+marker may preserve cooldown only when reconstructed HSL metrics at that marker
+confirm RED by tier, score, or raw drawdown. If reconstructed metrics are
+nowhere near the RED threshold, replay must ignore the marker, must not write a
+latch, and must not rebuild cooldown from the same marker through the generic
+latest-panic-fill fallback.
 
 ## Follow-Up Work
 
@@ -157,11 +161,9 @@ operator-invalid.
 - Include baseline source in HSL metrics/latch payloads.
 - Add startup diagnostics when raw drawdown is above red but EMA has not caught
   up yet.
-- Decide how to treat existing latch files or panic fills created by the unsafe
-  overridden account-level replay model. Any ignore/recovery mechanism must be
-  explicit, auditable, config- or exchange-derived, and covered by tests because
-  silently ignoring exchange-derived panic fills would weaken the stateless HSL
-  cooldown contract.
+- Add richer operator-facing diagnostics for ignored historical panic markers,
+  including marker timestamp, reconstructed drawdown, threshold, and whether the
+  marker came from an older unsafe balance-override run.
 - Add preflight/reporting that flags `balance_override` plus account-level HSL
   before an operator starts live, so this class of configuration cannot be
   missed in a manual restart.

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -539,6 +539,21 @@ def _equity_hard_stop_format_remaining_time(seconds: float) -> str:
     return "".join(parts)
 
 
+def _equity_hard_stop_replay_marker_confirms_red(metrics: dict) -> bool:
+    try:
+        drawdown_raw = float(metrics["drawdown_raw"])
+        drawdown_score = float(metrics["drawdown_score"])
+        red_threshold = float(metrics["red_threshold"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("HSL replay panic marker confirmation metrics are incomplete") from exc
+    threshold = red_threshold - 1e-12
+    return (
+        str(metrics.get("tier")) == "red"
+        or drawdown_score >= threshold
+        or drawdown_raw >= threshold
+    )
+
+
 def _equity_hard_stop_infer_replay_contract(
     self, pside: str, fill_events: list[dict], now_ms: int
 ) -> dict[str, Any]:
@@ -2255,6 +2270,7 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                 if current_metrics["tier"] == "red":
                     state["pending_red_since_ms"] = int(current_metrics["timestamp_ms"])
                 continue
+            ignored_panic_marker_timestamps: set[int] = set()
             for row in timeline:
                 if not isinstance(row, dict):
                     continue
@@ -2294,6 +2310,21 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                 n_rows[pside] += 1
                 panic_flatten_marker = panic_flatten_events_by_key.get((pside, ts))
                 if panic_flatten_marker is not None:
+                    marker_ts = int(panic_flatten_marker["timestamp"])
+                    if not _equity_hard_stop_replay_marker_confirms_red(current_metrics):
+                        ignored_panic_marker_timestamps.add(marker_ts)
+                        logging.warning(
+                            "[risk] HSL[%s] ignored historical panic marker without reconstructed RED | "
+                            "stop_ts=%s drawdown_raw=%.6f drawdown_ema=%.6f drawdown_score=%.6f "
+                            "red_threshold=%.6f source=panic_fill_flatten",
+                            pside,
+                            marker_ts,
+                            float(current_metrics["drawdown_raw"]),
+                            float(current_metrics["drawdown_ema"]),
+                            float(current_metrics["drawdown_score"]),
+                            float(current_metrics["red_threshold"]),
+                        )
+                        continue
                     state["pending_red_since_ms"] = int(ts)
                     stop_drawdown_raw = float(current_metrics["drawdown_raw"])
                     (
@@ -2311,10 +2342,10 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                     )
                     cooldown_until_ms = None
                     if not no_restart_latched and cooldown_ms > 0:
-                        cooldown_until_ms = int(panic_flatten_marker["timestamp"]) + cooldown_ms
+                        cooldown_until_ms = marker_ts + cooldown_ms
                     payload = self._equity_hard_stop_build_latch_payload(
                         pside,
-                        stop_event_timestamp_ms=int(panic_flatten_marker["timestamp"]),
+                        stop_event_timestamp_ms=marker_ts,
                         balance=float(row["balance"]),
                         realized_pnl_total=float(row["realized_pnl"]),
                         realized_pnl=float(row[f"realized_pnl_{pside}"]),
@@ -2344,7 +2375,7 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                         "no_restart_latched=%s cooldown_until_ms=%s diagnostic=%s "
                         "source=panic_fill_flatten",
                         pside,
-                        int(panic_flatten_marker["timestamp"]),
+                        marker_ts,
                         stop_drawdown_raw,
                         no_restart_drawdown_raw,
                         state["no_restart_latched"],
@@ -2357,6 +2388,7 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
             if (
                 not state["halted"]
                 and contract["latest_panic_ts"] is not None
+                and int(contract["latest_panic_ts"]) not in ignored_panic_marker_timestamps
                 and contract["active_cooldown_now"]
                 and not state["no_restart_latched"]
             ):
@@ -2746,6 +2778,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
 
                 replay_event_idx = 0
                 replay_size = 0.0
+                ignored_panic_marker_timestamps: set[int] = set()
 
                 def replay_size_at(row_ts_ms: int) -> float:
                     nonlocal replay_event_idx, replay_size
@@ -2867,7 +2900,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         peak_realized,
                         window_last_realized,
                         current_upnl,
-                        latch_red=marker is not None,
+                        latch_red=False,
                     )
                     applied_rows += 1
                     rows += 1
@@ -2875,6 +2908,21 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     if marker is None:
                         continue
                     stop_ts = int(marker["timestamp"])
+                    if not _equity_hard_stop_replay_marker_confirms_red(metrics):
+                        ignored_panic_marker_timestamps.add(stop_ts)
+                        logging.warning(
+                            "[risk] HSL[%s:%s] ignored historical coin panic marker without reconstructed RED | "
+                            "stop_ts=%s drawdown_raw=%.6f drawdown_ema=%.6f drawdown_score=%.6f "
+                            "red_threshold=%.6f source=panic_fill_flatten",
+                            pside,
+                            symbol,
+                            stop_ts,
+                            float(metrics["drawdown_raw"]),
+                            float(metrics["drawdown_ema"]),
+                            float(metrics["drawdown_score"]),
+                            float(metrics["red_threshold"]),
+                        )
+                        continue
                     stop_drawdown_raw = float(metrics["drawdown_raw"])
                     no_restart_latched = bool(stop_drawdown_raw >= no_restart_drawdown_threshold)
                     cooldown_until_ms = None
@@ -2948,6 +2996,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 if (
                     not state["halted"]
                     and contract["latest_panic_ts"] is not None
+                    and int(contract["latest_panic_ts"]) not in ignored_panic_marker_timestamps
                     and contract["active_cooldown_now"]
                     and not state["no_restart_latched"]
                     and not (

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -909,6 +909,66 @@ async def test_coin_hsl_history_replay_uses_stop_drawdown_for_no_restart():
 
 
 @pytest.mark.asyncio
+async def test_coin_hsl_history_replay_ignores_panic_marker_without_reconstructed_red():
+    bot = make_coin_bot()
+    symbol = "A"
+    writes = []
+    bot._equity_hard_stop_write_latch = (
+        lambda pside, payload, symbol=None: writes.append((pside, symbol, payload))
+        or "/tmp/hsl_coin_ignored.json"
+    )
+
+    async def fake_history(current_balance=None):
+        return {
+            "timeline": [
+                {
+                    "timestamp": 60_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {symbol: {"long": 0.0, "short": 0.0}},
+                    "unrealized_pnl_by_coin_pside": {symbol: {"long": 0.0, "short": 0.0}},
+                },
+                {
+                    "timestamp": 120_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {symbol: {"long": 0.0, "short": 0.0}},
+                    "unrealized_pnl_by_coin_pside": {symbol: {"long": 0.0, "short": 0.0}},
+                },
+            ],
+            "panic_flatten_events": [
+                {
+                    "timestamp": 120_500,
+                    "minute_timestamp": 120_000,
+                    "pside": "long",
+                    "symbol": symbol,
+                }
+            ],
+            "fill_events": [
+                {
+                    "timestamp": 120_500,
+                    "symbol": symbol,
+                    "pside": "long",
+                    "action": "decrease",
+                    "pb_order_type": "close_panic_long",
+                }
+            ],
+        }
+
+    bot.get_balance_equity_history = fake_history
+    bot.get_exchange_time = lambda: 180_000
+
+    await bot._equity_hard_stop_initialize_coin_from_history()
+
+    state = bot._hsl_coin_state("long", symbol)
+    assert state["halted"] is False
+    assert state["cooldown_until_ms"] is None
+    assert state["last_stop_event"] is None
+    assert state["runtime"].red_latched() is False
+    assert writes == []
+
+
+@pytest.mark.asyncio
 async def test_coin_hsl_history_replay_requires_coin_timeline_fields():
     bot = make_coin_bot()
     symbol = "A"

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1160,6 +1160,15 @@ def _make_unstuck_order(symbol="TEST/USDT", type_id=0x1234, price=100.0):
     }
 
 
+def test_hsl_replay_marker_confirmation_fails_loudly_on_incomplete_metrics():
+    import passivbot_hsl
+
+    with pytest.raises(ValueError, match="confirmation metrics are incomplete"):
+        passivbot_hsl._equity_hard_stop_replay_marker_confirms_red(
+            {"drawdown_raw": 0.0, "red_threshold": 0.1}
+        )
+
+
 def _make_order(
     symbol="TEST/USDT",
     *,
@@ -3248,6 +3257,93 @@ async def test_hard_stop_initialize_from_history_reconstructs_active_cooldown_wi
     assert _hsl_state(bot)["halted"] is True
     assert _hsl_state(bot)["no_restart_latched"] is False
     assert _hsl_state(bot)["cooldown_until_ms"] == 241_500
+
+
+@pytest.mark.asyncio
+async def test_hard_stop_initialize_from_history_ignores_panic_marker_without_reconstructed_red(
+    monkeypatch,
+):
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot, "XMR/USDT:USDT")
+    bot.positions[symbol]["long"]["size"] = 0.0
+    _hsl_cfg(bot)["enabled"] = True
+    _hsl_cfg(bot)["red_threshold"] = 0.05
+    _hsl_cfg(bot)["ema_span_minutes"] = 1.0
+    _hsl_cfg(bot)["cooldown_minutes_after_red"] = 5.0
+    _hsl_cfg(bot)["no_restart_drawdown_threshold"] = 0.2
+    bot.config["live"]["hsl_signal_mode"] = "pside"
+    bot.balance = 100.0
+
+    async def fake_history(*, current_balance=None):
+        return {
+            "timeline": [
+                {
+                    "timestamp": 1_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_long": 0.0,
+                    "realized_pnl_short": 0.0,
+                    "unrealized_pnl_long": 0.0,
+                    "unrealized_pnl_short": 0.0,
+                    "is_flat": True,
+                    "is_flat_long": True,
+                    "is_flat_short": True,
+                },
+                {
+                    "timestamp": 121_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_long": 0.0,
+                    "realized_pnl_short": 0.0,
+                    "unrealized_pnl_long": 0.0,
+                    "unrealized_pnl_short": 0.0,
+                    "is_flat": True,
+                    "is_flat_long": True,
+                    "is_flat_short": True,
+                },
+            ],
+            "panic_flatten_events": [
+                {
+                    "timestamp": 121_500,
+                    "minute_timestamp": 121_000,
+                    "pside": "long",
+                    "symbol": symbol,
+                }
+            ],
+            "fill_events": [
+                _make_hsl_fill_event(
+                    121_500,
+                    symbol=symbol,
+                    pside="long",
+                    action="decrease",
+                    pb_order_type="close_panic_long",
+                )
+            ],
+        }
+
+    writes = []
+
+    def fake_write(pside, payload):
+        writes.append((pside, payload))
+        return "/tmp/ignored_hsl_marker.json"
+
+    async def fake_upnl(*_args, **_kwargs):
+        return 0.0
+
+    monkeypatch.setattr(bot, "get_balance_equity_history", fake_history)
+    monkeypatch.setattr(bot, "_equity_hard_stop_write_latch", fake_write)
+    monkeypatch.setattr(bot, "_calc_upnl_sum_strict", fake_upnl)
+    monkeypatch.setattr(bot, "get_exchange_time", lambda: 150_000)
+
+    await bot._equity_hard_stop_initialize_from_history()
+
+    state = _hsl_state(bot)
+    assert state["halted"] is False
+    assert state["cooldown_until_ms"] is None
+    assert state["last_stop_event"] is None
+    assert state["runtime"].red_latched() is False
+    assert writes == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fixes the second half of the vps3 `ebybitsub03` wrong-HSL-panic incident: replay no longer treats a historical `close_panic_*` fill as authoritative RED cooldown unless reconstructed HSL metrics at that marker confirm RED by tier, score, or raw drawdown.
- If a marker is seen but not confirmed, replay logs a warning, does not write a latch, and skips the generic latest-panic-fill cooldown fallback for that marker.
- Applies the same contract to account-level HSL replay and coin-mode HSL replay.
- Updates the incident report and changelog.

## VPS3 evidence
- Bad run: `logs/20260628_211036_passivbot_live_-u_ebybitsub03_configs_xmr_migrated.json_-bo_1000.log` posted `close_panic_long` after synthetic `peak_strategy_equity=1213.126976` with `balance=1000`.
- Restart without `-bo`: `logs/20260629_123226_passivbot_live_-u_ebybitsub03_configs_xmr_migrated.json.log` replayed the latest panic marker as active cooldown even though reconstructed `drawdown_raw=0.001123`.

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_hsl_coin_mode.py tests/test_unstucking_safeguards.py::test_hard_stop_initialize_from_history_ignores_panic_marker_without_reconstructed_red tests/test_unstucking_safeguards.py::test_hsl_replay_contract_s1_clean_panic_flat_cooldown_active -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall -q src/passivbot_hsl.py tests/test_unstucking_safeguards.py tests/test_hsl_coin_mode.py`
- `git diff --check origin/v8...HEAD`

## Note
- Full `tests/test_unstucking_safeguards.py` currently has existing account-level fixture failures when run against current `v8` defaults (`signal_mode=coin` entering account-level history replay fixtures). This PR validated the changed replay paths directly and the full coin-HSL suite.