### PR TITLE
Expose event window flag in brief smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report --brief` now includes the structured event
+  window `enabled` flag, matching the full report and making unwindowed brief
+  smoke output explicit.
 - `passivbot tool live-smoke-report --brief` now includes bounded text-log
   window counters, making it clear when hard/attention log counts came from a
   time-windowed scan and how many log lines were skipped.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -163,7 +163,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   window, or dropped by the unparseable-line policy.
   For repeated recent-window smoke checks over large current monitor segments,
   `--event-tail-lines N` bounds monitor event parsing to the last N rows from
-  each event file; the default `0` keeps full monitor-event validation.
+  each event file; the default `0` keeps full monitor-event validation. Brief
+  output includes the structured event-window `enabled` flag plus the bounded
+  event-window counters.
   Startup timing summaries include report-only budget projections from prior local p95
   phase baselines when enough monitor evidence exists, and the summary/brief projections
   surface bounded startup timing counters for repeated smoke loops.

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -4428,6 +4428,7 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         "event_window": {
             key: event_window.get(key)
             for key in (
+                "enabled",
                 "since_ms",
                 "until_ms",
                 "events_considered",

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -954,6 +954,7 @@ def test_live_smoke_report_brief_summary_projects_top_level_counters(tmp_path):
         "total": 3,
     }
     assert brief["monitor"]["live_events"] == 2
+    assert brief["event_window"]["enabled"] is False
     assert brief["logs"] == {
         "files_scanned": 1,
         "hard_matches": 0,
@@ -3502,6 +3503,7 @@ def test_live_smoke_report_cli_brief_projects_event_tail_metadata(tmp_path, caps
 
     summary = json.loads(capsys.readouterr().out)
     assert summary["monitor"]["live_events"] == 1
+    assert summary["event_window"]["enabled"] is False
     assert summary["event_window"]["event_tail_lines"] == 1
     assert summary["event_window"]["event_tail_limited_files"] == 1
     assert summary["event_window"]["event_tail_skipped_lines"] == 1


### PR DESCRIPTION
## Summary
- add the structured `event_window.enabled` flag to `live-smoke-report --brief`
- keep brief event-window output aligned with full-report event-window metadata and the recently added `logs.window.enabled`
- update docs and changelog

## Risk boundary
- read-only smoke-report projection only
- no event producers, exchange calls, cache mutation, readiness gates, console routing, order/risk logic, or trading behavior changed
- no raw event payloads or log data added

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_smoke_report.py` -> 51 passed
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/live/smoke_report.py tests/test_live_smoke_report.py`
- `git diff --check`
- added-diff silent-handling scan: no matches