### PR TITLE
Include smoke source breakdown in incident bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-incident-bundle` now includes smoke verdict source
+  breakdowns and recovered problem-event counts in the returned report and
+  manifest, making red or attention incidents easier to attribute without
+  opening the embedded full smoke report.
 - `passivbot tool live-incident-bundle` now includes the bounded
   `problem_events` smoke summary in the returned report and manifest, including
   hard and non-hard problem-event type histograms for quicker incident triage.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,17 +19,17 @@ Last updated: 2026-07-02.
 
 Current `origin/v8` head:
 
-- `bc0eb4fe` after PR #1013, `Split smoke problem event type counts`.
+- `d5a9680f` after PR #1014, `Include problem event smoke summary in incident bundles`.
 
 Current logging-overhaul head:
 
-- `bc0eb4fe` after PR #1013, `Split smoke problem event type counts`.
+- `d5a9680f` after PR #1014, `Include problem event smoke summary in incident bundles`.
 
 Current work:
 
-- Branch `codex/v8-incident-problem-event-summary` adds the bounded
-  `problem_events` smoke summary to `live-incident-bundle` returned JSON and
-  `manifest.json`, including hard and non-hard problem-event type histograms.
+- Branch `codex/v8-incident-smoke-source-breakdown` adds smoke verdict source
+  breakdowns and recovered problem-event counts to `live-incident-bundle`
+  returned JSON and `manifest.json`.
 
 Current review gate:
 
@@ -59,6 +59,19 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1014 at `d5a9680f`.
+- PR #1014 added the bounded `problem_events` smoke summary to
+  `live-incident-bundle` returned JSON and `manifest.json`, including hard and
+  non-hard problem-event type histograms. It merged after Claude and Hermes
+  approved with no findings and CI was green. VPS5 checkout was updated to
+  `d5a9680f` without restarting running bots because the slice was report-only.
+  Smoke after the fast-forward reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, clean tracked repository state at
+  `repository.head=d5a9680f`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `fill_refresh.failed=0`, and no
+  hard log matches. A focused incident-bundle verification confirmed the
+  returned report and `manifest.json` both included the new `problem_events`
+  section with hard/non-hard event-type histogram keys.
 - Repository pulled through PR #1013 at `bc0eb4fe`.
 - PR #1013 split structured problem-event type histograms into hard and
   non-hard counts in `live-smoke-report --summary` and `--brief`, making mixed

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -757,6 +757,25 @@ def _smoke_problem_events_result_summary(
     return _smoke_brief_section_result_summary(smoke_brief_summary, "problem_events")
 
 
+def _smoke_verdict_result_summary(
+    smoke_brief_summary: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "hard_failure_sources": _smoke_brief_section_result_summary(
+            smoke_brief_summary,
+            "hard_failure_sources",
+        ),
+        "attention_sources": _smoke_brief_section_result_summary(
+            smoke_brief_summary,
+            "attention_sources",
+        ),
+        "recovered_problem_events": _smoke_brief_section_result_summary(
+            smoke_brief_summary,
+            "recovered_problem_events",
+        ),
+    }
+
+
 def _smoke_operational_result_summaries(
     smoke_brief_summary: dict[str, Any],
 ) -> dict[str, dict[str, Any]]:
@@ -1126,6 +1145,7 @@ def build_live_incident_bundle(
     smoke_problem_events_summary = _smoke_problem_events_result_summary(
         smoke_brief_summary
     )
+    smoke_verdict_summary = _smoke_verdict_result_summary(smoke_brief_summary)
     smoke_operational_summaries = _smoke_operational_result_summaries(
         smoke_brief_summary
     )
@@ -1232,6 +1252,7 @@ def build_live_incident_bundle(
             "monitor_snapshots": snapshots,
             "event_segments": segment_manifest,
             "smoke_report": {
+                **smoke_verdict_summary,
                 "problem_events": smoke_problem_events_summary,
                 "execution": smoke_execution_summary,
                 "risk_events": smoke_risk_summary,
@@ -1320,6 +1341,7 @@ def build_live_incident_bundle(
             "attention_count": smoke_report.get("attention_count"),
             "event_window": smoke_report.get("event_window"),
             "logs": _smoke_log_result_summary(smoke_report),
+            **smoke_verdict_summary,
             "problem_events": smoke_problem_events_summary,
             "execution": smoke_execution_summary,
             "risk_events": smoke_risk_summary,

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -460,6 +460,25 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
             "dropped_unparsed_hard_matches": 0,
         },
     }
+    assert report["smoke_report"]["hard_failure_sources"] == {
+        "monitor_errors": 0,
+        "invalid_event_rows": 0,
+        "hard_problem_events": 0,
+        "log_hard_matches": 0,
+        "process_hard_failures": 0,
+        "total": 0,
+    }
+    assert report["smoke_report"]["attention_sources"] == {
+        "problem_events": 6,
+        "log_attention_matches": 1,
+        "dropped_unparsed_attention_matches": 0,
+        "total": 7,
+    }
+    assert report["smoke_report"]["recovered_problem_events"] == {
+        "total": 0,
+        "hard": 0,
+        "event_types": {},
+    }
     assert report["smoke_report"]["problem_events"] == {
         "total": 6,
         "hard": 0,
@@ -732,6 +751,12 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         )
 
     assert manifest["config_hashes"][0]["sha256"] == config_hashes[0]["sha256"]
+    for section in (
+        "hard_failure_sources",
+        "attention_sources",
+        "recovered_problem_events",
+    ):
+        assert manifest["smoke_report"][section] == report["smoke_report"][section]
     assert manifest["smoke_report"]["problem_events"] == report["smoke_report"][
         "problem_events"
     ]


### PR DESCRIPTION
## Summary
- include smoke hard_failure_sources, attention_sources, and recovered_problem_events in live-incident-bundle returned JSON and manifest.json
- keep the fields sourced from the existing brief smoke projection
- record PR #1014 deploy evidence in the logging progress ledger

## Validation
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py::test_live_incident_bundle_collects_hashes_snapshots_events_and_window -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py -q
- ./venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check
- added-line silent-handling scan: no matches

Trading behavior unchanged; incident-bundle projection only.