### PR TITLE
Embed problem event reports in incident bundles

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-30.
 
 Current `origin/v8` logging-overhaul head:
 
-- `aef82af9` after PR #915, `Project brief smoke problem groups`.
+- `0f32aeff` after PR #916, `Filter live event query problem events`.
 
 Current review gate:
 
@@ -49,6 +49,28 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #916 at `0f32aeff`.
+- PR #916 added `live-event-query --problem-events` and
+  `--hard-problem-events`, using the same shared structured problem-event
+  predicate as `live-smoke-report`. The slice was read-only event-query tooling
+  and did not add event producers, exchange calls, live execution, report
+  verdict changes, console routing, order/risk logic, or trading behavior.
+- PR #916 used the documented degraded review gate: Claude remained absent
+  across repeated poll cycles, while Hermes approved the amended head, CI was
+  green, and the merge was clean. Local validation covered
+  `tests/test_live_event_query.py`, `tests/test_live_smoke_report.py`,
+  py_compile for touched files and tests, `git diff --check`, and a
+  touched-file silent-handling scan.
+- VPS5 pulled from `aef82af9` to `0f32aeff` without bot restart because the
+  deployed change was read-only event-query tooling. The five configured bots
+  were left running.
+- A 5-minute smoke at `0f32aeff` using `--event-tail-lines 1000`,
+  `--processes`, and `/root/bots_vps5.yaml` completed with `ok=true`,
+  `hard_failures=0`, all five configured bots matched, clean tracked repository
+  state, no failed remote calls, and no failed account-critical remote calls.
+  A focused `live-event-query --problem-events --trace-summary` over the same
+  recent window matched the same known non-hard EMA readiness and HSL status
+  attention groups shown by smoke.
 - Repository pulled through PR #915 at `aef82af9`.
 - PR #915 projected bounded, value-safe `problem_events.groups` and
   `event_types` into `live-smoke-report --brief`, with
@@ -1795,10 +1817,26 @@ VPS5 deployment status:
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events, HSL replay failure events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events; PR #707 restores throttled coin-mode HSL position status console lines from existing `hsl.status` metrics; PR #709 mirrors fill-cache startup readiness into off-console `fills.refresh_summary` events; PR #711 mirrors CCXT timestamp/nonce recovery into off-console `exchange.time_sync` events; PR #846 mirrors pre-create market-distance guard skips into off-console `execution.create_skipped` events; PR #848 mirrors pre-create planning/market snapshot skips into off-console `execution.create_skipped` events; PR #850 mirrors fill-cache doctor startup report/quarantine/rebuild decisions into off-console `fills.refresh_summary` events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
-| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, severity-level filters, problem-event filters, event-file discovery metadata, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/brief problem-event groups/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window reports, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation with summary/filter, decision-boundary, initial input-staleness, HSL replay pair/rate, forager/EMA readiness, cache warmup, resource-pressure percentiles, and unified operation-duration support | Cross-bot incident workflow, safe restart orchestration, richer symbol/market/config staleness performance metrics, active probe expansion beyond current endpoint/freshness summaries |
+| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, severity-level filters, problem-event filters, event-file discovery metadata, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/brief problem-event groups/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window/problem-event reports, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation with summary/filter, decision-boundary, initial input-staleness, HSL replay pair/rate, forager/EMA readiness, cache warmup, resource-pressure percentiles, and unified operation-duration support | Cross-bot incident workflow, safe restart orchestration, richer symbol/market/config staleness performance metrics, active probe expansion beyond current endpoint/freshness summaries |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup; PR #656/#668 cache integrity smoke doctor | Continue separate reviewed PRs for shutdown/warmup/cache proof improvements |
 
 ## Merged Slices
+
+### Pending PR: Incident Bundle Problem Event Report
+
+- Branch: `codex/v8-incident-problem-query`.
+- Scope: read-only incident bundle tooling and tests.
+- Result: `passivbot tool live-incident-bundle` now embeds
+  `problem_event_report.json` by default. The report is built with the shared
+  `live-event-query --problem-events` predicate, honors the bundle's existing
+  cycle/symbol/status/reason/time/tail filters, includes a trace summary, and
+  can be disabled with `--no-problem-report` for compact bundles. Event segment
+  selection now considers the problem-event report too, so bundles keep the raw
+  segment needed to reconstruct smoke attention rows.
+- Local validation: focused incident-bundle and event-query tests plus
+  py_compile passed before opening review. No event producers, exchange calls,
+  cache mutation, readiness gates, console routing, monitor writes, order/risk
+  logic, or trading behavior changed.
 
 ### Foundation Before PR #619
 

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -138,20 +138,23 @@ Related detailed plans:
    live-event trace reports, smoke summaries, redacted log excerpts, monitor
    snapshots, config hashes, runtime metadata, and bounded event segments into a
    tarball. Bundles can also include trace reports, optional smoke-report
