### PR TITLE
Project low-balance create skips to event console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Low-balance exposure-increasing create skips now appear through the
+  structured live event console as `execution.create_skipped` summaries, and
+  the legacy `[balance] too low` line is only a fallback when that path is
+  unavailable or disabled.
 - Legacy balance and position-change console lines are now suppressed when the
   structured live event console path is active, leaving `balance.changed` and
   `position.changed` projections as the default operator output while

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -104,6 +104,10 @@ events are console-visible because they explain operator-relevant order
 omissions: staged entries waiting for an acceptable market distance, entries
 skipped because the configured slot size is below exchange-effective minimums,
 and loss-realizing closes deferred by the realized-loss gate.
+Low-balance exposure-increasing create skips are also console-visible through
+`execution.create_skipped`; the legacy `[balance] too low` line is only a
+fallback when the structured event console path is unavailable or explicitly
+disabled.
 Periodic `health.summary` events are console-visible because they provide a
 compact operator heartbeat covering uptime, loop latency, position counts,
 recent order/fill activity, errors, and resource pressure. Degraded

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,20 +19,19 @@ Last updated: 2026-07-02.
 
 Current `origin/v8` head:
 
-- `f6700c5cd` after PR #983, `Dedupe order wave console summaries`.
+- `b15da359` after PR #984, `Dedupe account state console summaries`.
 
 Current logging-overhaul head:
 
-- `f6700c5cd` after PR #983, `Dedupe order wave console summaries`.
+- `b15da359` after PR #984, `Dedupe account state console summaries`.
 
 Current work:
 
-- Branch `codex/v8-dedupe-account-state-console` suppresses duplicate legacy
-  balance and position-change stdlib console lines when the structured
-  live-event console path is active. The existing `balance.changed` and
-  `position.changed` events remain the console source of truth, and the legacy
-  lines remain fallback output if the structured event console path is disabled
-  or unavailable.
+- Branch `codex/v8-low-balance-console-event` makes existing
+  `execution.create_skipped` low-balance create-skip events visible in the
+  structured live-event console and leaves the legacy `[balance] too low` line
+  as fallback output if the structured event console path is disabled or
+  unavailable.
 
 Current review gate:
 
@@ -62,6 +61,17 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #984 at `b15da359`.
+- PR #984 suppressed duplicate legacy balance and position-change stdlib
+  console lines when the structured live-event console path is active. It
+  merged after Claude and Hermes approved with no findings and CI was green.
+  VPS5 checkout was updated to `b15da359` on disk without restarting running
+  bots because the slice was console-only and HSL replay remained active. Smoke
+  after the fast-forward reported `ok=true`, `hard_failures=0`, five running
+  live processes, clean tracked repository state, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, and `fill_refresh.failed=0`;
+  remaining attention was non-hard active HSL replay and EMA/readiness
+  diagnostics.
 - Repository pulled through PR #983 at `f6700c5cd`.
 - PR #983 suppressed legacy order-wave complete/settled stdlib console lines
   when the structured live-event console path is active. It merged after Claude

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -698,7 +698,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.EXECUTION_CREATE_FAILED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CREATE_REJECTED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CREATE_DEFERRED: EventRoute(console=False, text=False),
-    EventTypes.EXECUTION_CREATE_SKIPPED: EventRoute(console=False, text=False),
+    EventTypes.EXECUTION_CREATE_SKIPPED: EventRoute(console=True, text=True),
     EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED: EventRoute(
         console=True, text=True
     ),
@@ -955,6 +955,21 @@ def _console_create_filter_summary(event: LiveEvent) -> list[str]:
     symbols = _compact_csv(data.get("symbols"), limit=4)
     if symbols:
         parts.append(f"symbols={symbols}")
+    raw_balance = _data_number(data, "raw_balance")
+    quote = _data_str(data, "quote")
+    if raw_balance is not None:
+        suffix = f" {quote}" if quote else ""
+        parts.append(f"balance={raw_balance:g}{suffix}")
+    balance_threshold = _data_number(data, "balance_threshold")
+    if balance_threshold is not None:
+        suffix = f" {quote}" if quote else ""
+        parts.append(f"threshold={balance_threshold:g}{suffix}")
+    allowed_cancel = _data_int(data, "allowed_cancel")
+    if allowed_cancel is not None:
+        parts.append(f"allow_cancel={allowed_cancel}")
+    allowed_protective_create = _data_int(data, "allowed_protective_create")
+    if allowed_protective_create is not None:
+        parts.append(f"allow_protective_create={allowed_protective_create}")
     return parts
 
 

