### PR TITLE
Record live-event level filter deploy

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-30.
 
 Current `origin/v8` logging-overhaul head:
 
-- `1498abc9c` after PR #890, `Expose event window flag in brief smoke`.
+- `7e7ce16f3` after PR #892, `Add live-event query level filter`.
 
 Current review gate:
 
@@ -49,6 +49,28 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #892 at `7e7ce16f`.
+- PR #892 added read-only `passivbot tool live-event-query --level`, so local
+  structured monitor-event queries can be scoped by envelope severity and
+  composed with existing timeline, trace-summary, order-trace, and cycle-trace
+  views. The slice did not add event producers, exchange calls, cache mutation,
+  readiness gates, console routing, order/risk logic, or trading behavior.
+- PR #892 passed the normal review gate on the final head: Claude approved
+  `e456ced6`, Hermes approved `e456ced6`, and CI was green. Local validation
+  covered `tests/test_live_event_query.py`, py_compile for touched Python
+  files, `git diff --check`, and a touched-file silent-handling scan.
+- After deploying PR #892 to VPS5, the bots were not restarted because the
+  change was read-only query tooling. All five configured `passivbot live`
+  processes remained running. A 10-minute `live-event-query --level
+  warning,error,critical --trace-summary --event-tail-lines 5000` smoke on
+  `v8@7e7ce16f` returned `ok=true`, `error_count=0`, `matched_events=33`,
+  and `trace_summary.levels.warning=33`. A parallel 5-minute brief smoke
+  showed all five configured bots matched, clean tracked repository state,
+  `remote_calls.failed=0`, and `account_critical_remote_calls.failed=0`, but
+  returned `ok=false` because Binance logged an existing non-risk traceback
+  from hourly hedge-mode config refresh (`binanceusdm -4084 Method is not
+  allowed currently`). That operational gap is tracked in
+  `docs/plans/live_ops_improvement_backlog.md`.
 - Repository pulled through PR #890 at `1498abc9c`.
 - PR #890 exposed the structured event-window `enabled` flag in
   `live-smoke-report --brief`, matching the full report and the existing
@@ -1375,7 +1397,7 @@ VPS5 deployment status:
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events, HSL replay failure events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events; PR #707 restores throttled coin-mode HSL position status console lines from existing `hsl.status` metrics; PR #709 mirrors fill-cache startup readiness into off-console `fills.refresh_summary` events; PR #711 mirrors CCXT timestamp/nonce recovery into off-console `exchange.time_sync` events; PR #846 mirrors pre-create market-distance guard skips into off-console `execution.create_skipped` events; PR #848 mirrors pre-create planning/market snapshot skips into off-console `execution.create_skipped` events; PR #850 mirrors fill-cache doctor startup report/quarantine/rebuild decisions into off-console `fills.refresh_summary` events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
-| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window reports, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation with summary/filter, decision-boundary, initial input-staleness, HSL replay pair/rate, forager/EMA readiness, cache warmup, resource-pressure percentiles, and unified operation-duration support | Cross-bot incident workflow, safe restart orchestration, richer symbol/market/config staleness performance metrics, active probe expansion beyond current endpoint/freshness summaries |
+| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, severity-level filters, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window reports, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation with summary/filter, decision-boundary, initial input-staleness, HSL replay pair/rate, forager/EMA readiness, cache warmup, resource-pressure percentiles, and unified operation-duration support | Cross-bot incident workflow, safe restart orchestration, richer symbol/market/config staleness performance metrics, active probe expansion beyond current endpoint/freshness summaries |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup; PR #656/#668 cache integrity smoke doctor | Continue separate reviewed PRs for shutdown/warmup/cache proof improvements |
 
 ## Merged Slices

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -577,6 +577,31 @@ Related detailed plans:
       within the configured forager staleness cap. Candidate-only symbols still
       remain unavailable instead of receiving synthetic ranking tails.
 
+18. [ ] Binance hourly hedge-mode/config refresh traceback classification.
+    Status: open.
+
+    VPS5 smoke after PR #892 deployed to `v8@7e7ce16f` returned hard-red from
+    a non-risk text-log traceback in the Binance bot while all five live
+    processes remained running and structured monitor events showed no hard
+    problem event. The surrounding lines were:
+    `error setting hedge mode: binanceusdm {"code":-4084,"msg":"Method is not
+    allowed currently. Upcoming soon."}` and `error with maintain_hourly_cycle`.
+
+    Target contract: recurring exchange-config maintenance failures should be
+    represented as structured, bounded, exchange-surface diagnostics with clear
+    severity and retry/backoff context. If a failure is trading-critical, the
+    structured stream should make that explicit. If it is expected/non-critical
+    on an already-running Binance futures account, it should not appear only as
+    a raw traceback that makes operator smoke red without explaining whether
+    trading was impaired. Do not weaken fail-loud behavior for required startup
+    exchange config or order construction.
+
+    Investigation directions: inspect the hourly `maintain_hourly_cycle` /
+    hedge-mode refresh path; distinguish startup-required config from recurring
+    maintenance refresh; add a structured `exchange.config_refresh` or similar
+    event if the path remains in live; and adjust smoke/report classification
+    only after the event contract makes criticality explicit.
+
 ## Merged Work Log
 
 | Date | Item | PR / Commit | Result | Remaining |
@@ -653,6 +678,7 @@ Related detailed plans:
 | 2026-06-30 | #3/#4 Live restart/smoke automation and startup budget tracking | PR #886 / `60c79c3a` | Exposed existing startup timing evidence in `live-smoke-report --summary` and `--brief`; VPS5 5-minute smoke stayed hard-green and showed the new `startup_timings` brief key | Safe pull/stop/start orchestration and durable startup budget config/events remain open |
 | 2026-06-30 | #3 Live restart/smoke automation | PR #888 / `4b435d33` | Exposed bounded text-log window counters in `live-smoke-report --brief`; VPS5 5-minute smoke stayed hard-green and showed `logs.window.lines_skipped_before=1730` | Safe pull/stop/start orchestration remains open |
 | 2026-06-30 | #3 Live restart/smoke automation | PR #890 / `1498abc9` | Exposed `event_window.enabled` in `live-smoke-report --brief`; VPS5 5-minute smoke stayed hard-green and showed `event_window.enabled=true` | Safe pull/stop/start orchestration remains open |
+| 2026-06-30 | #2 Event query and timeline CLI extensions | PR #892 / `7e7ce16f` | Added `live-event-query --level` filtering for structured event severity; VPS5 query smoke matched 33 warning-level events with `ok=true` and all five bots still running | Cross-bot incident workflow remains open; Binance config-refresh traceback classification added as item #18 |
 
 ## Suggested Priority
 


### PR DESCRIPTION
## Summary
- record PR #892 merge/deploy evidence in the live logging overhaul progress ledger
- add the Binance hourly hedge-mode/config refresh traceback as a new living backlog item
- add PR #892 to the live ops merged-work log and update the operator-tool checklist with severity-level filters

## Scope
- docs/plans only
- no runtime code, event producers, exchange calls, cache mutation, readiness gates, console routing, order/risk logic, or trading behavior changed

## Validation
- `git diff --check` - pass
