### PR TITLE
Label path-scoped event query output

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -28,6 +28,20 @@ Current review gate:
   gate may still be used after repeated Claude absence, but that exception must
   be called out in the progress evidence.
 
+Scope calibration:
+
+- The active loop remains the live logging/observability overhaul. Backlog work
+  belongs in this loop when it directly improves structured diagnosis, operator
+  smoke evidence, incident reconstruction, or the ability to finish the logging
+  overhaul.
+- Trading-behavior bugs discovered by the new observability, including HSL
+  panic/cooldown contract issues and HSL startup replay latency, should be
+  tracked in the backlog and handled as separate focused trading-path PRs unless
+  they block observability validation.
+- Prefer single-agent implementation for tightly scoped observability slices.
+  Use sub-agents only for isolated offline investigations or independent PRs
+  with explicit no-SSH/no-merge boundaries.
+
 VPS5 deployment status:
 
 - Repository pulled through PR #877 at `1c9d05036`.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -11,6 +11,12 @@ slice before implementation.
 The logging overhaul remains the foundation: a centralized event stream should
 make the items below easier to prove, test, and operate.
 
+This backlog feeds the logging-overhaul loop selectively. Items are in-scope for
+that loop when they improve diagnostics, smoke evidence, incident reconstruction,
+or operator workflow needed to complete the logging work. Trading-behavior bugs
+found through better observability should remain visible here, but should become
+separate focused trading-path PRs unless they block observability validation.
+
 Update policy:
 
 - Keep open work in `High-Value Follow-Ups` with checkboxes and short status

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -319,6 +319,8 @@ def _compact_record(
     row: dict[str, Any],
     live_event: dict[str, Any],
     include_data: bool,
+    exchange: Any = None,
+    user: Any = None,
 ) -> dict[str, Any]:
     ids = _event_ids(live_event)
     compact = {
@@ -331,8 +333,8 @@ def _compact_record(
         "status": live_event.get("status"),
         "reason_code": live_event.get("reason_code"),
         "component": live_event.get("component"),
-        "exchange": live_event.get("exchange") or row.get("exchange"),
-        "user": live_event.get("user") or row.get("user"),
+        "exchange": exchange or live_event.get("exchange") or row.get("exchange"),
+        "user": user or live_event.get("user") or row.get("user"),
         "symbol": live_event.get("symbol") or row.get("symbol"),
         "pside": live_event.get("pside") or row.get("pside"),
         "side": live_event.get("side"),
@@ -732,6 +734,8 @@ class _CycleTraceBuilder:
         live_event: dict[str, Any],
         event_type: str | None,
         ids: dict[str, Any],
+        exchange: Any = None,
+        user: Any = None,
     ) -> None:
         item = _compact_record(
             path=path,
@@ -739,6 +743,8 @@ class _CycleTraceBuilder:
             row=row,
             live_event=live_event,
             include_data=self.include_data,
+            exchange=exchange,
+            user=user,
         )
         cycle_id = ids.get("cycle_id")
         if cycle_id is None:
@@ -770,6 +776,8 @@ class _CycleTraceBuilder:
             row=row,
             live_event=live_event,
             event_type=event_type,
+            exchange=exchange,
+            user=user,
         )
         cycle["order_trace"].add(
             path=path,
@@ -848,6 +856,8 @@ class _TraceSummaryBuilder:
         row: dict[str, Any],
         live_event: dict[str, Any],
         event_type: str | None,
+        exchange: Any = None,
+        user: Any = None,
     ) -> None:
         self.events += 1
         ts = row.get("ts")
@@ -860,12 +870,19 @@ class _TraceSummaryBuilder:
             ("level", self.levels),
             ("source", self.sources),
             ("component", self.components),
-            ("exchange", self.exchanges),
-            ("user", self.users),
             ("status", self.statuses),
             ("reason_code", self.reason_codes),
         ):
             value = live_event.get(key)
+            if value is not None:
+                counter[str(value)] += 1
+        for value, counter in (
+            (
+                exchange or live_event.get("exchange") or row.get("exchange"),
+                self.exchanges,
+            ),
+            (user or live_event.get("user") or row.get("user"), self.users),
+        ):
             if value is not None:
                 counter[str(value)] += 1
         for tag in _event_tags(row, live_event):
