### PR TITLE
Add startup live event debug profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- The `startup` live-event debug profile now enriches existing startup timing
+  events with bounded phase, timing, and details-shape metadata without
+  changing default event payloads or console output.
 - The `state` live-event debug profile now enriches existing state refresh
   timing and progress events with bounded plan, pending-surface, and slowest
   surface metadata without changing default event payloads or console output.

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -70,9 +70,11 @@ Current profile behavior:
    data.
 3. `state` adds bounded state-refresh timing/progress shape metadata such as
    plan/pending counts, surface key lists, and slowest refreshed surface.
-4. `startup` is a reserved profile name for startup diagnostics. Startup
-   lifecycle events already surface which profiles are enabled, and live
-   performance reports can summarize them from existing monitor events.
+4. `startup` adds bounded phase/timing/details-shape metadata to existing
+   `bot.startup_timing` events. It does not duplicate raw startup details into
+   the debug block. Startup lifecycle events also surface which profiles are
+   enabled, and live performance reports can summarize them from existing
+   monitor events.
 
 Unknown profile names should fail visibly instead of being ignored silently.
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,18 +19,19 @@ Last updated: 2026-07-03.
 
 Current `origin/v8` head:
 
-- `85080299` after PR #1020, `Include bundle result in incident manifests`.
+- `2de5a6af` after PR #1026, `Add state live event debug profile`.
 
 Current logging-overhaul head:
 
-- `85080299` after PR #1020, `Include bundle result in incident manifests`.
+- `2de5a6af` after PR #1026, `Add state live event debug profile`.
 
 Current work:
 
-- Branch `codex/v8-incident-time-window-summary` adds the compact
-  `time_window` summary to `live-incident-bundle` `manifest.json`, so archived
-  bundles expose matched-event, truncation, and scan-bound evidence without
-  opening `time_window_report.json`.
+- Branch `codex/v8-startup-debug-profile` adds opt-in bounded debug shape to
+  existing `bot.startup_timing` events when the `startup` debug profile is
+  enabled. It does not change default startup timing payloads, console output,
+  event routing, startup behavior, exchange calls, order/risk logic, or monitor
+  writes.
 
 Current review gate:
 
@@ -60,6 +61,27 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1026 at `2de5a6af`.
+- PR #1026 added the opt-in `state` debug profile for existing
+  `state.refresh_timing` and `state.refresh_progress` events. It merged after
+  Claude and Hermes approved with no findings and CI was green. VPS5 checkout
+  was updated to `2de5a6af` without restarting running bots because the slice
+  was observability-only. Recent smoke reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, clean tracked repository state, zero event-pipeline
+  drops/sink errors, and only known non-hard HSL cooldown/status attention.
+- Repository pulled through PR #1025 at `7f8a1942`.
+- PR #1025 added the opt-in `forager` debug profile for existing
+  `forager.selection` and `forager.feature_unavailable` events. It merged after
+  Claude and Hermes approved with no findings and CI was green. VPS5 checkout
+  was updated to `7f8a1942` without restarting running bots. Post-deploy smoke
+  reported `ok=true`, `hard_failures=0`, clean tracked repository state, five
+  configured bots running, and no event-pipeline drops or sink errors.
+- Repository pulled through PR #1024 at `59c36ada`.
+- PR #1024 added allowlisted `risk_events.latest_data` to brief smoke output.
+  It merged after Claude and Hermes approved with no findings and CI was green.
+  VPS5 checkout was updated to `59c36ada` without restarting running bots.
+  Post-deploy smoke reported `ok=true`, `hard_failures=0`, clean tracked
+  repository state, and five configured bots still running.
 - Repository pulled through PR #1020 at `85080299`.
 - PR #1020 added a bundle-level `result` verdict to
   `live-incident-bundle` `manifest.json`, sharing the returned report's
@@ -6375,6 +6397,31 @@ VPS5 deployment status:
   output, refresh behavior, exchange calls, order/risk logic, monitor writes,
   or trading behavior.
 - Expected validation: focused state debug-profile monitor test,
