### PR TITLE
Limit incident bundle git status to tracked changes

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,18 +19,18 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `3425a14a` after PR #954, `Summarize execution health in incident bundles`.
+- `69603923` after PR #955, `Infer incident bundle git metadata from monitor root`.
 
 Current work:
 
-- Branch `codex/v8-incident-infer-repo` makes `live-incident-bundle` infer git
-  metadata from the monitor tree when invoked from outside the repo with an
-  absolute monitor path. The slice is read-only incident-response tooling: no
-  new event producers, exchange calls, cache mutation, readiness gates, smoke
-  verdict changes, process signaling, console routing, order logic, risk logic,
-  or trading behavior. Expected validation is focused incident-bundle tests,
-  py_compile for touched files, `git diff --check`, and an added-line
-  silent-handling scan.
+- Branch `codex/v8-incident-tracked-git-status` limits
+  `live-incident-bundle` manifest git status to tracked changes so local
+  untracked configs and monitor artifacts do not dominate incident metadata.
+  The slice is read-only incident-response tooling: no new event producers,
+  exchange calls, cache mutation, readiness gates, smoke verdict changes,
+  process signaling, console routing, order logic, risk logic, or trading
+  behavior. Expected validation is focused incident-bundle tests, py_compile
+  for touched files, `git diff --check`, and an added-line silent-handling scan.
 
 Current review gate:
 
@@ -60,6 +60,31 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #955 at `69603923`.
+- PR #955 made `live-incident-bundle` infer manifest git metadata from the
+  monitor tree when invoked from outside the repo with an absolute monitor
+  path, while preserving explicit `cwd` behavior and remote URL userinfo
+  redaction. The slice was read-only incident-bundle tooling and did not add
+  event producers, exchange calls, cache mutation, readiness gates, smoke
+  verdict changes, process signaling, console routing, order logic, risk logic,
+  or trading behavior.
+- PR #955 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_incident_bundle.py`, py_compile for touched files,
+  `git diff --check`, and an added-line silent-handling scan.
+- VPS5 pulled from `3425a14a` to `69603923` without bot restart because the
+  deployed change was read-only incident-bundle tooling. The five configured
+  bots were left running.
+- A VPS5 2-minute bounded smoke after deploy reported `ok=true`,
+  `hard_failures=0`, clean tracked repository state at `69603923`, all five
+  configured bots matched, config checks green, zero failed remote calls, zero
+  failed account-critical remote calls, and a populated brief `execution`
+  section with recent create/cancel/confirmation events. A focused
+  incident-bundle run from outside the repo with absolute `/root/passivbot`
+  monitor/log paths reported `ok=true`, returned populated
+  `smoke_report.execution`, and archive inspection confirmed
+  `manifest.git.cwd=/root/passivbot`, `manifest.git.branch=v8`, and
+  `manifest.git.head=69603923...`. Remaining attention came from known non-hard
+  EMA/HSL cooldown groups.
 - Repository pulled through PR #954 at `3425a14a`.
 - PR #954 added a compact `execution` summary to `live-incident-bundle` report
   and manifest output, sourced from the existing `live-smoke-report`

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -203,7 +203,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   smoke execution summary with only aggregate create/cancel/confirmation
   counters. When invoked from outside the repository with an absolute monitor
   path, the manifest infers git metadata from the monitor tree when possible.
-  It is read-only and does not contact exchanges. Use
+  Manifest git status is limited to tracked changes so local untracked configs
+  and monitor artifacts do not dominate the bundle metadata. It is read-only
+  and does not contact exchanges. Use
   `--smoke-section SECTION` one or more times to keep only selected top-level
   sections from the embedded full `smoke_report.json` plus common smoke
   metadata, for example `--smoke-section fill_refresh_health`. Use

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -404,7 +404,7 @@ def _git_metadata(cwd: str | Path | None = None) -> dict[str, Any]:
         "cwd": str(root),
         "head": run_git(["rev-parse", "HEAD"]),
         "branch": run_git(["branch", "--show-current"]),
-        "status_short": run_git(["status", "--short"]),
+        "status_short": run_git(["status", "--short", "--untracked-files=no"]),
         "remote_url": _redact_url_userinfo(run_git(["remote", "get-url", "origin"])),
     }
 

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -1604,6 +1604,9 @@ def test_live_incident_bundle_infers_git_metadata_from_monitor_root(tmp_path):
             ),
         ],
     )
+    untracked_config = repo / "configs" / "secret_local_config.json"
+    untracked_config.parent.mkdir()
+    untracked_config.write_text('{"api_key": "do-not-list"}\n', encoding="utf-8")
     output = tmp_path / "incident.tar.gz"
 
     report = build_live_incident_bundle(
@@ -1624,6 +1627,7 @@ def test_live_incident_bundle_infers_git_metadata_from_monitor_root(tmp_path):
         == "https://[redacted]@example.com/org/repo.git"
     )
     assert manifest["git"]["status_short"] is not None
+    assert "secret_local_config.json" not in manifest["git"]["status_short"]
 
 
 def test_live_incident_bundle_redacts_git_remote_url_userinfo():


### PR DESCRIPTION
## Summary
- limit live-incident-bundle manifest git status to tracked changes with git status --short --untracked-files=no
- keep untracked local configs/monitor artifacts out of the manifest git status block
- extend incident-bundle regression coverage to prove an untracked local config filename is not listed
- fold PR #955 VPS5 deploy/smoke evidence into the logging-overhaul progress ledger

## Behavior
Read-only incident-response tooling only. No new event producers, exchange calls, cache mutation, readiness gates, smoke verdict changes, process signaling, console routing, order logic, risk logic, or trading behavior.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_incident_bundle.py -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check
- added-line silent-handling scan: no matches