### PR TITLE
Dedupe unstuck event console logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Legacy unstuck status/selection console lines are now suppressed when the
+  structured live event console path is active, leaving the structured
+  `[unstuck]` projection as the default operator output while preserving a
+  fallback if that path is disabled.
 - Legacy startup timing console lines are now suppressed when the structured
   live event console path is active, leaving the structured `[boot]` projection
   as the default operator output while preserving a fallback if that path is

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -117,6 +117,8 @@ events are console-visible because they explain why an existing position is
 waiting, armed, triggered, over budget, selected for unstucking, or blocked by
 the unstuck EMA gate. Unsupported strategy diagnostics must say so explicitly
 instead of fabricating threshold/retracement prices.
+Legacy stdlib unstuck status/selection lines are only fallbacks when the
+structured event console path is unavailable or explicitly disabled.
 Supported trailing diagnostics should include the selected mode, such as
 `trailing`, `grid`, `auto_reduce`, `unstuck`, `none`, or `other`, when the next
 order state is known. They should also show the effective threshold percentage

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,18 +19,19 @@ Last updated: 2026-07-02.
 
 Current `origin/v8` head:
 
-- `f789dccc` after PR #972, `Project startup timing to event console`.
+- `c2a04904` after PR #973, `Dedupe startup timing console logs`.
 
 Current logging-overhaul head:
 
-- `f789dccc` after PR #972, `Project startup timing to event console`.
+- `c2a04904` after PR #973, `Dedupe startup timing console logs`.
 
 Current work:
 
-- Branch `codex/v8-dedupe-startup-timing-console` suppresses the duplicate
-  legacy startup timing line when the structured event-console path is active,
-  while keeping the legacy line as a fallback if that path is disabled or
-  unavailable.
+- Branch `codex/v8-trailing-unstuck-console-events` keeps the existing
+  structured `trailing.status`, `unstuck.status`, and `unstuck.selection`
+  operator summaries as the console source of truth and suppresses duplicate
+  legacy unstuck stdlib lines when the event-console path is active. The legacy
+  unstuck lines remain fallback output if that path is disabled or unavailable.
 
 Current review gate:
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -707,6 +707,13 @@ class Passivbot:
     _next_live_event_remote_call_id = live_event_emitters.next_live_event_remote_call_id
     _set_live_event_context_ids = live_event_emitters.set_live_event_context_ids
 
+    def _live_event_console_available(self) -> bool:
+        """Return True when structured live events already feed the console."""
+        return bool(
+            getattr(self, "live_event_console_enabled", False)
+            and getattr(self, "_live_event_pipeline", None) is not None
+        )
+
     @staticmethod
     def _log_symbol(symbol: Any) -> str:
         """Return a compact operator-facing symbol label for logs only."""
@@ -3353,7 +3360,8 @@ class Passivbot:
             status_changed
             or (now_ms - last_info_ms) >= self._unstuck_unchanged_info_log_interval_ms
         ):
