### PR TITLE
Keep waiting trailing diagnostics visible

### DIFF
--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -90,7 +90,8 @@ the console. Position-level `trailing.status` and `unstuck.status` events are
 console-visible because they explain why an existing position is waiting, armed,
 triggered, over budget, or blocked by the unstuck EMA gate. Unsupported strategy
 diagnostics must say so explicitly instead of fabricating threshold/retracement
-prices.
+prices. Supported trailing diagnostics should include the selected mode
+(`trailing`, `grid`, or `none`) when the next-order state is known.
 
 ## Review Heuristic
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,20 +19,19 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` head:
 
-- `c4a23aa9` after PR #960, `Add position trailing status events`.
+- `23552121` after PR #961, `Add trailing grid v7 diagnostics`.
 
 Current logging-overhaul head:
 
-- `c4a23aa9` after PR #960, `Add position trailing status events`.
+- `23552121` after PR #961, `Add trailing grid v7 diagnostics`.
 
 Current work:
 
-- Branch `codex/v8-trailing-grid-v7-diagnostics` adds Rust-aligned
-  `trailing_grid_v7` monitor diagnostics so the same position-status stream can
-  explain v7 compatibility positions instead of reporting that v7 trailing
-  diagnostics are unsupported. The helper calls existing Rust v7 order
-  functions and reports selected mode, WEL ratio, threshold/retracement status,
-  and projected retracement price without changing order generation.
+- Branch `codex/v8-trailing-waiting-diagnostics` keeps trailing-martingale
+  diagnostics visible when the current next order is grid/non-trailing. This
+  follow-up prevents active positions from being mislabeled as unsupported
+  merely because threshold or retracement has not selected a trailing order yet,
+  and exposes `selected_mode` in the structured event/console summary.
 
 Current review gate:
 
@@ -62,6 +61,28 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #961 at `23552121`.
+- PR #961 added Rust-aligned `trailing_grid_v7` monitor diagnostics so the same
+  position-status stream can explain v7 compatibility positions instead of
+  reporting that v7 trailing diagnostics are unsupported. The helper calls
+  existing Rust v7 order functions and reports selected mode, WEL ratio,
+  threshold/retracement status, and projected retracement price without
+  changing order generation.
+- Bots were restarted from `/root/bots_vps5.yaml` and left running. Hyperliquid
+  exited quickly after Ctrl-C; Binance, GateIO, and OKX exited within the longer
+  graceful window; Kucoin still required SIGTERM after the full wait window.
+- VPS5 smoke after restart reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, `missing_expected_count=0`, clean tracked repository
+  state at `repository.head=23552121`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `logs.hard_matches=0`, and
+  `logs.attention_matches=0`. Remaining attention was non-hard: four active HSL
+  replay workers, Hyperliquid EMA-unavailable diagnostics for cache-only stock
+  symbols, and shutdown-slow history from the restart.
+- The deployed event stream still reported the Hyperliquid `XYZ-MU/USDC:USDC`
+  long position as `active_unsupported` because that bot uses
+  `trailing_martingale` and the current helper suppresses diagnostics when the
+  selected next order is not trailing. This is the reason for the current
+  `codex/v8-trailing-waiting-diagnostics` follow-up.
 - Repository pulled through PR #960 at `c4a23aa9`.
 - PR #960 added structured `trailing.status` events for active trailing
   positions, projected `trailing.status` plus existing `unstuck.status` into the

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -1021,6 +1021,9 @@ def _console_trailing_status_summary(event: LiveEvent) -> list[str]:
     trailing_status = _data_str(data, "trailing_status")
     if trailing_status:
         parts.append(f"trailing_status={trailing_status}")
+    selected_mode = _data_str(data, "selected_mode")
+    if selected_mode:
+        parts.append(f"mode={selected_mode}")
     threshold_met = data.get("threshold_met")
     if threshold_met is not None:
         parts.append(f"threshold_met={bool(threshold_met)}")

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -3339,6 +3339,7 @@ def _trailing_status_summary(payload: dict[str, Any]) -> dict[str, Any]:
         "diagnostics_supported": bool(payload.get("diagnostics_supported", True)),
         "strategy_kind": str(payload.get("strategy_kind") or "") or None,
         "trailing_status": str(payload.get("status") or payload.get("trailing_status") or "unknown"),
+        "selected_mode": str(payload.get("selected_mode") or "") or None,
         "order_type": str(payload.get("order_type") or "") or None,
         "triggered": bool(payload.get("triggered", False)),
         "threshold_met": bool(payload.get("threshold_met", False))

--- a/src/trailing_diagnostics.py
+++ b/src/trailing_diagnostics.py
@@ -124,6 +124,15 @@ def trailing_status(
     return "armed"
 
 
+def selected_mode_from_order_type(order_type: str, *, has_order: bool) -> str:
+    normalized = str(order_type or "").lower()
+    if "trailing" in normalized:
+        return "trailing"
+    if has_order:
+        return "grid"
+    return "none"
+
+
 def calculate_wallet_exposure(
     *,
     balance_raw: float,
@@ -264,8 +273,8 @@ def build_trailing_entry_diagnostic(inputs: Mapping[str, Any]) -> Optional[dict[
     else:
         qty, price, order_type = pbr.calc_next_entry_short_py(*common_args)
     order_type = str(order_type)
-    if "trailing" not in order_type:
-        return None
+    has_order = bool(abs(_float(qty)) > 0.0 and _float(price) > 0.0)
+    is_trailing_order = "trailing" in order_type.lower()
 
     entry_multiplier = max(
         1.0,
@@ -307,12 +316,13 @@ def build_trailing_entry_diagnostic(inputs: Mapping[str, Any]) -> Optional[dict[
             if retracement_pct <= 0.0
             else trailing_bundle["min_since_max"] < float(retracement_price)
         )
-    triggered = bool(abs(_float(qty)) > 0.0 and _float(price) > 0.0)
+    triggered = bool(is_trailing_order and has_order)
     return {
         "kind": "entry",
         "symbol": symbol,
         "pside": pside,
         "mode": mode,
+        "selected_mode": selected_mode_from_order_type(order_type, has_order=has_order),
         "order_type": order_type,
         "wallet_exposure": wallet_exposure,
         "limit_cap": float(limit_cap),
@@ -395,8 +405,8 @@ def build_trailing_close_diagnostic(inputs: Mapping[str, Any]) -> Optional[dict[
     else:
         qty, price, order_type = pbr.calc_next_close_short_py(*common_args)
     order_type = str(order_type)
-    if "trailing" not in order_type:
-        return None
+    has_order = bool(abs(_float(qty)) > 0.0 and _float(price) > 0.0)
+    is_trailing_order = "trailing" in order_type.lower()
 
     close_multiplier = max(
         1.0,
@@ -432,11 +442,12 @@ def build_trailing_close_diagnostic(inputs: Mapping[str, Any]) -> Optional[dict[
             if retracement_pct <= 0.0
             else trailing_bundle["max_since_min"] > float(retracement_price)
         )
-    triggered = bool(abs(_float(qty)) > 0.0 and _float(price) > 0.0)
+    triggered = bool(is_trailing_order and has_order)
     return {
         "kind": "close",
         "symbol": symbol,
         "pside": pside,
+        "selected_mode": selected_mode_from_order_type(order_type, has_order=has_order),
         "order_type": order_type,
         "triggered": triggered,
         "status": trailing_status(

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -903,6 +903,7 @@ def test_console_format_summarizes_trailing_status():
         data={
             "kind": "entry",
             "trailing_status": "waiting_threshold",
+            "selected_mode": "grid",
             "threshold_met": False,
             "threshold_pct": 0.0125,
             "threshold_price": 98_750.0,
@@ -916,7 +917,7 @@ def test_console_format_summarizes_trailing_status():
 
     assert format_console_event(event) == (
         "[trailing] succeeded cycle=cy_trailing kind=entry "
-        "trailing_status=waiting_threshold threshold_met=False threshold=1.2500% "
+        "trailing_status=waiting_threshold mode=grid threshold_met=False threshold=1.2500% "
         "threshold_price=98750 retracement_met=False retracement=0.4000% "
         "retracement_price=99145 threshold_retrace_price=99145 current=101000 "
         "symbol=BTC/USDT:USDT pside=long reason=trailing_status"

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -2821,6 +2821,7 @@ def test_trailing_status_event_emits_structured_summary():
             "strategy_kind": "trailing_martingale",
             "status": "waiting_retracement",
             "order_type": "close_trailing_long",
+            "selected_mode": "trailing",
             "triggered": False,
             "threshold_met": True,
             "retracement_met": False,
@@ -2846,6 +2847,7 @@ def test_trailing_status_event_emits_structured_summary():
     assert event.data["changed"] is True
     assert event.data["kind"] == "close"
     assert event.data["trailing_status"] == "waiting_retracement"
+    assert event.data["selected_mode"] == "trailing"
     assert event.data["threshold_met"] is True
     assert event.data["retracement_met"] is False
     assert event.data["threshold_pct"] == pytest.approx(0.01)

--- a/tests/test_trailing_diagnostics.py
+++ b/tests/test_trailing_diagnostics.py
@@ -177,7 +177,30 @@ def test_build_trailing_diagnostic_matches_monitor_slice():
     assert diagnostic["entry"]["threshold_met"] is False
     assert diagnostic["entry"]["retracement_met"] is True
     assert diagnostic["close"]["order_type"] == "close_trailing_long"
+    assert diagnostic["close"]["selected_mode"] == "trailing"
     assert diagnostic["close"]["threshold_met"] is False
+
+
+def test_trailing_diagnostic_keeps_threshold_state_when_next_close_is_grid():
+    config = _sample_config()
+    config["bot"]["long"]["close_trailing_retracement_pct"] = 0.0
+    inputs = build_trailing_inputs_from_snapshot(
+        config,
+        _sample_snapshot(),
+        symbol="BTC/USDT:USDT",
+        pside="long",
+    )
+
+    diagnostic = build_trailing_diagnostic(inputs)
+
+    assert diagnostic["close"] is not None
+    assert diagnostic["close"]["order_type"] == "close_grid_long"
+    assert diagnostic["close"]["selected_mode"] == "grid"
+    assert diagnostic["close"]["triggered"] is False
+    assert diagnostic["close"]["status"] == "waiting_threshold"
+    assert diagnostic["close"]["threshold_met"] is False
+    assert diagnostic["close"]["threshold_price"] == pytest.approx(101000.0)
+    assert diagnostic["close"]["retracement_pct"] == pytest.approx(0.0)
 
 
 def test_trailing_diagnostics_tool_commands_render_and_set_values(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- keep trailing-martingale diagnostics visible when the current next order is grid/non-trailing instead of suppressing them as unavailable
- add selected_mode to trailing.status event data and opt-in console summaries
- update logging guide/progress ledger with #961 deploy evidence and the VPS5 Hyperliquid follow-up gap

## Motivation
After #961 was deployed to VPS5, Hyperliquid tradfi still emitted trailing.status active_unsupported for an open trailing_martingale position. The monitor had valid market.trailing extrema, but the helper returned None whenever the next order was not a trailing order. That hid threshold/retracement state from the event stream and console.

## Safety
Observability-only. No exchange calls, cache mutation, readiness gates, order construction, Rust strategy behavior, risk thresholds, or trading behavior changed.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_trailing_diagnostics.py tests/test_live_event_bus.py::test_console_format_summarizes_trailing_status tests/test_live_event_bus.py::test_console_format_summarizes_unsupported_trailing_status tests/test_passivbot_monitor.py::test_trailing_status_event_emits_structured_summary tests/test_passivbot_monitor.py::test_monitor_trailing_section_includes_trailing_grid_v7_diagnostics tests/test_passivbot_balance_split.py::test_trailing_status_emits_on_change_then_hourly -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/trailing_diagnostics.py src/live/event_emitters.py src/live/event_bus.py src/passivbot.py src/passivbot_monitor.py
- git diff --check