### PR TITLE
Dedupe account state console summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Legacy balance and position-change console lines are now suppressed when the
+  structured live event console path is active, leaving `balance.changed` and
+  `position.changed` projections as the default operator output while
+  preserving legacy lines as fallback.
 - Flat coin-mode HSL cooldown finalizations now emit their
   `hsl.red_triggered` event as informational instead of critical when no
   exchange close was needed, so smoke reports no longer treat cooldown-only

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -94,6 +94,8 @@ coin; routine flat coin-universe status remains in the structured event stream
 but is kept off the console. Fill, position, and balance change events are
 console-visible because they are the primary operator-facing account state
 changes.
+Legacy stdlib position-change and balance-change lines are only fallbacks when
+the structured event console path is unavailable or explicitly disabled.
 `risk.mode_changed` and `hsl.transition` events are console-visible because
 mode changes and HSL tier transitions explain risk-state changes that affect
 trading.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,20 @@ Last updated: 2026-07-02.
 
 Current `origin/v8` head:
 
-- `c2a04904` after PR #973, `Dedupe startup timing console logs`.
+- `f6700c5cd` after PR #983, `Dedupe order wave console summaries`.
 
 Current logging-overhaul head:
 
-- `c2a04904` after PR #973, `Dedupe startup timing console logs`.
+- `f6700c5cd` after PR #983, `Dedupe order wave console summaries`.
 
 Current work:
 
-- Branch `codex/v8-trailing-unstuck-console-events` keeps the existing
-  structured `trailing.status`, `unstuck.status`, and `unstuck.selection`
-  operator summaries as the console source of truth and suppresses duplicate
-  legacy unstuck stdlib lines when the event-console path is active. The legacy
-  unstuck lines remain fallback output if that path is disabled or unavailable.
+- Branch `codex/v8-dedupe-account-state-console` suppresses duplicate legacy
+  balance and position-change stdlib console lines when the structured
+  live-event console path is active. The existing `balance.changed` and
+  `position.changed` events remain the console source of truth, and the legacy
+  lines remain fallback output if the structured event console path is disabled
+  or unavailable.
 
 Current review gate:
 
@@ -61,6 +62,23 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #983 at `f6700c5cd`.
+- PR #983 suppressed legacy order-wave complete/settled stdlib console lines
+  when the structured live-event console path is active. It merged after Claude
+  and Hermes approved with no findings, CI was green, and local focused tests
+  passed. VPS5 checkout was updated to `f6700c5cd` on disk without restarting
+  running bots because the slice was console-only and HSL replay was still
+  active.
+- Repository pulled through PR #982 at `c7a89c9c`.
+- PR #982 made flat coin-mode HSL cooldown finalizations informational instead
+  of critical when no exchange close was needed. It merged after Claude and
+  Hermes approved with no findings and CI was green. VPS5 bots were restarted
+  and left running; settled smoke reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, clean tracked repository state at
+  `repository.head=c7a89c9c`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `fill_refresh.failed=0`, and
+  `logs.hard_matches=0`. Remaining attention was non-hard active HSL replay
+  and EMA-unavailable/staged-refresh diagnostics.
 - Repository pulled through PR #972 at `f789dccc`.
 - PR #972 projected existing `bot.startup_timing` events into the default live
   event console/text sinks and kept trading behavior unchanged. It merged after

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -10471,7 +10471,7 @@ class Passivbot:
             try:
                 equity = balance_raw + (await self.calc_upnl_sum())
                 self._monitor_last_equity = float(equity)
-                if should_log:
+                if should_log and not self._live_event_console_available():
                     logging.info(
                         "[balance] raw %.6f -> %.6f | snap %.6f -> %.6f | equity: %.4f source: %s",
                         self._previous_balance_raw,
@@ -10481,8 +10481,8 @@ class Passivbot:
                         equity,
                         source,
                     )
-                    if raw_only:
-                        self._last_raw_only_log_time = now
+                if should_log and raw_only:
+                    self._last_raw_only_log_time = now
                 self._monitor_record_event(
                     "account.balance",
                     ("account", "balance"),
@@ -13103,6 +13103,9 @@ class Passivbot:
                     pbr.round_dynamic(upnl, 3),
                 ]
             )
