### PR TITLE
Expose safe risk latest data in smoke brief

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report --brief` now includes allowlisted
+  `latest_data` for risk-event groups, exposing compact state such as HSL mode
+  transitions and unstuck over-budget summaries while still excluding raw
+  balances, drawdown internals, and per-side allowance details.
 - `passivbot tool live-smoke-report --summary` and `--brief` now include
   bounded dropped-unparsed log samples when `--log-window-unparsed-policy drop`
   suppresses contextless hard or attention-looking log lines.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -6290,6 +6290,40 @@ VPS5 deployment status:
   `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`, added-line
   silent-handling scan, and a read-only VPS5 smoke showing dropped samples when
   the condition is present.
+- Result: PR #1023 was reviewed by Hermes and Claude, merged to `v8`, and
+  deployed to VPS5 at `8aab137c`. A short post-deploy smoke reported
+  `ok=true`, `hard_failures=0`, clean tracked repository state, and five
+  configured live bots still running. The current VPS5 log window did not
+  contain dropped unparsed hard/attention matches after deployment, so the new
+  sample fields were absent as expected when the condition is not present.
+  The same smoke showed `unstuck.status` in brief `risk_events.latest_groups`,
+  but without compact `latest_data`; a follow-up event query showed the
+  underlying event had useful allowlisted state such as `changed`,
+  `status_counts`, and `over_budget_sides`.
+
+### Draft Slice: Brief Risk Latest Data
+
+- Branch: `codex/v8-smoke-risk-brief-latest-data`.
+- Scope: read-only `passivbot tool live-smoke-report --brief` projection over
+  existing summarized `risk_events.groups` and `risk_events.attention_groups`.
+- Triggering evidence: after PR #1023 deployment, VPS5 brief smoke exposed an
+  `unstuck.status` latest group for `hyperliquid/hyperliquid_tradfi`, but the
+  brief row did not explain whether the state changed, which status counts were
+  present, or whether any side was over budget. A focused `live-event-query`
+  showed the existing monitor event already contained safe compact fields:
+  `changed=true`, `status_counts`, and `over_budget_sides`, alongside raw
+  per-side allowance details that should remain out of brief smoke output.
+- Intended result: include only allowlisted `latest_data` keys in brief risk
+  groups, covering HSL mode/status/finalization context and unstuck status
+  summaries. Continue excluding raw balances, drawdown internals, price-distance
+  details, nested per-side allowance maps, and arbitrary event payload keys.
+  This changes only report output; it does not add event producers, exchange
+  calls, HSL behavior, order/risk logic, monitor writes, console routing, or
+  trading behavior.
+- Expected validation: focused risk-event smoke-report test, full
+  `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`,
+  added-line silent-handling scan, and a read-only VPS5 smoke after merge
+  proving the compact fields appear when the condition is present.
 
 ## Current Next Steps
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -3168,11 +3168,21 @@ def _compact_risk_group(group: dict[str, Any]) -> dict[str, Any]:
         "count",
         "latest_ts",
     )
-    return {
+    out = {
         key: group.get(key)
         for key in safe_group_keys
         if group.get(key) not in (None, "", {}, [])
     }
+    latest_data = group.get("latest_data")
+    if isinstance(latest_data, dict):
+        safe_latest_data = {
+            key: value
+            for key, value in latest_data.items()
+            if key in SHAREABLE_RISK_LATEST_DATA_KEYS and value not in (None, {}, [])
+        }
+        if safe_latest_data:
+            out["latest_data"] = safe_latest_data
+    return out
 
 
 def _summarize_risk_events(

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -587,6 +587,12 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
             "component": "risk.hsl",
             "count": 1,
             "latest_ts": 2200,
+            "latest_data": {
+                "signal_mode": "coin",
+                "tier": "red",
+                "cooldown_until_ms": 999999,
+                "cooldown_remaining_seconds": 123.4,
+            },
         }
     ]
     assert report["smoke_report"]["ema_readiness"] == {

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -3173,6 +3173,27 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
                     "changed": True,
                 },
             ),
+            _monitor_row(
+                event_type="unstuck.status",
+                seq=7,
+                ts=6000,
+                reason_code="unstuck_status",
+                ids={"cycle_id": "cy_risk_6"},
+                data={
+                    "changed": True,
+                    "status_counts": {"disabled": 1, "ok": 1},
+                    "over_budget_sides": ["long"],
+                    "sides": {
+                        "long": {
+                            "allowance": -0.6064111797120435,
+                            "loss_allowance_pct": 0.01,
+                            "over_budget": True,
+                        },
+                    },
+                    "balance": 12345.67,
+                    "secret_marker": "unstuck-secret",
+                },
+            ),
         ],
     )
 
@@ -3185,13 +3206,14 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
     assert report["ok"] is True
     assert report["attention"] is False
     assert report["risk_events"] == {
-        "total": 5,
+        "total": 6,
         "groups_truncated": False,
         "event_types": {
             "hsl.red_finalized_without_order": 1,
             "hsl.status": 2,
             "risk.mode_changed": 1,
             "unstuck.selection": 1,
+            "unstuck.status": 1,
         },
         "hsl_flat_finalization_anchors": {
             "total": 1,
@@ -3242,6 +3264,21 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
                 "component": "test",
                 "count": 1,
                 "latest_ts": 4500,
+                "latest_data": {
+                    "cooldown_until_ms": 999999,
+                    "entry_orders": 0,
+                    "exchange_close_order_submitted": False,
+                    "flat_confirmations": 2,
+                    "no_exchange_close_needed": True,
+                    "nonpanic_close_orders": 0,
+                    "panic_order_submitted_count": 0,
+                    "position_count": 0,
+                    "stop_event_anchor_fallback_used": True,
+                    "stop_event_anchor_source": "current_time_fallback",
+                    "stop_event_anchor_timestamp_ms": 4300,
+                    "stop_event_timestamp_ms": 4300,
+                    "symbol_position_open": False,
+                },
             },
             {
                 "bot": "binance/binance_01",
@@ -3253,10 +3290,31 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
                 "component": "test",
                 "count": 1,
                 "latest_ts": 4000,
+                "latest_data": {
+                    "action": "forced_modes",
+                    "mode": "panic",
+                    "previous_mode": "normal",
+                },
             },
         ],
         "attention_groups_truncated": False,
         "groups": [
+            {
+                "bot": "binance/binance_01",
+                "event_type": "unstuck.status",
+                "reason_code": "unstuck_status",
+                "status": "succeeded",
+                "level": "info",
+                "component": "test",
+                "count": 1,
+                "latest_ts": 6000,
+                "latest_data": {
+                    "changed": True,
+                    "status_counts": {"disabled": 1, "ok": 1},
+                    "over_budget_sides": ["long"],
+                },
+                "latest_ids": {"cycle_id": "cy_risk_6"},
+            },
             {
                 "bot": "binance/binance_01",
                 "event_type": "unstuck.selection",
@@ -3345,6 +3403,7 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
     assert "12345.67" not in rendered
     assert "0.42" not in rendered
     assert "flat-secret" not in rendered
+    assert "unstuck-secret" not in rendered
     summary = summarize_live_smoke_report(report)
     summary_risk_json = json.dumps(summary["risk_events"], sort_keys=True)
     assert "drawdown_raw" not in summary_risk_json
@@ -3411,6 +3470,21 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
     assert brief["risk_events"]["latest_groups"] == [
         {
             "bot": "binance/binance_01",
+            "event_type": "unstuck.status",
+            "reason_code": "unstuck_status",
+            "status": "succeeded",
+            "level": "info",
+            "component": "test",
+            "count": 1,
+            "latest_ts": 6000,
+            "latest_data": {
+                "changed": True,
+                "over_budget_sides": ["long"],
+                "status_counts": {"disabled": 1, "ok": 1},
+            },
+        },
+        {
+            "bot": "binance/binance_01",
             "event_type": "unstuck.selection",
             "reason_code": "unstuck_selection",
             "status": "succeeded",
@@ -3420,6 +3494,7 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
             "component": "test",
             "count": 1,
             "latest_ts": 5000,
+            "latest_data": {"changed": True},
         },
         {
             "bot": "binance/binance_01",
@@ -3432,6 +3507,21 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
             "component": "test",
             "count": 1,
             "latest_ts": 4500,
+            "latest_data": {
+                "cooldown_until_ms": 999999,
+                "entry_orders": 0,
+                "exchange_close_order_submitted": False,
+                "flat_confirmations": 2,
+                "no_exchange_close_needed": True,
+                "nonpanic_close_orders": 0,
+                "panic_order_submitted_count": 0,
+                "position_count": 0,
+                "stop_event_anchor_fallback_used": True,
+                "stop_event_anchor_source": "current_time_fallback",
+                "stop_event_anchor_timestamp_ms": 4300,
+                "stop_event_timestamp_ms": 4300,
+                "symbol_position_open": False,
+            },
         },
         {
             "bot": "binance/binance_01",
@@ -3443,6 +3533,11 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
             "component": "test",
             "count": 1,
             "latest_ts": 4000,
+            "latest_data": {
+                "action": "forced_modes",
+                "mode": "panic",
+                "previous_mode": "normal",
+            },
         },
         {
             "bot": "binance/binance_01",
@@ -3455,6 +3550,10 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
             "component": "test",
             "count": 2,
             "latest_ts": 3000,
+            "latest_data": {
+                "signal_mode": "coin",
+                "tier": "yellow",
+            },
         },
     ]
     assert brief["risk_events"]["latest_groups_truncated"] is False
@@ -3470,6 +3569,21 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
             "component": "test",
             "count": 1,
             "latest_ts": 4500,
+            "latest_data": {
+                "cooldown_until_ms": 999999,
+                "entry_orders": 0,
+                "exchange_close_order_submitted": False,
+                "flat_confirmations": 2,
+                "no_exchange_close_needed": True,
+                "nonpanic_close_orders": 0,
+                "panic_order_submitted_count": 0,
+                "position_count": 0,
+                "stop_event_anchor_fallback_used": True,
+                "stop_event_anchor_source": "current_time_fallback",
+                "stop_event_anchor_timestamp_ms": 4300,
+                "stop_event_timestamp_ms": 4300,
+                "symbol_position_open": False,
+            },
         },
         {
             "bot": "binance/binance_01",
@@ -3481,6 +3595,11 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
             "component": "test",
             "count": 1,
             "latest_ts": 4000,
+            "latest_data": {
+                "action": "forced_modes",
+                "mode": "panic",
+                "previous_mode": "normal",
+            },
         },
     ]
     assert brief["risk_events"]["attention_groups_truncated"] is False
@@ -3488,7 +3607,16 @@ def test_live_smoke_report_summarizes_recent_risk_events(tmp_path):
     assert "dist_to_red" not in json.dumps(summary["risk_events"]["hsl_status"])
     assert "red_threshold" not in json.dumps(brief["risk_events"]["hsl_status"])
     assert "drawdown_raw" not in json.dumps(brief["risk_events"]["hsl_status"])
-    assert "latest_data" not in json.dumps(brief["risk_events"])
+    brief_risk_json = json.dumps(brief["risk_events"], sort_keys=True)
+    assert "latest_data" in brief_risk_json
+    assert "allowance" not in brief_risk_json
+    assert '"sides":' not in brief_risk_json
+    assert "price_diff_pct" not in brief_risk_json
+    assert "drawdown_raw" not in brief_risk_json
+    assert "red_threshold" not in brief_risk_json
+    assert "balance" not in brief_risk_json
+    assert "flat-secret" not in brief_risk_json
+    assert "unstuck-secret" not in brief_risk_json
 
 
 def test_live_smoke_report_summarizes_hsl_cooldown_active_status(tmp_path):


### PR DESCRIPTION
## Summary
- include allowlisted latest_data in brief smoke risk latest/attention groups
- surface compact HSL mode/finalization and unstuck over-budget/status-count context
- continue excluding raw balance, drawdown internals, price-distance details, nested side allowance maps, and arbitrary payload keys

## Behavior
- observability-only report projection change
- no event producers, exchange calls, HSL behavior, order/risk logic, monitor writes, console routing, or trading behavior changed

## Validation
- ./venv/bin/python -m pytest tests/test_live_smoke_report.py -q
- ./venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- git diff --check
- added-line silent-handling scan over src/live/smoke_report.py and tests/test_live_smoke_report.py

## Triggering evidence
- VPS5 brief smoke after PR #1023 showed an unstuck.status latest group without compact state
- focused live-event-query showed the underlying event already had safe fields such as changed, status_counts, and over_budget_sides, alongside raw per-side allowance details that remain excluded