### PR TITLE
Add smoke event tail limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added opt-in `passivbot tool live-smoke-report --event-tail-lines` to bound
+  monitor event parsing for repeated recent-window smoke checks while leaving
+  full monitor-event validation as the default.
 - Added structured `hsl.raw_red_pending` diagnostics when HSL raw drawdown is
   already beyond red but EMA-confirmed drawdown has not crossed yet, helping
   operators spot pending RED risk without changing trading behavior.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -201,6 +201,11 @@ Related detailed plans:
      roughly 600 in-window events. First-pass fix: make `live-smoke-report`
      reuse one monitor-event parse for both monitor validation/summary and
      windowed smoke aggregates instead of parsing every event segment twice.
+   - 2026-06-30: Added an opt-in `live-smoke-report --event-tail-lines`
+     parser bound for repeated recent-window smoke checks over large current
+     monitor segments. The default remains full monitor-event validation; the
+     opt-in path reports tail-limit metadata in `event_window` so bounded smoke
+     evidence is explicit.
 
    Remaining refinements: safe pull/stop/start orchestration remains open.
    The concise and brief summaries are intentionally bounded; further changes

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -156,6 +156,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
 - `passivbot tool live-smoke-report` summarizes local live monitor events and text logs for
   operator smoke-test evidence. Use `--summary` for bounded event groups and log matches, or
   `--brief` for top-level counters suitable for repeated VPS smoke loops.
+  For repeated recent-window smoke checks over large current monitor segments,
+  `--event-tail-lines N` bounds monitor event parsing to the last N rows from
+  each event file; the default `0` keeps full monitor-event validation.
   Startup timing summaries include report-only budget projections from prior local p95
   phase baselines when enough monitor evidence exists.
   Existing structured EMA readiness degradation events are summarized as

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -3136,8 +3136,11 @@ def _event_window_report(
     events_skipped_before: int,
     events_skipped_after: int,
     invalid_window_ts: int,
+    event_tail_lines: int = 0,
+    event_tail_limited_files: int = 0,
+    event_tail_skipped_lines: int = 0,
 ) -> dict[str, Any]:
-    return {
+    report = {
         "enabled": since_ms is not None or until_ms is not None,
         "since_ms": since_ms,
         "until_ms": until_ms,
@@ -3146,6 +3149,11 @@ def _event_window_report(
         "events_skipped_after": int(events_skipped_after),
         "invalid_window_ts": int(invalid_window_ts),
     }
+    if int(event_tail_lines) > 0:
+        report["event_tail_lines"] = int(event_tail_lines)
+        report["event_tail_limited_files"] = int(event_tail_limited_files)
+        report["event_tail_skipped_lines"] = int(event_tail_skipped_lines)
+    return report
 
 
 def _monitor_issue(
@@ -3171,6 +3179,7 @@ def _scan_events(
     max_problem_events: int,
     since_ms: int | None = None,
     until_ms: int | None = None,
+    event_tail_lines: int = 0,
 ) -> dict[str, Any]:
     issues: list[dict[str, Any]] = []
     try:
@@ -3215,6 +3224,9 @@ def _scan_events(
     events_skipped_before = 0
     events_skipped_after = 0
     invalid_window_ts = 0
+    max_event_tail_lines = max(0, int(event_tail_lines))
+    event_tail_limited_files = 0
+    event_tail_skipped_lines = 0
     startup_timing_records: dict[str, list[dict[str, Any]]] = defaultdict(list)
     remote_call_failure_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     remote_call_health_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -3236,7 +3248,18 @@ def _scan_events(
     for path in files:
         try:
             with _open_text(path) as stream:
-                for line_no, raw_line in enumerate(stream, start=1):
+                if max_event_tail_lines:
+                    file_rows = deque(
+                        enumerate(stream, start=1),
+                        maxlen=max_event_tail_lines,
+                    )
+                    event_tail_limited_files += 1
+                    if file_rows:
+                        event_tail_skipped_lines += max(0, int(file_rows[0][0]) - 1)
+                    rows = file_rows
+                else:
+                    rows = enumerate(stream, start=1)
+                for line_no, raw_line in rows:
                     line = raw_line.strip()
                     if not line:
                         continue
@@ -3571,6 +3594,9 @@ def _scan_events(
             events_skipped_before=events_skipped_before,
             events_skipped_after=events_skipped_after,
             invalid_window_ts=invalid_window_ts,
+            event_tail_lines=max_event_tail_lines,
+            event_tail_limited_files=event_tail_limited_files,
+            event_tail_skipped_lines=event_tail_skipped_lines,
         ),
     }
 
@@ -3825,6 +3851,7 @@ def build_live_smoke_report(
     until_ms: int | None = None,
     max_problem_events: int = 50,
     max_log_files: int = 8,
+    event_tail_lines: int = 0,
     log_tail_lines: int = 300,
     max_log_matches: int = 50,
     log_window_unparsed_policy: str = DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
@@ -3836,6 +3863,7 @@ def build_live_smoke_report(
         max_problem_events=max_problem_events,
         since_ms=since_ms,
         until_ms=until_ms,
+        event_tail_lines=event_tail_lines,
     )
     event_report = event_scan["monitor"]
     log_scan = _scan_logs(
@@ -4304,6 +4332,9 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
                 "events_skipped_before",
                 "events_skipped_after",
                 "invalid_window_ts",
+                "event_tail_lines",
+                "event_tail_limited_files",
+                "event_tail_skipped_lines",
             )
             if key in event_window
         },

--- a/src/tools/live_smoke_report.py
+++ b/src/tools/live_smoke_report.py
@@ -120,6 +120,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Maximum recent log files to inspect.",
     )
     parser.add_argument(
+        "--event-tail-lines",
+        type=int,
+        default=0,
+        help=(
+            "Opt-in parser bound for monitor event segments: read only the last "
+            "N rows from each event file. Default 0 keeps full monitor validation."
+        ),
+    )
+    parser.add_argument(
         "--log-tail-lines",
         type=int,
         default=300,
@@ -171,6 +180,8 @@ def main(argv: list[str] | None = None) -> int:
     until_ms = args.until_ms
     if since_ms is not None and until_ms is not None and since_ms > until_ms:
         parser.error("--since-ms must be <= --until-ms")
+    if int(args.event_tail_lines) < 0:
+        parser.error("--event-tail-lines must be non-negative")
     report = build_live_smoke_report(
         args.monitor_root,
         logs_root=logs_root,
@@ -182,6 +193,7 @@ def main(argv: list[str] | None = None) -> int:
         until_ms=until_ms,
         max_problem_events=int(args.max_problem_events),
         max_log_files=int(args.max_log_files),
+        event_tail_lines=int(args.event_tail_lines),
         log_tail_lines=int(args.log_tail_lines),
         max_log_matches=int(args.max_log_matches),
         log_window_unparsed_policy=str(args.log_window_unparsed_policy),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -123,6 +123,74 @@ def test_live_smoke_report_scans_monitor_segments_once(tmp_path, monkeypatch):
     assert report["event_window"]["events_considered"] == 1
 
 
+def test_live_smoke_report_event_tail_lines_bounds_monitor_scan(tmp_path):
+    events_path = (
+        tmp_path / "monitor" / "binance" / "binance_01" / "events" / "current.ndjson"
+    )
+    _write_ndjson(
+        events_path,
+        [
+            _monitor_row(
+                event_type="bot.stopped",
+                seq=1,
+                ts=1000,
+                status="failed",
+                level="critical",
+                reason_code="old_failure_outside_tail",
+            ),
+            _monitor_row(
+                event_type="remote_call.succeeded",
+                seq=2,
+                ts=2000,
+                ids={"cycle_id": "cy_old"},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=3,
+                ts=3000,
+                ids={"cycle_id": "cy_old"},
+            ),
+            _monitor_row(
+                event_type="remote_call.succeeded",
+                seq=4,
+                ts=4000,
+                ids={"cycle_id": "cy_fresh"},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=5,
+                ts=5000,
+                ids={"cycle_id": "cy_fresh"},
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        since_ms=3500,
+        event_tail_lines=2,
+    )
+
+    assert report["ok"] is True
+    assert report["monitor"]["records_total"] == 2
+    assert report["monitor"]["live_events"] == 2
+    assert report["hard_problem_event_count"] == 0
+    assert report["event_window"] == {
+        "enabled": True,
+        "since_ms": 3500,
+        "until_ms": None,
+        "events_considered": 2,
+        "events_skipped_before": 0,
+        "events_skipped_after": 0,
+        "invalid_window_ts": 0,
+        "event_tail_lines": 2,
+        "event_tail_limited_files": 1,
+        "event_tail_skipped_lines": 3,
+    }
+    assert report["bots"][0]["events"] == 2
+
+
 def test_live_smoke_report_summarizes_monitor_events_and_log_attention(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(
@@ -3365,6 +3433,48 @@ def test_live_smoke_report_cli_can_emit_brief_summary(tmp_path, capsys):
     assert "groups" not in summary["account_critical_remote_calls"]
 
 
+def test_live_smoke_report_cli_brief_projects_event_tail_metadata(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_old"},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=2,
+                ts=2000,
+                ids={"cycle_id": "cy_fresh"},
+            ),
+        ],
+    )
+
+    assert (
+        live_smoke_report.main(
+            [
+                str(tmp_path / "monitor"),
+                "--logs-root",
+                "",
+                "--event-tail-lines",
+                "1",
+                "--brief",
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["monitor"]["live_events"] == 1
+    assert summary["event_window"]["event_tail_lines"] == 1
+    assert summary["event_window"]["event_tail_limited_files"] == 1
+    assert summary["event_window"]["event_tail_skipped_lines"] == 1
+
+
 def test_live_smoke_report_cli_can_drop_unparseable_window_log_lines(
     tmp_path,
     capsys,
@@ -3429,6 +3539,14 @@ def test_live_smoke_report_cli_rejects_invalid_window_timestamp(capsys):
 
     assert exc_info.value.code == 2
     assert "invalid int value" in capsys.readouterr().err
+
+
+def test_live_smoke_report_cli_rejects_negative_event_tail_lines(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_smoke_report.main(["monitor", "--event-tail-lines", "-1"])
+
+    assert exc_info.value.code == 2
+    assert "--event-tail-lines must be non-negative" in capsys.readouterr().err
 
 
 def test_live_smoke_report_process_status_matches_supervisor_config(


### PR DESCRIPTION
## Summary
- add opt-in `passivbot tool live-smoke-report --event-tail-lines N` to bound monitor event parsing for repeated recent-window smoke checks
- keep default behavior at `0`, preserving full monitor-event validation unless the operator explicitly opts into a tailed scan
- surface `event_tail_lines`, `event_tail_limited_files`, and `event_tail_skipped_lines` in `event_window` so bounded evidence is explicit
- document the flag in tools docs, changelog, and the live ops backlog

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_smoke_report.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/live/smoke_report.py src/tools/live_smoke_report.py tests/test_live_smoke_report.py
- git diff --check
- silent-handling scan on touched Python files; matches are existing smoke-report aggregation patterns, no new broad exception swallowing or trading-path fallback added

## Note
Attempted `tests/test_passivbot_cli.py`, but collection failed before this CLI path with the existing local Rust-extension stamp mismatch: `RuntimeError: Loaded Rust extension does not match current Rust sources; restart after rebuild.` No Rust files are touched by this PR.

Operator tooling only. No event producers, exchange calls, cache mutation, readiness gates, order/risk logic, or console routing changes.