### PR TITLE
Include trailing status in risk activity report

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -3085,20 +3085,21 @@ VPS5 deployment status:
 
 ## Current Work
 
-### In Progress: Smoke Execution Health
+### In Progress: Trailing Status Risk Activity Report
 
-- Branch: `codex/v8-smoke-execution-health`.
-- Scope: read-only smoke-report tooling and tests.
-- Result: `live-smoke-report` derives bounded `execution_health` from existing
-  `order_wave.*` and `execution.*` structured events, with concise `execution`
-  counters in brief output. The summary is intended to expose create/cancel
-  failures, rejections, ambiguous terminals, and confirmation timeouts without
-  opening full event streams.
-- Expected validation: focused live-smoke-report tests plus py_compile,
-  `git diff --check`, and an added-line silent-handling scan. No event
-  producers, exchange calls, cache mutation, readiness gates, console routing,
-  monitor writes, process signaling, smoke verdict policy, order/risk logic, or
-  trading behavior should change.
+- Branch: `codex/v8-live-performance-trailing-risk-activity`.
+- Scope: read-only live performance report projection and tests.
+- Result: `live-performance-report` includes existing `trailing.status` events
+  in the bounded `risk_activity` section, so trailing/waiting position state can
+  be found beside HSL and unstuck risk-state events without opening the full
+  event stream. The projection uses event-envelope labels and bounded symbol
+  samples only; threshold/retracement prices and detailed event payload values
+  remain out of the shareable report.
+- Expected validation: focused and full live-performance-report tests,
+  py_compile, `git diff --check`, and an added-line silent-handling scan. No
+  event producers, exchange calls, cache mutation, readiness gates, console
+  routing, monitor writes, process signaling, smoke verdict policy, order/risk
+  logic, or trading behavior should change.
 
 ## Merged Slices
 

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -175,6 +175,7 @@ _RISK_ACTIVITY_EVENT_TYPES = {
     "hsl.red_finalized_without_order",
     "hsl.cooldown_started",
     "hsl.cooldown_ended",
+    "trailing.status",
     "unstuck.status",
     "unstuck.selection",
 }

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -2658,8 +2658,26 @@ def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
                 },
             ),
             _monitor_row(
-                event_type="risk.realized_loss_gate_blocked",
+                event_type="trailing.status",
                 seq=6,
+                ts=4300,
+                component="risk.trailing.status",
+                status="pending",
+                reason_code="trailing_status",
+                symbol="XLM/USDT:USDT",
+                pside="long",
+                data={
+                    "threshold_pct": 0.031,
+                    "threshold_price": 0.20123,
+                    "retracement_pct": 0.012,
+                    "retracement_price": 0.19876,
+                    "projected_retracement_price": 0.19765,
+                    "secret_marker": "trailing-secret",
+                },
+            ),
+            _monitor_row(
+                event_type="risk.realized_loss_gate_blocked",
+                seq=7,
                 ts=4500,
                 component="risk.realized_loss_gate",
                 status="deferred",
@@ -2676,7 +2694,7 @@ def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
             ),
             _monitor_row(
                 event_type="hsl.replay.progress",
-                seq=7,
+                seq=8,
                 ts=5000,
                 component="risk.hsl.replay",
                 reason_code="replay_progress",
@@ -2695,13 +2713,14 @@ def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
     }
     rendered = json.dumps(risk, sort_keys=True)
 
-    assert risk["total_events"] == 6
+    assert risk["total_events"] == 7
     assert risk["event_types"] == {
         "hsl.red_finalized_without_order": 1,
         "hsl.red_triggered": 1,
         "hsl.status": 1,
         "risk.mode_changed": 1,
         "risk.realized_loss_gate_blocked": 1,
+        "trailing.status": 1,
         "unstuck.selection": 1,
     }
     assert "hsl.replay.progress" not in risk["event_types"]
@@ -2719,6 +2738,10 @@ def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
         "BTC/USDT:USDT"
     ]
     assert groups["unstuck.selection"]["symbols_sample"] == ["ETH/USDT:USDT"]
+    assert groups["trailing.status"]["symbols_sample"] == ["XLM/USDT:USDT"]
+    assert groups["trailing.status"]["statuses"] == {"pending": 1}
+    assert groups["trailing.status"]["reason_codes"] == {"trailing_status": 1}
+    assert groups["trailing.status"]["psides"] == {"long": 1}
     assert groups["risk.realized_loss_gate_blocked"]["symbols_sample"] == ["SOL/USDT:USDT"]
     assert groups["risk.realized_loss_gate_blocked"]["statuses"] == {"deferred": 1}
     assert "98765.43" not in rendered
@@ -2729,7 +2752,11 @@ def test_live_performance_report_risk_activity_is_value_safe(tmp_path):
     assert "flat-secret" not in rendered
     assert "mode-secret" not in rendered
     assert "unstuck-secret" not in rendered
+    assert "trailing-secret" not in rendered
     assert "loss-gate-secret" not in rendered
+    assert "0.20123" not in rendered
+    assert "0.19876" not in rendered
+    assert "0.19765" not in rendered
     assert "9800" not in rendered
     assert "replay-secret" not in rendered
 


### PR DESCRIPTION
## Summary
- include existing trailing.status events in live-performance-report risk_activity
- keep the projection value-safe: envelope labels, bounded symbol samples, statuses/reasons/psides only
- update the logging overhaul progress tracker for this slice

## Scope
Read-only report tooling and tests only. No event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, process signaling, smoke verdict policy, order/risk logic, or trading behavior changed.

## Reviewer focus
- trailing.status belongs beside HSL/unstuck risk-state events in risk_activity
- report remains shareable: threshold/retracement prices and detailed event payload values are not surfaced
- progress-doc update accurately reflects the slice without implying a producer or console change

## Validation
- ./venv/bin/python -m py_compile src/live/performance_report.py tests/test_live_performance_report.py
- ./venv/bin/python -m pytest tests/test_live_performance_report.py
- git diff --check
- added-line silent-handling scan found no matches
