### PR TITLE
Summarize staged readiness surfaces in smoke report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report` now names staged-readiness missing and
+  invalid surfaces in summary and brief output, so issues like stale
+  `completed_candles` are visible without a separate event query.
 - `passivbot tool live-smoke-report` now lists active HSL cooldown targets in
   concise risk summaries, so RED cooldown symbols are visible even when they do
   not have current drawdown-distance metrics.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -5757,6 +5757,31 @@ VPS5 deployment status:
 - Expected validation: focused HSL cooldown smoke-report test, full
   `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
   standard added-line silent-handling scan.
+- Result: PR #995 was reviewed by Hermes and Claude, merged to `v8`, and
+  deployed to VPS5 at `1a39d587`. The post-deploy 10-minute brief smoke
+  reported `ok=true`, `hard_failures=0`, `matched_expected=5`, clean tracked
+  repository state, and active HSL cooldown targets visible in
+  `risk_events.hsl_status.cooldown_active`.
+
+### Draft Slice: Staged Readiness Surface Smoke Summary
+
+- Branch: `codex/v8-smoke-staged-surface-summary`.
+- Scope: read-only smoke-report projection for existing staged-readiness
+  `cycle.degraded` events.
+- Triggering evidence: the post-PR #995 VPS5 smoke showed
+  `staged_readiness.total=1` and `latest_missing_surface_total=1`, but the
+  brief output did not name which surface was missing. A focused
+  `live-event-query` showed KuCoin deferred Rust order calculation with
+  `missing=["completed_candles"]` and
+  `defer_reason=staged_planner_inputs_not_fresh`.
+- Intended result: include bounded missing/invalid staged-readiness surface
+  maps in full, summary, and brief smoke-report output. This changes only
+  report output; it does not add event producers, exchange calls, readiness
+  gates, staged execution behavior, order logic, risk logic, monitor writes,
+  console routing, or trading behavior.
+- Expected validation: focused staged-readiness smoke-report test, full
+  `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
+  standard added-line silent-handling scan.
 
 ## Current Next Steps
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -2197,6 +2197,12 @@ def _summarize_staged_readiness_health(
             int(group.get("latest_invalid_surface_count") or 0)
             for group in groups.values()
         ),
+        "latest_missing_surfaces": _sum_counter_maps(
+            group.get("latest_missing_surfaces") for group in groups.values()
+        ),
+        "latest_invalid_surfaces": _sum_counter_maps(
+            group.get("latest_invalid_surfaces") for group in groups.values()
+        ),
         "groups": compact_groups,
     }
 
@@ -5528,6 +5534,8 @@ def _summary_limited_groups(
             or None,
             "latest_missing_surface_total": summary.get("latest_missing_surface_total"),
             "latest_invalid_surface_total": summary.get("latest_invalid_surface_total"),
+            "latest_missing_surfaces": summary.get("latest_missing_surfaces") or None,
+            "latest_invalid_surfaces": summary.get("latest_invalid_surfaces") or None,
             "latest_queue_depth_total": summary.get("latest_queue_depth_total"),
             "latest_queue_unfinished_total": summary.get(
                 "latest_queue_unfinished_total"
@@ -6231,6 +6239,21 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         value = ema_readiness_health.get(key)
         if isinstance(value, dict) and value:
             ema_readiness_brief[key] = value
+    staged_readiness_brief = {
+        "total": _count_value(staged_readiness_health.get("total")),
+        "bots": _count_value(staged_readiness_health.get("bots")),
+        "latest_missing_surface_total": _count_value(
+            staged_readiness_health.get("latest_missing_surface_total")
+        ),
+        "latest_invalid_surface_total": _count_value(
+            staged_readiness_health.get("latest_invalid_surface_total")
+        ),
+        "event_types": staged_readiness_health.get("event_types") or {},
+    }
+    for key in ("latest_missing_surfaces", "latest_invalid_surfaces"):
+        value = staged_readiness_health.get(key)
+        if isinstance(value, dict) and value:
+            staged_readiness_brief[key] = value
     return {
         "ok": bool(report.get("ok")),
         "attention": bool(report.get("attention")),
@@ -6386,17 +6409,7 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             ),
             "event_types": exchange_config_refresh_health.get("event_types") or {},
         },
-        "staged_readiness": {
-            "total": _count_value(staged_readiness_health.get("total")),
-            "bots": _count_value(staged_readiness_health.get("bots")),
-            "latest_missing_surface_total": _count_value(
-                staged_readiness_health.get("latest_missing_surface_total")
-            ),
-            "latest_invalid_surface_total": _count_value(
-                staged_readiness_health.get("latest_invalid_surface_total")
-            ),
-            "event_types": staged_readiness_health.get("event_types") or {},
-        },
+        "staged_readiness": staged_readiness_brief,
         "event_pipeline": {
             "total": _count_value(event_pipeline_health.get("total")),
             "bots": _count_value(event_pipeline_health.get("bots")),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2468,6 +2468,14 @@ def test_live_smoke_report_summarizes_staged_readiness_health(tmp_path):
     assert health["bots"] == 1
     assert health["latest_missing_surface_total"] == 2
     assert health["latest_invalid_surface_total"] == 3
+    assert health["latest_missing_surfaces"] == {
+        "completed_candles": 1,
+        "market_prices": 1,
+    }
+    assert health["latest_invalid_surfaces"] == {
+        "completed_candles": 2,
+        "market_prices": 1,
+    }
     assert health["event_types"] == {"cycle.degraded": 2}
     assert health["groups"][0]["count"] == 2
     assert health["groups"][0]["latest_ids"] == {"cycle_id": "cy_stage_2"}
@@ -2487,11 +2495,27 @@ def test_live_smoke_report_summarizes_staged_readiness_health(tmp_path):
     assert summary["staged_readiness_health"]["groups"][0]["latest_ids"] == {
         "cycle_id": "cy_stage_2"
     }
+    assert summary["staged_readiness_health"]["latest_missing_surfaces"] == {
+        "completed_candles": 1,
+        "market_prices": 1,
+    }
+    assert summary["staged_readiness_health"]["latest_invalid_surfaces"] == {
+        "completed_candles": 2,
+        "market_prices": 1,
+    }
     assert brief["staged_readiness"] == {
         "total": 2,
         "bots": 1,
         "latest_missing_surface_total": 2,
         "latest_invalid_surface_total": 3,
+        "latest_missing_surfaces": {
+            "completed_candles": 1,
+            "market_prices": 1,
+        },
+        "latest_invalid_surfaces": {
+            "completed_candles": 2,
+            "market_prices": 1,
+        },
         "event_types": {"cycle.degraded": 2},
     }
 


### PR DESCRIPTION
Summary
- Aggregate staged-readiness missing/invalid surface maps in full smoke reports.
- Carry those maps through summary and brief output when non-empty.
- Add regression coverage plus changelog/progress notes for the VPS5 completed_candles evidence.

Boundary
- Observability/reporting only. No event producers, exchange calls, readiness gates, staged execution behavior, order logic, risk logic, monitor writes, or console routing changed.

Validation
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_staged_readiness_health -q
- ./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- git diff --check -- CHANGELOG.md docs/plans/live_logging_overhaul_progress.md src/live/smoke_report.py tests/test_live_smoke_report.py
- rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])" src/live/smoke_report.py tests/test_live_smoke_report.py (pre-existing matches only; this slice adds none)