-   process status, event-file discovery metadata, and recent time windows.
+   process status, event-file discovery metadata, recent time windows, and
+   problem-event reports that reuse the same predicate as smoke/report query
+   tooling.
 
    Remaining refinements: richer remote smoke integration when the
    restart/smoke automation exists; keep recent-window bundle scans bounded for
-   very large current monitor segments.
+   very large current monitor segments; continue cross-bot incident workflow
+   improvements only where concrete operator diagnostics require them.
 
 2. [x] Event query and timeline CLI extensions.
    Status: core filter/timeline work merged. `passivbot tool live-event-query`
    now supports event discovery, compact JSON output, current-vs-rotated segment
    selection, terse timeline rendering, and filters for event type/kind, cycle
    id, order wave id, remote call id/group id, bot id, snapshot id, plan id,
-   action id, symbol, pside, reason code, status, and event time window. It
-   also supports aggregate trace summaries over matched events and order waves,
-   plus a
+   action id, symbol, pside, reason code, status, problem-event state, and event
+   time window. It also supports aggregate trace summaries over matched events
+   and order waves, plus a
    dedicated order-trace reconstruction view for order waves/actions and a
    cycle-trace reconstruction view with nested order traces. Incident bundles
    now embed the existing trace-summary/order-trace reports and cycle traces
@@ -693,7 +696,9 @@ Related detailed plans:
 
 | Date | Item | PR / Commit | Result | Remaining |
 |------|------|-------------|--------|-----------|
-| 2026-06-30 | #2/#3 Event query and live restart/smoke automation | PR #915 / `aef82af9` | Projected bounded, value-safe `problem_events.groups` and `event_types` into `live-smoke-report --brief`; VPS5 no-restart deploy stayed hard-green with all five bots matched and remaining attention attributable to EMA readiness plus HSL cooldown groups | Add a matching event-query problem-event filter so operators can jump from brief smoke attention groups to exact event rows |
+| 2026-06-30 | #1/#2/#3 Incident bundle generator, event query, and live restart/smoke automation | pending PR / `codex/v8-incident-problem-query` | Embeds a bounded `problem_event_report.json` in incident bundles by default, using the same shared problem-event predicate as `live-smoke-report` and `live-event-query --problem-events`, with `--no-problem-report` for compact bundles | Review, merge, and VPS5 no-restart smoke pending |
+| 2026-06-30 | #2/#3 Event query and live restart/smoke automation | PR #916 / `0f32aeff` | Added `live-event-query --problem-events` and `--hard-problem-events` using the same shared predicate as `live-smoke-report`; VPS5 no-restart deploy stayed hard-green and a focused query matched the same EMA/HSL attention groups shown by brief smoke | Embed the problem-event query view into incident bundles so bundle artifacts carry the exact attention rows |
+| 2026-06-30 | #2/#3 Event query and live restart/smoke automation | PR #915 / `aef82af9` | Projected bounded, value-safe `problem_events.groups` and `event_types` into `live-smoke-report --brief`; VPS5 no-restart deploy stayed hard-green with all five bots matched and remaining attention attributable to EMA readiness plus HSL cooldown groups | Completed by PR #916 query filters and the pending incident-bundle embedding slice |
 | 2026-06-30 | #1/#3 Incident bundle generator and live restart/smoke automation | PR #914 / `9ff335e4` | Moved incident-bundle event-segment SHA hashing behind actual segment inclusion; VPS5 no-restart deploy stayed green, bounded bundle smoke completed in 9.77s with zero event-segment bytes copied, and brief smoke stayed hard-green with all five bots matched | Brief smoke still reports `attention=true` from structured problem events without bounded top-cause groups; continue safe restart orchestration |
 | 2026-06-30 | #1/#3 Incident bundle generator and live restart/smoke automation | PR #913 / `d3f3264c` | Added opt-in `--event-tail-lines` to incident bundles and shared seek-tail event-row iteration for plain NDJSON across event-query, smoke-report, and incident time-window scans; VPS5 no-restart deploy stayed green and bounded bundle smoke completed in 15.51s with seek-tail metadata | Avoid remaining disabled-segment manifest hashing; continue safe restart orchestration |
 | 2026-06-30 | #1/#3 Incident bundle generator and live restart/smoke automation | PR #912 / `0eb29545` | Added `--recent-minutes` to incident bundles and deployed it read-only to VPS5; bundle smoke showed the recent window active with clean hard-failure status but still many matched current-segment events | Add opt-in event-tail bounding for recent incident bundles; continue safe restart orchestration |

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -544,12 +544,33 @@ def _event_report_result_summary(event_report: dict[str, Any]) -> dict[str, Any]
     }
 
 
