### PR TITLE
Prune live event queries by path bot id

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-30.
 
 Current `origin/v8` logging-overhaul head:
 
-- `1dd115ccd` after PR #903, `Summarize HSL status in smoke reports`.
+- `b7b347581` after PR #906, `Filter live events by envelope fields`.
 
 Current review gate:
 
@@ -49,6 +49,32 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #906 at `b7b34758`.
+- PR #906 added read-only `live-event-query` filters for envelope labels
+  `source`, `component`, and `side`, using the existing repeated/
+  comma-separated filter contract. The slice also made `source` visible in
+  compact query records and folded the PR #903/#904 progress evidence into the
+  same real observability PR, replacing the closed docs-only PR #905.
+- PR #906 passed Claude + Hermes + CI on the final head. Local validation
+  covered the full `tests/test_live_event_query.py` suite, py_compile for
+  touched query files and tests, `git diff --check`, and a touched-file
+  silent-handling scan.
+- VPS5 pulled from `1dd115cc` to `b7b34758` without bot restart because the
+  deployed change was read-only query tooling and docs. The five configured
+  bots were left running.
+- Focused VPS5 query smoke on Binance current monitor events showed the new
+  filter echo and no parser errors: `--source executor --component order_wave`
+  returned `ok=true` with `files_scanned=1`, and `--side buy,sell` returned
+  `ok=true` with one matched `entry.initial_distance_gate_blocked` event.
+  A bounded 2-minute brief smoke reported `ok=true`, `hard_failures=0`,
+  `logs.hard_matches=0`, `matched_expected=5`, clean tracked repository state
+  at `b7b34758`, `remote_calls.failed=0`, and
+  `account_critical_remote_calls.failed=0`.
+- Broad parallel VPS5 monitor scans over the full root were interrupted after
+  about 90 seconds. Follow-up smoke used single-bot/current-segment paths and
+  completed in under 13 seconds. Future VPS smoke probes should avoid parallel
+  broad monitor scans unless the query path is intentionally being stress
+  tested.
 - Repository pulled through PR #903 at `1dd115cc`.
 - PR #903 added read-only `risk_events.hsl_status` projections to
   `live-smoke-report` full, summary, and brief output, derived only from

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -171,7 +171,8 @@ Related detailed plans:
    `live-event-query --event-tail-lines` for repeated recent-window queries
    over large current monitor segments. The default remains full event
    validation; bounded query output reports tail-limit metadata in
-   `event_window`.
+   `event_window`. Another 2026-06-30 follow-up added source, component, and
+   side filters for envelope-scoped queries.
 
 3. [ ] Live restart/smoke automation.
    Status: partial. The read-only `live-smoke-report` tool exists and can now
@@ -689,6 +690,7 @@ Related detailed plans:
 
 | Date | Item | PR / Commit | Result | Remaining |
 |------|------|-------------|--------|-----------|
+| 2026-06-30 | #2 Event query and timeline CLI extensions | PR #906 / `b7b34758` | Added `live-event-query --source`, `--component`, and `--side` filters plus compact `source` output; folded #903/#904 deploy evidence into the same real observability PR; VPS5 no-restart deploy stayed green and focused single-bot query smokes validated the new filter echoes | Broad parallel root-level monitor scans were too slow for routine VPS smoke; prefer focused paths and continue query-pruning/index work where concrete smoke cost appears |
 | 2026-06-30 | #0/#3/#10 HSL status smoke evidence | PR #903 / `1dd115cc` | Added `risk_events.hsl_status` to `live-smoke-report` full, summary, and brief output from existing `hsl.status` events; fixed #904 by filtering shareable summary risk `latest_data` through a value-safe whitelist; VPS5 no-restart smoke stayed green and showed red HSL status counts for ZEC without magnitude fields in brief output | Actual HSL startup latency optimization remains open; broader event-driven console redesign remains open |
 | 2026-06-30 | #0/#3 HSL completed replay smoke evidence | PR #901 / `9b3c29ad` | Added `hsl_replay.max_completed_elapsed_ms` to `live-smoke-report --brief`; VPS5 no-restart smoke stayed green after deploy, with no HSL replay events in the sampled window | HSL startup latency remains a trading-path optimization; this slice only surfaces completed replay latency when completed replay events are in-window |
 | 2026-06-30 | #0/#3 HSL replay/startup smoke evidence | PR #899 / `e1fcb038` | Added `live-smoke-report --brief` projection for worst active HSL replay elapsed time, latest-event age, and active stage counts from existing sanitized groups; VPS5 no-restart smoke stayed green after deploy | HSL startup latency remains a trading-path optimization; this slice only surfaces active replay latency in brief smoke |

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -71,11 +71,13 @@ def discover_event_files(
     include_rotated: bool = False,
     exchange: str | Iterable[str] | None = None,
     user: str | Iterable[str] | None = None,
+    bot_id: str | Iterable[str] | None = None,
 ) -> list[Path]:
     """Find monitor event NDJSON segments below a monitor root, bot root, or events dir."""
     path = Path(root).expanduser()
     exchange_filter = _normalize_filter_values(exchange)
     user_filter = _normalize_filter_values(user)
