### PR TITLE
Add context to smoke log matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report` now attaches the timestamped log context
+  line to unparseable traceback/error matches, making hard text-log matches
+  easier to attribute without changing smoke verdict policy.
 - `passivbot tool live-smoke-report` now reports timestamp/nonce
   `cycle.degraded` events recovered by a subsequent successful
   `exchange.time_sync` event as recovered problem events instead of hard smoke

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -5638,6 +5638,25 @@ VPS5 deployment status:
   problem event in detailed, summary, and brief smoke output. This changes only
   report classification; it does not add exchange calls, change live recovery,
   or alter trading behavior.
+- Result: PR #990 was reviewed, merged to `v8`, and deployed to VPS5. After the
+  transient Kucoin maintenance timeout aged out of the requested 10-minute
+  window, VPS5 smoke was green on `bed4f285` with all five expected bots
+  running and no hard problem/log/process failures.
+
+### Draft Slice: Text Log Match Context
+
+- Branch: `codex/v8-log-match-context`.
+- Scope: read-only smoke-report text-log projection for existing log matches.
+- Triggering evidence: the post-PR #990 VPS5 smoke briefly stayed hard-red
+  because Kucoin logged a transient `maintain_hourly_cycle` exchange timeout
+  with traceback fragments. The structured event stream already classified the
+  config-refresh failure as a warning, but the hard text-log matches only showed
+  `Traceback (most recent call last):` without the timestamped context line in
+  the compact match entry.
+- Intended result: attach the nearest timestamped log context line to matched
+  unparseable traceback/error lines. This should make future smoke reports
+  explain what subsystem emitted a hard text-log fragment without suppressing
+  or down-classifying the hard match.
 
 ## Current Next Steps
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -5084,10 +5084,14 @@ def _scan_logs(
     dropped_unparsed_hard_matches = 0
     for path in files:
         log_context_ts_ms: int | None = None
+        log_context_line_no: int | None = None
+        log_context_text: str | None = None
         for line_no, line in _tail_lines(path, max_lines=tail_lines):
             line_ts = _parse_log_line_ts_ms(line)
             if line_ts is not None:
                 log_context_ts_ms = line_ts
+                log_context_line_no = int(line_no)
+                log_context_text = line
             attention = bool(ATTENTION_LOG_PATTERN.search(line))
             if window_enabled:
                 if line_ts is None:
@@ -5141,6 +5145,14 @@ def _scan_logs(
                 }
                 if line_ts is not None:
                     match["ts"] = line_ts
+                elif log_context_ts_ms is not None:
+                    match["context_ts"] = int(log_context_ts_ms)
+                    if log_context_line_no is not None:
+                        match["context_line"] = int(log_context_line_no)
+                    if log_context_text:
+                        match["context_text"] = _redact_log_text(
+                            log_context_text, max_len=500
+                        )
                 matches.append(match)
     return {
         "root": str(Path(root).expanduser()),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -4026,6 +4026,12 @@ def test_live_smoke_report_log_window_drop_preserves_unparseable_hard_signal(tmp
         "1970-01-01T00:00:03Z ERROR exchange call failed",
         "Traceback (most recent call last):",
     ]
+    assert report["logs"]["matches"][1]["context_ts"] == 3000
+    assert report["logs"]["matches"][1]["context_line"] == 1
+    assert (
+        report["logs"]["matches"][1]["context_text"]
+        == "1970-01-01T00:00:03Z ERROR exchange call failed"
+    )
 
 
 def test_live_smoke_report_log_window_drops_stale_traceback_with_context(tmp_path):


### PR DESCRIPTION
## Summary
- attach nearest timestamped log context to unparseable text-log matches in live-smoke-report
- keep existing hard/attention verdict behavior unchanged
- record PR #990 VPS5 smoke evidence and this follow-up slice in the logging progress notes

## Behavior boundary
- report output only
- no smoke verdict policy change
- no exchange calls, event emission changes, readiness gates, order/risk logic, or trading behavior changes

## Validation
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- ./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check -- CHANGELOG.md docs/plans/live_logging_overhaul_progress.md src/live/smoke_report.py tests/test_live_smoke_report.py
- silent-handling audit on touched smoke files; only existing aggregation defaults/broad catch patterns were reported