### PR TITLE
Accept brief smoke section aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report --section` and
+  `passivbot tool live-incident-bundle --smoke-section` now accept the brief
+  smoke-summary names such as `fill_refresh`, `hsl_replay`, and
+  `remote_calls` as aliases for their embedded full-report sections, reducing
+  CLI friction when moving between brief smoke output and incident bundles.
 - `passivbot tool live-incident-bundle` now includes bounded data-plane smoke
   summaries for remote calls, account-critical remote calls, fill refresh,
   startup timings, and HSL replay in the returned report and manifest, making

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,20 @@ Last updated: 2026-07-02.
 
 Current `origin/v8` head:
 
-- `60ed8f60` after PR #1009, `Summarize operational smoke in incident bundles`.
+- `2f91372a` after PR #1010, `Summarize data-plane smoke in incident bundles`.
 
 Current logging-overhaul head:
 
-- `60ed8f60` after PR #1009, `Summarize operational smoke in incident bundles`.
+- `2f91372a` after PR #1010, `Summarize data-plane smoke in incident bundles`.
 
 Current work:
 
-- Branch `codex/v8-incident-data-plane-smoke-summary` adds existing value-safe
-  data-plane smoke summaries to `live-incident-bundle` result and manifest
-  metadata: remote calls, account-critical remote calls, fill refresh, startup
-  timings, and HSL replay. This exposes common exchange/data-readiness and
-  startup-latency evidence without opening the full embedded smoke report.
+- Branch `codex/v8-incident-smoke-section-aliases` adds CLI smoke-section
+  aliases so brief smoke-summary names such as `fill_refresh`, `hsl_replay`,
+  `remote_calls`, `account_critical_remote_calls`, `ema_readiness`, and
+  operational brief keys resolve to their embedded full-report sections when
+  using `live-smoke-report --section` or
+  `live-incident-bundle --smoke-section`.
 
 Current review gate:
 
@@ -61,6 +62,21 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1010 at `2f91372a`.
+- PR #1010 added bounded data-plane smoke projections to
+  `live-incident-bundle` returned JSON and `manifest.json`: remote calls,
+  account-critical remote calls, fill refresh, startup timings, and HSL replay.
+  It merged after Claude and Hermes approved with no findings and CI was green.
+  VPS5 checkout was updated to `2f91372a` without restarting running bots
+  because the slice was report-only. Smoke after the fast-forward reported
+  `ok=true`, `hard_failures=0`, `matched_expected=5`, clean tracked repository
+  state at `repository.head=2f91372a`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `fill_refresh.failed=0`, and no
+  hard log matches. Remaining attention came from known non-hard EMA readiness
+  and ZEC HSL cooldown status. A focused incident-bundle verification confirmed
+  `remote_calls`, `account_critical_remote_calls`, `fill_refresh`,
+  `startup_timings`, and `hsl_replay` were present in both the returned report
+  and `manifest.json`.
 - Repository pulled through PR #1009 at `60ed8f60`.
 - PR #1009 added bounded operational smoke projections to
   `live-incident-bundle` returned JSON and `manifest.json`: exchange config

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -7167,6 +7167,18 @@ def available_live_smoke_report_sections(report: dict[str, Any]) -> list[str]:
     return sorted(key for key in report if key not in _SMOKE_REPORT_SECTION_BASE_KEYS)
 
 
+SMOKE_REPORT_SECTION_ALIASES: dict[str, tuple[str, ...]] = {
+    "account_critical_remote_calls": ("account_critical_remote_call_health",),
+    "ema_readiness": ("ema_readiness_health",),
+    "event_pipeline": ("event_pipeline_health",),
+    "exchange_config_refresh": ("exchange_config_refresh_health",),
+    "fill_refresh": ("fill_refresh_health",),
+    "hsl_replay": ("hsl_replay_health",),
+    "remote_calls": ("remote_call_health", "remote_call_timings"),
+    "staged_readiness": ("staged_readiness_health",),
+}
+
+
 def project_live_smoke_report_sections(
     report: dict[str, Any],
     sections: list[str] | tuple[str, ...] | set[str],
@@ -7181,7 +7193,17 @@ def project_live_smoke_report_sections(
 
     available = available_live_smoke_report_sections(report)
     available_set = set(available)
-    unknown = [section for section in requested if section not in available_set]
+    resolved = []
+    unknown = []
+    for section in requested:
+        targets = (section, *SMOKE_REPORT_SECTION_ALIASES.get(section, ()))
+        matched_targets = [target for target in targets if target in available_set]
+        if not matched_targets:
+            unknown.append(section)
+            continue
+        for target in matched_targets:
+            if target not in resolved:
+                resolved.append(target)
     if unknown:
         raise ValueError(
             "unknown --section value(s): "
@@ -7192,6 +7214,6 @@ def project_live_smoke_report_sections(
         )
 
     projected = {key: report[key] for key in _SMOKE_REPORT_SECTION_BASE_KEYS if key in report}
-    for section in requested:
+    for section in resolved:
         projected[section] = report[section]
     return projected

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -1135,7 +1135,7 @@ def test_live_incident_bundle_cli_can_focus_embedded_smoke_report(tmp_path, caps
                 "--no-trace-report",
                 "--no-problem-report",
                 "--smoke-section",
-                "fill_refresh_health",
+                "fill_refresh",
                 "--output",
                 str(output),
                 "--compact",
@@ -1155,7 +1155,7 @@ def test_live_incident_bundle_cli_can_focus_embedded_smoke_report(tmp_path, caps
     assert smoke_report["fill_refresh_health"]["total"] == 1
     assert "logs" not in smoke_report
     assert "remote_call_health" not in smoke_report
-    assert manifest["filters"]["smoke_sections"] == ["fill_refresh_health"]
+    assert manifest["filters"]["smoke_sections"] == ["fill_refresh"]
 
 
 def test_live_incident_bundle_cli_rejects_malformed_data_eq_filter(tmp_path, capsys):

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -5053,6 +5053,39 @@ def test_live_smoke_report_section_projection_keeps_common_metadata(tmp_path):
     assert "processes" not in projected
 
 
+def test_live_smoke_report_full_section_projection_accepts_brief_alias(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=1,
+                ts=1000,
+                status="succeeded",
+                reason_code="fills_refresh_succeeded",
+                data={
+                    "source": "cache",
+                    "refresh_mode": "startup",
+                    "history_scope": "all",
+                    "coverage_ready_after": True,
+                    "elapsed_ms": 25,
+                },
+            )
+        ],
+    )
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    projected = project_live_smoke_report_sections(report, ["fill_refresh"])
+
+    assert projected["ok"] is True
+    assert projected["monitor"]["live_events"] == 1
+    assert projected["fill_refresh_health"]["total"] == 1
+    assert "fill_refresh" not in projected
+    assert "remote_call_health" not in projected
+    assert "processes" not in projected
+
+
 def test_live_smoke_report_cli_brief_section_filter(tmp_path, capsys):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
Tooling-only observability slice.\n\nScope:\n- Allows brief smoke-summary section names such as fill_refresh, hsl_replay, remote_calls, account_critical_remote_calls, ema_readiness, and operational brief keys to resolve to the embedded full-report section names used by live-smoke-report --section and live-incident-bundle --smoke-section.\n- Exact section names still win, so brief reports continue to project exact brief keys unchanged.\n- No event producers, exchange calls, verdict policy, or trading behavior changed.\n\nWhy:\n- After PR #1010, incident bundles expose brief smoke sections at top level, but the embedded smoke selector still required names like fill_refresh_health/hsl_replay_health. This removes that operator/tooling friction.\n\nValidation:\n- ./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_section_projection_keeps_common_metadata tests/test_live_smoke_report.py::test_live_smoke_report_full_section_projection_accepts_brief_alias tests/test_live_smoke_report.py::test_live_smoke_report_cli_brief_section_filter tests/test_live_smoke_report.py::test_live_smoke_report_cli_rejects_unknown_section -q\n- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py::test_live_incident_bundle_cli_can_focus_embedded_smoke_report -q\n- ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py -q\n- ./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py tests/test_live_incident_bundle.py\n- git diff --check\n- Added-code silent-handling scan: no matches\n