### PR TITLE
Make planned smoke log file cap explicit

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `3e1335d` after PR #934, `Bound planned restart smoke log scans`.
+- `94f88dba` after PR #935, `Expose smoke log scan bounds`.
 
 Current review gate:
 
@@ -49,6 +49,29 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #935 at `94f88dba`.
+- PR #935 made `live-smoke-report` full, summary, and brief `logs` output
+  expose the configured text-log scan bounds: `max_files`, `tail_lines`, and
+  `max_matches`. The slice was read-only smoke-report projection tooling and
+  did not change log file discovery, line scanning, match classification,
+  smoke verdict policy, event routing, exchange access, cache/state behavior,
+  or order/risk/trading behavior.
+- PR #935 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_smoke_report.py`, py_compile for touched files,
+  `git diff --check`, and a diff-only silent-handling scan. A broad
+  touched-file silent scan still reports pre-existing patterns in the large
+  smoke-report module, but the diff added no new forbidden default-get or
+  silent-exception patterns.
+- VPS5 pulled from `3e1335d` to `94f88dba` without bot restart because the
+  deployed change was read-only smoke-report tooling. The five configured bots
+  were left running.
+- A bounded 5-minute brief smoke at `94f88dba` completed with `ok=true`,
+  `hard_failures=0`, clean tracked repository state, five matched expected
+  live processes, no missing/extra/duplicate live processes, and no failed
+  account-critical remote calls. The new log-bound metadata was present in
+  brief output: `logs.max_files=8`, `logs.tail_lines=1200`, and
+  `logs.max_matches=20`. Remaining attention came from known non-hard EMA
+  readiness and HSL status/cooldown diagnostics.
 - Repository pulled through PR #934 at `3e1335d`.
 - PR #934 made the read-only `live-restart-smoke-plan` generated smoke command
   include `--log-tail-lines 1200` and `--max-log-matches 20` by default, with

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -189,11 +189,11 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
 - `passivbot tool live-restart-smoke-plan` emits a read-only dry-run restart
   plan from a tmuxp-style supervisor config. The planned smoke command defaults
   to a brief compact smoke command with `--event-tail-lines 2000` and
-  `--max-event-files-per-bot 2`, plus `--log-tail-lines 1200` and
-  `--max-log-matches 20`, for repeated operator loops; use
-  `--event-tail-lines 0`, `--max-event-files-per-bot 0`, `--log-tail-lines 0`,
-  or `--max-log-matches 0` in the planner to omit those explicit bounds from
-  the generated smoke command. Use
+  `--max-event-files-per-bot 2`, plus `--max-log-files 8`,
+  `--log-tail-lines 1200`, and `--max-log-matches 20`, for repeated operator
+  loops; use `--event-tail-lines 0`, `--max-event-files-per-bot 0`,
+  `--max-log-files 0`, `--log-tail-lines 0`, or `--max-log-matches 0` in the
+  planner to omit those explicit bounds from the generated smoke command. Use
   `--summary-smoke-report` for bounded groups or `--full-smoke-report` for the
   full smoke report. The planner does not execute the restart, send signals,
   invoke tmux, run SSH, pull git, start bots, contact exchanges, or load

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -11,6 +11,7 @@ DEFAULT_STARTUP_WAIT_S = 180
 DEFAULT_SMOKE_WINDOW_MINUTES = 30
 DEFAULT_SMOKE_EVENT_TAIL_LINES = 2000
 DEFAULT_SMOKE_MAX_EVENT_FILES_PER_BOT = 2
+DEFAULT_SMOKE_MAX_LOG_FILES = 8
 DEFAULT_SMOKE_LOG_TAIL_LINES = 1200
 DEFAULT_SMOKE_MAX_LOG_MATCHES = 20
 DEFAULT_MONITOR_ROOT = "monitor"
