### PR TITLE
Enable live event console by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live event console summaries are now enabled by default for `passivbot live`;
+  set `logging.live_event_console=false` or `PASSIVBOT_LIVE_EVENT_CONSOLE=0`
+  to opt out while legacy console logs are still being migrated.
 - Improved opt-in live event console summaries for trailing and unstuck
   positions, including threshold/retracement prices and unstuck selection
   details from existing structured events.

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -77,20 +77,23 @@ Unknown profile names should fail visibly instead of being ignored silently.
 
 ## Live Event Console Projection
 
-`logging.live_event_console=true` or `PASSIVBOT_LIVE_EVENT_CONSOLE=1` enables
-an opt-in console sink fed by the structured live event pipeline. It is disabled
-by default while legacy stdlib console logs still exist, because enabling it can
-duplicate some order/execution lifecycle messages. Use it for controlled smoke
-tests of event-stream console formatting before migrating default console output.
+The live event console sink is enabled by default and is fed by the structured
+live event pipeline. Set `logging.live_event_console=false` or
+`PASSIVBOT_LIVE_EVENT_CONSOLE=0` to disable it during controlled comparisons.
+Some legacy stdlib console logs still exist, so the default projection may
+temporarily duplicate a few order/execution lifecycle messages until those
+legacy call sites are migrated.
 The console projection is operator-facing and local: it should prefer
-trading-relevant summaries over internal data plumbing. Do not ship opt-in
-console/text output containing account-state magnitudes such as balance, equity,
-PnL, fees, or position size to shared or centralized log aggregation without a
-deliberate redaction policy. HSL status events are console-visible
-only when they are pside-level, red/cooldown, or tied to a held coin; routine
-flat coin-universe status remains in the structured event stream but is kept off
-the console. Fill, position, and balance change events are console-visible
-because they are the primary operator-facing account state changes.
+trading-relevant summaries over internal data plumbing. Because this projection
+is enabled by default, account-state magnitudes such as balance, equity, PnL,
+fees, or position size may appear on the operator console by default. Do not
+forward console/stdout to shared or centralized log aggregation without either
+opting out or applying a deliberate redaction policy. HSL status events are
+console-visible only when they are pside-level, red/cooldown, or tied to a held
+coin; routine flat coin-universe status remains in the structured event stream
+but is kept off the console. Fill, position, and balance change events are
+console-visible because they are the primary operator-facing account state
+changes.
 `risk.mode_changed` and `hsl.transition` events are console-visible because
 mode changes and HSL tier transitions explain risk-state changes that affect
 trading.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,18 @@ Last updated: 2026-07-01.
 
 Current `origin/v8` head:
 
-- `426f3ae0b` after PR #969, `Project health summaries to event console`.
+- `ac425a1f0` after PR #970, `Refine trailing and unstuck event console summaries`.
 
 Current logging-overhaul head:
 
-- `426f3ae0b` after PR #969, `Project health summaries to event console`.
+- `ac425a1f0` after PR #970, `Refine trailing and unstuck event console summaries`.
 
 Current work:
 
-- Branch `codex/v8-trailing-unstuck-event-console` refines the existing
-  trailing/unstuck console projection. It keeps trading behavior unchanged,
-  routes the already-throttled `unstuck.selection` event to the opt-in live
-  event console/text sinks, and makes trailing/unstuck summaries more directly
-  operator-facing.
+- Branch `codex/v8-live-event-console-default` makes the structured live event
+  console projection default-on for `passivbot live`, while keeping explicit
+  config/env opt-outs. This moves default operator output closer to the target
+  shape where console is a projection of the structured event stream.
 
 Current review gate:
 
