### PR TITLE
Dedupe startup timing console logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Legacy startup timing console lines are now suppressed when the structured
+  live event console path is active, leaving the structured `[boot]` projection
+  as the default operator output while preserving a fallback if that path is
+  disabled.
 - Startup timing events now appear in the live event console projection by
   default, making account-ready, candle-ready, HSL-ready, market-ready, and
   startup-ready phase durations visible from the structured event stream.

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -109,7 +109,9 @@ recent order/fill activity, errors, and resource pressure. Degraded
 and must not expose raw exchange URLs or credentials in console summaries.
 Startup timing events are console-visible because they explain which startup
 phase is slow or complete: account state, active-candle warmup, HSL replay,
-full warmup, market state, and final startup readiness.
+full warmup, market state, and final startup readiness. The legacy stdlib
+startup timing line is only a fallback when the structured event console path
+is unavailable or explicitly disabled.
 Position-level `trailing.status`, `unstuck.status`, and `unstuck.selection`
 events are console-visible because they explain why an existing position is
 waiting, armed, triggered, over budget, selected for unstucking, or blocked by

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,17 +19,18 @@ Last updated: 2026-07-02.
 
 Current `origin/v8` head:
 
-- `45cd1d7e` after PR #971, `Enable live event console by default`.
+- `f789dccc` after PR #972, `Project startup timing to event console`.
 
 Current logging-overhaul head:
 
-- `45cd1d7e` after PR #971, `Enable live event console by default`.
+- `f789dccc` after PR #972, `Project startup timing to event console`.
 
 Current work:
 
-- Branch `codex/v8-startup-timing-event-console` projects existing
-  `bot.startup_timing` events into the default live event console/text sinks,
-  keeping startup phase timing visible from the structured event stream.
+- Branch `codex/v8-dedupe-startup-timing-console` suppresses the duplicate
+  legacy startup timing line when the structured event-console path is active,
+  while keeping the legacy line as a fallback if that path is disabled or
+  unavailable.
 
 Current review gate:
 
@@ -59,6 +60,26 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #972 at `f789dccc`.
+- PR #972 projected existing `bot.startup_timing` events into the default live
+  event console/text sinks and kept trading behavior unchanged. It merged after
+  Hermes and Claude approved with no findings, CI was green, and Cursor did not
+  post during the bounded wait.
+- Bots were restarted from `/root/bots_vps5.yaml` and left running. Hyperliquid
+  exited in the first graceful window; Binance, GateIO, and OKX exited during
+  the longer graceful window; Kucoin still required SIGTERM after the full wait
+  window.
+- VPS5 settled smoke after restart reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, clean tracked repository state at
+  `repository.head=f789dccc`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `fill_refresh.failed=0`, and
+  `logs.hard_matches=0`. Remaining attention was non-hard active HSL replay on
+  the four forager bots plus Hyperliquid EMA-unavailable/staged-refresh
+  diagnostics.
+- Focused log inspection confirmed the new structured startup projection was
+  active on VPS5, for example Hyperliquid emitted `[boot] succeeded
+  phase=account-ready ... reason=startup_phase_ready` and related
+  active-candle/startup/market/full-warmup phase lines.
 - Repository pulled through PR #971 at `45cd1d7e`.
 - PR #971 made the structured live event console projection default-on for
   `passivbot live` while preserving explicit config/env opt-outs. It merged

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -3943,14 +3943,19 @@ class Passivbot:
         since_previous_s = max(0.0, (now_ms - previous_ms) / 1000.0)
         marks[label] = now_ms
         self._startup_timing_last_mark_ms = now_ms
-        suffix = f" | {details}" if details else ""
-        logging.info(
-            "[boot] startup timing | %s-ready=%.2fs | since_previous=%.2fs%s",
-            label,
-            elapsed_s,
-            since_previous_s,
-            suffix,
+        event_console_available = bool(
+            getattr(self, "live_event_console_enabled", False)
+            and getattr(self, "_live_event_pipeline", None) is not None
         )
+        if not event_console_available:
+            suffix = f" | {details}" if details else ""
+            logging.info(
+                "[boot] startup timing | %s-ready=%.2fs | since_previous=%.2fs%s",
+                label,
+                elapsed_s,
+                since_previous_s,
+                suffix,
+            )
         Passivbot._emit_startup_timing_event(
             self,
             phase=label,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -211,6 +211,53 @@ def test_startup_timing_mark_emits_structured_event(monkeypatch, caplog):
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_startup_timing_mark_suppresses_legacy_log_when_event_console_active(
+    monkeypatch,
+    caplog,
+):
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+    clock_values = iter([1_000, 3_500])
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: next(clock_values))
+
+    class FakeBot:
+        _startup_timing_begin = pb_mod.Passivbot._startup_timing_begin
+        _startup_timing_mark = pb_mod.Passivbot._startup_timing_mark
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "gateio"
+            self.user = "gateio_01"
+            self.bot_id = "bot_1"
+            self.live_event_console_enabled = True
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+    bot._startup_timing_begin()
+    with caplog.at_level(logging.INFO):
+        bot._startup_timing_mark("account")
+
+    assert not any(
+        "[boot] startup timing | account-ready" in record.message
+        for record in caplog.records
+    )
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert len(sink.events) == 1
+    event = sink.events[0]
+    assert event.event_type == EventTypes.BOT_STARTUP_TIMING
+    assert event.level == "info"
+    assert event.data == {
+        "phase": "account",
+        "elapsed_ms": 2500,
+        "since_previous_ms": 2500,
+    }
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_routine_planning_defer_summary_emits_live_event(monkeypatch):
     import passivbot as pb_mod
 


### PR DESCRIPTION
## Summary

- suppress the legacy `[boot] startup timing | ...` stdlib line when the structured live event console path is active
- keep the legacy startup timing line as a fallback when the event console is disabled or no live event pipeline exists
- update docs/changelog/progress, including PR #972 VPS deploy evidence

## Behavior

Observability-only. No trading logic, exchange I/O, order construction, readiness gates, Rust behavior, or event payload schema changed. This only removes duplicate operator console output after `bot.startup_timing` became a default structured console projection.

## Validation

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_passivbot_monitor.py::test_startup_timing_mark_emits_structured_event tests/test_passivbot_monitor.py::test_startup_timing_mark_suppresses_legacy_log_when_event_console_active tests/test_live_event_bus.py::test_console_format_summarizes_startup_timing -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py::test_startup_timing_mark_emits_structured_event tests/test_passivbot_monitor.py::test_startup_timing_mark_suppresses_legacy_log_when_event_console_active -q`
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/passivbot.py src/live/event_bus.py src/live/event_emitters.py`
- `git diff --check`
- silent-handling scan on touched paths: no new exception swallowing or trading-input defaults added; hits are pre-existing in `src/passivbot.py`/tests
