### PR TITLE
Record HSL status smoke deploy evidence

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,8 +19,7 @@ Last updated: 2026-06-30.
 
 Current `origin/v8` logging-overhaul head:
 
-- `9b3c29adb` after PR #901, `Show completed HSL replay time in brief
-  smoke`.
+- `1dd115ccd` after PR #903, `Summarize HSL status in smoke reports`.
 
 Current review gate:
 
@@ -50,6 +49,32 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #903 at `1dd115cc`.
+- PR #903 added read-only `risk_events.hsl_status` projections to
+  `live-smoke-report` full, summary, and brief output, derived only from
+  existing `hsl.status` monitor events. The projection summarizes HSL status
+  totals, bot/symbol counts, tier counts, signal-mode counts, and bounded
+  closest-to-red labels.
+- PR #903 fixed issue #904 before merge by filtering shareable summary
+  `risk_events.groups[].latest_data` through a fixed value-safe whitelist.
+  Shareable summary and brief reports do not expose raw drawdown, distance, or
+  threshold magnitudes; the local full report keeps detailed HSL magnitudes for
+  local diagnostics.
+- PR #903 passed Claude + Hermes + CI. Local validation covered the focused
+  risk smoke-report regression, the full `tests/test_live_smoke_report.py`
+  suite, py_compile for touched files, `git diff --check`, and a touched-file
+  silent-handling scan.
+- VPS5 pulled from `852d4b89` to `1dd115cc` without bot restart because the
+  deployed change was read-only smoke-report projection code. The five
+  configured bots were left running.
+- A fresh 2-minute brief smoke after the pull reported `ok=true`,
+  `hard_failures=0`, `logs.hard_matches=0`, `matched_expected=5`,
+  `missing_expected_count=0`, clean tracked repository state at `1dd115cc`,
+  `remote_calls.failed=0`, and
+  `account_critical_remote_calls.failed=0`. The brief report included
+  `risk_events.hsl_status` with `tier_counts={"red":4}`, `bots=3`, and a
+  bounded symbol sample of `ZEC/USDT:USDT`; no magnitude fields were present in
+  the shareable brief output.
 - Repository pulled through PR #901 at `9b3c29ad`.
 - PR #901 added a read-only `live-smoke-report --brief` projection for
   `hsl_replay.max_completed_elapsed_ms`, derived only from existing sanitized

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -126,6 +126,11 @@ Related detailed plans:
      sanitized completed replay groups. This keeps settled post-replay smoke
      useful after `active_bots` falls back to zero, while still leaving the
      actual HSL startup latency optimization open.
+   - 2026-06-30: PR #903 added read-only `live-smoke-report`
+     `risk_events.hsl_status` projections from existing `hsl.status` monitor
+     events, with value-safe shareable summary/brief output. This makes current
+     HSL tier/symbol/bot status visible in smoke loops, but does not reduce
+     startup replay latency or change panic/cooldown behavior.
 
 1. [x] Incident bundle generator.
    Status: initial implementation plus trace-report integration merged.
@@ -425,7 +430,8 @@ Related detailed plans:
     burst warning into a structured `health.summary` event without changing
     console volume or restart/backoff behavior. PR #707 added a throttled
     console projection for active coin-mode HSL positions using existing
-    `hsl.status` distance-to-red metrics.
+    `hsl.status` distance-to-red metrics. PR #903 made HSL status visible in
+    smoke reports from the same event source without increasing console noise.
 
     Continue moving console output to be a projection of structured events.
     Default console should focus on fills, positions, balance, order writes,
@@ -434,6 +440,10 @@ Related detailed plans:
     they directly explain a blocked trading action.
 
     Work log:
+    - 2026-06-30: Added value-safe `live-smoke-report` HSL status projections
+      for full, summary, and brief reports. The local full report keeps HSL
+      magnitudes for diagnostics; shareable summary/brief output strips raw
+      drawdown, distance, and threshold values.
     - 2026-06-26: Added periodic `[risk] HSL[pside:symbol] status` console
       lines for active coin-mode HSL positions, including distance to red,
       drawdown, slot budget, realized PnL peak, and unrealized PnL. The
@@ -679,6 +689,7 @@ Related detailed plans:
 
 | Date | Item | PR / Commit | Result | Remaining |
 |------|------|-------------|--------|-----------|
+| 2026-06-30 | #0/#3/#10 HSL status smoke evidence | PR #903 / `1dd115cc` | Added `risk_events.hsl_status` to `live-smoke-report` full, summary, and brief output from existing `hsl.status` events; fixed #904 by filtering shareable summary risk `latest_data` through a value-safe whitelist; VPS5 no-restart smoke stayed green and showed red HSL status counts for ZEC without magnitude fields in brief output | Actual HSL startup latency optimization remains open; broader event-driven console redesign remains open |
 | 2026-06-30 | #0/#3 HSL completed replay smoke evidence | PR #901 / `9b3c29ad` | Added `hsl_replay.max_completed_elapsed_ms` to `live-smoke-report --brief`; VPS5 no-restart smoke stayed green after deploy, with no HSL replay events in the sampled window | HSL startup latency remains a trading-path optimization; this slice only surfaces completed replay latency when completed replay events are in-window |
 | 2026-06-30 | #0/#3 HSL replay/startup smoke evidence | PR #899 / `e1fcb038` | Added `live-smoke-report --brief` projection for worst active HSL replay elapsed time, latest-event age, and active stage counts from existing sanitized groups; VPS5 no-restart smoke stayed green after deploy | HSL startup latency remains a trading-path optimization; this slice only surfaces active replay latency in brief smoke |
 | 2026-06-30 | Logging loop scope/progress tracking | PR #898 / `05c48b5` | Recorded the retuned logging-loop boundary: backlog work is in-loop only when it helps diagnostics, smoke evidence, incident reconstruction, or logging-overhaul validation | Continue keeping scope decisions and deploy evidence current as the loop proceeds |


### PR DESCRIPTION
## Summary
- update the logging-overhaul progress ledger to current v8 head after PR #903
- record the #904 value-safety fix and VPS5 no-restart smoke evidence
- update the live-ops backlog work log for HSL status smoke visibility

## Validation
- git diff --check

Docs-only progress tracking; no runtime code or trading behavior changed.