### PR TITLE
Bound finite HSL replay to configured lookback

### DIFF
--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -493,6 +493,10 @@ Trading-impact labels:
 
 - [ ] Replace `timeline_rows * pairs` replay with an exact lower-complexity
   path.
+  - First optimization slice: finite-lookback replay now seeds pre-window state
+    from fills, clamps dense candle/timeline construction to the configured
+    lookback window, and skips old flat symbols with no in-window/current
+    exposure.
   - Preferred shape: one pass through the timeline updating all active pair
     states that have values on that row, or per-pair sparse series built once.
   - Avoid repeated nested dict scans and repeated full fill-list scans per

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -12319,7 +12319,7 @@ class Passivbot:
             record_start_ts = int(math.floor(start_ts / ONE_MIN_MS) * ONE_MIN_MS)
             record_start_minute = int(math.floor(start_ts / ONE_MIN_MS) * ONE_MIN_MS)
         else:
-            start_ts = min(ensure_millis(events[0]["timestamp"]), lookback_start)
+            start_ts = lookback_start
             record_start_ts = int(lookback_start)
             record_start_minute = int(
                 math.floor(lookback_start / ONE_MIN_MS) * ONE_MIN_MS
@@ -12329,17 +12329,27 @@ class Passivbot:
         if end_minute < record_start_minute:
             end_minute = record_start_minute
 
-        symbols = {evt["symbol"] for evt in events if evt["symbol"]}
+        current_position_symbols = {
+            symbol
+            for (symbol, _pside), (size, _price) in current_position_state.items()
+            if size > 1e-12
+        }
+        symbols = {
+            evt["symbol"]
+            for evt in events
+            if evt["symbol"]
+            and (
+                lookback_start is None
+                or int(evt["timestamp"]) >= int(record_start_ts)
+                or evt["symbol"] in current_position_symbols
+            )
+        }
+        symbols.update(current_position_symbols)
         price_replay_symbols = set(symbols)
         known_market_symbols = (
             set(self.c_mults) if isinstance(getattr(self, "c_mults", None), dict) else set()
         )
         if known_market_symbols:
-            current_position_symbols = {
-                symbol
-                for (symbol, _pside), (size, _price) in current_position_state.items()
-                if size > 1e-12
-            }
             skipped_price_symbols = {
                 symbol
                 for symbol in symbols
@@ -12603,6 +12613,7 @@ class Passivbot:
         balance = baseline_balance
         event_idx = 0
         last_price: Dict[str, float] = {}
+        pre_window_events_applied = 0
 
         history_minutes = int(max(0, (end_minute - start_minute) // ONE_MIN_MS)) + 1
         _emit_hsl_history_progress(
@@ -12619,69 +12630,92 @@ class Passivbot:
             reason_code=ReasonCodes.HSL_TIMELINE_REPLAY_STARTED,
         )
         timeline_replay_started_s = time.monotonic()
+
+        def apply_event_and_account(
+            evt: dict,
+            *,
+            minute_for_panic: Optional[int],
+        ) -> int:
+            nonlocal balance
+            _apply_event(evt)
+            realized_delta = evt["pnl"] + evt.get("fee", 0.0)
+            balance += realized_delta
+            realized_pnl_pside_running[evt["pside"]] += realized_delta
+            symbol_realized = realized_pnl_coin_pside_running.setdefault(
+                evt["symbol"], {"long": 0.0, "short": 0.0}
+            )
+            symbol_realized[evt["pside"]] += realized_delta
+            if minute_for_panic is None:
+                return 0
+            if "panic" not in str(evt.get("pb_order_type") or ""):
+                return 0
+            after_psize = _safe_float(evt.get("psize"), math.nan)
+            symbol_pside_key = (evt["symbol"], evt["pside"])
+            authoritative_symbol_flat_override = (
+                symbol_pside_key in actual_symbol_pside_flat
+                and actual_symbol_pside_flat[symbol_pside_key]
+                and last_event_ts_by_symbol_pside.get(symbol_pside_key)
+                == evt["timestamp"]
+            )
+            if authoritative_symbol_flat_override and (
+                not math.isfinite(after_psize) or after_psize > 1e-12
+            ):
+                logging.warning(
+                    "[risk] balance-equity replay trusting current flat %s symbol state over residual panic replay size | timestamp=%s replay_after_psize=%s symbol=%s",
+                    evt["pside"],
+                    evt["timestamp"],
+                    (
+                        f"{after_psize:.12f}"
+                        if math.isfinite(after_psize)
+                        else "nan"
+                    ),
+                    Passivbot._log_symbol(evt["symbol"]),
+                )
+            if (
+                (math.isfinite(after_psize) and after_psize <= 1e-12)
+                or authoritative_symbol_flat_override
+                or _symbol_pside_is_flat(evt["symbol"], evt["pside"])
+            ):
+                panic_flatten_events.append(
+                    {
+                        "timestamp": int(evt["timestamp"]),
+                        "minute_timestamp": int(minute_for_panic),
+                        "pside": str(evt["pside"]),
+                        "symbol": str(evt["symbol"]),
+                    }
+                )
+                return 1
+            return 0
+
+        while (
+            event_idx < len(events)
+            and int(events[event_idx]["timestamp"]) < int(record_start_ts)
+        ):
+            apply_event_and_account(events[event_idx], minute_for_panic=None)
+            event_idx += 1
+            pre_window_events_applied += 1
+        record_start_balance = float(balance)
+        record_start_realized_pnl_pside = {
+            "long": float(realized_pnl_pside_running["long"]),
+            "short": float(realized_pnl_pside_running["short"]),
+        }
+        record_start_realized_pnl_coin_pside = {
+            sym: {
+                "long": float(values["long"]),
+                "short": float(values["short"]),
+            }
+            for sym, values in realized_pnl_coin_pside_running.items()
+        }
+
         minute = start_minute
         while minute <= end_minute:
             boundary = minute + ONE_MIN_MS
             panic_fill_count = 0
             while event_idx < len(events) and events[event_idx]["timestamp"] < boundary:
                 evt = events[event_idx]
-                if record_start_balance is None and int(evt["timestamp"]) >= record_start_ts:
-                    record_start_balance = float(balance)
-                    record_start_realized_pnl_pside = {
-                        "long": float(realized_pnl_pside_running["long"]),
-                        "short": float(realized_pnl_pside_running["short"]),
-                    }
-                    record_start_realized_pnl_coin_pside = {
-                        sym: {
-                            "long": float(values["long"]),
-                            "short": float(values["short"]),
-                        }
-                        for sym, values in realized_pnl_coin_pside_running.items()
-                    }
-                _apply_event(evt)
-                realized_delta = evt["pnl"] + evt.get("fee", 0.0)
-                balance += realized_delta
-                realized_pnl_pside_running[evt["pside"]] += realized_delta
-                symbol_realized = realized_pnl_coin_pside_running.setdefault(
-                    evt["symbol"], {"long": 0.0, "short": 0.0}
+                panic_fill_count += apply_event_and_account(
+                    evt, minute_for_panic=int(minute)
                 )
-                symbol_realized[evt["pside"]] += realized_delta
-                if "panic" in str(evt.get("pb_order_type") or ""):
-                    panic_fill_count += 1
-                    after_psize = _safe_float(evt.get("psize"), math.nan)
-                    symbol_pside_key = (evt["symbol"], evt["pside"])
-                    authoritative_symbol_flat_override = (
-                        symbol_pside_key in actual_symbol_pside_flat
-                        and actual_symbol_pside_flat[symbol_pside_key]
-                        and last_event_ts_by_symbol_pside.get(symbol_pside_key) == evt["timestamp"]
-                    )
-                    if authoritative_symbol_flat_override and (
-                        not math.isfinite(after_psize) or after_psize > 1e-12
-                    ):
-                        logging.warning(
-                            "[risk] balance-equity replay trusting current flat %s symbol state over residual panic replay size | timestamp=%s replay_after_psize=%s symbol=%s",
-                            evt["pside"],
-                            evt["timestamp"],
-                            (
-                                f"{after_psize:.12f}"
-                                if math.isfinite(after_psize)
-                                else "nan"
-                            ),
-                            Passivbot._log_symbol(evt["symbol"]),
-                        )
-                    if (
-                        (math.isfinite(after_psize) and after_psize <= 1e-12)
-                        or authoritative_symbol_flat_override
-                        or _symbol_pside_is_flat(evt["symbol"], evt["pside"])
-                    ):
-                        panic_flatten_events.append(
-                            {
-                                "timestamp": int(evt["timestamp"]),
-                                "minute_timestamp": int(minute),
-                                "pside": str(evt["pside"]),
-                                "symbol": str(evt["symbol"]),
-                            }
-                        )
                 event_idx += 1
             upnl = 0.0
             upnl_by_pside = {"long": 0.0, "short": 0.0}
@@ -12831,6 +12865,7 @@ class Passivbot:
             "lookback_days": lookback.display_value,
             "resolution_ms": ONE_MIN_MS,
             "events_used": len(events),
+            "pre_window_events_applied": int(pre_window_events_applied),
             "symbols_covered": sorted(price_replay_symbols),
             "missing_price_symbols": sorted(missing_price_symbols),
             "approximate_price_sources": approximate_price_sources,
@@ -12845,6 +12880,7 @@ class Passivbot:
                 "panic_events": len(panic_flatten_events),
                 "missing_price_symbols": len(missing_price_symbols),
                 "history_minutes": history_minutes,
+                "pre_window_events_applied": int(pre_window_events_applied),
                 "timeline_replay_elapsed_s": round(
                     max(0.0, time.monotonic() - timeline_replay_started_s), 3
                 ),

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1437,6 +1437,110 @@ async def test_balance_equity_history_paces_replay_candle_fetches(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_balance_equity_history_clamps_finite_replay_to_lookback_after_state_seed(
+    monkeypatch,
+):
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {"pnls_max_lookback_days": 1.0}}
+    bot.exchange = "kucoin"
+    bot.user = "test_user"
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: bot.config["live"][key]
+    day_ms = 86_400_000
+    now_ms = 1_800_000_000_000
+    lookback_start_ms = now_ms - day_ms
+    lookback_start_minute = (lookback_start_ms // 60_000) * 60_000
+    old_open_ts = lookback_start_ms - 5 * day_ms
+    symbol = "XLM/USDT:USDT"
+    old_flat_symbol = "AAVE/USDT:USDT"
+    bot.get_exchange_time = lambda: now_ms
+    bot.get_raw_balance = lambda: 1000.0
+    bot.get_symbol_id_inv = lambda symbol: symbol
+    bot.positions = {
+        symbol: {
+            "long": {"size": 1.0, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    bot._pnls_manager = None
+    bot.inverse = False
+    bot._candle_fetch_concurrency = lambda *, context="runtime": 1
+    bot._get_fetch_delay_seconds = lambda: 0.0
+    bot.c_mults = {symbol: 1.0, old_flat_symbol: 1.0}
+    monkeypatch.setattr(
+        passivbot_module, "compute_psize_pprice", lambda *args, **kwargs: None
+    )
+
+    class _CM:
+        def __init__(self):
+            self.calls = []
+
+        async def get_candles(self, symbol_, **kwargs):
+            self.calls.append((symbol_, dict(kwargs)))
+            assert symbol_ == symbol
+            assert kwargs["start_ts"] == lookback_start_minute
+            assert kwargs["end_ts"] == (now_ms // 60_000) * 60_000
+            return np.array(
+                [
+                    (lookback_start_minute, 109.0, 111.0, 108.0, 110.0, 1.0),
+                    (lookback_start_minute + 60_000, 110.0, 112.0, 109.0, 111.0, 1.0),
+                    ((now_ms // 60_000) * 60_000, 111.0, 113.0, 110.0, 112.0, 1.0),
+                ],
+                dtype=passivbot_module.CANDLE_DTYPE,
+            )
+
+    bot.cm = _CM()
+    history = await bot.get_balance_equity_history(
+        fill_events=[
+            {
+                "timestamp": old_open_ts,
+                "symbol": symbol,
+                "position_side": "long",
+                "side": "buy",
+                "qty": 1.0,
+                "price": 100.0,
+                "pnl": 0.0,
+            },
+            {
+                "timestamp": old_open_ts,
+                "symbol": old_flat_symbol,
+                "position_side": "long",
+                "side": "buy",
+                "qty": 1.0,
+                "price": 50.0,
+                "pnl": 0.0,
+            },
+            {
+                "timestamp": old_open_ts + 60_000,
+                "symbol": old_flat_symbol,
+                "position_side": "long",
+                "side": "sell",
+                "qty": 1.0,
+                "price": 49.0,
+                "pnl": -1.0,
+            },
+        ],
+        current_balance=1000.0,
+        hsl_replay_signal_mode="coin",
+    )
+
+    assert [symbol_ for symbol_, _kwargs in bot.cm.calls] == [symbol]
+    assert history["timeline"]
+    assert history["timeline"][0]["timestamp"] == lookback_start_minute
+    assert len(history["timeline"]) == int(
+        ((now_ms // 60_000) * 60_000 - lookback_start_minute) // 60_000
+    ) + 1
+    assert history["timeline"][0]["unrealized_pnl_by_coin_pside"][symbol][
+        "long"
+    ] == pytest.approx(10.0)
+    assert history["timeline"][-1]["unrealized_pnl_by_coin_pside"][symbol][
+        "long"
+    ] == pytest.approx(12.0)
+    assert old_flat_symbol not in history["metadata"]["symbols_covered"]
+    assert history["metadata"]["events_used"] == 3
+
+
+@pytest.mark.asyncio
 async def test_balance_equity_history_skips_unsupported_closed_historical_symbols(monkeypatch):
     bot = Passivbot.__new__(Passivbot)
     bot.config = {"live": {}}


### PR DESCRIPTION
## Summary
- seed pre-window fill/account state before finite HSL replay windows
- clamp dense candle/timeline replay to the configured pnls_max_lookback_days window instead of oldest cached fill
- skip old flat symbols with no in-window/current exposure while always including current held symbols
- expose pre_window_events_applied in replay metadata/events and update the performance checklist

## Why
VPS5 Kucoin startup showed HSL replay using a 30-day config but building candles/timeline back to much older fills. This made startup replay far slower than the configured safety window required.

## Reviewer focus
- finite lookback semantics: pre-window fills should seed state, but dense HSL replay and panic/cooldown reconstruction remain bounded by the configured lookback window
- current held symbols must still be replayed even if fill history is sparse
- old flat symbols with only pre-window fills should not force candle replay
- full  behavior should remain full-history

## Validation
- 
- ........................................................................ [ 36%]
........................................................................ [ 73%]
.....................................................                    [100%]
=============================== warnings summary ===============================
tests/test_passivbot_balance_split.py::test_log_position_changes_batches_market_snapshot_request
  /Users/eiriknarjord/repos/passivbot-2/venv/lib/python3.12/site-packages/portalocker/utils.py:231: UserWarning: timeout has no effect in blocking mode
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
197 passed, 1 warning in 2.22s
- ......................................                                   [100%]
38 passed in 0.90s
- ..                                                                       [100%]
=============================== warnings summary ===============================
venv/lib/python3.12/site-packages/matplotlib/_fontconfig_pattern.py:88
venv/lib/python3.12/site-packages/matplotlib/_fontconfig_pattern.py:88
venv/lib/python3.12/site-packages/matplotlib/_fontconfig_pattern.py:88
venv/lib/python3.12/site-packages/matplotlib/_fontconfig_pattern.py:88
venv/lib/python3.12/site-packages/matplotlib/_fontconfig_pattern.py:88
venv/lib/python3.12/site-packages/matplotlib/_fontconfig_pattern.py:88
  /Users/eiriknarjord/repos/passivbot-2/venv/lib/python3.12/site-packages/matplotlib/_fontconfig_pattern.py:88: DeprecationWarning: 'parseString' deprecated - use 'parse_string'
    parse = parser.parseString(pattern)

venv/lib/python3.12/site-packages/matplotlib/_fontconfig_pattern.py:92
venv/lib/python3.12/site-packages/matplotlib/_fontconfig_pattern.py:92
venv/lib/python3.12/site-packages/matplotlib/_fontconfig_pattern.py:92
venv/lib/python3.12/site-packages/matplotlib/_fontconfig_pattern.py:92
venv/lib/python3.12/site-packages/matplotlib/_fontconfig_pattern.py:92
venv/lib/python3.12/site-packages/matplotlib/_fontconfig_pattern.py:92
  /Users/eiriknarjord/repos/passivbot-2/venv/lib/python3.12/site-packages/matplotlib/_fontconfig_pattern.py:92: DeprecationWarning: 'resetCache' deprecated - use 'reset_cache'
    parser.resetCache()

venv/lib/python3.12/site-packages/matplotlib/_mathtext.py:45
  /Users/eiriknarjord/repos/passivbot-2/venv/lib/python3.12/site-packages/matplotlib/_mathtext.py:45: DeprecationWarning: 'enablePackrat' deprecated - use 'enable_packrat'
    ParserElement.enablePackrat()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
2 passed, 13 warnings in 1.01s
- 
