### PR TITLE
Bound performance report event scans

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `31ef4d40` after PR #923, `Summarize market snapshot staleness`.
+- `652b019e` after PR #924, `Summarize startup phase readiness timing`.
 
 Current review gate:
 
@@ -49,6 +49,30 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #924 at `652b019e`.
+- PR #924 added aggregate startup phase timing counters to
+  `live-performance-report` `startup_readiness`, exposing bounded phase counts
+  plus elapsed and since-previous timing summaries from existing
+  `bot.startup_timing` events. It also routes startup phase labels through a
+  whitelist before they appear in `startup_readiness` or
+  `operation_durations`. The slice was read-only report tooling and did not add
+  event producers, exchange calls, cache mutation, readiness gates, console
+  routing, monitor writes, order/risk logic, or trading behavior.
+- PR #924 passed Hermes + Claude + Cursor + CI after fixing the
+  `operation_durations` phase-label leak found by Hermes. Local validation
+  covered `tests/test_live_performance_report.py`, py_compile for touched
+  files, `git diff --check`, and a touched-file silent-handling scan.
+- VPS5 pulled from `31ef4d40` to `652b019e` without bot restart because the
+  deployed change was read-only report tooling. The five configured bots were
+  left running.
+- A 5-minute smoke at `652b019e` completed with `ok=true`,
+  `hard_failures=0`, all five configured bots matched, clean tracked
+  repository state, no failed remote calls, and no failed account-critical
+  remote calls. Current monitor segments had no startup timing events, so
+  `startup_readiness` showed the new aggregate keys as empty. An attempted
+  full rotated `live-performance-report --include-rotated` verification was
+  interrupted after it proved too slow for smoke use, which motivated the next
+  bounded performance-report scan slice.
 - Repository pulled through PR #923 at `31ef4d40`.
 - PR #923 added aggregate market snapshot staleness counters to
   `live-performance-report` `input_staleness`, exposing snapshot observations,
@@ -1966,24 +1990,47 @@ VPS5 deployment status:
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events, HSL replay failure events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events; PR #707 restores throttled coin-mode HSL position status console lines from existing `hsl.status` metrics; PR #709 mirrors fill-cache startup readiness into off-console `fills.refresh_summary` events; PR #711 mirrors CCXT timestamp/nonce recovery into off-console `exchange.time_sync` events; PR #846 mirrors pre-create market-distance guard skips into off-console `execution.create_skipped` events; PR #848 mirrors pre-create planning/market snapshot skips into off-console `execution.create_skipped` events; PR #850 mirrors fill-cache doctor startup report/quarantine/rebuild decisions into off-console `fills.refresh_summary` events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
-| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, severity-level filters, problem-event filters, event-file discovery metadata, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/brief problem-event groups/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window/problem-event reports and query-scope filters, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation with summary/filter, decision-boundary, input-staleness including market snapshot staleness, HSL replay pair/rate/stage summaries, forager/EMA readiness, cache warmup, resource-pressure percentiles, and unified operation-duration support | Cross-bot incident workflow, safe restart orchestration, richer startup/protective-readiness summaries, active probe expansion beyond current endpoint/freshness summaries |
+| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, severity-level filters, problem-event filters, event-file discovery metadata, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/brief problem-event groups/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window/problem-event reports and query-scope filters, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation with summary/filter, decision-boundary, input-staleness including market snapshot staleness, startup phase timing summaries, HSL replay pair/rate/stage summaries, forager/EMA readiness, cache warmup, resource-pressure percentiles, and unified operation-duration support | Cross-bot incident workflow, safe restart orchestration, bounded historical performance-report scans, active probe expansion beyond current endpoint/freshness summaries |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup; PR #656/#668 cache integrity smoke doctor | Continue separate reviewed PRs for shutdown/warmup/cache proof improvements |
 
 ## Current Work
 
-### Pending PR: Startup Phase Readiness Summary
+### Pending PR: Performance Report Tail Window
 
-- Branch: `codex/v8-startup-readiness-summary`.
+- Branch: `codex/v8-performance-report-tail-window`.
 - Scope: read-only live performance report tooling and tests.
