### PR TITLE
Filter live smoke report sections

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `a85427bf` after PR #942, `Report fill refresh performance`.
+- `2dab5af0` after PR #943, `Filter live performance report sections`.
 
 Current review gate:
 
@@ -49,6 +49,25 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #943 at `2dab5af0`.
+- PR #943 added `live-performance-report --section`, allowing focused
+  top-level report sections plus common metadata after the full or summary
+  projection. The slice was read-only operator/report tooling and did not
+  change event producers, exchange calls, cache mutation, readiness gates,
+  console routing, order logic, risk logic, or trading behavior.
+- PR #943 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_performance_report.py`, py_compile for touched files,
+  `git diff --check`, and an added-line silent-handling scan.
+- VPS5 pulled from `a85427bf` to `2dab5af0` without bot restart because the
+  deployed change was read-only report tooling. The five configured bots were
+  left running.
+- A 2-minute smoke after deploy reported `ok=true`, `hard_failures=0`, clean
+  tracked repository state at `2dab5af0`, all five configured bots matched, no
+  failed account-critical remote calls, and `fill_refresh` populated with eight
+  succeeded and zero failed refreshes. A focused 10-minute performance report
+  using `--summary --section fill_refresh` then returned only common metadata
+  plus `fill_refresh`, with `fill_refresh.total_events=38`,
+  `failed_groups=0`, and `latest_failed_groups=0`.
 - Repository pulled through PR #942 at `a85427bf`.
 - PR #942 added a `fill_refresh` section to `live-performance-report`, derived
   only from existing `fills.refresh_summary` events. It also includes

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -157,7 +157,10 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   from each event file; the default `0` keeps full event validation.
 - `passivbot tool live-smoke-report` summarizes local live monitor events and text logs for
   operator smoke-test evidence. Use `--summary` for bounded event groups and log matches, or
-  `--brief` for top-level counters suitable for repeated VPS smoke loops.
+  `--brief` for top-level counters suitable for repeated VPS smoke loops. Use
+  `--section SECTION` one or more times to emit selected top-level smoke-report
+  sections plus common smoke metadata after the full/summary/brief projection is
+  selected, for example `--brief --section fill_refresh`.
   Full, summary, and brief output include text-log scan bounds and bounded
   text-log window counters so time-windowed smoke evidence shows the configured
   file/tail/match limits plus how many log lines were considered, skipped

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -60,6 +60,19 @@ REMOTE_CALL_HEALTH_VALUE_LIMIT = 8
 FILL_REFRESH_HEALTH_GROUP_LIMIT = 20
 FILL_REFRESH_HEALTH_VALUE_LIMIT = 8
 SMOKE_REPORT_SUMMARY_GROUP_LIMIT = 8
+_SMOKE_REPORT_SECTION_BASE_KEYS = (
+    "ok",
+    "attention",
+    "hard_failures",
+    "attention_count",
+    "hard_failure_sources",
+    "attention_sources",
+    "repository",
+    "monitor",
+    "event_window",
+    "problem_event_count",
+    "hard_problem_event_count",
+)
 SMOKE_REPORT_BRIEF_PROBLEM_GROUP_LIMIT = 5
 ACCOUNT_CRITICAL_REMOTE_CALL_KIND = "authoritative_state_fetch"
 ACCOUNT_CRITICAL_REMOTE_CALL_SURFACES = frozenset(
@@ -5470,3 +5483,37 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             "event_types": shutdown_events.get("event_types") or {},
         },
     }
+
+
+def available_live_smoke_report_sections(report: dict[str, Any]) -> list[str]:
+    return sorted(key for key in report if key not in _SMOKE_REPORT_SECTION_BASE_KEYS)
+
+
+def project_live_smoke_report_sections(
+    report: dict[str, Any],
+    sections: list[str] | tuple[str, ...] | set[str],
+) -> dict[str, Any]:
+    requested = []
+    for section in sections:
+        normalized = str(section).strip()
+        if normalized and normalized not in requested:
+            requested.append(normalized)
+    if not requested or "all" in requested:
+        return report
+
+    available = available_live_smoke_report_sections(report)
+    available_set = set(available)
+    unknown = [section for section in requested if section not in available_set]
+    if unknown:
+        raise ValueError(
+            "unknown --section value(s): "
+            + ", ".join(unknown)
+            + "; available sections: "
+            + ", ".join(available)
+            + "; use all for the full report"
+        )
+
+    projected = {key: report[key] for key in _SMOKE_REPORT_SECTION_BASE_KEYS if key in report}
+    for section in requested:
+        projected[section] = report[section]
+    return projected

