### PR TITLE
Plan focused restart smoke sections

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `2dab5af0` after PR #943, `Filter live performance report sections`.
+- `42999f19` after PR #944, `Filter live smoke report sections`.
 
 Current review gate:
 
@@ -49,6 +49,25 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #944 at `42999f19`.
+- PR #944 added `live-smoke-report --section`, allowing focused top-level
+  smoke-report sections plus common smoke metadata after the full, summary, or
+  brief projection is selected. The slice was read-only operator/report tooling
+  and did not change event producers, exchange calls, cache mutation, readiness
+  gates, smoke verdict policy, console routing, order logic, risk logic, or
+  trading behavior.
+- PR #944 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_smoke_report.py`, py_compile for touched files,
+  `git diff --check`, and an added-line silent-handling scan.
+- VPS5 pulled from `2dab5af0` to `42999f19` without bot restart because the
+  deployed change was read-only report tooling. The five configured bots were
+  left running.
+- A 2-minute smoke after deploy reported `ok=true`, `hard_failures=0`, clean
+  tracked repository state at `42999f19`, all five configured bots matched, no
+  failed account-critical remote calls, and `fill_refresh` populated with nine
+  succeeded and zero failed refreshes. A focused smoke report using
+  `--brief --section fill_refresh` then returned only common smoke metadata plus
+  `fill_refresh`, with `fill_refresh.total=9` and `failed=0`.
 - Repository pulled through PR #943 at `2dab5af0`.
 - PR #943 added `live-performance-report --section`, allowing focused
   top-level report sections plus common metadata after the full or summary

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -202,7 +202,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   `--max-log-files 0`, `--log-tail-lines 0`, or `--max-log-matches 0` in the
   planner to omit those explicit bounds from the generated smoke command. Use
   `--summary-smoke-report` for bounded groups or `--full-smoke-report` for the
-  full smoke report. The planner does not execute the restart, send signals,
+  full smoke report. Use `--smoke-section SECTION` one or more times to add
+  focused `live-smoke-report --section` values to the planned smoke command.
+  The planner does not execute the restart, send signals,
   invoke tmux, run SSH, pull git, start bots, contact exchanges, or load
   credentials. The plan also includes a bounded `live-incident-bundle` command
   for failure evidence, reusing the same event/log scan limits and disabling

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -78,6 +78,7 @@ def _smoke_report_command(
     compact: bool,
     brief: bool,
     summary: bool,
+    sections: list[str] | tuple[str, ...] | None = None,
 ) -> str:
     args = [
         "passivbot",
@@ -106,6 +107,10 @@ def _smoke_report_command(
         args.append("--summary")
     elif brief:
         args.append("--brief")
+    for section in sections or ():
+        normalized = str(section).strip()
+        if normalized:
+            args.extend(["--section", normalized])
     if compact:
         args.append("--compact")
     return _shell_join(args)
@@ -283,6 +288,7 @@ def build_live_restart_smoke_plan(
     compact_smoke_report: bool = True,
     brief_smoke_report: bool = True,
     summary_smoke_report: bool = False,
+    smoke_sections: list[str] | tuple[str, ...] | None = None,
     execute: bool = False,
 ) -> dict[str, Any]:
     if execute:
@@ -307,6 +313,11 @@ def build_live_restart_smoke_plan(
     )
     if incident_bundle_output is None or not str(incident_bundle_output).strip():
         incident_bundle_output = _default_incident_bundle_output()
+    smoke_sections = [
+        str(section).strip()
+        for section in (smoke_sections or ())
+        if str(section).strip()
+    ]
 
     supervisor = parse_tmuxp_live_commands(supervisor_config)
     bots = list(supervisor.get("expected") or [])
@@ -360,6 +371,7 @@ def build_live_restart_smoke_plan(
         compact=compact_smoke_report,
         brief=brief_smoke_report,
         summary=summary_smoke_report,
+        sections=smoke_sections,
     )
     incident_bundle_command = _incident_bundle_command(
         monitor_root=monitor_root,
@@ -411,6 +423,7 @@ def build_live_restart_smoke_plan(
             "smoke_max_log_files": smoke_max_log_files,
             "smoke_log_tail_lines": smoke_log_tail_lines,
             "smoke_max_log_matches": smoke_max_log_matches,
+            "smoke_sections": list(smoke_sections),
             "incident_bundle_output": _display_path(incident_bundle_output),
         },
         "supervisor_config": {

--- a/src/tools/live_restart_smoke_plan.py
+++ b/src/tools/live_restart_smoke_plan.py
@@ -138,6 +138,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Plan a full live-smoke-report command instead of --brief.",
     )
     parser.add_argument(
+        "--smoke-section",
+        action="append",
+        default=[],
+        help=(
+            "Add one --section value to the planned live-smoke-report command. "
+            "May be repeated; validation happens when live-smoke-report runs."
+        ),
+    )
+    parser.add_argument(
         "--pretty-smoke-report",
         action="store_true",
         help="Plan a pretty-printed live-smoke-report command instead of --compact.",
@@ -187,6 +196,7 @@ def main(argv: list[str] | None = None) -> int:
                 bool(args.full_smoke_report) or bool(args.summary_smoke_report)
             ),
             summary_smoke_report=bool(args.summary_smoke_report),
+            smoke_sections=args.smoke_section,
             execute=False,
         )
     except (NotImplementedError, ValueError) as exc:

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -112,6 +112,30 @@ def test_live_restart_smoke_plan_builds_plan_from_supervisor_config(tmp_path):
     assert "does_not_start_passivbot_live" in report["warnings"]
 
 
+def test_live_restart_smoke_plan_can_focus_smoke_sections(tmp_path):
+    supervisor_config = tmp_path / "bots_vps5.yaml"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u binance_01",
+        ],
+    )
+
+    report = build_live_restart_smoke_plan(
+        supervisor_config,
+        smoke_sections=["fill_refresh", "risk_events"],
+    )
+
+    assert report["inputs"]["smoke_sections"] == ["fill_refresh", "risk_events"]
+    assert "--section fill_refresh" in report["smoke_report"]["command"]
+    assert "--section risk_events" in report["smoke_report"]["command"]
+    assert report["smoke_report"]["execute"] is False
+
+
 def test_live_restart_smoke_plan_redacts_and_bounds_configured_commands(tmp_path):
     supervisor_config = tmp_path / "bots.yaml"
     long_secret = "S" * 600
