### PR TITLE
Add forager live event debug profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- The `forager` live-event debug profile now enriches existing forager
+  selection and feature-unavailable events with bounded count/key-shape
+  metadata without changing default event payloads or console output.
 - `passivbot tool live-smoke-report --brief` now includes allowlisted
   `latest_data` for risk-event groups, exposing compact state such as HSL mode
   transitions and unstuck over-budget summaries while still excluding raw

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -6324,6 +6324,34 @@ VPS5 deployment status:
   `tests/test_live_smoke_report.py`, `py_compile`, `git diff --check`,
   added-line silent-handling scan, and a read-only VPS5 smoke after merge
   proving the compact fields appear when the condition is present.
+- Result: PR #1024 was reviewed by Claude and Hermes, merged to `v8`, and
+  deployed to VPS5 at `59c36ada` without restarting bots. A short post-deploy
+  smoke reported `ok=true`, `hard_failures=0`, clean tracked repository state,
+  and five configured bots still running. The deployed brief `risk_events`
+  output now includes allowlisted `latest_data` for HSL cooldown and green
+  status rows, proving the compact state projection is active while keeping raw
+  drawdown/balance/allowance details out of brief output.
+
+### Draft Slice: Forager Debug Profile
+
+- Branch: `codex/v8-forager-debug-profile`.
+- Scope: Phase 5/6 opt-in structured debug enrichment for existing
+  `forager.selection` and `forager.feature_unavailable` events.
+- Triggering evidence: `forager` is already part of the documented
+  `logging.live_event_debug_profiles` / `PASSIVBOT_LIVE_EVENT_DEBUG_PROFILES`
+  surface, but the existing forager event emitters did not add any
+  profile-specific debug shape when that profile was enabled.
+- Intended result: when `forager` debug is enabled, add bounded count and
+  key-shape metadata to existing forager events: candidate/eligible/selected
+  counts, unavailable sample counts, top-score key shape, slot state, and
+  related decision counters. Do not add raw score values beyond the existing
+  default bounded top-score sample, do not change default forager events, and do
+  not change console output, event routing, selection behavior, exchange calls,
+  order/risk logic, monitor writes, or trading behavior.
+- Expected validation: focused forager debug-profile monitor test,
+  live-event debug-profile normalization test, broader live-event/monitor suite
+  if review asks for it, `py_compile`, `git diff --check`, and the standard
+  added-line silent-handling scan.
 
 ## Current Next Steps
 

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1295,6 +1295,47 @@ def _sorted_str_list(value: Any) -> list[str]:
         return []
 
 
