### PR TITLE
Add state live event debug profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- The `state` live-event debug profile now enriches existing state refresh
+  timing and progress events with bounded plan, pending-surface, and slowest
+  surface metadata without changing default event payloads or console output.
 - The `forager` live-event debug profile now enriches existing forager
   selection and feature-unavailable events with bounded count/key-shape
   metadata without changing default event payloads or console output.

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -68,10 +68,11 @@ Current profile behavior:
    reason/sample counts, correlation ids, and shape metadata. These summaries
    must not copy raw exchange/account payloads, credentials, or unbounded row
    data.
-3. `startup` and `state` are reserved profile names for startup/state
-   diagnostics. Startup lifecycle events already surface which profiles are
-   enabled, and live performance reports can summarize them from existing
-   monitor events.
+3. `state` adds bounded state-refresh timing/progress shape metadata such as
+   plan/pending counts, surface key lists, and slowest refreshed surface.
+4. `startup` is a reserved profile name for startup diagnostics. Startup
+   lifecycle events already surface which profiles are enabled, and live
+   performance reports can summarize them from existing monitor events.
 
 Unknown profile names should fail visibly instead of being ignored silently.
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -6352,6 +6352,32 @@ VPS5 deployment status:
   live-event debug-profile normalization test, broader live-event/monitor suite
   if review asks for it, `py_compile`, `git diff --check`, and the standard
   added-line silent-handling scan.
