### PR TITLE
Add per-bot incident bundle event file cap

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `1ff596d1` after PR #927, `Add per-bot performance report file cap`.
+- `98e653ba` after PR #928, `Add per-bot event query file cap`.
 
 Current review gate:
 
@@ -49,6 +49,35 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #928 at `98e653ba`.
+- PR #928 added `live-event-query --max-event-files-per-bot` and the matching
+  `build_event_report()` option for fair, opt-in per-events-directory rotated
+  file caps. It shares the same current-first/newest-mtime helper used by
+  `live-performance-report`, reports `event_file_limit_scope=per_bot`,
+  group count, before/after file counts, skipped file count, and selection
+  order in `event_window`, and keeps default scans unchanged. The slice was
+  read-only event-query/performance-report tooling and did not add event
+  producers, exchange calls, cache mutation, readiness gates, console routing,
+  monitor writes, order/risk logic, or trading behavior.
+- PR #928 passed Hermes + Claude + Cursor + CI on the amended head after a
+  reviewer-requested de-duplication cleanup. Local validation covered
+  `tests/test_live_event_query.py`, `tests/test_live_performance_report.py`,
+  py_compile for touched files, `git diff --check`, and a touched-file
+  silent-handling scan.
+- VPS5 pulled from `1ff596d1` to `98e653ba` without bot restart because the
+  deployed change was read-only query/report tooling. The five configured bots
+  were left running.
+- A bounded all-rotated event-query probe at `98e653ba` completed with
+  `ok=true`, `include_rotated=true`, `max_event_files_per_bot=2`,
+  `event_file_limit_scope=per_bot`, `event_file_limit_groups=6`,
+  `event_files_before_limit=942`, `event_files_skipped_by_limit=930`, and
+  `files_scanned=12`. A bounded 5-minute smoke completed with `ok=true`,
+  `hard_failures=0`, clean tracked repository state, all five live bot
+  processes running, and no failed account-critical remote calls. Attention
+  remained from existing non-hard EMA-readiness and HSL-cooldown problem
+  events. This verified fair per-bot event-query bounding, but
+  `live-incident-bundle` still needs to expose the same cap for its embedded
+  event-query reports.
 - Repository pulled through PR #927 at `1ff596d1`.
 - PR #927 added `live-performance-report --max-event-files-per-bot`, an
   opt-in fair event-segment scan bound for multi-bot monitor roots. It keeps

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -18,6 +18,7 @@ from urllib.parse import urlsplit, urlunsplit
 from live.event_bus import LIVE_EVENT_ID_KEYS, LIVE_EVENT_MONITOR_PAYLOAD_KEY
 from live.event_file_rows import event_file_rows
 from live.event_query import (
+    _limit_recent_event_files_per_bot,
     build_event_report,
     build_event_query_filters,
     discover_event_files_with_metadata,
@@ -178,6 +179,7 @@ def _build_time_window_report(
     include_rotated: bool,
     include_data: bool,
     event_tail_lines: int = 0,
+    max_event_files_per_bot: int = 0,
     limit: int,
 ) -> dict[str, Any]:
     if since_ms is None and until_ms is None:
@@ -220,12 +222,16 @@ def _build_time_window_report(
     matched_events = 0
     max_events = max(0, int(limit))
     max_event_tail_lines = max(0, int(event_tail_lines))
+    max_event_file_count_per_bot = max(0, int(max_event_files_per_bot))
     event_tail_limited_files = 0
     event_tail_skipped_lines = 0
     event_tail_skipped_lines_exact = True
     event_tail_skipped_bytes = 0
     event_tail_line_numbers_exact = True
     event_tail_methods: Counter[str] = Counter()
+    event_files_before_limit = 0
+    event_files_skipped_by_limit = 0
+    event_file_limit_groups = 0
     file_discovery: dict[str, Any] = {
         "candidate_files": 0,
         "event_segments": 0,
@@ -254,6 +260,11 @@ def _build_time_window_report(
                 "code": "path_not_found",
                 "message": str(exc),
             }
+        )
+    if max_event_file_count_per_bot and files:
+        event_files_before_limit = len(files)
+        files, event_files_skipped_by_limit, event_file_limit_groups = (
+            _limit_recent_event_files_per_bot(files, max_event_file_count_per_bot)
         )
 
     for path in files:
@@ -350,6 +361,13 @@ def _build_time_window_report(
         report["event_tail_skipped_bytes"] = event_tail_skipped_bytes
         report["event_tail_line_numbers_exact"] = event_tail_line_numbers_exact
         report["event_tail_methods"] = dict(sorted(event_tail_methods.items()))
+    if max_event_file_count_per_bot:
+        report["max_event_files_per_bot"] = max_event_file_count_per_bot
+        report["event_file_limit_scope"] = "per_bot"
+        report["event_file_limit_groups"] = event_file_limit_groups
+        report["event_files_before_limit"] = event_files_before_limit or len(files)
+        report["event_files_skipped_by_limit"] = event_files_skipped_by_limit
+        report["event_file_limit_order"] = "current_then_recent_mtime"
     return report
 
 
@@ -759,6 +777,7 @@ def build_live_incident_bundle(
     max_log_matches: int = 100,
     log_window_unparsed_policy: str = DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
     event_tail_lines: int = 0,
+    max_event_files_per_bot: int = 0,
     max_snapshot_files: int = 20,
     max_snapshot_file_bytes: int = 1_000_000,
     max_event_segment_bytes: int = 10_000_000,
@@ -799,6 +818,7 @@ def build_live_incident_bundle(
         limit=max_events,
         include_data=include_data,
         include_rotated=include_rotated,
+        max_event_files_per_bot=max_event_files_per_bot,
         timeline=True,
         trace_summary=include_trace_report,
         order_trace=include_trace_report,
@@ -832,6 +852,7 @@ def build_live_incident_bundle(
             limit=max_problem_events,
             include_data=include_data,
             include_rotated=include_rotated,
+            max_event_files_per_bot=max_event_files_per_bot,
             timeline=True,
             trace_summary=True,
         )
@@ -864,6 +885,7 @@ def build_live_incident_bundle(
         include_rotated=include_rotated,
         include_data=include_data,
         event_tail_lines=event_tail_lines,
+        max_event_files_per_bot=max_event_files_per_bot,
         limit=max_events,
     )
     smoke_report = build_live_smoke_report(
@@ -931,6 +953,9 @@ def build_live_incident_bundle(
                     "since_ms": since_ms,
                     "until_ms": until_ms,
                     "event_tail_lines": event_tail_lines if event_tail_lines else None,
+                    "max_event_files_per_bot": max_event_files_per_bot
+                    if max_event_files_per_bot
+                    else None,
                     "include_rotated": include_rotated,
                     "include_data": include_data,
                     "include_trace_report": include_trace_report,
@@ -1006,6 +1031,14 @@ def build_live_incident_bundle(
                 "event_tail_line_numbers_exact"
             ),
             "event_tail_methods": window_report.get("event_tail_methods"),
+            "max_event_files_per_bot": window_report.get("max_event_files_per_bot"),
+            "event_file_limit_scope": window_report.get("event_file_limit_scope"),
+            "event_file_limit_groups": window_report.get("event_file_limit_groups"),
+            "event_files_before_limit": window_report.get("event_files_before_limit"),
+            "event_files_skipped_by_limit": window_report.get(
+                "event_files_skipped_by_limit"
+            ),
+            "event_file_limit_order": window_report.get("event_file_limit_order"),
         },
         "smoke_report": {
             "ok": smoke_report.get("ok"),

--- a/src/tools/live_incident_bundle.py
+++ b/src/tools/live_incident_bundle.py
@@ -224,6 +224,16 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--max-event-files-per-bot",
+        type=int,
+        default=0,
+        help=(
+            "With --include-rotated, scan at most N event segments per bot/events "
+            "directory for embedded event reports, preferring current.ndjson and "
+            "then newest rotated files. Default 0 scans all discovered segments."
+        ),
+    )
+    parser.add_argument(
         "--no-event-segments",
         action="store_true",
         help="Do not copy bounded event segment files into the bundle.",
@@ -285,6 +295,8 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--since-ms and --recent-minutes are mutually exclusive")
     if int(args.event_tail_lines) < 0:
         parser.error("--event-tail-lines must be >= 0")
+    if int(args.max_event_files_per_bot) < 0:
+        parser.error("--max-event-files-per-bot must be >= 0")
     since_ms = args.since_ms
     if args.recent_minutes is not None:
         if args.recent_minutes <= 0:
@@ -326,6 +338,7 @@ def main(argv: list[str] | None = None) -> int:
             include_problem_report=not bool(args.no_problem_report),
             include_rotated=bool(args.include_rotated),
             event_tail_lines=int(args.event_tail_lines),
+            max_event_files_per_bot=int(args.max_event_files_per_bot),
             include_event_segments=not bool(args.no_event_segments),
             max_events=int(args.limit),
             max_log_files=int(args.max_log_files),

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import tarfile
 
 import pytest
@@ -64,6 +65,10 @@ def _write_ndjson(path, rows):
         "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
         encoding="utf-8",
     )
+
+
+def _set_mtime(path, seconds: int):
+    os.utime(path, (seconds, seconds))
 
 
 def _read_tar_json(tar, name: str):
@@ -812,6 +817,136 @@ def test_live_incident_bundle_cli_event_tail_lines_bounds_event_scans(tmp_path, 
     assert smoke_report["event_window"]["event_tail_skipped_lines"] == 2
 
 
+def test_live_incident_bundle_cli_max_event_files_per_bot_is_fair(tmp_path, capsys):
+    binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    okx_events = tmp_path / "monitor" / "okx" / "okx_01" / "events"
+    files = [
+        (
+            binance_events / "current.ndjson",
+            10,
+            "binance",
+            "binance_01",
+            "binance_current",
+        ),
+        (
+            binance_events / "new.ndjson",
+            11,
+            "binance",
+            "binance_01",
+            "binance_new",
+        ),
+        (
+            binance_events / "old.ndjson",
+            12,
+            "binance",
+            "binance_01",
+            "binance_old",
+        ),
+        (okx_events / "current.ndjson", 20, "okx", "okx_01", "okx_current"),
+        (okx_events / "new.ndjson", 21, "okx", "okx_01", "okx_new"),
+        (okx_events / "old.ndjson", 22, "okx", "okx_01", "okx_old"),
+    ]
+    for path, seq, exchange, user, label in files:
+        _write_ndjson(
+            path,
+            [
+                _monitor_row(
+                    event_type="remote_call.failed",
+                    seq=seq,
+                    ts=seq * 100,
+                    status="failed",
+                    level="warning",
+                    reason_code="request_timeout",
+                    exchange=exchange,
+                    user=user,
+                    data={"label": label},
+                )
+            ],
+        )
+    for path in (binance_events / "old.ndjson", okx_events / "old.ndjson"):
+        _set_mtime(path, 100)
+    for path in (binance_events / "new.ndjson", okx_events / "new.ndjson"):
+        _set_mtime(path, 200)
+    for path in (binance_events / "current.ndjson", okx_events / "current.ndjson"):
+        _set_mtime(path, 50)
+
+    output = tmp_path / "incident.tar.gz"
+
+    assert (
+        live_incident_bundle.main(
+            [
+                str(tmp_path / "monitor"),
+                "--logs-root",
+                "",
+                "--event-type",
+                "remote_call.failed",
+                "--since-ms",
+                "0",
+                "--include-rotated",
+                "--include-data",
+                "--max-event-files-per-bot",
+                "2",
+                "--no-event-segments",
+                "--output",
+                str(output),
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["ok"] is True
+    assert report["event_report"]["query_matched_events"] == 4
+    assert report["event_report"]["event_window"] == {
+        "enabled": False,
+        "since_ms": None,
+        "until_ms": None,
+        "events_considered": 4,
+        "events_skipped_before": 0,
+        "events_skipped_after": 0,
+        "invalid_window_ts": 0,
+        "files_skipped_before_window": 0,
+        "max_event_files_per_bot": 2,
+        "event_file_limit_scope": "per_bot",
+        "event_file_limit_groups": 2,
+        "event_files_before_limit": 6,
+        "event_files_skipped_by_limit": 2,
+        "event_file_limit_order": "current_then_recent_mtime",
+    }
+    assert report["problem_event_report"]["matched_events"] == 4
+    assert (
+        report["problem_event_report"]["event_window"]["event_file_limit_scope"]
+        == "per_bot"
+    )
+    assert report["time_window"]["matched_events"] == 4
+    assert report["time_window"]["max_event_files_per_bot"] == 2
+    assert report["time_window"]["event_file_limit_groups"] == 2
+    assert report["time_window"]["event_files_before_limit"] == 6
+    assert report["time_window"]["event_files_skipped_by_limit"] == 2
+
+    with tarfile.open(output, "r:gz") as tar:
+        manifest = _read_tar_json(tar, "manifest.json")
+        event_report = _read_tar_json(tar, "event_report.json")
+        problem_event_report = _read_tar_json(tar, "problem_event_report.json")
+        window_report = _read_tar_json(tar, "time_window_report.json")
+
+    assert manifest["filters"]["max_event_files_per_bot"] == 2
+    kept_labels = {event["data"]["label"] for event in event_report["query"]["events"]}
+    assert kept_labels == {
+        "binance_current",
+        "binance_new",
+        "okx_current",
+        "okx_new",
+    }
+    assert {
+        event["data"]["label"]
+        for event in problem_event_report["query"]["events"]
+    } == kept_labels
+    assert {event["data"]["label"] for event in window_report["events"]} == kept_labels
+    assert window_report["event_file_limit_order"] == "current_then_recent_mtime"
+
+
 def test_live_incident_bundle_cli_rejects_invalid_window_timestamp(capsys):
     with pytest.raises(SystemExit) as exc_info:
         live_incident_bundle.main(["monitor", "--since-ms", "not-an-int"])
@@ -844,6 +979,14 @@ def test_live_incident_bundle_cli_rejects_negative_event_tail_lines(capsys):
 
     assert exc_info.value.code == 2
     assert "--event-tail-lines must be >= 0" in capsys.readouterr().err
+
+
+def test_live_incident_bundle_cli_rejects_negative_max_event_files_per_bot(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_incident_bundle.main(["monitor", "--max-event-files-per-bot", "-1"])
+
+    assert exc_info.value.code == 2
+    assert "--max-event-files-per-bot must be >= 0" in capsys.readouterr().err
 
 
 def test_live_incident_bundle_cli_rejects_recent_window_after_until(capsys, monkeypatch):


### PR DESCRIPTION
## Summary
- add opt-in live-incident-bundle --max-event-files-per-bot for embedded event reports
- apply the fair per-events-directory cap to event_report, problem_event_report, and time_window_report
- expose limit metadata in compact output, bundled JSON, and manifest filters
- update logging-overhaul progress with PR #928 merge/VPS evidence

## Scope
Read-only incident-bundle/event-query tooling only. No event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, order/risk logic, or trading behavior changed.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_incident_bundle.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_query.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/incident_bundle.py src/tools/live_incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check
- touched-file silent-handling scan; hits are pre-existing incident-bundle summary defaults, no new trading-path fallbacks