-            logging.info("[unstuck] %s", " | ".join(parts))
+            if not self._live_event_console_available():
+                logging.info("[unstuck] %s", " | ".join(parts))
             self._emit_unstuck_status_event(
                 side_statuses=side_infos,
                 changed=status_changed,
@@ -3388,16 +3396,17 @@ class Passivbot:
             price_diff_pct = 0.0
             sign = ""
         coin = symbol.split("/")[0] if "/" in symbol else symbol
-        logging.info(
-            "[unstuck] selecting %s %s | entry=%.2f now=%.2f (%s%.1f%%) | allowance=%.2f",
-            coin,
-            pside,
-            entry_price,
-            current_price,
-            sign,
-            price_diff_pct,
-            allowance,
-        )
+        if not self._live_event_console_available():
+            logging.info(
+                "[unstuck] selecting %s %s | entry=%.2f now=%.2f (%s%.1f%%) | allowance=%.2f",
+                coin,
+                pside,
+                entry_price,
+                current_price,
+                sign,
+                price_diff_pct,
+                allowance,
+            )
         self._emit_unstuck_selection_event(
             symbol=symbol,
             pside=pside,
@@ -3943,11 +3952,7 @@ class Passivbot:
         since_previous_s = max(0.0, (now_ms - previous_ms) / 1000.0)
         marks[label] = now_ms
         self._startup_timing_last_mark_ms = now_ms
-        event_console_available = bool(
-            getattr(self, "live_event_console_enabled", False)
-            and getattr(self, "_live_event_pipeline", None) is not None
-        )
-        if not event_console_available:
+        if not self._live_event_console_available():
             suffix = f" | {details}" if details else ""
             logging.info(
                 "[boot] startup timing | %s-ready=%.2fs | since_previous=%.2fs%s",

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2853,6 +2853,41 @@ def test_unstuck_status_logs_info_on_change_then_hourly(monkeypatch, caplog):
     assert captured_events[0]["side_statuses"]["short"]["status"] == "disabled"
 
 
+def test_unstuck_status_suppresses_legacy_log_when_event_console_active(
+    monkeypatch, caplog
+):
+    bot = Passivbot.__new__(Passivbot)
+    bot.live_event_console_enabled = True
+    bot._live_event_pipeline = object()
+    bot._unstuck_last_log_ms = 0
+    bot._unstuck_log_interval_ms = 5 * 60 * 1000
+    bot._unstuck_unchanged_info_log_interval_ms = 60 * 60 * 1000
+    bot._unstuck_allowance_log_hyst_snap_pct = 0.002
+    bot._unstuck_allowance_log_snap_by_pside = {}
+    bot._unstuck_last_status_signature = None
+    bot._unstuck_last_status_info_ms = 0
+    bot._monitor_runtime_unstuck_hints = {}
+    captured_events = []
+    bot._emit_unstuck_status_event = lambda **kwargs: captured_events.append(kwargs)
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 5 * 60 * 1000)
+    bot._calc_unstuck_allowance_for_logging = lambda pside: (
+        {
+            "status": "ok",
+            "allowance": -41.01,
+            "peak": 16400.0,
+            "pct_from_peak": -0.3,
+        }
+        if pside == "long"
+        else {"status": "disabled"}
+    )
+
+    with caplog.at_level(logging.INFO):
+        bot._maybe_log_unstuck_status()
+
+    assert captured_events
+    assert not any("[unstuck]" in record.message for record in caplog.records)
+
+
 def test_hysteresis_snapped_unstuck_allowance_updates_only_after_threshold():
     bot = Passivbot.__new__(Passivbot)
     bot._unstuck_allowance_log_hyst_snap_pct = 0.002
@@ -2962,6 +2997,32 @@ def test_unstuck_selection_logs_on_change_then_hourly(monkeypatch, caplog):
     assert [event["changed"] for event in captured_events] == [True, False, True]
     assert captured_events[0]["symbol"] == "SUI/USDT:USDT"
     assert captured_events[2]["symbol"] == "ADA/USDT:USDT"
+
+
+def test_unstuck_selection_suppresses_legacy_log_when_event_console_active(
+    monkeypatch, caplog
+):
+    bot = Passivbot.__new__(Passivbot)
+    bot.live_event_console_enabled = True
+    bot._live_event_pipeline = object()
+    bot._unstuck_unchanged_info_log_interval_ms = 60 * 60 * 1000
+    bot._unstuck_last_selection_signature = None
+    bot._unstuck_last_selection_info_ms = 0
+    captured_events = []
+    bot._emit_unstuck_selection_event = lambda **kwargs: captured_events.append(kwargs)
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 0)
+
+    with caplog.at_level(logging.INFO):
+        bot._maybe_log_unstuck_selection(
+            symbol="SUI/USDT:USDT",
+            pside="long",
+            entry_price=1.0,
+            current_price=1.1,
+            allowance=-41.0,
+        )
+
+    assert captured_events
+    assert not any("[unstuck] selecting" in record.message for record in caplog.records)
 
 
 def test_trailing_status_emits_on_change_then_hourly(monkeypatch):


### PR DESCRIPTION
## Summary
- keep existing structured trailing/unstuck event-console summaries as the operator-facing source of truth
- suppress duplicate legacy stdlib unstuck status/selection lines when the structured event-console pipeline is active
- preserve legacy unstuck lines as fallback when event console is disabled or unavailable

## Validation
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py::test_console_format_summarizes_trailing_status tests/test_live_event_bus.py::test_console_format_summarizes_unstuck_status tests/test_live_event_bus.py::test_console_format_summarizes_unstuck_selection tests/test_passivbot_balance_split.py::test_unstuck_status_logs_info_on_change_then_hourly tests/test_passivbot_balance_split.py::test_unstuck_status_suppresses_legacy_log_when_event_console_active tests/test_passivbot_balance_split.py::test_unstuck_selection_logs_on_change_then_hourly tests/test_passivbot_balance_split.py::test_unstuck_selection_suppresses_legacy_log_when_event_console_active tests/test_passivbot_balance_split.py::test_trailing_status_emits_on_change_then_hourly tests/test_passivbot_monitor.py::test_trailing_status_event_emits_structured_summary tests/test_passivbot_monitor.py::test_unstuck_status_event_emits_structured_summary -q
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/passivbot.py src/live/event_bus.py src/live/event_emitters.py
- git diff --check