### PR TITLE
Summarize HSL cooldown targets in smoke report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report` now lists active HSL cooldown targets in
+  concise risk summaries, so RED cooldown symbols are visible even when they do
+  not have current drawdown-distance metrics.
 - `passivbot tool live-smoke-report` now includes normalized HSL red-proximity
   percentages in concise closest-to-red risk summaries, making current HSL
   proximity visible without exposing raw drawdown-space thresholds.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -5730,6 +5730,33 @@ VPS5 deployment status:
 - Expected validation: focused HSL risk smoke-report test, full
   `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
   standard added-line silent-handling scan.
+- Result: PR #994 was reviewed by Hermes and Claude, merged to `v8`, and
+  deployed to VPS5 at `a071492a`. The post-deploy 10-minute brief smoke
+  reported `ok=true`, `hard_failures=0`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `matched_expected=5`, clean tracked
+  repository state, and the new normalized `red_proximity_pct` values visible
+  in `risk_events.hsl_status.closest_to_red`.
+
+### Draft Slice: HSL Cooldown Smoke Summary
+
+- Branch: `codex/v8-smoke-hsl-cooldown-summary`.
+- Scope: read-only smoke-report projection for existing `hsl.status` cooldown
+  events.
+- Triggering evidence: the post-PR #994 VPS5 smoke showed
+  `risk_events.hsl_status.tier_counts.red > 0`, but `closest_to_red` contained
+  only green symbols. A focused `live-event-query` showed RED cooldown
+  `hsl.status` events for ZEC with `tier=red`, `reason_code=cooldown_active`,
+  `cooldown_remaining_seconds`, and `cooldown_until_ms`, but no drawdown
+  distance metrics. Operators should not need an event query to see which RED
+  cooldown targets explain the red tier count.
+- Intended result: include bounded active HSL cooldown target samples in full,
+  summary, and brief smoke-report risk summaries. This changes only report
+  output; it does not add event producers, exchange calls, readiness gates, HSL
+  behavior, order logic, risk logic, monitor writes, console routing, or
+  trading behavior.
+- Expected validation: focused HSL cooldown smoke-report test, full
+  `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
+  standard added-line silent-handling scan.
 
 ## Current Next Steps
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -2574,6 +2574,7 @@ def _summarize_hsl_status(
     tier_counts: Counter[str] = Counter()
     signal_mode_counts: Counter[str] = Counter()
     closest: list[dict[str, Any]] = []
+    cooldown_active: list[dict[str, Any]] = []
     for group in groups.values():
         if group.get("event_type") != EventTypes.HSL_STATUS:
             continue
@@ -2595,6 +2596,27 @@ def _summarize_hsl_status(
         signal_mode = data.get("signal_mode")
         if signal_mode not in (None, ""):
             signal_mode_counts[str(signal_mode)] += count
+        cooldown_until_ms = _non_negative_int(data.get("cooldown_until_ms"))
+        cooldown_remaining_seconds = _numeric_value(
+            data.get("cooldown_remaining_seconds")
+        )
+        if cooldown_until_ms is not None or cooldown_remaining_seconds is not None:
+            cooldown_active.append(
+                {
+                    key: value
+                    for key, value in {
+                        "bot": bot,
+                        "symbol": symbol,
+                        "pside": group.get("pside"),
+                        "tier": str(tier) if tier not in (None, "") else None,
+                        "reason_code": group.get("reason_code"),
+                        "cooldown_remaining_seconds": cooldown_remaining_seconds,
+                        "cooldown_until_ms": cooldown_until_ms,
+                        "latest_ts": _non_negative_int(group.get("latest_ts")),
+                    }.items()
+                    if value not in (None, "", {})
+                }
+            )
         dist_to_red = _numeric_value(data.get("dist_to_red"))
         if dist_to_red is None:
             continue
@@ -2645,7 +2667,16 @@ def _summarize_hsl_status(
             str(item.get("pside") or ""),
         ),
     )
-    return {
+    cooldown_sorted = sorted(
+        cooldown_active,
+        key=lambda item: (
+            -int(item.get("latest_ts") or 0),
+            str(item.get("bot") or ""),
+            str(item.get("symbol") or ""),
+            str(item.get("pside") or ""),
+        ),
+    )
+    out = {
         "total": total,
         "bots": len(bots),
         "symbols": _symbol_sample(symbols, limit=8),
@@ -2654,6 +2685,10 @@ def _summarize_hsl_status(
         "closest_to_red": closest_sorted[:5],
         "closest_to_red_truncated": max(0, len(closest_sorted) - 5),
     }
+    if cooldown_sorted:
+        out["cooldown_active"] = cooldown_sorted[:5]
+        out["cooldown_active_truncated"] = max(0, len(cooldown_sorted) - 5)
+    return out
 
 
 def _shareable_hsl_status(hsl_status: Any) -> dict[str, Any]:
@@ -2668,6 +2703,7 @@ def _shareable_hsl_status(hsl_status: Any) -> dict[str, Any]:
             "tier_counts",
             "signal_mode_counts",
             "closest_to_red_truncated",
+            "cooldown_active_truncated",
         )
         if hsl_status.get(key) is not None
     }
@@ -2690,6 +2726,28 @@ def _shareable_hsl_status(hsl_status: Any) -> dict[str, Any]:
             for item in closest[:5]
             if isinstance(item, dict)
         ]
+    cooldown_active = hsl_status.get("cooldown_active")
+    if isinstance(cooldown_active, list):
+        compact_cooldown_active = [
+            {
+                key: item.get(key)
+                for key in (
+                    "bot",
+                    "symbol",
+                    "pside",
+                    "tier",
+                    "reason_code",
+                    "cooldown_remaining_seconds",
+                    "cooldown_until_ms",
+                    "latest_ts",
+                )
+                if isinstance(item, dict) and item.get(key) not in (None, "", {})
+            }
+            for item in cooldown_active[:5]
+            if isinstance(item, dict)
+        ]
+        if compact_cooldown_active:
+            out["cooldown_active"] = compact_cooldown_active
     return out
 
 

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -3142,6 +3142,97 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
     assert "drawdown_raw" not in json.dumps(brief["risk_events"]["hsl_status"])
 
 
+def test_live_smoke_report_summarizes_hsl_cooldown_active_status(tmp_path):
+    events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.status",
+                seq=1,
+                ts=1000,
+                exchange="gateio",
+                user="gateio_01",
+                symbol="ZEC/USDT:USDT",
+                pside="long",
+                reason_code="cooldown_active",
+                status="degraded",
+                data={
+                    "tier": "red",
+                    "cooldown_remaining_seconds": 153446.467,
+                    "cooldown_until_ms": 1783176761357,
+                },
+            ),
+            _monitor_row(
+                event_type="hsl.status",
+                seq=2,
+                ts=2000,
+                exchange="gateio",
+                user="gateio_01",
+                symbol="NEAR/USDT:USDT",
+                pside="long",
+                reason_code="green",
+                data={
+                    "signal_mode": "coin",
+                    "tier": "green",
+                    "dist_to_red": 0.02,
+                    "drawdown_score": 0.08,
+                    "red_threshold": 0.10,
+                },
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    summary = summarize_live_smoke_report(report)
+    brief = summarize_live_smoke_report_brief(report)
+
+    assert report["ok"] is True
+    assert report["attention"] is True
+    assert report["risk_events"]["hsl_status"]["tier_counts"] == {
+        "green": 1,
+        "red": 1,
+    }
+    assert report["risk_events"]["hsl_status"]["cooldown_active"] == [
+        {
+            "bot": "gateio/gateio_01",
+            "symbol": "ZEC/USDT:USDT",
+            "pside": "long",
+            "tier": "red",
+            "reason_code": "cooldown_active",
+            "cooldown_remaining_seconds": 153446.467,
+            "cooldown_until_ms": 1783176761357,
+            "latest_ts": 1000,
+        }
+    ]
+    assert summary["risk_events"]["hsl_status"]["cooldown_active"] == [
+        {
+            "bot": "gateio/gateio_01",
+            "symbol": "ZEC/USDT:USDT",
+            "pside": "long",
+            "tier": "red",
+            "reason_code": "cooldown_active",
+            "cooldown_remaining_seconds": 153446.467,
+            "cooldown_until_ms": 1783176761357,
+            "latest_ts": 1000,
+        }
+    ]
+    assert brief["risk_events"]["hsl_status"]["cooldown_active"] == [
+        {
+            "bot": "gateio/gateio_01",
+            "symbol": "ZEC/USDT:USDT",
+            "pside": "long",
+            "tier": "red",
+            "reason_code": "cooldown_active",
+            "cooldown_remaining_seconds": 153446.467,
+            "cooldown_until_ms": 1783176761357,
+            "latest_ts": 1000,
+        }
+    ]
+    assert brief["risk_events"]["hsl_status"]["cooldown_active_truncated"] == 0
+    assert brief["problem_events"]["event_types"] == {"hsl.status": 1}
+
+
 def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
     monkeypatch.setattr(smoke_report_module, "utc_ms", lambda: 365000)
     _write_ndjson(


### PR DESCRIPTION
## Summary
- Add bounded `risk_events.hsl_status.cooldown_active` samples to full/summary/brief `live-smoke-report` output.
- This makes RED cooldown symbols visible even when the `hsl.status` event has no drawdown-distance metrics and therefore does not appear in `closest_to_red`.
- Record the PR #994 VPS5 deploy/smoke result in the logging-overhaul progress ledger.

## Behavior boundary
Read-only smoke-report projection only. No event producers, exchange calls, readiness gates, HSL behavior, order/risk logic, monitor writes, console routing, or trading behavior changed.

## Validation
- `./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_hsl_cooldown_active_status tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_recent_risk_events -q`
- `./venv/bin/python -m pytest tests/test_live_smoke_report.py -q`
- `./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py`
- `git diff --check -- CHANGELOG.md docs/plans/live_logging_overhaul_progress.md src/live/smoke_report.py tests/test_live_smoke_report.py`
- Silent-handling scan: only existing smoke-report aggregation/default patterns and one existing read-only parse catch; no new broad catch/silent fallback patterns.
