### PR TITLE
Pass performance sections through restart smoke plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-restart-smoke-plan` now supports
+  `--performance-section`, passing selected performance-report sections to the
+  planned failure incident-bundle command.
 - `passivbot tool live-smoke-report --section` now accepts base smoke metadata
   selectors such as `repository`, `monitor`, and `event_window`, so repeated
   smoke loops can request checkout or scan-window evidence directly.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,21 +19,22 @@ Last updated: 2026-07-03.
 
 Current `origin/v8` head:
 
-- `0a225f10` after PR #1033, `Add incident bundle performance section filter`.
+- `f068d9a4` after PR #1034, `Accept smoke base metadata sections`.
 
 Current logging-overhaul head:
 
-- `0a225f10` after PR #1033, `Add incident bundle performance section filter`.
+- `f068d9a4` after PR #1034, `Accept smoke base metadata sections`.
 
 Current work:
 
-- Branch `codex/v8-smoke-section-base-metadata` makes
-  `live-smoke-report --section` accept base metadata selectors such as
-  `repository`, `monitor`, and `event_window`. This removes operator friction
-  found during the PR #1033 VPS smoke while keeping the command read-only and
-  preserving existing regular-section behavior. It does not execute restarts,
-  contact exchanges, add event producers, write monitor events, alter console
-  routing, or change order/risk/trading behavior.
+- Branch `codex/v8-restart-smoke-performance-sections` lets
+  `live-restart-smoke-plan --performance-section` pass selected
+  performance-report sections through to the planned failure
+  `live-incident-bundle --performance-report` command. This keeps restart
+  smoke evidence planning aligned with the newer incident-bundle performance
+  projection surface. It does not execute restarts, contact exchanges, add
+  event producers, write monitor events, alter console routing, or change
+  order/risk/trading behavior.
 
 Current review gate:
 
@@ -63,6 +64,17 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1034 at `f068d9a4`.
+- PR #1034 made `live-smoke-report --section` accept base metadata selectors
+  such as `repository`, `monitor`, and `event_window`. It merged after Claude
+  and Hermes approved with no findings and CI was green; Cursor was absent, so
+  the low-risk read-only tooling degraded gate was used. VPS5 checkout was
+  updated to `f068d9a4` without restarting running bots because the slice was
+  read-only tooling. A focused VPS check proved `--section repository` now
+  returns clean checkout metadata directly, and the settled bounded smoke
+  reported `ok=true`, `hard_failures=0`, `matched_expected=5`, clean tracked
+  repository state, zero hard log/problem/process failures, and only known
+  non-hard ZEC HSL cooldown attention on binance/gateio/okx.
 - Repository pulled through PR #1033 at `0a225f10`.
 - PR #1033 added `live-incident-bundle --performance-section` for embedded
   performance reports. It merged after Claude and Hermes approved with no

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -247,8 +247,10 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   event-segment copying by default. The planned failure bundle includes
   `--performance-report` and `--restart-smoke-plan`, so the archive carries
   bounded performance timing/readiness evidence plus the non-executing restart
-  plan that produced it; use `--incident-bundle-output PATH` to choose the planned
-  bundle path. The default planned bundle path is a
+  plan that produced it. Use `--performance-section SECTION` one or more times
+  to add matching `live-incident-bundle --performance-section` values to the
+  planned failure bundle command; use `--incident-bundle-output PATH` to choose
+  the planned bundle path. The default planned bundle path is a
   timestamped `/tmp/passivbot_incident_bundle_restart_smoke_<utc>.tar.gz`
   path to avoid overwriting prior evidence. The pre-restart readiness phase also
   includes one deduplicated `live-config-preflight` command for each configured

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -145,6 +145,7 @@ def _incident_bundle_command(
     max_log_matches: int,
     log_window_unparsed_policy: str,
     smoke_sections: list[str] | tuple[str, ...] | None = None,
+    performance_sections: list[str] | tuple[str, ...] | None = None,
 ) -> str:
     args = [
         "passivbot",
@@ -181,6 +182,10 @@ def _incident_bundle_command(
         normalized = str(section).strip()
         if normalized:
             args.extend(["--smoke-section", normalized])
+    for section in performance_sections or ():
+        normalized = str(section).strip()
+        if normalized:
+            args.extend(["--performance-section", normalized])
     args.append("--compact")
     return _shell_join(args)
 
@@ -340,6 +345,7 @@ def build_live_restart_smoke_plan(
     brief_smoke_report: bool = True,
     summary_smoke_report: bool = False,
     smoke_sections: list[str] | tuple[str, ...] | None = None,
+    performance_sections: list[str] | tuple[str, ...] | None = None,
     execute: bool = False,
 ) -> dict[str, Any]:
     if execute:
@@ -370,6 +376,11 @@ def build_live_restart_smoke_plan(
     smoke_sections = [
         str(section).strip()
         for section in (smoke_sections or ())
+        if str(section).strip()
+    ]
+    performance_sections = [
+        str(section).strip()
+        for section in (performance_sections or ())
         if str(section).strip()
     ]
 
@@ -441,6 +452,7 @@ def build_live_restart_smoke_plan(
         max_log_matches=smoke_max_log_matches,
         log_window_unparsed_policy=log_window_unparsed_policy,
         smoke_sections=smoke_sections,
+        performance_sections=performance_sections,
     )
     config_preflight_plan = _config_preflight_plan(bots)
     config_preflight_commands = list(config_preflight_plan["commands"])
@@ -484,6 +496,7 @@ def build_live_restart_smoke_plan(
             "smoke_max_log_matches": smoke_max_log_matches,
             "log_window_unparsed_policy": log_window_unparsed_policy,
             "smoke_sections": list(smoke_sections),
+            "performance_sections": list(performance_sections),
             "incident_bundle_output": _display_path(incident_bundle_output),
         },
         "supervisor_config": {

--- a/src/tools/live_restart_smoke_plan.py
+++ b/src/tools/live_restart_smoke_plan.py
@@ -158,6 +158,16 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--performance-section",
+        action="append",
+        default=[],
+        help=(
+            "Add one --performance-section value to the planned "
+            "live-incident-bundle --performance-report command. May be repeated; "
+            "validation happens when live-incident-bundle runs."
+        ),
+    )
+    parser.add_argument(
         "--pretty-smoke-report",
         action="store_true",
         help="Plan a pretty-printed live-smoke-report command instead of --compact.",
@@ -209,6 +219,7 @@ def main(argv: list[str] | None = None) -> int:
             ),
             summary_smoke_report=bool(args.summary_smoke_report),
             smoke_sections=args.smoke_section,
+            performance_sections=args.performance_section,
             execute=False,
         )
     except (NotImplementedError, ValueError) as exc:

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -162,6 +162,41 @@ def test_live_restart_smoke_plan_can_focus_smoke_sections(tmp_path):
     assert report["smoke_report"]["execute"] is False
 
 
+def test_live_restart_smoke_plan_can_focus_performance_sections(tmp_path):
+    supervisor_config = tmp_path / "bots_vps5.yaml"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u binance_01",
+        ],
+    )
+
+    report = build_live_restart_smoke_plan(
+        supervisor_config,
+        performance_sections=["startup_readiness", "hsl_replay_profile"],
+    )
+
+    assert report["inputs"]["performance_sections"] == [
+        "startup_readiness",
+        "hsl_replay_profile",
+    ]
+    assert "--performance-report" in report["incident_bundle"]["command"]
+    assert (
+        "--performance-section startup_readiness"
+        in report["incident_bundle"]["command"]
+    )
+    assert (
+        "--performance-section hsl_replay_profile"
+        in report["incident_bundle"]["command"]
+    )
+    assert "--performance-section" not in report["smoke_report"]["command"]
+    assert report["incident_bundle"]["execute"] is False
+
+
 def test_live_restart_smoke_plan_deduplicates_config_preflight_commands(tmp_path):
     supervisor_config = tmp_path / "bots_vps5.yaml"
     _write_supervisor(
@@ -630,6 +665,50 @@ def test_live_restart_smoke_plan_cli_can_plan_smoke_sections(tmp_path, capsys):
     assert "--smoke-section hsl_replay" in report["incident_bundle"]["command"]
     assert "--restart-smoke-plan" in report["incident_bundle"]["command"]
     assert "--brief" in report["smoke_report"]["command"]
+
+
+def test_live_restart_smoke_plan_cli_can_plan_performance_sections(tmp_path, capsys):
+    supervisor_config = tmp_path / "bots.yaml"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u binance_01",
+        ],
+    )
+
+    assert (
+        live_restart_smoke_plan.main(
+            [
+                str(supervisor_config),
+                "--performance-section",
+                "startup_readiness",
+                "--performance-section",
+                "hsl_replay_profile",
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["inputs"]["performance_sections"] == [
+        "startup_readiness",
+        "hsl_replay_profile",
+    ]
+    assert "--performance-report" in report["incident_bundle"]["command"]
+    assert (
+        "--performance-section startup_readiness"
+        in report["incident_bundle"]["command"]
+    )
+    assert (
+        "--performance-section hsl_replay_profile"
+        in report["incident_bundle"]["command"]
+    )
+    assert "--performance-section" not in report["smoke_report"]["command"]
 
 
 def test_live_restart_smoke_plan_cli_can_plan_log_window_unparsed_policy(


### PR DESCRIPTION
## Summary
- add live-restart-smoke-plan --performance-section
- pass selected sections through to the planned live-incident-bundle --performance-report command
- document the option and update logging-overhaul progress

## Behavior boundary
- read-only tooling/planning change only
- does not execute restarts, contact exchanges, emit events, write monitor files, or alter live order/risk/trading behavior

## Validation
- ./venv/bin/python -m pytest tests/test_live_restart_smoke_plan.py::test_live_restart_smoke_plan_can_focus_performance_sections tests/test_live_restart_smoke_plan.py::test_live_restart_smoke_plan_cli_can_plan_performance_sections -q
- ./venv/bin/python -m pytest tests/test_live_restart_smoke_plan.py -q
- ./venv/bin/python -m py_compile src/live/restart_smoke_plan.py src/tools/live_restart_smoke_plan.py
- git diff --check
- touched-file silent-handling scan: no matches