### PR TITLE
Bound performance report event file scans

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `652b019e` after PR #924, `Summarize startup phase readiness timing`.
+- `dc0ad4dd` after PR #925, `Bound performance report event scans`.
 
 Current review gate:
 
@@ -49,6 +49,29 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #925 at `dc0ad4dd`.
+- PR #925 added `live-performance-report --event-tail-lines`, an opt-in
+  per-segment row bound for smoke/debug reports. Plain current segments can seek
+  from the file end; compressed rotated segments may still require sequential
+  decompression. The slice was read-only report tooling and did not add event
+  producers, exchange calls, cache mutation, readiness gates, console routing,
+  monitor writes, order/risk logic, or trading behavior.
+- PR #925 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_performance_report.py`, py_compile for touched files,
+  `git diff --check`, and a touched-file silent-handling scan.
+- VPS5 pulled from `652b019e` to `dc0ad4dd` without bot restart because the
+  deployed change was read-only report tooling. The five configured bots were
+  left running.
+- A bounded current-segment performance report at `dc0ad4dd` completed with
+  `ok=true`, `include_rotated=false`, `event_tail_lines=500`,
+  `event_tail_limited_files=6`, `event_tail_methods.seek_tail=6`,
+  `records_total=2389`, and `files_scanned=6`. A 5-minute smoke rerun completed
+  with `ok=true`, `hard_failures=0`, clean tracked repository state, all five
+  configured bots matched, no failed remote calls, and no failed
+  account-critical remote calls. An attempted all-rotated performance report
+  remained too slow because many compressed rotated segments still had to be
+  opened; the next slice should add an explicit newest-segment file-count bound
+  for smoke/debug reports.
 - Repository pulled through PR #924 at `652b019e`.
 - PR #924 added aggregate startup phase timing counters to
   `live-performance-report` `startup_readiness`, exposing bounded phase counts

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -61,6 +61,8 @@ slices.
   and full background replay.
 - [ ] Every long operation must answer whether it delayed protective action,
   fresh entries, normal cycle cadence, or diagnostics only.
+- [ ] Smoke/report tooling over monitor history must offer explicit bounded scan
+  modes so diagnostics do not become the slow path during live validation.
 - [ ] Acceptance: one `passivbot tool live-performance-report` run can explain
   the dominant live-vs-backtest delay without SSH log archaeology.
 

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -226,6 +226,29 @@ def _open_text(path: Path):
     return open(path, "r", encoding="utf-8")
 
 
+def _event_file_mtime_ms(path: Path) -> int:
+    try:
+        return int(path.stat().st_mtime * 1000)
+    except OSError:
+        return -1
+
+
+def _recent_event_file_sort_key(path: Path) -> tuple[int, int, str, str]:
+    return (
+        0 if path.name == "current.ndjson" else 1,
+        -_event_file_mtime_ms(path),
+        str(path.parent),
+        path.name,
+    )
+
+
+def _limit_recent_event_files(files: list[Path], max_event_files: int) -> tuple[list[Path], int]:
+    if max_event_files <= 0 or len(files) <= max_event_files:
+        return files, 0
+    ordered = sorted(files, key=_recent_event_file_sort_key)
+    return ordered[:max_event_files], len(ordered) - max_event_files
+
+
 def _record_ts(row: dict[str, Any]) -> int | None:
     try:
         return int(row.get("ts"))
