### PR TITLE
Add opt-in live event console sink

### DIFF
--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -75,6 +75,14 @@ Current profile behavior:
 
 Unknown profile names should fail visibly instead of being ignored silently.
 
+## Live Event Console Projection
+
+`logging.live_event_console=true` or `PASSIVBOT_LIVE_EVENT_CONSOLE=1` enables
+an opt-in console sink fed by the structured live event pipeline. It is disabled
+by default while legacy stdlib console logs still exist, because enabling it can
+duplicate some order/execution lifecycle messages. Use it for controlled smoke
+tests of event-stream console formatting before migrating default console output.
+
 ## Review Heuristic
 
 1. Can INFO be tailed for long periods without noise overload?

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,18 +19,19 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `69603923` after PR #955, `Infer incident bundle git metadata from monitor root`.
+- `df10b379` after PR #956, `Limit incident bundle git status to tracked changes`.
 
 Current work:
 
-- Branch `codex/v8-incident-tracked-git-status` limits
-  `live-incident-bundle` manifest git status to tracked changes so local
-  untracked configs and monitor artifacts do not dominate incident metadata.
-  The slice is read-only incident-response tooling: no new event producers,
-  exchange calls, cache mutation, readiness gates, smoke verdict changes,
-  process signaling, console routing, order logic, risk logic, or trading
-  behavior. Expected validation is focused incident-bundle tests, py_compile
-  for touched files, `git diff --check`, and an added-line silent-handling scan.
+- Branch `codex/v8-live-event-console-sink-opt-in` adds an opt-in
+  `logging.live_event_console` / `PASSIVBOT_LIVE_EVENT_CONSOLE` path that wires
+  the existing structured-event `ConsoleSummarySink` into the live event
+  pipeline. The slice is disabled by default and only affects operator
+  observability when explicitly enabled: no new event producers, exchange
+  calls, cache mutation, readiness gates, smoke verdict changes, process
+  signaling, order logic, risk logic, or trading behavior. Expected validation
+  is focused event-bus/monitor tests, py_compile for touched files,
+  `git diff --check`, and an added-line silent-handling scan.
 
 Current review gate:
 
@@ -60,6 +61,32 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #956 at `df10b379`.
+- PR #956 limited `live-incident-bundle` manifest git status to tracked changes
+  via `git status --short --untracked-files=no`, preserving tracked dirty-tree
+  evidence while keeping local untracked configs and monitor artifacts out of
+  the manifest status block. The slice was read-only incident-bundle tooling and
+  did not add event producers, exchange calls, cache mutation, readiness gates,
+  smoke verdict changes, process signaling, console routing, order logic, risk
+  logic, or trading behavior.
+- PR #956 passed Hermes + Claude + Cursor + CI. Local validation covered
+  `tests/test_live_incident_bundle.py`, py_compile for touched files,
+  `git diff --check`, and an added-line silent-handling scan.
+- VPS5 pulled from `69603923` to `df10b379` without bot restart because the
+  deployed change was read-only incident-bundle tooling. The five configured
+  bots were left running.
+- A VPS5 2-minute bounded smoke after deploy reported `ok=true`,
+  `hard_failures=0`, clean tracked repository state at `df10b379`, all five
+  configured bots matched, config checks green, zero failed remote calls, zero
+  failed account-critical remote calls, and a populated brief `execution`
+  section with recent create/cancel/confirmation events. A focused
+  incident-bundle run from outside the repo with absolute `/root/passivbot`
+  monitor/log paths reported `ok=true` and populated `smoke_report.execution`;
+  archive inspection confirmed `manifest.git.cwd=/root/passivbot`,
+  `manifest.git.branch=v8`, `manifest.git.head=df10b379...`, and
+  `manifest.git.status_short=""` despite the known untracked local config and
+  monitor artifacts. Remaining attention came from known non-hard EMA/HSL/candle
+  coverage groups.
 - Repository pulled through PR #955 at `69603923`.
 - PR #955 made `live-incident-bundle` infer manifest git metadata from the
   monitor tree when invoked from outside the repo with an absolute monitor

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -27,6 +27,7 @@ LIVE_EVENT_ID_KEYS = (
     "remote_call_group_id",
 )
 LIVE_EVENT_DEBUG_PROFILE_ENV = "PASSIVBOT_LIVE_EVENT_DEBUG_PROFILES"
