### PR TITLE
Show active HSL replay event age in reports

### DIFF
--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -8,7 +8,11 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
-from live.event_bus import LIVE_EVENT_DEBUG_PROFILES, LIVE_EVENT_MONITOR_PAYLOAD_KEY
+from live.event_bus import (
+    LIVE_EVENT_DEBUG_PROFILES,
+    LIVE_EVENT_MONITOR_PAYLOAD_KEY,
+    utc_ms,
+)
 from live.event_query import discover_event_files
 from live.smoke_report import _user_safe_display_path
 
@@ -1277,6 +1281,48 @@ def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _hsl_replay_latest_event_age_ms(
+    record: dict[str, Any],
+    *,
+    report_ts_ms: int,
+) -> int | None:
+    ts = _non_negative_number(record.get("ts"))
+    if ts is None:
+        return None
+    return int(max(0, int(report_ts_ms) - int(ts)))
+
+
+def _hsl_replay_active(latest: dict[str, Any] | None) -> bool:
+    if not isinstance(latest, dict):
+        return False
+    return latest.get("event_type") not in {
+        "hsl.replay.completed",
+        "hsl.replay.failed",
+    }
+
+
+def _with_hsl_replay_active_age(
+    group: dict[str, Any],
+    *,
+    report_ts_ms: int,
+) -> dict[str, Any]:
+    latest = group.get("latest")
+    if not _hsl_replay_active(latest):
+        return group
+    age_ms = _hsl_replay_latest_event_age_ms(latest, report_ts_ms=report_ts_ms)
+    if age_ms is None:
+        return group
+    out = dict(group)
+    latest_out = dict(latest)
+    derived = latest_out.get("derived")
+    derived_out = dict(derived) if isinstance(derived, dict) else {}
+    derived_out["latest_event_age_ms"] = int(age_ms)
+    latest_out["derived"] = derived_out
+    out["latest"] = latest_out
+    out["active_latest_event_age_ms"] = int(age_ms)
+    return out
+
+
 class _HslReplayProfileAccumulator:
     def __init__(self) -> None:
         self.bots: dict[str, dict[str, Any]] = {}
@@ -1338,7 +1384,14 @@ class _HslReplayProfileAccumulator:
                 state["latest_ts"] = int(ts)
             state["latest"] = record
 
-    def to_dict(self, *, group_limit: int = GROUP_LIMIT) -> dict[str, Any]:
+    def to_dict(
+        self,
+        *,
+        group_limit: int = GROUP_LIMIT,
+        report_ts_ms: int | None = None,
+    ) -> dict[str, Any]:
+        if report_ts_ms is None:
+            report_ts_ms = utc_ms()
         groups = []
         for bot, state in self.bots.items():
             group = {
@@ -1355,7 +1408,12 @@ class _HslReplayProfileAccumulator:
                 "completed": state.get("completed"),
                 "failed": state.get("failed"),
             }
