### PR TITLE
Add per-bot event query file cap

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `ec9f47fe` after PR #926, `Bound performance report event file scans`.
+- `1ff596d1` after PR #927, `Add per-bot performance report file cap`.
 
 Current review gate:
 
@@ -49,6 +49,37 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #927 at `1ff596d1`.
+- PR #927 added `live-performance-report --max-event-files-per-bot`, an
+  opt-in fair event-segment scan bound for multi-bot monitor roots. It keeps
+  the existing global `--max-event-files` mode, makes the two modes mutually
+  exclusive, groups by event directory, prefers `current.ndjson` first and then
+  newest rotated segments by mtime per group, and reports
+  `event_file_limit_scope=per_bot`, group count, before/after file counts, and
+  skipped file count in `event_window`. The slice was read-only report tooling
+  and did not add event producers, exchange calls, cache mutation, readiness
+  gates, console routing, monitor writes, order/risk logic, or trading
+  behavior.
+- PR #927 passed Cursor + Hermes + CI. Claude did not comment after repeated
+  polling, so it was merged under the documented low-risk degraded gate, with
+  the rationale recorded on the PR. Local validation covered
+  `tests/test_live_performance_report.py`, py_compile for touched files,
+  `git diff --check`, and a touched-file silent-handling scan.
+- VPS5 pulled from `ec9f47fe` to `1ff596d1` without bot restart because the
+  deployed change was read-only report tooling. The five configured bots were
+  left running.
+- A bounded all-rotated performance report at `1ff596d1` completed in about
+  12 seconds with `ok=true`, `include_rotated=true`,
+  `max_event_files_per_bot=2`, `event_file_limit_scope=per_bot`,
+  `event_file_limit_groups=6`, `event_files_before_limit=947`,
+  `event_files_skipped_by_limit=935`, and `files_scanned=12`. A bounded
+  5-minute smoke completed with `ok=true`, `hard_failures=0`, clean tracked
+  repository state, all five live bot processes running, and no failed
+  account-critical remote calls. Attention remained from existing non-hard
+  EMA-readiness and HSL-cooldown problem events plus one non-hard OKX candle
+  fetch timeout that later recovered. This verified fair per-bot performance
+  report bounding, but `live-event-query` still lacks the same per-bot file cap
+  for bounded rotated incident/debug queries.
 - Repository pulled through PR #926 at `ec9f47fe`.
 - PR #926 added `live-performance-report --max-event-files`, an opt-in global
   event-segment scan bound for smoke/debug reports. It prefers

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -201,6 +201,34 @@ def _file_mtime_ms(path: Path) -> int | None:
         return None
 
 
+def _recent_event_file_sort_key(path: Path) -> tuple[int, int, str, str]:
+    mtime_ms = _file_mtime_ms(path)
+    return (
+        0 if path.name == "current.ndjson" else 1,
+        -(mtime_ms if mtime_ms is not None else -1),
+        str(path.parent),
+        path.name,
+    )
+
+
+def _limit_recent_event_files_per_bot(
+    files: list[Path],
+    max_event_files_per_bot: int,
+) -> tuple[list[Path], int, int]:
+    if max_event_files_per_bot <= 0:
+        return files, 0, 0
+    grouped: dict[Path, list[Path]] = {}
+    for path in files:
+        grouped.setdefault(path.parent, []).append(path)
+    selected: list[Path] = []
+    skipped = 0
+    for _, group_files in sorted(grouped.items(), key=lambda item: str(item[0])):
+        ordered = sorted(group_files, key=_recent_event_file_sort_key)
+        selected.extend(ordered[:max_event_files_per_bot])
+        skipped += max(0, len(ordered) - max_event_files_per_bot)
+    return sorted(selected, key=_recent_event_file_sort_key), skipped, len(grouped)
+
+
 def _live_event_payload(row: dict[str, Any]) -> dict[str, Any] | None:
     payload = row.get("payload")
     if not isinstance(payload, dict):
