### PR TITLE
Summarize restart smoke plans

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `6b38c7dd` after PR #937, `Expose incident bundle log scan summary`.
+- `8ffb9a73` after PR #938, `Plan bounded incident bundle evidence command`.
 
 Current review gate:
 
@@ -49,6 +49,35 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #938 at `8ffb9a73`.
+- PR #938 made the read-only `live-restart-smoke-plan` output include a
+  bounded `live-incident-bundle` evidence command for non-clean restart/smoke
+  cases. The planned command reuses the same recent-window, event-tail,
+  per-bot event-file, log-file, log-tail, and log-match bounds as the planned
+  smoke command, defaults to `--no-event-segments` and `--compact`, and remains
+  plan-only with `execute=false`. The slice did not execute bundles, send
+  signals, invoke tmux, run SSH, pull git, start bots, contact exchanges, load
+  credentials, add event producers, mutate caches, change readiness gates,
+  route console output, or alter order/risk/trading behavior.
+- PR #938 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_restart_smoke_plan.py`, py_compile for touched files,
+  `git diff --check`, and a diff-only silent-handling scan.
+- VPS5 pulled from `6b38c7dd` to `8ffb9a73` without bot restart because the
+  deployed change was read-only planner tooling. The five configured bots were
+  left running.
+- A VPS5 `live-restart-smoke-plan` run against `/root/bots_vps5.yaml` completed
+  with `ok=true`, five configured bots, `execute=false`, and a new
+  `post_failure_incident_bundle` phase. The planned incident-bundle command
+  contained `--supervisor-config /root/bots_vps5.yaml`, `--recent-minutes 5`,
+  `--no-event-segments`, `--event-tail-lines 2000`,
+  `--max-event-files-per-bot 2`, `--max-log-files 8`,
+  `--log-tail-lines 1200`, `--max-log-matches 20`, and `--compact`.
+- A bounded 5-minute VPS5 smoke after the pull reported `ok=true`,
+  `hard_failures=0`, clean tracked repository state at `8ffb9a73`, five
+  matched expected live processes, no missing/extra/duplicate live processes,
+  no failed account-critical remote calls, `logs.max_files=8`,
+  `logs.tail_lines=1200`, and `logs.max_matches=20`. Remaining attention came
+  from known non-hard EMA readiness and HSL status/cooldown diagnostics.
 - Repository pulled through PR #937 at `6b38c7dd`.
 - PR #937 made the read-only `live-incident-bundle` compact result expose the
   embedded smoke report's bounded text-log scan summary under

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -200,7 +200,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   credentials. The plan also includes a bounded `live-incident-bundle` command
   for failure evidence, reusing the same event/log scan limits and disabling
   event-segment copying by default; use `--incident-bundle-output PATH` to
-  choose the planned bundle path.
+  choose the planned bundle path. Use planner `--summary` when you only need
+  the bot count, phase names, smoke command, and incident-bundle command without
+  every per-bot phase detail.
 - `passivbot tool live-performance-report` summarizes local live monitor event timings for
   operator performance analysis. It is read-only and does not contact exchanges. Use
   `--recent-minutes` for a time window, `--summary` for a bounded operator projection, and

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -547,3 +547,111 @@ def build_live_restart_smoke_plan(
         "warnings": warnings,
         "issues": issues,
     }
