### PR TITLE
Record exchange config refresh event progress

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-30.
 
 Current `origin/v8` logging-overhaul head:
 
-- `7e7ce16f3` after PR #892, `Add live-event query level filter`.
+- `796ceb389` after PR #894, `Emit exchange config refresh events`.
 
 Current review gate:
 
@@ -49,6 +49,29 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #894 at `796ceb38`.
+- PR #894 added the off-console/text structured event
+  `exchange.config_refresh` for hourly maintenance `init_markets` refresh
+  success/failure. Failures carry bounded sanitized error text, `error_type`,
+  `context=maintain_hourly_cycle`, `operation=init_markets`, elapsed timing,
+  and distinct success/failure reason codes. The wrapper re-raises the original
+  exception and has an extra best-effort guard so event emission cannot mask
+  refresh success or the original refresh failure.
+- PR #894 passed the normal review gate: Claude approved, Hermes approved, and
+  CI was green. Local validation covered
+  `tests/test_exchange_config_refresh_event.py`, `tests/test_live_event_bus.py`,
+  `tests/test_live_event_registry_docs.py`, py_compile for touched Python
+  files, and `git diff --check`.
+- After deploying PR #894 to VPS5, the bots were not restarted. All five
+  configured `passivbot live` processes remained running on the previously
+  loaded Python code while the repository was fast-forwarded to `796ceb38`.
+  Live emission evidence for `exchange.config_refresh` therefore remains
+  pending until the next planned bot restart and hourly maintenance cycle.
+- Repository pulled through PR #893 at `3be95aca`.
+- PR #893 was docs-only progress/backlog tracking for the PR #892 deploy and
+  the discovered Binance hourly hedge-mode/config-refresh traceback gap.
+  No bot restart or smoke was needed beyond confirming all five configured
+  `passivbot live` processes remained running.
 - Repository pulled through PR #892 at `7e7ce16f`.
 - PR #892 added read-only `passivbot tool live-event-query --level`, so local
   structured monitor-event queries can be scoped by envelope severity and

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -578,7 +578,8 @@ Related detailed plans:
       remain unavailable instead of receiving synthetic ranking tails.
 
 18. [ ] Binance hourly hedge-mode/config refresh traceback classification.
-    Status: open.
+    Status: first structured-event slice merged; smoke/report classification
+    remains open.
 
     VPS5 smoke after PR #892 deployed to `v8@7e7ce16f` returned hard-red from
     a non-risk text-log traceback in the Binance bot while all five live
@@ -601,6 +602,17 @@ Related detailed plans:
     maintenance refresh; add a structured `exchange.config_refresh` or similar
     event if the path remains in live; and adjust smoke/report classification
     only after the event contract makes criticality explicit.
+
+    Work log:
+    - 2026-06-30: PR #894 added off-console/text structured
+      `exchange.config_refresh` events around hourly maintenance
+      `init_markets` refresh success/failure. The event includes bounded
+      sanitized failure text, `error_type`, context/operation labels, elapsed
+      timing, and distinct reason codes while re-raising original refresh
+      exceptions. VPS5 was pulled to `796ceb38`, but bots were not restarted,
+      so live emission evidence is pending. Follow-up classification should use
+      the structured event and must avoid down-classifying startup-required
+      config or order-construction failures.
 
 ## Merged Work Log
 
@@ -679,6 +691,7 @@ Related detailed plans:
 | 2026-06-30 | #3 Live restart/smoke automation | PR #888 / `4b435d33` | Exposed bounded text-log window counters in `live-smoke-report --brief`; VPS5 5-minute smoke stayed hard-green and showed `logs.window.lines_skipped_before=1730` | Safe pull/stop/start orchestration remains open |
 | 2026-06-30 | #3 Live restart/smoke automation | PR #890 / `1498abc9` | Exposed `event_window.enabled` in `live-smoke-report --brief`; VPS5 5-minute smoke stayed hard-green and showed `event_window.enabled=true` | Safe pull/stop/start orchestration remains open |
 | 2026-06-30 | #2 Event query and timeline CLI extensions | PR #892 / `7e7ce16f` | Added `live-event-query --level` filtering for structured event severity; VPS5 query smoke matched 33 warning-level events with `ok=true` and all five bots still running | Cross-bot incident workflow remains open; Binance config-refresh traceback classification added as item #18 |
+| 2026-06-30 | #18 Binance hourly hedge-mode/config refresh classification | PR #894 / `796ceb38` | Added off-console/text `exchange.config_refresh` events for hourly maintenance refresh success/failure with sanitized bounded error fields and fail-loud behavior preserved | Live emission evidence after next bot restart; smoke/report classification remains open |
 
 ## Suggested Priority
 


### PR DESCRIPTION
Docs-only progress/backlog update after PR #894.\n\nScope:\n- update live logging progress head/deploy evidence through #894\n- mark backlog #18 as first structured-event slice merged, with smoke/report classification still open\n- record that VPS5 was pulled to 796ceb38 and bots were left running without restart\n\nValidation:\n- git diff --check