### PR TITLE
Plan bounded incident bundle evidence command

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `0da21e9c` after PR #936, `Make planned smoke log file cap explicit`.
+- `6b38c7dd` after PR #937, `Expose incident bundle log scan summary`.
 
 Current review gate:
 
@@ -49,6 +49,34 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #937 at `6b38c7dd`.
+- PR #937 made the read-only `live-incident-bundle` compact result expose the
+  embedded smoke report's bounded text-log scan summary under
+  `smoke_report.logs`, and added the log scan bounds/policy to the incident
+  bundle manifest filters. The slice projected existing smoke metadata only;
+  it did not change log/event scan behavior, smoke verdict policy, bundle
+  file selection beyond manifest/result metadata, event producers, exchange
+  calls, cache mutation, readiness gates, console routing, order logic, risk
+  logic, or trading behavior.
+- PR #937 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_incident_bundle.py`, py_compile for touched files,
+  `git diff --check`, and a diff-only silent-handling scan.
+- VPS5 pulled from `0da21e9c` to `6b38c7dd` without bot restart because the
+  deployed change was read-only incident-bundle reporting. The five configured
+  bots were left running.
+- A bounded 5-minute VPS5 smoke after the pull reported `ok=true`,
+  `hard_failures=0`, clean tracked repository state at `6b38c7dd`, five
+  matched expected live processes, no missing/extra/duplicate live processes,
+  no failed account-critical remote calls, `logs.max_files=8`,
+  `logs.tail_lines=1200`, and `logs.max_matches=20`. Remaining attention came
+  from known non-hard EMA readiness and HSL status/cooldown diagnostics.
+- A focused VPS5 incident-bundle smoke wrote
+  `/tmp/passivbot_incident_bundle_smoke_937.tar.gz` with `--no-event-segments`
+  and the same bounded event/log scan arguments; its compact output reported
+  `ok=true`, `hard_failures=0`, five expected live processes, and the new
+  `smoke_report.logs` projection with `max_files=8`, `tail_lines=1200`,
+  `max_matches=20`, `files_scanned=8`, and no hard or attention text-log
+  matches.
 - Repository pulled through PR #936 at `0da21e9c`.
 - PR #936 made the read-only `live-restart-smoke-plan` generated smoke command
   include `--max-log-files 8` by default, with `0` as an escape hatch to omit

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -197,7 +197,10 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   `--summary-smoke-report` for bounded groups or `--full-smoke-report` for the
   full smoke report. The planner does not execute the restart, send signals,
   invoke tmux, run SSH, pull git, start bots, contact exchanges, or load
-  credentials.
+  credentials. The plan also includes a bounded `live-incident-bundle` command
+  for failure evidence, reusing the same event/log scan limits and disabling
+  event-segment copying by default; use `--incident-bundle-output PATH` to
+  choose the planned bundle path.
 - `passivbot tool live-performance-report` summarizes local live monitor event timings for
   operator performance analysis. It is read-only and does not contact exchanges. Use
   `--recent-minutes` for a time window, `--summary` for a bounded operator projection, and

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -14,6 +14,7 @@ DEFAULT_SMOKE_MAX_EVENT_FILES_PER_BOT = 2
 DEFAULT_SMOKE_MAX_LOG_FILES = 8
 DEFAULT_SMOKE_LOG_TAIL_LINES = 1200
 DEFAULT_SMOKE_MAX_LOG_MATCHES = 20
