### PR TITLE
Expose restart plan issue summaries in incident bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable user-facing changes will be documented in this file.
 ## Unreleased
 
 - `passivbot tool live-incident-bundle --restart-smoke-plan` now exposes the
+  embedded restart plan's compact warning and issue summaries in the returned
+  report and bundle manifest.
+- `passivbot tool live-incident-bundle --restart-smoke-plan` now exposes the
   embedded restart plan's compact process-signal safety and execution-policy
   summaries in the returned report and bundle manifest.
 - `passivbot tool live-incident-bundle --restart-smoke-plan` now exposes the

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,18 @@ Last updated: 2026-07-03.
 
 Current `origin/v8` head:
 
-- `d840c008` after PR #1038, `Expose restart plan command summaries in incident bundles`.
+- `f761063f` after PR #1039, `Expose restart plan safety summaries in incident bundles`.
 
 Current logging-overhaul head:
 
-- `d840c008` after PR #1038, `Expose restart plan command summaries in incident bundles`.
+- `f761063f` after PR #1039, `Expose restart plan safety summaries in incident bundles`.
 
 Current work:
 
-- Branch `codex/v8-incident-restart-plan-safety-provenance` exposes the
-  embedded restart-smoke plan's process-signal safety and execution-policy
-  summaries in the returned incident-bundle report and manifest summary. This
-  lets operators verify the restart plan remains non-executing and forbids broad
-  process-pattern signals without extracting `restart_smoke_plan.json`. It does
+- Branch `codex/v8-incident-restart-plan-issue-provenance` exposes the embedded
+  restart-smoke plan's compact warning and issue summaries in the returned
+  incident-bundle report and manifest summary. This lets operators see malformed
+  or partial restart plans without extracting `restart_smoke_plan.json`. It does
   not execute restarts, contact exchanges, add event producers, write monitor
   events, alter console routing, or change order/risk/trading behavior.
 
@@ -63,6 +62,20 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1039 at `f761063f`.
+- PR #1039 made `live-incident-bundle --restart-smoke-plan` expose the embedded
+  restart-smoke plan's process-signal safety and execution-policy summaries in
+  the returned incident-bundle report and manifest summary. It merged after
+  Claude and Hermes approved with no findings and CI was green; Cursor was
+  absent, so the low-risk read-only tooling degraded gate was used. VPS5
+  checkout was updated to `f761063f` without restarting running bots because
+  the slice was read-only tooling. Bounded smoke reported `ok=true`,
+  `hard_failures=0`, `matched_expected=5`, clean tracked repository state, zero
+  hard log matches, and only known non-hard ZEC HSL cooldown attention. A
+  focused VPS incident-bundle check proved the manifest's embedded
+  restart-smoke summary includes `forbid_broad_process_pattern_signals=true`,
+  `execute_flag=not_implemented`, `future_execution_requires_review=true`, and
+  still omits config-preflight raw command lists.
 - Repository pulled through PR #1038 at `d840c008`.
 - PR #1038 made `live-incident-bundle --restart-smoke-plan` expose the embedded
   restart-smoke plan's planned smoke and follow-up incident-bundle command

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -228,8 +228,11 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   report and manifest include the embedded restart plan's selected smoke and
   performance sections plus the planned smoke and follow-up bundle command
   summaries, process-signal safety, and execution-policy summaries as compact
-  provenance. Its planned smoke command uses the restart planner's bounded scan
-  defaults rather than the incident bundle's event/log scan settings.
+  provenance. They also include the restart plan's compact warning and issue
+  summaries, so malformed or partial restart plans are visible without
+  extracting `restart_smoke_plan.json`. Its planned smoke command uses the
+  restart planner's bounded scan defaults rather than the incident bundle's
+  event/log scan settings.
 - `passivbot tool live-restart-smoke-plan` emits a read-only dry-run restart
   plan from a tmuxp-style supervisor config. The planned smoke command defaults
   to a brief compact smoke command with `--event-tail-lines 2000` and

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -1032,6 +1032,8 @@ def _restart_smoke_plan_result_summary(
         "incident_bundle": summary.get("incident_bundle"),
         "process_signal_safety": summary.get("process_signal_safety"),
         "execution_policy": summary.get("execution_policy"),
+        "warnings": summary.get("warnings"),
+        "issues": summary.get("issues"),
         "config_preflight": config_preflight_summary,
     }
 

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -2075,6 +2075,8 @@ def test_live_incident_bundle_can_embed_restart_smoke_plan(
     assert report["restart_smoke_plan"]["execution_policy"][
         "future_execution_requires_review"
     ] is True
+    assert report["restart_smoke_plan"]["warnings"]["count"] > 0
+    assert report["restart_smoke_plan"]["issues"]["count"] == 0
     assert report["restart_smoke_plan"]["config_preflight"]["command_count"] == 1
     assert "commands" not in report["restart_smoke_plan"]["config_preflight"]
 
@@ -2110,6 +2112,8 @@ def test_live_incident_bundle_can_embed_restart_smoke_plan(
     assert manifest["restart_smoke_plan"]["execution_policy"][
         "future_execution_requires_review"
     ] is True
+    assert manifest["restart_smoke_plan"]["warnings"]["count"] > 0
+    assert manifest["restart_smoke_plan"]["issues"]["count"] == 0
     assert "commands" not in manifest["restart_smoke_plan"]["config_preflight"]
     assert restart_plan["metadata"] == {
         "dry_run": True,
@@ -2226,6 +2230,8 @@ def test_live_incident_bundle_cli_can_embed_restart_smoke_plan(
     assert report["restart_smoke_plan"]["execution_policy"][
         "future_execution_requires_review"
     ] is True
+    assert report["restart_smoke_plan"]["warnings"]["count"] > 0
+    assert report["restart_smoke_plan"]["issues"]["count"] == 0
     with tarfile.open(output, "r:gz") as tar:
         restart_plan = _read_tar_json(tar, "restart_smoke_plan.json")
     assert restart_plan["inputs"]["smoke_window_minutes"] == 9


### PR DESCRIPTION
## Summary
- expose embedded restart-smoke plan warning and issue summaries in live-incident-bundle report/manifest
- keep raw config-preflight command lists omitted from the compact incident-bundle projection
- update tool docs, changelog, and logging-overhaul progress ledger with #1039 deploy evidence

## Behavior
- report-only / docs-only for live tooling
- no exchange calls, restarts, monitor writes, event producers, console routing, order/risk logic, or trading behavior changes

## Validation
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py::test_live_incident_bundle_can_embed_restart_smoke_plan tests/test_live_incident_bundle.py::test_live_incident_bundle_cli_can_embed_restart_smoke_plan -q
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py -q
- ./venv/bin/python -m py_compile src/live/incident_bundle.py
- git diff --check
- rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])" src/live/incident_bundle.py tests/test_live_incident_bundle.py (only pre-existing optional timeline reads)