### PR TITLE
Plan restart config preflights

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `123d59d6` after PR #947, `Focus restart incident bundle smoke sections`.
+- `79478e1f` after PR #948, `Plan restart log window policy`.
 
 Current review gate:
 
@@ -49,6 +49,29 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #948 at `79478e1f`.
+- PR #948 added `live-restart-smoke-plan --log-window-unparsed-policy`, passing
+  the existing `keep`/`drop` text-log window policy through to both planned
+  evidence commands: `live-smoke-report` and `live-incident-bundle`. The slice
+  was read-only dry-run planner tooling and did not add restart execution,
+  process signaling, tmux calls, SSH/git operations, exchange calls, event
+  producers, smoke verdict changes, console routing, order logic, risk logic, or
+  trading behavior.
+- PR #948 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_restart_smoke_plan.py`, py_compile for touched files,
+  `git diff --check`, and an added-line silent-handling scan.
+- VPS5 pulled from `123d59d6` to `79478e1f` without bot restart because the
+  deployed change was read-only planner tooling. The five configured bots were
+  left running.
+- A VPS5 `live-restart-smoke-plan /root/bots_vps5.yaml --smoke-section
+  fill_refresh_health --log-window-unparsed-policy drop --summary --compact`
+  run reported `ok=true`, five configured bots, six planned phases,
+  `execute=false`, zero issues, and both planned evidence commands carrying
+  `--log-window-unparsed-policy drop`. A follow-up 1-minute smoke reported
+  `ok=true`, `hard_failures=0`, clean tracked repository state at `79478e1f`,
+  all five configured bots matched, zero failed remote calls, zero failed
+  account-critical remote calls, text-log `unparsed_policy=drop`, and only known
+  non-hard EMA/HSL cooldown attention groups.
 - Repository pulled through PR #947 at `123d59d6`.
 - PR #947 made `live-restart-smoke-plan --smoke-section` apply to both planned
   evidence commands: `live-smoke-report --section` and

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -222,9 +222,11 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   event-segment copying by default; use `--incident-bundle-output PATH` to
   choose the planned bundle path. The default planned bundle path is a
   timestamped `/tmp/passivbot_incident_bundle_restart_smoke_<utc>.tar.gz`
-  path to avoid overwriting prior evidence. Use planner `--summary` when you
-  only need the bot count, phase names, smoke command, and incident-bundle
-  command without every per-bot phase detail.
+  path to avoid overwriting prior evidence. The pre-restart readiness phase also
+  includes one deduplicated `live-config-preflight` command for each configured
+  live config path found in the supervisor config. Use planner `--summary` when
+  you only need the bot count, phase names, preflight commands, smoke command,
+  and incident-bundle command without every per-bot phase detail.
 - `passivbot tool live-performance-report` summarizes local live monitor event timings for
   operator performance analysis. It is read-only and does not contact exchanges. Use
   `--recent-minutes` for a time window, `--summary` for a bounded operator projection, and

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -198,6 +198,22 @@ def _repo_check_commands(repo_path: str | Path | None) -> list[str]:
     ]
 
 