-            groups.append({key: value for key, value in group.items() if value not in (None, {}, [])})
+            group = {
+                key: value for key, value in group.items() if value not in (None, {}, [])
+            }
+            groups.append(
+                _with_hsl_replay_active_age(group, report_ts_ms=int(report_ts_ms))
+            )
         groups = sorted(
             groups,
             key=lambda item: (
@@ -3024,6 +3082,7 @@ def build_live_performance_report(
     decision_boundary = _DecisionBoundaryAccumulator()
     input_staleness = _InputStalenessAccumulator()
     startup_readiness = _StartupReadinessAccumulator()
+    report_ts_ms = utc_ms()
     hsl_replay_profile = _HslReplayProfileAccumulator()
     cache_warmup = _CacheWarmupAccumulator()
     forager_ema_readiness = _ForagerEmaReadinessAccumulator()
@@ -3167,7 +3226,10 @@ def build_live_performance_report(
         "decision_boundary_lag": decision_boundary.to_dict(group_limit=group_limit),
         "input_staleness": input_staleness.to_dict(group_limit=group_limit),
         "startup_readiness": startup_readiness.to_dict(group_limit=group_limit),
-        "hsl_replay_profile": hsl_replay_profile.to_dict(group_limit=group_limit),
+        "hsl_replay_profile": hsl_replay_profile.to_dict(
+            group_limit=group_limit,
+            report_ts_ms=report_ts_ms,
+        ),
         "cache_warmup": cache_warmup.to_dict(group_limit=group_limit),
         "forager_ema_readiness": forager_ema_readiness.to_dict(group_limit=group_limit),
         "resource_pressure": resource_pressure.to_dict(group_limit=group_limit),

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from live.event_bus import LIVE_EVENT_MONITOR_PAYLOAD_KEY, EventTypes
+from live.event_bus import LIVE_EVENT_MONITOR_PAYLOAD_KEY, EventTypes, utc_ms
 from live.event_query import build_event_report, discover_event_files
 
 
@@ -2001,10 +2001,47 @@ def _hsl_replay_group_active(group: dict[str, Any]) -> bool:
     }
 
 
+def _hsl_replay_latest_event_age_ms(
+    record: dict[str, Any],
+    *,
+    report_ts_ms: int,
+) -> int | None:
+    ts = _non_negative_int(record.get("ts"))
+    if ts is None:
+        return None
+    return int(max(0, int(report_ts_ms) - int(ts)))
+
+
+def _with_hsl_replay_active_age(
+    group: dict[str, Any],
+    *,
+    report_ts_ms: int,
+) -> dict[str, Any]:
+    latest = group.get("latest")
+    if not _hsl_replay_group_active(group) or not isinstance(latest, dict):
+        return group
+    age_ms = _hsl_replay_latest_event_age_ms(latest, report_ts_ms=report_ts_ms)
+    if age_ms is None:
+        return group
+    out = dict(group)
+    latest_out = dict(latest)
+    derived = latest_out.get("derived")
+    derived_out = dict(derived) if isinstance(derived, dict) else {}
+    derived_out["latest_event_age_ms"] = int(age_ms)
+    latest_out["derived"] = derived_out
+    out["latest"] = latest_out
+    out["active_latest_event_age_ms"] = int(age_ms)
+    return out
+
+
 def _summarize_hsl_replay_health(
     groups: dict[str, dict[str, Any]],
     event_type_counts: Counter[str],
+    *,
+    report_ts_ms: int | None = None,
 ) -> dict[str, Any]:
+    if report_ts_ms is None:
+        report_ts_ms = utc_ms()
     ordered = sorted(
         groups.values(),
         key=lambda item: (
@@ -2058,6 +2095,10 @@ def _summarize_hsl_replay_health(
             "completed": completed,
             "failed": failed,
         }
+        public_group = _with_hsl_replay_active_age(
+            public_group,
+            report_ts_ms=int(report_ts_ms),
+        )
         compact_groups.append(
             {
                 key: value
@@ -3018,6 +3059,7 @@ def _scan_events(
     until_ms: int | None = None,
 ) -> dict[str, Any]:
     files = discover_event_files(root, include_rotated=include_rotated)
+    report_ts_ms = utc_ms()
     bots: dict[str, dict[str, Any]] = defaultdict(
         lambda: {
             "events": 0,
@@ -3291,6 +3333,7 @@ def _scan_events(
         "hsl_replay_health": _summarize_hsl_replay_health(
             hsl_replay_health_groups,
             hsl_replay_health_event_type_counts,
+            report_ts_ms=report_ts_ms,
         ),
         "risk_events": _summarize_risk_events(
             risk_event_groups,

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1326,7 +1326,9 @@ def test_live_performance_report_hsl_replay_profile_whitelists_values(tmp_path):
 
 def test_live_performance_report_hsl_history_elapsed_is_latest_when_replay_not_started(
     tmp_path,
+    monkeypatch,
 ):
+    monkeypatch.setattr(performance_report_module, "utc_ms", lambda: 121000)
     events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
     _write_ndjson(
         events_dir / "current.ndjson",
@@ -1358,8 +1360,10 @@ def test_live_performance_report_hsl_history_elapsed_is_latest_when_replay_not_s
     assert group["latest"]["data"]["stage"] == "price_history_fetch_started"
     assert group["latest"]["derived"] == {
         "history_build_elapsed_ms": 91250,
+        "latest_event_age_ms": 120000,
         "latest_elapsed_ms": 91250,
     }
+    assert group["active_latest_event_age_ms"] == 120000
 
 
 def test_live_performance_report_hsl_replay_profile_summary_is_bounded(tmp_path):

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2015,7 +2015,8 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
     }
 
 
-def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
+def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
+    monkeypatch.setattr(smoke_report_module, "utc_ms", lambda: 65000)
     _write_ndjson(
         tmp_path
         / "monitor"
@@ -2231,6 +2232,7 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
     active_group = report["hsl_replay_health"]["groups"][0]
     assert active_group["bot"] == "gateio/gateio_01"
     assert active_group["active"] is True
+    assert active_group["active_latest_event_age_ms"] == 60000
     assert active_group["latest"]["symbol"] == "ZEC/USDT:USDT"
     assert active_group["latest"]["data"]["timeframe"] == "1m"
     assert active_group["latest"]["data"]["history_minutes"] == 43201
@@ -2242,6 +2244,7 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path):
     assert active_group["latest"]["data"]["end_ts"] == 1782492600000
     assert active_group["latest"]["data"]["record_start_ts"] == 1782492000000
     assert active_group["latest"]["derived"]["history_build_elapsed_ms"] == 255750
+    assert active_group["latest"]["derived"]["latest_event_age_ms"] == 60000
     assert active_group["latest"]["derived"]["price_history_fetch_elapsed_ms"] == 210500
     assert active_group["latest"]["derived"]["timeline_replay_elapsed_ms"] == 12250
     assert active_group["latest"]["derived"]["estimated_dense_pair_row_work"] == (


### PR DESCRIPTION
## Summary
- Add `active_latest_event_age_ms` to active HSL replay groups in live smoke and performance reports.
- Add `latest_event_age_ms` under the active latest record's derived fields.
- Use one report timestamp per report build, so active replay age is consistent across groups.

## Scope
Report-only / observability-only. No live event producers, exchange calls, startup behavior, HSL logic, or trading decisions changed.

## Why
After PR #862, active HSL history stages show elapsed time at event emission. This adds the missing current age since the last active HSL replay event, making stale/stuck stages like `price_history_symbol_fetch_started` visible without raw NDJSON inspection.

## Tests
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py tests/test_live_smoke_report.py -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/live/performance_report.py src/live/smoke_report.py tests/test_live_performance_report.py tests/test_live_smoke_report.py`
- `git diff --check`
- Silent-handling scan on touched files: only pre-existing report-style safe `.get(..., 0)` patterns were reported; no new exception swallowing or trading-path fallback.