+LIVE_EVENT_CONSOLE_ENV = "PASSIVBOT_LIVE_EVENT_CONSOLE"
 LIVE_EVENT_DEBUG_PROFILES = (
     "candles",
     "ema",
@@ -317,6 +318,18 @@ def live_event_debug_profile_enabled(holder: Any, profile: str) -> bool:
         pipeline = getattr(holder, "_live_event_pipeline", None)
         profiles = getattr(pipeline, "debug_profiles", ())
     return item in set(profiles or ())
+
+
+def normalize_live_event_console_enabled(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        cleaned = value.strip().lower()
+        if cleaned in {"", "0", "false", "no", "none", "off"}:
+            return False
+        if cleaned in {"1", "true", "yes", "on", "console"}:
+            return True
+    return bool(value)
 
 
 PHASE1_EVENT_TYPES = {

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -59,12 +59,15 @@ from live.data_packets import (
 from live.freshness import ACCOUNT_SURFACES, LIVE_STATE_SURFACES, FreshnessLedger
 from live.events import DiagnosticEvent, emit_diagnostic_event, run_diagnostic_step
 from live.event_bus import (
+    ConsoleSummarySink,
     EventTypes,
+    LIVE_EVENT_CONSOLE_ENV,
     LIVE_EVENT_DEBUG_PROFILE_ENV,
     LiveEventContext,
     LiveEventPipeline,
     MonitorEventSink,
     ReasonCodes,
+    normalize_live_event_console_enabled,
     normalize_live_event_debug_profiles,
     payload_hash_raw,
 )
@@ -860,6 +863,12 @@ class Passivbot:
                 ),
             )
         )
+        self.live_event_console_enabled = normalize_live_event_console_enabled(
+            os.environ.get(
+                LIVE_EVENT_CONSOLE_ENV,
+                get_optional_config_value(config, "logging.live_event_console", False),
+            )
+        )
         self.balance_threshold = (
             1.0  # don't create orders if balance is less than threshold
         )
@@ -919,14 +928,15 @@ class Passivbot:
                 )
                 self.monitor_publisher = None
                 self._live_event_pipeline = None
-            if self.monitor_publisher is not None:
-                try:
-                    self._install_live_event_pipeline()
-                except Exception as exc:
-                    logging.warning(
-                        "[monitor] live event pipeline disabled: %s", exc
-                    )
-                    self._live_event_pipeline = None
+        if self.monitor_publisher is not None or self.live_event_console_enabled:
+            try:
+                self._install_live_event_pipeline()
+            except Exception as exc:
+                if self.monitor_publisher is not None and not self.live_event_console_enabled:
+                    logging.warning("[monitor] live event pipeline disabled: %s", exc)
+                else:
+                    logging.warning("[event] live event pipeline disabled: %s", exc)
+                self._live_event_pipeline = None
         # CandlestickManager settings from config.live
         # Use denormalized exchange name for cache paths (e.g., "binance" not "binanceusdm")
         cm_kwargs = {
@@ -6589,7 +6599,12 @@ class Passivbot:
 
     def _install_live_event_pipeline(self) -> Optional[LiveEventPipeline]:
         publisher = getattr(self, "monitor_publisher", None)
-        if publisher is None:
+        console_sink = (
+            ConsoleSummarySink(logging.getLogger("passivbot.live_event_console"))
+            if bool(getattr(self, "live_event_console_enabled", False))
+            else None
+        )
+        if publisher is None and console_sink is None:
             return None
         existing = getattr(self, "_live_event_pipeline", None)
         if existing is not None:
@@ -6600,7 +6615,8 @@ class Passivbot:
                 user=getattr(self, "user", None),
                 bot_id=getattr(self, "bot_id", None),
             ),
