### PR TITLE
Emit HSL flat finalization event

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -58,6 +58,7 @@ across time.
 - `hsl.cooldown_ended`
 - `hsl.cooldown_started`
 - `hsl.raw_red_pending`
+- `hsl.red_finalized_without_order`
 - `hsl.red_triggered`
 - `hsl.replay.completed`
 - `hsl.replay.failed`
@@ -163,6 +164,7 @@ across time.
 - `hsl_price_history_symbol_fetch_completed`
 - `hsl_price_history_symbol_fetch_started`
 - `hsl_raw_red_pending_ema_confirmation`
+- `hsl_red_finalized_without_exchange_order`
 - `hsl_timeline_replay_completed`
 - `hsl_timeline_replay_started`
 - `initial_entry_distance_gate`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -122,6 +122,7 @@ class EventTypes:
     HSL_REPLAY_COMPLETED = "hsl.replay.completed"
     HSL_REPLAY_FAILED = "hsl.replay.failed"
     HSL_RED_TRIGGERED = "hsl.red_triggered"
+    HSL_RED_FINALIZED_WITHOUT_ORDER = "hsl.red_finalized_without_order"
     HSL_COOLDOWN_STARTED = "hsl.cooldown_started"
     HSL_COOLDOWN_ENDED = "hsl.cooldown_ended"
     UNSTUCK_STATUS = "unstuck.status"
@@ -231,6 +232,9 @@ class ReasonCodes:
     )
     HSL_PRICE_HISTORY_SYMBOL_FETCH_STARTED = "hsl_price_history_symbol_fetch_started"
     HSL_RAW_RED_PENDING_EMA_CONFIRMATION = "hsl_raw_red_pending_ema_confirmation"
+    HSL_RED_FINALIZED_WITHOUT_EXCHANGE_ORDER = (
+        "hsl_red_finalized_without_exchange_order"
+    )
     HSL_TIMELINE_REPLAY_COMPLETED = "hsl_timeline_replay_completed"
     HSL_TIMELINE_REPLAY_STARTED = "hsl_timeline_replay_started"
     RUST_OUTPUT_ACTIONS = "rust_output_actions"
@@ -378,6 +382,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.HSL_REPLAY_COMPLETED,
     EventTypes.HSL_REPLAY_FAILED,
     EventTypes.HSL_RED_TRIGGERED,
+    EventTypes.HSL_RED_FINALIZED_WITHOUT_ORDER,
     EventTypes.HSL_COOLDOWN_STARTED,
     EventTypes.HSL_COOLDOWN_ENDED,
     EventTypes.UNSTUCK_STATUS,
@@ -685,6 +690,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.HSL_REPLAY_COMPLETED: EventRoute(console=False, text=False),
     EventTypes.HSL_REPLAY_FAILED: EventRoute(console=False, text=False),
     EventTypes.HSL_RED_TRIGGERED: EventRoute(console=False, text=False),
