### PR TITLE
Report stale active HSL replay in smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report` now labels active HSL startup replay
+  groups as stale or long-running when existing monitor events show no recent
+  progress or prolonged replay elapsed time, making startup-blocked bots easier
+  to spot without changing trading behavior.
 - Low-balance exposure-increasing create skips now appear through the
   structured live event console as `execution.create_skipped` summaries, and
   the legacy `[balance] too low` line is only a fallback when that path is

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -5562,6 +5562,22 @@ VPS5 deployment status:
 - Local validation: targeted order-wave console tests and live-event console
   formatter tests passed, plus `py_compile` for touched Python files.
 
+### Draft Slice: HSL Replay Stale Smoke Classification
+
+- Branch: `codex/v8-hsl-replay-stale-smoke`.
+- Scope: read-only smoke-report refinement for existing HSL replay monitor
+  events.
+- Triggering evidence: after PR #987 was merged and VPS5 was fast-forwarded to
+  `c021376d`, a smoke run stayed non-green because GateIO had one recovered
+  `cycle.degraded` from market snapshots aging just past the 10s readiness
+  limit, and KuCoin showed an active coin-HSL replay with no completion event.
+  Follow-up event queries showed GateIO completed later cycles, while KuCoin
+  was still startup-blocked in HSL replay after long candle-history fetches.
+- Intended result: make active HSL replay groups easier to classify in smoke
+  output by adding stale-progress and long-running active counts from existing
+  bounded monitor data. This is observability-only and does not change HSL,
+  order, candle, exchange, readiness, or risk behavior.
+
 ### Critical Live Safety Gap: Coin-HSL Startup Replay Latency
 
 - Discovery: Binance VPS5 startup on 2026-06-26 showed coin-mode HSL history

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -96,6 +96,8 @@ EMA_READINESS_GROUP_LIMIT = 20
 STAGED_READINESS_GROUP_LIMIT = 20
 EVENT_PIPELINE_HEALTH_GROUP_LIMIT = 20
 HSL_REPLAY_HEALTH_GROUP_LIMIT = 20
+HSL_REPLAY_STALE_ACTIVE_EVENT_AGE_MS = 5 * 60 * 1000
+HSL_REPLAY_LONG_RUNNING_ACTIVE_MS = 10 * 60 * 1000
 EXCHANGE_CONFIG_REFRESH_HEALTH_GROUP_LIMIT = 20
 RISK_EVENT_TYPES = {
     EventTypes.RISK_MODE_CHANGED,
@@ -3152,6 +3154,25 @@ def _hsl_replay_latest_event_age_ms(
     return int(max(0, int(report_ts_ms) - int(ts)))
 
 
+def _hsl_replay_record_elapsed_ms(record: Any) -> int | None:
+    if not isinstance(record, dict):
+        return None
+    derived = record.get("derived") if isinstance(record.get("derived"), dict) else {}
+    elapsed_candidates = [
+        _non_negative_int(derived.get(key))
+        for key in (
+            "latest_elapsed_ms",
+            "startup_blocking_elapsed_ms",
+            "full_elapsed_ms",
+            "history_build_elapsed_ms",
+            "price_history_fetch_elapsed_ms",
+            "timeline_replay_elapsed_ms",
+        )
+    ]
+    elapsed_values = [int(value) for value in elapsed_candidates if value is not None]
+    return max(elapsed_values) if elapsed_values else None
+
+
 def _with_hsl_replay_active_age(
     group: dict[str, Any],
     *,
@@ -3171,6 +3192,18 @@ def _with_hsl_replay_active_age(
     latest_out["derived"] = derived_out
     out["latest"] = latest_out
     out["active_latest_event_age_ms"] = int(age_ms)
+    elapsed_ms = _hsl_replay_record_elapsed_ms(latest_out)
+    stale = int(age_ms) >= HSL_REPLAY_STALE_ACTIVE_EVENT_AGE_MS
+    long_running = (
+        elapsed_ms is not None
+        and int(elapsed_ms) >= HSL_REPLAY_LONG_RUNNING_ACTIVE_MS
+    )
+    if stale:
+        out["active_stale"] = True
+        out["active_stale_threshold_ms"] = HSL_REPLAY_STALE_ACTIVE_EVENT_AGE_MS
+    if long_running:
+        out["active_long_running"] = True
+        out["active_long_running_threshold_ms"] = HSL_REPLAY_LONG_RUNNING_ACTIVE_MS
     return out
 
 
@@ -3198,6 +3231,8 @@ def _summarize_hsl_replay_health(
     )
     compact_groups: list[dict[str, Any]] = []
     active_bots = 0
+    stale_active_bots = 0
+    long_running_active_bots = 0
     completed_bots = 0
     failed_bots = 0
     failed_attention_bots = 0
@@ -3239,6 +3274,10 @@ def _summarize_hsl_replay_health(
             public_group,
             report_ts_ms=int(report_ts_ms),
         )
+        if active and bool(public_group.get("active_stale")):
+            stale_active_bots += 1
+        if active and bool(public_group.get("active_long_running")):
+            long_running_active_bots += 1
         compact_groups.append(
             {
                 key: value
@@ -3252,6 +3291,8 @@ def _summarize_hsl_replay_health(
         "event_types": dict(event_type_counts.most_common()),
         "bots": len(groups),
         "active_bots": int(active_bots),
+        "stale_active_bots": int(stale_active_bots),
+        "long_running_active_bots": int(long_running_active_bots),
         "completed_bots": int(completed_bots),
         "failed_bots": int(failed_bots),
         "failed_attention_bots": int(failed_attention_bots),
@@ -5140,6 +5181,8 @@ def _summary_limited_groups(
             "outcomes": summary.get("outcomes"),
             "bots": summary.get("bots"),
             "active_bots": summary.get("active_bots"),
+            "stale_active_bots": summary.get("stale_active_bots"),
+            "long_running_active_bots": summary.get("long_running_active_bots"),
             "completed_bots": summary.get("completed_bots"),
             "failed_bots": summary.get("failed_bots"),
             "latest_failed_bots": summary.get("latest_failed_bots"),
@@ -5656,6 +5699,12 @@ def _brief_hsl_replay_health(hsl_replay_health: dict[str, Any]) -> dict[str, Any
         "total": _count_value(hsl_replay_health.get("total")),
         "bots": _count_value(hsl_replay_health.get("bots")),
         "active_bots": _count_value(hsl_replay_health.get("active_bots")),
+        "stale_active_bots": _count_value(
+            hsl_replay_health.get("stale_active_bots")
+        ),
+        "long_running_active_bots": _count_value(
+            hsl_replay_health.get("long_running_active_bots")
+        ),
         "completed_bots": _count_value(hsl_replay_health.get("completed_bots")),
         "failed_bots": _count_value(hsl_replay_health.get("failed_bots")),
         "failed_attention_bots": _count_value(
@@ -5674,30 +5723,10 @@ def _brief_hsl_replay_health(hsl_replay_health: dict[str, Any]) -> dict[str, Any
     max_completed_elapsed_ms: int | None = None
     active_stage_counts: Counter[str] = Counter()
 
-    def record_elapsed_ms(record: Any) -> int | None:
-        if not isinstance(record, dict):
-            return None
-        derived = record.get("derived") if isinstance(record.get("derived"), dict) else {}
-        elapsed_candidates = [
-            _non_negative_int(derived.get(key))
-            for key in (
-                "latest_elapsed_ms",
-                "startup_blocking_elapsed_ms",
-                "full_elapsed_ms",
-                "history_build_elapsed_ms",
-                "price_history_fetch_elapsed_ms",
-                "timeline_replay_elapsed_ms",
-            )
-        ]
-        elapsed_values = [
-            int(value) for value in elapsed_candidates if value is not None
-        ]
-        return max(elapsed_values) if elapsed_values else None
-
     for group in groups:
         if not isinstance(group, dict):
             continue
-        completed_elapsed_ms = record_elapsed_ms(group.get("completed"))
+        completed_elapsed_ms = _hsl_replay_record_elapsed_ms(group.get("completed"))
         if completed_elapsed_ms is not None:
             if max_completed_elapsed_ms is None:
                 max_completed_elapsed_ms = int(completed_elapsed_ms)
@@ -5718,7 +5747,7 @@ def _brief_hsl_replay_health(hsl_replay_health: dict[str, Any]) -> dict[str, Any
                     int(event_age_ms),
                 )
         latest = group.get("latest") if isinstance(group.get("latest"), dict) else {}
-        elapsed_ms = record_elapsed_ms(latest)
+        elapsed_ms = _hsl_replay_record_elapsed_ms(latest)
         if elapsed_ms is not None:
             if max_active_latest_elapsed_ms is None:
                 max_active_latest_elapsed_ms = int(elapsed_ms)

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2910,7 +2910,7 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
 
 
 def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
-    monkeypatch.setattr(smoke_report_module, "utc_ms", lambda: 65000)
+    monkeypatch.setattr(smoke_report_module, "utc_ms", lambda: 365000)
     _write_ndjson(
         tmp_path
         / "monitor"
@@ -3015,8 +3015,8 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
                     "skipped_price_symbols": 1,
                     "missing_price_symbols": 2,
                     "rows_per_second": 318.415,
-                    "elapsed_s": 201.2,
-                    "history_build_elapsed_s": 255.75,
+                    "elapsed_s": 701.2,
+                    "history_build_elapsed_s": 755.75,
                     "price_history_fetch_elapsed_s": 210.5,
                     "timeline_replay_elapsed_s": 12.25,
                     "timeframe": "1m",
@@ -3117,6 +3117,8 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
     assert report["attention_sources"]["hsl_replay_failed_bots"] == 1
     assert report["attention_sources"]["total"] == 3
     assert report["hsl_replay_health"]["active_bots"] == 1
+    assert report["hsl_replay_health"]["stale_active_bots"] == 1
+    assert report["hsl_replay_health"]["long_running_active_bots"] == 1
     assert report["hsl_replay_health"]["completed_bots"] == 1
     assert report["hsl_replay_health"]["failed_bots"] == 2
     assert report["hsl_replay_health"]["failed_attention_bots"] == 1
@@ -3129,7 +3131,11 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
     active_group = report["hsl_replay_health"]["groups"][0]
     assert active_group["bot"] == "gateio/gateio_01"
     assert active_group["active"] is True
-    assert active_group["active_latest_event_age_ms"] == 60000
+    assert active_group["active_latest_event_age_ms"] == 360000
+    assert active_group["active_stale"] is True
+    assert active_group["active_stale_threshold_ms"] == 300000
+    assert active_group["active_long_running"] is True
+    assert active_group["active_long_running_threshold_ms"] == 600000
     assert active_group["latest"]["symbol"] == "ZEC/USDT:USDT"
     assert active_group["latest"]["data"]["timeframe"] == "1m"
     assert active_group["latest"]["data"]["history_minutes"] == 43201
@@ -3140,8 +3146,8 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
     assert active_group["latest"]["data"]["start_ts"] == 1782492000000
     assert active_group["latest"]["data"]["end_ts"] == 1782492600000
     assert active_group["latest"]["data"]["record_start_ts"] == 1782492000000
-    assert active_group["latest"]["derived"]["history_build_elapsed_ms"] == 255750
-    assert active_group["latest"]["derived"]["latest_event_age_ms"] == 60000
+    assert active_group["latest"]["derived"]["history_build_elapsed_ms"] == 755750
+    assert active_group["latest"]["derived"]["latest_event_age_ms"] == 360000
     assert active_group["latest"]["derived"]["price_history_fetch_elapsed_ms"] == 210500
     assert active_group["latest"]["derived"]["timeline_replay_elapsed_ms"] == 12250
     assert active_group["latest"]["derived"]["estimated_dense_pair_row_work"] == (
@@ -3182,6 +3188,8 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
         sort_keys=True,
     )
     assert summary["hsl_replay_health"]["active_bots"] == 1
+    assert summary["hsl_replay_health"]["stale_active_bots"] == 1
+    assert summary["hsl_replay_health"]["long_running_active_bots"] == 1
     assert summary["hsl_replay_health"]["groups"][0]["active"] is True
     failed_group = next(
         group
@@ -3202,11 +3210,13 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
         "total": 9,
         "bots": 4,
         "active_bots": 1,
+        "stale_active_bots": 1,
+        "long_running_active_bots": 1,
         "completed_bots": 1,
         "failed_bots": 2,
         "failed_attention_bots": 1,
-        "max_active_latest_elapsed_ms": 255750,
-        "max_active_latest_event_age_ms": 60000,
+        "max_active_latest_elapsed_ms": 755750,
+        "max_active_latest_event_age_ms": 360000,
         "max_active_estimated_remaining_rows": 800020,
         "max_active_estimated_remaining_ms": 2512507,
         "max_completed_elapsed_ms": 1623400,


### PR DESCRIPTION
## Summary
- label active HSL replay smoke groups as stale when the latest active event is older than 5 minutes
- label active HSL replay groups as long-running when elapsed replay work exceeds 10 minutes
- expose the new counts in full, summary, and brief smoke-report output from existing monitor data only

## Behavior
- observability-only
- no trading, order, exchange, candle, HSL, readiness, or risk behavior changed
- no new event producers or exchange calls

## Validation
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- ./venv/bin/python -m py_compile src/live/smoke_report.py
- git diff --check
- silent-handling scan on touched smoke-report/test files; matches are existing read-only aggregation patterns