### PR TITLE
Report execution health in live smoke

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `a5a3a83f` after PR #951, `Embed restart smoke plans in incident bundles`.
+- `07ee5860` after PR #952, `Make restart failure bundles self-contained`.
 
 Current review gate:
 
@@ -49,6 +49,29 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #952 at `07ee5860`.
+- PR #952 made `live-restart-smoke-plan` planned failure-bundle commands
+  self-contained by adding `live-incident-bundle --restart-smoke-plan` and the
+  same `--restart-smoke-window-minutes` value. The slice was read-only restart
+  planner / incident-bundle tooling and did not add restart execution, process
+  signaling, tmux calls, SSH/git operations, exchange calls, event producers,
+  smoke verdict changes, console routing, order logic, risk logic, or trading
+  behavior.
+- PR #952 passed Hermes + Claude + CI. It was merged under the documented
+  degraded low-risk tooling gate after Cursor absence. Local validation covered
+  `tests/test_live_restart_smoke_plan.py`, py_compile for touched files,
+  `git diff --check`, and an added-line silent-handling scan.
+- VPS5 pulled from `a5a3a83f` to `07ee5860` without bot restart because the
+  deployed change was read-only restart planner / incident-bundle tooling. The
+  five configured bots were left running.
+- A VPS5 1-minute bounded smoke after deploy reported `ok=true`,
+  `hard_failures=0`, clean tracked repository state at `07ee5860`, all five
+  configured bots matched, config checks green, zero failed remote calls, zero
+  failed account-critical remote calls, and only known non-hard EMA/HSL
+  cooldown attention groups. A focused restart-plan run confirmed planned
+  failure-bundle commands include both `--restart-smoke-plan` and
+  `--restart-smoke-window-minutes 30`, while staying `execute=false` /
+  `plan_only=true`.
 - Repository pulled through PR #951 at `a5a3a83f`.
 - PR #951 added opt-in `live-incident-bundle --restart-smoke-plan`, requiring
   `--supervisor-config`, to embed a non-executing `restart_smoke_plan.json`
@@ -2668,23 +2691,25 @@ VPS5 deployment status:
 | Phase 4: order lifecycle and risk transitions | Mostly done | Order wave lifecycle, create/cancel/confirmation events, HSL/risk mode events, HSL replay failure events | Expand WEL/TWEL/unstuck transition coverage as those paths are touched |
 | Phase 5: migrate meaningful text logs | Partially started | Some noisy EMA console output already reduced; PR #646 improves event-projected console summaries for already-routed execution events; PR #707 restores throttled coin-mode HSL position status console lines from existing `hsl.status` metrics; PR #709 mirrors fill-cache startup readiness into off-console `fills.refresh_summary` events; PR #711 mirrors CCXT timestamp/nonce recovery into off-console `exchange.time_sync` events; PR #846 mirrors pre-create market-distance guard skips into off-console `execution.create_skipped` events; PR #848 mirrors pre-create planning/market snapshot skips into off-console `execution.create_skipped` events; PR #850 mirrors fill-cache doctor startup report/quarantine/rebuild decisions into off-console `fills.refresh_summary` events | Migrate high-value stdlib logs to structured-event projections without increasing console noise |
 | Phase 6: gatekeeper integration | Pending | Gatekeeper remains a planned producer | Instrument gate decisions once gatekeeper work resumes |
-| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, severity-level filters, problem-event filters, event-file discovery metadata, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/shutdown-events/time windows/unparseable-log policy/brief smoke counters/brief problem-event groups/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window/problem-event reports and query-scope filters, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation with summary/filter, decision-boundary, input-staleness including market snapshot staleness, startup phase timing summaries, HSL replay pair/rate/stage summaries, forager/EMA readiness, cache warmup, resource-pressure percentiles, and unified operation-duration support | Cross-bot incident workflow, safe restart orchestration, bounded historical performance-report scans, active probe expansion beyond current endpoint/freshness summaries |
+| Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, severity-level filters, problem-event filters, event-file discovery metadata, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/execution-health/shutdown-events/time windows/unparseable-log policy/brief smoke counters/brief problem-event groups/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window/problem-event reports and query-scope filters, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation with summary/filter, decision-boundary, input-staleness including market snapshot staleness, startup phase timing summaries, HSL replay pair/rate/stage summaries, forager/EMA readiness, cache warmup, resource-pressure percentiles, and unified operation-duration support | Cross-bot incident workflow, safe restart orchestration, bounded historical performance-report scans, active probe expansion beyond current endpoint/freshness summaries |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup; PR #656/#668 cache integrity smoke doctor | Continue separate reviewed PRs for shutdown/warmup/cache proof improvements |
 
 ## Current Work
 
-### Pending PR: Restart Plan Self-Contained Failure Bundle
+### In Progress: Smoke Execution Health
 
