### PR TITLE
Report live event file discovery metadata

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-30.
 
 Current `origin/v8` logging-overhaul head:
 
-- `b7b347581` after PR #906, `Filter live events by envelope fields`.
+- `f792f889f` after PR #907, `Prune live event queries by path bot id`.
 
 Current review gate:
 
@@ -49,6 +49,27 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #907 at `f792f889`.
+- PR #907 added conservative `live-event-query --bot-id` path pruning for
+  path-shaped bot ids such as `exchange/user`, while preserving full-scan
+  behavior for opaque event-level bot ids such as `bot_1`. The slice does not
+  add event producers, exchange calls, live execution, smoke verdict changes,
+  or trading behavior.
+- PR #907 passed Claude + Hermes + CI. Local validation covered the full
+  `tests/test_live_event_query.py` suite, py_compile for touched query files
+  and tests, `git diff --check`, and a touched-file silent-handling scan.
+- VPS5 pulled from `b7b34758` to `f792f889` without bot restart because the
+  deployed change was read-only query tooling and docs. The five configured
+  bots were left running.
+- Focused VPS5 query smoke showed the new path-pruning behavior:
+  `--bot-id binance/binance_01` over monitor root completed with `ok=true`,
+  `files_scanned=1`, and `event_tail_limited_files=1`; an opaque
+  `--bot-id bot_opaque_no_match` query preserved full-scan behavior with
+  `files_scanned=4` and no matched events. A bounded 2-minute brief smoke
+  reported `ok=true`, `hard_failures=0`, `logs.hard_matches=0`,
+  `matched_expected=5`, clean tracked repository state at `f792f889`,
+  `remote_calls.failed=0`, and
+  `account_critical_remote_calls.failed=0`.
 - Repository pulled through PR #906 at `b7b34758`.
 - PR #906 added read-only `live-event-query` filters for envelope labels
   `source`, `component`, and `side`, using the existing repeated/

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -172,7 +172,9 @@ Related detailed plans:
    over large current monitor segments. The default remains full event
    validation; bounded query output reports tail-limit metadata in
    `event_window`. Another 2026-06-30 follow-up added source, component, and
-   side filters for envelope-scoped queries.
+   side filters for envelope-scoped queries. A subsequent follow-up pruned
+   monitor file discovery for path-shaped `--bot-id` filters while preserving
+   full scans for opaque bot ids.
 
 3. [ ] Live restart/smoke automation.
    Status: partial. The read-only `live-smoke-report` tool exists and can now
@@ -690,6 +692,7 @@ Related detailed plans:
 
 | Date | Item | PR / Commit | Result | Remaining |
 |------|------|-------------|--------|-----------|
+| 2026-06-30 | #2 Event query and timeline CLI extensions | PR #907 / `f792f889` | Added conservative monitor path pruning for path-shaped `live-event-query --bot-id` filters; VPS5 no-restart deploy stayed green, path-shaped bot-id query scanned one file, and opaque bot-id query preserved full-scan behavior | Continue query-pruning/index work only where concrete smoke cost appears; expose pruning/discovery metadata so operators can see when scope pruning occurred |
 | 2026-06-30 | #2 Event query and timeline CLI extensions | PR #906 / `b7b34758` | Added `live-event-query --source`, `--component`, and `--side` filters plus compact `source` output; folded #903/#904 deploy evidence into the same real observability PR; VPS5 no-restart deploy stayed green and focused single-bot query smokes validated the new filter echoes | Broad parallel root-level monitor scans were too slow for routine VPS smoke; prefer focused paths and continue query-pruning/index work where concrete smoke cost appears |
 | 2026-06-30 | #0/#3/#10 HSL status smoke evidence | PR #903 / `1dd115cc` | Added `risk_events.hsl_status` to `live-smoke-report` full, summary, and brief output from existing `hsl.status` events; fixed #904 by filtering shareable summary risk `latest_data` through a value-safe whitelist; VPS5 no-restart smoke stayed green and showed red HSL status counts for ZEC without magnitude fields in brief output | Actual HSL startup latency optimization remains open; broader event-driven console redesign remains open |
 | 2026-06-30 | #0/#3 HSL completed replay smoke evidence | PR #901 / `9b3c29ad` | Added `hsl_replay.max_completed_elapsed_ms` to `live-smoke-report --brief`; VPS5 no-restart smoke stayed green after deploy, with no HSL replay events in the sampled window | HSL startup latency remains a trading-path optimization; this slice only surfaces completed replay latency when completed replay events are in-window |

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -57,6 +57,27 @@ class EventIssue:
         return asdict(self)
 
 
