### PR TITLE
Make event console gates test-stub safe

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,18 @@ Last updated: 2026-07-02.
 
 Current `origin/v8` head:
 
-- `b15da359` after PR #984, `Dedupe account state console summaries`.
+- `947b75b1` after PR #985, `Project low-balance create skips to event console`.
 
 Current logging-overhaul head:
 
-- `b15da359` after PR #984, `Dedupe account state console summaries`.
+- `947b75b1` after PR #985, `Project low-balance create skips to event console`.
 
 Current work:
 
-- Branch `codex/v8-low-balance-console-event` makes existing
-  `execution.create_skipped` low-balance create-skip events visible in the
-  structured live-event console and leaves the legacy `[balance] too low` line
-  as fallback output if the structured event console path is disabled or
-  unavailable.
+- Branch `codex/v8-defensive-event-console-gates` makes previously merged
+  passivbot.py console-dedup gates robust for borrowed-method FakeBot callers by
+  using the class helper directly. This is production-behavior neutral and
+  restores executor-path test coverage broken by #983/#984.
 
 Current review gate:
 
@@ -61,6 +60,18 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #985 at `947b75b1`.
+- PR #985 projected existing `execution.create_skipped` low-balance create-skip
+  events into the structured console/text sinks and made the legacy
+  `[balance] too low` line fallback-only. It merged after Claude and Hermes
+  approved with no findings and CI was green. VPS5 checkout was updated to
+  `947b75b1` on disk without restarting running bots because the slice was
+  console-only and HSL replay remained active. Smoke after the fast-forward
+  reported `ok=true`, `hard_failures=0`, five running live processes, clean
+  tracked repository state, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, and `fill_refresh.failed=0`;
+  remaining attention was non-hard active HSL replay and Hyperliquid EMA
+  readiness diagnostics.
 - Repository pulled through PR #984 at `b15da359`.
 - PR #984 suppressed duplicate legacy balance and position-change stdlib
   console lines when the structured live-event console path is active. It

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -3360,7 +3360,7 @@ class Passivbot:
             status_changed
             or (now_ms - last_info_ms) >= self._unstuck_unchanged_info_log_interval_ms
         ):
-            if not self._live_event_console_available():
+            if not Passivbot._live_event_console_available(self):
                 logging.info("[unstuck] %s", " | ".join(parts))
             self._emit_unstuck_status_event(
                 side_statuses=side_infos,
@@ -3396,7 +3396,7 @@ class Passivbot:
             price_diff_pct = 0.0
             sign = ""
         coin = symbol.split("/")[0] if "/" in symbol else symbol
-        if not self._live_event_console_available():
+        if not Passivbot._live_event_console_available(self):
             logging.info(
                 "[unstuck] selecting %s %s | entry=%.2f now=%.2f (%s%.1f%%) | allowance=%.2f",
                 coin,
@@ -3952,7 +3952,7 @@ class Passivbot:
         since_previous_s = max(0.0, (now_ms - previous_ms) / 1000.0)
         marks[label] = now_ms
         self._startup_timing_last_mark_ms = now_ms
-        if not self._live_event_console_available():
+        if not Passivbot._live_event_console_available(self):
             suffix = f" | {details}" if details else ""
             logging.info(
                 "[boot] startup timing | %s-ready=%.2fs | since_previous=%.2fs%s",
@@ -4501,7 +4501,7 @@ class Passivbot:
                 elapsed_ms=elapsed_ms,
                 level=logging.getLevelName(log_level).lower(),
             )
-        if self._live_event_console_available():
+        if Passivbot._live_event_console_available(self):
             return
         if log_level == logging.DEBUG and summary_key == getattr(
             self, "_order_wave_last_summary_key", None
@@ -4647,7 +4647,7 @@ class Passivbot:
                     confirm_ms=confirm_ms,
                     level=logging.getLevelName(log_level).lower(),
                 )
-            if self._live_event_console_available():
+            if Passivbot._live_event_console_available(self):
                 continue
             logging.log(
                 log_level,
@@ -10471,7 +10471,7 @@ class Passivbot:
             try:
                 equity = balance_raw + (await self.calc_upnl_sum())
                 self._monitor_last_equity = float(equity)
-                if should_log and not self._live_event_console_available():
+                if should_log and not Passivbot._live_event_console_available(self):
                     logging.info(
                         "[balance] raw %.6f -> %.6f | snap %.6f -> %.6f | equity: %.4f source: %s",
                         self._previous_balance_raw,
@@ -13104,7 +13104,7 @@ class Passivbot:
                 ]
             )
 
-        if self._live_event_console_available():
+        if Passivbot._live_event_console_available(self):
             return
 
         # Print aligned table with [pos] prefix


### PR DESCRIPTION
## Summary
- replace internal direct self._live_event_console_available() calls in passivbot.py with the class helper call, so borrowed Passivbot methods also work on duck-typed FakeBot stubs
- production behavior is unchanged for real Passivbot instances
- update logging-overhaul progress with PR #985 merge/deploy evidence

Closes #986.

## Validation
- ./venv/bin/python -m pytest tests/test_exchange_config_updates.py -k "execute_to_exchange or execute_order_plan"
- ./venv/bin/python -m pytest tests/test_passivbot_balance_split.py::test_order_wave_summary_uses_event_console_when_available tests/test_passivbot_balance_split.py::test_order_wave_settlement_uses_event_console_when_available tests/test_passivbot_balance_split.py::test_unstuck_status_suppresses_legacy_log_when_event_console_active tests/test_passivbot_balance_split.py::test_unstuck_selection_suppresses_legacy_log_when_event_console_active tests/test_passivbot_monitor.py::test_handle_balance_update_suppresses_legacy_log_when_event_console_active tests/test_passivbot_balance_split.py::test_log_position_changes_suppresses_legacy_table_when_event_console_active
- ./venv/bin/python -m py_compile src/passivbot.py
- git diff --check