### PR TITLE
Narrow coin HSL startup price replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Coin-mode HSL startup reconstruction now limits candle-price replay and
+  strict historical UPnL validation to current-position symbols and historical
+  panic-close cooldown symbols. Flat non-panic historical fill symbols no
+  longer block startup or force broad candle replay, while runtime coin-HSL
+  still evaluates them from fill history after startup.
 - `passivbot tool live-smoke-report` now labels active HSL startup replay
   groups as stale or long-running when existing monitor events show no recent
   progress or prolonged replay elapsed time, making startup-blocked bots easier

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -5594,6 +5594,24 @@ VPS5 deployment status:
   finishes. Fresh initial entries may remain blocked until full replay is
   complete.
 
+### Draft Slice: Coin-HSL Startup Replay Scope Narrowing
+
+- Branch: `codex/v8-hsl-coin-flat-history-upnl`.
+- Triggering evidence: after PR #988 was deployed to VPS5 at `d2021419`,
+  KuCoin was no longer running. Its latest log ended in terminal startup
+  failure during `equity_hard_stop_initialize_coin_from_history`:
+  `get_balance_equity_history()['timeline'][]['unrealized_pnl_by_coin_pside']`
+  missing required coin HSL symbol `AVAX/USDT:USDT`. The same startup had spent
+  more than an hour in coin-HSL history reconstruction and candle fetch locks
+  even though KuCoin had no current positions/open orders.
+- Root contract adjustment: coin-HSL startup replay should be strict for
+  current-position symbols and historical panic-close cooldown symbols, because
+  those can affect immediate protective action. Flat non-panic historical fill
+  symbols should not block startup or force candle-price replay; they remain
+  available to runtime coin-HSL through the PnL manager once the bot is active.
+- Intended result: faster and less brittle coin-HSL startup for flat accounts,
+  while preserving hard validation for held symbols and cooldown reconstruction.
+
 ## Current Next Steps
 
 1. Prioritize a separate trading-path PR for coin-HSL startup replay latency:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -12349,7 +12349,16 @@ class Passivbot:
             )
         }
         symbols.update(current_position_symbols)
+        panic_event_symbols = {
+            evt["symbol"]
+            for evt in events
+            if evt["symbol"]
+            and "panic" in str(evt.get("pb_order_type") or "").lower()
+        }
         price_replay_symbols = set(symbols)
+        if str(hsl_replay_signal_mode or "").lower() == "coin":
+            coin_required_price_symbols = current_position_symbols | panic_event_symbols
+            price_replay_symbols.intersection_update(coin_required_price_symbols)
         known_market_symbols = (
             set(self.c_mults) if isinstance(getattr(self, "c_mults", None), dict) else set()
         )
@@ -12386,6 +12395,8 @@ class Passivbot:
                     "symbols": len(symbols),
                     "price_replay_symbols": len(price_replay_symbols),
                     "skipped_price_symbols": len(symbols - price_replay_symbols),
+                    "current_position_symbols": len(current_position_symbols),
+                    "panic_event_symbols": len(panic_event_symbols),
                     "history_minutes": history_minutes,
                     "replay_concurrency": int(replay_concurrency),
                     "lookback_days": lookback.display_value,
@@ -12538,6 +12549,8 @@ class Passivbot:
                         1 for prices in price_lookup.values() if not prices
                     ),
                     "approximate_price_symbols": len(approximate_price_sources),
+                    "current_position_symbols": len(current_position_symbols),
+                    "panic_event_symbols": len(panic_event_symbols),
                     "history_minutes": history_minutes,
                     "replay_concurrency": int(replay_concurrency),
                     "price_history_fetch_elapsed_s": round(candle_fetch_elapsed_s, 3),

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -2648,8 +2648,9 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     continue
                 pside = _equity_hard_stop_fill_pside(event)
                 symbols.add(symbol)
-                required_replay_pairs.add((pside, symbol))
-                remember_required_replay_start(pside, symbol, ts)
+                if (pside, symbol) in current_position_pairs:
+                    required_replay_pairs.add((pside, symbol))
+                    remember_required_replay_start(pside, symbol, ts)
         for row in timeline:
             if not isinstance(row, dict):
                 continue
