### PR TITLE
Default restart smoke plans to brief output

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `103a4d11` after PR #930, `Add per-bot smoke report event file cap`.
+- `28b0687d` after PR #931, `Cap incident bundle segment fallback per bot`.
 
 Current review gate:
 
@@ -49,6 +49,31 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #931 at `28b0687d`.
+- PR #931 capped incident-bundle raw event-segment fallback copying with
+  `--max-event-files-per-bot`, while preserving exact matched report segment
+  paths. It exposes event-segment selection and limit metadata in compact
+  output and bundled manifests. The slice was read-only incident-bundle tooling
+  and did not add event producers, exchange calls, cache mutation, readiness
+  gates, console routing, monitor writes, order/risk logic, or trading
+  behavior.
+- PR #931 passed Hermes + Claude + Cursor + CI. A reviewer-requested regression
+  test now proves active file caps do not prune matched incident evidence.
+  Local validation covered `tests/test_live_incident_bundle.py`, py_compile for
+  touched files, `git diff --check`, and a touched-file silent-handling scan.
+- VPS5 pulled from `103a4d11` to `28b0687d` without bot restart because the
+  deployed change was read-only incident-bundle tooling. The five configured
+  bots were left running.
+- A targeted all-rotated incident-bundle smoke forced the fallback segment-copy
+  path with `--event-type no.such.event`, `--max-event-files-per-bot=2`, and
+  `--event-tail-lines=200`. It completed with `ok=true`,
+  `hard_failures=0`, `event_segments.selection=fallback_discovered_paths`,
+  `event_segments.files=12`, `included=12`, `event_files_before_limit=941`,
+  and `event_files_skipped_by_limit=929`. A standard bounded 5-minute smoke at
+  `28b0687d` also completed with `ok=true`, `hard_failures=0`, clean tracked
+  repository state, all five live bot processes running, and no failed
+  account-critical remote calls. Remaining attention came from known non-hard
+  EMA readiness, HSL cooldown, and candle coverage diagnostics.
 - Repository pulled through PR #930 at `103a4d11`.
 - PR #930 added `live-smoke-report --max-event-files-per-bot` and the matching
   `build_live_smoke_report()` option for fair, opt-in per-events-directory caps

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -185,6 +185,13 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   escalation ladder as policy only: graceful Ctrl+C/request stop, bounded wait, a second
   graceful signal when warranted, SIGTERM, then SIGKILL. The smoke report never sends those
   signals.
