### PR TITLE
Project account state events to console

### DIFF
--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -86,13 +86,15 @@ The console projection is operator-facing: it should prefer trading-relevant
 summaries over internal data plumbing. HSL status events are console-visible
 only when they are pside-level, red/cooldown, or tied to a held coin; routine
 flat coin-universe status remains in the structured event stream but is kept off
-the console. Position-level `trailing.status` and `unstuck.status` events are
-console-visible because they explain why an existing position is waiting, armed,
-triggered, over budget, or blocked by the unstuck EMA gate. Unsupported strategy
-diagnostics must say so explicitly instead of fabricating threshold/retracement
-prices. Supported trailing diagnostics should include the selected mode, such as
-`trailing`, `grid`, `auto_reduce`, `unstuck`, `none`, or `other`, when the
-next-order state is known. `forager.selection` events are also console-visible
+the console. Fill, position, and balance change events are console-visible
+because they are the primary operator-facing account state changes.
+Position-level `trailing.status` and `unstuck.status` events are console-visible
+because they explain why an existing position is waiting, armed, triggered, over
+budget, or blocked by the unstuck EMA gate. Unsupported strategy diagnostics
+must say so explicitly instead of fabricating threshold/retracement prices.
+Supported trailing diagnostics should include the selected mode, such as
+`trailing`, `grid`, `auto_reduce`, `unstuck`, `none`, or `other`, when the next
+order state is known. `forager.selection` events are also console-visible
 through a throttled compact summary because they explain which coins are being
 selected, retained, or skipped when forager entries are possible.
 

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -82,8 +82,11 @@ an opt-in console sink fed by the structured live event pipeline. It is disabled
 by default while legacy stdlib console logs still exist, because enabling it can
 duplicate some order/execution lifecycle messages. Use it for controlled smoke
 tests of event-stream console formatting before migrating default console output.
