### PR TITLE
Show brief smoke log match samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report --brief` now includes bounded hard and
+  attention log-match samples, so hard smoke verdicts can be attributed without
+  rerunning the larger summary report.
 - `passivbot tool live-smoke-report --brief` now adds dense and required HSL
   replay max remaining-work aggregates alongside the existing primary
   remaining-work max fields.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -5980,6 +5980,35 @@ VPS5 deployment status:
 - Expected validation: focused HSL replay smoke-report test, full
   `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
   standard added-line silent-handling scan.
+- Result: PR #1003 was reviewed by Hermes and Claude, merged to `v8`, and
+  deployed to VPS5 at `c0238f0d`. A short post-deploy smoke reported
+  `ok=true`, `hard_failures=0`, `matched_expected=5`, clean tracked repository
+  state, and the five configured live bots still running. The new dense max
+  aggregate fields were visible: dense remaining rows/time were nonzero while
+  the legacy primary required-work max fields correctly remained zero. A wider
+  45-minute smoke window also exposed an older KuCoin NEAR HSL RED hard text
+  match; finding the actual log lines required rerunning the larger summary
+  report.
+
+### Draft Slice: Brief Log Match Samples
+
+- Branch: `codex/v8-smoke-brief-log-match-samples`.
+- Scope: read-only brief smoke-report projection over existing sanitized text
+  log matches.
+- Triggering evidence: after PR #1003 deployment, the short post-deploy smoke
+  was green, but a wider window reported `log_hard_matches=2` from an older
+  KuCoin NEAR HSL RED event. The brief output showed only counts, so the
+  operator had to rerun summary sections to identify the log path, line, and
+  text.
+- Intended result: keep the full `matches` list out of `--brief`, but include
+  bounded `hard_samples` and `attention_samples` under `logs`, sourced from the
+  same redacted match objects already emitted by the summary report. This
+  changes only report output; it does not add log scanning, event producers,
+  exchange calls, HSL behavior, order/risk logic, monitor writes, console
+  routing, or trading behavior.
+- Expected validation: focused log-sample smoke-report tests, full
+  `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
+  standard added-line silent-handling scan.
 
 ## Current Next Steps
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -62,6 +62,7 @@ FILL_REFRESH_HEALTH_VALUE_LIMIT = 8
 EXECUTION_HEALTH_GROUP_LIMIT = 20
 EXECUTION_HEALTH_VALUE_LIMIT = 8
 SMOKE_REPORT_SUMMARY_GROUP_LIMIT = 8
+SMOKE_REPORT_BRIEF_LOG_SAMPLE_LIMIT = 3
 SMOKE_REPORT_BRIEF_REMOTE_CALL_SLOWEST_LIMIT = 3
 SMOKE_REPORT_BRIEF_HSL_REPLAY_ACTIVE_LIMIT = 5
 _SMOKE_REPORT_SECTION_BASE_KEYS = (
@@ -6531,6 +6532,52 @@ def _brief_log_window(logs: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _brief_log_match_samples(logs: dict[str, Any]) -> dict[str, Any]:
+    matches = logs.get("matches")
+    if not isinstance(matches, list):
+        return {}
+    limit = max(0, int(SMOKE_REPORT_BRIEF_LOG_SAMPLE_LIMIT))
+    hard_samples: list[dict[str, Any]] = []
+    attention_samples: list[dict[str, Any]] = []
+    for match in matches:
+        if not isinstance(match, dict):
+            continue
+        sample: dict[str, Any] = {}
+        for key in (
+            "category",
+            "hard",
+            "path",
+            "line",
+            "ts",
+            "context_ts",
+            "text",
+        ):
+            value = match.get(key)
+            if value is None or value == "" or value == {} or value == []:
+                continue
+            sample[key] = value
+        if not sample:
+            continue
+        if bool(match.get("hard")) and len(hard_samples) < limit:
+            hard_samples.append(sample)
+        if len(attention_samples) < limit:
+            attention_samples.append(sample)
+        if len(hard_samples) >= limit and len(attention_samples) >= limit:
+            break
+    out: dict[str, Any] = {}
+    if hard_samples:
+        out["hard_samples"] = hard_samples
+        out["hard_samples_truncated"] = int(logs.get("hard_matches") or 0) > len(
+            hard_samples
+        )
+    if attention_samples:
+        out["attention_samples"] = attention_samples
+        out["attention_samples_truncated"] = int(
+            logs.get("attention_matches") or 0
+        ) > len(attention_samples)
+    return out
+
+
 def _brief_hsl_replay_health(hsl_replay_health: dict[str, Any]) -> dict[str, Any]:
     out: dict[str, Any] = {
         "total": _count_value(hsl_replay_health.get("total")),
@@ -6935,7 +6982,8 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
                 logs.get("dropped_unparsed_hard_matches")
             ),
             "window": _brief_log_window(logs),
-        },
+        }
+        | _brief_log_match_samples(logs),
         "problem_events": {
             "total": _count_value(report.get("problem_event_count")),
             "hard": _count_value(report.get("hard_problem_event_count")),

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -6555,6 +6555,8 @@ def _brief_log_match_samples(logs: dict[str, Any]) -> dict[str, Any]:
             value = match.get(key)
             if value is None or value == "" or value == {} or value == []:
                 continue
+            if key == "path":
+                value = Path(str(value)).name
             sample[key] = value
         if not sample:
             continue

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1304,6 +1304,17 @@ def test_live_smoke_report_brief_summary_projects_top_level_counters(tmp_path):
         "non_risk_hard_matches": 0,
         "dropped_unparsed_attention_matches": 0,
         "dropped_unparsed_hard_matches": 0,
+        "attention_samples": [
+            {
+                "category": "general",
+                "hard": False,
+                "path": str(logs_dir / "kucoin_01.log"),
+                "line": 1,
+                "ts": 1782345600000,
+                "text": "2026-06-25T00:00:00Z ERROR exchange timeout",
+            }
+        ],
+        "attention_samples_truncated": False,
         "window": {
             "enabled": False,
             "since_ms": None,
@@ -4356,6 +4367,30 @@ def test_live_smoke_report_log_scan_classifies_risk_matches(tmp_path):
     assert summary["logs"]["non_risk_hard_matches"] == 1
     assert brief["logs"]["risk_hard_matches"] == 1
     assert brief["logs"]["non_risk_hard_matches"] == 1
+    assert "matches" not in brief["logs"]
+    assert brief["logs"]["hard_samples"] == [
+        {
+            "category": "risk",
+            "hard": True,
+            "path": str(logs_dir / "binance_01.log"),
+            "line": 1,
+            "ts": 1782576384000,
+            "text": (
+                "2026-06-27T16:06:24Z CRITICAL [binance] [risk] "
+                "HSL[long:XLM/USDT:USDT] reconstructed active coin RED cooldown"
+            ),
+        },
+        {
+            "category": "general",
+            "hard": True,
+            "path": str(logs_dir / "binance_01.log"),
+            "line": 2,
+            "ts": 1782576385000,
+            "text": "2026-06-27T16:06:25Z CRITICAL uncaught task failure",
+        },
+    ]
+    assert brief["logs"]["hard_samples_truncated"] is False
+    assert brief["logs"]["attention_samples_truncated"] is False
 
 
 def test_live_smoke_report_log_window_filters_parseable_timestamps(tmp_path):

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1308,7 +1308,7 @@ def test_live_smoke_report_brief_summary_projects_top_level_counters(tmp_path):
             {
                 "category": "general",
                 "hard": False,
-                "path": str(logs_dir / "kucoin_01.log"),
+                "path": "kucoin_01.log",
                 "line": 1,
                 "ts": 1782345600000,
                 "text": "2026-06-25T00:00:00Z ERROR exchange timeout",
@@ -4372,7 +4372,7 @@ def test_live_smoke_report_log_scan_classifies_risk_matches(tmp_path):
         {
             "category": "risk",
             "hard": True,
-            "path": str(logs_dir / "binance_01.log"),
+            "path": "binance_01.log",
             "line": 1,
             "ts": 1782576384000,
             "text": (
@@ -4383,7 +4383,7 @@ def test_live_smoke_report_log_scan_classifies_risk_matches(tmp_path):
         {
             "category": "general",
             "hard": True,
-            "path": str(logs_dir / "binance_01.log"),
+            "path": "binance_01.log",
             "line": 2,
             "ts": 1782576385000,
             "text": "2026-06-27T16:06:25Z CRITICAL uncaught task failure",


### PR DESCRIPTION
## Summary
- add bounded hard/attention log-match samples to brief live smoke output
- keep the full logs.matches list out of --brief
- record PR #1003 merge/VPS5 smoke evidence and the follow-up gap in the progress ledger

## Scope
- report-only projection over existing sanitized log matches
- no new log scanning, event producers, exchange calls, HSL behavior, order/risk logic, monitor writes, console routing, or trading behavior changes

## Validation
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_brief_summary_projects_top_level_counters tests/test_live_smoke_report.py::test_live_smoke_report_log_scan_classifies_risk_matches -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- ./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check
- added-line silent-handling scan: no matches

## VPS5 evidence from prior merged slice
- v8 deployed at c0238f0d
- short live-smoke-report --brief: ok=true, hard_failures=0, matched_expected=5, repository.dirty=false
- wider window showed old KuCoin NEAR HSL RED hard log matches, but brief output only had counts; summary rerun was needed to identify log path/line/text