@@ -56,6 +57,7 @@ def _smoke_report_command(
     smoke_window_minutes: int,
     event_tail_lines: int,
     max_event_files_per_bot: int,
+    max_log_files: int,
     log_tail_lines: int,
     max_log_matches: int,
     compact: bool,
@@ -79,6 +81,8 @@ def _smoke_report_command(
         args.extend(["--event-tail-lines", str(event_tail_lines)])
     if int(max_event_files_per_bot) > 0:
         args.extend(["--max-event-files-per-bot", str(max_event_files_per_bot)])
+    if int(max_log_files) > 0:
+        args.extend(["--max-log-files", str(max_log_files)])
     if int(log_tail_lines) > 0:
         args.extend(["--log-tail-lines", str(log_tail_lines)])
     if int(max_log_matches) > 0:
@@ -214,6 +218,7 @@ def build_live_restart_smoke_plan(
     smoke_window_minutes: int = DEFAULT_SMOKE_WINDOW_MINUTES,
     smoke_event_tail_lines: int = DEFAULT_SMOKE_EVENT_TAIL_LINES,
     smoke_max_event_files_per_bot: int = DEFAULT_SMOKE_MAX_EVENT_FILES_PER_BOT,
+    smoke_max_log_files: int = DEFAULT_SMOKE_MAX_LOG_FILES,
     smoke_log_tail_lines: int = DEFAULT_SMOKE_LOG_TAIL_LINES,
     smoke_max_log_matches: int = DEFAULT_SMOKE_MAX_LOG_MATCHES,
     compact_smoke_report: bool = True,
@@ -231,6 +236,9 @@ def build_live_restart_smoke_plan(
     )
     smoke_max_event_files_per_bot = _non_negative_int(
         smoke_max_event_files_per_bot, field="smoke_max_event_files_per_bot"
+    )
+    smoke_max_log_files = _non_negative_int(
+        smoke_max_log_files, field="smoke_max_log_files"
     )
     smoke_log_tail_lines = _non_negative_int(
         smoke_log_tail_lines, field="smoke_log_tail_lines"
@@ -285,6 +293,7 @@ def build_live_restart_smoke_plan(
         smoke_window_minutes=smoke_window_minutes,
         event_tail_lines=smoke_event_tail_lines,
         max_event_files_per_bot=smoke_max_event_files_per_bot,
+        max_log_files=smoke_max_log_files,
         log_tail_lines=smoke_log_tail_lines,
         max_log_matches=smoke_max_log_matches,
         compact=compact_smoke_report,
@@ -326,6 +335,7 @@ def build_live_restart_smoke_plan(
             "smoke_window_minutes": smoke_window_minutes,
             "smoke_event_tail_lines": smoke_event_tail_lines,
             "smoke_max_event_files_per_bot": smoke_max_event_files_per_bot,
+            "smoke_max_log_files": smoke_max_log_files,
             "smoke_log_tail_lines": smoke_log_tail_lines,
             "smoke_max_log_matches": smoke_max_log_matches,
         },

--- a/src/tools/live_restart_smoke_plan.py
+++ b/src/tools/live_restart_smoke_plan.py
@@ -12,6 +12,7 @@ if str(SRC_ROOT) not in sys.path:
 from live.restart_smoke_plan import (  # noqa: E402
     DEFAULT_SMOKE_EVENT_TAIL_LINES,
     DEFAULT_SMOKE_LOG_TAIL_LINES,
+    DEFAULT_SMOKE_MAX_LOG_FILES,
     DEFAULT_SMOKE_MAX_LOG_MATCHES,
     DEFAULT_SMOKE_MAX_EVENT_FILES_PER_BOT,
     DEFAULT_LOGS_ROOT,
@@ -80,6 +81,15 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Recent event files per bot for the planned smoke-report command. "
             "Use 0 to disable the per-bot file cap."
+        ),
+    )
+    parser.add_argument(
+        "--max-log-files",
+        type=int,
+        default=DEFAULT_SMOKE_MAX_LOG_FILES,
+        help=(
+            "Recent text log files for the planned smoke-report command. "
+            "Use 0 to omit the explicit smoke-report override."
         ),
     )
     parser.add_argument(
@@ -152,6 +162,7 @@ def main(argv: list[str] | None = None) -> int:
             smoke_window_minutes=int(args.smoke_window_minutes),
             smoke_event_tail_lines=int(args.event_tail_lines),
             smoke_max_event_files_per_bot=int(args.max_event_files_per_bot),
+            smoke_max_log_files=int(args.max_log_files),
             smoke_log_tail_lines=int(args.log_tail_lines),
             smoke_max_log_matches=int(args.max_log_matches),
             compact_smoke_report=not bool(args.pretty_smoke_report),

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -56,6 +56,7 @@ def test_live_restart_smoke_plan_builds_plan_from_supervisor_config(tmp_path):
     assert "--recent-minutes 15" in report["smoke_report"]["command"]
     assert "--event-tail-lines 2000" in report["smoke_report"]["command"]
     assert "--max-event-files-per-bot 2" in report["smoke_report"]["command"]
+    assert "--max-log-files 8" in report["smoke_report"]["command"]
     assert "--log-tail-lines 1200" in report["smoke_report"]["command"]
     assert "--max-log-matches 20" in report["smoke_report"]["command"]
     assert "--brief" in report["smoke_report"]["command"]
@@ -189,10 +190,12 @@ def test_live_restart_smoke_plan_cli_outputs_json(tmp_path, capsys):
     assert report["inputs"]["shutdown_timeout_s"] == 30
     assert report["inputs"]["smoke_event_tail_lines"] == 2000
     assert report["inputs"]["smoke_max_event_files_per_bot"] == 2
+    assert report["inputs"]["smoke_max_log_files"] == 8
     assert report["inputs"]["smoke_log_tail_lines"] == 1200
     assert report["inputs"]["smoke_max_log_matches"] == 20
     assert "--event-tail-lines 2000" in report["smoke_report"]["command"]
     assert "--max-event-files-per-bot 2" in report["smoke_report"]["command"]
+    assert "--max-log-files 8" in report["smoke_report"]["command"]
     assert "--log-tail-lines 1200" in report["smoke_report"]["command"]
     assert "--max-log-matches 20" in report["smoke_report"]["command"]
     assert "--brief" in report["smoke_report"]["command"]
@@ -251,6 +254,8 @@ def test_live_restart_smoke_plan_can_disable_planned_log_scan_bounds(tmp_path, c
         live_restart_smoke_plan.main(
             [
                 str(supervisor_config),
+                "--max-log-files",
+                "0",
                 "--log-tail-lines",
                 "0",
                 "--max-log-matches",
@@ -262,8 +267,10 @@ def test_live_restart_smoke_plan_can_disable_planned_log_scan_bounds(tmp_path, c
     )
 
     report = json.loads(capsys.readouterr().out)
+    assert report["inputs"]["smoke_max_log_files"] == 0
     assert report["inputs"]["smoke_log_tail_lines"] == 0
     assert report["inputs"]["smoke_max_log_matches"] == 0
+    assert "--max-log-files" not in report["smoke_report"]["command"]
     assert "--log-tail-lines" not in report["smoke_report"]["command"]
     assert "--max-log-matches" not in report["smoke_report"]["command"]
 
@@ -330,6 +337,12 @@ def test_live_restart_smoke_plan_cli_rejects_negative_event_scan_bounds(capsys):
 
 
 def test_live_restart_smoke_plan_cli_rejects_negative_log_scan_bounds(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_restart_smoke_plan.main(["bots.yaml", "--max-log-files", "-1"])
+
+    assert exc_info.value.code == 2
+    assert "smoke_max_log_files must be non-negative" in capsys.readouterr().err
+
     with pytest.raises(SystemExit) as exc_info:
         live_restart_smoke_plan.main(["bots.yaml", "--log-tail-lines", "-1"])
 


### PR DESCRIPTION
## Summary
- make live-restart-smoke-plan include --max-log-files 8 in generated smoke commands by default
- add planner CLI escape hatch --max-log-files 0 to omit the explicit smoke-report override
- update tool docs and fold PR #935 VPS smoke evidence into the logging progress ledger

## Scope
Read-only planner/tooling slice only. Does not execute restarts, signal processes, invoke tmux, run SSH, pull git, start bots, contact exchanges, load credentials, add event producers, mutate caches, change readiness gates, write monitor events, route console output, or alter order/risk/trading behavior.

## Tests
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_restart_smoke_plan.py
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/restart_smoke_plan.py src/tools/live_restart_smoke_plan.py tests/test_live_restart_smoke_plan.py
- git diff --check
- diff-only silent-handling scan on touched Python/test files is clean