### PR TITLE
Project forager selection to event console

### DIFF
--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -92,7 +92,9 @@ triggered, over budget, or blocked by the unstuck EMA gate. Unsupported strategy
 diagnostics must say so explicitly instead of fabricating threshold/retracement
 prices. Supported trailing diagnostics should include the selected mode, such as
 `trailing`, `grid`, `auto_reduce`, `unstuck`, `none`, or `other`, when the
-next-order state is known.
+next-order state is known. `forager.selection` events are also console-visible
+through a throttled compact summary because they explain which coins are being
+selected, retained, or skipped when forager entries are possible.
 
 ## Review Heuristic
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,20 +19,19 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` head:
 
-- `675e93ba` after PR #962, `Keep waiting trailing diagnostics visible`.
+- `f54c92147` after PR #963, `Refine trailing selected mode labels`.
 
 Current logging-overhaul head:
 
-- `675e93ba` after PR #962, `Keep waiting trailing diagnostics visible`.
+- `f54c92147` after PR #963, `Refine trailing selected mode labels`.
 
 Current work:
 
-- Branch `codex/v8-trailing-selected-mode-labels` refines the
-  trailing-martingale `selected_mode` label after VPS5 showed a live
-  `close_auto_reduce_wel_long` diagnostic being generically labeled as `grid`.
-  The follow-up keeps the diagnostic behavior from PR #962 but classifies
-  `auto_reduce`, `unstuck`, explicit `grid`, `trailing`, `none`, and `other`
-  separately for clearer operator console output.
+- Branch `codex/v8-forager-selection-console` projects existing
+  `forager.selection` events into the opt-in live event console/text sinks with
+  a compact, throttled operator summary. This continues the migration of useful
+  legacy console output into the structured event stream without changing
+  forager ranking or entry behavior.
 
 Current review gate:
 
@@ -62,6 +61,24 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #963 at `f54c92147`.
+- PR #963 refined the trailing `selected_mode` classifier so
+  `close_auto_reduce_wel_long` reports `auto_reduce` instead of generic `grid`.
+  It merged after Claude and Hermes approved with CI green.
+- Bots were restarted from `/root/bots_vps5.yaml` and left running. Hyperliquid
+  exited quickly after Ctrl-C; Binance, GateIO, and OKX exited within the longer
+  graceful window; Kucoin still required SIGTERM after the full wait window.
+- VPS5 smoke after restart reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, `missing_expected_count=0`, clean tracked repository
+  state at `repository.head=f54c9214`, `account_critical_remote_calls.failed=0`,
+  and `logs.hard_matches=0`. The focused follow-up report showed
+  `remote_calls.failed=0`; remaining attention was non-hard active HSL replay,
+  Hyperliquid EMA-unavailable diagnostics for cache-only stock symbols, staged
+  refresh progress, and shutdown-slow history from the restart.
+- The deployed Hyperliquid `XYZ-MU/USDC:USDC` long `trailing.status` event now
+  reports `selected_mode=auto_reduce` for
+  `order_type=close_auto_reduce_wel_long`, with threshold/retracement fields
+  still present and `triggered=false`.
 - Repository pulled through PR #962 at `675e93ba`.
 - PR #962 kept trailing-martingale diagnostics visible when the current next
   order is grid/non-trailing, exposed `selected_mode` in `trailing.status`, and

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -654,7 +654,9 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     ),
     EventTypes.PLANNING_DEFER_SUMMARY: EventRoute(console=False, text=False),
     EventTypes.PLANNING_SYMBOL_STATE: EventRoute(console=False, text=False),
-    EventTypes.FORAGER_SELECTION: EventRoute(console=False, text=False),
+    EventTypes.FORAGER_SELECTION: EventRoute(
+        console=True, text=True, throttle_interval_ms=5 * 60 * 1000
+    ),
     EventTypes.FORAGER_FEATURE_UNAVAILABLE: EventRoute(console=False, text=False),
     EventTypes.EMA_BUNDLE_STARTED: EventRoute(console=False, text=False),
     EventTypes.EMA_BUNDLE_COMPLETED: EventRoute(console=False, text=False),
@@ -769,6 +771,7 @@ _CONSOLE_EVENT_TAGS = {
     EventTypes.CYCLE_COMPLETED: "cycle",
     EventTypes.CYCLE_DEGRADED: "cycle",
     EventTypes.PLANNING_UNAVAILABLE: "gate",
+    EventTypes.FORAGER_SELECTION: "forager",
     EventTypes.RUST_ORCHESTRATOR_RETURNED: "rust",
     EventTypes.ORDER_WAVE_COMPLETED: "execute",
     EventTypes.EXECUTION_CREATE_SUCCEEDED: "order",
@@ -965,6 +968,53 @@ def _console_rust_summary(event: LiveEvent) -> list[str]:
     return parts
 
 
+def _console_forager_selection_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    selected = _data_int(data, "selected_count")
+    candidate = _data_int(data, "candidate_count")
+    eligible = _data_int(data, "eligible_count")
+    if selected is not None and candidate is not None:
+        if eligible is not None and eligible != candidate:
+            parts.append(f"selected={selected}/{eligible}/{candidate}")
+        else:
+            parts.append(f"selected={selected}/{candidate}")
+    elif selected is not None:
+        parts.append(f"selected={selected}")
+    slots_to_fill = _data_int(data, "slots_to_fill")
+    max_positions = _data_int(data, "max_n_positions")
+    if slots_to_fill is not None:
+        if max_positions is not None:
+            parts.append(f"slots={slots_to_fill}/{max_positions}")
+        else:
+            parts.append(f"slots={slots_to_fill}")
+    unavailable = _data_int(data, "feature_unavailable_count")
+    if unavailable:
+        parts.append(f"unavailable={unavailable}")
+    dropped = _data_int(data, "volatility_dropped_count")
+    if dropped:
+        parts.append(f"volatility_dropped={dropped}")
+    selected_symbols = _compact_csv(data.get("selected_symbols"), limit=4)
+    if selected_symbols:
+        parts.append(f"symbols={selected_symbols}")
+    incumbent_symbols = _compact_csv(data.get("incumbent_symbols"), limit=4)
+    if incumbent_symbols:
+        parts.append(f"incumbents={incumbent_symbols}")
+    max_age_ms = _data_int(data, "max_age_ms")
+    if max_age_ms is not None:
+        parts.append(f"max_age={max_age_ms / 1000.0:.0f}s")
+    fetch_budget = _data_int(data, "fetch_budget")
+    if fetch_budget is not None:
+        parts.append(f"fetch_budget={fetch_budget}")
+    hysteresis_events = _data_int(data, "hysteresis_event_count")
+    if hysteresis_events:
+        parts.append(f"hysteresis_events={hysteresis_events}")
+    source = _data_str(data, "source")
+    if source:
+        parts.append(f"source={source}")
+    return parts
+
+
 def _format_console_ratio(value: Any) -> str | None:
     if value is None:
         return None
@@ -1113,6 +1163,8 @@ def _console_data_summary(event: LiveEvent) -> list[str]:
         return _console_confirmation_summary(event)
     if event.event_type == EventTypes.RUST_ORCHESTRATOR_RETURNED:
         return _console_rust_summary(event)
+    if event.event_type == EventTypes.FORAGER_SELECTION:
+        return _console_forager_selection_summary(event)
     if event.event_type == EventTypes.HSL_STATUS:
         return _console_hsl_status_summary(event)
     if event.event_type == EventTypes.TRAILING_STATUS:

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1955,7 +1955,7 @@ def _emit_forager_selection_event_unchecked(
     _safe_emit(
         bot,
         EventTypes.FORAGER_SELECTION,
-        level="debug",
+        level="info",
         component="forager.selection",
         tags=(EventTags.FORAGER, EventTags.SELECTION),
         cycle_id=current_live_event_cycle_id(bot),

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -848,6 +848,52 @@ def test_console_format_summarizes_rust_return():
     assert format_console_event(event) == "[rust] succeeded cycle=cy_6 orders=4 elapsed=17ms"
 
 
+def test_console_format_summarizes_forager_selection():
+    event = LiveEvent(
+        EventTypes.FORAGER_SELECTION,
+        status="succeeded",
+        cycle_id="cy_forager",
+        pside="long",
+        reason_code="rust_orchestrator_selection",
+        data={
+            "candidate_count": 40,
+            "eligible_count": 33,
+            "selected_count": 3,
+            "selected_symbols": [
+                "BTC/USDT:USDT",
+                "ETH/USDT:USDT",
+                "SOL/USDT:USDT",
+            ],
+            "incumbent_symbols": ["BTC/USDT:USDT"],
+            "slots_to_fill": 1,
+            "max_n_positions": 3,
+            "feature_unavailable_count": 7,
+            "volatility_dropped_count": 5,
+            "max_age_ms": 180_000,
+            "fetch_budget": 4,
+            "hysteresis_event_count": 2,
+            "source": "rust_orchestrator",
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[forager] succeeded cycle=cy_forager selected=3/33/40 slots=1/3 "
+        "unavailable=7 volatility_dropped=5 "
+        "symbols=BTC/USDT:USDT,ETH/USDT:USDT,SOL/USDT:USDT "
+        "incumbents=BTC/USDT:USDT max_age=180s fetch_budget=4 "
+        "hysteresis_events=2 source=rust_orchestrator pside=long "
+        "reason=rust_orchestrator_selection"
+    )
+
+
+def test_forager_selection_console_route_is_throttled():
+    route = DEFAULT_ROUTES[EventTypes.FORAGER_SELECTION]
+
+    assert route.console is True
+    assert route.text is True
+    assert route.throttle_interval_ms == 5 * 60 * 1000
+
+
 def test_console_format_summarizes_hsl_status_distance_to_red():
     event = LiveEvent(
         EventTypes.HSL_STATUS,

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -218,7 +218,6 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.DATA_PACKET_UPDATED].monitor is True
     assert DEFAULT_ROUTES[EventTypes.DATA_PACKET_UPDATED].console is False
     for event_type in (
-        EventTypes.FORAGER_SELECTION,
         EventTypes.FORAGER_FEATURE_UNAVAILABLE,
         EventTypes.ACTION_PLANNED,
         EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2558,6 +2558,7 @@ def test_forager_selection_diagnostics_log_scores_and_hysteresis(caplog):
     ]
     assert len(events) == 2
     assert events[0].cycle_id == "cy_forager"
+    assert events[0].level == "info"
     assert events[0].data["source"] == "rust_orchestrator"
     assert events[0].data["selected_symbols"] == ["DOGE/USDT:USDT"]
     assert events[0].data["incumbent_symbols"] == ["DOGE/USDT:USDT"]


### PR DESCRIPTION
## Summary
- route existing forager.selection events to the opt-in live event console/text sinks with a 5-minute throttle
- add compact operator formatting for selected/eligible/candidate counts, slots, unavailable features, drops, selected/incumbent symbols, max age, fetch budget, and source
- make forager.selection an INFO-level structured summary while keeping feature-unavailable details DEBUG
- update logging guide and progress ledger with #963 deploy evidence and this current slice

## Safety
Observability-only. No forager ranking, coin selection, order construction, exchange calls, cache mutation, readiness gates, risk thresholds, or trading behavior changed.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py::test_console_format_summarizes_forager_selection tests/test_live_event_bus.py::test_forager_selection_console_route_is_throttled tests/test_passivbot_balance_split.py::test_forager_selection_diagnostics_log_scores_and_hysteresis -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py src/live/event_emitters.py
- git diff --check
- added-line/self-audit scan for touched files: no new exception/fallback handling added