### PR TITLE
Bound incident bundle event scans by tail

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-30.
 
 Current `origin/v8` logging-overhaul head:
 
-- `7c5c96f4a` after PR #911, `Expose incident bundle event discovery metadata`.
+- `0eb295452` after PR #912, `Add recent window option to incident bundles`.
 
 Current review gate:
 
@@ -49,6 +49,30 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #912 at `0eb29545`.
+- PR #912 added `--recent-minutes` to `passivbot tool live-incident-bundle`,
+  resolving it to the existing `since_ms` event/log time-window contract. The
+  slice was read-only incident-bundle/report tooling and did not add event
+  producers, exchange calls, live execution, report verdict changes, console
+  routing, order/risk logic, or trading behavior.
+- PR #912 passed Claude + Hermes + CI. Local validation covered
+  `tests/test_live_incident_bundle.py`, py_compile for touched files and tests,
+  `git diff --check`, and a touched-file silent-handling scan. The optional
+  passivbot CLI dispatch test was not collected because the local Rust
+  extension freshness guard tripped on import.
+- VPS5 pulled from `7c5c96f4` to `0eb29545` without bot restart because the
+  deployed change was read-only incident-bundle/report tooling and docs. The
+  five configured bots were left running.
+- A bounded incident-bundle smoke at `0eb29545` using `--recent-minutes 2`,
+  `--no-event-segments`, and `--no-trace-report` reported `ok=true`,
+  `hard_failures=0`, `time_window.enabled=true`, `matched_events=906`,
+  `events_truncated=true`, `event_report.files_scanned=6`, and matching
+  discovery counts in the event report and segment manifest
+  (`candidate_files=3750`, `event_segments=950`, `rotated_skipped=944`,
+  `scope_pruned=0`). A fresh 2-minute brief smoke reported `ok=true`,
+  `hard_failures=0`, `logs.hard_matches=0`, `matched_expected=5`, clean tracked
+  repository state, `remote_calls.failed=0`, and
+  `account_critical_remote_calls.failed=0`.
 - Repository pulled through PR #911 at `7c5c96f4`.
 - PR #911 projected bounded event-file discovery metadata into incident-bundle
   event-report summaries and event-segment manifests, using the same

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -137,11 +137,12 @@ Related detailed plans:
    `passivbot tool live-incident-bundle` collects local monitor event reports,
    live-event trace reports, smoke summaries, redacted log excerpts, monitor
    snapshots, config hashes, runtime metadata, and bounded event segments into a
-   tarball. Bundles can also include trace reports and optional smoke-report
-   process status.
+   tarball. Bundles can also include trace reports, optional smoke-report
+   process status, event-file discovery metadata, and recent time windows.
 
    Remaining refinements: richer remote smoke integration when the
-   restart/smoke automation exists.
+   restart/smoke automation exists; keep recent-window bundle scans bounded for
+   very large current monitor segments.
 
 2. [x] Event query and timeline CLI extensions.
    Status: core filter/timeline work merged. `passivbot tool live-event-query`
@@ -692,6 +693,7 @@ Related detailed plans:
 
 | Date | Item | PR / Commit | Result | Remaining |
 |------|------|-------------|--------|-----------|
+| 2026-06-30 | #1/#3 Incident bundle generator and live restart/smoke automation | PR #912 / `0eb29545` | Added `--recent-minutes` to incident bundles and deployed it read-only to VPS5; bundle smoke showed the recent window active with clean hard-failure status but still many matched current-segment events | Add opt-in event-tail bounding for recent incident bundles; continue safe restart orchestration |
 | 2026-06-30 | #1/#3 Incident bundle generator and live restart/smoke automation | PR #911 / `7c5c96f4` | Projected bounded event-file discovery metadata into incident-bundle event-report summaries and event-segment manifests; VPS5 no-restart deploy stayed green and bundle smoke showed matching discovery counts without copying event segments | Continue safe restart orchestration; add small incident-bundle CLI ergonomics where they reduce operator mistakes |
 | 2026-06-30 | #3/#4 Live restart/smoke automation and performance readiness | PR #910 / `ac949f03` | Projected bounded event-file discovery metadata into `live-performance-report` full and summary output; VPS5 no-restart deploy stayed green and concise performance smoke showed discovery counts without file paths | Continue safe restart orchestration; carry discovery visibility into incident bundles where it explains copied segment scope |
 | 2026-06-30 | #3 Live restart/smoke automation | PR #909 / `c8c51d73` | Projected bounded event-file discovery metadata into `live-smoke-report` full, summary, and brief output; VPS5 no-restart deploy stayed green and brief smoke showed discovery counts without file paths | Continue safe restart orchestration; carry discovery visibility into other read-only report surfaces where it explains scan cost |

