### PR TITLE
Report HSL replay remaining ETA

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -3085,7 +3085,24 @@ VPS5 deployment status:
 
 ## Current Work
 
-### In Progress: Trailing Status Risk Activity Report
+### In Progress: HSL Replay ETA Performance Report
+
+- Branch: `codex/v8-hsl-replay-eta-report`.
+- Scope: read-only live performance report projection and tests.
+- Result: `live-performance-report` derives HSL replay remaining row estimates
+  and ETA from existing sanitized `hsl.replay.*` monitor events. The report
+  keeps the existing conservative dense pair-row estimate and adds a
+  required-pair estimate when `required_pairs` is present, using
+  `rows_per_second` only when the event already supplies a positive finite rate.
+- Expected validation: focused and full live-performance-report tests,
+  py_compile, `git diff --check`, and an added-line silent-handling scan. No
+  event producers, exchange calls, cache mutation, readiness gates, console
+  routing, monitor writes, process signaling, smoke verdict policy, order/risk
+  logic, or trading behavior should change.
+
+## Merged Slices
+
+### PR #976: Trailing Status Risk Activity Report
 
 - Branch: `codex/v8-live-performance-trailing-risk-activity`.
 - Scope: read-only live performance report projection and tests.
@@ -3095,13 +3112,14 @@ VPS5 deployment status:
   event stream. The projection uses event-envelope labels and bounded symbol
   samples only; threshold/retracement prices and detailed event payload values
   remain out of the shareable report.
-- Expected validation: focused and full live-performance-report tests,
-  py_compile, `git diff --check`, and an added-line silent-handling scan. No
-  event producers, exchange calls, cache mutation, readiness gates, console
-  routing, monitor writes, process signaling, smoke verdict policy, order/risk
-  logic, or trading behavior should change.
-
-## Merged Slices
+- Review evidence: CI was green. Claude and Hermes approved with no findings.
+  Local validation covered the full live-performance-report test file,
+  py_compile, `git diff --check`, and an added-line silent-handling scan.
+- VPS5 evidence: deployed to `v8` at `1823d3e1` with all five configured bots
+  restarted and left running. Repeated smoke checks stayed hard-green with no
+  failed remote calls or account-critical remote calls. The final performance
+  report showed `risk_activity` populated with deployed `trailing.status`
+  events.
 
 ### PR #924: Startup Phase Readiness Summary
 

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1449,6 +1449,29 @@ def _hsl_replay_observed_rows(data: dict[str, Any]) -> int | None:
     return None
 
 
+def _hsl_replay_remaining_rows(
+    *,
+    estimated_work: int | None,
+    observed_rows: int | None,
+) -> int | None:
+    if estimated_work is None or observed_rows is None:
+        return None
+    return max(0, int(estimated_work) - int(observed_rows))
+
+
+def _hsl_replay_eta_ms(
+    *,
+    remaining_rows: int | None,
+    rows_per_second: Any,
+) -> int | None:
+    if remaining_rows is None:
+        return None
+    rate = _non_negative_number(rows_per_second)
+    if rate is None or float(rate) <= 0.0:
+        return None
+    return int(round(1000.0 * float(remaining_rows) / float(rate)))
+
+
 def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
     timeline_rows = _non_negative_number(data.get("timeline_rows"))
     pairs = _non_negative_number(data.get("pairs"))
@@ -1457,6 +1480,8 @@ def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
     cooldown_pairs = _non_negative_number(data.get("cooldown_pairs"))
     observed_rows = _hsl_replay_observed_rows(data)
     out: dict[str, Any] = {}
+    dense_work: int | None = None
+    required_work: int | None = None
     if timeline_rows is not None and pairs is not None:
         dense_work = int(timeline_rows) * int(pairs)
         out["estimated_dense_pair_row_work"] = dense_work
@@ -1465,13 +1490,55 @@ def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
                 min(100.0, max(0.0, 100.0 * float(observed_rows) / float(dense_work)))
             )
     if timeline_rows is not None and required_pairs is not None:
-        out["estimated_required_pair_row_work"] = int(timeline_rows) * int(required_pairs)
+        required_work = int(timeline_rows) * int(required_pairs)
+        out["estimated_required_pair_row_work"] = required_work
+        if observed_rows is not None and required_work > 0:
+            out["observed_required_work_pct"] = _rounded_float(
+                min(100.0, max(0.0, 100.0 * float(observed_rows) / float(required_work)))
+            )
     if timeline_rows is not None and held_pairs is not None:
         out["estimated_held_pair_row_work"] = int(timeline_rows) * int(held_pairs)
     if timeline_rows is not None and cooldown_pairs is not None:
         out["estimated_cooldown_pair_row_work"] = int(timeline_rows) * int(cooldown_pairs)
     if observed_rows is not None:
         out["observed_applied_rows"] = int(observed_rows)