--- a/src/live/executor.py
+++ b/src/live/executor.py
@@ -201,15 +201,22 @@ async def execute_order_plan(
                         "allowed_protective_create": len(to_create),
                     },
                 )
-            logging.info(
-                "[balance] too low: %.2f %s; skipped %d exposure-increasing order creates; "
-                "allowing %d cancellations and %d protective creates",
-                raw_balance,
-                bot.quote,
-                len(blocked_creates),
-                len(to_cancel),
-                len(to_create),
+            live_event_console_available = False
+            live_event_console_available_fn = getattr(
+                passivbot_cls, "_live_event_console_available", None
             )
+            if callable(live_event_console_available_fn):
+                live_event_console_available = bool(live_event_console_available_fn(bot))
+            if not live_event_console_available:
+                logging.info(
+                    "[balance] too low: %.2f %s; skipped %d exposure-increasing order creates; "
+                    "allowing %d cancellations and %d protective creates",
+                    raw_balance,
+                    bot.quote,
+                    len(blocked_creates),
+                    len(to_cancel),
+                    len(to_create),
+                )
     if bot.debug_mode:
         if to_cancel:
             print(

--- a/tests/test_exchange_config_updates.py
+++ b/tests/test_exchange_config_updates.py
@@ -550,6 +550,7 @@ async def test_execute_to_exchange_allows_cancellations_when_balance_too_low(
             pb_mod.Passivbot._emit_execution_create_filter_event
         )
         _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _live_event_console_available = pb_mod.Passivbot._live_event_console_available
         _shutdown_requested = pb_mod.Passivbot._shutdown_requested
 
         debug_mode = False
@@ -633,6 +634,95 @@ async def test_execute_to_exchange_allows_cancellations_when_balance_too_low(
         for record in caplog.records
     )
     assert any("allowing 1 cancellations and 0 protective creates" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_low_balance_create_skip_uses_event_console_when_available(caplog):
+    import passivbot as pb_mod
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_execution_create_filter_event = (
+            pb_mod.Passivbot._emit_execution_create_filter_event
+        )
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _live_event_console_available = pb_mod.Passivbot._live_event_console_available
+        _shutdown_requested = pb_mod.Passivbot._shutdown_requested
+
+        debug_mode = False
+        balance_threshold = 1.0
+        quote = "USDT"
+        stop_signal_received = False
+        state_change_detected_by_symbol = set()
+
+        def __init__(self):
+            self.live_event_console_enabled = True
+            self._live_event_current_cycle_id = "cy_low_balance"
+            self._live_event_sink = ListEventSink()
+            self._live_event_console_sink = ListEventSink()
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[self._live_event_sink],
+                monitor_sinks=[],
+                console_sink=self._live_event_console_sink,
+            )
+            self.cancel_called = False
+            self.create_called = False
+            self.config_called = False
+            self.execution_scheduled = False
+
+        async def execution_cycle(self):
+            return None
+
+        async def calc_orders_to_cancel_and_create(self):
+            return [
+                {
+                    "symbol": "BTC/USDT:USDT",
+                    "side": "buy",
+                    "position_side": "long",
+                    "price": 1.0,
+                    "qty": 1.0,
+                }
+            ], [
+                {
+                    "symbol": "BTC/USDT:USDT",
+                    "side": "sell",
+                    "position_side": "long",
+                    "price": 0.9,
+                    "qty": 1.0,
+                }
+            ]
+
+        def get_raw_balance(self):
+            return 0.0
+
+        async def execute_cancellations_parent(self, orders):
+            self.cancel_called = True
+            return []
+
+        async def update_exchange_configs(self, symbols=None):
+            self.config_called = True
+            return set(symbols or [])
+
+        async def execute_orders_parent(self, orders):
+            self.create_called = True
+            return []
+
+    bot = FakeBot()
+    with caplog.at_level(logging.INFO):
+        await pb_mod.Passivbot.execute_to_exchange(bot)
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert bot.cancel_called
+    assert not bot.create_called
+    assert not any("[balance] too low" in record.message for record in caplog.records)
+    assert [event.event_type for event in bot._live_event_console_sink.events] == [
+        EventTypes.EXECUTION_CREATE_SKIPPED
+    ]
+    console_event = bot._live_event_console_sink.events[0]
+    assert console_event.reason_code == ReasonCodes.LOW_BALANCE
+    assert console_event.data["raw_balance"] == pytest.approx(0.0)
+    assert console_event.data["balance_threshold"] == pytest.approx(1.0)
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -257,7 +257,8 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.ORDER_WAVE_COMPLETED].console is True
     assert DEFAULT_ROUTES[EventTypes.ORDER_WAVE_COMPLETED].text is True
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CREATE_DEFERRED].console is False
-    assert DEFAULT_ROUTES[EventTypes.EXECUTION_CREATE_SKIPPED].console is False
+    assert DEFAULT_ROUTES[EventTypes.EXECUTION_CREATE_SKIPPED].console is True
+    assert DEFAULT_ROUTES[EventTypes.EXECUTION_CREATE_SKIPPED].text is True
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CONFIRMATION_TIMEOUT].console is True
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CONFIRMATION_TIMEOUT].text is True
     assert DEFAULT_ROUTES[EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED].console is True
