### PR TITLE
Add live event query tail limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added opt-in `passivbot tool live-event-query --event-tail-lines` to bound
+  monitor event parsing for repeated recent-window queries while leaving full
+  event validation as the default.
 - Added opt-in `passivbot tool live-smoke-report --event-tail-lines` to bound
   monitor event parsing for repeated recent-window smoke checks while leaving
   full monitor-event validation as the default.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -28,12 +28,17 @@ Current review gate:
   gate may still be used after repeated Claude absence, but that exception must
   be called out in the progress evidence.
 
-Scope calibration:
+Retuned goal boundary:
 
 - The active loop remains the live logging/observability overhaul. Backlog work
   belongs in this loop when it directly improves structured diagnosis, operator
   smoke evidence, incident reconstruction, or the ability to finish the logging
   overhaul.
+- This loop should keep adding newly discovered operational gaps, non-urgent
+  bugs, and room-for-improvement notes to
+  `docs/plans/live_ops_improvement_backlog.md`, but implementation from that
+  backlog should stay selective: prioritize items that make the logging
+  overhaul easier to validate, deploy, and use.
 - Trading-behavior bugs discovered by the new observability, including HSL
   panic/cooldown contract issues and HSL startup replay latency, should be
   tracked in the backlog and handled as separate focused trading-path PRs unless

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -138,6 +138,11 @@ Related detailed plans:
    `files_skipped_before_window=160`. If that remains too slow for larger
    incident windows, consider an event index or reverse chronological scanning
    with early stop, while preserving direct file/events-dir workflows.
+   A 2026-06-30 follow-up added opt-in
+   `live-event-query --event-tail-lines` for repeated recent-window queries
+   over large current monitor segments. The default remains full event
+   validation; bounded query output reports tail-limit metadata in
+   `event_window`.
 
 3. [ ] Live restart/smoke automation.
    Status: partial. The read-only `live-smoke-report` tool exists and can now

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -152,7 +152,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   `--cycle-id`, ID filters, `--symbol`, `--pside`, `--tag`, `--data-eq`, and time-window
   filters to reconstruct incident slices. Use `--exchange EXCHANGE` and `--user USER` to
   focus one monitor account and prune unrelated monitor paths before scanning; `--bot-id`
-  remains available for event-envelope bot IDs.
+  remains available for event-envelope bot IDs. For repeated recent-window queries over
+  large current monitor segments, `--event-tail-lines N` bounds parsing to the last N rows
+  from each event file; the default `0` keeps full event validation.
 - `passivbot tool live-smoke-report` summarizes local live monitor events and text logs for
   operator smoke-test evidence. Use `--summary` for bounded event groups and log matches, or
   `--brief` for top-level counters suitable for repeated VPS smoke loops.

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import gzip
 import json
 from collections.abc import Iterable as IterableABC
