### PR TITLE
Summarize data-plane smoke in incident bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-incident-bundle` now includes bounded data-plane smoke
+  summaries for remote calls, account-critical remote calls, fill refresh,
+  startup timings, and HSL replay in the returned report and manifest, making
+  common exchange/data-readiness and startup-latency evidence visible without
+  opening the full embedded smoke report.
 - `passivbot tool live-incident-bundle` now includes bounded operational smoke
   summaries for exchange config refresh, staged readiness, event-pipeline
   health, and shutdown events in the returned report and manifest, so common

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,19 @@ Last updated: 2026-07-02.
 
 Current `origin/v8` head:
 
-- `52a2fbd3` after PR #1008, `Summarize EMA smoke in incident bundles`.
+- `60ed8f60` after PR #1009, `Summarize operational smoke in incident bundles`.
 
 Current logging-overhaul head:
 
-- `52a2fbd3` after PR #1008, `Summarize EMA smoke in incident bundles`.
+- `60ed8f60` after PR #1009, `Summarize operational smoke in incident bundles`.
 
 Current work:
 
-- Branch `codex/v8-incident-operational-smoke-summary` adds existing
-  value-safe operational smoke summaries to `live-incident-bundle` result and
-  manifest metadata: exchange config refresh, staged readiness, event-pipeline
-  health, and shutdown events. This exposes common live-smoke attention sources
-  without opening the full embedded smoke report.
+- Branch `codex/v8-incident-data-plane-smoke-summary` adds existing value-safe
+  data-plane smoke summaries to `live-incident-bundle` result and manifest
+  metadata: remote calls, account-critical remote calls, fill refresh, startup
+  timings, and HSL replay. This exposes common exchange/data-readiness and
+  startup-latency evidence without opening the full embedded smoke report.
 
 Current review gate:
 
@@ -61,6 +61,18 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1009 at `60ed8f60`.
+- PR #1009 added bounded operational smoke projections to
+  `live-incident-bundle` returned JSON and `manifest.json`: exchange config
+  refresh, staged readiness, event-pipeline health, and shutdown events. It
+  merged after Claude and Hermes approved with no findings and CI was green.
+  VPS5 checkout was updated to `60ed8f60` without restarting running bots
+  because the slice was report-only. Smoke after the fast-forward reported
+  `ok=true`, `hard_failures=0`, `matched_expected=5`, clean tracked repository
+  state, `remote_calls.failed=0`, `account_critical_remote_calls.failed=0`,
+  `fill_refresh.failed=0`, and no hard log matches. A focused
+  incident-bundle verification confirmed all four operational manifest
+  sections were present.
 - Repository pulled through PR #1008 at `52a2fbd3`.
 - PR #1008 added the bounded `ema_readiness` brief smoke projection to
   `live-incident-bundle` returned JSON and `manifest.json`, reusing the same

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -765,6 +765,21 @@ def _smoke_operational_result_summaries(
     }
 
 
+def _smoke_data_plane_result_summaries(
+    smoke_brief_summary: dict[str, Any],
+) -> dict[str, dict[str, Any]]:
+    return {
+        section: _smoke_brief_section_result_summary(smoke_brief_summary, section)
+        for section in (
+            "remote_calls",
+            "account_critical_remote_calls",
+            "fill_refresh",
+            "startup_timings",
+            "hsl_replay",
+        )
+    }
+
+
 def _copy_event_segments(
     *,
     monitor_root: str | Path,
@@ -1105,6 +1120,9 @@ def build_live_incident_bundle(
     smoke_operational_summaries = _smoke_operational_result_summaries(
         smoke_brief_summary
     )
+    smoke_data_plane_summaries = _smoke_data_plane_result_summaries(
+        smoke_brief_summary
+    )
     restart_smoke_plan: dict[str, Any] | None = None
     restart_smoke_plan_summary: dict[str, Any] | None = None
     if include_restart_smoke_plan:
@@ -1209,6 +1227,7 @@ def build_live_incident_bundle(
                 "risk_events": smoke_risk_summary,
                 "ema_readiness": smoke_ema_readiness_summary,
                 **smoke_operational_summaries,
+                **smoke_data_plane_summaries,
             },
         }
         if restart_smoke_plan_summary is not None:
@@ -1295,6 +1314,7 @@ def build_live_incident_bundle(
             "risk_events": smoke_risk_summary,
             "ema_readiness": smoke_ema_readiness_summary,
             **smoke_operational_summaries,
+            **smoke_data_plane_summaries,
             "processes": {
                 "enabled": smoke_report.get("processes", {}).get("enabled"),
                 "ok": smoke_report.get("processes", {}).get("ok"),

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -118,9 +118,17 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
                 ts=2000,
                 status="failed",
                 level="warning",
-                reason_code="request_timeout",
+                reason_code="authoritative_balance",
+                component="state.refresh",
                 symbol="BTC/USDT:USDT",
                 ids={"cycle_id": "cy_2", "remote_call_id": "rc_1"},
+                data={
+                    "kind": "authoritative_state_fetch",
+                    "surface": "balance",
+                    "elapsed_ms": 5000,
+                    "error_type": "RequestTimeout",
+                    "error": "api_key=REMOTE_SECRET",
+                },
             ),
             _monitor_row(
                 event_type="execution.create_succeeded",
@@ -288,6 +296,63 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
                     "error": "Authorization: Bearer SHUTDOWN_SECRET",
                 },
             ),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=12,
+                ts=2490,
+                status="ready",
+                level="debug",
+                reason_code="fill_cache_ready",
+                component="fills.refresh",
+                ids={"cycle_id": "cy_fill_1"},
+                data={
+                    "source": "exchange",
+                    "refresh_mode": "periodic",
+                    "elapsed_ms": 420,
+                    "history_scope": "all",
+                    "event_count_after": 2705,
+                    "new_count": 1,
+                    "coverage_ready_after": True,
+                    "raw_payload": "FILL_REFRESH_SECRET",
+                },
+            ),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=13,
+                ts=2492,
+                status="succeeded",
+                level="debug",
+                reason_code="startup_phase_ready",
+                component="startup",
+                ids={"cycle_id": "cy_startup_1"},
+                data={
+                    "phase": "startup",
+                    "elapsed_ms": 10000,
+                    "since_previous_ms": 7000,
+                    "details": "ready api_key=STARTUP_SECRET",
+                },
+            ),
+            _monitor_row(
+                event_type="hsl.replay.completed",
+                seq=14,
+                ts=2494,
+                status="succeeded",
+                level="debug",
+                reason_code="hsl_timeline_replay_completed",
+                component="risk.hsl",
+                ids={"cycle_id": "cy_hsl_replay_1"},
+                data={
+                    "signal_mode": "coin",
+                    "stage": "full_replay",
+                    "rows": 985965,
+                    "pairs": 24,
+                    "timeline_rows": 43201,
+                    "full_elapsed_s": 1623.4,
+                    "startup_blocking_elapsed_s": 1623.4,
+                    "balance": 123456.78,
+                    "secret": "HSL_REPLAY_SECRET",
+                },
+            ),
         ],
     )
     (events_dir / "20260629.ndjson.gz").write_bytes(b"")
@@ -358,12 +423,12 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         "rotated_skipped": 1,
         "scope_pruned": 0,
     }
-    assert report["time_window"]["matched_events"] == 8
+    assert report["time_window"]["matched_events"] == 11
     assert report["smoke_report"]["event_window"] == {
         "enabled": True,
         "since_ms": 1500,
         "until_ms": 2500,
-        "events_considered": 8,
+        "events_considered": 11,
         "events_skipped_before": 3,
         "events_skipped_after": 0,
         "invalid_window_ts": 0,
@@ -483,6 +548,65 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         "total": 1,
         "event_types": {"bot.shutdown.stage": 1},
     }
+    assert report["smoke_report"]["remote_calls"] == {
+        "total": 1,
+        "succeeded": 0,
+        "failed": 1,
+        "throttled": 0,
+        "failure_pct": 100,
+        "throttled_pct": 0,
+        "failed_reason_codes": {"authoritative_balance": 1},
+        "failed_error_types": {"RequestTimeout": 1},
+        "failed_kinds": {"authoritative_state_fetch": 1},
+        "failed_surfaces": {"balance": 1},
+        "slowest": [
+            {
+                "bot": "binance/binance_01",
+                "kind": "authoritative_state_fetch",
+                "surface": "balance",
+                "count": 1,
+                "failed": 1,
+                "max_ms": 5000,
+                "p95_ms": 5000,
+                "latest_elapsed_ms": 5000,
+                "latest_symbol": "BTC/USDT:USDT",
+            }
+        ],
+    }
+    assert report["smoke_report"]["account_critical_remote_calls"] == report[
+        "smoke_report"
+    ]["remote_calls"]
+    assert report["smoke_report"]["fill_refresh"] == {
+        "total": 1,
+        "bots": 1,
+        "failed": 0,
+        "failure_pct": 0.0,
+        "failed_bots": 0,
+        "latest_failed_bots": 0,
+        "recovered_groups": 0,
+        "statuses": {"ready": 1},
+    }
+    assert report["smoke_report"]["startup_timings"] == {
+        "bots": 1,
+        "phases": 1,
+        "over_budget_phases": 0,
+        "startup_phase_bots": 1,
+        "max_latest_elapsed_ms": 10000,
+        "max_latest_phase_ms": 7000,
+        "max_startup_elapsed_ms": 10000,
+    }
+    assert report["smoke_report"]["hsl_replay"] == {
+        "total": 1,
+        "bots": 1,
+        "active_bots": 0,
+        "stale_active_bots": 0,
+        "long_running_active_bots": 0,
+        "completed_bots": 1,
+        "failed_bots": 0,
+        "failed_attention_bots": 0,
+        "event_types": {"hsl.replay.completed": 1},
+        "max_completed_elapsed_ms": 1623400,
+    }
     assert report["config_hashes"] == 1
     assert report["monitor_snapshots"] == 1
     assert report["event_segments"]["included"] == 1
@@ -536,6 +660,11 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         "staged_readiness",
         "event_pipeline",
         "shutdown_events",
+        "remote_calls",
+        "account_critical_remote_calls",
+        "fill_refresh",
+        "startup_timings",
+        "hsl_replay",
     ):
         assert manifest["smoke_report"][section] == report["smoke_report"][section]
     manifest_dump = json.dumps(manifest, sort_keys=True)
@@ -548,7 +677,12 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     assert "STAGED_SECRET" not in manifest_dump
     assert "PIPELINE_SECRET" not in manifest_dump
     assert "SHUTDOWN_SECRET" not in manifest_dump
+    assert "REMOTE_SECRET" not in manifest_dump
+    assert "FILL_REFRESH_SECRET" not in manifest_dump
+    assert "STARTUP_SECRET" not in manifest_dump
+    assert "HSL_REPLAY_SECRET" not in manifest_dump
     assert "12345.67" not in manifest_dump
+    assert "123456.78" not in manifest_dump
     assert "0.42" not in manifest_dump
     assert '"price"' not in manifest_dump
     assert '"qty"' not in manifest_dump


### PR DESCRIPTION
Observability-only slice.\n\nScope:\n- Adds existing bounded brief smoke sections to live-incident-bundle returned JSON and manifest: remote_calls, account_critical_remote_calls, fill_refresh, startup_timings, hsl_replay.\n- Reuses summarize_live_smoke_report_brief() projections; no new event producers, exchange calls, verdict policy, or trading behavior.\n- Extends the incident-bundle fixture with representative data-plane events and secret markers to verify bounded manifest/report projection.\n\nValidation:\n- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py::test_live_incident_bundle_collects_hashes_snapshots_events_and_window -q\n- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py -q\n- ./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_remote_call_timings tests/test_live_smoke_report.py::test_live_smoke_report_account_critical_remote_call_health_subset tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_startup_phase_baselines -q\n- ./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_fill_refresh_health tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_hsl_replay_health -q\n- ./venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py\n- git diff --check\n- Added-code silent-handling scan: no matches\n