### PR TITLE
Summarize EMA smoke in incident bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-incident-bundle` now includes the bounded EMA-readiness
+  smoke summary in the returned report and manifest, so incident bundles expose
+  current EMA unavailable reason counts without requiring operators to open the
+  full embedded smoke report.
 - `passivbot tool live-incident-bundle` now includes a bounded risk-event
   smoke summary in the returned report and manifest, so incident bundles expose
   HSL RED/cooldown/raw-red context without requiring operators to open the full

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,18 +19,18 @@ Last updated: 2026-07-02.
 
 Current `origin/v8` head:
 
-- `68c3fe22` after PR #1006, `Show brief smoke risk attention groups`.
+- `9d3b4051` after PR #1007, `Summarize risk smoke in incident bundles`.
 
 Current logging-overhaul head:
 
-- `68c3fe22` after PR #1006, `Show brief smoke risk attention groups`.
+- `9d3b4051` after PR #1007, `Summarize risk smoke in incident bundles`.
 
 Current work:
 
-- Branch `codex/v8-incident-risk-smoke-summary` adds the existing value-safe
-  smoke risk-event summary to `live-incident-bundle` result and manifest
-  metadata, so incident bundles expose HSL RED/cooldown/raw-red context without
-  opening the full embedded smoke report.
+- Branch `codex/v8-incident-ema-smoke-summary` adds the existing value-safe
+  smoke EMA-readiness summary to `live-incident-bundle` result and manifest
+  metadata, so incident bundles expose current EMA unavailable reason counts
+  without opening the full embedded smoke report.
 
 Current review gate:
 
@@ -60,6 +60,17 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1007 at `9d3b4051`.
+- PR #1007 added the bounded `risk_events` brief smoke projection to
+  `live-incident-bundle` returned JSON and `manifest.json`, reusing the same
+  safe risk-event summary surfaced by brief smoke reports. It merged after
+  Claude and Hermes approved with no findings and CI was green. VPS5 checkout
+  was updated to `9d3b4051` without restarting running bots because the slice
+  was report-only. Smoke after the fast-forward reported `ok=true`,
+  `hard_failures=0`, `matched_expected=5`, clean tracked repository state,
+  `remote_calls.failed=0`, `account_critical_remote_calls.failed=0`, and
+  `fill_refresh.failed=0`. A focused incident-bundle verification confirmed
+  `manifest.smoke_report.risk_events` was present.
 - Repository pulled through PR #1006 at `68c3fe22`.
 - PR #1006 added bounded `risk_events.attention_groups` to
   `live-smoke-report --brief`, prioritizing HSL RED/cooldown/raw-red and

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -732,12 +732,23 @@ def _smoke_execution_result_summary(smoke_report: dict[str, Any]) -> dict[str, A
     }
 
 
-def _smoke_risk_result_summary(smoke_report: dict[str, Any]) -> dict[str, Any]:
-    summary = summarize_live_smoke_report_brief(smoke_report)
-    risk_events = summary.get("risk_events")
-    if not isinstance(risk_events, dict):
+def _smoke_brief_section_result_summary(
+    smoke_brief_summary: dict[str, Any], section: str
+) -> dict[str, Any]:
+    value = smoke_brief_summary.get(section)
+    if not isinstance(value, dict):
         return {}
-    return risk_events
+    return value
+
+
+def _smoke_risk_result_summary(smoke_brief_summary: dict[str, Any]) -> dict[str, Any]:
+    return _smoke_brief_section_result_summary(smoke_brief_summary, "risk_events")
+
+
+def _smoke_ema_readiness_result_summary(
+    smoke_brief_summary: dict[str, Any],
+) -> dict[str, Any]:
+    return _smoke_brief_section_result_summary(smoke_brief_summary, "ema_readiness")
 
 
 def _copy_event_segments(
@@ -1071,8 +1082,12 @@ def build_live_incident_bundle(
         smoke_report,
         smoke_sections,
     )
+    smoke_brief_summary = summarize_live_smoke_report_brief(smoke_report)
     smoke_execution_summary = _smoke_execution_result_summary(smoke_report)
-    smoke_risk_summary = _smoke_risk_result_summary(smoke_report)
+    smoke_risk_summary = _smoke_risk_result_summary(smoke_brief_summary)
+    smoke_ema_readiness_summary = _smoke_ema_readiness_result_summary(
+        smoke_brief_summary
+    )
     restart_smoke_plan: dict[str, Any] | None = None
     restart_smoke_plan_summary: dict[str, Any] | None = None
     if include_restart_smoke_plan:
@@ -1175,6 +1190,7 @@ def build_live_incident_bundle(
             "smoke_report": {
                 "execution": smoke_execution_summary,
                 "risk_events": smoke_risk_summary,
+                "ema_readiness": smoke_ema_readiness_summary,
             },
         }
         if restart_smoke_plan_summary is not None:
@@ -1259,6 +1275,7 @@ def build_live_incident_bundle(
             "logs": _smoke_log_result_summary(smoke_report),
             "execution": smoke_execution_summary,
             "risk_events": smoke_risk_summary,
+            "ema_readiness": smoke_ema_readiness_summary,
             "processes": {
                 "enabled": smoke_report.get("processes", {}).get("enabled"),
                 "ok": smoke_report.get("processes", {}).get("ok"),

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -165,6 +165,52 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
                     "secret_marker": "risk-secret",
                 },
             ),
+            _monitor_row(
+                event_type="ema.unavailable",
+                seq=7,
+                ts=2300,
+                status="degraded",
+                level="warning",
+                reason_code="required_ema_unavailable",
+                component="ema.bundle",
+                symbol="BTC/USDT:USDT",
+                ids={"cycle_id": "cy_ema_1"},
+                data={
+                    "candidate_unavailable": {
+                        "count": 1,
+                        "sample": ["BTC/USDT:USDT"],
+                        "truncated": 0,
+                    },
+                    "unavailable": {
+                        "count": 2,
+                        "sample": ["BTC/USDT:USDT", "ETH/USDT:USDT"],
+                        "truncated": 0,
+                    },
+                    "candidate_unavailable_groups": [
+                        {
+                            "reason": "cache_only_fetch_failed",
+                            "symbols": {
+                                "count": 1,
+                                "sample": ["BTC/USDT:USDT"],
+                                "truncated": 0,
+                            },
+                            "error_types": ["MissingCloseEma"],
+                            "example_error": "ema-secret-marker",
+                        }
+                    ],
+                    "unavailable_reasons": [
+                        {
+                            "reason": "cache_only_fetch_failed",
+                            "symbols": {
+                                "count": 2,
+                                "sample": ["BTC/USDT:USDT", "ETH/USDT:USDT"],
+                                "truncated": 0,
+                            },
+                        }
+                    ],
+                    "raw_exchange_payload": {"api_key": "EMA_SECRET"},
+                },
+            ),
         ],
     )
     (events_dir / "20260629.ndjson.gz").write_bytes(b"")
@@ -235,12 +281,12 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         "rotated_skipped": 1,
         "scope_pruned": 0,
     }
-    assert report["time_window"]["matched_events"] == 3
+    assert report["time_window"]["matched_events"] == 4
     assert report["smoke_report"]["event_window"] == {
         "enabled": True,
         "since_ms": 1500,
         "until_ms": 2500,
-        "events_considered": 3,
+        "events_considered": 4,
         "events_skipped_before": 3,
         "events_skipped_after": 0,
         "invalid_window_ts": 0,
@@ -298,6 +344,31 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
             "latest_ts": 2200,
         }
     ]
+    assert report["smoke_report"]["ema_readiness"] == {
+        "total": 1,
+        "bots": 1,
+        "latest_candidate_unavailable_total": 1,
+        "latest_unavailable_total": 2,
+        "latest_optional_drop_total": 0,
+        "event_types": {"ema.unavailable": 1},
+        "latest_candidate_reason_counts": {"cache_only_fetch_failed": 1},
+        "latest_unavailable_reason_counts": {"cache_only_fetch_failed": 2},
+        "latest_candidate_reason_symbols": {
+            "cache_only_fetch_failed": {
+                "count": 1,
+                "sample": ["BTC/USDT:USDT"],
+                "truncated": 0,
+            }
+        },
+        "latest_unavailable_reason_symbols": {
+            "cache_only_fetch_failed": {
+                "count": 2,
+                "sample": ["BTC/USDT:USDT", "ETH/USDT:USDT"],
+                "truncated": 0,
+            }
+        },
+        "latest_candidate_error_type_counts": {"MissingCloseEma": 1},
+    }
     assert report["config_hashes"] == 1
     assert report["monitor_snapshots"] == 1
     assert report["event_segments"]["included"] == 1
@@ -343,10 +414,15 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     assert manifest["smoke_report"]["risk_events"] == report["smoke_report"][
         "risk_events"
     ]
+    assert manifest["smoke_report"]["ema_readiness"] == report["smoke_report"][
+        "ema_readiness"
+    ]
     manifest_dump = json.dumps(manifest, sort_keys=True)
     assert "raw_order_id_should_not_summarize" not in manifest_dump
     assert "raw_client_id_should_not_summarize" not in manifest_dump
     assert "risk-secret" not in manifest_dump
+    assert "ema-secret-marker" not in manifest_dump
+    assert "EMA_SECRET" not in manifest_dump
     assert "12345.67" not in manifest_dump
     assert "0.42" not in manifest_dump
     assert '"price"' not in manifest_dump


### PR DESCRIPTION
## Summary
- add the existing bounded brief smoke EMA-readiness projection to live-incident-bundle returned JSON and manifest metadata
- reuse summarize_live_smoke_report_brief() so incident bundles expose reason counts/symbol samples without raw EMA event payloads
- update the logging-overhaul progress ledger and changelog for this slice

## Scope
- observability/report-only
- no event producers, exchange calls, smoke verdict logic, or trading behavior changed

## Validation
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py::test_live_incident_bundle_collects_hashes_snapshots_events_and_window -q
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py -q
- ./venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check
- added-line silent-handling scan: no matches