### PR TITLE
Include dropped unparsed log samples in smoke reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report --summary` and `--brief` now include
+  bounded dropped-unparsed log samples when `--log-window-unparsed-policy drop`
+  suppresses contextless hard or attention-looking log lines.
 - `passivbot tool live-event-query` now emits a warning issue when filtered
   current-only queries skip rotated monitor event segments, making empty
   incident queries less likely to be mistaken for complete history.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -6261,6 +6261,35 @@ VPS5 deployment status:
 - Expected validation: focused `tests/test_live_event_query.py`, `py_compile`,
   `git diff --check`, added-line silent-handling scan, and a read-only VPS5
   rotated query proving the HSL incident is recoverable with `--include-rotated`.
+- Result: PR #1022 was reviewed by Hermes and Claude, merged to `v8`, and
+  deployed to VPS5 at `c090fd5b`. A short post-deploy smoke reported
+  `ok=true`, `hard_failures=0`, `matched_expected=5`, clean tracked repository
+  state, and five configured live bots still running. A read-only Kucoin ASTER
+  current-only query now emits `current_only_rotated_segments_skipped`, while
+  `--include-rotated` recovers the HSL RED/cooldown incident events.
+
+### Draft Slice: Dropped Unparsed Log Samples
+
+- Branch: `codex/v8-smoke-dropped-unparsed-samples`.
+- Scope: read-only `passivbot tool live-smoke-report` summary/brief projection
+  over existing log-window dropped-unparsed counters.
+- Triggering evidence: after PR #1022 deployment, VPS5 brief smoke was green
+  but reported `dropped_unparsed_attention_matches=1` and
+  `dropped_unparsed_hard_matches=1` with `--log-window-unparsed-policy drop`.
+  The brief output showed the counts but not the dropped line, so an operator
+  could not tell whether the dropped hard-looking signal was a stale traceback
+  fragment or a fresh line cut off by the log tail.
+- Intended result: keep the existing verdict policy and drop behavior, but
+  retain bounded redacted samples for contextless attention/hard-looking lines
+  dropped by the unparsed-line policy. Project them into summary and brief
+  output with basename-only paths in brief, matching existing log sample
+  conventions. This changes only report output; it does not add log scanning,
+  event producers, exchange calls, monitor writes, console routing, or trading
+  behavior.
+- Expected validation: focused dropped-unparsed smoke-report test, full
+  `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, added-line
+  silent-handling scan, and a read-only VPS5 smoke showing dropped samples when
+  the condition is present.
 
 ## Current Next Steps
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -5621,6 +5621,7 @@ def _scan_logs(
             "non_risk_hard_matches": 0,
             "window": window_report,
             "matches": [],
+            "dropped_unparsed_matches": [],
             "dropped_unparsed_attention_matches": 0,
             "dropped_unparsed_hard_matches": 0,
         }
@@ -5639,6 +5640,7 @@ def _scan_logs(
     lines_skipped_unparsed = 0
     dropped_unparsed_attention_matches = 0
     dropped_unparsed_hard_matches = 0
+    dropped_unparsed_matches: list[dict[str, Any]] = []
     for path in files:
         log_context_ts_ms: int | None = None
         log_context_line_no: int | None = None
@@ -5665,8 +5667,21 @@ def _scan_logs(
                     ):
                         if log_context_ts_ms is None and attention:
                             dropped_unparsed_attention_matches += 1
-                            if HARD_LOG_PATTERN.search(line):
+                            hard_dropped = bool(HARD_LOG_PATTERN.search(line))
+                            if hard_dropped:
                                 dropped_unparsed_hard_matches += 1
+                            if len(dropped_unparsed_matches) < max(0, int(max_matches)):
+                                dropped_unparsed_matches.append(
+                                    {
+                                        "path": str(path),
+                                        "line": int(line_no),
+                                        "hard": hard_dropped,
+                                        "category": "risk"
+                                        if RISK_LOG_PATTERN.search(line)
+                                        else "general",
+                                        "text": _redact_log_text(line, max_len=500),
+                                    }
+                                )
                         lines_skipped_unparsed += 1
                         continue
                 else:
@@ -5736,6 +5751,7 @@ def _scan_logs(
             dropped_unparsed_hard_matches=dropped_unparsed_hard_matches,
         ),
         "matches": matches,
+        "dropped_unparsed_matches": dropped_unparsed_matches,
         "dropped_unparsed_attention_matches": dropped_unparsed_attention_matches,
         "dropped_unparsed_hard_matches": dropped_unparsed_hard_matches,
     }
@@ -6264,6 +6280,13 @@ def summarize_live_smoke_report(
             ),
             "matches_truncated": len(matches) > max_groups,
             "matches": matches[:max_groups],
