### PR TITLE
Include repository and monitor summaries in incident bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-incident-bundle` now includes bounded repository and
+  monitor smoke summaries in the returned report and `manifest.json`, making
+  checkout cleanliness and monitor event-count context visible in bundle-level
+  triage.
 - `passivbot tool live-incident-bundle` now includes bounded text-log and
   event-window smoke summaries in `manifest.json`, so bundle manifests can
   explain log-sourced hard or attention verdicts without opening the embedded

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,18 +19,18 @@ Last updated: 2026-07-03.
 
 Current `origin/v8` head:
 
-- `8d2499ad` after PR #1016, `Include process smoke summary in incident bundles`.
+- `c493ea5d` after PR #1017, `Include log smoke summaries in incident manifests`.
 
 Current logging-overhaul head:
 
-- `8d2499ad` after PR #1016, `Include process smoke summary in incident bundles`.
+- `c493ea5d` after PR #1017, `Include log smoke summaries in incident manifests`.
 
 Current work:
 
-- Branch `codex/v8-incident-log-window-manifest` adds the bounded text-log and
-  event-window smoke summaries to `live-incident-bundle` `manifest.json`, so
-  manifest-level triage can explain log-sourced verdicts without opening the
-  embedded full smoke report.
+- Branch `codex/v8-incident-repo-monitor-summary` adds bounded repository and
+  monitor smoke summaries to `live-incident-bundle` returned JSON and
+  `manifest.json`, so bundle-level triage can see checkout cleanliness and
+  monitor event-count context without opening the embedded full smoke report.
 
 Current review gate:
 
@@ -60,6 +60,17 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1017 at `c493ea5d`.
+- PR #1017 added bounded text-log and event-window smoke summaries to
+  `live-incident-bundle` `manifest.json`. It merged after Claude and Hermes
+  approved with no findings and CI was green. VPS5 checkout was updated to
+  `c493ea5d` without restarting running bots because the slice was
+  report-only. Recent-window smoke with stale unparsed traceback fragments
+  dropped reported `ok=true`, `hard_failures=0`, `matched_expected=5`, clean
+  tracked repository state at `repository.head=c493ea5d`, and no process hard
+  failures. A focused incident-bundle verification confirmed `manifest.json`
+  included `smoke_report.logs` and `smoke_report.event_window` with log hard
+  matches at zero and the event window enabled.
 - Repository pulled through PR #1016 at `8d2499ad`.
 - PR #1016 added the bounded process smoke summary to `live-incident-bundle`
   returned JSON and `manifest.json`. It merged after Claude and Hermes

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -763,6 +763,18 @@ def _smoke_process_result_summary(
     return _smoke_brief_section_result_summary(smoke_brief_summary, "processes")
 
 
+def _smoke_repository_result_summary(
+    smoke_brief_summary: dict[str, Any],
+) -> dict[str, Any]:
+    return _smoke_brief_section_result_summary(smoke_brief_summary, "repository")
+
+
+def _smoke_monitor_result_summary(
+    smoke_brief_summary: dict[str, Any],
+) -> dict[str, Any]:
+    return _smoke_brief_section_result_summary(smoke_brief_summary, "monitor")
+
+
 def _smoke_verdict_result_summary(
     smoke_brief_summary: dict[str, Any],
 ) -> dict[str, Any]:
@@ -1154,6 +1166,8 @@ def build_live_incident_bundle(
         smoke_brief_summary
     )
     smoke_process_summary = _smoke_process_result_summary(smoke_brief_summary)
+    smoke_repository_summary = _smoke_repository_result_summary(smoke_brief_summary)
+    smoke_monitor_summary = _smoke_monitor_result_summary(smoke_brief_summary)
     smoke_verdict_summary = _smoke_verdict_result_summary(smoke_brief_summary)
     smoke_operational_summaries = _smoke_operational_result_summaries(
         smoke_brief_summary
@@ -1263,6 +1277,8 @@ def build_live_incident_bundle(
             "smoke_report": {
                 "event_window": smoke_event_window_summary,
                 "logs": smoke_log_summary,
+                "repository": smoke_repository_summary,
+                "monitor": smoke_monitor_summary,
                 **smoke_verdict_summary,
                 "problem_events": smoke_problem_events_summary,
                 "execution": smoke_execution_summary,
@@ -1353,6 +1369,8 @@ def build_live_incident_bundle(
             "attention_count": smoke_report.get("attention_count"),
             "event_window": smoke_event_window_summary,
             "logs": smoke_log_summary,
+            "repository": smoke_repository_summary,
+            "monitor": smoke_monitor_summary,
             **smoke_verdict_summary,
             "problem_events": smoke_problem_events_summary,
             "execution": smoke_execution_summary,

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -755,6 +755,10 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         "event_window"
     ]
     assert manifest["smoke_report"]["logs"] == report["smoke_report"]["logs"]
+    assert manifest["smoke_report"]["repository"] == report["smoke_report"][
+        "repository"
+    ]
+    assert manifest["smoke_report"]["monitor"] == report["smoke_report"]["monitor"]
     for section in (
         "hard_failure_sources",
         "attention_sources",


### PR DESCRIPTION
## Summary
- add bounded smoke repository and monitor summaries to live-incident-bundle returned JSON
- include the same repository/monitor summaries in manifest.json for bundle-level triage
- update incident-bundle coverage, changelog, and logging progress ledger

## Validation
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py::test_live_incident_bundle_collects_hashes_snapshots_events_and_window -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py -q
- ./venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check
- added-line silent-handling scan for src/live/incident_bundle.py and tests/test_live_incident_bundle.py: no matches

Behavior: report-only/tooling-only; no trading path changes.