### PR TITLE
Report HSL replay ETA in smoke

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -3085,7 +3085,24 @@ VPS5 deployment status:
 
 ## Current Work
 
-### In Progress: HSL Replay ETA Performance Report
+### In Progress: HSL Replay ETA Smoke Report
+
+- Branch: `codex/v8-smoke-hsl-replay-eta`.
+- Scope: read-only live smoke report projection and tests.
+- Result: `live-smoke-report` derives the same HSL replay remaining row and ETA
+  estimates from existing sanitized `hsl.replay.*` monitor events, and exposes
+  max active primary remaining rows/time in the compact brief summary. The full
+  `hsl_replay_health` groups keep conservative dense estimates plus
+  required-pair estimates when available.
+- Expected validation: focused and full live-smoke-report tests,
+  py_compile, `git diff --check`, and an added-line silent-handling scan. No
+  event producers, exchange calls, cache mutation, readiness gates, console
+  routing, monitor writes, process signaling, smoke verdict policy, order/risk
+  logic, or trading behavior should change.
+
+## Merged Slices
+
+### PR #979: HSL Replay ETA Performance Report
 
 - Branch: `codex/v8-hsl-replay-eta-report`.
 - Scope: read-only live performance report projection and tests.
@@ -3094,13 +3111,15 @@ VPS5 deployment status:
   keeps the existing conservative dense pair-row estimate and adds a
   required-pair estimate when `required_pairs` is present, using
   `rows_per_second` only when the event already supplies a positive finite rate.
-- Expected validation: focused and full live-performance-report tests,
-  py_compile, `git diff --check`, and an added-line silent-handling scan. No
-  event producers, exchange calls, cache mutation, readiness gates, console
-  routing, monitor writes, process signaling, smoke verdict policy, order/risk
-  logic, or trading behavior should change.
-
-## Merged Slices
+- Review evidence: CI was green. Claude and Hermes approved with no findings.
+  Local validation covered the full live-performance-report test file,
+  py_compile, `git diff --check`, an added-line silent-handling scan, and a
+  local compact CLI smoke.
+- VPS5 evidence: deployed to `v8` at `b35becbc` without bot restart because the
+  change is read-only tooling. Smoke stayed hard-green with all five configured
+  bots running. The deployed performance report showed new remaining/ETA fields
+  for active Binance, GateIO, and OKX HSL pair replay; Kucoin was still in
+  price-history symbol fetch, so no row-rate ETA was available there.
 
 ### PR #976: Trailing Status Risk Activity Report
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -2897,11 +2897,42 @@ def _hsl_observed_rows(data: dict[str, Any]) -> int | None:
     return None
 
 
+def _hsl_replay_remaining_rows(
+    *,
+    estimated_work: int | None,
+    observed_rows: int | None,
+) -> int | None:
+    if estimated_work is None or observed_rows is None:
+        return None
+    return max(0, int(estimated_work) - int(observed_rows))
+
+
+def _hsl_replay_eta_ms(
+    *,
+    remaining_rows: int | None,
+    rows_per_second: Any,
+) -> int | None:
+    if remaining_rows is None:
+        return None
+    try:
+        rate = float(rows_per_second)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(rate) or rate <= 0.0:
+        return None
+    return int(round(1000.0 * float(remaining_rows) / rate))
+
+
 def _hsl_replay_derived(data: dict[str, Any]) -> dict[str, Any]:
     timeline_rows = _non_negative_int(data.get("timeline_rows"))
     pairs = _non_negative_int(data.get("pairs"))
+    required_pairs = _non_negative_int(data.get("required_pairs"))
+    held_pairs = _non_negative_int(data.get("held_pairs"))
+    cooldown_pairs = _non_negative_int(data.get("cooldown_pairs"))
     observed_rows = _hsl_observed_rows(data)
     out: dict[str, Any] = {}
+    dense_work: int | None = None
+    required_work: int | None = None
     if timeline_rows is not None and pairs is not None:
         dense_work = int(timeline_rows) * int(pairs)
         out["estimated_dense_pair_row_work"] = dense_work
@@ -2910,6 +2941,57 @@ def _hsl_replay_derived(data: dict[str, Any]) -> dict[str, Any]:
                 min(100.0, max(0.0, 100.0 * float(observed_rows) / float(dense_work))),
                 3,
             )