--- a/src/live/event_file_rows.py
+++ b/src/live/event_file_rows.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import gzip
+from collections import deque
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class EventRowWindow:
+    limited: bool = False
+    skipped_lines: int | None = None
+    skipped_lines_exact: bool = True
+    skipped_bytes: int = 0
+    line_numbers_exact: bool = True
+    method: str = "full_scan"
+
+
+def _open_text(path: Path):
+    if path.name.endswith(".gz"):
+        return gzip.open(path, "rt", encoding="utf-8", errors="replace")
+    return open(path, "r", encoding="utf-8", errors="replace")
+
+
+def _plain_tail_rows(path: Path, *, max_lines: int) -> tuple[list[tuple[int, str]], EventRowWindow]:
+    if max_lines <= 0:
+        return [], EventRowWindow()
+    size = path.stat().st_size
+    if size <= 0:
+        return [], EventRowWindow(
+            limited=True,
+            skipped_lines=0,
+            skipped_lines_exact=True,
+            skipped_bytes=0,
+            line_numbers_exact=True,
+            method="seek_tail",
+        )
+
+    chunk_size = 64 * 1024
+    chunks: list[bytes] = []
+    pos = size
+    newline_count = 0
+    with open(path, "rb") as stream:
+        while pos > 0 and newline_count <= max_lines:
+            read_size = min(chunk_size, pos)
+            pos -= read_size
+            stream.seek(pos)
+            chunk = stream.read(read_size)
+            chunks.append(chunk)
+            newline_count += chunk.count(b"\n")
+
+    reached_start = pos == 0
+    data = b"".join(reversed(chunks))
+    raw_lines = data.splitlines()
+    if not reached_start:
+        raw_lines = raw_lines[-max_lines:]
+    elif len(raw_lines) > max_lines:
+        raw_lines = raw_lines[-max_lines:]
+
+    decoded = [line.decode("utf-8", errors="replace") for line in raw_lines]
+    skipped_lines = None
+    if reached_start:
+        skipped_lines = max(0, len(data.splitlines()) - len(decoded))
+    skipped_bytes = max(0, pos)
+    line_numbers_exact = skipped_lines is not None
+    line_offset = int(skipped_lines or 0)
+    rows = [(line_offset + idx, line) for idx, line in enumerate(decoded, start=1)]
+    return rows, EventRowWindow(
+        limited=True,
+        skipped_lines=skipped_lines,
+        skipped_lines_exact=skipped_lines is not None,
+        skipped_bytes=skipped_bytes,
+        line_numbers_exact=line_numbers_exact,
+        method="seek_tail",
+    )
+
+
+@contextmanager
+def event_file_rows(path: Path, *, max_tail_lines: int = 0):
+    tail_lines = max(0, int(max_tail_lines))
+    if tail_lines <= 0:
+        with _open_text(path) as stream:
+            yield enumerate(stream, start=1), EventRowWindow()
+        return
+    if not path.name.endswith(".gz"):
+        rows, window = _plain_tail_rows(path, max_lines=tail_lines)
+        yield rows, window
+        return
+    with _open_text(path) as stream:
+        rows = deque(enumerate(stream, start=1), maxlen=tail_lines)
+    skipped_lines = max(0, int(rows[0][0]) - 1) if rows else 0
+    yield rows, EventRowWindow(
+        limited=True,
+        skipped_lines=skipped_lines,
+        skipped_lines_exact=True,
+        skipped_bytes=0,
+        line_numbers_exact=True,
+        method="sequential_gzip_tail",
+    )

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-import gzip
 import json
 from collections.abc import Iterable as IterableABC
-from collections import Counter, defaultdict, deque
+from collections import Counter, defaultdict
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
 from live.event_bus import EventTypes, LIVE_EVENT_ID_KEYS, LIVE_EVENT_MONITOR_PAYLOAD_KEY
