### PR TITLE
Project health summaries to event console

### DIFF
--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -99,6 +99,11 @@ events are console-visible because they explain operator-relevant order
 omissions: staged entries waiting for an acceptable market distance, entries
 skipped because the configured slot size is below exchange-effective minimums,
 and loss-realizing closes deferred by the realized-loss gate.
+Periodic `health.summary` events are console-visible because they provide a
+compact operator heartbeat covering uptime, loop latency, position counts,
+recent order/fill activity, errors, and resource pressure. Degraded
+`health.summary` events such as execution-loop error bursts must stay immediate
+and must not expose raw exchange URLs or credentials in console summaries.
 Position-level `trailing.status` and `unstuck.status` events are console-visible
 because they explain why an existing position is waiting, armed, triggered, over
 budget, or blocked by the unstuck EMA gate. Unsupported strategy diagnostics

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,20 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` head:
 
-- `ca686cf5a` after PR #967, `Project risk state events to console`.
+- `9ff2b8582` after PR #968, `Project entry gate events to console`.
 
 Current logging-overhaul head:
 
-- `ca686cf5a` after PR #967, `Project risk state events to console`.
+- `9ff2b8582` after PR #968, `Project entry gate events to console`.
 
 Current work:
 
-- Branch `codex/v8-next-logging-console-slice` projects existing entry/risk
-  gate-block events into the opt-in live event console/text sinks with compact
-  operator summaries. This covers initial-entry distance gate blocked/cleared,
-  min-effective-cost entry skips, and realized-loss gate deferrals without
-  changing producer throttling, gate policy, order generation, or exchange I/O.
+- Branch `codex/v8-next-logging-slice-2` projects existing `health.summary`
+  events into the opt-in live event console/text sinks with compact operator
+  summaries. It keeps periodic health as an INFO-level event matching the
+  existing legacy `[health]` line, keeps degraded execution-loop error bursts
+  immediate, and does not change health producer timing, trading behavior,
+  exchange I/O, or resource counters.
 
 Current review gate:
 
@@ -61,6 +62,28 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #968 at `9ff2b8582`.
+- PR #968 projected existing initial-entry distance gate blocked/cleared,
+  min-effective-cost entry skip, and realized-loss gate deferral events into
+  the opt-in live event console/text sinks with compact operator summaries. It
+  merged after Hermes and Claude approved and CI was green; Cursor did not post
+  during the bounded wait.
+- Bots were restarted from `/root/bots_vps5.yaml` and left running. Hyperliquid
+  exited quickly after Ctrl-C; Binance, Kucoin, GateIO, and OKX were still
+  present after 25 seconds, and all exited gracefully within the longer wait
+  window without SIGTERM.
+- VPS5 smoke immediately after restart reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, `missing_expected_count=0`, clean tracked repository
+  state at `repository.head=9ff2b858`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, and `logs.hard_matches=0`.
+  A later smoke observed one Hyperliquid routine fill-prefetch `RequestTimeout`
+  which recovered on subsequent refreshes while fill coverage remained ready.
+  The final short-window smoke reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, clean tracked state, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `fill_refresh.failed=0`, and
+  `logs.hard_matches=0`. Remaining attention was non-hard Hyperliquid EMA
+  unavailable diagnostics for cache-only stock symbols and active HSL replay on
+  two bots.
 - Repository pulled through PR #967 at `ca686cf5a`.
 - PR #967 projected existing `risk.mode_changed` and `hsl.transition` events
   into the opt-in live event console/text sinks with compact operator

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -636,7 +636,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.BOT_STOPPING: EventRoute(console=True, text=True),
     EventTypes.BOT_SHUTDOWN_STAGE: EventRoute(console=True, text=True),
     EventTypes.BOT_STOPPED: EventRoute(console=True, text=True),
-    EventTypes.HEALTH_SUMMARY: EventRoute(console=False, text=False),
+    EventTypes.HEALTH_SUMMARY: EventRoute(console=True, text=True),
     EventTypes.MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED: EventRoute(
         console=False, text=False
     ),
@@ -767,6 +767,7 @@ _CONSOLE_EVENT_TAGS = {
     EventTypes.BOT_STOPPING: "bot",
     EventTypes.BOT_SHUTDOWN_STAGE: "shutdown",
     EventTypes.BOT_STOPPED: "bot",
+    EventTypes.HEALTH_SUMMARY: "health",
     EventTypes.CYCLE_STARTED: "cycle",
     EventTypes.CYCLE_COMPLETED: "cycle",
     EventTypes.CYCLE_DEGRADED: "cycle",
@@ -1257,6 +1258,97 @@ def _console_forager_selection_summary(event: LiveEvent) -> list[str]:
     return parts
 
 
+def _console_health_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    if event.reason_code == ReasonCodes.EXECUTION_LOOP_ERROR_BURST:
+        count = _data_int(data, "count")
+        window = _data_int(data, "window_s")
+        if count is not None:
+            if window is not None:
+                parts.append(f"errors={count}/{window}s")
+            else:
+                parts.append(f"errors={count}")
+        endpoints = data.get("top_endpoints")
+        if isinstance(endpoints, list):
+            shown = []
+            for item in endpoints[:3]:
+                if not isinstance(item, Mapping):
+                    continue
+                endpoint = _data_str(item, "endpoint")
+                endpoint_count = _data_int(item, "count")
+                if endpoint and endpoint_count is not None:
+                    shown.append(f"{endpoint}:{endpoint_count}")
+            if shown:
+                parts.append("top=" + ",".join(shown))
+        latest_type = _data_str(data, "latest_error_type")
+        if latest_type:
+            parts.append(f"latest={latest_type}")
+        latest_status = _data_str(data, "latest_status")
+        if latest_status:
+            parts.append(f"status={latest_status}")
+        latest_code = _data_str(data, "latest_code")
+        if latest_code:
+            parts.append(f"code={latest_code}")
+        return parts
+
+    uptime_ms = _data_int(data, "uptime_ms")
+    if uptime_ms is not None:
+        parts.append(f"uptime={uptime_ms // 1000}s")
+    loop_ms = _data_int(data, "last_loop_duration_ms")
+    if loop_ms is not None:
+        parts.append(f"loop={loop_ms / 1000.0:.1f}s")
+    long_count = _data_int(data, "positions_long")
+    short_count = _data_int(data, "positions_short")
+    if long_count is not None or short_count is not None:
+        parts.append(f"positions={long_count or 0}L/{short_count or 0}S")
+    balance = _data_float(data, "balance_raw")
+    if balance:
+        parts.append(f"balance={balance}")
+    equity = _data_float(data, "equity")
+    if equity:
+        parts.append(f"equity={equity}")
+    placed = _data_int(data, "orders_placed")
+    cancelled = _data_int(data, "orders_cancelled")
+    if placed is not None or cancelled is not None:
+        parts.append(f"orders=+{placed or 0}/-{cancelled or 0}")
+    fills = _data_int(data, "fills")
+    if fills is not None:
+        fill_part = f"fills={fills}"
+        pnl = _data_float(data, "pnl")
+        if pnl and fills:
+            fill_part += f":pnl={pnl}"
+        parts.append(fill_part)
+    errors = _data_int(data, "errors_last_hour")
+    if errors is not None:
+        parts.append(f"errors={errors}/h")
+    ws = _data_int(data, "ws_reconnects")
+    if ws:
+        parts.append(f"ws={ws}")
+    rate_limits = _data_int(data, "rate_limits")
+    if rate_limits:
+        parts.append(f"rate_limits={rate_limits}")
+    rss_bytes = _data_int(data, "rss_bytes")
+    if rss_bytes is not None:
+        parts.append(f"rss={rss_bytes / 1024.0 / 1024.0:.1f}MiB")
+    queue_depth = _data_int(data, "event_queue_depth")
+    if queue_depth:
+        queue_max = _data_int(data, "event_queue_maxsize")
+        if queue_max:
+            parts.append(f"event_q={queue_depth}/{queue_max}")
+        else:
+            parts.append(f"event_q={queue_depth}")
+    dropped = _data_int(data, "event_dropped_total")
+    if dropped:
+        parts.append(f"event_dropped={dropped}")
+    sink_errors = _data_int(data, "event_sink_error_total")
+    if sink_errors:
+        parts.append(f"sink_errors={sink_errors}")
+    if data.get("event_pipeline_worker_alive") is False:
+        parts.append("event_worker=dead")
+    return parts
+
+
 def _format_console_ratio(value: Any) -> str | None:
     if value is None:
         return None
@@ -1423,6 +1515,8 @@ def _console_data_summary(event: LiveEvent) -> list[str]:
         return _console_rust_summary(event)
     if event.event_type == EventTypes.FORAGER_SELECTION:
         return _console_forager_selection_summary(event)
+    if event.event_type == EventTypes.HEALTH_SUMMARY:
+        return _console_health_summary(event)
     if event.event_type == EventTypes.FILL_INGESTED:
         return _console_fill_ingested_summary(event)
     if event.event_type == EventTypes.POSITION_CHANGED:

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1222,7 +1222,7 @@ def _emit_health_summary_event_unchecked(
     _safe_emit(
         bot,
         EventTypes.HEALTH_SUMMARY,
-        level="debug",
+        level="info",
         component="bot.health",
         tags=(EventTags.HEALTH, EventTags.RESOURCE),
         cycle_id=current_live_event_cycle_id(bot),

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -232,7 +232,6 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.EXCHANGE_CONFIG_REFRESH,
         EventTypes.FILLS_REFRESH_SUMMARY,
         EventTypes.BOT_STARTUP_TIMING,
-        EventTypes.HEALTH_SUMMARY,
         EventTypes.PLANNING_DEFER_SUMMARY,
         EventTypes.PLANNING_SYMBOL_STATE,
         EventTypes.HSL_RAW_RED_PENDING,
@@ -270,6 +269,8 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.HSL_TRANSITION].text is True
     assert DEFAULT_ROUTES[EventTypes.BOT_SHUTDOWN_STAGE].console is True
     assert DEFAULT_ROUTES[EventTypes.BOT_SHUTDOWN_STAGE].text is True
+    assert DEFAULT_ROUTES[EventTypes.HEALTH_SUMMARY].console is True
+    assert DEFAULT_ROUTES[EventTypes.HEALTH_SUMMARY].text is True
     assert DEFAULT_ROUTES[EventTypes.HSL_STATUS].console is True
     assert DEFAULT_ROUTES[EventTypes.HSL_STATUS].text is True
     assert DEFAULT_ROUTES[EventTypes.TRAILING_STATUS].console is True
@@ -1112,6 +1113,75 @@ def test_console_format_summarizes_unstuck_status():
         "next=BTC/USDT:USDT:target=101000:target_dist=0.5000%:ema_gate=1.2500% "
         "short:disabled over_budget=long changed=true reason=unstuck_status"
     )
+
+
+def test_console_format_summarizes_periodic_health():
+    event = LiveEvent(
+        EventTypes.HEALTH_SUMMARY,
+        status="succeeded",
+        cycle_id="cy_health",
+        reason_code=ReasonCodes.PERIODIC_HEALTH_SUMMARY,
+        data={
+            "uptime_ms": 123_456,
+            "last_loop_duration_ms": 1_250,
+            "positions_long": 2,
+            "positions_short": 1,
+            "balance_raw": 1_005.25,
+            "equity": 1_010.75,
+            "orders_placed": 3,
+            "orders_cancelled": 1,
+            "fills": 2,
+            "pnl": -1.5,
+            "errors_last_hour": 1,
+            "ws_reconnects": 2,
+            "rate_limits": 3,
+            "rss_bytes": 157_286_400,
+            "event_queue_depth": 4,
+            "event_queue_maxsize": 1000,
+            "event_dropped_total": 2,
+            "event_sink_error_total": 1,
+            "event_pipeline_worker_alive": True,
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[health] succeeded cycle=cy_health uptime=123s loop=1.2s "
+        "positions=2L/1S balance=1005.25 equity=1010.75 orders=+3/-1 "
+        "fills=2:pnl=-1.5 errors=1/h ws=2 rate_limits=3 rss=150.0MiB "
+        "event_q=4/1000 event_dropped=2 sink_errors=1 "
+        "reason=periodic_health_summary"
+    )
+
+
+def test_console_format_summarizes_health_error_burst_without_raw_error():
+    event = LiveEvent(
+        EventTypes.HEALTH_SUMMARY,
+        level="warning",
+        status="degraded",
+        cycle_id="cy_error",
+        reason_code=ReasonCodes.EXECUTION_LOOP_ERROR_BURST,
+        data={
+            "count": 3,
+            "window_s": 60,
+            "top_endpoints": [
+                {"endpoint": "account-overview", "count": 2},
+                {"endpoint": "open-orders", "count": 1},
+            ],
+            "latest_error_type": "RequestTimeout",
+            "latest_status": "-",
+            "latest_code": "-",
+            "latest_error": "kucoinfutures GET https://example.invalid/account?apiKey=SECRET",
+        },
+    )
+
+    rendered = format_console_event(event)
+    assert rendered == (
+        "[health] degraded cycle=cy_error errors=3/60s "
+        "top=account-overview:2,open-orders:1 latest=RequestTimeout "
+        "status=- code=- reason=execution_loop_error_burst"
+    )
+    assert "SECRET" not in rendered
+    assert "example.invalid" not in rendered
 
 
 def test_console_format_summarizes_fill_ingested():

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -964,7 +964,7 @@ def test_health_summary_event_emitter_records_payload():
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     event = sink.events[0]
     assert event.event_type == EventTypes.HEALTH_SUMMARY
-    assert event.level == "debug"
+    assert event.level == "info"
     assert event.component == "bot.health"
     assert event.tags == ("health", "resource")
     assert event.cycle_id == "cy_health"


### PR DESCRIPTION
## Summary
- Project existing health.summary events to the opt-in live-event console/text sinks.
- Add compact console summaries for periodic health heartbeat data and degraded execution-loop error bursts.
- Align periodic health.summary event level with the existing INFO legacy [health] line and update logging/progress docs.

## Behavior
- Observability-only: no trading behavior, exchange I/O, health producer timing, resource counters, or order/risk logic changes.
- Degraded execution-loop bursts omit raw error/URL text from console summaries; structured event data remains unchanged.

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py::test_route_table_keeps_data_events_off_console_by_default tests/test_live_event_bus.py::test_console_format_summarizes_periodic_health tests/test_live_event_bus.py::test_console_format_summarizes_health_error_burst_without_raw_error tests/test_passivbot_monitor.py::test_health_summary_event_emitter_records_payload tests/test_passivbot_monitor.py::test_planning_symbol_state_event_summarizes_and_bounds_records -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_passivbot_monitor.py::test_health_summary_event_emitter_records_payload tests/test_passivbot_monitor.py::test_log_health_summary_emits_structured_event tests/test_passivbot_balance_split.py::test_execution_loop_error_burst_emits_structured_health_event -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py src/live/event_emitters.py
- git diff --check
- silent-handling scan on touched files: only pre-existing event best-effort/sink and test-fake matches; no new exception/fallback handling added