### PR TITLE
Show dense HSL replay progress in brief smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report --brief` now distinguishes dense and
+  required HSL replay remaining-work estimates in active replay samples, so
+  dense pair replay is not hidden when required-position replay is already
+  complete.
 - `passivbot tool live-smoke-report --brief` now includes bounded active HSL
   replay samples with bot, stage, symbol, elapsed age, progress, and remaining
   work estimates, making long-running HSL startup replay easier to attribute.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -5918,6 +5918,35 @@ VPS5 deployment status:
 - Expected validation: focused HSL replay smoke-report test, full
   `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
   standard added-line silent-handling scan.
+- Result: PR #1001 was reviewed by Hermes and Claude, merged to `v8`, and
+  deployed to VPS5 at `1c6f5882`. The post-deploy smoke reported `ok=true`,
+  `hard_failures=0`, `matched_expected=5`, clean tracked repository state, and
+  the five configured live bots still running. The new brief `active` rows were
+  visible for OKX, KuCoin, Binance, and Gateio. Follow-up evidence showed the
+  primary required-work estimate could be `0` while dense pair replay was still
+  active, so the next slice should expose dense and required remaining work
+  separately.
+
+### Draft Slice: HSL Replay Dense Progress In Brief Smoke
+
+- Branch: `codex/v8-smoke-hsl-replay-dense-progress`.
+- Scope: read-only brief smoke-report projection over existing
+  `hsl_replay_health.groups` and `latest.derived` fields.
+- Triggering evidence: after PR #1001 deployment, VPS5 brief smoke remained
+  `ok=true` with zero hard failures and the active HSL replay rows were visible,
+  but several rows showed `estimated_remaining_rows=0` while the stage remained
+  `pair_replay` and dense progress was well below 100%. The primary estimate was
+  reflecting required-position work, not dense replay work.
+- Intended result: add bounded dense-vs-required remaining row/time fields to
+  active HSL replay rows: `estimated_dense_remaining_rows`,
+  `estimated_dense_remaining_ms`, `estimated_required_remaining_rows`, and
+  `estimated_required_remaining_ms`. This changes only report output; it does
+  not add event producers, exchange calls, HSL replay behavior, startup gating,
+  order logic, risk logic, monitor writes, console routing, or trading
+  behavior.
+- Expected validation: focused HSL replay smoke-report test, full
+  `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
+  standard added-line silent-handling scan.
 
 ## Current Next Steps
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -6381,6 +6381,18 @@ def _brief_hsl_replay_active_groups(groups: Any) -> list[dict[str, Any]]:
             "rows_per_second": _numeric_value(data.get("rows_per_second")),
             "observed_required_work_pct": derived.get("observed_required_work_pct"),
             "observed_work_pct": derived.get("observed_work_pct"),
+            "estimated_dense_remaining_rows": _non_negative_int(
+                derived.get("estimated_dense_remaining_rows")
+            ),
+            "estimated_dense_remaining_ms": _non_negative_int(
+                derived.get("estimated_dense_remaining_ms")
+            ),
+            "estimated_required_remaining_rows": _non_negative_int(
+                derived.get("estimated_required_remaining_rows")
+            ),
+            "estimated_required_remaining_ms": _non_negative_int(
+                derived.get("estimated_required_remaining_ms")
+            ),
             "estimated_remaining_rows": _non_negative_int(
                 derived.get("estimated_remaining_rows")
             ),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -3874,6 +3874,10 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
                 "rows_per_second": 318.415,
                 "observed_required_work_pct": 7.407,
                 "observed_work_pct": 5.108,
+                "estimated_dense_remaining_rows": 43201 * 29 - 64000,
+                "estimated_dense_remaining_ms": 3733584,
+                "estimated_required_remaining_rows": 43201 * 20 - 64000,
+                "estimated_required_remaining_ms": 2512507,
                 "estimated_remaining_rows": 800020,
                 "estimated_remaining_ms": 2512507,
             }


### PR DESCRIPTION
## Summary
- add dense-vs-required remaining rows/time to brief active HSL replay smoke rows
- update the HSL replay smoke fixture, changelog, and logging progress tracker

## Scope
- report-only projection over existing hsl_replay derived fields
- no event producers, exchange calls, HSL replay behavior, startup gating, order/risk logic, monitor writes, console routing, or trading behavior changes

## Validation
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_hsl_replay_health -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- ./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check
- added-line silent-handling scan: no matches