+    bot_path_filter = _path_like_bot_id_filter(_normalize_filter_values(bot_id))
     if path.is_file():
         return [path] if _is_event_segment(path) else []
     if not path.exists():
@@ -95,6 +97,7 @@ def discover_event_files(
                 candidate,
                 exchange_filter=exchange_filter,
                 user_filter=user_filter,
+                bot_path_filter=bot_path_filter,
             )
         ),
         key=_event_path_sort_key,
@@ -161,9 +164,10 @@ def _monitor_path_scope_matches_under_root(
     *,
     exchange_filter: set[str],
     user_filter: set[str],
+    bot_path_filter: set[str],
 ) -> bool:
     """Conservatively prune only obvious <monitor>/<exchange>/<user>/events files."""
-    if not exchange_filter and not user_filter:
+    if not exchange_filter and not user_filter and not bot_path_filter:
         return True
     try:
         relative_parts = path.relative_to(root).parts
@@ -172,10 +176,19 @@ def _monitor_path_scope_matches_under_root(
     if len(relative_parts) != 4 or relative_parts[2] != "events":
         return True
     exchange, user = relative_parts[0], relative_parts[1]
+    if bot_path_filter and f"{exchange}/{user}" not in bot_path_filter:
+        return False
     return _filter_matches(exchange, exchange_filter) and _filter_matches(
         user,
         user_filter,
     )
+
+
+def _path_like_bot_id_filter(bot_filter: set[str]) -> set[str]:
+    """Return path-derived bot ids only when pruning cannot drop opaque bot ids."""
+    if not bot_filter:
+        return set()
+    return set(bot_filter) if all("/" in value for value in bot_filter) else set()
 
 
 def _normalize_filter_values(values: str | Iterable[str] | None) -> set[str]:
@@ -1040,6 +1053,7 @@ def build_event_report(
             include_rotated=include_rotated,
             exchange=exchange,
             user=user,
+            bot_id=bot_id,
         )
     except FileNotFoundError as exc:
         files = []

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -814,6 +814,50 @@ def test_discover_event_files_filters_monitor_paths_by_exchange_and_user(tmp_pat
     assert missing_files == []
 
 
+def test_discover_event_files_prunes_path_like_bot_ids(tmp_path):
+    gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    kucoin_events = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(gateio_events / "current.ndjson", [])
+    _write_gz_ndjson(gateio_events / "20260629.ndjson.gz", [])
+    _write_ndjson(binance_events / "current.ndjson", [])
+    _write_ndjson(kucoin_events / "current.ndjson", [])
+
+    gateio_files = discover_event_files(
+        tmp_path / "monitor",
+        include_rotated=True,
+        bot_id="gateio/gateio_01",
+    )
+
+    assert [path.name for path in gateio_files] == [
+        "20260629.ndjson.gz",
+        "current.ndjson",
+    ]
+    assert {path.parent.parent.parent.name for path in gateio_files} == {"gateio"}
+    assert {path.parent.parent.name for path in gateio_files} == {"gateio_01"}
+
+    multi_bot_files = discover_event_files(
+        tmp_path / "monitor",
+        bot_id="gateio/gateio_01,kucoin/kucoin_01",
+    )
+
+    assert {path.parent.parent.parent.name for path in multi_bot_files} == {
+        "gateio",
+        "kucoin",
+    }
+
+    opaque_bot_files = discover_event_files(
+        tmp_path / "monitor",
+        bot_id="bot_1",
+    )
+
+    assert {path.parent.parent.parent.name for path in opaque_bot_files} == {
+        "binance",
+        "gateio",
+        "kucoin",
+    }
+
+
 def test_event_query_filters_exchange_user_and_prunes_monitor_paths(tmp_path):
     gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
     binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"


### PR DESCRIPTION
## Summary
- prune live-event-query file discovery for path-shaped bot ids like exchange/user
- preserve existing behavior for opaque event-level bot ids like bot_1 by not path-pruning them
- record PR #906 deploy and VPS smoke evidence in the logging progress/backlog docs

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_query.py tests/test_live_event_query.py
- git diff --check
- touched-file silent-handling scan: no matches

## VPS evidence from prior merged slice
- VPS5 pulled v8 to b7b34758 without bot restart; all five configured bots left running
- focused Binance current-segment query with --source/--component returned ok=true and files_scanned=1
- focused Binance current-segment query with --side buy,sell returned ok=true and matched one event
- bounded 2-minute brief smoke returned ok=true, hard_failures=0, matched_expected=5, remote_calls.failed=0, account_critical_remote_calls.failed=0, repo dirty=false

Observability/query tooling plus progress docs only; no event producers, exchange calls, live execution, or trading behavior changed.