### PR TITLE
Include smoke verdict fields in incident manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-incident-bundle` now includes top-level smoke verdict
+  fields in `manifest.json`, making the bundle manifest self-contained for
+  `ok`, `attention`, and smoke failure/count triage.
 - `passivbot tool live-incident-bundle` now includes bounded repository and
   monitor smoke summaries in the returned report and `manifest.json`, making
   checkout cleanliness and monitor event-count context visible in bundle-level

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,18 +19,18 @@ Last updated: 2026-07-03.
 
 Current `origin/v8` head:
 
-- `c493ea5d` after PR #1017, `Include log smoke summaries in incident manifests`.
+- `9488f2ad` after PR #1018, `Include repository monitor summaries in incident bundles`.
 
 Current logging-overhaul head:
 
-- `c493ea5d` after PR #1017, `Include log smoke summaries in incident manifests`.
+- `9488f2ad` after PR #1018, `Include repository monitor summaries in incident bundles`.
 
 Current work:
 
-- Branch `codex/v8-incident-repo-monitor-summary` adds bounded repository and
-  monitor smoke summaries to `live-incident-bundle` returned JSON and
-  `manifest.json`, so bundle-level triage can see checkout cleanliness and
-  monitor event-count context without opening the embedded full smoke report.
+- Branch `codex/v8-incident-verdict-summary` adds top-level smoke verdict
+  fields to `live-incident-bundle` `manifest.json`, so the manifest can report
+  the same `ok`, `attention`, and smoke failure/count fields as the returned
+  report without opening the embedded full smoke report.
 
 Current review gate:
 
@@ -60,6 +60,19 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1018 at `9488f2ad`.
+- PR #1018 added bounded repository and monitor smoke summaries to
+  `live-incident-bundle` returned JSON and `manifest.json`, making checkout
+  cleanliness and monitor event-count context visible in bundle-level triage.
+  It merged after Claude and Hermes approved with no findings and CI was green.
+  VPS5 checkout was updated to `9488f2ad` without restarting running bots
+  because the slice was report-only. Recent-window smoke with stale unparsed
+  traceback fragments dropped reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, clean tracked repository state at
+  `repository.head=9488f2ad`, no failed remote calls, and no process hard
+  failures. A focused incident-bundle verification confirmed `manifest.json`
+  included `smoke_report.repository` and `smoke_report.monitor`, with
+  repository dirty state false, zero tracked changes, and zero monitor errors.
 - Repository pulled through PR #1017 at `c493ea5d`.
 - PR #1017 added bounded text-log and event-window smoke summaries to
   `live-incident-bundle` `manifest.json`. It merged after Claude and Hermes

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -1275,6 +1275,10 @@ def build_live_incident_bundle(
             "monitor_snapshots": snapshots,
             "event_segments": segment_manifest,
             "smoke_report": {
+                "ok": smoke_report.get("ok"),
+                "attention": smoke_report.get("attention"),
+                "hard_failures": smoke_report.get("hard_failures"),
+                "attention_count": smoke_report.get("attention_count"),
                 "event_window": smoke_event_window_summary,
                 "logs": smoke_log_summary,
                 "repository": smoke_repository_summary,

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -751,6 +751,8 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         )
 
     assert manifest["config_hashes"][0]["sha256"] == config_hashes[0]["sha256"]
+    for section in ("ok", "attention", "hard_failures", "attention_count"):
+        assert manifest["smoke_report"][section] == report["smoke_report"][section]
     assert manifest["smoke_report"]["event_window"] == report["smoke_report"][
         "event_window"
     ]


### PR DESCRIPTION
## Summary
- add top-level smoke verdict fields to live-incident-bundle manifest smoke_report
- assert manifest parity with returned report for ok, attention, hard_failures, and attention_count
- update changelog and logging-overhaul progress ledger

## Validation
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py::test_live_incident_bundle_collects_hashes_snapshots_events_and_window -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py -q
- ./venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check
- added-line silent-handling scan over touched source/test: no matches