### PR TITLE
Expose startup timings in smoke summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report --summary` and `--brief` now expose
+  existing startup timing evidence, making slow restart phases visible in the
+  concise smoke-loop projections.
 - Added opt-in `passivbot tool live-event-query --event-tail-lines` to bound
   monitor event parsing for repeated recent-window queries while leaving full
   event validation as the default.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-30.
 
 Current `origin/v8` logging-overhaul head:
 
-- `5ca270800` after PR #883, `Add smoke event tail limit`.
+- `d0a8e0da5` after PR #885, `Add live event query tail limit`.
 
 Current review gate:
 
@@ -49,6 +49,29 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #885 at `d0a8e0da5`.
+- PR #885 added opt-in `passivbot tool live-event-query --event-tail-lines N`
+  for repeated recent-window event queries over large current monitor segments.
+  The default remains full event validation; bounded query output reports
+  `event_tail_lines`, `event_tail_limited_files`, and
+  `event_tail_skipped_lines` in `event_window`. The slice did not add event
+  producers, exchange calls, cache mutation, readiness gates, console routing,
+  order/risk logic, or trading behavior.
+- PR #885 passed the normal review gate: Claude approved head `f9550f8f`,
+  Hermes approved head `f9550f8f`, and CI was green. Local validation covered
+  `tests/test_live_event_query.py`, compileall for touched files,
+  `git diff --check`, and a touched-diff silent-handling scan.
+- After deploying PR #885 to VPS5, the bots were not restarted because the
+  change was read-only query tooling. All five configured `passivbot live`
+  processes remained running. A full-validation 5-minute `hsl.status` query on
+  `v8@d0a8e0da` reported `ok=true`, `error_count=0`, and
+  `matched_events=40` in 6.69s. The same query with
+  `--event-tail-lines 5000` reported `ok=true`, `error_count=0`,
+  `matched_events=38`, and exposed `event_tail_limited_files=4` in 7.04s.
+  A smaller `--event-tail-lines 500` smoke reported `ok=true`,
+  `matched_events=37`, `event_tail_limited_files=4`, and
+  `event_tail_skipped_lines=9941` in 3.26s, proving bounded-evidence metadata
+  is visible on live artifacts.
 - Repository pulled through PR #883 at `5ca270800`.
 - PR #883 added opt-in `passivbot tool live-smoke-report --event-tail-lines N`
   for repeated recent-window smoke checks over large current monitor segments.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -167,7 +167,10 @@ Related detailed plans:
    `repository.root` for shareable reports and surfaces explicit
    dropped-unparsed attention/hard counters when the opt-in log-window drop
    policy suppresses contextless hard-looking log fragments. The safe restart
-   orchestration contract is not implemented.
+   orchestration contract is not implemented. A 2026-06-30 follow-up made the
+   existing startup timing evidence visible in `live-smoke-report --summary`
+   and `--brief`, so repeated smoke loops can see slow startup phases without
+   opening the full report.
    For Rust-touching deploys, the restart flow must also make extension rebuild
    and freshness verification explicit before stopping/restarting live bots; PR
    #756 showed that the VPS has Rust under `/root/.cargo/bin` but non-login SSH

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -162,7 +162,8 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   `--event-tail-lines N` bounds monitor event parsing to the last N rows from
   each event file; the default `0` keeps full monitor-event validation.
   Startup timing summaries include report-only budget projections from prior local p95
-  phase baselines when enough monitor evidence exists.
+  phase baselines when enough monitor evidence exists, and the summary/brief projections
+  surface bounded startup timing counters for repeated smoke loops.
   Existing structured EMA readiness degradation events are summarized as
   `ema_readiness_health` in full/summary output and `ema_readiness` in brief output,
   including latest candidate/unavailable counts and bounded reason/error group evidence.

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -4020,6 +4020,83 @@ def _summary_limited_groups(
     }
 
 
+def _summary_startup_timings(
+    startup_timings: Any,
+    *,
+    limit: int,
+) -> dict[str, Any]:
+    rows = startup_timings if isinstance(startup_timings, list) else []
+    limit = max(0, int(limit))
+    return {
+        "bots": len(rows),
+        "groups_truncated": len(rows) > limit,
+        "groups": rows[:limit],
+    }
+
+
+def _brief_startup_timings(startup_timings: Any) -> dict[str, Any]:
+    rows = startup_timings if isinstance(startup_timings, list) else []
+    phase_count = 0
+    over_budget_phases = 0
+    max_latest_elapsed_ms: int | None = None
+    max_latest_phase_ms: int | None = None
+    max_startup_elapsed_ms: int | None = None
+    startup_phase_bots = 0
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        phases = row.get("phases")
+        if not isinstance(phases, dict):
+            continue
+        for phase, phase_data in phases.items():
+            if not isinstance(phase_data, dict):
+                continue
+            phase_count += 1
+            latest_elapsed = _non_negative_int(phase_data.get("latest_elapsed_ms"))
+            latest_phase = _non_negative_int(phase_data.get("latest_since_previous_ms"))
+            if latest_elapsed is not None:
+                max_latest_elapsed_ms = max(
+                    latest_elapsed,
+                    max_latest_elapsed_ms if max_latest_elapsed_ms is not None else 0,
+                )
+                if str(phase) == "startup":
+                    startup_phase_bots += 1
+                    max_startup_elapsed_ms = max(
+                        latest_elapsed,
+                        max_startup_elapsed_ms
+                        if max_startup_elapsed_ms is not None
+                        else 0,
+                    )
+            if latest_phase is not None:
+                max_latest_phase_ms = max(
+                    latest_phase,
+                    max_latest_phase_ms if max_latest_phase_ms is not None else 0,
+                )
+            elapsed_budget = phase_data.get("elapsed_budget")
+            phase_budget = phase_data.get("phase_budget")
+            if (
+                isinstance(elapsed_budget, dict)
+                and elapsed_budget.get("status") == "over_budget"
+            ) or (
+                isinstance(phase_budget, dict)
+                and phase_budget.get("status") == "over_budget"
+            ):
+                over_budget_phases += 1
+    return {
+        key: value
+        for key, value in {
+            "bots": len(rows),
+            "phases": phase_count,
+            "over_budget_phases": over_budget_phases,
+            "startup_phase_bots": startup_phase_bots,
+            "max_latest_elapsed_ms": max_latest_elapsed_ms,
+            "max_latest_phase_ms": max_latest_phase_ms,
+            "max_startup_elapsed_ms": max_startup_elapsed_ms,
+        }.items()
+        if value is not None
+    }
+
+
 def summarize_live_smoke_report(
     report: dict[str, Any],
     *,
@@ -4196,6 +4273,10 @@ def summarize_live_smoke_report(
         ),
         "account_critical_remote_calls": _summary_limited_groups(
             report.get("account_critical_remote_call_health") or {},
+            limit=max_groups,
+        ),
+        "startup_timings": _summary_startup_timings(
+            report.get("startup_timings"),
             limit=max_groups,
         ),
         "ema_readiness_health": _summary_limited_groups(
@@ -4406,6 +4487,7 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         "account_critical_remote_calls": _brief_remote_call_health(
             report.get("account_critical_remote_call_health")
         ),
+        "startup_timings": _brief_startup_timings(report.get("startup_timings")),
         "ema_readiness": {
             "total": _count_value(ema_readiness_health.get("total")),
             "bots": _count_value(ema_readiness_health.get("bots")),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1761,6 +1761,8 @@ def test_live_smoke_report_summarizes_startup_phase_baselines(tmp_path):
     )
 
     report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    summary = summarize_live_smoke_report(report)
+    brief = summarize_live_smoke_report_brief(report)
 
     assert report["startup_timings"] == [
         {
@@ -1852,6 +1854,21 @@ def test_live_smoke_report_summarizes_startup_phase_baselines(tmp_path):
     latest_details = report["startup_timings"][0]["phases"]["startup"]["latest_details"]
     assert "AKIA123" not in latest_details
     assert "TOKEN123" not in latest_details
+    assert summary["startup_timings"]["bots"] == 1
+    assert summary["startup_timings"]["groups"][0]["bot"] == "binance/binance_01"
+    assert (
+        summary["startup_timings"]["groups"][0]["phases"]["startup"]["latest_details"]
+        == "ready api_key=[redacted] Authorization: [redacted]"
+    )
+    assert brief["startup_timings"] == {
+        "bots": 1,
+        "phases": 2,
+        "over_budget_phases": 2,
+        "startup_phase_bots": 1,
+        "max_latest_elapsed_ms": 10000,
+        "max_latest_phase_ms": 7000,
+        "max_startup_elapsed_ms": 10000,
+    }
 
 
 def test_live_smoke_report_startup_budget_no_baseline(tmp_path):


### PR DESCRIPTION
## Summary
- add bounded startup timing projections to `live-smoke-report --summary` and `--brief`
- keep using existing `bot.startup_timing` events only; no new producers or live behavior
- record PR #885 deploy/smoke evidence in the logging progress ledger

## Risk boundary
- read-only operator/report tooling only
- no event producers, exchange calls, cache mutation, readiness gates, console routing, order/risk logic, or trading behavior changed
- full report already had `startup_timings`; this PR exposes the same sanitized evidence in concise projections

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_smoke_report.py` -> 51 passed
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/live/smoke_report.py tests/test_live_smoke_report.py`
- `git diff --check`
- added-diff silent-handling scan: no matches

## VPS5 evidence for included progress update
- deployed merged PR #885 to VPS5 at `d0a8e0da` without bot restart; all five configured live processes remained running
- full 5-minute `hsl.status` event-query smoke: `ok=true`, `error_count=0`, `matched_events=40`, 6.69s
- `--event-tail-lines 5000`: `ok=true`, `error_count=0`, `matched_events=38`, `event_tail_limited_files=4`, 7.04s
- `--event-tail-lines 500`: `ok=true`, `matched_events=37`, `event_tail_limited_files=4`, `event_tail_skipped_lines=9941`, 3.26s