+
+        if self._live_event_console_available():
+            return
 
         # Print aligned table with [pos] prefix
         for line in table.get_string().splitlines():

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -792,6 +792,78 @@ async def test_log_position_changes_classifies_signed_exposure_changes(
 
 
 @pytest.mark.asyncio
+async def test_log_position_changes_suppresses_legacy_table_when_event_console_active(
+    monkeypatch, caplog
+):
+    bot = Passivbot.__new__(Passivbot)
+    bot.inverse = False
+    bot.c_mults = {"XMR/USDT:USDT": 1.0}
+    bot.pside_int_map = {"long": 1, "short": -1}
+    bot.get_raw_balance = lambda: 1_000.0
+    bot.bp = lambda pside, key, symbol: 1.0 if key == "wallet_exposure_limit" else 0.0
+    bot.bot_value = lambda pside, key: 10.0
+    bot.live_event_console_enabled = True
+    sink = ListEventSink()
+    bot.exchange = "binance"
+    bot.user = "binance_01"
+    bot.bot_id = "bot_1"
+    bot._live_event_current_cycle_id = "cy_pos"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._current_live_event_cycle_id = Passivbot._current_live_event_cycle_id.__get__(
+        bot, Passivbot
+    )
+    bot._emit_live_event = Passivbot._emit_live_event.__get__(bot, Passivbot)
+    bot._emit_position_changed_event = (
+        Passivbot._emit_position_changed_event.__get__(bot, Passivbot)
+    )
+
+    async def _get_live_last_prices(symbols, **kwargs):
+        return {symbol: 0.0 for symbol in symbols}
+
+    bot._get_live_last_prices = _get_live_last_prices
+    monkeypatch.setattr(
+        passivbot_module.pbr,
+        "qty_to_cost",
+        lambda qty, price, c_mult: abs(qty) * price * c_mult,
+    )
+    monkeypatch.setattr(
+        passivbot_module.pbr, "calc_pprice_diff_int", lambda *args: 0.0, raising=False
+    )
+
+    with caplog.at_level(logging.INFO):
+        await bot.log_position_changes(
+            [
+                {
+                    "symbol": "XMR/USDT:USDT",
+                    "position_side": "long",
+                    "size": 0.1,
+                    "price": 100.0,
+                }
+            ],
+            [
+                {
+                    "symbol": "XMR/USDT:USDT",
+                    "position_side": "long",
+                    "size": 0.3,
+                    "price": 100.0,
+                }
+            ],
+        )
+
+    assert not any("[pos]" in record.getMessage() for record in caplog.records)
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[-1]
+    assert event.event_type == EventTypes.POSITION_CHANGED
+    assert event.reason_code == "added"
+    assert event.data["old_size"] == pytest.approx(0.1)
+    assert event.data["new_size"] == pytest.approx(0.3)
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
 async def test_shutdown_gracefully_awaits_cancelled_maintainers():
     bot = Passivbot.__new__(Passivbot)
     bot._shutdown_in_progress = False

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -2664,7 +2664,7 @@ def test_monitor_emit_stop_records_startup_terminal_structured_stopped():
 
 
 @pytest.mark.asyncio
-async def test_handle_balance_update_records_monitor_balance_event():
+async def test_handle_balance_update_records_monitor_balance_event(caplog):
     import passivbot as pb_mod
 
     sink = ListEventSink()
@@ -2673,12 +2673,14 @@ async def test_handle_balance_update_records_monitor_balance_event():
         _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
         _emit_balance_changed_event = pb_mod.Passivbot._emit_balance_changed_event
         _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _live_event_console_available = pb_mod.Passivbot._live_event_console_available
         _monitor_record_event = pb_mod.Passivbot._monitor_record_event
 
-        def __init__(self):
+        def __init__(self, *, live_event_console_enabled: bool = False):
             self.exchange = "binance"
             self.user = "binance_01"
             self.bot_id = "bot_1"
+            self.live_event_console_enabled = live_event_console_enabled
             self._live_event_current_cycle_id = "cy_20"
             self._live_event_pipeline = LiveEventPipeline(
                 structured_sinks=[sink],
@@ -2702,9 +2704,11 @@ async def test_handle_balance_update_records_monitor_balance_event():
 
     bot = FakeBot()
 
-    await pb_mod.Passivbot.handle_balance_update(bot, source="REST")
+    with caplog.at_level(logging.INFO):
+        await pb_mod.Passivbot.handle_balance_update(bot, source="REST")
 
     assert bot.execution_scheduled is True
+    assert any("[balance] raw" in record.message for record in caplog.records)
     assert bot._monitor_last_equity == pytest.approx(107.5)
     assert bot.monitor_publisher.events[-1]["kind"] == "account.balance"
     assert bot.monitor_publisher.events[-1]["payload"]["equity"] == pytest.approx(107.5)
@@ -2717,6 +2721,60 @@ async def test_handle_balance_update_records_monitor_balance_event():
     assert event.data["balance_raw_delta"] == pytest.approx(10.0)
     assert event.data["balance_snapped_delta"] == pytest.approx(7.0)
     assert event.data["equity"] == pytest.approx(107.5)
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_handle_balance_update_suppresses_legacy_log_when_event_console_active(
+    caplog,
+):
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_balance_changed_event = pb_mod.Passivbot._emit_balance_changed_event
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _live_event_console_available = pb_mod.Passivbot._live_event_console_available
+        _monitor_record_event = pb_mod.Passivbot._monitor_record_event
+
+        def __init__(self):
+            self.exchange = "binance"
+            self.user = "binance_01"
+            self.bot_id = "bot_1"
+            self.live_event_console_enabled = True
+            self._live_event_current_cycle_id = "cy_20"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+            self.monitor_publisher = RecorderPublisher()
+            self._previous_balance_raw = 90.0
+            self._previous_balance_snapped = 88.0
+            self._last_raw_only_log_time = 0.0
+            self._monitor_last_equity = 0.0
+            self.execution_scheduled = False
+
+        def get_raw_balance(self):
+            return 100.0
+
+        def get_hysteresis_snapped_balance(self):
+            return 95.0
+
+        async def calc_upnl_sum(self):
+            return 7.5
+
+    bot = FakeBot()
+
+    with caplog.at_level(logging.INFO):
+        await pb_mod.Passivbot.handle_balance_update(bot, source="REST")
+
+    assert bot.execution_scheduled is True
+    assert not any("[balance] raw" in record.message for record in caplog.records)
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert sink.events[-1].event_type == EventTypes.BALANCE_CHANGED
+    assert sink.events[-1].data["balance_raw_delta"] == pytest.approx(10.0)
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
## Summary
- suppress legacy stdlib [balance] and [pos] console lines when the structured live-event console path is active
- keep existing balance.changed and position.changed events as the console source of truth
- preserve legacy balance/position lines as fallback when the structured event console is disabled or unavailable
- update logging guide/changelog/progress ledger, including PR #982/#983 status catch-up

## Notes
- Fills are intentionally not deduped in this slice because the legacy >20 fill summary is not equivalent to per-fill fill.ingested console projections. That should wait for a batch-fill event/summary slice.

## Validation
- ./venv/bin/python -m pytest tests/test_passivbot_monitor.py::test_handle_balance_update_records_monitor_balance_event tests/test_passivbot_monitor.py::test_handle_balance_update_suppresses_legacy_log_when_event_console_active tests/test_passivbot_balance_split.py::test_log_position_changes_classifies_signed_exposure_changes tests/test_passivbot_balance_split.py::test_log_position_changes_suppresses_legacy_table_when_event_console_active tests/test_live_event_bus.py::test_console_format_summarizes_position_changed tests/test_live_event_bus.py::test_console_format_summarizes_balance_changed
- ./venv/bin/python -m py_compile src/passivbot.py src/live/event_bus.py src/live/event_emitters.py
- git diff --check