### PR TITLE
Summarize dense HSL replay max progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report --brief` now adds dense and required HSL
+  replay max remaining-work aggregates alongside the existing primary
+  remaining-work max fields.
 - `passivbot tool live-smoke-report --brief` now distinguishes dense and
   required HSL replay remaining-work estimates in active replay samples, so
   dense pair replay is not hidden when required-position replay is already

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -5947,6 +5947,39 @@ VPS5 deployment status:
 - Expected validation: focused HSL replay smoke-report test, full
   `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
   standard added-line silent-handling scan.
+- Result: PR #1002 was reviewed by Hermes and Claude, merged to `v8`, and
+  deployed to VPS5 at `433ec363`. The post-deploy smoke reported `ok=true`,
+  `hard_failures=0`, `matched_expected=5`, clean tracked repository state, and
+  the five configured live bots still running. The new active rows clearly
+  exposed dense replay work still remaining while required replay work was
+  already complete. Follow-up evidence showed the aggregate
+  `max_active_estimated_remaining_rows/ms` fields still reflected only the
+  primary required estimate and could therefore remain zero during active dense
+  replay.
+
+### Draft Slice: HSL Replay Dense Max Aggregates In Brief Smoke
+
+- Branch: `codex/v8-smoke-hsl-replay-dense-aggregates`.
+- Scope: read-only brief smoke-report projection over existing
+  `hsl_replay_health.groups` and `latest.derived` fields.
+- Triggering evidence: after PR #1002 deployment, VPS5 brief smoke showed four
+  active long-running HSL pair-replay workers. Each active row had
+  nonzero `estimated_dense_remaining_rows/ms`, but the top-level
+  `max_active_estimated_remaining_rows=0` and
+  `max_active_estimated_remaining_ms=0` because those legacy aggregate fields
+  use the primary required-position estimate.
+- Intended result: keep the legacy primary max fields for compatibility, and
+  add dense-vs-required aggregate max fields:
+  `max_active_estimated_dense_remaining_rows`,
+  `max_active_estimated_dense_remaining_ms`,
+  `max_active_estimated_required_remaining_rows`, and
+  `max_active_estimated_required_remaining_ms`. This changes only report
+  output; it does not add event producers, exchange calls, HSL replay behavior,
+  startup gating, order logic, risk logic, monitor writes, console routing, or
+  trading behavior.
+- Expected validation: focused HSL replay smoke-report test, full
+  `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
+  standard added-line silent-handling scan.
 
 ## Current Next Steps
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -6553,10 +6553,20 @@ def _brief_hsl_replay_health(hsl_replay_health: dict[str, Any]) -> dict[str, Any
     if not isinstance(groups, list):
         return out
 
+    def update_max(current: int | None, raw: Any) -> int | None:
+        value = _non_negative_int(raw)
+        if value is None:
+            return current
+        return int(value) if current is None else max(int(current), int(value))
+
     max_active_latest_elapsed_ms: int | None = None
     max_active_latest_event_age_ms: int | None = None
     max_active_estimated_remaining_rows: int | None = None
     max_active_estimated_remaining_ms: int | None = None
+    max_active_estimated_dense_remaining_rows: int | None = None
+    max_active_estimated_dense_remaining_ms: int | None = None
+    max_active_estimated_required_remaining_rows: int | None = None
+    max_active_estimated_required_remaining_ms: int | None = None
     max_completed_elapsed_ms: int | None = None
     active_stage_counts: Counter[str] = Counter()
 
@@ -6594,6 +6604,22 @@ def _brief_hsl_replay_health(hsl_replay_health: dict[str, Any]) -> dict[str, Any
                     int(elapsed_ms),
                 )
         derived = latest.get("derived") if isinstance(latest.get("derived"), dict) else {}
+        max_active_estimated_dense_remaining_rows = update_max(
+            max_active_estimated_dense_remaining_rows,
+            derived.get("estimated_dense_remaining_rows"),
+        )
+        max_active_estimated_dense_remaining_ms = update_max(
+            max_active_estimated_dense_remaining_ms,
+            derived.get("estimated_dense_remaining_ms"),
+        )
+        max_active_estimated_required_remaining_rows = update_max(
+            max_active_estimated_required_remaining_rows,
+            derived.get("estimated_required_remaining_rows"),
+        )
+        max_active_estimated_required_remaining_ms = update_max(
+            max_active_estimated_required_remaining_ms,
+            derived.get("estimated_required_remaining_ms"),
+        )
         estimated_remaining_rows = _non_negative_int(
             derived.get("estimated_remaining_rows")
         )
@@ -6632,6 +6658,22 @@ def _brief_hsl_replay_health(hsl_replay_health: dict[str, Any]) -> dict[str, Any
     if max_active_estimated_remaining_ms is not None:
         out["max_active_estimated_remaining_ms"] = int(
             max_active_estimated_remaining_ms
+        )
+    if max_active_estimated_dense_remaining_rows is not None:
+        out["max_active_estimated_dense_remaining_rows"] = int(
+            max_active_estimated_dense_remaining_rows
+        )
+    if max_active_estimated_dense_remaining_ms is not None:
+        out["max_active_estimated_dense_remaining_ms"] = int(
+            max_active_estimated_dense_remaining_ms
+        )
+    if max_active_estimated_required_remaining_rows is not None:
+        out["max_active_estimated_required_remaining_rows"] = int(
+            max_active_estimated_required_remaining_rows
+        )
+    if max_active_estimated_required_remaining_ms is not None:
+        out["max_active_estimated_required_remaining_ms"] = int(
+            max_active_estimated_required_remaining_ms
         )
     if max_completed_elapsed_ms is not None:
         out["max_completed_elapsed_ms"] = int(max_completed_elapsed_ms)

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -3852,6 +3852,10 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
         "max_active_latest_event_age_ms": 360000,
         "max_active_estimated_remaining_rows": 800020,
         "max_active_estimated_remaining_ms": 2512507,
+        "max_active_estimated_dense_remaining_rows": 43201 * 29 - 64000,
+        "max_active_estimated_dense_remaining_ms": 3733584,
+        "max_active_estimated_required_remaining_rows": 43201 * 20 - 64000,
+        "max_active_estimated_required_remaining_ms": 2512507,
         "max_completed_elapsed_ms": 1623400,
         "active_stage_counts": {"pair_replay": 1},
         "active": [


### PR DESCRIPTION
## Summary
- add dense-vs-required max remaining rows/time aggregates to brief HSL replay smoke output
- keep existing primary max remaining-work fields unchanged for compatibility
- record PR #1002 merge/VPS5 smoke evidence and the follow-up gap in the progress ledger

## Scope
- report-only projection over existing hsl_replay derived fields
- no event producers, exchange calls, HSL replay behavior, startup gating, order/risk logic, monitor writes, console routing, or trading behavior changes

## Validation
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_hsl_replay_health -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- ./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check
- added-line silent-handling scan: no matches

## VPS5 evidence from prior merged slice
- v8 deployed at 433ec363
- live-smoke-report --brief: ok=true, hard_failures=0, matched_expected=5, repository.dirty=false
- active rows showed nonzero estimated_dense_remaining_rows/ms while legacy max_active_estimated_remaining_rows/ms were 0