### PR TITLE
Fail loudly for invalid optimizer suite scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable user-facing changes will be documented in this file.
 - Fixed DEAP optimizer candidate recording so duplicate-guard perturbations and
   evaluated starting seeds keep the fitness attached to the actual evaluated
   parameter vector.
+- Suite optimizer context preparation now matches suite-runner exchange and
+  coin-universe setup, and fails loudly when a scenario cannot be prepared
+  instead of silently dropping scenarios or falling back to other exchanges.
 - The `cache` live-event debug profile now enriches existing cache load,
   flush, and warmup-decision events with bounded key/count/source metadata
   without changing default event payloads or console output.

--- a/src/optimize_suite.py
+++ b/src/optimize_suite.py
@@ -70,9 +70,23 @@ async def prepare_suite_contexts(
     """Prepare datasets and configs for every optimizer suite scenario."""
 
     base_exchanges = require_config_value(config, "backtest.exchanges")
-    for exchange in base_exchanges:
+    scenarios, aggregate_cfg = build_scenarios(suite_cfg, base_exchanges=base_exchanges)
+
+    # Determine which individual exchange datasets are needed for single-exchange scenarios
+    needed_individual = _determine_needed_individual_exchanges(scenarios, base_exchanges)
+    exchanges_list = sorted(set(base_exchanges) | needed_individual)
+    added_exchanges = needed_individual - set(base_exchanges)
+    if added_exchanges:
+        logging.info(
+            "Expanded optimizer suite exchanges from %s to %s (added %s from scenario requirements)",
+            base_exchanges,
+            exchanges_list,
+            sorted(added_exchanges),
+        )
+
+    for exchange in exchanges_list:
         await load_markets(exchange, verbose=False)
-    await format_approved_ignored_coins(config, base_exchanges, verbose=False)
+    await format_approved_ignored_coins(config, exchanges_list, verbose=False)
     validate_suite_side_coin_lists(config)
 
     base_start = require_config_value(config, "backtest.start_date")
@@ -95,32 +109,17 @@ async def prepare_suite_contexts(
     else:
         base_ignored_list = []
 
-    scenarios, aggregate_cfg = build_scenarios(suite_cfg, base_exchanges=base_exchanges)
-
-    # Determine which individual exchange datasets are needed for single-exchange scenarios
-    needed_individual = _determine_needed_individual_exchanges(scenarios, base_exchanges)
-
     suite_coin_sources = collect_suite_coin_sources(config, scenarios)
 
-    # Collect all coins from scenarios (or use base if no scenario-specific coins)
-    master_coins = set()
-    master_ignored = set()
+    # Match suite_runner: scenario-specific coins extend the base universe, they do not replace it.
+    master_coins = set(base_coins_list)
+    master_ignored = set(base_ignored_list)
     for scenario in scenarios:
         if scenario.coins:
             master_coins.update(scenario.coins)
         if scenario.ignored_coins:
             master_ignored.update(scenario.ignored_coins)
     master_coins.update(suite_coin_sources.keys())
-
-    # If no scenarios define explicit coins, fall back to base_coins_list
-    if not master_coins and base_coins_list:
-        logging.info(
-            "No scenario-specific coins found; using base approved_coins: %s",
-            base_coins_list,
-        )
-        master_coins = set(base_coins_list)
-    if not master_ignored and base_ignored_list:
-        master_ignored = set(base_ignored_list)
 
     master_coins_list = sorted(master_coins)
     master_ignored_list = sorted(master_ignored)
@@ -142,7 +141,7 @@ async def prepare_suite_contexts(
     candle_interval = int(base_config.get("backtest", {}).get("candle_interval_minutes", 1) or 1)
     datasets = await prepare_master_datasets(
         base_config,
-        base_exchanges,
+        exchanges_list,
         shared_array_manager=shared_array_manager,
         needed_individual_exchanges=needed_individual,
         candle_interval_minutes=candle_interval,
@@ -244,8 +243,7 @@ async def prepare_suite_contexts(
                 base_ignored=base_ignored_list,
             )
         except ValueError as exc:
-            logging.warning("Skipping scenario %s: %s", scenario.label, exc)
-            continue
+            raise ValueError(f"Suite scenario {scenario.label} could not be prepared: {exc}") from exc
         scenario_config = format_config(scenario_config_raw, verbose=False)
         scenario_config = parse_overrides(scenario_config, verbose=False)
         scenario_config.setdefault("backtest", {})
@@ -270,16 +268,11 @@ async def prepare_suite_contexts(
         if raw_scenario_exchanges:
             unavailable = raw_scenario_exchanges - all_exchanges_set
             if unavailable:
-                logging.debug(
-                    "Scenario %s: exchanges %s not available in dataset, using %s",
-                    scenario.label,
-                    sorted(unavailable),
-                    sorted(raw_scenario_exchanges & all_exchanges_set) or "all available",
+                raise ValueError(
+                    f"Suite scenario {scenario.label} requests unavailable exchange(s) "
+                    f"{sorted(unavailable)}; prepared exchanges are {sorted(all_exchanges_set)}"
                 )
             scenario_exchanges = raw_scenario_exchanges & all_exchanges_set
-            if not scenario_exchanges:
-                # If no overlap, fall back to all available exchanges
-                scenario_exchanges = all_exchanges_set
         else:
             scenario_exchanges = all_exchanges_set
 
@@ -306,11 +299,9 @@ async def prepare_suite_contexts(
                     ",".join(skipped_coins[:10]),
                 )
             if not selected_coins:
-                logging.warning(
-                    "Skipping scenario %s: no coins remain after exchange filtering.",
-                    scenario.label,
+                raise ValueError(
+                    f"Suite scenario {scenario.label} has no coins after applying exchange filters."
                 )
-                continue
             scenario_config["backtest"]["coins"][dataset.exchange] = list(selected_coins)
             if dataset.hlcvs_spec is not None:
                 start_idx, end_idx, coin_indices = _compute_slice_indices(
@@ -469,8 +460,7 @@ async def prepare_suite_contexts(
                 timestamps_map[exchange_key] = ts_window
 
         if not exchanges_for_scenario:
-            logging.warning("Skipping scenario %s: no exchanges after filtering.", scenario.label)
-            continue
+            raise ValueError(f"Suite scenario {scenario.label} had no exchanges after filtering.")
 
         # When using lazy slicing, populate master specs and coin indices per exchange.
         master_hlcvs_specs = {}

--- a/tests/optimization/test_optimize_suite_contexts.py
+++ b/tests/optimization/test_optimize_suite_contexts.py
@@ -11,6 +11,42 @@ class _NoSharedArrayManager:
         raise AssertionError("test dataset should use lazy master specs")
 
 
+def _make_lazy_dataset(
+    *,
+    exchange="combined",
+    coins=("HYPE",),
+    coin_exchange=None,
+    available_exchanges=None,
+):
+    timestamps = np.arange(1441, dtype=np.int64) * 60_000 + 1704067200000
+    coins = list(coins)
+    coin_exchange = coin_exchange or {coin: exchange for coin in coins}
+    return ExchangeDataset(
+        exchange=exchange,
+        coins=coins,
+        coin_index={coin: idx for idx, coin in enumerate(coins)},
+        coin_exchange=coin_exchange,
+        available_exchanges=available_exchanges or [exchange],
+        hlcvs=np.ones((len(timestamps), len(coins), 4), dtype=np.float64),
+        mss={
+            **{
+                coin: {
+                    "exchange": coin_exchange.get(coin, exchange),
+                    "first_valid_index": 0,
+                    "last_valid_index": len(timestamps) - 1,
+                }
+                for coin in coins
+            },
+            "__meta__": {"data_interval_minutes": 1},
+        },
+        btc_usd_prices=np.ones(len(timestamps), dtype=np.float64),
+        timestamps=timestamps,
+        cache_dir="",
+        hlcvs_spec=object(),
+        btc_spec=object(),
+    )
+
+
 @pytest.mark.asyncio
 async def test_prepare_suite_contexts_keeps_directional_scenarios_with_default_short_disabled(
     monkeypatch,
@@ -38,29 +74,11 @@ async def test_prepare_suite_contexts_keeps_directional_scenarios_with_default_s
         return None
 
     async def fake_prepare_master_datasets(*_args, **_kwargs):
-        timestamps = np.arange(1441, dtype=np.int64) * 60_000 + 1704067200000
-        hlcvs = np.ones((len(timestamps), 1, 4), dtype=np.float64)
         return {
-            "combined": ExchangeDataset(
-                exchange="combined",
-                coins=["HYPE"],
-                coin_index={"HYPE": 0},
+            "combined": _make_lazy_dataset(
+                coins=("HYPE",),
                 coin_exchange={"HYPE": "binance"},
                 available_exchanges=["binance", "bybit"],
-                hlcvs=hlcvs,
-                mss={
-                    "HYPE": {
-                        "exchange": "binance",
-                        "first_valid_index": 0,
-                        "last_valid_index": len(timestamps) - 1,
-                    },
-                    "__meta__": {"data_interval_minutes": 1},
-                },
-                btc_usd_prices=np.ones(len(timestamps), dtype=np.float64),
-                timestamps=timestamps,
-                cache_dir="",
-                hlcvs_spec=object(),
-                btc_spec=object(),
             )
         }
 
@@ -80,6 +98,184 @@ async def test_prepare_suite_contexts_keeps_directional_scenarios_with_default_s
     )
 
     assert [ctx.label for ctx in contexts] == ["base", "long_only", "short_only"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_suite_contexts_master_universe_keeps_base_and_scenario_coins(monkeypatch):
+    config = get_template_config()
+    config["backtest"]["start_date"] = "2024-01-01"
+    config["backtest"]["end_date"] = "2024-01-02"
+    config["backtest"]["exchanges"] = ["binance"]
+    config["backtest"]["suite_enabled"] = True
+    config["backtest"]["scenarios"] = [
+        {"label": "explicit", "coins": ["DOGE"]},
+        {"label": "default"},
+    ]
+    config["live"]["approved_coins"] = {"long": ["HYPE"], "short": ["HYPE"]}
+    config["live"]["ignored_coins"] = {"long": [], "short": []}
+    captured = {}
+
+    async def fake_load_markets(_exchange, verbose=False):
+        return {}
+
+    async def fake_format_approved_ignored_coins(_config, _exchanges, verbose=False):
+        return None
+
+    async def fake_prepare_master_datasets(base_config, exchanges, *_args, **_kwargs):
+        captured["approved"] = list(base_config["live"]["approved_coins"]["long"])
+        captured["exchanges"] = list(exchanges)
+        return {
+            "combined": _make_lazy_dataset(
+                coins=("DOGE", "HYPE"),
+                coin_exchange={"DOGE": "binance", "HYPE": "binance"},
+                available_exchanges=["binance"],
+            )
+        }
+
+    monkeypatch.setattr(optimize_suite, "load_markets", fake_load_markets)
+    monkeypatch.setattr(
+        optimize_suite,
+        "format_approved_ignored_coins",
+        fake_format_approved_ignored_coins,
+    )
+    monkeypatch.setattr(optimize_suite, "prepare_master_datasets", fake_prepare_master_datasets)
+
+    suite_cfg = optimize_suite.extract_suite_config(config, suite_override=None)
+    contexts, _aggregate_cfg = await optimize_suite.prepare_suite_contexts(
+        config,
+        suite_cfg,
+        shared_array_manager=_NoSharedArrayManager(),
+    )
+
+    assert captured["approved"] == ["DOGE", "HYPE"]
+    assert captured["exchanges"] == ["binance"]
+    assert [ctx.label for ctx in contexts] == ["explicit", "default"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_suite_contexts_expands_scenario_required_exchanges(monkeypatch):
+    config = get_template_config()
+    config["backtest"]["start_date"] = "2024-01-01"
+    config["backtest"]["end_date"] = "2024-01-02"
+    config["backtest"]["exchanges"] = ["binance"]
+    config["backtest"]["suite_enabled"] = True
+    config["backtest"]["scenarios"] = [
+        {"label": "bybit_only", "exchanges": ["bybit"], "coins": ["HYPE"]},
+    ]
+    config["live"]["approved_coins"] = {"long": ["HYPE"], "short": ["HYPE"]}
+    config["live"]["ignored_coins"] = {"long": [], "short": []}
+    loaded_exchanges = []
+    captured = {}
+
+    async def fake_load_markets(exchange, verbose=False):
+        loaded_exchanges.append(exchange)
+        return {}
+
+    async def fake_format_approved_ignored_coins(_config, exchanges, verbose=False):
+        captured["formatted_exchanges"] = list(exchanges)
+        return None
+
+    async def fake_prepare_master_datasets(_base_config, exchanges, *_args, **kwargs):
+        captured["dataset_exchanges"] = list(exchanges)
+        captured["needed"] = sorted(kwargs["needed_individual_exchanges"])
+        return {"bybit": _make_lazy_dataset(exchange="bybit", coins=("HYPE",))}
+
+    monkeypatch.setattr(optimize_suite, "load_markets", fake_load_markets)
+    monkeypatch.setattr(
+        optimize_suite,
+        "format_approved_ignored_coins",
+        fake_format_approved_ignored_coins,
+    )
+    monkeypatch.setattr(optimize_suite, "prepare_master_datasets", fake_prepare_master_datasets)
+
+    suite_cfg = optimize_suite.extract_suite_config(config, suite_override=None)
+    contexts, _aggregate_cfg = await optimize_suite.prepare_suite_contexts(
+        config,
+        suite_cfg,
+        shared_array_manager=_NoSharedArrayManager(),
+    )
+
+    assert loaded_exchanges == ["binance", "bybit"]
+    assert captured["formatted_exchanges"] == ["binance", "bybit"]
+    assert captured["dataset_exchanges"] == ["binance", "bybit"]
+    assert captured["needed"] == ["bybit"]
+    assert contexts[0].exchanges == ["bybit"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_suite_contexts_rejects_unavailable_scenario_exchange(monkeypatch):
+    config = get_template_config()
+    config["backtest"]["start_date"] = "2024-01-01"
+    config["backtest"]["end_date"] = "2024-01-02"
+    config["backtest"]["exchanges"] = ["binance"]
+    config["backtest"]["suite_enabled"] = True
+    config["backtest"]["scenarios"] = [
+        {"label": "bybit_only", "exchanges": ["bybit"], "coins": ["HYPE"]},
+    ]
+    config["live"]["approved_coins"] = {"long": ["HYPE"], "short": ["HYPE"]}
+    config["live"]["ignored_coins"] = {"long": [], "short": []}
+
+    async def fake_load_markets(_exchange, verbose=False):
+        return {}
+
+    async def fake_format_approved_ignored_coins(_config, _exchanges, verbose=False):
+        return None
+
+    async def fake_prepare_master_datasets(*_args, **_kwargs):
+        return {"binance": _make_lazy_dataset(exchange="binance", coins=("HYPE",))}
+
+    monkeypatch.setattr(optimize_suite, "load_markets", fake_load_markets)
+    monkeypatch.setattr(
+        optimize_suite,
+        "format_approved_ignored_coins",
+        fake_format_approved_ignored_coins,
+    )
+    monkeypatch.setattr(optimize_suite, "prepare_master_datasets", fake_prepare_master_datasets)
+
+    suite_cfg = optimize_suite.extract_suite_config(config, suite_override=None)
+    with pytest.raises(ValueError, match="requests unavailable exchange"):
+        await optimize_suite.prepare_suite_contexts(
+            config,
+            suite_cfg,
+            shared_array_manager=_NoSharedArrayManager(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_prepare_suite_contexts_rejects_scenario_with_no_usable_coins(monkeypatch):
+    config = get_template_config()
+    config["backtest"]["start_date"] = "2024-01-01"
+    config["backtest"]["end_date"] = "2024-01-02"
+    config["backtest"]["exchanges"] = ["binance"]
+    config["backtest"]["suite_enabled"] = True
+    config["backtest"]["scenarios"] = [{"label": "missing_coin", "coins": ["MISSING"]}]
+    config["live"]["approved_coins"] = {"long": ["HYPE"], "short": ["HYPE"]}
+    config["live"]["ignored_coins"] = {"long": [], "short": []}
+
+    async def fake_load_markets(_exchange, verbose=False):
+        return {}
+
+    async def fake_format_approved_ignored_coins(_config, _exchanges, verbose=False):
+        return None
+
+    async def fake_prepare_master_datasets(*_args, **_kwargs):
+        return {"combined": _make_lazy_dataset(coins=("HYPE",), available_exchanges=["binance"])}
+
+    monkeypatch.setattr(optimize_suite, "load_markets", fake_load_markets)
+    monkeypatch.setattr(
+        optimize_suite,
+        "format_approved_ignored_coins",
+        fake_format_approved_ignored_coins,
+    )
+    monkeypatch.setattr(optimize_suite, "prepare_master_datasets", fake_prepare_master_datasets)
+
+    suite_cfg = optimize_suite.extract_suite_config(config, suite_override=None)
+    with pytest.raises(ValueError, match="missing_coin could not be prepared"):
+        await optimize_suite.prepare_suite_contexts(
+            config,
+            suite_cfg,
+            shared_array_manager=_NoSharedArrayManager(),
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- align optimizer suite exchange expansion with suite-runner behavior for scenario-required exchanges
- keep base approved/ignored coins in the optimizer suite master universe when scenarios also define explicit coins
- raise scenario-specific errors instead of silently dropping scenarios or falling back to all exchanges when filters remove the requested data

## Tests
- ./venv/bin/python -m pytest tests/optimization/test_optimize_suite_contexts.py
- ./venv/bin/python -m pytest tests/optimization/test_optimize_suite_contexts.py tests/test_suite_runner.py