### PR TITLE
Add incident bundle performance section filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-incident-bundle --performance-report` now supports
+  `--performance-section`, so embedded performance evidence can be scoped to
+  selected top-level sections while keeping common metadata.
 - `passivbot tool live-restart-smoke-plan` now includes
   `live-incident-bundle --performance-report` in its planned failure evidence
   command, so restart-smoke incident bundles capture bounded performance timing

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,20 +19,22 @@ Last updated: 2026-07-03.
 
 Current `origin/v8` head:
 
-- `7d001553` after PR #1031, `Add performance report to incident bundles`.
+- `0f6611ae` after PR #1032, `Add performance reports to restart smoke bundles`.
 
 Current logging-overhaul head:
 
-- `7d001553` after PR #1031, `Add performance report to incident bundles`.
+- `0f6611ae` after PR #1032, `Add performance reports to restart smoke bundles`.
 
 Current work:
 
-- Branch `codex/v8-restart-smoke-performance-bundle` updates the read-only
-  restart-smoke plan so its planned post-failure incident bundle includes the
-  existing `--performance-report` artifact by default. It changes only planned
-  operator evidence commands and docs; it does not execute restarts, contact
-  exchanges, add event producers, write monitor events, alter console routing,
-  or change order/risk/trading behavior.
+- Branch `codex/v8-incident-performance-section` adds
+  `live-incident-bundle --performance-section` as a read-only projection for
+  embedded performance reports. The bundle still uses the existing
+  performance-report scanner and section validator; the new option only scopes
+  `performance_report.json`, the compact returned summary, and manifest
+  metadata. It does not execute restarts, contact exchanges, add event
+  producers, write monitor events, alter console routing, or change
+  order/risk/trading behavior.
 
 Current review gate:
 
@@ -62,6 +64,16 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1032 at `0f6611ae`.
+- PR #1032 updated `live-restart-smoke-plan` so planned post-failure incident
+  bundles include the existing `--performance-report` artifact by default. It
+  merged after Claude and Hermes approved with no findings and CI was green.
+  VPS5 checkout was updated to `0f6611ae` without restarting running bots
+  because the slice was read-only tooling. A first 5-minute smoke observed one
+  transient Kucoin `RequestTimeout` degradation, and a tighter settled
+  follow-up smoke was hard-green with five configured bots running, clean
+  tracked repository state, and only known non-hard HSL cooldown/status plus
+  stale dropped Kucoin traceback attention.
 - Repository pulled through PR #1031 at `7d001553`.
 - PR #1031 added opt-in `live-incident-bundle --performance-report`, embedding
   the existing read-only performance report artifact and compact summary in

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -212,6 +212,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   `--performance-report` to embed a bounded `performance_report.json` artifact
   plus compact manifest summary using the bundle's time, bot/exchange/user,
   debug-profile, rotated-file, tail-line, and per-bot file bounds. Use
+  `--performance-section SECTION` with `--performance-report` to keep only
+  selected top-level performance sections plus common performance metadata in
+  the embedded artifact and compact manifest summary. Use
   `--smoke-section SECTION` one or more times to keep only selected top-level
   sections from the embedded full `smoke_report.json` plus common smoke
   metadata, for example `--smoke-section fill_refresh_health`. Use

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -27,6 +27,7 @@ from live.event_query import (
 )
 from live.performance_report import (
     build_live_performance_report,
+    project_live_performance_report_sections,
     summarize_live_performance_report,
 )
 from live.restart_smoke_plan import (
@@ -1056,6 +1057,7 @@ def build_live_incident_bundle(
     include_trace_report: bool = True,
     include_problem_report: bool = True,
     include_performance_report: bool = False,
+    performance_sections: list[str] | tuple[str, ...] | None = None,
     include_rotated: bool = False,
     include_event_segments: bool = True,
     max_events: int = 500,
@@ -1250,9 +1252,17 @@ def build_live_incident_bundle(
             user_filters=user,
             debug_profile_filters=debug_profile,
         )
+        performance_report = project_live_performance_report_sections(
+            performance_report,
+            list(performance_sections or []),
+        )
         performance_report_summary = summarize_live_performance_report(
             performance_report,
             group_limit=max_events,
+        )
+        performance_report_summary = project_live_performance_report_sections(
+            performance_report_summary,
+            list(performance_sections or []),
         )
     hard_failures = _bundle_hard_failure_count(
         smoke_report=smoke_report,
@@ -1343,6 +1353,9 @@ def build_live_incident_bundle(
                     "max_log_matches": max_log_matches if max_log_matches else None,
                     "log_window_unparsed_policy": log_window_unparsed_policy,
                     "smoke_sections": list(smoke_sections),
+                    "performance_sections": list(performance_sections or [])
+                    if include_performance_report and performance_sections
+                    else None,
                     "include_restart_smoke_plan": include_restart_smoke_plan,
                     "restart_smoke_window_minutes": restart_smoke_window_minutes
                     if include_restart_smoke_plan

--- a/src/tools/live_incident_bundle.py
+++ b/src/tools/live_incident_bundle.py
@@ -228,6 +228,16 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--performance-section",
+        action="append",
+        default=[],
+        help=(
+            "Only keep one top-level section from the embedded performance_report.json "
+            "plus common performance metadata. May be repeated; section names are "
+            "validated by live-performance-report."
+        ),
+    )
+    parser.add_argument(
         "--include-rotated",
         action="store_true",
         help="Also scan rotated/compressed monitor event segments.",
@@ -353,6 +363,8 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--since-ms/--recent-minutes must be <= --until-ms")
     if args.restart_smoke_plan and not args.supervisor_config:
         parser.error("--restart-smoke-plan requires --supervisor-config")
+    if args.performance_section and not args.performance_report:
+        parser.error("--performance-section requires --performance-report")
     if int(args.restart_smoke_window_minutes) <= 0:
         parser.error("--restart-smoke-window-minutes must be > 0")
     try:
@@ -389,6 +401,7 @@ def main(argv: list[str] | None = None) -> int:
             include_trace_report=not bool(args.no_trace_report),
             include_problem_report=not bool(args.no_problem_report),
             include_performance_report=bool(args.performance_report),
+            performance_sections=args.performance_section,
             include_rotated=bool(args.include_rotated),
             event_tail_lines=int(args.event_tail_lines),
             max_event_files_per_bot=int(args.max_event_files_per_bot),

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -395,6 +395,7 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         until_ms=2500,
         include_data=False,
         include_performance_report=True,
+        performance_sections=["hsl_replay_profile"],
         max_event_segment_bytes=100_000,
         cwd=tmp_path,
     )
@@ -435,6 +436,8 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         "events_skipped_after": 0,
         "invalid_window_ts": 0,
     }
+    assert "hsl_replay_profile" in report["performance_report"]
+    assert "performance" not in report["performance_report"]
     assert report["smoke_report"]["event_window"] == {
         "enabled": True,
         "since_ms": 1500,
@@ -780,6 +783,9 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
     assert performance_report["event_window"] == report["performance_report"][
         "event_window"
     ]
+    assert "hsl_replay_profile" in performance_report
+    assert "performance" not in performance_report
+    assert manifest["filters"]["performance_sections"] == ["hsl_replay_profile"]
     for section in ("ok", "attention", "hard_failures", "attention_count"):
         assert manifest["smoke_report"][section] == report["smoke_report"][section]
     assert manifest["smoke_report"]["event_window"] == report["smoke_report"][
@@ -1077,6 +1083,8 @@ def test_live_incident_bundle_cli_filters_event_reports_by_query_scopes(
                 "--include-data",
                 "--no-event-segments",
                 "--performance-report",
+                "--performance-section",
+                "performance",
                 "--output",
                 str(output),
                 "--compact",
@@ -1091,6 +1099,8 @@ def test_live_incident_bundle_cli_filters_event_reports_by_query_scopes(
     assert report["problem_event_report"]["matched_events"] == 1
     assert report["performance_report"]["ok"] is True
     assert report["performance_report"]["filters"]["debug_profiles"] == ["startup"]
+    assert "performance" in report["performance_report"]
+    assert "startup_readiness" not in report["performance_report"]
     assert report["event_report"]["file_discovery"] == {
         "bot_path_pruning_applied": True,
         "candidate_files": 2,
@@ -1153,6 +1163,8 @@ def test_live_incident_bundle_cli_filters_event_reports_by_query_scopes(
     }
     assert time_window_report["matched_events"] == 1
     assert performance_report["filters"]["debug_profiles"] == ["startup"]
+    assert "performance" in performance_report
+    assert "startup_readiness" not in performance_report
     assert manifest["performance_report"] == report["performance_report"]
     assert event_report["query"]["events"][0]["exchange"] == "okx"
     assert event_report["query"]["events"][0]["user"] == "okx_01"
@@ -1168,10 +1180,25 @@ def test_live_incident_bundle_cli_filters_event_reports_by_query_scopes(
     assert manifest["filters"]["exchange"] == ["okx"]
     assert manifest["filters"]["bot_id"] == ["okx/okx_01"]
     assert manifest["filters"]["debug_profile"] == ["startup"]
+    assert manifest["filters"]["performance_sections"] == ["performance"]
     assert manifest["filters"]["include_performance_report"] is True
     assert manifest["filters"]["data_eq"] == ["scope=target"]
     assert manifest["filters"]["since_ms"] == 0
     assert manifest["filters"]["until_ms"] == 2000
+
+
+def test_live_incident_bundle_cli_requires_performance_report_for_performance_section(capsys):
+    with pytest.raises(SystemExit) as exc:
+        live_incident_bundle.main(
+            [
+                "monitor",
+                "--performance-section",
+                "startup_readiness",
+            ]
+        )
+
+    assert exc.value.code == 2
+    assert "--performance-section requires --performance-report" in capsys.readouterr().err
 
 
 def test_live_incident_bundle_can_skip_logs_and_segments_from_cli(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- add `live-incident-bundle --performance-section` for projected embedded performance reports
- apply the existing performance-report section projector to `performance_report.json`, returned summary, and manifest metadata
- document the flag and update the logging-overhaul progress ledger

## Validation
- `./venv/bin/python -m pytest tests/test_live_incident_bundle.py tests/test_live_performance_report.py -q`
- `./venv/bin/python -m py_compile src/live/incident_bundle.py src/tools/live_incident_bundle.py src/live/performance_report.py`
- `git diff --check`

## Behavior boundary
Read-only tooling only: no event producers, exchange calls, monitor writes, console routing, readiness gates, or order/risk/trading behavior changed.