### PR TITLE
Expose log window in brief smoke reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report --brief` now includes bounded text-log
+  window counters, making it clear when hard/attention log counts came from a
+  time-windowed scan and how many log lines were skipped.
 - `passivbot tool live-smoke-report --summary` and `--brief` now expose
   existing startup timing evidence, making slow restart phases visible in the
   concise smoke-loop projections.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -170,7 +170,10 @@ Related detailed plans:
    orchestration contract is not implemented. A 2026-06-30 follow-up made the
    existing startup timing evidence visible in `live-smoke-report --summary`
    and `--brief`, so repeated smoke loops can see slow startup phases without
-   opening the full report.
+   opening the full report. Another 2026-06-30 follow-up made bounded text-log
+   window counters visible in `--brief`, so hard/attention log counts show
+   whether they came from a time-windowed scan and how much log evidence was
+   skipped.
    For Rust-touching deploys, the restart flow must also make extension rebuild
    and freshness verification explicit before stopping/restarting live bots; PR
    #756 showed that the VPS has Rust under `/root/.cargo/bin` but non-login SSH

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -158,6 +158,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
 - `passivbot tool live-smoke-report` summarizes local live monitor events and text logs for
   operator smoke-test evidence. Use `--summary` for bounded event groups and log matches, or
   `--brief` for top-level counters suitable for repeated VPS smoke loops.
+  Brief output includes bounded text-log window counters so time-windowed smoke
+  evidence shows how many log lines were considered, skipped before/after the
+  window, or dropped by the unparseable-line policy.
   For repeated recent-window smoke checks over large current monitor segments,
   `--event-tail-lines N` bounds monitor event parsing to the last N rows from
   each event file; the default `0` keeps full monitor-event validation.

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -4327,6 +4327,27 @@ def _brief_remote_call_health(summary: Any) -> dict[str, Any]:
     }
 
 
+def _brief_log_window(logs: dict[str, Any]) -> dict[str, Any]:
+    window = logs.get("window") if isinstance(logs.get("window"), dict) else {}
+    return {
+        key: window.get(key)
+        for key in (
+            "enabled",
+            "since_ms",
+            "until_ms",
+            "lines_considered",
+            "lines_skipped_before",
+            "lines_skipped_after",
+            "unparsed_ts",
+            "unparsed_policy",
+            "lines_skipped_unparsed",
+            "dropped_unparsed_attention_matches",
+            "dropped_unparsed_hard_matches",
+        )
+        if key in window
+    }
+
+
 def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
     """Project a full smoke report into top-level smoke-loop counters."""
 
@@ -4478,6 +4499,7 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             "dropped_unparsed_hard_matches": _count_value(
                 logs.get("dropped_unparsed_hard_matches")
             ),
+            "window": _brief_log_window(logs),
         },
         "problem_events": {
             "total": _count_value(report.get("problem_event_count")),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -964,6 +964,19 @@ def test_live_smoke_report_brief_summary_projects_top_level_counters(tmp_path):
         "non_risk_hard_matches": 0,
         "dropped_unparsed_attention_matches": 0,
         "dropped_unparsed_hard_matches": 0,
+        "window": {
+            "enabled": False,
+            "since_ms": None,
+            "until_ms": None,
+            "lines_considered": 1,
+            "lines_skipped_before": 0,
+            "lines_skipped_after": 0,
+            "unparsed_ts": 0,
+            "unparsed_policy": "keep",
+            "lines_skipped_unparsed": 0,
+            "dropped_unparsed_attention_matches": 0,
+            "dropped_unparsed_hard_matches": 0,
+        },
     }
     assert brief["problem_events"] == {"total": 2, "hard": 0}
     assert brief["remote_calls"]["total"] == 1
@@ -3015,6 +3028,8 @@ def test_live_smoke_report_log_window_filters_parseable_timestamps(tmp_path):
     ]
     assert report["logs"]["matches"][0]["ts"] == 3000
     assert "future hard skipped" not in json.dumps(report["logs"]["matches"])
+    brief = summarize_live_smoke_report_brief(report)
+    assert brief["logs"]["window"] == report["logs"]["window"]
 
     drop_report = build_live_smoke_report(
         tmp_path / "monitor",


### PR DESCRIPTION
## Summary
- add bounded `logs.window` counters to `live-smoke-report --brief`
- make brief smoke evidence show whether log counts came from a time-windowed scan and how many lines were skipped/dropped
- update tools/backlog docs and changelog

## Risk boundary
- read-only smoke-report projection only
- no event producers, exchange calls, cache mutation, readiness gates, console routing, order/risk logic, or trading behavior changed
- no raw log lines, paths, matches, account data, or payloads added to brief output

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_smoke_report.py` -> 51 passed
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/live/smoke_report.py tests/test_live_smoke_report.py`
- `git diff --check`
- added-diff silent-handling scan: no matches