### PR TITLE
Summarize HSL replay stages in performance report

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-30.
 
 Current `origin/v8` logging-overhaul head:
 
-- `570875ab` after PR #920, `Summarize incident time-window discovery`.
+- `5808f679` after PR #921, `Summarize incident problem report discovery`.
 
 Current review gate:
 
@@ -49,6 +49,27 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #921 at `5808f679`.
+- PR #921 projected `problem_event_report.file_discovery` and
+  `problem_event_report.event_window` into compact incident-bundle output so
+  scoped problem-event discovery/window metadata can be verified without
+  opening the tarball. The slice was read-only incident-bundle tooling and did
+  not add event producers, exchange calls, live execution, report verdict
+  changes, console routing, order/risk logic, or trading behavior.
+- PR #921 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_incident_bundle.py`, `tests/test_live_event_query.py`,
+  py_compile for touched files, `git diff --check`, and a touched-file
+  silent-handling scan.
+- VPS5 pulled from `570875ab` to `5808f679` without bot restart because the
+  deployed change was read-only incident-bundle tooling. The five configured
+  bots were left running.
+- A 5-minute smoke at `5808f679` completed with `ok=true`, `hard_failures=0`,
+  all five configured bots matched, clean tracked repository state, no failed
+  remote calls, and no failed account-critical remote calls. A focused OKX
+  incident-bundle smoke verified compact output with
+  `problem_event_report.file_discovery.bot_path_pruning_applied=true`,
+  `problem_event_report.files_scanned=1`, `scope_pruned=5`, and
+  `problem_event_report.event_window` populated from the recent-window query.
 - Repository pulled through PR #920 at `570875ab`.
 - PR #920 projected `time_window.files_scanned` and
   `time_window.file_discovery` into compact incident-bundle output so focused
@@ -1908,20 +1929,39 @@ VPS5 deployment status:
 
 ## Current Work
 
-### Pending PR: Incident Bundle Problem Report Discovery Summary
+### Pending PR: HSL Replay Profile Stage Summary
+
+- Branch: `codex/v8-hsl-replay-profile-stage-summary`.
+- Scope: read-only live performance report tooling and tests.
+- Result: adds aggregate HSL replay stage/status counters to
+  `hsl_replay_profile`, so operators can see active/completed/failed replay
+  bots and current active replay stages without manually scanning per-bot
+  groups.
+- Expected validation: focused live-performance-report tests plus py_compile
+  and `git diff --check`. No event producers, exchange calls, cache mutation,
+  readiness gates, console routing, monitor writes, order/risk logic, or
+  trading behavior should change.
+
+## Merged Slices
+
+### PR #921: Incident Bundle Problem Report Discovery Summary
 
 - Branch: `codex/v8-incident-problem-discovery-summary`.
 - Scope: read-only incident bundle tooling and tests.
-- Result: projects problem-event report file-discovery and event-window
-  metadata into the compact incident-bundle result, so scoped problem-event
-  queries can be verified without opening `problem_event_report.json` from the
-  archive.
-- Expected validation: focused incident-bundle and event-query tests plus
+- Result: `passivbot tool live-incident-bundle` now projects
+  `problem_event_report.file_discovery` and
+  `problem_event_report.event_window` into the compact incident-bundle result
+  so scoped problem-event queries can be verified without opening the archive.
+- Review evidence: Cursor, Hermes, Claude, and CI approved the final head.
+  Local validation covered focused incident-bundle and event-query tests plus
   py_compile and `git diff --check`. No event producers, exchange calls, cache
   mutation, readiness gates, console routing, monitor writes, order/risk logic,
-  or trading behavior should change.
-
-## Merged Slices
+  or trading behavior changed.
+- VPS5 evidence: deployed to `v8` at `5808f679` without bot restart because
+  the change is read-only tooling. Smoke stayed hard-green with all five
+  configured bots running, clean tracked repository state, and focused OKX
+  incident-bundle output showing `problem_event_report.files_scanned=1` plus
+  path-pruned discovery/window metadata.
 
 ### PR #920: Incident Bundle Time-Window Discovery Summary
 

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -299,9 +299,10 @@ classification when enough source events exist.
   - Status: partial. Existing `hsl.replay.*` events are now summarized by
     `live-performance-report` as `hsl_replay_profile`, including bounded pair
     counts, timeline rows, rows/s, estimated dense pair-row work, observed