+    if timeline_rows is not None and required_pairs is not None:
+        required_work = int(timeline_rows) * int(required_pairs)
+        out["estimated_required_pair_row_work"] = required_work
+        if observed_rows is not None and required_work > 0:
+            out["observed_required_work_pct"] = round(
+                min(100.0, max(0.0, 100.0 * float(observed_rows) / float(required_work))),
+                3,
+            )
+    if timeline_rows is not None and held_pairs is not None:
+        out["estimated_held_pair_row_work"] = int(timeline_rows) * int(held_pairs)
+    if timeline_rows is not None and cooldown_pairs is not None:
+        out["estimated_cooldown_pair_row_work"] = int(timeline_rows) * int(cooldown_pairs)
+    if observed_rows is not None:
+        out["observed_applied_rows"] = int(observed_rows)
+    dense_remaining_rows = _hsl_replay_remaining_rows(
+        estimated_work=dense_work,
+        observed_rows=observed_rows,
+    )
+    if dense_remaining_rows is not None:
+        out["estimated_dense_remaining_rows"] = dense_remaining_rows
+        dense_remaining_ms = _hsl_replay_eta_ms(
+            remaining_rows=dense_remaining_rows,
+            rows_per_second=data.get("rows_per_second"),
+        )
+        if dense_remaining_ms is not None:
+            out["estimated_dense_remaining_ms"] = dense_remaining_ms
+    required_remaining_rows = _hsl_replay_remaining_rows(
+        estimated_work=required_work,
+        observed_rows=observed_rows,
+    )
+    if required_remaining_rows is not None:
+        out["estimated_required_remaining_rows"] = required_remaining_rows
+        required_remaining_ms = _hsl_replay_eta_ms(
+            remaining_rows=required_remaining_rows,
+            rows_per_second=data.get("rows_per_second"),
+        )
+        if required_remaining_ms is not None:
+            out["estimated_required_remaining_ms"] = required_remaining_ms
+    primary_remaining_rows = (
+        required_remaining_rows
+        if required_remaining_rows is not None
+        else dense_remaining_rows
+    )
+    if primary_remaining_rows is not None:
+        out["estimated_remaining_rows"] = primary_remaining_rows
+        primary_remaining_ms = _hsl_replay_eta_ms(
+            remaining_rows=primary_remaining_rows,
+            rows_per_second=data.get("rows_per_second"),
+        )
+        if primary_remaining_ms is not None:
+            out["estimated_remaining_ms"] = primary_remaining_ms
     for source_key, target_key in (
         ("elapsed_s", "latest_elapsed_ms"),
         ("history_build_elapsed_s", "history_build_elapsed_ms"),
@@ -5587,6 +5669,8 @@ def _brief_hsl_replay_health(hsl_replay_health: dict[str, Any]) -> dict[str, Any
 
     max_active_latest_elapsed_ms: int | None = None
     max_active_latest_event_age_ms: int | None = None
+    max_active_estimated_remaining_rows: int | None = None
+    max_active_estimated_remaining_ms: int | None = None
     max_completed_elapsed_ms: int | None = None
     active_stage_counts: Counter[str] = Counter()
 
@@ -5643,6 +5727,29 @@ def _brief_hsl_replay_health(hsl_replay_health: dict[str, Any]) -> dict[str, Any
                     max_active_latest_elapsed_ms,
                     int(elapsed_ms),
                 )
+        derived = latest.get("derived") if isinstance(latest.get("derived"), dict) else {}
+        estimated_remaining_rows = _non_negative_int(
+            derived.get("estimated_remaining_rows")
+        )
+        if estimated_remaining_rows is not None:
+            if max_active_estimated_remaining_rows is None:
+                max_active_estimated_remaining_rows = int(estimated_remaining_rows)
+            else:
+                max_active_estimated_remaining_rows = max(
+                    max_active_estimated_remaining_rows,
+                    int(estimated_remaining_rows),
+                )
+        estimated_remaining_ms = _non_negative_int(
+            derived.get("estimated_remaining_ms")
+        )
+        if estimated_remaining_ms is not None:
+            if max_active_estimated_remaining_ms is None:
+                max_active_estimated_remaining_ms = int(estimated_remaining_ms)
+            else:
+                max_active_estimated_remaining_ms = max(
+                    max_active_estimated_remaining_ms,
+                    int(estimated_remaining_ms),
+                )
         data = latest.get("data") if isinstance(latest.get("data"), dict) else {}
         stage = data.get("stage")
         if isinstance(stage, str) and stage:
@@ -5652,6 +5759,14 @@ def _brief_hsl_replay_health(hsl_replay_health: dict[str, Any]) -> dict[str, Any
         out["max_active_latest_elapsed_ms"] = int(max_active_latest_elapsed_ms)
     if max_active_latest_event_age_ms is not None:
         out["max_active_latest_event_age_ms"] = int(max_active_latest_event_age_ms)
+    if max_active_estimated_remaining_rows is not None:
+        out["max_active_estimated_remaining_rows"] = int(
+            max_active_estimated_remaining_rows
+        )
+    if max_active_estimated_remaining_ms is not None:
+        out["max_active_estimated_remaining_ms"] = int(
+            max_active_estimated_remaining_ms
+        )
     if max_completed_elapsed_ms is not None:
         out["max_completed_elapsed_ms"] = int(max_completed_elapsed_ms)
     if active_stage_counts:

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -3002,6 +3002,9 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
                     "stage": "pair_replay",
                     "pair_idx": 3,
                     "pairs": 29,
+                    "held_pairs": 1,
+                    "cooldown_pairs": 1,
+                    "required_pairs": 20,
                     "current_position_pairs": 1,
                     "timeline_rows": 43201,
                     "start_ts": 1782492000000,
@@ -3144,8 +3147,28 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
     assert active_group["latest"]["derived"]["estimated_dense_pair_row_work"] == (
         43201 * 29
     )
+    assert active_group["latest"]["derived"]["estimated_held_pair_row_work"] == 43201
+    assert active_group["latest"]["derived"]["estimated_cooldown_pair_row_work"] == 43201
+    assert active_group["latest"]["derived"]["estimated_required_pair_row_work"] == (
+        43201 * 20
+    )
+    assert active_group["latest"]["derived"]["estimated_dense_remaining_rows"] == (
+        43201 * 29 - 64000
+    )
+    assert active_group["latest"]["derived"]["estimated_required_remaining_rows"] == (
+        43201 * 20 - 64000
+    )
+    assert active_group["latest"]["derived"]["estimated_remaining_rows"] == (
+        43201 * 20 - 64000
+    )
+    assert active_group["latest"]["derived"]["estimated_dense_remaining_ms"] == 3733584
+    assert active_group["latest"]["derived"]["estimated_required_remaining_ms"] == 2512507
+    assert active_group["latest"]["derived"]["estimated_remaining_ms"] == 2512507
     assert active_group["latest"]["derived"]["observed_work_pct"] == pytest.approx(
         5.108
+    )
+    assert active_group["latest"]["derived"]["observed_required_work_pct"] == pytest.approx(
+        7.407
     )
     assert "AKIA123" not in json.dumps(report["hsl_replay_health"], sort_keys=True)
     assert "must-not-render" not in json.dumps(
@@ -3184,6 +3207,8 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
         "failed_attention_bots": 1,
         "max_active_latest_elapsed_ms": 255750,
         "max_active_latest_event_age_ms": 60000,
+        "max_active_estimated_remaining_rows": 800020,
+        "max_active_estimated_remaining_ms": 2512507,
         "max_completed_elapsed_ms": 1623400,
         "active_stage_counts": {"pair_replay": 1},
         "event_types": {


### PR DESCRIPTION
## Summary
- derive HSL replay remaining rows and ETA in live-smoke-report hsl_replay_health from existing sanitized hsl.replay.* events
- add max active primary remaining rows/time to the brief hsl_replay summary
- move PR #979 into merged progress evidence and mark this smoke slice as current

## Validation
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py
- ./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check
- added-line silent-handling scan on src/live/smoke_report.py and tests/test_live_smoke_report.py
- ./venv/bin/passivbot tool live-smoke-report monitor --logs-root /private/tmp/passivbot_empty_logs --recent-minutes 120 --max-event-files-per-bot 1 --event-tail-lines 5000 --brief --compact

## Behavior
Read-only smoke/report projection only. No event producers, exchange calls, cache mutation, readiness gates, console routing, monitor writes, process signaling, smoke verdict policy, order/risk logic, or trading behavior changed.