### PR TITLE
Focus incident bundle smoke reports

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `42999f19` after PR #944, `Filter live smoke report sections`.
+- `1a7c83ee` after PR #945, `Plan focused restart smoke sections`.
 
 Current review gate:
 
@@ -49,6 +49,31 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #945 at `1a7c83ee`.
+- PR #945 added `live-restart-smoke-plan --smoke-section`, allowing the
+  plan-only restart smoke command to include focused `live-smoke-report
+  --section` values while recording the selected sections in plan inputs. The
+  slice was read-only dry-run planner tooling and did not add restart
+  execution, process signaling, tmux calls, SSH/git operations, exchange calls,
+  event producers, smoke verdict changes, console routing, order logic, risk
+  logic, or trading behavior.
+- PR #945 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_restart_smoke_plan.py`, py_compile for touched files,
+  `git diff --check`, and an added-line silent-handling scan.
+- VPS5 pulled from `42999f19` to `1a7c83ee` without bot restart because the
+  deployed change was read-only planner tooling. The five configured bots were
+  left running.
+- A VPS5 `live-restart-smoke-plan /root/bots_vps5.yaml --smoke-section
+  fill_refresh --summary --compact` run reported `ok=true`, five configured
+  bots, six planned phases, `execute=false`, zero issues, and a planned smoke
+  command containing `--brief --section fill_refresh --compact`.
+- The first post-deploy 2-minute smoke surfaced one real transient GateIO
+  `cycle.degraded` hard event from `RequestTimeout` in cycle `cy_2130`,
+  involving one `authoritative_balance` timeout and one candle `fetch_ohlcv`
+  timeout for `POL/USDT:USDT`. A settled 1-minute smoke then reported
+  `ok=true`, `hard_failures=0`, clean tracked repository state at `1a7c83ee`,
+  all five configured bots matched, no failed remote calls, and no failed
+  account-critical remote calls.
 - Repository pulled through PR #944 at `42999f19`.
 - PR #944 added `live-smoke-report --section`, allowing focused top-level
   smoke-report sections plus common smoke metadata after the full, summary, or

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -193,6 +193,13 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   escalation ladder as policy only: graceful Ctrl+C/request stop, bounded wait, a second
   graceful signal when warranted, SIGTERM, then SIGKILL. The smoke report never sends those
   signals.
+- `passivbot tool live-incident-bundle` writes a local `.tar.gz` evidence
+  bundle with monitor event reports, problem-event reports, smoke evidence,
+  redacted log excerpts, monitor snapshots, runtime metadata, and optional
+  bounded event segments. It is read-only and does not contact exchanges. Use
+  `--smoke-section SECTION` one or more times to keep only selected top-level
+  sections from the embedded full `smoke_report.json` plus common smoke
+  metadata, for example `--smoke-section fill_refresh_health`.
 - `passivbot tool live-restart-smoke-plan` emits a read-only dry-run restart
   plan from a tmuxp-style supervisor config. The planned smoke command defaults
   to a brief compact smoke command with `--event-tail-lines 2000` and

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -976,7 +976,10 @@ def build_live_incident_bundle(
         max_log_matches=max_log_matches,
         log_window_unparsed_policy=log_window_unparsed_policy,
     )
-    smoke_report = project_live_smoke_report_sections(smoke_report, smoke_sections)
+    embedded_smoke_report = project_live_smoke_report_sections(
+        smoke_report,
+        smoke_sections,
+    )
 
     with tempfile.TemporaryDirectory(prefix="passivbot_incident_bundle_") as tmp_name:
         bundle_root = Path(tmp_name)
