### PR TITLE
Timestamp planned incident bundle output

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `8ffb9a73` after PR #938, `Plan bounded incident bundle evidence command`.
+- `e3c616d4` after PR #939, `Summarize restart smoke plans`.
 
 Current review gate:
 
@@ -49,6 +49,34 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #939 at `e3c616d4`.
+- PR #939 added a read-only `live-restart-smoke-plan --summary` projection for
+  repeated operator loops. The projection keeps bot count/names, phase names,
+  planned smoke and incident-bundle commands, execution policy, signal-safety
+  strategy, escalation command counts, and warning/issue counts without dumping
+  every per-bot phase. The slice did not alter full restart plan generation,
+  planned commands, smoke/incident-bundle behavior, execution policy, process
+  signaling, tmux/SSH/git behavior, event producers, exchange calls, cache
+  mutation, readiness gates, console routing, order logic, risk logic, or
+  trading behavior.
+- PR #939 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_restart_smoke_plan.py`, py_compile for touched files,
+  `git diff --check`, and a diff-only silent-handling scan.
+- VPS5 pulled from `8ffb9a73` to `e3c616d4` without bot restart because the
+  deployed change was read-only planner projection tooling. The five
+  configured bots were left running.
+- A VPS5 `live-restart-smoke-plan --summary` run against
+  `/root/bots_vps5.yaml` completed with `ok=true`, five configured bots, six
+  phase names, `execute=false` for both planned commands, zero issues, and
+  bounded smoke/incident-bundle commands carrying `--event-tail-lines 2000`,
+  `--max-event-files-per-bot 2`, `--max-log-files 8`,
+  `--log-tail-lines 1200`, `--max-log-matches 20`, and `--compact`.
+- A bounded 5-minute VPS5 smoke after the pull reported `ok=true`,
+  `hard_failures=0`, clean tracked repository state at `e3c616d4`, five
+  matched expected live processes, no missing/extra/duplicate live processes,
+  no failed account-critical remote calls, `logs.max_files=8`,
+  `logs.tail_lines=1200`, and `logs.max_matches=20`. Remaining attention came
+  from known non-hard EMA readiness and HSL status/cooldown diagnostics.
 - Repository pulled through PR #938 at `8ffb9a73`.
 - PR #938 made the read-only `live-restart-smoke-plan` output include a
   bounded `live-incident-bundle` evidence command for non-clean restart/smoke

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -200,9 +200,11 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   credentials. The plan also includes a bounded `live-incident-bundle` command
   for failure evidence, reusing the same event/log scan limits and disabling
   event-segment copying by default; use `--incident-bundle-output PATH` to
-  choose the planned bundle path. Use planner `--summary` when you only need
-  the bot count, phase names, smoke command, and incident-bundle command without
-  every per-bot phase detail.
+  choose the planned bundle path. The default planned bundle path is a
+  timestamped `/tmp/passivbot_incident_bundle_restart_smoke_<utc>.tar.gz`
+  path to avoid overwriting prior evidence. Use planner `--summary` when you
+  only need the bot count, phase names, smoke command, and incident-bundle
+  command without every per-bot phase detail.
 - `passivbot tool live-performance-report` summarizes local live monitor event timings for
   operator performance analysis. It is read-only and does not contact exchanges. Use
   `--recent-minutes` for a time window, `--summary` for a bounded operator projection, and

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -14,7 +15,12 @@ DEFAULT_SMOKE_MAX_EVENT_FILES_PER_BOT = 2
 DEFAULT_SMOKE_MAX_LOG_FILES = 8
 DEFAULT_SMOKE_LOG_TAIL_LINES = 1200
 DEFAULT_SMOKE_MAX_LOG_MATCHES = 20
