### PR TITLE
Focus restart incident bundle smoke sections

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `1a7c83ee` after PR #945, `Plan focused restart smoke sections`.
+- `fddd5491` after PR #946, `Focus incident bundle smoke reports`.
 
 Current review gate:
 
@@ -49,6 +49,34 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #946 at `fddd5491`.
+- PR #946 added `live-incident-bundle --smoke-section`, allowing the embedded
+  full `smoke_report.json` inside an incident bundle to keep selected
+  top-level smoke-report sections plus common metadata while preserving the
+  compact incident-bundle summary from the unfiltered smoke report. The slice
+  was read-only incident-response tooling and did not change event producers,
+  exchange calls, cache mutation, readiness gates, smoke verdict policy,
+  console routing, order logic, risk logic, or trading behavior.
+- PR #946 passed CI plus fresh Cursor and Claude approval at amended head
+  `5106af2c`. Hermes approved the original larger head and did not post a
+  second-pass review after the narrow amendment; the amendment only kept the
+  bundle summary unprojected while projecting the archived `smoke_report.json`.
+  Local validation covered `tests/test_live_incident_bundle.py`, py_compile for
+  touched files, `git diff --check`, and an added-line silent-handling scan.
+- VPS5 pulled from `1a7c83ee` to `fddd5491` without bot restart because the
+  deployed change was read-only incident-bundle tooling. The five configured
+  bots were left running.
+- A VPS5 focused incident-bundle smoke using `--smoke-section
+  fill_refresh_health` reported `ok=true`, `hard_failures=0`, and preserved
+  compact `logs`/`processes` summary fields. Archive inspection confirmed the
+  embedded `smoke_report.json` recorded
+  `filters.smoke_sections=["fill_refresh_health"]`, included
+  `fill_refresh_health`, and omitted `logs` as intended. A follow-up 1-minute
+  smoke reported `ok=true`,
+  `hard_failures=0`, clean tracked repository state at `fddd5491`, all five
+  configured bots matched, zero failed remote calls, zero failed
+  account-critical remote calls, and only known non-hard `ema.unavailable`
+  attention groups.
 - Repository pulled through PR #945 at `1a7c83ee`.
 - PR #945 added `live-restart-smoke-plan --smoke-section`, allowing the
   plan-only restart smoke command to include focused `live-smoke-report

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -210,7 +210,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   planner to omit those explicit bounds from the generated smoke command. Use
   `--summary-smoke-report` for bounded groups or `--full-smoke-report` for the
   full smoke report. Use `--smoke-section SECTION` one or more times to add
-  focused `live-smoke-report --section` values to the planned smoke command.
+  focused `live-smoke-report --section` values to the planned smoke command and
+  matching `live-incident-bundle --smoke-section` values to the planned failure
+  evidence bundle.
   The planner does not execute the restart, send signals,
   invoke tmux, run SSH, pull git, start bots, contact exchanges, or load
   credentials. The plan also includes a bounded `live-incident-bundle` command

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -128,6 +128,7 @@ def _incident_bundle_command(
     max_log_files: int,
     log_tail_lines: int,
     max_log_matches: int,
+    smoke_sections: list[str] | tuple[str, ...] | None = None,
 ) -> str:
     args = [
         "passivbot",
@@ -155,6 +156,10 @@ def _incident_bundle_command(
         args.extend(["--log-tail-lines", str(log_tail_lines)])
     if int(max_log_matches) > 0:
         args.extend(["--max-log-matches", str(max_log_matches)])
+    for section in smoke_sections or ():
+        normalized = str(section).strip()
+        if normalized:
+            args.extend(["--smoke-section", normalized])
     args.append("--compact")
     return _shell_join(args)
 
@@ -384,6 +389,7 @@ def build_live_restart_smoke_plan(
         max_log_files=smoke_max_log_files,
         log_tail_lines=smoke_log_tail_lines,
         max_log_matches=smoke_max_log_matches,
+        smoke_sections=smoke_sections,
     )
     planned_bots = []
     for index, bot in enumerate(bots, start=1):

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -133,6 +133,8 @@ def test_live_restart_smoke_plan_can_focus_smoke_sections(tmp_path):
     assert report["inputs"]["smoke_sections"] == ["fill_refresh", "risk_events"]
     assert "--section fill_refresh" in report["smoke_report"]["command"]
     assert "--section risk_events" in report["smoke_report"]["command"]
+    assert "--smoke-section fill_refresh" in report["incident_bundle"]["command"]
+    assert "--smoke-section risk_events" in report["incident_bundle"]["command"]
     assert report["smoke_report"]["execute"] is False
 
 
@@ -508,6 +510,8 @@ def test_live_restart_smoke_plan_cli_can_plan_smoke_sections(tmp_path, capsys):
     assert report["inputs"]["smoke_sections"] == ["fill_refresh", "hsl_replay"]
     assert "--section fill_refresh" in report["smoke_report"]["command"]
     assert "--section hsl_replay" in report["smoke_report"]["command"]
+    assert "--smoke-section fill_refresh" in report["incident_bundle"]["command"]
+    assert "--smoke-section hsl_replay" in report["incident_bundle"]["command"]
     assert "--brief" in report["smoke_report"]["command"]
 
 


### PR DESCRIPTION
## Summary
- pass restart smoke plan --smoke-section values through to the planned live-incident-bundle evidence command
- document that planner focus now applies to both planned smoke and failure-bundle commands
- carry forward PR #946 VPS deployment evidence in the logging progress ledger

## Validation
- PYTHONPATH=/private/tmp/passivbot-v8-restart-plan-incident-smoke-section/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_restart_smoke_plan.py -q
- PYTHONPATH=/private/tmp/passivbot-v8-restart-plan-incident-smoke-section/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/restart_smoke_plan.py src/tools/live_restart_smoke_plan.py tests/test_live_restart_smoke_plan.py
- git diff --check
- added-line silent-handling scan over touched Python files