+from live.event_file_rows import event_file_rows
 
 EVENT_ID_KEYS = LIVE_EVENT_ID_KEYS
 ORDER_TRACE_EVENT_TYPES = {
@@ -191,12 +191,6 @@ def _discover_event_files(
         bot_path_pruning_applied=bool(bot_path_filter),
         opaque_bot_id_full_scan=opaque_bot_full_scan,
     )
-
-
-def _open_text(path: Path):
-    if path.name.endswith(".gz"):
-        return gzip.open(path, "rt", encoding="utf-8")
-    return open(path, "r", encoding="utf-8")
 
 
 def _file_mtime_ms(path: Path) -> int | None:
@@ -1135,6 +1129,10 @@ def build_event_report(
     max_event_tail_lines = max(0, int(event_tail_lines))
     event_tail_limited_files = 0
     event_tail_skipped_lines = 0
+    event_tail_skipped_lines_exact = True
+    event_tail_skipped_bytes = 0
+    event_tail_line_numbers_exact = True
+    event_tail_methods: Counter[str] = Counter()
     issues: list[EventIssue] = []
     discovery = EventFileDiscovery(files=[])
     try:
@@ -1245,18 +1243,22 @@ def build_event_report(
 
     for path in files:
         try:
-            with _open_text(path) as stream:
-                if max_event_tail_lines:
-                    file_rows = deque(
-                        enumerate(stream, start=1),
-                        maxlen=max_event_tail_lines,
-                    )
+            with event_file_rows(path, max_tail_lines=max_event_tail_lines) as (
+                rows,
+                row_window,
+            ):
+                if max_event_tail_lines and row_window.limited:
                     event_tail_limited_files += 1
-                    if file_rows:
-                        event_tail_skipped_lines += max(0, int(file_rows[0][0]) - 1)
-                    rows = file_rows
-                else:
-                    rows = enumerate(stream, start=1)
+                    if row_window.skipped_lines is None:
+                        event_tail_skipped_lines_exact = False
+                    else:
+                        event_tail_skipped_lines += int(row_window.skipped_lines)
+                    event_tail_skipped_bytes += int(row_window.skipped_bytes)
+                    event_tail_line_numbers_exact = (
+                        event_tail_line_numbers_exact
+                        and bool(row_window.line_numbers_exact)
+                    )
+                    event_tail_methods[str(row_window.method)] += 1
                 for line_no, raw_line in rows:
                     line = raw_line.strip()
                     if not line:
@@ -1649,4 +1651,14 @@ def build_event_report(
             report["event_window"]["event_tail_lines"] = max_event_tail_lines
             report["event_window"]["event_tail_limited_files"] = event_tail_limited_files
             report["event_window"]["event_tail_skipped_lines"] = event_tail_skipped_lines
+            report["event_window"]["event_tail_skipped_lines_exact"] = (
+                event_tail_skipped_lines_exact
+            )
+            report["event_window"]["event_tail_skipped_bytes"] = event_tail_skipped_bytes
+            report["event_window"]["event_tail_line_numbers_exact"] = (
+                event_tail_line_numbers_exact
+            )
+            report["event_window"]["event_tail_methods"] = dict(
+                sorted(event_tail_methods.items())
+            )
     return report

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import gzip
 import hashlib
 import json
 import os
@@ -10,13 +9,14 @@ import sys
 import tarfile
 import tempfile
 import time
-from collections import deque
+from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
 from live.event_bus import LIVE_EVENT_ID_KEYS, LIVE_EVENT_MONITOR_PAYLOAD_KEY
+from live.event_file_rows import event_file_rows
 from live.event_query import (
     build_event_report,
     discover_event_files,
@@ -60,12 +60,6 @@ def _write_json(path: Path, data: Any) -> None:
         json.dumps(data, indent=2, sort_keys=True, default=_json_default) + "\n",
         encoding="utf-8",
     )
-
-
-def _open_text(path: Path):
-    if path.name.endswith(".gz"):
-        return gzip.open(path, "rt", encoding="utf-8", errors="replace")
-    return open(path, "r", encoding="utf-8", errors="replace")
 
 
 def _sha256_file(path: Path) -> str:
@@ -189,6 +183,10 @@ def _build_time_window_report(
     max_event_tail_lines = max(0, int(event_tail_lines))
     event_tail_limited_files = 0
     event_tail_skipped_lines = 0
+    event_tail_skipped_lines_exact = True
+    event_tail_skipped_bytes = 0
+    event_tail_line_numbers_exact = True
+    event_tail_methods: Counter[str] = Counter()
     try:
         files = discover_event_files(monitor_root, include_rotated=include_rotated)
     except FileNotFoundError as exc:
@@ -205,18 +203,22 @@ def _build_time_window_report(
 
     for path in files:
         try:
-            with _open_text(path) as stream:
-                if max_event_tail_lines:
-                    file_rows = deque(
-                        enumerate(stream, start=1),
-                        maxlen=max_event_tail_lines,
-                    )
+            with event_file_rows(path, max_tail_lines=max_event_tail_lines) as (
+                rows,
+                row_window,
+            ):
+                if max_event_tail_lines and row_window.limited:
                     event_tail_limited_files += 1
-                    if file_rows:
-                        event_tail_skipped_lines += max(0, int(file_rows[0][0]) - 1)
-                    rows = file_rows
-                else:
-                    rows = enumerate(stream, start=1)
+                    if row_window.skipped_lines is None:
+                        event_tail_skipped_lines_exact = False
+                    else:
+                        event_tail_skipped_lines += int(row_window.skipped_lines)
+                    event_tail_skipped_bytes += int(row_window.skipped_bytes)
+                    event_tail_line_numbers_exact = (
+                        event_tail_line_numbers_exact
+                        and bool(row_window.line_numbers_exact)
+                    )
+                    event_tail_methods[str(row_window.method)] += 1
                 for line_no, raw_line in rows:
                     line = raw_line.strip()
                     if not line:
@@ -280,6 +282,10 @@ def _build_time_window_report(
         report["event_tail_lines"] = max_event_tail_lines
         report["event_tail_limited_files"] = event_tail_limited_files
         report["event_tail_skipped_lines"] = event_tail_skipped_lines
+        report["event_tail_skipped_lines_exact"] = event_tail_skipped_lines_exact
+        report["event_tail_skipped_bytes"] = event_tail_skipped_bytes
+        report["event_tail_line_numbers_exact"] = event_tail_line_numbers_exact
+        report["event_tail_methods"] = dict(sorted(event_tail_methods.items()))
     return report
 
 
@@ -808,6 +814,14 @@ def build_live_incident_bundle(
             "event_tail_lines": window_report.get("event_tail_lines"),
             "event_tail_limited_files": window_report.get("event_tail_limited_files"),
             "event_tail_skipped_lines": window_report.get("event_tail_skipped_lines"),
+            "event_tail_skipped_lines_exact": window_report.get(
+                "event_tail_skipped_lines_exact"
+            ),
+            "event_tail_skipped_bytes": window_report.get("event_tail_skipped_bytes"),
+            "event_tail_line_numbers_exact": window_report.get(
+                "event_tail_line_numbers_exact"
+            ),
+            "event_tail_methods": window_report.get("event_tail_methods"),
         },
         "smoke_report": {
             "ok": smoke_report.get("ok"),

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -10,6 +10,7 @@ import sys
 import tarfile
 import tempfile
 import time
+from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -163,6 +164,7 @@ def _build_time_window_report(
     until_ms: int | None,
     include_rotated: bool,
     include_data: bool,
+    event_tail_lines: int = 0,
     limit: int,
 ) -> dict[str, Any]:
     if since_ms is None and until_ms is None:
@@ -184,6 +186,9 @@ def _build_time_window_report(
     events: list[dict[str, Any]] = []
     matched_events = 0
     max_events = max(0, int(limit))
+    max_event_tail_lines = max(0, int(event_tail_lines))
+    event_tail_limited_files = 0
+    event_tail_skipped_lines = 0
     try:
         files = discover_event_files(monitor_root, include_rotated=include_rotated)
     except FileNotFoundError as exc:
@@ -201,7 +206,18 @@ def _build_time_window_report(
     for path in files:
         try:
             with _open_text(path) as stream:
-                for line_no, raw_line in enumerate(stream, start=1):
+                if max_event_tail_lines:
+                    file_rows = deque(
+                        enumerate(stream, start=1),
+                        maxlen=max_event_tail_lines,
+                    )
+                    event_tail_limited_files += 1
+                    if file_rows:
+                        event_tail_skipped_lines += max(0, int(file_rows[0][0]) - 1)
+                    rows = file_rows
+                else:
+                    rows = enumerate(stream, start=1)
+                for line_no, raw_line in rows:
                     line = raw_line.strip()
                     if not line:
                         continue
@@ -251,7 +267,7 @@ def _build_time_window_report(
                     "message": str(exc),
                 }
             )
-    return {
+    report = {
         "enabled": True,
         "filters": filters,
         "matched_events": matched_events,
@@ -260,6 +276,11 @@ def _build_time_window_report(
         "timeline": [_timeline_line(event) for event in events],
         "issues": issues,
     }
+    if max_event_tail_lines:
+        report["event_tail_lines"] = max_event_tail_lines
+        report["event_tail_limited_files"] = event_tail_limited_files
+        report["event_tail_skipped_lines"] = event_tail_skipped_lines
+    return report
 
 
 def _git_metadata(cwd: str | Path | None = None) -> dict[str, Any]:
@@ -492,6 +513,7 @@ def _event_report_result_summary(event_report: dict[str, Any]) -> dict[str, Any]
         "live_events": event_report.get("live_events"),
         "error_count": event_report.get("error_count"),
         "warning_count": event_report.get("warning_count"),
+        "event_window": event_report.get("event_window"),
         "cycle_matched_events": (
             cycle_section.get("matched_events") if cycle_section is not None else None
         ),
@@ -631,6 +653,7 @@ def build_live_incident_bundle(
     log_tail_lines: int = 500,
     max_log_matches: int = 100,
     log_window_unparsed_policy: str = DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
+    event_tail_lines: int = 0,
     max_snapshot_files: int = 20,
     max_snapshot_file_bytes: int = 1_000_000,
     max_event_segment_bytes: int = 10_000_000,
@@ -657,6 +680,7 @@ def build_live_incident_bundle(
         pside=pside,
         reason_code=reason_code,
         status=status,
+        event_tail_lines=event_tail_lines,
         limit=max_events,
         include_data=include_data,
         include_rotated=include_rotated,
@@ -671,6 +695,7 @@ def build_live_incident_bundle(
         until_ms=until_ms,
         include_rotated=include_rotated,
         include_data=include_data,
+        event_tail_lines=event_tail_lines,
         limit=max_events,
     )
     smoke_report = build_live_smoke_report(
@@ -682,6 +707,7 @@ def build_live_incident_bundle(
         include_rotated=include_rotated,
         since_ms=since_ms,
         until_ms=until_ms,
+        event_tail_lines=event_tail_lines,
         max_problem_events=max_problem_events,
         max_log_files=max_log_files,
         log_tail_lines=log_tail_lines,
@@ -725,6 +751,7 @@ def build_live_incident_bundle(
                     "status": status,
                     "since_ms": since_ms,
                     "until_ms": until_ms,
+                    "event_tail_lines": event_tail_lines if event_tail_lines else None,
                     "include_rotated": include_rotated,
                     "include_data": include_data,
                     "include_trace_report": include_trace_report,
@@ -778,6 +805,9 @@ def build_live_incident_bundle(
             "enabled": window_report.get("enabled"),
             "matched_events": window_report.get("matched_events"),
             "events_truncated": window_report.get("events_truncated"),
+            "event_tail_lines": window_report.get("event_tail_lines"),
+            "event_tail_limited_files": window_report.get("event_tail_limited_files"),
+            "event_tail_skipped_lines": window_report.get("event_tail_skipped_lines"),
         },
         "smoke_report": {
             "ok": smoke_report.get("ok"),

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from live.event_bus import LIVE_EVENT_MONITOR_PAYLOAD_KEY, EventTypes, utc_ms
+from live.event_file_rows import event_file_rows
 from live.event_query import discover_event_files_with_metadata
 
 
@@ -3419,6 +3420,10 @@ def _event_window_report(
     event_tail_lines: int = 0,
     event_tail_limited_files: int = 0,
     event_tail_skipped_lines: int = 0,
+    event_tail_skipped_lines_exact: bool = True,
+    event_tail_skipped_bytes: int = 0,
+    event_tail_line_numbers_exact: bool = True,
+    event_tail_methods: dict[str, int] | None = None,
 ) -> dict[str, Any]:
     report = {
         "enabled": since_ms is not None or until_ms is not None,
@@ -3433,6 +3438,10 @@ def _event_window_report(
         report["event_tail_lines"] = int(event_tail_lines)
         report["event_tail_limited_files"] = int(event_tail_limited_files)
         report["event_tail_skipped_lines"] = int(event_tail_skipped_lines)
+        report["event_tail_skipped_lines_exact"] = bool(event_tail_skipped_lines_exact)
+        report["event_tail_skipped_bytes"] = int(event_tail_skipped_bytes)
+        report["event_tail_line_numbers_exact"] = bool(event_tail_line_numbers_exact)
+        report["event_tail_methods"] = dict(sorted((event_tail_methods or {}).items()))
     return report
 
 
@@ -3519,6 +3528,10 @@ def _scan_events(
     max_event_tail_lines = max(0, int(event_tail_lines))
     event_tail_limited_files = 0
     event_tail_skipped_lines = 0
+    event_tail_skipped_lines_exact = True
+    event_tail_skipped_bytes = 0
+    event_tail_line_numbers_exact = True
+    event_tail_methods: Counter[str] = Counter()
     startup_timing_records: dict[str, list[dict[str, Any]]] = defaultdict(list)
     remote_call_failure_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     remote_call_health_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -3541,18 +3554,22 @@ def _scan_events(
 
     for path in files:
         try:
-            with _open_text(path) as stream:
-                if max_event_tail_lines:
-                    file_rows = deque(
-                        enumerate(stream, start=1),
-                        maxlen=max_event_tail_lines,
-                    )
+            with event_file_rows(path, max_tail_lines=max_event_tail_lines) as (
+                rows,
+                row_window,
+            ):
+                if max_event_tail_lines and row_window.limited:
                     event_tail_limited_files += 1
-                    if file_rows:
-                        event_tail_skipped_lines += max(0, int(file_rows[0][0]) - 1)
-                    rows = file_rows
-                else:
-                    rows = enumerate(stream, start=1)
+                    if row_window.skipped_lines is None:
+                        event_tail_skipped_lines_exact = False
+                    else:
+                        event_tail_skipped_lines += int(row_window.skipped_lines)
+                    event_tail_skipped_bytes += int(row_window.skipped_bytes)
+                    event_tail_line_numbers_exact = (
+                        event_tail_line_numbers_exact
+                        and bool(row_window.line_numbers_exact)
+                    )
+                    event_tail_methods[str(row_window.method)] += 1
                 for line_no, raw_line in rows:
                     line = raw_line.strip()
                     if not line:
@@ -3908,6 +3925,10 @@ def _scan_events(
             event_tail_lines=max_event_tail_lines,
             event_tail_limited_files=event_tail_limited_files,
             event_tail_skipped_lines=event_tail_skipped_lines,
+            event_tail_skipped_lines_exact=event_tail_skipped_lines_exact,
+            event_tail_skipped_bytes=event_tail_skipped_bytes,
+            event_tail_line_numbers_exact=event_tail_line_numbers_exact,
+            event_tail_methods=dict(event_tail_methods),
         ),
     }
 
@@ -4894,6 +4915,10 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
                 "event_tail_lines",
                 "event_tail_limited_files",
                 "event_tail_skipped_lines",
+                "event_tail_skipped_lines_exact",
+                "event_tail_skipped_bytes",
+                "event_tail_line_numbers_exact",
+                "event_tail_methods",
             )
             if key in event_window
         },

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -200,8 +200,10 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=0,
         help=(
-            "Opt-in parser bound for monitor event segments: read only the last "
-            "N rows from each event file. Default 0 keeps full event validation."
+            "Opt-in bound for monitor event segments: inspect only the last N "
+            "rows from each event file. Plain NDJSON segments seek from file "
+            "end; compressed segments may still scan sequentially. Default 0 "
+            "keeps full event validation."
         ),
     )
     parser.add_argument(

--- a/src/tools/live_incident_bundle.py
+++ b/src/tools/live_incident_bundle.py
@@ -153,7 +153,9 @@ def build_parser() -> argparse.ArgumentParser:
         default=0,
         help=(
             "Only scan the last N lines from each monitor event segment for "
-            "event reports and smoke checks. Default 0 scans full segments."
+            "event reports and smoke checks. Plain NDJSON segments seek from "
+            "file end; compressed segments may still be scanned sequentially. "
+            "Default 0 scans full segments."
         ),
     )
     parser.add_argument(

--- a/src/tools/live_incident_bundle.py
+++ b/src/tools/live_incident_bundle.py
@@ -148,6 +148,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Also scan rotated/compressed monitor event segments.",
     )
     parser.add_argument(
+        "--event-tail-lines",
+        type=int,
+        default=0,
+        help=(
+            "Only scan the last N lines from each monitor event segment for "
+            "event reports and smoke checks. Default 0 scans full segments."
+        ),
+    )
+    parser.add_argument(
         "--no-event-segments",
         action="store_true",
         help="Do not copy bounded event segment files into the bundle.",
@@ -207,6 +216,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     if args.since_ms is not None and args.recent_minutes is not None:
         parser.error("--since-ms and --recent-minutes are mutually exclusive")
+    if int(args.event_tail_lines) < 0:
+        parser.error("--event-tail-lines must be >= 0")
     since_ms = args.since_ms
     if args.recent_minutes is not None:
         if args.recent_minutes <= 0:
@@ -235,6 +246,7 @@ def main(argv: list[str] | None = None) -> int:
         include_data=bool(args.include_data),
         include_trace_report=not bool(args.no_trace_report),
         include_rotated=bool(args.include_rotated),
+        event_tail_lines=int(args.event_tail_lines),
         include_event_segments=not bool(args.no_event_segments),
         max_events=int(args.limit),
         max_log_files=int(args.max_log_files),

--- a/src/tools/live_smoke_report.py
+++ b/src/tools/live_smoke_report.py
@@ -124,8 +124,10 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=0,
         help=(
-            "Opt-in parser bound for monitor event segments: read only the last "
-            "N rows from each event file. Default 0 keeps full monitor validation."
+            "Opt-in bound for monitor event segments: inspect only the last N "
+            "rows from each event file. Plain NDJSON segments seek from file "
+            "end; compressed segments may still scan sequentially. Default 0 "
+            "keeps full monitor validation."
         ),
     )
     parser.add_argument(

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -6,6 +6,7 @@ import os
 
 import pytest
 
+from live.event_file_rows import event_file_rows
 from live.event_query import (
     build_event_report,
     discover_event_files,
@@ -1317,12 +1318,34 @@ def test_event_query_event_tail_lines_bounds_window_scan(tmp_path):
         "event_tail_lines": 2,
         "event_tail_limited_files": 1,
         "event_tail_skipped_lines": 3,
+        "event_tail_skipped_lines_exact": True,
+        "event_tail_skipped_bytes": 0,
+        "event_tail_line_numbers_exact": True,
+        "event_tail_methods": {"seek_tail": 1},
     }
     assert report["query"]["matched_events"] == 2
     assert [event["ids"]["cycle_id"] for event in report["query"]["events"]] == [
         "cy_4",
         "cy_5",
     ]
+
+
+def test_event_file_rows_seek_tail_skips_plain_ndjson_prefix(tmp_path):
+    path = tmp_path / "current.ndjson"
+    old_prefix = json.dumps({"seq": 1, "payload": "x" * 80_000})
+    row_2 = json.dumps({"seq": 2})
+    row_3 = json.dumps({"seq": 3})
+    path.write_text(f"{old_prefix}\n{row_2}\n{row_3}\n", encoding="utf-8")
+
+    with event_file_rows(path, max_tail_lines=2) as (rows, window):
+        kept_rows = list(rows)
+
+    assert window.method == "seek_tail"
+    assert window.skipped_bytes > 0
+    assert window.skipped_lines is None
+    assert window.skipped_lines_exact is False
+    assert window.line_numbers_exact is False
+    assert [json.loads(raw_line)["seq"] for _, raw_line in kept_rows] == [2, 3]
 
 
 def test_event_query_timeline_renders_cycle_and_query_matches(tmp_path):

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -404,6 +404,82 @@ def test_live_incident_bundle_cli_recent_minutes_sets_since_ms(
     assert window_report["filters"] == {"since_ms": 2000}
 
 
+def test_live_incident_bundle_cli_event_tail_lines_bounds_event_scans(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="cycle.completed", seq=1, ts=1000),
+            _monitor_row(
+                event_type="remote_call.failed",
+                seq=2,
+                ts=2000,
+                status="failed",
+                level="warning",
+            ),
+            _monitor_row(event_type="cycle.completed", seq=3, ts=3000),
+        ],
+    )
+    output = tmp_path / "incident.tar.gz"
+
+    assert (
+        live_incident_bundle.main(
+            [
+                str(tmp_path / "monitor"),
+                "--logs-root",
+                "",
+                "--since-ms",
+                "1000",
+                "--event-type",
+                "cycle.completed",
+                "--event-tail-lines",
+                "1",
+                "--no-event-segments",
+                "--no-trace-report",
+                "--output",
+                str(output),
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["ok"] is True
+    assert report["event_report"]["query_matched_events"] == 1
+    assert report["event_report"]["event_window"] == {
+        "enabled": False,
+        "since_ms": None,
+        "until_ms": None,
+        "events_considered": 1,
+        "events_skipped_before": 0,
+        "events_skipped_after": 0,
+        "invalid_window_ts": 0,
+        "files_skipped_before_window": 0,
+        "event_tail_lines": 1,
+        "event_tail_limited_files": 1,
+        "event_tail_skipped_lines": 2,
+    }
+    assert report["time_window"]["matched_events"] == 1
+    assert report["time_window"]["event_tail_lines"] == 1
+    assert report["time_window"]["event_tail_limited_files"] == 1
+    assert report["time_window"]["event_tail_skipped_lines"] == 2
+    assert report["smoke_report"]["event_window"]["event_tail_lines"] == 1
+    assert report["smoke_report"]["event_window"]["event_tail_limited_files"] == 1
+    assert report["smoke_report"]["event_window"]["event_tail_skipped_lines"] == 2
+
+    with tarfile.open(output, "r:gz") as tar:
+        manifest = _read_tar_json(tar, "manifest.json")
+        event_report = _read_tar_json(tar, "event_report.json")
+        window_report = _read_tar_json(tar, "time_window_report.json")
+        smoke_report = _read_tar_json(tar, "smoke_report.json")
+    assert manifest["filters"]["event_tail_lines"] == 1
+    assert event_report["query"]["events"][0]["seq"] == 3
+    assert event_report["event_window"]["event_tail_skipped_lines"] == 2
+    assert window_report["events"][0]["seq"] == 3
+    assert smoke_report["event_window"]["event_tail_skipped_lines"] == 2
+
+
 def test_live_incident_bundle_cli_rejects_invalid_window_timestamp(capsys):
     with pytest.raises(SystemExit) as exc_info:
         live_incident_bundle.main(["monitor", "--since-ms", "not-an-int"])
@@ -428,6 +504,14 @@ def test_live_incident_bundle_cli_rejects_non_positive_recent_minutes(capsys):
 
     assert exc_info.value.code == 2
     assert "must be greater than 0" in capsys.readouterr().err
+
+
+def test_live_incident_bundle_cli_rejects_negative_event_tail_lines(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_incident_bundle.main(["monitor", "--event-tail-lines", "-1"])
+
+    assert exc_info.value.code == 2
+    assert "--event-tail-lines must be >= 0" in capsys.readouterr().err
 
 
 def test_live_incident_bundle_cli_rejects_recent_window_after_until(capsys, monkeypatch):

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -459,6 +459,10 @@ def test_live_incident_bundle_cli_event_tail_lines_bounds_event_scans(tmp_path, 
         "event_tail_lines": 1,
         "event_tail_limited_files": 1,
         "event_tail_skipped_lines": 2,
+        "event_tail_skipped_lines_exact": True,
+        "event_tail_skipped_bytes": 0,
+        "event_tail_line_numbers_exact": True,
+        "event_tail_methods": {"seek_tail": 1},
     }
     assert report["time_window"]["matched_events"] == 1
     assert report["time_window"]["event_tail_lines"] == 1

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+import live.event_file_rows as event_file_rows_module
 import live.smoke_report as smoke_report_module
 from live.smoke_report import (
     build_live_smoke_report,
@@ -107,13 +108,13 @@ def test_live_smoke_report_scans_monitor_segments_once(tmp_path, monkeypatch):
     )
     rotated_path.write_bytes(b"")
     opened = []
-    original_open_text = smoke_report_module._open_text
+    original_open_text = event_file_rows_module._open_text
 
     def spy_open_text(path):
         opened.append(path)
         return original_open_text(path)
 
-    monkeypatch.setattr(smoke_report_module, "_open_text", spy_open_text)
+    monkeypatch.setattr(event_file_rows_module, "_open_text", spy_open_text)
 
     report = build_live_smoke_report(
         tmp_path / "monitor",
@@ -199,6 +200,10 @@ def test_live_smoke_report_event_tail_lines_bounds_monitor_scan(tmp_path):
         "event_tail_lines": 2,
         "event_tail_limited_files": 1,
         "event_tail_skipped_lines": 3,
+        "event_tail_skipped_lines_exact": True,
+        "event_tail_skipped_bytes": 0,
+        "event_tail_line_numbers_exact": True,
+        "event_tail_methods": {"seek_tail": 1},
     }
     assert report["bots"][0]["events"] == 2
 


### PR DESCRIPTION
## Summary

Adds opt-in `--event-tail-lines` support to `passivbot tool live-incident-bundle`.

The option bounds monitor event parsing for the embedded event report, time-window report, and smoke report by scanning only the last N rows from each event segment. Default `0` preserves the existing full-scan behavior.

Also folds the latest PR #912 VPS5/progress evidence into the live logging progress/backlog docs instead of creating a separate docs-only PR.

## Scope

- Read-only incident-bundle/report tooling only.
- No event producers.
- No exchange calls.
- No live execution, order/risk logic, console routing, smoke verdict changes, or trading behavior.
- `--since-ms` / `--recent-minutes` semantics remain owned by the existing `time_window_report` and embedded smoke-report window; this PR does not change existing cycle-scoped event-report behavior.

## Validation

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_incident_bundle.py`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_incident_bundle.py tests/test_live_event_query.py tests/test_live_smoke_report.py`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/incident_bundle.py src/tools/live_incident_bundle.py tests/test_live_incident_bundle.py`
- `git diff --check`
- Touched-file silent-handling scan: only existing read-only report-summary `.get(..., default)` patterns were matched.