+def _forager_debug_payload(data: dict[str, Any], *, limit: int = 32) -> dict[str, Any]:
+    debug: dict[str, Any] = {"data_keys": _mapping_key_sample(data, limit=limit)}
+    for key in (
+        "candidate_count",
+        "eligible_count",
+        "selected_count",
+        "incumbent_count",
+        "max_n_positions",
+        "slots_to_fill",
+        "feature_unavailable_count",
+        "volatility_dropped_count",
+        "hysteresis_event_count",
+        "fetch_budget",
+    ):
+        value = _safe_int(data.get(key))
+        if value is not None:
+            debug[key] = max(0, int(value))
+    for key in ("slots_open",):
+        if key in data:
+            debug[key] = bool(data.get(key))
+    unavailable = data.get("unavailable")
+    if isinstance(unavailable, dict):
+        unavailable_count = _safe_int(unavailable.get("count"))
+        sample = unavailable.get("sample")
+        debug["unavailable_count"] = max(
+            0, int(unavailable_count) if unavailable_count is not None else 0
+        )
+        debug["unavailable_sample_count"] = len(sample) if isinstance(sample, list) else 0
+        debug["unavailable_truncated"] = bool(unavailable.get("truncated"))
+    top_scores = data.get("top_scores")
+    if isinstance(top_scores, list):
+        debug["top_scores_count"] = len(top_scores)
+        score_keys: set[str] = set()
+        for item in top_scores[:limit]:
+            if isinstance(item, dict):
+                score_keys.update(str(key) for key in item)
+        if score_keys:
+            debug["top_score_keys"] = sorted(score_keys)[:limit]
+    return debug
+
+
 def _emit_state_refresh_timing_event_unchecked(
     bot: Any,
     *,
@@ -1894,6 +1935,17 @@ def _emit_forager_feature_unavailable_event_unchecked(
 ) -> None:
     if not symbols:
         return
+    data: dict[str, Any] = {
+        "candidate_count": int(candidate_count),
+        "unavailable": _symbol_sample(symbols),
+        "volume_count": int(volume_count),
+        "log_range_count": int(log_range_count),
+        "max_age_ms": int(max_age_ms) if max_age_ms is not None else None,
+        "fetch_budget": int(fetch_budget) if fetch_budget is not None else None,
+    }
+    if live_event_debug_profile_enabled(bot, "forager"):
+        data["debug"] = _forager_debug_payload(data)
+        data["debug_profile"] = "forager"
     _safe_emit(
         bot,
         EventTypes.FORAGER_FEATURE_UNAVAILABLE,
@@ -1904,14 +1956,7 @@ def _emit_forager_feature_unavailable_event_unchecked(
         pside=str(pside),
         status="skipped",
         reason_code=ReasonCodes.RANKING_FEATURES_UNAVAILABLE,
-        data={
-            "candidate_count": int(candidate_count),
-            "unavailable": _symbol_sample(symbols),
-            "volume_count": int(volume_count),
-            "log_range_count": int(log_range_count),
-            "max_age_ms": int(max_age_ms) if max_age_ms is not None else None,
-            "fetch_budget": int(fetch_budget) if fetch_budget is not None else None,
-        },
+        data=data,
     )
 
 
@@ -1952,6 +1997,38 @@ def _emit_forager_selection_event_unchecked(
 ) -> None:
     selected = [str(symbol) for symbol in selected_symbols or []]
     incumbent = [str(symbol) for symbol in incumbent_symbols or []]
+    data: dict[str, Any] = {
+        "candidate_count": int(candidate_count),
+        "eligible_count": int(eligible_count),
+        "selected_count": len(selected),
+        "selected_symbols": selected[:12],
+        "incumbent_count": len(incumbent),
+        "incumbent_symbols": incumbent[:12],
+        "slots_open": bool(slots_open),
+        "max_n_positions": int(max_n_positions) if max_n_positions is not None else None,
+        "slots_to_fill": int(slots_to_fill) if slots_to_fill is not None else None,
+        "clip_pct": float(clip_pct) if clip_pct is not None else None,
+        "volatility_drop_pct": (
+            float(volatility_drop_pct)
+            if volatility_drop_pct is not None
+            else None
+        ),
+        "score_hysteresis_pct": (
+            float(score_hysteresis_pct)
+            if score_hysteresis_pct is not None
+            else None
+        ),
+        "max_age_ms": int(max_age_ms) if max_age_ms is not None else None,
+        "fetch_budget": int(fetch_budget) if fetch_budget is not None else None,
+        "source": str(source),
+        "feature_unavailable_count": int(feature_unavailable_count),
+        "volatility_dropped_count": int(volatility_dropped_count),
+        "hysteresis_event_count": int(hysteresis_event_count),
+        "top_scores": _forager_top_score_sample(top_scores),
+    }
+    if live_event_debug_profile_enabled(bot, "forager"):
+        data["debug"] = _forager_debug_payload(data)
+        data["debug_profile"] = "forager"
     _safe_emit(
         bot,
         EventTypes.FORAGER_SELECTION,
@@ -1962,35 +2039,7 @@ def _emit_forager_selection_event_unchecked(
         pside=str(pside),
         status=status,
         reason_code=reason_code,
-        data={
-            "candidate_count": int(candidate_count),
-            "eligible_count": int(eligible_count),
-            "selected_count": len(selected),
-            "selected_symbols": selected[:12],
-            "incumbent_count": len(incumbent),
-            "incumbent_symbols": incumbent[:12],
-            "slots_open": bool(slots_open),
-            "max_n_positions": int(max_n_positions) if max_n_positions is not None else None,
-            "slots_to_fill": int(slots_to_fill) if slots_to_fill is not None else None,
-            "clip_pct": float(clip_pct) if clip_pct is not None else None,
-            "volatility_drop_pct": (
-                float(volatility_drop_pct)
-                if volatility_drop_pct is not None
-                else None
-            ),
-            "score_hysteresis_pct": (
-                float(score_hysteresis_pct)
-                if score_hysteresis_pct is not None
-                else None
-            ),
-            "max_age_ms": int(max_age_ms) if max_age_ms is not None else None,
-            "fetch_budget": int(fetch_budget) if fetch_budget is not None else None,
-            "source": str(source),
-            "feature_unavailable_count": int(feature_unavailable_count),
-            "volatility_dropped_count": int(volatility_dropped_count),
-            "hysteresis_event_count": int(hysteresis_event_count),
-            "top_scores": _forager_top_score_sample(top_scores),
-        },
+        data=data,
     )
 
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1566,6 +1566,103 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_forager_debug_profile_adds_bounded_selection_shape():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_forager_feature_unavailable_event = (
+            pb_mod.Passivbot._emit_forager_feature_unavailable_event
+        )
+        _emit_forager_selection_event = pb_mod.Passivbot._emit_forager_selection_event
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "gateio"
+            self.user = "gateio_01"
+            self.bot_id = "bot_1"
+            self.live_event_debug_profiles = ("forager",)
+            self._live_event_current_cycle_id = "cy_forager"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+    bot._emit_forager_feature_unavailable_event(
+        pside="long",
+        symbols=["ETH/USDT:USDT", "BTC/USDT:USDT", "SOL/USDT:USDT"],
+        candidate_count=5,
+        volume_count=2,
+        log_range_count=1,
+        max_age_ms=300_000,
+        fetch_budget=2,
+    )
+    bot._emit_forager_selection_event(
+        pside="long",
+        candidate_count=5,
+        eligible_count=3,
+        selected_symbols=["BTC/USDT:USDT"],
+        slots_open=True,
+        max_n_positions=4,
+        clip_pct=0.1,
+        volatility_drop_pct=0.25,
+        max_age_ms=300_000,
+        fetch_budget=2,
+        incumbent_symbols=["ETH/USDT:USDT"],
+        slots_to_fill=1,
+        score_hysteresis_pct=0.03,
+        top_scores=[
+            {
+                "symbol": "BTC/USDT:USDT",
+                "score": 0.987654321,
+                "volume": 123456.0,
+                "log_range": 0.0123,
+            }
+        ],
+        hysteresis_event_count=1,
+        feature_unavailable_count=2,
+        volatility_dropped_count=1,
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    feature_unavailable, selection = sink.events
+    assert feature_unavailable.data["debug_profile"] == "forager"
+    assert selection.data["debug_profile"] == "forager"
+    assert feature_unavailable.data["debug"] == {
+        "data_keys": [
+            "candidate_count",
+            "fetch_budget",
+            "log_range_count",
+            "max_age_ms",
+            "unavailable",
+            "volume_count",
+        ],
+        "candidate_count": 5,
+        "fetch_budget": 2,
+        "unavailable_count": 3,
+        "unavailable_sample_count": 3,
+        "unavailable_truncated": False,
+    }
+    assert selection.data["debug"]["candidate_count"] == 5
+    assert selection.data["debug"]["eligible_count"] == 3
+    assert selection.data["debug"]["selected_count"] == 1
+    assert selection.data["debug"]["incumbent_count"] == 1
+    assert selection.data["debug"]["slots_to_fill"] == 1
+    assert selection.data["debug"]["top_scores_count"] == 1
+    assert selection.data["debug"]["top_score_keys"] == [
+        "incumbent",
+        "score",
+        "selected",
+        "symbol",
+    ]
+    assert selection.data["debug"]["slots_open"] is True
+    assert "0.987654321" not in str(selection.data["debug"])
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_candle_events_debug_profile_adds_bounded_tail_and_coverage_shape():
     import passivbot as pb_mod
 


### PR DESCRIPTION
## Summary
- implement the documented opt-in forager live-event debug profile for existing forager.selection and forager.feature_unavailable events
- add bounded count/key-shape metadata such as candidate/eligible/selected counts, unavailable sample counts, slot state, and top-score key shape
- record PR #1024 merge/deploy evidence in the logging progress ledger

## Behavior
- opt-in observability only; default forager event payloads and console output remain unchanged
- no event routing changes, selection behavior changes, exchange calls, order/risk logic, monitor writes, or trading behavior changed

## Validation
- ./venv/bin/python -m pytest tests/test_passivbot_monitor.py tests/test_live_event_bus.py -q
- ./venv/bin/python -m py_compile src/live/event_emitters.py tests/test_passivbot_monitor.py
- git diff --check
- added-line silent-handling scan over src/live/event_emitters.py and tests/test_passivbot_monitor.py