### PR TITLE
Prune old event segments for windowed queries

### DIFF
--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -107,6 +107,13 @@ def _open_text(path: Path):
     return open(path, "r", encoding="utf-8")
 
 
+def _file_mtime_ms(path: Path) -> int | None:
+    try:
+        return int(path.stat().st_mtime * 1000)
+    except OSError:
+        return None
+
+
 def _live_event_payload(row: dict[str, Any]) -> dict[str, Any] | None:
     payload = row.get("payload")
     if not isinstance(payload, dict):
@@ -987,6 +994,7 @@ def build_event_report(
     window_skipped_before = 0
     window_skipped_after = 0
     window_invalid_ts = 0
+    files_skipped_before_window = 0
     issues: list[EventIssue] = []
     try:
         files = discover_event_files(
@@ -1010,6 +1018,15 @@ def build_event_report(
                 "no event NDJSON files found",
             )
         )
+    if since_filter is not None and files:
+        window_files: list[Path] = []
+        for event_file in files:
+            file_mtime_ms = _file_mtime_ms(event_file)
+            if file_mtime_ms is not None and file_mtime_ms < since_filter:
+                files_skipped_before_window += 1
+                continue
+            window_files.append(event_file)
+        files = window_files
 
     event_type_counts: Counter[str] = Counter()
     cycle_counts: Counter[str] = Counter()
@@ -1429,5 +1446,6 @@ def build_event_report(
             "events_skipped_before": window_skipped_before,
             "events_skipped_after": window_skipped_after,
             "invalid_window_ts": window_invalid_ts,
+            "files_skipped_before_window": files_skipped_before_window,
         }
     return report

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import gzip
 import json
+import os
 
 import pytest
 
@@ -893,6 +894,7 @@ def test_event_query_filters_by_inclusive_time_window(tmp_path):
         "events_skipped_before": 1,
         "events_skipped_after": 1,
         "invalid_window_ts": 1,
+        "files_skipped_before_window": 0,
     }
     assert report["event_types"] == {
         "cycle.completed": 1,
@@ -911,6 +913,75 @@ def test_event_query_filters_by_inclusive_time_window(tmp_path):
             "reason_code=request_timeout ids=cycle_id=cy_2"
         ),
         "2000 seq=4 cycle.completed status=succeeded reason_code=test ids=cycle_id=cy_3",
+    ]
+
+
+def test_event_query_prunes_rotated_files_before_time_window_by_mtime(tmp_path):
+    events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    old_segment = events_dir / "2026-06-29T18-00-00.ndjson.gz"
+    recent_segment = events_dir / "2026-06-29T22-00-00.ndjson.gz"
+    current_segment = events_dir / "current.ndjson"
+    _write_gz_ndjson(
+        old_segment,
+        [
+            _monitor_row(
+                event_type="hsl.status",
+                cycle_id="cy_old",
+                seq=1,
+                ts=1_000,
+                exchange="gateio",
+                user="gateio_01",
+            )
+        ],
+    )
+    _write_gz_ndjson(
+        recent_segment,
+        [
+            _monitor_row(
+                event_type="hsl.status",
+                cycle_id="cy_recent",
+                seq=2,
+                ts=5_000,
+                exchange="gateio",
+                user="gateio_01",
+            )
+        ],
+    )
+    _write_ndjson(
+        current_segment,
+        [
+            _monitor_row(
+                event_type="hsl.status",
+                cycle_id="cy_current",
+                seq=3,
+                ts=6_000,
+                exchange="gateio",
+                user="gateio_01",
+            )
+        ],
+    )
+    os.utime(old_segment, (1.0, 1.0))
+    os.utime(recent_segment, (5.0, 5.0))
+    os.utime(current_segment, (6.0, 6.0))
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        exchange="gateio",
+        user="gateio_01",
+        event_type="hsl.status",
+        since_ms=4_000,
+        include_rotated=True,
+        timeline=True,
+    )
+
+    assert report["ok"] is True
+    assert report["files_scanned"] == 2
+    assert report["event_window"]["files_skipped_before_window"] == 1
+    assert report["event_window"]["events_considered"] == 2
+    assert report["query"]["matched_events"] == 2
+    assert [event["ids"]["cycle_id"] for event in report["query"]["events"]] == [
+        "cy_recent",
+        "cy_current",
     ]
 
 


### PR DESCRIPTION
## Summary
- skip event segment files whose filesystem mtime is strictly before a requested since_ms/recent-minutes window
- report files_skipped_before_window in event_window so skipped files are observable
- add regression coverage proving old rotated files are skipped while recent/current files are still scanned

## Scope
- Read-only live-event-query tooling only.
- No event producers, exchange calls, cache mutation, readiness gates, order/risk logic, console routing, or trading behavior changed.

## Rationale
A VPS5 Gate.io/ZEC query with --exchange/--user, --include-rotated, and --recent-minutes 180 still ran for roughly two minutes because old rotated files were opened and row-filtered. This keeps row-level filtering authoritative for possibly relevant files, but avoids opening segments whose mtime proves they cannot contain in-window rows.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/live/event_query.py tests/test_live_event_query.py
- git diff --check
- rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])\)" src/live/event_query.py tests/test_live_event_query.py