-- Result: adds bounded aggregate startup phase timing counters to
-  `startup_readiness`, so operators can see cross-bot startup phase elapsed and
-  since-previous summaries without opening every per-bot phase row.
+- Result: adds an opt-in `--event-tail-lines` scan bound to
+  `live-performance-report`, reusing the shared monitor-event tail reader so
+  smoke/debug runs can inspect recent rows from large monitor histories without
+  full rotated scans.
 - Expected validation: focused live-performance-report tests plus py_compile
   and `git diff --check`. No event producers, exchange calls, cache mutation,
   readiness gates, console routing, monitor writes, order/risk logic, or
   trading behavior should change.
 
 ## Merged Slices
+
+### PR #924: Startup Phase Readiness Summary
+
+- Branch: `codex/v8-startup-readiness-summary`.
+- Scope: read-only live performance report tooling and tests.
+- Result: `passivbot tool live-performance-report` now adds bounded aggregate
+  startup phase timing counters to `startup_readiness`, so operators can see
+  cross-bot startup phase elapsed and since-previous summaries without opening
+  every per-bot phase row. Startup phase labels are whitelisted before they
+  appear in either `startup_readiness` or `operation_durations`.
+- Review evidence: Cursor, Hermes, Claude, and CI approved the final head
+  after the Hermes finding about raw startup phase labels in
+  `operation_durations` was fixed. Local validation covered focused
+  live-performance-report tests plus py_compile and `git diff --check`. No
+  event producers, exchange calls, cache mutation, readiness gates, console
+  routing, monitor writes, order/risk logic, or trading behavior changed.
+- VPS5 evidence: deployed to `v8` at `652b019e` without bot restart because
+  the change is read-only tooling. Smoke stayed hard-green with all five
+  configured bots running, clean tracked repository state, no failed remote
+  calls, and no failed account-critical remote calls. Current monitor segments
+  had no startup timing rows, so the new `startup_readiness` aggregate fields
+  were present but empty.
 
 ### PR #923: Market Snapshot Staleness Summary
 

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -628,8 +628,8 @@ Trading-impact labels:
     for structured timing metrics.
   - It should not contact exchanges, mutate caches, or depend on live bot
     availability.
-  - It should support `--recent-minutes`, `--include-rotated`, `--summary`,
-    `--compact`, and bot/user filters.
+  - It should support `--recent-minutes`, `--include-rotated`,
+    `--event-tail-lines`, `--summary`, `--compact`, and bot/user filters.
 
 - [ ] Aggregate min/mean/max/p50/p95/count by bot and operation.
   - Required groups: startup stages, full cycle elapsed, cycle phase timings,
@@ -752,7 +752,8 @@ Trading-impact labels:
 - [ ] Add offline synthetic benchmarks for known hot paths.
   - HSL coin replay over 30 days and 30 pairs.
   - EMA readiness over a high-cardinality forager universe.
-  - Monitor event ingestion and smoke-report scan over large NDJSON segments.
+  - Monitor event ingestion plus smoke/performance-report scans over large
+    NDJSON segments.
 
 ### P2: Shutdown Latency
 

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -13,6 +13,7 @@ from live.event_bus import (
     LIVE_EVENT_MONITOR_PAYLOAD_KEY,
     utc_ms,
 )
+from live.event_file_rows import event_file_rows
 from live.event_query import discover_event_files_with_metadata
 from live.smoke_report import _user_safe_display_path
 
