### PR TITLE
Project risk state events to console

### DIFF
--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -91,6 +91,9 @@ only when they are pside-level, red/cooldown, or tied to a held coin; routine
 flat coin-universe status remains in the structured event stream but is kept off
 the console. Fill, position, and balance change events are console-visible
 because they are the primary operator-facing account state changes.
+`risk.mode_changed` and `hsl.transition` events are console-visible because
+mode changes and HSL tier transitions explain risk-state changes that affect
+trading.
 Position-level `trailing.status` and `unstuck.status` events are console-visible
 because they explain why an existing position is waiting, armed, triggered, over
 budget, or blocked by the unstuck EMA gate. Unsupported strategy diagnostics

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,20 +19,19 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` head:
 
-- `191af58ab` after PR #965, `Enrich trailing and unstuck console status`.
+- `47f84d8c5` after PR #966, `Project account state events to console`.
 
 Current logging-overhaul head:
 
-- `191af58ab` after PR #965, `Enrich trailing and unstuck console status`.
+- `47f84d8c5` after PR #966, `Project account state events to console`.
 
 Current work:
 
-- Branch `codex/v8-position-balance-console` projects existing `fill.ingested`,
-  `position.changed`, and `balance.changed` events into the opt-in live event
-  console/text sinks with compact operator summaries. This continues the
-  migration of user-facing account state logs into the structured event stream
-  without changing fill ingestion, account state, order generation, or risk
-  logic.
+- Branch `codex/v8-risk-hsl-console` projects existing `risk.mode_changed` and
+  `hsl.transition` events into the opt-in live event console/text sinks with
+  compact operator summaries. This continues the migration of user-facing
+  risk-state logs into the structured event stream without changing HSL mode
+  logic, risk decisions, order generation, or HSL replay behavior.
 
 Current review gate:
 
@@ -62,6 +61,22 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #966 at `47f84d8c5`.
+- PR #966 projected existing `fill.ingested`, `position.changed`, and
+  `balance.changed` events into the opt-in live event console/text sinks with
+  compact operator summaries. It merged after Hermes approved, Claude approved
+  with the docs sensitivity note addressed, and CI was green; Cursor did not
+  post during the bounded wait.
+- Bots were restarted from `/root/bots_vps5.yaml` and left running. Hyperliquid
+  exited quickly after Ctrl-C; Binance, GateIO, and OKX exited within the longer
+  graceful window; Kucoin still required SIGTERM after the full wait window.
+- VPS5 smoke after restart reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, `missing_expected_count=0`, clean tracked repository
+  state at `repository.head=47f84d8c`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, and `logs.hard_matches=0`.
+  Remaining attention was non-hard startup state: active HSL replay workers,
+  Hyperliquid EMA-unavailable diagnostics for cache-only stock symbols, staged
+  refresh progress, and shutdown-slow history from the restart.
 - Repository pulled through PR #965 at `191af58ab`.
 - PR #965 enriched existing trailing and unstuck console summaries with
   distance-to-threshold, distance-to-retracement, unstuck target distance, and

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -705,8 +705,8 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.FILL_INGESTED: EventRoute(console=True, text=True),
     EventTypes.POSITION_CHANGED: EventRoute(console=True, text=True),
     EventTypes.BALANCE_CHANGED: EventRoute(console=True, text=True),
-    EventTypes.RISK_MODE_CHANGED: EventRoute(console=False, text=False),
-    EventTypes.HSL_TRANSITION: EventRoute(console=False, text=False),
+    EventTypes.RISK_MODE_CHANGED: EventRoute(console=True, text=True),
+    EventTypes.HSL_TRANSITION: EventRoute(console=True, text=True),
     EventTypes.HSL_STATUS: EventRoute(console=True, text=True),
     EventTypes.HSL_RAW_RED_PENDING: EventRoute(console=False, text=False),
     EventTypes.HSL_REPLAY_STARTED: EventRoute(console=False, text=False),
@@ -788,6 +788,8 @@ _CONSOLE_EVENT_TAGS = {
     EventTypes.FILL_INGESTED: "fill",
     EventTypes.POSITION_CHANGED: "pos",
     EventTypes.BALANCE_CHANGED: "balance",
+    EventTypes.RISK_MODE_CHANGED: "risk",
+    EventTypes.HSL_TRANSITION: "risk",
     EventTypes.HSL_STATUS: "risk",
     EventTypes.TRAILING_STATUS: "trailing",
     EventTypes.UNSTUCK_STATUS: "unstuck",
@@ -1059,6 +1061,71 @@ def _console_balance_changed_summary(event: LiveEvent) -> list[str]:
     return parts
 
 
+def _console_risk_mode_changed_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    source = _data_str(data, "source")
+    if source:
+        parts.append(f"source={source}")
+    action = _data_str(data, "action")
+    if action:
+        parts.append(f"action={action}")
+    previous = _data_str(data, "previous_mode")
+    mode = _data_str(data, "mode")
+    if previous and mode:
+        parts.append(f"mode={previous}->{mode}")
+    elif mode:
+        parts.append(f"mode={mode}")
+    symbols = data.get("symbols")
+    if isinstance(symbols, Mapping):
+        count = _data_int(symbols, "count")
+        sample = _compact_csv(symbols.get("sample"), limit=4)
+        if count is not None:
+            bit = f"symbols={count}"
+            if sample:
+                bit += f":{sample}"
+            parts.append(bit)
+    prev_counts = data.get("previous_mode_counts")
+    if isinstance(prev_counts, Mapping) and prev_counts:
+        parts.append(
+            "previous_counts="
+            + ",".join(f"{key}:{prev_counts[key]}" for key in sorted(prev_counts))
+        )
+    mode_counts = data.get("mode_counts")
+    if isinstance(mode_counts, Mapping) and mode_counts:
+        parts.append(
+            "mode_counts="
+            + ",".join(f"{key}:{mode_counts[key]}" for key in sorted(mode_counts))
+        )
+    return parts
+
+
+def _console_hsl_transition_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    signal_mode = _data_str(data, "signal_mode")
+    if signal_mode:
+        parts.append(f"mode={signal_mode}")
+    previous = _data_str(data, "previous_tier")
+    tier = _data_str(data, "tier")
+    if previous and tier:
+        parts.append(f"tier={previous}->{tier}")
+    elif tier:
+        parts.append(f"tier={tier}")
+    for label, key in (
+        ("dist_to_red", "dist_to_red"),
+        ("drawdown_score", "drawdown_score"),
+        ("red_threshold", "red_threshold"),
+    ):
+        value = _format_console_ratio(_data_float(data, key))
+        if value is not None:
+            parts.append(f"{label}={value}")
+    timestamp_ms = _data_int(data, "timestamp_ms")
+    if timestamp_ms is not None:
+        parts.append(f"ts={timestamp_ms}")
+    return parts
+
+
 def _console_forager_selection_summary(event: LiveEvent) -> list[str]:
     data = event.data if isinstance(event.data, Mapping) else {}
     parts: list[str] = []
@@ -1271,6 +1338,10 @@ def _console_data_summary(event: LiveEvent) -> list[str]:
         return _console_position_changed_summary(event)
     if event.event_type == EventTypes.BALANCE_CHANGED:
         return _console_balance_changed_summary(event)
+    if event.event_type == EventTypes.RISK_MODE_CHANGED:
+        return _console_risk_mode_changed_summary(event)
+    if event.event_type == EventTypes.HSL_TRANSITION:
+        return _console_hsl_transition_summary(event)
     if event.event_type == EventTypes.HSL_STATUS:
         return _console_hsl_status_summary(event)
     if event.event_type == EventTypes.TRAILING_STATUS:

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -238,8 +238,6 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.HEALTH_SUMMARY,
         EventTypes.PLANNING_DEFER_SUMMARY,
         EventTypes.PLANNING_SYMBOL_STATE,
-        EventTypes.RISK_MODE_CHANGED,
-        EventTypes.HSL_TRANSITION,
         EventTypes.HSL_RAW_RED_PENDING,
         EventTypes.HSL_RED_TRIGGERED,
         EventTypes.HSL_RED_FINALIZED_WITHOUT_ORDER,
@@ -264,6 +262,10 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.POSITION_CHANGED].text is True
     assert DEFAULT_ROUTES[EventTypes.BALANCE_CHANGED].console is True
     assert DEFAULT_ROUTES[EventTypes.BALANCE_CHANGED].text is True
+    assert DEFAULT_ROUTES[EventTypes.RISK_MODE_CHANGED].console is True
+    assert DEFAULT_ROUTES[EventTypes.RISK_MODE_CHANGED].text is True
+    assert DEFAULT_ROUTES[EventTypes.HSL_TRANSITION].console is True
+    assert DEFAULT_ROUTES[EventTypes.HSL_TRANSITION].text is True
     assert DEFAULT_ROUTES[EventTypes.BOT_SHUTDOWN_STAGE].console is True
     assert DEFAULT_ROUTES[EventTypes.BOT_SHUTDOWN_STAGE].text is True
     assert DEFAULT_ROUTES[EventTypes.HSL_STATUS].console is True
@@ -1106,6 +1108,63 @@ def test_console_format_summarizes_balance_changed():
         "[balance] succeeded cycle=cy_balance balance=1005.25 delta=5.25 "
         "snapped=1004 snapped_delta=4 equity=1010.75 source=REST "
         "reason=balance_changed"
+    )
+
+
+def test_console_format_summarizes_risk_mode_changed():
+    event = LiveEvent(
+        EventTypes.RISK_MODE_CHANGED,
+        status="succeeded",
+        cycle_id="cy_risk_mode",
+        symbol="BTC/USDT:USDT",
+        pside="long",
+        reason_code="hsl_red_runtime_forced_modes",
+        data={
+            "source": "hsl",
+            "action": "replace",
+            "symbols": {
+                "count": 3,
+                "sample": ["BTC/USDT:USDT", "ETH/USDT:USDT", "SOL/USDT:USDT"],
+            },
+            "previous_mode_counts": {"normal": 3},
+            "mode_counts": {"panic": 2, "manual": 1},
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[risk] succeeded cycle=cy_risk_mode source=hsl action=replace "
+        "symbols=3:BTC/USDT:USDT,ETH/USDT:USDT,SOL/USDT:USDT "
+        "previous_counts=normal:3 mode_counts=manual:1,panic:2 "
+        "symbol=BTC/USDT:USDT pside=long reason=hsl_red_runtime_forced_modes"
+    )
+
+
+def test_console_format_summarizes_hsl_transition():
+    event = LiveEvent(
+        EventTypes.HSL_TRANSITION,
+        status="succeeded",
+        cycle_id="cy_hsl_transition",
+        symbol="NEAR/USDT:USDT",
+        pside="long",
+        reason_code="yellow_to_orange",
+        data={
+            "signal_mode": "coin",
+            "previous_tier": "yellow",
+            "tier": "orange",
+            "dist_to_red": 0.012345678,
+            "drawdown_score": 0.1875,
+            "red_threshold": 0.2,
+            "balance": 1_000.0,
+            "strategy_equity": 950.0,
+            "metrics": {"balance": 1_000.0},
+            "timestamp_ms": 1_782_946_000_000,
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[risk] succeeded cycle=cy_hsl_transition mode=coin tier=yellow->orange "
+        "dist_to_red=0.012346 drawdown_score=0.187500 red_threshold=0.200000 "
+        "ts=1782946000000 symbol=NEAR/USDT:USDT pside=long reason=yellow_to_orange"
     )
 
 


### PR DESCRIPTION
## Summary
- route existing `risk.mode_changed` and `hsl.transition` events to the opt-in live event console/text sinks
- add compact console summaries for HSL runtime mode changes and tier transitions
- update logging policy/progress docs with PR #966 deploy evidence and this slice

## Behavior
- observability-only: no HSL mode logic, risk decisions, order generation, replay behavior, or emitters changed
- event console remains opt-in via `logging.live_event_console` / `PASSIVBOT_LIVE_EVENT_CONSOLE`
- nested HSL metrics stay in the structured event stream; console prints only compact tier/threshold context

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py::test_route_table_keeps_data_events_off_console_by_default tests/test_live_event_bus.py::test_console_format_summarizes_risk_mode_changed tests/test_live_event_bus.py::test_console_format_summarizes_hsl_transition tests/test_passivbot_monitor.py::test_risk_mode_changed_event_emits_structured_summary tests/test_hsl_coin_mode.py::test_hsl_transition_falls_back_to_monitor_when_pipeline_absent -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py src/live/event_emitters.py src/passivbot_hsl.py`
- `git diff --check`