### PR TITLE
Plan restart log window policy

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `fddd5491` after PR #946, `Focus incident bundle smoke reports`.
+- `123d59d6` after PR #947, `Focus restart incident bundle smoke sections`.
 
 Current review gate:
 
@@ -49,6 +49,29 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #947 at `123d59d6`.
+- PR #947 made `live-restart-smoke-plan --smoke-section` apply to both planned
+  evidence commands: `live-smoke-report --section` and
+  `live-incident-bundle --smoke-section`. The slice was read-only dry-run
+  planner tooling and did not add restart execution, process signaling, tmux
+  calls, SSH/git operations, exchange calls, event producers, smoke verdict
+  changes, console routing, order logic, risk logic, or trading behavior.
+- PR #947 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_restart_smoke_plan.py`, py_compile for touched files,
+  `git diff --check`, and an added-line silent-handling scan.
+- VPS5 pulled from `fddd5491` to `123d59d6` without bot restart because the
+  deployed change was read-only planner tooling. The five configured bots were
+  left running.
+- A VPS5 `live-restart-smoke-plan /root/bots_vps5.yaml --smoke-section
+  fill_refresh_health --summary --compact` run reported `ok=true`, five
+  configured bots, six planned phases, `execute=false`, zero issues, and
+  matching focused evidence commands: `live-smoke-report ... --section
+  fill_refresh_health` and `live-incident-bundle ... --smoke-section
+  fill_refresh_health`. A follow-up 1-minute smoke reported `ok=true`,
+  `hard_failures=0`, clean tracked repository state at `123d59d6`, all five
+  configured bots matched, zero failed remote calls, zero failed
+  account-critical remote calls, and only known non-hard EMA/HSL cooldown
+  attention groups.
 - Repository pulled through PR #946 at `fddd5491`.
 - PR #946 added `live-incident-bundle --smoke-section`, allowing the embedded
   full `smoke_report.json` inside an incident bundle to keep selected

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -212,7 +212,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   full smoke report. Use `--smoke-section SECTION` one or more times to add
   focused `live-smoke-report --section` values to the planned smoke command and
   matching `live-incident-bundle --smoke-section` values to the planned failure
-  evidence bundle.
+  evidence bundle. Use `--log-window-unparsed-policy drop` to make both planned
+  commands drop unparseable text-log lines without in-window timestamp context;
+  the default planned policy is `keep`.
   The planner does not execute the restart, send signals,
   invoke tmux, run SSH, pull git, start bots, contact exchanges, or load
   credentials. The plan also includes a bounded `live-incident-bundle` command

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -4,7 +4,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from live.smoke_report import parse_tmuxp_live_commands, _user_safe_display_path
+from live.smoke_report import (
+    DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
+    LOG_WINDOW_UNPARSED_POLICIES,
+    parse_tmuxp_live_commands,
+    _user_safe_display_path,
+)
 
 
 DEFAULT_SHUTDOWN_TIMEOUT_S = 90
@@ -44,6 +49,14 @@ def _non_negative_int(value: int, *, field: str) -> int:
     return parsed
 
 