@@ -856,6 +857,34 @@ def test_console_format_summarizes_create_filter_payload():
         "symbols=BTC/USDT:USDT,ETH/USDT:USDT "
         "reason=pending_exchange_config "
         "create orders skipped while exchange config update is pending"
+    )
+
+
+def test_console_format_summarizes_low_balance_create_skip():
+    event = LiveEvent(
+        EventTypes.EXECUTION_CREATE_SKIPPED,
+        status="skipped",
+        cycle_id="cy_low_balance",
+        order_wave_id="ow_5",
+        reason_code=ReasonCodes.LOW_BALANCE,
+        message="exposure-increasing creates skipped because balance is below threshold",
+        data={
+            "order_count": 3,
+            "symbols": ["BTC/USDT:USDT", "ETH/USDT:USDT", "SOL/USDT:USDT"],
+            "raw_balance": 0.25,
+            "balance_threshold": 1.0,
+            "quote": "USDT",
+            "allowed_cancel": 2,
+            "allowed_protective_create": 1,
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[gate] skipped cycle=cy_low_balance wave=ow_5 orders=3 "
+        "symbols=BTC/USDT:USDT,ETH/USDT:USDT,SOL/USDT:USDT "
+        "balance=0.25 USDT threshold=1 USDT allow_cancel=2 "
+        "allow_protective_create=1 reason=low_balance "
+        "exposure-increasing creates skipped because balance is below threshold"
     )
 
 


### PR DESCRIPTION
## Summary
- make existing execution.create_skipped events console/text visible so skipped creates are surfaced through the structured live event pipeline
- enrich create-skip console summaries with low-balance context: balance, threshold, allowed cancellations, and allowed protective creates
- suppress the legacy [balance] too low stdlib line when the structured event console path is active, while keeping it as fallback output
- update logging guide, changelog, and progress ledger with PR #984 deploy evidence

## Behavior
Observability-only. Order filtering and execution behavior are unchanged: exposure-increasing creates are still skipped below balance_threshold, cancellations and protective creates remain allowed, and the structured event emission remains best-effort.

## Validation
- ./venv/bin/python -m pytest tests/test_live_event_bus.py::test_route_table_keeps_data_events_off_console_by_default tests/test_live_event_bus.py::test_console_format_summarizes_create_filter_payload tests/test_live_event_bus.py::test_console_format_summarizes_low_balance_create_skip tests/test_exchange_config_updates.py::test_execute_to_exchange_allows_cancellations_when_balance_too_low tests/test_exchange_config_updates.py::test_low_balance_create_skip_uses_event_console_when_available
- ./venv/bin/python -m py_compile src/live/executor.py src/live/event_bus.py src/passivbot.py
- git diff --check