### PR TITLE
Add position trailing status events

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -86,6 +86,7 @@ across time.
 - `snapshot.built`
 - `state.refresh_progress`
 - `state.refresh_timing`
+- `trailing.status`
 - `unstuck.selection`
 - `unstuck.status`
 
@@ -134,6 +135,7 @@ across time.
 - `tail`
 - `timeout`
 - `time_sync`
+- `trailing`
 - `unavailable`
 - `unstuck`
 - `warmup`
@@ -198,6 +200,7 @@ across time.
 - `staged_refresh_timing`
 - `state_change_detected`
 - `submitted_to_exchange`
+- `trailing_status`
 - `unstuck_selection`
 - `unstuck_status`
 - `warmup_cache_decision`

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -86,7 +86,11 @@ The console projection is operator-facing: it should prefer trading-relevant
 summaries over internal data plumbing. HSL status events are console-visible
 only when they are pside-level, red/cooldown, or tied to a held coin; routine
 flat coin-universe status remains in the structured event stream but is kept off
-the console.
+the console. Position-level `trailing.status` and `unstuck.status` events are
+console-visible because they explain why an existing position is waiting, armed,
+triggered, over budget, or blocked by the unstuck EMA gate. Unsupported strategy
+diagnostics must say so explicitly instead of fabricating threshold/retracement
+prices.
 
 ## Review Heuristic
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,26 +19,26 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` head:
 
-- `a989a3f2` after PR #958, `Refresh v8 long bot defaults`.
+- `c763d84d` after PR #959, `Project HSL status into event console`.
 
 Current logging-overhaul head:
 
-- `d038c405` after PR #957, `Add opt-in live event console sink`.
+- `c763d84d` after PR #959, `Project HSL status into event console`.
 
 Current work:
 
-- Branch `codex/v8-hsl-status-console-projection` improves the opt-in
-  structured-event console projection for HSL status. It formats existing
-  `hsl.status` distance-to-red fields for operator console use, adds a
-  coin-mode `has_open_position` event field, and filters flat green coin
-  universe status away from console/text sinks while preserving the full
-  structured event stream. The slice is observability-only and remains disabled
-  unless `logging.live_event_console` or `PASSIVBOT_LIVE_EVENT_CONSOLE` is
-  enabled: no exchange calls, cache mutation, readiness gates, smoke verdict
-  changes, process signaling, order construction, risk thresholds, or trading
-  behavior changes. Expected validation is focused event-bus tests, py_compile
-  for touched files, `git diff --check`, and an added-line silent-handling
-  scan.
+- Branch `codex/v8-position-status-console` adds structured
+  `trailing.status` events for active trailing positions and projects
+  `trailing.status` plus existing `unstuck.status` into the opt-in event-console.
+  The trailing producer uses already-prepared monitor/trailing diagnostic data,
+  emits on state-signature change plus hourly heartbeat with a five-minute check
+  interval, and reports unsupported strategy diagnostics explicitly rather than
+  reimplementing Rust strategy logic in Python. The slice is observability-only:
+  no exchange calls, cache mutation, readiness gates, smoke verdict changes,
+  process signaling, order construction, risk thresholds, or trading behavior
+  changes. Expected validation is focused event-bus/monitor/balance-split tests,
+  py_compile for touched files, `git diff --check`, and an added-line
+  silent-handling scan.
 
 Current review gate:
 

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -127,6 +127,7 @@ class EventTypes:
     HSL_RED_FINALIZED_WITHOUT_ORDER = "hsl.red_finalized_without_order"
     HSL_COOLDOWN_STARTED = "hsl.cooldown_started"
     HSL_COOLDOWN_ENDED = "hsl.cooldown_ended"
+    TRAILING_STATUS = "trailing.status"
     UNSTUCK_STATUS = "unstuck.status"
     UNSTUCK_SELECTION = "unstuck.selection"
     RISK_ENTRY_COOLDOWN_DELTA_ANCHORED = "risk.entry_cooldown_delta_anchored"
@@ -178,6 +179,7 @@ class EventTags:
     TAIL = "tail"
     TIMEOUT = "timeout"
     TIME_SYNC = "time_sync"
+    TRAILING = "trailing"
     UNAVAILABLE = "unavailable"
     UNSTUCK = "unstuck"
     WARMUP = "warmup"
@@ -250,6 +252,7 @@ class ReasonCodes:
     STATE_CHANGE_DETECTED = "state_change_detected"
     SUBMITTED_TO_EXCHANGE = "submitted_to_exchange"
     REALIZED_LOSS_GATE_BLOCKED = "realized_loss_gate_blocked"
+    TRAILING_STATUS = "trailing_status"
     UNSTUCK_SELECTION = "unstuck_selection"
     UNSTUCK_STATUS = "unstuck_status"
     WARMUP_CACHE_DECISION = "warmup_cache_decision"
@@ -402,6 +405,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.HSL_RED_FINALIZED_WITHOUT_ORDER,
     EventTypes.HSL_COOLDOWN_STARTED,
     EventTypes.HSL_COOLDOWN_ENDED,
+    EventTypes.TRAILING_STATUS,
     EventTypes.UNSTUCK_STATUS,
     EventTypes.UNSTUCK_SELECTION,
     EventTypes.RISK_ENTRY_COOLDOWN_DELTA_ANCHORED,
@@ -711,7 +715,8 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.HSL_RED_FINALIZED_WITHOUT_ORDER: EventRoute(console=False, text=False),
     EventTypes.HSL_COOLDOWN_STARTED: EventRoute(console=False, text=False),
     EventTypes.HSL_COOLDOWN_ENDED: EventRoute(console=False, text=False),
-    EventTypes.UNSTUCK_STATUS: EventRoute(console=False, text=False),
+    EventTypes.TRAILING_STATUS: EventRoute(console=True, text=True),
+    EventTypes.UNSTUCK_STATUS: EventRoute(console=True, text=True),
     EventTypes.UNSTUCK_SELECTION: EventRoute(console=False, text=False),
     EventTypes.RISK_ENTRY_COOLDOWN_DELTA_ANCHORED: EventRoute(
         console=False, text=False
@@ -778,6 +783,8 @@ _CONSOLE_EVENT_TAGS = {
     EventTypes.EXECUTION_CONFIRMATION_SATISFIED: "execute",
     EventTypes.EXECUTION_CONFIRMATION_TIMEOUT: "execute",
     EventTypes.HSL_STATUS: "risk",
+    EventTypes.TRAILING_STATUS: "trailing",
+    EventTypes.UNSTUCK_STATUS: "unstuck",
     EventTypes.SINK_DEGRADED: "logging",
 }
 
@@ -997,6 +1004,87 @@ def _console_hsl_status_summary(event: LiveEvent) -> list[str]:
     return parts
 
 
+def _console_trailing_status_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    kind = _data_str(data, "kind")
+    if kind:
+        parts.append(f"kind={kind}")
+    if data.get("diagnostics_supported") is False:
+        strategy_kind = _data_str(data, "strategy_kind")
+        if strategy_kind:
+            parts.append(f"strategy={strategy_kind}")
+        reason = _data_str(data, "unsupported_reason")
+        if reason:
+            parts.append(f"unsupported={reason}")
+        return parts
+    trailing_status = _data_str(data, "trailing_status")
+    if trailing_status:
+        parts.append(f"trailing_status={trailing_status}")
+    threshold_met = data.get("threshold_met")
+    if threshold_met is not None:
+        parts.append(f"threshold_met={bool(threshold_met)}")
+    threshold_pct = _data_number(data, "threshold_pct")
+    if threshold_pct is not None:
+        parts.append(f"threshold={threshold_pct * 100.0:.4f}%")
+    threshold_price = _data_float(data, "threshold_price")
+    if threshold_price:
+        parts.append(f"threshold_price={threshold_price}")
+    retracement_met = data.get("retracement_met")
+    if retracement_met is not None:
+        parts.append(f"retracement_met={bool(retracement_met)}")
+    retracement_pct = _data_number(data, "retracement_pct")
+    if retracement_pct is not None:
+        parts.append(f"retracement={retracement_pct * 100.0:.4f}%")
+    retracement_price = _data_float(data, "retracement_price")
+    if retracement_price:
+        parts.append(f"retracement_price={retracement_price}")
+    projected = _data_float(data, "threshold_projection_retracement_price")
+    if projected:
+        parts.append(f"threshold_retrace_price={projected}")
+    current_price = _data_float(data, "current_price")
+    if current_price:
+        parts.append(f"current={current_price}")
+    return parts
+
+
+def _console_unstuck_status_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    sides = data.get("sides")
+    if isinstance(sides, Mapping):
+        side_parts = []
+        for pside in ("long", "short"):
+            info = sides.get(pside)
+            if not isinstance(info, Mapping):
+                continue
+            status = str(info.get("status") or "unknown")
+            bit = f"{pside}:{status}"
+            allowance = _data_float(info, "allowance")
+            if allowance:
+                bit += f":allowance={allowance}"
+            if info.get("over_budget") is True:
+                bit += ":over_budget"
+            next_symbol = _data_str(info, "next_symbol")
+            if next_symbol:
+                bit += f":next={next_symbol}"
+            target_price = _data_float(info, "next_target_price")
+            if target_price:
+                bit += f":target={target_price}"
+            trigger_dist = _data_number(info, "next_unstuck_trigger_distance_ratio")
+            if trigger_dist is not None:
+                bit += f":ema_gate={trigger_dist * 100.0:.4f}%"
+            side_parts.append(bit)
+        if side_parts:
+            parts.append(" ".join(side_parts))
+    over_budget = _compact_csv(data.get("over_budget_sides"), limit=2)
+    if over_budget:
+        parts.append(f"over_budget={over_budget}")
+    if data.get("changed") is True:
+        parts.append("changed=true")
+    return parts
+
+
 def _console_data_summary(event: LiveEvent) -> list[str]:
     if event.event_type == EventTypes.ORDER_WAVE_COMPLETED:
         return _console_order_wave_summary(event)
@@ -1024,6 +1112,10 @@ def _console_data_summary(event: LiveEvent) -> list[str]:
         return _console_rust_summary(event)
     if event.event_type == EventTypes.HSL_STATUS:
         return _console_hsl_status_summary(event)
+    if event.event_type == EventTypes.TRAILING_STATUS:
+        return _console_trailing_status_summary(event)
+    if event.event_type == EventTypes.UNSTUCK_STATUS:
+        return _console_unstuck_status_summary(event)
     return []
 
 

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -3293,7 +3293,123 @@ def _unstuck_status_side_summary(
                 symbol: allowance for symbol, allowance in clean_items[:override_limit]
             }
             out["override_allowances_truncated"] = max(0, len(clean_items) - override_limit)
+    for key in (
+        "next_symbol",
+        "next_target_price",
+        "next_target_distance_ratio",
+        "next_unstuck_trigger_distance_ratio",
+    ):
+        value = info.get(key)
+        if value is None:
+            continue
+        if key == "next_symbol":
+            out[key] = str(value)
+            continue
+        number = _safe_float(value)
+        if number is not None:
+            out[key] = number
     return out
+
+
+def _trailing_threshold_projection(
+    *,
+    kind: str,
+    pside: str,
+    threshold_price: float | None,
+    retracement_pct: float | None,
+) -> float | None:
+    if threshold_price is None or retracement_pct is None:
+        return None
+    if threshold_price <= 0.0 or retracement_pct < 0.0:
+        return None
+    if (kind == "entry" and pside == "long") or (kind == "close" and pside == "short"):
+        return threshold_price * (1.0 + retracement_pct)
+    if (kind == "entry" and pside == "short") or (kind == "close" and pside == "long"):
+        return threshold_price * (1.0 - retracement_pct)
+    return None
+
+
+def _trailing_status_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    kind = str(payload.get("kind") or "unknown")
+    pside = str(payload.get("pside") or "unknown")
+    threshold_price = _safe_float(payload.get("threshold_price"))
+    retracement_pct = _safe_float(payload.get("retracement_pct"))
+    out: dict[str, Any] = {
+        "kind": kind,
+        "diagnostics_supported": bool(payload.get("diagnostics_supported", True)),
+        "strategy_kind": str(payload.get("strategy_kind") or "") or None,
+        "trailing_status": str(payload.get("status") or payload.get("trailing_status") or "unknown"),
+        "order_type": str(payload.get("order_type") or "") or None,
+        "triggered": bool(payload.get("triggered", False)),
+        "threshold_met": bool(payload.get("threshold_met", False))
+        if "threshold_met" in payload
+        else None,
+        "retracement_met": bool(payload.get("retracement_met", False))
+        if "retracement_met" in payload
+        else None,
+        "threshold_pct": _safe_float(payload.get("threshold_pct")),
+        "threshold_price": threshold_price,
+        "retracement_pct": retracement_pct,
+        "retracement_price": _safe_float(payload.get("retracement_price")),
+        "threshold_projection_retracement_price": _trailing_threshold_projection(
+            kind=kind,
+            pside=pside,
+            threshold_price=threshold_price,
+            retracement_pct=retracement_pct,
+        ),
+        "current_price": _safe_float(payload.get("current_price")),
+        "position_price": _safe_float(payload.get("position_price")),
+        "position_size": _safe_float(payload.get("position_size")),
+        "current_vs_threshold_ratio": _safe_float(
+            payload.get("current_vs_threshold_ratio")
+        ),
+        "current_vs_retracement_ratio": _safe_float(
+            payload.get("current_vs_retracement_ratio")
+        ),
+        "unsupported_reason": str(payload.get("unsupported_reason") or "") or None,
+        "changed": bool(payload.get("changed", False)),
+    }
+    return {key: value for key, value in out.items() if value is not None}
+
+
+def emit_trailing_status_event(
+    bot: Any,
+    *,
+    symbol: str,
+    pside: str,
+    kind: str,
+    payload: dict[str, Any],
+    changed: bool,
+) -> None:
+    try:
+        data = _trailing_status_summary(
+            {
+                **dict(payload or {}),
+                "kind": str(kind),
+                "pside": str(pside),
+                "changed": bool(changed),
+            }
+        )
+        bot._emit_live_event(
+            EventTypes.TRAILING_STATUS,
+            level="info",
+            component="risk.trailing.status",
+            tags=(EventTags.RISK, EventTags.TRAILING, EventTags.POSITION),
+            cycle_id=bot._current_live_event_cycle_id(),
+            symbol=str(symbol),
+            pside=str(pside),
+            status="succeeded",
+            reason_code=ReasonCodes.TRAILING_STATUS,
+            data=data,
+        )
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit trailing status event symbol=%s pside=%s kind=%s: %s",
+            symbol,
+            pside,
+            kind,
+            exc,
+        )
 
 
 def emit_unstuck_status_event(

--- a/src/live/planning_gates.py
+++ b/src/live/planning_gates.py
@@ -381,6 +381,7 @@ async def defer_staged_execution_cycle(bot, details: dict, loop_start_ms: int) -
     bot._log_staged_execution_defer(details)
     bot._last_loop_duration_ms = _utc_ms() - loop_start_ms
     bot._maybe_log_health_summary()
+    bot._maybe_log_trailing_status()
     bot._maybe_log_unstuck_status()
     bot._set_log_silence_watchdog_context(phase="runtime", stage="flush_snapshot")
     await bot._monitor_flush_snapshot()

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -651,6 +651,7 @@ class Passivbot:
     _emit_entry_min_effective_cost_blocked_event = (
         live_event_emitters.emit_entry_min_effective_cost_blocked_event
     )
+    _emit_trailing_status_event = live_event_emitters.emit_trailing_status_event
     _emit_unstuck_status_event = live_event_emitters.emit_unstuck_status_event
     _emit_unstuck_selection_event = live_event_emitters.emit_unstuck_selection_event
     _emit_forager_feature_unavailable_event = (
@@ -1181,6 +1182,11 @@ class Passivbot:
         self._unstuck_last_selection_info_ms = 0
         self._unstuck_allowance_log_hyst_snap_pct = 0.002
         self._unstuck_allowance_log_snap_by_pside = {}
+        self._trailing_last_status_check_ms = 0
+        self._trailing_status_check_interval_ms = 5 * 60 * 1000
+        self._trailing_unchanged_info_log_interval_ms = 60 * 60 * 1000
+        self._trailing_last_status_signature = None
+        self._trailing_last_status_info_ms = 0
 
         # Realized-loss gate logging throttle
         self._loss_gate_last_log_ms = {}
@@ -3371,6 +3377,278 @@ class Passivbot:
         )
         self._unstuck_last_selection_signature = signature
         self._unstuck_last_selection_info_ms = now_ms
+
+    def _active_trailing_position_sides(self) -> list[tuple[str, str, dict]]:
+        out: list[tuple[str, str, dict]] = []
+        positions = getattr(self, "positions", {}) or {}
+        if not isinstance(positions, dict):
+            return out
+        for symbol, pos_entry in sorted(positions.items()):
+            if not isinstance(pos_entry, dict):
+                continue
+            for pside in ("long", "short"):
+                pos = pos_entry.get(pside, {})
+                if not isinstance(pos, dict):
+                    continue
+                try:
+                    size = float(pos.get("size", 0.0) or 0.0)
+                except (TypeError, ValueError):
+                    continue
+                if size == 0.0:
+                    continue
+                try:
+                    trailing_active = bool(self.is_trailing(symbol, pside))
+                except Exception:
+                    trailing_active = False
+                if trailing_active:
+                    out.append((str(symbol), pside, dict(pos)))
+        return out
+
+    @staticmethod
+    def _trailing_status_float(value, default: float = 0.0) -> float:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return float(default)
+        return number if math.isfinite(number) else float(default)
+
+    @staticmethod
+    def _trailing_status_signature(items: list[dict]) -> tuple:
+        signature = []
+        for item in items:
+            payload = item.get("payload", {}) if isinstance(item, dict) else {}
+            if not isinstance(payload, dict):
+                payload = {}
+            signature.append(
+                (
+                    item.get("symbol"),
+                    item.get("pside"),
+                    item.get("kind"),
+                    bool(payload.get("diagnostics_supported", True)),
+                    str(
+                        payload.get("status")
+                        or payload.get("trailing_status")
+                        or "unknown"
+                    ),
+                    bool(payload.get("threshold_met"))
+                    if "threshold_met" in payload
+                    else None,
+                    bool(payload.get("retracement_met"))
+                    if "retracement_met" in payload
+                    else None,
+                    round(
+                        Passivbot._trailing_status_float(payload.get("threshold_pct")),
+                        8,
+                    ),
+                    round(
+                        Passivbot._trailing_status_float(
+                            payload.get("retracement_pct")
+                        ),
+                        8,
+                    ),
+                    round(
+                        Passivbot._trailing_status_float(payload.get("threshold_price")),
+                        8,
+                    ),
+                    round(
+                        Passivbot._trailing_status_float(
+                            payload.get("retracement_price")
+                        ),
+                        8,
+                    ),
+                    str(payload.get("unsupported_reason") or ""),
+                )
+            )
+        return tuple(sorted(signature))
+
+    def _unsupported_trailing_status_item(
+        self,
+        *,
+        symbol: str,
+        pside: str,
+        pos: dict,
+        strategy_kind: str,
+        reason: str,
+    ) -> dict:
+        return {
+            "symbol": symbol,
+            "pside": pside,
+            "kind": "position",
+            "payload": {
+                "kind": "position",
+                "diagnostics_supported": False,
+                "strategy_kind": strategy_kind,
+                "unsupported_reason": reason,
+                "status": "active_unsupported",
+                "position_size": self._trailing_status_float(pos.get("size")),
+                "position_price": self._trailing_status_float(pos.get("price")),
+            },
+        }
+
+    def _build_trailing_status_items(self) -> list[dict]:
+        active_sides = self._active_trailing_position_sides()
+        if not active_sides:
+            return []
+        strategy_kind = normalize_strategy_kind(
+            self.config.get("live", {}).get("strategy_kind")
+            if isinstance(getattr(self, "config", None), dict)
+            else None
+        )
+        try:
+            market = self._build_monitor_market_section()
+        except Exception as exc:
+            return [
+                self._unsupported_trailing_status_item(
+                    symbol=symbol,
+                    pside=pside,
+                    pos=pos,
+                    strategy_kind=strategy_kind,
+                    reason=f"market_snapshot_unavailable:{type(exc).__name__}",
+                )
+                for symbol, pside, pos in active_sides
+            ]
+        try:
+            balance_raw = float(self.get_raw_balance())
+        except Exception:
+            balance_raw = float(getattr(self, "balance_raw", 0.0) or 0.0)
+        try:
+            trailing_section = self._build_monitor_trailing_section(
+                balance_raw=balance_raw,
+                market=market,
+            )
+        except Exception as exc:
+            return [
+                self._unsupported_trailing_status_item(
+                    symbol=symbol,
+                    pside=pside,
+                    pos=pos,
+                    strategy_kind=strategy_kind,
+                    reason=f"diagnostic_build_failed:{type(exc).__name__}",
+                )
+                for symbol, pside, pos in active_sides
+            ]
+        meta = (
+            trailing_section.get("_meta", {})
+            if isinstance(trailing_section, dict)
+            else {}
+        )
+        if isinstance(meta, dict) and meta.get("diagnostics_supported") is False:
+            reason = str(meta.get("reason") or "diagnostics_unsupported")
+            return [
+                self._unsupported_trailing_status_item(
+                    symbol=symbol,
+                    pside=pside,
+                    pos=pos,
+                    strategy_kind=str(meta.get("strategy_kind") or strategy_kind),
+                    reason=reason,
+                )
+                for symbol, pside, pos in active_sides
+            ]
+        out: list[dict] = []
+        for symbol, pside, pos in active_sides:
+            symbol_section = (
+                trailing_section.get(symbol, {})
+                if isinstance(trailing_section, dict)
+                else {}
+            )
+            side_section = (
+                symbol_section.get(pside, {})
+                if isinstance(symbol_section, dict)
+                else {}
+            )
+            if not isinstance(side_section, dict):
+                out.append(
+                    self._unsupported_trailing_status_item(
+                        symbol=symbol,
+                        pside=pside,
+                        pos=pos,
+                        strategy_kind=strategy_kind,
+                        reason="diagnostic_unavailable",
+                    )
+                )
+                continue
+            emitted = False
+            for kind in ("entry", "close"):
+                payload = side_section.get(kind)
+                if not isinstance(payload, dict):
+                    continue
+                item_payload = dict(payload)
+                item_payload["strategy_kind"] = strategy_kind
+                item_payload["position_size"] = self._trailing_status_float(
+                    pos.get("size")
+                )
+                item_payload["position_price"] = self._trailing_status_float(
+                    pos.get("price")
+                )
+                item_payload["diagnostics_supported"] = True
+                out.append(
+                    {
+                        "symbol": symbol,
+                        "pside": pside,
+                        "kind": kind,
+                        "payload": item_payload,
+                    }
+                )
+                emitted = True
+            if not emitted:
+                out.append(
+                    self._unsupported_trailing_status_item(
+                        symbol=symbol,
+                        pside=pside,
+                        pos=pos,
+                        strategy_kind=strategy_kind,
+                        reason="no_trailing_diagnostic",
+                    )
+                )
+        return out
+
+    def _maybe_log_trailing_status(self) -> None:
+        now_ms = utc_ms()
+        last_check = int(getattr(self, "_trailing_last_status_check_ms", 0) or 0)
+        check_interval = int(
+            getattr(self, "_trailing_status_check_interval_ms", 5 * 60 * 1000)
+            or 0
+        )
+        if check_interval > 0 and (now_ms - last_check) < check_interval:
+            return
+        self._trailing_last_status_check_ms = now_ms
+        try:
+            items = self._build_trailing_status_items()
+        except Exception as exc:
+            logging.debug("[trailing] failed building status event items: %s", exc)
+            return
+        if not items:
+            return
+        signature = self._trailing_status_signature(items)
+        status_changed = signature != getattr(
+            self, "_trailing_last_status_signature", None
+        )
+        last_info_ms = int(getattr(self, "_trailing_last_status_info_ms", 0) or 0)
+        unchanged_interval = int(
+            getattr(
+                self,
+                "_trailing_unchanged_info_log_interval_ms",
+                60 * 60 * 1000,
+            )
+            or 0
+        )
+        if (
+            not status_changed
+            and unchanged_interval > 0
+            and (now_ms - last_info_ms) < unchanged_interval
+        ):
+            return
+        for item in items:
+            payload = dict(item.get("payload", {}) or {})
+            self._emit_trailing_status_event(
+                symbol=str(item.get("symbol") or ""),
+                pside=str(item.get("pside") or ""),
+                kind=str(item.get("kind") or "position"),
+                payload=payload,
+                changed=status_changed,
+            )
+        self._trailing_last_status_signature = signature
+        self._trailing_last_status_info_ms = now_ms
 
     async def start_bot(self):
         """Initialise state, warm cached data, and launch background loops."""
@@ -5965,6 +6243,7 @@ class Passivbot:
                     self._last_loop_duration_ms = utc_ms() - loop_start_ms
                     self._last_loop_timing_ms = dict(loop_timings_ms)
                     self._maybe_log_health_summary()
+                    self._maybe_log_trailing_status()
                     self._maybe_log_unstuck_status()
                     self._set_log_silence_watchdog_context(
                         phase="runtime", stage="flush_snapshot"
@@ -6114,6 +6393,7 @@ class Passivbot:
                 self._last_loop_timing_ms = dict(loop_timings_ms)
                 # Periodic health summary
                 self._maybe_log_health_summary()
+                self._maybe_log_trailing_status()
                 self._maybe_log_unstuck_status()
                 self._set_log_silence_watchdog_context(
                     phase="runtime", stage="flush_snapshot"

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -246,7 +246,6 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.HSL_RED_FINALIZED_WITHOUT_ORDER,
         EventTypes.HSL_COOLDOWN_STARTED,
         EventTypes.HSL_COOLDOWN_ENDED,
-        EventTypes.UNSTUCK_STATUS,
         EventTypes.UNSTUCK_SELECTION,
         EventTypes.REALIZED_LOSS_GATE_BLOCKED,
     ):
@@ -264,6 +263,10 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.BOT_SHUTDOWN_STAGE].text is True
     assert DEFAULT_ROUTES[EventTypes.HSL_STATUS].console is True
     assert DEFAULT_ROUTES[EventTypes.HSL_STATUS].text is True
+    assert DEFAULT_ROUTES[EventTypes.TRAILING_STATUS].console is True
+    assert DEFAULT_ROUTES[EventTypes.TRAILING_STATUS].text is True
+    assert DEFAULT_ROUTES[EventTypes.UNSTUCK_STATUS].console is True
+    assert DEFAULT_ROUTES[EventTypes.UNSTUCK_STATUS].text is True
 
 
 def test_redact_payload_recurses_and_payload_hash_is_stable():
@@ -886,6 +889,88 @@ def test_console_format_summarizes_hsl_cooldown_seconds():
     assert format_console_event(event) == (
         "[risk] degraded tier=red cooldown=300s symbol=NEAR/USDT:USDT "
         "pside=long reason=cooldown_active"
+    )
+
+
+def test_console_format_summarizes_trailing_status():
+    event = LiveEvent(
+        EventTypes.TRAILING_STATUS,
+        status="succeeded",
+        cycle_id="cy_trailing",
+        symbol="BTC/USDT:USDT",
+        pside="long",
+        reason_code="trailing_status",
+        data={
+            "kind": "entry",
+            "trailing_status": "waiting_threshold",
+            "threshold_met": False,
+            "threshold_pct": 0.0125,
+            "threshold_price": 98_750.0,
+            "retracement_met": False,
+            "retracement_pct": 0.004,
+            "retracement_price": 99_145.0,
+            "threshold_projection_retracement_price": 99_145.0,
+            "current_price": 101_000.0,
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[trailing] succeeded cycle=cy_trailing kind=entry "
+        "trailing_status=waiting_threshold threshold_met=False threshold=1.2500% "
+        "threshold_price=98750 retracement_met=False retracement=0.4000% "
+        "retracement_price=99145 threshold_retrace_price=99145 current=101000 "
+        "symbol=BTC/USDT:USDT pside=long reason=trailing_status"
+    )
+
+
+def test_console_format_summarizes_unsupported_trailing_status():
+    event = LiveEvent(
+        EventTypes.TRAILING_STATUS,
+        status="succeeded",
+        symbol="BTC/USDT:USDT",
+        pside="long",
+        reason_code="trailing_status",
+        data={
+            "kind": "position",
+            "diagnostics_supported": False,
+            "strategy_kind": "trailing_grid_v7",
+            "unsupported_reason": "monitor trailing diagnostics use trailing_martingale helper formulas",
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[trailing] succeeded kind=position strategy=trailing_grid_v7 "
+        "unsupported=monitor trailing diagnostics use trailing_martingale helper "
+        "formulas symbol=BTC/USDT:USDT pside=long reason=trailing_status"
+    )
+
+
+def test_console_format_summarizes_unstuck_status():
+    event = LiveEvent(
+        EventTypes.UNSTUCK_STATUS,
+        status="succeeded",
+        reason_code="unstuck_status",
+        data={
+            "changed": True,
+            "over_budget_sides": ["long"],
+            "sides": {
+                "long": {
+                    "status": "ok",
+                    "allowance": -12.3,
+                    "over_budget": True,
+                    "next_symbol": "BTC/USDT:USDT",
+                    "next_target_price": 101_000.0,
+                    "next_unstuck_trigger_distance_ratio": 0.0125,
+                },
+                "short": {"status": "disabled"},
+            },
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[unstuck] succeeded long:ok:allowance=-12.3:over_budget:"
+        "next=BTC/USDT:USDT:target=101000:ema_gate=1.2500% "
+        "short:disabled over_budget=long changed=true reason=unstuck_status"
     )
 
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2944,6 +2944,56 @@ def test_unstuck_selection_logs_on_change_then_hourly(monkeypatch, caplog):
     assert captured_events[2]["symbol"] == "ADA/USDT:USDT"
 
 
+def test_trailing_status_emits_on_change_then_hourly(monkeypatch):
+    bot = Passivbot.__new__(Passivbot)
+    bot._trailing_last_status_check_ms = 0
+    bot._trailing_status_check_interval_ms = 5 * 60 * 1000
+    bot._trailing_unchanged_info_log_interval_ms = 60 * 60 * 1000
+    bot._trailing_last_status_signature = None
+    bot._trailing_last_status_info_ms = 0
+    captured_events = []
+    bot._emit_trailing_status_event = lambda **kwargs: captured_events.append(kwargs)
+    now = [5 * 60 * 1000]
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now[0])
+
+    item = {
+        "symbol": "BTC/USDT:USDT",
+        "pside": "long",
+        "kind": "entry",
+        "payload": {
+            "kind": "entry",
+            "status": "waiting_threshold",
+            "threshold_met": False,
+            "retracement_met": False,
+            "threshold_pct": 0.01,
+            "retracement_pct": 0.004,
+            "threshold_price": 99_000.0,
+            "retracement_price": 99_396.0,
+        },
+    }
+    items = [deepcopy(item)]
+    bot._build_trailing_status_items = lambda: deepcopy(items)
+
+    bot._maybe_log_trailing_status()
+    now[0] += 5 * 60 * 1000
+    bot._maybe_log_trailing_status()
+    items[0]["payload"]["status"] = "waiting_retracement"
+    items[0]["payload"]["threshold_met"] = True
+    now[0] += 5 * 60 * 1000
+    bot._maybe_log_trailing_status()
+    now[0] += 5 * 60 * 1000
+    bot._maybe_log_trailing_status()
+    now[0] += 60 * 60 * 1000
+    bot._maybe_log_trailing_status()
+
+    assert len(captured_events) == 3
+    assert [event["changed"] for event in captured_events] == [True, True, False]
+    assert captured_events[0]["symbol"] == "BTC/USDT:USDT"
+    assert captured_events[0]["pside"] == "long"
+    assert captured_events[0]["kind"] == "entry"
+    assert captured_events[1]["payload"]["status"] == "waiting_retracement"
+
+
 @pytest.mark.asyncio
 async def test_update_pnls_all_lookback_backfills_when_cache_scope_is_narrower():
     bot = Passivbot.__new__(Passivbot)

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -2789,6 +2789,75 @@ def test_unstuck_status_event_emits_structured_summary():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_trailing_status_event_emits_structured_summary():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _emit_trailing_status_event = pb_mod.Passivbot._emit_trailing_status_event
+
+        def __init__(self):
+            self.exchange = "hyperliquid"
+            self.user = "hyperliquid_canon"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_trailing_status"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+
+    bot._emit_trailing_status_event(
+        symbol="BTC/USDC:USDC",
+        pside="long",
+        kind="close",
+        changed=True,
+        payload={
+            "kind": "close",
+            "strategy_kind": "trailing_martingale",
+            "status": "waiting_retracement",
+            "order_type": "close_trailing_long",
+            "triggered": False,
+            "threshold_met": True,
+            "retracement_met": False,
+            "threshold_pct": 0.01,
+            "threshold_price": 101_000.0,
+            "retracement_pct": 0.004,
+            "retracement_price": 100_596.0,
+            "current_price": 100_700.0,
+            "position_price": 100_000.0,
+            "position_size": 0.01,
+        },
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[-1]
+    assert event.event_type == EventTypes.TRAILING_STATUS
+    assert event.cycle_id == "cy_trailing_status"
+    assert event.symbol == "BTC/USDC:USDC"
+    assert event.pside == "long"
+    assert event.reason_code == "trailing_status"
+    assert event.component == "risk.trailing.status"
+    assert event.tags == ("risk", "trailing", "position")
+    assert event.data["changed"] is True
+    assert event.data["kind"] == "close"
+    assert event.data["trailing_status"] == "waiting_retracement"
+    assert event.data["threshold_met"] is True
+    assert event.data["retracement_met"] is False
+    assert event.data["threshold_pct"] == pytest.approx(0.01)
+    assert event.data["threshold_price"] == pytest.approx(101_000.0)
+    assert event.data["retracement_pct"] == pytest.approx(0.004)
+    assert event.data["retracement_price"] == pytest.approx(100_596.0)
+    assert event.data["threshold_projection_retracement_price"] == pytest.approx(
+        100_596.0
+    )
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_unstuck_selection_event_emits_structured_summary():
     import passivbot as pb_mod
 


### PR DESCRIPTION
## Summary
- Add structured trailing.status events for active trailing positions, emitted on status-signature changes plus hourly heartbeat with a five-minute check interval.
- Project trailing.status and existing unstuck.status into the opt-in live event console.
- Preserve behavior: no exchange calls, cache mutation, readiness gates, order construction, risk thresholds, or trading behavior changes.

## Notes
- The producer uses already-prepared monitor/trailing diagnostic data.
- trailing_grid_v7 remains explicitly reported as diagnostics unsupported instead of reimplementing Rust strategy logic in Python.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py src/live/event_emitters.py src/passivbot.py src/live/planning_gates.py
- git diff --check
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py::test_trailing_status_event_emits_structured_summary tests/test_passivbot_monitor.py::test_unstuck_status_event_emits_structured_summary tests/test_passivbot_balance_split.py::test_trailing_status_emits_on_change_then_hourly -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_registry_docs.py -q