+DEFAULT_INCIDENT_BUNDLE_OUTPUT = "/tmp/passivbot_incident_bundle_restart_smoke.tar.gz"
 DEFAULT_MONITOR_ROOT = "monitor"
 DEFAULT_LOGS_ROOT = "logs"
 UNSAFE_PROCESS_SIGNAL_PATTERNS = (
@@ -93,6 +94,49 @@ def _smoke_report_command(
         args.append("--brief")
     if compact:
         args.append("--compact")
+    return _shell_join(args)
+
+
+def _incident_bundle_command(
+    *,
+    monitor_root: str | Path,
+    logs_root: str | Path | None,
+    supervisor_config: str | Path,
+    output_path: str | Path,
+    smoke_window_minutes: int,
+    event_tail_lines: int,
+    max_event_files_per_bot: int,
+    max_log_files: int,
+    log_tail_lines: int,
+    max_log_matches: int,
+) -> str:
+    args = [
+        "passivbot",
+        "tool",
+        "live-incident-bundle",
+        str(monitor_root),
+        "--output",
+        str(output_path),
+        "--supervisor-config",
+        str(supervisor_config),
+        "--processes",
+        "--recent-minutes",
+        str(smoke_window_minutes),
+        "--no-event-segments",
+    ]
+    if logs_root is not None:
+        args.extend(["--logs-root", str(logs_root)])
+    if int(event_tail_lines) > 0:
+        args.extend(["--event-tail-lines", str(event_tail_lines)])
+    if int(max_event_files_per_bot) > 0:
+        args.extend(["--max-event-files-per-bot", str(max_event_files_per_bot)])
+    if int(max_log_files) > 0:
+        args.extend(["--max-log-files", str(max_log_files)])
+    if int(log_tail_lines) > 0:
+        args.extend(["--log-tail-lines", str(log_tail_lines)])
+    if int(max_log_matches) > 0:
+        args.extend(["--max-log-matches", str(max_log_matches)])
+    args.append("--compact")
     return _shell_join(args)
 
 
@@ -221,6 +265,7 @@ def build_live_restart_smoke_plan(
     smoke_max_log_files: int = DEFAULT_SMOKE_MAX_LOG_FILES,
     smoke_log_tail_lines: int = DEFAULT_SMOKE_LOG_TAIL_LINES,
     smoke_max_log_matches: int = DEFAULT_SMOKE_MAX_LOG_MATCHES,
+    incident_bundle_output: str | Path = DEFAULT_INCIDENT_BUNDLE_OUTPUT,
     compact_smoke_report: bool = True,
     brief_smoke_report: bool = True,
     summary_smoke_report: bool = False,
@@ -300,6 +345,18 @@ def build_live_restart_smoke_plan(
         brief=brief_smoke_report,
         summary=summary_smoke_report,
     )
+    incident_bundle_command = _incident_bundle_command(
+        monitor_root=monitor_root,
+        logs_root=logs_root,
+        supervisor_config=supervisor_config,
+        output_path=incident_bundle_output,
+        smoke_window_minutes=smoke_window_minutes,
+        event_tail_lines=smoke_event_tail_lines,
+        max_event_files_per_bot=smoke_max_event_files_per_bot,
+        max_log_files=smoke_max_log_files,
+        log_tail_lines=smoke_log_tail_lines,
+        max_log_matches=smoke_max_log_matches,
+    )
     planned_bots = []
     for index, bot in enumerate(bots, start=1):
         planned_bots.append(
@@ -338,6 +395,7 @@ def build_live_restart_smoke_plan(
             "smoke_max_log_files": smoke_max_log_files,
             "smoke_log_tail_lines": smoke_log_tail_lines,
             "smoke_max_log_matches": smoke_max_log_matches,
+            "incident_bundle_output": _display_path(incident_bundle_output),
         },
         "supervisor_config": {
             "path": _display_path(supervisor.get("path")),
@@ -386,6 +444,16 @@ def build_live_restart_smoke_plan(
                 "description": "Collect bounded read-only startup smoke evidence.",
                 "planned_commands": [{"command": smoke_command, "execute": False}],
             },
+            {
+                "name": "post_failure_incident_bundle",
+                "description": (
+                    "If smoke or shutdown evidence is not clean, collect a bounded "
+                    "local incident bundle for review."
+                ),
+                "planned_commands": [
+                    {"command": incident_bundle_command, "execute": False}
+                ],
+            },
         ],
         "smoke_report": {
             "command": smoke_command,
@@ -405,6 +473,21 @@ def build_live_restart_smoke_plan(
                 "risk/HSL events",
             ],
         },
+        "incident_bundle": {
+            "command": incident_bundle_command,
+            "execute": False,
+            "output_path": _display_path(incident_bundle_output),
+            "event_segments": "disabled_by_default_for_fast_restart_smoke_bundle",
+            "expected_fields": [
+                "manifest filters and runtime metadata",
+                "bounded smoke report with process and log scan metadata",
+                "problem-event report",
+                "trace summary/order trace reports",
+                "time-window event report",
+                "monitor snapshots",
+                "config hashes when configured explicitly",
+            ],
+        },
         "process_signal_safety": _process_signal_safety_contract(),
         "timeout_escalation_ladder": [
             {
@@ -420,6 +503,10 @@ def build_live_restart_smoke_plan(
                     "collect smoke report and inspect shutdown events/logs before "
                     "escalation"
                 ),
+                "planned_commands": [
+                    {"command": smoke_command, "execute": False},
+                    {"command": incident_bundle_command, "execute": False},
+                ],
                 "execute": False,
             },
             {

--- a/src/tools/live_restart_smoke_plan.py
+++ b/src/tools/live_restart_smoke_plan.py
@@ -10,6 +10,7 @@ if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
 from live.restart_smoke_plan import (  # noqa: E402
+    DEFAULT_INCIDENT_BUNDLE_OUTPUT,
     DEFAULT_SMOKE_EVENT_TAIL_LINES,
     DEFAULT_SMOKE_LOG_TAIL_LINES,
     DEFAULT_SMOKE_MAX_LOG_FILES,
@@ -110,6 +111,14 @@ def build_parser() -> argparse.ArgumentParser:
             "Use 0 to omit the explicit smoke-report override."
         ),
     )
+    parser.add_argument(
+        "--incident-bundle-output",
+        default=DEFAULT_INCIDENT_BUNDLE_OUTPUT,
+        help=(
+            "Output path for the planned live-incident-bundle evidence command. "
+            "The plan never creates the bundle."
+        ),
+    )
     smoke_projection = parser.add_mutually_exclusive_group()
     smoke_projection.add_argument(
         "--brief-smoke-report",
@@ -165,6 +174,7 @@ def main(argv: list[str] | None = None) -> int:
             smoke_max_log_files=int(args.max_log_files),
             smoke_log_tail_lines=int(args.log_tail_lines),
             smoke_max_log_matches=int(args.max_log_matches),
+            incident_bundle_output=args.incident_bundle_output,
             compact_smoke_report=not bool(args.pretty_smoke_report),
             brief_smoke_report=not (
                 bool(args.full_smoke_report) or bool(args.summary_smoke_report)

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -61,6 +61,25 @@ def test_live_restart_smoke_plan_builds_plan_from_supervisor_config(tmp_path):
     assert "--max-log-matches 20" in report["smoke_report"]["command"]
     assert "--brief" in report["smoke_report"]["command"]
     assert "--summary" not in report["smoke_report"]["command"]
+    assert report["incident_bundle"]["execute"] is False
+    assert report["incident_bundle"]["output_path"].endswith(
+        "/passivbot_incident_bundle_restart_smoke.tar.gz"
+    )
+    incident_command = report["incident_bundle"]["command"]
+    assert "passivbot tool live-incident-bundle" in incident_command
+    assert "--output /tmp/passivbot_incident_bundle_restart_smoke.tar.gz" in incident_command
+    assert "--supervisor-config" in incident_command
+    assert "--processes" in incident_command
+    assert "--recent-minutes 15" in incident_command
+    assert "--no-event-segments" in incident_command
+    assert "--event-tail-lines 2000" in incident_command
+    assert "--max-event-files-per-bot 2" in incident_command
+    assert "--max-log-files 8" in incident_command
+    assert "--log-tail-lines 1200" in incident_command
+    assert "--max-log-matches 20" in incident_command
+    assert "--compact" in incident_command
+    assert report["phases"][-1]["name"] == "post_failure_incident_bundle"
+    assert report["phases"][-1]["planned_commands"][0]["command"] == incident_command
     assert report["process_signal_safety"]["strategy"] == (
         "exact_tmux_pane_or_exact_pid_only"
     )
@@ -193,12 +212,17 @@ def test_live_restart_smoke_plan_cli_outputs_json(tmp_path, capsys):
     assert report["inputs"]["smoke_max_log_files"] == 8
     assert report["inputs"]["smoke_log_tail_lines"] == 1200
     assert report["inputs"]["smoke_max_log_matches"] == 20
+    assert report["inputs"]["incident_bundle_output"].endswith(
+        "/passivbot_incident_bundle_restart_smoke.tar.gz"
+    )
     assert "--event-tail-lines 2000" in report["smoke_report"]["command"]
     assert "--max-event-files-per-bot 2" in report["smoke_report"]["command"]
     assert "--max-log-files 8" in report["smoke_report"]["command"]
     assert "--log-tail-lines 1200" in report["smoke_report"]["command"]
     assert "--max-log-matches 20" in report["smoke_report"]["command"]
     assert "--brief" in report["smoke_report"]["command"]
+    assert "--no-event-segments" in report["incident_bundle"]["command"]
+    assert "--compact" in report["incident_bundle"]["command"]
 
 
 def test_live_restart_smoke_plan_can_disable_planned_event_scan_bounds(
@@ -235,6 +259,8 @@ def test_live_restart_smoke_plan_can_disable_planned_event_scan_bounds(
     assert report["inputs"]["smoke_max_event_files_per_bot"] == 0
     assert "--event-tail-lines" not in report["smoke_report"]["command"]
     assert "--max-event-files-per-bot" not in report["smoke_report"]["command"]
+    assert "--event-tail-lines" not in report["incident_bundle"]["command"]
+    assert "--max-event-files-per-bot" not in report["incident_bundle"]["command"]
 
 
 def test_live_restart_smoke_plan_can_disable_planned_log_scan_bounds(tmp_path, capsys):
@@ -273,6 +299,41 @@ def test_live_restart_smoke_plan_can_disable_planned_log_scan_bounds(tmp_path, c
     assert "--max-log-files" not in report["smoke_report"]["command"]
     assert "--log-tail-lines" not in report["smoke_report"]["command"]
     assert "--max-log-matches" not in report["smoke_report"]["command"]
+    assert "--max-log-files" not in report["incident_bundle"]["command"]
+    assert "--log-tail-lines" not in report["incident_bundle"]["command"]
+    assert "--max-log-matches" not in report["incident_bundle"]["command"]
+
+
+def test_live_restart_smoke_plan_can_override_incident_bundle_output(tmp_path, capsys):
+    supervisor_config = tmp_path / "bots.yaml"
+    output_path = tmp_path / "incident.tar.gz"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u binance_01",
+        ],
+    )
+
+    assert (
+        live_restart_smoke_plan.main(
+            [
+                str(supervisor_config),
+                "--incident-bundle-output",
+                str(output_path),
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["inputs"]["incident_bundle_output"] == str(output_path)
+    assert report["incident_bundle"]["output_path"] == str(output_path)
+    assert f"--output {output_path}" in report["incident_bundle"]["command"]
 
 
 def test_live_restart_smoke_plan_can_plan_summary_or_full_smoke_projection(


### PR DESCRIPTION
Scope:
- Add a plan-only live-incident-bundle evidence command to live-restart-smoke-plan.
- Reuse the same recent-window, event-tail, per-bot file cap, log file, log tail, and log match bounds as the planned smoke command.
- Default the planned bundle to --no-event-segments and --compact for quick failure evidence capture.
- Add --incident-bundle-output to choose the planned output path.
- Fold PR #937 deployment/smoke evidence into the progress ledger and document the new planned command.

Behavior boundary:
- Read-only planner/tooling only.
- Does not execute the incident bundle command, create bundles, signal processes, invoke tmux, SSH, git pull, start bots, contact exchanges, load credentials, add event producers, mutate caches, change readiness gates, route console output, or alter order/risk/trading behavior.

Validation:
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_restart_smoke_plan.py -q
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/restart_smoke_plan.py src/tools/live_restart_smoke_plan.py tests/test_live_restart_smoke_plan.py
- git diff --check
- diff-only silent-handling scan for touched Python/test files: clean