### PR TITLE
Fix DEAP optimizer evaluated vector propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable user-facing changes will be documented in this file.
 - Optimizer stepped bounds now stay on the configured grid for fractional steps
   such as `0.25`, `0.125`, and `0.0025`, avoiding off-grid candidate values in
   DEAP, pymoo repair, seed conversion, and result hashing.
+- Fixed DEAP optimizer candidate recording so duplicate-guard perturbations and
+  evaluated starting seeds keep the fitness attached to the actual evaluated
+  parameter vector.
 - The `cache` live-event debug profile now enriches existing cache load,
   flush, and warmup-decision events with bounded key/count/source metadata
   without changing default event payloads or console output.

--- a/src/optimization/backends/deap_backend.py
+++ b/src/optimization/backends/deap_backend.py
@@ -23,6 +23,7 @@ from optimization.backend_shared import (
     log_seed_memory,
     stream_async_results,
 )
+from optimization.evaluation_payload import apply_evaluation_payload
 from optimization.deap_adapters import (
     cxSimulatedBinaryBoundedWrapper,
     mutPolynomialBoundedWrapper,
@@ -41,6 +42,22 @@ def _resolve_deap_population_size(config: dict[str, Any]) -> int:
         )
         return DEFAULT_DEAP_POPULATION_SIZE
     return max(1, int(raw))