--- a/src/tools/live_smoke_report.py
+++ b/src/tools/live_smoke_report.py
@@ -15,6 +15,7 @@ from live.smoke_report import (  # noqa: E402
     LOG_WINDOW_UNPARSED_POLICIES,
     build_live_smoke_report,
     default_logs_root_for_monitor,
+    project_live_smoke_report_sections,
     summarize_live_smoke_report,
     summarize_live_smoke_report_brief,
 )
@@ -170,6 +171,15 @@ def build_parser() -> argparse.ArgumentParser:
             "matches. Implies --summary."
         ),
     )
+    parser.add_argument(
+        "--section",
+        action="append",
+        default=[],
+        help=(
+            "Only emit one top-level smoke-report section plus common smoke "
+            "metadata. May be repeated; use all for the default selected output."
+        ),
+    )
     return parser
 
 
@@ -219,6 +229,10 @@ def main(argv: list[str] | None = None) -> int:
         output = summarize_live_smoke_report(report)
     else:
         output = report
+    try:
+        output = project_live_smoke_report_sections(output, args.section)
+    except ValueError as exc:
+        parser.error(str(exc))
     print(json.dumps(output, indent=None if args.compact else 2, sort_keys=True))
     return 0 if report.get("ok") else 1
 

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -10,6 +10,7 @@ import live.smoke_report as smoke_report_module
 from live.smoke_report import (
     build_live_smoke_report,
     default_logs_root_for_monitor,
+    project_live_smoke_report_sections,
     summarize_live_smoke_report,
     summarize_live_smoke_report_brief,
 )
@@ -3945,6 +3946,94 @@ def test_live_smoke_report_cli_can_emit_brief_summary(tmp_path, capsys):
     assert "matches" not in summary["logs"]
     assert "groups" not in summary["remote_calls"]
     assert "groups" not in summary["account_critical_remote_calls"]
+
+
+def test_live_smoke_report_section_projection_keeps_common_metadata(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=1,
+                ts=1000,
+                status="succeeded",
+                reason_code="fills_refresh_succeeded",
+                data={
+                    "source": "cache",
+                    "refresh_mode": "startup",
+                    "history_scope": "all",
+                    "coverage_ready_after": True,
+                    "elapsed_ms": 25,
+                },
+            )
+        ],
+    )
+    report = summarize_live_smoke_report_brief(
+        build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    )
+
+    projected = project_live_smoke_report_sections(report, ["fill_refresh"])
+
+    assert projected["ok"] is True
+    assert projected["attention"] is False
+    assert projected["monitor"]["live_events"] == 1
+    assert projected["fill_refresh"]["total"] == 1
+    assert "logs" not in projected
+    assert "remote_calls" not in projected
+    assert "processes" not in projected
+
+
+def test_live_smoke_report_cli_brief_section_filter(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=1,
+                ts=1000,
+                status="succeeded",
+                reason_code="fills_refresh_succeeded",
+                data={
+                    "source": "cache",
+                    "refresh_mode": "startup",
+                    "history_scope": "all",
+                    "coverage_ready_after": True,
+                    "elapsed_ms": 25,
+                },
+            )
+        ],
+    )
+
+    assert (
+        live_smoke_report.main(
+            [
+                str(tmp_path / "monitor"),
+                "--logs-root",
+                "",
+                "--brief",
+                "--section",
+                "fill_refresh",
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["ok"] is True
+    assert summary["fill_refresh"]["total"] == 1
+    assert "logs" not in summary
+    assert "remote_calls" not in summary
+    assert "processes" not in summary
+
+
+def test_live_smoke_report_cli_rejects_unknown_section(capsys):
+    with pytest.raises(SystemExit):
+        live_smoke_report.main(["monitor", "--brief", "--section", "not_a_section"])
+
+    assert "unknown --section value" in capsys.readouterr().err
 
 
 def test_live_smoke_report_cli_brief_projects_event_tail_metadata(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- add live-smoke-report --section for selected top-level smoke-report sections plus common smoke metadata
- apply section projection after full/summary/brief output selection so valid section names match the requested projection
- document the option and record PR #943 deploy evidence in the logging-overhaul progress ledger

## Behavior
- read-only operator/report tooling only
- no event producers, exchange calls, cache mutation, readiness gates, smoke verdict policy, console routing, order logic, risk logic, or trading behavior changed

## Validation
- PYTHONPATH=/private/tmp/passivbot-v8-live-smoke-section-filter/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- PYTHONPATH=/private/tmp/passivbot-v8-live-smoke-section-filter/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/smoke_report.py src/tools/live_smoke_report.py tests/test_live_smoke_report.py
- git diff --check
- added-line silent-handling scan clean