+- `passivbot tool live-restart-smoke-plan` emits a read-only dry-run restart
+  plan from a tmuxp-style supervisor config. The planned smoke command defaults
+  to `live-smoke-report --brief --compact` for repeated operator loops; use
+  `--summary-smoke-report` for bounded groups or `--full-smoke-report` for the
+  full smoke report. The planner does not execute the restart, send signals,
+  invoke tmux, run SSH, pull git, start bots, contact exchanges, or load
+  credentials.
 - `passivbot tool live-performance-report` summarizes local live monitor event timings for
   operator performance analysis. It is read-only and does not contact exchanges. Use
   `--recent-minutes` for a time window, `--summary` for a bounded operator projection, and

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -44,6 +44,7 @@ def _smoke_report_command(
     supervisor_config: str | Path,
     smoke_window_minutes: int,
     compact: bool,
+    brief: bool,
     summary: bool,
 ) -> str:
     args = [
@@ -61,6 +62,8 @@ def _smoke_report_command(
         args.extend(["--logs-root", str(logs_root)])
     if summary:
         args.append("--summary")
+    elif brief:
+        args.append("--brief")
     if compact:
         args.append("--compact")
     return _shell_join(args)
@@ -187,7 +190,8 @@ def build_live_restart_smoke_plan(
     startup_wait_s: int = DEFAULT_STARTUP_WAIT_S,
     smoke_window_minutes: int = DEFAULT_SMOKE_WINDOW_MINUTES,
     compact_smoke_report: bool = True,
-    summary_smoke_report: bool = True,
+    brief_smoke_report: bool = True,
+    summary_smoke_report: bool = False,
     execute: bool = False,
 ) -> dict[str, Any]:
     if execute:
@@ -241,6 +245,7 @@ def build_live_restart_smoke_plan(
         supervisor_config=supervisor_config,
         smoke_window_minutes=smoke_window_minutes,
         compact=compact_smoke_report,
+        brief=brief_smoke_report,
         summary=summary_smoke_report,
     )
     planned_bots = []

--- a/src/tools/live_restart_smoke_plan.py
+++ b/src/tools/live_restart_smoke_plan.py
@@ -60,10 +60,21 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_SMOKE_WINDOW_MINUTES,
         help="Recent time window for the planned smoke-report command.",
     )
-    parser.add_argument(
+    smoke_projection = parser.add_mutually_exclusive_group()
+    smoke_projection.add_argument(
+        "--brief-smoke-report",
+        action="store_true",
+        help="Plan a brief live-smoke-report command; this is the default.",
+    )
+    smoke_projection.add_argument(
+        "--summary-smoke-report",
+        action="store_true",
+        help="Plan a summary live-smoke-report command instead of --brief.",
+    )
+    smoke_projection.add_argument(
         "--full-smoke-report",
         action="store_true",
-        help="Plan a full live-smoke-report command instead of --summary.",
+        help="Plan a full live-smoke-report command instead of --brief.",
     )
     parser.add_argument(
         "--pretty-smoke-report",
@@ -100,7 +111,10 @@ def main(argv: list[str] | None = None) -> int:
             startup_wait_s=int(args.startup_wait_s),
             smoke_window_minutes=int(args.smoke_window_minutes),
             compact_smoke_report=not bool(args.pretty_smoke_report),
-            summary_smoke_report=not bool(args.full_smoke_report),
+            brief_smoke_report=not (
+                bool(args.full_smoke_report) or bool(args.summary_smoke_report)
+            ),
+            summary_smoke_report=bool(args.summary_smoke_report),
             execute=False,
         )
     except (NotImplementedError, ValueError) as exc:

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -54,6 +54,8 @@ def test_live_restart_smoke_plan_builds_plan_from_supervisor_config(tmp_path):
     assert "passivbot tool live-smoke-report" in report["smoke_report"]["command"]
     assert "--supervisor-config" in report["smoke_report"]["command"]
     assert "--recent-minutes 15" in report["smoke_report"]["command"]
+    assert "--brief" in report["smoke_report"]["command"]
+    assert "--summary" not in report["smoke_report"]["command"]
     assert report["process_signal_safety"]["strategy"] == (
         "exact_tmux_pane_or_exact_pid_only"
     )
@@ -181,6 +183,43 @@ def test_live_restart_smoke_plan_cli_outputs_json(tmp_path, capsys):
     report = json.loads(capsys.readouterr().out)
     assert report["ok"] is True
     assert report["inputs"]["shutdown_timeout_s"] == 30
+    assert "--brief" in report["smoke_report"]["command"]
+
+
+def test_live_restart_smoke_plan_can_plan_summary_or_full_smoke_projection(
+    tmp_path, capsys
+):
+    supervisor_config = tmp_path / "bots.yaml"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u binance_01",
+        ],
+    )
+
+    assert (
+        live_restart_smoke_plan.main(
+            [str(supervisor_config), "--summary-smoke-report", "--compact"]
+        )
+        == 0
+    )
+    summary_report = json.loads(capsys.readouterr().out)
+    assert "--summary" in summary_report["smoke_report"]["command"]
+    assert "--brief" not in summary_report["smoke_report"]["command"]
+
+    assert (
+        live_restart_smoke_plan.main(
+            [str(supervisor_config), "--full-smoke-report", "--compact"]
+        )
+        == 0
+    )
+    full_report = json.loads(capsys.readouterr().out)
+    assert "--summary" not in full_report["smoke_report"]["command"]
+    assert "--brief" not in full_report["smoke_report"]["command"]
 
 
 def test_live_restart_smoke_plan_cli_rejects_execute(capsys):


### PR DESCRIPTION
## Summary
- make plan-only `live-restart-smoke-plan` generate `live-smoke-report --brief --compact` by default
- add explicit `--summary-smoke-report` override while keeping `--full-smoke-report` for full output
- document the projection choices and fold PR #931 VPS smoke evidence into the progress ledger

## Validation
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_restart_smoke_plan.py`
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/restart_smoke_plan.py src/tools/live_restart_smoke_plan.py tests/test_live_restart_smoke_plan.py`
- `git diff --check`
- touched-file silent-handling scan: no matches

## Behavior
Read-only operator planning tooling only. No restart execution, SSH/tmux/process signaling, exchange calls, event producers, cache mutation, readiness gates, order/risk logic, monitor writes, console routing, or trading behavior changed.