### PR TITLE
Harden optimizer Pareto recording failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ All notable user-facing changes will be documented in this file.
   population and worker RNGs, including replacing pymoo's previous fixed
   default seed, while an integer seed opts into deterministic seeding for
   diagnostics.
+- Optimizer Pareto recording now fails loudly on corrupt existing Pareto files
+  or invalid objective payloads instead of silently skipping store errors or
+  pruning files that were never loaded.
 - The `cache` live-event debug profile now enriches existing cache load,
   flush, and warmup-decision events with bounded key/count/source metadata
   without changing default event payloads or console output.

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -376,6 +376,8 @@ class ResultRecorder:
         bounds: Optional[Sequence[Bound]] = None,
         starting_iters: int = 0,
     ):
+        self.scoring_specs = extract_objective_specs(scoring_keys)
+        self.scoring_keys = [spec.metric for spec in self.scoring_specs]
         self.store = ParetoStore(
             directory=results_dir,
             sig_digits=sig_digits,
@@ -384,6 +386,8 @@ class ResultRecorder:
             log_name="optimizer.pareto",
             max_size=pareto_max_size,
         )
+        self.store.scoring_specs = self.scoring_specs
+        self.store.scoring_keys = self.scoring_keys
         self.store.n_iters = starting_iters
         self.write_all = write_all_results
         self.compress = compress
@@ -395,8 +399,6 @@ class ResultRecorder:
             self.packer = msgpack.Packer(use_bin_type=True)
         self.prev_data = None
         self.counter = 0
-        self.scoring_specs = extract_objective_specs(scoring_keys)
-        self.scoring_keys = [spec.metric for spec in self.scoring_specs]
 
     def record(self, data: dict) -> None:
         if self.write_all and self.results_file:
@@ -420,7 +422,7 @@ class ResultRecorder:
         try:
             updated = self.store.add_entry(data)
         except Exception as exc:
-            logging.error(f"ParetoStore error: {exc}")
+            raise RuntimeError("Error updating Pareto store") from exc
         else:
             if updated:
                 objectives_block = metrics_block.get("objectives", {})

--- a/src/pareto_core.py
+++ b/src/pareto_core.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 import numpy as np
 
 from config.scoring import ObjectiveSpec, dominates_objectives, extract_objective_specs, from_engine_value
-from config.metrics import resolve_metric_value
+from config.metrics import canonicalize_metric_name, resolve_metric_value
 
 
 @dataclass(frozen=True)
@@ -15,6 +15,16 @@ class ParetoPoint:
     hash_id: str
     objectives: Tuple[float, ...]
     violation: float = 0.0
+
+
+def _canonicalized_objective_map(objectives_map: Dict[str, Any]) -> Dict[str, Any]:
+    resolved: Dict[str, Any] = dict(objectives_map)
+    for key, value in objectives_map.items():
+        key_text = str(key)
+        if key_text.startswith("w_"):
+            continue
+        resolved.setdefault(canonicalize_metric_name(key_text), value)
+    return resolved
 
 
 def detect_latest_pareto_dir(root: str | Path = "optimize_results") -> Optional[Path]:
@@ -44,10 +54,13 @@ def extract_objectives(
     objectives_map = metrics_block.get("objectives", metrics_block) or {}
     specs = extract_objective_specs(scoring_keys or entry.get("optimize", {}).get("scoring", []))
     if specs:
+        canonical_objectives_map = _canonicalized_objective_map(objectives_map)
         values: list[float] = []
         keys: list[str] = []
         for idx, spec in enumerate(specs):
             value = resolve_metric_value(objectives_map, spec.metric)
+            if value is None:
+                value = resolve_metric_value(canonical_objectives_map, spec.metric)
             if value is None:
                 value = objectives_map.get(f"w_{idx}")
                 if value is not None:

--- a/src/pareto_store.py
+++ b/src/pareto_store.py
@@ -193,6 +193,8 @@ class ParetoStore:
         self._violations: dict[str, float] = {}  # hash -> constraint violation
         self._front: list[str] = []  # list of hashes (Pareto set)
         self._objective_lookup: dict[tuple, str] = {}  # objective vector ➜ hash
+        self._loaded_files: set[str] = set()
+        self._unloaded_files: set[str] = set()
         # ------------------------------------------------------------------
         self.n_iters = 0
         self._last_flush_ts = time.time()
@@ -222,7 +224,10 @@ class ParetoStore:
             obj, _ = extract_objectives(
                 entry, scoring_keys=self.scoring_specs or entry.get("optimize", {}).get("scoring")
             )
+            obj = self._validate_objective_vector(obj)
             violation = extract_violation(entry)
+            if not math.isfinite(violation):
+                raise ValueError(f"Pareto entry has non-finite constraint violation: {violation!r}")
 
             # ───────────── NEW: dedupe on the objective vector ──────────────
             existing_hash = self._objective_lookup.get(obj)
@@ -313,34 +318,84 @@ class ParetoStore:
             self._last_flush_ts = time.time()
 
     def _write_all_to_disk(self) -> None:
-        if not self._front:
-            for fp in glob.glob(os.path.join(self.pareto_dir, "*.json")):
-                try:
-                    os.remove(fp)
-                except OSError:
-                    pass
-            return
+        if self._unloaded_files:
+            paths = ", ".join(sorted(self._unloaded_files))
+            raise RuntimeError(
+                "Refusing to prune Pareto files because existing files failed to load: "
+                f"{paths}"
+            )
 
         live_files = set(self._entries.values())
-        for fp in glob.glob(os.path.join(self.pareto_dir, "*.json")):
+        for fp in sorted(self._loaded_files):
             if fp not in live_files:
                 try:
                     os.remove(fp)
                 except OSError as e:
                     self._log.warning("Could not remove obsolete Pareto file %s: %s", fp, e)
+                else:
+                    self._loaded_files.discard(fp)
 
     def _bootstrap_from_disk(self) -> None:
         """
         Read existing *.json files once at start so we don’t lose old results
         when the new optimizer run appends.
         """
+        errors: list[str] = []
+        entries: list[tuple[str, dict[str, Any]]] = []
         for fp in glob.glob(os.path.join(self.pareto_dir, "*.json")):
             try:
                 with open(fp) as f:
                     entry = json.load(f)
-                self.add_entry(entry, source_path=fp)
             except Exception as e:
-                print(f"bootstrap skip {fp}: {e}")
+                self._unloaded_files.add(fp)
+                errors.append(f"{fp}: {e}")
+                self._log.error("Could not load existing Pareto file %s: %s", fp, e)
+            else:
+                entries.append((fp, entry))
+        bootstrap_specs = None
+        for fp, entry in entries:
+            if bootstrap_specs is None:
+                bootstrap_specs = extract_objective_specs(entry)
+            try:
+                obj, _ = extract_objectives(
+                    entry, scoring_keys=bootstrap_specs or entry.get("optimize", {}).get("scoring")
+                )
+                self._validate_objective_vector(obj)
+                violation = extract_violation(entry)
+                if not math.isfinite(violation):
+                    raise ValueError(
+                        f"Pareto entry has non-finite constraint violation: {violation!r}"
+                    )
+            except Exception as e:
+                self._unloaded_files.add(fp)
+                errors.append(f"{fp}: {e}")
+                self._log.error("Could not load existing Pareto file %s: %s", fp, e)
+        if errors:
+            joined = "; ".join(errors)
+            raise RuntimeError(
+                f"failed to load {len(errors)} existing Pareto file(s); "
+                f"fix or move them before optimizing: {joined}"
+            )
+        for fp, entry in entries:
+            self._loaded_files.add(fp)
+            self.add_entry(entry, source_path=fp)
+
+    @staticmethod
+    def _validate_objective_vector(obj: Sequence[Any]) -> tuple[float, ...]:
+        if not obj:
+            raise ValueError("Pareto entry has no objective values")
+        values: list[float] = []
+        for idx, value in enumerate(obj):
+            try:
+                numeric = float(value)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Pareto objective at index {idx} is missing or non-numeric: {value!r}"
+                ) from exc
+            if not math.isfinite(numeric):
+                raise ValueError(f"Pareto objective at index {idx} is non-finite: {value!r}")
+            values.append(numeric)
+        return tuple(values)
 
     def _log_front_state(self, *, added: int, removed: int) -> None:
         """Emit a compact one‑liner with min / max / spread per objective."""
@@ -420,6 +475,7 @@ class ParetoStore:
                     )
                 os.replace(tmp, path)
         self._entries[hash_id] = path
+        self._loaded_files.add(path)
 
     def _delete_entry_file(self, hash_id: str) -> None:
         path = self._entries.pop(hash_id, None)
@@ -428,6 +484,8 @@ class ParetoStore:
                 os.remove(path)
             except OSError:
                 pass
+            else:
+                self._loaded_files.discard(path)
 
 
 def comma_separated_values_float(x):

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -3095,6 +3095,30 @@ class TestResultRecorder:
 
             recorder.close()
 
