### PR TITLE
Filter live performance report sections

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `462afac7` after PR #941, `Summarize fill refresh health in smoke reports`.
+- `a85427bf` after PR #942, `Report fill refresh performance`.
 
 Current review gate:
 
@@ -49,6 +49,27 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #942 at `a85427bf`.
+- PR #942 added a `fill_refresh` section to `live-performance-report`, derived
+  only from existing `fills.refresh_summary` events. It also includes
+  `fills_refresh.elapsed` in the report's performance and operation-duration
+  tables with `blocks_or_delays_hsl_readiness` impact classification. The slice
+  did not change event producers, exchange calls, cache mutation, readiness
+  gates, console routing, order logic, risk logic, or trading behavior.
+- PR #942 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_performance_report.py`, py_compile for touched files,
+  `git diff --check`, and an added-line silent-handling scan.
+- VPS5 pulled from `462afac7` to `a85427bf` without bot restart because the
+  deployed change was read-only performance-report tooling. The five configured
+  bots were left running.
+- A 2-minute smoke after deploy reported `ok=true`, `hard_failures=0`, clean
+  tracked repository state at `a85427bf`, all five configured bots matched, no
+  failed account-critical remote calls, and the new brief `fill_refresh`
+  projection populated with seven succeeded and zero failed refreshes. A focused
+  10-minute performance report then reported `ok=true`,
+  `fill_refresh.total_events=38`, `failed_groups=0`,
+  `latest_failed_groups=0`, and
+  `operation_durations.operation_category_counts.fill_refresh=4`.
 - Repository pulled through PR #941 at `462afac7`.
 - PR #941 added bounded `fill_refresh_health` projections to
   `live-smoke-report` full/summary output and concise `fill_refresh` counters

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -213,7 +213,10 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   operator performance analysis. It is read-only and does not contact exchanges. Use
   `--recent-minutes` for a time window, `--summary` for a bounded operator projection, and
   `--bot EXCHANGE/USER`, `--exchange EXCHANGE`, or `--user USER` to focus one account or
-  exchange. The report includes decision-boundary lag groups showing how far after the
+  exchange. Use `--section SECTION` one or more times to emit selected top-level report
+  sections plus common metadata, for example `--summary --section fill_refresh`; use
+  `--section all` for the default full output. The report includes
+  decision-boundary lag groups showing how far after the
   whole-minute boundary cycles reached start, Rust planning, action planning, writes,
   confirmations, and completion. It also includes an input-staleness section derived from
   existing packet, snapshot, EMA, and Rust-call events, covering account packet age at

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -24,6 +24,23 @@ from live.smoke_report import _user_safe_display_path
 
 GROUP_LIMIT = 80
 SUMMARY_GROUP_LIMIT = 12