-- Branch: `codex/v8-restart-plan-self-contained-bundle`.
-- Scope: read-only restart-smoke planner tooling and tests.
-- Result: planned post-failure `live-incident-bundle` commands emitted by
-  `live-restart-smoke-plan` now include `--restart-smoke-plan` and the same
-  restart-smoke window, so a failure bundle collected from the plan carries the
-  non-executing restart/smoke/config-preflight plan that produced it.
-- Expected validation: focused live-restart-smoke-plan tests plus py_compile
-  and `git diff --check`. No event producers, exchange calls, cache mutation,
-  readiness gates, console routing, monitor writes, process signaling,
-  order/risk logic, or trading behavior should change.
+- Branch: `codex/v8-smoke-execution-health`.
+- Scope: read-only smoke-report tooling and tests.
+- Result: `live-smoke-report` derives bounded `execution_health` from existing
+  `order_wave.*` and `execution.*` structured events, with concise `execution`
+  counters in brief output. The summary is intended to expose create/cancel
+  failures, rejections, ambiguous terminals, and confirmation timeouts without
+  opening full event streams.
+- Expected validation: focused live-smoke-report tests plus py_compile,
+  `git diff --check`, and an added-line silent-handling scan. No event
+  producers, exchange calls, cache mutation, readiness gates, console routing,
+  monitor writes, process signaling, smoke verdict policy, order/risk logic, or
+  trading behavior should change.
 
 ## Merged Slices
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -183,6 +183,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   Existing staged execution readiness degradations are summarized as
   `staged_readiness_health` in full/summary output and `staged_readiness` in brief output,
   including latest missing/invalid surface counts and bounded completed-candle mismatch evidence.
+  Existing structured execution/order-wave events are summarized as
+  `execution_health` in full/summary output and `execution` in brief output,
+  including create/cancel/confirmation outcome counters and bounded write/confirmation groups.
   Existing structured shutdown events are also summarized as `shutdown_events`,
   so recent Ctrl+C/restart behavior can be inspected from the same smoke output.
   With `--supervisor-config`, the read-only process section compares configured

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -59,6 +59,8 @@ REMOTE_CALL_TIMING_GROUP_LIMIT = 20
 REMOTE_CALL_HEALTH_VALUE_LIMIT = 8
 FILL_REFRESH_HEALTH_GROUP_LIMIT = 20
 FILL_REFRESH_HEALTH_VALUE_LIMIT = 8
