### PR TITLE
Include problem event smoke summary in incident bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-incident-bundle` now includes the bounded
+  `problem_events` smoke summary in the returned report and manifest, including
+  hard and non-hard problem-event type histograms for quicker incident triage.
 - `passivbot tool live-smoke-report --summary` and `--brief` now split
   structured problem-event type counts into hard and non-hard histograms,
   making mixed smoke attention easier to triage without opening grouped event

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,18 +19,17 @@ Last updated: 2026-07-02.
 
 Current `origin/v8` head:
 
-- `b8cfe90b` after PR #1012, `Show non-hard problem event counts in smoke`.
+- `bc0eb4fe` after PR #1013, `Split smoke problem event type counts`.
 
 Current logging-overhaul head:
 
-- `b8cfe90b` after PR #1012, `Show non-hard problem event counts in smoke`.
+- `bc0eb4fe` after PR #1013, `Split smoke problem event type counts`.
 
 Current work:
 
-- Branch `codex/v8-smoke-problem-type-splits` splits structured
-  problem-event type histograms into hard and non-hard counts in
-  `live-smoke-report --summary` and `--brief`, making mixed smoke attention
-  easier to triage without opening grouped event rows.
+- Branch `codex/v8-incident-problem-event-summary` adds the bounded
+  `problem_events` smoke summary to `live-incident-bundle` returned JSON and
+  `manifest.json`, including hard and non-hard problem-event type histograms.
 
 Current review gate:
 
@@ -60,6 +59,20 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1013 at `bc0eb4fe`.
+- PR #1013 split structured problem-event type histograms into hard and
+  non-hard counts in `live-smoke-report --summary` and `--brief`, making mixed
+  smoke attention easier to triage without opening grouped event rows. It
+  merged after Claude and Hermes approved with no findings and CI was green.
+  VPS5 checkout was updated to `bc0eb4fe` without restarting running bots
+  because the slice was report-only. Smoke after the fast-forward reported
+  `ok=true`, `hard_failures=0`, `matched_expected=5`, clean tracked repository
+  state at `repository.head=bc0eb4fe`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `fill_refresh.failed=0`, and no
+  hard log matches. The new `problem_events.hard_event_types` and
+  `problem_events.non_hard_event_types` fields were visible; current attention
+  remained non-hard EMA-readiness, candle coverage, cycle degraded, and HSL
+  cooldown status.
 - Repository pulled through PR #1012 at `b8cfe90b`.
 - PR #1012 added a bounded `problem_events.non_hard` count to
   `live-smoke-report --summary` and `--brief`, making non-fatal structured

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -751,6 +751,12 @@ def _smoke_ema_readiness_result_summary(
     return _smoke_brief_section_result_summary(smoke_brief_summary, "ema_readiness")
 
 
+def _smoke_problem_events_result_summary(
+    smoke_brief_summary: dict[str, Any],
+) -> dict[str, Any]:
+    return _smoke_brief_section_result_summary(smoke_brief_summary, "problem_events")
+
+
 def _smoke_operational_result_summaries(
     smoke_brief_summary: dict[str, Any],
 ) -> dict[str, dict[str, Any]]:
@@ -1117,6 +1123,9 @@ def build_live_incident_bundle(
     smoke_ema_readiness_summary = _smoke_ema_readiness_result_summary(
         smoke_brief_summary
     )
+    smoke_problem_events_summary = _smoke_problem_events_result_summary(
+        smoke_brief_summary
+    )
     smoke_operational_summaries = _smoke_operational_result_summaries(
         smoke_brief_summary
     )
@@ -1223,6 +1232,7 @@ def build_live_incident_bundle(
             "monitor_snapshots": snapshots,
             "event_segments": segment_manifest,
             "smoke_report": {
+                "problem_events": smoke_problem_events_summary,
                 "execution": smoke_execution_summary,
                 "risk_events": smoke_risk_summary,
                 "ema_readiness": smoke_ema_readiness_summary,
@@ -1310,6 +1320,7 @@ def build_live_incident_bundle(
             "attention_count": smoke_report.get("attention_count"),
             "event_window": smoke_report.get("event_window"),
             "logs": _smoke_log_result_summary(smoke_report),
+            "problem_events": smoke_problem_events_summary,
             "execution": smoke_execution_summary,
             "risk_events": smoke_risk_summary,
             "ema_readiness": smoke_ema_readiness_summary,

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -460,6 +460,90 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
             "dropped_unparsed_hard_matches": 0,
         },
     }
+    assert report["smoke_report"]["problem_events"] == {
+        "total": 6,
+        "hard": 0,
+        "non_hard": 6,
+        "groups_truncated": True,
+        "event_types_truncated": True,
+        "hard_event_types_truncated": False,
+        "non_hard_event_types_truncated": True,
+        "event_types": {
+            "bot.shutdown.stage": 1,
+            "ema.unavailable": 1,
+            "exchange.config_refresh": 1,
+            "hsl.status": 1,
+            "planning.unavailable": 1,
+        },
+        "hard_event_types": {},
+        "non_hard_event_types": {
+            "bot.shutdown.stage": 1,
+            "ema.unavailable": 1,
+            "exchange.config_refresh": 1,
+            "hsl.status": 1,
+            "planning.unavailable": 1,
+        },
+        "groups": [
+            {
+                "bot": "binance/binance_01",
+                "event_type": "bot.shutdown.stage",
+                "reason_code": "maintainers_timeout",
+                "status": "degraded",
+                "level": "warning",
+                "hard": False,
+                "component": "shutdown",
+                "count": 1,
+                "latest_ts": 2480,
+            },
+            {
+                "bot": "binance/binance_01",
+                "event_type": "planning.unavailable",
+                "reason_code": "staged_execution_precondition",
+                "status": "degraded",
+                "level": "debug",
+                "hard": False,
+                "component": "planning",
+                "count": 1,
+                "latest_ts": 2400,
+            },
+            {
+                "bot": "binance/binance_01",
+                "event_type": "exchange.config_refresh",
+                "reason_code": "exchange_config_refresh_failed",
+                "status": "failed",
+                "level": "warning",
+                "hard": False,
+                "component": "exchange.config",
+                "count": 1,
+                "latest_ts": 2350,
+            },
+            {
+                "bot": "binance/binance_01",
+                "event_type": "ema.unavailable",
+                "reason_code": "required_ema_unavailable",
+                "status": "degraded",
+                "level": "warning",
+                "hard": False,
+                "symbol": "BTC/USDT:USDT",
+                "component": "ema.bundle",
+                "count": 1,
+                "latest_ts": 2300,
+            },
+            {
+                "bot": "binance/binance_01",
+                "event_type": "hsl.status",
+                "reason_code": "cooldown_active",
+                "status": "degraded",
+                "level": "info",
+                "hard": False,
+                "symbol": "ZEC/USDT:USDT",
+                "pside": "long",
+                "component": "risk.hsl",
+                "count": 1,
+                "latest_ts": 2200,
+            },
+        ],
+    }
     assert report["smoke_report"]["execution"] == {
         "total": 1,
         "bots": 1,
@@ -648,6 +732,9 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         )
 
     assert manifest["config_hashes"][0]["sha256"] == config_hashes[0]["sha256"]
+    assert manifest["smoke_report"]["problem_events"] == report["smoke_report"][
+        "problem_events"
+    ]
     assert manifest["smoke_report"]["execution"] == report["smoke_report"]["execution"]
     assert manifest["smoke_report"]["risk_events"] == report["smoke_report"][
         "risk_events"


### PR DESCRIPTION
## Summary
- add the bounded problem_events smoke summary to live-incident-bundle returned JSON and manifest.json
- include hard/non-hard problem-event type histograms from the smoke brief projection
- record PR #1013 deploy evidence in the logging progress ledger

## Validation
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py::test_live_incident_bundle_collects_hashes_snapshots_events_and_window -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py -q
- ./venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check
- added-line silent-handling scan: no matches

Trading behavior unchanged; incident-bundle projection only.