### PR TITLE
Instrument HSL price history fetch progress

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -160,6 +160,8 @@ across time.
 - `hsl_history_inputs_loaded`
 - `hsl_price_history_fetch_completed`
 - `hsl_price_history_fetch_started`
+- `hsl_price_history_symbol_fetch_completed`
+- `hsl_price_history_symbol_fetch_started`
 - `hsl_raw_red_pending_ema_confirmation`
 - `hsl_timeline_replay_completed`
 - `hsl_timeline_replay_started`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -226,6 +226,10 @@ class ReasonCodes:
     HSL_HISTORY_INPUTS_LOADED = "hsl_history_inputs_loaded"
     HSL_PRICE_HISTORY_FETCH_COMPLETED = "hsl_price_history_fetch_completed"
     HSL_PRICE_HISTORY_FETCH_STARTED = "hsl_price_history_fetch_started"
+    HSL_PRICE_HISTORY_SYMBOL_FETCH_COMPLETED = (
+        "hsl_price_history_symbol_fetch_completed"
+    )
+    HSL_PRICE_HISTORY_SYMBOL_FETCH_STARTED = "hsl_price_history_symbol_fetch_started"
     HSL_RAW_RED_PENDING_EMA_CONFIRMATION = "hsl_raw_red_pending_ema_confirmation"
     HSL_TIMELINE_REPLAY_COMPLETED = "hsl_timeline_replay_completed"
     HSL_TIMELINE_REPLAY_STARTED = "hsl_timeline_replay_started"

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -74,8 +74,10 @@ _EXECUTION_CONFIRMATION_TERMINALS = {
     "execution.confirmation_timeout",
 }
 _HSL_REPLAY_STRING_FIELDS = (
+    "error_type",
     "signal_mode",
     "stage",
+    "timeframe",
 )
 _HSL_REPLAY_BOOL_FIELDS = (
     "is_held_pair",
@@ -92,6 +94,13 @@ _HSL_REPLAY_NUMERIC_FIELDS = (
     "fill_events",
     "panic_events",
     "skipped_unsupported_symbols",
+    "events",
+    "price_replay_symbols",
+    "priced_symbols",
+    "empty_price_symbols",
+    "approximate_price_symbols",
+    "history_minutes",
+    "replay_concurrency",
     "pair_idx",
     "applied_rows",
     "total_applied_rows",
@@ -99,6 +108,7 @@ _HSL_REPLAY_NUMERIC_FIELDS = (
     "skipped_pairs",
     "rows_per_second",
     "elapsed_s",
+    "price_history_fetch_elapsed_s",
     "full_elapsed_s",
     "startup_blocking_elapsed_s",
 )

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -1780,7 +1780,7 @@ def _compact_hsl_replay_data(live_event: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(data, dict):
         return {}
     out: dict[str, Any] = {}
-    for key in ("signal_mode", "stage"):
+    for key in ("error_type", "signal_mode", "stage", "timeframe"):
         value = data.get(key)
         if isinstance(value, str) and value:
             out[key] = _redact_log_text(value, max_len=80)
@@ -1799,6 +1799,13 @@ def _compact_hsl_replay_data(live_event: dict[str, Any]) -> dict[str, Any]:
         "fill_events",
         "panic_events",
         "skipped_unsupported_symbols",
+        "events",
+        "price_replay_symbols",
+        "priced_symbols",
+        "empty_price_symbols",
+        "approximate_price_symbols",
+        "history_minutes",
+        "replay_concurrency",
         "pair_idx",
         "applied_rows",
         "total_applied_rows",
@@ -1806,6 +1813,7 @@ def _compact_hsl_replay_data(live_event: dict[str, Any]) -> dict[str, Any]:
         "skipped_pairs",
         "rows_per_second",
         "elapsed_s",
+        "price_history_fetch_elapsed_s",
         "full_elapsed_s",
         "startup_blocking_elapsed_s",
     ):

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11692,6 +11692,8 @@ class Passivbot:
             stage: str,
             data: Optional[Dict[str, Any]] = None,
             *,
+            symbol: Optional[str] = None,
+            pside: Optional[str] = None,
             status: str = "started",
             reason_code: Optional[str] = None,
         ) -> None:
@@ -11711,6 +11713,8 @@ class Passivbot:
                     self,
                     EventTypes.HSL_REPLAY_PROGRESS,
                     payload,
+                    symbol=symbol,
+                    pside=pside,
                     status=status,
                     reason_code=reason_code or str(stage),
                 )
@@ -12030,6 +12034,22 @@ class Passivbot:
 
             async def fetch_replay_candles(sym: str, *, timeframe: str = "1m"):
                 async with replay_sem:
+                    symbol_fetch_started_s = time.monotonic()
+                    symbol_payload = {
+                        "events": len(events),
+                        "symbols": len(symbols),
+                        "price_replay_symbols": len(price_replay_symbols),
+                        "history_minutes": history_minutes,
+                        "timeframe": str(timeframe),
+                        "start_ts": int(start_minute),
+                        "end_ts": int(end_minute),
+                    }
+                    _emit_hsl_history_progress(
+                        "price_history_symbol_fetch_started",
+                        symbol_payload,
+                        symbol=sym,
+                        reason_code=ReasonCodes.HSL_PRICE_HISTORY_SYMBOL_FETCH_STARTED,
+                    )
                     try:
                         arr = await self.cm.get_candles(
                             sym,
@@ -12038,8 +12058,44 @@ class Passivbot:
                             strict=False,
                             timeframe=timeframe,
                         )
+                        rows = int(getattr(arr, "size", 0) or 0)
+                        _emit_hsl_history_progress(
+                            "price_history_symbol_fetch_completed",
+                            {
+                                **symbol_payload,
+                                "rows": rows,
+                                "elapsed_s": round(
+                                    max(
+                                        0.0,
+                                        time.monotonic() - symbol_fetch_started_s,
+                                    ),
+                                    3,
+                                ),
+                            },
+                            symbol=sym,
+                            status="succeeded",
+                            reason_code=ReasonCodes.HSL_PRICE_HISTORY_SYMBOL_FETCH_COMPLETED,
+                        )
                         return sym, arr, None
                     except Exception as exc:
+                        _emit_hsl_history_progress(
+                            "price_history_symbol_fetch_completed",
+                            {
+                                **symbol_payload,
+                                "rows": 0,
+                                "elapsed_s": round(
+                                    max(
+                                        0.0,
+                                        time.monotonic() - symbol_fetch_started_s,
+                                    ),
+                                    3,
+                                ),
+                                "error_type": type(exc).__name__,
+                            },
+                            symbol=sym,
+                            status="failed",
+                            reason_code=ReasonCodes.HSL_PRICE_HISTORY_SYMBOL_FETCH_COMPLETED,
+                        )
                         return sym, None, exc
                     finally:
                         if replay_fetch_delay_s > 0.0:

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1259,9 +1259,14 @@ def test_live_performance_report_hsl_replay_profile_whitelists_values(tmp_path):
                 ts=1000,
                 component="risk.hsl",
                 data={
-                    "stage": "pair_replay",
-                    "pairs": 1,
-                    "timeline_rows": 10,
+                    "stage": "price_history_symbol_fetch_completed",
+                    "timeframe": "1m",
+                    "error_type": "TimeoutError",
+                    "events": 2,
+                    "price_replay_symbols": 3,
+                    "history_minutes": 10,
+                    "rows": 9,
+                    "elapsed_s": 4.5,
                     "balance": 1000.0,
                     "equity": 999.0,
                     "raw_payload": {"leak_marker": "raw"},
@@ -1276,9 +1281,14 @@ def test_live_performance_report_hsl_replay_profile_whitelists_values(tmp_path):
     rendered = json.dumps(report["hsl_replay_profile"], sort_keys=True)
 
     assert report["hsl_replay_profile"]["groups"][0]["progress"]["data"] == {
-        "pairs": 1,
-        "stage": "pair_replay",
-        "timeline_rows": 10,
+        "elapsed_s": 4.5,
+        "error_type": "TimeoutError",
+        "events": 2,
+        "history_minutes": 10,
+        "price_replay_symbols": 3,
+        "rows": 9,
+        "stage": "price_history_symbol_fetch_completed",
+        "timeframe": "1m",
     }
     assert "balance" not in rendered
     assert "equity" not in rendered

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2112,6 +2112,9 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
                     "total_applied_rows": 64000,
                     "rows_per_second": 318.415,
                     "elapsed_s": 201.2,
+                    "timeframe": "1m",
+                    "history_minutes": 43201,
+                    "price_replay_symbols": 29,
                     "is_held_pair": True,
                     "is_cooldown_pair": False,
                     "balance": 1234.56,
@@ -2220,6 +2223,9 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
     assert active_group["bot"] == "gateio/gateio_01"
     assert active_group["active"] is True
     assert active_group["latest"]["symbol"] == "ZEC/USDT:USDT"
+    assert active_group["latest"]["data"]["timeframe"] == "1m"
+    assert active_group["latest"]["data"]["history_minutes"] == 43201
+    assert active_group["latest"]["data"]["price_replay_symbols"] == 29
     assert active_group["latest"]["derived"]["estimated_dense_pair_row_work"] == (
         43201 * 29
     )

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1385,7 +1385,26 @@ async def test_balance_equity_history_paces_replay_candle_fetches(monkeypatch):
     ) == sorted(bot.c_mults)
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     events = [event for event in sink.events if event.event_type == EventTypes.HSL_REPLAY_PROGRESS]
-    assert [event.reason_code for event in events] == [
+    batch_events = [
+        event
+        for event in events
+        if event.reason_code
+        not in {
+            ReasonCodes.HSL_PRICE_HISTORY_SYMBOL_FETCH_STARTED,
+            ReasonCodes.HSL_PRICE_HISTORY_SYMBOL_FETCH_COMPLETED,
+        }
+    ]
+    symbol_started_events = [
+        event
+        for event in events
+        if event.reason_code == ReasonCodes.HSL_PRICE_HISTORY_SYMBOL_FETCH_STARTED
+    ]
+    symbol_completed_events = [
+        event
+        for event in events
+        if event.reason_code == ReasonCodes.HSL_PRICE_HISTORY_SYMBOL_FETCH_COMPLETED
+    ]
+    assert [event.reason_code for event in batch_events] == [
         ReasonCodes.HSL_HISTORY_INPUTS_LOADED,
         ReasonCodes.HSL_PRICE_HISTORY_FETCH_STARTED,
         ReasonCodes.HSL_PRICE_HISTORY_FETCH_COMPLETED,
@@ -1394,12 +1413,26 @@ async def test_balance_equity_history_paces_replay_candle_fetches(monkeypatch):
     ]
     assert {event.cycle_id for event in events} == {"cy_hsl_history_build"}
     assert {event.data["signal_mode"] for event in events} == {"coin"}
-    assert events[0].data["fill_events"] == 3
-    assert events[1].data["price_replay_symbols"] == 3
-    assert events[2].data["priced_symbols"] == 3
-    assert events[3].data["history_minutes"] >= 3
-    assert events[4].data["timeline_rows"] == events[3].data["history_minutes"]
-    assert events[4].data["timeline_replay_elapsed_s"] is not None
+    assert batch_events[0].data["fill_events"] == 3
+    assert batch_events[1].data["price_replay_symbols"] == 3
+    assert batch_events[2].data["priced_symbols"] == 3
+    assert batch_events[3].data["history_minutes"] >= 3
+    assert (
+        batch_events[4].data["timeline_rows"]
+        == batch_events[3].data["history_minutes"]
+    )
+    assert batch_events[4].data["timeline_replay_elapsed_s"] is not None
+    assert {event.symbol for event in symbol_started_events} == set(bot.c_mults)
+    assert {event.symbol for event in symbol_completed_events} == set(bot.c_mults)
+    assert {event.status for event in symbol_started_events} == {"started"}
+    assert {event.status for event in symbol_completed_events} == {"succeeded"}
+    assert {event.data["timeframe"] for event in symbol_completed_events} == {"1m"}
+    assert {event.data["rows"] for event in symbol_completed_events} == {3}
+    assert all(
+        event.data["stage"] == "price_history_symbol_fetch_completed"
+        for event in symbol_completed_events
+    )
+    assert all("elapsed_s" in event.data for event in symbol_completed_events)
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
Observability-only slice after PR #858.

Context:
- VPS5 showed HSL history-build reaching hsl_price_history_fetch_started but not completion/timeline replay in the early smoke window.
- This keeps the existing batch start/completion events and adds bounded per-symbol price-history fetch start/completion events so we can identify slow/stuck symbols/timeframes on the next smoke.

Changes:
- emits hsl.replay.progress with hsl_price_history_symbol_fetch_started / hsl_price_history_symbol_fetch_completed around each HSL replay candle fetch
- payloads include symbol envelope, timeframe, history-minute/range counters, row count, elapsed seconds, and error type only; no raw candles, prices, balances, equity, PnL, sizes, fill rows, or raw exception text
- event emission remains best-effort and does not change candle fetch, exception-return, replay, console, or trading behavior
- smoke/performance reports whitelist the new bounded fields

Validation:
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_passivbot_balance_split.py::test_balance_equity_history_paces_replay_candle_fetches tests/test_passivbot_balance_split.py::test_balance_equity_history_skips_unsupported_closed_historical_symbols tests/test_live_event_registry_docs.py tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_hsl_replay_health tests/test_live_performance_report.py::test_live_performance_report_hsl_replay_profile_whitelists_values -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/passivbot.py src/live/event_bus.py src/live/performance_report.py src/live/smoke_report.py
- git diff --check origin/v8..HEAD
