### PR TITLE
Expose incident bundle log scan summary

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `94f88dba` after PR #935, `Expose smoke log scan bounds`.
+- `0da21e9c` after PR #936, `Make planned smoke log file cap explicit`.
 
 Current review gate:
 
@@ -49,6 +49,34 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #936 at `0da21e9c`.
+- PR #936 made the read-only `live-restart-smoke-plan` generated smoke command
+  include `--max-log-files 8` by default, with `0` as an escape hatch to omit
+  that explicit smoke-report override. This completed the generated
+  smoke-command log bound set alongside `--log-tail-lines 1200` and
+  `--max-log-matches 20`. The slice was plan-only operator tooling and did not
+  execute restarts, send signals, invoke tmux, run SSH, pull git, start bots,
+  contact exchanges, load credentials, add event producers, mutate caches,
+  change readiness gates, write monitor events, route console output, or alter
+  order/risk/trading behavior.
+- PR #936 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_restart_smoke_plan.py`, py_compile for touched files,
+  `git diff --check`, and a diff-only silent-handling scan.
+- VPS5 pulled from `94f88dba` to `0da21e9c` without bot restart because the
+  deployed change was read-only planner tooling. The five configured bots were
+  left running.
+- A VPS5 `live-restart-smoke-plan` run against `/root/bots_vps5.yaml` completed
+  with `ok=true`, five configured bots, `execute=false`, and planned smoke
+  commands containing `--event-tail-lines 2000`,
+  `--max-event-files-per-bot 2`, `--max-log-files 8`,
+  `--log-tail-lines 1200`, `--max-log-matches 20`, `--brief`, and
+  `--compact`. The planned command was then run as a bounded 5-minute brief
+  smoke; it reported `ok=true`, `hard_failures=0`, clean tracked repository
+  state at `0da21e9c`, five matched expected live processes, no
+  missing/extra/duplicate live processes, no failed account-critical remote
+  calls, `logs.max_files=8`, `logs.tail_lines=1200`, and
+  `logs.max_matches=20`. Remaining attention came from known non-hard EMA
+  readiness and HSL status/cooldown diagnostics.
 - Repository pulled through PR #935 at `94f88dba`.
 - PR #935 made `live-smoke-report` full, summary, and brief `logs` output
   expose the configured text-log scan bounds: `max_files`, `tail_lines`, and

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -648,6 +648,44 @@ def _problem_report_result_summary(problem_report: dict[str, Any]) -> dict[str, 
     }
 
 
