### PR TITLE
Dedupe order wave console summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable user-facing changes will be documented in this file.
   `hsl.red_triggered` event as informational instead of critical when no
   exchange close was needed, so smoke reports no longer treat cooldown-only
   flat symbols as hard panic failures.
+- Legacy order-wave complete/settled console lines are now suppressed when the
+  structured live event console path is active, leaving structured execution
+  wave summaries as the default operator output while preserving the legacy
+  lines as fallback.
 - Legacy unstuck status/selection console lines are now suppressed when the
   structured live event console path is active, leaving the structured
   `[unstuck]` projection as the default operator output while preserving a

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -112,6 +112,9 @@ phase is slow or complete: account state, active-candle warmup, HSL replay,
 full warmup, market state, and final startup readiness. The legacy stdlib
 startup timing line is only a fallback when the structured event console path
 is unavailable or explicitly disabled.
+Order-wave complete/settled summaries are console-visible through structured
+events, and the legacy stdlib order-wave summary lines are only fallbacks when
+the structured event console path is unavailable or explicitly disabled.
 Position-level `trailing.status`, `unstuck.status`, and `unstuck.selection`
 events are console-visible because they explain why an existing position is
 waiting, armed, triggered, over budget, selected for unstucking, or blocked by

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -5510,6 +5510,19 @@ VPS5 deployment status:
   `hard_failures=0`, `logs.hard_matches=0`, `matched_expected=5`, clean tracked
   repository state, and all hard failure sources at zero.
 
+### Draft Slice: Order Wave Console Dedupe
+
+- Branch: `codex/v8-dedupe-order-wave-console`.
+- Scope: observability-only console routing cleanup for order-wave lifecycle
+  summaries.
+- Result: when the structured live-event console path is active, legacy stdlib
+  `[order] wave complete` and `[order] wave settled` lines are suppressed so
+  operators see the structured execution/confirmation summaries without
+  duplicate legacy lines. If the structured console path is unavailable or
+  disabled, legacy order-wave lines remain the fallback.
+- Local validation: targeted order-wave console tests and live-event console
+  formatter tests passed, plus `py_compile` for touched Python files.
+
 ### Critical Live Safety Gap: Coin-HSL Startup Replay Latency
 
 - Discovery: Binance VPS5 startup on 2026-06-26 showed coin-mode HSL history

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -4501,6 +4501,8 @@ class Passivbot:
                 elapsed_ms=elapsed_ms,
                 level=logging.getLevelName(log_level).lower(),
             )
+        if self._live_event_console_available():
+            return
         if log_level == logging.DEBUG and summary_key == getattr(
             self, "_order_wave_last_summary_key", None
         ):
@@ -4645,6 +4647,8 @@ class Passivbot:
                     confirm_ms=confirm_ms,
                     level=logging.getLevelName(log_level).lower(),
                 )
+            if self._live_event_console_available():
+                continue
             logging.log(
                 log_level,
                 "[order] wave settled | id=%s | elapsed_ms=%d | confirm_ms=%d | "

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2412,6 +2412,35 @@ def test_order_wave_summary_logs_elapsed_lifecycle(monkeypatch, caplog):
     )
 
 
+def test_order_wave_summary_uses_event_console_when_available(monkeypatch, caplog):
+    bot = Passivbot.__new__(Passivbot)
+    bot._order_wave_seq = 0
+    bot._order_wave_last_summary_key = None
+    bot.live_event_console_enabled = True
+    bot._live_event_pipeline = object()
+    emitted = []
+    bot._emit_order_wave_completed_event = lambda wave, **kwargs: emitted.append(
+        (wave, kwargs)
+    )
+    clock = iter([1_000_000, 1_002_500])
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: next(clock))
+
+    wave = bot._begin_order_wave(
+        [{"symbol": "BTC/USDT:USDT"}],
+        [{"symbol": "ETH/USDT:USDT"}],
+    )
+    wave["cancel_posted"] = 1
+    wave["create_posted"] = 1
+
+    with caplog.at_level(logging.INFO):
+        bot._log_order_wave_summary(wave)
+
+    assert emitted
+    assert emitted[0][1]["elapsed_ms"] == 2500
+    assert emitted[0][1]["level"] == "info"
+    assert not any("[order] wave complete" in record.message for record in caplog.records)
+
+
 def test_order_wave_settlement_logs_authoritative_confirmation(monkeypatch, caplog):
     bot = Passivbot.__new__(Passivbot)
     bot._order_wave_seq = 0