@@ -3181,6 +3204,7 @@ def build_live_performance_report(
     until_ms: int | None = None,
     include_rotated: bool = False,
     event_tail_lines: int = 0,
+    max_event_files: int = 0,
     group_limit: int = GROUP_LIMIT,
     bot_filters: list[str] | tuple[str, ...] | set[str] | None = None,
     exchange_filters: list[str] | tuple[str, ...] | set[str] | None = None,
@@ -3196,6 +3220,7 @@ def build_live_performance_report(
         raise ValueError("since_ms must be <= until_ms")
     window_enabled = since_filter is not None or until_filter is not None
     max_event_tail_lines = max(0, int(event_tail_lines))
+    max_event_file_count = max(0, int(max_event_files))
     event_window = {
         "enabled": bool(window_enabled),
         "since_ms": since_filter,
@@ -3215,6 +3240,16 @@ def build_live_performance_report(
                 "event_tail_skipped_bytes": 0,
                 "event_tail_line_numbers_exact": True,
                 "event_tail_methods": {},
+            }
+        )
+    if max_event_file_count:
+        event_window.update(
+            {
+                "max_event_files": int(max_event_file_count),
+                "event_file_limit_scope": "global",
+                "event_files_before_limit": 0,
+                "event_files_skipped_by_limit": 0,
+                "event_file_limit_order": "current_then_recent_mtime",
             }
         )
     bot_filter_set = _string_filter(bot_filters)
@@ -3242,6 +3277,13 @@ def build_live_performance_report(
         )
         files = discovery.files
         file_discovery = discovery.to_dict()
+        if max_event_file_count:
+            event_window["event_files_before_limit"] = len(files)
+            files, skipped_by_file_limit = _limit_recent_event_files(
+                files,
+                max_event_file_count,
+            )
+            event_window["event_files_skipped_by_limit"] = int(skipped_by_file_limit)
     except FileNotFoundError as exc:
         files = []
         issues.append(
@@ -3474,7 +3516,7 @@ def build_live_performance_report(
             group_limit=group_limit,
         ),
     }
-    if window_enabled or max_event_tail_lines:
+    if window_enabled or max_event_tail_lines or max_event_file_count:
         report["event_window"] = event_window
     if filters["enabled"]:
         report["filters"] = filters

--- a/src/tools/live_performance_report.py
+++ b/src/tools/live_performance_report.py
@@ -64,6 +64,18 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--max-event-files",
+        type=int,
+        default=0,
+        help=(
+            "Opt-in bound for monitor event file scans. When set, scan at most "
+            "N discovered event segments, preferring current.ndjson files first "
+            "and then the newest rotated files by mtime. Default 0 scans every "
+            "discovered segment. This is a global cap; use --bot, --exchange, "
+            "or --user to narrow multi-bot monitor roots."
+        ),
+    )
+    parser.add_argument(
         "--group-limit",
         type=int,
         default=80,
@@ -116,12 +128,15 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--group-limit must be >= 0")
     if args.event_tail_lines < 0:
         parser.error("--event-tail-lines must be >= 0")
+    if args.max_event_files < 0:
+        parser.error("--max-event-files must be >= 0")
     report = build_live_performance_report(
         args.path,
         since_ms=since_ms,
         until_ms=args.until_ms,
         include_rotated=bool(args.include_rotated),
         event_tail_lines=int(args.event_tail_lines),
+        max_event_files=int(args.max_event_files),
         group_limit=int(args.group_limit),
         bot_filters=args.bot,
         exchange_filters=args.exchange,

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -3024,6 +3025,8 @@ def test_live_performance_report_cli_event_tail_lines(tmp_path, capsys):
             "--compact",
             "--event-tail-lines",
             "1",
+            "--max-event-files",
+            "1",
         ]
     )
 
@@ -3033,6 +3036,9 @@ def test_live_performance_report_cli_event_tail_lines(tmp_path, capsys):
     assert out["event_window"]["event_tail_lines"] == 1
     assert out["event_window"]["event_tail_limited_files"] == 1
     assert out["event_window"]["event_tail_methods"] == {"seek_tail": 1}
+    assert out["event_window"]["max_event_files"] == 1
+    assert out["event_window"]["event_file_limit_scope"] == "global"
+    assert out["event_window"]["event_files_skipped_by_limit"] == 0
 
 
 def test_live_performance_report_cli_rejects_negative_event_tail_lines(capsys):
@@ -3044,6 +3050,92 @@ def test_live_performance_report_cli_rejects_negative_event_tail_lines(capsys):
         raise AssertionError("negative --event-tail-lines must be rejected")
 
     assert "--event-tail-lines must be >= 0" in capsys.readouterr().err
+
+
+def test_live_performance_report_max_event_files_prefers_current_then_recent(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    old_rotated = events_dir / "2026-06-25T00-00-00.ndjson"
+    new_rotated = events_dir / "2026-06-26T00-00-00.ndjson"
+    current = events_dir / "current.ndjson"
+    _write_ndjson(
+        old_rotated,
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_old"},
+                data={"elapsed_ms": 1000},
+            )
+        ],
+    )
+    _write_ndjson(
+        new_rotated,
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=2,
+                ts=2000,
+                ids={"cycle_id": "cy_new"},
+                data={"elapsed_ms": 2000},
+            )
+        ],
+    )
+    _write_ndjson(
+        current,
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=3,
+                ts=3000,
+                ids={"cycle_id": "cy_current"},
+                data={"elapsed_ms": 3000},
+            )
+        ],
+    )
+    os.utime(old_rotated, (1000, 1000))
+    os.utime(new_rotated, (2000, 2000))
+    os.utime(current, (1500, 1500))
+
+    report = build_live_performance_report(
+        tmp_path / "monitor",
+        include_rotated=True,
+        max_event_files=2,
+    )
+
+    assert report["ok"] is True
+    assert report["files"] == [
+        str(current),
+        str(new_rotated),
+    ]
+    assert report["files_scanned"] == 2
+    assert report["records_total"] == 2
+    assert report["event_window"] == {
+        "enabled": False,
+        "since_ms": None,
+        "until_ms": None,
+        "events_considered": 0,
+        "events_skipped_before": 0,
+        "events_skipped_after": 0,
+        "invalid_window_ts": 0,
+        "max_event_files": 2,
+        "event_file_limit_scope": "global",
+        "event_files_before_limit": 3,
+        "event_files_skipped_by_limit": 1,
+        "event_file_limit_order": "current_then_recent_mtime",
+    }
+    assert report["file_discovery"]["event_segments"] == 3
+
+
+def test_live_performance_report_cli_rejects_negative_max_event_files(capsys):
+    try:
+        live_performance_report.main(["monitor", "--max-event-files", "-1"])
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("negative --max-event-files must be rejected")
+
+    assert "--max-event-files must be >= 0" in capsys.readouterr().err
 
 
 def test_live_performance_report_redacts_missing_root_paths():


### PR DESCRIPTION
## Summary
- add opt-in live-performance-report --max-event-files to cap event segment scans for smoke/debug runs
- when capped, prefer current.ndjson files first, then newest rotated segments by mtime, and report skipped segment metadata in event_window
- record PR #925 VPS5 evidence and the report-tooling bound goal in docs/plans

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py tests/test_live_performance_report.py
- git diff --check
- touched-file silent-handling scan: only existing report aggregation default reads matched

## Behavior
Read-only report tooling only. No event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, order/risk logic, or trading behavior.