### PR TITLE
Fix optimizer stepped bound quantization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Optimizer stepped bounds now stay on the configured grid for fractional steps
+  such as `0.25`, `0.125`, and `0.0025`, avoiding off-grid candidate values in
+  DEAP, pymoo repair, seed conversion, and result hashing.
 - The `cache` live-event debug profile now enriches existing cache load,
   flush, and warmup-decision events with bounded key/count/source metadata
   without changing default event payloads or console output.

--- a/src/optimization/bounds.py
+++ b/src/optimization/bounds.py
@@ -7,6 +7,7 @@ to discrete steps and enforcing bounds on configuration dictionaries.
 
 import logging
 from dataclasses import dataclass
+from decimal import Decimal
 import math
 from typing import List, Optional, Sequence, Tuple
 
@@ -14,6 +15,13 @@ import numpy as np
 
 # Epsilon for floating-point comparisons in step calculations
 STEP_EPSILON = 1e-9
+
+
+def _decimal_places(value: float) -> int:
+    if not isinstance(value, (int, float)) or not math.isfinite(float(value)):
+        return 0
+    exponent = Decimal(str(float(value))).normalize().as_tuple().exponent
+    return max(0, -int(exponent))
 
 
 def round_to_sig_digits(value: float, sig_digits: int) -> float:
@@ -51,6 +59,13 @@ class Bound:
     low: float
     high: float
     step: Optional[float] = None
+
+    def _grid_value(self, index: int) -> float:
+        value = self.low + int(index) * self.step
+        decimal_places = max(_decimal_places(self.low), _decimal_places(self.step))
+        if decimal_places:
+            value = round(value, decimal_places)
+        return value
 
     @property
     def is_stepped(self) -> bool:
@@ -94,13 +109,7 @@ class Bound:
         # Clamp index to valid range
         clamped_index = max(0, min(self.max_index, n_steps_from_low))
 
-        quantized = self.low + clamped_index * self.step
-
-        # Clean up floating-point artifacts by rounding to step precision
-        # e.g., step=0.0002 -> 4 decimal places, step=0.01 -> 2 decimal places
-        if self.step < 1:
-            decimal_places = -int(math.floor(math.log10(self.step)))
-            quantized = round(quantized, decimal_places)
+        quantized = self._grid_value(clamped_index)
 
         # Final safety clamp
         return max(self.low, min(self.high, quantized))
@@ -118,7 +127,7 @@ class Bound:
         if not self.is_stepped:
             return np.random.uniform(self.low, self.high)
         random_idx = np.random.randint(0, self.max_index + 1)
-        return self.low + random_idx * self.step
+        return self._grid_value(random_idx)
 
     def value_to_index(self, value: float) -> float:
         """
@@ -155,7 +164,7 @@ class Bound:
         # Round to nearest integer index and convert
         rounded_index = int(index + 0.5)
         clamped_index = max(0, min(self.max_index, rounded_index))
-        return self.low + clamped_index * self.step
+        return self._grid_value(clamped_index)
 
     def get_index_bounds(self) -> Tuple[float, float]:
         """

--- a/tests/optimization/test_bounds.py
+++ b/tests/optimization/test_bounds.py
@@ -49,6 +49,27 @@ class TestBound:
         assert b.quantize(1.1) == 1.0
         assert b.quantize(0.5) == pytest.approx(0.5)
 
+    @pytest.mark.parametrize(
+        ("step", "expected"),
+        [
+            (0.25, [0.25, 0.5, 0.75]),
+            (0.125, [0.125, 0.25, 0.375]),
+            (0.0025, [0.0025, 0.005, 0.0075]),
+        ],
+    )
+    def test_quantize_preserves_non_power_of_ten_step_grid(self, step, expected):
+        b = Bound(0.0, 1.0, step)
+
+        assert [b.quantize(step * idx) for idx in range(1, 4)] == pytest.approx(expected)
+
+    def test_quantize_preserves_nonzero_low_step_grid(self):
+        b = Bound(1.125, 2.125, 0.25)
+
+        assert b.quantize(1.37) == pytest.approx(1.375)
+        assert b.quantize(1.62) == pytest.approx(1.625)
+        assert b.quantize(0.0) == pytest.approx(1.125)
+        assert b.quantize(9.0) == pytest.approx(2.125)
+
     def test_random_on_grid_continuous(self):
         b = Bound(0.0, 10.0)
         val = b.random_on_grid()
