### PR TITLE
Refine trailing and unstuck event console summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Improved opt-in live event console summaries for trailing and unstuck
+  positions, including threshold/retracement prices and unstuck selection
+  details from existing structured events.
 - Added `--level` filtering to `passivbot tool live-event-query`, so operator
   event, timeline, trace-summary, order-trace, and cycle-trace reports can be
   scoped by live-event severity.

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -104,15 +104,19 @@ compact operator heartbeat covering uptime, loop latency, position counts,
 recent order/fill activity, errors, and resource pressure. Degraded
 `health.summary` events such as execution-loop error bursts must stay immediate
 and must not expose raw exchange URLs or credentials in console summaries.
-Position-level `trailing.status` and `unstuck.status` events are console-visible
-because they explain why an existing position is waiting, armed, triggered, over
-budget, or blocked by the unstuck EMA gate. Unsupported strategy diagnostics
-must say so explicitly instead of fabricating threshold/retracement prices.
+Position-level `trailing.status`, `unstuck.status`, and `unstuck.selection`
+events are console-visible because they explain why an existing position is
+waiting, armed, triggered, over budget, selected for unstucking, or blocked by
+the unstuck EMA gate. Unsupported strategy diagnostics must say so explicitly
+instead of fabricating threshold/retracement prices.
 Supported trailing diagnostics should include the selected mode, such as
 `trailing`, `grid`, `auto_reduce`, `unstuck`, `none`, or `other`, when the next