+    dense_remaining_rows = _hsl_replay_remaining_rows(
+        estimated_work=dense_work,
+        observed_rows=observed_rows,
+    )
+    if dense_remaining_rows is not None:
+        out["estimated_dense_remaining_rows"] = dense_remaining_rows
+        dense_remaining_ms = _hsl_replay_eta_ms(
+            remaining_rows=dense_remaining_rows,
+            rows_per_second=data.get("rows_per_second"),
+        )
+        if dense_remaining_ms is not None:
+            out["estimated_dense_remaining_ms"] = dense_remaining_ms
+    required_remaining_rows = _hsl_replay_remaining_rows(
+        estimated_work=required_work,
+        observed_rows=observed_rows,
+    )
+    if required_remaining_rows is not None:
+        out["estimated_required_remaining_rows"] = required_remaining_rows
+        required_remaining_ms = _hsl_replay_eta_ms(
+            remaining_rows=required_remaining_rows,
+            rows_per_second=data.get("rows_per_second"),
+        )
+        if required_remaining_ms is not None:
+            out["estimated_required_remaining_ms"] = required_remaining_ms
+    primary_remaining_rows = (
+        required_remaining_rows
+        if required_remaining_rows is not None
+        else dense_remaining_rows
+    )
+    if primary_remaining_rows is not None:
+        out["estimated_remaining_rows"] = primary_remaining_rows
+        primary_remaining_ms = _hsl_replay_eta_ms(
+            remaining_rows=primary_remaining_rows,
+            rows_per_second=data.get("rows_per_second"),
+        )
+        if primary_remaining_ms is not None:
+            out["estimated_remaining_ms"] = primary_remaining_ms
     for source_key, target_key in (
         ("elapsed_s", "latest_elapsed_ms"),
         ("history_build_elapsed_s", "history_build_elapsed_ms"),

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1441,9 +1441,16 @@ def test_live_performance_report_hsl_replay_profile(tmp_path):
     assert group["loaded"]["data"]["symbols"] == 5
     assert group["progress"]["data"]["is_held_pair"] is True
     assert group["progress"]["derived"]["observed_work_pct"] == 30
+    assert group["progress"]["derived"]["observed_required_work_pct"] == 40
     assert group["progress"]["derived"]["estimated_dense_pair_row_work"] == 40
     assert group["progress"]["derived"]["estimated_held_pair_row_work"] == 10
     assert group["progress"]["derived"]["estimated_required_pair_row_work"] == 30
+    assert group["progress"]["derived"]["estimated_dense_remaining_rows"] == 28
+    assert group["progress"]["derived"]["estimated_required_remaining_rows"] == 18
+    assert group["progress"]["derived"]["estimated_remaining_rows"] == 18
+    assert group["progress"]["derived"]["estimated_dense_remaining_ms"] == 227
+    assert group["progress"]["derived"]["estimated_required_remaining_ms"] == 146
+    assert group["progress"]["derived"]["estimated_remaining_ms"] == 146
     assert group["progress"]["derived"]["latest_elapsed_ms"] == 2500
     assert group["completed"]["derived"]["startup_blocking_elapsed_ms"] == 7500
     assert group["completed"]["derived"]["startup_blocking"] is True
@@ -1452,6 +1459,10 @@ def test_live_performance_report_hsl_replay_profile(tmp_path):
     assert group["failed"]["derived"]["latest_elapsed_ms"] == 8000
     assert "must-not-render" not in json.dumps(group, sort_keys=True)
     assert group["completed"]["derived"]["observed_work_pct"] == 75
+    assert group["completed"]["derived"]["estimated_dense_remaining_rows"] == 10
+    assert group["completed"]["derived"]["estimated_dense_remaining_ms"] == 250
+    assert group["completed"]["derived"]["estimated_remaining_rows"] == 0
+    assert group["completed"]["derived"]["estimated_remaining_ms"] == 0
 
 
 def test_live_performance_report_hsl_replay_profile_stage_summary(tmp_path):


### PR DESCRIPTION
## Summary
- derive HSL replay remaining rows and ETA in live-performance-report from existing sanitized hsl.replay.* events
- keep conservative dense pair-row estimates and add required-pair progress/ETA when required_pairs is available
- update the logging-overhaul progress tracker with this active slice and the merged trailing-risk slice

## Validation
- ./venv/bin/python -m pytest tests/test_live_performance_report.py
- ./venv/bin/python -m py_compile src/live/performance_report.py tests/test_live_performance_report.py
- git diff --check
- added-line silent-handling scan on src/live/performance_report.py and tests/test_live_performance_report.py
- ./venv/bin/passivbot tool live-performance-report monitor --recent-minutes 120 --max-event-files-per-bot 1 --event-tail-lines 5000 --section hsl_replay_profile --compact

## Behavior
Read-only report projection only. No event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, order/risk logic, or trading behavior changed.