### PR TITLE
Propagate performance sections to embedded restart plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-incident-bundle --restart-smoke-plan` now passes
+  `--performance-section` filters into the embedded restart plan's planned
+  failure-bundle command when performance sections are selected.
 - `passivbot tool live-restart-smoke-plan` now supports
   `--performance-section`, passing selected performance-report sections to the
   planned failure incident-bundle command.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,22 +19,21 @@ Last updated: 2026-07-03.
 
 Current `origin/v8` head:
 
-- `f068d9a4` after PR #1034, `Accept smoke base metadata sections`.
+- `9b83ca2a` after PR #1035, `Pass performance sections through restart smoke plans`.
 
 Current logging-overhaul head:
 
-- `f068d9a4` after PR #1034, `Accept smoke base metadata sections`.
+- `9b83ca2a` after PR #1035, `Pass performance sections through restart smoke plans`.
 
 Current work:
 
-- Branch `codex/v8-restart-smoke-performance-sections` lets
-  `live-restart-smoke-plan --performance-section` pass selected
-  performance-report sections through to the planned failure
-  `live-incident-bundle --performance-report` command. This keeps restart
-  smoke evidence planning aligned with the newer incident-bundle performance
-  projection surface. It does not execute restarts, contact exchanges, add
-  event producers, write monitor events, alter console routing, or change
-  order/risk/trading behavior.
+- Branch `codex/v8-incident-restart-performance-sections` lets
+  `live-incident-bundle --restart-smoke-plan` pass selected
+  `--performance-section` filters into the embedded restart plan's planned
+  failure-bundle command. This keeps direct incident-bundle performance
+  projections and restart-smoke follow-up plans aligned. It does not execute
+  restarts, contact exchanges, add event producers, write monitor events, alter
+  console routing, or change order/risk/trading behavior.
 
 Current review gate:
 
@@ -64,6 +63,19 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1035 at `9b83ca2a`.
+- PR #1035 made `live-restart-smoke-plan --performance-section` pass selected
+  performance-report sections through to the planned failure
+  `live-incident-bundle --performance-report` command. It merged after Claude
+  and Hermes approved with no findings and CI was green; Cursor was absent, so
+  the low-risk read-only tooling degraded gate was used. VPS5 checkout was
+  updated to `9b83ca2a` without restarting running bots because the slice was
+  read-only tooling. A focused VPS planner check proved the generated
+  incident-bundle command includes both `--performance-section
+  startup_readiness` and `--performance-section hsl_replay_profile`, and the
+  bounded smoke reported `ok=true`, `hard_failures=0`, `matched_expected=5`,
+  clean tracked repository state, zero hard log matches, no event-pipeline
+  drops or sink errors, and only known non-hard ZEC HSL cooldown attention.
 - Repository pulled through PR #1034 at `f068d9a4`.
 - PR #1034 made `live-smoke-report --section` accept base metadata selectors
   such as `repository`, `monitor`, and `event_window`. It merged after Claude

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -215,7 +215,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   debug-profile, rotated-file, tail-line, and per-bot file bounds. Use
   `--performance-section SECTION` with `--performance-report` to keep only
   selected top-level performance sections plus common performance metadata in
-  the embedded artifact and compact manifest summary. Use
+  the embedded artifact and compact manifest summary. When
+  `--restart-smoke-plan` is also used, the same performance section filters are
+  passed into the embedded restart plan's planned failure bundle command. Use
   `--smoke-section SECTION` one or more times to keep only selected top-level
   sections from the embedded full `smoke_report.json` plus common smoke
   metadata, for example `--smoke-section fill_refresh_health`. Use

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -1091,6 +1091,11 @@ def build_live_incident_bundle(
         for section in (smoke_sections or ())
         if str(section).strip()
     ]
+    performance_sections = [
+        str(section).strip()
+        for section in (performance_sections or ())
+        if str(section).strip()
+    ]
     if include_restart_smoke_plan and supervisor_config is None:
         raise ValueError("restart smoke plan requires --supervisor-config")
     restart_smoke_window_minutes = int(restart_smoke_window_minutes)
@@ -1254,7 +1259,7 @@ def build_live_incident_bundle(
         )
         performance_report = project_live_performance_report_sections(
             performance_report,
-            list(performance_sections or []),
+            performance_sections,
         )
         performance_report_summary = summarize_live_performance_report(
             performance_report,
@@ -1262,7 +1267,7 @@ def build_live_incident_bundle(
         )
         performance_report_summary = project_live_performance_report_sections(
             performance_report_summary,
-            list(performance_sections or []),
+            performance_sections,
         )
     hard_failures = _bundle_hard_failure_count(
         smoke_report=smoke_report,
@@ -1286,6 +1291,7 @@ def build_live_incident_bundle(
             smoke_max_log_matches=DEFAULT_RESTART_SMOKE_MAX_LOG_MATCHES,
             log_window_unparsed_policy=log_window_unparsed_policy,
             smoke_sections=smoke_sections,
+            performance_sections=performance_sections,
         )
         restart_smoke_plan_summary = summarize_live_restart_smoke_plan(
             restart_smoke_plan
@@ -1353,7 +1359,7 @@ def build_live_incident_bundle(
                     "max_log_matches": max_log_matches if max_log_matches else None,
                     "log_window_unparsed_policy": log_window_unparsed_policy,
                     "smoke_sections": list(smoke_sections),
-                    "performance_sections": list(performance_sections or [])
+                    "performance_sections": list(performance_sections)
                     if include_performance_report and performance_sections
                     else None,
                     "include_restart_smoke_plan": include_restart_smoke_plan,

--- a/src/tools/live_incident_bundle.py
+++ b/src/tools/live_incident_bundle.py
@@ -234,7 +234,9 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "Only keep one top-level section from the embedded performance_report.json "
             "plus common performance metadata. May be repeated; section names are "
-            "validated by live-performance-report."
+            "validated by live-performance-report. When --restart-smoke-plan is "
+            "also used, the same sections are passed to the embedded restart "
+            "plan's planned failure bundle command."
         ),
     )
     parser.add_argument(

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -2043,6 +2043,8 @@ def test_live_incident_bundle_can_embed_restart_smoke_plan(
         logs_root=None,
         supervisor_config=supervisor_config,
         include_event_segments=False,
+        include_performance_report=True,
+        performance_sections=["startup_readiness"],
         include_restart_smoke_plan=True,
         restart_smoke_window_minutes=7,
         smoke_sections=["fill_refresh_health"],
@@ -2064,6 +2066,7 @@ def test_live_incident_bundle_can_embed_restart_smoke_plan(
     assert manifest["filters"]["include_restart_smoke_plan"] is True
     assert manifest["filters"]["restart_smoke_window_minutes"] == 7
     assert manifest["filters"]["smoke_sections"] == ["fill_refresh_health"]
+    assert manifest["filters"]["performance_sections"] == ["startup_readiness"]
     assert manifest["restart_smoke_plan"]["bots"]["count"] == 1
     assert "commands" not in manifest["restart_smoke_plan"]["config_preflight"]
     assert restart_plan["metadata"] == {
@@ -2077,12 +2080,16 @@ def test_live_incident_bundle_can_embed_restart_smoke_plan(
     assert restart_plan["inputs"]["smoke_max_event_files_per_bot"] == 2
     assert restart_plan["inputs"]["smoke_log_tail_lines"] == 1200
     assert restart_plan["inputs"]["smoke_max_log_matches"] == 20
+    assert restart_plan["inputs"]["performance_sections"] == ["startup_readiness"]
     assert "--event-tail-lines 2000" in restart_plan["smoke_report"]["command"]
     assert "--max-event-files-per-bot 2" in restart_plan["smoke_report"]["command"]
     assert "--section fill_refresh_health" in restart_plan["smoke_report"]["command"]
     assert "--smoke-section fill_refresh_health" in restart_plan["incident_bundle"][
         "command"
     ]
+    assert "--performance-section startup_readiness" in restart_plan[
+        "incident_bundle"
+    ]["command"]
 
 
 def test_live_incident_bundle_cli_can_embed_restart_smoke_plan(
@@ -2142,6 +2149,9 @@ def test_live_incident_bundle_cli_can_embed_restart_smoke_plan(
             "--supervisor-config",
             str(supervisor_config),
             "--restart-smoke-plan",
+            "--performance-report",
+            "--performance-section",
+            "startup_readiness",
             "--restart-smoke-window-minutes",
             "9",
             "--no-event-segments",
@@ -2156,6 +2166,10 @@ def test_live_incident_bundle_cli_can_embed_restart_smoke_plan(
     with tarfile.open(output, "r:gz") as tar:
         restart_plan = _read_tar_json(tar, "restart_smoke_plan.json")
     assert restart_plan["inputs"]["smoke_window_minutes"] == 9
+    assert restart_plan["inputs"]["performance_sections"] == ["startup_readiness"]
+    assert "--performance-section startup_readiness" in restart_plan[
+        "incident_bundle"
+    ]["command"]
 
 
 def test_live_incident_bundle_cli_requires_supervisor_for_restart_plan(capsys):


### PR DESCRIPTION
## Summary
- normalize incident-bundle performance sections once
- pass selected performance sections into embedded restart-smoke-plan artifacts
- document the propagation and record the PR #1035 deploy evidence in the progress ledger

## Behavior boundary
- read-only incident-bundle/restart-plan tooling only
- does not execute restarts, contact exchanges, emit events, write monitor files, or alter live order/risk/trading behavior

## Validation
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py::test_live_incident_bundle_can_embed_restart_smoke_plan tests/test_live_incident_bundle.py::test_live_incident_bundle_cli_can_embed_restart_smoke_plan -q
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py -q
- ./venv/bin/python -m py_compile src/live/incident_bundle.py src/tools/live_incident_bundle.py
- git diff --check
- touched-file silent-handling scan: only pre-existing bounded timeline fallback reads in incident bundle assembly