### PR TITLE
Report restart preflight skips

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `79478e1f` after PR #948, `Plan restart log window policy`.
+- `c7b09bf8` after PR #949, `Plan restart config preflights`.
 
 Current review gate:
 
@@ -49,6 +49,28 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #949 at `c7b09bf8`.
+- PR #949 added deduplicated planned `live-config-preflight ... --compact`
+  commands to `live-restart-smoke-plan` pre-restart readiness and summary
+  output. The slice was read-only dry-run planner tooling and did not add
+  restart execution, process signaling, tmux calls, SSH/git operations, exchange
+  calls, event producers, smoke verdict changes, console routing, order logic,
+  risk logic, or trading behavior.
+- PR #949 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_restart_smoke_plan.py`, py_compile for touched files,
+  `git diff --check`, and an added-line silent-handling scan.
+- VPS5 pulled from `79478e1f` to `c7b09bf8` without bot restart because the
+  deployed change was read-only planner tooling. The five configured bots were
+  left running.
+- A VPS5 `live-restart-smoke-plan /root/bots_vps5.yaml --smoke-section
+  fill_refresh_health --log-window-unparsed-policy drop --summary --compact`
+  run reported `ok=true`, five configured bots, six planned phases,
+  `execute=false`, zero issues, and two deduplicated config-preflight commands
+  for the configured forager and tradfi configs. A follow-up 1-minute smoke
+  reported `ok=true`, `hard_failures=0`, clean tracked repository state at
+  `c7b09bf8`, all five configured bots matched, config checks green, zero
+  failed remote calls, zero failed account-critical remote calls, and only known
+  non-hard EMA/HSL cooldown attention groups.
 - Repository pulled through PR #948 at `79478e1f`.
 - PR #948 added `live-restart-smoke-plan --log-window-unparsed-policy`, passing
   the existing `keep`/`drop` text-log window policy through to both planned

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -224,9 +224,10 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   timestamped `/tmp/passivbot_incident_bundle_restart_smoke_<utc>.tar.gz`
   path to avoid overwriting prior evidence. The pre-restart readiness phase also
   includes one deduplicated `live-config-preflight` command for each configured
-  live config path found in the supervisor config. Use planner `--summary` when
-  you only need the bot count, phase names, preflight commands, smoke command,
-  and incident-bundle command without every per-bot phase detail.
+  live config path found in the supervisor config, plus a skip count for any
+  configured live command whose config path could not be derived. Use planner
+  `--summary` when you only need the bot count, phase names, preflight commands,
+  smoke command, and incident-bundle command without every per-bot phase detail.
 - `passivbot tool live-performance-report` summarizes local live monitor event timings for
   operator performance analysis. It is read-only and does not contact exchanges. Use
   `--recent-minutes` for a time window, `--summary` for a bounded operator projection, and

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -198,12 +198,16 @@ def _repo_check_commands(repo_path: str | Path | None) -> list[str]:
     ]
 
 
-def _config_preflight_commands(bots: list[dict[str, Any]]) -> list[str]:
+def _config_preflight_plan(bots: list[dict[str, Any]]) -> dict[str, Any]:
     commands: list[str] = []
     seen: set[str] = set()
+    skipped_without_config_path = 0
     for bot in bots:
         config_path = str(bot.get("config_path") or "").strip()
-        if not config_path or config_path in seen:
+        if not config_path:
+            skipped_without_config_path += 1
+            continue
+        if config_path in seen:
             continue
         seen.add(config_path)
         commands.append(
@@ -211,7 +215,11 @@ def _config_preflight_commands(bots: list[dict[str, Any]]) -> list[str]:
                 ["passivbot", "tool", "live-config-preflight", config_path, "--compact"]
             )
         )
-    return commands
+    return {
+        "commands": commands,
+        "command_count": len(commands),
+        "skipped_without_config_path_count": skipped_without_config_path,
+    }
 
 
 def _process_signal_safety_contract() -> dict[str, Any]:
@@ -430,7 +438,8 @@ def build_live_restart_smoke_plan(
         log_window_unparsed_policy=log_window_unparsed_policy,
         smoke_sections=smoke_sections,
     )
-    config_preflight_commands = _config_preflight_commands(bots)
+    config_preflight_plan = _config_preflight_plan(bots)
+    config_preflight_commands = list(config_preflight_plan["commands"])
     planned_bots = []
     for index, bot in enumerate(bots, start=1):
         planned_bots.append(
@@ -567,7 +576,10 @@ def build_live_restart_smoke_plan(
         },
         "config_preflight": {
             "commands": config_preflight_commands,
-            "command_count": len(config_preflight_commands),
+            "command_count": config_preflight_plan["command_count"],
+            "skipped_without_config_path_count": config_preflight_plan[
+                "skipped_without_config_path_count"
+            ],
             "execute": False,
             "expected_fields": [
                 "identity hints",
@@ -703,6 +715,11 @@ def summarize_live_restart_smoke_plan(report: dict[str, Any]) -> dict[str, Any]:
         "config_preflight": {
             "command_count": (
                 config_preflight.get("command_count")
+                if isinstance(config_preflight, dict)
+                else 0
+            ),
+            "skipped_without_config_path_count": (
+                config_preflight.get("skipped_without_config_path_count")
                 if isinstance(config_preflight, dict)
                 else 0
             ),

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -76,6 +76,7 @@ def test_live_restart_smoke_plan_builds_plan_from_supervisor_config(tmp_path):
         "command_count": 1,
         "commands": ["passivbot tool live-config-preflight configs/forager.json --compact"],
         "execute": False,
+        "skipped_without_config_path_count": 0,
         "expected_fields": [
             "identity hints",
             "HSL signal mode and enabled sides",
@@ -183,6 +184,31 @@ def test_live_restart_smoke_plan_deduplicates_config_preflight_commands(tmp_path
         "passivbot tool live-config-preflight configs/tradfi.json --compact",
     ]
     assert report["config_preflight"]["command_count"] == 2
+    assert report["config_preflight"]["skipped_without_config_path_count"] == 0
+
+
+def test_live_restart_smoke_plan_reports_config_preflight_skips(tmp_path):
+    supervisor_config = tmp_path / "bots_vps5.yaml"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            "      - passivbot live -u binance_01",
+            "  - window_name: gateio_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u gateio_01",
+        ],
+    )
+
+    report = build_live_restart_smoke_plan(supervisor_config)
+    summary = summarize_live_restart_smoke_plan(report)
+
+    assert report["config_preflight"]["command_count"] == 1
+    assert report["config_preflight"]["skipped_without_config_path_count"] == 1
+    assert summary["config_preflight"]["skipped_without_config_path_count"] == 1
 
 
 def test_live_restart_smoke_plan_can_set_log_window_unparsed_policy(tmp_path):
@@ -501,6 +527,7 @@ def test_live_restart_smoke_plan_summary_projects_concise_commands(tmp_path, cap
         "command_count": 1,
         "commands": ["passivbot tool live-config-preflight configs/forager.json --compact"],
         "execute": False,
+        "skipped_without_config_path_count": 0,
     }
     assert summary["incident_bundle"]["event_segments"] == (
         "disabled_by_default_for_fast_restart_smoke_bundle"


### PR DESCRIPTION
## Summary
- report how many configured live commands could not produce a planned live-config-preflight command because no config path was parsed
- project the skip count in full and summary live-restart-smoke-plan output
- document the skip count and carry forward PR #949 VPS deployment evidence

## Validation
- PYTHONPATH=/private/tmp/passivbot-v8-restart-plan-preflight-skips/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_restart_smoke_plan.py -q
- PYTHONPATH=/private/tmp/passivbot-v8-restart-plan-preflight-skips/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/restart_smoke_plan.py src/tools/live_restart_smoke_plan.py tests/test_live_restart_smoke_plan.py
- git diff --check
- added-line silent-handling scan over touched Python files