### PR TITLE
Fix live event query bot path filtering

### DIFF
--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -111,6 +111,20 @@ def _event_ids(live_event: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _monitor_path_bot_id(path: Path) -> str | None:
+    """Return monitor path-derived bot id for .../<exchange>/<user>/events/*.ndjson."""
+    if path.parent.name != "events":
+        return None
+    try:
+        user = path.parent.parent.name
+        exchange = path.parent.parent.parent.name
+    except IndexError:
+        return None
+    if not exchange or not user:
+        return None
+    return f"{exchange}/{user}"
+
+
 def _normalize_filter_values(values: str | Iterable[str] | None) -> set[str]:
     if values is None:
         return set()
@@ -1047,7 +1061,9 @@ def build_event_report(
                         record_event_type, event_type_filter
                     )
                     cycle_matches = cycle_id is None or record_cycle_id == str(cycle_id)
-                    bot_matches = _filter_matches(ids.get("bot_id"), bot_filter)
+                    bot_matches = _filter_matches(
+                        ids.get("bot_id") or _monitor_path_bot_id(path), bot_filter
+                    )
                     snapshot_matches = _filter_matches(
                         ids.get("snapshot_id"), snapshot_filter
                     )

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -543,6 +543,58 @@ def test_event_query_filters_by_remaining_event_ids(tmp_path):
     }
 
 
+def test_event_query_bot_filter_falls_back_to_monitor_path(tmp_path):
+    events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.status",
+                cycle_id="cy_1",
+                seq=1,
+                ts=1000,
+                symbol="ZEC/USDT:USDT",
+                pside="long",
+            ),
+            _monitor_row(
+                event_type="hsl.cooldown_started",
+                cycle_id="cy_1",
+                seq=2,
+                ts=1100,
+                symbol="ZEC/USDT:USDT",
+                pside="long",
+            ),
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        bot_id="gateio/gateio_01",
+        event_type=["hsl.status", "hsl.cooldown_started"],
+        symbol="ZEC/USDT:USDT",
+    )
+
+    assert report["ok"] is True
+    assert report["query"]["filters"] == {
+        "bot_ids": ["gateio/gateio_01"],
+        "event_types": ["hsl.cooldown_started", "hsl.status"],
+        "symbols": ["ZEC/USDT:USDT"],
+    }
+    assert report["query"]["matched_events"] == 2
+    assert [event["event_type"] for event in report["query"]["events"]] == [
+        "hsl.status",
+        "hsl.cooldown_started",
+    ]
+
+    wrong_bot_report = build_event_report(
+        tmp_path / "monitor",
+        bot_id="binance/binance_01",
+        event_type=["hsl.status", "hsl.cooldown_started"],
+    )
+
+    assert wrong_bot_report["query"]["matched_events"] == 0
+
+
 def test_event_query_filters_legacy_snapshot_id_from_event_data(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- Match live-event-query --bot-id filters against the monitor path-derived bot id when an event lacks nested ids.bot_id.
- Keep emitted event IDs unchanged; the path-derived id is only a query fallback.
- Add a regression for HSL events under monitor/gateio/gateio_01/events/current.ndjson without event-level bot_id.

## Tests
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/live/event_query.py tests/test_live_event_query.py
- git diff --check
- rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])\)" src/live/event_query.py tests/test_live_event_query.py