### PR TITLE
Expose smoke log scan bounds

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `0fd30b6b` after PR #933, `Bound planned restart smoke event scans`.
+- `3e1335d` after PR #934, `Bound planned restart smoke log scans`.
 
 Current review gate:
 
@@ -49,6 +49,33 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #934 at `3e1335d`.
+- PR #934 made the read-only `live-restart-smoke-plan` generated smoke command
+  include `--log-tail-lines 1200` and `--max-log-matches 20` by default, with
+  `0` escape hatches to omit those explicit smoke-report overrides. The slice
+  was plan-only operator tooling and did not execute restarts, send signals,
+  invoke tmux, run SSH, pull git, start bots, contact exchanges, load
+  credentials, add event producers, mutate caches, change readiness gates,
+  write monitor events, route console output, or alter order/risk/trading
+  behavior.
+- PR #934 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_restart_smoke_plan.py`, py_compile for touched files,
+  `git diff --check`, and a touched-file silent-handling scan.
+- VPS5 pulled from `0fd30b6b` to `3e1335d` without bot restart because the
+  deployed change was read-only planner tooling. The five configured bots were
+  left running.
+- A VPS5 `live-restart-smoke-plan` run against `/root/bots_vps5.yaml` completed
+  with `ok=true`, five configured bots, `execute=false`, and planned smoke
+  commands containing `--event-tail-lines 2000`,
+  `--max-event-files-per-bot 2`, `--log-tail-lines 1200`,
+  `--max-log-matches 20`, `--brief`, and `--compact`. The planned command was
+  then run as a bounded 5-minute brief smoke; it reported `ok=true`,
+  `hard_failures=0`, clean tracked repository state at `3e1335d`, five matched
+  expected live processes, no missing/extra/duplicate live processes, no failed
+  account-critical remote calls, `event_tail_limited_files=6`,
+  `event_files_skipped_by_limit=0`, `logs.files_scanned=8`, and
+  `logs.window.lines_considered=34`. Remaining attention came from known
+  non-hard EMA readiness and HSL status/cooldown diagnostics.
 - Repository pulled through PR #933 at `0fd30b6b`.
 - PR #933 made the read-only `live-restart-smoke-plan` generated smoke command
   include `--event-tail-lines 2000` and `--max-event-files-per-bot 2` by

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -158,9 +158,10 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
 - `passivbot tool live-smoke-report` summarizes local live monitor events and text logs for
   operator smoke-test evidence. Use `--summary` for bounded event groups and log matches, or
   `--brief` for top-level counters suitable for repeated VPS smoke loops.
