### PR TITLE
Add per-bot performance report file cap

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `dc0ad4dd` after PR #925, `Bound performance report event scans`.
+- `ec9f47fe` after PR #926, `Bound performance report event file scans`.
 
 Current review gate:
 
@@ -49,6 +49,34 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #926 at `ec9f47fe`.
+- PR #926 added `live-performance-report --max-event-files`, an opt-in global
+  event-segment scan bound for smoke/debug reports. It prefers
+  `current.ndjson` files first, then newest rotated segments by mtime, and
+  reports `event_file_limit_scope=global`, before/after file counts, skipped
+  file count, and selection order in `event_window`. The slice was read-only
+  report tooling and did not add event producers, exchange calls, cache
+  mutation, readiness gates, console routing, monitor writes, order/risk logic,
+  or trading behavior.
+- PR #926 passed Cursor + Hermes + CI on the amended head. Claude did not
+  comment after repeated polling, so it was merged under the documented
+  low-risk degraded gate, with the rationale recorded on the PR. Local
+  validation covered `tests/test_live_performance_report.py`, py_compile for
+  touched files, `git diff --check`, and a touched-file silent-handling scan.
+- VPS5 pulled from `dc0ad4dd` to `ec9f47fe` without bot restart because the
+  deployed change was read-only report tooling. The five configured bots were
+  left running.
+- A bounded 5-minute smoke at `ec9f47fe` completed with `ok=true`,
+  `hard_failures=0`, clean tracked repository state, all five live bot
+  processes running, no failed remote calls, and no failed account-critical
+  remote calls. Attention remained from existing EMA-readiness and HSL-cooldown
+  problem events. A bounded all-rotated performance report completed in about
+  13 seconds with `ok=true`, `include_rotated=true`, `max_event_files=12`,
+  `event_files_before_limit=944`, `event_files_skipped_by_limit=932`,
+  `files_scanned=12`, and `event_tail_methods` showing both `seek_tail` and
+  `sequential_gzip_tail`. This verified the file-count bound works, but the
+  global cap can still drop whole bots if the cap is too low; the next slice
+  should add a per-bot fair file cap for fleet-wide smoke/debug reports.
 - Repository pulled through PR #925 at `dc0ad4dd`.
 - PR #925 added `live-performance-report --event-tail-lines`, an opt-in
   per-segment row bound for smoke/debug reports. Plain current segments can seek

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -249,6 +249,24 @@ def _limit_recent_event_files(files: list[Path], max_event_files: int) -> tuple[
     return ordered[:max_event_files], len(ordered) - max_event_files
 
 
+def _limit_recent_event_files_per_bot(
+    files: list[Path],
+    max_event_files_per_bot: int,
+) -> tuple[list[Path], int, int]:
+    if max_event_files_per_bot <= 0:
+        return files, 0, 0
+    grouped: dict[Path, list[Path]] = {}
+    for path in files:
+        grouped.setdefault(path.parent, []).append(path)
+    selected: list[Path] = []
+    skipped = 0
+    for _, group_files in sorted(grouped.items(), key=lambda item: str(item[0])):
+        ordered = sorted(group_files, key=_recent_event_file_sort_key)
+        selected.extend(ordered[:max_event_files_per_bot])
+        skipped += max(0, len(ordered) - max_event_files_per_bot)
+    return sorted(selected, key=_recent_event_file_sort_key), skipped, len(grouped)
+
+
 def _record_ts(row: dict[str, Any]) -> int | None:
     try:
         return int(row.get("ts"))
@@ -3205,6 +3223,7 @@ def build_live_performance_report(
     include_rotated: bool = False,
     event_tail_lines: int = 0,
     max_event_files: int = 0,
+    max_event_files_per_bot: int = 0,
     group_limit: int = GROUP_LIMIT,
     bot_filters: list[str] | tuple[str, ...] | set[str] | None = None,
     exchange_filters: list[str] | tuple[str, ...] | set[str] | None = None,
@@ -3221,6 +3240,9 @@ def build_live_performance_report(
     window_enabled = since_filter is not None or until_filter is not None
     max_event_tail_lines = max(0, int(event_tail_lines))
     max_event_file_count = max(0, int(max_event_files))
+    max_event_file_count_per_bot = max(0, int(max_event_files_per_bot))
+    if max_event_file_count and max_event_file_count_per_bot:
+        raise ValueError("max_event_files and max_event_files_per_bot are mutually exclusive")
     event_window = {
         "enabled": bool(window_enabled),
         "since_ms": since_filter,
@@ -3247,6 +3269,17 @@ def build_live_performance_report(
             {
                 "max_event_files": int(max_event_file_count),
                 "event_file_limit_scope": "global",
+                "event_files_before_limit": 0,
+                "event_files_skipped_by_limit": 0,
+                "event_file_limit_order": "current_then_recent_mtime",
+            }
+        )
+    if max_event_file_count_per_bot:
+        event_window.update(
+            {
+                "max_event_files_per_bot": int(max_event_file_count_per_bot),
+                "event_file_limit_scope": "per_bot",
+                "event_file_limit_groups": 0,
                 "event_files_before_limit": 0,
                 "event_files_skipped_by_limit": 0,
                 "event_file_limit_order": "current_then_recent_mtime",
@@ -3284,6 +3317,14 @@ def build_live_performance_report(
                 max_event_file_count,
             )
             event_window["event_files_skipped_by_limit"] = int(skipped_by_file_limit)
+        elif max_event_file_count_per_bot:
+            event_window["event_files_before_limit"] = len(files)
+            files, skipped_by_file_limit, limit_groups = _limit_recent_event_files_per_bot(
+                files,
+                max_event_file_count_per_bot,
+            )
+            event_window["event_files_skipped_by_limit"] = int(skipped_by_file_limit)
+            event_window["event_file_limit_groups"] = int(limit_groups)
     except FileNotFoundError as exc:
         files = []
         issues.append(
@@ -3516,7 +3557,12 @@ def build_live_performance_report(
             group_limit=group_limit,
         ),
     }
-    if window_enabled or max_event_tail_lines or max_event_file_count:
+    if (
+        window_enabled
+        or max_event_tail_lines
+        or max_event_file_count
+        or max_event_file_count_per_bot
+    ):
         report["event_window"] = event_window
     if filters["enabled"]:
         report["filters"] = filters

--- a/src/tools/live_performance_report.py
+++ b/src/tools/live_performance_report.py
@@ -76,6 +76,17 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--max-event-files-per-bot",
+        type=int,
+        default=0,
+        help=(
+            "Opt-in fair bound for monitor event file scans. When set, scan at "
+            "most N discovered event segments per events directory, preferring "
+            "current.ndjson first and then the newest rotated files by mtime. "
+            "Mutually exclusive with --max-event-files."
+        ),
+    )
+    parser.add_argument(
         "--group-limit",
         type=int,
         default=80,
@@ -130,6 +141,10 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--event-tail-lines must be >= 0")
     if args.max_event_files < 0:
         parser.error("--max-event-files must be >= 0")
+    if args.max_event_files_per_bot < 0:
+        parser.error("--max-event-files-per-bot must be >= 0")
+    if args.max_event_files and args.max_event_files_per_bot:
+        parser.error("--max-event-files and --max-event-files-per-bot are mutually exclusive")
     report = build_live_performance_report(
         args.path,
         since_ms=since_ms,
@@ -137,6 +152,7 @@ def main(argv: list[str] | None = None) -> int:
         include_rotated=bool(args.include_rotated),
         event_tail_lines=int(args.event_tail_lines),
         max_event_files=int(args.max_event_files),
+        max_event_files_per_bot=int(args.max_event_files_per_bot),
         group_limit=int(args.group_limit),
         bot_filters=args.bot,
         exchange_filters=args.exchange,

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -3138,6 +3138,142 @@ def test_live_performance_report_cli_rejects_negative_max_event_files(capsys):
     assert "--max-event-files must be >= 0" in capsys.readouterr().err
 
 
+def test_live_performance_report_max_event_files_per_bot_is_fair(tmp_path):
+    paths = {
+        "binance_old": tmp_path
+        / "monitor"
+        / "binance"
+        / "binance_01"
+        / "events"
+        / "2026-06-25T00-00-00.ndjson",
+        "binance_new": tmp_path
+        / "monitor"
+        / "binance"
+        / "binance_01"
+        / "events"
+        / "2026-06-26T00-00-00.ndjson",
+        "binance_current": tmp_path
+        / "monitor"
+        / "binance"
+        / "binance_01"
+        / "events"
+        / "current.ndjson",
+        "okx_old": tmp_path
+        / "monitor"
+        / "okx"
+        / "okx_01"
+        / "events"
+        / "2026-06-25T00-00-00.ndjson",
+        "okx_new": tmp_path
+        / "monitor"
+        / "okx"
+        / "okx_01"
+        / "events"
+        / "2026-06-26T00-00-00.ndjson",
+        "okx_current": tmp_path
+        / "monitor"
+        / "okx"
+        / "okx_01"
+        / "events"
+        / "current.ndjson",
+    }
+    for idx, (name, path) in enumerate(paths.items(), start=1):
+        exchange = "okx" if name.startswith("okx") else "binance"
+        user = "okx_01" if name.startswith("okx") else "binance_01"
+        _write_ndjson(
+            path,
+            [
+                _monitor_row(
+                    event_type="cycle.completed",
+                    seq=idx,
+                    ts=idx * 1000,
+                    exchange=exchange,
+                    user=user,
+                    ids={"cycle_id": f"cy_{name}"},
+                    data={"elapsed_ms": idx * 1000},
+                )
+            ],
+        )
+    os.utime(paths["binance_old"], (1000, 1000))
+    os.utime(paths["binance_new"], (2000, 2000))
+    os.utime(paths["binance_current"], (1500, 1500))
+    os.utime(paths["okx_old"], (1100, 1100))
+    os.utime(paths["okx_new"], (2100, 2100))
+    os.utime(paths["okx_current"], (1600, 1600))
+
+    report = build_live_performance_report(
+        tmp_path / "monitor",
+        include_rotated=True,
+        max_event_files_per_bot=2,
+    )
+
+    assert report["ok"] is True
+    assert report["files"] == [
+        str(paths["okx_current"]),
+        str(paths["binance_current"]),
+        str(paths["okx_new"]),
+        str(paths["binance_new"]),
+    ]
+    assert report["files_scanned"] == 4
+    assert report["records_total"] == 4
+    assert report["event_window"] == {
+        "enabled": False,
+        "since_ms": None,
+        "until_ms": None,
+        "events_considered": 0,
+        "events_skipped_before": 0,
+        "events_skipped_after": 0,
+        "invalid_window_ts": 0,
+        "max_event_files_per_bot": 2,
+        "event_file_limit_scope": "per_bot",
+        "event_file_limit_groups": 2,
+        "event_files_before_limit": 6,
+        "event_files_skipped_by_limit": 2,
+        "event_file_limit_order": "current_then_recent_mtime",
+    }
+    assert report["bots"] == [
+        {"bot": "binance/binance_01", "events": 2},
+        {"bot": "okx/okx_01", "events": 2},
+    ]
+
+
+def test_live_performance_report_rejects_ambiguous_event_file_limits():
+    try:
+        build_live_performance_report(
+            "monitor",
+            max_event_files=1,
+            max_event_files_per_bot=1,
+        )
+    except ValueError as exc:
+        assert "mutually exclusive" in str(exc)
+    else:
+        raise AssertionError("ambiguous event file limits must be rejected")
+
+
+def test_live_performance_report_cli_rejects_negative_max_event_files_per_bot(capsys):
+    try:
+        live_performance_report.main(["monitor", "--max-event-files-per-bot", "-1"])
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("negative --max-event-files-per-bot must be rejected")
+
+    assert "--max-event-files-per-bot must be >= 0" in capsys.readouterr().err
+
+
+def test_live_performance_report_cli_rejects_ambiguous_event_file_limits(capsys):
+    try:
+        live_performance_report.main(
+            ["monitor", "--max-event-files", "1", "--max-event-files-per-bot", "1"]
+        )
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("ambiguous event file limits must be rejected")
+
+    assert "mutually exclusive" in capsys.readouterr().err
+
+
 def test_live_performance_report_redacts_missing_root_paths():
     report = build_live_performance_report("/Users/operator/passivbot/missing-monitor")
 


### PR DESCRIPTION
## Summary
- add opt-in live-performance-report --max-event-files-per-bot for fair bounded rotated scans across multi-bot monitor roots
- keep it mutually exclusive with the existing global --max-event-files cap
- expose per-bot cap scope/group/skipped metadata in event_window
- record PR #926 merge/deploy/smoke evidence in the logging progress ledger

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py tests/test_live_performance_report.py
- git diff --check
- touched-file silent-handling scan: only existing report aggregation default reads matched

## Behavior
Read-only report tooling only. No event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, order/risk logic, or trading behavior.