+
+
+def _clone_evaluated_individual(individual):
+    clone = individual.__class__(individual)
+    source_fitness = getattr(individual, "fitness", None)
+    clone_fitness = getattr(clone, "fitness", None)
+    if source_fitness is not None and clone_fitness is not None:
+        if getattr(source_fitness, "valid", False):
+            clone_fitness.values = tuple(source_fitness.values)
+        if hasattr(source_fitness, "constraint_violation"):
+            clone_fitness.constraint_violation = source_fitness.constraint_violation
+    if hasattr(individual, "constraint_violation"):
+        clone.constraint_violation = individual.constraint_violation
+    if hasattr(individual, "evaluation_metrics"):
+        clone.evaluation_metrics = deepcopy(individual.evaluation_metrics)
+    return clone
 
 
 def run_backend(
@@ -145,10 +162,7 @@ def run_backend(
             completed = {"count": 0}
 
             def _on_result(ind, payload):
-                fit_values, penalty, metrics = payload
-                ind.fitness.values = fit_values
-                ind.fitness.constraint_violation = penalty
-                ind.constraint_violation = penalty
+                metrics = apply_evaluation_payload(ind, payload)
                 if metrics is not None:
                     ind.evaluation_metrics = metrics
                     record_individual_result(
@@ -252,7 +266,7 @@ def run_backend(
                         approx_bytes=approx_object_size(evaluated_seeds),
                     )
                 for i, ind in enumerate(evaluated_seeds):
-                    population[i] = creator.Individual(ind)
+                    population[i] = _clone_evaluated_individual(ind)
 
                 remaining = population_size - len(evaluated_seeds)
                 seed_pool = evaluated_seeds if evaluated_seeds else []

--- a/src/optimization/evaluation_payload.py
+++ b/src/optimization/evaluation_payload.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+
+def build_evaluation_payload(
+    fit_values: Sequence[float],
+    penalty: float,
+    metrics_payload: dict | None,
+    individual,
+) -> dict[str, Any]:
+    return {
+        "fitness": tuple(fit_values),
+        "constraint_violation": penalty,
+        "metrics": metrics_payload,
+        "evaluation_vector": list(individual),
+    }
+
+
+def unpack_evaluation_payload(payload):
+    if isinstance(payload, dict):
+        try:
+            fit_values = tuple(payload["fitness"])
+            penalty = payload["constraint_violation"]
+        except KeyError as exc:
+            raise ValueError(f"missing optimizer evaluation payload field: {exc.args[0]}") from exc
+        return fit_values, penalty, payload.get("metrics"), payload.get("evaluation_vector")
+    fit_values, penalty, metrics = payload
+    return tuple(fit_values), penalty, metrics, None
+
+
+def apply_evaluation_payload(individual, payload):
+    fit_values, penalty, metrics, evaluation_vector = unpack_evaluation_payload(payload)
+    if evaluation_vector is not None:
+        individual[:] = list(evaluation_vector)
+    individual.fitness.values = fit_values
+    individual.fitness.constraint_violation = penalty
+    individual.constraint_violation = penalty
+    return metrics

--- a/src/optimization/problem.py
+++ b/src/optimization/problem.py
@@ -11,6 +11,7 @@ from pymoo.core.problem import ElementwiseProblem
 from optimization.backend_shared import drain_async_results
 from optimization.bounds import Bound
 from optimization.callback import build_pymoo_record_entry
+from optimization.evaluation_payload import unpack_evaluation_payload
 
 
 _PYMOO_WORKER_EVALUATOR = None
@@ -58,10 +59,14 @@ def _evaluate_pymoo_worker(
     has_constraints: bool,
 ) -> dict[str, Any]:
     evaluated_vector = list(float(v) for v in vector)
-    objectives, constraint_violation, metrics = evaluator.evaluate(
-        evaluated_vector,
-        list(overrides_list or []),
+    objectives, constraint_violation, metrics, payload_vector = unpack_evaluation_payload(
+        evaluator.evaluate(
+            evaluated_vector,
+            list(overrides_list or []),
+        )
     )
+    if payload_vector is not None:
+        evaluated_vector = list(float(v) for v in payload_vector)
     objectives_arr = np.asarray(objectives, dtype=np.float64)
     if len(objectives_arr) != int(n_obj):
         raise ValueError(
@@ -104,10 +109,14 @@ class PymooEvaluatorAdapter:
 
     def evaluate(self, vector: Sequence[float]) -> dict[str, Any]:
         evaluated_vector = list(float(v) for v in vector)
-        objectives, constraint_violation, metrics = self.evaluator.evaluate(
-            evaluated_vector,
-            self.overrides_list,
+        objectives, constraint_violation, metrics, payload_vector = unpack_evaluation_payload(
+            self.evaluator.evaluate(
+                evaluated_vector,
+                self.overrides_list,
+            )
         )
+        if payload_vector is not None:
+            evaluated_vector = list(float(v) for v in payload_vector)
         return {
             "objectives": list(objectives),
             "constraint_violation": float(constraint_violation),

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -188,6 +188,7 @@ from optimization.config_adapter import (
     get_optimization_key_paths,
     resolve_optimization_bound_path,
 )
+from optimization.evaluation_payload import apply_evaluation_payload, build_evaluation_payload
 from optimization.warmup import (
     build_optimizer_vector_config,
     compute_optimizer_per_coin_warmup_minutes,
@@ -954,11 +955,8 @@ def ea_mu_plus_lambda_stream(
 
         def _on_result(idx, payload):
             nonlocal liquidation_total
-            fit_values, penalty, metrics = payload
             ind = individuals[idx]
-            ind.fitness.values = fit_values
-            ind.fitness.constraint_violation = penalty
-            ind.constraint_violation = penalty
+            metrics = apply_evaluation_payload(ind, payload)
             if metrics and isinstance(metrics, dict):
                 suite = metrics.get("suite_metrics", {}) or {}
                 metric_map = suite.get("metrics", {}) or {}
@@ -1548,7 +1546,12 @@ class Evaluator:
                 else:
                     if existing_score is not None:
                         self.duplicate_counter["reused"] += 1
-                        return tuple(existing_score), existing_penalty, None
+                        return build_evaluation_payload(
+                            existing_score,
+                            existing_penalty,
+                            None,
+                            individual,
+                        )
             else:
                 self.seen_hashes[individual_hash] = None
         analyses = {}
@@ -1590,7 +1593,12 @@ class Evaluator:
                 _set_candidate_metrics(individual, metrics_payload)
                 actual_hash = calc_hash(individual)
                 self.seen_hashes[actual_hash] = (tuple(objectives), total_penalty)
-                return tuple(objectives), total_penalty, metrics_payload
+                return build_evaluation_payload(
+                    objectives,
+                    total_penalty,
+                    metrics_payload,
+                    individual,
+                )
             analyses[exchange] = analysis
             liquidated = liquidated or _analysis_indicates_liquidation(analysis, config)
 
@@ -1621,7 +1629,12 @@ class Evaluator:
             actual_hash = calc_hash(individual)
             if self.use_duplicate_guard:
                 self.seen_hashes[actual_hash] = (tuple(objectives), total_penalty)
-            return tuple(objectives), total_penalty, metrics_payload
+            return build_evaluation_payload(
+                objectives,
+                total_penalty,
+                metrics_payload,
+                individual,
+            )
         metrics_payload = {
             "stats": aggregate_stats,
             "objectives": raw_objectives,
@@ -1632,7 +1645,7 @@ class Evaluator:
         actual_hash = calc_hash(individual)
         if self.use_duplicate_guard:
             self.seen_hashes[actual_hash] = (tuple(objectives), total_penalty)
-        return tuple(objectives), total_penalty, metrics_payload
+        return build_evaluation_payload(objectives, total_penalty, metrics_payload, individual)
 
     def build_limit_checks(self, aggregate_cfg: Dict[str, Any] | None = None):
         limits = self.config["optimize"].get("limits", [])
@@ -1876,7 +1889,12 @@ class SuiteEvaluator:
                 else:
                     if existing_score is not None:
                         duplicate_counter["reused"] += 1
-                        return tuple(existing_score), existing_penalty, None
+                        return build_evaluation_payload(
+                            existing_score,
+                            existing_penalty,
+                            None,
+                            individual,
+                        )
             else:
                 seen_hashes[individual_hash] = None
 
@@ -1974,7 +1992,12 @@ class SuiteEvaluator:
                     _set_candidate_metrics(individual, metrics_payload)
                     actual_hash = calc_hash(individual)
                     self.base.seen_hashes[actual_hash] = (tuple(objectives), total_penalty)
-                    return tuple(objectives), total_penalty, metrics_payload
+                    return build_evaluation_payload(
+                        objectives,
+                        total_penalty,
+                        metrics_payload,
+                        individual,
+                    )
                 analyses[exchange] = analysis
                 liquidated = liquidated or _analysis_indicates_liquidation(
                     analysis, scenario_config
@@ -2005,7 +2028,12 @@ class SuiteEvaluator:
                 _set_candidate_metrics(individual, metrics_payload)
                 actual_hash = calc_hash(individual)
                 self.base.seen_hashes[actual_hash] = (tuple(objectives), total_penalty)
-                return tuple(objectives), total_penalty, metrics_payload
+                return build_evaluation_payload(
+                    objectives,
+                    total_penalty,
+                    metrics_payload,
+                    individual,
+                )
             _profile_add(timings, "combine_metrics_ms", phase_start)
             stats = combined_metrics.get("stats", {})
             logging.debug(
@@ -2094,7 +2122,7 @@ class SuiteEvaluator:
         actual_hash = calc_hash(individual)
         if self.base.use_duplicate_guard:
             self.base.seen_hashes[actual_hash] = (tuple(objectives), total_penalty)
-        return tuple(objectives), total_penalty, metrics_payload
+        return build_evaluation_payload(objectives, total_penalty, metrics_payload, individual)
 
     def __del__(self):
         for ctx in self.contexts:

--- a/tests/optimization/test_backends.py
+++ b/tests/optimization/test_backends.py
@@ -13,10 +13,12 @@ from config_utils import (
 from optimization.backends import get_backend_runner
 from optimization.backends.deap_backend import (
     DEFAULT_DEAP_POPULATION_SIZE,
+    _clone_evaluated_individual,
     _resolve_deap_population_size,
 )
 from optimization.backends.deap_backend import run_backend as run_deap_backend
 from optimization.backends.pymoo_backend import run_backend as run_pymoo_backend
+from optimization.evaluation_payload import apply_evaluation_payload
 
 
 def _optimize_parser():
@@ -127,6 +129,64 @@ def test_format_config_preserves_null_population_size_for_pymoo():
 
 def test_resolve_deap_population_size_uses_fallback_for_null():
     assert _resolve_deap_population_size({"optimize": {"population_size": None}}) == DEFAULT_DEAP_POPULATION_SIZE
+
+
+def test_deap_backend_apply_payload_uses_worker_evaluation_vector():
+    class Fitness:
+        values = ()
+        constraint_violation = None
+
+    class Candidate(list):
+        def __init__(self, values):
+            super().__init__(values)
+            self.fitness = Fitness()
+
+    individual = Candidate([1.0, 2.0])
+    payload = {
+        "fitness": (0.3,),
+        "constraint_violation": 4.0,
+        "metrics": {"objective": 1.0},
+        "evaluation_vector": [5.0, 6.0],
+    }
+
+    metrics = apply_evaluation_payload(individual, payload)
+
+    assert individual == [5.0, 6.0]
+    assert individual.fitness.values == (0.3,)
+    assert individual.fitness.constraint_violation == 4.0
+    assert individual.constraint_violation == 4.0
+    assert metrics == {"objective": 1.0}
+
+
+def test_clone_evaluated_individual_preserves_fitness_and_metrics():
+    class Fitness:
+        def __init__(self):
+            self.values = ()
+            self.valid = False
+            self.constraint_violation = None
+
+    class Candidate(list):
+        def __init__(self, values):
+            super().__init__(values)
+            self.fitness = Fitness()
+
+    individual = Candidate([1.0, 2.0])
+    individual.fitness.values = (0.7,)
+    individual.fitness.valid = True
+    individual.fitness.constraint_violation = 1.5
+    individual.constraint_violation = 1.5
+    individual.evaluation_metrics = {"nested": {"value": 1}}
+
+    clone = _clone_evaluated_individual(individual)
+
+    assert clone is not individual
+    assert clone == [1.0, 2.0]
+    assert clone.fitness.values == (0.7,)
+    assert clone.fitness.constraint_violation == 1.5
+    assert clone.constraint_violation == 1.5
+    assert clone.evaluation_metrics == {"nested": {"value": 1}}
+    individual.evaluation_metrics["nested"]["value"] = 2
+    assert clone.evaluation_metrics == {"nested": {"value": 1}}
 
 
 def test_get_backend_runner_resolves_supported_backends():

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -53,6 +53,11 @@ from optimization.bounds import Bound
 from optimization.callback import build_pymoo_record_entry
 from optimization.config_adapter import extract_bounds_tuple_list_from_config
 from optimization.config_adapter import get_optimization_key_paths
+from optimization.evaluation_payload import (
+    apply_evaluation_payload,
+    build_evaluation_payload,
+    unpack_evaluation_payload,
+)
 from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, ANCHOR_PLAN_KEY
 from optimization.shape import build_optimization_shape
 from optimization.warmup import build_optimizer_max_config
@@ -88,6 +93,54 @@ def test_candidate_metrics_sidecars_only_attach_to_objects():
     assert not hasattr(plain_vector, "evaluation_metrics")
     _clear_candidate_metrics(plain_vector)
     assert plain_vector == [1.0, 2.0]
+
+
+def test_deap_evaluation_payload_applies_evaluated_vector_to_parent_individual():
+    class Fitness:
+        values = ()
+        constraint_violation = None
+
+    class Candidate(list):
+        def __init__(self, values):
+            super().__init__(values)
+            self.fitness = Fitness()
+
+    individual = Candidate([1.0, 2.0])
+    payload = build_evaluation_payload(
+        (0.1, 0.2),
+        3.0,
+        {"liquidated": False},
+        [4.0, 5.0],
+    )
+
+    metrics = apply_evaluation_payload(individual, payload)
+
+    assert individual == [4.0, 5.0]
+    assert individual.fitness.values == (0.1, 0.2)
+    assert individual.fitness.constraint_violation == 3.0
+    assert individual.constraint_violation == 3.0
+    assert metrics == {"liquidated": False}
+
+
+def test_deap_evaluation_payload_accepts_legacy_tuple_payload_without_mutating_vector():
+    class Fitness:
+        values = ()
+        constraint_violation = None
+
+    class Candidate(list):
+        def __init__(self, values):
+            super().__init__(values)
+            self.fitness = Fitness()
+
+    individual = Candidate([1.0, 2.0])
+
+    metrics = apply_evaluation_payload(individual, ((0.1,), 2.0, None))
+
+    assert individual == [1.0, 2.0]
+    assert individual.fitness.values == (0.1,)
+    assert individual.fitness.constraint_violation == 2.0
+    assert individual.constraint_violation == 2.0
+    assert metrics is None
 
 
 class TestApplyConfigOverrides:
@@ -3232,7 +3285,9 @@ class TestEvaluator:
                 "hard-stop evaluation failed at k 1 ts 2 equity -1 peak_strategy_equity 10: equity must be finite and > 0"
             ),
         ):
-            objectives, penalty, metrics = evaluator.evaluate(individual, [])
+            objectives, penalty, metrics, _ = unpack_evaluation_payload(
+                evaluator.evaluate(individual, [])
+            )
 
         assert objectives == (0.0, 0.0)
         assert penalty == INVALID_BACKTEST_CANDIDATE_PENALTY
@@ -3274,7 +3329,9 @@ class TestEvaluator:
                 "pside 1: equity must be finite and > 0"
             ),
         ):
-            objectives, penalty, metrics = evaluator.evaluate(individual, [])
+            objectives, penalty, metrics, _ = unpack_evaluation_payload(
+                evaluator.evaluate(individual, [])
+            )
 
         assert objectives == (0.0, 0.0)
         assert penalty == INVALID_BACKTEST_CANDIDATE_PENALTY
@@ -3435,7 +3492,9 @@ class TestEvaluator:
                 "hard-stop evaluation failed at k 1 ts 2 equity -1 peak_strategy_equity 10: equity must be finite and > 0"
             ),
         ):
-            objectives, penalty, metrics = evaluator.evaluate(individual, [])
+            objectives, penalty, metrics, _ = unpack_evaluation_payload(
+                evaluator.evaluate(individual, [])
+            )
 
         assert objectives == (0.0,)
         assert penalty == INVALID_BACKTEST_CANDIDATE_PENALTY
@@ -3501,7 +3560,9 @@ class TestEvaluator:
             "tools.iterative_backtester.combine_analyses",
             return_value={"stats": {"adg_pnl_w": {"mean": 0.1}}},
         ):
-            objectives, penalty, metrics = evaluator.evaluate(individual, [])
+            objectives, penalty, metrics, _ = unpack_evaluation_payload(
+                evaluator.evaluate(individual, [])
+            )
 
         assert objectives == (-0.1,)
         assert penalty == 0.0
@@ -3568,7 +3629,9 @@ class TestEvaluator:
             "tools.iterative_backtester.combine_analyses",
             return_value={"stats": {"adg_pnl_w": {"mean": 0.1}}},
         ):
-            objectives, penalty, metrics = evaluator.evaluate(individual, [])
+            objectives, penalty, metrics, _ = unpack_evaluation_payload(
+                evaluator.evaluate(individual, [])
+            )
 
         assert objectives == (-0.1,)
         assert penalty == 0.0

--- a/tests/optimization/test_problem.py
+++ b/tests/optimization/test_problem.py
@@ -40,6 +40,18 @@ class SingleObjectiveEvaluator:
         )
 
 
+class PayloadEvaluator:
+    limit_checks = []
+
+    def evaluate(self, vector, overrides_list):
+        return {
+            "fitness": (-2.0,),
+            "constraint_violation": 0.0,
+            "metrics": {"objectives": {"w_0": -2.0}},
+            "evaluation_vector": [0.42, float(vector[1])],
+        }
+
+
 class FakeAsyncResult:
     def __init__(self, value):
         self._value = value
@@ -95,6 +107,21 @@ def test_problem_without_constraints_omits_g():
 
     assert "G" not in out
     assert out["F"].tolist() == [-1.5]
+
+
+def test_problem_accepts_shared_evaluation_payload_vector():
+    adapter = PymooEvaluatorAdapter(PayloadEvaluator())
+    problem = PassivbotProblem(
+        bounds=[Bound(0.0, 1.0), Bound(0.0, 2.0)],
+        scoring_keys=["adg"],
+        evaluator_adapter=adapter,
+    )
+
+    out = {}
+    problem._evaluate(np.asarray([0.7, 1.1]), out)
+
+    assert out["F"].tolist() == [-2.0]
+    assert out["evaluation_vector"].tolist() == [0.42, 1.1]
 
 
 def test_async_recording_runner_records_and_strips_metrics():


### PR DESCRIPTION
## Summary
- return DEAP evaluator payloads with the actual worker-side evaluated vector
- apply evaluated vectors before recording candidates in generation and starting-config callbacks
- preserve fitness, constraint violation, and evaluation metrics when inserting evaluated seed configs into the DEAP population

## Tests
- ./venv/bin/python -m pytest tests/optimization/test_optimize.py::test_deap_evaluation_payload_applies_evaluated_vector_to_parent_individual tests/optimization/test_optimize.py::test_deap_evaluation_payload_accepts_legacy_tuple_payload_without_mutating_vector tests/optimization/test_backends.py::test_deap_backend_apply_payload_uses_worker_evaluation_vector tests/optimization/test_backends.py::test_clone_evaluated_individual_preserves_fitness_and_metrics
- ./venv/bin/python -m pytest tests/optimization/test_backends.py