### PR TITLE
Filter live events by envelope fields

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,8 +19,7 @@ Last updated: 2026-06-30.
 
 Current `origin/v8` logging-overhaul head:
 
-- `9b3c29adb` after PR #901, `Show completed HSL replay time in brief
-  smoke`.
+- `1dd115ccd` after PR #903, `Summarize HSL status in smoke reports`.
 
 Current review gate:
 
@@ -50,6 +49,32 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #903 at `1dd115cc`.
+- PR #903 added read-only `risk_events.hsl_status` projections to
+  `live-smoke-report` full, summary, and brief output, derived only from
+  existing `hsl.status` monitor events. The projection summarizes HSL status
+  totals, bot/symbol counts, tier counts, signal-mode counts, and bounded
+  closest-to-red labels.
+- PR #903 fixed issue #904 before merge by filtering shareable summary
+  `risk_events.groups[].latest_data` through a fixed value-safe whitelist.
+  Shareable summary and brief reports do not expose raw drawdown, distance, or
+  threshold magnitudes; the local full report keeps detailed HSL magnitudes for
+  local diagnostics.
+- PR #903 passed Claude + Hermes + CI. Local validation covered the focused
+  risk smoke-report regression, the full `tests/test_live_smoke_report.py`
+  suite, py_compile for touched files, `git diff --check`, and a touched-file
+  silent-handling scan.
+- VPS5 pulled from `852d4b89` to `1dd115cc` without bot restart because the
+  deployed change was read-only smoke-report projection code. The five
+  configured bots were left running.
+- A fresh 2-minute brief smoke after the pull reported `ok=true`,
+  `hard_failures=0`, `logs.hard_matches=0`, `matched_expected=5`,
+  `missing_expected_count=0`, clean tracked repository state at `1dd115cc`,
+  `remote_calls.failed=0`, and
+  `account_critical_remote_calls.failed=0`. The brief report included
+  `risk_events.hsl_status` with `tier_counts={"red":4}`, `bots=3`, and a
+  bounded symbol sample of `ZEC/USDT:USDT`; no magnitude fields were present in
+  the shareable brief output.
 - Repository pulled through PR #901 at `9b3c29ad`.
 - PR #901 added a read-only `live-smoke-report --brief` projection for
   `hsl_replay.max_completed_elapsed_ms`, derived only from existing sanitized

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -126,6 +126,11 @@ Related detailed plans:
      sanitized completed replay groups. This keeps settled post-replay smoke
      useful after `active_bots` falls back to zero, while still leaving the
      actual HSL startup latency optimization open.
+   - 2026-06-30: PR #903 added read-only `live-smoke-report`
+     `risk_events.hsl_status` projections from existing `hsl.status` monitor
+     events, with value-safe shareable summary/brief output. This makes current
+     HSL tier/symbol/bot status visible in smoke loops, but does not reduce
+     startup replay latency or change panic/cooldown behavior.
 
 1. [x] Incident bundle generator.
    Status: initial implementation plus trace-report integration merged.
@@ -425,7 +430,8 @@ Related detailed plans:
     burst warning into a structured `health.summary` event without changing
     console volume or restart/backoff behavior. PR #707 added a throttled
     console projection for active coin-mode HSL positions using existing
-    `hsl.status` distance-to-red metrics.
+    `hsl.status` distance-to-red metrics. PR #903 made HSL status visible in
+    smoke reports from the same event source without increasing console noise.
 
     Continue moving console output to be a projection of structured events.
     Default console should focus on fills, positions, balance, order writes,
@@ -434,6 +440,10 @@ Related detailed plans:
     they directly explain a blocked trading action.
 
     Work log:
+    - 2026-06-30: Added value-safe `live-smoke-report` HSL status projections
+      for full, summary, and brief reports. The local full report keeps HSL
+      magnitudes for diagnostics; shareable summary/brief output strips raw
+      drawdown, distance, and threshold values.
     - 2026-06-26: Added periodic `[risk] HSL[pside:symbol] status` console
       lines for active coin-mode HSL positions, including distance to red,
       drawdown, slot budget, realized PnL peak, and unrealized PnL. The
@@ -679,6 +689,7 @@ Related detailed plans:
 
 | Date | Item | PR / Commit | Result | Remaining |
 |------|------|-------------|--------|-----------|
+| 2026-06-30 | #0/#3/#10 HSL status smoke evidence | PR #903 / `1dd115cc` | Added `risk_events.hsl_status` to `live-smoke-report` full, summary, and brief output from existing `hsl.status` events; fixed #904 by filtering shareable summary risk `latest_data` through a value-safe whitelist; VPS5 no-restart smoke stayed green and showed red HSL status counts for ZEC without magnitude fields in brief output | Actual HSL startup latency optimization remains open; broader event-driven console redesign remains open |
 | 2026-06-30 | #0/#3 HSL completed replay smoke evidence | PR #901 / `9b3c29ad` | Added `hsl_replay.max_completed_elapsed_ms` to `live-smoke-report --brief`; VPS5 no-restart smoke stayed green after deploy, with no HSL replay events in the sampled window | HSL startup latency remains a trading-path optimization; this slice only surfaces completed replay latency when completed replay events are in-window |
 | 2026-06-30 | #0/#3 HSL replay/startup smoke evidence | PR #899 / `e1fcb038` | Added `live-smoke-report --brief` projection for worst active HSL replay elapsed time, latest-event age, and active stage counts from existing sanitized groups; VPS5 no-restart smoke stayed green after deploy | HSL startup latency remains a trading-path optimization; this slice only surfaces active replay latency in brief smoke |
 | 2026-06-30 | Logging loop scope/progress tracking | PR #898 / `05c48b5` | Recorded the retuned logging-loop boundary: backlog work is in-loop only when it helps diagnostics, smoke evidence, incident reconstruction, or logging-overhaul validation | Continue keeping scope decisions and deploy evidence current as the loop proceeds |

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -264,6 +264,8 @@ def _filter_report(
     psides: set[str],
     reason_codes: set[str],
     statuses: set[str],
+    sources: set[str],
+    components: set[str],
     tags: set[str],
     data_eq_filters: dict[str, set[str]],
     since_ms: int | None = None,
@@ -306,6 +308,10 @@ def _filter_report(
         filters["reason_codes"] = sorted(reason_codes)
     if statuses:
         filters["statuses"] = sorted(statuses)
+    if sources:
+        filters["sources"] = sorted(sources)
+    if components:
+        filters["components"] = sorted(components)
     if tags:
         filters["tags"] = sorted(tags)
     if data_eq_filters:
@@ -335,6 +341,7 @@ def _compact_record(
         "level": live_event.get("level"),
         "status": live_event.get("status"),
         "reason_code": live_event.get("reason_code"),
+        "source": live_event.get("source"),
         "component": live_event.get("component"),
         "exchange": exchange or live_event.get("exchange") or row.get("exchange"),
         "user": user or live_event.get("user") or row.get("user"),
@@ -990,6 +997,8 @@ def build_event_report(
     pside: str | Iterable[str] | None = None,
     reason_code: str | Iterable[str] | None = None,
     status: str | Iterable[str] | None = None,
+    source: str | Iterable[str] | None = None,
+    component: str | Iterable[str] | None = None,
     tag: str | Iterable[str] | None = None,
     data_eq: str | Iterable[str] | None = None,
     since_ms: int | None = None,
@@ -1091,6 +1100,8 @@ def build_event_report(
     pside_filter = _normalize_filter_values(pside)
     reason_code_filter = _normalize_filter_values(reason_code)
     status_filter = _normalize_filter_values(status)
+    source_filter = _normalize_filter_values(source)
+    component_filter = _normalize_filter_values(component)
     tag_filter = _normalize_filter_values(tag)
     data_eq_filters = _normalize_data_eq_filters(data_eq)
     has_non_cycle_filter = any(
@@ -1110,6 +1121,8 @@ def build_event_report(
             pside_filter,
             reason_code_filter,
             status_filter,
+            source_filter,
+            component_filter,
             tag_filter,
             data_eq_filters,
         )
@@ -1231,6 +1244,8 @@ def build_event_report(
                     record_pside = live_event.get("pside") or row.get("pside")
                     record_status = live_event.get("status")
                     record_reason_code = live_event.get("reason_code")
+                    record_source = live_event.get("source")
+                    record_component = live_event.get("component")
                     record_tags = _event_tags(row, live_event)
                     path_scope = _monitor_path_exchange_user(path)
                     record_exchange = live_event.get("exchange") or row.get("exchange")
@@ -1275,6 +1290,10 @@ def build_event_report(
                         record_reason_code, reason_code_filter
                     )
                     status_matches = _filter_matches(record_status, status_filter)
+                    source_matches = _filter_matches(record_source, source_filter)
+                    component_matches = _filter_matches(
+                        record_component, component_filter
+                    )
                     tag_matches = not tag_filter or bool(
                         set(record_tags).intersection(tag_filter)
                     )
@@ -1296,6 +1315,8 @@ def build_event_report(
                         and pside_matches
                         and reason_code_matches
                         and status_matches
+                        and source_matches
+                        and component_matches
                         and tag_matches
                         and data_matches
                     )
@@ -1428,6 +1449,8 @@ def build_event_report(
             psides=pside_filter,
             reason_codes=reason_code_filter,
             statuses=status_filter,
+            sources=source_filter,
+            components=component_filter,
             tags=tag_filter,
             data_eq_filters=data_eq_filters,
             since_ms=since_filter,
@@ -1467,6 +1490,8 @@ def build_event_report(
             psides=pside_filter,
             reason_codes=reason_code_filter,
             statuses=status_filter,
+            sources=source_filter,
+            components=component_filter,
             tags=tag_filter,
             data_eq_filters=data_eq_filters,
             since_ms=since_filter,

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -262,6 +262,7 @@ def _filter_report(
     remote_call_group_ids: set[str],
     symbols: set[str],
     psides: set[str],
+    sides: set[str],
     reason_codes: set[str],
     statuses: set[str],
     sources: set[str],
@@ -304,6 +305,8 @@ def _filter_report(
         filters["symbols"] = sorted(symbols)
     if psides:
         filters["psides"] = sorted(psides)
+    if sides:
+        filters["sides"] = sorted(sides)
     if reason_codes:
         filters["reason_codes"] = sorted(reason_codes)
     if statuses:
@@ -995,6 +998,7 @@ def build_event_report(
     remote_call_group_id: str | Iterable[str] | None = None,
     symbol: str | Iterable[str] | None = None,
     pside: str | Iterable[str] | None = None,
+    side: str | Iterable[str] | None = None,
     reason_code: str | Iterable[str] | None = None,
     status: str | Iterable[str] | None = None,
     source: str | Iterable[str] | None = None,
@@ -1098,6 +1102,7 @@ def build_event_report(
     remote_call_group_filter = _normalize_filter_values(remote_call_group_id)
     symbol_filter = _normalize_filter_values(symbol)
     pside_filter = _normalize_filter_values(pside)
+    side_filter = _normalize_filter_values(side)
     reason_code_filter = _normalize_filter_values(reason_code)
     status_filter = _normalize_filter_values(status)
     source_filter = _normalize_filter_values(source)
@@ -1119,6 +1124,7 @@ def build_event_report(
             remote_call_group_filter,
             symbol_filter,
             pside_filter,
+            side_filter,
             reason_code_filter,
             status_filter,
             source_filter,
@@ -1242,6 +1248,7 @@ def build_event_report(
 
                     record_symbol = live_event.get("symbol") or row.get("symbol")
                     record_pside = live_event.get("pside") or row.get("pside")
+                    record_side = live_event.get("side")
                     record_status = live_event.get("status")
                     record_reason_code = live_event.get("reason_code")
                     record_source = live_event.get("source")
@@ -1286,6 +1293,7 @@ def build_event_report(
                     )
                     symbol_matches = _filter_matches(record_symbol, symbol_filter)
                     pside_matches = _filter_matches(record_pside, pside_filter)
+                    side_matches = _filter_matches(record_side, side_filter)
                     reason_code_matches = _filter_matches(
                         record_reason_code, reason_code_filter
                     )
@@ -1313,6 +1321,7 @@ def build_event_report(
                         and remote_call_group_matches
                         and symbol_matches
                         and pside_matches
+                        and side_matches
                         and reason_code_matches
                         and status_matches
                         and source_matches
@@ -1447,6 +1456,7 @@ def build_event_report(
             remote_call_group_ids=remote_call_group_filter,
             symbols=symbol_filter,
             psides=pside_filter,
+            sides=side_filter,
             reason_codes=reason_code_filter,
             statuses=status_filter,
             sources=source_filter,
@@ -1488,6 +1498,7 @@ def build_event_report(
             remote_call_group_ids=remote_call_group_filter,
             symbols=symbol_filter,
             psides=pside_filter,
+            sides=side_filter,
             reason_codes=reason_code_filter,
             statuses=status_filter,
             sources=source_filter,

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -144,6 +144,22 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--source",
+        action="append",
+        help=(
+            "Return compact records matching one event source. May be repeated "
+            "or comma-separated."
+        ),
+    )
+    parser.add_argument(
+        "--component",
+        action="append",
+        help=(
+            "Return compact records matching one event component. May be repeated "
+            "or comma-separated."
+        ),
+    )
+    parser.add_argument(
         "--tag",
         action="append",
         help=(
@@ -274,6 +290,8 @@ def main(argv: list[str] | None = None) -> int:
             pside=args.pside,
             reason_code=args.reason_code,
             status=args.status,
+            source=args.source,
+            component=args.component,
             tag=args.tag,
             data_eq=args.data_eq,
             since_ms=since_ms,

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -128,6 +128,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Return compact records matching one position side. May be repeated or comma-separated.",
     )
     parser.add_argument(
+        "--side",
+        action="append",
+        help="Return compact records matching one order side. May be repeated or comma-separated.",
+    )
+    parser.add_argument(
         "--reason-code",
         action="append",
         help=(
@@ -288,6 +293,7 @@ def main(argv: list[str] | None = None) -> int:
             remote_call_group_id=args.remote_call_group_id,
             symbol=args.symbol,
             pside=args.pside,
+            side=args.side,
             reason_code=args.reason_code,
             status=args.status,
             source=args.source,

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -502,6 +502,7 @@ def test_event_query_filters_by_source_and_component(tmp_path):
                 ts=1000,
                 source="executor",
                 component="order_wave",
+                side="buy",
             ),
             _monitor_row(
                 event_type="candle.tail_projected",
@@ -518,6 +519,7 @@ def test_event_query_filters_by_source_and_component(tmp_path):
                 ts=1200,
                 source="executor",
                 component="order_wave",
+                side="sell",
             ),
         ],
     )
@@ -527,18 +529,21 @@ def test_event_query_filters_by_source_and_component(tmp_path):
         cycle_id="cy_1",
         source="executor",
         component="order_wave",
+        side="buy",
     )
 
     assert report["ok"] is True
     assert report["cycle"]["filters"] == {
         "components": ["order_wave"],
         "cycle_id": "cy_1",
+        "sides": ["buy"],
         "sources": ["executor"],
     }
     assert report["cycle"]["matched_events"] == 1
     assert report["cycle"]["events"][0]["event_type"] == "execution.create_sent"
     assert report["cycle"]["events"][0]["source"] == "executor"
     assert report["cycle"]["events"][0]["component"] == "order_wave"
+    assert report["cycle"]["events"][0]["side"] == "buy"
 
 
 def test_event_query_filters_by_top_level_data_fields(tmp_path):
@@ -1366,6 +1371,7 @@ def test_live_event_query_cli_accepts_scope_filters_and_timeline(tmp_path, capsy
                 ts=1000,
                 symbol="SOL/USDT:USDT",
                 pside="short",
+                side="sell",
                 status="failed",
                 reason_code="exchange_exception",
                 source="executor",
@@ -1379,6 +1385,7 @@ def test_live_event_query_cli_accepts_scope_filters_and_timeline(tmp_path, capsy
                 ts=1100,
                 symbol="SOL/USDT:USDT",
                 pside="short",
+                side="buy",
                 status="succeeded",
                 reason_code="exchange_acknowledged",
                 source="executor",
@@ -1398,6 +1405,8 @@ def test_live_event_query_cli_accepts_scope_filters_and_timeline(tmp_path, capsy
                 "SOL/USDT:USDT",
                 "--pside",
                 "short",
+                "--side",
+                "sell",
                 "--status",
                 "failed",
                 "--reason-code",
@@ -1418,6 +1427,7 @@ def test_live_event_query_cli_accepts_scope_filters_and_timeline(tmp_path, capsy
         "components": ["order_wave"],
         "psides": ["short"],
         "reason_codes": ["exchange_exception"],
+        "sides": ["sell"],
         "sources": ["executor"],
         "statuses": ["failed"],
         "symbols": ["SOL/USDT:USDT"],
@@ -1426,7 +1436,7 @@ def test_live_event_query_cli_accepts_scope_filters_and_timeline(tmp_path, capsy
     assert report["query"]["timeline"] == [
         (
             "1000 seq=1 execution.cancel_failed status=failed "
-            "reason_code=exchange_exception symbol=SOL/USDT:USDT pside=short "
+            "reason_code=exchange_exception symbol=SOL/USDT:USDT pside=short side=sell "
             "ids=cycle_id=cy_9,order_wave_id=ow_9"
         )
     ]

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -490,6 +490,57 @@ def test_event_query_filters_by_tags(tmp_path):
     assert risk_report["cycle"]["events"][0]["event_type"] == "risk.hsl_status"
 
 
+def test_event_query_filters_by_source_and_component(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="execution.create_sent",
+                cycle_id="cy_1",
+                seq=1,
+                ts=1000,
+                source="executor",
+                component="order_wave",
+            ),
+            _monitor_row(
+                event_type="candle.tail_projected",
+                cycle_id="cy_1",
+                seq=2,
+                ts=1100,
+                source="candles",
+                component="tail_projection",
+            ),
+            _monitor_row(
+                event_type="execution.cancel_sent",
+                cycle_id="cy_2",
+                seq=3,
+                ts=1200,
+                source="executor",
+                component="order_wave",
+            ),
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        cycle_id="cy_1",
+        source="executor",
+        component="order_wave",
+    )
+
+    assert report["ok"] is True
+    assert report["cycle"]["filters"] == {
+        "components": ["order_wave"],
+        "cycle_id": "cy_1",
+        "sources": ["executor"],
+    }
+    assert report["cycle"]["matched_events"] == 1
+    assert report["cycle"]["events"][0]["event_type"] == "execution.create_sent"
+    assert report["cycle"]["events"][0]["source"] == "executor"
+    assert report["cycle"]["events"][0]["component"] == "order_wave"
+
+
 def test_event_query_filters_by_top_level_data_fields(tmp_path):
     events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
     _write_ndjson(
@@ -1317,6 +1368,8 @@ def test_live_event_query_cli_accepts_scope_filters_and_timeline(tmp_path, capsy
                 pside="short",
                 status="failed",
                 reason_code="exchange_exception",
+                source="executor",
+                component="order_wave",
                 ids={"order_wave_id": "ow_9"},
             ),
             _monitor_row(
@@ -1328,6 +1381,8 @@ def test_live_event_query_cli_accepts_scope_filters_and_timeline(tmp_path, capsy
                 pside="short",
                 status="succeeded",
                 reason_code="exchange_acknowledged",
+                source="executor",
+                component="order_wave",
                 ids={"order_wave_id": "ow_9"},
             ),
         ],
@@ -1347,6 +1402,10 @@ def test_live_event_query_cli_accepts_scope_filters_and_timeline(tmp_path, capsy
                 "failed",
                 "--reason-code",
                 "exchange_exception",
+                "--source",
+                "executor",
+                "--component",
+                "order_wave",
                 "--timeline",
             ]
         )
@@ -1356,8 +1415,10 @@ def test_live_event_query_cli_accepts_scope_filters_and_timeline(tmp_path, capsy
     report = json.loads(capsys.readouterr().out)
     assert report["query"]["filters"] == {
         "order_wave_ids": ["ow_9"],
+        "components": ["order_wave"],
         "psides": ["short"],
         "reason_codes": ["exchange_exception"],
+        "sources": ["executor"],
         "statuses": ["failed"],
         "symbols": ["SOL/USDT:USDT"],
     }


### PR DESCRIPTION
## Summary
- add live-event-query --source, --component, and --side filters using the existing repeated/comma-separated filter contract
- include source in compact event records alongside existing component and side output
- cover library and CLI filter paths
- fold the PR #903/#904 progress and backlog evidence into this real observability PR, replacing the closed docs-only PR #905

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_query.py src/tools/live_event_query.py tests/test_live_event_query.py
- git diff --check origin/v8...HEAD
- touched-file silent-handling scan: no matches

Observability/query tooling plus progress docs only; no event producers, exchange calls, live execution, or trading behavior changed.