### PR TITLE
Summarize market snapshot staleness

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-06-30.
 
 Current `origin/v8` logging-overhaul head:
 
-- `5808f679` after PR #921, `Summarize incident problem report discovery`.
+- `82b1990c` after PR #922, `Summarize HSL replay stages in performance report`.
 
 Current review gate:
 
@@ -49,6 +49,27 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #922 at `82b1990c`.
+- PR #922 added aggregate HSL replay stage/status counters to
+  `live-performance-report` `hsl_replay_profile`, exposing
+  active/completed/failed replay bot counts and active/latest replay stage
+  counts from existing sanitized `hsl.replay.*` events. The slice was read-only
+  report tooling and did not add event producers, exchange calls, cache
+  mutation, readiness gates, console routing, monitor writes, order/risk logic,
+  or trading behavior.
+- PR #922 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_performance_report.py`, py_compile for touched files,
+  `git diff --check`, and a touched-file silent-handling scan.
+- VPS5 pulled from `5808f679` to `82b1990c` without bot restart because the
+  deployed change was read-only report tooling. The five configured bots were
+  left running.
+- A 5-minute smoke at `82b1990c` completed with `ok=true`, `hard_failures=0`,
+  all five configured bots matched, clean tracked repository state, no failed
+  remote calls, and no failed account-critical remote calls. A VPS5
+  `live-performance-report --summary` verified the new HSL replay counters in
+  live output, including `active_bot_count=1`,
+  `active_stage_counts.price_history_symbol_fetch_started=1`, and
+  `latest_status_counts.active=1` for the existing Kucoin replay evidence.
 - Repository pulled through PR #921 at `5808f679`.
 - PR #921 projected `problem_event_report.file_discovery` and
   `problem_event_report.event_window` into compact incident-bundle output so
@@ -1929,20 +1950,39 @@ VPS5 deployment status:
 
 ## Current Work
 
-### Pending PR: HSL Replay Profile Stage Summary
+### Pending PR: Market Snapshot Staleness Summary
 
-- Branch: `codex/v8-hsl-replay-profile-stage-summary`.
+- Branch: `codex/v8-market-snapshot-staleness-summary`.
 - Scope: read-only live performance report tooling and tests.
-- Result: adds aggregate HSL replay stage/status counters to
-  `hsl_replay_profile`, so operators can see active/completed/failed replay
-  bots and current active replay stages without manually scanning per-bot
-  groups.
+- Result: adds bounded aggregate market-snapshot staleness counters to
+  `input_staleness`, so operators can see snapshot observations, missing
+  symbol totals, configured-age excess counts, source labels, and age summaries
+  without opening every `snapshot.built` event.
 - Expected validation: focused live-performance-report tests plus py_compile
   and `git diff --check`. No event producers, exchange calls, cache mutation,
   readiness gates, console routing, monitor writes, order/risk logic, or
   trading behavior should change.
 
 ## Merged Slices
+
+### PR #922: HSL Replay Profile Stage Summary
+
+- Branch: `codex/v8-hsl-replay-profile-stage-summary`.
+- Scope: read-only live performance report tooling and tests.
+- Result: `passivbot tool live-performance-report` now adds aggregate HSL
+  replay stage/status counters to `hsl_replay_profile`, so operators can see
+  active/completed/failed replay bots and current active replay stages without
+  manually scanning per-bot groups.
+- Review evidence: Cursor, Hermes, Claude, and CI approved the final head.
+  Local validation covered focused live-performance-report tests plus
+  py_compile and `git diff --check`. No event producers, exchange calls, cache
+  mutation, readiness gates, console routing, monitor writes, order/risk logic,
+  or trading behavior changed.
+- VPS5 evidence: deployed to `v8` at `82b1990c` without bot restart because
+  the change is read-only tooling. Smoke stayed hard-green with all five
+  configured bots running, clean tracked repository state, and
+  `live-performance-report --summary` showed the new HSL replay aggregate
+  counters from existing monitor data.
 
 ### PR #921: Incident Bundle Problem Report Discovery Summary
 

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -318,8 +318,10 @@ classification when enough source events exist.
   forager feature age, candle remote fetch latency, synthetic/no-trade gap
   repair counts.
   - Status: partial. New `snapshot.built` metadata and performance-report
