### PR TITLE
Emit exchange config refresh events

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -31,6 +31,7 @@ across time.
 - `ema.bundle.started`
 - `ema.fallback_used`
 - `ema.unavailable`
+- `exchange.config_refresh`
 - `exchange.time_sync`
 - `execution.ambiguous`
 - `execution.cancel_ambiguous_terminal`
@@ -147,6 +148,8 @@ across time.
 - `candle_disk_load_completed`
 - `ema_fallback_used`
 - `exchange_acknowledged`
+- `exchange_config_refresh`
+- `exchange_config_refresh_failed`
 - `exchange_exception`
 - `exchange_time_sync`
 - `exchange_time_sync_unavailable`

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -80,6 +80,7 @@ class EventTypes:
     CACHE_LOAD_COMPLETED = "cache.load.completed"
     CACHE_FLUSH_COMPLETED = "cache.flush.completed"
     CACHE_WARMUP_DECISION = "cache.warmup_decision"
+    EXCHANGE_CONFIG_REFRESH = "exchange.config_refresh"
     EXCHANGE_TIME_SYNC = "exchange.time_sync"
     REMOTE_CALL_STARTED = "remote_call.started"
     REMOTE_CALL_SUCCEEDED = "remote_call.succeeded"
@@ -190,6 +191,8 @@ class ReasonCodes:
     CANDLE_DISK_LOAD_COMPLETED = "candle_disk_load_completed"
     EMA_FALLBACK_USED = "ema_fallback_used"
     EXCHANGE_ACKNOWLEDGED = "exchange_acknowledged"
+    EXCHANGE_CONFIG_REFRESH = "exchange_config_refresh"
+    EXCHANGE_CONFIG_REFRESH_FAILED = "exchange_config_refresh_failed"
     EXCHANGE_EXCEPTION = "exchange_exception"
     EXCHANGE_TIME_SYNC = "exchange_time_sync"
     EXCHANGE_TIME_SYNC_UNAVAILABLE = "exchange_time_sync_unavailable"
@@ -343,6 +346,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.CACHE_LOAD_COMPLETED,
     EventTypes.CACHE_FLUSH_COMPLETED,
     EventTypes.CACHE_WARMUP_DECISION,
+    EventTypes.EXCHANGE_CONFIG_REFRESH,
     EventTypes.EXCHANGE_TIME_SYNC,
     EventTypes.REMOTE_CALL_STARTED,
     EventTypes.REMOTE_CALL_SUCCEEDED,
@@ -644,6 +648,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.CACHE_LOAD_COMPLETED: EventRoute(console=False, text=False),
     EventTypes.CACHE_FLUSH_COMPLETED: EventRoute(console=False, text=False),
     EventTypes.CACHE_WARMUP_DECISION: EventRoute(console=False, text=False),
