### PR TITLE
Scope live event queries by exchange and user

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-29.
 
 Current `origin/v8` logging-overhaul head:
 
-- `20351283` after PR #873, `Filter live event queries by data fields`.
+- `f09c79887` after PR #874, `Record HSL anchor and query progress`.
 
 Current review gate:
 
@@ -30,6 +30,16 @@ Current review gate:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #874 at `f09c79887`.
+- PR #874 was progress-ledger-only and recorded the HSL anchor/query evidence
+  after PR #873. No live bot restart was needed. All five configured
+  `passivbot live` processes remained running after the deploy. A 5-minute
+  brief smoke on `v8@f09c79887` reported `ok=true`, `hard_failures=0`,
+  `hard_failure_sources.total=0`, `logs.hard_matches=0`, `matched_expected=5`,
+  `missing_expected_count=0`, clean tracked repository state,
+  `account_critical_remote_calls.failed=0`, and one non-account-critical
+  remote-call failure. Known non-hard attention remained from EMA readiness and
+  HSL status/cooldown groups.
 - Repository pulled through PR #873 at `20351283`.
 - PR #873 added `passivbot tool live-event-query --data-eq key=value`, a
   repeated top-level live-event `data` equality filter. It lets operators query

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -147,6 +147,12 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   local HSL status/cooldown observations when present, while explicitly marking current
   drawdown and startup panic-order prediction unavailable unless a future slice adds safe
   local replay inputs.
