### PR TITLE
Summarize execution health in incident bundles

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,7 +19,18 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `07ee5860` after PR #952, `Make restart failure bundles self-contained`.
+- `8981464a` after PR #953, `Report execution health in live smoke`.
+
+Current work:
+
+- Branch `codex/v8-incident-execution-summary` summarizes existing
+  `execution_health` smoke-report counters in `live-incident-bundle` report and
+  manifest output. The slice is read-only incident-response tooling: no new
+  event producers, exchange calls, cache mutation, readiness gates, smoke
+  verdict changes, process signaling, console routing, order logic, risk logic,
+  or trading behavior. Expected validation is focused incident-bundle tests,
+  py_compile for touched files, `git diff --check`, and an added-line
+  silent-handling scan.
 
 Current review gate:
 
@@ -49,6 +60,26 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #953 at `8981464a`.
+- PR #953 added an `execution_health` section to `live-smoke-report` full and
+  summary output and an `execution` line to brief output, deriving aggregate
+  execution-write health from existing `order_wave.*` and `execution.*`
+  structured events. The slice was read-only smoke-report tooling and did not
+  add event producers, exchange calls, cache mutation, readiness gates, smoke
+  verdict changes, process signaling, console routing, order logic, risk logic,
+  or trading behavior.
+- PR #953 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_smoke_report.py`, py_compile for touched files,
+  `git diff --check`, and an added-line silent-handling scan.
+- VPS5 pulled from `07ee5860` to `8981464a` without bot restart because the
+  deployed change was read-only smoke-report tooling. The five configured bots
+  were left running.
+- A VPS5 1-minute bounded smoke after deploy reported `ok=true`,
+  `hard_failures=0`, clean tracked repository state at `8981464a`, all five
+  configured bots matched, config checks green, zero failed remote calls, zero
+  failed account-critical remote calls, and the new brief `execution` section
+  present with zero recent execution events. Remaining attention came from known
+  non-hard EMA/HSL cooldown groups.
 - Repository pulled through PR #952 at `07ee5860`.
 - PR #952 made `live-restart-smoke-plan` planned failure-bundle commands
   self-contained by adding `live-incident-bundle --restart-smoke-plan` and the

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -199,7 +199,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
 - `passivbot tool live-incident-bundle` writes a local `.tar.gz` evidence
   bundle with monitor event reports, problem-event reports, smoke evidence,
   redacted log excerpts, monitor snapshots, runtime metadata, and optional