+            "dropped_unparsed_matches_truncated": len(
+                logs.get("dropped_unparsed_matches") or []
+            )
+            > max_groups,
+            "dropped_unparsed_matches": (
+                logs.get("dropped_unparsed_matches") or []
+            )[:max_groups],
             "window": logs.get("window"),
         },
         "problem_events": {
@@ -6666,11 +6689,13 @@ def _brief_log_window(logs: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _brief_log_match_samples(logs: dict[str, Any]) -> dict[str, Any]:
-    matches = logs.get("matches")
+def _brief_log_sample_rows(
+    matches: Any,
+    *,
+    limit: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     if not isinstance(matches, list):
-        return {}
-    limit = max(0, int(SMOKE_REPORT_BRIEF_LOG_SAMPLE_LIMIT))
+        return [], []
     hard_samples: list[dict[str, Any]] = []
     attention_samples: list[dict[str, Any]] = []
     for match in matches:
@@ -6700,6 +6725,16 @@ def _brief_log_match_samples(logs: dict[str, Any]) -> dict[str, Any]:
             attention_samples.append(sample)
         if len(hard_samples) >= limit and len(attention_samples) >= limit:
             break
+    return hard_samples, attention_samples
+
+
+def _brief_log_match_samples(logs: dict[str, Any]) -> dict[str, Any]:
+    matches = logs.get("matches")
+    limit = max(0, int(SMOKE_REPORT_BRIEF_LOG_SAMPLE_LIMIT))
+    hard_samples, attention_samples = _brief_log_sample_rows(
+        matches,
+        limit=limit,
+    )
     out: dict[str, Any] = {}
     if hard_samples:
         out["hard_samples"] = hard_samples
@@ -6710,6 +6745,27 @@ def _brief_log_match_samples(logs: dict[str, Any]) -> dict[str, Any]:
         out["attention_samples"] = attention_samples
         out["attention_samples_truncated"] = int(
             logs.get("attention_matches") or 0
+        ) > len(attention_samples)
+    return out
+
+
+def _brief_dropped_unparsed_log_match_samples(logs: dict[str, Any]) -> dict[str, Any]:
+    matches = logs.get("dropped_unparsed_matches")
+    limit = max(0, int(SMOKE_REPORT_BRIEF_LOG_SAMPLE_LIMIT))
+    hard_samples, attention_samples = _brief_log_sample_rows(
+        matches,
+        limit=limit,
+    )
+    out: dict[str, Any] = {}
+    if hard_samples:
+        out["dropped_unparsed_hard_samples"] = hard_samples
+        out["dropped_unparsed_hard_samples_truncated"] = int(
+            logs.get("dropped_unparsed_hard_matches") or 0
+        ) > len(hard_samples)
+    if attention_samples:
+        out["dropped_unparsed_attention_samples"] = attention_samples
+        out["dropped_unparsed_attention_samples_truncated"] = int(
+            logs.get("dropped_unparsed_attention_matches") or 0
         ) > len(attention_samples)
     return out
 
@@ -7133,7 +7189,8 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             ),
             "window": _brief_log_window(logs),
         }
-        | _brief_log_match_samples(logs),
+        | _brief_log_match_samples(logs)
+        | _brief_dropped_unparsed_log_match_samples(logs),
         "problem_events": {
             "total": problem_event_count,
             "hard": hard_problem_event_count,

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -4820,6 +4820,15 @@ def test_live_smoke_report_log_window_drops_contextless_tailed_traceback(tmp_pat
     assert report["logs"]["hard_matches"] == 0
     assert report["logs"]["dropped_unparsed_attention_matches"] == 1
     assert report["logs"]["dropped_unparsed_hard_matches"] == 1
+    assert report["logs"]["dropped_unparsed_matches"] == [
+        {
+            "path": str(logs_dir / "kucoin_01.log"),
+            "line": 3,
+            "hard": True,
+            "category": "general",
+            "text": "Traceback (most recent call last):",
+        }
+    ]
     assert report["logs"]["matches"] == []
     assert report["logs"]["window"] == {
         "enabled": True,
@@ -4834,6 +4843,26 @@ def test_live_smoke_report_log_window_drops_contextless_tailed_traceback(tmp_pat
         "dropped_unparsed_attention_matches": 1,
         "dropped_unparsed_hard_matches": 1,
     }
+    summary = summarize_live_smoke_report(report)
+    assert summary["logs"]["dropped_unparsed_matches"] == [
+        report["logs"]["dropped_unparsed_matches"][0]
+    ]
+    assert summary["logs"]["dropped_unparsed_matches_truncated"] is False
+    brief = summarize_live_smoke_report_brief(report)
+    assert brief["logs"]["dropped_unparsed_hard_samples"] == [
+        {
+            "category": "general",
+            "hard": True,
+            "path": "kucoin_01.log",
+            "line": 3,
+            "text": "Traceback (most recent call last):",
+        }
+    ]
+    assert brief["logs"]["dropped_unparsed_attention_samples"] == [
+        brief["logs"]["dropped_unparsed_hard_samples"][0]
+    ]
+    assert brief["logs"]["dropped_unparsed_hard_samples_truncated"] is False
+    assert brief["logs"]["dropped_unparsed_attention_samples_truncated"] is False
 
 
 def test_live_smoke_report_log_scan_ignores_traceback_prose(tmp_path):


### PR DESCRIPTION
## Summary
- retain bounded redacted samples for contextless hard/attention-looking log lines dropped by --log-window-unparsed-policy drop
- project those samples into live-smoke-report summary and brief output using basename-only paths in brief
- record the slice in the logging progress ledger and changelog

## Validation
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- ./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check
- added-line silent-handling scan for touched smoke-report/test diff
- local brief smoke over existing monitor/log artifacts showed dropped_unparsed_hard_samples and dropped_unparsed_attention_samples for the contextless traceback header

## Behavior
Observability-only. No verdict-policy, event producer, monitor write, exchange call, console routing, order/risk, or trading behavior changes.