### PR TITLE
Infer incident bundle git metadata from monitor root

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,14 +19,14 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `8981464a` after PR #953, `Report execution health in live smoke`.
+- `3425a14a` after PR #954, `Summarize execution health in incident bundles`.
 
 Current work:
 
-- Branch `codex/v8-incident-execution-summary` summarizes existing
-  `execution_health` smoke-report counters in `live-incident-bundle` report and
-  manifest output. The slice is read-only incident-response tooling: no new
-  event producers, exchange calls, cache mutation, readiness gates, smoke
+- Branch `codex/v8-incident-infer-repo` makes `live-incident-bundle` infer git
+  metadata from the monitor tree when invoked from outside the repo with an
+  absolute monitor path. The slice is read-only incident-response tooling: no
+  new event producers, exchange calls, cache mutation, readiness gates, smoke
   verdict changes, process signaling, console routing, order logic, risk logic,
   or trading behavior. Expected validation is focused incident-bundle tests,
   py_compile for touched files, `git diff --check`, and an added-line
@@ -60,6 +60,30 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #954 at `3425a14a`.
+- PR #954 added a compact `execution` summary to `live-incident-bundle` report
+  and manifest output, sourced from the existing `live-smoke-report`
+  `execution_health` section. The projection includes only aggregate execution
+  counters and event/status/outcome maps. The slice was read-only
+  incident-bundle tooling and did not add event producers, exchange calls,
+  cache mutation, readiness gates, smoke verdict changes, process signaling,
+  console routing, order logic, risk logic, or trading behavior.
+- PR #954 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_incident_bundle.py`, py_compile for touched files,
+  `git diff --check`, and an added-line silent-handling scan.
+- VPS5 pulled from `8981464a` to `3425a14a` without bot restart because the
+  deployed change was read-only incident-bundle tooling. The five configured
+  bots were left running.
+- A VPS5 2-minute bounded smoke after deploy reported `ok=true`,
+  `hard_failures=0`, clean tracked repository state at `3425a14a`, all five
+  configured bots matched, config checks green, zero failed remote calls, zero
+  failed account-critical remote calls, and the new brief `execution` section
+  present with zero recent execution events. A focused incident-bundle run with
+  `--smoke-section execution_health --no-event-segments` reported `ok=true`
+  and returned `smoke_report.execution` with aggregate zero counters for the
+  quiet sample window; archive inspection confirmed
+  `manifest.smoke_report.execution` was present. Remaining attention came from
+  known non-hard EMA/HSL cooldown groups.
 - Repository pulled through PR #953 at `8981464a`.
 - PR #953 added an `execution_health` section to `live-smoke-report` full and
   summary output and an `execution` line to brief output, deriving aggregate

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -201,7 +201,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   redacted log excerpts, monitor snapshots, runtime metadata, and optional
   bounded event segments. The returned report and manifest include a compact
   smoke execution summary with only aggregate create/cancel/confirmation
-  counters. It is read-only and does not contact exchanges. Use
+  counters. When invoked from outside the repository with an absolute monitor
+  path, the manifest infers git metadata from the monitor tree when possible.
+  It is read-only and does not contact exchanges. Use
   `--smoke-section SECTION` one or more times to keep only selected top-level
   sections from the embedded full `smoke_report.json` plus common smoke
   metadata, for example `--smoke-section fill_refresh_health`. Use

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -37,6 +37,7 @@ from live.restart_smoke_plan import (
 )
 from live.smoke_report import (
     DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
+    _find_repository_root,
     _redact_log_text,
     build_live_smoke_report,
     default_logs_root_for_monitor,
@@ -406,6 +407,16 @@ def _git_metadata(cwd: str | Path | None = None) -> dict[str, Any]:
         "status_short": run_git(["status", "--short"]),
         "remote_url": _redact_url_userinfo(run_git(["remote", "get-url", "origin"])),
     }
+
+
+def _incident_git_metadata_cwd(
+    *,
+    cwd: str | Path | None,
+    monitor_root: str | Path,
+) -> Path:
+    if cwd is not None:
+        return Path(cwd).expanduser()
+    return _find_repository_root(monitor_root, repo_root=None)
 
 
 def _redact_url_userinfo(value: str | None) -> str | None:
@@ -1145,7 +1156,9 @@ def build_live_incident_bundle(
                 if value not in (None, [], "")
             },
             "runtime": _runtime_metadata(),
-            "git": _git_metadata(cwd=cwd),
+            "git": _git_metadata(
+                cwd=_incident_git_metadata_cwd(cwd=cwd, monitor_root=monitor_path)
+            ),
             "config_hashes": config_hashes,
             "monitor_snapshots": snapshots,
             "event_segments": segment_manifest,

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import tarfile
 from pathlib import Path
 
@@ -1573,6 +1574,56 @@ def test_live_incident_bundle_cli_requires_supervisor_for_restart_plan(capsys):
         live_incident_bundle.main(["monitor", "--restart-smoke-plan"])
 
     assert "--restart-smoke-plan requires --supervisor-config" in capsys.readouterr().err
+
+
+def test_live_incident_bundle_infers_git_metadata_from_monitor_root(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(
+        [
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://token:secret@example.com/org/repo.git",
+        ],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    events_dir = repo / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+            ),
+        ],
+    )
+    output = tmp_path / "incident.tar.gz"
+
+    report = build_live_incident_bundle(
+        repo / "monitor",
+        output_path=output,
+        logs_root="",
+        include_processes=False,
+        include_event_segments=False,
+    )
+
+    assert report["ok"] is True
+    with tarfile.open(output, "r:gz") as tar:
+        manifest = _read_tar_json(tar, "manifest.json")
+
+    assert manifest["git"]["cwd"] == str(repo)
+    assert (
+        manifest["git"]["remote_url"]
+        == "https://[redacted]@example.com/org/repo.git"
+    )
+    assert manifest["git"]["status_short"] is not None
 
 
 def test_live_incident_bundle_redacts_git_remote_url_userinfo():


### PR DESCRIPTION
## Summary
- infer live-incident-bundle manifest git metadata from the monitor tree when no explicit cwd is supplied
- preserve explicit cwd behavior for tests/callers that pass it directly
- add regression coverage for running from outside the repo with an absolute monitor path and a credential-bearing remote URL
- fold PR #954 VPS5 deploy/smoke evidence into the logging-overhaul progress ledger

## Behavior
Read-only incident-response tooling only. No new event producers, exchange calls, cache mutation, readiness gates, smoke verdict changes, process signaling, console routing, order logic, risk logic, or trading behavior.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_incident_bundle.py -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check
- added-line silent-handling scan: no matches