### PR TITLE
Refine trailing selected mode labels

### DIFF
--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -90,8 +90,9 @@ the console. Position-level `trailing.status` and `unstuck.status` events are
 console-visible because they explain why an existing position is waiting, armed,
 triggered, over budget, or blocked by the unstuck EMA gate. Unsupported strategy
 diagnostics must say so explicitly instead of fabricating threshold/retracement
-prices. Supported trailing diagnostics should include the selected mode
-(`trailing`, `grid`, or `none`) when the next-order state is known.
+prices. Supported trailing diagnostics should include the selected mode, such as
+`trailing`, `grid`, `auto_reduce`, `unstuck`, `none`, or `other`, when the
+next-order state is known.
 
 ## Review Heuristic
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,20 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` head:
 
-- `23552121` after PR #961, `Add trailing grid v7 diagnostics`.
+- `675e93ba` after PR #962, `Keep waiting trailing diagnostics visible`.
 
 Current logging-overhaul head:
 
-- `23552121` after PR #961, `Add trailing grid v7 diagnostics`.
+- `675e93ba` after PR #962, `Keep waiting trailing diagnostics visible`.
 
 Current work:
 
-- Branch `codex/v8-trailing-waiting-diagnostics` keeps trailing-martingale
-  diagnostics visible when the current next order is grid/non-trailing. This
-  follow-up prevents active positions from being mislabeled as unsupported
-  merely because threshold or retracement has not selected a trailing order yet,
-  and exposes `selected_mode` in the structured event/console summary.
+- Branch `codex/v8-trailing-selected-mode-labels` refines the
+  trailing-martingale `selected_mode` label after VPS5 showed a live
+  `close_auto_reduce_wel_long` diagnostic being generically labeled as `grid`.
+  The follow-up keeps the diagnostic behavior from PR #962 but classifies
+  `auto_reduce`, `unstuck`, explicit `grid`, `trailing`, `none`, and `other`
+  separately for clearer operator console output.
 
 Current review gate:
 
@@ -61,6 +62,25 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #962 at `675e93ba`.
+- PR #962 kept trailing-martingale diagnostics visible when the current next
+  order is grid/non-trailing, exposed `selected_mode` in `trailing.status`, and
+  kept `triggered` false for non-trailing next orders. It merged after Claude
+  and Hermes approved with CI green.
+- Bots were restarted from `/root/bots_vps5.yaml` and left running. Hyperliquid
+  exited quickly after Ctrl-C; Binance, GateIO, and OKX exited within the longer
+  graceful window; Kucoin still required SIGTERM after the full wait window.
+- VPS5 smoke after restart reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, `missing_expected_count=0`, clean tracked repository
+  state at `repository.head=675e93ba`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `logs.hard_matches=0`, and
+  `logs.attention_matches=0`. Remaining attention was non-hard: active HSL
+  replay workers, Hyperliquid EMA-unavailable diagnostics for cache-only stock
+  symbols, and shutdown-slow history from the restart.
+- The deployed Hyperliquid `XYZ-MU/USDC:USDC` long `trailing.status` event now
+  emits `diagnostics_supported=true` with threshold/retracement fields instead
+  of `active_unsupported`. It also showed `order_type=close_auto_reduce_wel_long`
+  with `selected_mode=grid`, motivating the current label-refinement follow-up.
 - Repository pulled through PR #961 at `23552121`.
 - PR #961 added Rust-aligned `trailing_grid_v7` monitor diagnostics so the same
   position-status stream can explain v7 compatibility positions instead of

--- a/src/trailing_diagnostics.py
+++ b/src/trailing_diagnostics.py
@@ -128,8 +128,14 @@ def selected_mode_from_order_type(order_type: str, *, has_order: bool) -> str:
     normalized = str(order_type or "").lower()
     if "trailing" in normalized:
         return "trailing"
-    if has_order:
+    if "auto_reduce" in normalized:
+        return "auto_reduce"
+    if "unstuck" in normalized:
+        return "unstuck"
+    if "grid" in normalized:
         return "grid"
+    if has_order:
+        return "other"
     return "none"
 
 

--- a/tests/test_trailing_diagnostics.py
+++ b/tests/test_trailing_diagnostics.py
@@ -8,6 +8,7 @@ import pytest
 from trailing_diagnostics import (
     build_trailing_diagnostic,
     build_trailing_inputs_from_snapshot,
+    selected_mode_from_order_type,
 )
 from trailing_diagnostics_tool import (
     TrailingDiagnosticsState,
@@ -201,6 +202,23 @@ def test_trailing_diagnostic_keeps_threshold_state_when_next_close_is_grid():
     assert diagnostic["close"]["threshold_met"] is False
     assert diagnostic["close"]["threshold_price"] == pytest.approx(101000.0)
     assert diagnostic["close"]["retracement_pct"] == pytest.approx(0.0)
+
+
+@pytest.mark.parametrize(
+    ("order_type", "has_order", "expected"),
+    [
+        ("close_trailing_long", True, "trailing"),
+        ("close_auto_reduce_wel_long", True, "auto_reduce"),
+        ("close_unstuck_long", True, "unstuck"),
+        ("close_grid_long", True, "grid"),
+        ("empty", False, "none"),
+        ("unknown_custom_order", True, "other"),
+    ],
+)
+def test_selected_mode_from_order_type_uses_specific_non_trailing_labels(
+    order_type, has_order, expected
+):
+    assert selected_mode_from_order_type(order_type, has_order=has_order) == expected
 
 
 def test_trailing_diagnostics_tool_commands_render_and_set_values(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- classify trailing diagnostic selected_mode more precisely: trailing, auto_reduce, unstuck, grid, none, or other
- document the expanded fixed-label set
- update progress ledger with #962 deploy evidence and the live auto-reduce observation that motivated this follow-up

## Motivation
VPS5 verification after #962 showed Hyperliquid XYZ-MU now emits diagnostics_supported=true with threshold/retracement fields, but the next order was close_auto_reduce_wel_long and selected_mode was generically grid. That is misleading operator-facing logging.

## Safety
Observability-only label refinement. No exchange calls, cache mutation, readiness gates, diagnostic math, order construction, Rust strategy behavior, risk thresholds, or trading behavior changed.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_trailing_diagnostics.py tests/test_live_event_bus.py::test_console_format_summarizes_trailing_status -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/trailing_diagnostics.py src/live/event_bus.py src/live/event_emitters.py
- git diff --check