### PR TITLE
Show brief smoke risk event samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report --brief` now includes bounded latest risk
+  event samples, making HSL RED/cooldown/mode-change smoke context visible
+  without dumping verbose risk event payloads.
 - `passivbot tool live-smoke-report --brief` now includes bounded hard and
   attention log-match samples, so hard smoke verdicts can be attributed without
   rerunning the larger summary report.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -6009,6 +6009,35 @@ VPS5 deployment status:
 - Expected validation: focused log-sample smoke-report tests, full
   `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
   standard added-line silent-handling scan.
+- Result: PR #1004 was reviewed by Hermes and Claude, merged to `v8`, and
+  deployed to VPS5 at `291a8711`. A short post-deploy smoke reported
+  `ok=true`, `hard_failures=0`, `matched_expected=5`, clean tracked repository
+  state, and the five configured live bots still running. A wider logs-only
+  smoke verified the new bounded `hard_samples`/`attention_samples` fields and
+  showed basename-only log paths for recent HSL RED log lines. The same smoke
+  also showed several recent HSL RED/cooldown/mode events in structured
+  `risk_events`, but brief output still required reading specialized HSL
+  status fields or a summary rerun to see the latest risk event rows.
+
+### Draft Slice: Brief Risk Event Samples
+
+- Branch: `codex/v8-smoke-brief-risk-event-samples`.
+- Scope: read-only brief smoke-report projection over existing summarized
+  `risk_events.groups`.
+- Triggering evidence: after PR #1004 deployment, VPS5 brief smoke showed
+  HSL cooldown and RED context through `risk_events.hsl_status`, but recent
+  structured rows such as `hsl.red_finalized_without_order`,
+  `risk.mode_changed`, and `unstuck.status` were only visible in the larger
+  summary `risk_events.groups` output.
+- Intended result: add bounded `risk_events.latest_groups` to brief output with
+  safe identifiers only: bot, event type, reason code, status, level,
+  symbol/pside, component, count, and latest timestamp. Do not include
+  `latest_data` or raw drawdown/balance/order payload fields. This changes only
+  report output; it does not add event producers, exchange calls, HSL behavior,
+  order/risk logic, monitor writes, console routing, or trading behavior.
+- Expected validation: focused risk-event smoke-report test, full
+  `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
+  standard added-line silent-handling scan.
 
 ## Current Next Steps
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -6511,6 +6511,38 @@ def _brief_problem_event_groups(summary: Any) -> dict[str, Any]:
     }
 
 
+def _brief_risk_event_groups(risk_events: dict[str, Any]) -> list[dict[str, Any]]:
+    groups = risk_events.get("groups")
+    if not isinstance(groups, list):
+        return []
+    limit = max(0, int(SMOKE_REPORT_BRIEF_PROBLEM_GROUP_LIMIT))
+    safe_group_keys = (
+        "bot",
+        "event_type",
+        "reason_code",
+        "status",
+        "level",
+        "symbol",
+        "pside",
+        "component",
+        "count",
+        "latest_ts",
+    )
+    rows: list[dict[str, Any]] = []
+    for group in groups[:limit]:
+        if not isinstance(group, dict):
+            continue
+        compact: dict[str, Any] = {}
+        for key in safe_group_keys:
+            value = group.get(key)
+            if value is None or value == "" or value == {} or value == []:
+                continue
+            compact[key] = value
+        if compact:
+            rows.append(compact)
+    return rows
+
+
 def _brief_log_window(logs: dict[str, Any]) -> dict[str, Any]:
     window = logs.get("window") if isinstance(logs.get("window"), dict) else {}
     return {
@@ -6856,6 +6888,12 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
     )
     if raw_red_pending:
         risk_events_brief["hsl_raw_red_pending"] = raw_red_pending
+    latest_risk_groups = _brief_risk_event_groups(risk_events)
+    if latest_risk_groups:
+        risk_events_brief["latest_groups"] = latest_risk_groups
+        risk_events_brief["latest_groups_truncated"] = bool(
+            risk_events.get("groups_truncated")
+        )
     return {
         "ok": bool(report.get("ok")),
         "attention": bool(report.get("attention")),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -3317,10 +3317,61 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
         ],
         "closest_to_red_truncated": 0,
     }
+    assert brief["risk_events"]["latest_groups"] == [
+        {
+            "bot": "binance/binance_01",
+            "event_type": "unstuck.selection",
+            "reason_code": "unstuck_selection",
+            "status": "succeeded",
+            "level": "info",
+            "symbol": "SUI/USDT:USDT",
+            "pside": "long",
+            "component": "test",
+            "count": 1,
+            "latest_ts": 5000,
+        },
+        {
+            "bot": "binance/binance_01",
+            "event_type": "hsl.red_finalized_without_order",
+            "reason_code": "hsl_red_finalized_without_exchange_order",
+            "status": "succeeded",
+            "level": "info",
+            "symbol": "ZEC/USDT:USDT",
+            "pside": "long",
+            "component": "test",
+            "count": 1,
+            "latest_ts": 4500,
+        },
+        {
+            "bot": "binance/binance_01",
+            "event_type": "risk.mode_changed",
+            "reason_code": "hsl_runtime_forced_modes",
+            "status": "succeeded",
+            "level": "info",
+            "pside": "long",
+            "component": "test",
+            "count": 1,
+            "latest_ts": 4000,
+        },
+        {
+            "bot": "binance/binance_01",
+            "event_type": "hsl.status",
+            "reason_code": "yellow",
+            "status": "succeeded",
+            "level": "info",
+            "symbol": "ZEC/USDT:USDT",
+            "pside": "long",
+            "component": "test",
+            "count": 2,
+            "latest_ts": 3000,
+        },
+    ]
+    assert brief["risk_events"]["latest_groups_truncated"] is False
     assert "red_proximity_pct" in json.dumps(summary["risk_events"]["hsl_status"])
     assert "dist_to_red" not in json.dumps(summary["risk_events"]["hsl_status"])
     assert "red_threshold" not in json.dumps(brief["risk_events"]["hsl_status"])
     assert "drawdown_raw" not in json.dumps(brief["risk_events"]["hsl_status"])
+    assert "latest_data" not in json.dumps(brief["risk_events"])
 
 
 def test_live_smoke_report_summarizes_hsl_cooldown_active_status(tmp_path):


### PR DESCRIPTION
## Summary
- add bounded latest risk-event samples to brief live smoke output
- keep verbose latest_data/raw risk payloads out of --brief
- record PR #1004 merge/VPS5 smoke evidence and the follow-up gap in the progress ledger

## Scope
- report-only projection over existing summarized risk_events.groups
- no event producers, exchange calls, HSL behavior, order/risk logic, monitor writes, console routing, or trading behavior changes

## Validation
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_recent_risk_events -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- ./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check
- added-line silent-handling scan: no matches

## VPS5 evidence from prior merged slice
- v8 deployed at 291a8711
- short live-smoke-report --brief: ok=true, hard_failures=0, matched_expected=5, repository.dirty=false
- wider logs-only smoke verified brief hard_samples and showed recent HSL RED/cooldown/mode events where brief risk output lacked the latest summarized risk rows