+EXECUTION_HEALTH_GROUP_LIMIT = 20
+EXECUTION_HEALTH_VALUE_LIMIT = 8
 SMOKE_REPORT_SUMMARY_GROUP_LIMIT = 8
 _SMOKE_REPORT_SECTION_BASE_KEYS = (
     "ok",
@@ -122,6 +124,24 @@ REMOTE_CALL_TIMING_EVENT_TYPES = {
     EventTypes.REMOTE_CALL_SUCCEEDED,
     EventTypes.REMOTE_CALL_FAILED,
     EventTypes.REMOTE_CALL_THROTTLED,
+}
+EXECUTION_HEALTH_EVENT_TYPES = {
+    EventTypes.ORDER_WAVE_STARTED,
+    EventTypes.ORDER_WAVE_COMPLETED,
+    EventTypes.EXECUTION_CREATE_SENT,
+    EventTypes.EXECUTION_CREATE_SUCCEEDED,
+    EventTypes.EXECUTION_CREATE_FAILED,
+    EventTypes.EXECUTION_CREATE_REJECTED,
+    EventTypes.EXECUTION_CREATE_DEFERRED,
+    EventTypes.EXECUTION_CREATE_SKIPPED,
+    EventTypes.EXECUTION_CANCEL_SENT,
+    EventTypes.EXECUTION_CANCEL_SUCCEEDED,
+    EventTypes.EXECUTION_CANCEL_FAILED,
+    EventTypes.EXECUTION_CANCEL_AMBIGUOUS_TERMINAL,
+    EventTypes.EXECUTION_AMBIGUOUS,
+    EventTypes.EXECUTION_CONFIRMATION_REQUESTED,
+    EventTypes.EXECUTION_CONFIRMATION_SATISFIED,
+    EventTypes.EXECUTION_CONFIRMATION_TIMEOUT,
 }
 PROBLEM_EVENT_DATA_KEYS: dict[str, tuple[str, ...]] = {
     EventTypes.CYCLE_DEGRADED: ("details", "authoritative_epoch"),
@@ -410,7 +430,7 @@ def _merge_remote_call_failure_group(
     if existing is None:
         groups[key] = group
         return
-    existing["count"] = int(existing.get("count", 0)) + 1
+    existing["count"] = _count_value(existing.get("count")) + 1
     current_key = _sort_event_position_key(
         ts=group.get("latest_ts"),
         seq=group.get("latest_seq"),
@@ -549,7 +569,7 @@ def _merge_remote_call_health_group(
     if existing is None:
         groups[key] = group
         return
-    existing["count"] = int(existing.get("count", 0)) + 1
+    existing["count"] = _count_value(existing.get("count")) + 1
     existing.setdefault("elapsed_values", []).extend(group.get("elapsed_values") or [])
     for field in ("statuses", "raw_statuses", "reason_codes", "error_types", "symbols"):
         counter = existing.setdefault(field, Counter())
@@ -719,6 +739,381 @@ def _summarize_remote_call_health(
         "failure_pct": _usage_pct(total_failed_count, total),
         "throttled_pct": _usage_pct(total_throttled_count, total),
         "groups_truncated": len(ordered) > REMOTE_CALL_HEALTH_GROUP_LIMIT,
+        "groups": compact_groups,
+    }
+
+
+def _execution_health_outcome(event_type: str, status: str | None) -> str:
+    if event_type == EventTypes.ORDER_WAVE_STARTED:
+        return "wave_started"
+    if event_type == EventTypes.ORDER_WAVE_COMPLETED:
+        return "wave_completed"
+    if event_type == EventTypes.EXECUTION_CREATE_SENT:
+        return "create_sent"
+    if event_type == EventTypes.EXECUTION_CREATE_SUCCEEDED:
+        return "create_succeeded"
+    if event_type == EventTypes.EXECUTION_CREATE_FAILED:
+        return "create_failed"
+    if event_type == EventTypes.EXECUTION_CREATE_REJECTED:
+        return "create_rejected"
+    if event_type == EventTypes.EXECUTION_CREATE_DEFERRED:
+        return "create_deferred"
+    if event_type == EventTypes.EXECUTION_CREATE_SKIPPED:
+        return "create_skipped"
+    if event_type == EventTypes.EXECUTION_CANCEL_SENT:
+        return "cancel_sent"
+    if event_type == EventTypes.EXECUTION_CANCEL_SUCCEEDED:
+        return "cancel_succeeded"
+    if event_type == EventTypes.EXECUTION_CANCEL_FAILED:
+        return "cancel_failed"
+    if event_type == EventTypes.EXECUTION_CANCEL_AMBIGUOUS_TERMINAL:
+        return "cancel_ambiguous_terminal"
+    if event_type == EventTypes.EXECUTION_AMBIGUOUS:
+        return "ambiguous"
+    if event_type == EventTypes.EXECUTION_CONFIRMATION_REQUESTED:
+        return "confirmation_requested"
+    if event_type == EventTypes.EXECUTION_CONFIRMATION_SATISFIED:
+        return "confirmation_satisfied"
+    if event_type == EventTypes.EXECUTION_CONFIRMATION_TIMEOUT:
+        return "confirmation_timeout"
+    if status not in (None, ""):
+        return str(status).lower()
+    return "unknown"
+
+
+def _execution_health_elapsed_values(payload: dict[str, Any]) -> list[int]:
+    values: list[int] = []
+    for key in ("elapsed_ms", "confirm_ms", "cancel_ms", "create_ms"):
+        value = _non_negative_int(payload.get(key))
+        if value is not None:
+            values.append(int(value))
+    return values
+
+
+def _safe_string_sample(values: Any, *, limit: int) -> dict[str, Any]:
+    if not isinstance(values, (list, tuple, set)):
+        return {}
+    safe_values = sorted(
+        {
+            _redact_log_text(str(value), max_len=80)
+            for value in values
+            if value not in (None, "")
+        }
+    )
+    return {
+        "count": len(safe_values),
+        "sample": safe_values[:limit],
+        "truncated": max(0, len(safe_values) - limit),
+    }
+
+
+def _execution_health_latest_data(payload: dict[str, Any]) -> dict[str, Any]:
+    safe_keys = (
+        "index",
+        "order_type",
+        "pb_order_type",
+        "context",
+        "reason",
+        "reduce_only",
+        "elapsed_ms",
+        "confirm_ms",
+        "timeout_ms",
+        "planned_cancel",
+        "planned_create",
+        "cancel_posted",
+        "create_posted",
+        "skipped_cancel",
+        "deferred_create",
+        "skipped_create",
+        "order_count",
+        "symbols_count",
+        "symbols_truncated",
+        "pending_surfaces",
+        "fresh_surfaces",
+        "changed_surfaces",
+        "error_type",
+        "result_status",
+    )
+    latest: dict[str, Any] = {}
+    for key in safe_keys:
+        value = payload.get(key)
+        if value in (None, "", {}, []):
+            continue
+        latest[key] = _compact_problem_event_data_value(value)
+    symbol_sample = _safe_string_sample(
+        payload.get("symbols"),
+        limit=EXECUTION_HEALTH_VALUE_LIMIT,
+    )
+    if symbol_sample:
+        latest["symbols"] = symbol_sample
+    return latest
+
+
+def _execution_health_group(
+    *,
+    bot_key: str,
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+    path: Path,
+    line_no: int,
+) -> dict[str, Any]:
+    event_type = str(live_event.get("event_type") or row.get("kind") or "")
+    data = live_event.get("data")
+    payload = data if isinstance(data, dict) else {}
+    status = (
+        str(live_event.get("status")).lower()
+        if live_event.get("status") not in (None, "")
+        else None
+    )
+    reason_code = live_event.get("reason_code")
+    error_type = payload.get("error_type")
+    symbol = live_event.get("symbol")
+    pside = live_event.get("pside")
+    side = live_event.get("side")
+    outcome = _execution_health_outcome(event_type, status)
+    ids = _event_ids(live_event)
+    return {
+        "bot": bot_key,
+        "event_type": event_type,
+        "component": live_event.get("component"),
+        "status": status,
+        "outcome": outcome,
+        "reason_code": reason_code,
+        "symbol": symbol,
+        "pside": pside,
+        "side": side,
+        "count": 1,
+        "event_types": Counter([event_type]) if event_type else Counter(),
+        "statuses": Counter([status]) if status else Counter(),
+        "outcomes": Counter([outcome]) if outcome else Counter(),
+        "reason_codes": Counter([str(reason_code)]) if reason_code not in (None, "") else Counter(),
+        "error_types": Counter([str(error_type)]) if error_type not in (None, "") else Counter(),
+        "symbols": Counter([str(symbol)]) if symbol not in (None, "") else Counter(),
+        "psides": Counter([str(pside)]) if pside not in (None, "") else Counter(),
+        "sides": Counter([str(side)]) if side not in (None, "") else Counter(),
+        "elapsed_values": _execution_health_elapsed_values(payload),
+        "latest_ts": row.get("ts"),
+        "latest_seq": row.get("seq"),
+        "latest_path": str(path),
+        "latest_line": int(line_no),
+        "latest_level": live_event.get("level"),
+        "latest_error_type": error_type,
+        "latest_data": _execution_health_latest_data(payload),
+        "latest_ids": {
+            key: ids.get(key)
+            for key in ("cycle_id", "order_wave_id", "action_id")
+            if ids.get(key) is not None
+        },
+    }
+
+
+def _merge_execution_health_group(
+    groups: dict[tuple[Any, ...], dict[str, Any]],
+    group: dict[str, Any],
+) -> None:
+    key = (
+        group.get("bot"),
+        group.get("event_type"),
+        group.get("component"),
+        group.get("status"),
+        group.get("reason_code"),
+        group.get("symbol"),
+        group.get("pside"),
+        group.get("side"),
+    )
+    existing = groups.get(key)
+    if existing is None:
+        groups[key] = group
+        return
+    existing["count"] = _count_value(existing.get("count")) + 1
+    existing.setdefault("elapsed_values", []).extend(group.get("elapsed_values") or [])
+    for field in (
+        "event_types",
+        "statuses",
+        "outcomes",
+        "reason_codes",
+        "error_types",
+        "symbols",
+        "psides",
+        "sides",
+    ):
+        counter = existing.setdefault(field, Counter())
+        counter.update(group.get(field) or Counter())
+    current_key = _sort_event_position_key(
+        ts=group.get("latest_ts"),
+        seq=group.get("latest_seq"),
+        path=group.get("latest_path") or "",
+        line_no=int(group.get("latest_line") or 0),
+    )
+    existing_key = _sort_event_position_key(
+        ts=existing.get("latest_ts"),
+        seq=existing.get("latest_seq"),
+        path=existing.get("latest_path") or "",
+        line_no=int(existing.get("latest_line") or 0),
+    )
+    if current_key > existing_key:
+        for field in (
+            "latest_ts",
+            "latest_seq",
+            "latest_path",
+            "latest_line",
+            "latest_level",
+            "latest_error_type",
+            "latest_data",
+            "latest_ids",
+        ):
+            existing[field] = group.get(field)
+
+
+def _execution_health_sort_key(
+    group: dict[str, Any],
+) -> tuple[int, int, int, int, int, int, str, str]:
+    outcomes = group.get("outcomes") if isinstance(group.get("outcomes"), Counter) else Counter()
+    elapsed = _ms_summary(
+        [
+            int(value)
+            for value in (group.get("elapsed_values") or [])
+            if _non_negative_int(value) is not None
+        ]
+    )
+    return (
+        -_count_value(outcomes.get("ambiguous")),
+        -_count_value(outcomes.get("cancel_ambiguous_terminal")),
+        -_count_value(outcomes.get("confirmation_timeout")),
+        -(
+            _count_value(outcomes.get("create_failed"))
+            + _count_value(outcomes.get("cancel_failed"))
+        ),
+        -_count_value(outcomes.get("create_rejected")),
+        -int(elapsed.get("p95_ms") or 0),
+        str(group.get("bot") or ""),
+        str(group.get("event_type") or ""),
+    )
+
+
+def _summarize_execution_health(
+    groups: dict[tuple[Any, ...], dict[str, Any]]
+) -> dict[str, Any]:
+    ordered = sorted(groups.values(), key=_execution_health_sort_key)
+    event_types: Counter[str] = Counter()
+    statuses: Counter[str] = Counter()
+    outcomes: Counter[str] = Counter()
+    bots: Counter[str] = Counter()
+    for group in groups.values():
+        event_types.update(group.get("event_types") or Counter())
+        statuses.update(group.get("statuses") or Counter())
+        outcomes.update(group.get("outcomes") or Counter())
+        if group.get("bot") not in (None, ""):
+            bots[str(group.get("bot"))] += int(group.get("count") or 0)
+    total = sum(_count_value(group.get("count")) for group in groups.values())
+    failed = _count_value(outcomes.get("create_failed")) + _count_value(
+        outcomes.get("cancel_failed")
+    )
+    rejected = _count_value(outcomes.get("create_rejected"))
+    ambiguous = int(
+        _count_value(outcomes.get("ambiguous"))
+        + _count_value(outcomes.get("cancel_ambiguous_terminal"))
+    )
+    confirmation_timeout = _count_value(outcomes.get("confirmation_timeout"))
+    compact_groups = []
+    for group in ordered[:EXECUTION_HEALTH_GROUP_LIMIT]:
+        statuses_counter = (
+            group.get("statuses") if isinstance(group.get("statuses"), Counter) else Counter()
+        )
+        outcomes_counter = (
+            group.get("outcomes") if isinstance(group.get("outcomes"), Counter) else Counter()
+        )
+        reason_codes = (
+            group.get("reason_codes")
+            if isinstance(group.get("reason_codes"), Counter)
+            else Counter()
+        )
+        error_types = (
+            group.get("error_types") if isinstance(group.get("error_types"), Counter) else Counter()
+        )
+        symbols = group.get("symbols") if isinstance(group.get("symbols"), Counter) else Counter()
+        psides = group.get("psides") if isinstance(group.get("psides"), Counter) else Counter()
+        sides = group.get("sides") if isinstance(group.get("sides"), Counter) else Counter()
+        compact = {
+            "bot": group.get("bot"),
+            "event_type": group.get("event_type"),
+            "component": group.get("component"),
+            "status": group.get("status"),
+            "outcome": group.get("outcome"),
+            "reason_code": group.get("reason_code"),
+            "symbol": group.get("symbol"),
+            "pside": group.get("pside"),
+            "side": group.get("side"),
+            "count": _count_value(group.get("count")),
+            "statuses": _top_counter_values(
+                statuses_counter,
+                limit=EXECUTION_HEALTH_VALUE_LIMIT,
+            ),
+            "outcomes": _top_counter_values(
+                outcomes_counter,
+                limit=EXECUTION_HEALTH_VALUE_LIMIT,
+            ),
+            "reason_codes": _top_counter_values(
+                reason_codes,
+                limit=EXECUTION_HEALTH_VALUE_LIMIT,
+            ),
+            "error_types": _top_counter_values(
+                error_types,
+                limit=EXECUTION_HEALTH_VALUE_LIMIT,
+            ),
+            "symbols": _symbol_sample(
+                symbols,
+                limit=EXECUTION_HEALTH_VALUE_LIMIT,
+            ),
+            "psides": _symbol_sample(
+                psides,
+                limit=EXECUTION_HEALTH_VALUE_LIMIT,
+            ),
+            "sides": _symbol_sample(
+                sides,
+                limit=EXECUTION_HEALTH_VALUE_LIMIT,
+            ),
+            "elapsed_ms": _ms_summary(
+                [
+                    int(value)
+                    for value in (group.get("elapsed_values") or [])
+                    if _non_negative_int(value) is not None
+                ]
+            ),
+            "latest_ts": group.get("latest_ts"),
+            "latest_level": group.get("latest_level"),
+            "latest_error_type": group.get("latest_error_type"),
+            "latest_data": group.get("latest_data"),
+            "latest_ids": group.get("latest_ids"),
+        }
+        compact_groups.append(
+            {
+                key: value
+                for key, value in compact.items()
+                if key not in {"latest_path", "latest_line", "latest_seq"}
+                and value not in (None, {}, [])
+            }
+        )
+    return {
+        "total": total,
+        "bots": len(bots),
+        "failed": failed,
+        "rejected": rejected,
+        "ambiguous": ambiguous,
+        "confirmation_timeout": confirmation_timeout,
+        "event_types": _top_counter_values(
+            event_types,
+            limit=EXECUTION_HEALTH_VALUE_LIMIT,
+        ),
+        "statuses": _top_counter_values(
+            statuses,
+            limit=EXECUTION_HEALTH_VALUE_LIMIT,
+        ),
+        "outcomes": _top_counter_values(
+            outcomes,
+            limit=EXECUTION_HEALTH_VALUE_LIMIT,
+        ),
+        "groups_truncated": len(ordered) > EXECUTION_HEALTH_GROUP_LIMIT,
         "groups": compact_groups,
     }
 
@@ -3816,6 +4211,7 @@ def _scan_events(
     remote_call_failure_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     remote_call_health_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     remote_call_timing_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
+    execution_health_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     fill_refresh_health_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     ema_readiness_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     ema_readiness_event_type_counts: Counter[str] = Counter()
@@ -3991,6 +4387,17 @@ def _scan_events(
                                 remote_call_timing_groups,
                                 remote_call_timing_group,
                             )
+                    if event_type in EXECUTION_HEALTH_EVENT_TYPES:
+                        _merge_execution_health_group(
+                            execution_health_groups,
+                            _execution_health_group(
+                                bot_key=bot_key,
+                                row=row,
+                                live_event=live_event,
+                                path=path,
+                                line_no=line_no,
+                            ),
+                        )
                     if event_type == EventTypes.FILLS_REFRESH_SUMMARY:
                         _merge_fill_refresh_health_group(
                             fill_refresh_health_groups,
@@ -4183,6 +4590,7 @@ def _scan_events(
             _account_critical_remote_call_health_groups(remote_call_health_groups)
         ),
         "remote_call_timings": _summarize_remote_call_timings(remote_call_timing_groups),
+        "execution_health": _summarize_execution_health(execution_health_groups),
         "fill_refresh_health": _summarize_fill_refresh_health(
             fill_refresh_health_groups
         ),
@@ -4595,6 +5003,7 @@ def build_live_smoke_report(
             "account_critical_remote_call_health"
         ],
         "remote_call_timings": event_scan["remote_call_timings"],
+        "execution_health": event_scan["execution_health"],
         "fill_refresh_health": event_scan["fill_refresh_health"],
         "ema_readiness_health": event_scan["ema_readiness_health"],
         "exchange_config_refresh_health": event_scan[
@@ -4639,10 +5048,14 @@ def _summary_limited_groups(
             "succeeded": summary.get("succeeded"),
             "failed": summary.get("failed"),
             "throttled": summary.get("throttled"),
+            "rejected": summary.get("rejected"),
+            "ambiguous": summary.get("ambiguous"),
+            "confirmation_timeout": summary.get("confirmation_timeout"),
             "failure_pct": summary.get("failure_pct"),
             "throttled_pct": summary.get("throttled_pct"),
             "event_types": summary.get("event_types"),
             "statuses": summary.get("statuses"),
+            "outcomes": summary.get("outcomes"),
             "bots": summary.get("bots"),
             "active_bots": summary.get("active_bots"),
             "completed_bots": summary.get("completed_bots"),
@@ -4824,6 +5237,11 @@ def summarize_live_smoke_report(
         if isinstance(report.get("fill_refresh_health"), dict)
         else {}
     )
+    execution_health = (
+        report.get("execution_health")
+        if isinstance(report.get("execution_health"), dict)
+        else {}
+    )
     exchange_config_refresh_health = (
         report.get("exchange_config_refresh_health")
         if isinstance(report.get("exchange_config_refresh_health"), dict)
@@ -4975,6 +5393,10 @@ def summarize_live_smoke_report(
             report.get("startup_timings"),
             limit=max_groups,
         ),
+        "execution_health": _summary_limited_groups(
+            execution_health,
+            limit=max_groups,
+        ),
         "fill_refresh_health": _summary_limited_groups(
             fill_refresh_health,
             limit=max_groups,
@@ -5049,6 +5471,28 @@ def _brief_fill_refresh_health(summary: Any) -> dict[str, Any]:
             "latest_failed_bots": _count_value(summary.get("latest_failed_bots")),
             "recovered_groups": _count_value(summary.get("recovered_groups")),
             "statuses": summary.get("statuses") or {},
+        }.items()
+        if value is not None
+    }
+
+
+def _brief_execution_health(summary: Any) -> dict[str, Any]:
+    if not isinstance(summary, dict):
+        summary = {}
+    return {
+        key: value
+        for key, value in {
+            "total": _count_value(summary.get("total")),
+            "bots": _count_value(summary.get("bots")),
+            "failed": _count_value(summary.get("failed")),
+            "rejected": _count_value(summary.get("rejected")),
+            "ambiguous": _count_value(summary.get("ambiguous")),
+            "confirmation_timeout": _count_value(
+                summary.get("confirmation_timeout")
+            ),
+            "event_types": summary.get("event_types") or {},
+            "statuses": summary.get("statuses") or {},
+            "outcomes": summary.get("outcomes") or {},
         }.items()
         if value is not None
     }
@@ -5244,6 +5688,11 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         if isinstance(report.get("fill_refresh_health"), dict)
         else {}
     )
+    execution_health = (
+        report.get("execution_health")
+        if isinstance(report.get("execution_health"), dict)
+        else {}
+    )
     exchange_config_refresh_health = (
         report.get("exchange_config_refresh_health")
         if isinstance(report.get("exchange_config_refresh_health"), dict)
@@ -5403,6 +5852,7 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             report.get("account_critical_remote_call_health")
         ),
         "startup_timings": _brief_startup_timings(report.get("startup_timings")),
+        "execution": _brief_execution_health(execution_health),
         "fill_refresh": _brief_fill_refresh_health(fill_refresh_health),
         "ema_readiness": {
             "total": _count_value(ema_readiness_health.get("total")),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -29,6 +29,7 @@ def _monitor_row(
     reason_code: str = "test",
     symbol: str | None = None,
     pside: str | None = None,
+    side: str | None = None,
     ids: dict | None = None,
     data: dict | None = None,
     message: str | None = None,
@@ -44,6 +45,7 @@ def _monitor_row(
         "user": user,
         "symbol": symbol,
         "pside": pside,
+        "side": side,
         "status": status,
         "reason_code": reason_code,
         "data": dict(data or {"seq": seq}),
@@ -895,6 +897,213 @@ def test_live_smoke_report_account_critical_remote_call_health_subset(tmp_path):
     assert account_health["throttled_pct"] == 0
     group_surfaces = {group.get("surface") for group in account_health["groups"]}
     assert group_surfaces == {"balance", "positions", "open_orders"}
+
+
+def test_live_smoke_report_summarizes_execution_health(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    rows = [
+        _monitor_row(
+            event_type="order_wave.started",
+            seq=1,
+            ts=1000,
+            status="started",
+            ids={"cycle_id": "cy_1", "order_wave_id": "ow_1"},
+            data={
+                "id": 1,
+                "planned_cancel": 1,
+                "planned_create": 2,
+                "symbols": ["BTC/USDT:USDT", "ETH/USDT:USDT"],
+            },
+        ),
+        _monitor_row(
+            event_type="execution.create_sent",
+            seq=2,
+            ts=1100,
+            status="started",
+            symbol="BTC/USDT:USDT",
+            pside="long",
+            ids={
+                "cycle_id": "cy_1",
+                "order_wave_id": "ow_1",
+                "action_id": "ow_1:create:0",
+            },
+            data={
+                "index": 0,
+                "order_type": "limit",
+                "context": "entry",
+                "qty": 1.0,
+                "price": 10.0,
+                "client_order_id_short": "pb_secret_create",
+            },
+        ),
+        _monitor_row(
+            event_type="execution.create_failed",
+            seq=3,
+            ts=1200,
+            status="failed",
+            level="warning",
+            reason_code="exchange_exception",
+            symbol="BTC/USDT:USDT",
+            pside="long",
+            ids={
+                "cycle_id": "cy_1",
+                "order_wave_id": "ow_1",
+                "action_id": "ow_1:create:0",
+            },
+            data={
+                "index": 0,
+                "order_type": "limit",
+                "error_type": "RequestTimeout",
+                "error": "raw exchange error should stay out",
+                "result_order_id_short": "exchange_order_secret",
+                "result_client_order_id_short": "client_secret",
+            },
+        ),
+        _monitor_row(
+            event_type="execution.cancel_ambiguous_terminal",
+            seq=4,
+            ts=1300,
+            status="degraded",
+            level="warning",
+            reason_code="exchange_exception",
+            symbol="ETH/USDT:USDT",
+            pside="short",
+            side="sell",
+            ids={
+                "cycle_id": "cy_1",
+                "order_wave_id": "ow_1",
+                "action_id": "ow_1:cancel:0",
+            },
+            data={
+                "index": 0,
+                "order_type": "limit",
+                "error_type": "NetworkError",
+                "order_id_short": "cancel_order_secret",
+            },
+        ),
+        _monitor_row(
+            event_type="execution.confirmation_timeout",
+            seq=5,
+            ts=1400,
+            status="degraded",
+            level="warning",
+            reason_code="authoritative_confirmation_timeout",
+            ids={"cycle_id": "cy_1", "order_wave_id": "ow_1"},
+            data={
+                "elapsed_ms": 5000,
+                "confirm_ms": 3000,
+                "timeout_ms": 2500,
+                "pending_surfaces": ["open_orders"],
+                "symbols": ["BTC/USDT:USDT", "ETH/USDT:USDT"],
+            },
+        ),
+        _monitor_row(
+            event_type="order_wave.completed",
+            seq=6,
+            ts=1500,
+            status="degraded",
+            reason_code="order_filtered",
+            ids={"cycle_id": "cy_1", "order_wave_id": "ow_1"},
+            data={
+                "id": 1,
+                "elapsed_ms": 6000,
+                "planned_cancel": 1,
+                "planned_create": 2,
+                "cancel_posted": 0,
+                "create_posted": 0,
+                "skipped_cancel": 0,
+                "deferred_create": 1,
+                "skipped_create": 1,
+                "symbols": ["BTC/USDT:USDT", "ETH/USDT:USDT"],
+            },
+        ),
+    ]
+    rows[2]["payload"]["_live_event"]["order_id"] = "raw_exchange_order_id"
+    rows[2]["payload"]["_live_event"]["client_order_id"] = "raw_client_order_id"
+    _write_ndjson(events_dir / "current.ndjson", rows)
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    execution = report["execution_health"]
+
+    assert execution["total"] == 6
+    assert execution["bots"] == 1
+    assert execution["failed"] == 1
+    assert execution["rejected"] == 0
+    assert execution["ambiguous"] == 1
+    assert execution["confirmation_timeout"] == 1
+    assert execution["event_types"] == {
+        "execution.cancel_ambiguous_terminal": 1,
+        "execution.confirmation_timeout": 1,
+        "execution.create_failed": 1,
+        "execution.create_sent": 1,
+        "order_wave.completed": 1,
+        "order_wave.started": 1,
+    }
+    assert execution["outcomes"]["create_failed"] == 1
+    assert execution["outcomes"]["cancel_ambiguous_terminal"] == 1
+    assert execution["outcomes"]["confirmation_timeout"] == 1
+    assert execution["statuses"] == {
+        "degraded": 3,
+        "failed": 1,
+        "started": 2,
+    }
+    assert execution["groups_truncated"] is False
+    rendered_execution = json.dumps(execution, sort_keys=True)
+    assert "raw_exchange_order_id" not in rendered_execution
+    assert "raw_client_order_id" not in rendered_execution
+    assert "exchange_order_secret" not in rendered_execution
+    assert "client_secret" not in rendered_execution
+    assert "cancel_order_secret" not in rendered_execution
+    assert "raw exchange error" not in rendered_execution
+    assert '"price"' not in rendered_execution
+    assert '"qty"' not in rendered_execution
+    assert "RequestTimeout" in rendered_execution
+    assert "ow_1:create:0" in rendered_execution
+
+    summary = summarize_live_smoke_report(report, max_groups=2)
+    assert summary["execution_health"]["total"] == 6
+    assert summary["execution_health"]["failed"] == 1
+    assert summary["execution_health"]["ambiguous"] == 1
+    assert summary["execution_health"]["confirmation_timeout"] == 1
+    assert summary["execution_health"]["groups_truncated"] is True
+
+    brief = summarize_live_smoke_report_brief(report)
+    assert brief["execution"] == {
+        "total": 6,
+        "bots": 1,
+        "failed": 1,
+        "rejected": 0,
+        "ambiguous": 1,
+        "confirmation_timeout": 1,
+        "event_types": {
+            "execution.cancel_ambiguous_terminal": 1,
+            "execution.confirmation_timeout": 1,
+            "execution.create_failed": 1,
+            "execution.create_sent": 1,
+            "order_wave.completed": 1,
+            "order_wave.started": 1,
+        },
+        "statuses": {
+            "degraded": 3,
+            "failed": 1,
+            "started": 2,
+        },
+        "outcomes": {
+            "cancel_ambiguous_terminal": 1,
+            "confirmation_timeout": 1,
+            "create_failed": 1,
+            "create_sent": 1,
+            "wave_completed": 1,
+            "wave_started": 1,
+        },
+    }
+
+    projected = project_live_smoke_report_sections(
+        summarize_live_smoke_report_brief(report),
+        ["execution"],
+    )
+    assert projected["execution"]["total"] == 6
+    assert "remote_calls" not in projected
 
 
 def test_live_smoke_report_summary_projects_high_signal_fields(tmp_path):


### PR DESCRIPTION
## Summary
- add passive live-smoke-report execution_health aggregation for existing order_wave.* and execution.* structured events
- expose concise execution counters in --brief output and --section execution projection
- update tooling docs and fold current progress ledger updates into this real code PR

## Scope
- read-only smoke-report tooling, docs, and tests only
- no event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, process signaling, smoke verdict policy, order/risk logic, or trading behavior changes

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check
- added-line silent-handling scan clean: git diff -U0 -- src/live/smoke_report.py tests/test_live_smoke_report.py | rg -n '^\+.*(except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\]))' returned no matches