### PR TITLE
Add cache live-event debug profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- The `cache` live-event debug profile now enriches existing cache load,
+  flush, and warmup-decision events with bounded key/count/source metadata
+  without changing default event payloads or console output.
 - `passivbot tool live-incident-bundle --restart-smoke-plan` now exposes the
   embedded restart plan's compact timeout-escalation ladder summary in the
   returned report and bundle manifest.

--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -217,6 +217,7 @@ to add bounded, opt-in diagnostic details for selected live event families.
 `all` enables every profile. Empty, false-like, or `none` values disable debug
 profile enrichment.
 
+- `cache`
 - `candles`
 - `ema`
 - `execution`

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -63,11 +63,11 @@ Current profile behavior:
    to the existing `rust_orchestrator.called` and
    `rust_orchestrator.returned` events. Full raw Rust payload persistence remains
    disabled; hashes stay present for correlation.
-2. `remote_calls`, `candles`, `ema`, `fills`, `forager`, `execution`, and `hsl`
-   add bounded event-specific debug summaries such as data-key lists,
-   reason/sample counts, correlation ids, and shape metadata. These summaries
-   must not copy raw exchange/account payloads, credentials, or unbounded row
-   data.
+2. `remote_calls`, `cache`, `candles`, `ema`, `fills`, `forager`,
+   `execution`, and `hsl` add bounded event-specific debug summaries such as
+   data-key lists, reason/sample counts, correlation ids, and shape metadata.
+   These summaries must not copy raw exchange/account payloads, credentials, or
+   unbounded row data.
 3. `state` adds bounded state-refresh timing/progress shape metadata such as
    plan/pending counts, surface key lists, and slowest refreshed surface.
 4. `startup` adds bounded phase/timing/details-shape metadata to existing

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,21 +19,20 @@ Last updated: 2026-07-03.
 
 Current `origin/v8` head:
 
-- `030d77aa` after PR #1040, `Expose restart plan issue summaries in incident bundles`.
+- `c5ba5f5d` after PR #1041, `Expose restart plan timeout summaries in incident bundles`.
 
 Current logging-overhaul head:
 
-- `030d77aa` after PR #1040, `Expose restart plan issue summaries in incident bundles`.
+- `c5ba5f5d` after PR #1041, `Expose restart plan timeout summaries in incident bundles`.
 
 Current work:
 
-- Branch `codex/v8-incident-restart-plan-timeout-provenance` exposes the
-  embedded restart-smoke plan's compact timeout-escalation ladder summary in the
-  returned incident-bundle report and manifest summary. This lets operators see
-  the planned timeout escalation shape without extracting
-  `restart_smoke_plan.json`. It does not execute restarts, contact exchanges,
-  add event producers, write monitor events, alter console routing, or change
-  order/risk/trading behavior.
+- Branch `codex/v8-cache-debug-profile` adds an opt-in `cache` live-event debug
+  profile for existing cache load, flush, and warmup-decision events. The slice
+  adds bounded key/count/source metadata only when the profile is enabled. It
+  does not change default event payloads, console output, event routing,
+  exchange calls, cache behavior, startup behavior, order/risk logic, or trading
+  behavior.
 
 Current review gate:
 
@@ -63,6 +62,19 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1041 at `c5ba5f5d`.
+- PR #1041 made `live-incident-bundle --restart-smoke-plan` expose the embedded
+  restart-smoke plan's compact timeout-escalation ladder summary in the returned
+  incident-bundle report and manifest summary. It merged after Claude and Hermes
+  approved with no findings and CI was green. VPS5 checkout was updated to
+  `c5ba5f5d` without restarting running bots because the slice was read-only
+  tooling. Bounded smoke reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, clean tracked repository state, zero hard log matches,
+  no event-pipeline drops or sink errors, and only known non-hard ZEC HSL
+  cooldown attention. A focused VPS incident-bundle check proved the manifest's
+  embedded restart-smoke summary includes a four-row non-executing
+  `timeout_escalation_ladder`, `ok=true`, and still omits config-preflight raw
+  command lists.
 - Repository pulled through PR #1040 at `030d77aa`.
 - PR #1040 made `live-incident-bundle --restart-smoke-plan` expose the embedded
   restart-smoke plan's compact warning and issue summaries in the returned