+@dataclass(frozen=True)
+class EventFileDiscovery:
+    files: list[Path]
+    candidate_files: int = 0
+    event_segments: int = 0
+    rotated_skipped: int = 0
+    scope_pruned: int = 0
+    bot_path_pruning_applied: bool = False
+    opaque_bot_id_full_scan: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "candidate_files": int(self.candidate_files),
+            "event_segments": int(self.event_segments),
+            "rotated_skipped": int(self.rotated_skipped),
+            "scope_pruned": int(self.scope_pruned),
+            "bot_path_pruning_applied": bool(self.bot_path_pruning_applied),
+            "opaque_bot_id_full_scan": bool(self.opaque_bot_id_full_scan),
+        }
+
+
 def _is_event_segment(path: Path) -> bool:
     return path.name.endswith(".ndjson") or path.name.endswith(".ndjson.gz")
 
@@ -74,33 +95,83 @@ def discover_event_files(
     bot_id: str | Iterable[str] | None = None,
 ) -> list[Path]:
     """Find monitor event NDJSON segments below a monitor root, bot root, or events dir."""
+    return _discover_event_files(
+        root,
+        include_rotated=include_rotated,
+        exchange=exchange,
+        user=user,
+        bot_id=bot_id,
+    ).files
+
+
+def _discover_event_files(
+    root: str | Path,
+    *,
+    include_rotated: bool = False,
+    exchange: str | Iterable[str] | None = None,
+    user: str | Iterable[str] | None = None,
+    bot_id: str | Iterable[str] | None = None,
+) -> EventFileDiscovery:
+    """Find monitor event NDJSON segments and report bounded discovery metadata."""
     path = Path(root).expanduser()
     exchange_filter = _normalize_filter_values(exchange)
     user_filter = _normalize_filter_values(user)
-    bot_path_filter = _path_like_bot_id_filter(_normalize_filter_values(bot_id))
+    bot_filter = _normalize_filter_values(bot_id)
+    bot_path_filter = _path_like_bot_id_filter(bot_filter)
+    opaque_bot_full_scan = bool(bot_filter and not bot_path_filter)
     if path.is_file():
-        return [path] if _is_event_segment(path) else []
+        files = [path] if _is_event_segment(path) else []
+        return EventFileDiscovery(
+            files=files,
+            candidate_files=1,
+            event_segments=len(files),
+            bot_path_pruning_applied=False,
+            opaque_bot_id_full_scan=opaque_bot_full_scan,
+        )
     if not path.exists():
         raise FileNotFoundError(str(path))
     if not path.is_dir():
