### PR TITLE
Project startup timing to event console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Startup timing events now appear in the live event console projection by
+  default, making account-ready, candle-ready, HSL-ready, market-ready, and
+  startup-ready phase durations visible from the structured event stream.
 - Live event console summaries are now enabled by default for `passivbot live`;
   set `logging.live_event_console=false` or `PASSIVBOT_LIVE_EVENT_CONSOLE=0`
   to opt out while legacy console logs are still being migrated.

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -107,6 +107,9 @@ compact operator heartbeat covering uptime, loop latency, position counts,
 recent order/fill activity, errors, and resource pressure. Degraded
 `health.summary` events such as execution-loop error bursts must stay immediate
 and must not expose raw exchange URLs or credentials in console summaries.
+Startup timing events are console-visible because they explain which startup
+phase is slow or complete: account state, active-candle warmup, HSL replay,
+full warmup, market state, and final startup readiness.
 Position-level `trailing.status`, `unstuck.status`, and `unstuck.selection`
 events are console-visible because they explain why an existing position is
 waiting, armed, triggered, over budget, selected for unstucking, or blocked by

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,22 +15,21 @@ merge, live smoke evidence changes, or new gaps are discovered.
 
 ## Current Status
 
-Last updated: 2026-07-01.
+Last updated: 2026-07-02.
 
 Current `origin/v8` head:
 
-- `ac425a1f0` after PR #970, `Refine trailing and unstuck event console summaries`.
+- `45cd1d7e` after PR #971, `Enable live event console by default`.
 
 Current logging-overhaul head:
 
-- `ac425a1f0` after PR #970, `Refine trailing and unstuck event console summaries`.
+- `45cd1d7e` after PR #971, `Enable live event console by default`.
 
 Current work:
 
-- Branch `codex/v8-live-event-console-default` makes the structured live event
-  console projection default-on for `passivbot live`, while keeping explicit
-  config/env opt-outs. This moves default operator output closer to the target
-  shape where console is a projection of the structured event stream.
+- Branch `codex/v8-startup-timing-event-console` projects existing
+  `bot.startup_timing` events into the default live event console/text sinks,
+  keeping startup phase timing visible from the structured event stream.
 
 Current review gate:
 
