### PR TITLE
Show brief smoke risk attention groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report --brief` now includes bounded risk
+  attention groups, prioritizing HSL RED/cooldown/raw-red and risk panic-mode
+  context even when newer routine risk status events would otherwise bury them
+  in latest-event ordering.
 - `passivbot tool live-smoke-report --brief` now includes bounded latest risk
   event samples, making HSL RED/cooldown/mode-change smoke context visible
   without dumping verbose risk event payloads.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,18 +19,18 @@ Last updated: 2026-07-02.
 
 Current `origin/v8` head:
 
-- `947b75b1` after PR #985, `Project low-balance create skips to event console`.
+- `f54dae3e` after PR #1005, `Show brief smoke risk event samples`.
 
 Current logging-overhaul head:
 
-- `947b75b1` after PR #985, `Project low-balance create skips to event console`.
+- `f54dae3e` after PR #1005, `Show brief smoke risk event samples`.
 
 Current work:
 
-- Branch `codex/v8-defensive-event-console-gates` makes previously merged
-  passivbot.py console-dedup gates robust for borrowed-method FakeBot callers by
-  using the class helper directly. This is production-behavior neutral and
-  restores executor-path test coverage broken by #983/#984.
+- Branch `codex/v8-smoke-risk-attention-groups` adds bounded
+  `risk_events.attention_groups` to `live-smoke-report --brief`, so HSL RED,
+  cooldown, raw-red-pending, and panic-mode risk context stays visible even
+  when newer routine green/status events dominate latest-event ordering.
 
 Current review gate:
 
@@ -60,6 +60,17 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1005 at `f54dae3e`.
+- PR #1005 added bounded `risk_events.latest_groups` to
+  `live-smoke-report --brief`, sourced from existing structured risk events and
+  limited to safe metadata fields. VPS5 smoke after deploy reported `ok=true`,
+  `hard_failures=0`, `matched_expected=5`, clean tracked repository state at
+  `repository.head=f54dae3e`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, and `fill_refresh.failed=0`. The
+  new field was visible in smoke output. A wider risk-events-only smoke
+  confirmed current HSL cooldown/raw-red evidence, but also showed that
+  latest-time ordering can bury older RED/cooldown context behind newer routine
+  green HSL status groups, motivating the current attention-groups follow-up.
 - Repository pulled through PR #985 at `947b75b1`.
 - PR #985 projected existing `execution.create_skipped` low-balance create-skip
   events into the structured console/text sinks and made the legacy

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -3110,6 +3110,62 @@ SHAREABLE_RISK_LATEST_DATA_KEYS = frozenset(
 )
 
 
+def _risk_attention_rank(group: dict[str, Any]) -> int:
+    event_type = str(group.get("event_type") or "")
+    reason_code = str(group.get("reason_code") or "")
+    status = str(group.get("status") or "")
+    level = str(group.get("level") or "").lower()
+    latest_data = group.get("latest_data")
+    if not isinstance(latest_data, dict):
+        latest_data = {}
+    tier = str(latest_data.get("tier") or "").lower()
+    modes = {
+        str(latest_data.get("mode") or "").lower(),
+        str(latest_data.get("new_mode") or "").lower(),
+    }
+    if event_type == "hsl.red_triggered" or event_type.startswith("hsl.red_"):
+        return 50
+    if event_type == "hsl.cooldown_started":
+        return 45
+    if event_type == "hsl.raw_red_pending":
+        return 40
+    if event_type == "hsl.status" and (
+        tier == "red" or reason_code == "cooldown_active"
+    ):
+        return 35
+    if event_type == "risk.mode_changed" and "panic" in modes:
+        return 30
+    if level in {"error", "critical"}:
+        return 25
+    if status in {"degraded", "failed"}:
+        return 20
+    return 0
+
+
+def _is_risk_attention_group(group: dict[str, Any]) -> bool:
+    return _risk_attention_rank(group) > 0
+
+
+def _compact_risk_group(group: dict[str, Any]) -> dict[str, Any]:
+    safe_group_keys = (
+        "bot",
+        "event_type",
+        "reason_code",
+        "status",
+        "level",
+        "symbol",
+        "pside",
+        "component",
+        "count",
+        "latest_ts",
+    )
+    return {
+        key: group.get(key)
+        for key in safe_group_keys
+        if group.get(key) not in (None, "", {}, [])
+    }
+
+
 def _summarize_risk_events(
     groups: dict[tuple[Any, ...], dict[str, Any]],
     event_type_counts: Counter[str],
@@ -3141,6 +3197,20 @@ def _summarize_risk_events(
         }
         for group in ordered[:RISK_EVENT_GROUP_LIMIT]
     ]
+    attention_ordered = sorted(
+        (group for group in groups.values() if _is_risk_attention_group(group)),
+        key=lambda item: (
+            -_risk_attention_rank(item),
+            -int(_non_negative_int(item.get("latest_ts")) or 0),
+            str(item.get("bot") or ""),
+            str(item.get("event_type") or ""),
+            str(item.get("symbol") or ""),
+            str(item.get("pside") or ""),
+        ),
+    )
+    attention_groups = [
+        _compact_risk_group(group) for group in attention_ordered[:RISK_EVENT_GROUP_LIMIT]
+    ]
     out = {
         "total": sum(int(group.get("count", 0)) for group in groups.values()),
         "groups_truncated": len(ordered) > RISK_EVENT_GROUP_LIMIT,
@@ -3151,6 +3221,9 @@ def _summarize_risk_events(
         "hsl_status": _summarize_hsl_status(groups),
         "groups": compact_groups,
     }
+    if attention_groups:
+        out["attention_groups"] = attention_groups
+        out["attention_groups_truncated"] = len(attention_ordered) > RISK_EVENT_GROUP_LIMIT
     hsl_raw_red_pending = _summarize_hsl_raw_red_pending(groups)
     if int(hsl_raw_red_pending.get("total") or 0) > 0:
         out["hsl_raw_red_pending"] = hsl_raw_red_pending
@@ -6516,28 +6589,26 @@ def _brief_risk_event_groups(risk_events: dict[str, Any]) -> list[dict[str, Any]
     if not isinstance(groups, list):
         return []
     limit = max(0, int(SMOKE_REPORT_BRIEF_PROBLEM_GROUP_LIMIT))
-    safe_group_keys = (
-        "bot",
-        "event_type",
-        "reason_code",
-        "status",
-        "level",
-        "symbol",
-        "pside",
-        "component",
-        "count",
-        "latest_ts",
-    )
     rows: list[dict[str, Any]] = []
     for group in groups[:limit]:
         if not isinstance(group, dict):
             continue
-        compact: dict[str, Any] = {}
-        for key in safe_group_keys:
-            value = group.get(key)
-            if value is None or value == "" or value == {} or value == []:
-                continue
-            compact[key] = value
+        compact = _compact_risk_group(group)
+        if compact:
+            rows.append(compact)
+    return rows
+
+
+def _brief_risk_attention_groups(risk_events: dict[str, Any]) -> list[dict[str, Any]]:
+    groups = risk_events.get("attention_groups")
+    if not isinstance(groups, list):
+        return []
+    limit = max(0, int(SMOKE_REPORT_BRIEF_PROBLEM_GROUP_LIMIT))
+    rows: list[dict[str, Any]] = []
+    for group in groups[:limit]:
+        if not isinstance(group, dict):
+            continue
+        compact = _compact_risk_group(group)
         if compact:
             rows.append(compact)
     return rows
@@ -6893,6 +6964,12 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         risk_events_brief["latest_groups"] = latest_risk_groups
         risk_events_brief["latest_groups_truncated"] = bool(
             risk_events.get("groups_truncated")
+        )
+    risk_attention_groups = _brief_risk_attention_groups(risk_events)
+    if risk_attention_groups:
+        risk_events_brief["attention_groups"] = risk_attention_groups
+        risk_events_brief["attention_groups_truncated"] = bool(
+            risk_events.get("attention_groups_truncated")
         )
     return {
         "ok": bool(report.get("ok")),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -3165,6 +3165,32 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
             ],
             "closest_to_red_truncated": 0,
         },
+        "attention_groups": [
+            {
+                "bot": "binance/binance_01",
+                "event_type": "hsl.red_finalized_without_order",
+                "reason_code": "hsl_red_finalized_without_exchange_order",
+                "status": "succeeded",
+                "level": "info",
+                "symbol": "ZEC/USDT:USDT",
+                "pside": "long",
+                "component": "test",
+                "count": 1,
+                "latest_ts": 4500,
+            },
+            {
+                "bot": "binance/binance_01",
+                "event_type": "risk.mode_changed",
+                "reason_code": "hsl_runtime_forced_modes",
+                "status": "succeeded",
+                "level": "info",
+                "pside": "long",
+                "component": "test",
+                "count": 1,
+                "latest_ts": 4000,
+            },
+        ],
+        "attention_groups_truncated": False,
         "groups": [
             {
                 "bot": "binance/binance_01",
@@ -3367,6 +3393,32 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
         },
     ]
     assert brief["risk_events"]["latest_groups_truncated"] is False
+    assert brief["risk_events"]["attention_groups"] == [
+        {
+            "bot": "binance/binance_01",
+            "event_type": "hsl.red_finalized_without_order",
+            "reason_code": "hsl_red_finalized_without_exchange_order",
+            "status": "succeeded",
+            "level": "info",
+            "symbol": "ZEC/USDT:USDT",
+            "pside": "long",
+            "component": "test",
+            "count": 1,
+            "latest_ts": 4500,
+        },
+        {
+            "bot": "binance/binance_01",
+            "event_type": "risk.mode_changed",
+            "reason_code": "hsl_runtime_forced_modes",
+            "status": "succeeded",
+            "level": "info",
+            "pside": "long",
+            "component": "test",
+            "count": 1,
+            "latest_ts": 4000,
+        },
+    ]
+    assert brief["risk_events"]["attention_groups_truncated"] is False
     assert "red_proximity_pct" in json.dumps(summary["risk_events"]["hsl_status"])
     assert "dist_to_red" not in json.dumps(summary["risk_events"]["hsl_status"])
     assert "red_threshold" not in json.dumps(brief["risk_events"]["hsl_status"])


### PR DESCRIPTION
## Summary

Adds bounded `risk_events.attention_groups` to `passivbot tool live-smoke-report --brief`.

This is report-only. It prioritizes existing structured risk groups for HSL RED, cooldown started/active, raw-red-pending, panic-mode changes, and degraded/failed risk states so serious risk context stays visible even when newer routine green/status events dominate latest-event ordering.

## Scope

- Uses only existing monitor/smoke-report data.
- Emits only safe group metadata: bot, event type, reason/status/level, symbol/pside, component, count, latest timestamp.
- Does not include `latest_data`, raw drawdown/balance/PnL/order payloads, exchange calls, process signaling, event producers, readiness gates, or trading behavior changes.
- Bundles the progress-ledger update for PR #1005 and this current slice to avoid a docs-only PR.

## Validation

- `./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_recent_risk_events -q`
- `./venv/bin/python -m pytest tests/test_live_smoke_report.py -q`
- `./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py`
- `git diff --check`
- Added-line silent-handling scan had no true issue; the only match was the safe metadata compactor filtering empty values.

## VPS5 Evidence Before Slice

VPS5 was already deployed at `f54dae3e` with all five configured bots running. Short smoke after PR #1005 deploy reported `ok=true`, `hard_failures=0`, `matched_expected=5`, clean tracked repo state at `f54dae3e`, `remote_calls.failed=0`, `account_critical_remote_calls.failed=0`, and `fill_refresh.failed=0`.

A wider `--section risk_events` smoke confirmed the #1005 latest-groups field is useful, but also showed newer routine green HSL statuses can bury older HSL RED/cooldown context in latest-time ordering. This PR addresses only that reporting gap.
