### PR TITLE
Enrich trailing and unstuck console status

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,20 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` head:
 
-- `f54c92147` after PR #963, `Refine trailing selected mode labels`.
+- `b9a3110e8` after PR #964, `Project forager selection to event console`.
 
 Current logging-overhaul head:
 
-- `f54c92147` after PR #963, `Refine trailing selected mode labels`.
+- `b9a3110e8` after PR #964, `Project forager selection to event console`.
 
 Current work:
 
-- Branch `codex/v8-forager-selection-console` projects existing
-  `forager.selection` events into the opt-in live event console/text sinks with
-  a compact, throttled operator summary. This continues the migration of useful
-  legacy console output into the structured event stream without changing
-  forager ranking or entry behavior.
+- Branch `codex/v8-trailing-unstuck-console` enriches existing trailing and
+  unstuck structured-event console summaries with distance-to-threshold,
+  distance-to-retracement, unstuck target distance, and the already-computed
+  monitor runtime hint for the next unstuck candidate. This continues the
+  migration of user-facing status logs into the event stream without changing
+  order generation, risk logic, or cadence.
 
 Current review gate:
 
@@ -61,6 +62,20 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #964 at `b9a3110e8`.
+- PR #964 projected existing `forager.selection` events into the opt-in live
+  event console/text sinks with a compact 5-minute-throttled operator summary.
+  It merged after Claude and Hermes approved with CI green.
+- Bots were restarted from `/root/bots_vps5.yaml` and left running. Hyperliquid
+  exited quickly after Ctrl-C; Binance, GateIO, and OKX exited within the longer
+  graceful window; Kucoin still required SIGTERM after the full wait window.
+- VPS5 smoke after restart reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, `missing_expected_count=0`, clean tracked repository
+  state at `repository.head=b9a3110e`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, and `logs.hard_matches=0`.
+  Remaining attention was non-hard startup state: four active HSL replay
+  workers, Hyperliquid EMA-unavailable diagnostics for cache-only stock
+  symbols, staged refresh progress, and shutdown-slow history from the restart.
 - Repository pulled through PR #963 at `f54c92147`.
 - PR #963 refined the trailing `selected_mode` classifier so
   `close_auto_reduce_wel_long` reports `auto_reduce` instead of generic `grid`.

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -1083,6 +1083,9 @@ def _console_trailing_status_summary(event: LiveEvent) -> list[str]:
     threshold_price = _data_float(data, "threshold_price")
     if threshold_price:
         parts.append(f"threshold_price={threshold_price}")
+    threshold_dist = _data_number(data, "current_vs_threshold_ratio")
+    if threshold_dist is not None:
+        parts.append(f"threshold_dist={threshold_dist * 100.0:.4f}%")
     retracement_met = data.get("retracement_met")
     if retracement_met is not None:
         parts.append(f"retracement_met={bool(retracement_met)}")
@@ -1092,6 +1095,9 @@ def _console_trailing_status_summary(event: LiveEvent) -> list[str]:
     retracement_price = _data_float(data, "retracement_price")
     if retracement_price:
         parts.append(f"retracement_price={retracement_price}")
+    retracement_dist = _data_number(data, "current_vs_retracement_ratio")
+    if retracement_dist is not None:
+        parts.append(f"retracement_dist={retracement_dist * 100.0:.4f}%")
     projected = _data_float(data, "threshold_projection_retracement_price")
     if projected:
         parts.append(f"threshold_retrace_price={projected}")
@@ -1124,6 +1130,9 @@ def _console_unstuck_status_summary(event: LiveEvent) -> list[str]:
             target_price = _data_float(info, "next_target_price")
             if target_price:
                 bit += f":target={target_price}"
+            target_dist = _data_number(info, "next_target_distance_ratio")
+            if target_dist is not None:
+                bit += f":target_dist={target_dist * 100.0:.4f}%"
             trigger_dist = _data_number(info, "next_unstuck_trigger_distance_ratio")
             if trigger_dist is not None:
                 bit += f":ema_gate={trigger_dist * 100.0:.4f}%"

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -3234,6 +3234,19 @@ class Passivbot:
         signature_parts = []
         for pside in ["long", "short"]:
             info = self._calc_unstuck_allowance_for_logging(pside)
+            runtime_hints = getattr(self, "_monitor_runtime_unstuck_hints", {})
+            if isinstance(runtime_hints, dict):
+                hint = runtime_hints.get(pside)
+                if isinstance(hint, dict):
+                    info = dict(info or {})
+                    for key in (
+                        "next_symbol",
+                        "next_target_price",
+                        "next_target_distance_ratio",
+                        "next_unstuck_trigger_distance_ratio",
+                    ):
+                        if hint.get(key) is not None:
+                            info[key] = hint[key]
             side_infos[pside] = dict(info or {})
             status = info.get("status")
             if status == "disabled":
@@ -3270,6 +3283,23 @@ class Passivbot:
                         "over_budget" if allowance < 0 else "ok",
                         round(float(snapped_allowance), 2),
                         tuple(sorted(info.get("override_loss_allowance_pcts", {}).items())),
+                        str(info.get("next_symbol") or ""),
+                        round(
+                            self._trailing_status_float(info.get("next_target_price")),
+                            8,
+                        ),
+                        round(
+                            self._trailing_status_float(
+                                info.get("next_target_distance_ratio")
+                            ),
+                            8,
+                        ),
+                        round(
+                            self._trailing_status_float(
+                                info.get("next_unstuck_trigger_distance_ratio")
+                            ),
+                            8,
+                        ),
                     )
                 )
         return side_infos, parts, tuple(signature_parts)

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -957,14 +957,16 @@ def test_console_format_summarizes_trailing_status():
             "retracement_price": 99_145.0,
             "threshold_projection_retracement_price": 99_145.0,
             "current_price": 101_000.0,
+            "current_vs_threshold_ratio": 101_000.0 / 98_750.0 - 1.0,
+            "current_vs_retracement_ratio": 101_000.0 / 99_145.0 - 1.0,
         },
     )
 
     assert format_console_event(event) == (
         "[trailing] succeeded cycle=cy_trailing kind=entry "
         "trailing_status=waiting_threshold mode=grid threshold_met=False threshold=1.2500% "
-        "threshold_price=98750 retracement_met=False retracement=0.4000% "
-        "retracement_price=99145 threshold_retrace_price=99145 current=101000 "
+        "threshold_price=98750 threshold_dist=2.2785% retracement_met=False retracement=0.4000% "
+        "retracement_price=99145 retracement_dist=1.8710% threshold_retrace_price=99145 current=101000 "
         "symbol=BTC/USDT:USDT pside=long reason=trailing_status"
     )
 
@@ -1006,6 +1008,7 @@ def test_console_format_summarizes_unstuck_status():
                     "over_budget": True,
                     "next_symbol": "BTC/USDT:USDT",
                     "next_target_price": 101_000.0,
+                    "next_target_distance_ratio": 0.005,
                     "next_unstuck_trigger_distance_ratio": 0.0125,
                 },
                 "short": {"status": "disabled"},
@@ -1015,7 +1018,7 @@ def test_console_format_summarizes_unstuck_status():
 
     assert format_console_event(event) == (
         "[unstuck] succeeded long:ok:allowance=-12.3:over_budget:"
-        "next=BTC/USDT:USDT:target=101000:ema_gate=1.2500% "
+        "next=BTC/USDT:USDT:target=101000:target_dist=0.5000%:ema_gate=1.2500% "
         "short:disabled over_budget=long changed=true reason=unstuck_status"
     )
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2781,6 +2781,14 @@ def test_unstuck_status_logs_info_on_change_then_hourly(monkeypatch, caplog):
     bot._unstuck_allowance_log_snap_by_pside = {}
     bot._unstuck_last_status_signature = None
     bot._unstuck_last_status_info_ms = 0
+    bot._monitor_runtime_unstuck_hints = {
+        "long": {
+            "next_symbol": "BTC/USDT:USDT",
+            "next_target_price": 101_000.0,
+            "next_target_distance_ratio": 0.005,
+            "next_unstuck_trigger_distance_ratio": 0.0125,
+        }
+    }
     captured_events = []
     bot._emit_unstuck_status_event = lambda **kwargs: captured_events.append(kwargs)
     now = [5 * 60 * 1000]
@@ -2809,6 +2817,12 @@ def test_unstuck_status_logs_info_on_change_then_hourly(monkeypatch, caplog):
             "peak": 16550.0,
             "pct_from_peak": -0.2,
         }
+        bot._monitor_runtime_unstuck_hints["long"] = {
+            "next_symbol": "ETH/USDT:USDT",
+            "next_target_price": 2_500.0,
+            "next_target_distance_ratio": -0.01,
+            "next_unstuck_trigger_distance_ratio": 0.02,
+        }
         now[0] += 5 * 60 * 1000
         bot._maybe_log_unstuck_status()
         state_by_pside["long"] = {
@@ -2825,11 +2839,16 @@ def test_unstuck_status_logs_info_on_change_then_hourly(monkeypatch, caplog):
     unstuck_logs = [
         record.message for record in caplog.records if "[unstuck]" in record.message
     ]
-    assert len(unstuck_logs) == 3
-    assert len(captured_events) == 3
-    assert [event["changed"] for event in captured_events] == [True, True, False]
+    assert len(unstuck_logs) == 4
+    assert len(captured_events) == 4
+    assert [event["changed"] for event in captured_events] == [True, True, True, False]
     assert captured_events[0]["side_statuses"]["long"]["allowance"] == pytest.approx(
         -41.01
+    )
+    assert captured_events[0]["side_statuses"]["long"]["next_symbol"] == "BTC/USDT:USDT"
+    assert captured_events[1]["side_statuses"]["long"]["next_symbol"] == "ETH/USDT:USDT"
+    assert captured_events[1]["side_statuses"]["long"]["next_target_distance_ratio"] == pytest.approx(
+        -0.01
     )
     assert captured_events[0]["side_statuses"]["short"]["status"] == "disabled"
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -2757,6 +2757,10 @@ def test_unstuck_status_event_emits_structured_summary():
                     "ETH/USDT:USDT": -3.0,
                     "BTC/USDT:USDT": -5.0,
                 },
+                "next_symbol": "BTC/USDT:USDT",
+                "next_target_price": 101_000.0,
+                "next_target_distance_ratio": 0.005,
+                "next_unstuck_trigger_distance_ratio": 0.0125,
             },
             "short": {"status": "disabled"},
         },
@@ -2786,6 +2790,10 @@ def test_unstuck_status_event_emits_structured_summary():
         "BTC/USDT:USDT": pytest.approx(-5.0),
         "ETH/USDT:USDT": pytest.approx(-3.0),
     }
+    assert long["next_symbol"] == "BTC/USDT:USDT"
+    assert long["next_target_price"] == pytest.approx(101_000.0)
+    assert long["next_target_distance_ratio"] == pytest.approx(0.005)
+    assert long["next_unstuck_trigger_distance_ratio"] == pytest.approx(0.0125)
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
## Summary
- add threshold/retracement distance fields to the existing `trailing.status` console projection
- bridge already-computed monitor unstuck runtime hints into `unstuck.status` events so console/disk events can show next candidate, target distance, and EMA gate distance
- update logging progress ledger with PR #964 deploy evidence and this slice

## Behavior
- observability-only: no Rust/order/risk behavior changes
- keeps existing 5-minute status check and 1-hour unchanged heartbeat cadence
- candidate/target hint changes now count as meaningful unstuck status changes

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py::test_console_format_summarizes_trailing_status tests/test_live_event_bus.py::test_console_format_summarizes_unstuck_status tests/test_passivbot_balance_split.py::test_unstuck_status_logs_info_on_change_then_hourly tests/test_passivbot_monitor.py::test_unstuck_status_event_emits_structured_summary tests/test_passivbot_monitor.py::test_trailing_status_event_emits_structured_summary -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/passivbot.py src/live/event_bus.py src/live/event_emitters.py`
- `git diff --check`