### PR TITLE
Add live event query debug profile filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-event-query` now supports `--debug-profile`, a
+  first-class filter for events whose structured data has a matching
+  `debug_profile` value.
 - The `startup` live-event debug profile now enriches existing startup timing
   events with bounded phase, timing, and details-shape metadata without
   changing default event payloads or console output.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,20 @@ Last updated: 2026-07-03.
 
 Current `origin/v8` head:
 
-- `2de5a6af` after PR #1026, `Add state live event debug profile`.
+- `9c555384` after PR #1027, `Add startup live event debug profile`.
 
 Current logging-overhaul head:
 
-- `2de5a6af` after PR #1026, `Add state live event debug profile`.
+- `9c555384` after PR #1027, `Add startup live event debug profile`.
 
 Current work:
 
-- Branch `codex/v8-startup-debug-profile` adds opt-in bounded debug shape to
-  existing `bot.startup_timing` events when the `startup` debug profile is
-  enabled. It does not change default startup timing payloads, console output,
-  event routing, startup behavior, exchange calls, order/risk logic, or monitor
-  writes.
+- Branch `codex/v8-event-query-debug-profile` adds a read-only
+  `live-event-query --debug-profile` filter so operators can query the now
+  complete debug-profile event surface without spelling it as a generic
+  `--data-eq debug_profile=...` predicate. It does not add event producers,
+  exchange calls, monitor writes, console routing, startup behavior, order/risk
+  logic, or trading behavior.
 
 Current review gate:
 
@@ -61,6 +62,15 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1027 at `9c555384`.
+- PR #1027 added the opt-in `startup` debug profile for existing
+  `bot.startup_timing` events. It merged after Claude and Hermes approved with
+  no findings and CI was green. VPS5 checkout was updated to `9c555384`
+  without restarting running bots because default startup behavior and console
+  output are unchanged. Post-deploy smoke reported `ok=true`,
+  `hard_failures=0`, `matched_expected=5`, clean tracked repository state,
+  zero event-pipeline drops/sink errors, and only known non-hard HSL
+  cooldown/status attention.
 - Repository pulled through PR #1026 at `2de5a6af`.
 - PR #1026 added the opt-in `state` debug profile for existing
   `state.refresh_timing` and `state.refresh_progress` events. It merged after
@@ -6425,6 +6435,29 @@ VPS5 deployment status:
   live-event debug-profile normalization test, broader live-event/monitor suite
   if review asks for it, `py_compile`, `git diff --check`, and the standard
   added-line silent-handling scan.
+- Result: PR #1027 was reviewed by Claude and Hermes, merged to `v8`, and
+  deployed to VPS5 at `9c555384` without restarting bots. A short post-deploy
+  smoke reported `ok=true`, `hard_failures=0`, clean tracked repository state,
+  five configured bots still running, no event-pipeline drops/sink errors, and
+  only known non-hard HSL cooldown/status attention.
+
+### Draft Slice: Event Query Debug Profile Filter
+
+- Branch: `codex/v8-event-query-debug-profile`.
+- Scope: read-only operator tooling for the completed live-event debug-profile
+  surface.
+- Triggering evidence: the documented debug-profile event surface is now
+  complete, but querying those events requires remembering the generic
+  `--data-eq debug_profile=...` predicate. A first-class filter reduces
+  operator friction during incident reconstruction.
+- Intended result: add `passivbot tool live-event-query --debug-profile` as a
+  shortcut for matching `event.data.debug_profile`, with query metadata
+  reporting the selected profile names. Keep existing `--data-eq` behavior
+  unchanged. Do not add event producers, exchange calls, monitor writes, console
+  routing, startup behavior, order/risk logic, or trading behavior.
+- Expected validation: focused API and CLI live-event-query tests, full
+  `tests/test_live_event_query.py`, `py_compile`, `git diff --check`, and the
+  standard added-line silent-handling scan.
 
 ## Current Next Steps
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -149,8 +149,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   local replay inputs.
 - `passivbot tool live-event-query` validates and queries local structured monitor event
   segments. It is read-only and does not contact exchanges. Use `--event-type`,
-  `--level`, `--cycle-id`, ID filters, `--symbol`, `--pside`, `--tag`, `--data-eq`, and
-  time-window filters to reconstruct incident slices. Use `--exchange EXCHANGE` and
+  `--level`, `--cycle-id`, ID filters, `--symbol`, `--pside`, `--tag`,
+  `--debug-profile`, `--data-eq`, and time-window filters to reconstruct
+  incident slices. Use `--exchange EXCHANGE` and
   `--user USER` to focus one monitor account and prune unrelated monitor paths before
   scanning; `--bot-id` remains available for event-envelope bot IDs. Directory scans
   read `current.ndjson` by default; add `--include-rotated` for complete history

--- a/src/live/event_query.py
+++ b/src/live/event_query.py
@@ -393,6 +393,7 @@ def _filter_report(
     sources: set[str],
     components: set[str],
     tags: set[str],
+    debug_profiles: set[str],
     data_eq_filters: dict[str, set[str]],
     problem_events: bool,
     hard_problem_events: bool,
@@ -444,6 +445,8 @@ def _filter_report(
         filters["components"] = sorted(components)
     if tags:
         filters["tags"] = sorted(tags)
+    if debug_profiles:
+        filters["debug_profiles"] = sorted(debug_profiles)
     if data_eq_filters:
         filters["data_eq"] = {
             key: sorted(values) for key, values in sorted(data_eq_filters.items())
@@ -477,6 +480,7 @@ def build_event_query_filters(
     source: str | Iterable[str] | None = None,
     component: str | Iterable[str] | None = None,
     tag: str | Iterable[str] | None = None,
+    debug_profile: str | Iterable[str] | None = None,
     data_eq: str | Iterable[str] | None = None,
     problem_events: bool = False,
     hard_problem_events: bool = False,
@@ -491,6 +495,7 @@ def build_event_query_filters(
         and since_filter > until_filter
     ):
         raise ValueError("since_ms must be <= until_ms")
+    debug_profiles = _normalize_filter_values(debug_profile)
     return {
         "cycle_id": str(cycle_id) if cycle_id is not None else None,
         "event_types": _normalize_filter_values(event_type),
@@ -512,6 +517,7 @@ def build_event_query_filters(
         "sources": _normalize_filter_values(source),
         "components": _normalize_filter_values(component),
         "tags": _normalize_filter_values(tag),
+        "debug_profiles": debug_profiles,
         "data_eq_filters": _normalize_data_eq_filters(data_eq),
         "problem_events": bool(problem_events),
         "hard_problem_events": bool(hard_problem_events),
@@ -542,6 +548,7 @@ def event_query_filter_report(filters: dict[str, Any]) -> dict[str, Any]:
         sources=filters["sources"],
         components=filters["components"],
         tags=filters["tags"],
+        debug_profiles=filters["debug_profiles"],
         data_eq_filters=filters["data_eq_filters"],
         problem_events=bool(filters["problem_events"]),
         hard_problem_events=bool(filters["hard_problem_events"]),
@@ -568,6 +575,9 @@ def event_matches_query_filters(
     record_source = live_event.get("source")
     record_component = live_event.get("component")
     record_tags = _event_tags(row, live_event)
+    record_data = (
+        live_event.get("data") if isinstance(live_event.get("data"), dict) else {}
+    )
     path_scope = _monitor_path_exchange_user(path)
     record_exchange = live_event.get("exchange") or row.get("exchange")
     record_user = live_event.get("user") or row.get("user")
@@ -620,6 +630,10 @@ def event_matches_query_filters(
     if not _filter_matches(record_component, filters["components"]):
         return False
     if filters["tags"] and not set(record_tags).intersection(filters["tags"]):
+        return False
+    if not _filter_matches(
+        record_data.get("debug_profile"), filters["debug_profiles"]
+    ):
         return False
     if not _data_filters_match(live_event, filters["data_eq_filters"]):
         return False
@@ -1312,6 +1326,7 @@ def build_event_report(
     component: str | Iterable[str] | None = None,
     tag: str | Iterable[str] | None = None,
     data_eq: str | Iterable[str] | None = None,
+    debug_profile: str | Iterable[str] | None = None,
     problem_events: bool = False,
     hard_problem_events: bool = False,
     since_ms: int | None = None,
@@ -1348,6 +1363,7 @@ def build_event_report(
         component=component,
         tag=tag,
         data_eq=data_eq,
+        debug_profile=debug_profile,
         problem_events=problem_events,
         hard_problem_events=hard_problem_events,
         since_ms=since_ms,
@@ -1455,6 +1471,7 @@ def build_event_report(
     source_filter = query_filters["sources"]
     component_filter = query_filters["components"]
     tag_filter = query_filters["tags"]
+    debug_profile_filter = query_filters["debug_profiles"]
     data_eq_filters = query_filters["data_eq_filters"]
     problem_event_filter = bool(query_filters["problem_events"])
     hard_problem_event_filter = bool(query_filters["hard_problem_events"])
@@ -1479,6 +1496,7 @@ def build_event_report(
             source_filter,
             component_filter,
             tag_filter,
+            debug_profile_filter,
             data_eq_filters,
             problem_event_filter,
             hard_problem_event_filter,
@@ -1764,6 +1782,7 @@ def build_event_report(
             components=component_filter,
             tags=tag_filter,
             data_eq_filters=data_eq_filters,
+            debug_profiles=debug_profile_filter,
             problem_events=problem_event_filter,
             hard_problem_events=hard_problem_event_filter,
             since_ms=since_filter,
@@ -1808,6 +1827,7 @@ def build_event_report(
             components=component_filter,
             tags=tag_filter,
             data_eq_filters=data_eq_filters,
+            debug_profiles=debug_profile_filter,
             problem_events=problem_event_filter,
             hard_problem_events=hard_problem_event_filter,
             since_ms=since_filter,

--- a/src/tools/live_event_query.py
+++ b/src/tools/live_event_query.py
@@ -173,6 +173,14 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--debug-profile",
+        action="append",
+        help=(
+            "Return compact records whose event data has debug_profile=VALUE. "
+            "May be repeated or comma-separated."
+        ),
+    )
+    parser.add_argument(
         "--data-eq",
         action="append",
         help=(
@@ -330,6 +338,7 @@ def main(argv: list[str] | None = None) -> int:
             source=args.source,
             component=args.component,
             tag=args.tag,
+            debug_profile=args.debug_profile,
             data_eq=args.data_eq,
             problem_events=bool(args.problem_events),
             hard_problem_events=bool(args.hard_problem_events),

--- a/tests/test_live_event_query.py
+++ b/tests/test_live_event_query.py
@@ -856,6 +856,48 @@ def test_event_query_filters_by_top_level_data_fields(tmp_path):
     assert event["data"]["stop_event_anchor_source"] == "current_time_fallback"
 
 
+def test_event_query_filters_by_debug_profile(tmp_path):
+    events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.startup_timing",
+                cycle_id="cy_1",
+                seq=1,
+                ts=1000,
+                data={"debug_profile": "startup", "phase": "hsl"},
+            ),
+            _monitor_row(
+                event_type="state.refresh_timing",
+                cycle_id="cy_2",
+                seq=2,
+                ts=1100,
+                data={"debug_profile": "state", "plan": ["positions"]},
+            ),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                cycle_id="cy_3",
+                seq=3,
+                ts=1200,
+                data={"phase": "market"},
+            ),
+        ],
+    )
+
+    report = build_event_report(
+        tmp_path / "monitor",
+        debug_profile="startup",
+        include_data=True,
+    )
+
+    assert report["ok"] is True
+    assert report["query"]["filters"] == {"debug_profiles": ["startup"]}
+    assert report["query"]["matched_events"] == 1
+    assert report["query"]["events"][0]["event_type"] == "bot.startup_timing"
+    assert report["query"]["events"][0]["data"]["debug_profile"] == "startup"
+
+
 def test_event_query_rejects_malformed_data_eq_filter(tmp_path):
     with pytest.raises(ValueError, match="key=value"):
         build_event_report(tmp_path, data_eq="missing_equals")
@@ -2142,6 +2184,46 @@ def test_live_event_query_cli_accepts_data_eq_filter(tmp_path, capsys):
     assert report["query"]["events"][0]["data"]["stop_event_anchor_source"] == (
         "current_time_fallback"
     )
+
+
+def test_live_event_query_cli_accepts_debug_profile_filter(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.startup_timing",
+                cycle_id="cy_1",
+                seq=1,
+                ts=1000,
+                data={"debug_profile": "startup", "phase": "hsl"},
+            ),
+            _monitor_row(
+                event_type="state.refresh_timing",
+                cycle_id="cy_2",
+                seq=2,
+                ts=1100,
+                data={"debug_profile": "state", "plan": ["positions"]},
+            ),
+        ],
+    )
+
+    assert (
+        live_event_query.main(
+            [
+                str(tmp_path / "monitor"),
+                "--debug-profile",
+                "startup",
+                "--include-data",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["query"]["filters"] == {"debug_profiles": ["startup"]}
+    assert report["query"]["matched_events"] == 1
+    assert report["query"]["events"][0]["data"]["debug_profile"] == "startup"
 
 
 def test_live_event_query_cli_rejects_malformed_data_eq_filter(tmp_path, capsys):


### PR DESCRIPTION
## Summary

Adds a read-only `passivbot tool live-event-query --debug-profile PROFILE` filter.

This is a first-class shortcut for querying structured events whose `event.data.debug_profile` matches the given profile, useful now that the live-event debug-profile surface is complete. Existing `--data-eq debug_profile=...` behavior remains unchanged.

Also updates docs/changelog and the logging-overhaul progress ledger through PR #1027.

## Behavior Boundary

Read-only tooling/docs only. No event producers, exchange calls, monitor writes, console routing, startup behavior, order/risk logic, or trading behavior changed.

## Validation

- `./venv/bin/python -m pytest tests/test_live_event_query.py::test_event_query_filters_by_debug_profile tests/test_live_event_query.py::test_live_event_query_cli_accepts_debug_profile_filter tests/test_live_event_query.py::test_live_event_query_cli_accepts_data_eq_filter -q`
- `./venv/bin/python -m pytest tests/test_live_event_query.py -q`
- `./venv/bin/python -m py_compile src/live/event_query.py src/tools/live_event_query.py tests/test_live_event_query.py`
- `git diff --check`
- Added-line silent-handling scan over touched source/test files: no matches