+def _problem_report_result_summary(problem_report: dict[str, Any]) -> dict[str, Any]:
+    query = problem_report.get("query")
+    query_section = query if isinstance(query, dict) else {}
+    trace_summary = query_section.get("trace_summary")
+    return {
+        "enabled": bool(problem_report),
+        "files_scanned": problem_report.get("files_scanned"),
+        "live_events": problem_report.get("live_events"),
+        "error_count": problem_report.get("error_count"),
+        "warning_count": problem_report.get("warning_count"),
+        "matched_events": query_section.get("matched_events"),
+        "events_truncated": query_section.get("events_truncated"),
+        "trace_summary_matched_events": (
+            trace_summary.get("matched_events")
+            if isinstance(trace_summary, dict)
+            else None
+        ),
+    }
+
+
 def _copy_event_segments(
     *,
     monitor_root: str | Path,
     bundle_root: Path,
     event_report: dict[str, Any],
     window_report: dict[str, Any],
+    problem_report: dict[str, Any],
     include_rotated: bool,
     include_segments: bool,
     max_total_bytes: int,
@@ -570,7 +591,7 @@ def _copy_event_segments(
         file_discovery = discovery.to_dict()
     except FileNotFoundError:
         discovered = []
-    matched_paths = _matched_segment_paths(event_report, window_report)
+    matched_paths = _matched_segment_paths(event_report, window_report, problem_report)
     if matched_paths:
         paths = [Path(path) for path in sorted(matched_paths)]
     else:
@@ -652,6 +673,7 @@ def build_live_incident_bundle(
     until_ms: int | None = None,
     include_data: bool = False,
     include_trace_report: bool = True,
+    include_problem_report: bool = True,
     include_rotated: bool = False,
     include_event_segments: bool = True,
     max_events: int = 500,
@@ -696,6 +718,30 @@ def build_live_incident_bundle(
         order_trace=include_trace_report,
         cycle_trace=include_trace_report and cycle_id is not None,
     )
+    problem_report = (
+        build_event_report(
+            monitor_path,
+            cycle_id=cycle_id,
+            event_type=event_type,
+            order_wave_id=order_wave_id,
+            remote_call_id=remote_call_id,
+            symbol=symbol,
+            pside=pside,
+            reason_code=reason_code,
+            status=status,
+            problem_events=True,
+            since_ms=since_ms,
+            until_ms=until_ms,
+            event_tail_lines=event_tail_lines,
+            limit=max_problem_events,
+            include_data=include_data,
+            include_rotated=include_rotated,
+            timeline=True,
+            trace_summary=True,
+        )
+        if include_problem_report
+        else {}
+    )
     window_report = _build_time_window_report(
         monitor_path,
         since_ms=since_ms,
@@ -736,6 +782,7 @@ def build_live_incident_bundle(
             bundle_root=bundle_root,
             event_report=event_report,
             window_report=window_report,
+            problem_report=problem_report,
             include_rotated=include_rotated,
             include_segments=include_event_segments,
             max_total_bytes=max_event_segment_bytes,
@@ -762,6 +809,7 @@ def build_live_incident_bundle(
                     "include_rotated": include_rotated,
                     "include_data": include_data,
                     "include_trace_report": include_trace_report,
+                    "include_problem_report": include_problem_report,
                     "include_processes": include_processes,
                     "supervisor_config": str(supervisor_config)
                     if supervisor_config is not None
@@ -778,6 +826,8 @@ def build_live_incident_bundle(
 
         _write_json(bundle_root / "manifest.json", metadata)
         _write_json(bundle_root / "event_report.json", event_report)
+        if include_problem_report:
+            _write_json(bundle_root / "problem_event_report.json", problem_report)
         _write_json(bundle_root / "time_window_report.json", window_report)
         _write_json(bundle_root / "smoke_report.json", smoke_report)
         timeline_lines: list[str] = []
@@ -785,6 +835,11 @@ def build_live_incident_bundle(
             value = event_report.get(section)
             if isinstance(value, dict):
                 timeline_lines.extend(str(line) for line in value.get("timeline", []))
+        problem_query = problem_report.get("query")
+        if isinstance(problem_query, dict):
+            problem_timeline = problem_query.get("timeline")
+            if isinstance(problem_timeline, list):
+                timeline_lines.extend(str(line) for line in problem_timeline)
         timeline_lines.extend(str(line) for line in window_report.get("timeline", []))
         (bundle_root / "timeline.txt").write_text(
             "\n".join(timeline_lines) + ("\n" if timeline_lines else ""),
@@ -808,6 +863,7 @@ def build_live_incident_bundle(
         "bundle_version": BUNDLE_VERSION,
         "hard_failures": hard_failures,
         "event_report": _event_report_result_summary(event_report),
+        "problem_event_report": _problem_report_result_summary(problem_report),
         "time_window": {
             "enabled": window_report.get("enabled"),
             "matched_events": window_report.get("matched_events"),

--- a/src/tools/live_incident_bundle.py
+++ b/src/tools/live_incident_bundle.py
@@ -143,6 +143,15 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--no-problem-report",
+        action="store_true",
+        help=(
+            "Do not include the bundled live-event-query problem-event report. "
+            "Enabled by default so smoke attention can be reconstructed from "
+            "the incident bundle."
+        ),
+    )
+    parser.add_argument(
         "--include-rotated",
         action="store_true",
         help="Also scan rotated/compressed monitor event segments.",
@@ -247,6 +256,7 @@ def main(argv: list[str] | None = None) -> int:
         until_ms=args.until_ms,
         include_data=bool(args.include_data),
         include_trace_report=not bool(args.no_trace_report),
+        include_problem_report=not bool(args.no_problem_report),
         include_rotated=bool(args.include_rotated),
         event_tail_lines=int(args.event_tail_lines),
         include_event_segments=not bool(args.no_event_segments),

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -157,6 +157,8 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     assert report["event_report"]["trace_summary_matched_events"] == 3
     assert report["event_report"]["order_trace_matched_events"] == 2
     assert report["event_report"]["cycle_trace_matched_events"] == 3
+    assert report["problem_event_report"]["enabled"] is True
+    assert report["problem_event_report"]["matched_events"] == 0
     assert report["time_window"]["matched_events"] == 1
     assert report["smoke_report"]["event_window"] == {
         "enabled": True,
@@ -185,6 +187,7 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         assert len(tar_names) == len(names)
         assert "manifest.json" in names
         assert "event_report.json" in names
+        assert "problem_event_report.json" in names
         assert "time_window_report.json" in names
         assert "smoke_report.json" in names
         assert "timeline.txt" in names
@@ -196,6 +199,7 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
 
         manifest = _read_tar_json(tar, "manifest.json")
         event_report = _read_tar_json(tar, "event_report.json")
+        problem_event_report = _read_tar_json(tar, "problem_event_report.json")
         event_segments_manifest = _read_tar_json(tar, "event_segments_manifest.json")
         window_report = _read_tar_json(tar, "time_window_report.json")
         smoke_report = _read_tar_json(tar, "smoke_report.json")
@@ -225,6 +229,13 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     assert redacted_snapshot["nested"]["url"] == "https://[redacted]@example.com/path"
     assert event_report["cycle"]["events"][0]["seq"] == 1
     assert event_report["file_discovery"] == report["event_report"]["file_discovery"]
+    assert problem_event_report["query"]["filters"] == {
+        "cycle_id": "cy_1",
+        "problem_events": True,
+        "since_ms": 1500,
+        "until_ms": 2500,
+    }
+    assert problem_event_report["query"]["matched_events"] == 0
     assert "data" not in event_report["cycle"]["events"][0]
     assert event_report["cycle"]["trace_summary"]["matched_events"] == 3
     assert event_report["cycle"]["order_trace"]["matched_order_events"] == 2
@@ -239,6 +250,81 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     assert "remote_call.failed" in window_report["timeline"][0]
     assert smoke_report["event_window"] == report["smoke_report"]["event_window"]
     assert smoke_report["remote_call_failures"]["total"] == 1
+
+
+def test_live_incident_bundle_embeds_problem_event_report(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="remote_call.failed",
+                seq=2,
+                ts=1100,
+                status="failed",
+                level="warning",
+                reason_code="request_timeout",
+                symbol="BTC/USDT:USDT",
+                ids={"cycle_id": "cy_1", "remote_call_id": "rc_1"},
+            ),
+            _monitor_row(
+                event_type="ema.unavailable",
+                seq=3,
+                ts=1200,
+                status="degraded",
+                level="warning",
+                reason_code="stale_ema",
+                symbol="ETH/USDT:USDT",
+                ids={"cycle_id": "cy_2"},
+            ),
+        ],
+    )
+    output = tmp_path / "incident.tar.gz"
+
+    report = build_live_incident_bundle(
+        tmp_path / "monitor",
+        output_path=output,
+        logs_root="",
+        cycle_id="cy_1",
+        include_data=True,
+        max_problem_events=10,
+    )
+
+    assert report["ok"] is True
+    assert report["problem_event_report"] == {
+        "enabled": True,
+        "files_scanned": 1,
+        "live_events": 3,
+        "error_count": 0,
+        "warning_count": 0,
+        "matched_events": 1,
+        "events_truncated": False,
+        "trace_summary_matched_events": 1,
+    }
+
+    with tarfile.open(output, "r:gz") as tar:
+        problem_event_report = _read_tar_json(tar, "problem_event_report.json")
+
+    assert problem_event_report["query"]["filters"] == {
+        "cycle_id": "cy_1",
+        "problem_events": True,
+    }
+    assert problem_event_report["query"]["matched_events"] == 1
+    assert (
+        problem_event_report["query"]["events"][0]["event_type"]
+        == "remote_call.failed"
+    )
+    assert problem_event_report["query"]["events"][0]["data"] == {
+        "detail": "kept only when include_data is enabled",
+        "seq": 2,
+    }
+    assert problem_event_report["query"]["trace_summary"]["matched_events"] == 1
 
 
 def test_live_incident_bundle_can_skip_logs_and_segments_from_cli(tmp_path, capsys):
@@ -270,6 +356,7 @@ def test_live_incident_bundle_can_skip_logs_and_segments_from_cli(tmp_path, caps
                 "",
                 "--no-event-segments",
                 "--no-trace-report",
+                "--no-problem-report",
                 "--output",
                 str(output),
                 "--compact",
@@ -281,8 +368,20 @@ def test_live_incident_bundle_can_skip_logs_and_segments_from_cli(tmp_path, caps
     report = json.loads(capsys.readouterr().out)
     assert report["ok"] is True
     assert report["bundle_path"] == str(output)
+    assert report["problem_event_report"] == {
+        "enabled": False,
+        "files_scanned": None,
+        "live_events": None,
+        "error_count": None,
+        "warning_count": None,
+        "matched_events": None,
+        "events_truncated": None,
+        "trace_summary_matched_events": None,
+    }
     assert report["event_segments"]["included"] == 0
     assert output.exists()
+    with tarfile.open(output, "r:gz") as tar:
+        assert "problem_event_report.json" not in set(tar.getnames())
 
     with tarfile.open(output, "r:gz") as tar:
         tar_names = tar.getnames()


### PR DESCRIPTION
## Summary
- embed a bounded problem_event_report.json in live incident bundles by default
- use the shared live-event-query problem-event predicate and existing incident filters/window/tail bounds
- add --no-problem-report for compact bundles and include the report in segment selection/result summaries
- fold progress/backlog updates into this real tooling PR

## Scope
Observability/read-only tooling only. No event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, order/risk logic, or trading behavior changed.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_incident_bundle.py tests/test_live_event_query.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/incident_bundle.py src/tools/live_incident_bundle.py
- git diff --check
- silent-handling scan on touched report/test files; remaining hits are pre-existing non-trading report summary defaults in incident_bundle.py