-    progress percentage, and startup-blocking elapsed time where present.
-    Remaining work: true protective-ready elapsed time and per-stage internal
-    replay CPU/IO profiling.
+    progress percentage, startup-blocking elapsed time where present, and
+    aggregate replay stage/status counters. Remaining work: true
+    protective-ready elapsed time and per-stage internal replay CPU/IO
+    profiling.
 - [ ] Cache readiness: fill cache coverage proof, candle coverage proof,
   checkpoint compatibility decision, repair scope, repair elapsed time.
   - Status: partial. Existing `cache.warmup_decision`,
@@ -796,9 +797,10 @@ Each slice should update this checklist with its result.
      replay using realistic pair count, fill count, and row count.
    - Acceptance: report current elapsed, rows/s, and per-stage timing without
      contacting exchanges or changing live behavior.
-   - Status: first report slice adds `hsl_replay_profile` from existing live
-     events. Offline deterministic replay fixtures and internal stage profiling
-     remain open.
+   - Status: first report slices add `hsl_replay_profile` from existing live
+     events, including per-bot replay records plus aggregate stage/status
+     counters for active/completed/failed replay state. Offline deterministic
+     replay fixtures and internal stage profiling remain open.
 
 3. [ ] Held-position protective readiness slice.
    - Classify currently held `coin+pside` pairs before unrelated flat pairs and

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1315,6 +1315,17 @@ def _hsl_replay_active(latest: dict[str, Any] | None) -> bool:
     }
 
 
+def _hsl_replay_latest_status(latest: dict[str, Any] | None) -> str | None:
+    if not isinstance(latest, dict):
+        return None
+    event_type = latest.get("event_type")
+    if event_type == "hsl.replay.failed":
+        return "failed"
+    if event_type == "hsl.replay.completed":
+        return "completed"
+    return "active"
+
+
 def _with_hsl_replay_active_age(
     group: dict[str, Any],
     *,
@@ -1341,6 +1352,7 @@ class _HslReplayProfileAccumulator:
     def __init__(self) -> None:
         self.bots: dict[str, dict[str, Any]] = {}
         self.event_types: Counter[str] = Counter()
+        self.stage_counts: Counter[str] = Counter()
         self.total_events = 0
 
     def add(self, *, row: dict[str, Any], live_event: dict[str, Any]) -> None:
@@ -1362,6 +1374,9 @@ class _HslReplayProfileAccumulator:
             self.bots[bot] = state
         self.total_events += 1
         self.event_types[event_type] += 1
+        stage = str(data.get("stage") or "")
+        if stage:
+            self.stage_counts[stage] += 1
         state["total_events"] = int(state["total_events"]) + 1
         state["event_types"][event_type] += 1
         ts = _record_ts(row)
@@ -1382,7 +1397,6 @@ class _HslReplayProfileAccumulator:
             }.items()
             if value not in (None, {}, [])
         }
-        stage = str(data.get("stage") or "")
         if event_type == "hsl.replay.progress" and stage == "loaded":
             state["loaded"] = record
         elif event_type == "hsl.replay.completed":
@@ -1407,6 +1421,9 @@ class _HslReplayProfileAccumulator:
         if report_ts_ms is None:
             report_ts_ms = utc_ms()
         groups = []
+        latest_status_counts: Counter[str] = Counter()
+        latest_stage_counts: Counter[str] = Counter()
+        active_stage_counts: Counter[str] = Counter()
         for bot, state in self.bots.items():
             group = {
                 "bot": bot,
@@ -1425,6 +1442,20 @@ class _HslReplayProfileAccumulator:
             group = {
                 key: value for key, value in group.items() if value not in (None, {}, [])
             }
+            latest = group.get("latest")
+            latest_status = _hsl_replay_latest_status(latest)
+            if latest_status is not None:
+                latest_status_counts[latest_status] += 1
+                latest_data = latest.get("data") if isinstance(latest, dict) else {}
+                latest_stage = (
+                    str(latest_data.get("stage") or "")
+                    if isinstance(latest_data, dict)
+                    else ""
+                )
+                if latest_stage:
+                    latest_stage_counts[latest_stage] += 1
+                    if latest_status == "active":
+                        active_stage_counts[latest_stage] += 1
             groups.append(
                 _with_hsl_replay_active_age(group, report_ts_ms=int(report_ts_ms))
             )
@@ -1456,6 +1487,13 @@ class _HslReplayProfileAccumulator:
             "total_events": int(self.total_events),
             "bot_count": len(groups),
             "event_types": dict(self.event_types.most_common()),
+            "stage_counts": dict(self.stage_counts.most_common()),
+            "latest_status_counts": dict(latest_status_counts.most_common()),
+            "latest_stage_counts": dict(latest_stage_counts.most_common()),
+            "active_stage_counts": dict(active_stage_counts.most_common()),
+            "active_bot_count": int(latest_status_counts.get("active", 0)),
+            "completed_bot_count": int(latest_status_counts.get("completed", 0)),
+            "failed_bot_count": int(latest_status_counts.get("failed", 0)),
             "groups_truncated": len(groups) > limit,
             "groups": groups[:limit],
         }

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1259,6 +1259,17 @@ def test_live_performance_report_hsl_replay_profile(tmp_path):
         "hsl.replay.completed": 1,
         "hsl.replay.failed": 1,
     }
