### PR TITLE
Include bundle result in incident manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-incident-bundle` now includes the bundle-level result
+  verdict in `manifest.json`, so archived incident bundles expose total
+  `ok`/`hard_failures` without opening the command output.
 - `passivbot tool live-incident-bundle` now includes top-level smoke verdict
   fields in `manifest.json`, making the bundle manifest self-contained for
   `ok`, `attention`, and smoke failure/count triage.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,18 +19,17 @@ Last updated: 2026-07-03.
 
 Current `origin/v8` head:
 
-- `9488f2ad` after PR #1018, `Include repository monitor summaries in incident bundles`.
+- `b741f49b` after PR #1019, `Include smoke verdict fields in incident manifests`.
 
 Current logging-overhaul head:
 
-- `9488f2ad` after PR #1018, `Include repository monitor summaries in incident bundles`.
+- `b741f49b` after PR #1019, `Include smoke verdict fields in incident manifests`.
 
 Current work:
 
-- Branch `codex/v8-incident-verdict-summary` adds top-level smoke verdict
-  fields to `live-incident-bundle` `manifest.json`, so the manifest can report
-  the same `ok`, `attention`, and smoke failure/count fields as the returned
-  report without opening the embedded full smoke report.
+- Branch `codex/v8-incident-bundle-result` adds the bundle-level result verdict
+  to `live-incident-bundle` `manifest.json`, so an archived bundle can expose
+  total `ok` and `hard_failures` without relying on command stdout.
 
 Current review gate:
 
@@ -60,6 +59,18 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1019 at `b741f49b`.
+- PR #1019 added top-level smoke verdict fields to `live-incident-bundle`
+  `manifest.json`: `ok`, `attention`, `hard_failures`, and `attention_count`.
+  It merged after Claude and Hermes approved with no findings and CI was green.
+  VPS5 checkout was updated to `b741f49b` without restarting running bots
+  because the slice was report-only. Recent-window smoke with stale unparsed
+  traceback fragments dropped reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, clean tracked repository state at
+  `repository.head=b741f49b`, no failed remote calls, no failed
+  account-critical remote calls, and no process hard failures. A focused
+  incident-bundle verification confirmed `manifest.json` included the four
+  smoke verdict fields and that they matched `smoke_report.json`.
 - Repository pulled through PR #1018 at `9488f2ad`.
 - PR #1018 added bounded repository and monitor smoke summaries to
   `live-incident-bundle` returned JSON and `manifest.json`, making checkout

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -823,6 +823,25 @@ def _smoke_data_plane_result_summaries(
     }
 
 
+def _bundle_hard_failure_count(
+    *,
+    smoke_report: dict[str, Any],
+    event_report: dict[str, Any],
+    window_report: dict[str, Any],
+) -> int:
+    hard_failures = int(smoke_report["hard_failures"]) + int(
+        event_report["error_count"]
+    )
+    window_issues = window_report.get("issues")
+    issues = window_issues if isinstance(window_issues, list) else []
+    hard_failures += sum(
+        1
+        for issue in issues
+        if isinstance(issue, dict) and issue.get("severity") == "error"
+    )
+    return hard_failures
+
+
 def _copy_event_segments(
     *,
     monitor_root: str | Path,
@@ -1175,6 +1194,12 @@ def build_live_incident_bundle(
     smoke_data_plane_summaries = _smoke_data_plane_result_summaries(
         smoke_brief_summary
     )
+    hard_failures = _bundle_hard_failure_count(
+        smoke_report=smoke_report,
+        event_report=event_report,
+        window_report=window_report,
+    )
+    bundle_ok = hard_failures == 0
     restart_smoke_plan: dict[str, Any] | None = None
     restart_smoke_plan_summary: dict[str, Any] | None = None
     if include_restart_smoke_plan:
@@ -1217,6 +1242,10 @@ def build_live_incident_bundle(
         )
         metadata = {
             "bundle_version": BUNDLE_VERSION,
+            "result": {
+                "ok": bundle_ok,
+                "hard_failures": hard_failures,
+            },
             "monitor_root": str(monitor_path),
             "logs_root": str(logs_path) if logs_path is not None else None,
             "output_path": str(out_path),
@@ -1325,16 +1354,8 @@ def build_live_incident_bundle(
         _write_json(bundle_root / "event_segments_manifest.json", segment_manifest)
         _tar_directory(bundle_root, out_path)
 
-    hard_failures = int(smoke_report.get("hard_failures", 0)) + int(
-        event_report.get("error_count", 0)
-    )
-    hard_failures += sum(
-        1
-        for issue in window_report.get("issues", [])
-        if isinstance(issue, dict) and issue.get("severity") == "error"
-    )
     return {
-        "ok": hard_failures == 0,
+        "ok": bundle_ok,
         "bundle_path": str(out_path),
         "bundle_version": BUNDLE_VERSION,
         "hard_failures": hard_failures,

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -751,6 +751,10 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         )
 
     assert manifest["config_hashes"][0]["sha256"] == config_hashes[0]["sha256"]
+    assert manifest["result"] == {
+        "ok": report["ok"],
+        "hard_failures": report["hard_failures"],
+    }
     for section in ("ok", "attention", "hard_failures", "attention_count"):
         assert manifest["smoke_report"][section] == report["smoke_report"][section]
     assert manifest["smoke_report"]["event_window"] == report["smoke_report"][


### PR DESCRIPTION
## Summary
- add a manifest-level result block with the bundle-level ok/hard_failures verdict
- reuse the same hard-failure calculation for manifest and returned command JSON
- add manifest parity coverage and record PR #1019 VPS5 evidence in the progress ledger

## Validation
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py::test_live_incident_bundle_collects_hashes_snapshots_events_and_window -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py -q
- ./venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check
- added-line silent-handling scan over touched source/test: no matches