### PR TITLE
Refresh v8 long bot defaults

### DIFF
--- a/configs/examples/default_trailing_martingale_long.json
+++ b/configs/examples/default_trailing_martingale_long.json
@@ -160,73 +160,73 @@
     "bot": {
         "long": {
             "forager": {
-                "score_weights": {"ema_readiness": 0.23, "volatility": 0.41, "volume": 0.36},
-                "volatility_ema_span_1m": 907.0,
-                "volume_drop_pct": 0.09,
-                "volume_ema_span_1m": 2855.0
+                "score_weights": {"ema_readiness": 0.08, "volatility": 0.48, "volume": 0.44},
+                "volatility_ema_span_1m": 661.0,
+                "volume_drop_pct": 0.06,
+                "volume_ema_span_1m": 2369.0
             },
             "hsl": {
-                "cooldown_minutes_after_red": 4051.0,
-                "ema_span_minutes": 647.0,
+                "cooldown_minutes_after_red": 3981.0,
+                "ema_span_minutes": 644.0,
                 "enabled": false,
                 "no_restart_drawdown_threshold": 1,
                 "orange_tier_mode": "tp_only_with_active_entry_cancellation",
                 "panic_close_order_type": "limit",
-                "red_threshold": 0.082,
+                "red_threshold": 0.025,
                 "tier_ratios": {"orange": 0.75, "yellow": 0.5}
             },
             "risk": {
-                "entry_cooldown_minutes": 7.0,
+                "entry_cooldown_minutes": 7.1,
                 "n_positions": 5.0,
                 "position_exposure_enforcer_enabled": false,
                 "position_exposure_enforcer_threshold": 1.0,
                 "total_exposure_enforcer_enabled": true,
                 "total_exposure_enforcer_policy": "reduce_overweight",
-                "total_exposure_enforcer_threshold": 0.909,
+                "total_exposure_enforcer_threshold": 1.004,
                 "total_exposure_entry_gate_enabled": true,
                 "total_wallet_exposure_limit": 1.5,
                 "we_excess_allowance_mode": "bounded",
-                "we_excess_allowance_pct": 1.04
+                "we_excess_allowance_pct": 0.5
             },
             "strategy": {
                 "trailing_martingale": {
                     "close": {
-                        "qty_pct": 0.55,
-                        "retracement_base_pct": 0.0055,
-                        "retracement_volatility_1h_weight": 30.15,
-                        "retracement_volatility_1m_weight": 6.19,
-                        "threshold_base_pct": -0.0175,
-                        "threshold_volatility_1h_weight": 0.12,
-                        "threshold_volatility_1m_weight": 9.89,
-                        "threshold_we_weight": 0.0158
+                        "qty_pct": 0.4,
+                        "retracement_base_pct": 0.0001,
+                        "retracement_volatility_1h_weight": 0.93,
+                        "retracement_volatility_1m_weight": 1.33,
+                        "threshold_base_pct": -0.0138,
+                        "threshold_volatility_1h_weight": 0.02,
+                        "threshold_volatility_1m_weight": 7.58,
+                        "threshold_we_weight": 0.0142
                     },
-                    "ema_span_0": 270.0,
-                    "ema_span_1": 360.0,
+                    "ema_span_0": 200.0,
+                    "ema_span_1": 150.0,
                     "entry": {
-                        "double_down_factor": 0.78,
+                        "double_down_factor": 0.39,
                         "ema_gate_mode": "all",
-                        "initial_ema_dist": 0.0175,
-                        "initial_qty_pct": 0.0179,
-                        "retracement_base_pct": 0.0043,
-                        "retracement_volatility_1h_weight": 27.22,
-                        "retracement_volatility_1m_weight": 8.57,
-                        "retracement_we_weight": 2.913,
-                        "threshold_base_pct": 0.0321,
-                        "threshold_volatility_1h_weight": 12.07,
-                        "threshold_volatility_1m_weight": 34.58,
-                        "threshold_we_weight": 1.973
+                        "initial_ema_dist": 0.0193,
+                        "initial_qty_pct": 0.0703,
+                        "retracement_base_pct": 0.0006,
+                        "retracement_volatility_1h_weight": 6.24,
+                        "retracement_volatility_1m_weight": 24.21,
+                        "retracement_we_weight": 2.984,
+                        "threshold_base_pct": 0.032,
+                        "threshold_volatility_1h_weight": 1.71,
+                        "threshold_volatility_1m_weight": 35.44,
+                        "threshold_we_weight": 4.821
                     },
-                    "volatility_ema_span_1h": 881.0,
-                    "volatility_ema_span_1m": 1377.0
+                    "volatility_ema_span_1h": 672.0,
+                    "volatility_ema_span_1m": 1049.0
                 }
             },
             "unstuck": {
-                "close_pct": 0.017,
-                "ema_dist": -0.1845,
+                "close_pct": 0.028,
+                "ema_dist": -0.086,
                 "ema_gating_enabled": true,
                 "enabled": true,
-                "loss_allowance_pct": 0.0279,
-                "threshold": 0.444
+                "loss_allowance_pct": 0.0065,
+                "threshold": 0.46
             }
         },
         "short": {

--- a/passivbot-rust/src/strategies/spec.rs
+++ b/passivbot-rust/src/strategies/spec.rs
@@ -52,7 +52,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "ema_span_0",
         path: &["ema_span_0"],
-        long_default: 270.0,
+        long_default: 200.0,
         short_default: 60.0,
         long_bounds: &[100.0, 2880.0, 10.0],
         short_bounds: &[100.0, 2880.0, 10.0],
@@ -60,7 +60,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "ema_span_1",
         path: &["ema_span_1"],
-        long_default: 360.0,
+        long_default: 150.0,
         short_default: 60.0,
         long_bounds: &[100.0, 2880.0, 10.0],
         short_bounds: &[100.0, 2880.0, 10.0],
@@ -68,7 +68,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "volatility_ema_span_1h",
         path: &["volatility_ema_span_1h"],
-        long_default: 881.0,
+        long_default: 672.0,
         short_default: 672.0,
         long_bounds: &[168.0, 2016.0, 1.0],
         short_bounds: &[168.0, 2016.0, 1.0],
@@ -76,7 +76,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "volatility_ema_span_1m",
         path: &["volatility_ema_span_1m"],
-        long_default: 1377.0,
+        long_default: 1049.0,
         short_default: 5.0,
         long_bounds: &[5.0, 1440.0, 1.0],
         short_bounds: &[5.0, 1440.0, 1.0],
@@ -84,7 +84,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_double_down_factor",
         path: &["entry", "double_down_factor"],
-        long_default: 0.78,
+        long_default: 0.39,
         short_default: 0.2,
         long_bounds: &[0.2, 1.0, 0.01],
         short_bounds: &[0.2, 1.0, 0.01],
@@ -92,7 +92,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_initial_qty_pct",
         path: &["entry", "initial_qty_pct"],
-        long_default: 0.0179,
+        long_default: 0.0703,
         short_default: 0.005,
         long_bounds: &[0.005, 0.1, 0.0001],
         short_bounds: &[0.005, 0.1, 0.0001],
@@ -100,7 +100,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_initial_ema_dist",
         path: &["entry", "initial_ema_dist"],
-        long_default: 0.0175,
+        long_default: 0.0193,
         short_default: -0.1,
         long_bounds: &[-0.1, 0.02, 0.0001],
         short_bounds: &[-0.1, 0.02, 0.0001],
@@ -108,7 +108,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_threshold_base_pct",
         path: &["entry", "threshold_base_pct"],
-        long_default: 0.0321,
+        long_default: 0.032,
         short_default: 0.001,
         long_bounds: &[0.001, 0.035, 0.0001],
         short_bounds: &[0.001, 0.035, 0.0001],
@@ -116,7 +116,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_threshold_we_weight",
         path: &["entry", "threshold_we_weight"],
-        long_default: 1.973,
+        long_default: 4.821,
         short_default: 0.0,
         long_bounds: &[0.0, 5.0, 0.001],
         short_bounds: &[0.0, 5.0, 0.001],
@@ -124,7 +124,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_threshold_volatility_1h_weight",
         path: &["entry", "threshold_volatility_1h_weight"],
-        long_default: 12.07,
+        long_default: 1.71,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -132,7 +132,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_threshold_volatility_1m_weight",
         path: &["entry", "threshold_volatility_1m_weight"],
-        long_default: 34.58,
+        long_default: 35.44,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -140,7 +140,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_retracement_base_pct",
         path: &["entry", "retracement_base_pct"],
-        long_default: 0.0043,
+        long_default: 0.0006,
         short_default: -0.01,
         long_bounds: &[0.0001, 0.01, 0.0001],
         short_bounds: &[0.0001, 0.01, 0.0001],
@@ -148,7 +148,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_retracement_we_weight",
         path: &["entry", "retracement_we_weight"],
-        long_default: 2.913,
+        long_default: 2.984,
         short_default: 0.0,
         long_bounds: &[0.0, 5.0, 0.001],
         short_bounds: &[0.0, 5.0, 0.001],
@@ -156,7 +156,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_retracement_volatility_1h_weight",
         path: &["entry", "retracement_volatility_1h_weight"],
-        long_default: 27.22,
+        long_default: 6.24,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -164,7 +164,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_retracement_volatility_1m_weight",
         path: &["entry", "retracement_volatility_1m_weight"],
-        long_default: 8.57,
+        long_default: 24.21,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -172,7 +172,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_qty_pct",
         path: &["close", "qty_pct"],
-        long_default: 0.55,
+        long_default: 0.4,
         short_default: 0.05,
         long_bounds: &[0.05, 1.0, 0.01],
         short_bounds: &[0.05, 1.0, 0.01],
@@ -180,7 +180,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_threshold_base_pct",
         path: &["close", "threshold_base_pct"],
-        long_default: -0.0175,
+        long_default: -0.0138,
         short_default: -0.02,
         long_bounds: &[-0.02, 0.02, 0.0001],
         short_bounds: &[-0.02, 0.02, 0.0001],
@@ -188,7 +188,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_threshold_we_weight",
         path: &["close", "threshold_we_weight"],
-        long_default: 0.0158,
+        long_default: 0.0142,
         short_default: -0.1,
         long_bounds: &[-0.1, 0.1, 0.0001],
         short_bounds: &[-0.1, 0.1, 0.0001],
@@ -196,7 +196,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_threshold_volatility_1h_weight",
         path: &["close", "threshold_volatility_1h_weight"],
-        long_default: 0.12,
+        long_default: 0.02,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -204,7 +204,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_threshold_volatility_1m_weight",
         path: &["close", "threshold_volatility_1m_weight"],
-        long_default: 9.89,
+        long_default: 7.58,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -212,7 +212,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_retracement_base_pct",
         path: &["close", "retracement_base_pct"],
-        long_default: 0.0055,
+        long_default: 0.0001,
         short_default: 0.0,
         long_bounds: &[0.0001, 0.01, 0.0001],
         short_bounds: &[0.0001, 0.01, 0.0001],
@@ -220,7 +220,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_retracement_volatility_1h_weight",
         path: &["close", "retracement_volatility_1h_weight"],
-        long_default: 30.15,
+        long_default: 0.93,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -228,7 +228,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_retracement_volatility_1m_weight",
         path: &["close", "retracement_volatility_1m_weight"],
-        long_default: 6.19,
+        long_default: 1.33,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -13,47 +13,47 @@ def _get_shared_bot_defaults():
         "long": {
             "forager": {
                 "score_weights": {
-                    "ema_readiness": 0.23,
-                    "volatility": 0.41,
-                    "volume": 0.36
+                    "ema_readiness": 0.08,
+                    "volatility": 0.48,
+                    "volume": 0.44
                 },
-                "volatility_ema_span_1m": 907.0,
-                "volume_drop_pct": 0.09,
-                "volume_ema_span_1m": 2855.0
+                "volatility_ema_span_1m": 661.0,
+                "volume_drop_pct": 0.06,
+                "volume_ema_span_1m": 2369.0
             },
             "hsl": {
-                "cooldown_minutes_after_red": 4051.0,
-                "ema_span_minutes": 647.0,
+                "cooldown_minutes_after_red": 3981.0,
+                "ema_span_minutes": 644.0,
                 "enabled": False,
                 "no_restart_drawdown_threshold": 1,
                 "orange_tier_mode": "tp_only_with_active_entry_cancellation",
                 "panic_close_order_type": "limit",
-                "red_threshold": 0.082,
+                "red_threshold": 0.025,
                 "tier_ratios": {
                     "orange": 0.75,
                     "yellow": 0.5
                 }
             },
             "risk": {
-                "entry_cooldown_minutes": 7.0,
+                "entry_cooldown_minutes": 7.1,
                 "n_positions": 5.0,
                 "position_exposure_enforcer_enabled": False,
                 "position_exposure_enforcer_threshold": 1.0,
                 "total_exposure_enforcer_enabled": True,
                 "total_exposure_enforcer_policy": "reduce_overweight",
-                "total_exposure_enforcer_threshold": 0.909,
+                "total_exposure_enforcer_threshold": 1.004,
                 "total_exposure_entry_gate_enabled": True,
                 "total_wallet_exposure_limit": 1.5,
                 "we_excess_allowance_mode": "bounded",
-                "we_excess_allowance_pct": 1.04
+                "we_excess_allowance_pct": 0.5
             },
             "unstuck": {
-                "close_pct": 0.017,
-                "ema_dist": -0.1845,
+                "close_pct": 0.028,
+                "ema_dist": -0.086,
                 "ema_gating_enabled": True,
                 "enabled": True,
-                "loss_allowance_pct": 0.0279,
-                "threshold": 0.444
+                "loss_allowance_pct": 0.0065,
+                "threshold": 0.46
             }
         },
         "short": {


### PR DESCRIPTION
## Summary
- update v8 bot.long schema defaults from tmp/canon_candidate.json
- refresh trailing_martingale long strategy defaults in Rust metadata
- regenerate configs/examples/default_trailing_martingale_long.json

## Scope
Only bot.long defaults were changed. Candidate differences outside bot.long were intentionally ignored.

## Validation
- rebuilt and restamped Rust extension
- verified template/example bot.long matches tmp/canon_candidate.json
- pytest tests/test_config_pipeline.py tests/test_config_utils_helpers.py tests/test_format_config.py tests/test_streamlined_json.py
- cargo fmt --check
- git diff --check