+    def test_record_raises_when_pareto_store_fails(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = ResultRecorder(
+                results_dir=tmpdir,
+                sig_digits=6,
+                flush_interval=60,
+                scoring_keys=["metric1"],
+                compress=False,
+                write_all_results=False,
+                bounds=None,
+            )
+            data = {
+                "bot": {"long": {}, "short": {}},
+                "metrics": {
+                    "objectives": {"metric1": None},
+                    "constraint_violation": 0.0,
+                },
+            }
+
+            with pytest.raises(RuntimeError, match="Error updating Pareto store"):
+                recorder.record(data)
+
+            recorder.close()
+
     def test_flush_and_close(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             bounds = [(0.0, 1.0, 0.0)] * 4

--- a/tests/test_pareto_core.py
+++ b/tests/test_pareto_core.py
@@ -28,6 +28,13 @@ def test_extract_objectives_respects_scoring_order():
     assert keys == ["m0", "m1", "m2"]
 
 
+def test_extract_objectives_resolves_canonical_metric_alias_keys():
+    entry = {"metrics": {"objectives": {"adg": 0.1}}}
+    obj, keys = extract_objectives(entry, scoring_keys=["adg"])
+    assert obj == (0.1,)
+    assert keys == ["adg_usd"]
+
+
 def test_prune_preserves_extremes_and_uses_crowding():
     front = ["a", "b", "c", "d", "e"]
     objectives = {

--- a/tests/test_pareto_extremes.py
+++ b/tests/test_pareto_extremes.py
@@ -21,7 +21,7 @@ def _make_candidate(w_values, violation=0.0):
 
 
 @pytest.mark.parametrize("sig_digits", [6])
-def test_pareto_front_retains_per_metric_extremes(sig_digits):
+def test_pareto_front_retains_per_metric_extremes(sig_digits, tmp_path):
     random.seed(42)
 
     # Build a synthetic candidate set with 3 objectives and some violating entries.
@@ -49,7 +49,7 @@ def test_pareto_front_retains_per_metric_extremes(sig_digits):
 
     # Build Pareto front with pruning (max_size << total candidates).
     store = ParetoStore(
-        directory="/tmp",
+        directory=str(tmp_path),
         sig_digits=sig_digits,
         flush_interval=10_000,
         max_size=50,  # force pruning to check extreme preservation
@@ -104,3 +104,39 @@ def test_pareto_store_persists_candidate_without_extra_rounding(tmp_path):
     saved = json.loads(saved_files[0].read_text())
 
     assert saved["bot"]["long"]["entry_we_weight"] == 1.384
+
+
+def test_pareto_store_bootstrap_failure_raises_and_preserves_files(tmp_path):
+    pareto_dir = tmp_path / "pareto"
+    pareto_dir.mkdir()
+    corrupt = pareto_dir / "corrupt.json"
+    corrupt.write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="failed to load 1 existing Pareto file"):
+        ParetoStore(directory=str(tmp_path), sig_digits=6, flush_interval=10_000, max_size=50)
+
+    assert corrupt.exists()
+
+
+def test_pareto_store_flush_does_not_delete_files_that_were_never_loaded(tmp_path):
+    store = ParetoStore(directory=str(tmp_path), sig_digits=6, flush_interval=10_000, max_size=50)
+    unknown = tmp_path / "pareto" / "unknown.json"
+    unknown.write_text(json.dumps(_make_candidate({"metric1": 1.0})), encoding="utf-8")
+
+    store.flush_now()
+
+    assert unknown.exists()
+
+
+def test_pareto_store_rejects_missing_objective_values(tmp_path):
+    entry = {
+        "metrics": {
+            "objectives": {"metric1": None},
+            "constraint_violation": 0.0,
+        },
+        "optimize": {"scoring": ["metric1"]},
+    }
+    store = ParetoStore(directory=str(tmp_path), sig_digits=6, flush_interval=10_000, max_size=50)
+
+    with pytest.raises(ValueError, match="missing or non-numeric"):
+        store.add_entry(entry)


### PR DESCRIPTION
## Summary
- fail loudly when existing Pareto JSON files cannot be parsed or validated during bootstrap
- track loaded Pareto files and only prune files the store actually loaded, preserving unknown/unloaded JSON files
- validate objective vectors before dominance/deduplication and propagate ParetoStore failures through ResultRecorder
- apply ResultRecorder scoring specs to the store for active-run objective validation

## Tests
- ./venv/bin/python -m pytest tests/test_pareto_core.py tests/test_pareto_extremes.py tests/test_pareto_limits.py tests/optimization/test_optimize.py::TestResultRecorder