@@ -61,6 +60,25 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #970 at `ac425a1f0`.
+- PR #970 refined existing trailing/unstuck event-console summaries, routed the
+  already-throttled `unstuck.selection` event to the opt-in console/text sinks,
+  and kept trading behavior unchanged. It merged after Claude and Hermes
+  approved with no findings and CI was green; Cursor did not post during the
+  bounded wait.
+- Bots were restarted from `/root/bots_vps5.yaml` and left running. Hyperliquid
+  exited during the first graceful window; Binance, GateIO, and OKX exited
+  during the longer graceful window; Kucoin still required SIGTERM after the
+  full wait window.
+- VPS5 settled smoke after restart reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, clean tracked repository state at
+  `repository.head=ac425a1f`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `fill_refresh.failed=0`, and
+  `logs.hard_matches=0`. Remaining attention was non-hard active HSL replay on
+  three forager bots and Hyperliquid EMA-unavailable diagnostics.
+- The deployed VPS5 configs did not set `logging.live_event_console`, so PR
+  #970's new console projection was present in the event-console path but not
+  visible in the default legacy console logs on that host.
 - Repository pulled through PR #969 at `426f3ae0b`.
 - PR #969 projected existing `health.summary` events into the opt-in live event
   console/text sinks with compact operator summaries. It kept periodic health

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -335,6 +335,19 @@ def normalize_live_event_console_enabled(value: Any) -> bool:
     return bool(value)
 
 
+def resolve_live_event_console_enabled(
+    *,
+    config_value: Any = None,
+    env_value: Any = None,
+    default: bool = True,
+) -> bool:
+    if env_value is not None:
+        return normalize_live_event_console_enabled(env_value)
+    if config_value is not None:
+        return normalize_live_event_console_enabled(config_value)
+    return bool(default)
+
+
 PHASE1_EVENT_TYPES = {
     EventTypes.BOT_STARTED,
     EventTypes.BOT_READY,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -67,9 +67,9 @@ from live.event_bus import (
     LiveEventPipeline,
     MonitorEventSink,
     ReasonCodes,
-    normalize_live_event_console_enabled,
     normalize_live_event_debug_profiles,
     payload_hash_raw,
+    resolve_live_event_console_enabled,
 )
 import live.event_emitters as live_event_emitters
 from monitor_publisher import MonitorPublisher
@@ -864,11 +864,12 @@ class Passivbot:
                 ),
             )
         )
-        self.live_event_console_enabled = normalize_live_event_console_enabled(
-            os.environ.get(
-                LIVE_EVENT_CONSOLE_ENV,
-                get_optional_config_value(config, "logging.live_event_console", False),
-            )
+        self.live_event_console_enabled = resolve_live_event_console_enabled(
+            env_value=os.environ.get(LIVE_EVENT_CONSOLE_ENV),
+            config_value=get_optional_config_value(
+                config, "logging.live_event_console", None
+            ),
+            default=True,
         )
         self.balance_threshold = (
             1.0  # don't create orders if balance is less than threshold

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -29,6 +29,7 @@ from live.event_bus import (
     payload_hash,
     payload_hash_raw,
     redact_payload,
+    resolve_live_event_console_enabled,
     sink_failed_reason_code,
 )
 from live.events import DiagnosticEvent
@@ -131,6 +132,16 @@ def test_live_event_console_flag_normalizes_common_config_values():
     assert normalize_live_event_console_enabled("on") is True
     assert normalize_live_event_console_enabled("1") is True
     assert normalize_live_event_console_enabled("console") is True
+
+
+def test_live_event_console_resolver_defaults_on_with_explicit_opt_outs():
+    assert resolve_live_event_console_enabled() is True
+    assert resolve_live_event_console_enabled(config_value=None, env_value=None) is True
+    assert resolve_live_event_console_enabled(config_value=False) is False
+    assert resolve_live_event_console_enabled(config_value="off") is False
+    assert resolve_live_event_console_enabled(config_value=True) is True
+    assert resolve_live_event_console_enabled(config_value=False, env_value="1") is True
+    assert resolve_live_event_console_enabled(config_value=True, env_value="0") is False
 
 
 def test_live_event_serializes_stable_envelope_and_redacts_sensitive_data():


### PR DESCRIPTION
## Summary
- enable the structured live event console projection by default for `passivbot live`
- keep explicit opt-outs via `logging.live_event_console=false` or `PASSIVBOT_LIVE_EVENT_CONSOLE=0`
- document the temporary duplicate-log caveat while legacy stdlib console call sites are still being migrated
- record PR #970 deploy/smoke evidence in the progress ledger

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py::test_live_event_console_flag_normalizes_common_config_values tests/test_live_event_bus.py::test_live_event_console_resolver_defaults_on_with_explicit_opt_outs -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py src/passivbot.py`
- `git diff --check`

Trading behavior unchanged: logging default/pipeline setup only; no Rust, exchange I/O, order construction, readiness gates, or event payload semantics changed.