+def _log_window_unparsed_policy(value: str | None) -> str:
+    policy = str(value or DEFAULT_LOG_WINDOW_UNPARSED_POLICY).strip().lower()
+    if policy not in LOG_WINDOW_UNPARSED_POLICIES:
+        allowed = ", ".join(sorted(LOG_WINDOW_UNPARSED_POLICIES))
+        raise ValueError(f"log_window_unparsed_policy must be one of {allowed}")
+    return policy
+
+
 def _default_incident_bundle_output() -> str:
     stamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S_%f")
     return (
@@ -75,6 +88,7 @@ def _smoke_report_command(
     max_log_files: int,
     log_tail_lines: int,
     max_log_matches: int,
+    log_window_unparsed_policy: str,
     compact: bool,
     brief: bool,
     summary: bool,
@@ -103,6 +117,7 @@ def _smoke_report_command(
         args.extend(["--log-tail-lines", str(log_tail_lines)])
     if int(max_log_matches) > 0:
         args.extend(["--max-log-matches", str(max_log_matches)])
+    args.extend(["--log-window-unparsed-policy", str(log_window_unparsed_policy)])
     if summary:
         args.append("--summary")
     elif brief:
@@ -128,6 +143,7 @@ def _incident_bundle_command(
     max_log_files: int,
     log_tail_lines: int,
     max_log_matches: int,
+    log_window_unparsed_policy: str,
     smoke_sections: list[str] | tuple[str, ...] | None = None,
 ) -> str:
     args = [
@@ -156,6 +172,7 @@ def _incident_bundle_command(
         args.extend(["--log-tail-lines", str(log_tail_lines)])
     if int(max_log_matches) > 0:
         args.extend(["--max-log-matches", str(max_log_matches)])
+    args.extend(["--log-window-unparsed-policy", str(log_window_unparsed_policy)])
     for section in smoke_sections or ():
         normalized = str(section).strip()
         if normalized:
@@ -289,6 +306,7 @@ def build_live_restart_smoke_plan(
     smoke_max_log_files: int = DEFAULT_SMOKE_MAX_LOG_FILES,
     smoke_log_tail_lines: int = DEFAULT_SMOKE_LOG_TAIL_LINES,
     smoke_max_log_matches: int = DEFAULT_SMOKE_MAX_LOG_MATCHES,
+    log_window_unparsed_policy: str = DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
     incident_bundle_output: str | Path | None = None,
     compact_smoke_report: bool = True,
     brief_smoke_report: bool = True,
@@ -315,6 +333,9 @@ def build_live_restart_smoke_plan(
     )
     smoke_max_log_matches = _non_negative_int(
         smoke_max_log_matches, field="smoke_max_log_matches"
+    )
+    log_window_unparsed_policy = _log_window_unparsed_policy(
+        log_window_unparsed_policy
     )
     if incident_bundle_output is None or not str(incident_bundle_output).strip():
         incident_bundle_output = _default_incident_bundle_output()
@@ -373,6 +394,7 @@ def build_live_restart_smoke_plan(
         max_log_files=smoke_max_log_files,
         log_tail_lines=smoke_log_tail_lines,
         max_log_matches=smoke_max_log_matches,
+        log_window_unparsed_policy=log_window_unparsed_policy,
         compact=compact_smoke_report,
         brief=brief_smoke_report,
         summary=summary_smoke_report,
@@ -389,6 +411,7 @@ def build_live_restart_smoke_plan(
         max_log_files=smoke_max_log_files,
         log_tail_lines=smoke_log_tail_lines,
         max_log_matches=smoke_max_log_matches,
+        log_window_unparsed_policy=log_window_unparsed_policy,
         smoke_sections=smoke_sections,
     )
     planned_bots = []
@@ -429,6 +452,7 @@ def build_live_restart_smoke_plan(
             "smoke_max_log_files": smoke_max_log_files,
             "smoke_log_tail_lines": smoke_log_tail_lines,
             "smoke_max_log_matches": smoke_max_log_matches,
+            "log_window_unparsed_policy": log_window_unparsed_policy,
             "smoke_sections": list(smoke_sections),
             "incident_bundle_output": _display_path(incident_bundle_output),
         },

--- a/src/tools/live_restart_smoke_plan.py
+++ b/src/tools/live_restart_smoke_plan.py
@@ -11,6 +11,7 @@ if str(SRC_ROOT) not in sys.path:
 
 from live.restart_smoke_plan import (  # noqa: E402
     DEFAULT_INCIDENT_BUNDLE_OUTPUT_HELP,
+    DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
     DEFAULT_SMOKE_EVENT_TAIL_LINES,
     DEFAULT_SMOKE_LOG_TAIL_LINES,
     DEFAULT_SMOKE_MAX_LOG_FILES,
@@ -21,6 +22,7 @@ from live.restart_smoke_plan import (  # noqa: E402
     DEFAULT_SHUTDOWN_TIMEOUT_S,
     DEFAULT_SMOKE_WINDOW_MINUTES,
     DEFAULT_STARTUP_WAIT_S,
+    LOG_WINDOW_UNPARSED_POLICIES,
     build_live_restart_smoke_plan,
     summarize_live_restart_smoke_plan,
 )
@@ -113,6 +115,15 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--log-window-unparsed-policy",
+        choices=sorted(LOG_WINDOW_UNPARSED_POLICIES),
+        default=DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
+        help=(
+            "Policy for unparseable text log lines when the planned smoke and "
+            "incident-bundle commands use a recent log window."
+        ),
+    )
+    parser.add_argument(
         "--incident-bundle-output",
         default=None,
         help=(
@@ -190,6 +201,7 @@ def main(argv: list[str] | None = None) -> int:
             smoke_max_log_files=int(args.max_log_files),
             smoke_log_tail_lines=int(args.log_tail_lines),
             smoke_max_log_matches=int(args.max_log_matches),
+            log_window_unparsed_policy=str(args.log_window_unparsed_policy),
             incident_bundle_output=args.incident_bundle_output,
             compact_smoke_report=not bool(args.pretty_smoke_report),
             brief_smoke_report=not (

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -69,6 +69,7 @@ def test_live_restart_smoke_plan_builds_plan_from_supervisor_config(tmp_path):
     assert "--max-log-files 8" in report["smoke_report"]["command"]
     assert "--log-tail-lines 1200" in report["smoke_report"]["command"]
     assert "--max-log-matches 20" in report["smoke_report"]["command"]
+    assert "--log-window-unparsed-policy keep" in report["smoke_report"]["command"]
     assert "--brief" in report["smoke_report"]["command"]
     assert "--summary" not in report["smoke_report"]["command"]
     assert report["incident_bundle"]["execute"] is False
@@ -89,6 +90,7 @@ def test_live_restart_smoke_plan_builds_plan_from_supervisor_config(tmp_path):
     assert "--max-log-files 8" in incident_command
     assert "--log-tail-lines 1200" in incident_command
     assert "--max-log-matches 20" in incident_command
+    assert "--log-window-unparsed-policy keep" in incident_command
     assert "--compact" in incident_command
     assert report["phases"][-1]["name"] == "post_failure_incident_bundle"
     assert report["phases"][-1]["planned_commands"][0]["command"] == incident_command
@@ -136,6 +138,32 @@ def test_live_restart_smoke_plan_can_focus_smoke_sections(tmp_path):
     assert "--smoke-section fill_refresh" in report["incident_bundle"]["command"]
     assert "--smoke-section risk_events" in report["incident_bundle"]["command"]
     assert report["smoke_report"]["execute"] is False
+
+
+def test_live_restart_smoke_plan_can_set_log_window_unparsed_policy(tmp_path):
+    supervisor_config = tmp_path / "bots_vps5.yaml"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u binance_01",
+        ],
+    )
+
+    report = build_live_restart_smoke_plan(
+        supervisor_config,
+        log_window_unparsed_policy="drop",
+    )
+
+    assert report["inputs"]["log_window_unparsed_policy"] == "drop"
+    assert "--log-window-unparsed-policy drop" in report["smoke_report"]["command"]
+    assert (
+        "--log-window-unparsed-policy drop"
+        in report["incident_bundle"]["command"]
+    )
 
 
 def test_live_restart_smoke_plan_redacts_and_bounds_configured_commands(tmp_path):
@@ -259,8 +287,13 @@ def test_live_restart_smoke_plan_cli_outputs_json(tmp_path, capsys):
     assert "--max-log-files 8" in report["smoke_report"]["command"]
     assert "--log-tail-lines 1200" in report["smoke_report"]["command"]
     assert "--max-log-matches 20" in report["smoke_report"]["command"]
+    assert "--log-window-unparsed-policy keep" in report["smoke_report"]["command"]
     assert "--brief" in report["smoke_report"]["command"]
     assert "--no-event-segments" in report["incident_bundle"]["command"]
+    assert (
+        "--log-window-unparsed-policy keep"
+        in report["incident_bundle"]["command"]
+    )
     assert "--compact" in report["incident_bundle"]["command"]
 
 
@@ -513,6 +546,42 @@ def test_live_restart_smoke_plan_cli_can_plan_smoke_sections(tmp_path, capsys):
     assert "--smoke-section fill_refresh" in report["incident_bundle"]["command"]
     assert "--smoke-section hsl_replay" in report["incident_bundle"]["command"]
     assert "--brief" in report["smoke_report"]["command"]
+
+
+def test_live_restart_smoke_plan_cli_can_plan_log_window_unparsed_policy(
+    tmp_path, capsys
+):
+    supervisor_config = tmp_path / "bots.yaml"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u binance_01",
+        ],
+    )
+
+    assert (
+        live_restart_smoke_plan.main(
+            [
+                str(supervisor_config),
+                "--log-window-unparsed-policy",
+                "drop",
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["inputs"]["log_window_unparsed_policy"] == "drop"
+    assert "--log-window-unparsed-policy drop" in report["smoke_report"]["command"]
+    assert (
+        "--log-window-unparsed-policy drop"
+        in report["incident_bundle"]["command"]
+    )
 
 
 def test_live_restart_smoke_plan_cli_rejects_execute(capsys):


### PR DESCRIPTION
## Summary
- add live-restart-smoke-plan --log-window-unparsed-policy with the same keep/drop contract as live-smoke-report and live-incident-bundle
- pass the selected policy to both planned evidence commands
- document the planner option and carry forward PR #947 VPS deployment evidence

## Validation
- PYTHONPATH=/private/tmp/passivbot-v8-restart-plan-log-window-policy/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_restart_smoke_plan.py -q
- PYTHONPATH=/private/tmp/passivbot-v8-restart-plan-log-window-policy/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/restart_smoke_plan.py src/tools/live_restart_smoke_plan.py tests/test_live_restart_smoke_plan.py
- git diff --check
- added-line silent-handling scan over touched Python files