### PR TITLE
Show slow remote calls in brief smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report --brief` now includes bounded slowest
+  remote-call latency samples, making slow exchange/account/candle surfaces
+  visible without dumping the full summary.
 - `passivbot tool live-smoke-report` now includes bounded EMA-readiness symbol
   samples by unavailable reason in summary and brief output, so operators can
   see which symbols are affected without a separate event query.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -5834,6 +5834,32 @@ VPS5 deployment status:
 - Expected validation: focused EMA-readiness smoke-report test, full
   `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
   standard added-line silent-handling scan.
+- Result: PR #998 was reviewed by Hermes and Claude, merged to `v8`, and
+  deployed to VPS5 at `d5c239e9`. The post-deploy smoke reported `ok=true`,
+  `hard_failures=0`, `matched_expected=5`, clean tracked repository state, and
+  the five configured live bots still running. The new bounded EMA symbol
+  fields were visible in VPS5 brief smoke output.
+
+### Draft Slice: Remote-Call Latency Samples In Brief Smoke
+
+- Branch: `codex/v8-smoke-remote-latency-brief`.
+- Scope: read-only brief smoke-report projection over existing
+  `remote_call_health.groups`.
+- Triggering evidence: post-PR #998 VPS5 brief smoke showed healthy remote-call
+  counts but hid latency details, while summary output showed slow surfaces
+  such as account-critical open-orders calls above 16s and candle remote fetch
+  groups above 30s. Operators had to run the larger summary to see which
+  bot/surface was slow.
+- Intended result: add a bounded `slowest` list to brief `remote_calls` and
+  `account_critical_remote_calls`, containing bot, kind/surface, count,
+  failed/throttled counts when nonzero, max/p95/latest elapsed milliseconds,
+  and latest symbol when present. This changes only report output; it does not
+  add event producers, exchange calls, remote-call behavior, readiness gates,
+  order logic, risk logic, monitor writes, console routing, or trading
+  behavior.
+- Expected validation: focused brief smoke-report test, full
+  `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
+  standard added-line silent-handling scan.
 
 ## Current Next Steps
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -62,6 +62,7 @@ FILL_REFRESH_HEALTH_VALUE_LIMIT = 8
 EXECUTION_HEALTH_GROUP_LIMIT = 20
 EXECUTION_HEALTH_VALUE_LIMIT = 8
 SMOKE_REPORT_SUMMARY_GROUP_LIMIT = 8
+SMOKE_REPORT_BRIEF_REMOTE_CALL_SLOWEST_LIMIT = 3
 _SMOKE_REPORT_SECTION_BASE_KEYS = (
     "ok",
     "attention",
@@ -6174,6 +6175,67 @@ def _count_value(value: Any) -> int:
         return 0
 
 
+def _brief_remote_call_slowest(summary: dict[str, Any]) -> list[dict[str, Any]]:
+    groups = summary.get("groups")
+    if not isinstance(groups, list):
+        return []
+    rows: list[dict[str, Any]] = []
+    for group in groups:
+        if not isinstance(group, dict):
+            continue
+        elapsed = group.get("elapsed_ms")
+        elapsed_map = elapsed if isinstance(elapsed, dict) else {}
+        max_ms = _non_negative_int(elapsed_map.get("max_ms"))
+        p95_ms = _non_negative_int(elapsed_map.get("p95_ms"))
+        latest_elapsed_ms = _non_negative_int(group.get("latest_elapsed_ms"))
+        sort_ms = max(
+            int(max_ms or 0),
+            int(p95_ms or 0),
+            int(latest_elapsed_ms or 0),
+        )
+        if sort_ms <= 0:
+            continue
+        latest_symbol = group.get("latest_symbol")
+        row = {
+            "bot": _redact_log_text(str(group.get("bot")), max_len=120)
+            if group.get("bot") not in (None, "")
+            else None,
+            "kind": _redact_log_text(str(group.get("kind")), max_len=80)
+            if group.get("kind") not in (None, "")
+            else None,
+            "surface": _redact_log_text(str(group.get("surface")), max_len=80)
+            if group.get("surface") not in (None, "")
+            else None,
+            "count": _count_value(group.get("count")),
+            "failed": _count_value(group.get("failed")),
+            "throttled": _count_value(group.get("throttled")),
+            "max_ms": int(max_ms or 0),
+            "p95_ms": int(p95_ms or 0),
+            "latest_elapsed_ms": int(latest_elapsed_ms or 0),
+            "latest_symbol": _redact_log_text(str(latest_symbol), max_len=120)
+            if latest_symbol not in (None, "")
+            else None,
+        }
+        rows.append(
+            {
+                key: value
+                for key, value in row.items()
+                if value not in (None, "", {}, [])
+                and not (key in {"failed", "throttled"} and value == 0)
+            }
+        )
+    rows.sort(
+        key=lambda item: (
+            -int(item.get("max_ms") or 0),
+            -int(item.get("p95_ms") or 0),
+            -int(item.get("latest_elapsed_ms") or 0),
+            str(item.get("bot") or ""),
+            str(item.get("kind") or item.get("surface") or ""),
+        )
+    )
+    return rows[:SMOKE_REPORT_BRIEF_REMOTE_CALL_SLOWEST_LIMIT]
+
+
 def _brief_remote_call_health(summary: Any) -> dict[str, Any]:
     if not isinstance(summary, dict):
         summary = {}
@@ -6198,6 +6260,9 @@ def _brief_remote_call_health(summary: Any) -> dict[str, Any]:
         value = summary.get(key)
         if isinstance(value, dict) and value:
             out[key] = value
+    slowest = _brief_remote_call_slowest(summary)
+    if slowest:
+        out["slowest"] = slowest
     return out
 
 

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1347,6 +1347,18 @@ def test_live_smoke_report_brief_summary_projects_top_level_counters(tmp_path):
         "authoritative_state_fetch": 1
     }
     assert brief["remote_calls"]["failed_surfaces"] == {"balance": 1}
+    assert brief["remote_calls"]["slowest"] == [
+        {
+            "bot": "binance/binance_01",
+            "kind": "authoritative_state_fetch",
+            "surface": "balance",
+            "count": 1,
+            "failed": 1,
+            "max_ms": 5000,
+            "p95_ms": 5000,
+            "latest_elapsed_ms": 5000,
+        }
+    ]
     assert brief["account_critical_remote_calls"]["total"] == 1
     assert brief["account_critical_remote_calls"]["failed"] == 1
     assert brief["account_critical_remote_calls"]["failed_reason_codes"] == {
@@ -1361,6 +1373,18 @@ def test_live_smoke_report_brief_summary_projects_top_level_counters(tmp_path):
     assert brief["account_critical_remote_calls"]["failed_surfaces"] == {
         "balance": 1
     }
+    assert brief["account_critical_remote_calls"]["slowest"] == [
+        {
+            "bot": "binance/binance_01",
+            "kind": "authoritative_state_fetch",
+            "surface": "balance",
+            "count": 1,
+            "failed": 1,
+            "max_ms": 5000,
+            "p95_ms": 5000,
+            "latest_elapsed_ms": 5000,
+        }
+    ]
     assert brief["ema_readiness"] == {
         "total": 1,
         "bots": 1,


### PR DESCRIPTION
## Summary
- add a bounded slowest remote-call list to brief smoke output for all and account-critical remote calls
- project only bot/kind/surface/count/failure counters and max/p95/latest elapsed milliseconds, plus latest symbol when present
- update the logging progress ledger and changelog

## Validation
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_brief_summary_projects_top_level_counters -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- ./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check
- git diff -U0 | rg '^\+.*(except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\]))' (no matches)

Observability-only: no event producers, exchange calls, remote-call behavior, readiness gates, order/risk behavior, monitor writes, or console routing changed.