+
+
+def summarize_live_restart_smoke_plan(report: dict[str, Any]) -> dict[str, Any]:
+    bots = report.get("bots")
+    phases = report.get("phases")
+    timeout_ladder = report.get("timeout_escalation_ladder")
+    warnings = report.get("warnings")
+    issues = report.get("issues")
+    bot_rows = bots if isinstance(bots, list) else []
+    phase_rows = phases if isinstance(phases, list) else []
+    timeout_rows = timeout_ladder if isinstance(timeout_ladder, list) else []
+    warning_rows = warnings if isinstance(warnings, list) else []
+    issue_rows = issues if isinstance(issues, list) else []
+    smoke_report = report.get("smoke_report")
+    incident_bundle = report.get("incident_bundle")
+    execution_policy = report.get("execution_policy")
+    signal_safety = report.get("process_signal_safety")
+    return {
+        "tool": report.get("tool"),
+        "schema_version": report.get("schema_version"),
+        "ok": report.get("ok"),
+        "metadata": report.get("metadata"),
+        "inputs": report.get("inputs"),
+        "supervisor_config": report.get("supervisor_config"),
+        "bots": {
+            "count": len(bot_rows),
+            "names": [str(bot.get("name") or "") for bot in bot_rows[:20]],
+            "truncated": max(0, len(bot_rows) - 20),
+        },
+        "phases": {
+            "count": len(phase_rows),
+            "names": [str(phase.get("name") or "") for phase in phase_rows],
+        },
+        "smoke_report": {
+            "command": (
+                smoke_report.get("command") if isinstance(smoke_report, dict) else None
+            ),
+            "execute": (
+                smoke_report.get("execute") if isinstance(smoke_report, dict) else None
+            ),
+        },
+        "incident_bundle": {
+            "command": (
+                incident_bundle.get("command")
+                if isinstance(incident_bundle, dict)
+                else None
+            ),
+            "execute": (
+                incident_bundle.get("execute")
+                if isinstance(incident_bundle, dict)
+                else None
+            ),
+            "output_path": (
+                incident_bundle.get("output_path")
+                if isinstance(incident_bundle, dict)
+                else None
+            ),
+            "event_segments": (
+                incident_bundle.get("event_segments")
+                if isinstance(incident_bundle, dict)
+                else None
+            ),
+        },
+        "process_signal_safety": {
+            "strategy": (
+                signal_safety.get("strategy") if isinstance(signal_safety, dict) else None
+            ),
+            "forbid_broad_process_pattern_signals": (
+                signal_safety.get("forbid_broad_process_pattern_signals")
+                if isinstance(signal_safety, dict)
+                else None
+            ),
+        },
+        "timeout_escalation_ladder": [
+            {
+                "level": row.get("level"),
+                "condition": row.get("condition"),
+                "execute": row.get("execute"),
+                "planned_command_count": len(
+                    row.get("planned_commands")
+                    if isinstance(row.get("planned_commands"), list)
+                    else []
+                ),
+            }
+            for row in timeout_rows
+            if isinstance(row, dict)
+        ],
+        "execution_policy": {
+            "execute_flag": (
+                execution_policy.get("execute_flag")
+                if isinstance(execution_policy, dict)
+                else None
+            ),
+            "future_execution_requires_review": (
+                execution_policy.get("future_execution_requires_review")
+                if isinstance(execution_policy, dict)
+                else None
+            ),
+            "rejected_operation_count": len(
+                execution_policy.get("rejected_operations")
+                if isinstance(execution_policy, dict)
+                and isinstance(execution_policy.get("rejected_operations"), list)
+                else []
+            ),
+        },
+        "warnings": {"count": len(warning_rows), "items": warning_rows[:20]},
+        "issues": {"count": len(issue_rows), "items": issue_rows[:20]},
+    }

--- a/src/tools/live_restart_smoke_plan.py
+++ b/src/tools/live_restart_smoke_plan.py
@@ -22,6 +22,7 @@ from live.restart_smoke_plan import (  # noqa: E402
     DEFAULT_SMOKE_WINDOW_MINUTES,
     DEFAULT_STARTUP_WAIT_S,
     build_live_restart_smoke_plan,
+    summarize_live_restart_smoke_plan,
 )
 
 
@@ -150,6 +151,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Emit compact single-line JSON.",
     )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Emit a concise plan summary instead of the full per-bot plan.",
+    )
     return parser
 
 
@@ -184,6 +190,8 @@ def main(argv: list[str] | None = None) -> int:
         )
     except (NotImplementedError, ValueError) as exc:
         parser.error(str(exc))
+    if args.summary:
+        report = summarize_live_restart_smoke_plan(report)
     print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
     return 0 if report["ok"] else 1
 

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -6,7 +6,11 @@ import sys
 
 import pytest
 