-The console projection is operator-facing: it should prefer trading-relevant
-summaries over internal data plumbing. HSL status events are console-visible
+The console projection is operator-facing and local: it should prefer
+trading-relevant summaries over internal data plumbing. Do not ship opt-in
+console/text output containing account-state magnitudes such as balance, equity,
+PnL, fees, or position size to shared or centralized log aggregation without a
+deliberate redaction policy. HSL status events are console-visible
 only when they are pside-level, red/cooldown, or tied to a held coin; routine
 flat coin-universe status remains in the structured event stream but is kept off
 the console. Fill, position, and balance change events are console-visible

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,20 +19,20 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` head:
 
-- `b9a3110e8` after PR #964, `Project forager selection to event console`.
+- `191af58ab` after PR #965, `Enrich trailing and unstuck console status`.
 
 Current logging-overhaul head:
 
-- `b9a3110e8` after PR #964, `Project forager selection to event console`.
+- `191af58ab` after PR #965, `Enrich trailing and unstuck console status`.
 
 Current work:
 
-- Branch `codex/v8-trailing-unstuck-console` enriches existing trailing and
-  unstuck structured-event console summaries with distance-to-threshold,
-  distance-to-retracement, unstuck target distance, and the already-computed
-  monitor runtime hint for the next unstuck candidate. This continues the
-  migration of user-facing status logs into the event stream without changing
-  order generation, risk logic, or cadence.
+- Branch `codex/v8-position-balance-console` projects existing `fill.ingested`,
+  `position.changed`, and `balance.changed` events into the opt-in live event
+  console/text sinks with compact operator summaries. This continues the
+  migration of user-facing account state logs into the structured event stream
+  without changing fill ingestion, account state, order generation, or risk
+  logic.
 
 Current review gate:
 
@@ -62,6 +62,26 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #965 at `191af58ab`.
+- PR #965 enriched existing trailing and unstuck console summaries with
+  distance-to-threshold, distance-to-retracement, unstuck target distance, and
+  the already-computed monitor runtime hint for the next unstuck candidate. It
+  merged after Hermes approved, Claude approved with no findings, and CI was
+  green; Cursor did not post during the bounded wait.
+- Bots were restarted from `/root/bots_vps5.yaml` and left running. Hyperliquid
+  exited quickly after Ctrl-C; Binance, GateIO, and OKX exited within the longer
+  graceful window; Kucoin still required SIGTERM after the full wait window.
+- VPS5 smoke after restart reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, `missing_expected_count=0`, clean tracked repository
+  state at `repository.head=191af58a`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, and `logs.hard_matches=0`.
+  Remaining attention was non-hard startup state: active HSL replay workers,
+  Hyperliquid EMA-unavailable diagnostics for cache-only stock symbols, staged
+  refresh progress, and shutdown-slow history from the restart.
+- A focused monitor-event check confirmed deployed `trailing.status` events for
+  Hyperliquid include the new distance ratio fields. The observed
+  `unstuck.status` event had no next-candidate hint because no close-unstuck
+  candidate was active in that window; that path is covered by focused tests.
 - Repository pulled through PR #964 at `b9a3110e8`.
 - PR #964 projected existing `forager.selection` events into the opt-in live
   event console/text sinks with a compact 5-minute-throttled operator summary.

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -702,9 +702,9 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.EXECUTION_CONFIRMATION_SATISFIED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CONFIRMATION_TIMEOUT: EventRoute(console=True, text=True),
     EventTypes.FILLS_REFRESH_SUMMARY: EventRoute(console=False, text=False),
-    EventTypes.FILL_INGESTED: EventRoute(console=False, text=False),
-    EventTypes.POSITION_CHANGED: EventRoute(console=False, text=False),
-    EventTypes.BALANCE_CHANGED: EventRoute(console=False, text=False),
+    EventTypes.FILL_INGESTED: EventRoute(console=True, text=True),
+    EventTypes.POSITION_CHANGED: EventRoute(console=True, text=True),
+    EventTypes.BALANCE_CHANGED: EventRoute(console=True, text=True),
     EventTypes.RISK_MODE_CHANGED: EventRoute(console=False, text=False),
     EventTypes.HSL_TRANSITION: EventRoute(console=False, text=False),
     EventTypes.HSL_STATUS: EventRoute(console=True, text=True),
@@ -785,6 +785,9 @@ _CONSOLE_EVENT_TAGS = {
     EventTypes.EXECUTION_AMBIGUOUS: "order",
     EventTypes.EXECUTION_CONFIRMATION_SATISFIED: "execute",
     EventTypes.EXECUTION_CONFIRMATION_TIMEOUT: "execute",
+    EventTypes.FILL_INGESTED: "fill",
+    EventTypes.POSITION_CHANGED: "pos",
+    EventTypes.BALANCE_CHANGED: "balance",
     EventTypes.HSL_STATUS: "risk",
     EventTypes.TRAILING_STATUS: "trailing",
     EventTypes.UNSTUCK_STATUS: "unstuck",
@@ -965,6 +968,94 @@ def _console_rust_summary(event: LiveEvent) -> list[str]:
     error_type = _data_str(data, "error_type")
     if error_type:
         parts.append(f"error_type={error_type}")
+    return parts
+
+
+def _console_fill_ingested_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    if event.side:
+        parts.append(f"side={event.side}")
+    order_type = _data_str(data, "pb_order_type")
+    if order_type:
+        parts.append(f"type={order_type}")
+    qty = _data_float(data, "qty")
+    price = _data_float(data, "price")
+    if qty:
+        parts.append(f"qty={qty}")
+    if price:
+        parts.append(f"price={price}")
+    pnl = _data_float(data, "pnl")
+    if pnl:
+        parts.append(f"pnl={pnl}")
+    fee = _data_float(data, "fee")
+    if fee:
+        parts.append(f"fee={fee}")
+    client_id = _data_str(data, "client_order_id_short")
+    if client_id:
+        parts.append(f"client_id={client_id}")
+    return parts
+
+
+def _console_position_changed_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    action = _data_str(data, "action")
+    if action:
+        parts.append(f"action={action}")
+    old_size = _data_float(data, "old_size")
+    new_size = _data_float(data, "new_size")
+    if old_size is not None and new_size is not None:
+        parts.append(f"size={old_size}->{new_size}")
+    else:
+        if old_size is not None:
+            parts.append(f"old_size={old_size}")
+        if new_size is not None:
+            parts.append(f"new_size={new_size}")
+    size_delta = _data_float(data, "size_delta")
+    if size_delta:
+        parts.append(f"delta={size_delta}")
+    new_price = _data_float(data, "new_price")
+    if new_price:
+        parts.append(f"price={new_price}")
+    last_price = _data_float(data, "last_price")
+    if last_price:
+        parts.append(f"last={last_price}")
+    for label, key in (
+        ("we", "wallet_exposure"),
+        ("wel", "wel_ratio"),
+        ("twel", "twel_ratio"),
+    ):
+        value = _data_number(data, key)
+        if value is not None:
+            parts.append(f"{label}={value * 100.0:.4f}%")
+    upnl = _data_float(data, "upnl")
+    if upnl:
+        parts.append(f"upnl={upnl}")
+    return parts
+
+
+def _console_balance_changed_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    balance = _data_float(data, "balance_raw")
+    if balance:
+        parts.append(f"balance={balance}")
+    delta = _data_float(data, "balance_raw_delta")
+    if delta:
+        parts.append(f"delta={delta}")
+    snapped = _data_float(data, "balance_snapped")
+    if snapped:
+        parts.append(f"snapped={snapped}")
+    snapped_delta = _data_float(data, "balance_snapped_delta")
+    if snapped_delta:
+        parts.append(f"snapped_delta={snapped_delta}")
+    equity = _data_float(data, "equity")
+    if equity:
+        parts.append(f"equity={equity}")
+    source = _data_str(data, "source")
+    if source:
+        parts.append(f"source={source}")
     return parts
 
 
@@ -1174,6 +1265,12 @@ def _console_data_summary(event: LiveEvent) -> list[str]:
         return _console_rust_summary(event)
     if event.event_type == EventTypes.FORAGER_SELECTION:
         return _console_forager_selection_summary(event)
+    if event.event_type == EventTypes.FILL_INGESTED:
+        return _console_fill_ingested_summary(event)
+    if event.event_type == EventTypes.POSITION_CHANGED:
+        return _console_position_changed_summary(event)
+    if event.event_type == EventTypes.BALANCE_CHANGED:
+        return _console_balance_changed_summary(event)
     if event.event_type == EventTypes.HSL_STATUS:
         return _console_hsl_status_summary(event)
     if event.event_type == EventTypes.TRAILING_STATUS:

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -258,6 +258,12 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CREATE_SKIPPED].console is False
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CONFIRMATION_TIMEOUT].console is True
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CONFIRMATION_TIMEOUT].text is True
+    assert DEFAULT_ROUTES[EventTypes.FILL_INGESTED].console is True
+    assert DEFAULT_ROUTES[EventTypes.FILL_INGESTED].text is True
+    assert DEFAULT_ROUTES[EventTypes.POSITION_CHANGED].console is True
+    assert DEFAULT_ROUTES[EventTypes.POSITION_CHANGED].text is True
+    assert DEFAULT_ROUTES[EventTypes.BALANCE_CHANGED].console is True
+    assert DEFAULT_ROUTES[EventTypes.BALANCE_CHANGED].text is True
     assert DEFAULT_ROUTES[EventTypes.BOT_SHUTDOWN_STAGE].console is True
     assert DEFAULT_ROUTES[EventTypes.BOT_SHUTDOWN_STAGE].text is True
     assert DEFAULT_ROUTES[EventTypes.HSL_STATUS].console is True
@@ -1020,6 +1026,86 @@ def test_console_format_summarizes_unstuck_status():
         "[unstuck] succeeded long:ok:allowance=-12.3:over_budget:"
         "next=BTC/USDT:USDT:target=101000:target_dist=0.5000%:ema_gate=1.2500% "
         "short:disabled over_budget=long changed=true reason=unstuck_status"
+    )
+
+
+def test_console_format_summarizes_fill_ingested():
+    event = LiveEvent(
+        EventTypes.FILL_INGESTED,
+        status="succeeded",
+        cycle_id="cy_fill",
+        symbol="BTC/USDT:USDT",
+        pside="long",
+        side="buy",
+        reason_code="new_fill",
+        data={
+            "pb_order_type": "entry_grid_normal_long",
+            "qty": 0.001,
+            "price": 101_234.5,
+            "pnl": -1.25,
+            "fee": -0.04,
+            "client_order_id_short": "abc123",
+            "fill_id_hash": "9f54f33d005de125ca93371eeda0374f039e520574633e8335066351e275c6a2",
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[fill] succeeded cycle=cy_fill side=buy type=entry_grid_normal_long "
+        "qty=0.001 price=101234.5 pnl=-1.25 fee=-0.04 client_id=abc123 "
+        "symbol=BTC/USDT:USDT pside=long reason=new_fill"
+    )
+
+
+def test_console_format_summarizes_position_changed():
+    event = LiveEvent(
+        EventTypes.POSITION_CHANGED,
+        status="succeeded",
+        cycle_id="cy_pos",
+        symbol="ETH/USDT:USDT",
+        pside="short",
+        reason_code="short_increased",
+        data={
+            "action": "short_increased",
+            "old_size": -0.2,
+            "new_size": -0.35,
+            "size_delta": -0.15,
+            "new_price": 2_500.0,
+            "last_price": 2_480.0,
+            "wallet_exposure": 0.12,
+            "wel_ratio": 0.6,
+            "twel_ratio": 0.24,
+            "upnl": 7.5,
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[pos] succeeded cycle=cy_pos action=short_increased size=-0.2->-0.35 "
+        "delta=-0.15 price=2500 last=2480 we=12.0000% wel=60.0000% "
+        "twel=24.0000% upnl=7.5 symbol=ETH/USDT:USDT pside=short "
+        "reason=short_increased"
+    )
+
+
+def test_console_format_summarizes_balance_changed():
+    event = LiveEvent(
+        EventTypes.BALANCE_CHANGED,
+        status="succeeded",
+        cycle_id="cy_balance",
+        reason_code="balance_changed",
+        data={
+            "balance_raw": 1_005.25,
+            "balance_raw_delta": 5.25,
+            "balance_snapped": 1_004.0,
+            "balance_snapped_delta": 4.0,
+            "equity": 1_010.75,
+            "source": "REST",
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[balance] succeeded cycle=cy_balance balance=1005.25 delta=5.25 "
+        "snapped=1004 snapped_delta=4 equity=1010.75 source=REST "
+        "reason=balance_changed"
     )
 
 


### PR DESCRIPTION
## Summary
- route existing `fill.ingested`, `position.changed`, and `balance.changed` events to the opt-in live event console/text sinks
- add compact console summaries for fill, position, and balance changes
- update logging policy/progress docs with #965 deploy evidence and this slice

## Behavior
- observability-only: no fill ingestion, account state, order, risk, or Rust behavior changes
- event console remains opt-in via `logging.live_event_console` / `PASSIVBOT_LIVE_EVENT_CONSOLE`
- full structured events remain persisted through the existing event pipeline

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py -q`
- focused integration coverage: `tests/test_passivbot_monitor.py::test_handle_balance_update_records_monitor_balance_event` and `tests/test_passivbot_balance_split.py::test_log_position_changes_classifies_signed_exposure_changes`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py src/live/event_emitters.py src/passivbot.py`
- `git diff --check`