### PR TITLE
Add performance report to incident bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-incident-bundle --performance-report` now embeds an
+  opt-in `live-performance-report` artifact and compact manifest summary using
+  compatible bundle time, bot/exchange/user, debug-profile, and event-file
+  bounds.
 - `passivbot tool live-performance-report` now supports `--debug-profile`, so
   performance summaries can be scoped to events enriched by one live-event
   debug profile.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,20 @@ Last updated: 2026-07-03.
 
 Current `origin/v8` head:
 
-- `65a01d27` after PR #1029, `Add incident bundle debug profile filter`.
+- `a5faeaa8` after PR #1030, `Add performance report debug profile filter`.
 
 Current logging-overhaul head:
 
-- `65a01d27` after PR #1029, `Add incident bundle debug profile filter`.
+- `a5faeaa8` after PR #1030, `Add performance report debug profile filter`.
 
 Current work:
 
-- Branch `codex/v8-performance-debug-profile-filter` extends the first-class
-  `--debug-profile` filter to `live-performance-report`, allowing timing and
-  readiness summaries to be scoped to events enriched by one debug profile. It
-  does not add event producers, exchange calls, monitor writes, console routing,
-  startup behavior, order/risk logic, or trading behavior.
+- Branch `codex/v8-incident-performance-report` adds an opt-in
+  `live-incident-bundle --performance-report` artifact, embedding the existing
+  read-only performance report and compact summary into incident bundles using
+  compatible bundle bounds. It does not add event producers, exchange calls,
+  monitor writes, console routing, startup behavior, order/risk logic, or
+  trading behavior.
 
 Current review gate:
 
@@ -61,6 +62,17 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1030 at `a5faeaa8`.
+- PR #1030 added `live-performance-report --debug-profile`, letting
+  performance summaries scope to events enriched by one live-event debug
+  profile. It merged after Claude approval, green CI, and repeated absent
+  Hermes/Cursor polling under the degraded low-risk tooling gate; Hermes later
+  approved the merged SHA with no findings. VPS5 checkout was updated to
+  `a5faeaa8` without restarting running bots because the slice was read-only
+  tooling. Post-deploy smoke reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, clean tracked repository state, zero hard
+  log/problem/process failures, and only known non-hard HSL cooldown/status
+  attention.
 - Repository pulled through PR #1029 at `65a01d27`.
 - PR #1029 added `live-incident-bundle --debug-profile` and passed the filter
   through embedded event, problem-event, and time-window reports plus manifest
@@ -6506,6 +6518,26 @@ VPS5 deployment status:
 - Expected validation: focused performance-report CLI filter test, full
   `tests/test_live_performance_report.py`, `py_compile`, `git diff --check`,
   and the standard added-line silent-handling scan.
+
+### Draft Slice: Incident Bundle Performance Report Artifact
+
+- Branch: `codex/v8-incident-performance-report`.
+- Scope: read-only incident-bundle/performance-report tooling.
+- Triggering evidence: performance reports now expose startup, HSL replay,
+  readiness, operation duration, and debug-profile scoped timing summaries, but
+  incident bundles do not yet package that artifact with the rest of the local
+  evidence.
+- Intended result: add opt-in
+  `passivbot tool live-incident-bundle --performance-report`, writing a
+  `performance_report.json` artifact and compact manifest/command summary using
+  compatible bundle bounds: time window, include-rotated, event-tail lines,
+  max-event-files-per-bot, bot/exchange/user, and debug-profile. Keep it opt-in
+  to avoid extra default scan work. Do not add event producers, exchange calls,
+  monitor writes, console routing, startup behavior, order/risk logic, or
+  trading behavior.
+- Expected validation: focused incident-bundle API/CLI tests, full
+  `tests/test_live_incident_bundle.py`, `py_compile`, `git diff --check`, and
+  the standard added-line silent-handling scan.
 
 ## Current Next Steps
 

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -25,6 +25,10 @@ from live.event_query import (
     event_matches_query_filters,
     event_query_filter_report,
 )
+from live.performance_report import (
+    build_live_performance_report,
+    summarize_live_performance_report,
+)
 from live.restart_smoke_plan import (
     DEFAULT_SMOKE_EVENT_TAIL_LINES as DEFAULT_RESTART_SMOKE_EVENT_TAIL_LINES,
     DEFAULT_SMOKE_LOG_TAIL_LINES as DEFAULT_RESTART_SMOKE_LOG_TAIL_LINES,
@@ -1051,6 +1055,7 @@ def build_live_incident_bundle(
     include_data: bool = False,
     include_trace_report: bool = True,
     include_problem_report: bool = True,
+    include_performance_report: bool = False,
     include_rotated: bool = False,
     include_event_segments: bool = True,
     max_events: int = 500,
@@ -1229,6 +1234,26 @@ def build_live_incident_bundle(
     smoke_data_plane_summaries = _smoke_data_plane_result_summaries(
         smoke_brief_summary
     )
+    performance_report: dict[str, Any] | None = None
+    performance_report_summary: dict[str, Any] | None = None
+    if include_performance_report:
+        performance_report = build_live_performance_report(
+            monitor_path,
+            since_ms=since_ms,
+            until_ms=until_ms,
+            include_rotated=include_rotated,
+            event_tail_lines=event_tail_lines,
+            max_event_files_per_bot=max_event_files_per_bot,
+            group_limit=max_events,
+            bot_filters=bot_id,
+            exchange_filters=exchange,
+            user_filters=user,
+            debug_profile_filters=debug_profile,
+        )
+        performance_report_summary = summarize_live_performance_report(
+            performance_report,
+            group_limit=max_events,
+        )
     hard_failures = _bundle_hard_failure_count(
         smoke_report=smoke_report,
         event_report=event_report,
@@ -1326,6 +1351,7 @@ def build_live_incident_bundle(
                     "include_data": include_data,
                     "include_trace_report": include_trace_report,
                     "include_problem_report": include_problem_report,
+                    "include_performance_report": include_performance_report,
                     "include_processes": include_processes,
                     "supervisor_config": str(supervisor_config)
                     if supervisor_config is not None
@@ -1360,6 +1386,8 @@ def build_live_incident_bundle(
                 **smoke_data_plane_summaries,
             },
         }
+        if performance_report_summary is not None:
+            metadata["performance_report"] = performance_report_summary
         if restart_smoke_plan_summary is not None:
             metadata["restart_smoke_plan"] = _restart_smoke_plan_result_summary(
                 restart_smoke_plan_summary
@@ -1371,6 +1399,8 @@ def build_live_incident_bundle(
             _write_json(bundle_root / "problem_event_report.json", problem_report)
         _write_json(bundle_root / "time_window_report.json", window_report)
         _write_json(bundle_root / "smoke_report.json", embedded_smoke_report)
+        if performance_report is not None:
+            _write_json(bundle_root / "performance_report.json", performance_report)
         if restart_smoke_plan is not None:
             _write_json(bundle_root / "restart_smoke_plan.json", restart_smoke_plan)
         timeline_lines: list[str] = []
@@ -1421,6 +1451,7 @@ def build_live_incident_bundle(
         "restart_smoke_plan": _restart_smoke_plan_result_summary(
             restart_smoke_plan_summary
         ),
+        "performance_report": performance_report_summary,
         "config_hashes": len(config_hashes),
         "monitor_snapshots": len(metadata["monitor_snapshots"]),
         "event_segments": {

--- a/src/tools/live_incident_bundle.py
+++ b/src/tools/live_incident_bundle.py
@@ -219,6 +219,15 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--performance-report",
+        action="store_true",
+        help=(
+            "Embed a read-only live-performance-report JSON artifact and compact "
+            "summary using the bundle's compatible time, bot/exchange/user, "
+            "debug-profile, rotated, tail-line, and per-bot file bounds."
+        ),
+    )
+    parser.add_argument(
         "--include-rotated",
         action="store_true",
         help="Also scan rotated/compressed monitor event segments.",
@@ -379,6 +388,7 @@ def main(argv: list[str] | None = None) -> int:
             include_data=bool(args.include_data),
             include_trace_report=not bool(args.no_trace_report),
             include_problem_report=not bool(args.no_problem_report),
+            include_performance_report=bool(args.performance_report),
             include_rotated=bool(args.include_rotated),
             event_tail_lines=int(args.event_tail_lines),
             max_event_files_per_bot=int(args.max_event_files_per_bot),

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -394,6 +394,7 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         since_ms=1500,
         until_ms=2500,
         include_data=False,
+        include_performance_report=True,
         max_event_segment_bytes=100_000,
         cwd=tmp_path,
     )
@@ -424,6 +425,16 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         "scope_pruned": 0,
     }
     assert report["time_window"]["matched_events"] == 11
+    assert report["performance_report"]["ok"] is True
+    assert report["performance_report"]["event_window"] == {
+        "enabled": True,
+        "since_ms": 1500,
+        "until_ms": 2500,
+        "events_considered": 11,
+        "events_skipped_before": 3,
+        "events_skipped_after": 0,
+        "invalid_window_ts": 0,
+    }
     assert report["smoke_report"]["event_window"] == {
         "enabled": True,
         "since_ms": 1500,
@@ -737,6 +748,7 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         assert "problem_event_report.json" in names
         assert "time_window_report.json" in names
         assert "smoke_report.json" in names
+        assert "performance_report.json" in names
         assert "timeline.txt" in names
         assert "config_hashes.json" in names
         assert "binance/binance_01/state.latest.json" not in names
@@ -750,6 +762,7 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         event_segments_manifest = _read_tar_json(tar, "event_segments_manifest.json")
         window_report = _read_tar_json(tar, "time_window_report.json")
         smoke_report = _read_tar_json(tar, "smoke_report.json")
+        performance_report = _read_tar_json(tar, "performance_report.json")
         config_hashes = _read_tar_json(tar, "config_hashes.json")
         redacted_snapshot = _read_tar_json(
             tar,
@@ -763,6 +776,10 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     }
     assert manifest["time_window"] == report["time_window"]
     assert manifest["time_window"]["matched_events"] == window_report["matched_events"]
+    assert manifest["performance_report"] == report["performance_report"]
+    assert performance_report["event_window"] == report["performance_report"][
+        "event_window"
+    ]
     for section in ("ok", "attention", "hard_failures", "attention_count"):
         assert manifest["smoke_report"][section] == report["smoke_report"][section]
     assert manifest["smoke_report"]["event_window"] == report["smoke_report"][
@@ -824,6 +841,7 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     assert manifest["filters"]["log_tail_lines"] == 500
     assert manifest["filters"]["max_log_matches"] == 100
     assert manifest["filters"]["log_window_unparsed_policy"] == "keep"
+    assert manifest["filters"]["include_performance_report"] is True
     assert manifest["event_segments"]["file_discovery"] == report["event_segments"][
         "file_discovery"
     ]
@@ -1058,6 +1076,7 @@ def test_live_incident_bundle_cli_filters_event_reports_by_query_scopes(
                 "2000",
                 "--include-data",
                 "--no-event-segments",
+                "--performance-report",
                 "--output",
                 str(output),
                 "--compact",
@@ -1070,6 +1089,8 @@ def test_live_incident_bundle_cli_filters_event_reports_by_query_scopes(
     assert report["ok"] is True
     assert report["event_report"]["query_matched_events"] == 1
     assert report["problem_event_report"]["matched_events"] == 1
+    assert report["performance_report"]["ok"] is True
+    assert report["performance_report"]["filters"]["debug_profiles"] == ["startup"]
     assert report["event_report"]["file_discovery"] == {
         "bot_path_pruning_applied": True,
         "candidate_files": 2,
@@ -1100,6 +1121,7 @@ def test_live_incident_bundle_cli_filters_event_reports_by_query_scopes(
         event_report = _read_tar_json(tar, "event_report.json")
         problem_event_report = _read_tar_json(tar, "problem_event_report.json")
         time_window_report = _read_tar_json(tar, "time_window_report.json")
+        performance_report = _read_tar_json(tar, "performance_report.json")
         timeline_text = tar.extractfile("timeline.txt").read().decode("utf-8")
         event_segments_manifest = _read_tar_json(tar, "event_segments_manifest.json")
         manifest = _read_tar_json(tar, "manifest.json")
@@ -1130,6 +1152,8 @@ def test_live_incident_bundle_cli_filters_event_reports_by_query_scopes(
         "until_ms": 2000,
     }
     assert time_window_report["matched_events"] == 1
+    assert performance_report["filters"]["debug_profiles"] == ["startup"]
+    assert manifest["performance_report"] == report["performance_report"]
     assert event_report["query"]["events"][0]["exchange"] == "okx"
     assert event_report["query"]["events"][0]["user"] == "okx_01"
     assert event_report["query"]["events"][0]["side"] == "sell"
@@ -1144,6 +1168,7 @@ def test_live_incident_bundle_cli_filters_event_reports_by_query_scopes(
     assert manifest["filters"]["exchange"] == ["okx"]
     assert manifest["filters"]["bot_id"] == ["okx/okx_01"]
     assert manifest["filters"]["debug_profile"] == ["startup"]
+    assert manifest["filters"]["include_performance_report"] is True
     assert manifest["filters"]["data_eq"] == ["scope=target"]
     assert manifest["filters"]["since_ms"] == 0
     assert manifest["filters"]["until_ms"] == 2000


### PR DESCRIPTION
## Summary
- add opt-in `passivbot tool live-incident-bundle --performance-report`
- embed `performance_report.json` and compact manifest/command summary
- inherit compatible incident bundle bounds for time window, rotated/tail/per-bot scans, bot/exchange/user, and debug-profile filters
- update changelog and logging progress ledger, including PR #1030 deploy evidence

## Scope
Read-only incident-bundle/performance-report operator tooling. No event producers, exchange calls, monitor writes, console routing, startup behavior, order/risk logic, or trading behavior changed.

## Validation
- `./venv/bin/python -m pytest tests/test_live_incident_bundle.py::test_live_incident_bundle_collects_hashes_snapshots_events_and_window tests/test_live_incident_bundle.py::test_live_incident_bundle_cli_filters_event_reports_by_query_scopes -q`
- `./venv/bin/python -m pytest tests/test_live_incident_bundle.py -q`
- `./venv/bin/python -m py_compile src/live/incident_bundle.py src/tools/live_incident_bundle.py tests/test_live_incident_bundle.py`
- `git diff --check`
- added-line silent-handling scan over touched code/tests: no matches