### PR TITLE
Show non-hard problem event counts in smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report --summary` and `--brief` now include
+  `problem_events.non_hard`, making non-fatal structured attention easier to
+  distinguish from hard problem events at a glance.
 - `passivbot tool live-smoke-report --section` and
   `passivbot tool live-incident-bundle --smoke-section` now accept the brief
   smoke-summary names such as `fill_refresh`, `hsl_replay`, and

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,20 +19,18 @@ Last updated: 2026-07-02.
 
 Current `origin/v8` head:
 
-- `2f91372a` after PR #1010, `Summarize data-plane smoke in incident bundles`.
+- `57a52e80` after PR #1011, `Accept brief smoke section aliases`.
 
 Current logging-overhaul head:
 
-- `2f91372a` after PR #1010, `Summarize data-plane smoke in incident bundles`.
+- `57a52e80` after PR #1011, `Accept brief smoke section aliases`.
 
 Current work:
 
-- Branch `codex/v8-incident-smoke-section-aliases` adds CLI smoke-section
-  aliases so brief smoke-summary names such as `fill_refresh`, `hsl_replay`,
-  `remote_calls`, `account_critical_remote_calls`, `ema_readiness`, and
-  operational brief keys resolve to their embedded full-report sections when
-  using `live-smoke-report --section` or
-  `live-incident-bundle --smoke-section`.
+- Branch `codex/v8-smoke-problem-non-hard-count` adds a bounded
+  `problem_events.non_hard` count to `live-smoke-report --summary` and
+  `--brief`, making non-fatal structured attention easier to distinguish from
+  hard problem events without changing smoke verdict policy.
 
 Current review gate:
 
@@ -62,6 +60,21 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1011 at `57a52e80`.
+- PR #1011 added CLI smoke-section aliases so brief names such as
+  `fill_refresh`, `hsl_replay`, and `remote_calls` resolve to their embedded
+  full-report smoke sections. It merged after Claude and Hermes approved with
+  no findings and CI was green. VPS5 checkout was updated to `57a52e80`
+  without restarting running bots because the slice was report-only/tooling
+  only. Smoke after the fast-forward reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, clean tracked repository state at
+  `repository.head=57a52e80`, no failed remote calls, no failed
+  account-critical remote calls, `fill_refresh.failed=0`, and no hard log
+  matches. Remaining attention came from known non-hard EMA readiness and ZEC
+  HSL cooldown status. A focused incident-bundle verification confirmed
+  `--smoke-section fill_refresh` selected embedded `fill_refresh_health`,
+  omitted unrelated embedded full sections, and preserved
+  `manifest.filters.smoke_sections=["fill_refresh"]`.
 - Repository pulled through PR #1010 at `2f91372a`.
 - PR #1010 added bounded data-plane smoke projections to
   `live-incident-bundle` returned JSON and `manifest.json`: remote calls,

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -6147,6 +6147,8 @@ def summarize_live_smoke_report(
         if isinstance(report.get("shutdown_events"), dict)
         else {}
     )
+    problem_event_count = int(report.get("problem_event_count") or 0)
+    hard_problem_event_count = int(report.get("hard_problem_event_count") or 0)
 
     return {
         "ok": bool(report.get("ok", False)),
@@ -6256,8 +6258,9 @@ def summarize_live_smoke_report(
             "window": logs.get("window"),
         },
         "problem_events": {
-            "total": int(report.get("problem_event_count") or 0),
-            "hard": int(report.get("hard_problem_event_count") or 0),
+            "total": problem_event_count,
+            "hard": hard_problem_event_count,
+            "non_hard": max(0, problem_event_count - hard_problem_event_count),
             "groups_truncated": bool(problem_groups.get("groups_truncated"))
             or len(problem_group_rows) > max_groups,
             "groups": problem_group_rows[:max_groups],
@@ -6899,6 +6902,8 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
     event_window = (
         report.get("event_window") if isinstance(report.get("event_window"), dict) else {}
     )
+    problem_event_count = _count_value(report.get("problem_event_count"))
+    hard_problem_event_count = _count_value(report.get("hard_problem_event_count"))
     ema_readiness_brief = {
         "total": _count_value(ema_readiness_health.get("total")),
         "bots": _count_value(ema_readiness_health.get("bots")),
@@ -7102,8 +7107,9 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         }
         | _brief_log_match_samples(logs),
         "problem_events": {
-            "total": _count_value(report.get("problem_event_count")),
-            "hard": _count_value(report.get("hard_problem_event_count")),
+            "total": problem_event_count,
+            "hard": hard_problem_event_count,
+            "non_hard": max(0, problem_event_count - hard_problem_event_count),
         }
         | _brief_problem_event_groups(report.get("problem_event_groups")),
         "remote_calls": _brief_remote_call_health(report.get("remote_call_health")),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1202,6 +1202,7 @@ def test_live_smoke_report_summary_projects_high_signal_fields(tmp_path):
     assert len(summary["logs"]["matches"]) == 1
     assert summary["problem_events"]["total"] == 2
     assert summary["problem_events"]["hard"] == 0
+    assert summary["problem_events"]["non_hard"] == 2
     assert summary["problem_events"]["groups_truncated"] is True
     assert len(summary["problem_events"]["groups"]) == 1
     assert summary["problem_events"]["groups"][0]["event_type"] in {
@@ -1331,6 +1332,7 @@ def test_live_smoke_report_brief_summary_projects_top_level_counters(tmp_path):
     }
     assert brief["problem_events"]["total"] == 2
     assert brief["problem_events"]["hard"] == 0
+    assert brief["problem_events"]["non_hard"] == 2
     assert brief["problem_events"]["groups_truncated"] is False
     assert brief["problem_events"]["event_types_truncated"] is False
     assert brief["problem_events"]["event_types"] == {
@@ -1449,6 +1451,7 @@ def test_live_smoke_report_brief_bounds_problem_event_types(tmp_path):
 
     assert brief["problem_events"]["total"] == limit + 1
     assert brief["problem_events"]["hard"] == 0
+    assert brief["problem_events"]["non_hard"] == limit + 1
     assert brief["problem_events"]["groups_truncated"] is True
     assert brief["problem_events"]["event_types_truncated"] is True
     assert len(brief["problem_events"]["groups"]) == limit
@@ -4995,6 +4998,7 @@ def test_live_smoke_report_cli_can_emit_brief_summary(tmp_path, capsys):
     assert summary["logs"]["attention_matches"] == 1
     assert summary["problem_events"]["hard"] == 0
     assert summary["problem_events"]["total"] == 1
+    assert summary["problem_events"]["non_hard"] == 1
     assert summary["problem_events"]["event_types"] == {"remote_call.failed": 1}
     assert summary["problem_events"]["event_types_truncated"] is False
     assert summary["problem_events"]["groups"] == [


### PR DESCRIPTION
Observability-only smoke-report slice.\n\nScope:\n- Adds derived problem_events.non_hard to live-smoke-report --summary and --brief.\n- This makes attention=true / hard_failures=0 cases easier to read by explicitly splitting structured problem events into hard and non-hard counts.\n- No event producers, exchange calls, verdict policy, process handling, or trading behavior changed.\n\nMotivation:\n- VPS5 smoke after recent deployments commonly has non-hard EMA readiness and HSL cooldown attention. The existing report exposed total and hard problem-event counts; this adds the bounded derived non-hard count at the same projection layer.\n\nValidation:\n- ./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_summary_projects_high_signal_fields tests/test_live_smoke_report.py::test_live_smoke_report_brief_summary_projects_top_level_counters tests/test_live_smoke_report.py::test_live_smoke_report_brief_bounds_problem_event_types tests/test_live_smoke_report.py::test_live_smoke_report_cli_can_emit_brief_summary -q\n- ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py -q\n- ./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py\n- git diff --check\n- Added-code silent-handling scan: no matches\n