### PR TITLE
Surface HSL flat finalizations in live reports

### DIFF
--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -147,6 +147,7 @@ _RISK_ACTIVITY_EVENT_TYPES = {
     "hsl.transition",
     "hsl.status",
     "hsl.red_triggered",
+    "hsl.red_finalized_without_order",
     "hsl.cooldown_started",
     "hsl.cooldown_ended",
     "unstuck.status",

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -78,6 +78,7 @@ RISK_EVENT_TYPES = {
     EventTypes.HSL_TRANSITION,
     EventTypes.HSL_STATUS,
     EventTypes.HSL_RED_TRIGGERED,
+    EventTypes.HSL_RED_FINALIZED_WITHOUT_ORDER,
     EventTypes.HSL_COOLDOWN_STARTED,
     EventTypes.HSL_COOLDOWN_ENDED,
     EventTypes.UNSTUCK_STATUS,
@@ -1509,6 +1510,15 @@ def _risk_event_group(
             "cooldown_remaining_seconds",
             "last_red_ts",
             "pending_red_since_ms",
+            "stop_event_timestamp_ms",
+            "no_exchange_close_needed",
+            "exchange_close_order_submitted",
+            "panic_order_submitted_count",
+            "symbol_position_open",
+            "position_count",
+            "entry_orders",
+            "nonpanic_close_orders",
+            "flat_confirmations",
             "changed",
             "price_diff_pct",
             "status_counts",
@@ -1516,9 +1526,19 @@ def _risk_event_group(
         )
         if payload.get(key) is not None
     }
+    event_type = live_event.get("event_type") or row.get("kind")
+    if event_type == EventTypes.HSL_RED_FINALIZED_WITHOUT_ORDER:
+        for key in (
+            "drawdown_score",
+            "drawdown_raw",
+            "drawdown_ema",
+            "dist_to_red",
+            "red_threshold",
+        ):
+            latest_data.pop(key, None)
     return {
         "bot": bot_key,
-        "event_type": live_event.get("event_type") or row.get("kind"),
+        "event_type": event_type,
         "reason_code": live_event.get("reason_code"),
         "status": live_event.get("status"),
         "level": live_event.get("level"),

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -2148,8 +2148,24 @@ def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
                 },
             ),
             _monitor_row(
-                event_type="risk.mode_changed",
+                event_type="hsl.red_finalized_without_order",
                 seq=3,
+                ts=2500,
+                component="risk.hsl",
+                status="succeeded",
+                reason_code="hsl_red_finalized_without_exchange_order",
+                symbol="BTC/USDT:USDT",
+                pside="long",
+                data={
+                    "cooldown_until_ms": 999999,
+                    "stop_event_timestamp_ms": 2400,
+                    "balance": 12345.67,
+                    "secret_marker": "flat-secret",
+                },
+            ),
+            _monitor_row(
+                event_type="risk.mode_changed",
+                seq=4,
                 ts=3000,
                 component="risk.hsl.mode",
                 reason_code="hsl_halted",
@@ -2162,7 +2178,7 @@ def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
             ),
             _monitor_row(
                 event_type="unstuck.selection",
-                seq=4,
+                seq=5,
                 ts=4000,
                 component="risk.unstuck.selection",
                 reason_code="unstuck_selection",
@@ -2177,7 +2193,7 @@ def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
             ),
             _monitor_row(
                 event_type="risk.realized_loss_gate_blocked",
-                seq=5,
+                seq=6,
                 ts=4500,
                 component="risk.realized_loss_gate",
                 status="deferred",
@@ -2194,7 +2210,7 @@ def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
             ),
             _monitor_row(
                 event_type="hsl.replay.progress",
-                seq=6,
+                seq=7,
                 ts=5000,
                 component="risk.hsl.replay",
                 reason_code="replay_progress",
@@ -2213,8 +2229,9 @@ def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
     }
     rendered = json.dumps(risk, sort_keys=True)
 
-    assert risk["total_events"] == 5
+    assert risk["total_events"] == 6
     assert risk["event_types"] == {
+        "hsl.red_finalized_without_order": 1,
         "hsl.red_triggered": 1,
         "hsl.status": 1,
         "risk.mode_changed": 1,
@@ -2226,6 +2243,15 @@ def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
     assert groups["hsl.status"]["reason_codes"] == {"cooldown_active": 1}
     assert groups["hsl.status"]["symbols_sample"] == ["BTC/USDT:USDT"]
     assert groups["hsl.status"]["psides"] == {"long": 1}
+    assert groups["hsl.red_finalized_without_order"]["statuses"] == {
+        "succeeded": 1
+    }
+    assert groups["hsl.red_finalized_without_order"]["reason_codes"] == {
+        "hsl_red_finalized_without_exchange_order": 1
+    }
+    assert groups["hsl.red_finalized_without_order"]["symbols_sample"] == [
+        "BTC/USDT:USDT"
+    ]
     assert groups["unstuck.selection"]["symbols_sample"] == ["ETH/USDT:USDT"]
     assert groups["risk.realized_loss_gate_blocked"]["symbols_sample"] == ["SOL/USDT:USDT"]
     assert groups["risk.realized_loss_gate_blocked"]["statuses"] == {"deferred": 1}
@@ -2234,6 +2260,7 @@ def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
     assert "1111.22" not in rendered
     assert "hsl-secret" not in rendered
     assert "red-secret" not in rendered
+    assert "flat-secret" not in rendered
     assert "mode-secret" not in rendered
     assert "unstuck-secret" not in rendered
     assert "loss-gate-secret" not in rendered

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1924,13 +1924,37 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
                 },
             ),
             _monitor_row(
-                event_type="unstuck.selection",
+                event_type="hsl.red_finalized_without_order",
                 seq=5,
+                ts=4500,
+                symbol="ZEC/USDT:USDT",
+                pside="long",
+                reason_code="hsl_red_finalized_without_exchange_order",
+                ids={"cycle_id": "cy_risk_4"},
+                data={
+                    "no_exchange_close_needed": True,
+                    "exchange_close_order_submitted": False,
+                    "panic_order_submitted_count": 0,
+                    "symbol_position_open": False,
+                    "position_count": 0,
+                    "entry_orders": 0,
+                    "nonpanic_close_orders": 0,
+                    "flat_confirmations": 2,
+                    "stop_event_timestamp_ms": 4300,
+                    "cooldown_until_ms": 999999,
+                    "drawdown_raw": 0.42,
+                    "balance": 12345.67,
+                    "secret_marker": "flat-secret",
+                },
+            ),
+            _monitor_row(
+                event_type="unstuck.selection",
+                seq=6,
                 ts=5000,
                 symbol="SUI/USDT:USDT",
                 pside="long",
                 reason_code="unstuck_selection",
-                ids={"cycle_id": "cy_risk_4"},
+                ids={"cycle_id": "cy_risk_5"},
                 data={
                     "allowance": -12.3,
                     "price_diff_pct": 10.0,
@@ -1949,9 +1973,10 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
     assert report["ok"] is True
     assert report["attention"] is False
     assert report["risk_events"] == {
-        "total": 4,
+        "total": 5,
         "groups_truncated": False,
         "event_types": {
+            "hsl.red_finalized_without_order": 1,
             "hsl.status": 2,
             "risk.mode_changed": 1,
             "unstuck.selection": 1,
@@ -1971,6 +1996,31 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
                 "latest_data": {
                     "changed": True,
                     "price_diff_pct": 10.0,
+                },
+                "latest_ids": {"cycle_id": "cy_risk_5"},
+            },
+            {
+                "bot": "binance/binance_01",
+                "event_type": "hsl.red_finalized_without_order",
+                "reason_code": "hsl_red_finalized_without_exchange_order",
+                "status": "succeeded",
+                "level": "info",
+                "symbol": "ZEC/USDT:USDT",
+                "pside": "long",
+                "component": "test",
+                "count": 1,
+                "latest_ts": 4500,
+                "latest_data": {
+                    "cooldown_until_ms": 999999,
+                    "stop_event_timestamp_ms": 4300,
+                    "no_exchange_close_needed": True,
+                    "exchange_close_order_submitted": False,
+                    "panic_order_submitted_count": 0,
+                    "symbol_position_open": False,
+                    "position_count": 0,
+                    "entry_orders": 0,
+                    "nonpanic_close_orders": 0,
+                    "flat_confirmations": 2,
                 },
                 "latest_ids": {"cycle_id": "cy_risk_4"},
             },
@@ -2013,6 +2063,10 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
             },
         ],
     }
+    rendered = json.dumps(report["risk_events"], sort_keys=True)
+    assert "12345.67" not in rendered
+    assert "0.42" not in rendered
+    assert "flat-secret" not in rendered
 
 
 def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- include hsl.red_finalized_without_order in live smoke risk_events
- include the same event in live performance risk_activity
- keep projected fields bounded to provenance/ratio fields and extend value-safety tests

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_performance_report.py
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/live/smoke_report.py src/live/performance_report.py tests/test_live_smoke_report.py tests/test_live_performance_report.py
- git diff --check