### PR TITLE
Show active HSL age in startup readiness

### DIFF
--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1001,7 +1001,14 @@ class _StartupReadinessAccumulator:
                 if key in data:
                     hsl_state[key] = data[key]
 
-    def to_dict(self, *, group_limit: int = GROUP_LIMIT) -> dict[str, Any]:
+    def to_dict(
+        self,
+        *,
+        group_limit: int = GROUP_LIMIT,
+        report_ts_ms: int | None = None,
+    ) -> dict[str, Any]:
+        if report_ts_ms is None:
+            report_ts_ms = utc_ms()
         bot_items = []
         ready_count = 0
         hsl_active_count = 0
@@ -1028,9 +1035,15 @@ class _StartupReadinessAccumulator:
                     for key, value in state["hsl_replay"].items()
                     if value is not None
                 }
-                item["hsl_replay"] = hsl_state
                 if hsl_state.get("status") not in ("succeeded", "failed"):
                     hsl_active_count += 1
+                    age_ms = _hsl_replay_latest_event_age_ms(
+                        {"ts": hsl_state.get("latest_ts")},
+                        report_ts_ms=int(report_ts_ms),
+                    )
+                    if age_ms is not None:
+                        hsl_state["latest_event_age_ms"] = int(age_ms)
+                item["hsl_replay"] = hsl_state
             debug_profiles = sorted(state.get("debug_profiles") or [])
             if debug_profiles:
                 item["debug_profiles"] = debug_profiles
@@ -3225,7 +3238,10 @@ def build_live_performance_report(
         "performance": accumulator.to_dict(group_limit=group_limit),
         "decision_boundary_lag": decision_boundary.to_dict(group_limit=group_limit),
         "input_staleness": input_staleness.to_dict(group_limit=group_limit),
-        "startup_readiness": startup_readiness.to_dict(group_limit=group_limit),
+        "startup_readiness": startup_readiness.to_dict(
+            group_limit=group_limit,
+            report_ts_ms=report_ts_ms,
+        ),
         "hsl_replay_profile": hsl_replay_profile.to_dict(
             group_limit=group_limit,
             report_ts_ms=report_ts_ms,

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -870,7 +870,8 @@ def test_live_performance_report_summary_includes_bounded_input_staleness(tmp_pa
     assert len(summary["input_staleness"]["groups"]) == 1
 
 
-def test_live_performance_report_startup_readiness_summary(tmp_path):
+def test_live_performance_report_startup_readiness_summary(tmp_path, monkeypatch):
+    monkeypatch.setattr(performance_report_module, "utc_ms", lambda: 64000)
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(
         events_dir / "current.ndjson",
@@ -944,6 +945,7 @@ def test_live_performance_report_startup_readiness_summary(tmp_path):
     assert bot["hsl_replay"]["pairs"] == 26
     assert bot["hsl_replay"]["held_pairs"] == 1
     assert bot["hsl_replay"]["rows_per_second"] == 289.4
+    assert bot["hsl_replay"]["latest_event_age_ms"] == 60000
 
 
 def test_live_performance_report_startup_readiness_completed_hsl_not_active(tmp_path):
@@ -977,6 +979,7 @@ def test_live_performance_report_startup_readiness_completed_hsl_not_active(tmp_
     assert startup["ready_count"] == 0
     assert startup["hsl_replay_active_count"] == 0
     assert startup["bots"][0]["hsl_replay"]["status"] == "succeeded"
+    assert "latest_event_age_ms" not in startup["bots"][0]["hsl_replay"]
     assert startup["bots"][0]["hsl_replay"]["skipped_pairs"] == 1
 
 
@@ -1063,7 +1066,8 @@ def test_live_performance_report_startup_readiness_is_bounded(tmp_path):
     assert list(startup["bots"][0]["startup_phases_ms"]) == ["account"]
 
 
-def test_live_performance_report_startup_readiness_hsl_whitelist(tmp_path):
+def test_live_performance_report_startup_readiness_hsl_whitelist(tmp_path, monkeypatch):
+    monkeypatch.setattr(performance_report_module, "utc_ms", lambda: 122000)
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(
         events_dir / "current.ndjson",
@@ -1097,6 +1101,7 @@ def test_live_performance_report_startup_readiness_hsl_whitelist(tmp_path):
         "reason_code": "test",
         "stage": "pair_replay",
         "pairs": 1,
+        "latest_event_age_ms": 120000,
     }
 
 


### PR DESCRIPTION
Observability-only performance-report slice.

`hsl_replay_profile` already exposes `active_latest_event_age_ms` for non-terminal HSL replay groups. This extends the same bounded age projection to `startup_readiness.bots[].hsl_replay.latest_event_age_ms` for active startup HSL replay entries, so the startup section can show how stale/stuck the latest replay stage is without requiring the separate HSL profile section.

No event producers, exchange calls, readiness gates, console routing, HSL behavior, or trading behavior changed. The value is a clamped time delta derived from the monitor event timestamp and a single report timestamp.

Validation:

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py::test_live_performance_report_startup_readiness_summary tests/test_live_performance_report.py::test_live_performance_report_startup_readiness_completed_hsl_not_active tests/test_live_performance_report.py::test_live_performance_report_startup_readiness_hsl_whitelist tests/test_live_performance_report.py::test_live_performance_report_hsl_history_elapsed_is_latest_when_replay_not_started -q` -> 4 passed.
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py -q` -> 47 passed.
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/live/performance_report.py tests/test_live_performance_report.py` -> pass.
- `git diff --check` -> pass.
- Silent-handling audit over touched files found only existing report sorting/projection defaults, no new critical-path fallback.