-    groups expose planning surface ages plus market-snapshot max/mean age at
-    snapshot build. Existing `forager.selection`,
+    groups expose planning surface ages plus market-snapshot max/mean age,
+    missing symbol counts, configured-age excess counts, source labels, and
+    aggregate market-snapshot age summaries at snapshot build. Existing
+    `forager.selection`,
     `forager.feature_unavailable`, `ema.unavailable`, and
     `ema.fallback_used` events are now summarized as
     `forager_ema_readiness`, including bounded selection counts,

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -654,6 +654,17 @@ class _InputStalenessAccumulator:
         self.snapshot_surface_age_rows = 0
         self.snapshot_market_summaries_seen = 0
         self.snapshot_market_stale_count = 0
+        self.market_snapshot_observations = 0
+        self.market_snapshot_count_values: list[int] = []
+        self.market_snapshot_symbol_count_values: list[int] = []
+        self.market_snapshot_missing_count_values: list[int] = []
+        self.market_snapshot_missing_symbols_total = 0
+        self.market_snapshot_missing_observation_count = 0
+        self.market_snapshot_max_age_values: list[int] = []
+        self.market_snapshot_mean_age_values: list[int] = []
+        self.market_snapshot_configured_max_age_values: list[int] = []
+        self.market_snapshot_configured_excess_values: list[int] = []
+        self.market_snapshot_source_counts: Counter[str] = Counter()
         self.rust_calls_seen = 0
         self.packet_refs_missing = 0
         self.snapshot_to_rust_exact_matches = 0
@@ -742,12 +753,37 @@ class _InputStalenessAccumulator:
                     )
             market_summary = data.get("market_snapshot_summary")
             if isinstance(market_summary, dict):
+                self.market_snapshot_observations += 1
                 max_age_ms = _non_negative_ms(market_summary.get("max_age_ms"))
                 mean_age_ms = _non_negative_ms(market_summary.get("mean_age_ms"))
                 configured_max_age_ms = _non_negative_ms(
                     market_summary.get("configured_max_age_ms")
                 )
+                for key, values in (
+                    ("count", self.market_snapshot_count_values),
+                    ("symbol_count", self.market_snapshot_symbol_count_values),
+                    ("missing_count", self.market_snapshot_missing_count_values),
+                ):
+                    value = _non_negative_number(market_summary.get(key))
+                    if value is not None:
+                        values.append(int(value))
+                missing_count = _non_negative_number(market_summary.get("missing_count"))
+                if missing_count is not None:
+                    missing_symbols = int(missing_count)
+                    self.market_snapshot_missing_symbols_total += missing_symbols
+                    if missing_symbols > 0:
+                        self.market_snapshot_missing_observation_count += 1
+                if configured_max_age_ms is not None:
+                    self.market_snapshot_configured_max_age_values.append(
+                        int(configured_max_age_ms)
+                    )
+                sources = market_summary.get("sources")
+                if isinstance(sources, list):
+                    for source in sources:
+                        if source is not None:
+                            self.market_snapshot_source_counts[str(source)] += 1
                 if max_age_ms is not None:
+                    self.market_snapshot_max_age_values.append(max_age_ms)
                     self.snapshot_market_summaries_seen += 1
                     self._add_group(
                         row=row,
@@ -761,16 +797,21 @@ class _InputStalenessAccumulator:
                         configured_max_age_ms is not None
                         and max_age_ms > configured_max_age_ms
                     ):