@@ -3179,6 +3180,7 @@ def build_live_performance_report(
     since_ms: int | None = None,
     until_ms: int | None = None,
     include_rotated: bool = False,
+    event_tail_lines: int = 0,
     group_limit: int = GROUP_LIMIT,
     bot_filters: list[str] | tuple[str, ...] | set[str] | None = None,
     exchange_filters: list[str] | tuple[str, ...] | set[str] | None = None,
@@ -3193,6 +3195,7 @@ def build_live_performance_report(
     ):
         raise ValueError("since_ms must be <= until_ms")
     window_enabled = since_filter is not None or until_filter is not None
+    max_event_tail_lines = max(0, int(event_tail_lines))
     event_window = {
         "enabled": bool(window_enabled),
         "since_ms": since_filter,
@@ -3202,6 +3205,18 @@ def build_live_performance_report(
         "events_skipped_after": 0,
         "invalid_window_ts": 0,
     }
+    if max_event_tail_lines:
+        event_window.update(
+            {
+                "event_tail_lines": int(max_event_tail_lines),
+                "event_tail_limited_files": 0,
+                "event_tail_skipped_lines": 0,
+                "event_tail_skipped_lines_exact": True,
+                "event_tail_skipped_bytes": 0,
+                "event_tail_line_numbers_exact": True,
+                "event_tail_methods": {},
+            }
+        )
     bot_filter_set = _string_filter(bot_filters)
     exchange_filter_set = _string_filter(exchange_filters)
     user_filter_set = _string_filter(user_filters)
@@ -3268,96 +3283,125 @@ def build_live_performance_report(
     legacy_events = 0
     event_types: Counter[str] = Counter()
     bots: Counter[str] = Counter()
+    event_tail_methods: Counter[str] = Counter()
+
+    def process_event_row(path: Path, line_no: int, raw_line: str) -> None:
+        nonlocal records_total, live_events, legacy_events
+        line = raw_line.strip()
+        if not line:
+            return
+        records_total += 1
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            issues.append(
+                {
+                    "path": _user_safe_display_path(path),
+                    "line": int(line_no),
+                    "severity": "error",
+                    "code": "invalid_json",
+                    "message": str(exc),
+                }
+            )
+            return
+        if not isinstance(row, dict):
+            issues.append(
+                {
+                    "path": _user_safe_display_path(path),
+                    "line": int(line_no),
+                    "severity": "error",
+                    "code": "invalid_record",
+                    "message": "event row is not a JSON object",
+                }
+            )
+            return
+        live_event = _live_event_payload(row)
+        if live_event is None:
+            legacy_events += 1
+            return
+        if not _matches_filters(
+            row,
+            live_event,
+            bot_filters=bot_filter_set,
+            exchange_filters=exchange_filter_set,
+            user_filters=user_filter_set,
+        ):
+            filters["events_skipped"] += 1
+            return
+        live_events += 1
+        if window_enabled:
+            record_ts = _record_ts(row)
+            if record_ts is None:
+                event_window["invalid_window_ts"] += 1
+                return
+            if since_filter is not None and record_ts < since_filter:
+                event_window["events_skipped_before"] += 1
+                return
+            if until_filter is not None and record_ts > until_filter:
+                event_window["events_skipped_after"] += 1
+                return
+            event_window["events_considered"] += 1
+        event_type = str(live_event.get("event_type") or row.get("kind") or "unknown")
+        cycle_scope = cycle_scope_tracker.observe(row=row, live_event=live_event)
+        event_types[event_type] += 1
+        bots[_bot_key(row, live_event)] += 1
+        _add_event_timings(
+            accumulator,
+            row=row,
+            live_event=live_event,
+        )
+        decision_boundary.add(
+            row=row,
+            live_event=live_event,
+            cycle_scope=cycle_scope,
+        )
+        input_staleness.add(
+            row=row,
+            live_event=live_event,
+            cycle_scope=cycle_scope,
+        )
+        startup_readiness.add(row=row, live_event=live_event)
+        hsl_replay_profile.add(row=row, live_event=live_event)
+        cache_warmup.add(row=row, live_event=live_event)
+        forager_ema_readiness.add(row=row, live_event=live_event)
+        resource_pressure.add(row=row, live_event=live_event)
+        shutdown_latency.add(row=row, live_event=live_event)
+        execution_timing.add(
+            row=row,
+            live_event=live_event,
+            cycle_scope=cycle_scope,
+        )
+        account_state_changes.add(row=row, live_event=live_event)
+        risk_activity.add(row=row, live_event=live_event)
+
     for path in files:
         try:
-            with _open_text(path) as stream:
-                for line_no, raw_line in enumerate(stream, start=1):
-                    line = raw_line.strip()
-                    if not line:
-                        continue
-                    records_total += 1
-                    try:
-                        row = json.loads(line)
-                    except json.JSONDecodeError as exc:
-                        issues.append(
-                            {
-                                "path": _user_safe_display_path(path),
-                                "line": int(line_no),
-                                "severity": "error",
-                                "code": "invalid_json",
-                                "message": str(exc),
-                            }
+            if max_event_tail_lines:
+                with event_file_rows(
+                    path, max_tail_lines=max_event_tail_lines
+                ) as (row_iter, row_window):
+                    if row_window.limited:
+                        event_window["event_tail_limited_files"] += 1
+                        if row_window.skipped_lines is None:
+                            event_window["event_tail_skipped_lines_exact"] = False
+                        else:
+                            event_window["event_tail_skipped_lines"] += int(
+                                row_window.skipped_lines
+                            )
+                        event_window["event_tail_skipped_bytes"] += int(
+                            row_window.skipped_bytes
                         )
-                        continue
-                    if not isinstance(row, dict):
-                        issues.append(
-                            {
-                                "path": _user_safe_display_path(path),
-                                "line": int(line_no),
-                                "severity": "error",
-                                "code": "invalid_record",
-                                "message": "event row is not a JSON object",
-                            }
+                        event_window["event_tail_line_numbers_exact"] = bool(
+                            event_window["event_tail_line_numbers_exact"]
+                            and row_window.line_numbers_exact
                         )
-                        continue
-                    live_event = _live_event_payload(row)
-                    if live_event is None:
-                        legacy_events += 1
-                        continue
-                    if not _matches_filters(
-                        row,
-                        live_event,
-                        bot_filters=bot_filter_set,
-                        exchange_filters=exchange_filter_set,
-                        user_filters=user_filter_set,
-                    ):
-                        filters["events_skipped"] += 1
-                        continue
-                    live_events += 1
-                    if window_enabled:
-                        record_ts = _record_ts(row)
-                        if record_ts is None:
-                            event_window["invalid_window_ts"] += 1
-                            continue
-                        if since_filter is not None and record_ts < since_filter:
-                            event_window["events_skipped_before"] += 1
-                            continue
-                        if until_filter is not None and record_ts > until_filter:
-                            event_window["events_skipped_after"] += 1
-                            continue
-                        event_window["events_considered"] += 1
-                    event_type = str(live_event.get("event_type") or row.get("kind") or "unknown")
-                    cycle_scope = cycle_scope_tracker.observe(row=row, live_event=live_event)
-                    event_types[event_type] += 1
-                    bots[_bot_key(row, live_event)] += 1
-                    _add_event_timings(
-                        accumulator,
-                        row=row,
-                        live_event=live_event,
-                    )
-                    decision_boundary.add(
-                        row=row,
-                        live_event=live_event,
-                        cycle_scope=cycle_scope,
-                    )
-                    input_staleness.add(
-                        row=row,
-                        live_event=live_event,
-                        cycle_scope=cycle_scope,
-                    )
-                    startup_readiness.add(row=row, live_event=live_event)
-                    hsl_replay_profile.add(row=row, live_event=live_event)
-                    cache_warmup.add(row=row, live_event=live_event)
-                    forager_ema_readiness.add(row=row, live_event=live_event)
-                    resource_pressure.add(row=row, live_event=live_event)
-                    shutdown_latency.add(row=row, live_event=live_event)
-                    execution_timing.add(
-                        row=row,
-                        live_event=live_event,
-                        cycle_scope=cycle_scope,
-                    )
-                    account_state_changes.add(row=row, live_event=live_event)
-                    risk_activity.add(row=row, live_event=live_event)
+                        event_tail_methods[str(row_window.method)] += 1
+                    for line_no, raw_line in row_iter:
+                        process_event_row(path, int(line_no), raw_line)
+            else:
+                with _open_text(path) as stream:
+                    for line_no, raw_line in enumerate(stream, start=1):
+                        process_event_row(path, int(line_no), raw_line)
         except OSError as exc:
             issues.append(
                 {
@@ -3371,6 +3415,8 @@ def build_live_performance_report(
 
     error_count = sum(1 for issue in issues if issue.get("severity") == "error")
     warning_count = sum(1 for issue in issues if issue.get("severity") == "warning")
+    if max_event_tail_lines:
+        event_window["event_tail_methods"] = dict(sorted(event_tail_methods.items()))
     performance_groups = accumulator.groups_list()
     decision_boundary_groups = decision_boundary.groups_list()
     input_staleness_groups = input_staleness.groups_list()
@@ -3428,7 +3474,7 @@ def build_live_performance_report(
             group_limit=group_limit,
         ),
     }
-    if window_enabled:
+    if window_enabled or max_event_tail_lines:
         report["event_window"] = event_window
     if filters["enabled"]:
         report["filters"] = filters

--- a/src/tools/live_performance_report.py
+++ b/src/tools/live_performance_report.py
@@ -53,6 +53,17 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--event-tail-lines",
+        type=int,
+        default=0,
+        help=(
+            "Opt-in bound for monitor event segments: inspect only the last N rows "
+            "from each event file. Plain NDJSON segments seek from file end; "
+            "compressed segments may still scan sequentially. Default 0 keeps "
+            "full monitor validation."
+        ),
+    )
+    parser.add_argument(
         "--group-limit",
         type=int,
         default=80,
@@ -103,11 +114,14 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--since-ms/--recent-minutes must be <= --until-ms")
     if args.group_limit < 0:
         parser.error("--group-limit must be >= 0")
+    if args.event_tail_lines < 0:
+        parser.error("--event-tail-lines must be >= 0")
     report = build_live_performance_report(
         args.path,
         since_ms=since_ms,
         until_ms=args.until_ms,
         include_rotated=bool(args.include_rotated),
+        event_tail_lines=int(args.event_tail_lines),
         group_limit=int(args.group_limit),
         bot_filters=args.bot,
         exchange_filters=args.exchange,

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -2921,6 +2921,131 @@ def test_live_performance_report_cli_summary_and_filters(tmp_path, capsys):
     assert "files" not in out
 
 
+def test_live_performance_report_event_tail_lines_bounds_monitor_scan(tmp_path):
+    events_path = (
+        tmp_path / "monitor" / "binance" / "binance_01" / "events" / "current.ndjson"
+    )
+    _write_ndjson(
+        events_path,
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_old"},
+                data={"elapsed_ms": 1000},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=2,
+                ts=2000,
+                ids={"cycle_id": "cy_old"},
+                data={"elapsed_ms": 2000},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=3,
+                ts=3000,
+                ids={"cycle_id": "cy_old"},
+                data={"elapsed_ms": 3000},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=4,
+                ts=4000,
+                ids={"cycle_id": "cy_fresh"},
+                data={"elapsed_ms": 4000},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=5,
+                ts=5000,
+                ids={"cycle_id": "cy_fresh"},
+                data={"elapsed_ms": 5000},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(
+        tmp_path / "monitor",
+        since_ms=3500,
+        event_tail_lines=2,
+    )
+
+    assert report["ok"] is True
+    assert report["records_total"] == 2
+    assert report["live_events"] == 2
+    assert report["event_window"] == {
+        "enabled": True,
+        "since_ms": 3500,
+        "until_ms": None,
+        "events_considered": 2,
+        "events_skipped_before": 0,
+        "events_skipped_after": 0,
+        "invalid_window_ts": 0,
+        "event_tail_lines": 2,
+        "event_tail_limited_files": 1,
+        "event_tail_skipped_lines": 3,
+        "event_tail_skipped_lines_exact": True,
+        "event_tail_skipped_bytes": 0,
+        "event_tail_line_numbers_exact": True,
+        "event_tail_methods": {"seek_tail": 1},
+    }
+    assert report["bots"] == [{"bot": "binance/binance_01", "events": 2}]
+    assert report["performance"]["groups"][0]["count"] == 2
+
+
+def test_live_performance_report_cli_event_tail_lines(tmp_path, capsys):
+    events_path = (
+        tmp_path / "monitor" / "binance" / "binance_01" / "events" / "current.ndjson"
+    )
+    _write_ndjson(
+        events_path,
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                data={"elapsed_ms": 1000},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=2,
+                ts=2000,
+                data={"elapsed_ms": 2000},
+            ),
+        ],
+    )
+
+    rc = live_performance_report.main(
+        [
+            str(tmp_path / "monitor"),
+            "--summary",
+            "--compact",
+            "--event-tail-lines",
+            "1",
+        ]
+    )
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["records_total"] == 1
+    assert out["event_window"]["event_tail_lines"] == 1
+    assert out["event_window"]["event_tail_limited_files"] == 1
+    assert out["event_window"]["event_tail_methods"] == {"seek_tail": 1}
+
+
+def test_live_performance_report_cli_rejects_negative_event_tail_lines(capsys):
+    try:
+        live_performance_report.main(["monitor", "--event-tail-lines", "-1"])
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("negative --event-tail-lines must be rejected")
+
+    assert "--event-tail-lines must be >= 0" in capsys.readouterr().err
+
+
 def test_live_performance_report_redacts_missing_root_paths():
     report = build_live_performance_report("/Users/operator/passivbot/missing-monitor")
 


### PR DESCRIPTION
## Summary
- add opt-in --event-tail-lines to passivbot tool live-performance-report
- reuse the shared monitor event tail reader so recent smoke/debug scans can avoid full large/rotated monitor reads
- report tail-window metadata in event_window, matching the existing smoke-report metadata shape
- refactor report row processing so full-scan and tail-scan modes share identical parsing/filtering/aggregation behavior
- fold PR #924 merge/deploy progress into the logging-overhaul/readiness docs

## Scope
- read-only report tooling and tests only
- no event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, order/risk logic, or trading behavior changes

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py
- git diff --check
- touched-file silent-handling scan; hits are existing offline report projection defaults, not trading-critical fallbacks