@@ -79,6 +100,10 @@ class TestBound:
         assert b_step.index_to_value(3.0) == pytest.approx(1.3)
         assert b_step.index_to_value(3.4) == pytest.approx(1.3)
         assert b_step.index_to_value(3.6) == pytest.approx(1.4)
+
+        b_quarter = Bound(0.0, 1.0, 0.25)
+        assert b_quarter.index_to_value(1.0) == pytest.approx(0.25)
+        assert b_quarter.index_to_value(3.0) == pytest.approx(0.75)
 
     def test_get_index_bounds(self):
         b_cont = Bound(1.0, 5.0)
@@ -158,6 +183,14 @@ class TestBoundUtils:
         result = enforce_bounds(values, bounds)
         assert result[0] == 1.0
         assert result[1] == pytest.approx(1.3)
+
+    def test_enforce_bounds_preserves_step_grid_over_sig_digits(self):
+        bounds = [Bound(0.0, 1.0, 0.25), Bound(0.0, 0.01, 0.0025)]
+        values = [0.76, 0.0076]
+
+        result = enforce_bounds(values, bounds, sig_digits=1)
+
+        assert result == pytest.approx([0.75, 0.0075])
 
     def test_enforce_bounds_with_sig_digits(self):
         bounds = [Bound(0.0, 1.0), Bound(1.0, 2.0)]

--- a/tests/optimization/test_deap_adapters.py
+++ b/tests/optimization/test_deap_adapters.py
@@ -43,6 +43,10 @@ class TestDeapAdapters:
         vals_eq = from_index_space([5.0, 99.0], bounds, mask_with_equal)
         assert vals_eq[1] == 1.0  # Reset to low
 
+        quarter_bounds = [Bound(0.0, 1.0, 0.25), Bound(0.0, 0.01, 0.0025)]
+        vals = from_index_space([3.0, 3.0], quarter_bounds, np.array([False, False]))
+        assert vals == pytest.approx([0.75, 0.0075])
+
     @patch("optimization.deap_adapters.deap_tools")
     def test_mutPolynomialBoundedWrapper(self, mock_deap_tools):
         mock_deap_tools.mutPolynomialBounded = MagicMock()

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -1157,10 +1157,10 @@ class TestIndividualToConfig:
         )
         assert vector[key_to_idx["short_close_retracement_base_pct"]] == pytest.approx(0.002)
         assert vector[key_to_idx["short_close_retracement_volatility_1h_weight"]] == pytest.approx(
-            41.0
+            40.0
         )
         assert long_close["retracement_base_pct"] == pytest.approx(0.0)
-        assert short_close["retracement_volatility_1h_weight"] == pytest.approx(41.0)
+        assert short_close["retracement_volatility_1h_weight"] == pytest.approx(40.0)
 
     def test_anchored_fine_tune_materializes_fixed_values_from_anchor(self):
         template = {

--- a/tests/optimization/test_repair.py
+++ b/tests/optimization/test_repair.py
@@ -12,7 +12,7 @@ def test_bounds_repair_quantizes_stepped_and_continuous_values():
 
     repaired = repair._do(
         None,
-        np.asarray([[0.62, 9.876], [-0.2, 12.3]], dtype=np.float64),
+        np.asarray([[0.62, 9.876], [0.76, 12.3], [-0.2, 12.3]], dtype=np.float64),
     )
 
-    assert repaired.tolist() == [[0.5, 9.88], [0.0, 10.0]]
+    assert repaired.tolist() == [[0.5, 9.88], [0.75, 10.0], [0.0, 10.0]]


### PR DESCRIPTION
## Summary
- fix stepped optimizer bounds to round from the actual configured grid instead of decimal-place guesses
- apply the same grid cleanup to quantize, random grid sampling, and DEAP index-to-value conversion
- add regressions for 0.25, 0.125, and 0.0025 steps across bounds, pymoo repair, and DEAP adapters
- update a stale optimizer canonicalization assertion to expect bound-clamped 40.0 for a 0.01..40.0 stepped bound

## Tests
- ./venv/bin/python -m pytest tests/optimization
