### PR TITLE
Summarize startup phase readiness timing

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,11 +15,11 @@ merge, live smoke evidence changes, or new gaps are discovered.
 
 ## Current Status
 
-Last updated: 2026-06-30.
+Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `82b1990c` after PR #922, `Summarize HSL replay stages in performance report`.
+- `31ef4d40` after PR #923, `Summarize market snapshot staleness`.
 
 Current review gate:
 
@@ -49,6 +49,27 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #923 at `31ef4d40`.
+- PR #923 added aggregate market snapshot staleness counters to
+  `live-performance-report` `input_staleness`, exposing snapshot observations,
+  count/symbol/missing summaries, max/mean/configured age summaries,
+  configured-age excess, missing-symbol totals, and bounded source labels from
+  existing `snapshot.built` events. The slice was read-only report tooling and
+  did not add event producers, exchange calls, cache mutation, readiness gates,
+  console routing, monitor writes, order/risk logic, or trading behavior.
+- PR #923 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_performance_report.py`, py_compile for touched files,
+  `git diff --check`, and a touched-file silent-handling scan.
+- VPS5 pulled from `82b1990c` to `31ef4d40` without bot restart because the
+  deployed change was read-only report tooling. The five configured bots were
+  left running.
+- A 5-minute smoke at `31ef4d40` completed with `ok=true`, `hard_failures=0`,
+  all five configured bots matched, clean tracked repository state, no failed
+  remote calls, and no failed account-critical remote calls. A VPS5
+  `live-performance-report --summary` verified
+  `input_staleness.market_snapshot` in live output with 67 observations, max
+  age 1128 ms, no missing symbols, and source labels
+  `fetch_tickers`/`hyperliquid_hip3_asset_ctx`.
 - Repository pulled through PR #922 at `82b1990c`.
 - PR #922 added aggregate HSL replay stage/status counters to
   `live-performance-report` `hsl_replay_profile`, exposing
@@ -1945,25 +1966,45 @@ VPS5 deployment status:
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events, HSL replay failure events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events; PR #707 restores throttled coin-mode HSL position status console lines from existing `hsl.status` metrics; PR #709 mirrors fill-cache startup readiness into off-console `fills.refresh_summary` events; PR #711 mirrors CCXT timestamp/nonce recovery into off-console `exchange.time_sync` events; PR #846 mirrors pre-create market-distance guard skips into off-console `execution.create_skipped` events; PR #848 mirrors pre-create planning/market snapshot skips into off-console `execution.create_skipped` events; PR #850 mirrors fill-cache doctor startup report/quarantine/rebuild decisions into off-console `fills.refresh_summary` events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
-| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, severity-level filters, problem-event filters, event-file discovery metadata, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/brief problem-event groups/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window/problem-event reports and query-scope filters, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation with summary/filter, decision-boundary, initial input-staleness, HSL replay pair/rate, forager/EMA readiness, cache warmup, resource-pressure percentiles, and unified operation-duration support | Cross-bot incident workflow, safe restart orchestration, richer symbol/market/config staleness performance metrics, active probe expansion beyond current endpoint/freshness summaries |
+| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, severity-level filters, problem-event filters, event-file discovery metadata, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/brief problem-event groups/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window/problem-event reports and query-scope filters, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation with summary/filter, decision-boundary, input-staleness including market snapshot staleness, HSL replay pair/rate/stage summaries, forager/EMA readiness, cache warmup, resource-pressure percentiles, and unified operation-duration support | Cross-bot incident workflow, safe restart orchestration, richer startup/protective-readiness summaries, active probe expansion beyond current endpoint/freshness summaries |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup; PR #656/#668 cache integrity smoke doctor | Continue separate reviewed PRs for shutdown/warmup/cache proof improvements |
 
 ## Current Work
 
-### Pending PR: Market Snapshot Staleness Summary
+### Pending PR: Startup Phase Readiness Summary
 
-- Branch: `codex/v8-market-snapshot-staleness-summary`.
+- Branch: `codex/v8-startup-readiness-summary`.
 - Scope: read-only live performance report tooling and tests.
-- Result: adds bounded aggregate market-snapshot staleness counters to
-  `input_staleness`, so operators can see snapshot observations, missing
-  symbol totals, configured-age excess counts, source labels, and age summaries
-  without opening every `snapshot.built` event.
+- Result: adds bounded aggregate startup phase timing counters to
+  `startup_readiness`, so operators can see cross-bot startup phase elapsed and
+  since-previous summaries without opening every per-bot phase row.
 - Expected validation: focused live-performance-report tests plus py_compile
   and `git diff --check`. No event producers, exchange calls, cache mutation,
   readiness gates, console routing, monitor writes, order/risk logic, or
   trading behavior should change.
 
 ## Merged Slices