-DEFAULT_INCIDENT_BUNDLE_OUTPUT = "/tmp/passivbot_incident_bundle_restart_smoke.tar.gz"
+DEFAULT_INCIDENT_BUNDLE_OUTPUT_DIR = "/tmp"
+DEFAULT_INCIDENT_BUNDLE_OUTPUT_PREFIX = "passivbot_incident_bundle_restart_smoke"
+DEFAULT_INCIDENT_BUNDLE_OUTPUT_HELP = (
+    f"{DEFAULT_INCIDENT_BUNDLE_OUTPUT_DIR}/"
+    f"{DEFAULT_INCIDENT_BUNDLE_OUTPUT_PREFIX}_<utc>.tar.gz"
+)
 DEFAULT_MONITOR_ROOT = "monitor"
 DEFAULT_LOGS_ROOT = "logs"
 UNSAFE_PROCESS_SIGNAL_PATTERNS = (
@@ -36,6 +42,14 @@ def _non_negative_int(value: int, *, field: str) -> int:
     if parsed < 0:
         raise ValueError(f"{field} must be non-negative")
     return parsed
+
+
+def _default_incident_bundle_output() -> str:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
+    return (
+        f"{DEFAULT_INCIDENT_BUNDLE_OUTPUT_DIR}/"
+        f"{DEFAULT_INCIDENT_BUNDLE_OUTPUT_PREFIX}_{stamp}.tar.gz"
+    )
 
 
 def _display_path(value: str | Path | None) -> str | None:
@@ -265,7 +279,7 @@ def build_live_restart_smoke_plan(
     smoke_max_log_files: int = DEFAULT_SMOKE_MAX_LOG_FILES,
     smoke_log_tail_lines: int = DEFAULT_SMOKE_LOG_TAIL_LINES,
     smoke_max_log_matches: int = DEFAULT_SMOKE_MAX_LOG_MATCHES,
-    incident_bundle_output: str | Path = DEFAULT_INCIDENT_BUNDLE_OUTPUT,
+    incident_bundle_output: str | Path | None = None,
     compact_smoke_report: bool = True,
     brief_smoke_report: bool = True,
     summary_smoke_report: bool = False,
@@ -291,6 +305,8 @@ def build_live_restart_smoke_plan(
     smoke_max_log_matches = _non_negative_int(
         smoke_max_log_matches, field="smoke_max_log_matches"
     )
+    if incident_bundle_output is None or not str(incident_bundle_output).strip():
+        incident_bundle_output = _default_incident_bundle_output()
 
     supervisor = parse_tmuxp_live_commands(supervisor_config)
     bots = list(supervisor.get("expected") or [])

--- a/src/tools/live_restart_smoke_plan.py
+++ b/src/tools/live_restart_smoke_plan.py
@@ -10,7 +10,7 @@ if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
 from live.restart_smoke_plan import (  # noqa: E402
-    DEFAULT_INCIDENT_BUNDLE_OUTPUT,
+    DEFAULT_INCIDENT_BUNDLE_OUTPUT_HELP,
     DEFAULT_SMOKE_EVENT_TAIL_LINES,
     DEFAULT_SMOKE_LOG_TAIL_LINES,
     DEFAULT_SMOKE_MAX_LOG_FILES,
@@ -114,9 +114,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--incident-bundle-output",
-        default=DEFAULT_INCIDENT_BUNDLE_OUTPUT,
+        default=None,
         help=(
             "Output path for the planned live-incident-bundle evidence command. "
+            f"Defaults to {DEFAULT_INCIDENT_BUNDLE_OUTPUT_HELP}. "
             "The plan never creates the bundle."
         ),
     )

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 
 import pytest
@@ -13,6 +14,11 @@ from live.restart_smoke_plan import (
 )
 from passivbot_cli import main as cli_main
 from tools import live_restart_smoke_plan
+
+
+INCIDENT_BUNDLE_OUTPUT_PATTERN = (
+    r"/passivbot_incident_bundle_restart_smoke_\d{8}_\d{6}_\d{6}\.tar\.gz$"
+)
 
 
 def _write_supervisor(path, lines):
@@ -66,12 +72,14 @@ def test_live_restart_smoke_plan_builds_plan_from_supervisor_config(tmp_path):
     assert "--brief" in report["smoke_report"]["command"]
     assert "--summary" not in report["smoke_report"]["command"]
     assert report["incident_bundle"]["execute"] is False
-    assert report["incident_bundle"]["output_path"].endswith(
-        "/passivbot_incident_bundle_restart_smoke.tar.gz"
+    assert re.search(
+        INCIDENT_BUNDLE_OUTPUT_PATTERN,
+        report["incident_bundle"]["output_path"],
     )
     incident_command = report["incident_bundle"]["command"]
     assert "passivbot tool live-incident-bundle" in incident_command
-    assert "--output /tmp/passivbot_incident_bundle_restart_smoke.tar.gz" in incident_command
+    assert "--output /tmp/passivbot_incident_bundle_restart_smoke_" in incident_command
+    assert ".tar.gz" in incident_command
     assert "--supervisor-config" in incident_command
     assert "--processes" in incident_command
     assert "--recent-minutes 15" in incident_command
@@ -216,8 +224,9 @@ def test_live_restart_smoke_plan_cli_outputs_json(tmp_path, capsys):
     assert report["inputs"]["smoke_max_log_files"] == 8
     assert report["inputs"]["smoke_log_tail_lines"] == 1200
     assert report["inputs"]["smoke_max_log_matches"] == 20
-    assert report["inputs"]["incident_bundle_output"].endswith(
-        "/passivbot_incident_bundle_restart_smoke.tar.gz"
+    assert re.search(
+        INCIDENT_BUNDLE_OUTPUT_PATTERN,
+        report["inputs"]["incident_bundle_output"],
     )
     assert "--event-tail-lines 2000" in report["smoke_report"]["command"]
     assert "--max-event-files-per-bot 2" in report["smoke_report"]["command"]


### PR DESCRIPTION
Scope:
- Change live-restart-smoke-plan's default planned incident-bundle output from a fixed /tmp path to a UTC timestamped /tmp/passivbot_incident_bundle_restart_smoke_<utc>.tar.gz path.
- Keep --incident-bundle-output as the explicit override; empty/omitted values use the timestamped default.
- Update CLI help/tests/docs and fold PR #939 deployment/smoke evidence into the progress ledger.

Behavior boundary:
- Read-only planner output behavior only.
- Does not execute bundles, create files, alter full restart plan semantics beyond the default planned output path, signal processes, invoke tmux, SSH, git, start bots, contact exchanges, load credentials, add event producers, mutate caches, change readiness gates, route console output, order logic, risk logic, or trading behavior.

Validation:
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_restart_smoke_plan.py -q
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/restart_smoke_plan.py src/tools/live_restart_smoke_plan.py tests/test_live_restart_smoke_plan.py
- git diff --check
- diff-only silent-handling scan for touched Python/test files: clean