@@ -2723,11 +2724,12 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
         rows = 0
         replay_started_s = time.monotonic()
         last_progress_log_s = replay_started_s
+        replay_symbols = set(symbols)
         active_pairs = [
             (pside, symbol)
             for pside in self._hsl_psides()
             if self._equity_hard_stop_coin_active_pside(pside)
-            for symbol in sorted(symbols)
+            for symbol in sorted(replay_symbols)
         ]
         active_pair_set = set(active_pairs)
         active_held_pairs = active_pair_set.intersection(current_position_pairs)
@@ -2823,7 +2825,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             cooldown_minutes = float(cfg["cooldown_minutes_after_red"])
             cooldown_ms = int(round(cooldown_minutes * 60_000.0)) if cooldown_minutes > 0.0 else 0
             no_restart_drawdown_threshold = float(cfg["no_restart_drawdown_threshold"])
-            for symbol in sorted(symbols):
+            for symbol in sorted(replay_symbols):
                 check_shutdown("hsl_coin_history_replay_pair")
                 pair_idx += 1
                 state = self._hsl_coin_state(pside, symbol)
@@ -2956,6 +2958,8 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     if not has_unrealized and require_coin_timeline_value:
                         replay_position_size = replay_size_at(ts)
                         if replay_ambiguous or replay_position_size > 1e-12:
+                            if not require_coin_timeline_fields:
+                                continue
                             current_upnl = _equity_hard_stop_history_coin_value(
                                 row,
                                 "unrealized_pnl_by_coin_pside",

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -1271,6 +1271,60 @@ async def test_coin_hsl_history_replay_requires_relevant_symbol_fields():
 
 
 @pytest.mark.asyncio
+async def test_coin_hsl_startup_skips_flat_nonpanic_history_missing_upnl():
+    bot = make_coin_bot()
+    symbol = "A"
+
+    async def fake_history(current_balance=None, **kwargs):
+        return {
+            "timeline": [
+                {
+                    "timestamp": 60_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {symbol: {"long": 0.0, "short": 0.0}},
+                    "unrealized_pnl_by_coin_pside": {},
+                },
+                {
+                    "timestamp": 120_000,
+                    "balance": 95.0,
+                    "realized_pnl": -5.0,
+                    "realized_pnl_by_coin_pside": {symbol: {"long": -5.0, "short": 0.0}},
+                    "unrealized_pnl_by_coin_pside": {},
+                },
+            ],
+            "panic_flatten_events": [],
+            "fill_events": [
+                {
+                    "timestamp": 60_000,
+                    "symbol": symbol,
+                    "pside": "long",
+                    "action": "increase",
+                    "qty": 1.0,
+                    "price": 100.0,
+                    "pnl": 0.0,
+                },
+                {
+                    "timestamp": 120_000,
+                    "symbol": symbol,
+                    "pside": "long",
+                    "action": "decrease",
+                    "qty": 1.0,
+                    "price": 95.0,
+                    "pnl": -5.0,
+                },
+            ],
+        }
+
+    bot.get_balance_equity_history = fake_history
+
+    await bot._equity_hard_stop_initialize_coin_from_history()
+
+    assert bot._equity_hard_stop_coin_initialized is True
+    assert bot._runtime_forced_modes == {"long": {}, "short": {}}
+
+
+@pytest.mark.asyncio
 async def test_coin_hsl_history_replay_allows_flat_realized_only_rows():
     bot = make_coin_bot()
     symbol = "A"
@@ -1380,7 +1434,14 @@ async def test_coin_hsl_history_replay_requires_upnl_for_flat_ambiguous_decrease
                     "unrealized_pnl_by_coin_pside": {},
                 },
             ],
