### PR TITLE
Bound planned restart smoke log scans

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `908c955e` after PR #932, `Default restart smoke plans to brief output`.
+- `0fd30b6b` after PR #933, `Bound planned restart smoke event scans`.
 
 Current review gate:
 
@@ -49,6 +49,30 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #933 at `0fd30b6b`.
+- PR #933 made the read-only `live-restart-smoke-plan` generated smoke command
+  include `--event-tail-lines 2000` and `--max-event-files-per-bot 2` by
+  default, with `0` escape hatches for full event validation. The slice was
+  plan-only operator tooling and did not execute restarts, send signals, invoke
+  tmux, run SSH, pull git, start bots, contact exchanges, load credentials, add
+  event producers, mutate caches, change readiness gates, write monitor events,
+  route console output, or alter order/risk/trading behavior.
+- PR #933 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_restart_smoke_plan.py`, py_compile for touched files,
+  `git diff --check`, and a touched-file silent-handling scan.
+- VPS5 pulled from `908c955e` to `0fd30b6b` without bot restart because the
+  deployed change was read-only planner tooling. The five configured bots were
+  left running.
+- A VPS5 `live-restart-smoke-plan` run against `/root/bots_vps5.yaml` completed
+  with `ok=true`, five configured bots, `execute=false`, and planned smoke
+  commands containing `--event-tail-lines 2000`,
+  `--max-event-files-per-bot 2`, `--brief`, and `--compact`. The planned
+  command was then run as a 5-minute brief smoke; it reported `ok=true`,
+  `hard_failures=0`, clean tracked repository state at `0fd30b6b`, five
+  matched expected live processes, no missing/extra/duplicate live processes,
+  no failed account-critical remote calls, `event_tail_limited_files=6`, and
+  `event_files_skipped_by_limit=0`. Remaining attention came from known
+  non-hard EMA readiness, HSL status/cooldown, and staged-readiness diagnostics.
 - Repository pulled through PR #932 at `908c955e`.
 - PR #932 made the read-only `live-restart-smoke-plan` generated smoke command
   default to `live-smoke-report --brief --compact`, with explicit

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -188,9 +188,11 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
 - `passivbot tool live-restart-smoke-plan` emits a read-only dry-run restart
   plan from a tmuxp-style supervisor config. The planned smoke command defaults
   to a brief compact smoke command with `--event-tail-lines 2000` and
-  `--max-event-files-per-bot 2` for repeated operator loops; use
-  `--event-tail-lines 0` and `--max-event-files-per-bot 0` in the planner to
-  request full event validation in the generated smoke command. Use
+  `--max-event-files-per-bot 2`, plus `--log-tail-lines 1200` and
+  `--max-log-matches 20`, for repeated operator loops; use
+  `--event-tail-lines 0`, `--max-event-files-per-bot 0`, `--log-tail-lines 0`,
+  or `--max-log-matches 0` in the planner to omit those explicit bounds from
+  the generated smoke command. Use
   `--summary-smoke-report` for bounded groups or `--full-smoke-report` for the
   full smoke report. The planner does not execute the restart, send signals,
   invoke tmux, run SSH, pull git, start bots, contact exchanges, or load

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -11,6 +11,8 @@ DEFAULT_STARTUP_WAIT_S = 180
 DEFAULT_SMOKE_WINDOW_MINUTES = 30
 DEFAULT_SMOKE_EVENT_TAIL_LINES = 2000
 DEFAULT_SMOKE_MAX_EVENT_FILES_PER_BOT = 2
