### PR TITLE
Summarize EMA readiness reasons in smoke report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable user-facing changes will be documented in this file.
 - `passivbot tool live-smoke-report` now attaches the timestamped log context
   line to unparseable traceback/error matches, making hard text-log matches
   easier to attribute without changing smoke verdict policy.
+- `passivbot tool live-smoke-report` now summarizes EMA-readiness unavailable
+  reasons and candidate error types in concise smoke output, making
+  `cache_only_fetch_failed` vs `never_fetched_cache_only` visible without a
+  separate event query.
 - `passivbot tool live-smoke-report` now reports timestamp/nonce
   `cycle.degraded` events recovered by a subsequent successful
   `exchange.time_sync` event as recovered problem events instead of hard smoke

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -5657,6 +5657,28 @@ VPS5 deployment status:
   unparseable traceback/error lines. This should make future smoke reports
   explain what subsystem emitted a hard text-log fragment without suppressing
   or down-classifying the hard match.
+- Result: PR #991 was reviewed by Hermes and Claude, merged to `v8`, and is
+  pending VPS5 deployment together with the next approved smoke-report slice.
+
+### Draft Slice: EMA Readiness Reason Smoke Summary
+
+- Branch: `codex/v8-smoke-ema-reason-summary`.
+- Scope: read-only smoke-report projection for existing `ema.unavailable`
+  events.
+- Triggering evidence: current VPS5 smoke was green but still showed non-hard
+  EMA-readiness attention. A focused `live-event-query` revealed useful
+  structured detail already present in the events, including
+  `cache_only_fetch_failed`, `never_fetched_cache_only`, and candidate error
+  type groups. Operators should not need a second event-query just to identify
+  the dominant EMA-readiness reason in concise smoke output.
+- Intended result: aggregate latest EMA-readiness candidate reason counts,
+  unavailable reason counts, and candidate error-type counts into the full,
+  summary, and brief smoke-report projections. This changes only report output;
+  it does not add event producers, exchange calls, readiness gates, EMA
+  behavior, order logic, risk logic, or trading behavior.
+- Expected validation: focused EMA-readiness smoke-report test, full
+  `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
+  standard added-line silent-handling scan.
 
 ## Current Next Steps
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -9,7 +9,7 @@ import subprocess
 from collections import Counter, defaultdict, deque
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 from live.event_bus import LIVE_EVENT_MONITOR_PAYLOAD_KEY, EventTypes, utc_ms
 from live.event_file_rows import event_file_rows
@@ -1687,6 +1687,18 @@ def _candidate_error_type_counts(value: Any) -> dict[str, int]:
     return dict(counts.most_common())
 
 
+def _sum_counter_maps(values: Iterable[Any]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for value in values:
+        if not isinstance(value, dict):
+            continue
+        for key, count in value.items():
+            if key is None:
+                continue
+            counts[str(key)] += int(_non_negative_int(count) or 0)
+    return dict(counts.most_common())
+
+
 def _ema_readiness_group(
     *,
     bot_key: str,
@@ -1819,6 +1831,15 @@ def _summarize_ema_readiness_health(
         "latest_optional_drop_total": sum(
             int(group.get("latest_optional_drop_count") or 0)
             for group in groups.values()
+        ),
+        "latest_candidate_reason_counts": _sum_counter_maps(
+            group.get("candidate_reason_counts") for group in groups.values()
+        ),
+        "latest_unavailable_reason_counts": _sum_counter_maps(
+            group.get("unavailable_reason_counts") for group in groups.values()
+        ),
+        "latest_candidate_error_type_counts": _sum_counter_maps(
+            group.get("candidate_error_type_counts") for group in groups.values()
         ),
         "groups": compact_groups,
     }
@@ -5367,6 +5388,18 @@ def _summary_limited_groups(
             ),
             "latest_unavailable_total": summary.get("latest_unavailable_total"),
             "latest_optional_drop_total": summary.get("latest_optional_drop_total"),
+            "latest_candidate_reason_counts": summary.get(
+                "latest_candidate_reason_counts"
+            )
+            or None,
+            "latest_unavailable_reason_counts": summary.get(
+                "latest_unavailable_reason_counts"
+            )
+            or None,
+            "latest_candidate_error_type_counts": summary.get(
+                "latest_candidate_error_type_counts"
+            )
+            or None,
             "latest_missing_surface_total": summary.get("latest_missing_surface_total"),
             "latest_invalid_surface_total": summary.get("latest_invalid_surface_total"),
             "latest_queue_depth_total": summary.get("latest_queue_depth_total"),
@@ -6040,6 +6073,28 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
     event_window = (
         report.get("event_window") if isinstance(report.get("event_window"), dict) else {}
     )
+    ema_readiness_brief = {
+        "total": _count_value(ema_readiness_health.get("total")),
+        "bots": _count_value(ema_readiness_health.get("bots")),
+        "latest_candidate_unavailable_total": _count_value(
+            ema_readiness_health.get("latest_candidate_unavailable_total")
+        ),
+        "latest_unavailable_total": _count_value(
+            ema_readiness_health.get("latest_unavailable_total")
+        ),
+        "latest_optional_drop_total": _count_value(
+            ema_readiness_health.get("latest_optional_drop_total")
+        ),
+        "event_types": ema_readiness_health.get("event_types") or {},
+    }
+    for key in (
+        "latest_candidate_reason_counts",
+        "latest_unavailable_reason_counts",
+        "latest_candidate_error_type_counts",
+    ):
+        value = ema_readiness_health.get(key)
+        if isinstance(value, dict) and value:
+            ema_readiness_brief[key] = value
     return {
         "ok": bool(report.get("ok")),
         "attention": bool(report.get("attention")),
@@ -6181,20 +6236,7 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         "startup_timings": _brief_startup_timings(report.get("startup_timings")),
         "execution": _brief_execution_health(execution_health),
         "fill_refresh": _brief_fill_refresh_health(fill_refresh_health),
-        "ema_readiness": {
-            "total": _count_value(ema_readiness_health.get("total")),
-            "bots": _count_value(ema_readiness_health.get("bots")),
-            "latest_candidate_unavailable_total": _count_value(
-                ema_readiness_health.get("latest_candidate_unavailable_total")
-            ),
-            "latest_unavailable_total": _count_value(
-                ema_readiness_health.get("latest_unavailable_total")
-            ),
-            "latest_optional_drop_total": _count_value(
-                ema_readiness_health.get("latest_optional_drop_total")
-            ),
-            "event_types": ema_readiness_health.get("event_types") or {},
-        },
+        "ema_readiness": ema_readiness_brief,
         "exchange_config_refresh": {
             "total": _count_value(exchange_config_refresh_health.get("total")),
             "bots": _count_value(exchange_config_refresh_health.get("bots")),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1781,6 +1781,16 @@ def test_live_smoke_report_summarizes_ema_readiness_health(tmp_path):
     assert health["latest_unavailable_total"] == 5
     assert health["latest_optional_drop_total"] == 2
     assert health["event_types"] == {"ema.unavailable": 2}
+    assert health["latest_candidate_reason_counts"] == {
+        "cache_only_fetch_failed": 2
+    }
+    assert health["latest_unavailable_reason_counts"] == {
+        "never_fetched_cache_only": 3,
+        "cache_only_fetch_failed": 2,
+    }
+    assert health["latest_candidate_error_type_counts"] == {
+        "MissingLogRangeEma": 1
+    }
     assert health["groups"][0]["count"] == 2
     assert health["groups"][0]["latest_ids"] == {"cycle_id": "cy_ema_2"}
     assert health["groups"][0]["latest_candidate_unavailable_count"] == 2
@@ -1805,6 +1815,12 @@ def test_live_smoke_report_summarizes_ema_readiness_health(tmp_path):
         "latest_candidate_unavailable_total": 2,
         "latest_unavailable_total": 5,
         "latest_optional_drop_total": 2,
+        "latest_candidate_reason_counts": {"cache_only_fetch_failed": 2},
+        "latest_unavailable_reason_counts": {
+            "never_fetched_cache_only": 3,
+            "cache_only_fetch_failed": 2,
+        },
+        "latest_candidate_error_type_counts": {"MissingLogRangeEma": 1},
         "event_types": {"ema.unavailable": 2},
     }
 


### PR DESCRIPTION
## Summary
- aggregate existing EMA-readiness reason and candidate error-type counts into full/summary/brief live-smoke-report output
- keep empty reason maps out of concise output
- record the PR #990 deployed smoke result and this slice in the logging progress ledger

## Behavior boundary
- read-only report projection only
- no event producers, exchange calls, readiness gates, EMA behavior, order logic, risk logic, or trading behavior changed

## Validation
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_ema_readiness_health -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- ./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check -- CHANGELOG.md docs/plans/live_logging_overhaul_progress.md src/live/smoke_report.py tests/test_live_smoke_report.py
- added-line silent-handling scan; only existing smoke-report aggregation/default patterns and one existing read-only monitor parse catch were reported