@@ -1288,6 +1316,7 @@ def build_event_report(
     since_ms: int | None = None,
     until_ms: int | None = None,
     event_tail_lines: int = 0,
+    max_event_files_per_bot: int = 0,
     limit: int = 200,
     include_data: bool = False,
     include_rotated: bool = False,
@@ -1332,6 +1361,10 @@ def build_event_report(
     window_invalid_ts = 0
     files_skipped_before_window = 0
     max_event_tail_lines = max(0, int(event_tail_lines))
+    max_event_file_count_per_bot = max(0, int(max_event_files_per_bot))
+    event_files_before_limit = 0
+    event_files_skipped_by_limit = 0
+    event_file_limit_groups = 0
     event_tail_limited_files = 0
     event_tail_skipped_lines = 0
     event_tail_skipped_lines_exact = True
@@ -1373,6 +1406,11 @@ def build_event_report(
                 continue
             window_files.append(event_file)
         files = window_files
+    if max_event_file_count_per_bot and files:
+        event_files_before_limit = len(files)
+        files, event_files_skipped_by_limit, event_file_limit_groups = (
+            _limit_recent_event_files_per_bot(files, max_event_file_count_per_bot)
+        )
 
     event_type_counts: Counter[str] = Counter()
     cycle_counts: Counter[str] = Counter()
@@ -1779,7 +1817,7 @@ def build_event_report(
             report["cycle"]["cycle_trace"] = cycle_cycle_trace.to_dict()
         if not event_type_filter:
             report["cycle"].pop("event_types", None)
-    if window_enabled or max_event_tail_lines:
+    if window_enabled or max_event_tail_lines or max_event_file_count_per_bot:
         report["event_window"] = {
             "enabled": window_enabled,
             "since_ms": since_filter,
@@ -1790,6 +1828,19 @@ def build_event_report(
             "invalid_window_ts": window_invalid_ts,
             "files_skipped_before_window": files_skipped_before_window,
         }
+        if max_event_file_count_per_bot:
+            report["event_window"]["max_event_files_per_bot"] = (
+                max_event_file_count_per_bot
+            )
+            report["event_window"]["event_file_limit_scope"] = "per_bot"
+            report["event_window"]["event_file_limit_groups"] = event_file_limit_groups
+            report["event_window"]["event_files_before_limit"] = event_files_before_limit
+            report["event_window"]["event_files_skipped_by_limit"] = (
+                event_files_skipped_by_limit
+            )
+            report["event_window"]["event_file_limit_order"] = (
+                "current_then_recent_mtime"
+            )
         if max_event_tail_lines:
             report["event_window"]["event_tail_lines"] = max_event_tail_lines
             report["event_window"]["event_tail_limited_files"] = event_tail_limited_files

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -14,7 +14,11 @@ from live.event_bus import (
     utc_ms,
 )
 from live.event_file_rows import event_file_rows
-from live.event_query import discover_event_files_with_metadata
+from live.event_query import (
+    _limit_recent_event_files_per_bot,
+    _recent_event_file_sort_key,
+    discover_event_files_with_metadata,
+)
 from live.smoke_report import _user_safe_display_path
 
 
@@ -226,45 +230,11 @@ def _open_text(path: Path):
     return open(path, "r", encoding="utf-8")
 
 
-def _event_file_mtime_ms(path: Path) -> int:
-    try:
-        return int(path.stat().st_mtime * 1000)
-    except OSError:
-        return -1
-
-
-def _recent_event_file_sort_key(path: Path) -> tuple[int, int, str, str]:
-    return (
-        0 if path.name == "current.ndjson" else 1,
-        -_event_file_mtime_ms(path),
-        str(path.parent),
-        path.name,
-    )
-
-
 def _limit_recent_event_files(files: list[Path], max_event_files: int) -> tuple[list[Path], int]:
     if max_event_files <= 0 or len(files) <= max_event_files:
         return files, 0
     ordered = sorted(files, key=_recent_event_file_sort_key)
     return ordered[:max_event_files], len(ordered) - max_event_files
-
-
-def _limit_recent_event_files_per_bot(
-    files: list[Path],
-    max_event_files_per_bot: int,
-) -> tuple[list[Path], int, int]:
-    if max_event_files_per_bot <= 0:
-        return files, 0, 0
-    grouped: dict[Path, list[Path]] = {}
-    for path in files:
-        grouped.setdefault(path.parent, []).append(path)
-    selected: list[Path] = []
-    skipped = 0
-    for _, group_files in sorted(grouped.items(), key=lambda item: str(item[0])):
-        ordered = sorted(group_files, key=_recent_event_file_sort_key)
-        selected.extend(ordered[:max_event_files_per_bot])
-        skipped += max(0, len(ordered) - max_event_files_per_bot)
-    return sorted(selected, key=_recent_event_file_sort_key), skipped, len(grouped)
 
 
 def _record_ts(row: dict[str, Any]) -> int | None:

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -224,6 +224,16 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--max-event-files-per-bot",
+        type=int,
+        default=0,
+        help=(
+            "Opt-in fair bound for monitor event file scans. When set, scan at "
+            "most N discovered event segments per events directory, preferring "
+            "current.ndjson first and then the newest rotated files by mtime."
+        ),
+    )
+    parser.add_argument(
         "--limit",
         type=int,
         default=200,
@@ -295,6 +305,8 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--since-ms/--recent-minutes must be <= --until-ms")
     if int(args.event_tail_lines) < 0:
         parser.error("--event-tail-lines must be non-negative")
+    if int(args.max_event_files_per_bot) < 0:
+        parser.error("--max-event-files-per-bot must be non-negative")
     try:
         report = build_event_report(
             args.path,
@@ -324,6 +336,7 @@ def main(argv: list[str] | None = None) -> int:
             since_ms=since_ms,
             until_ms=args.until_ms,
             event_tail_lines=int(args.event_tail_lines),
+            max_event_files_per_bot=int(args.max_event_files_per_bot),
             limit=args.limit,
             include_data=bool(args.include_data),
             include_rotated=bool(args.include_rotated),

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -1449,6 +1449,107 @@ def test_event_query_event_tail_lines_bounds_window_scan(tmp_path):
     ]
 
 
+def test_event_query_max_event_files_per_bot_is_fair(tmp_path):
+    paths = {
+        "binance_old": tmp_path
+        / "monitor"
+        / "binance"
+        / "binance_01"
+        / "events"
+        / "2026-06-25T00-00-00.ndjson",
+        "binance_new": tmp_path
+        / "monitor"
+        / "binance"
+        / "binance_01"
+        / "events"
+        / "2026-06-26T00-00-00.ndjson",
+        "binance_current": tmp_path
+        / "monitor"
+        / "binance"
+        / "binance_01"
+        / "events"
+        / "current.ndjson",
+        "okx_old": tmp_path
+        / "monitor"
+        / "okx"
+        / "okx_01"
+        / "events"
+        / "2026-06-25T00-00-00.ndjson",
+        "okx_new": tmp_path
+        / "monitor"
+        / "okx"
+        / "okx_01"
+        / "events"
+        / "2026-06-26T00-00-00.ndjson",
+        "okx_current": tmp_path
+        / "monitor"
+        / "okx"
+        / "okx_01"
+        / "events"
+        / "current.ndjson",
+    }
+    for idx, (name, path) in enumerate(paths.items(), start=1):
+        exchange = "okx" if name.startswith("okx") else "binance"
+        user = "okx_01" if name.startswith("okx") else "binance_01"
+        _write_ndjson(
+            path,
+            [
+                _monitor_row(
+                    event_type="cycle.completed",
+                    cycle_id=f"cy_{name}",
+                    seq=idx,
+                    ts=idx * 1000,
+                    exchange=exchange,
+                    user=user,
+                )
+            ],
+        )
+    os.utime(paths["binance_old"], (1000, 1000))
+    os.utime(paths["binance_new"], (2000, 2000))
+    os.utime(paths["binance_current"], (1500, 1500))
+    os.utime(paths["okx_old"], (1100, 1100))
+    os.utime(paths["okx_new"], (2100, 2100))
+    os.utime(paths["okx_current"], (1600, 1600))
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        include_rotated=True,
+        max_event_files_per_bot=2,
+    )
+
+    assert report["ok"] is True
+    assert report["files"] == [
+        str(paths["okx_current"]),
+        str(paths["binance_current"]),
+        str(paths["okx_new"]),
+        str(paths["binance_new"]),
+    ]
+    assert report["files_scanned"] == 4
+    assert report["records_total"] == 4
+    assert report["cycle_ids_sample"] == [
+        {"cycle_id": "cy_okx_current", "events": 1},
+        {"cycle_id": "cy_binance_current", "events": 1},
+        {"cycle_id": "cy_okx_new", "events": 1},
+        {"cycle_id": "cy_binance_new", "events": 1},
+    ]
+    assert report["event_window"] == {
+        "enabled": False,
+        "since_ms": None,
+        "until_ms": None,
+        "events_considered": 4,
+        "events_skipped_before": 0,
+        "events_skipped_after": 0,
+        "invalid_window_ts": 0,
+        "files_skipped_before_window": 0,
+        "max_event_files_per_bot": 2,
+        "event_file_limit_scope": "per_bot",
+        "event_file_limit_groups": 2,
+        "event_files_before_limit": 6,
+        "event_files_skipped_by_limit": 2,
+        "event_file_limit_order": "current_then_recent_mtime",
+    }
+
+
 def test_event_file_rows_seek_tail_skips_plain_ndjson_prefix(tmp_path):
     path = tmp_path / "current.ndjson"
     old_prefix = json.dumps({"seq": 1, "payload": "x" * 80_000})
@@ -2020,6 +2121,61 @@ def test_live_event_query_cli_rejects_negative_event_tail_lines(tmp_path, capsys
     assert exc_info.value.code == 2
     err = capsys.readouterr().err
     assert "--event-tail-lines must be non-negative" in err
+
+
+def test_live_event_query_cli_accepts_max_event_files_per_bot(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "2026-06-25T00-00-00.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                cycle_id="cy_old",
+                seq=1,
+                ts=1000,
+            )
+        ],
+    )
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                cycle_id="cy_current",
+                seq=2,
+                ts=2000,
+            )
+        ],
+    )
+
+    assert (
+        live_event_query.main(
+            [
+                str(tmp_path / "monitor"),
+                "--include-rotated",
+                "--max-event-files-per-bot",
+                "1",
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["files"] == [str(events_dir / "current.ndjson")]
+    assert report["records_total"] == 1
+    assert report["event_window"]["max_event_files_per_bot"] == 1
+    assert report["event_window"]["event_file_limit_scope"] == "per_bot"
+    assert report["event_window"]["event_files_skipped_by_limit"] == 1
+    assert report["cycle_ids_sample"] == [{"cycle_id": "cy_current", "events": 1}]
+
+
+def test_live_event_query_cli_rejects_negative_max_event_files_per_bot(tmp_path, capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_event_query.main([str(tmp_path), "--max-event-files-per-bot", "-1"])
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "--max-event-files-per-bot must be non-negative" in err
 
 
 def test_live_event_query_cli_accepts_additional_id_scopes(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- add opt-in live-event-query --max-event-files-per-bot for fair bounded rotated scans across multi-bot monitor roots
- report per-bot file cap scope/group/skipped metadata in event_window
- keep default event-query behavior unchanged
- record PR #927 deploy/smoke evidence in the logging progress ledger

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_query.py src/tools/live_event_query.py tests/test_live_event_query.py
- git diff --check
- touched-file silent-handling scan: no matches

## Behavior
Read-only query/report tooling only. No event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, order/risk logic, or trading behavior.