### PR TITLE
Bound planned restart smoke event scans

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `28b0687d` after PR #931, `Cap incident bundle segment fallback per bot`.
+- `908c955e` after PR #932, `Default restart smoke plans to brief output`.
 
 Current review gate:
 
@@ -49,6 +49,29 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #932 at `908c955e`.
+- PR #932 made the read-only `live-restart-smoke-plan` generated smoke command
+  default to `live-smoke-report --brief --compact`, with explicit
+  `--summary-smoke-report` and `--full-smoke-report` overrides. The slice was
+  plan-only operator tooling and did not execute restarts, send signals, invoke
+  tmux, run SSH, pull git, start bots, contact exchanges, load credentials, add
+  event producers, mutate caches, change readiness gates, write monitor events,
+  route console output, or alter order/risk/trading behavior.
+- PR #932 passed Hermes + Claude + Cursor + CI after a reviewer-requested CLI
+  boolean cleanup. Local validation covered `tests/test_live_restart_smoke_plan.py`,
+  py_compile for touched files, `git diff --check`, and a touched-file
+  silent-handling scan.
+- VPS5 pulled from `28b0687d` to `908c955e` without bot restart because the
+  deployed change was read-only planner tooling. The five configured bots were
+  left running.
+- A VPS5 `live-restart-smoke-plan` run against `/root/bots_vps5.yaml` completed
+  with `ok=true`, five configured bots, `execute=false`, and planned smoke
+  commands containing `--brief --compact`. The planned command was then run as
+  a 5-minute brief smoke; it reported `ok=true`, `hard_failures=0`, clean
+  tracked repository state at `908c955e`, five matched expected live processes,
+  no missing/extra/duplicate live processes, and no failed account-critical
+  remote calls. Remaining attention came from known non-hard EMA readiness,
+  HSL status, and staged-readiness diagnostics.
 - Repository pulled through PR #931 at `28b0687d`.
 - PR #931 capped incident-bundle raw event-segment fallback copying with
   `--max-event-files-per-bot`, while preserving exact matched report segment

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -187,7 +187,10 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   signals.
 - `passivbot tool live-restart-smoke-plan` emits a read-only dry-run restart
   plan from a tmuxp-style supervisor config. The planned smoke command defaults
-  to `live-smoke-report --brief --compact` for repeated operator loops; use
+  to a brief compact smoke command with `--event-tail-lines 2000` and
+  `--max-event-files-per-bot 2` for repeated operator loops; use
+  `--event-tail-lines 0` and `--max-event-files-per-bot 0` in the planner to
+  request full event validation in the generated smoke command. Use
   `--summary-smoke-report` for bounded groups or `--full-smoke-report` for the
   full smoke report. The planner does not execute the restart, send signals,
   invoke tmux, run SSH, pull git, start bots, contact exchanges, or load

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -9,6 +9,8 @@ from live.smoke_report import parse_tmuxp_live_commands, _user_safe_display_path
 DEFAULT_SHUTDOWN_TIMEOUT_S = 90
 DEFAULT_STARTUP_WAIT_S = 180
 DEFAULT_SMOKE_WINDOW_MINUTES = 30
