### PR TITLE
Record completed HSL brief smoke deploy evidence

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-30.
 
 Current `origin/v8` logging-overhaul head:
 
-- `e1fcb038c` after PR #899, `Show active HSL replay age in brief
+- `9b3c29adb` after PR #901, `Show completed HSL replay time in brief
   smoke`.
 
 Current review gate:
@@ -50,6 +50,27 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #901 at `9b3c29ad`.
+- PR #901 added a read-only `live-smoke-report --brief` projection for
+  `hsl_replay.max_completed_elapsed_ms`, derived only from existing sanitized
+  completed HSL replay groups and the same bounded elapsed-field policy used
+  for active replay timing. The slice does not add event producers, exchange
+  calls, cache mutation, readiness gates, smoke verdict changes, console
+  routing, order/risk logic, or trading behavior.
+- PR #901 passed Claude + Hermes + CI. Local validation covered the focused HSL
+  replay smoke-report regression, the full `tests/test_live_smoke_report.py`
+  suite, py_compile for touched files, `git diff --check`, and a
+  touched-file silent-handling scan.
+- VPS5 pulled from `e1fcb038` to `9b3c29ad` without bot restart because the
+  deployed change was read-only smoke-report projection code. The five
+  configured bots were left running.
+- A fresh 2-minute brief smoke after the pull reported `ok=true`,
+  `hard_failures=0`, `logs.hard_matches=0`, `matched_expected=5`,
+  `missing_expected_count=0`, clean tracked repository state at `9b3c29ad`,
+  `remote_calls.failed=0`, and
+  `account_critical_remote_calls.failed=0`. The short sampled window had
+  `hsl_replay.total=0`, so the new completed-HSL replay brief field was not
+  populated by live data in that smoke.
 - Repository pulled through PR #899 at `e1fcb038`.
 - PR #898 was docs-only retuned-loop progress tracking. PR #899 added a
   read-only `live-smoke-report --brief` projection for the worst active HSL

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -121,6 +121,11 @@ Related detailed plans:
      and stage counts from existing sanitized HSL replay groups. This does not
      reduce startup latency or change trading behavior, but it makes repeated
      smoke loops surface active replay latency without opening the full report.
+   - 2026-06-30: PR #901 added read-only `live-smoke-report --brief`
+     projection of the worst completed HSL replay elapsed time from existing
+     sanitized completed replay groups. This keeps settled post-replay smoke
+     useful after `active_bots` falls back to zero, while still leaving the
+     actual HSL startup latency optimization open.
 
 1. [x] Incident bundle generator.
    Status: initial implementation plus trace-report integration merged.
@@ -674,6 +679,7 @@ Related detailed plans:
 
 | Date | Item | PR / Commit | Result | Remaining |
 |------|------|-------------|--------|-----------|
+| 2026-06-30 | #0/#3 HSL completed replay smoke evidence | PR #901 / `9b3c29ad` | Added `hsl_replay.max_completed_elapsed_ms` to `live-smoke-report --brief`; VPS5 no-restart smoke stayed green after deploy, with no HSL replay events in the sampled window | HSL startup latency remains a trading-path optimization; this slice only surfaces completed replay latency when completed replay events are in-window |
 | 2026-06-30 | #0/#3 HSL replay/startup smoke evidence | PR #899 / `e1fcb038` | Added `live-smoke-report --brief` projection for worst active HSL replay elapsed time, latest-event age, and active stage counts from existing sanitized groups; VPS5 no-restart smoke stayed green after deploy | HSL startup latency remains a trading-path optimization; this slice only surfaces active replay latency in brief smoke |
 | 2026-06-30 | Logging loop scope/progress tracking | PR #898 / `05c48b5` | Recorded the retuned logging-loop boundary: backlog work is in-loop only when it helps diagnostics, smoke evidence, incident reconstruction, or logging-overhaul validation | Continue keeping scope decisions and deploy evidence current as the loop proceeds |
 | 2026-06-30 | #0/#3/#18 Progress and evidence tracking | PR #897 / `aebc3667` | Recorded exchange-config-refresh smoke projection evidence; VPS5 was then restarted so live processes loaded the producer/projection, with a green settled smoke and a wider real HSL ZEC cooldown window | Prove `exchange.config_refresh` during an hourly refresh; implement HSL startup latency and safe restart orchestration separately |


### PR DESCRIPTION
## Summary
- Update logging-overhaul progress to current v8 head after PR #901.
- Record PR #901 review/deploy evidence and VPS5 no-restart smoke result.
- Add backlog work-log entries noting that completed HSL replay elapsed time is now visible in brief smoke when completed replay events are in-window.

## Validation
- `git diff --check`

## Runtime evidence
- VPS5 pulled to `9b3c29ad`.
- No bot restart because the merged change was read-only smoke-report projection code.
- 2-minute brief smoke: `ok=true`, `hard_failures=0`, `logs.hard_matches=0`, `matched_expected=5`, `missing_expected_count=0`, `remote_calls.failed=0`, `account_critical_remote_calls.failed=0`, tracked repo clean.
- Sampled window had `hsl_replay.total=0`, so the new completed-HSL brief field was not populated by live data in that smoke.
