### PR TITLE
Summarize risk smoke in incident bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-incident-bundle` now includes a bounded risk-event
+  smoke summary in the returned report and manifest, so incident bundles expose
+  HSL RED/cooldown/raw-red context without requiring operators to open the full
+  embedded smoke report.
 - `passivbot tool live-smoke-report --brief` now includes bounded risk
   attention groups, prioritizing HSL RED/cooldown/raw-red and risk panic-mode
   context even when newer routine risk status events would otherwise bury them

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,18 +19,18 @@ Last updated: 2026-07-02.
 
 Current `origin/v8` head:
 
-- `f54dae3e` after PR #1005, `Show brief smoke risk event samples`.
+- `68c3fe22` after PR #1006, `Show brief smoke risk attention groups`.
 
 Current logging-overhaul head:
 
-- `f54dae3e` after PR #1005, `Show brief smoke risk event samples`.
+- `68c3fe22` after PR #1006, `Show brief smoke risk attention groups`.
 
 Current work:
 
-- Branch `codex/v8-smoke-risk-attention-groups` adds bounded
-  `risk_events.attention_groups` to `live-smoke-report --brief`, so HSL RED,
-  cooldown, raw-red-pending, and panic-mode risk context stays visible even
-  when newer routine green/status events dominate latest-event ordering.
+- Branch `codex/v8-incident-risk-smoke-summary` adds the existing value-safe
+  smoke risk-event summary to `live-incident-bundle` result and manifest
+  metadata, so incident bundles expose HSL RED/cooldown/raw-red context without
+  opening the full embedded smoke report.
 
 Current review gate:
 
@@ -60,6 +60,18 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1006 at `68c3fe22`.
+- PR #1006 added bounded `risk_events.attention_groups` to
+  `live-smoke-report --brief`, prioritizing HSL RED/cooldown/raw-red and
+  panic-mode context over routine latest-event ordering while emitting only
+  safe group metadata. It merged after Claude and Hermes approved with no
+  findings and CI was green. VPS5 checkout was updated to `68c3fe22` without
+  restarting running bots because the slice was report-only. Smoke after the
+  fast-forward reported `ok=true`, `hard_failures=0`, `matched_expected=5`,
+  clean tracked repository state, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, and `fill_refresh.failed=0`. The
+  new `risk_events.attention_groups` field was visible and surfaced current
+  ZEC cooldown evidence.
 - Repository pulled through PR #1005 at `f54dae3e`.
 - PR #1005 added bounded `risk_events.latest_groups` to
   `live-smoke-report --brief`, sourced from existing structured risk events and

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -42,6 +42,7 @@ from live.smoke_report import (
     build_live_smoke_report,
     default_logs_root_for_monitor,
     project_live_smoke_report_sections,
+    summarize_live_smoke_report_brief,
 )
 
 
@@ -731,6 +732,14 @@ def _smoke_execution_result_summary(smoke_report: dict[str, Any]) -> dict[str, A
     }
 
 
+def _smoke_risk_result_summary(smoke_report: dict[str, Any]) -> dict[str, Any]:
+    summary = summarize_live_smoke_report_brief(smoke_report)
+    risk_events = summary.get("risk_events")
+    if not isinstance(risk_events, dict):
+        return {}
+    return risk_events
+
+
 def _copy_event_segments(
     *,
     monitor_root: str | Path,
@@ -1063,6 +1072,7 @@ def build_live_incident_bundle(
         smoke_sections,
     )
     smoke_execution_summary = _smoke_execution_result_summary(smoke_report)
+    smoke_risk_summary = _smoke_risk_result_summary(smoke_report)
     restart_smoke_plan: dict[str, Any] | None = None
     restart_smoke_plan_summary: dict[str, Any] | None = None
     if include_restart_smoke_plan:
@@ -1164,6 +1174,7 @@ def build_live_incident_bundle(
             "event_segments": segment_manifest,
             "smoke_report": {
                 "execution": smoke_execution_summary,
+                "risk_events": smoke_risk_summary,
             },
         }
         if restart_smoke_plan_summary is not None:
@@ -1247,6 +1258,7 @@ def build_live_incident_bundle(
             "event_window": smoke_report.get("event_window"),
             "logs": _smoke_log_result_summary(smoke_report),
             "execution": smoke_execution_summary,
+            "risk_events": smoke_risk_summary,
             "processes": {
                 "enabled": smoke_report.get("processes", {}).get("enabled"),
                 "ok": smoke_report.get("processes", {}).get("ok"),

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -30,6 +30,7 @@ def _monitor_row(
     source: str = "live",
     component: str = "test",
     symbol: str | None = None,
+    pside: str | None = None,
     side: str | None = None,
     ids: dict | None = None,
     tags: list[str] | None = None,
@@ -48,6 +49,7 @@ def _monitor_row(
         "exchange": exchange,
         "user": user,
         "symbol": symbol,
+        "pside": pside,
         "side": side,
         "status": status,
         "reason_code": reason_code,
@@ -142,6 +144,27 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
                     "result_status": "open",
                 },
             ),
+            _monitor_row(
+                event_type="hsl.status",
+                seq=6,
+                ts=2200,
+                status="degraded",
+                level="info",
+                reason_code="cooldown_active",
+                component="risk.hsl",
+                symbol="ZEC/USDT:USDT",
+                pside="long",
+                ids={"cycle_id": "cy_risk_1"},
+                data={
+                    "signal_mode": "coin",
+                    "tier": "red",
+                    "cooldown_until_ms": 999999,
+                    "cooldown_remaining_seconds": 123.4,
+                    "drawdown_raw": 0.42,
+                    "balance": 12345.67,
+                    "secret_marker": "risk-secret",
+                },
+            ),
         ],
     )
     (events_dir / "20260629.ndjson.gz").write_bytes(b"")
@@ -212,12 +235,12 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         "rotated_skipped": 1,
         "scope_pruned": 0,
     }
-    assert report["time_window"]["matched_events"] == 2
+    assert report["time_window"]["matched_events"] == 3
     assert report["smoke_report"]["event_window"] == {
         "enabled": True,
         "since_ms": 1500,
         "until_ms": 2500,
-        "events_considered": 2,
+        "events_considered": 3,
         "events_skipped_before": 3,
         "events_skipped_after": 0,
         "invalid_window_ts": 0,
@@ -260,6 +283,21 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         "statuses": {"succeeded": 1},
         "outcomes": {"create_succeeded": 1},
     }
+    assert report["smoke_report"]["risk_events"]["total"] == 1
+    assert report["smoke_report"]["risk_events"]["attention_groups"] == [
+        {
+            "bot": "binance/binance_01",
+            "event_type": "hsl.status",
+            "reason_code": "cooldown_active",
+            "status": "degraded",
+            "level": "info",
+            "symbol": "ZEC/USDT:USDT",
+            "pside": "long",
+            "component": "risk.hsl",
+            "count": 1,
+            "latest_ts": 2200,
+        }
+    ]
     assert report["config_hashes"] == 1
     assert report["monitor_snapshots"] == 1
     assert report["event_segments"]["included"] == 1
@@ -302,9 +340,15 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
 
     assert manifest["config_hashes"][0]["sha256"] == config_hashes[0]["sha256"]
     assert manifest["smoke_report"]["execution"] == report["smoke_report"]["execution"]
+    assert manifest["smoke_report"]["risk_events"] == report["smoke_report"][
+        "risk_events"
+    ]
     manifest_dump = json.dumps(manifest, sort_keys=True)
     assert "raw_order_id_should_not_summarize" not in manifest_dump
     assert "raw_client_id_should_not_summarize" not in manifest_dump
+    assert "risk-secret" not in manifest_dump
+    assert "12345.67" not in manifest_dump
+    assert "0.42" not in manifest_dump
     assert '"price"' not in manifest_dump
     assert '"qty"' not in manifest_dump
     assert manifest["filters"]["max_log_files"] == 8


### PR DESCRIPTION
## Summary

Adds a bounded risk-event smoke summary to `passivbot tool live-incident-bundle` result and manifest metadata.

The summary reuses the existing `live-smoke-report --brief` risk projection, so incident bundles surface HSL RED/cooldown/raw-red context without requiring operators to open the full embedded `smoke_report.json`.

## Scope

- Read-only incident-bundle metadata/report projection.
- Uses only already-built smoke-report data.
- Emits the existing safe brief risk projection, including bounded `attention_groups` and HSL status/cooldown summaries.
- Does not add event producers, exchange calls, cache mutation, readiness gates, smoke verdict changes, process signaling, order logic, risk logic, or trading behavior.

## Redaction / Safety

The test fixture includes raw order price/qty/id fields and raw HSL `drawdown_raw`, balance, and a secret marker. The returned report and manifest risk summary exclude those values.

## Validation

- `./venv/bin/python -m pytest tests/test_live_incident_bundle.py::test_live_incident_bundle_collects_hashes_snapshots_events_and_window -q`
- `./venv/bin/python -m pytest tests/test_live_incident_bundle.py -q`
- `./venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py`
- `git diff --check`
- Added-line silent-handling scan: no matches.

## VPS5 Context

Before this slice, VPS5 was at `68c3fe22` with all five configured bots running. Short smoke reported `ok=true`, `hard_failures=0`, `matched_expected=5`, clean tracked repo state, `remote_calls.failed=0`, `account_critical_remote_calls.failed=0`, and `fill_refresh.failed=0`. The new `risk_events.attention_groups` field from PR #1006 was visible and surfaced current ZEC cooldown evidence.