-        return []
-    return sorted(
-        (
-            candidate
-            for candidate in path.rglob("*.ndjson*")
-            if candidate.is_file()
-            and candidate.parent.name == "events"
+        return EventFileDiscovery(
+            files=[],
+            bot_path_pruning_applied=bool(bot_path_filter),
+            opaque_bot_id_full_scan=opaque_bot_full_scan,
+        )
+    files: list[Path] = []
+    candidate_files = 0
+    event_segments = 0
+    rotated_skipped = 0
+    scope_pruned = 0
+    for candidate in path.rglob("*.ndjson*"):
+        if not candidate.is_file():
+            continue
+        candidate_files += 1
+        if not (
+            candidate.parent.name == "events"
             and _is_event_segment(candidate)
-            and (include_rotated or candidate.name == "current.ndjson")
-            and _monitor_path_scope_matches_under_root(
-                path,
-                candidate,
-                exchange_filter=exchange_filter,
-                user_filter=user_filter,
-                bot_path_filter=bot_path_filter,
-            )
-        ),
-        key=_event_path_sort_key,
+        ):
+            continue
+        event_segments += 1
+        if not include_rotated and candidate.name != "current.ndjson":
+            rotated_skipped += 1
+            continue
+        if not _monitor_path_scope_matches_under_root(
+            path,
+            candidate,
+            exchange_filter=exchange_filter,
+            user_filter=user_filter,
+            bot_path_filter=bot_path_filter,
+        ):
+            scope_pruned += 1
+            continue
+        files.append(candidate)
+    return EventFileDiscovery(
+        files=sorted(files, key=_event_path_sort_key),
+        candidate_files=candidate_files,
+        event_segments=event_segments,
+        rotated_skipped=rotated_skipped,
+        scope_pruned=scope_pruned,
+        bot_path_pruning_applied=bool(bot_path_filter),
+        opaque_bot_id_full_scan=opaque_bot_full_scan,
     )
 
 
@@ -1047,14 +1118,16 @@ def build_event_report(
     event_tail_limited_files = 0
     event_tail_skipped_lines = 0
     issues: list[EventIssue] = []
+    discovery = EventFileDiscovery(files=[])
     try:
-        files = discover_event_files(
+        discovery = _discover_event_files(
             root,
             include_rotated=include_rotated,
             exchange=exchange,
             user=user,
             bot_id=bot_id,
         )
+        files = discovery.files
     except FileNotFoundError as exc:
         files = []
         issues.append(
@@ -1441,6 +1514,7 @@ def build_event_report(
         "include_rotated": bool(include_rotated),
         "files": [str(path) for path in files],
         "files_scanned": len(files),
+        "file_discovery": discovery.to_dict(),
         "records_total": records_total,
         "live_events": live_events,
         "legacy_events": legacy_events,

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -858,6 +858,49 @@ def test_discover_event_files_prunes_path_like_bot_ids(tmp_path):
     }
 
 
+def test_event_query_reports_file_discovery_metadata(tmp_path):
+    gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    kucoin_events = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(gateio_events / "current.ndjson", [])
+    _write_gz_ndjson(gateio_events / "20260629.ndjson.gz", [])
+    _write_ndjson(binance_events / "current.ndjson", [])
+    _write_ndjson(kucoin_events / "current.ndjson", [])
+
+    path_bot_report = build_event_report(
+        tmp_path / "monitor",
+        bot_id="gateio/gateio_01",
+        include_rotated=True,
+    )
+
+    assert path_bot_report["ok"] is True
+    assert path_bot_report["files_scanned"] == 2
+    assert path_bot_report["file_discovery"] == {
+        "bot_path_pruning_applied": True,
+        "candidate_files": 4,
+        "event_segments": 4,
+        "opaque_bot_id_full_scan": False,
+        "rotated_skipped": 0,
+        "scope_pruned": 2,
+    }
+
+    opaque_bot_report = build_event_report(
+        tmp_path / "monitor",
+        bot_id="bot_1",
+    )
+
+    assert opaque_bot_report["ok"] is True
+    assert opaque_bot_report["files_scanned"] == 3
+    assert opaque_bot_report["file_discovery"] == {
+        "bot_path_pruning_applied": False,
+        "candidate_files": 4,
+        "event_segments": 4,
+        "opaque_bot_id_full_scan": True,
+        "rotated_skipped": 1,
+        "scope_pruned": 0,
+    }
+
+
 def test_event_query_filters_exchange_user_and_prunes_monitor_paths(tmp_path):
     gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
     binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"


### PR DESCRIPTION
## Summary
- add a bounded file_discovery block to live-event-query reports
- surface candidate file counts, event-segment counts, rotated skips, scope-pruned counts, and bot-id pruning/fallback flags
- preserve discover_event_files() as the existing list-returning API
- record PR #907 deploy and VPS smoke evidence in the logging progress/backlog docs

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_query.py tests/test_live_event_query.py
- git diff --check
- touched-file silent-handling scan: no matches

Observability/query reporting plus progress docs only; no event producers, exchange calls, live execution, smoke verdict changes, or trading behavior changed.