-from collections import Counter, defaultdict
+from collections import Counter, defaultdict, deque
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Iterable
@@ -990,6 +990,7 @@ def build_event_report(
     data_eq: str | Iterable[str] | None = None,
     since_ms: int | None = None,
     until_ms: int | None = None,
+    event_tail_lines: int = 0,
     limit: int = 200,
     include_data: bool = False,
     include_rotated: bool = False,
@@ -1012,6 +1013,9 @@ def build_event_report(
     window_skipped_after = 0
     window_invalid_ts = 0
     files_skipped_before_window = 0
+    max_event_tail_lines = max(0, int(event_tail_lines))
+    event_tail_limited_files = 0
+    event_tail_skipped_lines = 0
     issues: list[EventIssue] = []
     try:
         files = discover_event_files(
@@ -1112,7 +1116,18 @@ def build_event_report(
     for path in files:
         try:
             with _open_text(path) as stream:
-                for line_no, raw_line in enumerate(stream, start=1):
+                if max_event_tail_lines:
+                    file_rows = deque(
+                        enumerate(stream, start=1),
+                        maxlen=max_event_tail_lines,
+                    )
+                    event_tail_limited_files += 1
+                    if file_rows:
+                        event_tail_skipped_lines += max(0, int(file_rows[0][0]) - 1)
+                    rows = file_rows
+                else:
+                    rows = enumerate(stream, start=1)
+                for line_no, raw_line in rows:
                     line = raw_line.strip()
                     if not line:
                         continue
@@ -1466,15 +1481,19 @@ def build_event_report(
             report["cycle"]["cycle_trace"] = cycle_cycle_trace.to_dict()
         if not event_type_filter:
             report["cycle"].pop("event_types", None)
-    if window_enabled:
+    if window_enabled or max_event_tail_lines:
         report["event_window"] = {
-            "enabled": True,
+            "enabled": window_enabled,
             "since_ms": since_filter,
             "until_ms": until_filter,
-            "events_considered": window_considered,
+            "events_considered": window_considered if window_enabled else live_events,
             "events_skipped_before": window_skipped_before,
             "events_skipped_after": window_skipped_after,
             "invalid_window_ts": window_invalid_ts,
             "files_skipped_before_window": files_skipped_before_window,
         }
+        if max_event_tail_lines:
+            report["event_window"]["event_tail_lines"] = max_event_tail_lines
+            report["event_window"]["event_tail_limited_files"] = event_tail_limited_files
+            report["event_window"]["event_tail_skipped_lines"] = event_tail_skipped_lines
     return report

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -167,6 +167,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Only include live events from the last N minutes.",
     )
     parser.add_argument(
+        "--event-tail-lines",
+        type=int,
+        default=0,
+        help=(
+            "Opt-in parser bound for monitor event segments: read only the last "
+            "N rows from each event file. Default 0 keeps full event validation."
+        ),
+    )
+    parser.add_argument(
         "--limit",
         type=int,
         default=200,
@@ -236,6 +245,8 @@ def main(argv: list[str] | None = None) -> int:
         since_ms = int(time.time() * 1000) - int(args.recent_minutes * 60_000)
     if since_ms is not None and args.until_ms is not None and since_ms > args.until_ms:
         parser.error("--since-ms/--recent-minutes must be <= --until-ms")
+    if int(args.event_tail_lines) < 0:
+        parser.error("--event-tail-lines must be non-negative")
     try:
         report = build_event_report(
             args.path,
@@ -258,6 +269,7 @@ def main(argv: list[str] | None = None) -> int:
             data_eq=args.data_eq,
             since_ms=since_ms,
             until_ms=args.until_ms,
+            event_tail_lines=int(args.event_tail_lines),
             limit=args.limit,
             include_data=bool(args.include_data),
             include_rotated=bool(args.include_rotated),

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -1025,6 +1025,86 @@ def test_event_query_prunes_rotated_files_before_time_window_by_mtime(tmp_path):
     ]
 
 
+def test_event_query_event_tail_lines_bounds_window_scan(tmp_path):
+    events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.started",
+                cycle_id="cy_1",
+                seq=1,
+                ts=1000,
+                exchange="gateio",
+                user="gateio_01",
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                cycle_id="cy_2",
+                seq=2,
+                ts=2000,
+                exchange="gateio",
+                user="gateio_01",
+            ),
+            _monitor_row(
+                event_type="hsl.status",
+                cycle_id="cy_3",
+                seq=3,
+                ts=3000,
+                exchange="gateio",
+                user="gateio_01",
+            ),
+            _monitor_row(
+                event_type="hsl.status",
+                cycle_id="cy_4",
+                seq=4,
+                ts=4000,
+                exchange="gateio",
+                user="gateio_01",
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                cycle_id="cy_5",
+                seq=5,
+                ts=5000,
+                exchange="gateio",
+                user="gateio_01",
+            ),
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        exchange="gateio",
+        user="gateio_01",
+        since_ms=2500,
+        event_tail_lines=2,
+        timeline=True,
+    )
+
+    assert report["ok"] is True
+    assert report["records_total"] == 2
+    assert report["live_events"] == 2
+    assert report["event_window"] == {
+        "enabled": True,
+        "since_ms": 2500,
+        "until_ms": None,
+        "events_considered": 2,
+        "events_skipped_before": 0,
+        "events_skipped_after": 0,
+        "invalid_window_ts": 0,
+        "files_skipped_before_window": 0,
+        "event_tail_lines": 2,
+        "event_tail_limited_files": 1,
+        "event_tail_skipped_lines": 3,
+    }
+    assert report["query"]["matched_events"] == 2
+    assert [event["ids"]["cycle_id"] for event in report["query"]["events"]] == [
+        "cy_4",
+        "cy_5",
+    ]
+
+
 def test_event_query_timeline_renders_cycle_and_query_matches(tmp_path):
     events_dir = tmp_path / "monitor" / "okx" / "okx_faisal" / "events"
     _write_ndjson(
@@ -1423,6 +1503,48 @@ def test_live_event_query_cli_accepts_recent_minutes(tmp_path, capsys, monkeypat
     assert report["query"]["events"][0]["seq"] == 2
 
 
+def test_live_event_query_cli_projects_event_tail_metadata(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                cycle_id="cy_1",
+                seq=1,
+                ts=1000,
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                cycle_id="cy_2",
+                seq=2,
+                ts=2000,
+            ),
+        ],
+    )
+
+    assert (
+        live_event_query.main(
+            [
+                str(tmp_path / "monitor"),
+                "--since-ms",
+                "1",
+                "--event-tail-lines",
+                "1",
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["records_total"] == 1
+    assert report["event_window"]["event_tail_lines"] == 1
+    assert report["event_window"]["event_tail_limited_files"] == 1
+    assert report["event_window"]["event_tail_skipped_lines"] == 1
+    assert report["query"]["events"][0]["ids"]["cycle_id"] == "cy_2"
+
+
 def test_live_event_query_cli_rejects_invalid_time_window(tmp_path, capsys):
     with pytest.raises(SystemExit) as exc_info:
         live_event_query.main(
@@ -1431,6 +1553,14 @@ def test_live_event_query_cli_rejects_invalid_time_window(tmp_path, capsys):
     assert exc_info.value.code == 2
     err = capsys.readouterr().err
     assert "must be <= --until-ms" in err
+
+
+def test_live_event_query_cli_rejects_negative_event_tail_lines(tmp_path, capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_event_query.main([str(tmp_path), "--event-tail-lines", "-1"])
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "--event-tail-lines must be non-negative" in err
 
 
 def test_live_event_query_cli_accepts_additional_id_scopes(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- add opt-in `passivbot tool live-event-query --event-tail-lines N` for repeated recent-window operator queries over large current monitor segments
- report tail-limit metadata in `event_window` so bounded evidence is explicit
- record the retuned loop boundary in the logging progress ledger and note the backlog follow-up

## Risk boundary
- read-only operator tooling only
- default `--event-tail-lines 0` preserves full event validation
- no event producers, exchange calls, cache mutation, readiness gates, console routing, order/risk logic, or trading behavior changed
- this bounds parsing/aggregation work for selected rows; it still reads the segment to keep the direct file/events-dir workflow simple

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py` -> 39 passed
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/live/event_query.py src/tools/live_event_query.py tests/test_live_event_query.py`
- `git diff --check`
- touched-file silent-handling scan: no matches