+DEFAULT_SMOKE_LOG_TAIL_LINES = 1200
+DEFAULT_SMOKE_MAX_LOG_MATCHES = 20
 DEFAULT_MONITOR_ROOT = "monitor"
 DEFAULT_LOGS_ROOT = "logs"
 UNSAFE_PROCESS_SIGNAL_PATTERNS = (
@@ -54,6 +56,8 @@ def _smoke_report_command(
     smoke_window_minutes: int,
     event_tail_lines: int,
     max_event_files_per_bot: int,
+    log_tail_lines: int,
+    max_log_matches: int,
     compact: bool,
     brief: bool,
     summary: bool,
@@ -75,6 +79,10 @@ def _smoke_report_command(
         args.extend(["--event-tail-lines", str(event_tail_lines)])
     if int(max_event_files_per_bot) > 0:
         args.extend(["--max-event-files-per-bot", str(max_event_files_per_bot)])
+    if int(log_tail_lines) > 0:
+        args.extend(["--log-tail-lines", str(log_tail_lines)])
+    if int(max_log_matches) > 0:
+        args.extend(["--max-log-matches", str(max_log_matches)])
     if summary:
         args.append("--summary")
     elif brief:
@@ -206,6 +214,8 @@ def build_live_restart_smoke_plan(
     smoke_window_minutes: int = DEFAULT_SMOKE_WINDOW_MINUTES,
     smoke_event_tail_lines: int = DEFAULT_SMOKE_EVENT_TAIL_LINES,
     smoke_max_event_files_per_bot: int = DEFAULT_SMOKE_MAX_EVENT_FILES_PER_BOT,
+    smoke_log_tail_lines: int = DEFAULT_SMOKE_LOG_TAIL_LINES,
+    smoke_max_log_matches: int = DEFAULT_SMOKE_MAX_LOG_MATCHES,
     compact_smoke_report: bool = True,
     brief_smoke_report: bool = True,
     summary_smoke_report: bool = False,
@@ -221,6 +231,12 @@ def build_live_restart_smoke_plan(
     )
     smoke_max_event_files_per_bot = _non_negative_int(
         smoke_max_event_files_per_bot, field="smoke_max_event_files_per_bot"
+    )
+    smoke_log_tail_lines = _non_negative_int(
+        smoke_log_tail_lines, field="smoke_log_tail_lines"
+    )
+    smoke_max_log_matches = _non_negative_int(
+        smoke_max_log_matches, field="smoke_max_log_matches"
     )
 
     supervisor = parse_tmuxp_live_commands(supervisor_config)
@@ -269,6 +285,8 @@ def build_live_restart_smoke_plan(
         smoke_window_minutes=smoke_window_minutes,
         event_tail_lines=smoke_event_tail_lines,
         max_event_files_per_bot=smoke_max_event_files_per_bot,
+        log_tail_lines=smoke_log_tail_lines,
+        max_log_matches=smoke_max_log_matches,
         compact=compact_smoke_report,
         brief=brief_smoke_report,
         summary=summary_smoke_report,
@@ -308,6 +326,8 @@ def build_live_restart_smoke_plan(
             "smoke_window_minutes": smoke_window_minutes,
             "smoke_event_tail_lines": smoke_event_tail_lines,
             "smoke_max_event_files_per_bot": smoke_max_event_files_per_bot,
+            "smoke_log_tail_lines": smoke_log_tail_lines,
+            "smoke_max_log_matches": smoke_max_log_matches,
         },
         "supervisor_config": {
             "path": _display_path(supervisor.get("path")),
@@ -366,6 +386,7 @@ def build_live_restart_smoke_plan(
                 "extra passivbot live processes",
                 "repository branch/head/dirty tracked state",
                 "recent hard log matches",
+                "bounded text log scan metadata",
                 "monitor problem-event counts",
                 "bounded monitor event scan metadata",
                 "startup timings",

--- a/src/tools/live_restart_smoke_plan.py
+++ b/src/tools/live_restart_smoke_plan.py
@@ -11,6 +11,8 @@ if str(SRC_ROOT) not in sys.path:
 
 from live.restart_smoke_plan import (  # noqa: E402
     DEFAULT_SMOKE_EVENT_TAIL_LINES,
+    DEFAULT_SMOKE_LOG_TAIL_LINES,
+    DEFAULT_SMOKE_MAX_LOG_MATCHES,
     DEFAULT_SMOKE_MAX_EVENT_FILES_PER_BOT,
     DEFAULT_LOGS_ROOT,
     DEFAULT_MONITOR_ROOT,
@@ -80,6 +82,24 @@ def build_parser() -> argparse.ArgumentParser:
             "Use 0 to disable the per-bot file cap."
         ),
     )
+    parser.add_argument(
+        "--log-tail-lines",
+        type=int,
+        default=DEFAULT_SMOKE_LOG_TAIL_LINES,
+        help=(
+            "Rows per text log file for the planned smoke-report command. "
+            "Use 0 to omit the explicit smoke-report override."
+        ),
+    )
+    parser.add_argument(
+        "--max-log-matches",
+        type=int,
+        default=DEFAULT_SMOKE_MAX_LOG_MATCHES,
+        help=(
+            "Maximum matched text log lines for the planned smoke-report command. "
+            "Use 0 to omit the explicit smoke-report override."
+        ),
+    )
     smoke_projection = parser.add_mutually_exclusive_group()
     smoke_projection.add_argument(
         "--brief-smoke-report",
@@ -132,6 +152,8 @@ def main(argv: list[str] | None = None) -> int:
             smoke_window_minutes=int(args.smoke_window_minutes),
             smoke_event_tail_lines=int(args.event_tail_lines),
             smoke_max_event_files_per_bot=int(args.max_event_files_per_bot),
+            smoke_log_tail_lines=int(args.log_tail_lines),
+            smoke_max_log_matches=int(args.max_log_matches),
             compact_smoke_report=not bool(args.pretty_smoke_report),
             brief_smoke_report=not (
                 bool(args.full_smoke_report) or bool(args.summary_smoke_report)

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -56,6 +56,8 @@ def test_live_restart_smoke_plan_builds_plan_from_supervisor_config(tmp_path):
     assert "--recent-minutes 15" in report["smoke_report"]["command"]
     assert "--event-tail-lines 2000" in report["smoke_report"]["command"]
     assert "--max-event-files-per-bot 2" in report["smoke_report"]["command"]
+    assert "--log-tail-lines 1200" in report["smoke_report"]["command"]
+    assert "--max-log-matches 20" in report["smoke_report"]["command"]
     assert "--brief" in report["smoke_report"]["command"]
     assert "--summary" not in report["smoke_report"]["command"]
     assert report["process_signal_safety"]["strategy"] == (
@@ -187,8 +189,12 @@ def test_live_restart_smoke_plan_cli_outputs_json(tmp_path, capsys):
     assert report["inputs"]["shutdown_timeout_s"] == 30
     assert report["inputs"]["smoke_event_tail_lines"] == 2000
     assert report["inputs"]["smoke_max_event_files_per_bot"] == 2
+    assert report["inputs"]["smoke_log_tail_lines"] == 1200
+    assert report["inputs"]["smoke_max_log_matches"] == 20
     assert "--event-tail-lines 2000" in report["smoke_report"]["command"]
     assert "--max-event-files-per-bot 2" in report["smoke_report"]["command"]
+    assert "--log-tail-lines 1200" in report["smoke_report"]["command"]
+    assert "--max-log-matches 20" in report["smoke_report"]["command"]
     assert "--brief" in report["smoke_report"]["command"]
 
 
@@ -226,6 +232,40 @@ def test_live_restart_smoke_plan_can_disable_planned_event_scan_bounds(
     assert report["inputs"]["smoke_max_event_files_per_bot"] == 0
     assert "--event-tail-lines" not in report["smoke_report"]["command"]
     assert "--max-event-files-per-bot" not in report["smoke_report"]["command"]
+
+
+def test_live_restart_smoke_plan_can_disable_planned_log_scan_bounds(tmp_path, capsys):
+    supervisor_config = tmp_path / "bots.yaml"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u binance_01",
+        ],
+    )
+
+    assert (
+        live_restart_smoke_plan.main(
+            [
+                str(supervisor_config),
+                "--log-tail-lines",
+                "0",
+                "--max-log-matches",
+                "0",
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["inputs"]["smoke_log_tail_lines"] == 0
+    assert report["inputs"]["smoke_max_log_matches"] == 0
+    assert "--log-tail-lines" not in report["smoke_report"]["command"]
+    assert "--max-log-matches" not in report["smoke_report"]["command"]
 
 
 def test_live_restart_smoke_plan_can_plan_summary_or_full_smoke_projection(
@@ -287,6 +327,20 @@ def test_live_restart_smoke_plan_cli_rejects_negative_event_scan_bounds(capsys):
         "smoke_max_event_files_per_bot must be non-negative"
         in capsys.readouterr().err
     )
+
+
+def test_live_restart_smoke_plan_cli_rejects_negative_log_scan_bounds(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_restart_smoke_plan.main(["bots.yaml", "--log-tail-lines", "-1"])
+
+    assert exc_info.value.code == 2
+    assert "smoke_log_tail_lines must be non-negative" in capsys.readouterr().err
+
+    with pytest.raises(SystemExit) as exc_info:
+        live_restart_smoke_plan.main(["bots.yaml", "--max-log-matches", "-1"])
+
+    assert exc_info.value.code == 2
+    assert "smoke_max_log_matches must be non-negative" in capsys.readouterr().err
 
 
 def test_live_restart_smoke_plan_tool_dispatch_forwards_module_and_prog(monkeypatch):


### PR DESCRIPTION
## Summary
- make live-restart-smoke-plan include bounded text-log scan flags in generated smoke commands by default
- add planner CLI escape hatches for --log-tail-lines 0 and --max-log-matches 0
- update tool docs and fold PR #933 VPS smoke evidence into the logging progress ledger

## Scope
Read-only planner/tooling slice only. Does not execute restarts, signal processes, invoke tmux, run SSH, pull git, start bots, contact exchanges, load credentials, add event producers, mutate caches, change readiness gates, write monitor events, route console output, or alter order/risk/trading behavior.

## Tests
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_restart_smoke_plan.py
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/restart_smoke_plan.py src/tools/live_restart_smoke_plan.py tests/test_live_restart_smoke_plan.py
- git diff --check
- rg silent-handling scan on touched Python/test files