+- Result: PR #1025 was reviewed by Claude and Hermes, merged to `v8`, and
+  deployed to VPS5 at `7f8a1942` without restarting bots. A short post-deploy
+  smoke reported `ok=true`, `hard_failures=0`, clean tracked repository state,
+  five configured bots still running, no event-pipeline drops/sink errors, and
+  only known non-hard HSL cooldown/status attention.
+
+### Draft Slice: State Debug Profile
+
+- Branch: `codex/v8-state-debug-profile`.
+- Scope: Phase 5/6 opt-in structured debug enrichment for existing
+  `state.refresh_timing` and `state.refresh_progress` events.
+- Triggering evidence: `state` is part of the documented
+  `logging.live_event_debug_profiles` / `PASSIVBOT_LIVE_EVENT_DEBUG_PROFILES`
+  surface, but only startup events and live performance reports exposed profile
+  state. Existing state-refresh events did not add profile-specific debug shape
+  when the profile was enabled.
+- Intended result: when `state` debug is enabled, add bounded plan/pending
+  counts, surface key lists, slowest refreshed surface, and timing scalar
+  summaries to existing state refresh timing/progress events. Do not add raw
+  account payloads, exchange responses, credentials, event routes, console
+  output, refresh behavior, exchange calls, order/risk logic, monitor writes,
+  or trading behavior.
+- Expected validation: focused state debug-profile monitor test,
+  live-event debug-profile normalization test, broader live-event/monitor suite
+  if review asks for it, `py_compile`, `git diff --check`, and the standard
+  added-line silent-handling scan.
 
 ## Current Next Steps
 

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1336,6 +1336,69 @@ def _forager_debug_payload(data: dict[str, Any], *, limit: int = 32) -> dict[str
     return debug
 
 
+def _state_refresh_debug_payload(
+    data: dict[str, Any], *, limit: int = 32
+) -> dict[str, Any]:
+    debug: dict[str, Any] = {"data_keys": _mapping_key_sample(data, limit=limit)}
+    plan = data.get("plan")
+    if isinstance(plan, list):
+        debug["plan_count"] = len(plan)
+        debug["plan_sample"] = [str(item) for item in plan[:limit]]
+    pending = data.get("pending")
+    if isinstance(pending, list):
+        debug["pending_count"] = len(pending)
+        debug["pending_sample"] = [str(item) for item in pending[:limit]]
+    epoch_changed = data.get("epoch_changed")
+    if isinstance(epoch_changed, list):
+        debug["epoch_changed_count"] = len(epoch_changed)
+        debug["epoch_changed_sample"] = [str(item) for item in epoch_changed[:limit]]
+    for key in (
+        "timings_ms",
+        "completed_timings_ms",
+        "surfaces_ms",
+    ):
+        value = data.get(key)
+        if isinstance(value, dict):
+            keys = _mapping_key_sample(value, limit=limit)
+            debug[f"{key}_count"] = len(value)
+            debug[f"{key}_keys"] = keys
+            if key in {"timings_ms", "completed_timings_ms"} and value:
+                slowest_key, slowest_value = max(
+                    value.items(),
+                    key=lambda item: int(_safe_int(item[1]) or 0),
+                )
+                debug[f"{key}_slowest"] = {
+                    "surface": str(slowest_key),
+                    "elapsed_ms": max(0, int(_safe_int(slowest_value) or 0)),
+                }
+    for key in (
+        "wall_ms",
+        "surface_sum_ms",
+        "surface_max_ms",
+        "residual_ms",
+        "elapsed_ms",
+        "count",
+        "since_ms",
+    ):
+        value = _safe_int(data.get(key))
+        if value is not None:
+            debug[key] = max(0, int(value))
+    threshold = _safe_float(data.get("threshold_s"))
+    if threshold is not None:
+        debug["threshold_s"] = max(0.0, float(threshold))
+    for key in (
+        "parallel",
+        "pending_confirmations",
+        "meaningful_change",
+        "unusual_plan",
+        "repeated",
+        "summary",
+    ):
+        if key in data:
+            debug[key] = bool(data.get(key))
+    return debug
+
+
 def _emit_state_refresh_timing_event_unchecked(
     bot: Any,
     *,
@@ -1364,6 +1427,9 @@ def _emit_state_refresh_timing_event_unchecked(
         "unusual_plan": bool(unusual_plan),
         "epoch_changed": _sorted_str_list(epoch_changed or []),
     }
+    if live_event_debug_profile_enabled(bot, "state"):
+        data["debug"] = _state_refresh_debug_payload(data)
+        data["debug_profile"] = "state"
     _safe_emit(
         bot,
         EventTypes.STATE_REFRESH_TIMING,
@@ -1426,6 +1492,9 @@ def _emit_state_refresh_timing_summary_event_unchecked(
             )
         },
     }
+    if live_event_debug_profile_enabled(bot, "state"):
+        data["debug"] = _state_refresh_debug_payload(data)
+        data["debug_profile"] = "state"
     _safe_emit(
         bot,
         EventTypes.STATE_REFRESH_TIMING,
@@ -1471,6 +1540,9 @@ def _emit_state_refresh_progress_event_unchecked(
     threshold = _safe_float(threshold_s)
     if threshold is not None:
         data["threshold_s"] = max(0.0, float(threshold))
+    if live_event_debug_profile_enabled(bot, "state"):
+        data["debug"] = _state_refresh_debug_payload(data)
+        data["debug_profile"] = "state"
     _safe_emit(
         bot,
         EventTypes.STATE_REFRESH_PROGRESS,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1127,6 +1127,112 @@ def test_state_refresh_progress_event_emitter_records_payload():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_state_debug_profile_adds_bounded_refresh_shape():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _emit_state_refresh_timing_event = (
+            pb_mod.Passivbot._emit_state_refresh_timing_event
+        )
+        _emit_state_refresh_timing_summary_event = (
+            pb_mod.Passivbot._emit_state_refresh_timing_summary_event
+        )
+        _emit_state_refresh_progress_event = (
+            pb_mod.Passivbot._emit_state_refresh_progress_event
+        )
+
+        def __init__(self):
+            self.live_event_debug_profiles = ("state",)
+            self._live_event_current_cycle_id = "cy_state_debug"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+    bot._emit_state_refresh_timing_event(
+        plan={"open_orders", "balance", "positions"},
+        timings_ms={"balance": 25, "open_orders": 40, "positions": 15},
+        wall_ms=45,
+        sum_ms=80,
+        max_surface_ms=40,
+        residual_ms=5,
+        pending_confirmations=True,
+        meaningful_change=True,
+        unusual_plan=False,
+        epoch_changed={"open_orders", "balance"},
+        level="info",
+    )
+    bot._emit_state_refresh_timing_summary_event(
+        plan={"open_orders", "balance"},
+        count=3,
+        since_ms=60_000,
+        wall={"count": 3, "sum": 150, "min": 40, "max": 60},
+        surface_sum={"count": 3, "sum": 250, "min": 60, "max": 100},
+        surface_max={"count": 3, "sum": 120, "min": 30, "max": 50},
+        residual={"count": 3, "sum": 15, "min": 2, "max": 8},
+        surfaces={
+            "balance": {"count": 3, "sum": 75, "min": 20, "max": 30},
+            "open_orders": {"count": 3, "sum": 120, "min": 35, "max": 50},
+        },
+    )
+    bot._emit_state_refresh_progress_event(
+        plan={"balance", "positions", "open_orders"},
+        pending=("positions", "open_orders"),
+        elapsed_ms=12_500,
+        completed_timings_ms={"balance": 120},
+        threshold_s=10.0,
+        repeated=True,
+        level="debug",
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    timing, summary, progress = sink.events
+    assert timing.data["debug_profile"] == "state"
+    assert timing.data["debug"]["data_keys"] == [
+        "epoch_changed",
+        "meaningful_change",
+        "parallel",
+        "pending_confirmations",
+        "plan",
+        "residual_ms",
+        "surface_max_ms",
+        "surface_sum_ms",
+        "timings_ms",
+        "unusual_plan",
+        "wall_ms",
+    ]
+    assert timing.data["debug"]["plan_count"] == 3
+    assert timing.data["debug"]["timings_ms_count"] == 3
+    assert timing.data["debug"]["timings_ms_slowest"] == {
+        "surface": "open_orders",
+        "elapsed_ms": 40,
+    }
+    assert timing.data["debug"]["epoch_changed_count"] == 2
+    assert timing.data["debug"]["pending_confirmations"] is True
+    assert timing.data["debug"]["wall_ms"] == 45
+    assert summary.data["debug_profile"] == "state"
+    assert summary.data["debug"]["summary"] is True
+    assert summary.data["debug"]["surfaces_ms_count"] == 2
+    assert summary.data["debug"]["surfaces_ms_keys"] == ["balance", "open_orders"]
+    assert summary.data["debug"]["count"] == 3
+    assert progress.data["debug_profile"] == "state"
+    assert progress.data["debug"]["pending_count"] == 2
+    assert progress.data["debug"]["completed_timings_ms_count"] == 1
+    assert progress.data["debug"]["completed_timings_ms_slowest"] == {
+        "surface": "balance",
+        "elapsed_ms": 120,
+    }
+    assert progress.data["debug"]["elapsed_ms"] == 12_500
+    assert progress.data["debug"]["threshold_s"] == 10.0
+    assert progress.data["debug"]["repeated"] is True
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
     import passivbot as pb_mod
 


### PR DESCRIPTION
## Summary
- implement the documented opt-in state live-event debug profile for existing state.refresh_timing and state.refresh_progress events
- add bounded plan/pending counts, surface key lists, slowest refreshed surface, and timing scalar summaries
- update logging docs and progress ledger with PR #1025 deploy evidence

## Behavior
- opt-in observability only; default state-refresh event payloads and console output remain unchanged
- no event routing changes, refresh behavior changes, exchange calls, order/risk logic, monitor writes, or trading behavior changed

## Validation
- ./venv/bin/python -m pytest tests/test_passivbot_monitor.py tests/test_live_event_bus.py -q
- ./venv/bin/python -m py_compile src/live/event_emitters.py tests/test_passivbot_monitor.py
- git diff --check
- added-line silent-handling scan over src/live/event_emitters.py and tests/test_passivbot_monitor.py

## VPS evidence before slice
- VPS5 at 7f8a1942 before branch work: brief smoke ok=true, hard_failures=0, 5/5 bots running, no event-pipeline drops or sink errors; remaining attention was known non-hard HSL cooldown/status.