+_PERFORMANCE_REPORT_SECTION_BASE_KEYS = (
+    "ok",
+    "root",
+    "include_rotated",
+    "files_scanned",
+    "file_discovery",
+    "records_total",
+    "live_events",
+    "legacy_events",
+    "error_count",
+    "warning_count",
+    "bots",
+    "event_window",
+    "filters",
+    "issues",
+)
+_PERFORMANCE_REPORT_SECTION_EXCLUDED_KEYS = {"files"}
 
 _NON_BLOCKING_IMPACTS = {"diagnostics_only", "observability"}
 _BLOCKING_SCOPE_BY_IMPACT = {
@@ -4075,3 +4092,44 @@ def summarize_live_performance_report(
     if report.get("issues"):
         summary["issues"] = report.get("issues")
     return summary
+
+
+def available_live_performance_report_sections(report: dict[str, Any]) -> list[str]:
+    return sorted(
+        key
+        for key in report
+        if key not in _PERFORMANCE_REPORT_SECTION_BASE_KEYS
+        and key not in _PERFORMANCE_REPORT_SECTION_EXCLUDED_KEYS
+    )
+
+
+def project_live_performance_report_sections(
+    report: dict[str, Any],
+    sections: list[str] | tuple[str, ...] | set[str],
+) -> dict[str, Any]:
+    requested = []
+    for section in sections:
+        normalized = str(section).strip()
+        if normalized and normalized not in requested:
+            requested.append(normalized)
+    if not requested or "all" in requested:
+        return report
+
+    available = available_live_performance_report_sections(report)
+    available_set = set(available)
+    unknown = [section for section in requested if section not in available_set]
+    if unknown:
+        raise ValueError(
+            "unknown --section value(s): "
+            + ", ".join(unknown)
+            + "; available sections: "
+            + ", ".join(available)
+            + "; use all for the full report"
+        )
+
+    projected = {
+        key: report[key] for key in _PERFORMANCE_REPORT_SECTION_BASE_KEYS if key in report
+    }
+    for section in requested:
+        projected[section] = report[section]
+    return projected

--- a/src/tools/live_performance_report.py
+++ b/src/tools/live_performance_report.py
@@ -12,6 +12,7 @@ if str(SRC_ROOT) not in sys.path:
 
 from live.performance_report import (  # noqa: E402
     build_live_performance_report,
+    project_live_performance_report_sections,
     summarize_live_performance_report,
 )
 
@@ -116,6 +117,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit a bounded operator summary instead of the full report.",
     )
     parser.add_argument(
+        "--section",
+        action="append",
+        default=[],
+        help=(
+            "Only emit one top-level report section plus common report metadata. "
+            "May be repeated; use all for the default full output."
+        ),
+    )
+    parser.add_argument(
         "--compact",
         action="store_true",
         help="Emit compact single-line JSON.",
@@ -160,6 +170,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     if args.summary:
         report = summarize_live_performance_report(report, group_limit=int(args.group_limit))
+    try:
+        report = project_live_performance_report_sections(report, args.section)
+    except ValueError as exc:
+        parser.error(str(exc))
     print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
     return 0 if report.get("ok") else 1
 

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -6,8 +6,13 @@ import os
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 import live.performance_report as performance_report_module
-from live.performance_report import build_live_performance_report, summarize_live_performance_report
+from live.performance_report import (
+    build_live_performance_report,
+    project_live_performance_report_sections,
+    summarize_live_performance_report,
+)
 from tools import live_performance_report
 
 
@@ -3103,6 +3108,108 @@ def test_live_performance_report_cli_summary_and_filters(tmp_path, capsys):
     assert out["filters"]["events_skipped"] == 1
     assert len(out["performance"]["groups"]) == 1
     assert "files" not in out
+
+
+def test_live_performance_report_section_projection_keeps_common_metadata(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                data={"elapsed_ms": 1000},
+            ),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=2,
+                ts=2000,
+                component="fills.refresh",
+                status="succeeded",
+                reason_code="fill_cache_ready",
+                data={
+                    "source": "cache",
+                    "refresh_mode": "startup",
+                    "elapsed_ms": 40,
+                    "history_scope": "all",
+                    "event_count_after": 100,
+                    "coverage_ready_after": True,
+                },
+            ),
+        ],
+    )
+
+    report = summarize_live_performance_report(
+        build_live_performance_report(tmp_path / "monitor"),
+        group_limit=1,
+    )
+
+    projected = project_live_performance_report_sections(report, ["fill_refresh"])
+
+    assert projected["ok"] is True
+    assert projected["records_total"] == 2
+    assert projected["live_events"] == 2
+    assert "fill_refresh" in projected
+    assert projected["fill_refresh"]["total_events"] == 1
+    assert "performance" not in projected
+    assert "operation_durations" not in projected
+    assert "files" not in projected
+
+
+def test_live_performance_report_cli_section_filter(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                data={"elapsed_ms": 1000},
+            ),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=2,
+                ts=2000,
+                component="fills.refresh",
+                status="succeeded",
+                reason_code="fill_cache_ready",
+                data={
+                    "source": "cache",
+                    "refresh_mode": "startup",
+                    "elapsed_ms": 40,
+                    "history_scope": "all",
+                    "event_count_after": 100,
+                    "coverage_ready_after": True,
+                },
+            ),
+        ],
+    )
+
+    rc = live_performance_report.main(
+        [
+            str(tmp_path / "monitor"),
+            "--summary",
+            "--section",
+            "fill_refresh",
+            "--compact",
+        ]
+    )
+
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
+    assert out["fill_refresh"]["total_events"] == 1
+    assert "performance" not in out
+    assert "operation_durations" not in out
+
+
+def test_live_performance_report_cli_rejects_unknown_section(capsys):
+    with pytest.raises(SystemExit):
+        live_performance_report.main(["monitor", "--section", "not_a_section"])
+
+    assert "unknown --section value" in capsys.readouterr().err
 
 
 def test_live_performance_report_event_tail_lines_bounds_monitor_scan(tmp_path):


### PR DESCRIPTION
## Summary
- add live-performance-report --section for selected top-level sections plus common metadata
- reject unknown section names instead of emitting misleading partial reports
- document the option and update the logging-overhaul progress ledger with PR #942 deployment evidence

## Behavior
- read-only operator/report tooling only
- no event producers, exchange calls, cache mutation, readiness gates, order logic, risk logic, or trading behavior changed

## Validation
- PYTHONPATH=/private/tmp/passivbot-v8-live-performance-section-filter/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py -q
- PYTHONPATH=/private/tmp/passivbot-v8-live-performance-section-filter/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py tests/test_live_performance_report.py
- git diff --check
- added-line silent-handling scan clean