### PR TITLE
Add live-event query level filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `--level` filtering to `passivbot tool live-event-query`, so operator
+  event, timeline, trace-summary, order-trace, and cycle-trace reports can be
+  scoped by live-event severity.
 - `passivbot tool live-smoke-report --brief` now includes the structured event
   window `enabled` flag, matching the full report and making unwindowed brief
   smoke output explicit.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -149,10 +149,10 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   local replay inputs.
 - `passivbot tool live-event-query` validates and queries local structured monitor event
   segments. It is read-only and does not contact exchanges. Use `--event-type`,
-  `--cycle-id`, ID filters, `--symbol`, `--pside`, `--tag`, `--data-eq`, and time-window
-  filters to reconstruct incident slices. Use `--exchange EXCHANGE` and `--user USER` to
-  focus one monitor account and prune unrelated monitor paths before scanning; `--bot-id`
-  remains available for event-envelope bot IDs. For repeated recent-window queries over
+  `--level`, `--cycle-id`, ID filters, `--symbol`, `--pside`, `--tag`, `--data-eq`, and
+  time-window filters to reconstruct incident slices. Use `--exchange EXCHANGE` and
+  `--user USER` to focus one monitor account and prune unrelated monitor paths before
+  scanning; `--bot-id` remains available for event-envelope bot IDs. For repeated recent-window queries over
   large current monitor segments, `--event-tail-lines N` bounds parsing to the last N rows
   from each event file; the default `0` keeps full event validation.
 - `passivbot tool live-smoke-report` summarizes local live monitor events and text logs for

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -250,6 +250,7 @@ def _filter_report(
     *,
     cycle_id: str | None,
     event_types: set[str],
+    levels: set[str],
     exchanges: set[str],
     users: set[str],
     bot_ids: set[str],
@@ -277,6 +278,8 @@ def _filter_report(
         filters["until_ms"] = int(until_ms)
     if event_types:
         filters["event_types"] = sorted(event_types)
+    if levels:
+        filters["levels"] = sorted(levels)
     if exchanges:
         filters["exchanges"] = sorted(exchanges)
     if users:
@@ -973,6 +976,7 @@ def build_event_report(
     *,
     cycle_id: str | None = None,
     event_type: str | Iterable[str] | None = None,
+    level: str | Iterable[str] | None = None,
     exchange: str | Iterable[str] | None = None,
     user: str | Iterable[str] | None = None,
     bot_id: str | Iterable[str] | None = None,
@@ -1073,6 +1077,7 @@ def build_event_report(
         include_data=include_data,
     )
     event_type_filter = _normalize_filter_values(event_type)
+    level_filter = _normalize_filter_values(level)
     exchange_filter = _normalize_filter_values(exchange)
     user_filter = _normalize_filter_values(user)
     bot_filter = _normalize_filter_values(bot_id)
@@ -1091,6 +1096,7 @@ def build_event_report(
     has_non_cycle_filter = any(
         (
             event_type_filter,
+            level_filter,
             exchange_filter,
             user_filter,
             bot_filter,
@@ -1176,6 +1182,7 @@ def build_event_report(
                         window_considered += 1
 
                     record_event_type = live_event.get("event_type") or row.get("kind")
+                    record_level = live_event.get("level")
                     if not record_event_type:
                         issues.append(
                             EventIssue(
@@ -1236,6 +1243,7 @@ def build_event_report(
                     event_type_matches = _filter_matches(
                         record_event_type, event_type_filter
                     )
+                    level_matches = _filter_matches(record_level, level_filter)
                     cycle_matches = cycle_id is None or record_cycle_id == str(cycle_id)
                     exchange_matches = _filter_matches(
                         record_exchange,
@@ -1273,6 +1281,7 @@ def build_event_report(
                     data_matches = _data_filters_match(live_event, data_eq_filters)
                     query_matches = (
                         event_type_matches
+                        and level_matches
                         and cycle_matches
                         and exchange_matches
                         and user_matches
@@ -1405,6 +1414,7 @@ def build_event_report(
         query_filters = _filter_report(
             cycle_id=cycle_id,
             event_types=event_type_filter,
+            levels=level_filter,
             exchanges=exchange_filter,
             users=user_filter,
             bot_ids=bot_filter,
@@ -1443,6 +1453,7 @@ def build_event_report(
         cycle_filters = _filter_report(
             cycle_id=cycle_id,
             event_types=event_type_filter,
+            levels=level_filter,
             exchanges=exchange_filter,
             users=user_filter,
             bot_ids=bot_filter,

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -38,6 +38,14 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--level",
+        action="append",
+        help=(
+            "Return compact records matching one live-event level, for example "
+            "warning,error,critical. May be repeated or comma-separated."
+        ),
+    )
+    parser.add_argument(
         "--bot-id",
         action="append",
         help=(
@@ -252,6 +260,7 @@ def main(argv: list[str] | None = None) -> int:
             args.path,
             cycle_id=args.cycle_id,
             event_type=args.event_types,
+            level=args.level,
             exchange=args.exchange,
             user=args.user,
             bot_id=args.bot_id,

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -23,6 +23,7 @@ def _monitor_row(
     reason_code: str = "test",
     ids: dict | None = None,
     data: dict | None = None,
+    level: str = "debug",
     source: str = "live",
     component: str = "test",
     tags: list[str] | None = None,
@@ -38,7 +39,7 @@ def _monitor_row(
         "schema_version": 1,
         "event_id": f"evt_{seq}",
         "event_type": event_type,
-        "level": "debug",
+        "level": level,
         "source": source,
         "component": component,
         "exchange": exchange,
@@ -252,6 +253,66 @@ def test_event_query_filters_by_event_type_without_changing_summary_counts(tmp_p
         "SOL/USDT:USDT",
     ]
     assert report["query"]["events"][0]["data"] == {"seq": 1}
+
+
+def test_event_query_filters_by_level(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.started",
+                cycle_id="cy_1",
+                seq=1,
+                ts=1000,
+                level="info",
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                cycle_id="cy_1",
+                seq=2,
+                ts=1100,
+                level="warning",
+            ),
+            _monitor_row(
+                event_type="execution.create_failed",
+                cycle_id="cy_1",
+                seq=3,
+                ts=1200,
+                level="error",
+            ),
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        level=["warning,error"],
+        timeline=True,
+        trace_summary=True,
+    )
+
+    assert report["event_types"] == {
+        "cycle.started": 1,
+        "execution.create_failed": 1,
+        "remote_call.failed": 1,
+    }
+    assert report["query"]["filters"] == {"levels": ["error", "warning"]}
+    assert report["query"]["matched_events"] == 2
+    assert [event["level"] for event in report["query"]["events"]] == [
+        "warning",
+        "error",
+    ]
+    assert report["query"]["trace_summary"]["levels"] == {"error": 1, "warning": 1}
+    assert report["query"]["timeline"] == [
+        (
+            "1100 seq=2 remote_call.failed status=succeeded "
+            "reason_code=test ids=cycle_id=cy_1"
+        ),
+        (
+            "1200 seq=3 execution.create_failed status=succeeded "
+            "reason_code=test ids=cycle_id=cy_1"
+        ),
+    ]
 
 
 def test_event_query_combines_cycle_and_event_type_filters(tmp_path):
@@ -1411,6 +1472,47 @@ def test_live_event_query_cli_accepts_time_window(tmp_path, capsys):
     assert report["query"]["filters"] == {"since_ms": 1100, "until_ms": 1300}
     assert report["query"]["matched_events"] == 1
     assert report["query"]["events"][0]["seq"] == 2
+
+
+def test_live_event_query_cli_accepts_level_filter(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="remote_call.succeeded",
+                cycle_id="cy_9",
+                seq=1,
+                ts=1000,
+                level="info",
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                cycle_id="cy_9",
+                seq=2,
+                ts=1100,
+                level="error",
+            ),
+        ],
+    )
+
+    assert (
+        live_event_query.main(
+            [
+                str(tmp_path / "monitor"),
+                "--level",
+                "error",
+                "--include-data",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["query"]["filters"] == {"levels": ["error"]}
+    assert report["query"]["matched_events"] == 1
+    assert report["query"]["events"][0]["event_type"] == "remote_call.failed"
+    assert report["query"]["events"][0]["level"] == "error"
 
 
 def test_live_event_query_cli_accepts_data_eq_filter(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- add `passivbot tool live-event-query --level` for filtering existing structured live events by envelope level
- include level filters in query/cycle filter metadata and compose them with timeline/trace-summary paths
- add API and CLI regression coverage for warning/error level queries

## Scope
- read-only operator tooling only
- no event producers, exchange calls, cache mutation, readiness gates, console routing, order/risk logic, or trading behavior changed

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py` - 41 passed
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_query.py src/tools/live_event_query.py tests/test_live_event_query.py` - pass
- `git diff --check` - pass
- silent-handling scan on touched files - no matches

Note: adjacent `tests/test_passivbot_cli.py` collection is currently blocked in this detached worktree by the existing Rust-extension freshness guard: `Loaded Rust extension does not match current Rust sources; restart after rebuild.`
