### PR TITLE
Cap incident bundle segment fallback per bot

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `109c4342` after PR #929, `Add per-bot incident bundle event file cap`.
+- `103a4d11` after PR #930, `Add per-bot smoke report event file cap`.
 
 Current review gate:
 
@@ -49,6 +49,31 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #930 at `103a4d11`.
+- PR #930 added `live-smoke-report --max-event-files-per-bot` and the matching
+  `build_live_smoke_report()` option for fair, opt-in per-events-directory caps
+  in smoke-report event scanning. The slice was read-only smoke/report tooling
+  and did not add event producers, exchange calls, cache mutation, readiness
+  gates, console routing, monitor writes, order/risk logic, or trading
+  behavior.
+- PR #930 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_smoke_report.py`, `tests/test_live_incident_bundle.py`,
+  py_compile for touched files, `git diff --check`, and a touched-file
+  silent-handling scan.
+- VPS5 pulled from `109c4342` to `103a4d11` without bot restart because the
+  deployed change was read-only smoke/incident tooling. The five configured bots
+  were left running.
+- A bounded 5-minute smoke at `103a4d11` completed with `ok=true`,
+  `hard_failures=0`, clean tracked repository state, all five live bot
+  processes running, and no failed account-critical remote calls. A bounded
+  all-rotated incident-bundle smoke with `--max-event-files-per-bot=2`
+  completed successfully with `event_report.files_scanned=12`,
+  `event_report.event_window.event_files_before_limit=945`,
+  `event_report.event_window.event_files_skipped_by_limit=933`,
+  `time_window.files_scanned=12`, and the embedded smoke report carrying the
+  same per-bot file cap metadata. This verified the embedded smoke-report gap
+  from PR #929, but event-segment copying still needs the same cap on its
+  fallback-discovered path when no report has matched exact segment paths.
 - Repository pulled through PR #929 at `109c4342`.
 - PR #929 added `live-incident-bundle --max-event-files-per-bot` and the
   matching `build_live_incident_bundle()` option for fair, opt-in

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -658,6 +658,7 @@ def _copy_event_segments(
     include_rotated: bool,
     include_segments: bool,
     max_total_bytes: int,
+    max_event_files_per_bot: int = 0,
 ) -> dict[str, Any]:
     file_discovery: dict[str, Any] = {
         "candidate_files": 0,
@@ -676,10 +677,21 @@ def _copy_event_segments(
     except FileNotFoundError:
         discovered = []
     matched_paths = _matched_segment_paths(event_report, window_report, problem_report)
+    max_event_file_count_per_bot = max(0, int(max_event_files_per_bot))
+    event_files_before_limit = 0
+    event_files_skipped_by_limit = 0
+    event_file_limit_groups = 0
     if matched_paths:
         paths = [Path(path) for path in sorted(matched_paths)]
+        selection = "matched_report_paths"
     else:
         paths = discovered
+        selection = "fallback_discovered_paths"
+        if max_event_file_count_per_bot and paths:
+            event_files_before_limit = len(paths)
+            paths, event_files_skipped_by_limit, event_file_limit_groups = (
+                _limit_recent_event_files_per_bot(paths, max_event_file_count_per_bot)
+            )
     total_bytes = 0
     files: list[dict[str, Any]] = []
     for path in paths:
@@ -719,14 +731,28 @@ def _copy_event_segments(
             }
         )
         files.append(item)
-    return {
+    report = {
         "include_segments": bool(include_segments),
         "include_rotated": bool(include_rotated),
         "max_total_bytes": int(max_total_bytes),
         "file_discovery": file_discovery,
+        "selection": selection,
         "total_included_bytes": total_bytes,
         "files": files,
     }
+    if max_event_file_count_per_bot:
+        report["max_event_files_per_bot"] = max_event_file_count_per_bot
+        report["event_file_limit_scope"] = "per_bot"
+        report["event_file_limit_applies_to"] = (
+            "fallback_discovered_segments"
+            if selection == "fallback_discovered_paths"
+            else "matched_report_paths_preserved"
+        )
+        report["event_file_limit_groups"] = event_file_limit_groups
+        report["event_files_before_limit"] = event_files_before_limit or len(paths)
+        report["event_files_skipped_by_limit"] = event_files_skipped_by_limit
+        report["event_file_limit_order"] = "current_then_recent_mtime"
+    return report
 
 
 def _tar_directory(source_dir: Path, output_path: Path) -> None:
@@ -924,6 +950,7 @@ def build_live_incident_bundle(
             include_rotated=include_rotated,
             include_segments=include_event_segments,
             max_total_bytes=max_event_segment_bytes,
+            max_event_files_per_bot=max_event_files_per_bot,
         )
         metadata = {
             "bundle_version": BUNDLE_VERSION,
@@ -1067,6 +1094,18 @@ def build_live_incident_bundle(
             "files": len(segment_manifest["files"]),
             "included": sum(1 for item in segment_manifest["files"] if item.get("included")),
             "file_discovery": segment_manifest.get("file_discovery") or {},
+            "selection": segment_manifest.get("selection"),
             "total_included_bytes": segment_manifest["total_included_bytes"],
+            "max_event_files_per_bot": segment_manifest.get("max_event_files_per_bot"),
+            "event_file_limit_scope": segment_manifest.get("event_file_limit_scope"),
+            "event_file_limit_applies_to": segment_manifest.get(
+                "event_file_limit_applies_to"
+            ),
+            "event_file_limit_groups": segment_manifest.get("event_file_limit_groups"),
+            "event_files_before_limit": segment_manifest.get("event_files_before_limit"),
+            "event_files_skipped_by_limit": segment_manifest.get(
+                "event_files_skipped_by_limit"
+            ),
+            "event_file_limit_order": segment_manifest.get("event_file_limit_order"),
         },
     }

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 import json
 import os
 import tarfile
+from pathlib import Path
 
 import pytest
 
 import live.smoke_report as smoke_report_module
-from live.incident_bundle import _redact_url_userinfo, build_live_incident_bundle
+from live.incident_bundle import (
+    _copy_event_segments,
+    _redact_url_userinfo,
+    build_live_incident_bundle,
+)
 from tools import live_incident_bundle
 
 
@@ -945,6 +950,176 @@ def test_live_incident_bundle_cli_max_event_files_per_bot_is_fair(tmp_path, caps
     } == kept_labels
     assert {event["data"]["label"] for event in window_report["events"]} == kept_labels
     assert window_report["event_file_limit_order"] == "current_then_recent_mtime"
+
+
+def test_live_incident_bundle_cli_caps_fallback_event_segments_per_bot(tmp_path, capsys):
+    binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    okx_events = tmp_path / "monitor" / "okx" / "okx_01" / "events"
+    files = [
+        (
+            binance_events / "current.ndjson",
+            10,
+            "binance",
+            "binance_01",
+            "binance_current",
+        ),
+        (
+            binance_events / "new.ndjson",
+            11,
+            "binance",
+            "binance_01",
+            "binance_new",
+        ),
+        (
+            binance_events / "old.ndjson",
+            12,
+            "binance",
+            "binance_01",
+            "binance_old",
+        ),
+        (okx_events / "current.ndjson", 20, "okx", "okx_01", "okx_current"),
+        (okx_events / "new.ndjson", 21, "okx", "okx_01", "okx_new"),
+        (okx_events / "old.ndjson", 22, "okx", "okx_01", "okx_old"),
+    ]
+    for path, seq, exchange, user, label in files:
+        _write_ndjson(
+            path,
+            [
+                _monitor_row(
+                    event_type="cycle.completed",
+                    seq=seq,
+                    ts=seq * 100,
+                    exchange=exchange,
+                    user=user,
+                    data={"label": label},
+                )
+            ],
+        )
+    for path in (binance_events / "old.ndjson", okx_events / "old.ndjson"):
+        _set_mtime(path, 100)
+    for path in (binance_events / "new.ndjson", okx_events / "new.ndjson"):
+        _set_mtime(path, 200)
+    for path in (binance_events / "current.ndjson", okx_events / "current.ndjson"):
+        _set_mtime(path, 50)
+
+    output = tmp_path / "incident.tar.gz"
+
+    assert (
+        live_incident_bundle.main(
+            [
+                str(tmp_path / "monitor"),
+                "--logs-root",
+                "",
+                "--event-type",
+                "no.such.event",
+                "--include-rotated",
+                "--max-event-files-per-bot",
+                "2",
+                "--max-event-segment-bytes",
+                "1000000",
+                "--output",
+                str(output),
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["ok"] is True
+    assert report["event_report"]["query_matched_events"] == 0
+    assert report["event_segments"]["files"] == 4
+    assert report["event_segments"]["included"] == 4
+    assert report["event_segments"]["selection"] == "fallback_discovered_paths"
+    assert report["event_segments"]["max_event_files_per_bot"] == 2
+    assert report["event_segments"]["event_file_limit_applies_to"] == (
+        "fallback_discovered_segments"
+    )
+    assert report["event_segments"]["event_file_limit_groups"] == 2
+    assert report["event_segments"]["event_files_before_limit"] == 6
+    assert report["event_segments"]["event_files_skipped_by_limit"] == 2
+
+    with tarfile.open(output, "r:gz") as tar:
+        names = set(tar.getnames())
+        event_segments_manifest = _read_tar_json(tar, "event_segments_manifest.json")
+        manifest = _read_tar_json(tar, "manifest.json")
+
+    included_paths = {
+        item["path"]
+        for item in event_segments_manifest["files"]
+        if item.get("included")
+    }
+    assert {Path(path).name for path in included_paths} == {
+        "current.ndjson",
+        "new.ndjson",
+    }
+    assert len(included_paths) == 4
+    assert not any(path.endswith("old.ndjson") for path in included_paths)
+    assert sum(1 for name in names if name.startswith("event_segments/")) == 4
+    assert event_segments_manifest["event_file_limit_order"] == (
+        "current_then_recent_mtime"
+    )
+    assert manifest["event_segments"]["event_files_skipped_by_limit"] == 2
+
+
+def test_live_incident_bundle_preserves_matched_event_segments_under_cap(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    files = [
+        events_dir / "current.ndjson",
+        events_dir / "new.ndjson",
+        events_dir / "old.ndjson",
+    ]
+    for seq, path in enumerate(files, start=1):
+        _write_ndjson(
+            path,
+            [
+                _monitor_row(
+                    event_type="cycle.completed",
+                    seq=seq,
+                    ts=seq * 100,
+                    exchange="binance",
+                    user="binance_01",
+                )
+            ],
+        )
+    _set_mtime(events_dir / "old.ndjson", 100)
+    _set_mtime(events_dir / "new.ndjson", 200)
+    _set_mtime(events_dir / "current.ndjson", 50)
+
+    bundle_root = tmp_path / "bundle"
+    manifest = _copy_event_segments(
+        monitor_root=tmp_path / "monitor",
+        bundle_root=bundle_root,
+        event_report={
+            "query": {
+                "events": [
+                    {"path": str(events_dir / "current.ndjson")},
+                    {"path": str(events_dir / "new.ndjson")},
+                    {"path": str(events_dir / "old.ndjson")},
+                ]
+            }
+        },
+        window_report={},
+        problem_report={},
+        include_rotated=True,
+        include_segments=True,
+        max_total_bytes=1_000_000,
+        max_event_files_per_bot=1,
+    )
+
+    included_paths = {
+        item["path"]
+        for item in manifest["files"]
+        if item.get("included")
+    }
+    assert included_paths == {str(path) for path in files}
+    assert manifest["selection"] == "matched_report_paths"
+    assert manifest["max_event_files_per_bot"] == 1
+    assert manifest["event_file_limit_applies_to"] == "matched_report_paths_preserved"
+    assert manifest["event_file_limit_groups"] == 0
+    assert manifest["event_files_before_limit"] == 3
+    assert manifest["event_files_skipped_by_limit"] == 0
+    assert len(list((bundle_root / "event_segments").iterdir())) == 3
 
 
 def test_live_incident_bundle_cli_rejects_invalid_window_timestamp(capsys):


### PR DESCRIPTION
## Summary
- cap incident-bundle raw event segment fallback copying with --max-event-files-per-bot
- keep exact matched report segment paths preserved when reports already identify relevant files
- expose segment-selection/file-limit metadata in compact output and bundle manifests
- fold PR #930 VPS/progress evidence into the logging overhaul progress ledger

## Validation
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_incident_bundle.py
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check
- touched-file silent-handling scan: only pre-existing report-summary .get() usage in src/live/incident_bundle.py

## Behavior
Read-only incident-bundle tooling only. No event producers, exchange calls, monitor writes, readiness gates, order/risk logic, or trading behavior changed.