@@ -1266,6 +1283,8 @@ def build_event_report(
                                 row=row,
                                 live_event=live_event,
                                 event_type=record_event_type,
+                                exchange=record_exchange,
+                                user=record_user,
                             )
                         if order_trace:
                             query_order_trace.add(
@@ -1284,6 +1303,8 @@ def build_event_report(
                                 live_event=live_event,
                                 event_type=record_event_type,
                                 ids=ids,
+                                exchange=record_exchange,
+                                user=record_user,
                             )
                         if len(query_events) < max_events:
                             query_events.append(
@@ -1293,6 +1314,8 @@ def build_event_report(
                                     row=row,
                                     live_event=live_event,
                                     include_data=include_data,
+                                    exchange=record_exchange,
+                                    user=record_user,
                                 )
                             )
                     if cycle_id is not None and query_matches:
@@ -1302,6 +1325,8 @@ def build_event_report(
                                 row=row,
                                 live_event=live_event,
                                 event_type=record_event_type,
+                                exchange=record_exchange,
+                                user=record_user,
                             )
                         if order_trace:
                             cycle_order_trace.add(
@@ -1320,6 +1345,8 @@ def build_event_report(
                                 live_event=live_event,
                                 event_type=record_event_type,
                                 ids=ids,
+                                exchange=record_exchange,
+                                user=record_user,
                             )
                         if len(cycle_events) < max_events:
                             cycle_events.append(
@@ -1329,6 +1356,8 @@ def build_event_report(
                                     row=row,
                                     live_event=live_event,
                                     include_data=include_data,
+                                    exchange=record_exchange,
+                                    user=record_user,
                                 )
                             )
         except OSError as exc:

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -784,6 +784,46 @@ def test_event_query_exchange_user_filter_keeps_direct_events_dir(tmp_path):
     assert report["query"]["events"][0]["user"] == "gateio_01"
 
 
+def test_event_query_path_scope_labels_legacy_rows_in_output(tmp_path):
+    events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    row = _monitor_row(
+        event_type="hsl.status",
+        cycle_id="cy_gateio",
+        seq=1,
+        ts=1000,
+        symbol="ZEC/USDT:USDT",
+        exchange="gateio",
+        user="gateio_01",
+    )
+    live_event = row["payload"]["_live_event"]
+    live_event.pop("exchange")
+    live_event.pop("user")
+    row.pop("exchange")
+    row.pop("user")
+    _write_ndjson(events_dir / "current.ndjson", [row])
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        exchange="gateio",
+        user="gateio_01",
+        event_type="hsl.status",
+        trace_summary=True,
+        cycle_trace=True,
+    )
+
+    assert report["ok"] is True
+    assert report["query"]["matched_events"] == 1
+    assert report["query"]["events"][0]["exchange"] == "gateio"
+    assert report["query"]["events"][0]["user"] == "gateio_01"
+    assert report["query"]["trace_summary"]["exchanges"] == {"gateio": 1}
+    assert report["query"]["trace_summary"]["users"] == {"gateio_01": 1}
+    cycle = report["query"]["cycle_trace"]["cycles"][0]
+    assert cycle["timeline"][0]["exchange"] == "gateio"
+    assert cycle["timeline"][0]["user"] == "gateio_01"
+    assert cycle["trace_summary"]["exchanges"] == {"gateio": 1}
+    assert cycle["trace_summary"]["users"] == {"gateio_01": 1}
+
+
 def test_event_query_filters_legacy_snapshot_id_from_event_data(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- when live-event-query resolves exchange/user from monitor path scope, carry those labels into compact events and trace summaries
- add regression coverage for legacy rows that lack exchange/user in the row/envelope but are under monitor/<exchange>/<user>/events
- record the retuned logging-loop scope in the progress/backlog docs

## Scope
- Read-only event-query output and docs only.
- No event producers, exchange calls, cache mutation, readiness gates, order/risk logic, console routing, or trading behavior changed.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/live/event_query.py tests/test_live_event_query.py
- git diff --check
- rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])\)" src/live/event_query.py tests/test_live_event_query.py