### PR TITLE
Add trailing grid v7 diagnostics

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,26 +19,20 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` head:
 
-- `c763d84d` after PR #959, `Project HSL status into event console`.
+- `c4a23aa9` after PR #960, `Add position trailing status events`.
 
 Current logging-overhaul head:
 
-- `c763d84d` after PR #959, `Project HSL status into event console`.
+- `c4a23aa9` after PR #960, `Add position trailing status events`.
 
 Current work:
 
-- Branch `codex/v8-position-status-console` adds structured
-  `trailing.status` events for active trailing positions and projects
-  `trailing.status` plus existing `unstuck.status` into the opt-in event-console.
-  The trailing producer uses already-prepared monitor/trailing diagnostic data,
-  emits on state-signature change plus hourly heartbeat with a five-minute check
-  interval, and reports unsupported strategy diagnostics explicitly rather than
-  reimplementing Rust strategy logic in Python. The slice is observability-only:
-  no exchange calls, cache mutation, readiness gates, smoke verdict changes,
-  process signaling, order construction, risk thresholds, or trading behavior
-  changes. Expected validation is focused event-bus/monitor/balance-split tests,
-  py_compile for touched files, `git diff --check`, and an added-line
-  silent-handling scan.
+- Branch `codex/v8-trailing-grid-v7-diagnostics` adds Rust-aligned
+  `trailing_grid_v7` monitor diagnostics so the same position-status stream can
+  explain v7 compatibility positions instead of reporting that v7 trailing
+  diagnostics are unsupported. The helper calls existing Rust v7 order
+  functions and reports selected mode, WEL ratio, threshold/retracement status,
+  and projected retracement price without changing order generation.
 
 Current review gate:
 
@@ -68,6 +62,28 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #960 at `c4a23aa9`.
+- PR #960 added structured `trailing.status` events for active trailing
+  positions, projected `trailing.status` plus existing `unstuck.status` into the
+  opt-in event console, and kept unsupported strategy diagnostics explicit until
+  strategy-specific Rust diagnostics exist. It was merged after Claude and
+  Hermes approved with CI green. Cursor had not posted a review after repeated
+  polling, so this was treated as a reviewer-availability exception for an
+  observability-only live-path slice; no reviewer findings were outstanding.
+- Bots were restarted from `/root/bots_vps5.yaml` and left running. Graceful
+  Ctrl-C shutdown improved for Binance but Kucoin, GateIO, OKX, and
+  Hyperliquid still needed SIGTERM after the full Ctrl-C wait window; this
+  remains evidence for the existing shutdown/backlog work.
+- VPS5 smoke after restart reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, `missing_expected_count=0`, clean tracked repository
+  state at `repository.head=c4a23aa9`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `logs.hard_matches=0`, and
+  `logs.attention_matches=0`. Attention was limited to four active HSL replay
+  workers during startup, with no failed HSL replay bots.
+- The deployed monitor event stream emitted a `trailing.status` event for the
+  Hyperliquid `XYZ-MU/USDC:USDC` long position. It was correctly marked
+  `active_unsupported` because the Rust-aligned `trailing_grid_v7` diagnostics
+  follow-up had not merged yet.
 - Repository pulled through PR #958 at `a989a3f2`.
 - PR #958 refreshed v8 long-side default values in Rust metadata, Python schema,
   and the default example config. It was not a logging-overhaul slice, but it

--- a/passivbot-rust/src/lib.rs
+++ b/passivbot-rust/src/lib.rs
@@ -40,6 +40,7 @@ fn passivbot_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(calc_wallet_exposure, m)?)?;
     m.add_function(wrap_pyfunction!(calc_new_psize_pprice, m)?)?;
     m.add_function(wrap_pyfunction!(calc_next_entry_long_py, m)?)?;
+    m.add_function(wrap_pyfunction!(calc_trailing_grid_v7_diagnostic_py, m)?)?;
     m.add_function(wrap_pyfunction!(calc_next_close_long_py, m)?)?;
     m.add_function(wrap_pyfunction!(calc_entries_long_py, m)?)?;
     m.add_function(wrap_pyfunction!(calc_next_entry_short_py, m)?)?;

--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -17,9 +17,10 @@ use crate::risk::{
 };
 use crate::strategies::ema_anchor::calc_quote_prices as calc_ema_anchor_quote_prices;
 use crate::strategies::registry::{strategy_kind_from_name, strategy_kind_names, strategy_spec};
+use crate::strategies::trailing_grid_v7::calc_trailing_grid_v7_diagnostics;
 use crate::strategies::{
-    EmaAnchorParams, EmaGateMode, StrategySide, TrailingMartingaleCloseParams,
-    TrailingMartingaleEntryParams,
+    EmaAnchorParams, EmaGateMode, StrategySide, TrailingGridV7Params,
+    TrailingMartingaleCloseParams, TrailingMartingaleEntryParams,
 };
 use crate::trailing::{
     trailing_bundle_to_tuple, tuple_to_trailing_bundle, update_trailing_bundle_sequence,
@@ -2537,6 +2538,108 @@ fn make_runtime_order_context(wallet_exposure_limit: f64) -> RuntimeOrderContext
     RuntimeOrderContext {
         effective_wallet_exposure_limit: wallet_exposure_limit,
     }
+}
+
+fn json_f64(value: &Value, key: &str, default: f64) -> f64 {
+    value.get(key).and_then(Value::as_f64).unwrap_or(default)
+}
+
+fn json_usize(value: &Value, key: &str, default: usize) -> usize {
+    value
+        .get(key)
+        .and_then(Value::as_u64)
+        .map(|value| value as usize)
+        .unwrap_or(default)
+}
+
+fn bot_params_from_trailing_grid_v7_diagnostic_json(value: &Value) -> PyResult<BotParams> {
+    let mut bot = BotParams::default();
+    bot.wallet_exposure_limit = json_f64(value, "wallet_exposure_limit", 0.0);
+    bot.total_wallet_exposure_limit = json_f64(value, "total_wallet_exposure_limit", 0.0);
+    bot.n_positions = json_usize(value, "n_positions", 1);
+    bot.risk_we_excess_allowance_pct = json_f64(value, "risk_we_excess_allowance_pct", 0.0);
+    bot.risk_wel_enforcer_threshold = json_f64(value, "risk_wel_enforcer_threshold", 0.0);
+    if let Some(raw) = value
+        .get("risk_we_excess_allowance_mode")
+        .and_then(Value::as_str)
+    {
+        bot.risk_we_excess_allowance_mode =
+            WeExcessAllowanceMode::from_str(raw.trim()).map_err(|_| {
+                PyValueError::new_err(format!(
+                    "risk_we_excess_allowance_mode must be one of: bounded, legacy_raw; got {:?}",
+                    raw
+                ))
+            })?;
+    }
+    Ok(bot)
+}
+
+#[pyfunction]
+pub fn calc_trailing_grid_v7_diagnostic_py(input_json: &str) -> PyResult<String> {
+    let input: Value = serde_json::from_str(input_json).map_err(|err| {
+        PyValueError::new_err(format!("invalid trailing_grid_v7 diagnostic json: {err}"))
+    })?;
+    let side = match input.get("pside").and_then(Value::as_str).unwrap_or("long") {
+        "long" => StrategySide::Long,
+        "short" => StrategySide::Short,
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "pside must be long or short; got {other:?}"
+            )))
+        }
+    };
+    let exchange: ExchangeParams = serde_json::from_value(
+        input
+            .get("exchange")
+            .cloned()
+            .ok_or_else(|| PyValueError::new_err("missing exchange"))?,
+    )
+    .map_err(|err| PyValueError::new_err(format!("invalid exchange: {err}")))?;
+    let state: StateParams = serde_json::from_value(
+        input
+            .get("state")
+            .cloned()
+            .ok_or_else(|| PyValueError::new_err("missing state"))?,
+    )
+    .map_err(|err| PyValueError::new_err(format!("invalid state: {err}")))?;
+    let position: Position = serde_json::from_value(
+        input
+            .get("position")
+            .cloned()
+            .ok_or_else(|| PyValueError::new_err("missing position"))?,
+    )
+    .map_err(|err| PyValueError::new_err(format!("invalid position: {err}")))?;
+    let trailing: TrailingPriceBundle = serde_json::from_value(
+        input
+            .get("trailing")
+            .cloned()
+            .ok_or_else(|| PyValueError::new_err("missing trailing"))?,
+    )
+    .map_err(|err| PyValueError::new_err(format!("invalid trailing: {err}")))?;
+    let params: TrailingGridV7Params = serde_json::from_value(
+        input
+            .get("strategy_params")
+            .cloned()
+            .ok_or_else(|| PyValueError::new_err("missing strategy_params"))?,
+    )
+    .map_err(|err| PyValueError::new_err(format!("invalid strategy_params: {err}")))?;
+    let bot = bot_params_from_trailing_grid_v7_diagnostic_json(
+        input
+            .get("bot_params")
+            .ok_or_else(|| PyValueError::new_err("missing bot_params"))?,
+    )?;
+    let runtime = RuntimeOrderContext {
+        effective_wallet_exposure_limit: input
+            .get("runtime")
+            .and_then(|runtime| runtime.get("effective_wallet_exposure_limit"))
+            .and_then(Value::as_f64)
+            .unwrap_or(bot.wallet_exposure_limit),
+    };
+    let out = calc_trailing_grid_v7_diagnostics(
+        side, &exchange, &state, &bot, &runtime, &params, &position, &trailing,
+    );
+    serde_json::to_string(&out)
+        .map_err(|err| PyValueError::new_err(format!("failed to serialize diagnostic: {err}")))
 }
 
 #[pyfunction]

--- a/passivbot-rust/src/strategies/trailing_grid_v7.rs
+++ b/passivbot-rust/src/strategies/trailing_grid_v7.rs
@@ -2497,6 +2497,27 @@ mod tests {
         }
     }
 
+    fn expected_mode_from_order_type(order_type: OrderType) -> &'static str {
+        match order_type {
+            OrderType::EntryTrailingNormalLong
+            | OrderType::EntryTrailingCroppedLong
+            | OrderType::EntryTrailingNormalShort
+            | OrderType::EntryTrailingCroppedShort
+            | OrderType::CloseTrailingLong
+            | OrderType::CloseTrailingShort => "trailing",
+            OrderType::EntryGridNormalLong
+            | OrderType::EntryGridCroppedLong
+            | OrderType::EntryGridInflatedLong
+            | OrderType::EntryGridNormalShort
+            | OrderType::EntryGridCroppedShort
+            | OrderType::EntryGridInflatedShort
+            | OrderType::CloseGridLong
+            | OrderType::CloseGridShort => "grid",
+            OrderType::CloseAutoReduceWelLong | OrderType::CloseAutoReduceWelShort => "auto_reduce",
+            other => panic!("unexpected order type for v7 diagnostic parity: {other:?}"),
+        }
+    }
+
     #[test]
     fn diagnostic_reports_trailing_grid_v7_threshold_and_projection() {
         let exchange = exchange();
@@ -2555,6 +2576,106 @@ mod tests {
         assert_eq!(close["status"].as_str(), Some("waiting_threshold"));
         assert_eq!(close["threshold_price"].as_f64().unwrap(), 102.0);
         assert!((close["projected_retracement_price"].as_f64().unwrap() - 100.98).abs() < 1e-12);
+    }
+
+    #[test]
+    fn diagnostic_selected_modes_match_next_orders_for_split_branches() {
+        let exchange = exchange();
+        let state = state();
+        let bot = bot();
+        let runtime = runtime();
+        let trailing = TrailingPriceBundle {
+            min_since_open: 98.0,
+            max_since_min: 99.0,
+            max_since_open: 102.0,
+            min_since_max: 101.0,
+        };
+        let entry = entry_params();
+        let close = TrailingGridV7CloseParams {
+            grid_markup_start: 0.01,
+            grid_markup_end: 0.005,
+            grid_qty_pct: 0.2,
+            trailing_grid_ratio: 0.5,
+            trailing_qty_pct: 0.25,
+            trailing_retracement_pct: 0.005,
+            trailing_threshold_pct: 0.01,
+        };
+        let params = TrailingGridV7Params {
+            ema_span_0: 10.0,
+            ema_span_1: 20.0,
+            entry,
+            close,
+        };
+
+        let cases = [
+            (
+                StrategySide::Long,
+                Position {
+                    size: 40.0,
+                    price: 100.0,
+                },
+            ),
+            (
+                StrategySide::Long,
+                Position {
+                    size: 80.0,
+                    price: 100.0,
+                },
+            ),
+            (
+                StrategySide::Short,
+                Position {
+                    size: -40.0,
+                    price: 100.0,
+                },
+            ),
+            (
+                StrategySide::Short,
+                Position {
+                    size: -80.0,
+                    price: 100.0,
+                },
+            ),
+        ];
+
+        for (side, position) in cases {
+            let diagnostic = calc_trailing_grid_v7_diagnostics(
+                side, &exchange, &state, &bot, &runtime, &params, &position, &trailing,
+            );
+            let entry_order = match side {
+                StrategySide::Long => calc_next_entry_long(
+                    &exchange, &state, &bot, &runtime, &entry, &position, &trailing,
+                ),
+                StrategySide::Short => calc_next_entry_short(
+                    &exchange, &state, &bot, &runtime, &entry, &position, &trailing,
+                ),
+            };
+            let close_order = match side {
+                StrategySide::Long => calc_next_close_long(
+                    &exchange, &state, &bot, &runtime, &close, &position, &trailing,
+                ),
+                StrategySide::Short => calc_next_close_short(
+                    &exchange, &state, &bot, &runtime, &close, &position, &trailing,
+                ),
+            };
+
+            assert_eq!(
+                diagnostic["entry"]["selected_mode"].as_str(),
+                Some(expected_mode_from_order_type(entry_order.order_type))
+            );
+            assert_eq!(
+                diagnostic["close"]["selected_mode"].as_str(),
+                Some(expected_mode_from_order_type(close_order.order_type))
+            );
+            assert_eq!(
+                diagnostic["entry"]["order"]["order_type"].as_str(),
+                Some(entry_order.order_type.to_string().as_str())
+            );
+            assert_eq!(
+                diagnostic["close"]["order"]["order_type"].as_str(),
+                Some(close_order.order_type.to_string().as_str())
+            );
+        }
     }
 
     #[test]

--- a/passivbot-rust/src/strategies/trailing_grid_v7.rs
+++ b/passivbot-rust/src/strategies/trailing_grid_v7.rs
@@ -16,6 +16,7 @@ use crate::utils::{
     calc_ema_price_ask, calc_ema_price_bid, calc_new_psize_pprice, calc_wallet_exposure,
     cost_to_qty, quantize_price, quantize_qty, round_, round_dn, round_up, RoundingMode,
 };
+use serde::Serialize;
 
 fn push_if_nonzero(out: &mut Vec<Order>, order: Order) {
     if order.qty != 0.0 {
@@ -1412,6 +1413,467 @@ fn calc_next_close_short(
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct Selection {
+    mode: &'static str,
+    reason: &'static str,
+    cap: f64,
+}
+
+#[derive(Debug, Serialize)]
+struct OrderDiagnostic {
+    qty: f64,
+    price: f64,
+    order_type: String,
+}
+
+#[derive(Debug, Serialize)]
+struct TrailingDiagnostic {
+    kind: &'static str,
+    pside: &'static str,
+    selected_mode: &'static str,
+    selection_reason: &'static str,
+    status: &'static str,
+    wallet_exposure: f64,
+    wallet_exposure_ratio: f64,
+    effective_wallet_exposure_limit: f64,
+    trailing_grid_ratio: f64,
+    order: OrderDiagnostic,
+    threshold_pct: Option<f64>,
+    threshold_price: Option<f64>,
+    threshold_met: Option<bool>,
+    retracement_pct: Option<f64>,
+    retracement_price: Option<f64>,
+    projected_retracement_price: Option<f64>,
+    retracement_met: Option<bool>,
+    current_vs_threshold_ratio: Option<f64>,
+    current_vs_retracement_ratio: Option<f64>,
+}
+
+#[inline]
+fn order_diagnostic(order: Order) -> OrderDiagnostic {
+    OrderDiagnostic {
+        qty: order.qty,
+        price: order.price,
+        order_type: order.order_type.to_string(),
+    }
+}
+
+#[inline]
+fn order_triggered(order: &Order) -> bool {
+    order.qty != 0.0 && order.price > 0.0
+}
+
+#[inline]
+fn ratio(value: f64, reference: Option<f64>) -> Option<f64> {
+    reference.and_then(|reference| {
+        if reference > 0.0 {
+            Some(value / reference - 1.0)
+        } else {
+            None
+        }
+    })
+}
+
+#[inline]
+fn status_for<'a>(
+    selected_mode: &'a str,
+    order: &Order,
+    threshold_met: bool,
+    retracement_met: bool,
+) -> &'a str {
+    if selected_mode != "trailing" {
+        selected_mode
+    } else if order_triggered(order) {
+        "triggered"
+    } else if !threshold_met {
+        "waiting_threshold"
+    } else if !retracement_met {
+        "waiting_retracement"
+    } else {
+        "armed"
+    }
+}
+
+#[inline]
+fn wallet_exposure_ratio(
+    exchange: &ExchangeParams,
+    state: &StateParams,
+    position: &Position,
+    allowed_limit: f64,
+) -> (f64, f64) {
+    let wallet_exposure = calc_wallet_exposure(
+        exchange.c_mult,
+        state.balance,
+        position.size.abs(),
+        position.price,
+    );
+    let ratio = if allowed_limit > 0.0 {
+        wallet_exposure / allowed_limit
+    } else {
+        10.0
+    };
+    (wallet_exposure, ratio)
+}
+
+fn select_entry(
+    entry: &TrailingGridV7EntryParams,
+    base_limit: f64,
+    wallet_exposure: f64,
+) -> Selection {
+    if entry.trailing_grid_ratio >= 1.0 || entry.trailing_grid_ratio <= -1.0 {
+        return Selection {
+            mode: "trailing",
+            reason: "all_trailing",
+            cap: base_limit,
+        };
+    }
+    if entry.trailing_grid_ratio == 0.0 {
+        return Selection {
+            mode: "grid",
+            reason: "grid_ratio_zero",
+            cap: base_limit,
+        };
+    }
+    let wallet_exposure_ratio = if base_limit > 0.0 {
+        wallet_exposure / base_limit
+    } else {
+        10.0
+    };
+    if entry.trailing_grid_ratio > 0.0 {
+        if wallet_exposure_ratio < entry.trailing_grid_ratio {
+            let cap = if wallet_exposure == 0.0 {
+                base_limit
+            } else {
+                (base_limit * entry.trailing_grid_ratio * 1.01).min(base_limit)
+            };
+            Selection {
+                mode: "trailing",
+                reason: "below_positive_trailing_ratio",
+                cap,
+            }
+        } else {
+            Selection {
+                mode: "grid",
+                reason: "above_positive_trailing_ratio",
+                cap: base_limit,
+            }
+        }
+    } else if wallet_exposure_ratio < 1.0 + entry.trailing_grid_ratio {
+        let cap = if wallet_exposure == 0.0 {
+            base_limit
+        } else {
+            (base_limit * (1.0 + entry.trailing_grid_ratio) * 1.01).min(base_limit)
+        };
+        Selection {
+            mode: "grid",
+            reason: "below_negative_grid_ratio",
+            cap,
+        }
+    } else {
+        Selection {
+            mode: "trailing",
+            reason: "above_negative_grid_ratio",
+            cap: base_limit,
+        }
+    }
+}
+
+fn select_close(close: &TrailingGridV7CloseParams, wallet_exposure_ratio: f64) -> Selection {
+    if close.trailing_grid_ratio >= 1.0 || close.trailing_grid_ratio <= -1.0 {
+        return Selection {
+            mode: "trailing",
+            reason: "all_trailing",
+            cap: 0.0,
+        };
+    }
+    if close.trailing_grid_ratio == 0.0 {
+        return Selection {
+            mode: "grid",
+            reason: "grid_ratio_zero",
+            cap: 0.0,
+        };
+    }
+    if close.trailing_grid_ratio > 0.0 {
+        if wallet_exposure_ratio < close.trailing_grid_ratio {
+            Selection {
+                mode: "trailing",
+                reason: "below_positive_trailing_ratio",
+                cap: 0.0,
+            }
+        } else {
+            Selection {
+                mode: "grid",
+                reason: "above_positive_trailing_ratio",
+                cap: 0.0,
+            }
+        }
+    } else if wallet_exposure_ratio < 1.0 + close.trailing_grid_ratio {
+        Selection {
+            mode: "grid",
+            reason: "below_negative_grid_ratio",
+            cap: 0.0,
+        }
+    } else {
+        Selection {
+            mode: "trailing",
+            reason: "above_negative_grid_ratio",
+            cap: 0.0,
+        }
+    }
+}
+
+fn entry_thresholds(
+    entry: &TrailingGridV7EntryParams,
+    state: &StateParams,
+    wallet_exposure: f64,
+    effective_limit: f64,
+) -> (f64, f64) {
+    let threshold_multiplier = if effective_limit > 0.0 {
+        (wallet_exposure / effective_limit) * entry.trailing_threshold_we_weight
+    } else {
+        0.0
+    };
+    let threshold_log_multiplier =
+        state.volatility_ema_1h * entry.trailing_threshold_volatility_weight;
+    let threshold_pct = entry.trailing_threshold_pct
+        * (1.0 + threshold_multiplier + threshold_log_multiplier).max(0.0);
+    let retracement_multiplier = if effective_limit > 0.0 {
+        (wallet_exposure / effective_limit) * entry.trailing_retracement_we_weight
+    } else {
+        0.0
+    };
+    let retracement_log_multiplier =
+        state.volatility_ema_1h * entry.trailing_retracement_volatility_weight;
+    let retracement_pct = entry.trailing_retracement_pct
+        * (1.0 + retracement_multiplier + retracement_log_multiplier).max(0.0);
+    (threshold_pct, retracement_pct)
+}
+
+fn entry_diagnostic(
+    side: StrategySide,
+    exchange: &ExchangeParams,
+    state: &StateParams,
+    bot: &BotParams,
+    runtime: &RuntimeOrderContext,
+    entry: &TrailingGridV7EntryParams,
+    position: &Position,
+    trailing: &TrailingPriceBundle,
+) -> TrailingDiagnostic {
+    let allowed_limit = wallet_exposure_limit_with_allowance(bot, runtime);
+    let (wallet_exposure, wallet_exposure_ratio) =
+        wallet_exposure_ratio(exchange, state, position, allowed_limit);
+    let selection = select_entry(entry, allowed_limit, wallet_exposure);
+    let order = match side {
+        StrategySide::Long => {
+            calc_next_entry_long(exchange, state, bot, runtime, entry, position, trailing)
+        }
+        StrategySide::Short => {
+            calc_next_entry_short(exchange, state, bot, runtime, entry, position, trailing)
+        }
+    };
+    let (threshold_pct, retracement_pct) =
+        entry_thresholds(entry, state, wallet_exposure, selection.cap);
+    let is_long = side == StrategySide::Long;
+    let threshold_price = if threshold_pct > 0.0 {
+        Some(if is_long {
+            position.price * (1.0 - threshold_pct)
+        } else {
+            position.price * (1.0 + threshold_pct)
+        })
+    } else {
+        None
+    };
+    let threshold_met = if threshold_pct <= 0.0 {
+        true
+    } else if is_long {
+        trailing.min_since_open < threshold_price.unwrap_or(0.0)
+    } else {
+        trailing.max_since_open > threshold_price.unwrap_or(0.0)
+    };
+    let retracement_price = if retracement_pct > 0.0 {
+        Some(if is_long {
+            trailing.min_since_open * (1.0 + retracement_pct)
+        } else {
+            trailing.max_since_open * (1.0 - retracement_pct)
+        })
+    } else {
+        None
+    };
+    let projected_retracement_price = threshold_price.map(|price| {
+        if is_long {
+            price * (1.0 + retracement_pct)
+        } else {
+            price * (1.0 - retracement_pct)
+        }
+    });
+    let retracement_met = if retracement_pct <= 0.0 {
+        true
+    } else if is_long {
+        trailing.max_since_min > retracement_price.unwrap_or(0.0)
+    } else {
+        trailing.min_since_max < retracement_price.unwrap_or(0.0)
+    };
+    TrailingDiagnostic {
+        kind: "entry",
+        pside: if is_long { "long" } else { "short" },
+        selected_mode: selection.mode,
+        selection_reason: selection.reason,
+        status: status_for(selection.mode, &order, threshold_met, retracement_met),
+        wallet_exposure,
+        wallet_exposure_ratio,
+        effective_wallet_exposure_limit: selection.cap,
+        trailing_grid_ratio: entry.trailing_grid_ratio,
+        order: order_diagnostic(order),
+        threshold_pct: Some(threshold_pct),
+        threshold_price,
+        threshold_met: Some(threshold_met),
+        retracement_pct: Some(retracement_pct),
+        retracement_price,
+        projected_retracement_price,
+        retracement_met: Some(retracement_met),
+        current_vs_threshold_ratio: ratio(
+            if is_long {
+                state.order_book.bid
+            } else {
+                state.order_book.ask
+            },
+            threshold_price,
+        ),
+        current_vs_retracement_ratio: ratio(
+            if is_long {
+                state.order_book.bid
+            } else {
+                state.order_book.ask
+            },
+            retracement_price,
+        ),
+    }
+}
+
+fn close_diagnostic(
+    side: StrategySide,
+    exchange: &ExchangeParams,
+    state: &StateParams,
+    bot: &BotParams,
+    runtime: &RuntimeOrderContext,
+    close: &TrailingGridV7CloseParams,
+    position: &Position,
+    trailing: &TrailingPriceBundle,
+) -> TrailingDiagnostic {
+    let allowed_limit = wallet_exposure_limit_with_allowance(bot, runtime);
+    let (wallet_exposure, wallet_exposure_ratio) =
+        wallet_exposure_ratio(exchange, state, position, allowed_limit);
+    let selection = select_close(close, wallet_exposure_ratio);
+    let order = match side {
+        StrategySide::Long => {
+            calc_next_close_long(exchange, state, bot, runtime, close, position, trailing)
+        }
+        StrategySide::Short => {
+            calc_next_close_short(exchange, state, bot, runtime, close, position, trailing)
+        }
+    };
+    let order_type = order.order_type.to_string();
+    let selected_mode = if order_type.contains("auto_reduce") {
+        "auto_reduce"
+    } else {
+        selection.mode
+    };
+    let is_long = side == StrategySide::Long;
+    let threshold_pct = close.trailing_threshold_pct;
+    let retracement_pct = close.trailing_retracement_pct;
+    let threshold_price = if threshold_pct > 0.0 {
+        Some(if is_long {
+            position.price * (1.0 + threshold_pct)
+        } else {
+            position.price * (1.0 - threshold_pct)
+        })
+    } else {
+        None
+    };
+    let threshold_met = if threshold_pct <= 0.0 {
+        true
+    } else if is_long {
+        trailing.max_since_open > threshold_price.unwrap_or(0.0)
+    } else {
+        trailing.min_since_open < threshold_price.unwrap_or(0.0)
+    };
+    let retracement_price = if retracement_pct > 0.0 {
+        Some(if is_long {
+            trailing.max_since_open * (1.0 - retracement_pct)
+        } else {
+            trailing.min_since_open * (1.0 + retracement_pct)
+        })
+    } else {
+        None
+    };
+    let projected_retracement_price = threshold_price.map(|price| {
+        if is_long {
+            price * (1.0 - retracement_pct)
+        } else {
+            price * (1.0 + retracement_pct)
+        }
+    });
+    let retracement_met = if retracement_pct <= 0.0 {
+        true
+    } else if is_long {
+        trailing.min_since_max < retracement_price.unwrap_or(0.0)
+    } else {
+        trailing.max_since_min > retracement_price.unwrap_or(0.0)
+    };
+    TrailingDiagnostic {
+        kind: "close",
+        pside: if is_long { "long" } else { "short" },
+        selected_mode,
+        selection_reason: selection.reason,
+        status: status_for(selected_mode, &order, threshold_met, retracement_met),
+        wallet_exposure,
+        wallet_exposure_ratio,
+        effective_wallet_exposure_limit: allowed_limit,
+        trailing_grid_ratio: close.trailing_grid_ratio,
+        order: order_diagnostic(order),
+        threshold_pct: Some(threshold_pct),
+        threshold_price,
+        threshold_met: Some(threshold_met),
+        retracement_pct: Some(retracement_pct),
+        retracement_price,
+        projected_retracement_price,
+        retracement_met: Some(retracement_met),
+        current_vs_threshold_ratio: ratio(
+            if is_long {
+                state.order_book.ask
+            } else {
+                state.order_book.bid
+            },
+            threshold_price,
+        ),
+        current_vs_retracement_ratio: ratio(
+            if is_long {
+                state.order_book.ask
+            } else {
+                state.order_book.bid
+            },
+            retracement_price,
+        ),
+    }
+}
+
+pub fn calc_trailing_grid_v7_diagnostics(
+    side: StrategySide,
+    exchange: &ExchangeParams,
+    state: &StateParams,
+    bot: &BotParams,
+    runtime: &RuntimeOrderContext,
+    params: &TrailingGridV7Params,
+    position: &Position,
+    trailing: &TrailingPriceBundle,
+) -> serde_json::Value {
+    serde_json::json!({
+        "entry": entry_diagnostic(side, exchange, state, bot, runtime, &params.entry, position, trailing),
+        "close": close_diagnostic(side, exchange, state, bot, runtime, &params.close, position, trailing),
+    })
+}
+
 fn calc_entries_long(
     exchange: &ExchangeParams,
     state: &StateParams,
@@ -2033,6 +2495,66 @@ mod tests {
             trailing_threshold_pct: 0.01,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn diagnostic_reports_trailing_grid_v7_threshold_and_projection() {
+        let exchange = exchange();
+        let state = state();
+        let bot = bot();
+        let runtime = runtime();
+        let params = TrailingGridV7Params {
+            ema_span_0: 10.0,
+            ema_span_1: 20.0,
+            entry: TrailingGridV7EntryParams {
+                trailing_grid_ratio: 1.0,
+                trailing_retracement_pct: 0.005,
+                trailing_threshold_pct: 0.01,
+                ..entry_params()
+            },
+            close: TrailingGridV7CloseParams {
+                trailing_grid_ratio: 1.0,
+                trailing_qty_pct: 0.1,
+                trailing_retracement_pct: 0.01,
+                trailing_threshold_pct: 0.02,
+                ..Default::default()
+            },
+        };
+        let position = Position {
+            size: 40.0,
+            price: 100.0,
+        };
+        let trailing = TrailingPriceBundle {
+            min_since_open: 98.5,
+            max_since_min: 98.7,
+            max_since_open: 101.0,
+            min_since_max: 100.0,
+        };
+
+        let diagnostic = calc_trailing_grid_v7_diagnostics(
+            StrategySide::Long,
+            &exchange,
+            &state,
+            &bot,
+            &runtime,
+            &params,
+            &position,
+            &trailing,
+        );
+
+        let entry = &diagnostic["entry"];
+        assert_eq!(entry["selected_mode"].as_str(), Some("trailing"));
+        assert_eq!(entry["status"].as_str(), Some("waiting_retracement"));
+        assert_eq!(entry["threshold_met"].as_bool(), Some(true));
+        assert_eq!(entry["retracement_met"].as_bool(), Some(false));
+        assert_eq!(entry["threshold_price"].as_f64().unwrap(), 99.0);
+        assert!((entry["projected_retracement_price"].as_f64().unwrap() - 99.495).abs() < 1e-12);
+
+        let close = &diagnostic["close"];
+        assert_eq!(close["selected_mode"].as_str(), Some("trailing"));
+        assert_eq!(close["status"].as_str(), Some("waiting_threshold"));
+        assert_eq!(close["threshold_price"].as_f64().unwrap(), 102.0);
+        assert!((close["projected_retracement_price"].as_f64().unwrap() - 100.98).abs() < 1e-12);
     }
 
     #[test]

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -12,6 +12,7 @@ import passivbot_rust as pbr
 
 from live.event_bus import EventTypes
 from trailing_diagnostics import (
+    build_trailing_grid_v7_diagnostic,
     build_trailing_close_diagnostic,
     build_trailing_entry_diagnostic,
     normalize_trailing_extrema,
@@ -975,7 +976,7 @@ def _monitor_entry_trailing_limit_cap(
     return None, "grid_only"
 
 
-def _monitor_h1_entry_logrange(self, pside: str, symbol: str) -> float:
+def _monitor_h1_logrange_for_span(self, symbol: str, span: float) -> float:
     h1_log_range_emas = getattr(self, "_monitor_runtime_h1_log_range_emas", {})
     if not isinstance(h1_log_range_emas, dict):
         return 0.0
@@ -983,16 +984,20 @@ def _monitor_h1_entry_logrange(self, pside: str, symbol: str) -> float:
     if not isinstance(symbol_entry, dict):
         return 0.0
     try:
+        return float(symbol_entry.get(float(span), 0.0) or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _monitor_h1_entry_logrange(self, pside: str, symbol: str) -> float:
+    try:
         span = _monitor_strategy_value(self, pside, "offset_volatility_ema_span_1h", symbol)
     except Exception:
         try:
             span = _monitor_strategy_value(self, pside, "entry_volatility_ema_span_1h", symbol)
         except Exception:
             return 0.0
-    try:
-        return float(symbol_entry.get(span, 0.0) or 0.0)
-    except (TypeError, ValueError):
-        return 0.0
+    return _monitor_h1_logrange_for_span(self, symbol, span)
 
 
 def _monitor_m1_entry_logrange(self, pside: str, symbol: str) -> float:
@@ -1159,6 +1164,80 @@ def _build_monitor_trailing_close_payload(
     return payload
 
 
+def _build_monitor_trailing_grid_v7_payload(
+    self,
+    symbol: str,
+    pside: str,
+    *,
+    balance_raw: float,
+    current_price: float,
+    position_size: float,
+    position_price: float,
+    trailing_bundle: dict[str, float],
+    market_entry: dict[str, Any],
+) -> Optional[dict[str, Any]]:
+    strategy_getter = getattr(self, "_strategy_params_to_rust_dict", None)
+    if not callable(strategy_getter):
+        return None
+    strategy_params = strategy_getter(pside, symbol)
+    if not isinstance(strategy_params, dict):
+        return None
+    entry_params = strategy_params.get("entry", {})
+    if not isinstance(entry_params, dict):
+        return None
+    ema_bands = market_entry.get("ema_bands", {}) if isinstance(market_entry, dict) else {}
+    side_ema_bands = ema_bands.get(pside, {}) if isinstance(ema_bands, dict) else {}
+    if not isinstance(side_ema_bands, dict):
+        return None
+    try:
+        h1_span = float(entry_params.get("volatility_ema_span_hours", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        h1_span = 0.0
+    try:
+        n_positions = int(round(float(self.bp(pside, "n_positions", symbol) or 0.0)))
+    except (AttributeError, KeyError, TypeError, ValueError):
+        n_positions = int(self.get_max_n_positions(pside) or 1)
+    inputs = {
+        "symbol": symbol,
+        "pside": pside,
+        "balance_raw": float(balance_raw),
+        "current_price": float(current_price),
+        "position_size": float(position_size),
+        "position_price": float(position_price),
+        "qty_step": float(self.qty_steps[symbol]),
+        "price_step": float(self.price_steps[symbol]),
+        "min_qty": float(self.min_qtys[symbol]),
+        "min_cost": float(
+            max(
+                getattr(self, "effective_min_cost", {}).get(symbol, 0.0) or 0.0,
+                getattr(self, "min_costs", {}).get(symbol, 0.0) or 0.0,
+            )
+        ),
+        "c_mult": float(self.c_mults[symbol]),
+        "ema_lower": float(side_ema_bands.get("lower", 0.0) or 0.0),
+        "ema_upper": float(side_ema_bands.get("upper", 0.0) or 0.0),
+        "h1_log_range_ema": float(_monitor_h1_logrange_for_span(self, symbol, h1_span)),
+        "strategy_params": strategy_params,
+        "n_positions": n_positions,
+        "wallet_exposure_limit": float(self.bp(pside, "wallet_exposure_limit", symbol)),
+        "total_wallet_exposure_limit": float(
+            self.bot_value(pside, "total_wallet_exposure_limit") or 0.0
+        ),
+        "risk_we_excess_allowance_pct": float(
+            self.bp(pside, "risk_we_excess_allowance_pct", symbol)
+        ),
+        "risk_we_excess_allowance_mode": self.bp(
+            pside, "risk_we_excess_allowance_mode", symbol
+        )
+        or None,
+        "risk_wel_enforcer_threshold": float(
+            self.bp(pside, "risk_wel_enforcer_threshold", symbol)
+        ),
+        **dict(trailing_bundle),
+    }
+    return build_trailing_grid_v7_diagnostic(inputs)
+
+
 def _build_monitor_trailing_section(
     self,
     *,
@@ -1168,15 +1247,6 @@ def _build_monitor_trailing_section(
     config = getattr(self, "config", {})
     live_cfg = config.get("live", {}) if isinstance(config, dict) else {}
     strategy_kind = str(live_cfg.get("strategy_kind") or "").strip().lower()
-    if strategy_kind == "trailing_grid_v7":
-        return {
-            "_meta": {
-                "diagnostics_supported": False,
-                "strategy_kind": "trailing_grid_v7",
-                "reason": "monitor trailing diagnostics use trailing_martingale helper formulas",
-            }
-        }
-
     out: dict[str, dict[str, Any]] = {}
     for symbol, market_entry in sorted(market.items()):
         if not isinstance(market_entry, dict):
@@ -1198,31 +1268,46 @@ def _build_monitor_trailing_section(
             position_size = float(pos.get("size", 0.0) or 0.0)
             position_price = float(pos.get("price", 0.0) or 0.0)
             side_payload: dict[str, Any] = {"extrema": dict(trailing_bundle)}
-            entry_payload = _build_monitor_trailing_entry_payload(
-                self,
-                symbol,
-                pside,
-                balance_raw=balance_raw,
-                current_price=current_price,
-                position_size=position_size,
-                position_price=position_price,
-                trailing_bundle=trailing_bundle,
-                market_entry=market_entry,
-            )
-            if entry_payload is not None:
-                side_payload["entry"] = entry_payload
-            close_payload = _build_monitor_trailing_close_payload(
-                self,
-                symbol,
-                pside,
-                balance_raw=balance_raw,
-                current_price=current_price,
-                position_size=position_size,
-                position_price=position_price,
-                trailing_bundle=trailing_bundle,
-            )
-            if close_payload is not None:
-                side_payload["close"] = close_payload
+            if strategy_kind == "trailing_grid_v7":
+                v7_payload = _build_monitor_trailing_grid_v7_payload(
+                    self,
+                    symbol,
+                    pside,
+                    balance_raw=balance_raw,
+                    current_price=current_price,
+                    position_size=position_size,
+                    position_price=position_price,
+                    trailing_bundle=trailing_bundle,
+                    market_entry=market_entry,
+                )
+                if v7_payload is not None:
+                    side_payload.update(v7_payload)
+            else:
+                entry_payload = _build_monitor_trailing_entry_payload(
+                    self,
+                    symbol,
+                    pside,
+                    balance_raw=balance_raw,
+                    current_price=current_price,
+                    position_size=position_size,
+                    position_price=position_price,
+                    trailing_bundle=trailing_bundle,
+                    market_entry=market_entry,
+                )
+                if entry_payload is not None:
+                    side_payload["entry"] = entry_payload
+                close_payload = _build_monitor_trailing_close_payload(
+                    self,
+                    symbol,
+                    pside,
+                    balance_raw=balance_raw,
+                    current_price=current_price,
+                    position_size=position_size,
+                    position_price=position_price,
+                    trailing_bundle=trailing_bundle,
+                )
+                if close_payload is not None:
+                    side_payload["close"] = close_payload
             if "entry" in side_payload or "close" in side_payload:
                 symbol_payload[pside] = side_payload
         if symbol_payload:

--- a/src/trailing_diagnostics.py
+++ b/src/trailing_diagnostics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from copy import deepcopy
 from typing import Any, Mapping, Optional
 
@@ -464,6 +465,71 @@ def build_trailing_close_diagnostic(inputs: Mapping[str, Any]) -> Optional[dict[
         ),
         "extrema": deepcopy(trailing_bundle),
     }
+
+
+def build_trailing_grid_v7_diagnostic(inputs: Mapping[str, Any]) -> Optional[dict[str, Any]]:
+    strategy_params = inputs.get("strategy_params")
+    if not isinstance(strategy_params, Mapping):
+        return None
+    pside = str(inputs.get("pside", "long"))
+    if pside not in {"long", "short"}:
+        return None
+    position_size = _float(inputs.get("position_size"))
+    if pside == "long":
+        position_size = abs(position_size)
+    else:
+        position_size = -abs(position_size)
+    position_price = _float(inputs.get("position_price"))
+    current_price = _float(inputs.get("current_price"))
+    if position_size == 0.0 or position_price <= 0.0 or current_price <= 0.0:
+        return None
+    trailing_bundle = normalize_trailing_extrema(inputs)
+    payload = {
+        "pside": pside,
+        "exchange": {
+            "qty_step": _float(inputs.get("qty_step")),
+            "price_step": _float(inputs.get("price_step")),
+            "min_qty": _float(inputs.get("min_qty")),
+            "min_cost": _float(inputs.get("min_cost")),
+            "c_mult": _float(inputs.get("c_mult")),
+            "maker_fee": _float(inputs.get("maker_fee"), default=0.0002),
+            "taker_fee": _float(inputs.get("taker_fee"), default=0.00055),
+        },
+        "state": {
+            "balance": _float(inputs.get("balance_raw")),
+            "order_book": {"bid": current_price, "ask": current_price},
+            "ema_bands": {
+                "lower": _float(inputs.get("ema_lower")),
+                "upper": _float(inputs.get("ema_upper")),
+            },
+            "volatility_ema_1m": 0.0,
+            "volatility_ema_1h": _float(inputs.get("h1_log_range_ema")),
+        },
+        "bot_params": {
+            "n_positions": int(round(_float(inputs.get("n_positions"), default=1.0))) or 1,
+            "wallet_exposure_limit": _float(inputs.get("wallet_exposure_limit")),
+            "total_wallet_exposure_limit": _float(inputs.get("total_wallet_exposure_limit")),
+            "risk_we_excess_allowance_pct": _float(inputs.get("risk_we_excess_allowance_pct")),
+            "risk_we_excess_allowance_mode": inputs.get("risk_we_excess_allowance_mode") or "bounded",
+            "risk_wel_enforcer_threshold": _float(inputs.get("risk_wel_enforcer_threshold")),
+        },
+        "runtime": {
+            "effective_wallet_exposure_limit": _float(
+                inputs.get("effective_wallet_exposure_limit"),
+                default=_float(inputs.get("wallet_exposure_limit")),
+            )
+        },
+        "strategy_params": deepcopy(dict(strategy_params)),
+        "position": {"size": position_size, "price": position_price},
+        "trailing": trailing_bundle,
+    }
+    raw = pbr.calc_trailing_grid_v7_diagnostic_py(json.dumps(payload, separators=(",", ":")))
+    diagnostic = json.loads(raw)
+    if not isinstance(diagnostic, dict):
+        return None
+    diagnostic["symbol"] = str(inputs.get("symbol", ""))
+    diagnostic["pside"] = pside
+    return diagnostic
 
 
 def build_trailing_diagnostic(inputs: Mapping[str, Any]) -> dict[str, Any]:

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -4464,7 +4464,7 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
     assert snapshot["recent"]["order_cancellations"][0]["pb_order_type"] == "close_unstuck_long"
 
 
-def test_monitor_trailing_section_marks_trailing_grid_v7_diagnostics_unsupported():
+def test_monitor_trailing_section_includes_trailing_grid_v7_diagnostics():
     import passivbot as pb_mod
 
     class FakeBot:
@@ -4472,6 +4472,70 @@ def test_monitor_trailing_section_marks_trailing_grid_v7_diagnostics_unsupported
 
         def __init__(self):
             self.config = {"live": {"strategy_kind": "trailing_grid_v7"}}
+            self.positions = {
+                "BTC/USDT:USDT": {
+                    "long": {"size": 0.1, "price": 100.0},
+                    "short": {"size": 0.0, "price": 0.0},
+                }
+            }
+            self.qty_steps = {"BTC/USDT:USDT": 0.001}
+            self.price_steps = {"BTC/USDT:USDT": 0.1}
+            self.min_qtys = {"BTC/USDT:USDT": 0.001}
+            self.min_costs = {"BTC/USDT:USDT": 1.0}
+            self.effective_min_cost = {"BTC/USDT:USDT": 1.0}
+            self.c_mults = {"BTC/USDT:USDT": 1.0}
+            self._monitor_runtime_h1_log_range_emas = {"BTC/USDT:USDT": {24.0: 0.0}}
+
+        def _strategy_params_to_rust_dict(self, pside, symbol=None):
+            assert pside in {"long", "short"}
+            return {
+                "ema_span_0": 10.0,
+                "ema_span_1": 20.0,
+                "entry": {
+                    "grid_double_down_factor": 1.0,
+                    "grid_spacing_pct": 0.01,
+                    "grid_spacing_we_weight": 0.0,
+                    "grid_spacing_volatility_weight": 0.0,
+                    "initial_ema_dist": 0.0,
+                    "initial_qty_pct": 0.01,
+                    "trailing_double_down_factor": 1.0,
+                    "trailing_grid_ratio": 1.0,
+                    "trailing_retracement_pct": 0.005,
+                    "trailing_retracement_we_weight": 0.0,
+                    "trailing_retracement_volatility_weight": 0.0,
+                    "trailing_threshold_pct": 0.01,
+                    "trailing_threshold_we_weight": 0.0,
+                    "trailing_threshold_volatility_weight": 0.0,
+                    "volatility_ema_span_hours": 24.0,
+                },
+                "close": {
+                    "grid_markup_start": 0.01,
+                    "grid_markup_end": 0.02,
+                    "grid_qty_pct": 0.1,
+                    "trailing_grid_ratio": 1.0,
+                    "trailing_qty_pct": 0.1,
+                    "trailing_retracement_pct": 0.01,
+                    "trailing_threshold_pct": 0.02,
+                },
+            }
+
+        def bp(self, pside, key, symbol=None):
+            values = {
+                "n_positions": 1,
+                "wallet_exposure_limit": 0.2,
+                "risk_we_excess_allowance_pct": 0.0,
+                "risk_we_excess_allowance_mode": "bounded",
+                "risk_wel_enforcer_threshold": 0.0,
+            }
+            return values[key]
+
+        def bot_value(self, pside, key):
+            if key == "total_wallet_exposure_limit":
+                return 0.2
+            raise KeyError(key)
+
+        def get_max_n_positions(self, pside):
+            return 1
 
     bot = FakeBot()
 
@@ -4480,23 +4544,33 @@ def test_monitor_trailing_section_marks_trailing_grid_v7_diagnostics_unsupported
         market={
             "BTC/USDT:USDT": {
                 "last_price": 100.0,
+                "ema_bands": {"long": {"lower": 100.0, "upper": 100.0}},
                 "trailing": {
                     "long": {
-                        "min_since_open": 90.0,
-                        "max_since_min": 95.0,
+                        "min_since_open": 98.5,
+                        "max_since_min": 98.7,
+                        "max_since_open": 101.0,
+                        "min_since_max": 100.0,
                     }
                 },
             }
         },
     )
 
-    assert payload == {
-        "_meta": {
-            "diagnostics_supported": False,
-            "strategy_kind": "trailing_grid_v7",
-            "reason": "monitor trailing diagnostics use trailing_martingale helper formulas",
-        }
-    }
+    entry = payload["BTC/USDT:USDT"]["long"]["entry"]
+    assert entry["selected_mode"] == "trailing"
+    assert entry["status"] == "waiting_retracement"
+    assert entry["threshold_pct"] == pytest.approx(0.01)
+    assert entry["threshold_price"] == pytest.approx(99.0)
+    assert entry["threshold_met"] is True
+    assert entry["retracement_pct"] == pytest.approx(0.005)
+    assert entry["retracement_price"] == pytest.approx(98.5 * 1.005)
+    assert entry["projected_retracement_price"] == pytest.approx(99.0 * 1.005)
+    close = payload["BTC/USDT:USDT"]["long"]["close"]
+    assert close["selected_mode"] == "trailing"
+    assert close["status"] == "waiting_threshold"
+    assert close["threshold_price"] == pytest.approx(102.0)
+    assert close["projected_retracement_price"] == pytest.approx(102.0 * 0.99)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add a Rust/PyO3 `trailing_grid_v7` diagnostic helper that calls existing v7 order functions and reports selected mode, WEL ratio, threshold/retracement status, and projected retracement price.
- Route v7 monitor trailing snapshots through that helper instead of returning unsupported diagnostics.
- Add Rust and monitor regression coverage; update the logging progress ledger.

## Safety
- Observability-only: no order-generation path changed; the helper calls existing Rust functions and serializes diagnostics.
- No exchange calls, cache mutation, readiness gates, risk-threshold changes, process signaling, or trading behavior changes.

## Validation
- `cargo test --no-default-features` (190 passed)
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_passivbot_monitor.py -q` (67 passed)
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/trailing_diagnostics.py src/passivbot_monitor.py`
- `cargo fmt --check`
- `git diff --check`
