### PR TITLE
Summarize remote call failures in smoke report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report` now summarizes failed remote-call
+  reasons, surfaces, kinds, and error types in concise smoke output, making
+  transient exchange failures easier to identify without a separate event
+  query.
 - `passivbot tool live-smoke-report` now attaches the timestamped log context
   line to unparseable traceback/error matches, making hard text-log matches
   easier to attribute without changing smoke verdict policy.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -5657,8 +5657,8 @@ VPS5 deployment status:
   unparseable traceback/error lines. This should make future smoke reports
   explain what subsystem emitted a hard text-log fragment without suppressing
   or down-classifying the hard match.
-- Result: PR #991 was reviewed by Hermes and Claude, merged to `v8`, and is
-  pending VPS5 deployment together with the next approved smoke-report slice.
+- Result: PR #991 was reviewed by Hermes and Claude, merged to `v8`, and
+  deployed to VPS5 together with PR #992 at `03f2fc10`.
 
 ### Draft Slice: EMA Readiness Reason Smoke Summary
 
@@ -5677,6 +5677,32 @@ VPS5 deployment status:
   it does not add event producers, exchange calls, readiness gates, EMA
   behavior, order logic, risk logic, or trading behavior.
 - Expected validation: focused EMA-readiness smoke-report test, full
+  `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
+  standard added-line silent-handling scan.
+- Result: PR #992 was reviewed by Hermes and Claude, merged to `v8`, and
+  deployed to VPS5 at `03f2fc10`. The first post-deploy smoke showed a
+  transient GateIO positions `RequestTimeout` from an existing running bot; a
+  follow-up after the event aged out reported `ok=true`, `hard_failures=0`,
+  five expected bots matched, clean tracked repository state, zero
+  account-critical failures, no hard log matches, and the new EMA-readiness
+  reason maps visible in brief output.
+
+### Draft Slice: Remote Call Failure Cause Smoke Summary
+
+- Branch: `codex/v8-smoke-remote-call-failure-summary`.
+- Scope: read-only smoke-report projection for existing `remote_call.*`
+  health events.
+- Triggering evidence: the post-PR #991/#992 VPS5 smoke briefly went hard-red
+  from one GateIO `remote_call.failed` / `cycle.degraded` pair. The brief smoke
+  showed remote-call failure counts, but identifying that the failing surface
+  was `authoritative_positions` and the error type was `RequestTimeout`
+  required a separate `live-event-query`.
+- Intended result: aggregate failed remote-call reason codes, surfaces, logical
+  call kinds, and error types into full, summary, and brief smoke-report
+  projections. This changes only report output; it does not add event
+  producers, exchange calls, readiness gates, order logic, risk logic, or
+  trading behavior.
+- Expected validation: focused remote-call smoke-report tests, full
   `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
   standard added-line silent-handling scan.
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -524,12 +524,15 @@ def _remote_call_health_group(
     raw_status = _remote_call_raw_status(live_event)
     reason_code = live_event.get("reason_code")
     error_type = payload.get("error_type")
+    kind = payload.get("kind")
+    surface = payload.get("surface")
     symbol = live_event.get("symbol")
+    failed = status == "failed"
     return {
         "bot": bot_key,
         "component": live_event.get("component"),
-        "kind": payload.get("kind"),
-        "surface": payload.get("surface"),
+        "kind": kind,
+        "surface": surface,
         "count": 1,
         "elapsed_values": [elapsed_ms] if elapsed_ms is not None else [],
         "statuses": Counter([status]) if status else Counter(),
@@ -539,6 +542,18 @@ def _remote_call_health_group(
         "reason_codes": Counter([str(reason_code)]) if reason_code not in (None, "") else Counter(),
         "error_types": Counter([str(error_type)]) if error_type not in (None, "") else Counter(),
         "symbols": Counter([str(symbol)]) if symbol not in (None, "") else Counter(),
+        "failed_reason_codes": Counter([str(reason_code)])
+        if failed and reason_code not in (None, "")
+        else Counter(),
+        "failed_error_types": Counter([str(error_type)])
+        if failed and error_type not in (None, "")
+        else Counter(),
+        "failed_kinds": Counter([str(kind)])
+        if failed and kind not in (None, "")
+        else Counter(),
+        "failed_surfaces": Counter([str(surface)])
+        if failed and surface not in (None, "")
+        else Counter(),
         "latest_ts": row.get("ts"),
         "latest_seq": row.get("seq"),
         "latest_path": str(path),
@@ -573,7 +588,17 @@ def _merge_remote_call_health_group(
         return
     existing["count"] = _count_value(existing.get("count")) + 1
     existing.setdefault("elapsed_values", []).extend(group.get("elapsed_values") or [])
-    for field in ("statuses", "raw_statuses", "reason_codes", "error_types", "symbols"):
+    for field in (
+        "statuses",
+        "raw_statuses",
+        "reason_codes",
+        "error_types",
+        "symbols",
+        "failed_reason_codes",
+        "failed_error_types",
+        "failed_kinds",
+        "failed_surfaces",
+    ):
         counter = existing.setdefault(field, Counter())
         counter.update(group.get(field) or Counter())
     current_key = _sort_event_position_key(
@@ -651,9 +676,22 @@ def _summarize_remote_call_health(
 ) -> dict[str, Any]:
     ordered = sorted(groups.values(), key=_remote_call_health_sort_key)
     status_totals: Counter[str] = Counter()
+    failed_reason_codes: Counter[str] = Counter()
+    failed_error_types: Counter[str] = Counter()
+    failed_kinds: Counter[str] = Counter()
+    failed_surfaces: Counter[str] = Counter()
     for group in groups.values():
         statuses = group.get("statuses") if isinstance(group.get("statuses"), Counter) else Counter()
         status_totals.update(statuses)
+        for source, target in (
+            ("failed_reason_codes", failed_reason_codes),
+            ("failed_error_types", failed_error_types),
+            ("failed_kinds", failed_kinds),
+            ("failed_surfaces", failed_surfaces),
+        ):
+            values = group.get(source)
+            if isinstance(values, Counter):
+                target.update(values)
     total = sum(int(group.get("count", 0)) for group in groups.values())
     total_succeeded_count = int(status_totals.get("succeeded", 0))
     total_failed_count = int(status_totals.get("failed", 0))
@@ -733,7 +771,7 @@ def _summarize_remote_call_health(
                 and value not in (None, {}, [])
             }
         )
-    return {
+    out = {
         "total": total,
         "succeeded": total_succeeded_count,
         "failed": total_failed_count,
@@ -743,6 +781,19 @@ def _summarize_remote_call_health(
         "groups_truncated": len(ordered) > REMOTE_CALL_HEALTH_GROUP_LIMIT,
         "groups": compact_groups,
     }
+    for key, values in (
+        ("failed_reason_codes", failed_reason_codes),
+        ("failed_error_types", failed_error_types),
+        ("failed_kinds", failed_kinds),
+        ("failed_surfaces", failed_surfaces),
+    ):
+        compact_values = _top_counter_values(
+            values,
+            limit=REMOTE_CALL_HEALTH_VALUE_LIMIT,
+        )
+        if compact_values:
+            out[key] = compact_values
+    return out
 
 
 def _execution_health_outcome(event_type: str, status: str | None) -> str:
@@ -5374,6 +5425,10 @@ def _summary_limited_groups(
             "event_types": summary.get("event_types"),
             "statuses": summary.get("statuses"),
             "outcomes": summary.get("outcomes"),
+            "failed_reason_codes": summary.get("failed_reason_codes") or None,
+            "failed_error_types": summary.get("failed_error_types") or None,
+            "failed_kinds": summary.get("failed_kinds") or None,
+            "failed_surfaces": summary.get("failed_surfaces") or None,
             "bots": summary.get("bots"),
             "active_bots": summary.get("active_bots"),
             "stale_active_bots": summary.get("stale_active_bots"),
@@ -5776,7 +5831,7 @@ def _count_value(value: Any) -> int:
 def _brief_remote_call_health(summary: Any) -> dict[str, Any]:
     if not isinstance(summary, dict):
         summary = {}
-    return {
+    out = {
         key: value
         for key, value in {
             "total": _count_value(summary.get("total")),
@@ -5788,6 +5843,16 @@ def _brief_remote_call_health(summary: Any) -> dict[str, Any]:
         }.items()
         if value is not None
     }
+    for key in (
+        "failed_reason_codes",
+        "failed_error_types",
+        "failed_kinds",
+        "failed_surfaces",
+    ):
+        value = summary.get(key)
+        if isinstance(value, dict) and value:
+            out[key] = value
+    return out
 
 
 def _brief_fill_refresh_health(summary: Any) -> dict[str, Any]:

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -423,6 +423,9 @@ def test_live_smoke_report_summarizes_monitor_events_and_log_attention(tmp_path)
         "throttled": 0,
         "failure_pct": 100,
         "throttled_pct": 0,
+        "failed_reason_codes": {"request_timeout": 1},
+        "failed_error_types": {"RequestTimeout": 1},
+        "failed_surfaces": {"balance": 1},
         "groups_truncated": False,
         "groups": [
             {
@@ -774,6 +777,10 @@ def test_live_smoke_report_remote_call_health_totals_mixed_groups(tmp_path):
     assert health["throttled"] == 1
     assert health["failure_pct"] == 18
     assert health["throttled_pct"] == 9
+    assert health["failed_reason_codes"] == {"authoritative_balance": 2}
+    assert health["failed_error_types"] == {"RequestTimeout": 2}
+    assert health["failed_kinds"] == {"authoritative_state_fetch": 2}
+    assert health["failed_surfaces"] == {"balance": 2}
     groups_by_surface = {
         (group.get("kind"), group.get("surface")): group for group in health["groups"]
     }
@@ -895,6 +902,10 @@ def test_live_smoke_report_account_critical_remote_call_health_subset(tmp_path):
     assert account_health["throttled"] == 0
     assert account_health["failure_pct"] == 33
     assert account_health["throttled_pct"] == 0
+    assert account_health["failed_reason_codes"] == {"authoritative_balance": 1}
+    assert account_health["failed_error_types"] == {"RequestTimeout": 1}
+    assert account_health["failed_kinds"] == {"authoritative_state_fetch": 1}
+    assert account_health["failed_surfaces"] == {"balance": 1}
     group_surfaces = {group.get("surface") for group in account_health["groups"]}
     assert group_surfaces == {"balance", "positions", "open_orders"}
 
@@ -1328,8 +1339,28 @@ def test_live_smoke_report_brief_summary_projects_top_level_counters(tmp_path):
         assert "latest_line" not in group
     assert brief["remote_calls"]["total"] == 1
     assert brief["remote_calls"]["failed"] == 1
+    assert brief["remote_calls"]["failed_reason_codes"] == {
+        "authoritative_balance": 1
+    }
+    assert brief["remote_calls"]["failed_error_types"] == {"RequestTimeout": 1}
+    assert brief["remote_calls"]["failed_kinds"] == {
+        "authoritative_state_fetch": 1
+    }
+    assert brief["remote_calls"]["failed_surfaces"] == {"balance": 1}
     assert brief["account_critical_remote_calls"]["total"] == 1
     assert brief["account_critical_remote_calls"]["failed"] == 1
+    assert brief["account_critical_remote_calls"]["failed_reason_codes"] == {
+        "authoritative_balance": 1
+    }
+    assert brief["account_critical_remote_calls"]["failed_error_types"] == {
+        "RequestTimeout": 1
+    }
+    assert brief["account_critical_remote_calls"]["failed_kinds"] == {
+        "authoritative_state_fetch": 1
+    }
+    assert brief["account_critical_remote_calls"]["failed_surfaces"] == {
+        "balance": 1
+    }
     assert brief["ema_readiness"] == {
         "total": 1,
         "bots": 1,


### PR DESCRIPTION
## Summary
- Aggregate failed remote-call reasons, surfaces, kinds, and error types in full/summary/brief `live-smoke-report` output.
- Keep the added maps absent when no failed remote calls are present, so green brief output stays compact.
- Record the #991/#992 VPS5 deploy/smoke result in the logging-overhaul progress ledger.

## Behavior boundary
Read-only observability slice only. No event producers, exchange calls, readiness gates, order/risk logic, or trading behavior changed.

## Validation
- `./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_brief_summary_projects_top_level_counters tests/test_live_smoke_report.py::test_live_smoke_report_account_critical_remote_call_health_subset tests/test_live_smoke_report.py::test_live_smoke_report_remote_call_health_totals_mixed_groups -q`
- `./venv/bin/python -m pytest tests/test_live_smoke_report.py -q`
- `./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py`
- `git diff --check -- CHANGELOG.md docs/plans/live_logging_overhaul_progress.md src/live/smoke_report.py tests/test_live_smoke_report.py`
- Silent-handling scan: only existing smoke-report aggregation/default patterns and one existing read-only parse catch; no new broad catch/silent fallback patterns.
