### PR TITLE
Add per-bot smoke report event file cap

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `98e653ba` after PR #928, `Add per-bot event query file cap`.
+- `109c4342` after PR #929, `Add per-bot incident bundle event file cap`.
 
 Current review gate:
 
@@ -49,6 +49,31 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #929 at `109c4342`.
+- PR #929 added `live-incident-bundle --max-event-files-per-bot` and the
+  matching `build_live_incident_bundle()` option for fair, opt-in
+  per-events-directory caps in the embedded event report, problem-event
+  report, and time-window report. It reuses the shared event-query cap helper,
+  reports limit metadata in compact output and bundled JSON, and records the
+  cap in manifest filters. The slice was read-only incident-bundle/event-query
+  tooling and did not add event producers, exchange calls, cache mutation,
+  readiness gates, console routing, monitor writes, order/risk logic, or
+  trading behavior.
+- PR #929 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_incident_bundle.py`, `tests/test_live_event_query.py`,
+  `tests/test_live_performance_report.py`, py_compile for touched files,
+  `git diff --check`, and a touched-file silent-handling scan.
+- VPS5 pulled from `98e653ba` to `109c4342` without bot restart because the
+  deployed change was read-only incident-bundle tooling. The five configured
+  bots were left running.
+- A bounded 5-minute smoke at `109c4342` completed with `ok=true`,
+  `hard_failures=0`, clean tracked repository state, all five live bot
+  processes running, and no failed account-critical remote calls. A first
+  all-rotated incident-bundle smoke with `--max-event-files-per-bot=2` was
+  interrupted after exposing a remaining slow path: the embedded smoke report
+  still received `include_rotated=true` without a file-count cap. The follow-up
+  branch `codex/v8-smoke-report-per-bot-file-limit` addresses that embedded
+  smoke-report gap.
 - Repository pulled through PR #928 at `98e653ba`.
 - PR #928 added `live-event-query --max-event-files-per-bot` and the matching
   `build_event_report()` option for fair, opt-in per-events-directory rotated

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -898,6 +898,7 @@ def build_live_incident_bundle(
         since_ms=since_ms,
         until_ms=until_ms,
         event_tail_lines=event_tail_lines,
+        max_event_files_per_bot=max_event_files_per_bot,
         max_problem_events=max_problem_events,
         max_log_files=max_log_files,
         log_tail_lines=log_tail_lines,

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -13,7 +13,10 @@ from typing import Any
 
 from live.event_bus import LIVE_EVENT_MONITOR_PAYLOAD_KEY, EventTypes, utc_ms
 from live.event_file_rows import event_file_rows
-from live.event_query import discover_event_files_with_metadata
+from live.event_query import (
+    _limit_recent_event_files_per_bot,
+    discover_event_files_with_metadata,
+)
 from live.problem_events import is_hard_problem_event, is_problem_event
 
 
@@ -3412,6 +3415,10 @@ def _event_window_report(
     event_tail_skipped_bytes: int = 0,
     event_tail_line_numbers_exact: bool = True,
     event_tail_methods: dict[str, int] | None = None,
+    max_event_files_per_bot: int = 0,
+    event_file_limit_groups: int = 0,
+    event_files_before_limit: int = 0,
+    event_files_skipped_by_limit: int = 0,
 ) -> dict[str, Any]:
     report = {
         "enabled": since_ms is not None or until_ms is not None,
@@ -3430,6 +3437,13 @@ def _event_window_report(
         report["event_tail_skipped_bytes"] = int(event_tail_skipped_bytes)
         report["event_tail_line_numbers_exact"] = bool(event_tail_line_numbers_exact)
         report["event_tail_methods"] = dict(sorted((event_tail_methods or {}).items()))
+    if int(max_event_files_per_bot) > 0:
+        report["max_event_files_per_bot"] = int(max_event_files_per_bot)
+        report["event_file_limit_scope"] = "per_bot"
+        report["event_file_limit_groups"] = int(event_file_limit_groups)
+        report["event_files_before_limit"] = int(event_files_before_limit)
+        report["event_files_skipped_by_limit"] = int(event_files_skipped_by_limit)
+        report["event_file_limit_order"] = "current_then_recent_mtime"
     return report
 
 
@@ -3457,6 +3471,7 @@ def _scan_events(
     since_ms: int | None = None,
     until_ms: int | None = None,
     event_tail_lines: int = 0,
+    max_event_files_per_bot: int = 0,
 ) -> dict[str, Any]:
     issues: list[dict[str, Any]] = []
     file_discovery: dict[str, Any] = {
@@ -3514,12 +3529,16 @@ def _scan_events(
     events_skipped_after = 0
     invalid_window_ts = 0
     max_event_tail_lines = max(0, int(event_tail_lines))
+    max_event_file_count_per_bot = max(0, int(max_event_files_per_bot))
     event_tail_limited_files = 0
     event_tail_skipped_lines = 0
     event_tail_skipped_lines_exact = True
     event_tail_skipped_bytes = 0
     event_tail_line_numbers_exact = True
     event_tail_methods: Counter[str] = Counter()
+    event_files_before_limit = 0
+    event_files_skipped_by_limit = 0
+    event_file_limit_groups = 0
     startup_timing_records: dict[str, list[dict[str, Any]]] = defaultdict(list)
     remote_call_failure_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     remote_call_health_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -3539,6 +3558,11 @@ def _scan_events(
     shutdown_event_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     shutdown_event_type_counts: Counter[str] = Counter()
     problem_event_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
+    if max_event_file_count_per_bot and files:
+        event_files_before_limit = len(files)
+        files, event_files_skipped_by_limit, event_file_limit_groups = (
+            _limit_recent_event_files_per_bot(files, max_event_file_count_per_bot)
+        )
 
     for path in files:
         try:
@@ -3917,6 +3941,10 @@ def _scan_events(
             event_tail_skipped_bytes=event_tail_skipped_bytes,
             event_tail_line_numbers_exact=event_tail_line_numbers_exact,
             event_tail_methods=dict(event_tail_methods),
+            max_event_files_per_bot=max_event_file_count_per_bot,
+            event_file_limit_groups=event_file_limit_groups,
+            event_files_before_limit=event_files_before_limit or len(files),
+            event_files_skipped_by_limit=event_files_skipped_by_limit,
         ),
     }
 
@@ -4172,6 +4200,7 @@ def build_live_smoke_report(
     max_problem_events: int = 50,
     max_log_files: int = 8,
     event_tail_lines: int = 0,
+    max_event_files_per_bot: int = 0,
     log_tail_lines: int = 300,
     max_log_matches: int = 50,
     log_window_unparsed_policy: str = DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
@@ -4184,6 +4213,7 @@ def build_live_smoke_report(
         since_ms=since_ms,
         until_ms=until_ms,
         event_tail_lines=event_tail_lines,
+        max_event_files_per_bot=max_event_files_per_bot,
     )
     event_report = event_scan["monitor"]
     log_scan = _scan_logs(
@@ -4957,6 +4987,12 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
                 "event_tail_skipped_bytes",
                 "event_tail_line_numbers_exact",
                 "event_tail_methods",
+                "max_event_files_per_bot",
+                "event_file_limit_scope",
+                "event_file_limit_groups",
+                "event_files_before_limit",
+                "event_files_skipped_by_limit",
+                "event_file_limit_order",
             )
             if key in event_window
         },

--- a/src/tools/live_smoke_report.py
+++ b/src/tools/live_smoke_report.py
@@ -131,6 +131,16 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--max-event-files-per-bot",
+        type=int,
+        default=0,
+        help=(
+            "With --include-rotated, scan at most N event segments per bot/events "
+            "directory, preferring current.ndjson and then newest rotated files. "
+            "Default 0 scans all discovered segments."
+        ),
+    )
+    parser.add_argument(
         "--log-tail-lines",
         type=int,
         default=300,
@@ -184,6 +194,8 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--since-ms must be <= --until-ms")
     if int(args.event_tail_lines) < 0:
         parser.error("--event-tail-lines must be non-negative")
+    if int(args.max_event_files_per_bot) < 0:
+        parser.error("--max-event-files-per-bot must be non-negative")
     report = build_live_smoke_report(
         args.monitor_root,
         logs_root=logs_root,
@@ -196,6 +208,7 @@ def main(argv: list[str] | None = None) -> int:
         max_problem_events=int(args.max_problem_events),
         max_log_files=int(args.max_log_files),
         event_tail_lines=int(args.event_tail_lines),
+        max_event_files_per_bot=int(args.max_event_files_per_bot),
         log_tail_lines=int(args.log_tail_lines),
         max_log_matches=int(args.max_log_matches),
         log_window_unparsed_policy=str(args.log_window_unparsed_policy),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 
 import pytest
 
@@ -66,6 +67,10 @@ def _write_ndjson(path, rows):
         "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
         encoding="utf-8",
     )
+
+
+def _set_mtime(path, seconds: int):
+    os.utime(path, (seconds, seconds))
 
 
 def _write_minimal_monitor_event(monitor_root):
@@ -206,6 +211,99 @@ def test_live_smoke_report_event_tail_lines_bounds_monitor_scan(tmp_path):
         "event_tail_methods": {"seek_tail": 1},
     }
     assert report["bots"][0]["events"] == 2
+
+
+def test_live_smoke_report_max_event_files_per_bot_is_fair(tmp_path):
+    binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    okx_events = tmp_path / "monitor" / "okx" / "okx_01" / "events"
+    files = [
+        (
+            binance_events / "current.ndjson",
+            10,
+            "binance",
+            "binance_01",
+            "binance_current",
+        ),
+        (
+            binance_events / "new.ndjson",
+            11,
+            "binance",
+            "binance_01",
+            "binance_new",
+        ),
+        (
+            binance_events / "old.ndjson",
+            12,
+            "binance",
+            "binance_01",
+            "binance_old",
+        ),
+        (okx_events / "current.ndjson", 20, "okx", "okx_01", "okx_current"),
+        (okx_events / "new.ndjson", 21, "okx", "okx_01", "okx_new"),
+        (okx_events / "old.ndjson", 22, "okx", "okx_01", "okx_old"),
+    ]
+    for path, seq, exchange, user, cycle_id in files:
+        _write_ndjson(
+            path,
+            [
+                _monitor_row(
+                    event_type="cycle.completed",
+                    seq=seq,
+                    ts=seq * 100,
+                    exchange=exchange,
+                    user=user,
+                    ids={"cycle_id": cycle_id},
+                )
+            ],
+        )
+    for path in (binance_events / "old.ndjson", okx_events / "old.ndjson"):
+        _set_mtime(path, 100)
+    for path in (binance_events / "new.ndjson", okx_events / "new.ndjson"):
+        _set_mtime(path, 200)
+    for path in (binance_events / "current.ndjson", okx_events / "current.ndjson"):
+        _set_mtime(path, 50)
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        include_rotated=True,
+        max_event_files_per_bot=2,
+    )
+
+    assert report["ok"] is True
+    assert report["monitor"]["files_scanned"] == 4
+    assert report["monitor"]["live_events"] == 4
+    assert report["event_window"] == {
+        "enabled": False,
+        "since_ms": None,
+        "until_ms": None,
+        "events_considered": 4,
+        "events_skipped_before": 0,
+        "events_skipped_after": 0,
+        "invalid_window_ts": 0,
+        "max_event_files_per_bot": 2,
+        "event_file_limit_scope": "per_bot",
+        "event_file_limit_groups": 2,
+        "event_files_before_limit": 6,
+        "event_files_skipped_by_limit": 2,
+        "event_file_limit_order": "current_then_recent_mtime",
+    }
+    cycle_ids = {item["cycle_id"] for item in report["monitor"]["cycle_ids_sample"]}
+    assert cycle_ids == {
+        "binance_current",
+        "binance_new",
+        "okx_current",
+        "okx_new",
+    }
+    assert {bot["bot"]: bot["events"] for bot in report["bots"]} == {
+        "binance/binance_01": 2,
+        "okx/okx_01": 2,
+    }
+
+    brief = summarize_live_smoke_report_brief(report)
+    assert brief["event_window"]["max_event_files_per_bot"] == 2
+    assert brief["event_window"]["event_file_limit_scope"] == "per_bot"
+    assert brief["event_window"]["event_files_skipped_by_limit"] == 2
 
 
 def test_live_smoke_report_summarizes_monitor_events_and_log_attention(tmp_path):
@@ -3829,6 +3927,14 @@ def test_live_smoke_report_cli_rejects_negative_event_tail_lines(capsys):
 
     assert exc_info.value.code == 2
     assert "--event-tail-lines must be non-negative" in capsys.readouterr().err
+
+
+def test_live_smoke_report_cli_rejects_negative_max_event_files_per_bot(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_smoke_report.main(["monitor", "--max-event-files-per-bot", "-1"])
+
+    assert exc_info.value.code == 2
+    assert "--max-event-files-per-bot must be non-negative" in capsys.readouterr().err
 
 
 def test_live_smoke_report_process_status_matches_supervisor_config(


### PR DESCRIPTION
## Summary
- add opt-in live-smoke-report --max-event-files-per-bot
- apply the same fair per-events-directory cap to build_live_smoke_report()
- pass the cap from live-incident-bundle into the embedded smoke report
- expose limit metadata in smoke event_window and brief summaries
- update logging-overhaul progress with PR #929 deploy evidence and the VPS-discovered slow path

## Why
After PR #929 merged and deployed, a bounded all-rotated incident-bundle smoke was interrupted: the new incident-bundle event reports were capped, but the embedded smoke report still received include_rotated=true without a file-count cap and could scan the full rotated monitor history. This PR closes that remaining read-only tooling gap.

## Scope
Read-only smoke/incident-bundle tooling only. No event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, order/risk logic, or trading behavior changed.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/incident_bundle.py src/live/smoke_report.py src/tools/live_smoke_report.py tests/test_live_smoke_report.py
- git diff --check
- touched-file silent-handling scan; hits are pre-existing report aggregation defaults / process inspection catch, no new trading-path fallbacks