### PR TITLE
Add performance report debug profile filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-performance-report` now supports `--debug-profile`, so
+  performance summaries can be scoped to events enriched by one live-event
+  debug profile.
 - `passivbot tool live-incident-bundle` now supports `--debug-profile`, passing
   the first-class debug-profile filter through its embedded event, problem-event,
   and time-window reports plus the bundle manifest.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,19 @@ Last updated: 2026-07-03.
 
 Current `origin/v8` head:
 
-- `87754dc2` after PR #1028, `Add live event query debug profile filter`.
+- `65a01d27` after PR #1029, `Add incident bundle debug profile filter`.
 
 Current logging-overhaul head:
 
-- `87754dc2` after PR #1028, `Add live event query debug profile filter`.
+- `65a01d27` after PR #1029, `Add incident bundle debug profile filter`.
 
 Current work:
 
-- Branch `codex/v8-incident-debug-profile-filter` extends the same read-only
-  `--debug-profile` query shortcut to `live-incident-bundle`, passing the filter
-  through embedded event, problem-event, and time-window reports plus manifest
-  metadata. It does not add event producers, exchange calls, monitor writes,
-  console routing, startup behavior, order/risk logic, or trading behavior.
+- Branch `codex/v8-performance-debug-profile-filter` extends the first-class
+  `--debug-profile` filter to `live-performance-report`, allowing timing and
+  readiness summaries to be scoped to events enriched by one debug profile. It
+  does not add event producers, exchange calls, monitor writes, console routing,
+  startup behavior, order/risk logic, or trading behavior.
 
 Current review gate:
 
@@ -61,6 +61,22 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1029 at `65a01d27`.
+- PR #1029 added `live-incident-bundle --debug-profile` and passed the filter
+  through embedded event, problem-event, and time-window reports plus manifest
+  metadata. It merged after Claude and Hermes approved with no findings and CI
+  was green; Cursor did not post before the degraded low-risk tooling gate was
+  used. VPS5 checkout was updated to `65a01d27` without restarting running bots
+  because the slice was read-only tooling. Post-deploy smoke reported `ok=true`,
+  `hard_failures=0`, `matched_expected=5`, clean tracked repository state,
+  zero hard log/problem/process failures, and only known non-hard HSL
+  cooldown/status attention.
+- Repository pulled through PR #1028 at `87754dc2`.
+- PR #1028 added the read-only `live-event-query --debug-profile` filter. It
+  merged after Claude and Hermes approved with no findings and CI was green.
+  VPS5 checkout was updated to `87754dc2` without restarting running bots
+  because the slice was read-only tooling. Smoke stayed hard-green with all five
+  configured bots running and only known non-hard HSL cooldown/status attention.
 - Repository pulled through PR #1027 at `9c555384`.
 - PR #1027 added the opt-in `startup` debug profile for existing
   `bot.startup_timing` events. It merged after Claude and Hermes approved with
@@ -6473,6 +6489,23 @@ VPS5 deployment status:
 - Expected validation: focused incident-bundle CLI/API test, full
   `tests/test_live_incident_bundle.py`, `py_compile`, `git diff --check`, and
   the standard added-line silent-handling scan.
+
+### Draft Slice: Performance Report Debug Profile Filter
+
+- Branch: `codex/v8-performance-debug-profile-filter`.
+- Scope: read-only performance-report tooling.
+- Triggering evidence: `live-event-query` and `live-incident-bundle` can now
+  scope reports to one debug profile, but `live-performance-report` still
+  aggregates all events for timing/readiness summaries even when an operator is
+  investigating one enriched profile.
+- Intended result: add `passivbot tool live-performance-report --debug-profile`
+  and filter events at the same scan boundary as bot/exchange/user filters,
+  recording the selected profiles and skipped-event count in report metadata.
+  Do not add event producers, exchange calls, monitor writes, console routing,
+  startup behavior, order/risk logic, or trading behavior.
+- Expected validation: focused performance-report CLI filter test, full
+  `tests/test_live_performance_report.py`, `py_compile`, `git diff --check`,
+  and the standard added-line silent-handling scan.
 
 ## Current Next Steps
 

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -323,6 +323,7 @@ def _matches_filters(
     bot_filters: set[str],
     exchange_filters: set[str],
     user_filters: set[str],
+    debug_profile_filters: set[str],
 ) -> bool:
     if bot_filters and _bot_key(row, live_event) not in bot_filters:
         return False
@@ -331,6 +332,10 @@ def _matches_filters(
         return False
     user = str(live_event.get("user") or row.get("user") or "")
     if user_filters and user not in user_filters:
+        return False
+    data = live_event.get("data") if isinstance(live_event.get("data"), dict) else {}
+    debug_profile = str(data.get("debug_profile") or "")
+    if debug_profile_filters and debug_profile not in debug_profile_filters:
         return False
     return True
 
@@ -3577,6 +3582,7 @@ def build_live_performance_report(
     bot_filters: list[str] | tuple[str, ...] | set[str] | None = None,
     exchange_filters: list[str] | tuple[str, ...] | set[str] | None = None,
     user_filters: list[str] | tuple[str, ...] | set[str] | None = None,
+    debug_profile_filters: list[str] | tuple[str, ...] | set[str] | None = None,
 ) -> dict[str, Any]:
     since_filter = int(since_ms) if since_ms is not None else None
     until_filter = int(until_ms) if until_ms is not None else None
@@ -3637,11 +3643,18 @@ def build_live_performance_report(
     bot_filter_set = _string_filter(bot_filters)
     exchange_filter_set = _string_filter(exchange_filters)
     user_filter_set = _string_filter(user_filters)
+    debug_profile_filter_set = _string_filter(debug_profile_filters)
     filters = {
-        "enabled": bool(bot_filter_set or exchange_filter_set or user_filter_set),
+        "enabled": bool(
+            bot_filter_set
+            or exchange_filter_set
+            or user_filter_set
+            or debug_profile_filter_set
+        ),
         "bots": sorted(bot_filter_set),
         "exchanges": sorted(exchange_filter_set),
         "users": sorted(user_filter_set),
+        "debug_profiles": sorted(debug_profile_filter_set),
         "events_skipped": 0,
     }
     issues: list[dict[str, Any]] = []
@@ -3758,6 +3771,7 @@ def build_live_performance_report(
             bot_filters=bot_filter_set,
             exchange_filters=exchange_filter_set,
             user_filters=user_filter_set,
+            debug_profile_filters=debug_profile_filter_set,
         ):
             filters["events_skipped"] += 1
             return

--- a/src/tools/live_performance_report.py
+++ b/src/tools/live_performance_report.py
@@ -112,6 +112,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Only include one user/account name. May be repeated.",
     )
     parser.add_argument(
+        "--debug-profile",
+        action="append",
+        default=[],
+        help=(
+            "Only include events whose data has debug_profile=VALUE. "
+            "May be repeated."
+        ),
+    )
+    parser.add_argument(
         "--summary",
         action="store_true",
         help="Emit a bounded operator summary instead of the full report.",
@@ -167,6 +176,7 @@ def main(argv: list[str] | None = None) -> int:
         bot_filters=args.bot,
         exchange_filters=args.exchange,
         user_filters=args.user,
+        debug_profile_filters=args.debug_profile,
     )
     if args.summary:
         report = summarize_live_performance_report(report, group_limit=int(args.group_limit))

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -274,7 +274,7 @@ def test_live_performance_report_filters_by_bot_exchange_and_user(tmp_path):
                 ts=1000,
                 exchange="binance",
                 user="binance_01",
-                data={"elapsed_ms": 1000},
+                data={"elapsed_ms": 1000, "debug_profile": "state"},
             ),
             _monitor_row(
                 event_type="cycle.completed",
@@ -282,7 +282,7 @@ def test_live_performance_report_filters_by_bot_exchange_and_user(tmp_path):
                 ts=2000,
                 exchange="okx",
                 user="okx_faisal",
-                data={"elapsed_ms": 2000},
+                data={"elapsed_ms": 2000, "debug_profile": "startup"},
             ),
             _monitor_row(
                 event_type="cycle.completed",
@@ -306,6 +306,7 @@ def test_live_performance_report_filters_by_bot_exchange_and_user(tmp_path):
         "bots": ["okx/okx_faisal"],
         "exchanges": [],
         "users": [],
+        "debug_profiles": [],
         "events_skipped": 2,
     }
     assert report["bots"] == [{"bot": "okx/okx_faisal", "events": 1}]
@@ -3106,7 +3107,7 @@ def test_live_performance_report_cli_summary_and_filters(tmp_path, capsys):
                 ts=1000,
                 exchange="binance",
                 user="binance_01",
-                data={"elapsed_ms": 1000},
+                data={"elapsed_ms": 1000, "debug_profile": "state"},
             ),
             _monitor_row(
                 event_type="cycle.completed",
@@ -3114,7 +3115,7 @@ def test_live_performance_report_cli_summary_and_filters(tmp_path, capsys):
                 ts=2000,
                 exchange="okx",
                 user="okx_faisal",
-                data={"elapsed_ms": 2000},
+                data={"elapsed_ms": 2000, "debug_profile": "startup"},
             ),
         ],
     )
@@ -3126,6 +3127,8 @@ def test_live_performance_report_cli_summary_and_filters(tmp_path, capsys):
             "--compact",
             "--exchange",
             "okx",
+            "--debug-profile",
+            "startup",
             "--group-limit",
             "1",
         ]
@@ -3143,6 +3146,7 @@ def test_live_performance_report_cli_summary_and_filters(tmp_path, capsys):
         "scope_pruned": 0,
     }
     assert out["filters"]["exchanges"] == ["okx"]
+    assert out["filters"]["debug_profiles"] == ["startup"]
     assert out["filters"]["events_skipped"] == 1
     assert len(out["performance"]["groups"]) == 1
     assert "files" not in out


### PR DESCRIPTION
## Summary
- add passivbot tool live-performance-report --debug-profile
- filter performance-report events at the existing bot/exchange/user scan boundary
- include selected debug profiles in report filter metadata and skipped-event counts
- update changelog and logging progress ledger, including PR #1029 deploy evidence

## Scope
Read-only performance-report/operator tooling. No event producers, exchange calls, monitor writes, console routing, startup behavior, order/risk logic, or trading behavior changed.

## Validation
- ./venv/bin/python -m pytest tests/test_live_performance_report.py::test_live_performance_report_cli_summary_and_filters -q
- ./venv/bin/python -m pytest tests/test_live_performance_report.py -q
- ./venv/bin/python -m py_compile src/live/performance_report.py src/tools/live_performance_report.py tests/test_live_performance_report.py
- git diff --check
- added-line silent-handling scan over touched code/tests: no matches