+    EventTypes.EXCHANGE_CONFIG_REFRESH: EventRoute(console=False, text=False),
     EventTypes.EXCHANGE_TIME_SYNC: EventRoute(console=False, text=False),
     EventTypes.REMOTE_CALL_STARTED: EventRoute(console=False),
     EventTypes.REMOTE_CALL_SUCCEEDED: EventRoute(console=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -616,6 +616,54 @@ def emit_exchange_time_sync_event(bot: Any, *args: Any, **kwargs: Any) -> None:
         logging.debug("[event] failed to emit exchange time-sync event: %s", exc)
 
 
+def _emit_exchange_config_refresh_event_unchecked(
+    bot: Any,
+    *,
+    context: str,
+    operation: str,
+    status: str,
+    started_ms: int | None = None,
+    elapsed_ms: int | None = None,
+    error: BaseException | None = None,
+) -> None:
+    status_value = str(status or "unknown")
+    failed = status_value == "failed"
+    data: dict[str, Any] = {
+        "context": str(context or "unknown"),
+        "operation": str(operation or "unknown"),
+        "started_ms": int(started_ms) if started_ms is not None else None,
+        "elapsed_ms": int(elapsed_ms) if elapsed_ms is not None else None,
+    }
+    if error is not None:
+        data["error_type"] = type(error).__name__
+        data["error"] = _sanitize_remote_text(error, max_len=500)
+    _safe_emit(
+        bot,
+        EventTypes.EXCHANGE_CONFIG_REFRESH,
+        level="warning" if failed else "debug",
+        component="exchange.config_refresh",
+        tags=(EventTags.EXCHANGE,),
+        cycle_id=current_live_event_cycle_id(bot),
+        status=status_value,
+        reason_code=(
+            ReasonCodes.EXCHANGE_CONFIG_REFRESH_FAILED
+            if failed
+            else ReasonCodes.EXCHANGE_CONFIG_REFRESH
+        ),
+        data={key: value for key, value in data.items() if value is not None},
+    )
+
+
+def emit_exchange_config_refresh_event(
+    bot: Any, *args: Any, **kwargs: Any
+) -> None:
+    """Best-effort structured visibility for periodic exchange config refresh."""
+    try:
+        _emit_exchange_config_refresh_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug("[event] failed to emit exchange config-refresh event: %s", exc)
+
+
 def begin_live_event_cycle(bot: Any, *, loop_start_ms: int) -> str:
     bot._live_event_cycle_seq = int(getattr(bot, "_live_event_cycle_seq", 0) or 0) + 1
     cycle_id = f"cy_{int(bot._live_event_cycle_seq)}"

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -607,6 +607,9 @@ class Passivbot:
     _emit_live_cycle_degraded = live_event_emitters.emit_live_cycle_degraded
     _emit_live_event = live_event_emitters.emit_live_event
     _emit_startup_timing_event = live_event_emitters.emit_startup_timing_event
+    _emit_exchange_config_refresh_event = (
+        live_event_emitters.emit_exchange_config_refresh_event
+    )
     _emit_execution_confirmation_requested_event = (
         live_event_emitters.emit_execution_confirmation_requested_event
     )
@@ -17300,7 +17303,7 @@ class Passivbot:
                     self.init_markets_last_update_ms = 0
                 if now - int(last_markets_update_ms) > hourly_interval_ms:
                     try:
-                        await self.init_markets(verbose=False)
+                        await self._refresh_markets_for_maintenance()
                     except RateLimitExceeded:
                         self._health_rate_limits += 1
                         logging.warning(
@@ -17312,6 +17315,38 @@ class Passivbot:
                 logging.error("error with %s %s", get_function_name(), e, exc_info=True)
                 await self.restart_bot_on_too_many_errors()
                 await asyncio.sleep(5)
+
+    def _emit_maintenance_exchange_config_refresh_event(self, **kwargs):
+        try:
+            self._emit_exchange_config_refresh_event(**kwargs)
+        except Exception as exc:
+            logging.debug(
+                "[event] failed to emit maintenance exchange config-refresh event: %s",
+                exc,
+            )
+
+    async def _refresh_markets_for_maintenance(self):
+        started_ms = utc_ms()
+        try:
+            result = await self.init_markets(verbose=False)
+        except Exception as exc:
+            self._emit_maintenance_exchange_config_refresh_event(
+                context="maintain_hourly_cycle",
+                operation="init_markets",
+                status="failed",
+                started_ms=started_ms,
+                elapsed_ms=max(0, utc_ms() - started_ms),
+                error=exc,
+            )
+            raise
+        self._emit_maintenance_exchange_config_refresh_event(
+            context="maintain_hourly_cycle",
+            operation="init_markets",
+            status="succeeded",
+            started_ms=started_ms,
+            elapsed_ms=max(0, utc_ms() - started_ms),
+        )
+        return result
 
     async def start_data_maintainers(self):
         """Spawn background tasks responsible for market metadata and order watching."""

--- a/tests/test_exchange_config_refresh_event.py
+++ b/tests/test_exchange_config_refresh_event.py
@@ -1,0 +1,108 @@
+import sys
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
+
+sys.modules.setdefault(
+    "passivbot_rust",
+    types.SimpleNamespace(
+        qty_to_cost=lambda *args, **kwargs: 0.0,
+        round_dynamic=lambda x, y=None: x,
+        calc_order_price_diff=lambda *args, **kwargs: 0.0,
+        hysteresis=lambda x, y, z: x,
+    ),
+)
+
+from passivbot import Passivbot
+
+
+def _make_bot_with_event_sink():
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "binance"
+    bot.user = "binance_01"
+    bot.bot_id = "bot_1"
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    return bot, sink
+
+
+def _raise_emit_failure(**_kwargs):
+    raise RuntimeError("emit failed")
+
+
+@pytest.mark.asyncio
+async def test_maintenance_exchange_config_refresh_success_emits_event():
+    bot, sink = _make_bot_with_event_sink()
+    bot.init_markets = AsyncMock(return_value="ok")
+
+    result = await bot._refresh_markets_for_maintenance()
+
+    assert result == "ok"
+    bot.init_markets.assert_awaited_once_with(verbose=False)
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert len(sink.events) == 1
+    event = sink.events[0]
+    assert event.event_type == EventTypes.EXCHANGE_CONFIG_REFRESH
+    assert event.component == "exchange.config_refresh"
+    assert event.status == "succeeded"
+    assert event.level == "debug"
+    assert event.reason_code == ReasonCodes.EXCHANGE_CONFIG_REFRESH
+    assert event.data["context"] == "maintain_hourly_cycle"
+    assert event.data["operation"] == "init_markets"
+    assert event.data["elapsed_ms"] >= 0
+    assert "error" not in event.data
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_maintenance_exchange_config_refresh_failure_is_sanitized_and_reraised():
+    bot, sink = _make_bot_with_event_sink()
+    exc = RuntimeError("binanceusdm apiKey=supersecret code=-4084")
+    bot.init_markets = AsyncMock(side_effect=exc)
+
+    with pytest.raises(RuntimeError) as raised:
+        await bot._refresh_markets_for_maintenance()
+
+    assert raised.value is exc
+    bot.init_markets.assert_awaited_once_with(verbose=False)
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert len(sink.events) == 1
+    event = sink.events[0]
+    assert event.event_type == EventTypes.EXCHANGE_CONFIG_REFRESH
+    assert event.status == "failed"
+    assert event.level == "warning"
+    assert event.reason_code == ReasonCodes.EXCHANGE_CONFIG_REFRESH_FAILED
+    assert event.data["error_type"] == "RuntimeError"
+    assert "supersecret" not in event.data["error"]
+    assert "[redacted]" in event.data["error"]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_maintenance_exchange_config_emit_failure_preserves_success():
+    bot, _sink = _make_bot_with_event_sink()
+    bot.init_markets = AsyncMock(return_value="ok")
+    bot._emit_exchange_config_refresh_event = _raise_emit_failure
+
+    assert await bot._refresh_markets_for_maintenance() == "ok"
+    bot.init_markets.assert_awaited_once_with(verbose=False)
+
+
+@pytest.mark.asyncio
+async def test_maintenance_exchange_config_emit_failure_preserves_original_error():
+    bot, _sink = _make_bot_with_event_sink()
+    exc = RuntimeError("exchange failed")
+    bot.init_markets = AsyncMock(side_effect=exc)
+    bot._emit_exchange_config_refresh_event = _raise_emit_failure
+
+    with pytest.raises(RuntimeError) as raised:
+        await bot._refresh_markets_for_maintenance()
+
+    assert raised.value is exc
+    bot.init_markets.assert_awaited_once_with(verbose=False)

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -80,6 +80,7 @@ def test_live_event_reason_code_registry_values_are_unique_and_query_safe():
 
     assert ReasonCodes.REQUIRED_EMA_UNAVAILABLE == "required_ema_unavailable"
     assert ReasonCodes.EXCHANGE_ACKNOWLEDGED == "exchange_acknowledged"
+    assert ReasonCodes.EXCHANGE_CONFIG_REFRESH == "exchange_config_refresh"
     assert ReasonCodes.EXECUTION_LOOP_ERROR_BURST == "execution_loop_error_burst"
     assert ReasonCodes.WARMUP_CACHE_DECISION == "warmup_cache_decision"
     assert authoritative_reason_code("balance") == "authoritative_balance"
@@ -219,6 +220,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.CACHE_LOAD_COMPLETED,
         EventTypes.CACHE_FLUSH_COMPLETED,
         EventTypes.CACHE_WARMUP_DECISION,
+        EventTypes.EXCHANGE_CONFIG_REFRESH,
         EventTypes.FILLS_REFRESH_SUMMARY,
         EventTypes.BOT_STARTUP_TIMING,
         EventTypes.HEALTH_SUMMARY,


### PR DESCRIPTION
Adds structured live-event visibility for hourly exchange config/markets refresh results without changing maintenance behavior.\n\nScope:\n- new off-console/text event type: exchange.config_refresh\n- best-effort emitter with sanitized error payloads\n- hourly maintainance init_markets wrapper emits succeeded/failed events and re-raises original errors\n- registry docs and focused tests\n\nValidation:\n- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_exchange_config_refresh_event.py tests/test_live_event_bus.py tests/test_live_event_registry_docs.py -> 41 passed\n- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py src/live/event_emitters.py src/passivbot.py tests/test_exchange_config_refresh_event.py\n- git diff --check