+
+### PR #923: Market Snapshot Staleness Summary
+
+- Branch: `codex/v8-market-snapshot-staleness-summary`.
+- Scope: read-only live performance report tooling and tests.
+- Result: `passivbot tool live-performance-report` now adds aggregate market
+  snapshot staleness counters to `input_staleness`, so operators can see
+  snapshot observations, missing symbol totals, configured-age excess, bounded
+  source labels, and age/count summaries without opening each `snapshot.built`
+  event.
+- Review evidence: Cursor, Hermes, Claude, and CI approved the final head.
+  Local validation covered focused live-performance-report tests plus
+  py_compile and `git diff --check`. No event producers, exchange calls, cache
+  mutation, readiness gates, console routing, monitor writes, order/risk logic,
+  or trading behavior changed.
+- VPS5 evidence: deployed to `v8` at `31ef4d40` without bot restart because
+  the change is read-only tooling. Smoke stayed hard-green with all five
+  configured bots running, clean tracked repository state, no failed remote
+  calls, no failed account-critical remote calls, and
+  `live-performance-report --summary` showed
+  `input_staleness.market_snapshot` from live monitor data.
 
 ### PR #922: HSL Replay Profile Stage Summary
 

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -289,6 +289,12 @@ the time go?" for a live bot. Every row below should expose `count`, `min`,
 classification when enough source events exist.
 
 - [ ] Startup: process start to account-critical ready.
+- Status: partial. Existing `bot.startup_timing` events are summarized by
+  `live-performance-report` as `startup_readiness`, including per-bot startup
+  phases and aggregate bounded phase elapsed/since-previous timing. Remaining
+  work: explicit account-critical ready, held-position protective HSL ready,
+  fresh-entry ready, first cycle/Rust call, and first exchange-write readiness
+  events.
 - [ ] Startup: process start to held-position protective HSL ready.
 - [ ] Startup: process start to fresh-entry ready.
 - [ ] Startup: process start to first planning cycle started/completed.
@@ -658,6 +664,9 @@ Trading-impact labels:
     exchange write eligibility, and full background replay complete.
   - Group by exchange/user/bot so VPS-class regressions are visible before a
     panic incident.
+  - Status: partial. Startup phase timing aggregation is available from
+    existing phase events, but true order-class readiness SLA events are still
+    missing.
 
 - [ ] Add a full live-operation duration table.
   - Include startup, account refresh, fill refresh, cache proof, HSL replay,

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -947,6 +947,14 @@ def _startup_elapsed_ms(data: dict[str, Any]) -> int | None:
 
 
 _LIVE_EVENT_DEBUG_PROFILE_SET = set(LIVE_EVENT_DEBUG_PROFILES)
+_STARTUP_PHASE_LABELS = {
+    "account",
+    "active-candle",
+    "full-warmup",
+    "hsl",
+    "market",
+    "startup",
+}
 
 
 def _known_debug_profiles(value: Any) -> list[str]:
@@ -966,9 +974,19 @@ def _known_debug_profiles(value: Any) -> list[str]:
     return sorted(profiles)
 
 
+def _startup_phase_label(value: Any) -> str:
+    label = str(value or "startup").strip()
+    if label in _STARTUP_PHASE_LABELS:
+        return label
+    return "other"
+
+
 class _StartupReadinessAccumulator:
     def __init__(self) -> None:
         self.bots: dict[str, dict[str, Any]] = {}
+        self.startup_phase_counts: Counter[str] = Counter()
+        self.startup_phase_elapsed_values: dict[str, list[int]] = {}
+        self.startup_phase_since_previous_values: dict[str, list[int]] = {}
 
     @staticmethod
     def _update_debug_profiles(state: dict[str, Any], data: dict[str, Any]) -> None:
@@ -1027,10 +1045,19 @@ class _StartupReadinessAccumulator:
             return
         if event_type == "bot.startup_timing":
             state = self._bot_state(row=row, live_event=live_event)
-            stage = data.get("stage") or data.get("phase") or "startup"
+            stage = _startup_phase_label(data.get("stage") or data.get("phase"))
             elapsed_ms = _startup_elapsed_ms(data)
             if elapsed_ms is not None:
-                state["startup_phases_ms"][str(stage)] = int(elapsed_ms)
+                state["startup_phases_ms"][stage] = int(elapsed_ms)
+                self.startup_phase_counts[stage] += 1
+                self.startup_phase_elapsed_values.setdefault(stage, []).append(
+                    int(elapsed_ms)
+                )
+            since_previous_ms = _non_negative_ms(data.get("since_previous_ms"))
+            if since_previous_ms is not None:
+                self.startup_phase_since_previous_values.setdefault(stage, []).append(
+                    int(since_previous_ms)
+                )
             return
         if event_type.startswith("hsl.replay."):
             state = self._bot_state(row=row, live_event=live_event)
@@ -1075,6 +1102,12 @@ class _StartupReadinessAccumulator:
         hsl_active_count = 0
         debug_profile_counts: Counter[str] = Counter()
         limit = max(0, int(group_limit))