-  bounded event segments. It is read-only and does not contact exchanges. Use
+  bounded event segments. The returned report and manifest include a compact
+  smoke execution summary with only aggregate create/cancel/confirmation
+  counters. It is read-only and does not contact exchanges. Use
   `--smoke-section SECTION` one or more times to keep only selected top-level
   sections from the embedded full `smoke_report.json` plus common smoke
   metadata, for example `--smoke-section fill_refresh_health`. Use

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -697,6 +697,29 @@ def _smoke_log_result_summary(smoke_report: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _smoke_counter_summary(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _smoke_execution_result_summary(smoke_report: dict[str, Any]) -> dict[str, Any]:
+    execution = (
+        smoke_report.get("execution_health")
+        if isinstance(smoke_report.get("execution_health"), dict)
+        else {}
+    )
+    return {
+        "total": _safe_int(execution.get("total")) or 0,
+        "bots": _safe_int(execution.get("bots")) or 0,
+        "failed": _safe_int(execution.get("failed")) or 0,
+        "rejected": _safe_int(execution.get("rejected")) or 0,
+        "ambiguous": _safe_int(execution.get("ambiguous")) or 0,
+        "confirmation_timeout": _safe_int(execution.get("confirmation_timeout")) or 0,
+        "event_types": _smoke_counter_summary(execution.get("event_types")),
+        "statuses": _smoke_counter_summary(execution.get("statuses")),
+        "outcomes": _smoke_counter_summary(execution.get("outcomes")),
+    }
+
+
 def _copy_event_segments(
     *,
     monitor_root: str | Path,
@@ -1028,6 +1051,7 @@ def build_live_incident_bundle(
         smoke_report,
         smoke_sections,
     )
+    smoke_execution_summary = _smoke_execution_result_summary(smoke_report)
     restart_smoke_plan: dict[str, Any] | None = None
     restart_smoke_plan_summary: dict[str, Any] | None = None
     if include_restart_smoke_plan:
@@ -1125,6 +1149,9 @@ def build_live_incident_bundle(
             "config_hashes": config_hashes,
             "monitor_snapshots": snapshots,
             "event_segments": segment_manifest,
+            "smoke_report": {
+                "execution": smoke_execution_summary,
+            },
         }
         if restart_smoke_plan_summary is not None:
             metadata["restart_smoke_plan"] = _restart_smoke_plan_result_summary(
@@ -1206,6 +1233,7 @@ def build_live_incident_bundle(
             "attention_count": smoke_report.get("attention_count"),
             "event_window": smoke_report.get("event_window"),
             "logs": _smoke_log_result_summary(smoke_report),
+            "execution": smoke_execution_summary,
             "processes": {
                 "enabled": smoke_report.get("processes", {}).get("enabled"),
                 "ok": smoke_report.get("processes", {}).get("ok"),

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -119,6 +119,28 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
                 symbol="BTC/USDT:USDT",
                 ids={"cycle_id": "cy_2", "remote_call_id": "rc_1"},
             ),
+            _monitor_row(
+                event_type="execution.create_succeeded",
+                seq=5,
+                ts=2100,
+                status="succeeded",
+                level="info",
+                reason_code="exchange_acknowledged",
+                component="execution.order_write",
+                symbol="ETH/USDT:USDT",
+                ids={
+                    "cycle_id": "cy_3",
+                    "order_wave_id": "wave_2",
+                    "action_id": "wave_2:create:0",
+                },
+                data={
+                    "price": 123.45,
+                    "qty": 0.678,
+                    "order_id_short": "raw_order_id_should_not_summarize",
+                    "client_order_id_short": "raw_client_id_should_not_summarize",
+                    "result_status": "open",
+                },
+            ),
         ],
     )
     (events_dir / "20260629.ndjson.gz").write_bytes(b"")
@@ -189,12 +211,12 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         "rotated_skipped": 1,
         "scope_pruned": 0,
     }
-    assert report["time_window"]["matched_events"] == 1
+    assert report["time_window"]["matched_events"] == 2
     assert report["smoke_report"]["event_window"] == {
         "enabled": True,
         "since_ms": 1500,
         "until_ms": 2500,
-        "events_considered": 1,
+        "events_considered": 2,
         "events_skipped_before": 3,
         "events_skipped_after": 0,
         "invalid_window_ts": 0,
@@ -225,6 +247,17 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
             "dropped_unparsed_attention_matches": 0,
             "dropped_unparsed_hard_matches": 0,
         },
+    }
+    assert report["smoke_report"]["execution"] == {
+        "total": 1,
+        "bots": 1,
+        "failed": 0,
+        "rejected": 0,
+        "ambiguous": 0,
+        "confirmation_timeout": 0,
+        "event_types": {"execution.create_succeeded": 1},
+        "statuses": {"succeeded": 1},
+        "outcomes": {"create_succeeded": 1},
     }
     assert report["config_hashes"] == 1
     assert report["monitor_snapshots"] == 1
@@ -267,6 +300,12 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         )
 
     assert manifest["config_hashes"][0]["sha256"] == config_hashes[0]["sha256"]
+    assert manifest["smoke_report"]["execution"] == report["smoke_report"]["execution"]
+    manifest_dump = json.dumps(manifest, sort_keys=True)
+    assert "raw_order_id_should_not_summarize" not in manifest_dump
+    assert "raw_client_id_should_not_summarize" not in manifest_dump
+    assert '"price"' not in manifest_dump
+    assert '"qty"' not in manifest_dump
     assert manifest["filters"]["max_log_files"] == 8
     assert manifest["filters"]["log_tail_lines"] == 500
     assert manifest["filters"]["max_log_matches"] == 100
@@ -321,6 +360,12 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     ]
     assert smoke_report["logs"]["window"] == report["smoke_report"]["logs"]["window"]
     assert smoke_report["remote_call_failures"]["total"] == 1
+    assert smoke_report["execution_health"]["total"] == 1
+    smoke_dump = json.dumps(smoke_report, sort_keys=True)
+    assert "raw_order_id_should_not_summarize" not in smoke_dump
+    assert "raw_client_id_should_not_summarize" not in smoke_dump
+    assert '"price"' not in smoke_dump
+    assert '"qty"' not in smoke_dump
 
 
 def test_live_incident_bundle_embeds_problem_event_report(tmp_path):


### PR DESCRIPTION
## Summary
- add a compact execution summary to live-incident-bundle report and manifest output, sourced from existing live-smoke-report execution_health
- keep the bundle summary aggregate-only: total/bot/failure/rejection/ambiguity/confirmation-timeout counters plus event/status/outcome maps
- update docs and the logging-overhaul progress ledger with PR #953 deployment evidence and this current slice

## Behavior
Read-only incident-response tooling only. No new event producers, exchange calls, cache mutation, readiness gates, smoke verdict changes, process signaling, console routing, order logic, risk logic, or trading behavior.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_incident_bundle.py -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check
- added-line silent-handling scan: no matches