-order state is known. `forager.selection` events are also console-visible
-through a throttled compact summary because they explain which coins are being
-selected, retained, or skipped when forager entries are possible.
+order state is known. They should also show the effective threshold percentage
+and price, retracement percentage and price, and the projected retracement price
+that would apply if the threshold were reached. `forager.selection` events are
+also console-visible through a throttled compact summary because they explain
+which coins are being selected, retained, or skipped when forager entries are
+possible.
 
 ## Review Heuristic
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,20 +19,19 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` head:
 
-- `9ff2b8582` after PR #968, `Project entry gate events to console`.
+- `426f3ae0b` after PR #969, `Project health summaries to event console`.
 
 Current logging-overhaul head:
 
-- `9ff2b8582` after PR #968, `Project entry gate events to console`.
+- `426f3ae0b` after PR #969, `Project health summaries to event console`.
 
 Current work:
 
-- Branch `codex/v8-next-logging-slice-2` projects existing `health.summary`
-  events into the opt-in live event console/text sinks with compact operator
-  summaries. It keeps periodic health as an INFO-level event matching the
-  existing legacy `[health]` line, keeps degraded execution-loop error bursts
-  immediate, and does not change health producer timing, trading behavior,
-  exchange I/O, or resource counters.
+- Branch `codex/v8-trailing-unstuck-event-console` refines the existing
+  trailing/unstuck console projection. It keeps trading behavior unchanged,
+  routes the already-throttled `unstuck.selection` event to the opt-in live
+  event console/text sinks, and makes trailing/unstuck summaries more directly
+  operator-facing.
 
 Current review gate:
 
@@ -62,6 +61,25 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #969 at `426f3ae0b`.
+- PR #969 projected existing `health.summary` events into the opt-in live event
+  console/text sinks with compact operator summaries. It kept periodic health
+  as an INFO-level event matching the existing legacy `[health]` line, kept
+  degraded execution-loop error bursts immediate, and did not change health
+  producer timing, trading behavior, exchange I/O, or resource counters. It
+  merged after Hermes approved, Claude approved, and CI was green; Cursor did
+  not post during the bounded wait.
+- Bots were restarted from `/root/bots_vps5.yaml` and left running. Hyperliquid
+  exited within the first graceful window; Binance, GateIO, and OKX exited
+  during the longer graceful window; Kucoin still required SIGTERM after the
+  full wait window.
+- VPS5 smoke after restart reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, clean tracked repository state at
+  `repository.head=426f3ae0`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `logs.hard_matches=0`, and
+  `fill_refresh.failed=0`. The event pipeline saw `health.summary` with no
+  degraded/dropped/sink errors. Remaining attention was non-hard Hyperliquid
+  EMA-unavailable diagnostics and active HSL replay.
 - Repository pulled through PR #968 at `9ff2b8582`.
 - PR #968 projected existing initial-entry distance gate blocked/cleared,
   min-effective-cost entry skip, and realized-loss gate deferral events into

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -719,7 +719,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.HSL_COOLDOWN_ENDED: EventRoute(console=False, text=False),
     EventTypes.TRAILING_STATUS: EventRoute(console=True, text=True),
     EventTypes.UNSTUCK_STATUS: EventRoute(console=True, text=True),
-    EventTypes.UNSTUCK_SELECTION: EventRoute(console=False, text=False),
+    EventTypes.UNSTUCK_SELECTION: EventRoute(console=True, text=True),
     EventTypes.RISK_ENTRY_COOLDOWN_DELTA_ANCHORED: EventRoute(
         console=False, text=False
     ),
@@ -797,6 +797,7 @@ _CONSOLE_EVENT_TAGS = {
     EventTypes.HSL_STATUS: "risk",
     EventTypes.TRAILING_STATUS: "trailing",
     EventTypes.UNSTUCK_STATUS: "unstuck",
+    EventTypes.UNSTUCK_SELECTION: "unstuck",
     EventTypes.REALIZED_LOSS_GATE_BLOCKED: "risk",
     EventTypes.SINK_DEGRADED: "logging",
 }
@@ -1410,34 +1411,40 @@ def _console_trailing_status_summary(event: LiveEvent) -> list[str]:
         parts.append(f"mode={selected_mode}")
     threshold_met = data.get("threshold_met")
     if threshold_met is not None:
-        parts.append(f"threshold_met={bool(threshold_met)}")
+        parts.append(f"threshold_met={'yes' if bool(threshold_met) else 'no'}")
     threshold_pct = _data_number(data, "threshold_pct")
-    if threshold_pct is not None:
+    threshold_price = _data_number(data, "threshold_price")
+    if threshold_pct is not None and threshold_price:
+        parts.append(f"threshold={threshold_pct * 100.0:.4f}%@{threshold_price:g}")
+    elif threshold_pct is not None:
         parts.append(f"threshold={threshold_pct * 100.0:.4f}%")
-    threshold_price = _data_float(data, "threshold_price")
-    if threshold_price:
-        parts.append(f"threshold_price={threshold_price}")
+    elif threshold_price:
+        parts.append(f"threshold_price={threshold_price:g}")
     threshold_dist = _data_number(data, "current_vs_threshold_ratio")
     if threshold_dist is not None:
         parts.append(f"threshold_dist={threshold_dist * 100.0:.4f}%")
     retracement_met = data.get("retracement_met")
     if retracement_met is not None:
-        parts.append(f"retracement_met={bool(retracement_met)}")
+        parts.append(f"retracement_met={'yes' if bool(retracement_met) else 'no'}")
     retracement_pct = _data_number(data, "retracement_pct")
-    if retracement_pct is not None:
+    retracement_price = _data_number(data, "retracement_price")
+    if retracement_pct is not None and retracement_price:
+        parts.append(f"retracement={retracement_pct * 100.0:.4f}%@{retracement_price:g}")
+    elif retracement_pct is not None:
         parts.append(f"retracement={retracement_pct * 100.0:.4f}%")
-    retracement_price = _data_float(data, "retracement_price")
-    if retracement_price:
-        parts.append(f"retracement_price={retracement_price}")
+    elif retracement_price:
+        parts.append(f"retracement_price={retracement_price:g}")
     retracement_dist = _data_number(data, "current_vs_retracement_ratio")
     if retracement_dist is not None:
         parts.append(f"retracement_dist={retracement_dist * 100.0:.4f}%")
-    projected = _data_float(data, "threshold_projection_retracement_price")
-    if projected:
-        parts.append(f"threshold_retrace_price={projected}")
-    current_price = _data_float(data, "current_price")
+    projected = _data_number(data, "threshold_projection_retracement_price")
+    if projected and retracement_pct is not None:
+        parts.append(f"if_threshold_retrace={retracement_pct * 100.0:.4f}%@{projected:g}")
+    elif projected:
+        parts.append(f"if_threshold_retrace_price={projected:g}")
+    current_price = _data_number(data, "current_price")
     if current_price:
-        parts.append(f"current={current_price}")
+        parts.append(f"current={current_price:g}")
     return parts
 
 
@@ -1453,29 +1460,49 @@ def _console_unstuck_status_summary(event: LiveEvent) -> list[str]:
                 continue
             status = str(info.get("status") or "unknown")
             bit = f"{pside}:{status}"
-            allowance = _data_float(info, "allowance")
-            if allowance:
-                bit += f":allowance={allowance}"
+            allowance = _data_number(info, "allowance")
+            if allowance is not None:
+                bit += f" allowance={allowance:g}"
             if info.get("over_budget") is True:
-                bit += ":over_budget"
+                bit += " over_budget"
             next_symbol = _data_str(info, "next_symbol")
             if next_symbol:
-                bit += f":next={next_symbol}"
-            target_price = _data_float(info, "next_target_price")
+                bit += f" candidate={next_symbol}"
+            target_price = _data_number(info, "next_target_price")
             if target_price:
-                bit += f":target={target_price}"
+                bit += f" target={target_price:g}"
             target_dist = _data_number(info, "next_target_distance_ratio")
             if target_dist is not None:
-                bit += f":target_dist={target_dist * 100.0:.4f}%"
+                bit += f" target_dist={target_dist * 100.0:.4f}%"
             trigger_dist = _data_number(info, "next_unstuck_trigger_distance_ratio")
             if trigger_dist is not None:
-                bit += f":ema_gate={trigger_dist * 100.0:.4f}%"
+                bit += f" ema_gate_dist={trigger_dist * 100.0:.4f}%"
             side_parts.append(bit)
         if side_parts:
             parts.append(" ".join(side_parts))
     over_budget = _compact_csv(data.get("over_budget_sides"), limit=2)
     if over_budget:
         parts.append(f"over_budget={over_budget}")
+    if data.get("changed") is True:
+        parts.append("changed=true")
+    return parts
+
+
+def _console_unstuck_selection_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    entry_price = _data_number(data, "entry_price")
+    if entry_price:
+        parts.append(f"entry={entry_price:g}")
+    current_price = _data_number(data, "current_price")
+    if current_price:
+        parts.append(f"current={current_price:g}")
+    diff_pct = _data_number(data, "price_diff_pct")
+    if diff_pct is not None:
+        parts.append(f"pos_pnl_dist={diff_pct:.4f}%")
+    allowance = _data_number(data, "allowance")
+    if allowance is not None:
+        parts.append(f"allowance={allowance:g}")
     if data.get("changed") is True:
         parts.append("changed=true")
     return parts
@@ -1533,6 +1560,8 @@ def _console_data_summary(event: LiveEvent) -> list[str]:
         return _console_trailing_status_summary(event)
     if event.event_type == EventTypes.UNSTUCK_STATUS:
         return _console_unstuck_status_summary(event)
+    if event.event_type == EventTypes.UNSTUCK_SELECTION:
+        return _console_unstuck_selection_summary(event)
     if event.event_type == EventTypes.REALIZED_LOSS_GATE_BLOCKED:
         return _console_realized_loss_gate_summary(event)
     return []

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -239,7 +239,6 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.HSL_RED_FINALIZED_WITHOUT_ORDER,
         EventTypes.HSL_COOLDOWN_STARTED,
         EventTypes.HSL_COOLDOWN_ENDED,
-        EventTypes.UNSTUCK_SELECTION,
     ):
         assert DEFAULT_ROUTES[event_type].structured is True
         assert DEFAULT_ROUTES[event_type].monitor is True
@@ -277,6 +276,8 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.TRAILING_STATUS].text is True
     assert DEFAULT_ROUTES[EventTypes.UNSTUCK_STATUS].console is True
     assert DEFAULT_ROUTES[EventTypes.UNSTUCK_STATUS].text is True
+    assert DEFAULT_ROUTES[EventTypes.UNSTUCK_SELECTION].console is True
+    assert DEFAULT_ROUTES[EventTypes.UNSTUCK_SELECTION].text is True
     assert DEFAULT_ROUTES[EventTypes.REALIZED_LOSS_GATE_BLOCKED].console is True
     assert DEFAULT_ROUTES[EventTypes.REALIZED_LOSS_GATE_BLOCKED].text is True
 
@@ -1056,9 +1057,9 @@ def test_console_format_summarizes_trailing_status():
 
     assert format_console_event(event) == (
         "[trailing] succeeded cycle=cy_trailing kind=entry "
-        "trailing_status=waiting_threshold mode=grid threshold_met=False threshold=1.2500% "
-        "threshold_price=98750 threshold_dist=2.2785% retracement_met=False retracement=0.4000% "
-        "retracement_price=99145 retracement_dist=1.8710% threshold_retrace_price=99145 current=101000 "
+        "trailing_status=waiting_threshold mode=grid threshold_met=no threshold=1.2500%@98750 "
+        "threshold_dist=2.2785% retracement_met=no retracement=0.4000%@99145 "
+        "retracement_dist=1.8710% if_threshold_retrace=0.4000%@99145 current=101000 "
         "symbol=BTC/USDT:USDT pside=long reason=trailing_status"
     )
 
@@ -1109,9 +1110,32 @@ def test_console_format_summarizes_unstuck_status():
     )
 
     assert format_console_event(event) == (
-        "[unstuck] succeeded long:ok:allowance=-12.3:over_budget:"
-        "next=BTC/USDT:USDT:target=101000:target_dist=0.5000%:ema_gate=1.2500% "
+        "[unstuck] succeeded long:ok allowance=-12.3 over_budget "
+        "candidate=BTC/USDT:USDT target=101000 target_dist=0.5000% ema_gate_dist=1.2500% "
         "short:disabled over_budget=long changed=true reason=unstuck_status"
+    )
+
+
+def test_console_format_summarizes_unstuck_selection():
+    event = LiveEvent(
+        EventTypes.UNSTUCK_SELECTION,
+        status="succeeded",
+        symbol="SUI/USDT:USDT",
+        pside="long",
+        reason_code="unstuck_selection",
+        data={
+            "changed": True,
+            "entry_price": 1.0,
+            "current_price": 1.1,
+            "price_diff_pct": 10.0,
+            "allowance": -12.3,
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[unstuck] succeeded entry=1 current=1.1 pos_pnl_dist=10.0000% "
+        "allowance=-12.3 changed=true symbol=SUI/USDT:USDT pside=long "
+        "reason=unstuck_selection"
     )
 
 


### PR DESCRIPTION
## Summary
- route the existing throttled unstuck.selection event to the opt-in live event console/text sinks
- make trailing console summaries show threshold/retracement pct@price and projected retracement-at-threshold more directly
- make unstuck status/selection summaries more operator-facing and update logging docs/progress

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_passivbot_monitor.py::test_unstuck_status_event_emits_structured_summary tests/test_passivbot_monitor.py::test_trailing_status_event_emits_structured_summary tests/test_passivbot_monitor.py::test_unstuck_selection_event_emits_structured_summary -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py
- git diff --check

Trading behavior unchanged: event routing/formatting only; no Rust, exchange I/O, order construction, or readiness gates touched.