@@ -60,6 +59,26 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #971 at `45cd1d7e`.
+- PR #971 made the structured live event console projection default-on for
+  `passivbot live` while preserving explicit config/env opt-outs. It merged
+  after Claude and Hermes approved the amended head, CI was green, and no open
+  PRs remained.
+- Bots were restarted from `/root/bots_vps5.yaml` and left running. Hyperliquid
+  exited in the first graceful window; Binance, Kucoin, GateIO, and OKX exited
+  during the longer graceful window without SIGTERM.
+- VPS5 settled smoke after restart reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, clean tracked repository state at
+  `repository.head=45cd1d7e`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `fill_refresh.failed=0`, and
+  `logs.hard_matches=0`. Remaining attention was non-hard active HSL replay on
+  the four forager bots plus Hyperliquid EMA-unavailable/staged-refresh
+  diagnostics.
+- Focused log inspection confirmed the default console projection was active:
+  Hyperliquid emitted structured `[trailing]` and `[unstuck]` summaries with
+  threshold, retracement, allowance, and distance fields, while legacy duplicate
+  text lines still remained for some account-state changes pending later
+  cleanup.
 - Repository pulled through PR #970 at `ac425a1f0`.
 - PR #970 refined existing trailing/unstuck event-console summaries, routed the
   already-throttled `unstuck.selection` event to the opt-in console/text sinks,

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -645,7 +645,7 @@ DEFAULT_ROUTE = EventRoute(structured=True, monitor=True, console=False, text=Fa
 DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.BOT_STARTED: EventRoute(console=True, text=True),
     EventTypes.BOT_READY: EventRoute(console=True, text=True),
-    EventTypes.BOT_STARTUP_TIMING: EventRoute(console=False, text=False),
+    EventTypes.BOT_STARTUP_TIMING: EventRoute(console=True, text=True),
     EventTypes.BOT_STOPPING: EventRoute(console=True, text=True),
     EventTypes.BOT_SHUTDOWN_STAGE: EventRoute(console=True, text=True),
     EventTypes.BOT_STOPPED: EventRoute(console=True, text=True),
@@ -777,6 +777,7 @@ class ListEventSink:
 _CONSOLE_EVENT_TAGS = {
     EventTypes.BOT_STARTED: "bot",
     EventTypes.BOT_READY: "bot",
+    EventTypes.BOT_STARTUP_TIMING: "boot",
     EventTypes.BOT_STOPPING: "bot",
     EventTypes.BOT_SHUTDOWN_STAGE: "shutdown",
     EventTypes.BOT_STOPPED: "bot",
@@ -1402,6 +1403,24 @@ def _console_hsl_status_summary(event: LiveEvent) -> list[str]:
     return parts
 
 
+def _console_startup_timing_summary(event: LiveEvent) -> list[str]:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    parts: list[str] = []
+    phase = _data_str(data, "phase")
+    if phase:
+        parts.append(f"phase={phase}-ready")
+    elapsed_ms = _data_number(data, "elapsed_ms")
+    if elapsed_ms is not None:
+        parts.append(f"elapsed={elapsed_ms / 1000.0:.2f}s")
+    since_previous_ms = _data_number(data, "since_previous_ms")
+    if since_previous_ms is not None:
+        parts.append(f"since_previous={since_previous_ms / 1000.0:.2f}s")
+    details = _data_str(data, "details")
+    if details:
+        parts.append(f"details={details}")
+    return parts
+
+
 def _console_trailing_status_summary(event: LiveEvent) -> list[str]:
     data = event.data if isinstance(event.data, Mapping) else {}
     parts: list[str] = []
@@ -1522,6 +1541,8 @@ def _console_unstuck_selection_summary(event: LiveEvent) -> list[str]:
 
 
 def _console_data_summary(event: LiveEvent) -> list[str]:
+    if event.event_type == EventTypes.BOT_STARTUP_TIMING:
+        return _console_startup_timing_summary(event)
     if event.event_type == EventTypes.ORDER_WAVE_COMPLETED:
         return _console_order_wave_summary(event)
     if event.event_type in {

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1193,7 +1193,7 @@ def _emit_startup_timing_event_unchecked(
     _safe_emit(
         bot,
         EventTypes.BOT_STARTUP_TIMING,
-        level="debug",
+        level="info",
         component="bot.startup",
         tags=("bot", "startup", "timing"),
         cycle_id=current_live_event_cycle_id(bot),

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -242,7 +242,6 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.CACHE_WARMUP_DECISION,
         EventTypes.EXCHANGE_CONFIG_REFRESH,
         EventTypes.FILLS_REFRESH_SUMMARY,
-        EventTypes.BOT_STARTUP_TIMING,
         EventTypes.PLANNING_DEFER_SUMMARY,
         EventTypes.PLANNING_SYMBOL_STATE,
         EventTypes.HSL_RAW_RED_PENDING,
@@ -277,6 +276,8 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.RISK_MODE_CHANGED].text is True
     assert DEFAULT_ROUTES[EventTypes.HSL_TRANSITION].console is True
     assert DEFAULT_ROUTES[EventTypes.HSL_TRANSITION].text is True
+    assert DEFAULT_ROUTES[EventTypes.BOT_STARTUP_TIMING].console is True
+    assert DEFAULT_ROUTES[EventTypes.BOT_STARTUP_TIMING].text is True
     assert DEFAULT_ROUTES[EventTypes.BOT_SHUTDOWN_STAGE].console is True
     assert DEFAULT_ROUTES[EventTypes.BOT_SHUTDOWN_STAGE].text is True
     assert DEFAULT_ROUTES[EventTypes.HEALTH_SUMMARY].console is True
@@ -786,6 +787,25 @@ def test_console_format_summarizes_order_wave_payload():
         "deferred_create=1 elapsed=642ms "
         "symbols=BTC/USDT:USDT,ETH/USDT:USDT,SOL/USDT:USDT "
         "reason=create_deferred"
+    )
+
+
+def test_console_format_summarizes_startup_timing():
+    event = LiveEvent(
+        EventTypes.BOT_STARTUP_TIMING,
+        status="succeeded",
+        reason_code=ReasonCodes.STARTUP_PHASE_READY,
+        data={
+            "phase": "hsl",
+            "elapsed_ms": 12345,
+            "since_previous_ms": 2345,
+            "details": "mode=coin",
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[boot] succeeded phase=hsl-ready elapsed=12.35s since_previous=2.35s "
+        "details=mode=coin reason=startup_phase_ready"
     )
 
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -194,6 +194,7 @@ def test_startup_timing_mark_emits_structured_event(monkeypatch, caplog):
         EventTypes.BOT_STARTUP_TIMING,
     ]
     assert events[0].component == "bot.startup"
+    assert events[0].level == "info"
     assert events[0].reason_code == "startup_phase_ready"
     assert events[0].data == {
         "phase": "account",
@@ -206,6 +207,7 @@ def test_startup_timing_mark_emits_structured_event(monkeypatch, caplog):
         "since_previous_ms": 4500,
         "details": "mode=coin",
     }
+    assert events[1].level == "info"
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
## Summary

- route existing `bot.startup_timing` events to the live event console/text sinks
- format startup phase timing as compact `[boot]` summaries from the structured event stream
- promote startup timing events from DEBUG to INFO to match the existing operator-facing startup timing line
- update logging docs, changelog, and progress ledger with PR #971 deploy evidence

## Behavior

Observability-only. No trading logic, exchange I/O, order construction, readiness gates, or Rust behavior changed. Legacy startup timing stdlib logs remain for now, so this may temporarily duplicate startup timing until the legacy cleanup phase.

## Validation

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py::test_route_table_keeps_data_events_off_console_by_default tests/test_live_event_bus.py::test_console_format_summarizes_startup_timing tests/test_passivbot_monitor.py::test_startup_timing_mark_emits_structured_event -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py -q`
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py src/live/event_emitters.py`
- `git diff --check`
- silent-handling scan on touched paths: no new exception swallowing or trading-input defaults added; hits are pre-existing best-effort event-emitter/test patterns
