### PR TITLE
Accept smoke base metadata sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-smoke-report --section` now accepts base smoke metadata
+  selectors such as `repository`, `monitor`, and `event_window`, so repeated
+  smoke loops can request checkout or scan-window evidence directly.
 - `passivbot tool live-incident-bundle --performance-report` now supports
   `--performance-section`, so embedded performance evidence can be scoped to
   selected top-level sections while keeping common metadata.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,22 +19,21 @@ Last updated: 2026-07-03.
 
 Current `origin/v8` head:
 
-- `0f6611ae` after PR #1032, `Add performance reports to restart smoke bundles`.
+- `0a225f10` after PR #1033, `Add incident bundle performance section filter`.
 
 Current logging-overhaul head:
 
-- `0f6611ae` after PR #1032, `Add performance reports to restart smoke bundles`.
+- `0a225f10` after PR #1033, `Add incident bundle performance section filter`.
 
 Current work:
 
-- Branch `codex/v8-incident-performance-section` adds
-  `live-incident-bundle --performance-section` as a read-only projection for
-  embedded performance reports. The bundle still uses the existing
-  performance-report scanner and section validator; the new option only scopes
-  `performance_report.json`, the compact returned summary, and manifest
-  metadata. It does not execute restarts, contact exchanges, add event
-  producers, write monitor events, alter console routing, or change
-  order/risk/trading behavior.
+- Branch `codex/v8-smoke-section-base-metadata` makes
+  `live-smoke-report --section` accept base metadata selectors such as
+  `repository`, `monitor`, and `event_window`. This removes operator friction
+  found during the PR #1033 VPS smoke while keeping the command read-only and
+  preserving existing regular-section behavior. It does not execute restarts,
+  contact exchanges, add event producers, write monitor events, alter console
+  routing, or change order/risk/trading behavior.
 
 Current review gate:
 
@@ -64,6 +63,19 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1033 at `0a225f10`.
+- PR #1033 added `live-incident-bundle --performance-section` for embedded
+  performance reports. It merged after Claude and Hermes approved with no
+  findings and CI was green; Cursor was absent, so the low-risk read-only
+  tooling degraded gate was used. VPS5 checkout was updated to `0a225f10`
+  without restarting running bots because the slice was read-only tooling. A
+  first 2-minute smoke was hard-red from a transient Kucoin
+  `maintain_hourly_cycle` open-orders traceback, while process and event
+  pipeline checks were green. After the transient log window rolled forward, a
+  settled 2-minute smoke reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, clean tracked repository state, zero hard
+  log/problem/process failures, and only known non-hard ZEC HSL cooldown
+  attention on binance/gateio/okx.
 - Repository pulled through PR #1032 at `0f6611ae`.
 - PR #1032 updated `live-restart-smoke-plan` so planned post-failure incident
   bundles include the existing `--performance-report` artifact by default. It

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -163,7 +163,8 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   `--brief` for top-level counters suitable for repeated VPS smoke loops. Use
   `--section SECTION` one or more times to emit selected top-level smoke-report
   sections plus common smoke metadata after the full/summary/brief projection is
-  selected, for example `--brief --section fill_refresh`.
+  selected, for example `--brief --section fill_refresh` or
+  `--section repository` for checkout metadata only.
   Full, summary, and brief output include text-log scan bounds and bounded
   text-log window counters so time-windowed smoke evidence shows the configured
   file/tail/match limits plus how many log lines were considered, skipped

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -7268,6 +7268,19 @@ def available_live_smoke_report_sections(report: dict[str, Any]) -> list[str]:
     return sorted(key for key in report if key not in _SMOKE_REPORT_SECTION_BASE_KEYS)
 
 
+SMOKE_REPORT_SECTION_BASE_SELECTORS = frozenset(
+    {
+        "repository",
+        "monitor",
+        "event_window",
+        "hard_failure_sources",
+        "attention_sources",
+        "problem_event_count",
+        "hard_problem_event_count",
+    }
+)
+
+
 SMOKE_REPORT_SECTION_ALIASES: dict[str, tuple[str, ...]] = {
     "account_critical_remote_calls": ("account_critical_remote_call_health",),
     "ema_readiness": ("ema_readiness_health",),
@@ -7294,9 +7307,14 @@ def project_live_smoke_report_sections(
 
     available = available_live_smoke_report_sections(report)
     available_set = set(available)
+    base_selector_set = set(SMOKE_REPORT_SECTION_BASE_SELECTORS)
     resolved = []
+    resolved_base = []
     unknown = []
     for section in requested:
+        if section in base_selector_set:
+            resolved_base.append(section)
+            continue
         targets = (section, *SMOKE_REPORT_SECTION_ALIASES.get(section, ()))
         matched_targets = [target for target in targets if target in available_set]
         if not matched_targets:
@@ -7310,11 +7328,22 @@ def project_live_smoke_report_sections(
             "unknown --section value(s): "
             + ", ".join(unknown)
             + "; available sections: "
-            + ", ".join(available)
+            + ", ".join(sorted((*available, *base_selector_set)))
             + "; use all for the full report"
         )
 
     projected = {key: report[key] for key in _SMOKE_REPORT_SECTION_BASE_KEYS if key in report}
+    if resolved_base:
+        selected_base = {
+            "ok",
+            "attention",
+            "hard_failures",
+            "attention_count",
+            *resolved_base,
+        }
+        projected = {
+            key: value for key, value in projected.items() if key in selected_base
+        }
     for section in resolved:
         projected[section] = report[section]
     return projected

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -5311,6 +5311,38 @@ def test_live_smoke_report_full_section_projection_accepts_brief_alias(tmp_path)
     assert "processes" not in projected
 
 
+def test_live_smoke_report_section_projection_accepts_base_metadata(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=1,
+                ts=1000,
+                status="succeeded",
+                reason_code="fills_refresh_succeeded",
+            )
+        ],
+    )
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    projected = project_live_smoke_report_sections(
+        report,
+        ["repository", "event_window"],
+    )
+
+    assert projected["ok"] is True
+    assert projected["attention"] is False
+    assert projected["hard_failures"] == 0
+    assert projected["attention_count"] == 0
+    assert projected["repository"]["is_git_repo"] in {True, False}
+    assert "event_window" in projected
+    assert "monitor" not in projected
+    assert "logs" not in projected
+    assert "fill_refresh_health" not in projected
+
+
 def test_live_smoke_report_cli_brief_section_filter(tmp_path, capsys):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(
@@ -5354,6 +5386,43 @@ def test_live_smoke_report_cli_brief_section_filter(tmp_path, capsys):
     assert "logs" not in summary
     assert "remote_calls" not in summary
     assert "processes" not in summary
+
+
+def test_live_smoke_report_cli_accepts_base_metadata_section(tmp_path, capsys):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=1,
+                ts=1000,
+                status="succeeded",
+                reason_code="fills_refresh_succeeded",
+            )
+        ],
+    )
+
+    assert (
+        live_smoke_report.main(
+            [
+                str(tmp_path / "monitor"),
+                "--logs-root",
+                "",
+                "--brief",
+                "--section",
+                "repository",
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["ok"] is True
+    assert "repository" in summary
+    assert "monitor" not in summary
+    assert "logs" not in summary
 
 
 def test_live_smoke_report_cli_rejects_unknown_section(capsys):


### PR DESCRIPTION
## Summary
- allow `live-smoke-report --section` to request base metadata selectors such as `repository`, `monitor`, and `event_window`
- keep existing regular-section behavior unchanged and preserve verdict counters with selected base metadata
- document the smoke CLI friction fix and update the logging-overhaul progress ledger with PR #1033 deploy evidence

## Validation
- `./venv/bin/python -m pytest tests/test_live_smoke_report.py -q`
- `./venv/bin/python -m pytest tests/test_live_smoke_report.py::test_live_smoke_report_section_projection_accepts_base_metadata tests/test_live_smoke_report.py::test_live_smoke_report_cli_accepts_base_metadata_section tests/test_live_smoke_report.py::test_live_smoke_report_cli_rejects_unknown_section -q`
- `./venv/bin/python -m py_compile src/live/smoke_report.py src/tools/live_smoke_report.py`
- `git diff --check`

## Behavior boundary
Read-only smoke tooling only: no event producers, exchange calls, monitor writes, console routing, readiness gates, or order/risk/trading behavior changed.