### PR TITLE
Expose HSL history elapsed in reports

### DIFF
--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -95,12 +95,18 @@ _HSL_REPLAY_NUMERIC_FIELDS = (
     "panic_events",
     "skipped_unsupported_symbols",
     "events",
+    "current_position_pairs",
     "price_replay_symbols",
     "priced_symbols",
     "empty_price_symbols",
     "approximate_price_symbols",
+    "skipped_price_symbols",
+    "missing_price_symbols",
     "history_minutes",
     "replay_concurrency",
+    "start_ts",
+    "end_ts",
+    "record_start_ts",
     "pair_idx",
     "applied_rows",
     "total_applied_rows",
@@ -108,7 +114,9 @@ _HSL_REPLAY_NUMERIC_FIELDS = (
     "skipped_pairs",
     "rows_per_second",
     "elapsed_s",
+    "history_build_elapsed_s",
     "price_history_fetch_elapsed_s",
+    "timeline_replay_elapsed_s",
     "full_elapsed_s",
     "startup_blocking_elapsed_s",
 )
@@ -1253,12 +1261,17 @@ def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
         out["observed_applied_rows"] = int(observed_rows)
     for source_key, target_key in (
         ("elapsed_s", "latest_elapsed_ms"),
+        ("history_build_elapsed_s", "history_build_elapsed_ms"),
+        ("price_history_fetch_elapsed_s", "price_history_fetch_elapsed_ms"),
+        ("timeline_replay_elapsed_s", "timeline_replay_elapsed_ms"),
         ("full_elapsed_s", "full_elapsed_ms"),
         ("startup_blocking_elapsed_s", "startup_blocking_elapsed_ms"),
     ):
         value_ms = _elapsed_s_to_ms(data.get(source_key))
         if value_ms is not None:
             out[target_key] = value_ms
+            if source_key == "history_build_elapsed_s" and "latest_elapsed_ms" not in out:
+                out["latest_elapsed_ms"] = value_ms
     if data.get("startup_blocking_elapsed_s") is not None:
         out["startup_blocking"] = True
     return out

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -1800,12 +1800,18 @@ def _compact_hsl_replay_data(live_event: dict[str, Any]) -> dict[str, Any]:
         "panic_events",
         "skipped_unsupported_symbols",
         "events",
+        "current_position_pairs",
         "price_replay_symbols",
         "priced_symbols",
         "empty_price_symbols",
         "approximate_price_symbols",
+        "skipped_price_symbols",
+        "missing_price_symbols",
         "history_minutes",
         "replay_concurrency",
+        "start_ts",
+        "end_ts",
+        "record_start_ts",
         "pair_idx",
         "applied_rows",
         "total_applied_rows",
@@ -1813,7 +1819,9 @@ def _compact_hsl_replay_data(live_event: dict[str, Any]) -> dict[str, Any]:
         "skipped_pairs",
         "rows_per_second",
         "elapsed_s",
+        "history_build_elapsed_s",
         "price_history_fetch_elapsed_s",
+        "timeline_replay_elapsed_s",
         "full_elapsed_s",
         "startup_blocking_elapsed_s",
     ):
@@ -1846,6 +1854,9 @@ def _hsl_replay_derived(data: dict[str, Any]) -> dict[str, Any]:
             )
     for source_key, target_key in (
         ("elapsed_s", "latest_elapsed_ms"),
+        ("history_build_elapsed_s", "history_build_elapsed_ms"),
+        ("price_history_fetch_elapsed_s", "price_history_fetch_elapsed_ms"),
+        ("timeline_replay_elapsed_s", "timeline_replay_elapsed_ms"),
         ("full_elapsed_s", "full_elapsed_ms"),
         ("startup_blocking_elapsed_s", "startup_blocking_elapsed_ms"),
     ):
@@ -1856,6 +1867,8 @@ def _hsl_replay_derived(data: dict[str, Any]) -> dict[str, Any]:
             continue
         if parsed == parsed and parsed >= 0.0:
             out[target_key] = int(round(parsed * 1000.0))
+            if source_key == "history_build_elapsed_s" and "latest_elapsed_ms" not in out:
+                out["latest_elapsed_ms"] = out[target_key]
     return out
 
 

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1263,10 +1263,19 @@ def test_live_performance_report_hsl_replay_profile_whitelists_values(tmp_path):
                     "timeframe": "1m",
                     "error_type": "TimeoutError",
                     "events": 2,
+                    "current_position_pairs": 1,
                     "price_replay_symbols": 3,
+                    "skipped_price_symbols": 1,
+                    "missing_price_symbols": 2,
                     "history_minutes": 10,
+                    "start_ts": 1782492000000,
+                    "end_ts": 1782492600000,
+                    "record_start_ts": 1782492000000,
                     "rows": 9,
                     "elapsed_s": 4.5,
+                    "history_build_elapsed_s": 17.25,
+                    "price_history_fetch_elapsed_s": 16.5,
+                    "timeline_replay_elapsed_s": 3.2,
                     "balance": 1000.0,
                     "equity": 999.0,
                     "raw_payload": {"leak_marker": "raw"},
