### PR TITLE
Record HSL brief smoke deploy evidence

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,8 +19,8 @@ Last updated: 2026-06-30.
 
 Current `origin/v8` logging-overhaul head:
 
-- `aebc3667f` after PR #897, `Record exchange config refresh smoke
-  projection`.
+- `e1fcb038c` after PR #899, `Show active HSL replay age in brief
+  smoke`.
 
 Current review gate:
 
@@ -50,6 +50,32 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #899 at `e1fcb038`.
+- PR #898 was docs-only retuned-loop progress tracking. PR #899 added a
+  read-only `live-smoke-report --brief` projection for the worst active HSL
+  replay elapsed time, latest-event age, and active stage counts from existing
+  sanitized HSL replay groups. PR #899 does not add event producers, exchange
+  calls, cache mutation, readiness gates, smoke verdict changes, console
+  routing, order/risk logic, or trading behavior.
+- PR #899 had one reviewer finding on the first head: the brief
+  `max_active_latest_elapsed_ms` field under-reported active replay time by
+  reading only `latest_elapsed_ms`. The final head fixed this by taking the
+  maximum across the bounded HSL elapsed fields already exposed by the summary
+  projection, and updated the regression test. Hermes approved the fixed head;
+  CI was green. Claude posted comment-type approvals on both final heads, but
+  not formal `APPROVED`-state reviews, so PR #898 and PR #899 used the
+  degraded low-risk docs/tooling gate.
+- VPS5 pulled from `aebc3667` to `e1fcb038` without bot restart because the
+  deployed changes were docs plus read-only smoke-report projection code. The
+  five configured bots were left running.
+- A fresh 2-minute brief smoke after the pull reported `ok=true`,
+  `hard_failures=0`, `logs.hard_matches=0`, `matched_expected=5`,
+  `missing_expected_count=0`, clean tracked repository state at `e1fcb038`,
+  `remote_calls.failed=0`, and
+  `account_critical_remote_calls.failed=0`. The short sampled window had
+  `hsl_replay.active_bots=0`, so the new active HSL replay brief fields were
+  not populated by live data in that smoke. Local tests and Hermes review
+  validated the active-HSL fixture path.
 - Repository pulled through PR #897 at `aebc3667`.
 - PR #897 was docs-only progress/backlog tracking for the
   `exchange.config_refresh` smoke projection and did not change runtime code.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -116,6 +116,11 @@ Related detailed plans:
      entered cooldown. This is a second post-restart exchange/account example
      of the same latency pattern and strengthens the case for a position-first
      protective classification path before full cooldown replay completes.
+   - 2026-06-30: PR #899 added read-only `live-smoke-report --brief`
+     projection of the worst active HSL replay elapsed time, latest-event age,
+     and stage counts from existing sanitized HSL replay groups. This does not
+     reduce startup latency or change trading behavior, but it makes repeated
+     smoke loops surface active replay latency without opening the full report.
 
 1. [x] Incident bundle generator.
    Status: initial implementation plus trace-report integration merged.
@@ -238,6 +243,12 @@ Related detailed plans:
      configured bots running. This adds another concrete data point for
      per-bot shutdown timing, current-phase attribution, and a bounded
      escalation ladder in future restart automation.
+   - 2026-06-30: PR #899 added worst-active-HSL replay elapsed/event-age/stage
+     counters to `live-smoke-report --brief`, so short operator smoke loops can
+     see whether startup HSL replay is still active and how old the active
+     stage evidence is. VPS5 deploy smoke at `e1fcb038` was green, but its
+     sampled window had `hsl_replay.active_bots=0`, so the active fields were
+     not populated by live data in that run.
 
    Remaining refinements: safe pull/stop/start orchestration remains open.
    The concise and brief summaries are intentionally bounded; further changes
@@ -663,6 +674,8 @@ Related detailed plans:
 
 | Date | Item | PR / Commit | Result | Remaining |
 |------|------|-------------|--------|-----------|
+| 2026-06-30 | #0/#3 HSL replay/startup smoke evidence | PR #899 / `e1fcb038` | Added `live-smoke-report --brief` projection for worst active HSL replay elapsed time, latest-event age, and active stage counts from existing sanitized groups; VPS5 no-restart smoke stayed green after deploy | HSL startup latency remains a trading-path optimization; this slice only surfaces active replay latency in brief smoke |
+| 2026-06-30 | Logging loop scope/progress tracking | PR #898 / `05c48b5` | Recorded the retuned logging-loop boundary: backlog work is in-loop only when it helps diagnostics, smoke evidence, incident reconstruction, or logging-overhaul validation | Continue keeping scope decisions and deploy evidence current as the loop proceeds |
 | 2026-06-30 | #0/#3/#18 Progress and evidence tracking | PR #897 / `aebc3667` | Recorded exchange-config-refresh smoke projection evidence; VPS5 was then restarted so live processes loaded the producer/projection, with a green settled smoke and a wider real HSL ZEC cooldown window | Prove `exchange.config_refresh` during an hourly refresh; implement HSL startup latency and safe restart orchestration separately |
 | 2026-06-25 | #1 Incident bundle generator | PR #641 / `e1f99002` | Added `passivbot tool live-incident-bundle`; bundle smoke on VPS5 created an archive with redacted monitor/config evidence | Supervisor/process status and tighter remote smoke integration |
 | 2026-06-25 | #2 Event query and timeline CLI extensions | PR #638 / `1b15b2d5` | Added broader live event query filters | More ID scopes still needed at that point |


### PR DESCRIPTION
## Summary
- Update logging-overhaul progress to current v8 head after PR #899.
- Record review/deploy evidence for PR #898/#899, including degraded low-risk gate context.
- Add backlog entries showing PR #899 is observability-only: brief smoke now exposes worst active HSL replay elapsed/event age/stage counts when an active HSL replay is present.

## Validation
- git diff --check

## Runtime evidence
- VPS5 pulled to e1fcb038 after PR #899.
- No bot restart because changes were docs plus read-only smoke-report projection code.
- 2-minute brief smoke: ok=true, hard_failures=0, logs.hard_matches=0, matched_expected=5, missing_expected_count=0, remote_calls.failed=0, account_critical_remote_calls.failed=0, tracked repo clean.
- Sampled window had hsl_replay.active_bots=0, so the new active-HSL brief fields were not populated by live data in that smoke.