### PR TITLE
Expose restart plan timeout summaries in incident bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable user-facing changes will be documented in this file.
 ## Unreleased
 
 - `passivbot tool live-incident-bundle --restart-smoke-plan` now exposes the
+  embedded restart plan's compact timeout-escalation ladder summary in the
+  returned report and bundle manifest.
+- `passivbot tool live-incident-bundle --restart-smoke-plan` now exposes the
   embedded restart plan's compact warning and issue summaries in the returned
   report and bundle manifest.
 - `passivbot tool live-incident-bundle --restart-smoke-plan` now exposes the

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,20 +19,21 @@ Last updated: 2026-07-03.
 
 Current `origin/v8` head:
 
-- `f761063f` after PR #1039, `Expose restart plan safety summaries in incident bundles`.
+- `030d77aa` after PR #1040, `Expose restart plan issue summaries in incident bundles`.
 
 Current logging-overhaul head:
 
-- `f761063f` after PR #1039, `Expose restart plan safety summaries in incident bundles`.
+- `030d77aa` after PR #1040, `Expose restart plan issue summaries in incident bundles`.
 
 Current work:
 
-- Branch `codex/v8-incident-restart-plan-issue-provenance` exposes the embedded
-  restart-smoke plan's compact warning and issue summaries in the returned
-  incident-bundle report and manifest summary. This lets operators see malformed
-  or partial restart plans without extracting `restart_smoke_plan.json`. It does
-  not execute restarts, contact exchanges, add event producers, write monitor
-  events, alter console routing, or change order/risk/trading behavior.
+- Branch `codex/v8-incident-restart-plan-timeout-provenance` exposes the
+  embedded restart-smoke plan's compact timeout-escalation ladder summary in the
+  returned incident-bundle report and manifest summary. This lets operators see
+  the planned timeout escalation shape without extracting
+  `restart_smoke_plan.json`. It does not execute restarts, contact exchanges,
+  add event producers, write monitor events, alter console routing, or change
+  order/risk/trading behavior.
 
 Current review gate:
 
@@ -62,6 +63,19 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1040 at `030d77aa`.
+- PR #1040 made `live-incident-bundle --restart-smoke-plan` expose the embedded
+  restart-smoke plan's compact warning and issue summaries in the returned
+  incident-bundle report and manifest summary. It merged after Claude and Hermes
+  approved with no findings and CI was green; Cursor was absent, so the
+  low-risk read-only tooling degraded gate was used. VPS5 checkout was updated
+  to `030d77aa` without restarting running bots because the slice was read-only
+  tooling. Bounded smoke reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, clean tracked repository state, zero hard log matches,
+  no event-pipeline drops or sink errors, and only known non-hard ZEC HSL
+  cooldown attention. A focused VPS incident-bundle check proved the manifest's
+  embedded restart-smoke summary includes `warnings.count=7`, `issues.count=0`,
+  warning items, and still omits config-preflight raw command lists.
 - Repository pulled through PR #1039 at `f761063f`.
 - PR #1039 made `live-incident-bundle --restart-smoke-plan` expose the embedded
   restart-smoke plan's process-signal safety and execution-policy summaries in

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -230,9 +230,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   summaries, process-signal safety, and execution-policy summaries as compact
   provenance. They also include the restart plan's compact warning and issue
   summaries, so malformed or partial restart plans are visible without
-  extracting `restart_smoke_plan.json`. Its planned smoke command uses the
-  restart planner's bounded scan defaults rather than the incident bundle's
-  event/log scan settings.
+  extracting `restart_smoke_plan.json`, plus the compact timeout-escalation
+  ladder summary. Its planned smoke command uses the restart planner's bounded
+  scan defaults rather than the incident bundle's event/log scan settings.
 - `passivbot tool live-restart-smoke-plan` emits a read-only dry-run restart
   plan from a tmuxp-style supervisor config. The planned smoke command defaults
   to a brief compact smoke command with `--event-tail-lines 2000` and

--- a/src/live/incident_bundle.py
+++ b/src/live/incident_bundle.py
@@ -1034,6 +1034,7 @@ def _restart_smoke_plan_result_summary(
         "execution_policy": summary.get("execution_policy"),
         "warnings": summary.get("warnings"),
         "issues": summary.get("issues"),
+        "timeout_escalation_ladder": summary.get("timeout_escalation_ladder"),
         "config_preflight": config_preflight_summary,
     }
 

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -2077,6 +2077,10 @@ def test_live_incident_bundle_can_embed_restart_smoke_plan(
     ] is True
     assert report["restart_smoke_plan"]["warnings"]["count"] > 0
     assert report["restart_smoke_plan"]["issues"]["count"] == 0
+    assert report["restart_smoke_plan"]["timeout_escalation_ladder"]
+    assert report["restart_smoke_plan"]["timeout_escalation_ladder"][0][
+        "planned_command_count"
+    ] >= 0
     assert report["restart_smoke_plan"]["config_preflight"]["command_count"] == 1
     assert "commands" not in report["restart_smoke_plan"]["config_preflight"]
 
@@ -2114,6 +2118,10 @@ def test_live_incident_bundle_can_embed_restart_smoke_plan(
     ] is True
     assert manifest["restart_smoke_plan"]["warnings"]["count"] > 0
     assert manifest["restart_smoke_plan"]["issues"]["count"] == 0
+    assert manifest["restart_smoke_plan"]["timeout_escalation_ladder"]
+    assert manifest["restart_smoke_plan"]["timeout_escalation_ladder"][0][
+        "planned_command_count"
+    ] >= 0
     assert "commands" not in manifest["restart_smoke_plan"]["config_preflight"]
     assert restart_plan["metadata"] == {
         "dry_run": True,
@@ -2232,6 +2240,10 @@ def test_live_incident_bundle_cli_can_embed_restart_smoke_plan(
     ] is True
     assert report["restart_smoke_plan"]["warnings"]["count"] > 0
     assert report["restart_smoke_plan"]["issues"]["count"] == 0
+    assert report["restart_smoke_plan"]["timeout_escalation_ladder"]
+    assert report["restart_smoke_plan"]["timeout_escalation_ladder"][0][
+        "planned_command_count"
+    ] >= 0
     with tarfile.open(output, "r:gz") as tar:
         restart_plan = _read_tar_json(tar, "restart_smoke_plan.json")
     assert restart_plan["inputs"]["smoke_window_minutes"] == 9


### PR DESCRIPTION
## Summary
- expose embedded restart-smoke plan timeout escalation ladder summaries in live-incident-bundle report/manifest
- keep raw config-preflight command lists omitted from the compact incident-bundle projection
- update tool docs, changelog, and logging-overhaul progress ledger with #1040 deploy evidence

## Behavior
- report-only / docs-only for live tooling
- no exchange calls, restarts, monitor writes, event producers, console routing, order/risk logic, or trading behavior changes

## Validation
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py::test_live_incident_bundle_can_embed_restart_smoke_plan tests/test_live_incident_bundle.py::test_live_incident_bundle_cli_can_embed_restart_smoke_plan -q
- ./venv/bin/python -m pytest tests/test_live_incident_bundle.py -q
- ./venv/bin/python -m py_compile src/live/incident_bundle.py
- git diff --check
- rg -n "except Exception|return_exceptions=True|\.get\([^\n]*,\s*(0|0\.0|None|False|\{\}|\[\])" src/live/incident_bundle.py tests/test_live_incident_bundle.py (only pre-existing optional timeline reads)