@@ -1281,14 +1290,30 @@ def test_live_performance_report_hsl_replay_profile_whitelists_values(tmp_path):
     rendered = json.dumps(report["hsl_replay_profile"], sort_keys=True)
 
     assert report["hsl_replay_profile"]["groups"][0]["progress"]["data"] == {
+        "current_position_pairs": 1,
+        "end_ts": 1782492600000,
         "elapsed_s": 4.5,
         "error_type": "TimeoutError",
         "events": 2,
+        "history_build_elapsed_s": 17.25,
         "history_minutes": 10,
+        "missing_price_symbols": 2,
+        "price_history_fetch_elapsed_s": 16.5,
         "price_replay_symbols": 3,
+        "record_start_ts": 1782492000000,
         "rows": 9,
+        "skipped_price_symbols": 1,
         "stage": "price_history_symbol_fetch_completed",
+        "start_ts": 1782492000000,
         "timeframe": "1m",
+        "timeline_replay_elapsed_s": 3.2,
+    }
+    assert report["hsl_replay_profile"]["groups"][0]["progress"]["derived"] == {
+        "history_build_elapsed_ms": 17250,
+        "latest_elapsed_ms": 4500,
+        "observed_applied_rows": 9,
+        "price_history_fetch_elapsed_ms": 16500,
+        "timeline_replay_elapsed_ms": 3200,
     }
     assert "balance" not in rendered
     assert "equity" not in rendered
@@ -1297,6 +1322,44 @@ def test_live_performance_report_hsl_replay_profile_whitelists_values(tmp_path):
     assert "api_key" not in rendered
     assert "secret" not in rendered
     assert "drawdown_raw" not in rendered
+
+
+def test_live_performance_report_hsl_history_elapsed_is_latest_when_replay_not_started(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.replay.progress",
+                seq=1,
+                ts=1000,
+                exchange="gateio",
+                user="gateio_01",
+                component="risk.hsl",
+                status="started",
+                reason_code="hsl_price_history_fetch_started",
+                data={
+                    "stage": "price_history_fetch_started",
+                    "history_build_elapsed_s": 91.25,
+                    "history_minutes": 43201,
+                    "price_replay_symbols": 24,
+                    "replay_concurrency": 4,
+                },
+            )
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    group = report["hsl_replay_profile"]["groups"][0]
+
+    assert group["bot"] == "gateio/gateio_01"
+    assert group["latest"]["data"]["stage"] == "price_history_fetch_started"
+    assert group["latest"]["derived"] == {
+        "history_build_elapsed_ms": 91250,
+        "latest_elapsed_ms": 91250,
+    }
 
 
 def test_live_performance_report_hsl_replay_profile_summary_is_bounded(tmp_path):

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2107,11 +2107,20 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
                     "stage": "pair_replay",
                     "pair_idx": 3,
                     "pairs": 29,
+                    "current_position_pairs": 1,
                     "timeline_rows": 43201,
+                    "start_ts": 1782492000000,
+                    "end_ts": 1782492600000,
+                    "record_start_ts": 1782492000000,
                     "applied_rows": 12000,
                     "total_applied_rows": 64000,
+                    "skipped_price_symbols": 1,
+                    "missing_price_symbols": 2,
                     "rows_per_second": 318.415,
                     "elapsed_s": 201.2,
+                    "history_build_elapsed_s": 255.75,
+                    "price_history_fetch_elapsed_s": 210.5,
+                    "timeline_replay_elapsed_s": 12.25,
                     "timeframe": "1m",
                     "history_minutes": 43201,
                     "price_replay_symbols": 29,
@@ -2226,6 +2235,15 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
     assert active_group["latest"]["data"]["timeframe"] == "1m"
     assert active_group["latest"]["data"]["history_minutes"] == 43201
     assert active_group["latest"]["data"]["price_replay_symbols"] == 29
+    assert active_group["latest"]["data"]["current_position_pairs"] == 1
+    assert active_group["latest"]["data"]["skipped_price_symbols"] == 1
+    assert active_group["latest"]["data"]["missing_price_symbols"] == 2
+    assert active_group["latest"]["data"]["start_ts"] == 1782492000000
+    assert active_group["latest"]["data"]["end_ts"] == 1782492600000
+    assert active_group["latest"]["data"]["record_start_ts"] == 1782492000000
+    assert active_group["latest"]["derived"]["history_build_elapsed_ms"] == 255750
+    assert active_group["latest"]["derived"]["price_history_fetch_elapsed_ms"] == 210500
+    assert active_group["latest"]["derived"]["timeline_replay_elapsed_ms"] == 12250
     assert active_group["latest"]["derived"]["estimated_dense_pair_row_work"] == (
         43201 * 29
     )


### PR DESCRIPTION
## Summary
- Preserve existing HSL history-build timing/count fields in live smoke and performance report projections.
- Derive `history_build_elapsed_ms`, `price_history_fetch_elapsed_ms`, and `timeline_replay_elapsed_ms` from already-emitted HSL replay progress data.
- Use `history_build_elapsed_s` as `latest_elapsed_ms` when a replay is still active before per-symbol/pair `elapsed_s` exists.

## Scope
Report-only / observability-only. No live event producers, exchange calls, startup behavior, HSL logic, or trading decisions changed.

## Tests
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py tests/test_live_smoke_report.py -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/live/performance_report.py src/live/smoke_report.py tests/test_live_performance_report.py tests/test_live_smoke_report.py`
- `git diff --check`
- Silent-handling scan on touched files: only pre-existing report-style safe `.get(..., 0)` patterns were reported; no new exception swallowing or trading-path fallback.