-            "panic_flatten_events": [],
+            "panic_flatten_events": [
+                {
+                    "timestamp": 120_000,
+                    "minute_timestamp": 120_000,
+                    "symbol": symbol,
+                    "pside": "long",
+                }
+            ],
             "fill_events": [
                 {
                     "timestamp": 120_000,
@@ -1390,6 +1451,7 @@ async def test_coin_hsl_history_replay_requires_upnl_for_flat_ambiguous_decrease
                     "qty": 1.0,
                     "price": 95.0,
                     "pnl": -5.0,
+                    "pb_order_type": "close_panic_long",
                 },
             ],
         }

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -3663,6 +3663,76 @@ async def test_get_balance_equity_history_hyperliquid_backfills_from_5m(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_get_balance_equity_history_coin_hsl_skips_nonpanic_flat_price_fetch(
+    monkeypatch,
+):
+    cfg = _dummy_config()
+    cfg["live"]["pnls_max_lookback_days"] = 30.0
+    bot = _make_dummy_bot(cfg)
+    bot._live_values["pnls_max_lookback_days"] = 30.0
+    symbol = "AVAX/USDT:USDT"
+    base_minute = (1_700_000_000_000 // 60_000) * 60_000
+    bot.c_mults = {symbol: 1.0}
+    bot.inverse = False
+    bot.positions = {}
+    bot.fetched_positions = []
+    bot.get_exchange_time = lambda: base_minute + 180_000
+    bot.get_raw_balance = lambda: 95.0
+
+    async def fake_init_pnls():
+        return None
+
+    class FakeCM:
+        async def get_candles(
+            self, symbol_, start_ts=None, end_ts=None, strict=False, timeframe=None
+        ):
+            raise AssertionError(
+                f"non-panic flat coin-HSL history should not fetch candles for {symbol_}"
+            )
+
+    monkeypatch.setattr(bot, "init_pnls", fake_init_pnls)
+    bot.cm = FakeCM()
+
+    fill_events = [
+        {
+            "timestamp": base_minute,
+            "symbol": symbol,
+            "position_side": "long",
+            "qty": 1.0,
+            "price": 100.0,
+            "side": "buy",
+            "pnl": 0.0,
+            "pb_order_type": "entry",
+        },
+        {
+            "timestamp": base_minute + 60_000,
+            "symbol": symbol,
+            "position_side": "long",
+            "qty": 1.0,
+            "price": 95.0,
+            "side": "sell",
+            "pnl": -5.0,
+            "pb_order_type": "close_grid",
+        },
+    ]
+
+    history = await bot.get_balance_equity_history(
+        fill_events=fill_events,
+        current_balance=95.0,
+        hsl_replay_signal_mode="coin",
+    )
+
+    assert history["metadata"]["symbols_covered"] == []
+    assert history["metadata"]["missing_price_symbols"] == []
+    assert history["timeline"][-1]["realized_pnl_by_coin_pside"][symbol][
+        "long"
+    ] == pytest.approx(-5.0)
+    assert history["timeline"][-1]["unrealized_pnl_by_coin_pside"][symbol][
+        "long"
+    ] == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
 async def test_get_balance_equity_history_records_panic_flatten_with_same_minute_reentry(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- narrow coin-mode HSL history candle-price replay to current-position symbols and historical panic-close symbols
- keep startup replay strict for current-position/cooldown-required pairs, but do not terminally fail flat non-panic historical symbols when historical UPnL is missing during optional open-history rows
- add regression coverage for the VPS5 KuCoin shape: flat non-panic historical AVAX-style fills should not fetch candles or block startup, while panic/cooldown ambiguity remains strict

## Triggering evidence
After #988 was deployed to VPS5 at d2021419, KuCoin was not running. Its log ended with terminal startup failure during coin-HSL reconstruction:



That startup also spent more than an hour in coin-HSL history reconstruction/candle fetch locks despite having no current positions/open orders.

## Behavior and safety
- trading-path change, scoped to coin-HSL startup replay
- held symbols and historical panic-close cooldown symbols remain strict
- flat non-panic historical fill symbols still contribute realized rows when usable and remain available to runtime coin-HSL through the PnL manager
- no order/exchange submission behavior changed directly

## Validation
- ./venv/bin/python -m pytest tests/test_hsl_coin_mode.py -q
- ./venv/bin/python -m pytest tests/test_unstucking_safeguards.py -k get_balance_equity_history -q
- ./venv/bin/python -m py_compile src/passivbot.py src/passivbot_hsl.py
- git diff --check
- silent-handling scan on touched live/test files; matches are existing large-file/test-fixture patterns, no new broad catch or neutral trading fallback added