### PR TITLE
Instrument HSL history build progress

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -156,7 +156,13 @@ across time.
 - `fill_cache_ready`
 - `fill_cache_rebuild_started`
 - `hsl_balance_override_account_level_replay_unsafe`
+- `hsl_history_empty`
+- `hsl_history_inputs_loaded`
+- `hsl_price_history_fetch_completed`
+- `hsl_price_history_fetch_started`
 - `hsl_raw_red_pending_ema_confirmation`
+- `hsl_timeline_replay_completed`
+- `hsl_timeline_replay_started`
 - `initial_entry_distance_gate`
 - `length_mismatch`
 - `limit_order_create_market_distance`

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,8 @@ Last updated: 2026-06-29.
 
 Current `origin/v8` logging-overhaul head:
 
-- `2fb9ffc5` after PR #854, `Flag unsafe HSL balance override in smoke report`.
+- `7c199df1` after PR #857, `Validate historical HSL panic markers before
+  preserving replay cooldown`.
 
 Current review gate:
 
@@ -30,6 +31,28 @@ Current review gate:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #857 at `7c199df1`.
+- PR #856 added structured `hsl.raw_red_pending` diagnostics for coin-mode HSL
+  cases where raw drawdown is beyond red but EMA-confirmed drawdown has not
+  crossed red. The event is routed away from console/text by default and keeps
+  payloads to bounded HSL metrics/status fields.
+- PR #857 was a trading-safety interruption, not a logging slice: historical
+  HSL replay now preserves a panic-marker cooldown only when reconstructed RED
+  metrics confirm the historical panic marker. Incomplete marker metrics fail
+  loudly, and ignored markers are logged/observable instead of silently keeping
+  a stale bad cooldown alive.
+- After deploying PRs #856/#857 to VPS5, all five configured bots were
+  restarted and left running on `v8@7c199df1`. A read-only smoke reported
+  `ok=true`, `hard_failures=0`, `logs.hard_matches=0`, `matched_expected=5`,
+  `missing_expected_count=0`, clean tracked repository state,
+  `remote_calls.failed=0`, `account_critical_remote_calls.failed=0`, and
+  `processes.config_checks.ok=true`.
+- The same smoke showed the remaining live startup-readiness gap more
+  precisely: Binance, Kucoin, GateIO, and OKX had emitted
+  `hsl.replay.started` but not `hsl.replay.progress`/`completed` after the
+  restart window, meaning they were still blocked inside HSL balance/equity
+  history assembly before the per-pair replay loop. That gap is now the driver
+  for the next observability slice.
 - Current ledger catch-up through PR #854:
   - PR #836 updated this progress ledger after the realized-loss gate event
     slice.

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -222,7 +222,13 @@ class ReasonCodes:
     HSL_BALANCE_OVERRIDE_ACCOUNT_LEVEL_REPLAY_UNSAFE = (
         "hsl_balance_override_account_level_replay_unsafe"
     )
+    HSL_HISTORY_EMPTY = "hsl_history_empty"
+    HSL_HISTORY_INPUTS_LOADED = "hsl_history_inputs_loaded"
+    HSL_PRICE_HISTORY_FETCH_COMPLETED = "hsl_price_history_fetch_completed"
+    HSL_PRICE_HISTORY_FETCH_STARTED = "hsl_price_history_fetch_started"
     HSL_RAW_RED_PENDING_EMA_CONFIRMATION = "hsl_raw_red_pending_ema_confirmation"
+    HSL_TIMELINE_REPLAY_COMPLETED = "hsl_timeline_replay_completed"
+    HSL_TIMELINE_REPLAY_STARTED = "hsl_timeline_replay_started"
     RUST_OUTPUT_ACTIONS = "rust_output_actions"
     SINK_PIPELINE_CLOSING = "pipeline_closing"
     SNAPSHOT_SYMBOL_STATE = "snapshot_symbol_state"

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11682,9 +11682,44 @@ class Passivbot:
         self,
         fill_events: Optional[List[dict]] = None,
         current_balance: Optional[float] = None,
+        hsl_replay_signal_mode: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Replay canonical fill events to produce historical balance/equity curves."""
+        history_started_s = time.monotonic()
         await self.init_pnls()
+
+        def _emit_hsl_history_progress(
+            stage: str,
+            data: Optional[Dict[str, Any]] = None,
+            *,
+            status: str = "started",
+            reason_code: Optional[str] = None,
+        ) -> None:
+            if not hsl_replay_signal_mode:
+                return
+            try:
+                payload = {
+                    "signal_mode": str(hsl_replay_signal_mode),
+                    "stage": str(stage),
+                    "history_build_elapsed_s": round(
+                        max(0.0, time.monotonic() - history_started_s), 3
+                    ),
+                }
+                if data:
+                    payload.update(data)
+                pb_hsl._emit_hsl_replay_event(
+                    self,
+                    EventTypes.HSL_REPLAY_PROGRESS,
+                    payload,
+                    status=status,
+                    reason_code=reason_code or str(stage),
+                )
+            except Exception as exc:
+                logging.debug(
+                    "[event] failed to emit HSL history progress stage=%s: %s",
+                    stage,
+                    exc,
+                )
 
         def _safe_float(val: Any, default: float = 0.0) -> float:
             try:
@@ -11826,6 +11861,19 @@ class Passivbot:
 
         events = _extract_events(fill_events)
         current_position_state = _current_position_state()
+        _emit_hsl_history_progress(
+            "history_inputs_loaded",
+            {
+                "fill_events": len(fill_events),
+                "events": len(events),
+                "current_position_pairs": sum(
+                    1
+                    for size, _price in current_position_state.values()
+                    if size > 1e-12
+                ),
+            },
+            reason_code=ReasonCodes.HSL_HISTORY_INPUTS_LOADED,
+        )
         if events:
             try:
                 compute_psize_pprice(
@@ -11858,6 +11906,17 @@ class Passivbot:
                 "is_flat_short": True,
                 "panic_fill_count": 0,
             }
+            _emit_hsl_history_progress(
+                "history_empty",
+                {
+                    "timeline_rows": 1,
+                    "fill_events": 0,
+                    "events": 0,
+                    "price_replay_symbols": 0,
+                },
+                status="succeeded",
+                reason_code=ReasonCodes.HSL_HISTORY_EMPTY,
+            )
             return {
                 "timeline": [point],
                 "panic_flatten_events": [],
@@ -11951,6 +12010,23 @@ class Passivbot:
             )
             replay_sem = asyncio.Semaphore(max(1, int(replay_concurrency)))
             replay_fetch_delay_s = self._get_fetch_delay_seconds()
+            candle_fetch_started_s = time.monotonic()
+            history_minutes = int(max(0, (end_minute - start_minute) // ONE_MIN_MS)) + 1
+            _emit_hsl_history_progress(
+                "price_history_fetch_started",
+                {
+                    "events": len(events),
+                    "symbols": len(symbols),
+                    "price_replay_symbols": len(price_replay_symbols),
+                    "skipped_price_symbols": len(symbols - price_replay_symbols),
+                    "history_minutes": history_minutes,
+                    "replay_concurrency": int(replay_concurrency),
+                    "lookback_days": lookback.display_value,
+                    "start_ts": int(start_minute),
+                    "end_ts": int(end_minute),
+                },
+                reason_code=ReasonCodes.HSL_PRICE_HISTORY_FETCH_STARTED,
+            )
 
             async def fetch_replay_candles(sym: str, *, timeframe: str = "1m"):
                 async with replay_sem:
@@ -12029,6 +12105,27 @@ class Passivbot:
                             approximate_price_sources.setdefault(sym, {})[
                                 timeframe
                             ] = added
+            candle_fetch_elapsed_s = max(0.0, time.monotonic() - candle_fetch_started_s)
+            _emit_hsl_history_progress(
+                "price_history_fetch_completed",
+                {
+                    "events": len(events),
+                    "symbols": len(symbols),
+                    "price_replay_symbols": len(price_replay_symbols),
+                    "priced_symbols": sum(
+                        1 for prices in price_lookup.values() if prices
+                    ),
+                    "empty_price_symbols": sum(
+                        1 for prices in price_lookup.values() if not prices
+                    ),
+                    "approximate_price_symbols": len(approximate_price_sources),
+                    "history_minutes": history_minutes,
+                    "replay_concurrency": int(replay_concurrency),
+                    "price_history_fetch_elapsed_s": round(candle_fetch_elapsed_s, 3),
+                },
+                status="succeeded",
+                reason_code=ReasonCodes.HSL_PRICE_HISTORY_FETCH_COMPLETED,
+            )
         else:
             price_lookup = {sym: {} for sym in price_replay_symbols}
 
@@ -12102,6 +12199,21 @@ class Passivbot:
         event_idx = 0
         last_price: Dict[str, float] = {}
 
+        history_minutes = int(max(0, (end_minute - start_minute) // ONE_MIN_MS)) + 1
+        _emit_hsl_history_progress(
+            "timeline_replay_started",
+            {
+                "events": len(events),
+                "symbols": len(symbols),
+                "price_replay_symbols": len(price_replay_symbols),
+                "history_minutes": history_minutes,
+                "record_start_ts": int(record_start_ts),
+                "start_ts": int(start_minute),
+                "end_ts": int(end_minute),
+            },
+            reason_code=ReasonCodes.HSL_TIMELINE_REPLAY_STARTED,
+        )
+        timeline_replay_started_s = time.monotonic()
         minute = start_minute
         while minute <= end_minute:
             boundary = minute + ONE_MIN_MS
@@ -12318,6 +12430,23 @@ class Passivbot:
             "missing_price_symbols": sorted(missing_price_symbols),
             "approximate_price_sources": approximate_price_sources,
         }
+        _emit_hsl_history_progress(
+            "timeline_replay_completed",
+            {
+                "events": len(events),
+                "symbols": len(symbols),
+                "price_replay_symbols": len(price_replay_symbols),
+                "timeline_rows": len(timeline),
+                "panic_events": len(panic_flatten_events),
+                "missing_price_symbols": len(missing_price_symbols),
+                "history_minutes": history_minutes,
+                "timeline_replay_elapsed_s": round(
+                    max(0.0, time.monotonic() - timeline_replay_started_s), 3
+                ),
+            },
+            status="succeeded",
+            reason_code=ReasonCodes.HSL_TIMELINE_REPLAY_COMPLETED,
+        )
         return {
             "timeline": timeline,
             "panic_flatten_events": panic_flatten_events,

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -2166,7 +2166,10 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
             lookback.display_value,
             signal_mode,
         )
-        history = await self.get_balance_equity_history(current_balance=self.get_raw_balance())
+        history = await self.get_balance_equity_history(
+            current_balance=self.get_raw_balance(),
+            hsl_replay_signal_mode=signal_mode,
+        )
         if "timeline" not in history:
             raise ValueError("get_balance_equity_history() missing required key: timeline")
         timeline = history["timeline"]
@@ -2499,7 +2502,10 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             status="started",
             reason_code="coin_history_replay",
         )
-        history = await self.get_balance_equity_history(current_balance=self.get_raw_balance())
+        history = await self.get_balance_equity_history(
+            current_balance=self.get_raw_balance(),
+            hsl_replay_signal_mode="coin",
+        )
         check_shutdown("hsl_coin_history_replay_history_loaded")
         panic_flatten_events = history["panic_flatten_events"] if "panic_flatten_events" in history else []
         if panic_flatten_events is None:

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -192,7 +192,7 @@ async def test_coin_hsl_replay_cancels_when_shutdown_requested_after_history_loa
     )
     bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         bot.stop_signal_received = True
         return {
             "timeline": [
@@ -252,7 +252,7 @@ async def test_coin_hsl_history_replay_emits_lifecycle_events():
     )
     bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -589,7 +589,7 @@ async def test_coin_hsl_history_replay_skips_enabled_side_with_zero_budget():
 
     bot.bot_value = bot_value
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -646,7 +646,7 @@ async def test_coin_hsl_history_replay_does_not_latch_recovered_red_without_pani
     symbol = "A"
     bot.positions = {symbol: {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}}
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -816,7 +816,7 @@ async def test_coin_hsl_history_replay_rebases_lookback_window_realized_points()
     ]
     bot._pnls_manager = make_fake_pnls_manager(fill_events)
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -861,7 +861,7 @@ async def test_coin_hsl_history_replay_uses_stop_drawdown_for_no_restart():
     symbol = "A"
     bot.hsl["long"]["no_restart_drawdown_threshold"] = 0.7
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -918,7 +918,7 @@ async def test_coin_hsl_history_replay_ignores_panic_marker_without_reconstructe
         or "/tmp/hsl_coin_ignored.json"
     )
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -974,7 +974,7 @@ async def test_coin_hsl_history_replay_requires_coin_timeline_fields():
     symbol = "A"
     bot.positions = {symbol: {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}}
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -1006,7 +1006,7 @@ async def test_coin_hsl_open_position_missing_history_uses_current_sample():
     symbol = "A"
     bot.positions = {symbol: {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}}
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -1034,7 +1034,7 @@ async def test_coin_hsl_open_position_empty_coin_history_uses_current_sample():
     symbol = "A"
     bot.positions = {symbol: {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}}
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -1064,7 +1064,7 @@ async def test_coin_hsl_history_replay_allows_leading_rows_before_first_fill():
     symbol = "A"
     bot.positions = {symbol: {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}}
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -1108,7 +1108,7 @@ async def test_coin_hsl_history_replay_requires_relevant_symbol_fields():
     symbol = "A"
     bot.positions = {symbol: {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}}
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -1141,7 +1141,7 @@ async def test_coin_hsl_history_replay_allows_flat_realized_only_rows():
     bot = make_coin_bot()
     symbol = "A"
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -1199,7 +1199,7 @@ async def test_coin_hsl_history_replay_requires_upnl_for_carry_in_decrease():
         symbol: {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}
     }
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -1235,7 +1235,7 @@ async def test_coin_hsl_history_replay_requires_upnl_for_flat_ambiguous_decrease
     bot = make_coin_bot()
     symbol = "A"
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -1273,7 +1273,7 @@ async def test_coin_hsl_reconstructs_unresolved_panic_residue_on_restart():
     bot.positions = {symbol: {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}}
     bot.get_exchange_time = lambda: 200_000
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -1328,7 +1328,7 @@ async def test_coin_hsl_reconstructs_manual_cooldown_intervention_on_restart():
     bot.positions = {symbol: {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}}
     bot.get_exchange_time = lambda: 180_000
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -1384,7 +1384,7 @@ async def test_coin_hsl_reconstructs_normal_cooldown_intervention_as_override():
     bot.positions = {symbol: {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}}
     bot.get_exchange_time = lambda: 180_000
 
-    async def fake_history(current_balance=None):
+    async def fake_history(current_balance=None, **kwargs):
         return {
             "timeline": [
                 {

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1319,6 +1319,13 @@ async def test_balance_equity_history_paces_replay_candle_fetches(monkeypatch):
     bot.inverse = False
     bot._candle_fetch_concurrency = lambda *, context="runtime": 2
     bot._get_fetch_delay_seconds = lambda: 0.0
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._live_event_current_cycle_id = "cy_hsl_history_build"
+    bot._emit_live_event = Passivbot._emit_live_event.__get__(bot, Passivbot)
     bot.c_mults = {
         "BTC/USDT:USDT": 1.0,
         "ETH/USDT:USDT": 1.0,
@@ -1366,12 +1373,34 @@ async def test_balance_equity_history_paces_replay_candle_fetches(monkeypatch):
         for symbol in bot.c_mults
     ]
 
-    await bot.get_balance_equity_history(fill_events=fill_events, current_balance=100.0)
+    await bot.get_balance_equity_history(
+        fill_events=fill_events,
+        current_balance=100.0,
+        hsl_replay_signal_mode="coin",
+    )
 
     assert cm.max_active == 2
     assert sorted(
         symbol for symbol, timeframe in cm.calls if timeframe == "1m"
     ) == sorted(bot.c_mults)
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [event for event in sink.events if event.event_type == EventTypes.HSL_REPLAY_PROGRESS]
+    assert [event.reason_code for event in events] == [
+        ReasonCodes.HSL_HISTORY_INPUTS_LOADED,
+        ReasonCodes.HSL_PRICE_HISTORY_FETCH_STARTED,
+        ReasonCodes.HSL_PRICE_HISTORY_FETCH_COMPLETED,
+        ReasonCodes.HSL_TIMELINE_REPLAY_STARTED,
+        ReasonCodes.HSL_TIMELINE_REPLAY_COMPLETED,
+    ]
+    assert {event.cycle_id for event in events} == {"cy_hsl_history_build"}
+    assert {event.data["signal_mode"] for event in events} == {"coin"}
+    assert events[0].data["fill_events"] == 3
+    assert events[1].data["price_replay_symbols"] == 3
+    assert events[2].data["priced_symbols"] == 3
+    assert events[3].data["history_minutes"] >= 3
+    assert events[4].data["timeline_rows"] == events[3].data["history_minutes"]
+    assert events[4].data["timeline_replay_elapsed_s"] is not None
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -3025,7 +3025,7 @@ async def test_hard_stop_initialize_from_history_terminal_stop_sets_latch(monkey
     _hsl_cfg(bot)["no_restart_drawdown_threshold"] = 0.1
     bot.balance = 80.0
 
-    async def fake_history(*, current_balance=None):
+    async def fake_history(*, current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -3107,7 +3107,7 @@ async def test_hard_stop_initialize_from_history_does_not_latch_recovered_red_wi
     _hsl_cfg(bot)["ema_span_minutes"] = 1.0
     bot.balance = 100.0
 
-    async def fake_history(*, current_balance=None):
+    async def fake_history(*, current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -3180,7 +3180,7 @@ async def test_hard_stop_initialize_from_history_reconstructs_active_cooldown_wi
     bot.balance = 104.0
     bot._live_values["execution_delay_seconds"] = 60.0
 
-    async def fake_history(*, current_balance=None):
+    async def fake_history(*, current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -3275,7 +3275,7 @@ async def test_hard_stop_initialize_from_history_ignores_panic_marker_without_re
     bot.config["live"]["hsl_signal_mode"] = "pside"
     bot.balance = 100.0
 
-    async def fake_history(*, current_balance=None):
+    async def fake_history(*, current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -3360,7 +3360,7 @@ async def test_hard_stop_initialize_from_history_replay_cooldown_resets_cycle(
     bot.balance = 104.0
     bot._live_values["execution_delay_seconds"] = 60.0
 
-    async def fake_history(*, current_balance=None):
+    async def fake_history(*, current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -3476,7 +3476,7 @@ async def test_hard_stop_initialize_from_history_preserves_no_restart_peak_acros
     bot.balance = 86.0
     bot._live_values["execution_delay_seconds"] = 60.0
 
-    async def fake_history(*, current_balance=None):
+    async def fake_history(*, current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -4058,7 +4058,7 @@ async def test_hard_stop_initialize_from_history_resets_after_panic_marker_same_
     bot.balance = 80.0
     bot._live_values["execution_delay_seconds"] = 60.0
 
-    async def fake_history(*, current_balance=None):
+    async def fake_history(*, current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -4169,7 +4169,7 @@ async def test_hard_stop_initialize_from_history_normal_policy_replays_from_entr
     bot.positions[symbol]["long"]["price"] = 90.0
     bot.balance = 90.0
 
-    async def fake_history(*, current_balance=None):
+    async def fake_history(*, current_balance=None, **kwargs):
         return {
             "timeline": [
                 {
@@ -4290,7 +4290,7 @@ async def test_hard_stop_initialize_from_history_unresolved_panic_residue_stays_
     bot.positions[symbol]["long"]["price"] = 90.0
     bot.balance = 80.0
 
-    async def fake_history(*, current_balance=None):
+    async def fake_history(*, current_balance=None, **kwargs):
         return {
             "timeline": [
                 {


### PR DESCRIPTION
## Summary
- add opt-in structured HSL replay progress events from balance/equity history assembly
- distinguish history inputs loaded, price-history fetch start/completion, and timeline replay start/completion before the existing HSL history-loaded event
- opt HSL account-level and coin-mode replay callers into the progress events
- register new reason codes and catch up the live logging progress ledger through PRs #856/#857 + VPS5 smoke

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_passivbot_balance_split.py::test_balance_equity_history_paces_replay_candle_fetches tests/test_passivbot_balance_split.py::test_balance_equity_history_skips_unsupported_closed_historical_symbols tests/test_live_event_registry_docs.py tests/test_hsl_coin_mode.py -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall -q src/passivbot.py src/passivbot_hsl.py src/live/event_bus.py tests/test_passivbot_balance_split.py tests/test_hsl_coin_mode.py tests/test_unstucking_safeguards.py tests/test_live_event_registry_docs.py
- git diff --check

## Notes
- observability-only; the new get_balance_equity_history keyword defaults off and only HSL replay callers opt in
- one broader legacy account-level HSL safeguard test still fails on the existing unified-mode fixture missing unrealized_pnl_total; not changed by this slice