### PR TITLE
Warn on current-only event queries with rotated segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-event-query` now emits a warning issue when filtered
+  current-only queries skip rotated monitor event segments, making empty
+  incident queries less likely to be mistaken for complete history.
 - `passivbot tool live-incident-bundle` now includes the compact time-window
   query summary in `manifest.json`, so archived bundles expose matched-event,
   truncation, and scan-bound evidence without opening `time_window_report.json`.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -6243,6 +6243,25 @@ VPS5 deployment status:
   `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, and the
   standard added-line silent-handling scan.
 
+### Draft Slice: Event Query Rotation Warning
+
+- Branch: `codex/v8-event-query-rotation-warning`.
+- Scope: read-only `passivbot tool live-event-query` report output and docs.
+- Triggering evidence: a VPS5 Kucoin ASTER HSL RED/cooldown incident was
+  visible in text logs and recoverable from rotated monitor event segments with
+  `--include-rotated`, but a default filtered `live-event-query` scan over
+  `current.ndjson` returned zero matches after event rotation. The same query
+  also showed scan-order trace bounds when current segments were read before
+  older rotated files.
+- Intended result: keep current-only directory scans as the default for speed,
+  but emit a warning issue when a filtered query skips rotated event segments.
+  Also report trace-summary `first_ts`/`last_ts` as chronological min/max
+  timestamps rather than scan-order first/last. No event producers, monitor
+  writes, exchange calls, or trading behavior change.
+- Expected validation: focused `tests/test_live_event_query.py`, `py_compile`,
+  `git diff --check`, added-line silent-handling scan, and a read-only VPS5
+  rotated query proving the HSL incident is recoverable with `--include-rotated`.
+
 ## Current Next Steps
 
 1. Prioritize a separate trading-path PR for coin-HSL startup replay latency:

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -152,7 +152,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   `--level`, `--cycle-id`, ID filters, `--symbol`, `--pside`, `--tag`, `--data-eq`, and
   time-window filters to reconstruct incident slices. Use `--exchange EXCHANGE` and
   `--user USER` to focus one monitor account and prune unrelated monitor paths before
-  scanning; `--bot-id` remains available for event-envelope bot IDs. For repeated recent-window queries over
+  scanning; `--bot-id` remains available for event-envelope bot IDs. Directory scans
+  read `current.ndjson` by default; add `--include-rotated` for complete history
+  queries after monitor event rotation. For repeated recent-window queries over
   large current monitor segments, `--event-tail-lines N` bounds parsing to the last N rows
   from each event file; the default `0` keeps full event validation.
 - `passivbot tool live-smoke-report` summarizes local live monitor events and text logs for

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -170,9 +170,6 @@ def _discover_event_files(
         ):
             continue
         event_segments += 1