+                        configured_excess_ms = max_age_ms - configured_max_age_ms
+                        self.market_snapshot_configured_excess_values.append(
+                            configured_excess_ms
+                        )
                         self.snapshot_market_stale_count += 1
                         self._add_group(
                             row=row,
                             live_event=live_event,
                             operation="input_staleness.market_snapshot.configured_excess",
-                            value_ms=max_age_ms - configured_max_age_ms,
+                            value_ms=configured_excess_ms,
                             timing_kind="configured_age_excess",
                             trading_impact="blocks_exchange_actions",
                         )
                 if mean_age_ms is not None:
+                    self.market_snapshot_mean_age_values.append(mean_age_ms)
                     self._add_group(
                         row=row,
                         live_event=live_event,
@@ -865,6 +906,25 @@ class _InputStalenessAccumulator:
             "snapshot_surface_age_rows": int(self.snapshot_surface_age_rows),
             "snapshot_market_summaries_seen": int(self.snapshot_market_summaries_seen),
             "snapshot_market_stale_count": int(self.snapshot_market_stale_count),
+            "market_snapshot": {
+                "observations": int(self.market_snapshot_observations),
+                "count": _number_summary(self.market_snapshot_count_values),
+                "symbol_count": _number_summary(self.market_snapshot_symbol_count_values),
+                "missing_count": _number_summary(self.market_snapshot_missing_count_values),
+                "missing_symbols_total": int(self.market_snapshot_missing_symbols_total),
+                "missing_observation_count": int(
+                    self.market_snapshot_missing_observation_count
+                ),
+                "max_age_ms": _number_summary(self.market_snapshot_max_age_values),
+                "mean_age_ms": _number_summary(self.market_snapshot_mean_age_values),
+                "configured_max_age_ms": _number_summary(
+                    self.market_snapshot_configured_max_age_values
+                ),
+                "configured_excess_ms": _number_summary(
+                    self.market_snapshot_configured_excess_values
+                ),
+                "sources": dict(self.market_snapshot_source_counts.most_common(12)),
+            },
             "rust_calls_seen": int(self.rust_calls_seen),
             "packet_refs_missing": int(self.packet_refs_missing),
             "snapshot_to_rust_exact_matches": int(self.snapshot_to_rust_exact_matches),
@@ -3386,6 +3446,7 @@ def summarize_live_performance_report(
             "snapshot_market_stale_count": int(
                 input_staleness.get("snapshot_market_stale_count") or 0
             ),
+            "market_snapshot": input_staleness.get("market_snapshot") or {},
             "rust_calls_seen": int(input_staleness.get("rust_calls_seen") or 0),
             "packet_refs_missing": int(input_staleness.get("packet_refs_missing") or 0),
             "snapshot_to_rust_exact_matches": int(

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -688,6 +688,61 @@ def test_live_performance_report_input_staleness(tmp_path):
     assert report["input_staleness"]["snapshot_surface_age_rows"] == 2
     assert report["input_staleness"]["snapshot_market_summaries_seen"] == 1
     assert report["input_staleness"]["snapshot_market_stale_count"] == 1
+    assert report["input_staleness"]["market_snapshot"] == {
+        "observations": 1,
+        "count": {"count": 1, "max": 2, "mean": 2, "median": 2, "min": 2, "p95": 2},
+        "symbol_count": {
+            "count": 1,
+            "max": 2,
+            "mean": 2,
+            "median": 2,
+            "min": 2,
+            "p95": 2,
+        },
+        "missing_count": {
+            "count": 1,
+            "max": 0,
+            "mean": 0,
+            "median": 0,
+            "min": 0,
+            "p95": 0,
+        },
+        "missing_symbols_total": 0,
+        "missing_observation_count": 0,
+        "max_age_ms": {
+            "count": 1,
+            "max": 700,
+            "mean": 700,
+            "median": 700,
+            "min": 700,
+            "p95": 700,
+        },
+        "mean_age_ms": {
+            "count": 1,
+            "max": 450,
+            "mean": 450,
+            "median": 450,
+            "min": 450,
+            "p95": 450,
+        },
+        "configured_max_age_ms": {
+            "count": 1,
+            "max": 600,
+            "mean": 600,
+            "median": 600,
+            "min": 600,
+            "p95": 600,
+        },
+        "configured_excess_ms": {
+            "count": 1,
+            "max": 100,
+            "mean": 100,
+            "median": 100,
+            "min": 100,
+            "p95": 100,
+        },
+        "sources": {"ticker": 1},
+    }
     assert report["input_staleness"]["rust_calls_seen"] == 1
     assert report["input_staleness"]["packet_refs_missing"] == 0
     assert report["input_staleness"]["snapshot_to_rust_exact_matches"] == 0
@@ -713,6 +768,64 @@ def test_live_performance_report_input_staleness(tmp_path):
     assert staleness_groups["input_staleness.ema_bundle_to_rust"]["trading_impact"] == (
         "blocks_indicator_readiness"
     )
+
+
+def test_live_performance_report_market_snapshot_summary_counts_missing_sources(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=1,
+                ts=1000,
+                data={
+                    "market_snapshot_summary": {
+                        "count": 5,
+                        "symbol_count": 6,
+                        "missing_count": 1,
+                        "max_age_ms": 1500,
+                        "mean_age_ms": 400,
+                        "configured_max_age_ms": 1000,
+                        "sources": ["ticker", "websocket"],
+                    }
+                },
+            ),
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=2,
+                ts=2000,
+                data={
+                    "market_snapshot_summary": {
+                        "count": 6,
+                        "symbol_count": 6,
+                        "missing_count": 0,
+                        "max_age_ms": 800,
+                        "mean_age_ms": 300,
+                        "configured_max_age_ms": 1000,
+                        "sources": ["ticker"],
+                    }
+                },
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    market = report["input_staleness"]["market_snapshot"]
+
+    assert report["input_staleness"]["snapshot_market_summaries_seen"] == 2
+    assert report["input_staleness"]["snapshot_market_stale_count"] == 1
+    assert market["observations"] == 2
+    assert market["count"]["max"] == 6
+    assert market["symbol_count"]["min"] == 6
+    assert market["missing_count"]["max"] == 1
+    assert market["missing_symbols_total"] == 1
+    assert market["missing_observation_count"] == 1
+    assert market["max_age_ms"]["max"] == 1500
+    assert market["mean_age_ms"]["mean"] == 350
+    assert market["configured_max_age_ms"]["median"] == 1000
+    assert market["configured_excess_ms"]["max"] == 500
+    assert market["sources"] == {"ticker": 2, "websocket": 1}
 
 
 def test_live_performance_report_input_staleness_handles_cycle_id_reuse(tmp_path):
@@ -887,6 +1000,10 @@ def test_live_performance_report_summary_includes_bounded_input_staleness(tmp_pa
     assert summary["input_staleness"]["snapshot_surface_age_rows"] == 1
     assert summary["input_staleness"]["snapshot_market_summaries_seen"] == 1
     assert summary["input_staleness"]["snapshot_market_stale_count"] == 1
+    assert summary["input_staleness"]["market_snapshot"]["observations"] == 1
+    assert summary["input_staleness"]["market_snapshot"]["configured_excess_ms"][
+        "max"
+    ] == 50
     assert summary["input_staleness"]["rust_calls_seen"] == 1
     assert summary["input_staleness"]["snapshot_to_rust_latest_snapshot_matches"] == 1
     assert summary["input_staleness"]["rust_calls_missing_ema"] == 1


### PR DESCRIPTION
## Summary
- add bounded aggregate market snapshot staleness counters to live-performance-report input_staleness
- include observations, count/symbol/missing summaries, age summaries, configured-age excess, and source labels from existing snapshot.built monitor events
- update logging-overhaul progress/readiness docs for the latest merged slice and this pending slice

## Scope
- read-only report tooling and tests only
- no event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, order/risk logic, or trading behavior changes

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py
- git diff --check
- touched-file silent-handling scan; hits are existing offline report projection defaults, not trading-critical fallbacks