### PR TITLE
Include log smoke summaries in incident manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-incident-bundle` now includes bounded text-log and
+  event-window smoke summaries in `manifest.json`, so bundle manifests can
+  explain log-sourced hard or attention verdicts without opening the embedded
+  full smoke report.
 - `passivbot tool live-incident-bundle` now includes the bounded process
   smoke summary in the returned report and manifest, making missing,
   duplicate, or unexpected live-bot process evidence visible without opening

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,22 +15,22 @@ merge, live smoke evidence changes, or new gaps are discovered.
 
 ## Current Status
 
-Last updated: 2026-07-02.
+Last updated: 2026-07-03.
 
 Current `origin/v8` head:
 
-- `f02d53a9` after PR #1015, `Include smoke source breakdown in incident bundles`.
+- `8d2499ad` after PR #1016, `Include process smoke summary in incident bundles`.
 
 Current logging-overhaul head:
 
-- `f02d53a9` after PR #1015, `Include smoke source breakdown in incident bundles`.
+- `8d2499ad` after PR #1016, `Include process smoke summary in incident bundles`.
 
 Current work:
 
-- Branch `codex/v8-incident-process-summary` adds the bounded process smoke
-  summary to `live-incident-bundle` returned JSON and `manifest.json`, so
-  incident bundles can explain missing, duplicate, or unexpected live-bot
-  process smoke evidence without opening the embedded full smoke report.
+- Branch `codex/v8-incident-log-window-manifest` adds the bounded text-log and
+  event-window smoke summaries to `live-incident-bundle` `manifest.json`, so
+  manifest-level triage can explain log-sourced verdicts without opening the
+  embedded full smoke report.
 
 Current review gate:
 
@@ -60,6 +60,17 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1016 at `8d2499ad`.
+- PR #1016 added the bounded process smoke summary to `live-incident-bundle`
+  returned JSON and `manifest.json`. It merged after Claude and Hermes
+  approved with no findings and CI was green. VPS5 checkout was updated to
+  `8d2499ad` without restarting running bots because the slice was
+  report-only. Recent-window smoke after the fast-forward reported `ok=true`,
+  `hard_failures=0`, `matched_expected=5`, clean tracked repository state at
+  `repository.head=8d2499ad`, and no process hard failures. A focused
+  incident-bundle verification confirmed `manifest.json` included
+  `smoke_report.processes` with `expected_total=5`, `matched_expected=5`,
+  no missing/duplicate/unexpected processes, and zero config-check issues.
 - Repository pulled through PR #1015 at `f02d53a9`.
 - PR #1015 added smoke verdict source breakdowns and recovered problem-event
   counts to `live-incident-bundle` returned JSON and `manifest.json`. It

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -1142,6 +1142,8 @@ def build_live_incident_bundle(
         smoke_report,
         smoke_sections,
     )
+    smoke_event_window_summary = smoke_report.get("event_window")
+    smoke_log_summary = _smoke_log_result_summary(smoke_report)
     smoke_brief_summary = summarize_live_smoke_report_brief(smoke_report)
     smoke_execution_summary = _smoke_execution_result_summary(smoke_report)
     smoke_risk_summary = _smoke_risk_result_summary(smoke_brief_summary)
@@ -1259,6 +1261,8 @@ def build_live_incident_bundle(
             "monitor_snapshots": snapshots,
             "event_segments": segment_manifest,
             "smoke_report": {
+                "event_window": smoke_event_window_summary,
+                "logs": smoke_log_summary,
                 **smoke_verdict_summary,
                 "problem_events": smoke_problem_events_summary,
                 "execution": smoke_execution_summary,
@@ -1347,8 +1351,8 @@ def build_live_incident_bundle(
             "attention": smoke_report.get("attention"),
             "hard_failures": smoke_report.get("hard_failures"),
             "attention_count": smoke_report.get("attention_count"),
-            "event_window": smoke_report.get("event_window"),
-            "logs": _smoke_log_result_summary(smoke_report),
+            "event_window": smoke_event_window_summary,
+            "logs": smoke_log_summary,
             **smoke_verdict_summary,
             "problem_events": smoke_problem_events_summary,
             "execution": smoke_execution_summary,

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -751,6 +751,10 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         )
 
     assert manifest["config_hashes"][0]["sha256"] == config_hashes[0]["sha256"]
+    assert manifest["smoke_report"]["event_window"] == report["smoke_report"][
+        "event_window"
+    ]
+    assert manifest["smoke_report"]["logs"] == report["smoke_report"]["logs"]
     for section in (
         "hard_failure_sources",
         "attention_sources",


### PR DESCRIPTION
## Summary
- add bounded smoke event-window and text-log summaries to live-incident-bundle manifest.json
- reuse the same returned-report summary objects for manifest parity
- update incident-bundle coverage, changelog, and logging progress ledger

## Validation
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py::test_live_incident_bundle_collects_hashes_snapshots_events_and_window -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py -q
- ./venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check
- added-line silent-handling scan for src/live/incident_bundle.py and tests/test_live_incident_bundle.py: no matches

Behavior: report-only/tooling-only; no trading path changes.