-from live.restart_smoke_plan import _display_path, build_live_restart_smoke_plan
+from live.restart_smoke_plan import (
+    _display_path,
+    build_live_restart_smoke_plan,
+    summarize_live_restart_smoke_plan,
+)
 from passivbot_cli import main as cli_main
 from tools import live_restart_smoke_plan
 
@@ -334,6 +338,74 @@ def test_live_restart_smoke_plan_can_override_incident_bundle_output(tmp_path, c
     assert report["inputs"]["incident_bundle_output"] == str(output_path)
     assert report["incident_bundle"]["output_path"] == str(output_path)
     assert f"--output {output_path}" in report["incident_bundle"]["command"]
+
+
+def test_live_restart_smoke_plan_summary_projects_concise_commands(tmp_path, capsys):
+    supervisor_config = tmp_path / "bots.yaml"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u binance_01",
+            "  - window_name: gateio_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u gateio_01",
+        ],
+    )
+
+    full_report = build_live_restart_smoke_plan(
+        supervisor_config,
+        repo_path="/srv/passivbot",
+        smoke_window_minutes=7,
+    )
+    summary = summarize_live_restart_smoke_plan(full_report)
+
+    assert summary["ok"] is True
+    assert "bots" not in summary["bots"]
+    assert summary["bots"] == {
+        "count": 2,
+        "names": ["binance_01", "gateio_01"],
+        "truncated": 0,
+    }
+    assert summary["phases"]["names"] == [
+        "pre_restart_readiness",
+        "graceful_stop_all",
+        "orphan_duplicate_check",
+        "supervisor_reload_start",
+        "post_start_smoke_report",
+        "post_failure_incident_bundle",
+    ]
+    assert "passivbot tool live-smoke-report" in summary["smoke_report"]["command"]
+    assert "--recent-minutes 7" in summary["smoke_report"]["command"]
+    assert "passivbot tool live-incident-bundle" in summary["incident_bundle"][
+        "command"
+    ]
+    assert summary["incident_bundle"]["execute"] is False
+    assert summary["incident_bundle"]["event_segments"] == (
+        "disabled_by_default_for_fast_restart_smoke_bundle"
+    )
+    assert summary["timeout_escalation_ladder"][1]["planned_command_count"] == 2
+    assert summary["execution_policy"]["execute_flag"] == "not_implemented"
+    assert summary["execution_policy"]["rejected_operation_count"] >= 1
+    assert summary["warnings"]["count"] == len(full_report["warnings"])
+    assert summary["issues"] == {"count": 0, "items": []}
+
+    assert (
+        live_restart_smoke_plan.main(
+            [str(supervisor_config), "--summary", "--compact"]
+        )
+        == 0
+    )
+    cli_summary = json.loads(capsys.readouterr().out)
+    assert cli_summary["bots"]["count"] == 2
+    assert "phases" in cli_summary
+    assert "passivbot tool live-incident-bundle" in cli_summary["incident_bundle"][
+        "command"
+    ]
+    assert "command_key" not in json.dumps(cli_summary["bots"])
 
 
 def test_live_restart_smoke_plan_can_plan_summary_or_full_smoke_projection(


### PR DESCRIPTION
Scope:
- Add summarize_live_restart_smoke_plan() as a concise projection of the existing full live-restart-smoke-plan report.
- Add CLI --summary to emit bot count/names, phase names, planned smoke command, planned incident-bundle command, execution policy, warning/issue counts, and escalation command counts without per-bot phase detail.
- Fold PR #938 deployment/smoke evidence into the progress ledger and document planner --summary.

Behavior boundary:
- Read-only output projection only.
- Does not alter full restart plan generation, planned commands, smoke/incident-bundle behavior, execution policy, process signaling, tmux/SSH/git behavior, event producers, exchange calls, cache mutation, readiness gates, console routing, order logic, risk logic, or trading behavior.

Validation:
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_restart_smoke_plan.py -q
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/restart_smoke_plan.py src/tools/live_restart_smoke_plan.py tests/test_live_restart_smoke_plan.py
- git diff --check
- diff-only silent-handling scan for touched Python/test files: clean