+    EventTypes.HSL_RED_FINALIZED_WITHOUT_ORDER: EventRoute(console=False, text=False),
     EventTypes.HSL_COOLDOWN_STARTED: EventRoute(console=False, text=False),
     EventTypes.HSL_COOLDOWN_ENDED: EventRoute(console=False, text=False),
     EventTypes.UNSTUCK_STATUS: EventRoute(console=False, text=False),

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -270,6 +270,63 @@ def _emit_hsl_red_triggered_once(
     state["red_trigger_event_emitted"] = True
 
 
+def _emit_hsl_red_finalized_without_order(
+    self,
+    stop_event: dict,
+    *,
+    pside: str,
+    symbol: str | None,
+    stop_ts_ms: int,
+    cooldown_until_ms: int | None,
+    flat_confirmations: int | None,
+    position_count: int | None = None,
+    entry_orders: int | None = None,
+    nonpanic_close_orders: int | None = None,
+) -> None:
+    data: dict[str, Any] = {
+        "reason": "red_finalized_without_exchange_order",
+        "no_exchange_close_needed": True,
+        "exchange_close_order_submitted": False,
+        "panic_order_submitted_count": 0,
+        "stop_event_timestamp_ms": int(stop_ts_ms),
+        "cooldown_until_ms": None
+        if cooldown_until_ms is None
+        else int(cooldown_until_ms),
+    }
+    if symbol is not None:
+        data["symbol_position_open"] = False
+    if position_count is not None:
+        data["position_count"] = int(position_count)
+    if entry_orders is not None:
+        data["entry_orders"] = int(entry_orders)
+    if nonpanic_close_orders is not None:
+        data["nonpanic_close_orders"] = int(nonpanic_close_orders)
+    if flat_confirmations is not None:
+        data["flat_confirmations"] = int(flat_confirmations)
+    for key in (
+        "signal_mode",
+        "tier",
+        "drawdown_raw",
+        "drawdown_ema",
+        "drawdown_score",
+        "red_threshold",
+    ):
+        if key in stop_event:
+            data[key] = stop_event[key]
+    _emit_hsl_event(
+        self,
+        EventTypes.HSL_RED_FINALIZED_WITHOUT_ORDER,
+        ("hsl", "risk", "red"),
+        data,
+        pside=pside,
+        symbol=symbol,
+        ts=stop_ts_ms,
+        level="info",
+        status="succeeded",
+        reason_code=ReasonCodes.HSL_RED_FINALIZED_WITHOUT_EXCHANGE_ORDER,
+    )
+
+
 def _emit_hsl_replay_event(
     self,
     event_type: str,
@@ -3764,7 +3821,17 @@ def _equity_hard_stop_log_red_progress(
     )
 
 
-async def _equity_hard_stop_finalize_red_stop(self, pside: str, stop_event: Optional[dict] = None) -> None:
+async def _equity_hard_stop_finalize_red_stop(
+    self,
+    pside: str,
+    stop_event: Optional[dict] = None,
+    *,
+    finalized_without_order: bool = False,
+    flat_confirmations: int | None = None,
+    position_count: int | None = None,
+    entry_orders: int | None = None,
+    nonpanic_close_orders: int | None = None,
+) -> None:
     state = self._hsl_state(pside)
     cfg = self.hsl[pside]
     stop_ts_ms = int(self.get_exchange_time())
@@ -3814,6 +3881,19 @@ async def _equity_hard_stop_finalize_red_stop(self, pside: str, stop_event: Opti
     state["red_flat_confirmations"] = 0
     state["pending_red_since_ms"] = None
     latch_path = self._equity_hard_stop_write_latch(pside, payload)
+    if finalized_without_order:
+        _emit_hsl_red_finalized_without_order(
+            self,
+            stop_event,
+            pside=pside,
+            symbol=None,
+            stop_ts_ms=stop_ts_ms,
+            cooldown_until_ms=cooldown_until_ms,
+            flat_confirmations=flat_confirmations,
+            position_count=position_count,
+            entry_orders=entry_orders,
+            nonpanic_close_orders=nonpanic_close_orders,
+        )
     _emit_hsl_red_triggered_once(
         self,
         state,
@@ -3876,7 +3956,15 @@ async def _equity_hard_stop_finalize_red_stop(self, pside: str, stop_event: Opti
 
 
 async def _equity_hard_stop_finalize_coin_red_stop(
-    self, pside: str, symbol: str, stop_event: Optional[dict] = None
+    self,
+    pside: str,
+    symbol: str,
+    stop_event: Optional[dict] = None,
+    *,
+    finalized_without_order: bool = False,
+    flat_confirmations: int | None = None,
+    entry_orders: int | None = None,
+    nonpanic_close_orders: int | None = None,
 ) -> None:
     state = self._hsl_coin_state(pside, symbol)
     cfg = self.hsl[pside]
@@ -3924,6 +4012,19 @@ async def _equity_hard_stop_finalize_coin_red_stop(
     state["pending_red_since_ms"] = None
     state["pnl_reset_timestamp_ms"] = int(stop_ts_ms) + 1
     latch_path = self._equity_hard_stop_write_latch(pside, payload, symbol=symbol)
+    if finalized_without_order:
+        _emit_hsl_red_finalized_without_order(
+            self,
+            stop_event,
+            pside=pside,
+            symbol=symbol,
+            stop_ts_ms=stop_ts_ms,
+            cooldown_until_ms=cooldown_until_ms,
+            flat_confirmations=flat_confirmations,
+            position_count=0,
+            entry_orders=entry_orders,
+            nonpanic_close_orders=nonpanic_close_orders,
+        )
     _emit_hsl_red_triggered_once(
         self,
         state,
@@ -4020,7 +4121,15 @@ async def _equity_hard_stop_run_red_supervisor(self) -> None:
                     state["red_flat_confirmations"],
                 )
                 if state["red_flat_confirmations"] >= 2:
-                    await self._equity_hard_stop_finalize_red_stop(pside, state["pending_stop_event"])
+                    await self._equity_hard_stop_finalize_red_stop(
+                        pside,
+                        state["pending_stop_event"],
+                        finalized_without_order=True,
+                        flat_confirmations=state["red_flat_confirmations"],
+                        position_count=n_positions,
+                        entry_orders=entry_orders,
+                        nonpanic_close_orders=nonpanic_close_orders,
+                    )
             active_red_psides = [
                 pside
                 for pside in self._hsl_psides()
@@ -4098,7 +4207,13 @@ async def _equity_hard_stop_run_coin_red_supervisor(self) -> None:
                         )
                     else:
                         await self._equity_hard_stop_finalize_coin_red_stop(
-                            pside, symbol, state["pending_stop_event"]
+                            pside,
+                            symbol,
+                            state["pending_stop_event"],
+                            finalized_without_order=True,
+                            flat_confirmations=state["red_flat_confirmations"],
+                            entry_orders=entry_orders,
+                            nonpanic_close_orders=nonpanic_close_orders,
                         )
                 else:
                     self._equity_hard_stop_set_coin_runtime_forced_mode(pside, symbol, "panic")

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -769,6 +769,65 @@ async def test_coin_hsl_finalize_uses_latest_panic_fill_for_reset_boundary():
     assert events[0].reason_code == "coin_red_stop_finalized"
     assert events[0].data["stop_event_timestamp_ms"] == 170_000
     assert events[0].data["cooldown_until_ms"] == 470_000
+    assert [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.HSL_RED_FINALIZED_WITHOUT_ORDER
+    ] == []
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_finalize_emits_flat_without_order_event():
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
+
+    bot = make_coin_bot()
+    symbol = "A"
+    bot.get_exchange_time = lambda: 180_000
+    sink = ListEventSink()
+    bot.bot_id = "bot_1"
+    bot._live_event_current_cycle_id = "cy_coin_flat_finalize"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+    state = bot._hsl_coin_state("long", symbol)
+    state["pending_red_since_ms"] = 120_000
+
+    await bot._equity_hard_stop_finalize_coin_red_stop(
+        "long",
+        symbol,
+        finalized_without_order=True,
+        flat_confirmations=2,
+        entry_orders=0,
+        nonpanic_close_orders=0,
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.HSL_RED_FINALIZED_WITHOUT_ORDER
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.cycle_id == "cy_coin_flat_finalize"
+    assert event.pside == "long"
+    assert event.symbol == symbol
+    assert event.status == "succeeded"
+    assert event.reason_code == ReasonCodes.HSL_RED_FINALIZED_WITHOUT_EXCHANGE_ORDER
+    assert event.data["no_exchange_close_needed"] is True
+    assert event.data["exchange_close_order_submitted"] is False
+    assert event.data["panic_order_submitted_count"] == 0
+    assert event.data["symbol_position_open"] is False
+    assert event.data["position_count"] == 0
+    assert event.data["entry_orders"] == 0
+    assert event.data["nonpanic_close_orders"] == 0
+    assert event.data["flat_confirmations"] == 2
+    assert event.data["stop_event_timestamp_ms"] == 180_000
+    assert event.data["cooldown_until_ms"] == 480_000
+    assert event.data["drawdown_raw"] == 0.0
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -229,6 +229,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.HSL_STATUS,
         EventTypes.HSL_RAW_RED_PENDING,
         EventTypes.HSL_RED_TRIGGERED,
+        EventTypes.HSL_RED_FINALIZED_WITHOUT_ORDER,
         EventTypes.HSL_COOLDOWN_STARTED,
         EventTypes.HSL_COOLDOWN_ENDED,
         EventTypes.UNSTUCK_STATUS,


### PR DESCRIPTION
Observability-only HSL slice from the GateIO ZEC investigation.

Adds a structured `hsl.red_finalized_without_order` event when the HSL RED supervisor finalizes cooldown after proving the symbol/side or pside is already flat and no exchange close order is needed.

The event is routed away from console/text by default and carries bounded correlation fields: stop/cooldown timestamps, flat confirmation count, blocking-order counts, no-exchange-close booleans, and HSL drawdown summary fields.

No trading behavior changes: finalization conditions, panic supervision, order creation, cooldown math, forced modes, and exchange writes are unchanged.

Validation:

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_hsl_coin_mode.py::test_coin_hsl_finalize_uses_latest_panic_fill_for_reset_boundary tests/test_hsl_coin_mode.py::test_coin_hsl_finalize_emits_flat_without_order_event tests/test_hsl_coin_mode.py::test_coin_hsl_finalize_does_not_duplicate_prior_red_trigger_event tests/test_live_event_bus.py::test_route_table_keeps_data_events_off_console_by_default tests/test_live_event_bus.py::test_live_event_reason_code_registry_values_are_unique_and_query_safe tests/test_live_event_registry_docs.py -q` -> 9 passed.
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/passivbot_hsl.py src/live/event_bus.py tests/test_hsl_coin_mode.py tests/test_live_event_bus.py` -> pass.
- `git diff --check` -> pass.
- Silent-handling audit over touched files ran; only pre-existing broad HSL/event-bus best-effort patterns and legacy `.get(..., 0)` sites were reported, no new ones added by this slice.