@@ -2451,6 +2480,47 @@ def test_order_wave_settlement_logs_authoritative_confirmation(monkeypatch, capl
         and "symbols=BTC,ETH" in record.message
         for record in caplog.records
     )
+
+
+def test_order_wave_settlement_uses_event_console_when_available(monkeypatch, caplog):
+    bot = Passivbot.__new__(Passivbot)
+    bot._order_wave_seq = 0
+    bot._pending_order_waves = []
+    bot.live_event_console_enabled = True
+    bot._live_event_pipeline = object()
+    emitted = []
+    bot._emit_execution_confirmation_satisfied_event = (
+        lambda **kwargs: emitted.append(kwargs)
+    )
+    times = iter([1_000_000, 1_000_500, 1_003_000, 1_003_000])
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: next(times))
+
+    wave = bot._begin_order_wave(
+        [{"symbol": "BTC/USDT:USDT"}],
+        [{"symbol": "ETH/USDT:USDT"}],
+    )
+    bot._authoritative_refresh_epoch = 4
+    bot._authoritative_pending_confirmations = {}
+    bot._order_wave_in_progress = wave
+    bot._request_authoritative_confirmation({"open_orders"})
+    bot._order_wave_in_progress = None
+    wave["cancel_posted"] = 1
+    wave["create_posted"] = 1
+    bot._track_order_wave_confirmation(wave)
+
+    with caplog.at_level(logging.INFO):
+        bot._log_settled_order_waves(
+            current_epoch=5,
+            fresh_surfaces={"open_orders"},
+            changed_surfaces=["open_orders", "positions"],
+        )
+
+    assert emitted
+    assert emitted[0]["elapsed_ms"] == 3000
+    assert emitted[0]["confirm_ms"] == 2500
+    assert emitted[0]["level"] == "info"
+    assert bot._pending_order_waves == []
+    assert not any("[order] wave settled" in record.message for record in caplog.records)
 
 
 def test_order_wave_settlement_demotes_quick_open_orders_confirmation(


### PR DESCRIPTION
## Scope
Observability-only live logging slice. When the structured live-event console path is active, suppress legacy stdlib `[order] wave complete` and `[order] wave settled` lines so operators see the structured execution/confirmation summaries without duplicate legacy output. Legacy lines remain fallback when the structured console path is unavailable or disabled.

## Validation
- `./venv/bin/python -m pytest tests/test_passivbot_balance_split.py::test_order_wave_summary_logs_elapsed_lifecycle tests/test_passivbot_balance_split.py::test_order_wave_summary_uses_event_console_when_available tests/test_passivbot_balance_split.py::test_order_wave_settlement_logs_authoritative_confirmation tests/test_passivbot_balance_split.py::test_order_wave_settlement_uses_event_console_when_available tests/test_passivbot_balance_split.py::test_order_wave_settlement_demotes_quick_open_orders_confirmation tests/test_live_event_bus.py::test_console_format_summarizes_order_wave_payload tests/test_live_event_bus.py::test_console_format_summarizes_confirmation_timeout`
- `./venv/bin/python -m py_compile src/passivbot.py src/live/event_bus.py`
- `git diff --check`

No exchange calls, order construction, risk logic, readiness gates, monitor persistence, or trading behavior changed.