+def _smoke_log_result_summary(smoke_report: dict[str, Any]) -> dict[str, Any]:
+    logs = smoke_report.get("logs") if isinstance(smoke_report.get("logs"), dict) else {}
+    window = logs.get("window") if isinstance(logs.get("window"), dict) else {}
+    return {
+        "max_files": logs.get("max_files"),
+        "tail_lines": logs.get("tail_lines"),
+        "max_matches": logs.get("max_matches"),
+        "files_scanned": logs.get("files_scanned"),
+        "hard_matches": logs.get("hard_matches"),
+        "attention_matches": logs.get("attention_matches"),
+        "risk_attention_matches": logs.get("risk_attention_matches"),
+        "risk_hard_matches": logs.get("risk_hard_matches"),
+        "non_risk_attention_matches": logs.get("non_risk_attention_matches"),
+        "non_risk_hard_matches": logs.get("non_risk_hard_matches"),
+        "dropped_unparsed_attention_matches": logs.get(
+            "dropped_unparsed_attention_matches"
+        ),
+        "dropped_unparsed_hard_matches": logs.get("dropped_unparsed_hard_matches"),
+        "window": {
+            "enabled": window.get("enabled"),
+            "since_ms": window.get("since_ms"),
+            "until_ms": window.get("until_ms"),
+            "lines_considered": window.get("lines_considered"),
+            "lines_skipped_before": window.get("lines_skipped_before"),
+            "lines_skipped_after": window.get("lines_skipped_after"),
+            "lines_skipped_unparsed": window.get("lines_skipped_unparsed"),
+            "unparsed_policy": window.get("unparsed_policy"),
+            "unparsed_ts": window.get("unparsed_ts"),
+            "dropped_unparsed_attention_matches": window.get(
+                "dropped_unparsed_attention_matches"
+            ),
+            "dropped_unparsed_hard_matches": window.get(
+                "dropped_unparsed_hard_matches"
+            ),
+        },
+    }
+
+
 def _copy_event_segments(
     *,
     monitor_root: str | Path,
@@ -984,6 +1022,10 @@ def build_live_incident_bundle(
                     "max_event_files_per_bot": max_event_files_per_bot
                     if max_event_files_per_bot
                     else None,
+                    "max_log_files": max_log_files if max_log_files else None,
+                    "log_tail_lines": log_tail_lines if log_tail_lines else None,
+                    "max_log_matches": max_log_matches if max_log_matches else None,
+                    "log_window_unparsed_policy": log_window_unparsed_policy,
                     "include_rotated": include_rotated,
                     "include_data": include_data,
                     "include_trace_report": include_trace_report,
@@ -1074,6 +1116,7 @@ def build_live_incident_bundle(
             "hard_failures": smoke_report.get("hard_failures"),
             "attention_count": smoke_report.get("attention_count"),
             "event_window": smoke_report.get("event_window"),
+            "logs": _smoke_log_result_summary(smoke_report),
             "processes": {
                 "enabled": smoke_report.get("processes", {}).get("enabled"),
                 "ok": smoke_report.get("processes", {}).get("ok"),

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -144,7 +144,7 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     logs_dir = tmp_path / "logs"
     logs_dir.mkdir()
     (logs_dir / "bot.log").write_text(
-        "2026-06-25T00:00:00Z ERROR request timeout\n",
+        "1970-01-01T00:00:02Z ERROR request timeout\n",
         encoding="utf-8",
     )
     config_path = tmp_path / "config.json"
@@ -199,6 +199,33 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         "events_skipped_after": 0,
         "invalid_window_ts": 0,
     }
+    assert report["smoke_report"]["logs"] == {
+        "max_files": 8,
+        "tail_lines": 500,
+        "max_matches": 100,
+        "files_scanned": 1,
+        "hard_matches": 0,
+        "attention_matches": 1,
+        "risk_attention_matches": 0,
+        "risk_hard_matches": 0,
+        "non_risk_attention_matches": 1,
+        "non_risk_hard_matches": 0,
+        "dropped_unparsed_attention_matches": 0,
+        "dropped_unparsed_hard_matches": 0,
+        "window": {
+            "enabled": True,
+            "since_ms": 1500,
+            "until_ms": 2500,
+            "lines_considered": 1,
+            "lines_skipped_before": 0,
+            "lines_skipped_after": 0,
+            "lines_skipped_unparsed": 0,
+            "unparsed_policy": "keep",
+            "unparsed_ts": 0,
+            "dropped_unparsed_attention_matches": 0,
+            "dropped_unparsed_hard_matches": 0,
+        },
+    }
     assert report["config_hashes"] == 1
     assert report["monitor_snapshots"] == 1
     assert report["event_segments"]["included"] == 1
@@ -240,6 +267,10 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         )
 
     assert manifest["config_hashes"][0]["sha256"] == config_hashes[0]["sha256"]
+    assert manifest["filters"]["max_log_files"] == 8
+    assert manifest["filters"]["log_tail_lines"] == 500
+    assert manifest["filters"]["max_log_matches"] == 100
+    assert manifest["filters"]["log_window_unparsed_policy"] == "keep"
     assert manifest["event_segments"]["file_discovery"] == report["event_segments"][
         "file_discovery"
     ]
@@ -279,6 +310,16 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     assert window_report["events"][0]["seq"] == 2
     assert "remote_call.failed" in window_report["timeline"][0]
     assert smoke_report["event_window"] == report["smoke_report"]["event_window"]
+    assert smoke_report["logs"]["max_files"] == report["smoke_report"]["logs"][
+        "max_files"
+    ]
+    assert smoke_report["logs"]["tail_lines"] == report["smoke_report"]["logs"][
+        "tail_lines"
+    ]
+    assert smoke_report["logs"]["max_matches"] == report["smoke_report"]["logs"][
+        "max_matches"
+    ]
+    assert smoke_report["logs"]["window"] == report["smoke_report"]["logs"]["window"]
     assert smoke_report["remote_call_failures"]["total"] == 1
 
 
@@ -598,6 +639,10 @@ def test_live_incident_bundle_can_skip_logs_and_segments_from_cli(tmp_path, caps
         "events_truncated": None,
         "trace_summary_matched_events": None,
     }
+    assert report["smoke_report"]["logs"]["max_files"] == 8
+    assert report["smoke_report"]["logs"]["tail_lines"] == 500
+    assert report["smoke_report"]["logs"]["max_matches"] == 100
+    assert report["smoke_report"]["logs"]["files_scanned"] == 0
     assert report["event_segments"]["included"] == 0
     assert output.exists()
     with tarfile.open(output, "r:gz") as tar:
@@ -619,6 +664,9 @@ def test_live_incident_bundle_can_skip_logs_and_segments_from_cli(tmp_path, caps
     assert "trace_summary" not in event_report["query"]
     assert "order_trace" not in event_report["query"]
     assert smoke_report["logs"]["root"] is None
+    assert smoke_report["logs"]["max_files"] == report["smoke_report"]["logs"][
+        "max_files"
+    ]
     assert smoke_report["logs"]["hard_matches"] == 0
 
 


### PR DESCRIPTION
Scope:
- Add a compact incident-bundle projection of smoke log scan bounds and counters under smoke_report.logs.
- Add incident-bundle manifest filter metadata for max_log_files, log_tail_lines, max_log_matches, and log_window_unparsed_policy.
- Keep the embedded full smoke report unchanged and assert compact fields match the embedded smoke metadata.

Behavior boundary:
- Read-only reporting/metadata only.
- No change to log scan behavior, smoke verdict policy, bundle file selection beyond manifest/result metadata, event producers, monitor event routing, exchange calls, cache mutation, readiness gates, console output, order logic, risk logic, or trading behavior.

Validation:
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_incident_bundle.py -q
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check
- diff-only silent-handling scan for touched Python/test files: clean