### PR TITLE
Project entry gate events to console

### DIFF
--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -94,6 +94,11 @@ because they are the primary operator-facing account state changes.
 `risk.mode_changed` and `hsl.transition` events are console-visible because
 mode changes and HSL tier transitions explain risk-state changes that affect
 trading.
+Initial-entry distance-gate, min-effective-cost, and realized-loss gate block
+events are console-visible because they explain operator-relevant order
+omissions: staged entries waiting for an acceptable market distance, entries
+skipped because the configured slot size is below exchange-effective minimums,
+and loss-realizing closes deferred by the realized-loss gate.
 Position-level `trailing.status` and `unstuck.status` events are console-visible
 because they explain why an existing position is waiting, armed, triggered, over
 budget, or blocked by the unstuck EMA gate. Unsupported strategy diagnostics

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,19 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` head:
 
-- `47f84d8c5` after PR #966, `Project account state events to console`.
+- `ca686cf5a` after PR #967, `Project risk state events to console`.
 
 Current logging-overhaul head:
 
-- `47f84d8c5` after PR #966, `Project account state events to console`.
+- `ca686cf5a` after PR #967, `Project risk state events to console`.
 
 Current work:
 
-- Branch `codex/v8-risk-hsl-console` projects existing `risk.mode_changed` and
-  `hsl.transition` events into the opt-in live event console/text sinks with
-  compact operator summaries. This continues the migration of user-facing
-  risk-state logs into the structured event stream without changing HSL mode
-  logic, risk decisions, order generation, or HSL replay behavior.
+- Branch `codex/v8-next-logging-console-slice` projects existing entry/risk
+  gate-block events into the opt-in live event console/text sinks with compact
+  operator summaries. This covers initial-entry distance gate blocked/cleared,
+  min-effective-cost entry skips, and realized-loss gate deferrals without
+  changing producer throttling, gate policy, order generation, or exchange I/O.
 
 Current review gate:
 
@@ -61,6 +61,24 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #967 at `ca686cf5a`.
+- PR #967 projected existing `risk.mode_changed` and `hsl.transition` events
+  into the opt-in live event console/text sinks with compact operator
+  summaries. It merged after Hermes and Claude approved and CI was green; Cursor
+  did not post during the bounded wait.
+- Bots were restarted from `/root/bots_vps5.yaml` and left running. Hyperliquid
+  exited quickly after Ctrl-C; Binance, Kucoin, GateIO, and OKX were still
+  present after the first 25-second grace window, then all exited within the
+  longer graceful wait without SIGTERM.
+- VPS5 smoke after restart reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, `missing_expected_count=0`, clean tracked repository
+  state at `repository.head=ca686cf5`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, and `logs.hard_matches=0`.
+  A second smoke after another five minutes stayed hard-green with the same
+  core signals. Remaining attention was non-hard startup state: active HSL
+  replay workers on four bots, Hyperliquid EMA-unavailable diagnostics for
+  cache-only stock symbols, staged refresh progress, and shutdown-slow history
+  from the restart.
 - Repository pulled through PR #966 at `47f84d8c5`.
 - PR #966 projected existing `fill.ingested`, `position.changed`, and
   `balance.changed` events into the opt-in live event console/text sinks with

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -687,12 +687,12 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.EXECUTION_CREATE_DEFERRED: EventRoute(console=False, text=False),
     EventTypes.EXECUTION_CREATE_SKIPPED: EventRoute(console=False, text=False),
     EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED: EventRoute(
-        console=False, text=False
+        console=True, text=True
     ),
     EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED: EventRoute(
-        console=False, text=False
+        console=True, text=True
     ),
-    EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED: EventRoute(console=False, text=False),
+    EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CANCEL_SENT: EventRoute(console=False),
     EventTypes.EXECUTION_CANCEL_SUCCEEDED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CANCEL_FAILED: EventRoute(console=True, text=True),
@@ -723,7 +723,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.RISK_ENTRY_COOLDOWN_DELTA_ANCHORED: EventRoute(
         console=False, text=False
     ),
-    EventTypes.REALIZED_LOSS_GATE_BLOCKED: EventRoute(console=False, text=False),
+    EventTypes.REALIZED_LOSS_GATE_BLOCKED: EventRoute(console=True, text=True),
     EventTypes.SINK_DEGRADED: EventRoute(console=True, text=True),
 }
 
@@ -779,6 +779,9 @@ _CONSOLE_EVENT_TAGS = {
     EventTypes.EXECUTION_CREATE_REJECTED: "order",
     EventTypes.EXECUTION_CREATE_DEFERRED: "gate",
     EventTypes.EXECUTION_CREATE_SKIPPED: "gate",
+    EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED: "entry",
+    EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED: "entry",
+    EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED: "entry",
     EventTypes.EXECUTION_CANCEL_SUCCEEDED: "order",
     EventTypes.EXECUTION_CANCEL_FAILED: "order",
     EventTypes.EXECUTION_CANCEL_AMBIGUOUS_TERMINAL: "order",
@@ -793,6 +796,7 @@ _CONSOLE_EVENT_TAGS = {
     EventTypes.HSL_STATUS: "risk",
     EventTypes.TRAILING_STATUS: "trailing",
     EventTypes.UNSTUCK_STATUS: "unstuck",
+    EventTypes.REALIZED_LOSS_GATE_BLOCKED: "risk",
     EventTypes.SINK_DEGRADED: "logging",
 }
 
@@ -935,6 +939,86 @@ def _console_create_filter_summary(event: LiveEvent) -> list[str]:
     symbols = _compact_csv(data.get("symbols"), limit=4)
     if symbols:
         parts.append(f"symbols={symbols}")
+    return parts
+
+
+def _console_entry_gate_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    action = _data_str(data, "action")
+    if action:
+        parts.append(f"action={action}")
+    order_type = _data_str(data, "order_type")
+    if order_type:
+        parts.append(f"type={order_type}")
+    qty = _data_float(data, "qty")
+    price = _data_float(data, "price")
+    market = _data_float(data, "market_price")
+    if qty:
+        parts.append(f"qty={qty}")
+    if price:
+        parts.append(f"price={price}")
+    if market:
+        parts.append(f"market={market}")
+    for label, key in (
+        ("dist", "distance_pct"),
+        ("threshold", "threshold_pct"),
+        ("tolerance", "tolerance_pct"),
+    ):
+        value = _data_number(data, key)
+        if value is not None:
+            parts.append(f"{label}={value:.4f}%")
+    return parts
+
+
+def _console_min_effective_cost_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    action = _data_str(data, "action")
+    if action:
+        parts.append(f"action={action}")
+    wanted = _data_float(data, "projected_initial_cost")
+    required = _data_float(data, "effective_min_cost")
+    if wanted and required:
+        parts.append(f"notional={wanted}/{required}")
+    else:
+        if wanted:
+            parts.append(f"wanted={wanted}")
+        if required:
+            parts.append(f"required={required}")
+    effective_limit = _data_number(data, "effective_limit")
+    if effective_limit is not None:
+        parts.append(f"effective_limit={effective_limit * 100.0:.4f}%")
+    entry_qty_pct = _data_number(data, "entry_initial_qty_pct")
+    if entry_qty_pct is not None:
+        parts.append(f"initial_qty={entry_qty_pct * 100.0:.4f}%")
+    return parts
+
+
+def _console_realized_loss_gate_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    order_type = _data_str(data, "order_type")
+    if order_type:
+        parts.append(f"type={order_type}")
+    qty = _data_float(data, "qty")
+    price = _data_float(data, "price")
+    if qty:
+        parts.append(f"qty={qty}")
+    if price:
+        parts.append(f"price={price}")
+    projected_pnl = _data_float(data, "projected_pnl")
+    if projected_pnl:
+        parts.append(f"projected_pnl={projected_pnl}")
+    projected_balance = _data_float(data, "projected_balance_after")
+    if projected_balance:
+        parts.append(f"projected_balance={projected_balance}")
+    balance_floor = _data_float(data, "balance_floor")
+    if balance_floor:
+        parts.append(f"floor={balance_floor}")
+    max_loss = _data_number(data, "max_realized_loss_pct")
+    if max_loss is not None:
+        parts.append(f"max_loss={max_loss * 100.0:.4f}%")
     return parts
 
 
@@ -1314,6 +1398,13 @@ def _console_data_summary(event: LiveEvent) -> list[str]:
     }:
         return _console_create_filter_summary(event)
     if event.event_type in {
+        EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
+        EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
+    }:
+        return _console_entry_gate_summary(event)
+    if event.event_type == EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED:
+        return _console_min_effective_cost_summary(event)
+    if event.event_type in {
         EventTypes.EXECUTION_CREATE_SUCCEEDED,
         EventTypes.EXECUTION_CREATE_FAILED,
         EventTypes.EXECUTION_CREATE_REJECTED,
@@ -1348,6 +1439,8 @@ def _console_data_summary(event: LiveEvent) -> list[str]:
         return _console_trailing_status_summary(event)
     if event.event_type == EventTypes.UNSTUCK_STATUS:
         return _console_unstuck_status_summary(event)
+    if event.event_type == EventTypes.REALIZED_LOSS_GATE_BLOCKED:
+        return _console_realized_loss_gate_summary(event)
     return []
 
 

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -220,9 +220,6 @@ def test_route_table_keeps_data_events_off_console_by_default():
     for event_type in (
         EventTypes.FORAGER_FEATURE_UNAVAILABLE,
         EventTypes.ACTION_PLANNED,
-        EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
-        EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
-        EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED,
         EventTypes.EMA_BUNDLE_STARTED,
         EventTypes.EMA_BUNDLE_COMPLETED,
         EventTypes.EMA_FALLBACK_USED,
@@ -244,7 +241,6 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.HSL_COOLDOWN_STARTED,
         EventTypes.HSL_COOLDOWN_ENDED,
         EventTypes.UNSTUCK_SELECTION,
-        EventTypes.REALIZED_LOSS_GATE_BLOCKED,
     ):
         assert DEFAULT_ROUTES[event_type].structured is True
         assert DEFAULT_ROUTES[event_type].monitor is True
@@ -256,6 +252,12 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CREATE_SKIPPED].console is False
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CONFIRMATION_TIMEOUT].console is True
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CONFIRMATION_TIMEOUT].text is True
+    assert DEFAULT_ROUTES[EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED].console is True
+    assert DEFAULT_ROUTES[EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED].text is True
+    assert DEFAULT_ROUTES[EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED].console is True
+    assert DEFAULT_ROUTES[EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED].text is True
+    assert DEFAULT_ROUTES[EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED].console is True
+    assert DEFAULT_ROUTES[EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED].text is True
     assert DEFAULT_ROUTES[EventTypes.FILL_INGESTED].console is True
     assert DEFAULT_ROUTES[EventTypes.FILL_INGESTED].text is True
     assert DEFAULT_ROUTES[EventTypes.POSITION_CHANGED].console is True
@@ -274,6 +276,8 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.TRAILING_STATUS].text is True
     assert DEFAULT_ROUTES[EventTypes.UNSTUCK_STATUS].console is True
     assert DEFAULT_ROUTES[EventTypes.UNSTUCK_STATUS].text is True
+    assert DEFAULT_ROUTES[EventTypes.REALIZED_LOSS_GATE_BLOCKED].console is True
+    assert DEFAULT_ROUTES[EventTypes.REALIZED_LOSS_GATE_BLOCKED].text is True
 
 
 def test_redact_payload_recurses_and_payload_hash_is_stable():
@@ -942,6 +946,85 @@ def test_console_format_summarizes_hsl_cooldown_seconds():
     assert format_console_event(event) == (
         "[risk] degraded tier=red cooldown=300s symbol=NEAR/USDT:USDT "
         "pside=long reason=cooldown_active"
+    )
+
+
+def test_console_format_summarizes_initial_entry_distance_gate_block():
+    event = LiveEvent(
+        EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
+        status="skipped",
+        cycle_id="cy_entry_gate",
+        symbol="BTC/USDT:USDT",
+        pside="long",
+        side="buy",
+        reason_code="initial_entry_distance_gate",
+        data={
+            "action": "skip_create",
+            "order_type": "entry_initial_normal_long",
+            "qty": 0.001,
+            "price": 98_750.0,
+            "market_price": 101_000.0,
+            "distance_pct": 2.278481012658,
+            "threshold_pct": 1.25,
+            "tolerance_pct": 0.1,
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[entry] skipped cycle=cy_entry_gate action=skip_create "
+        "type=entry_initial_normal_long qty=0.001 price=98750 market=101000 "
+        "dist=2.2785% threshold=1.2500% tolerance=0.1000% "
+        "symbol=BTC/USDT:USDT pside=long reason=initial_entry_distance_gate"
+    )
+
+
+def test_console_format_summarizes_min_effective_cost_block():
+    event = LiveEvent(
+        EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED,
+        status="skipped",
+        symbol="SOL/USDT:USDT",
+        pside="long",
+        reason_code="min_effective_cost_blocked",
+        data={
+            "action": "skip_create",
+            "projected_initial_cost": 3.25,
+            "effective_min_cost": 10.0,
+            "balance": 250.0,
+            "effective_limit": 0.12,
+            "entry_initial_qty_pct": 0.05,
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[entry] skipped action=skip_create notional=3.25/10 "
+        "effective_limit=12.0000% initial_qty=5.0000% "
+        "symbol=SOL/USDT:USDT pside=long reason=min_effective_cost_blocked"
+    )
+
+
+def test_console_format_summarizes_realized_loss_gate_block():
+    event = LiveEvent(
+        EventTypes.REALIZED_LOSS_GATE_BLOCKED,
+        status="deferred",
+        symbol="ETH/USDT:USDT",
+        pside="short",
+        reason_code="realized_loss_gate_blocked",
+        data={
+            "order_type": "close_grid_short",
+            "qty": 0.25,
+            "price": 3_100.0,
+            "projected_pnl": -12.5,
+            "projected_balance_after": 987.5,
+            "balance_floor": 990.0,
+            "max_realized_loss_pct": 0.01,
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[risk] deferred type=close_grid_short qty=0.25 price=3100 "
+        "projected_pnl=-12.5 projected_balance=987.5 floor=990 "
+        "max_loss=1.0000% symbol=ETH/USDT:USDT pside=short "
+        "reason=realized_loss_gate_blocked"
     )
 
 


### PR DESCRIPTION
## Summary
- Project existing entry/risk gate-block events to the opt-in live event console/text sinks.
- Add compact summaries for initial-entry distance gate blocked/cleared, min-effective-cost entry skips, and realized-loss gate deferrals.
- Update logging policy/progress docs for the console projection slice.

## Behavior
- Observability-only: no producer throttling, gate policy, order generation, exchange I/O, or Rust behavior changes.
- Uses already-emitted structured events and existing event data.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py::test_route_table_keeps_data_events_off_console_by_default tests/test_live_event_bus.py::test_console_format_summarizes_initial_entry_distance_gate_block tests/test_live_event_bus.py::test_console_format_summarizes_min_effective_cost_block tests/test_live_event_bus.py::test_console_format_summarizes_realized_loss_gate_block -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py
- git diff --check
- silent-handling scan on touched files: only pre-existing event-bus sink protection matches