### PR TITLE
Summarize EMA readiness symbols in smoke report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report` now includes bounded EMA-readiness symbol
+  samples by unavailable reason in summary and brief output, so operators can
+  see which symbols are affected without a separate event query.
 - `passivbot tool live-smoke-report` now summarizes HSL raw-red-pending
   targets in concise risk output, including bounded red-proximity and
   EMA-gap-to-red percentages without exposing raw drawdown internals.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -5809,6 +5809,31 @@ VPS5 deployment status:
 - Expected validation: focused raw-red-pending smoke-report test, full
   `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
   standard added-line silent-handling scan.
+- Result: PR #997 was reviewed by Hermes and Claude, merged to `v8`, and
+  deployed to VPS5 at `f7e49f37`. The post-deploy smoke reported `ok=true`,
+  `hard_failures=0`, `matched_expected=5`, clean tracked repository state, and
+  the five configured live bots still running. The raw-red-pending event had
+  aged out of the 10-minute smoke window by the deployment check.
+
+### Draft Slice: EMA-Readiness Symbol Samples In Smoke Summary
+
+- Branch: `codex/v8-smoke-ema-symbol-samples`.
+- Scope: read-only smoke-report projection for existing `ema.unavailable`
+  monitor events.
+- Triggering evidence: the post-PR #997 VPS5 smoke still showed EMA-readiness
+  attention by reason, but identifying affected symbols required a separate
+  `live-event-query`. The underlying `ema.unavailable` events already included
+  bounded `candidate_unavailable_groups` and `unavailable_reasons` symbol
+  samples.
+- Intended result: include bounded symbol samples by EMA unavailable reason in
+  full, summary, and brief smoke-report output. The projection must omit
+  `example_error` prose and payload extras from the concise fields. This
+  changes only report output; it does not add event producers, exchange calls,
+  readiness gates, EMA behavior, order logic, risk logic, monitor writes,
+  console routing, or trading behavior.
+- Expected validation: focused EMA-readiness smoke-report test, full
+  `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
+  standard added-line silent-handling scan.
 
 ## Current Next Steps
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -93,6 +93,7 @@ RISK_EVENT_GROUP_LIMIT = 20
 SHUTDOWN_EVENT_GROUP_LIMIT = 20
 PROBLEM_EVENT_GROUP_LIMIT = 20
 EMA_READINESS_GROUP_LIMIT = 20
+EMA_READINESS_REASON_SYMBOL_SAMPLE_LIMIT = 8
 STAGED_READINESS_GROUP_LIMIT = 20
 EVENT_PIPELINE_HEALTH_GROUP_LIMIT = 20
 HSL_REPLAY_HEALTH_GROUP_LIMIT = 20
@@ -1724,6 +1725,82 @@ def _reason_symbol_counts(value: Any) -> dict[str, int]:
     return dict(counts.most_common())
 
 
+def _summary_symbol_sample(value: Any, *, limit: int) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    count = int(_non_negative_int(value.get("count")) or 0)
+    raw_sample = value.get("sample")
+    sample: list[str] = []
+    if isinstance(raw_sample, list):
+        for symbol in raw_sample:
+            if symbol is None:
+                continue
+            safe_symbol = _redact_log_text(str(symbol), max_len=80)
+            if safe_symbol and safe_symbol not in sample:
+                sample.append(safe_symbol)
+            if len(sample) >= limit:
+                break
+    if count <= 0:
+        count = len(sample)
+    if count <= 0 and not sample:
+        return {}
+    return {
+        "count": count,
+        "sample": sample,
+        "truncated": max(0, count - len(sample)),
+    }
+
+
+def _reason_symbol_summaries(value: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(value, list):
+        return {}
+    summaries: dict[str, dict[str, Any]] = {}
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        reason = str(item.get("reason") or "unknown")
+        symbol_summary = _summary_symbol_sample(
+            item.get("symbols"),
+            limit=EMA_READINESS_REASON_SYMBOL_SAMPLE_LIMIT,
+        )
+        if symbol_summary:
+            summaries[reason] = symbol_summary
+    return summaries
+
+
+def _sum_reason_symbol_summaries(values: Iterable[Any]) -> dict[str, dict[str, Any]]:
+    totals: dict[str, int] = defaultdict(int)
+    samples: dict[str, Counter[str]] = defaultdict(Counter)
+    for value in values:
+        if not isinstance(value, dict):
+            continue
+        for reason, summary in value.items():
+            if not isinstance(summary, dict):
+                continue
+            key = str(reason)
+            totals[key] += int(_non_negative_int(summary.get("count")) or 0)
+            raw_sample = summary.get("sample")
+            if isinstance(raw_sample, list):
+                for symbol in raw_sample:
+                    if symbol is not None:
+                        safe_symbol = _redact_log_text(str(symbol), max_len=80)
+                        if safe_symbol:
+                            samples[key][safe_symbol] += 1
+    merged: dict[str, dict[str, Any]] = {}
+    for reason, count in sorted(totals.items(), key=lambda item: (-item[1], item[0])):
+        sample_summary = _symbol_sample(
+            samples.get(reason, Counter()),
+            limit=EMA_READINESS_REASON_SYMBOL_SAMPLE_LIMIT,
+        )
+        sample = sample_summary.get("sample") if isinstance(sample_summary, dict) else []
+        merged[reason] = {
+            "count": int(count),
+            "sample": sample or [],
+            "truncated": max(0, int(count) - len(sample or [])),
+        }
+    return merged
+
+
 def _candidate_error_type_counts(value: Any) -> dict[str, int]:
     if not isinstance(value, list):
         return {}
@@ -1786,6 +1863,12 @@ def _ema_readiness_group(
         "unavailable_reason_counts": _reason_symbol_counts(
             payload.get("unavailable_reasons")
         ),
+        "candidate_reason_symbols": _reason_symbol_summaries(
+            payload.get("candidate_unavailable_groups")
+        ),
+        "unavailable_reason_symbols": _reason_symbol_summaries(
+            payload.get("unavailable_reasons")
+        ),
         "candidate_error_type_counts": _candidate_error_type_counts(
             payload.get("candidate_unavailable_groups")
         ),
@@ -1837,6 +1920,8 @@ def _merge_ema_readiness_group(
             "latest_optional_drop_count",
             "candidate_reason_counts",
             "unavailable_reason_counts",
+            "candidate_reason_symbols",
+            "unavailable_reason_symbols",
             "candidate_error_type_counts",
             "latest_ids",
             "latest_data",
@@ -1889,6 +1974,12 @@ def _summarize_ema_readiness_health(
         ),
         "latest_unavailable_reason_counts": _sum_counter_maps(
             group.get("unavailable_reason_counts") for group in groups.values()
+        ),
+        "latest_candidate_reason_symbols": _sum_reason_symbol_summaries(
+            group.get("candidate_reason_symbols") for group in groups.values()
+        ),
+        "latest_unavailable_reason_symbols": _sum_reason_symbol_summaries(
+            group.get("unavailable_reason_symbols") for group in groups.values()
         ),
         "latest_candidate_error_type_counts": _sum_counter_maps(
             group.get("candidate_error_type_counts") for group in groups.values()
@@ -5693,6 +5784,14 @@ def _summary_limited_groups(
                 "latest_unavailable_reason_counts"
             )
             or None,
+            "latest_candidate_reason_symbols": summary.get(
+                "latest_candidate_reason_symbols"
+            )
+            or None,
+            "latest_unavailable_reason_symbols": summary.get(
+                "latest_unavailable_reason_symbols"
+            )
+            or None,
             "latest_candidate_error_type_counts": summary.get(
                 "latest_candidate_error_type_counts"
             )
@@ -6402,6 +6501,8 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
     for key in (
         "latest_candidate_reason_counts",
         "latest_unavailable_reason_counts",
+        "latest_candidate_reason_symbols",
+        "latest_unavailable_reason_symbols",
         "latest_candidate_error_type_counts",
     ):
         value = ema_readiness_health.get(key)

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1725,6 +1725,7 @@ def test_live_smoke_report_summarizes_ema_readiness_health(tmp_path):
                                 "truncated": 0,
                             },
                             "error_types": ["MissingCloseEma"],
+                            "example_error": "stale api_key=OLDSECRET",
                         }
                     ],
                     "unavailable_reasons": [
@@ -1776,6 +1777,7 @@ def test_live_smoke_report_summarizes_ema_readiness_health(tmp_path):
                                 "truncated": 0,
                             },
                             "error_types": ["MissingLogRangeEma"],
+                            "example_error": "fresh api_key=NEWSECRET",
                         }
                     ],
                     "unavailable_reasons": [
@@ -1819,6 +1821,25 @@ def test_live_smoke_report_summarizes_ema_readiness_health(tmp_path):
         "never_fetched_cache_only": 3,
         "cache_only_fetch_failed": 2,
     }
+    assert health["latest_candidate_reason_symbols"] == {
+        "cache_only_fetch_failed": {
+            "count": 2,
+            "sample": ["AVAX/USDT:USDT", "WLD/USDT:USDT"],
+            "truncated": 0,
+        }
+    }
+    assert health["latest_unavailable_reason_symbols"] == {
+        "never_fetched_cache_only": {
+            "count": 3,
+            "sample": ["SUI/USDT:USDT"],
+            "truncated": 2,
+        },
+        "cache_only_fetch_failed": {
+            "count": 2,
+            "sample": ["AVAX/USDT:USDT", "WLD/USDT:USDT"],
+            "truncated": 0,
+        },
+    }
     assert health["latest_candidate_error_type_counts"] == {
         "MissingLogRangeEma": 1
     }
@@ -1833,6 +1854,25 @@ def test_live_smoke_report_summarizes_ema_readiness_health(tmp_path):
         "never_fetched_cache_only": 3,
         "cache_only_fetch_failed": 2,
     }
+    assert health["groups"][0]["candidate_reason_symbols"] == {
+        "cache_only_fetch_failed": {
+            "count": 2,
+            "sample": ["AVAX/USDT:USDT", "WLD/USDT:USDT"],
+            "truncated": 0,
+        }
+    }
+    assert health["groups"][0]["unavailable_reason_symbols"] == {
+        "cache_only_fetch_failed": {
+            "count": 2,
+            "sample": ["AVAX/USDT:USDT", "WLD/USDT:USDT"],
+            "truncated": 0,
+        },
+        "never_fetched_cache_only": {
+            "count": 3,
+            "sample": ["SUI/USDT:USDT"],
+            "truncated": 2,
+        },
+    }
     assert health["groups"][0]["candidate_error_type_counts"] == {
         "MissingLogRangeEma": 1
     }
@@ -1840,6 +1880,15 @@ def test_live_smoke_report_summarizes_ema_readiness_health(tmp_path):
     assert summary["ema_readiness_health"]["groups"][0]["latest_ids"] == {
         "cycle_id": "cy_ema_2"
     }
+    assert summary["ema_readiness_health"]["latest_candidate_reason_symbols"] == {
+        "cache_only_fetch_failed": {
+            "count": 2,
+            "sample": ["AVAX/USDT:USDT", "WLD/USDT:USDT"],
+            "truncated": 0,
+        }
+    }
+    assert "OLDSECRET" not in json.dumps(summary["ema_readiness_health"])
+    assert "NEWSECRET" not in json.dumps(summary["ema_readiness_health"])
     assert brief["ema_readiness"] == {
         "total": 2,
         "bots": 1,
@@ -1850,6 +1899,25 @@ def test_live_smoke_report_summarizes_ema_readiness_health(tmp_path):
         "latest_unavailable_reason_counts": {
             "never_fetched_cache_only": 3,
             "cache_only_fetch_failed": 2,
+        },
+        "latest_candidate_reason_symbols": {
+            "cache_only_fetch_failed": {
+                "count": 2,
+                "sample": ["AVAX/USDT:USDT", "WLD/USDT:USDT"],
+                "truncated": 0,
+            }
+        },
+        "latest_unavailable_reason_symbols": {
+            "never_fetched_cache_only": {
+                "count": 3,
+                "sample": ["SUI/USDT:USDT"],
+                "truncated": 2,
+            },
+            "cache_only_fetch_failed": {
+                "count": 2,
+                "sample": ["AVAX/USDT:USDT", "WLD/USDT:USDT"],
+                "truncated": 0,
+            },
         },
         "latest_candidate_error_type_counts": {"MissingLogRangeEma": 1},
         "event_types": {"ema.unavailable": 2},


### PR DESCRIPTION
## Summary
- add bounded EMA-readiness symbol samples by unavailable reason to full, summary, and brief smoke-report output
- keep the projection read-only and omit example_error/payload extras from concise fields
- update the logging progress ledger and changelog

## Validation
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_ema_readiness_health -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- ./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check
- git diff -U0 | rg '^\+.*(except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\]))' (no matches)

Observability-only: no event producers, exchange calls, readiness gates, EMA/order/risk behavior, monitor writes, or console routing changed.