+        phase_labels = [
+            phase
+            for phase, _count in self.startup_phase_counts.most_common(
+                SUMMARY_GROUP_LIMIT
+            )
+        ]
         for bot, state in sorted(self.bots.items()):
             phases = dict(sorted(state.get("startup_phases_ms", {}).items()))
             item = {
@@ -1115,6 +1148,20 @@ class _StartupReadinessAccumulator:
             "ready_count": int(ready_count),
             "hsl_replay_active_count": int(hsl_active_count),
             "debug_profile_counts": dict(sorted(debug_profile_counts.items())),
+            "startup_phase_counts": {
+                phase: int(self.startup_phase_counts[phase]) for phase in phase_labels
+            },
+            "startup_phase_elapsed_ms": {
+                phase: _number_summary(self.startup_phase_elapsed_values.get(phase, []))
+                for phase in phase_labels
+            },
+            "startup_phase_since_previous_ms": {
+                phase: _number_summary(
+                    self.startup_phase_since_previous_values.get(phase, [])
+                )
+                for phase in phase_labels
+                if self.startup_phase_since_previous_values.get(phase)
+            },
             "bots_truncated": len(bot_items) > limit,
             "bots": bot_items[:limit],
         }
@@ -3112,7 +3159,7 @@ def _add_event_timings(
         return
 
     if event_type == "bot.startup_timing":
-        stage = data.get("stage") or data.get("phase") or "startup"
+        stage = _startup_phase_label(data.get("stage") or data.get("phase"))
         operation = f"startup.{stage}"
         value_ms = _non_negative_ms(data.get("elapsed_ms"))
         if value_ms is None:

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1034,14 +1034,14 @@ def test_live_performance_report_startup_readiness_summary(tmp_path, monkeypatch
                 seq=2,
                 ts=2000,
                 component="bot.startup",
-                data={"stage": "account", "elapsed_ms": 900},
+                data={"stage": "account", "elapsed_ms": 900, "since_previous_ms": 900},
             ),
             _monitor_row(
                 event_type="bot.startup_timing",
                 seq=3,
                 ts=3000,
                 component="bot.startup",
-                data={"stage": "hsl", "elapsed_s": 2.5},
+                data={"stage": "hsl", "elapsed_s": 2.5, "since_previous_ms": 1600},
             ),
             _monitor_row(
                 event_type="hsl.replay.progress",
@@ -1082,6 +1082,18 @@ def test_live_performance_report_startup_readiness_summary(tmp_path, monkeypatch
     assert startup["debug_profile_counts"] == {"ema": 1, "rust": 1}
     assert "api_key=should_not_render" not in json.dumps(startup, sort_keys=True)
     assert bot["startup_phases_ms"] == {"account": 900, "hsl": 2500}
+    assert startup["startup_phase_counts"] == {"account": 1, "hsl": 1}
+    assert startup["startup_phase_elapsed_ms"]["account"] == {
+        "count": 1,
+        "min": 900,
+        "max": 900,
+        "mean": 900,
+        "median": 900,
+        "p95": 900,
+    }
+    assert startup["startup_phase_elapsed_ms"]["hsl"]["max"] == 2500
+    assert startup["startup_phase_since_previous_ms"]["account"]["max"] == 900
+    assert startup["startup_phase_since_previous_ms"]["hsl"]["max"] == 1600
     assert bot["hsl_replay"]["stage"] == "pair_replay"
     assert bot["hsl_replay"]["pairs"] == 26
     assert bot["hsl_replay"]["held_pairs"] == 1
@@ -1261,6 +1273,37 @@ def test_live_performance_report_summary_includes_startup_readiness(tmp_path):
 
     assert summary["startup_readiness"]["bot_count"] == 1
     assert summary["startup_readiness"]["ready_count"] == 1
+
+
+def test_live_performance_report_startup_phase_labels_are_whitelisted(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=2,
+                ts=2000,
+                data={
+                    "stage": "api_key=should_not_render",
+                    "elapsed_ms": 100,
+                    "since_previous_ms": 50,
+                },
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    startup = report["startup_readiness"]
+    rendered = json.dumps(report, sort_keys=True)
+
+    assert "api_key=should_not_render" not in rendered
+    assert startup["startup_phase_counts"] == {"other": 1}
+    assert startup["startup_phase_elapsed_ms"]["other"]["max"] == 100
+    assert startup["startup_phase_since_previous_ms"]["other"]["max"] == 50
+    assert startup["bots"][0]["startup_phases_ms"] == {"other": 100}
+    assert report["operation_durations"]["groups"][0]["operation"] == "startup.other"
 
 
 def test_live_performance_report_hsl_replay_profile(tmp_path):


### PR DESCRIPTION
## Summary
- add bounded aggregate startup phase timing counters to live-performance-report startup_readiness
- summarize existing bot.startup_timing phase elapsed and since-previous timings across bots
- whitelist startup phase labels, mapping unknown phase labels to other so malformed event labels are not surfaced
- fold PR #923 merge/deploy progress into the logging-overhaul/readiness docs

## Scope
- read-only report tooling and tests only
- no event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, order/risk logic, or trading behavior changes

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py
- git diff --check
- touched-file silent-handling scan; hits are existing offline report projection defaults, not trading-critical fallbacks