+def _config_preflight_commands(bots: list[dict[str, Any]]) -> list[str]:
+    commands: list[str] = []
+    seen: set[str] = set()
+    for bot in bots:
+        config_path = str(bot.get("config_path") or "").strip()
+        if not config_path or config_path in seen:
+            continue
+        seen.add(config_path)
+        commands.append(
+            _shell_join(
+                ["passivbot", "tool", "live-config-preflight", config_path, "--compact"]
+            )
+        )
+    return commands
+
+
 def _process_signal_safety_contract() -> dict[str, Any]:
     return {
         "strategy": "exact_tmux_pane_or_exact_pid_only",
@@ -414,6 +430,7 @@ def build_live_restart_smoke_plan(
         log_window_unparsed_policy=log_window_unparsed_policy,
         smoke_sections=smoke_sections,
     )
+    config_preflight_commands = _config_preflight_commands(bots)
     planned_bots = []
     for index, bot in enumerate(bots, start=1):
         planned_bots.append(
@@ -473,6 +490,7 @@ def build_live_restart_smoke_plan(
                 "planned_commands": [
                     {"command": command, "execute": False}
                     for command in _repo_check_commands(repo_path)
+                    + config_preflight_commands
                 ],
             },
             {
@@ -545,6 +563,18 @@ def build_live_restart_smoke_plan(
                 "time-window event report",
                 "monitor snapshots",
                 "config hashes when configured explicitly",
+            ],
+        },
+        "config_preflight": {
+            "commands": config_preflight_commands,
+            "command_count": len(config_preflight_commands),
+            "execute": False,
+            "expected_fields": [
+                "identity hints",
+                "HSL signal mode and enabled sides",
+                "approved and ignored universe counts",
+                "forager slot and staleness settings",
+                "cache-related live settings and readiness attention",
             ],
         },
         "process_signal_safety": _process_signal_safety_contract(),
@@ -621,6 +651,7 @@ def summarize_live_restart_smoke_plan(report: dict[str, Any]) -> dict[str, Any]:
     issue_rows = issues if isinstance(issues, list) else []
     smoke_report = report.get("smoke_report")
     incident_bundle = report.get("incident_bundle")
+    config_preflight = report.get("config_preflight")
     execution_policy = report.get("execution_policy")
     signal_safety = report.get("process_signal_safety")
     return {
@@ -666,6 +697,24 @@ def summarize_live_restart_smoke_plan(report: dict[str, Any]) -> dict[str, Any]:
             "event_segments": (
                 incident_bundle.get("event_segments")
                 if isinstance(incident_bundle, dict)
+                else None
+            ),
+        },
+        "config_preflight": {
+            "command_count": (
+                config_preflight.get("command_count")
+                if isinstance(config_preflight, dict)
+                else 0
+            ),
+            "commands": (
+                (config_preflight.get("commands") or [])[:20]
+                if isinstance(config_preflight, dict)
+                and isinstance(config_preflight.get("commands"), list)
+                else []
+            ),
+            "execute": (
+                config_preflight.get("execute")
+                if isinstance(config_preflight, dict)
                 else None
             ),
         },

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -72,6 +72,23 @@ def test_live_restart_smoke_plan_builds_plan_from_supervisor_config(tmp_path):
     assert "--log-window-unparsed-policy keep" in report["smoke_report"]["command"]
     assert "--brief" in report["smoke_report"]["command"]
     assert "--summary" not in report["smoke_report"]["command"]
+    assert report["config_preflight"] == {
+        "command_count": 1,
+        "commands": ["passivbot tool live-config-preflight configs/forager.json --compact"],
+        "execute": False,
+        "expected_fields": [
+            "identity hints",
+            "HSL signal mode and enabled sides",
+            "approved and ignored universe counts",
+            "forager slot and staleness settings",
+            "cache-related live settings and readiness attention",
+        ],
+    }
+    assert (
+        report["phases"][0]["planned_commands"][-1]["command"]
+        == "passivbot tool live-config-preflight configs/forager.json --compact"
+    )
+    assert report["phases"][0]["planned_commands"][-1]["execute"] is False
     assert report["incident_bundle"]["execute"] is False
     assert re.search(
         INCIDENT_BUNDLE_OUTPUT_PATTERN,
@@ -138,6 +155,34 @@ def test_live_restart_smoke_plan_can_focus_smoke_sections(tmp_path):
     assert "--smoke-section fill_refresh" in report["incident_bundle"]["command"]
     assert "--smoke-section risk_events" in report["incident_bundle"]["command"]
     assert report["smoke_report"]["execute"] is False
+
+
+def test_live_restart_smoke_plan_deduplicates_config_preflight_commands(tmp_path):
+    supervisor_config = tmp_path / "bots_vps5.yaml"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u binance_01",
+            "  - window_name: kucoin_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u kucoin_01",
+            "  - window_name: gateio_01",
+            "    panes:",
+            "      - passivbot live configs/tradfi.json -u gateio_01",
+        ],
+    )
+
+    report = build_live_restart_smoke_plan(supervisor_config)
+
+    assert report["config_preflight"]["commands"] == [
+        "passivbot tool live-config-preflight configs/forager.json --compact",
+        "passivbot tool live-config-preflight configs/tradfi.json --compact",
+    ]
+    assert report["config_preflight"]["command_count"] == 2
 
 
 def test_live_restart_smoke_plan_can_set_log_window_unparsed_policy(tmp_path):
@@ -452,6 +497,11 @@ def test_live_restart_smoke_plan_summary_projects_concise_commands(tmp_path, cap
         "command"
     ]
     assert summary["incident_bundle"]["execute"] is False
+    assert summary["config_preflight"] == {
+        "command_count": 1,
+        "commands": ["passivbot tool live-config-preflight configs/forager.json --compact"],
+        "execute": False,
+    }
     assert summary["incident_bundle"]["event_segments"] == (
         "disabled_by_default_for_fast_restart_smoke_bundle"
     )
@@ -473,6 +523,7 @@ def test_live_restart_smoke_plan_summary_projects_concise_commands(tmp_path, cap
     assert "passivbot tool live-incident-bundle" in cli_summary["incident_bundle"][
         "command"
     ]
+    assert cli_summary["config_preflight"]["command_count"] == 1
     assert "command_key" not in json.dumps(cli_summary["bots"])
 
 


### PR DESCRIPTION
## Summary
- add deduplicated planned live-config-preflight commands to live-restart-smoke-plan pre-restart readiness
- project those commands in full and summary planner output
- document the planned preflight commands and carry forward PR #948 VPS deployment evidence

## Validation
- PYTHONPATH=/private/tmp/passivbot-v8-restart-plan-config-preflight/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_restart_smoke_plan.py -q
- PYTHONPATH=/private/tmp/passivbot-v8-restart-plan-config-preflight/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/restart_smoke_plan.py src/tools/live_restart_smoke_plan.py tests/test_live_restart_smoke_plan.py
- git diff --check
- added-line silent-handling scan over touched Python files