@@ -451,6 +475,40 @@ def test_live_restart_smoke_plan_can_plan_summary_or_full_smoke_projection(
     full_report = json.loads(capsys.readouterr().out)
     assert "--summary" not in full_report["smoke_report"]["command"]
     assert "--brief" not in full_report["smoke_report"]["command"]
+
+
+def test_live_restart_smoke_plan_cli_can_plan_smoke_sections(tmp_path, capsys):
+    supervisor_config = tmp_path / "bots.yaml"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u binance_01",
+        ],
+    )
+
+    assert (
+        live_restart_smoke_plan.main(
+            [
+                str(supervisor_config),
+                "--smoke-section",
+                "fill_refresh",
+                "--smoke-section",
+                "hsl_replay",
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["inputs"]["smoke_sections"] == ["fill_refresh", "hsl_replay"]
+    assert "--section fill_refresh" in report["smoke_report"]["command"]
+    assert "--section hsl_replay" in report["smoke_report"]["command"]
+    assert "--brief" in report["smoke_report"]["command"]
 
 
 def test_live_restart_smoke_plan_cli_rejects_execute(capsys):


### PR DESCRIPTION
## Summary
- add live-restart-smoke-plan --smoke-section for planned live-smoke-report --section values
- record selected smoke sections in restart plan inputs and planned smoke commands
- document the planner option and fold in PR #944 VPS5 deploy evidence

## Behavior
- read-only dry-run planner tooling only
- no restart execution, process signaling, tmux, SSH, git pull, exchange calls, event producers, smoke verdict policy, order logic, risk logic, or trading behavior changed

## Validation
- PYTHONPATH=/private/tmp/passivbot-v8-restart-plan-smoke-section/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_restart_smoke_plan.py -q
- PYTHONPATH=/private/tmp/passivbot-v8-restart-plan-smoke-section/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/restart_smoke_plan.py src/tools/live_restart_smoke_plan.py tests/test_live_restart_smoke_plan.py
- git diff --check
- added-line silent-handling scan clean