### PR TITLE
Include time window summary in incident manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-incident-bundle` now includes the compact time-window
+  query summary in `manifest.json`, so archived bundles expose matched-event,
+  truncation, and scan-bound evidence without opening `time_window_report.json`.
 - `passivbot tool live-incident-bundle` now includes the bundle-level result
   verdict in `manifest.json`, so archived incident bundles expose total
   `ok`/`hard_failures` without opening the command output.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,17 +19,18 @@ Last updated: 2026-07-03.
 
 Current `origin/v8` head:
 
-- `b741f49b` after PR #1019, `Include smoke verdict fields in incident manifests`.
+- `85080299` after PR #1020, `Include bundle result in incident manifests`.
 
 Current logging-overhaul head:
 
-- `b741f49b` after PR #1019, `Include smoke verdict fields in incident manifests`.
+- `85080299` after PR #1020, `Include bundle result in incident manifests`.
 
 Current work:
 
-- Branch `codex/v8-incident-bundle-result` adds the bundle-level result verdict
-  to `live-incident-bundle` `manifest.json`, so an archived bundle can expose
-  total `ok` and `hard_failures` without relying on command stdout.
+- Branch `codex/v8-incident-time-window-summary` adds the compact
+  `time_window` summary to `live-incident-bundle` `manifest.json`, so archived
+  bundles expose matched-event, truncation, and scan-bound evidence without
+  opening `time_window_report.json`.
 
 Current review gate:
 
@@ -59,6 +60,22 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1020 at `85080299`.
+- PR #1020 added a bundle-level `result` verdict to
+  `live-incident-bundle` `manifest.json`, sharing the returned report's
+  total `ok` and `hard_failures` calculation. It merged after Claude and Hermes
+  approved with no findings and CI was green. VPS5 checkout was updated to
+  `85080299` without restarting running bots because the slice was report-only.
+  The first post-deploy smoke caught an unrelated transient Kucoin
+  `cycle.degraded` market snapshot miss still inside the 20-minute window; a
+  Kucoin-focused event query then showed subsequent clean `cy_32` candle work
+  with hundreds of successful remote calls and no errors. After the transient
+  aged out, standard 20-minute smoke reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, clean tracked repository state at
+  `repository.head=85080299`, no failed remote calls, no failed
+  account-critical remote calls, and no hard log matches. A focused
+  incident-bundle verification confirmed `manifest.result` matched the bundle
+  result.
 - Repository pulled through PR #1019 at `b741f49b`.
 - PR #1019 added top-level smoke verdict fields to `live-incident-bundle`
   `manifest.json`: `ok`, `attention`, `hard_failures`, and `attention_count`.

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -842,6 +842,35 @@ def _bundle_hard_failure_count(
     return hard_failures
 
 
+def _time_window_result_summary(window_report: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "enabled": window_report["enabled"],
+        "files_scanned": window_report["files_scanned"],
+        "file_discovery": window_report["file_discovery"],
+        "matched_events": window_report["matched_events"],
+        "events_truncated": window_report["events_truncated"],
+        "event_tail_lines": window_report.get("event_tail_lines"),
+        "event_tail_limited_files": window_report.get("event_tail_limited_files"),
+        "event_tail_skipped_lines": window_report.get("event_tail_skipped_lines"),
+        "event_tail_skipped_lines_exact": window_report.get(
+            "event_tail_skipped_lines_exact"
+        ),
+        "event_tail_skipped_bytes": window_report.get("event_tail_skipped_bytes"),
+        "event_tail_line_numbers_exact": window_report.get(
+            "event_tail_line_numbers_exact"
+        ),
+        "event_tail_methods": window_report.get("event_tail_methods"),
+        "max_event_files_per_bot": window_report.get("max_event_files_per_bot"),
+        "event_file_limit_scope": window_report.get("event_file_limit_scope"),
+        "event_file_limit_groups": window_report.get("event_file_limit_groups"),
+        "event_files_before_limit": window_report.get("event_files_before_limit"),
+        "event_files_skipped_by_limit": window_report.get(
+            "event_files_skipped_by_limit"
+        ),
+        "event_file_limit_order": window_report.get("event_file_limit_order"),
+    }
+
+
 def _copy_event_segments(
     *,
     monitor_root: str | Path,
@@ -1200,6 +1229,7 @@ def build_live_incident_bundle(
         window_report=window_report,
     )
     bundle_ok = hard_failures == 0
+    time_window_summary = _time_window_result_summary(window_report)
     restart_smoke_plan: dict[str, Any] | None = None
     restart_smoke_plan_summary: dict[str, Any] | None = None
     if include_restart_smoke_plan:
@@ -1303,6 +1333,7 @@ def build_live_incident_bundle(
             "config_hashes": config_hashes,
             "monitor_snapshots": snapshots,
             "event_segments": segment_manifest,
+            "time_window": time_window_summary,
             "smoke_report": {
                 "ok": smoke_report.get("ok"),
                 "attention": smoke_report.get("attention"),
@@ -1361,32 +1392,7 @@ def build_live_incident_bundle(
         "hard_failures": hard_failures,
         "event_report": _event_report_result_summary(event_report),
         "problem_event_report": _problem_report_result_summary(problem_report),
-        "time_window": {
-            "enabled": window_report.get("enabled"),
-            "files_scanned": window_report.get("files_scanned"),
-            "file_discovery": window_report.get("file_discovery") or {},
-            "matched_events": window_report.get("matched_events"),
-            "events_truncated": window_report.get("events_truncated"),
-            "event_tail_lines": window_report.get("event_tail_lines"),
-            "event_tail_limited_files": window_report.get("event_tail_limited_files"),
-            "event_tail_skipped_lines": window_report.get("event_tail_skipped_lines"),
-            "event_tail_skipped_lines_exact": window_report.get(
-                "event_tail_skipped_lines_exact"
-            ),
-            "event_tail_skipped_bytes": window_report.get("event_tail_skipped_bytes"),
-            "event_tail_line_numbers_exact": window_report.get(
-                "event_tail_line_numbers_exact"
-            ),
-            "event_tail_methods": window_report.get("event_tail_methods"),
-            "max_event_files_per_bot": window_report.get("max_event_files_per_bot"),
-            "event_file_limit_scope": window_report.get("event_file_limit_scope"),
-            "event_file_limit_groups": window_report.get("event_file_limit_groups"),
-            "event_files_before_limit": window_report.get("event_files_before_limit"),
-            "event_files_skipped_by_limit": window_report.get(
-                "event_files_skipped_by_limit"
-            ),
-            "event_file_limit_order": window_report.get("event_file_limit_order"),
-        },
+        "time_window": time_window_summary,
         "smoke_report": {
             "ok": smoke_report.get("ok"),
             "attention": smoke_report.get("attention"),

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -755,6 +755,8 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         "ok": report["ok"],
         "hard_failures": report["hard_failures"],
     }
+    assert manifest["time_window"] == report["time_window"]
+    assert manifest["time_window"]["matched_events"] == window_report["matched_events"]
     for section in ("ok", "attention", "hard_failures", "attention_count"):
         assert manifest["smoke_report"][section] == report["smoke_report"][section]
     assert manifest["smoke_report"]["event_window"] == report["smoke_report"][


### PR DESCRIPTION
## Summary
- add compact time_window summary to live-incident-bundle manifest.json
- reuse one helper for manifest and returned command JSON to prevent drift
- update changelog and progress ledger with PR #1020 deployment evidence

## Validation
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py::test_live_incident_bundle_collects_hashes_snapshots_events_and_window -q
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py tests/test_live_incident_bundle.py -q
- ./venv/bin/python -m py_compile src/live/incident_bundle.py tests/test_live_incident_bundle.py
- git diff --check
- added-line silent-handling scan over touched source/test: no matches