+    assert profile["stage_counts"] == {
+        "loaded": 1,
+        "pair_replay": 1,
+        "full_replay": 1,
+    }
+    assert profile["latest_status_counts"] == {"failed": 1}
+    assert profile["latest_stage_counts"] == {}
+    assert profile["active_stage_counts"] == {}
+    assert profile["active_bot_count"] == 0
+    assert profile["completed_bot_count"] == 0
+    assert profile["failed_bot_count"] == 1
     assert group["bot"] == "binance/binance_01"
     assert group["event_types"]["hsl.replay.progress"] == 2
     assert group["loaded"]["data"]["symbols"] == 5
@@ -1275,6 +1286,88 @@ def test_live_performance_report_hsl_replay_profile(tmp_path):
     assert group["failed"]["derived"]["latest_elapsed_ms"] == 8000
     assert "must-not-render" not in json.dumps(group, sort_keys=True)
     assert group["completed"]["derived"]["observed_work_pct"] == 75
+
+
+def test_live_performance_report_hsl_replay_profile_stage_summary(tmp_path):
+    rows = [
+        _monitor_row(
+            event_type="hsl.replay.progress",
+            seq=1,
+            ts=1000,
+            exchange="binance",
+            user="binance_01",
+            component="risk.hsl",
+            status="started",
+            data={
+                "stage": "price_history_fetch_started",
+                "history_build_elapsed_s": 45.0,
+            },
+        ),
+        _monitor_row(
+            event_type="hsl.replay.progress",
+            seq=2,
+            ts=2000,
+            exchange="gateio",
+            user="gateio_01",
+            component="risk.hsl",
+            status="started",
+            data={"stage": "pair_replay", "elapsed_s": 12.0},
+        ),
+        _monitor_row(
+            event_type="hsl.replay.completed",
+            seq=3,
+            ts=3000,
+            exchange="okx",
+            user="okx_01",
+            component="risk.hsl",
+            status="succeeded",
+            data={"stage": "full_replay", "full_elapsed_s": 18.0},
+        ),
+        _monitor_row(
+            event_type="hsl.replay.failed",
+            seq=4,
+            ts=4000,
+            exchange="kucoin",
+            user="kucoin_01",
+            component="risk.hsl",
+            status="failed",
+            data={"stage": "price_history_fetch_started", "elapsed_s": 3.0},
+        ),
+    ]
+    for row in rows:
+        exchange = row["exchange"]
+        user = row["user"]
+        _write_ndjson(
+            tmp_path / "monitor" / exchange / user / "events" / "current.ndjson",
+            [row],
+        )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    profile = report["hsl_replay_profile"]
+
+    assert profile["bot_count"] == 4
+    assert profile["stage_counts"] == {
+        "price_history_fetch_started": 2,
+        "pair_replay": 1,
+        "full_replay": 1,
+    }
+    assert profile["latest_status_counts"] == {
+        "active": 2,
+        "completed": 1,
+        "failed": 1,
+    }
+    assert profile["latest_stage_counts"] == {
+        "price_history_fetch_started": 2,
+        "full_replay": 1,
+        "pair_replay": 1,
+    }
+    assert profile["active_stage_counts"] == {
+        "price_history_fetch_started": 1,
+        "pair_replay": 1,
+    }
+    assert profile["active_bot_count"] == 2
+    assert profile["completed_bot_count"] == 1
+    assert profile["failed_bot_count"] == 1
 
 
 def test_live_performance_report_hsl_replay_profile_whitelists_values(tmp_path):


### PR DESCRIPTION
## Summary
- add aggregate HSL replay stage/status counters to live-performance-report hsl_replay_profile
- expose active/completed/failed bot counts plus latest/active stage counts from existing sanitized hsl.replay.* events
- update logging/progress docs with #921 deploy evidence and the current performance-readiness status

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py
- git diff --check
- silent-handling scan over touched source/test files: existing read-only report projection defaults plus aggregate counter defaults only

No event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, order/risk logic, or trading behavior changed.