### PR TITLE
Clarify flat coin HSL cooldown severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Flat coin-mode HSL cooldown finalizations now emit their
+  `hsl.red_triggered` event as informational instead of critical when no
+  exchange close was needed, so smoke reports no longer treat cooldown-only
+  flat symbols as hard panic failures.
 - Legacy unstuck status/selection console lines are now suppressed when the
   structured live event console path is active, leaving the structured
   `[unstuck]` projection as the default operator output while preserving a

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -255,6 +255,7 @@ def _emit_hsl_red_triggered_once(
 ) -> None:
     if state.get("red_trigger_event_emitted"):
         return
+    no_exchange_close_needed = bool(data.get("no_exchange_close_needed"))
     _emit_hsl_event(
         self,
         "hsl.red_triggered",
@@ -263,8 +264,8 @@ def _emit_hsl_red_triggered_once(
         pside=pside,
         symbol=symbol,
         ts=ts,
-        level="critical",
-        status="degraded",
+        level="info" if no_exchange_close_needed else "critical",
+        status="succeeded" if no_exchange_close_needed else "degraded",
         reason_code=reason_code,
     )
     state["red_trigger_event_emitted"] = True
@@ -4070,17 +4071,27 @@ async def _equity_hard_stop_finalize_coin_red_stop(
             entry_orders=entry_orders,
             nonpanic_close_orders=nonpanic_close_orders,
         )
+    trigger_extra = {
+        "reason": "coin_red_stop_finalized",
+        "cooldown_until_ms": cooldown_until_ms,
+        "no_restart_latched": bool(no_restart_latched),
+    }
+    if finalized_without_order:
+        trigger_extra.update(
+            {
+                "no_exchange_close_needed": True,
+                "exchange_close_order_submitted": False,
+                "panic_order_submitted_count": 0,
+                "symbol_position_open": False,
+                "entry_orders": entry_orders,
+                "nonpanic_close_orders": nonpanic_close_orders,
+                "flat_confirmations": flat_confirmations,
+            }
+        )
     _emit_hsl_red_triggered_once(
         self,
         state,
-        _hsl_event_data(
-            stop_event,
-            {
-                "reason": "coin_red_stop_finalized",
-                "cooldown_until_ms": cooldown_until_ms,
-                "no_restart_latched": bool(no_restart_latched),
-            },
-        ),
+        _hsl_event_data(stop_event, trigger_extra),
         pside=pside,
         symbol=symbol,
         ts=stop_ts_ms,

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -832,6 +832,21 @@ async def test_coin_hsl_finalize_emits_flat_without_order_event():
     assert event.data["stop_event_anchor_fallback_used"] is True
     assert event.data["cooldown_until_ms"] == 480_000
     assert event.data["drawdown_raw"] == 0.0
+    red_events = [
+        event for event in sink.events if event.event_type == EventTypes.HSL_RED_TRIGGERED
+    ]
+    assert len(red_events) == 1
+    red_event = red_events[0]
+    assert red_event.level == "info"
+    assert red_event.status == "succeeded"
+    assert red_event.reason_code == "coin_red_stop_finalized"
+    assert red_event.data["no_exchange_close_needed"] is True
+    assert red_event.data["exchange_close_order_submitted"] is False
+    assert red_event.data["panic_order_submitted_count"] == 0
+    assert red_event.data["symbol_position_open"] is False
+    assert red_event.data["entry_orders"] == 0
+    assert red_event.data["nonpanic_close_orders"] == 0
+    assert red_event.data["flat_confirmations"] == 2
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -3294,6 +3294,22 @@ def test_live_smoke_report_distinguishes_attention_and_hard_structured_events(
                 level="critical",
                 reason_code="terminal_startup_failure",
             ),
+            _monitor_row(
+                event_type="hsl.red_triggered",
+                seq=3,
+                ts=1200,
+                status="succeeded",
+                level="info",
+                reason_code="coin_red_stop_finalized",
+                symbol="ZEC/USDT:USDT",
+                pside="long",
+                data={
+                    "no_exchange_close_needed": True,
+                    "exchange_close_order_submitted": False,
+                    "panic_order_submitted_count": 0,
+                    "symbol_position_open": False,
+                },
+            ),
         ],
     )
 


### PR DESCRIPTION
## Summary
- Keep coin-mode HSL flat cooldown behavior unchanged, but emit the final flat/no-exchange-close hsl.red_triggered event as info/succeeded instead of critical/degraded.
- Add no-exchange-close context to that event so smoke/review tooling can distinguish cooldown-only flat symbols from real panic-close failures.
- Add regression coverage for HSL flat finalization event severity and live-smoke hard/problem classification.

## VPS evidence
- VPS5 ZEC HSL events showed flat finalization with no_exchange_close_needed=true, exchange_close_order_submitted=false, panic_order_submitted_count=0, symbol_position_open=false, position_count=0, flat_confirmations=2.
- A fresh read-only VPS5 query over the last 12h found no ZEC action.planned, execution.create_*, fill.ingested, or position.changed events.
- Local incident notes are in local_reports/hsl_zec_coin_mode_cooldown_vps5_20260702.md and are intentionally not committed.

## Tests
- ./venv/bin/python -m pytest tests/test_hsl_coin_mode.py::test_coin_hsl_finalize_uses_latest_panic_fill_for_reset_boundary tests/test_hsl_coin_mode.py::test_coin_hsl_finalize_emits_flat_without_order_event tests/test_hsl_coin_mode.py::test_coin_hsl_finalize_flat_without_order_event_records_panic_fill_anchor tests/test_live_smoke_report.py::test_live_smoke_report_distinguishes_attention_and_hard_structured_events
- ./venv/bin/python -m py_compile src/passivbot_hsl.py
- git diff --check