### PR TITLE
Include process smoke summary in incident bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-incident-bundle` now includes the bounded process
+  smoke summary in the returned report and manifest, making missing,
+  duplicate, or unexpected live-bot process evidence visible without opening
+  the embedded full smoke report.
 - `passivbot tool live-incident-bundle` now includes smoke verdict source
   breakdowns and recovered problem-event counts in the returned report and
   manifest, making red or attention incidents easier to attribute without

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,17 +19,18 @@ Last updated: 2026-07-02.
 
 Current `origin/v8` head:
 
-- `d5a9680f` after PR #1014, `Include problem event smoke summary in incident bundles`.
+- `f02d53a9` after PR #1015, `Include smoke source breakdown in incident bundles`.
 
 Current logging-overhaul head:
 
-- `d5a9680f` after PR #1014, `Include problem event smoke summary in incident bundles`.
+- `f02d53a9` after PR #1015, `Include smoke source breakdown in incident bundles`.
 
 Current work:
 
-- Branch `codex/v8-incident-smoke-source-breakdown` adds smoke verdict source
-  breakdowns and recovered problem-event counts to `live-incident-bundle`
-  returned JSON and `manifest.json`.
+- Branch `codex/v8-incident-process-summary` adds the bounded process smoke
+  summary to `live-incident-bundle` returned JSON and `manifest.json`, so
+  incident bundles can explain missing, duplicate, or unexpected live-bot
+  process smoke evidence without opening the embedded full smoke report.
 
 Current review gate:
 
@@ -59,6 +60,18 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1015 at `f02d53a9`.
+- PR #1015 added smoke verdict source breakdowns and recovered problem-event
+  counts to `live-incident-bundle` returned JSON and `manifest.json`. It
+  merged after Claude and Hermes approved with no findings and CI was green.
+  VPS5 checkout was updated to `f02d53a9` without restarting running bots
+  because the slice was report-only. Smoke after the fast-forward reported
+  `ok=true`, `hard_failures=0`, `matched_expected=5`, clean tracked repository
+  state at `repository.head=f02d53a9`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `fill_refresh.failed=0`, and no
+  hard log matches. A focused incident-bundle verification confirmed the
+  returned report and `manifest.json` both included `hard_failure_sources`,
+  `attention_sources`, `recovered_problem_events`, and `problem_events`.
 - Repository pulled through PR #1014 at `d5a9680f`.
 - PR #1014 added the bounded `problem_events` smoke summary to
   `live-incident-bundle` returned JSON and `manifest.json`, including hard and

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -757,6 +757,12 @@ def _smoke_problem_events_result_summary(
     return _smoke_brief_section_result_summary(smoke_brief_summary, "problem_events")
 
 
+def _smoke_process_result_summary(
+    smoke_brief_summary: dict[str, Any],
+) -> dict[str, Any]:
+    return _smoke_brief_section_result_summary(smoke_brief_summary, "processes")
+
+
 def _smoke_verdict_result_summary(
     smoke_brief_summary: dict[str, Any],
 ) -> dict[str, Any]:
@@ -1145,6 +1151,7 @@ def build_live_incident_bundle(
     smoke_problem_events_summary = _smoke_problem_events_result_summary(
         smoke_brief_summary
     )
+    smoke_process_summary = _smoke_process_result_summary(smoke_brief_summary)
     smoke_verdict_summary = _smoke_verdict_result_summary(smoke_brief_summary)
     smoke_operational_summaries = _smoke_operational_result_summaries(
         smoke_brief_summary
@@ -1257,6 +1264,7 @@ def build_live_incident_bundle(
                 "execution": smoke_execution_summary,
                 "risk_events": smoke_risk_summary,
                 "ema_readiness": smoke_ema_readiness_summary,
+                "processes": smoke_process_summary,
                 **smoke_operational_summaries,
                 **smoke_data_plane_summaries,
             },
@@ -1346,21 +1354,9 @@ def build_live_incident_bundle(
             "execution": smoke_execution_summary,
             "risk_events": smoke_risk_summary,
             "ema_readiness": smoke_ema_readiness_summary,
+            "processes": smoke_process_summary,
             **smoke_operational_summaries,
             **smoke_data_plane_summaries,
-            "processes": {
-                "enabled": smoke_report.get("processes", {}).get("enabled"),
-                "ok": smoke_report.get("processes", {}).get("ok"),
-                "expected_total": smoke_report.get("processes", {}).get(
-                    "expected_total"
-                ),
-                "running_live_total": smoke_report.get("processes", {}).get(
-                    "running_live_total"
-                ),
-                "missing_expected": len(
-                    smoke_report.get("processes", {}).get("missing_expected", [])
-                ),
-            },
         },
         "restart_smoke_plan": _restart_smoke_plan_result_summary(
             restart_smoke_plan_summary

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -1882,12 +1882,32 @@ def test_live_incident_bundle_includes_process_status_when_requested(
     assert report["smoke_report"]["processes"] == {
         "enabled": True,
         "ok": True,
+        "hard_failures": 0,
         "expected_total": 1,
+        "matched_expected": 1,
         "running_live_total": 1,
-        "missing_expected": 0,
+        "classification_source": "local_process_table_command_match",
+        "tmux_pane_ownership": "not_available_from_process_table",
+        "scan_error": None,
+        "missing_expected_count": 0,
+        "duplicate_configured_command_matches_count": 0,
+        "extra_passivbot_live_processes_count": 0,
+        "unexpected_running_count": 0,
+        "config_checks": {
+            "enabled": True,
+            "ok": True,
+            "checked": 1,
+            "skipped": 0,
+            "hard_failures": 0,
+            "issues_count": 1,
+        },
     }
     with tarfile.open(output, "r:gz") as tar:
         smoke_report = _read_tar_json(tar, "smoke_report.json")
+        manifest = _read_tar_json(tar, "manifest.json")
+    assert manifest["smoke_report"]["processes"] == report["smoke_report"][
+        "processes"
+    ]
     assert smoke_report["processes"]["expected_total"] == 1
     assert smoke_report["processes"]["matched_expected"] == 1
     assert smoke_report["processes"]["missing_expected"] == []


### PR DESCRIPTION
## Summary
- add the bounded brief process smoke summary to live-incident-bundle returned JSON
- include the same process summary in manifest.json for bundle-level process triage
- update incident-bundle process test coverage, changelog, and logging progress ledger

## Validation
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py::test_live_incident_bundle_includes_process_status_when_requested -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py -q
- ./venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check
- added-line silent-handling scan for src/live/incident_bundle.py and tests/test_live_incident_bundle.py: no matches

Behavior: report-only/tooling-only; no trading path changes.