-            monitor_sinks=[MonitorEventSink(publisher)],
+            monitor_sinks=[MonitorEventSink(publisher)] if publisher is not None else [],
+            console_sink=console_sink,
             debug_profiles=getattr(self, "live_event_debug_profiles", ()),
         )
         self._live_event_pipeline = pipeline

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -944,7 +944,7 @@ class Passivbot:
             "exchange_name": self.exchange,
             "debug": self.logging_level,
         }
-        if self._live_event_pipeline is not None:
+        if self._live_event_pipeline_records_candle_remote_fetch():
             cm_kwargs["remote_fetch_callback"] = self._handle_candle_remote_fetch_event
         mem_cap_raw = require_live_value(config, "max_memory_candles_per_symbol")
         mem_cap_effective = DEFAULT_MAX_MEMORY_CANDLES_PER_SYMBOL
@@ -6621,6 +6621,12 @@ class Passivbot:
         )
         self._live_event_pipeline = pipeline
         return pipeline
+
+    def _live_event_pipeline_records_candle_remote_fetch(self) -> bool:
+        return (
+            getattr(self, "_live_event_pipeline", None) is not None
+            and getattr(self, "monitor_publisher", None) is not None
+        )
 
     def _close_live_event_pipeline(self, *, timeout: float = 2.0) -> bool:
         pipeline = getattr(self, "_live_event_pipeline", None)

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -23,6 +23,7 @@ from live.event_bus import (
     authoritative_reason_code,
     format_console_event,
     live_event_debug_profile_enabled,
+    normalize_live_event_console_enabled,
     normalize_live_event_debug_profiles,
     normalize_event_type,
     payload_hash,
@@ -118,6 +119,18 @@ def test_live_event_debug_profiles_normalize_and_validate():
     assert LiveEventPipeline(debug_profiles="rust", start=False).debug_profiles == (
         "rust",
     )
+
+
+def test_live_event_console_flag_normalizes_common_config_values():
+    assert normalize_live_event_console_enabled(None) is False
+    assert normalize_live_event_console_enabled(False) is False
+    assert normalize_live_event_console_enabled("") is False
+    assert normalize_live_event_console_enabled("off") is False
+    assert normalize_live_event_console_enabled("0") is False
+    assert normalize_live_event_console_enabled(True) is True
+    assert normalize_live_event_console_enabled("on") is True
+    assert normalize_live_event_console_enabled("1") is True
+    assert normalize_live_event_console_enabled("console") is True
 
 
 def test_live_event_serializes_stable_envelope_and_redacts_sensitive_data():

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -10,7 +10,13 @@ import numpy as np
 import pytest
 
 import live.event_emitters as live_event_emitters
-from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
+from live.event_bus import (
+    EventTypes,
+    ListEventSink,
+    LiveEvent,
+    LiveEventPipeline,
+    ReasonCodes,
+)
 
 
 class RecorderPublisher:
@@ -3814,6 +3820,54 @@ def test_live_event_pipeline_install_routes_diagnostics_to_monitor_projection():
     assert live_event["event_type"] == EventTypes.PLANNING_UNAVAILABLE
     assert live_event["ids"]["bot_id"] == "bot_1"
     assert live_event["data"]["apiKey"] == "[redacted]"
+    assert bot._close_live_event_pipeline(timeout=2.0) is True
+    assert bot._live_event_pipeline is None
+
+
+def test_live_event_pipeline_install_can_enable_console_projection_without_monitor(caplog):
+    import passivbot as pb_mod
+
+    class FakeBot:
+        _install_live_event_pipeline = pb_mod.Passivbot._install_live_event_pipeline
+        _close_live_event_pipeline = pb_mod.Passivbot._close_live_event_pipeline
+
+        def __init__(self):
+            self.monitor_publisher = None
+            self._live_event_pipeline = None
+            self.exchange = "bybit"
+            self.user = "bybit_01"
+            self.bot_id = "bot_1"
+            self.live_event_console_enabled = True
+            self.live_event_debug_profiles = ()
+
+    bot = FakeBot()
+    with caplog.at_level(logging.INFO, logger="passivbot.live_event_console"):
+        pipeline = bot._install_live_event_pipeline()
+        emitted = pipeline.emit(
+            LiveEvent(
+                EventTypes.ORDER_WAVE_COMPLETED,
+                status="succeeded",
+                order_wave_id="ow_1",
+                data={
+                    "planned_cancel": 1,
+                    "cancel_posted": 1,
+                    "planned_create": 2,
+                    "create_posted": 2,
+                    "elapsed_ms": 123,
+                },
+            )
+        )
+
+    assert emitted.event_type == EventTypes.ORDER_WAVE_COMPLETED
+    assert emitted.exchange == "bybit"
+    assert emitted.user == "bybit_01"
+    assert emitted.bot_id == "bot_1"
+    assert any(
+        record.name == "passivbot.live_event_console"
+        and "[execute] succeeded wave=ow_1 cancel=1/1 create=2/2 elapsed=123ms"
+        in record.message
+        for record in caplog.records
+    )
     assert bot._close_live_event_pipeline(timeout=2.0) is True
     assert bot._live_event_pipeline is None
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -3872,6 +3872,26 @@ def test_live_event_pipeline_install_can_enable_console_projection_without_monit
     assert bot._live_event_pipeline is None
 
 
+def test_live_event_pipeline_records_candle_remote_fetch_only_with_monitor_sink():
+    import passivbot as pb_mod
+
+    class FakeBot:
+        _live_event_pipeline_records_candle_remote_fetch = (
+            pb_mod.Passivbot._live_event_pipeline_records_candle_remote_fetch
+        )
+
+    bot = FakeBot()
+    bot._live_event_pipeline = object()
+    bot.monitor_publisher = None
+    assert bot._live_event_pipeline_records_candle_remote_fetch() is False
+
+    bot.monitor_publisher = object()
+    assert bot._live_event_pipeline_records_candle_remote_fetch() is True
+
+    bot._live_event_pipeline = None
+    assert bot._live_event_pipeline_records_candle_remote_fetch() is False
+
+
 def test_close_live_event_pipeline_is_best_effort_and_clears_reference():
     import passivbot as pb_mod
 


### PR DESCRIPTION
## Summary
- add `logging.live_event_console` / `PASSIVBOT_LIVE_EVENT_CONSOLE` as an opt-in path for the existing structured-event `ConsoleSummarySink`
- allow the live event pipeline to install as console-only when monitor persistence is disabled
- keep default behavior unchanged: the new console projection is off unless explicitly enabled, because legacy stdlib console logs still exist and may duplicate some lifecycle messages
- fold PR #956 VPS5 deploy/smoke evidence into the logging-overhaul progress ledger

## Behavior
Opt-in observability plumbing only. Default live behavior and default console output are unchanged. No new event producers, exchange calls, cache mutation, readiness gates, smoke verdict changes, process signaling, order logic, risk logic, or trading behavior.

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py::test_live_event_pipeline_install_routes_diagnostics_to_monitor_projection tests/test_passivbot_monitor.py::test_live_event_pipeline_install_can_enable_console_projection_without_monitor -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py src/passivbot.py tests/test_live_event_bus.py tests/test_passivbot_monitor.py`
- `git diff --check`
- added-line silent-handling scan: one expected non-trading best-effort pipeline-install `except Exception as exc`; it logs a warning and clears the pipeline reference, preserving existing monitor behavior while allowing console-only install attempts