+- `passivbot tool live-event-query` validates and queries local structured monitor event
+  segments. It is read-only and does not contact exchanges. Use `--event-type`,
+  `--cycle-id`, ID filters, `--symbol`, `--pside`, `--tag`, `--data-eq`, and time-window
+  filters to reconstruct incident slices. Use `--exchange EXCHANGE` and `--user USER` to
+  focus one monitor account and prune unrelated monitor paths before scanning; `--bot-id`
+  remains available for event-envelope bot IDs.
 - `passivbot tool live-smoke-report` summarizes local live monitor events and text logs for
   operator smoke-test evidence. Use `--summary` for bounded event groups and log matches, or
   `--brief` for top-level counters suitable for repeated VPS smoke loops.

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -77,16 +77,7 @@ def discover_event_files(
     exchange_filter = _normalize_filter_values(exchange)
     user_filter = _normalize_filter_values(user)
     if path.is_file():
-        return (
-            [path]
-            if _is_event_segment(path)
-            and _monitor_path_scope_matches(
-                path,
-                exchange_filter=exchange_filter,
-                user_filter=user_filter,
-            )
-            else []
-        )
+        return [path] if _is_event_segment(path) else []
     if not path.exists():
         raise FileNotFoundError(str(path))
     if not path.is_dir():
@@ -99,7 +90,8 @@ def discover_event_files(
             and candidate.parent.name == "events"
             and _is_event_segment(candidate)
             and (include_rotated or candidate.name == "current.ndjson")
-            and _monitor_path_scope_matches(
+            and _monitor_path_scope_matches_under_root(
+                path,
                 candidate,
                 exchange_filter=exchange_filter,
                 user_filter=user_filter,
@@ -156,16 +148,23 @@ def _monitor_path_bot_id(path: Path) -> str | None:
     return f"{exchange}/{user}"
 
 
-def _monitor_path_scope_matches(
+def _monitor_path_scope_matches_under_root(
+    root: Path,
     path: Path,
     *,
     exchange_filter: set[str],
     user_filter: set[str],
 ) -> bool:
-    scope = _monitor_path_exchange_user(path)
-    if scope is None:
+    """Conservatively prune only obvious <monitor>/<exchange>/<user>/events files."""
+    if not exchange_filter and not user_filter:
         return True
-    exchange, user = scope
+    try:
+        relative_parts = path.relative_to(root).parts
+    except ValueError:
+        return True
+    if len(relative_parts) != 4 or relative_parts[2] != "events":
+        return True
+    exchange, user = relative_parts[0], relative_parts[1]
     return _filter_matches(exchange, exchange_filter) and _filter_matches(
         user,
         user_filter,

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -65,11 +65,28 @@ def _event_path_sort_key(path: Path) -> tuple[str, int, str]:
     return (str(path.parent), 1 if path.name == "current.ndjson" else 0, path.name)
 
 
-def discover_event_files(root: str | Path, *, include_rotated: bool = False) -> list[Path]:
+def discover_event_files(
+    root: str | Path,
+    *,
+    include_rotated: bool = False,
+    exchange: str | Iterable[str] | None = None,
+    user: str | Iterable[str] | None = None,
+) -> list[Path]:
     """Find monitor event NDJSON segments below a monitor root, bot root, or events dir."""
     path = Path(root).expanduser()
+    exchange_filter = _normalize_filter_values(exchange)
+    user_filter = _normalize_filter_values(user)
     if path.is_file():
-        return [path] if _is_event_segment(path) else []
+        return (
+            [path]
+            if _is_event_segment(path)
+            and _monitor_path_scope_matches(
+                path,
+                exchange_filter=exchange_filter,
+                user_filter=user_filter,
+            )
+            else []
+        )
     if not path.exists():
         raise FileNotFoundError(str(path))
     if not path.is_dir():
@@ -82,6 +99,11 @@ def discover_event_files(root: str | Path, *, include_rotated: bool = False) -> 
             and candidate.parent.name == "events"
             and _is_event_segment(candidate)
             and (include_rotated or candidate.name == "current.ndjson")
+            and _monitor_path_scope_matches(
+                candidate,
+                exchange_filter=exchange_filter,
+                user_filter=user_filter,
+            )
         ),
         key=_event_path_sort_key,
     )
@@ -111,8 +133,8 @@ def _event_ids(live_event: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
-def _monitor_path_bot_id(path: Path) -> str | None:
-    """Return monitor path-derived bot id for .../<exchange>/<user>/events/*.ndjson."""
+def _monitor_path_exchange_user(path: Path) -> tuple[str, str] | None:
+    """Return monitor path-derived exchange/user for .../<exchange>/<user>/events/*.ndjson."""
     if path.parent.name != "events":
         return None
     try:
@@ -122,7 +144,32 @@ def _monitor_path_bot_id(path: Path) -> str | None:
         return None
     if not exchange or not user:
         return None
+    return exchange, user
+
+
+def _monitor_path_bot_id(path: Path) -> str | None:
+    """Return monitor path-derived bot id for .../<exchange>/<user>/events/*.ndjson."""
+    scope = _monitor_path_exchange_user(path)
+    if scope is None:
+        return None
+    exchange, user = scope
     return f"{exchange}/{user}"
+
+
+def _monitor_path_scope_matches(
+    path: Path,
+    *,
+    exchange_filter: set[str],
+    user_filter: set[str],
+) -> bool:
+    scope = _monitor_path_exchange_user(path)
+    if scope is None:
+        return True
+    exchange, user = scope
+    return _filter_matches(exchange, exchange_filter) and _filter_matches(
+        user,
+        user_filter,
+    )
 
 
 def _normalize_filter_values(values: str | Iterable[str] | None) -> set[str]:
@@ -197,6 +244,8 @@ def _filter_report(
     *,
     cycle_id: str | None,
     event_types: set[str],
+    exchanges: set[str],
+    users: set[str],
     bot_ids: set[str],
     snapshot_ids: set[str],
     plan_ids: set[str],
@@ -222,6 +271,10 @@ def _filter_report(
         filters["until_ms"] = int(until_ms)
     if event_types:
         filters["event_types"] = sorted(event_types)
+    if exchanges:
+        filters["exchanges"] = sorted(exchanges)
+    if users:
+        filters["users"] = sorted(users)
     if bot_ids:
         filters["bot_ids"] = sorted(bot_ids)
     if snapshot_ids:
@@ -897,6 +950,8 @@ def build_event_report(
     *,
     cycle_id: str | None = None,
     event_type: str | Iterable[str] | None = None,
+    exchange: str | Iterable[str] | None = None,
+    user: str | Iterable[str] | None = None,
     bot_id: str | Iterable[str] | None = None,
     snapshot_id: str | Iterable[str] | None = None,
     plan_id: str | Iterable[str] | None = None,
@@ -935,7 +990,12 @@ def build_event_report(
     window_invalid_ts = 0
     issues: list[EventIssue] = []
     try:
-        files = discover_event_files(root, include_rotated=include_rotated)
+        files = discover_event_files(
+            root,
+            include_rotated=include_rotated,
+            exchange=exchange,
+            user=user,
+        )
     except FileNotFoundError as exc:
         files = []
         issues.append(
@@ -976,6 +1036,8 @@ def build_event_report(
         include_data=include_data,
     )
     event_type_filter = _normalize_filter_values(event_type)
+    exchange_filter = _normalize_filter_values(exchange)
+    user_filter = _normalize_filter_values(user)
     bot_filter = _normalize_filter_values(bot_id)
     snapshot_filter = _normalize_filter_values(snapshot_id)
     plan_filter = _normalize_filter_values(plan_id)
@@ -992,6 +1054,8 @@ def build_event_report(
     has_non_cycle_filter = any(
         (
             event_type_filter,
+            exchange_filter,
+            user_filter,
             bot_filter,
             snapshot_filter,
             plan_filter,
@@ -1113,10 +1177,23 @@ def build_event_report(
                     record_status = live_event.get("status")
                     record_reason_code = live_event.get("reason_code")
                     record_tags = _event_tags(row, live_event)
+                    path_scope = _monitor_path_exchange_user(path)
+                    record_exchange = live_event.get("exchange") or row.get("exchange")
+                    record_user = live_event.get("user") or row.get("user")
+                    if path_scope is not None:
+                        if record_exchange is None:
+                            record_exchange = path_scope[0]
+                        if record_user is None:
+                            record_user = path_scope[1]
                     event_type_matches = _filter_matches(
                         record_event_type, event_type_filter
                     )
                     cycle_matches = cycle_id is None or record_cycle_id == str(cycle_id)
+                    exchange_matches = _filter_matches(
+                        record_exchange,
+                        exchange_filter,
+                    )
+                    user_matches = _filter_matches(record_user, user_filter)
                     bot_matches = _filter_matches(
                         ids.get("bot_id") or _monitor_path_bot_id(path), bot_filter
                     )
@@ -1149,6 +1226,8 @@ def build_event_report(
                     query_matches = (
                         event_type_matches
                         and cycle_matches
+                        and exchange_matches
+                        and user_matches
                         and bot_matches
                         and snapshot_matches
                         and plan_matches
@@ -1266,6 +1345,8 @@ def build_event_report(
         query_filters = _filter_report(
             cycle_id=cycle_id,
             event_types=event_type_filter,
+            exchanges=exchange_filter,
+            users=user_filter,
             bot_ids=bot_filter,
             snapshot_ids=snapshot_filter,
             plan_ids=plan_filter,
@@ -1302,6 +1383,8 @@ def build_event_report(
         cycle_filters = _filter_report(
             cycle_id=cycle_id,
             event_types=event_type_filter,
+            exchanges=exchange_filter,
+            users=user_filter,
             bot_ids=bot_filter,
             snapshot_ids=snapshot_filter,
             plan_ids=plan_filter,

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -49,7 +49,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--exchange",
         action="append",
         help=(
-            "Return compact records for one exchange and prune matching monitor "
+            "Return compact records for one exchange and prune unrelated monitor "
             "paths before scanning. May be repeated or comma-separated."
         ),
     )
@@ -57,7 +57,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--user",
         action="append",
         help=(
-            "Return compact records for one user/account and prune matching "
+            "Return compact records for one user/account and prune unrelated "
             "monitor paths before scanning. May be repeated or comma-separated."
         ),
     )

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -46,6 +46,22 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--exchange",
+        action="append",
+        help=(
+            "Return compact records for one exchange and prune matching monitor "
+            "paths before scanning. May be repeated or comma-separated."
+        ),
+    )
+    parser.add_argument(
+        "--user",
+        action="append",
+        help=(
+            "Return compact records for one user/account and prune matching "
+            "monitor paths before scanning. May be repeated or comma-separated."
+        ),
+    )
+    parser.add_argument(
         "--snapshot-id",
         action="append",
         help=(
@@ -225,6 +241,8 @@ def main(argv: list[str] | None = None) -> int:
             args.path,
             cycle_id=args.cycle_id,
             event_type=args.event_types,
+            exchange=args.exchange,
+            user=args.user,
             bot_id=args.bot_id,
             snapshot_id=args.snapshot_id,
             plan_id=args.plan_id,

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -27,6 +27,8 @@ def _monitor_row(
     tags: list[str] | None = None,
     order_id: str | None = None,
     client_order_id: str | None = None,
+    exchange: str = "binance",
+    user: str = "binance_01",
 ) -> dict:
     event_ids = dict(ids or {})
     if cycle_id is not None:
@@ -38,8 +40,8 @@ def _monitor_row(
         "level": "debug",
         "source": source,
         "component": component,
-        "exchange": "binance",
-        "user": "binance_01",
+        "exchange": exchange,
+        "user": user,
         "symbol": symbol,
         "pside": pside,
         "side": side,
@@ -53,8 +55,8 @@ def _monitor_row(
     payload = {"_live_event": live_event}
     payload.update(live_event["data"])
     row = {
-        "exchange": "binance",
-        "user": "binance_01",
+        "exchange": exchange,
+        "user": user,
         "kind": event_type,
         "tags": list(tags or ["test"]),
         "payload": payload,
@@ -662,6 +664,94 @@ def test_event_query_bot_filter_falls_back_to_monitor_path(tmp_path):
     assert wrong_bot_report["query"]["matched_events"] == 0
 
 
+def test_discover_event_files_filters_monitor_paths_by_exchange_and_user(tmp_path):
+    gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    kucoin_events = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(gateio_events / "current.ndjson", [])
+    _write_gz_ndjson(gateio_events / "20260629.ndjson.gz", [])
+    _write_ndjson(binance_events / "current.ndjson", [])
+    _write_ndjson(kucoin_events / "current.ndjson", [])
+
+    gateio_files = discover_event_files(
+        tmp_path / "monitor",
+        include_rotated=True,
+        exchange="gateio",
+        user="gateio_01",
+    )
+
+    assert [path.name for path in gateio_files] == [
+        "20260629.ndjson.gz",
+        "current.ndjson",
+    ]
+    assert {path.parent.parent.parent.name for path in gateio_files} == {"gateio"}
+    assert {path.parent.parent.name for path in gateio_files} == {"gateio_01"}
+
+    missing_files = discover_event_files(
+        tmp_path / "monitor",
+        exchange="gateio",
+        user="binance_01",
+    )
+
+    assert missing_files == []
+
+
+def test_event_query_filters_exchange_user_and_prunes_monitor_paths(tmp_path):
+    gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        gateio_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.red_triggered",
+                cycle_id="cy_gateio",
+                seq=1,
+                ts=1000,
+                symbol="ZEC/USDT:USDT",
+                pside="long",
+                exchange="gateio",
+                user="gateio_01",
+            ),
+        ],
+    )
+    _write_ndjson(
+        binance_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.red_triggered",
+                cycle_id="cy_binance",
+                seq=2,
+                ts=1100,
+                symbol="ZEC/USDT:USDT",
+                pside="long",
+                exchange="binance",
+                user="binance_01",
+            ),
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        exchange="gateio",
+        user="gateio_01",
+        event_type="hsl.red_triggered",
+        symbol="ZEC/USDT:USDT",
+    )
+
+    assert report["ok"] is True
+    assert report["files_scanned"] == 1
+    assert report["query"]["filters"] == {
+        "event_types": ["hsl.red_triggered"],
+        "exchanges": ["gateio"],
+        "symbols": ["ZEC/USDT:USDT"],
+        "users": ["gateio_01"],
+    }
+    assert report["query"]["matched_events"] == 1
+    assert report["query"]["events"][0]["exchange"] == "gateio"
+    assert report["query"]["events"][0]["user"] == "gateio_01"
+    assert report["query"]["events"][0]["ids"]["cycle_id"] == "cy_gateio"
+
+
 def test_event_query_filters_legacy_snapshot_id_from_event_data(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(
@@ -996,6 +1086,65 @@ def test_live_event_query_cli_accepts_scope_filters_and_timeline(tmp_path, capsy
             "ids=cycle_id=cy_9,order_wave_id=ow_9"
         )
     ]
+
+
+def test_live_event_query_cli_accepts_exchange_and_user_filters(tmp_path, capsys):
+    gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    okx_events = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
+    _write_ndjson(
+        gateio_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.cooldown_started",
+                cycle_id="cy_gateio",
+                seq=1,
+                ts=1000,
+                symbol="ZEC/USDT:USDT",
+                exchange="gateio",
+                user="gateio_01",
+            )
+        ],
+    )
+    _write_ndjson(
+        okx_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.cooldown_started",
+                cycle_id="cy_okx",
+                seq=2,
+                ts=1100,
+                symbol="ZEC/USDT:USDT",
+                exchange="okx",
+                user="okx_faisal",
+            )
+        ],
+    )
+
+    assert (
+        live_event_query.main(
+            [
+                str(tmp_path / "monitor"),
+                "--exchange",
+                "gateio",
+                "--user",
+                "gateio_01",
+                "--event-type",
+                "hsl.cooldown_started",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["files_scanned"] == 1
+    assert report["query"]["filters"] == {
+        "event_types": ["hsl.cooldown_started"],
+        "exchanges": ["gateio"],
+        "users": ["gateio_01"],
+    }
+    assert report["query"]["matched_events"] == 1
+    assert report["query"]["events"][0]["exchange"] == "gateio"
+    assert report["query"]["events"][0]["ids"]["cycle_id"] == "cy_gateio"
 
 
 def test_live_event_query_cli_accepts_time_window(tmp_path, capsys):

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -752,6 +752,37 @@ def test_event_query_filters_exchange_user_and_prunes_monitor_paths(tmp_path):
     assert report["query"]["events"][0]["ids"]["cycle_id"] == "cy_gateio"
 
 
+def test_event_query_exchange_user_filter_keeps_direct_events_dir(tmp_path):
+    events_dir = tmp_path / "ad_hoc" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.red_triggered",
+                cycle_id="cy_gateio",
+                seq=1,
+                ts=1000,
+                symbol="ZEC/USDT:USDT",
+                exchange="gateio",
+                user="gateio_01",
+            )
+        ],
+    )
+
+    report = build_event_report(
+        events_dir,
+        exchange="gateio",
+        user="gateio_01",
+        event_type="hsl.red_triggered",
+    )
+
+    assert report["ok"] is True
+    assert report["files_scanned"] == 1
+    assert report["query"]["matched_events"] == 1
+    assert report["query"]["events"][0]["exchange"] == "gateio"
+    assert report["query"]["events"][0]["user"] == "gateio_01"
+
+
 def test_event_query_filters_legacy_snapshot_id_from_event_data(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- add read-only live-event-query exchange/user filters and monitor-path scan pruning
- include the filters in query/cycle filter reports and CLI flags
- document the operator usage and refresh the progress ledger through PR #874

## Scope
- Operator tooling only: no event producers, exchange calls, cache mutation, readiness gates, order/risk logic, console routing, or trading behavior changed.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/live/event_query.py src/tools/live_event_query.py tests/test_live_event_query.py
- git diff --check
- rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])\)" src/live/event_query.py src/tools/live_event_query.py tests/test_live_event_query.py