-  Brief output includes bounded text-log window counters so time-windowed smoke
-  evidence shows how many log lines were considered, skipped before/after the
-  window, or dropped by the unparseable-line policy.
+  Full, summary, and brief output include text-log scan bounds and bounded
+  text-log window counters so time-windowed smoke evidence shows the configured
+  file/tail/match limits plus how many log lines were considered, skipped
+  before/after the window, or dropped by the unparseable-line policy.
   For repeated recent-window smoke checks over large current monitor segments,
   `--event-tail-lines N` bounds monitor event parsing to the last N rows from
   each event file; the default `0` keeps full monitor-event validation. Brief

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -4072,6 +4072,9 @@ def _scan_logs(
     if root is None:
         return {
             "root": None,
+            "max_files": max(0, int(max_files)),
+            "tail_lines": max(0, int(tail_lines)),
+            "max_matches": max(0, int(max_matches)),
             "files_scanned": 0,
             "hard_matches": 0,
             "attention_matches": 0,
@@ -4161,6 +4164,9 @@ def _scan_logs(
                 matches.append(match)
     return {
         "root": str(Path(root).expanduser()),
+        "max_files": max(0, int(max_files)),
+        "tail_lines": max(0, int(tail_lines)),
+        "max_matches": max(0, int(max_matches)),
         "files_scanned": len(files),
         "hard_matches": hard_matches,
         "attention_matches": attention_matches,
@@ -4632,6 +4638,9 @@ def summarize_live_smoke_report(
         },
         "logs": {
             "root": logs.get("root"),
+            "max_files": int(logs.get("max_files") or 0),
+            "tail_lines": int(logs.get("tail_lines") or 0),
+            "max_matches": int(logs.get("max_matches") or 0),
             "files_scanned": int(logs.get("files_scanned") or 0),
             "hard_matches": int(logs.get("hard_matches") or 0),
             "attention_matches": int(logs.get("attention_matches") or 0),
@@ -5036,6 +5045,9 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             },
         },
         "logs": {
+            "max_files": _count_value(logs.get("max_files")),
+            "tail_lines": _count_value(logs.get("tail_lines")),
+            "max_matches": _count_value(logs.get("max_matches")),
             "files_scanned": _count_value(logs.get("files_scanned")),
             "hard_matches": _count_value(logs.get("hard_matches")),
             "attention_matches": _count_value(logs.get("attention_matches")),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1071,6 +1071,9 @@ def test_live_smoke_report_brief_summary_projects_top_level_counters(tmp_path):
     assert brief["monitor"]["live_events"] == 2
     assert brief["event_window"]["enabled"] is False
     assert brief["logs"] == {
+        "max_files": 8,
+        "tail_lines": 10,
+        "max_matches": 50,
         "files_scanned": 1,
         "hard_matches": 0,
         "attention_matches": 1,
@@ -3220,6 +3223,9 @@ def test_live_smoke_report_log_scan_deduplicates_aliases_and_matches_levels(
     )
 
     assert report["ok"] is True
+    assert report["logs"]["max_files"] == 10
+    assert report["logs"]["tail_lines"] == 10
+    assert report["logs"]["max_matches"] == 50
     assert report["logs"]["files_scanned"] == 1
     assert report["logs"]["attention_matches"] == 4
     assert report["logs"]["hard_matches"] == 0
@@ -3233,6 +3239,15 @@ def test_live_smoke_report_log_scan_deduplicates_aliases_and_matches_levels(
     assert "AKIA123" not in emitted
     assert "hunter2" not in emitted
     assert "TOKEN123" not in emitted
+
+    summary = summarize_live_smoke_report(report)
+    assert summary["logs"]["max_files"] == 10
+    assert summary["logs"]["tail_lines"] == 10
+    assert summary["logs"]["max_matches"] == 50
+    brief = summarize_live_smoke_report_brief(report)
+    assert brief["logs"]["max_files"] == 10
+    assert brief["logs"]["tail_lines"] == 10
+    assert brief["logs"]["max_matches"] == 50
 
 
 def test_live_smoke_report_log_scan_classifies_risk_matches(tmp_path):
@@ -3683,6 +3698,9 @@ def test_live_smoke_report_cli_outputs_json_and_can_skip_logs(tmp_path, capsys):
     }
     assert report["bots"] == []
     assert report["logs"]["files_scanned"] == 0
+    assert report["logs"]["max_files"] == 8
+    assert report["logs"]["tail_lines"] == 300
+    assert report["logs"]["max_matches"] == 50
     assert report["logs"]["root"] is None
     assert report["monitor"]["live_events"] == 1
 


### PR DESCRIPTION
## Summary
- include text-log scan bound metadata in live-smoke-report full output, summary output, and brief output
- document that smoke evidence now shows configured log file/tail/match limits
- fold PR #934 VPS deployment/smoke evidence into the logging progress ledger

## Scope
Read-only smoke-report projection/tooling slice only. It does not change which log files or lines are scanned, does not change smoke verdict policy, does not add event producers, does not contact exchanges, does not mutate caches, and does not alter order/risk/trading behavior.

## Tests
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_smoke_report.py
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check
- broad silent-handling scan reports pre-existing smoke_report.py matches; diff-only scan on touched Python/test files is clean