-        if not include_rotated and candidate.name != "current.ndjson":
-            rotated_skipped += 1
-            continue
         if not _monitor_path_scope_matches_under_root(
             path,
             candidate,
@@ -181,6 +178,9 @@ def _discover_event_files(
             bot_path_filter=bot_path_filter,
         ):
             scope_pruned += 1
+            continue
+        if not include_rotated and candidate.name != "current.ndjson":
+            rotated_skipped += 1
             continue
         files.append(candidate)
     return EventFileDiscovery(
@@ -1180,9 +1180,10 @@ class _TraceSummaryBuilder:
     ) -> None:
         self.events += 1
         ts = row.get("ts")
-        if self.first_ts is None:
+        if self.first_ts is None or (ts is not None and ts < self.first_ts):
             self.first_ts = ts
-        self.last_ts = ts
+        if self.last_ts is None or (ts is not None and ts > self.last_ts):
+            self.last_ts = ts
         if event_type:
             self.event_types[str(event_type)] += 1
         for key, counter in (
@@ -1702,6 +1703,21 @@ def build_event_report(
             issues.append(
                 EventIssue(str(path), None, "error", "read_failed", str(exc))
             )
+
+    if has_query_filter and not include_rotated and discovery.rotated_skipped > 0:
+        issues.append(
+            EventIssue(
+                str(root),
+                None,
+                "warning",
+                "current_only_rotated_segments_skipped",
+                (
+                    "query scanned current.ndjson only while rotated event segments "
+                    "were present; rerun with --include-rotated for a complete "
+                    "history query"
+                ),
+            )
+        )
 
     error_count = sum(1 for issue in issues if issue.severity == "error")
     warning_count = sum(1 for issue in issues if issue.severity == "warning")

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -208,6 +208,130 @@ def test_event_query_current_only_skips_rotated_segments(tmp_path):
     assert report["cycle_ids_sample"] == [{"cycle_id": "cy_current", "events": 1}]
 
 
+def test_event_query_warns_when_filtered_query_skips_rotated_segments(tmp_path):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "2026-07-03T04-25-00.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.red_triggered",
+                cycle_id="cy_34",
+                seq=1,
+                ts=1783052758000,
+                symbol="ASTER/USDT:USDT",
+                pside="long",
+                exchange="kucoin",
+                user="kucoin_01",
+            )
+        ],
+    )
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="remote_call.succeeded",
+                cycle_id="cy_37",
+                seq=2,
+                ts=1783053568000,
+                symbol="ASTER/USDT:USDT",
+                exchange="kucoin",
+                user="kucoin_01",
+            )
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        include_rotated=False,
+        event_type="hsl.red_triggered",
+        exchange="kucoin",
+        user="kucoin_01",
+        symbol="ASTER/USDT:USDT",
+        since_ms=1783050000000,
+    )
+
+    assert report["ok"] is True
+    assert report["warning_count"] == 1
+    assert report["issues"] == [
+        {
+            "path": str(tmp_path / "monitor"),
+            "line": None,
+            "severity": "warning",
+            "code": "current_only_rotated_segments_skipped",
+            "message": (
+                "query scanned current.ndjson only while rotated event segments "
+                "were present; rerun with --include-rotated for a complete "
+                "history query"
+            ),
+        }
+    ]
+    assert report["query"]["matched_events"] == 0
+    assert report["file_discovery"]["rotated_skipped"] == 1
+
+    full_report = build_event_report(
+        tmp_path / "monitor",
+        include_rotated=True,
+        event_type=["hsl.red_triggered", "remote_call.succeeded"],
+        exchange="kucoin",
+        user="kucoin_01",
+        symbol="ASTER/USDT:USDT",
+        since_ms=1783050000000,
+        trace_summary=True,
+    )
+
+    assert full_report["warning_count"] == 0
+    assert full_report["query"]["matched_events"] == 2
+    assert full_report["query"]["trace_summary"]["first_ts"] == 1783052758000
+    assert full_report["query"]["trace_summary"]["last_ts"] == 1783053568000
+
+
+def test_event_query_rotation_warning_ignores_out_of_scope_rotated_segments(tmp_path):
+    binance_events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    kucoin_events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        binance_events_dir / "2026-07-03T04-25-00.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.red_triggered",
+                cycle_id="cy_binance",
+                seq=1,
+                ts=1783052758000,
+                symbol="ASTER/USDT:USDT",
+            )
+        ],
+    )
+    _write_ndjson(
+        kucoin_events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="target",
+                cycle_id="cy_kucoin",
+                seq=2,
+                ts=1783053568000,
+                symbol="ASTER/USDT:USDT",
+                exchange="kucoin",
+                user="kucoin_01",
+            )
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        include_rotated=False,
+        event_type="target",
+        exchange="kucoin",
+        user="kucoin_01",
+        symbol="ASTER/USDT:USDT",
+    )
+
+    assert report["ok"] is True
+    assert report["warning_count"] == 0
+    assert report["issues"] == []
+    assert report["query"]["matched_events"] == 1
+    assert report["file_discovery"]["rotated_skipped"] == 0
+    assert report["file_discovery"]["scope_pruned"] == 1
+
+
 def test_event_query_filters_by_event_type_without_changing_summary_counts(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- add a warning issue when filtered live-event-query scans skip rotated monitor event segments in current-only mode
- report trace-summary first_ts/last_ts as chronological min/max timestamps instead of scan-order bounds
- document the --include-rotated incident-query path and record the slice in the logging progress plan

## Validation
- ./venv/bin/python -m pytest tests/test_live_event_query.py -q
- ./venv/bin/python -m py_compile src/live/event_query.py tests/test_live_event_query.py
- git diff --check
- added-line silent-handling scan on src/live/event_query.py and tests/test_live_event_query.py
- VPS5 read-only rotated query recovered the Kucoin ASTER HSL incident with --include-rotated and showed 11 matching HSL events

## Behavior
Observability-only. No event producers, monitor writes, exchange calls, or trading behavior changed.