### PR TITLE
Filter live event queries by data fields

### DIFF
--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -145,6 +145,54 @@ def _filter_matches(value: Any, filter_values: set[str]) -> bool:
     return not filter_values or (value is not None and str(value) in filter_values)
 
 
+def _normalize_data_eq_filters(
+    values: str | Iterable[str] | None,
+) -> dict[str, set[str]]:
+    if values is None:
+        return {}
+    if isinstance(values, str):
+        raw_values = [values]
+    else:
+        raw_values = list(values)
+    out: dict[str, set[str]] = defaultdict(set)
+    for raw_value in raw_values:
+        text = str(raw_value)
+        if "=" not in text:
+            raise ValueError("data_eq filters must use key=value")
+        key, expected = text.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError("data_eq filters must include a non-empty key")
+        out[key].add(expected.strip())
+    return {key: set(values) for key, values in sorted(out.items())}
+
+
+def _data_value_matches(value: Any, expected_values: set[str]) -> bool:
+    candidates = {str(value)}
+    if isinstance(value, bool):
+        candidates.add(str(value).lower())
+    elif value is None:
+        candidates.add("null")
+    return bool(candidates.intersection(expected_values))
+
+
+def _data_filters_match(
+    live_event: dict[str, Any],
+    data_eq_filters: dict[str, set[str]],
+) -> bool:
+    if not data_eq_filters:
+        return True
+    data = live_event.get("data")
+    if not isinstance(data, dict):
+        return False
+    for key, expected_values in data_eq_filters.items():
+        if key not in data:
+            return False
+        if not _data_value_matches(data.get(key), expected_values):
+            return False
+    return True
+
+
 def _filter_report(
     *,
     cycle_id: str | None,
@@ -161,6 +209,7 @@ def _filter_report(
     reason_codes: set[str],
     statuses: set[str],
     tags: set[str],
+    data_eq_filters: dict[str, set[str]],
     since_ms: int | None = None,
     until_ms: int | None = None,
 ) -> dict[str, Any]:
@@ -197,6 +246,10 @@ def _filter_report(
         filters["statuses"] = sorted(statuses)
     if tags:
         filters["tags"] = sorted(tags)
+    if data_eq_filters:
+        filters["data_eq"] = {
+            key: sorted(values) for key, values in sorted(data_eq_filters.items())
+        }
     return filters
 
 
@@ -856,6 +909,7 @@ def build_event_report(
     reason_code: str | Iterable[str] | None = None,
     status: str | Iterable[str] | None = None,
     tag: str | Iterable[str] | None = None,
+    data_eq: str | Iterable[str] | None = None,
     since_ms: int | None = None,
     until_ms: int | None = None,
     limit: int = 200,
@@ -934,6 +988,7 @@ def build_event_report(
     reason_code_filter = _normalize_filter_values(reason_code)
     status_filter = _normalize_filter_values(status)
     tag_filter = _normalize_filter_values(tag)
+    data_eq_filters = _normalize_data_eq_filters(data_eq)
     has_non_cycle_filter = any(
         (
             event_type_filter,
@@ -949,6 +1004,7 @@ def build_event_report(
             reason_code_filter,
             status_filter,
             tag_filter,
+            data_eq_filters,
         )
     )
     trace_without_cycle = (
@@ -1089,6 +1145,7 @@ def build_event_report(
                     tag_matches = not tag_filter or bool(
                         set(record_tags).intersection(tag_filter)
                     )
+                    data_matches = _data_filters_match(live_event, data_eq_filters)
                     query_matches = (
                         event_type_matches
                         and cycle_matches
@@ -1104,6 +1161,7 @@ def build_event_report(
                         and reason_code_matches
                         and status_matches
                         and tag_matches
+                        and data_matches
                     )
 
                     if has_query_filter and query_matches:
@@ -1220,6 +1278,7 @@ def build_event_report(
             reason_codes=reason_code_filter,
             statuses=status_filter,
             tags=tag_filter,
+            data_eq_filters=data_eq_filters,
             since_ms=since_filter,
             until_ms=until_filter,
         )
@@ -1255,6 +1314,7 @@ def build_event_report(
             reason_codes=reason_code_filter,
             statuses=status_filter,
             tags=tag_filter,
+            data_eq_filters=data_eq_filters,
             since_ms=since_filter,
             until_ms=until_filter,
         )

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -128,6 +128,14 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--data-eq",
+        action="append",
+        help=(
+            "Return compact records whose top-level event data field exactly "
+            "matches key=value. May be repeated; filters are ANDed."
+        ),
+    )
+    parser.add_argument(
         "--since-ms",
         type=int,
         help="Only include live events with monitor ts at or after this epoch-ms value.",
@@ -212,32 +220,36 @@ def main(argv: list[str] | None = None) -> int:
         since_ms = int(time.time() * 1000) - int(args.recent_minutes * 60_000)
     if since_ms is not None and args.until_ms is not None and since_ms > args.until_ms:
         parser.error("--since-ms/--recent-minutes must be <= --until-ms")
-    report = build_event_report(
-        args.path,
-        cycle_id=args.cycle_id,
-        event_type=args.event_types,
-        bot_id=args.bot_id,
-        snapshot_id=args.snapshot_id,
-        plan_id=args.plan_id,
-        action_id=args.action_id,
-        order_wave_id=args.order_wave_id,
-        remote_call_id=args.remote_call_id,
-        remote_call_group_id=args.remote_call_group_id,
-        symbol=args.symbol,
-        pside=args.pside,
-        reason_code=args.reason_code,
-        status=args.status,
-        tag=args.tag,
-        since_ms=since_ms,
-        until_ms=args.until_ms,
-        limit=args.limit,
-        include_data=bool(args.include_data),
-        include_rotated=bool(args.include_rotated),
-        timeline=bool(args.timeline),
-        trace_summary=bool(args.trace_summary),
-        order_trace=bool(args.order_trace),
-        cycle_trace=bool(args.cycle_trace),
-    )
+    try:
+        report = build_event_report(
+            args.path,
+            cycle_id=args.cycle_id,
+            event_type=args.event_types,
+            bot_id=args.bot_id,
+            snapshot_id=args.snapshot_id,
+            plan_id=args.plan_id,
+            action_id=args.action_id,
+            order_wave_id=args.order_wave_id,
+            remote_call_id=args.remote_call_id,
+            remote_call_group_id=args.remote_call_group_id,
+            symbol=args.symbol,
+            pside=args.pside,
+            reason_code=args.reason_code,
+            status=args.status,
+            tag=args.tag,
+            data_eq=args.data_eq,
+            since_ms=since_ms,
+            until_ms=args.until_ms,
+            limit=args.limit,
+            include_data=bool(args.include_data),
+            include_rotated=bool(args.include_rotated),
+            timeline=bool(args.timeline),
+            trace_summary=bool(args.trace_summary),
+            order_trace=bool(args.order_trace),
+            cycle_trace=bool(args.cycle_trace),
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
     print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
     return 0 if report.get("ok") else 1
 

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -426,6 +426,73 @@ def test_event_query_filters_by_tags(tmp_path):
     assert risk_report["cycle"]["events"][0]["event_type"] == "risk.hsl_status"
 
 
+def test_event_query_filters_by_top_level_data_fields(tmp_path):
+    events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.red_finalized_without_order",
+                cycle_id="cy_1",
+                seq=1,
+                ts=1000,
+                symbol="ZEC/USDT:USDT",
+                pside="long",
+                tags=["risk", "hsl"],
+                data={
+                    "stop_event_anchor_source": "current_time_fallback",
+                    "stop_event_anchor_fallback_used": True,
+                    "flat_confirmations": 2,
+                },
+            ),
+            _monitor_row(
+                event_type="hsl.red_finalized_without_order",
+                cycle_id="cy_2",
+                seq=2,
+                ts=1100,
+                symbol="XLM/USDT:USDT",
+                pside="long",
+                tags=["risk", "hsl"],
+                data={
+                    "stop_event_anchor_source": "panic_fill",
+                    "stop_event_anchor_fallback_used": False,
+                    "flat_confirmations": 2,
+                },
+            ),
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        event_type="hsl.red_finalized_without_order",
+        tag="hsl",
+        data_eq=[
+            "stop_event_anchor_source=current_time_fallback",
+            "stop_event_anchor_fallback_used=true",
+        ],
+        include_data=True,
+    )
+
+    assert report["ok"] is True
+    assert report["query"]["filters"] == {
+        "data_eq": {
+            "stop_event_anchor_fallback_used": ["true"],
+            "stop_event_anchor_source": ["current_time_fallback"],
+        },
+        "event_types": ["hsl.red_finalized_without_order"],
+        "tags": ["hsl"],
+    }
+    assert report["query"]["matched_events"] == 1
+    event = report["query"]["events"][0]
+    assert event["symbol"] == "ZEC/USDT:USDT"
+    assert event["data"]["stop_event_anchor_source"] == "current_time_fallback"
+
+
+def test_event_query_rejects_malformed_data_eq_filter(tmp_path):
+    with pytest.raises(ValueError, match="key=value"):
+        build_event_report(tmp_path, data_eq="missing_equals")
+
+
 def test_event_query_filters_by_remaining_event_ids(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(
@@ -973,6 +1040,61 @@ def test_live_event_query_cli_accepts_time_window(tmp_path, capsys):
     assert report["query"]["filters"] == {"since_ms": 1100, "until_ms": 1300}
     assert report["query"]["matched_events"] == 1
     assert report["query"]["events"][0]["seq"] == 2
+
+
+def test_live_event_query_cli_accepts_data_eq_filter(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.red_finalized_without_order",
+                cycle_id="cy_1",
+                seq=1,
+                ts=1000,
+                data={"stop_event_anchor_source": "current_time_fallback"},
+            ),
+            _monitor_row(
+                event_type="hsl.red_finalized_without_order",
+                cycle_id="cy_2",
+                seq=2,
+                ts=1100,
+                data={"stop_event_anchor_source": "panic_fill"},
+            ),
+        ],
+    )
+
+    assert (
+        live_event_query.main(
+            [
+                str(tmp_path / "monitor"),
+                "--event-type",
+                "hsl.red_finalized_without_order",
+                "--data-eq",
+                "stop_event_anchor_source=current_time_fallback",
+                "--include-data",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["query"]["filters"] == {
+        "data_eq": {"stop_event_anchor_source": ["current_time_fallback"]},
+        "event_types": ["hsl.red_finalized_without_order"],
+    }
+    assert report["query"]["matched_events"] == 1
+    assert report["query"]["events"][0]["data"]["stop_event_anchor_source"] == (
+        "current_time_fallback"
+    )
+
+
+def test_live_event_query_cli_rejects_malformed_data_eq_filter(tmp_path, capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_event_query.main([str(tmp_path), "--data-eq", "missing_equals"])
+
+    assert exc_info.value.code == 2
+    assert "key=value" in capsys.readouterr().err
 
 
 def test_live_event_query_cli_accepts_recent_minutes(tmp_path, capsys, monkeypatch):


### PR DESCRIPTION
## Summary
- add --data-eq key=value to passivbot tool live-event-query
- support repeated top-level event data equality filters in build_event_report
- include data_eq in query/cycle filter metadata and compose it with existing event/tag/symbol/id filters

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py::test_event_query_filters_by_top_level_data_fields tests/test_live_event_query.py::test_event_query_rejects_malformed_data_eq_filter tests/test_live_event_query.py::test_live_event_query_cli_accepts_data_eq_filter tests/test_live_event_query.py::test_live_event_query_cli_rejects_malformed_data_eq_filter -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall -q src/live/event_query.py src/tools/live_event_query.py tests/test_live_event_query.py
- git diff --check
- silent-handling scan on touched files

Query/tooling-only: no event producers, exchange calls, cache mutation, readiness gates, console routing, order/risk logic, or trading behavior changed.