+  live-event debug-profile normalization test, broader live-event/monitor suite
+  if review asks for it, `py_compile`, `git diff --check`, and the standard
+  added-line silent-handling scan.
+- Result: PR #1026 was reviewed by Claude and Hermes, merged to `v8`, and
+  deployed to VPS5 at `2de5a6af` without restarting bots. A short post-deploy
+  smoke reported `ok=true`, `hard_failures=0`, clean tracked repository state,
+  five configured bots still running, no event-pipeline drops/sink errors, and
+  only known non-hard HSL cooldown/status attention.
+
+### Draft Slice: Startup Debug Profile
+
+- Branch: `codex/v8-startup-debug-profile`.
+- Scope: Phase 5/6 opt-in structured debug enrichment for existing
+  `bot.startup_timing` events.
+- Triggering evidence: `startup` is part of the documented
+  `logging.live_event_debug_profiles` / `PASSIVBOT_LIVE_EVENT_DEBUG_PROFILES`
+  surface. Startup lifecycle events already expose enabled profiles and
+  performance reports summarize them, but the startup timing events themselves
+  did not add profile-specific debug shape when the profile was enabled.
+- Intended result: when `startup` debug is enabled, add bounded phase, timing,
+  and details-shape metadata to existing startup timing events. Do not duplicate
+  raw startup details into the debug block, and do not change default startup
+  timing payloads, console output, event routing, startup behavior, exchange
+  calls, order/risk logic, monitor writes, or trading behavior.
+- Expected validation: focused startup debug-profile monitor test,
   live-event debug-profile normalization test, broader live-event/monitor suite
   if review asks for it, `py_compile`, `git diff --check`, and the standard
   added-line silent-handling scan.

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1171,6 +1171,22 @@ def _best_effort_rust_output_order_debug_sample(
         return None
 
 
+def _startup_debug_payload(data: dict[str, Any], *, limit: int = 32) -> dict[str, Any]:
+    debug: dict[str, Any] = {"data_keys": _mapping_key_sample(data, limit=limit)}
+    phase = data.get("phase")
+    if phase is not None:
+        debug["phase"] = str(phase)
+    for key in ("elapsed_ms", "since_previous_ms"):
+        value = _safe_int(data.get(key))
+        if value is not None:
+            debug[key] = max(0, int(value))
+    if "details" in data:
+        details = str(data.get("details") or "")
+        debug["details_present"] = bool(details)
+        debug["details_len"] = len(details)
+    return debug
+
+
 def _emit_startup_timing_event_unchecked(
     bot: Any,
     *,
@@ -1190,6 +1206,9 @@ def _emit_startup_timing_event_unchecked(
     }
     if details:
         data["details"] = str(details)
+    if live_event_debug_profile_enabled(bot, "startup"):
+        data["debug_profile"] = "startup"
+        data["debug"] = _startup_debug_payload(data)
     _safe_emit(
         bot,
         EventTypes.BOT_STARTUP_TIMING,

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -211,6 +211,58 @@ def test_startup_timing_mark_emits_structured_event(monkeypatch, caplog):
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_startup_timing_debug_profile_adds_bounded_phase_shape(
+    monkeypatch,
+):
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+    clock_values = iter([1_000, 3_500])
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: next(clock_values))
+
+    class FakeBot:
+        _startup_timing_begin = pb_mod.Passivbot._startup_timing_begin
+        _startup_timing_mark = pb_mod.Passivbot._startup_timing_mark
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "gateio"
+            self.user = "gateio_01"
+            self.bot_id = "bot_1"
+            self.live_event_debug_profiles = ("startup",)
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+    bot._startup_timing_begin()
+    bot._startup_timing_mark("account", details="api_key=SECRET mode=coin")
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[0]
+    assert event.event_type == EventTypes.BOT_STARTUP_TIMING
+    assert event.data["debug_profile"] == "startup"
+    assert event.data["details"] == "api_key=SECRET mode=coin"
+    assert event.data["debug"] == {
+        "data_keys": [
+            "debug_profile",
+            "details",
+            "elapsed_ms",
+            "phase",
+            "since_previous_ms",
+        ],
+        "phase": "account",
+        "elapsed_ms": 2500,
+        "since_previous_ms": 2500,
+        "details_present": True,
+        "details_len": len("api_key=SECRET mode=coin"),
+    }
+    assert "SECRET" not in str(event.data["debug"])
+    assert "api_key" not in str(event.data["debug"])
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_startup_timing_mark_suppresses_legacy_log_when_event_console_active(
     monkeypatch,
     caplog,


### PR DESCRIPTION
## Summary

Adds opt-in `startup` debug-profile enrichment to existing `bot.startup_timing` live events.

When `logging.live_event_debug_profiles` / `PASSIVBOT_LIVE_EVENT_DEBUG_PROFILES` includes `startup`, startup timing events now include bounded debug shape:

- `debug_profile="startup"`
- phase/timing scalars
- `data_keys`
- `details_present` / `details_len`

The debug block deliberately does not duplicate raw startup `details` text. Default startup timing event payloads and console output are unchanged when the profile is not enabled.

Also updates the logging guide, changelog, and progress ledger to reflect the current logging-loop state through PR #1026.

## Behavior Boundary

Observability-only. No changes to startup behavior, exchange calls, event routing, console routing, order/risk logic, monitor writes, or trading behavior.

## Validation

- `./venv/bin/python -m pytest tests/test_passivbot_monitor.py::test_startup_timing_debug_profile_adds_bounded_phase_shape tests/test_passivbot_monitor.py::test_startup_timing_mark_emits_structured_event tests/test_live_event_bus.py::test_live_event_debug_profiles_normalize_and_validate -q`
- `./venv/bin/python -m pytest tests/test_passivbot_monitor.py tests/test_live_event_bus.py -q`
- `./venv/bin/python -m py_compile src/live/event_emitters.py tests/test_passivbot_monitor.py`
- `git diff --check`
- Added-line silent-handling scan over touched source/test files: no matches
