### PR TITLE
Split smoke problem event type counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report --summary` and `--brief` now split
+  structured problem-event type counts into hard and non-hard histograms,
+  making mixed smoke attention easier to triage without opening grouped event
+  rows.
 - `passivbot tool live-smoke-report --summary` and `--brief` now include
   `problem_events.non_hard`, making non-fatal structured attention easier to
   distinguish from hard problem events at a glance.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,18 +19,18 @@ Last updated: 2026-07-02.
 
 Current `origin/v8` head:
 
-- `57a52e80` after PR #1011, `Accept brief smoke section aliases`.
+- `b8cfe90b` after PR #1012, `Show non-hard problem event counts in smoke`.
 
 Current logging-overhaul head:
 
-- `57a52e80` after PR #1011, `Accept brief smoke section aliases`.
+- `b8cfe90b` after PR #1012, `Show non-hard problem event counts in smoke`.
 
 Current work:
 
-- Branch `codex/v8-smoke-problem-non-hard-count` adds a bounded
-  `problem_events.non_hard` count to `live-smoke-report --summary` and
-  `--brief`, making non-fatal structured attention easier to distinguish from
-  hard problem events without changing smoke verdict policy.
+- Branch `codex/v8-smoke-problem-type-splits` splits structured
+  problem-event type histograms into hard and non-hard counts in
+  `live-smoke-report --summary` and `--brief`, making mixed smoke attention
+  easier to triage without opening grouped event rows.
 
 Current review gate:
 
@@ -60,6 +60,19 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1012 at `b8cfe90b`.
+- PR #1012 added a bounded `problem_events.non_hard` count to
+  `live-smoke-report --summary` and `--brief`, making non-fatal structured
+  attention easier to distinguish from hard problem events without changing
+  smoke verdict policy. It merged after Claude and Hermes approved with no
+  findings and CI was green. VPS5 checkout was updated to `b8cfe90b` without
+  restarting running bots because the slice was report-only. Smoke after the
+  fast-forward reported `ok=true`, `hard_failures=0`, `matched_expected=5`,
+  clean tracked repository state at `repository.head=b8cfe90b`,
+  `remote_calls.failed=0`, `account_critical_remote_calls.failed=0`,
+  `fill_refresh.failed=0`, and no hard log matches. The new
+  `problem_events.non_hard` field was visible with known non-hard
+  EMA-readiness and HSL cooldown attention.
 - Repository pulled through PR #1011 at `57a52e80`.
 - PR #1011 added CLI smoke-section aliases so brief names such as
   `fill_refresh`, `hsl_replay`, and `remote_calls` resolve to their embedded

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -1678,10 +1678,17 @@ def _summarize_problem_event_groups(
     groups: dict[tuple[Any, ...], dict[str, Any]],
 ) -> dict[str, Any]:
     event_types: Counter[str] = Counter()
+    hard_event_types: Counter[str] = Counter()
+    non_hard_event_types: Counter[str] = Counter()
     for group in groups.values():
         event_type = group.get("event_type")
         if isinstance(event_type, str) and event_type:
-            event_types[event_type] += int(_non_negative_int(group.get("count")) or 0)
+            count = int(_non_negative_int(group.get("count")) or 0)
+            event_types[event_type] += count
+            if bool(group.get("hard")):
+                hard_event_types[event_type] += count
+            else:
+                non_hard_event_types[event_type] += count
     ordered = sorted(
         groups.values(),
         key=lambda item: (
@@ -1707,6 +1714,8 @@ def _summarize_problem_event_groups(
         "total": sum(int(group.get("count", 0)) for group in groups.values()),
         "groups_truncated": len(ordered) > PROBLEM_EVENT_GROUP_LIMIT,
         "event_types": dict(event_types.most_common()),
+        "hard_event_types": dict(hard_event_types.most_common()),
+        "non_hard_event_types": dict(non_hard_event_types.most_common()),
         "groups": compact_groups,
     }
 
@@ -6261,6 +6270,9 @@ def summarize_live_smoke_report(
             "total": problem_event_count,
             "hard": hard_problem_event_count,
             "non_hard": max(0, problem_event_count - hard_problem_event_count),
+            "event_types": problem_groups.get("event_types") or {},
+            "hard_event_types": problem_groups.get("hard_event_types") or {},
+            "non_hard_event_types": problem_groups.get("non_hard_event_types") or {},
             "groups_truncated": bool(problem_groups.get("groups_truncated"))
             or len(problem_group_rows) > max_groups,
             "groups": problem_group_rows[:max_groups],
@@ -6568,21 +6580,37 @@ def _brief_problem_event_groups(summary: Any) -> dict[str, Any]:
         }
         if compact:
             compact_groups.append(compact)
-    event_types = summary.get("event_types")
-    if not isinstance(event_types, dict):
-        event_types = {}
-    ordered_event_types = sorted(
-        event_types.items(),
-        key=lambda item: (-_count_value(item[1]), str(item[0])),
+    def _brief_event_types(value: Any) -> tuple[dict[str, int], bool]:
+        if not isinstance(value, dict):
+            value = {}
+        ordered = sorted(
+            value.items(),
+            key=lambda item: (-_count_value(item[1]), str(item[0])),
+        )
+        return (
+            {
+                str(key): _count_value(count)
+                for key, count in ordered[:limit]
+                if str(key)
+            },
+            len(ordered) > limit,
+        )
+
+    event_types, event_types_truncated = _brief_event_types(summary.get("event_types"))
+    hard_event_types, hard_event_types_truncated = _brief_event_types(
+        summary.get("hard_event_types")
+    )
+    non_hard_event_types, non_hard_event_types_truncated = _brief_event_types(
+        summary.get("non_hard_event_types")
     )
     return {
         "groups_truncated": bool(summary.get("groups_truncated")) or len(groups) > limit,
-        "event_types_truncated": len(ordered_event_types) > limit,
-        "event_types": {
-            str(key): _count_value(value)
-            for key, value in ordered_event_types[:limit]
-            if str(key)
-        },
+        "event_types_truncated": event_types_truncated,
+        "hard_event_types_truncated": hard_event_types_truncated,
+        "non_hard_event_types_truncated": non_hard_event_types_truncated,
+        "event_types": event_types,
+        "hard_event_types": hard_event_types,
+        "non_hard_event_types": non_hard_event_types,
         "groups": compact_groups,
     }
 

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1428,6 +1428,68 @@ def test_live_smoke_report_brief_summary_projects_top_level_counters(tmp_path):
     assert "groups" not in brief["account_critical_remote_calls"]
 
 
+def test_live_smoke_report_splits_problem_event_types_by_hardness(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="execution.create_failed",
+                seq=1,
+                ts=1000,
+                status="failed",
+                level="error",
+                reason_code="exchange_exception",
+                ids={"cycle_id": "cy_hard"},
+            ),
+            _monitor_row(
+                event_type="ema.unavailable",
+                seq=2,
+                ts=2000,
+                status="degraded",
+                level="warning",
+                reason_code="required_ema_unavailable",
+                ids={"cycle_id": "cy_attention"},
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor")
+    summary = summarize_live_smoke_report(report)
+    brief = summarize_live_smoke_report_brief(report)
+
+    assert report["problem_event_groups"]["event_types"] == {
+        "execution.create_failed": 1,
+        "ema.unavailable": 1,
+    }
+    assert report["problem_event_groups"]["hard_event_types"] == {
+        "execution.create_failed": 1
+    }
+    assert report["problem_event_groups"]["non_hard_event_types"] == {
+        "ema.unavailable": 1
+    }
+    assert summary["problem_events"]["event_types"] == {
+        "execution.create_failed": 1,
+        "ema.unavailable": 1,
+    }
+    assert summary["problem_events"]["hard_event_types"] == {
+        "execution.create_failed": 1
+    }
+    assert summary["problem_events"]["non_hard_event_types"] == {
+        "ema.unavailable": 1
+    }
+    assert brief["problem_events"]["event_types"] == {
+        "ema.unavailable": 1,
+        "execution.create_failed": 1,
+    }
+    assert brief["problem_events"]["hard_event_types"] == {
+        "execution.create_failed": 1
+    }
+    assert brief["problem_events"]["non_hard_event_types"] == {
+        "ema.unavailable": 1
+    }
+
+
 def test_live_smoke_report_brief_bounds_problem_event_types(tmp_path):
     events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
     limit = smoke_report_module.SMOKE_REPORT_BRIEF_PROBLEM_GROUP_LIMIT
@@ -4222,6 +4284,8 @@ def test_live_smoke_report_summarizes_problem_event_groups(tmp_path):
         "total": 3,
         "groups_truncated": False,
         "event_types": {"ema.unavailable": 2, "bot.stopped": 1},
+        "hard_event_types": {"bot.stopped": 1},
+        "non_hard_event_types": {"ema.unavailable": 2},
         "groups": [
             {
                 "bot": "binance/binance_01",


### PR DESCRIPTION
## Summary
- split structured problem-event type histograms into hard and non-hard counts
- expose the split counts in live-smoke-report summary and brief projections
- record PR #1012 VPS5 deploy evidence in the logging progress ledger

## Validation
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_summary_projects_high_signal_fields tests/test_live_smoke_report.py::test_live_smoke_report_brief_summary_projects_top_level_counters tests/test_live_smoke_report.py::test_live_smoke_report_splits_problem_event_types_by_hardness tests/test_live_smoke_report.py::test_live_smoke_report_brief_bounds_problem_event_types -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py -q
- ./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check
- added-line silent-handling scan: no matches

Trading behavior unchanged; smoke-report projection only.