@@ -1058,7 +1061,7 @@ def build_live_incident_bundle(
         if include_problem_report:
             _write_json(bundle_root / "problem_event_report.json", problem_report)
         _write_json(bundle_root / "time_window_report.json", window_report)
-        _write_json(bundle_root / "smoke_report.json", smoke_report)
+        _write_json(bundle_root / "smoke_report.json", embedded_smoke_report)
         timeline_lines: list[str] = []
         for section in ("cycle", "query"):
             value = event_report.get(section)

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -30,6 +30,7 @@ from live.smoke_report import (
     _redact_log_text,
     build_live_smoke_report,
     default_logs_root_for_monitor,
+    project_live_smoke_report_sections,
 )
 
 
@@ -840,6 +841,7 @@ def build_live_incident_bundle(
     log_tail_lines: int = 500,
     max_log_matches: int = 100,
     log_window_unparsed_policy: str = DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
+    smoke_sections: list[str] | tuple[str, ...] | None = None,
     event_tail_lines: int = 0,
     max_event_files_per_bot: int = 0,
     max_snapshot_files: int = 20,
@@ -857,6 +859,11 @@ def build_live_incident_bundle(
         if output_path is not None
         else Path(f"passivbot_incident_bundle_{_utc_stamp()}.tar.gz")
     )
+    smoke_sections = [
+        str(section).strip()
+        for section in (smoke_sections or ())
+        if str(section).strip()
+    ]
 
     event_report = build_event_report(
         monitor_path,
@@ -969,6 +976,7 @@ def build_live_incident_bundle(
         max_log_matches=max_log_matches,
         log_window_unparsed_policy=log_window_unparsed_policy,
     )
+    smoke_report = project_live_smoke_report_sections(smoke_report, smoke_sections)
 
     with tempfile.TemporaryDirectory(prefix="passivbot_incident_bundle_") as tmp_name:
         bundle_root = Path(tmp_name)
@@ -1026,6 +1034,7 @@ def build_live_incident_bundle(
                     "log_tail_lines": log_tail_lines if log_tail_lines else None,
                     "max_log_matches": max_log_matches if max_log_matches else None,
                     "log_window_unparsed_policy": log_window_unparsed_policy,
+                    "smoke_sections": list(smoke_sections),
                     "include_rotated": include_rotated,
                     "include_data": include_data,
                     "include_trace_report": include_trace_report,

--- a/src/tools/live_incident_bundle.py
+++ b/src/tools/live_incident_bundle.py
@@ -284,6 +284,16 @@ def build_parser() -> argparse.ArgumentParser:
             "lines without in-window timestamp context."
         ),
     )
+    parser.add_argument(
+        "--smoke-section",
+        action="append",
+        default=[],
+        help=(
+            "Only keep one top-level section from the embedded full "
+            "smoke_report.json plus common smoke metadata. May be repeated; "
+            "section names are validated by live-smoke-report."
+        ),
+    )
     parser.add_argument("--compact", action="store_true", help="Emit compact single-line JSON.")
     return parser
 
@@ -345,6 +355,7 @@ def main(argv: list[str] | None = None) -> int:
             log_tail_lines=int(args.log_tail_lines),
             max_log_matches=int(args.max_log_matches),
             log_window_unparsed_policy=str(args.log_window_unparsed_policy),
+            smoke_sections=args.smoke_section,
             max_snapshot_files=int(args.max_snapshot_files),
             max_snapshot_file_bytes=int(args.max_snapshot_file_bytes),
             max_event_segment_bytes=int(args.max_event_segment_bytes),

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -693,13 +693,19 @@ def test_live_incident_bundle_cli_can_focus_embedded_smoke_report(tmp_path, caps
         ],
     )
     output = tmp_path / "incident.tar.gz"
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "bot.log").write_text(
+        "1970-01-01T00:00:01Z ERROR kept in compact summary\n",
+        encoding="utf-8",
+    )
 
     assert (
         live_incident_bundle.main(
             [
                 str(tmp_path / "monitor"),
                 "--logs-root",
-                "",
+                str(logs_dir),
                 "--no-event-segments",
                 "--no-trace-report",
                 "--no-problem-report",
@@ -715,6 +721,8 @@ def test_live_incident_bundle_cli_can_focus_embedded_smoke_report(tmp_path, caps
 
     report = json.loads(capsys.readouterr().out)
     assert report["ok"] is True
+    assert report["smoke_report"]["logs"]["files_scanned"] == 1
+    assert report["smoke_report"]["logs"]["attention_matches"] == 1
     with tarfile.open(output, "r:gz") as tar:
         smoke_report = _read_tar_json(tar, "smoke_report.json")
         manifest = _read_tar_json(tar, "manifest.json")

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -670,6 +670,61 @@ def test_live_incident_bundle_can_skip_logs_and_segments_from_cli(tmp_path, caps
     assert smoke_report["logs"]["hard_matches"] == 0
 
 
+def test_live_incident_bundle_cli_can_focus_embedded_smoke_report(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=1,
+                ts=1000,
+                status="succeeded",
+                reason_code="fills_refresh_succeeded",
+                component="fills.refresh",
+                data={
+                    "source": "cache",
+                    "refresh_mode": "startup",
+                    "history_scope": "all",
+                    "coverage_ready_after": True,
+                    "elapsed_ms": 30,
+                },
+            )
+        ],
+    )
+    output = tmp_path / "incident.tar.gz"
+
+    assert (
+        live_incident_bundle.main(
+            [
+                str(tmp_path / "monitor"),
+                "--logs-root",
+                "",
+                "--no-event-segments",
+                "--no-trace-report",
+                "--no-problem-report",
+                "--smoke-section",
+                "fill_refresh_health",
+                "--output",
+                str(output),
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["ok"] is True
+    with tarfile.open(output, "r:gz") as tar:
+        smoke_report = _read_tar_json(tar, "smoke_report.json")
+        manifest = _read_tar_json(tar, "manifest.json")
+    assert smoke_report["ok"] is True
+    assert smoke_report["fill_refresh_health"]["total"] == 1
+    assert "logs" not in smoke_report
+    assert "remote_call_health" not in smoke_report
+    assert manifest["filters"]["smoke_sections"] == ["fill_refresh_health"]
+
+
 def test_live_incident_bundle_cli_rejects_malformed_data_eq_filter(tmp_path, capsys):
     with pytest.raises(SystemExit) as exc_info:
         live_incident_bundle.main(


### PR DESCRIPTION
## Summary
- add live-incident-bundle --smoke-section for focused embedded full smoke_report.json output
- record selected smoke sections in the bundle manifest filters
- document the option and fold in PR #945 VPS5 deploy evidence

## Behavior
- read-only incident-bundle/report tooling only
- no exchange calls, event producers, smoke verdict policy, live execution, cache mutation, readiness gates, order logic, risk logic, or trading behavior changed

## Validation
- PYTHONPATH=/private/tmp/passivbot-v8-incident-bundle-smoke-section/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_incident_bundle.py -q
- PYTHONPATH=/private/tmp/passivbot-v8-incident-bundle-smoke-section/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/incident_bundle.py src/tools/live_incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check
- added-line silent-handling scan clean