@@ -6592,6 +6604,27 @@ VPS5 deployment status:
   smoke reported `ok=true`, `hard_failures=0`, clean tracked repository state,
   five configured bots still running, no event-pipeline drops/sink errors, and
   only known non-hard HSL cooldown/status attention.
+
+### Draft Slice: Cache Debug Profile
+
+- Branch: `codex/v8-cache-debug-profile`.
+- Scope: Phase 5/6 opt-in structured debug enrichment for existing
+  `cache.load.completed`, `cache.flush.completed`, and `cache.warmup_decision`
+  events.
+- Triggering evidence: restart/warm-cache startup speed has been a repeated
+  live-ops concern, and cache events plus performance-report cache aggregation
+  already exist. Unlike `startup`, `state`, `forager`, and other debug-profile
+  event families, cache events did not yet support profile-specific bounded
+  shape metadata when operators enable a focused profile during restart
+  investigations.
+- Intended result: when `cache` debug is enabled, add bounded key/count/source
+  metadata to existing cache load, flush, and warmup-decision events. Keep raw
+  candle rows, file paths, cache contents, event routes, console output, cache
+  behavior, startup behavior, exchange calls, monitor writes, order/risk logic,
+  and trading behavior unchanged.
+- Expected validation: focused cache debug-profile monitor test, live-event
+  debug-profile normalization and registry-doc tests, `py_compile`,
+  `git diff --check`, and the standard added-line silent-handling scan.
 
 ### Draft Slice: Event Query Debug Profile Filter
 

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -29,6 +29,7 @@ LIVE_EVENT_ID_KEYS = (
 LIVE_EVENT_DEBUG_PROFILE_ENV = "PASSIVBOT_LIVE_EVENT_DEBUG_PROFILES"
 LIVE_EVENT_CONSOLE_ENV = "PASSIVBOT_LIVE_EVENT_CONSOLE"
 LIVE_EVENT_DEBUG_PROFILES = (
+    "cache",
     "candles",
     "ema",
     "execution",
@@ -42,7 +43,9 @@ LIVE_EVENT_DEBUG_PROFILES = (
 )
 _LIVE_EVENT_DEBUG_PROFILE_SET = frozenset(LIVE_EVENT_DEBUG_PROFILES)
 _LIVE_EVENT_DEBUG_PROFILE_ALIASES = {
+    "warmup": "cache",
     "candle": "candles",
+    "caches": "cache",
     "emas": "ema",
     "ema-readiness": "ema",
     "ema_readiness": "ema",

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -2326,6 +2326,54 @@ def _reason_counts(data: Any) -> dict[str, int]:
     return dict(sorted(out.items()))
 
 
+def _cache_debug_payload(
+    payload: dict[str, Any],
+    *,
+    data: dict[str, Any],
+    event_kind: str,
+    limit: int = 32,
+) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "event_kind": str(event_kind),
+        "payload_keys": sorted(str(key) for key in payload)[:limit],
+        "data_keys": sorted(str(key) for key in data)[:limit],
+    }
+    numeric_keys: list[str] = []
+    nonzero_numeric_keys: list[str] = []
+    for key in sorted(data):
+        parsed = _safe_int(data.get(key))
+        if parsed is None:
+            continue
+        numeric_keys.append(str(key))
+        if parsed != 0:
+            nonzero_numeric_keys.append(str(key))
+    if numeric_keys:
+        out["numeric_keys"] = numeric_keys[:limit]
+    if nonzero_numeric_keys:
+        out["nonzero_numeric_keys"] = nonzero_numeric_keys[:limit]
+    source_days = data.get("source_days")
+    if isinstance(source_days, dict) and source_days:
+        out["source_day_sources"] = sorted(str(key) for key in source_days)[:limit]
+        out["source_day_total"] = int(
+            sum(
+                int(value)
+                for value in source_days.values()
+                if _safe_int(value) is not None
+            )
+        )
+    reason_counts = data.get("reason_counts")
+    if isinstance(reason_counts, dict) and reason_counts:
+        out["reason_count_keys"] = sorted(str(key) for key in reason_counts)[:limit]
+        out["reason_count_total"] = int(
+            sum(
+                int(value)
+                for value in reason_counts.values()
+                if _safe_int(value) is not None
+            )
+        )
+    return {key: value for key, value in out.items() if value not in (None, {}, [])}
+
+
 def _emit_cache_load_completed_event_unchecked(
     bot: Any,
     payload: dict[str, Any],
@@ -2359,6 +2407,13 @@ def _emit_cache_load_completed_event_unchecked(
                 clean_source_days[str(key)] = int(count)
         if clean_source_days:
             data["source_days"] = dict(sorted(clean_source_days.items()))
+    if live_event_debug_profile_enabled(bot, "cache"):
+        data["debug_profile"] = "cache"
+        data["debug"] = _cache_debug_payload(
+            data_in,
+            data=data,
+            event_kind="load_completed",
+        )
     _safe_emit(
         bot,
         EventTypes.CACHE_LOAD_COMPLETED,
@@ -2402,6 +2457,13 @@ def _emit_cache_flush_completed_event_unchecked(
         value = _safe_int(data_in.get(key))
         if value is not None:
             data[key] = value
+    if live_event_debug_profile_enabled(bot, "cache"):
+        data["debug_profile"] = "cache"
+        data["debug"] = _cache_debug_payload(
+            data_in,
+            data=data,
+            event_kind="flush_completed",
+        )
     _safe_emit(
         bot,
         EventTypes.CACHE_FLUSH_COMPLETED,
@@ -2463,6 +2525,13 @@ def _emit_cache_warmup_decision_event_unchecked(
         safe = _safe_int(value)
         if safe is not None:
             data[key] = safe
+    if live_event_debug_profile_enabled(bot, "cache"):
+        data["debug_profile"] = "cache"
+        data["debug"] = _cache_debug_payload(
+            {},
+            data=data,
+            event_kind="warmup_decision",
+        )
     _safe_emit(
         bot,
         EventTypes.CACHE_WARMUP_DECISION,

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -95,8 +95,9 @@ def test_live_event_debug_profiles_normalize_and_validate():
     assert normalize_live_event_debug_profiles(None) == ()
     assert normalize_live_event_debug_profiles("") == ()
     assert normalize_live_event_debug_profiles(
-        "rust,remote-calls candle EMA-readiness"
+        "rust,remote-calls candle EMA-readiness warmup"
     ) == (
+        "cache",
         "candles",
         "ema",
         "remote_calls",

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1724,6 +1724,116 @@ def test_forager_and_ema_summary_emitters_emit_structured_events():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_cache_debug_profile_adds_bounded_cache_event_shape():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_cache_load_completed_event = (
+            pb_mod.Passivbot._emit_cache_load_completed_event
+        )
+        _emit_cache_flush_completed_event = (
+            pb_mod.Passivbot._emit_cache_flush_completed_event
+        )
+        _emit_cache_warmup_decision_event = (
+            pb_mod.Passivbot._emit_cache_warmup_decision_event
+        )
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "gateio"
+            self.user = "gateio_01"
+            self.bot_id = "bot_1"
+            self.live_event_debug_profiles = ("cache",)
+            self._live_event_current_cycle_id = "cy_cache"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+
+    bot._emit_cache_load_completed_event(
+        {
+            "symbol": "ETH/USDT:USDT",
+            "timeframe": "1m",
+            "start_ts": 120_000,
+            "end_ts": 240_000,
+            "loaded_rows": 3,
+            "source_days": {"primary": 1, "legacy": 0},
+            "path": "/tmp/secret-cache-path/ETH.json",
+        }
+    )
+    bot._emit_cache_flush_completed_event(
+        {
+            "symbol": "ETH/USDT:USDT",
+            "timeframe": "1m",
+            "persisted_rows": 4,
+            "persisted_start_ts": 300_000,
+            "persisted_end_ts": 480_000,
+        }
+    )
+    bot._emit_cache_warmup_decision_event(
+        context="trading-ready warmup",
+        timeframe="1m",
+        symbol_count=3,
+        reused_count=1,
+        cold_count=2,
+        reason_counts={"missing_coverage": 2, "warm_cache_accepted": 1},
+        elapsed_ms=1234,
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    load, flush, warmup = sink.events
+    assert [event.event_type for event in sink.events] == [
+        EventTypes.CACHE_LOAD_COMPLETED,
+        EventTypes.CACHE_FLUSH_COMPLETED,
+        EventTypes.CACHE_WARMUP_DECISION,
+    ]
+    assert {event.data["debug_profile"] for event in sink.events} == {"cache"}
+    assert load.data["debug"] == {
+        "event_kind": "load_completed",
+        "payload_keys": [
+            "end_ts",
+            "loaded_rows",
+            "path",
+            "source_days",
+            "start_ts",
+            "symbol",
+            "timeframe",
+        ],
+        "data_keys": [
+            "debug_profile",
+            "end_ts",
+            "loaded_rows",
+            "source_days",
+            "start_ts",
+            "timeframe",
+        ],
+        "numeric_keys": ["end_ts", "loaded_rows", "start_ts"],
+        "nonzero_numeric_keys": ["end_ts", "loaded_rows", "start_ts"],
+        "source_day_sources": ["legacy", "primary"],
+        "source_day_total": 1,
+    }
+    assert flush.data["debug"]["event_kind"] == "flush_completed"
+    assert flush.data["debug"]["numeric_keys"] == [
+        "persisted_end_ts",
+        "persisted_rows",
+        "persisted_start_ts",
+    ]
+    assert warmup.data["debug"]["event_kind"] == "warmup_decision"
+    assert warmup.data["debug"]["reason_count_keys"] == [
+        "missing_coverage",
+        "warm_cache_accepted",
+    ]
+    assert warmup.data["debug"]["reason_count_total"] == 3
+    rendered = json.dumps([event.data for event in sink.events], sort_keys=True)
+    assert "/tmp/secret-cache-path" not in rendered
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_forager_debug_profile_adds_bounded_selection_shape():
     import passivbot as pb_mod
 


### PR DESCRIPTION
## Summary
- add an opt-in `cache` live-event debug profile for existing cache load, flush, and warmup-decision events
- enrich only profile-enabled cache events with bounded key/count/source metadata; default payloads and console output stay unchanged
- update registry/logging docs, changelog, and logging-overhaul progress ledger

## Validation
- `./venv/bin/python -m pytest tests/test_live_event_bus.py::test_live_event_debug_profiles_normalize_and_validate tests/test_live_event_registry_docs.py::test_live_event_debug_profile_docs_match_registry tests/test_passivbot_monitor.py::test_cache_debug_profile_adds_bounded_cache_event_shape -q`
- `./venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_live_event_registry_docs.py -q`
- `./venv/bin/python -m pytest tests/test_passivbot_monitor.py -q`
- `./venv/bin/python -m py_compile src/live/event_bus.py src/live/event_emitters.py`
- `git diff --check`

## Behavior
Observability-only. No exchange calls, cache behavior, startup behavior, console routing, order/risk logic, or trading behavior changed.