+DEFAULT_SMOKE_EVENT_TAIL_LINES = 2000
+DEFAULT_SMOKE_MAX_EVENT_FILES_PER_BOT = 2
 DEFAULT_MONITOR_ROOT = "monitor"
 DEFAULT_LOGS_ROOT = "logs"
 UNSAFE_PROCESS_SIGNAL_PATTERNS = (
@@ -22,6 +24,13 @@ def _positive_int(value: int, *, field: str) -> int:
     parsed = int(value)
     if parsed <= 0:
         raise ValueError(f"{field} must be positive")
+    return parsed
+
+
+def _non_negative_int(value: int, *, field: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise ValueError(f"{field} must be non-negative")
     return parsed
 
 
@@ -43,6 +52,8 @@ def _smoke_report_command(
     logs_root: str | Path | None,
     supervisor_config: str | Path,
     smoke_window_minutes: int,
+    event_tail_lines: int,
+    max_event_files_per_bot: int,
     compact: bool,
     brief: bool,
     summary: bool,
@@ -60,6 +71,10 @@ def _smoke_report_command(
     ]
     if logs_root is not None:
         args.extend(["--logs-root", str(logs_root)])
+    if int(event_tail_lines) > 0:
+        args.extend(["--event-tail-lines", str(event_tail_lines)])
+    if int(max_event_files_per_bot) > 0:
+        args.extend(["--max-event-files-per-bot", str(max_event_files_per_bot)])
     if summary:
         args.append("--summary")
     elif brief:
@@ -189,6 +204,8 @@ def build_live_restart_smoke_plan(
     shutdown_timeout_s: int = DEFAULT_SHUTDOWN_TIMEOUT_S,
     startup_wait_s: int = DEFAULT_STARTUP_WAIT_S,
     smoke_window_minutes: int = DEFAULT_SMOKE_WINDOW_MINUTES,
+    smoke_event_tail_lines: int = DEFAULT_SMOKE_EVENT_TAIL_LINES,
+    smoke_max_event_files_per_bot: int = DEFAULT_SMOKE_MAX_EVENT_FILES_PER_BOT,
     compact_smoke_report: bool = True,
     brief_smoke_report: bool = True,
     summary_smoke_report: bool = False,
@@ -199,6 +216,12 @@ def build_live_restart_smoke_plan(
     shutdown_timeout_s = _positive_int(shutdown_timeout_s, field="shutdown_timeout_s")
     startup_wait_s = _positive_int(startup_wait_s, field="startup_wait_s")
     smoke_window_minutes = _positive_int(smoke_window_minutes, field="smoke_window_minutes")
+    smoke_event_tail_lines = _non_negative_int(
+        smoke_event_tail_lines, field="smoke_event_tail_lines"
+    )
+    smoke_max_event_files_per_bot = _non_negative_int(
+        smoke_max_event_files_per_bot, field="smoke_max_event_files_per_bot"
+    )
 
     supervisor = parse_tmuxp_live_commands(supervisor_config)
     bots = list(supervisor.get("expected") or [])
@@ -244,6 +267,8 @@ def build_live_restart_smoke_plan(
         logs_root=logs_root,
         supervisor_config=supervisor_config,
         smoke_window_minutes=smoke_window_minutes,
+        event_tail_lines=smoke_event_tail_lines,
+        max_event_files_per_bot=smoke_max_event_files_per_bot,
         compact=compact_smoke_report,
         brief=brief_smoke_report,
         summary=summary_smoke_report,
@@ -281,6 +306,8 @@ def build_live_restart_smoke_plan(
             "shutdown_timeout_s": shutdown_timeout_s,
             "startup_wait_s": startup_wait_s,
             "smoke_window_minutes": smoke_window_minutes,
+            "smoke_event_tail_lines": smoke_event_tail_lines,
+            "smoke_max_event_files_per_bot": smoke_max_event_files_per_bot,
         },
         "supervisor_config": {
             "path": _display_path(supervisor.get("path")),
@@ -340,6 +367,7 @@ def build_live_restart_smoke_plan(
                 "repository branch/head/dirty tracked state",
                 "recent hard log matches",
                 "monitor problem-event counts",
+                "bounded monitor event scan metadata",
                 "startup timings",
                 "shutdown lifecycle events",
                 "remote-call health",

--- a/src/tools/live_restart_smoke_plan.py
+++ b/src/tools/live_restart_smoke_plan.py
@@ -10,6 +10,8 @@ if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
 from live.restart_smoke_plan import (  # noqa: E402
+    DEFAULT_SMOKE_EVENT_TAIL_LINES,
+    DEFAULT_SMOKE_MAX_EVENT_FILES_PER_BOT,
     DEFAULT_LOGS_ROOT,
     DEFAULT_MONITOR_ROOT,
     DEFAULT_SHUTDOWN_TIMEOUT_S,
@@ -59,6 +61,24 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=DEFAULT_SMOKE_WINDOW_MINUTES,
         help="Recent time window for the planned smoke-report command.",
+    )
+    parser.add_argument(
+        "--event-tail-lines",
+        type=int,
+        default=DEFAULT_SMOKE_EVENT_TAIL_LINES,
+        help=(
+            "Rows per monitor event file for the planned smoke-report command. "
+            "Use 0 for full event-file validation."
+        ),
+    )
+    parser.add_argument(
+        "--max-event-files-per-bot",
+        type=int,
+        default=DEFAULT_SMOKE_MAX_EVENT_FILES_PER_BOT,
+        help=(
+            "Recent event files per bot for the planned smoke-report command. "
+            "Use 0 to disable the per-bot file cap."
+        ),
     )
     smoke_projection = parser.add_mutually_exclusive_group()
     smoke_projection.add_argument(
@@ -110,6 +130,8 @@ def main(argv: list[str] | None = None) -> int:
             shutdown_timeout_s=int(args.shutdown_timeout_s),
             startup_wait_s=int(args.startup_wait_s),
             smoke_window_minutes=int(args.smoke_window_minutes),
+            smoke_event_tail_lines=int(args.event_tail_lines),
+            smoke_max_event_files_per_bot=int(args.max_event_files_per_bot),
             compact_smoke_report=not bool(args.pretty_smoke_report),
             brief_smoke_report=not (
                 bool(args.full_smoke_report) or bool(args.summary_smoke_report)

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -54,6 +54,8 @@ def test_live_restart_smoke_plan_builds_plan_from_supervisor_config(tmp_path):
     assert "passivbot tool live-smoke-report" in report["smoke_report"]["command"]
     assert "--supervisor-config" in report["smoke_report"]["command"]
     assert "--recent-minutes 15" in report["smoke_report"]["command"]
+    assert "--event-tail-lines 2000" in report["smoke_report"]["command"]
+    assert "--max-event-files-per-bot 2" in report["smoke_report"]["command"]
     assert "--brief" in report["smoke_report"]["command"]
     assert "--summary" not in report["smoke_report"]["command"]
     assert report["process_signal_safety"]["strategy"] == (
@@ -183,7 +185,47 @@ def test_live_restart_smoke_plan_cli_outputs_json(tmp_path, capsys):
     report = json.loads(capsys.readouterr().out)
     assert report["ok"] is True
     assert report["inputs"]["shutdown_timeout_s"] == 30
+    assert report["inputs"]["smoke_event_tail_lines"] == 2000
+    assert report["inputs"]["smoke_max_event_files_per_bot"] == 2
+    assert "--event-tail-lines 2000" in report["smoke_report"]["command"]
+    assert "--max-event-files-per-bot 2" in report["smoke_report"]["command"]
     assert "--brief" in report["smoke_report"]["command"]
+
+
+def test_live_restart_smoke_plan_can_disable_planned_event_scan_bounds(
+    tmp_path, capsys
+):
+    supervisor_config = tmp_path / "bots.yaml"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u binance_01",
+        ],
+    )
+
+    assert (
+        live_restart_smoke_plan.main(
+            [
+                str(supervisor_config),
+                "--event-tail-lines",
+                "0",
+                "--max-event-files-per-bot",
+                "0",
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["inputs"]["smoke_event_tail_lines"] == 0
+    assert report["inputs"]["smoke_max_event_files_per_bot"] == 0
+    assert "--event-tail-lines" not in report["smoke_report"]["command"]
+    assert "--max-event-files-per-bot" not in report["smoke_report"]["command"]
 
 
 def test_live_restart_smoke_plan_can_plan_summary_or_full_smoke_projection(
@@ -228,6 +270,23 @@ def test_live_restart_smoke_plan_cli_rejects_execute(capsys):
 
     assert exc_info.value.code == 2
     assert "--execute is not implemented" in capsys.readouterr().err
+
+
+def test_live_restart_smoke_plan_cli_rejects_negative_event_scan_bounds(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_restart_smoke_plan.main(["bots.yaml", "--event-tail-lines", "-1"])
+
+    assert exc_info.value.code == 2
+    assert "smoke_event_tail_lines must be non-negative" in capsys.readouterr().err
+
+    with pytest.raises(SystemExit) as exc_info:
+        live_restart_smoke_plan.main(["bots.yaml", "--max-event-files-per-bot", "-1"])
+
+    assert exc_info.value.code == 2
+    assert (
+        "smoke_max_event_files_per_bot must be non-negative"
+        in capsys.readouterr().err
+    )
 
 
 def test_live_restart_smoke_plan_tool_dispatch_forwards_module_and_prog(monkeypatch):


### PR DESCRIPTION
## Summary
- make `live-restart-smoke-plan` include bounded smoke event scan options by default: `--event-tail-lines 2000` and `--max-event-files-per-bot 2`
- add planner CLI overrides to tune or disable those generated smoke-report bounds
- document the default and fold PR #932 VPS smoke evidence into the logging progress ledger

## Validation
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_restart_smoke_plan.py`
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/restart_smoke_plan.py src/tools/live_restart_smoke_plan.py tests/test_live_restart_smoke_plan.py`
- `git diff --check`
- touched-file silent-handling scan: no matches

## Behavior
Read-only operator planning tooling only. No restart execution, SSH/tmux/process signaling, exchange calls, event producers, cache mutation, readiness gates, order/risk logic, monitor writes, console routing, or trading behavior changed.