### PR TITLE
Project HSL status into event console

### DIFF
--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -82,6 +82,11 @@ an opt-in console sink fed by the structured live event pipeline. It is disabled
 by default while legacy stdlib console logs still exist, because enabling it can
 duplicate some order/execution lifecycle messages. Use it for controlled smoke
 tests of event-stream console formatting before migrating default console output.
+The console projection is operator-facing: it should prefer trading-relevant
+summaries over internal data plumbing. HSL status events are console-visible
+only when they are pside-level, red/cooldown, or tied to a held coin; routine
+flat coin-universe status remains in the structured event stream but is kept off
+the console.
 
 ## Review Heuristic
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -17,7 +17,11 @@ merge, live smoke evidence changes, or new gaps are discovered.
 
 Last updated: 2026-07-01.
 
-Current `origin/v8` logging-overhaul head:
+Current `origin/v8` head:
+
+- `a989a3f2` after PR #958, `Refresh v8 long bot defaults`.
+
+Current logging-overhaul head:
 
 - `d038c405` after PR #957, `Add opt-in live event console sink`.
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,22 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` logging-overhaul head:
 
-- `df10b379` after PR #956, `Limit incident bundle git status to tracked changes`.
+- `d038c405` after PR #957, `Add opt-in live event console sink`.
 
 Current work:
 
-- Branch `codex/v8-live-event-console-sink-opt-in` adds an opt-in
-  `logging.live_event_console` / `PASSIVBOT_LIVE_EVENT_CONSOLE` path that wires
-  the existing structured-event `ConsoleSummarySink` into the live event
-  pipeline. The slice is disabled by default and only affects operator
-  observability when explicitly enabled: no new event producers, exchange
-  calls, cache mutation, readiness gates, smoke verdict changes, process
-  signaling, order logic, risk logic, or trading behavior. Expected validation
-  is focused event-bus/monitor tests, py_compile for touched files,
-  `git diff --check`, and an added-line silent-handling scan.
+- Branch `codex/v8-hsl-status-console-projection` improves the opt-in
+  structured-event console projection for HSL status. It formats existing
+  `hsl.status` distance-to-red fields for operator console use, adds a
+  coin-mode `has_open_position` event field, and filters flat green coin
+  universe status away from console/text sinks while preserving the full
+  structured event stream. The slice is observability-only and remains disabled
+  unless `logging.live_event_console` or `PASSIVBOT_LIVE_EVENT_CONSOLE` is
+  enabled: no exchange calls, cache mutation, readiness gates, smoke verdict
+  changes, process signaling, order construction, risk thresholds, or trading
+  behavior changes. Expected validation is focused event-bus tests, py_compile
+  for touched files, `git diff --check`, and an added-line silent-handling
+  scan.
 
 Current review gate:
 
@@ -61,6 +64,39 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #958 at `a989a3f2`.
+- PR #958 refreshed v8 long-side default values in Rust metadata, Python schema,
+  and the default example config. It was not a logging-overhaul slice, but it
+  advanced `origin/v8` after PR #957 and was therefore deployed before the next
+  logging branch was created. Running bots were not restarted because the
+  deployed change only affects defaults for newly generated/loaded configs and
+  the active VPS5 bots use explicit configs.
+- PR #958 passed Hermes + Claude + CI. A VPS5 2-minute bounded smoke after the
+  pull reported `ok=true`, `hard_failures=0`, clean tracked repository state at
+  `a989a3f2`, all five configured bots matched, config checks green, zero
+  failed remote calls, and zero failed account-critical remote calls. Remaining
+  attention came from known non-hard EMA readiness and HSL cooldown/status
+  groups.
+- Repository pulled through PR #957 at `d038c405`.
+- PR #957 added the disabled-by-default
+  `logging.live_event_console` / `PASSIVBOT_LIVE_EVENT_CONSOLE` opt-in path for
+  the existing structured-event `ConsoleSummarySink`, and then narrowed candle
+  remote-fetch callback installation so console-only mode does not create
+  unused remote-call event traffic. The slice was observability-only and did not
+  add exchange calls, cache mutation, readiness gates, smoke verdict changes,
+  process signaling, order logic, risk logic, or trading behavior.
+- PR #957 passed Claude + Hermes + CI. Cursor did not post during the bounded
+  wait, so the merge used a documented reviewer-availability exception rather
+  than claiming full three-reviewer coverage. Local validation covered
+  `tests/test_live_event_bus.py`, focused monitor pipeline tests, py_compile for
+  touched files, `git diff --check`, and an added-line silent-handling scan.
+- VPS5 pulled from `df10b379` to `d038c405` without bot restart because the new
+  console sink is disabled by default. A VPS5 2-minute bounded smoke after
+  deploy reported `ok=true`, `hard_failures=0`, clean tracked repository state
+  at `d038c405`, all five configured bots matched, config checks green, zero
+  failed remote calls, and zero failed account-critical remote calls. Remaining
+  attention came from known non-hard EMA readiness and HSL cooldown/status
+  groups.
 - Repository pulled through PR #956 at `df10b379`.
 - PR #956 limited `live-incident-bundle` manifest git status to tracked changes
   via `git status --short --untracked-files=no`, preserving tracked dirty-tree

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -701,7 +701,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.BALANCE_CHANGED: EventRoute(console=False, text=False),
     EventTypes.RISK_MODE_CHANGED: EventRoute(console=False, text=False),
     EventTypes.HSL_TRANSITION: EventRoute(console=False, text=False),
-    EventTypes.HSL_STATUS: EventRoute(console=False, text=False),
+    EventTypes.HSL_STATUS: EventRoute(console=True, text=True),
     EventTypes.HSL_RAW_RED_PENDING: EventRoute(console=False, text=False),
     EventTypes.HSL_REPLAY_STARTED: EventRoute(console=False, text=False),
     EventTypes.HSL_REPLAY_PROGRESS: EventRoute(console=False, text=False),
@@ -777,6 +777,7 @@ _CONSOLE_EVENT_TAGS = {
     EventTypes.EXECUTION_AMBIGUOUS: "order",
     EventTypes.EXECUTION_CONFIRMATION_SATISFIED: "execute",
     EventTypes.EXECUTION_CONFIRMATION_TIMEOUT: "execute",
+    EventTypes.HSL_STATUS: "risk",
     EventTypes.SINK_DEGRADED: "logging",
 }
 
@@ -944,6 +945,45 @@ def _console_rust_summary(event: LiveEvent) -> list[str]:
     return parts
 
 
+def _format_console_ratio(value: Any) -> str | None:
+    if value is None:
+        return None
+    return f"{float(value):.6f}"
+
+
+def _console_hsl_status_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    signal_mode = _data_str(data, "signal_mode")
+    if signal_mode:
+        parts.append(f"mode={signal_mode}")
+    tier = _data_str(data, "tier")
+    if tier:
+        parts.append(f"tier={tier}")
+    for label, key in (
+        ("dist_to_red", "dist_to_red"),
+        ("drawdown_score", "drawdown_score"),
+        ("red_threshold", "red_threshold"),
+    ):
+        value = _format_console_ratio(_data_float(data, key))
+        if value is not None:
+            parts.append(f"{label}={value}")
+    cooldown = _data_str(data, "cooldown_remaining")
+    if not cooldown:
+        seconds = _data_float(data, "cooldown_remaining_seconds")
+        if seconds is not None:
+            cooldown = f"{seconds:.0f}s"
+    if cooldown:
+        parts.append(f"cooldown={cooldown}")
+    last_red_ts = _data_int(data, "last_red_ts")
+    if last_red_ts is not None:
+        parts.append(f"last_red_ts={last_red_ts}")
+    pending_red_since_ms = _data_int(data, "pending_red_since_ms")
+    if pending_red_since_ms is not None:
+        parts.append(f"pending_red_since_ms={pending_red_since_ms}")
+    return parts
+
+
 def _console_data_summary(event: LiveEvent) -> list[str]:
     if event.event_type == EventTypes.ORDER_WAVE_COMPLETED:
         return _console_order_wave_summary(event)
@@ -969,7 +1009,26 @@ def _console_data_summary(event: LiveEvent) -> list[str]:
         return _console_confirmation_summary(event)
     if event.event_type == EventTypes.RUST_ORCHESTRATOR_RETURNED:
         return _console_rust_summary(event)
+    if event.event_type == EventTypes.HSL_STATUS:
+        return _console_hsl_status_summary(event)
     return []
+
+
+def _hsl_status_operator_visible(event: LiveEvent) -> bool:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    if event.symbol is None:
+        return True
+    if data.get("has_open_position") is True:
+        return True
+    if str(event.reason_code or "") == "cooldown_active":
+        return True
+    return str(data.get("tier") or "").lower() == "red"
+
+
+def _operator_sink_event_visible(event: LiveEvent) -> bool:
+    if event.event_type == EventTypes.HSL_STATUS:
+        return _hsl_status_operator_visible(event)
+    return True
 
 
 def format_console_event(event: LiveEvent) -> str:
@@ -1120,12 +1179,14 @@ class LiveEventPipeline:
         if (
             route.console
             and self.console_sink is not None
+            and _operator_sink_event_visible(live_event)
             and self._should_emit_throttled_sink("console", live_event, route)
         ):
             self._write_sink("console", self.console_sink, live_event)
         if (
             route.text
             and self.text_sink is not None
+            and _operator_sink_event_visible(live_event)
             and self._should_emit_throttled_sink("text", live_event, route)
         ):
             self._write_sink("text", self.text_sink, live_event)

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -816,6 +816,19 @@ def _data_float(data: Mapping[str, Any], key: str) -> str | None:
     return f"{number:.10g}"
 
 
+def _data_number(data: Mapping[str, Any], key: str) -> float | None:
+    try:
+        value = data.get(key)
+        if value is None:
+            return None
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number != number:
+        return None
+    return number
+
+
 def _compact_csv(values: Any, *, limit: int = 4) -> str | None:
     if not isinstance(values, (list, tuple, set)):
         return None
@@ -970,7 +983,7 @@ def _console_hsl_status_summary(event: LiveEvent) -> list[str]:
             parts.append(f"{label}={value}")
     cooldown = _data_str(data, "cooldown_remaining")
     if not cooldown:
-        seconds = _data_float(data, "cooldown_remaining_seconds")
+        seconds = _data_number(data, "cooldown_remaining_seconds")
         if seconds is not None:
             cooldown = f"{seconds:.0f}s"
     if cooldown:

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -3495,7 +3495,8 @@ def _equity_hard_stop_emit_coin_status(self, pside: str, symbol: str, metrics: d
             last_red_ts = state["last_stop_event"].get("stop_event_timestamp_ms")
         if last_red_ts is None:
             last_red_ts = state["pending_red_since_ms"]
-        if self._equity_hard_stop_has_open_position_symbol(pside, symbol):
+        has_open_position = self._equity_hard_stop_has_open_position_symbol(pside, symbol)
+        if has_open_position:
             try:
                 logging.info(
                     "[risk] HSL[%s:%s] status | tier=%s dist_to_red=%.6f drawdown_raw=%.6f "
@@ -3540,6 +3541,7 @@ def _equity_hard_stop_emit_coin_status(self, pside: str, symbol: str, metrics: d
                     "cooldown_remaining": cooldown_remaining,
                     "last_red_ts": last_red_ts,
                     "pending_red_since_ms": state["pending_red_since_ms"],
+                    "has_open_position": bool(has_open_position),
                 },
             ),
             pside=pside,

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -241,7 +241,6 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.PLANNING_SYMBOL_STATE,
         EventTypes.RISK_MODE_CHANGED,
         EventTypes.HSL_TRANSITION,
-        EventTypes.HSL_STATUS,
         EventTypes.HSL_RAW_RED_PENDING,
         EventTypes.HSL_RED_TRIGGERED,
         EventTypes.HSL_RED_FINALIZED_WITHOUT_ORDER,
@@ -263,6 +262,8 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CONFIRMATION_TIMEOUT].text is True
     assert DEFAULT_ROUTES[EventTypes.BOT_SHUTDOWN_STAGE].console is True
     assert DEFAULT_ROUTES[EventTypes.BOT_SHUTDOWN_STAGE].text is True
+    assert DEFAULT_ROUTES[EventTypes.HSL_STATUS].console is True
+    assert DEFAULT_ROUTES[EventTypes.HSL_STATUS].text is True
 
 
 def test_redact_payload_recurses_and_payload_hash_is_stable():
@@ -842,6 +843,102 @@ def test_console_format_summarizes_rust_return():
     )
 
     assert format_console_event(event) == "[rust] succeeded cycle=cy_6 orders=4 elapsed=17ms"
+
+
+def test_console_format_summarizes_hsl_status_distance_to_red():
+    event = LiveEvent(
+        EventTypes.HSL_STATUS,
+        status="succeeded",
+        cycle_id="cy_hsl",
+        symbol="ZEC/USDT:USDT",
+        pside="long",
+        reason_code="green",
+        data={
+            "signal_mode": "coin",
+            "tier": "green",
+            "dist_to_red": 0.02,
+            "drawdown_score": 0.03,
+            "red_threshold": 0.05,
+            "cooldown_remaining": "none",
+            "last_red_ts": 1_600_000,
+            "has_open_position": True,
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[risk] succeeded cycle=cy_hsl mode=coin tier=green "
+        "dist_to_red=0.020000 drawdown_score=0.030000 red_threshold=0.050000 "
+        "cooldown=none last_red_ts=1600000 symbol=ZEC/USDT:USDT "
+        "pside=long reason=green"
+    )
+
+
+def test_operator_console_filters_flat_green_coin_hsl_status():
+    console = ListEventSink()
+    text = ListEventSink()
+    pipeline = LiveEventPipeline(
+        structured_sinks=[],
+        monitor_sinks=[],
+        console_sink=console,
+        text_sink=text,
+    )
+
+    flat_green = LiveEvent(
+        EventTypes.HSL_STATUS,
+        status="succeeded",
+        symbol="ARB/USDT:USDT",
+        pside="long",
+        reason_code="green",
+        data={
+            "signal_mode": "coin",
+            "tier": "green",
+            "dist_to_red": 0.02,
+            "has_open_position": False,
+        },
+    )
+    held_green = LiveEvent(
+        EventTypes.HSL_STATUS,
+        status="succeeded",
+        symbol="ZEC/USDT:USDT",
+        pside="long",
+        reason_code="green",
+        data={
+            "signal_mode": "coin",
+            "tier": "green",
+            "dist_to_red": 0.02,
+            "has_open_position": True,
+        },
+    )
+    flat_orange = LiveEvent(
+        EventTypes.HSL_STATUS,
+        status="succeeded",
+        symbol="MORPHO/USDT:USDT",
+        pside="long",
+        reason_code="orange",
+        data={
+            "signal_mode": "coin",
+            "tier": "orange",
+            "dist_to_red": 0.01,
+            "has_open_position": False,
+        },
+    )
+    cooldown = LiveEvent(
+        EventTypes.HSL_STATUS,
+        status="degraded",
+        symbol="NEAR/USDT:USDT",
+        pside="long",
+        reason_code="cooldown_active",
+        data={"tier": "red", "cooldown_remaining_seconds": 300.0},
+    )
+
+    pipeline.emit(flat_green)
+    pipeline.emit(held_green)
+    pipeline.emit(flat_orange)
+    pipeline.emit(cooldown)
+
+    assert console.events == [held_green, cooldown]
+    assert text.events == [held_green, cooldown]
+    assert pipeline.close(timeout=2.0) is True
 
 
 def test_shutdown_stage_console_format_uses_shutdown_tag():

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -873,6 +873,22 @@ def test_console_format_summarizes_hsl_status_distance_to_red():
     )
 
 
+def test_console_format_summarizes_hsl_cooldown_seconds():
+    event = LiveEvent(
+        EventTypes.HSL_STATUS,
+        status="degraded",
+        symbol="NEAR/USDT:USDT",
+        pside="long",
+        reason_code="cooldown_active",
+        data={"tier": "red", "cooldown_remaining_seconds": 300.0},
+    )
+
+    assert format_console_event(event) == (
+        "[risk] degraded tier=red cooldown=300s symbol=NEAR/USDT:USDT "
+        "pside=long reason=cooldown_active"
+    )
+
+
 def test_operator_console_filters_flat_green_coin_hsl_status():
     console = ListEventSink()
     text = ListEventSink()


### PR DESCRIPTION
## Summary
- route existing `hsl.status` events to the opt-in live-event console/text projection
- format concise HSL distance-to-red fields for operator-facing console lines
- add `has_open_position` to coin-mode HSL status event data so flat green coin-universe status can stay off console while remaining in the structured stream
- record PR #957/#958 VPS5 deploy and smoke evidence in the logging progress ledger

## Behavior
Observability-only. The new console output remains disabled unless `logging.live_event_console` or `PASSIVBOT_LIVE_EVENT_CONSOLE` is enabled. Full `hsl.status` events remain persisted/routed to structured/monitor sinks; the console/text projection filters routine flat coin-universe status and only shows pside-level, held-symbol, cooldown-active, or red HSL status. No exchange calls, cache mutation, readiness gates, smoke verdict changes, process signaling, order construction, risk thresholds, or trading behavior changes.

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_unstucking_safeguards.py::test_hard_stop_status_logging_is_throttled tests/test_passivbot_balance_split.py::test_coin_hsl_status_logs_distance_only_for_open_position tests/test_hsl_coin_mode.py::test_coin_hsl_check_skips_enabled_side_with_zero_budget tests/test_hsl_coin_mode.py::test_coin_hsl_check_emits_raw_red_pending_event_with_bounded_payload -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py src/passivbot_hsl.py tests/test_live_event_bus.py`
- `git diff --check`
- added-line silent-handling scan: no matches
