### PR TITLE
Summarize staged readiness reasons in smoke report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report` now summarizes staged-readiness reason
+  codes, defer reasons, contexts, and bounded max timing fields in concise
+  output, making current-epoch planning delays easier to attribute without a
+  separate event query.
 - `passivbot tool live-smoke-report --brief` now includes bounded slowest
   remote-call latency samples, making slow exchange/account/candle surfaces
   visible without dumping the full summary.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -5860,6 +5860,35 @@ VPS5 deployment status:
 - Expected validation: focused brief smoke-report test, full
   `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
   standard added-line silent-handling scan.
+- Result: PR #999 was reviewed by Hermes and Claude, merged to `v8`, and
+  deployed to VPS5 at `8e6aaf4b`. The post-deploy smoke reported `ok=true`,
+  `hard_failures=0`, `matched_expected=5`, clean tracked repository state, and
+  the five configured live bots still running. The new brief `slowest` rows
+  exposed slow surfaces such as OKX candle fetches near 35s and account-critical
+  open-orders/balance calls above 10s.
+
+### Draft Slice: Staged Readiness Reason And Timing Smoke Summary
+
+- Branch: `codex/v8-smoke-staged-degraded-timing`.
+- Scope: read-only smoke-report projection over existing `cycle.degraded` and
+  `planning.unavailable` staged-readiness events.
+- Triggering evidence: post-PR #999 VPS5 brief smoke showed
+  `staged_readiness.total=1` and `latest_missing_surface_total=0`, while a
+  focused event query showed KuCoin degraded because Rust order calculation was
+  deferred with `defer_reason=staged_planner_inputs_not_fresh`,
+  `reason_code=staged_execution_precondition`, and long `timings_ms` such as
+  `market_state=303339`. The brief smoke did not surface those reason/timing
+  fields, so the operator still needed a separate event query to understand why
+  planning degraded.
+- Intended result: include bounded reason-code counts, latest defer-reason
+  counts, latest context counts, and max latest timing fields in full, summary,
+  and brief staged-readiness smoke output. This changes only report output; it
+  does not add event producers, exchange calls, readiness gates, staged
+  execution behavior, order logic, risk logic, monitor writes, console routing,
+  or trading behavior.
+- Expected validation: focused staged-readiness smoke-report test, full
+  `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
+  standard added-line silent-handling scan.
 
 ## Current Next Steps
 
@@ -5890,10 +5919,10 @@ VPS5 deployment status:
    `exchange_surface_health` notes over the existing endpoint outcomes.
    Remaining useful slices should be driven by a concrete live exchange gap
    rather than broad probe expansion.
-5. Continue monitoring staged-readiness summaries after PR #762. The first
-   post-restart smokes showed `staged_readiness.total=0`; if the signal returns,
-   inspect whether it is a real current-epoch account surface delay or a new
-   completed-candle readiness shape.
+5. Continue monitoring staged-readiness summaries. After PR #999 the signal
+   returned without missing/invalid surfaces, and the next slice should make
+   defer reason, context, and slow timing evidence visible directly in smoke
+   output.
 6. Start the live restart/smoke automation slice if operational workflow speed
    becomes the higher leverage next step.
 7. Continue cache-doctor refinements in separate adjacent PRs: deeper metadata

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -96,6 +96,7 @@ PROBLEM_EVENT_GROUP_LIMIT = 20
 EMA_READINESS_GROUP_LIMIT = 20
 EMA_READINESS_REASON_SYMBOL_SAMPLE_LIMIT = 8
 STAGED_READINESS_GROUP_LIMIT = 20
+STAGED_READINESS_VALUE_LIMIT = 8
 EVENT_PIPELINE_HEALTH_GROUP_LIMIT = 20
 HSL_REPLAY_HEALTH_GROUP_LIMIT = 20
 HSL_REPLAY_STALE_ACTIVE_EVENT_AGE_MS = 5 * 60 * 1000
@@ -2121,10 +2122,11 @@ def _summarize_exchange_config_refresh_health(
 
 
 def _staged_readiness_event(live_event: dict[str, Any]) -> bool:
-    if (live_event.get("event_type") or "") != EventTypes.CYCLE_DEGRADED:
-        return False
+    event_type = live_event.get("event_type") or ""
     reason_code = str(live_event.get("reason_code") or "")
-    return reason_code.startswith("staged_execution")
+    if event_type == EventTypes.CYCLE_DEGRADED:
+        return reason_code.startswith("staged_execution")
+    return event_type == EventTypes.PLANNING_UNAVAILABLE
 
 
 def _string_counts(value: Any) -> dict[str, int]:
@@ -2162,6 +2164,47 @@ def _completed_candle_mismatch_counts(value: Any) -> dict[str, int]:
     return dict(counts.most_common())
 
 
+def _staged_readiness_text(value: Any) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    return _redact_log_text(value, max_len=120)
+
+
+def _staged_readiness_timings_ms(value: Any) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    timings: dict[str, int] = {}
+    for key, raw in value.items():
+        parsed = _non_negative_int(raw)
+        if parsed is None:
+            continue
+        timings[_redact_log_text(str(key), max_len=80)] = int(parsed)
+    return dict(
+        sorted(timings.items(), key=lambda item: (-int(item[1]), str(item[0])))[
+            :STAGED_READINESS_VALUE_LIMIT
+        ]
+    )
+
+
+def _max_counter_maps(values: Iterable[Any]) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for value in values:
+        if not isinstance(value, dict):
+            continue
+        for key, raw in value.items():
+            parsed = _non_negative_int(raw)
+            if parsed is None:
+                continue
+            safe_key = str(key)
+            current = out.get(safe_key)
+            out[safe_key] = int(parsed) if current is None else max(int(parsed), current)
+    return dict(
+        sorted(out.items(), key=lambda item: (-int(item[1]), str(item[0])))[
+            :STAGED_READINESS_VALUE_LIMIT
+        ]
+    )
+
+
 def _staged_readiness_group(
     *,
     bot_key: str,
@@ -2173,14 +2216,18 @@ def _staged_readiness_group(
     data = live_event.get("data")
     payload = data if isinstance(data, dict) else {}
     details = payload.get("details")
-    detail_payload = details if isinstance(details, dict) else {}
+    detail_payload = details if isinstance(details, dict) else payload
     ids = _event_ids(live_event)
     invalid = detail_payload.get("invalid")
     missing_surfaces = _string_counts(detail_payload.get("missing"))
     invalid_surfaces = _invalid_surface_counts(invalid)
+    reason_code = _staged_readiness_text(live_event.get("reason_code"))
+    latest_context = _staged_readiness_text(detail_payload.get("context"))
+    latest_defer_reason = _staged_readiness_text(detail_payload.get("defer_reason"))
+    latest_timings_ms = _staged_readiness_timings_ms(payload.get("timings_ms"))
     return {
         "bot": bot_key,
-        "reason_code": live_event.get("reason_code"),
+        "reason_code": reason_code,
         "status": live_event.get("status"),
         "level": live_event.get("level"),
         "component": live_event.get("component"),
@@ -2189,10 +2236,11 @@ def _staged_readiness_group(
         "latest_seq": row.get("seq"),
         "latest_path": str(path),
         "latest_line": int(line_no),
-        "latest_context": detail_payload.get("context"),
-        "latest_defer_reason": detail_payload.get("defer_reason"),
+        "latest_context": latest_context,
+        "latest_defer_reason": latest_defer_reason,
         "latest_missing_surfaces": missing_surfaces,
         "latest_invalid_surfaces": invalid_surfaces,
+        "latest_timings_ms": latest_timings_ms,
         "latest_completed_candle_mismatch_counts": _completed_candle_mismatch_counts(
             invalid
         ),
@@ -2245,6 +2293,7 @@ def _merge_staged_readiness_group(
             "latest_defer_reason",
             "latest_missing_surfaces",
             "latest_invalid_surfaces",
+            "latest_timings_ms",
             "latest_completed_candle_mismatch_counts",
             "latest_missing_surface_count",
             "latest_invalid_surface_count",
@@ -2295,6 +2344,24 @@ def _summarize_staged_readiness_health(
         ),
         "latest_invalid_surfaces": _sum_counter_maps(
             group.get("latest_invalid_surfaces") for group in groups.values()
+        ),
+        "reason_codes": _sum_counter_maps(
+            {group.get("reason_code"): group.get("count")}
+            for group in groups.values()
+            if group.get("reason_code") not in (None, "")
+        ),
+        "latest_defer_reasons": _sum_counter_maps(
+            {group.get("latest_defer_reason"): 1}
+            for group in groups.values()
+            if group.get("latest_defer_reason") not in (None, "")
+        ),
+        "latest_contexts": _sum_counter_maps(
+            {group.get("latest_context"): 1}
+            for group in groups.values()
+            if group.get("latest_context") not in (None, "")
+        ),
+        "latest_timings_ms_max": _max_counter_maps(
+            group.get("latest_timings_ms") for group in groups.values()
         ),
         "groups": compact_groups,
     }
@@ -5801,6 +5868,10 @@ def _summary_limited_groups(
             "latest_invalid_surface_total": summary.get("latest_invalid_surface_total"),
             "latest_missing_surfaces": summary.get("latest_missing_surfaces") or None,
             "latest_invalid_surfaces": summary.get("latest_invalid_surfaces") or None,
+            "reason_codes": summary.get("reason_codes") or None,
+            "latest_defer_reasons": summary.get("latest_defer_reasons") or None,
+            "latest_contexts": summary.get("latest_contexts") or None,
+            "latest_timings_ms_max": summary.get("latest_timings_ms_max") or None,
             "latest_queue_depth_total": summary.get("latest_queue_depth_total"),
             "latest_queue_unfinished_total": summary.get(
                 "latest_queue_unfinished_total"
@@ -6584,7 +6655,14 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         ),
         "event_types": staged_readiness_health.get("event_types") or {},
     }
-    for key in ("latest_missing_surfaces", "latest_invalid_surfaces"):
+    for key in (
+        "latest_missing_surfaces",
+        "latest_invalid_surfaces",
+        "reason_codes",
+        "latest_defer_reasons",
+        "latest_contexts",
+        "latest_timings_ms_max",
+    ):
         value = staged_readiness_health.get(key)
         if isinstance(value, dict) and value:
             staged_readiness_brief[key] = value

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2502,7 +2502,29 @@ def test_live_smoke_report_summarizes_staged_readiness_health(tmp_path):
                                 }
                             ]
                         },
-                    }
+                    },
+                    "timings_ms": {"market_state": 112},
+                },
+            ),
+            _monitor_row(
+                event_type="planning.unavailable",
+                seq=4,
+                ts=1500,
+                status="degraded",
+                level="debug",
+                reason_code="staged_execution_precondition",
+                ids={"cycle_id": "33"},
+                data={
+                    "context": "rust order calculation",
+                    "defer_reason": "staged_planner_inputs_not_fresh",
+                    "missing": [],
+                    "required_surfaces": ["market_snapshot"],
+                    "min_epochs": {"market_snapshot": 33},
+                    "timings_ms": {
+                        "authoritative": "[redacted]",
+                        "market_state": 303339,
+                        "planning_universe": 16,
+                    },
                 },
             ),
             _monitor_row(
@@ -2535,7 +2557,11 @@ def test_live_smoke_report_summarizes_staged_readiness_health(tmp_path):
                                 {"mismatch_type": "epoch_stale", "missing_count": 1}
                             ],
                         },
-                    }
+                    },
+                    "timings_ms": {
+                        "market_state": 239061,
+                        "planning_universe": 1919,
+                    },
                 },
             ),
             _monitor_row(
@@ -2556,7 +2582,7 @@ def test_live_smoke_report_summarizes_staged_readiness_health(tmp_path):
     brief = summarize_live_smoke_report_brief(report)
 
     health = report["staged_readiness_health"]
-    assert health["total"] == 2
+    assert health["total"] == 3
     assert health["bots"] == 1
     assert health["latest_missing_surface_total"] == 2
     assert health["latest_invalid_surface_total"] == 3
@@ -2568,7 +2594,19 @@ def test_live_smoke_report_summarizes_staged_readiness_health(tmp_path):
         "completed_candles": 2,
         "market_prices": 1,
     }
-    assert health["event_types"] == {"cycle.degraded": 2}
+    assert health["event_types"] == {"cycle.degraded": 2, "planning.unavailable": 1}
+    assert health["reason_codes"] == {
+        "staged_execution_not_ready": 2,
+        "staged_execution_precondition": 1,
+    }
+    assert health["latest_defer_reasons"] == {"staged_planner_inputs_not_fresh": 2}
+    assert health["latest_contexts"] == {
+        "rust order calculation": 2,
+    }
+    assert health["latest_timings_ms_max"] == {
+        "market_state": 303339,
+        "planning_universe": 1919,
+    }
     assert health["groups"][0]["count"] == 2
     assert health["groups"][0]["latest_ids"] == {"cycle_id": "cy_stage_2"}
     assert health["groups"][0]["latest_context"] == "rust order calculation"
@@ -2583,7 +2621,7 @@ def test_live_smoke_report_summarizes_staged_readiness_health(tmp_path):
     assert health["groups"][0]["latest_completed_candle_mismatch_counts"] == {
         "completed_candle_target_changed": 2
     }
-    assert summary["staged_readiness_health"]["total"] == 2
+    assert summary["staged_readiness_health"]["total"] == 3
     assert summary["staged_readiness_health"]["groups"][0]["latest_ids"] == {
         "cycle_id": "cy_stage_2"
     }
@@ -2595,8 +2633,12 @@ def test_live_smoke_report_summarizes_staged_readiness_health(tmp_path):
         "completed_candles": 2,
         "market_prices": 1,
     }
+    assert summary["staged_readiness_health"]["latest_timings_ms_max"] == {
+        "market_state": 303339,
+        "planning_universe": 1919,
+    }
     assert brief["staged_readiness"] == {
-        "total": 2,
+        "total": 3,
         "bots": 1,
         "latest_missing_surface_total": 2,
         "latest_invalid_surface_total": 3,
@@ -2608,7 +2650,19 @@ def test_live_smoke_report_summarizes_staged_readiness_health(tmp_path):
             "completed_candles": 2,
             "market_prices": 1,
         },
-        "event_types": {"cycle.degraded": 2},
+        "event_types": {"cycle.degraded": 2, "planning.unavailable": 1},
+        "reason_codes": {
+            "staged_execution_not_ready": 2,
+            "staged_execution_precondition": 1,
+        },
+        "latest_defer_reasons": {"staged_planner_inputs_not_fresh": 2},
+        "latest_contexts": {
+            "rust order calculation": 2,
+        },
+        "latest_timings_ms_max": {
+            "market_state": 303339,
+            "planning_universe": 1919,
+        },
     }
 
 


### PR DESCRIPTION
## Summary
- include staged-readiness reason-code, defer-reason, context, and bounded max timing summaries in full/summary/brief smoke output
- include existing planning.unavailable events in staged-readiness smoke health alongside staged cycle.degraded events
- update the logging-overhaul progress tracker with the prior PR #999 result and this slice plan

## Behavior
- observability/reporting only
- no event producers, exchange calls, readiness gates, staged execution behavior, order logic, risk logic, monitor writes, console routing, or trading behavior changed

## Validation
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_staged_readiness_health -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- ./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check
- git diff -U0 | rg '^\+.*(except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\]))'  # no matches