### PR TITLE
Add optional optimizer seed control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable user-facing changes will be documented in this file.
 - Suite optimizer context preparation now matches suite-runner exchange and
   coin-universe setup, and fails loudly when a scenario cannot be prepared
   instead of silently dropping scenarios or falling back to other exchanges.
+- Added optional `optimize.seed`; the default `null` randomizes optimizer
+  population and worker RNGs, including replacing pymoo's previous fixed
+  default seed, while an integer seed opts into deterministic seeding for
+  diagnostics.
 - The `cache` live-event debug profile now enriches existing cache load,
   flush, and warmup-decision events with bounded key/count/source metadata
   without changing default event payloads or console output.

--- a/src/config/hydrate.py
+++ b/src/config/hydrate.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from typing import Any, Dict, Iterable, Optional
 
 from utils import format_end_date, normalize_coins_source, symbol_to_coin
+from optimization.random_seed import normalize_optional_seed
 
 from .limits import _resolve_optimize_limits_for_load
 from .log_output import log_config_message
@@ -224,6 +225,7 @@ def apply_non_live_adjustments(
     if population_size is not None and population_size <= 0:
         raise ValueError("optimize.population_size must be > 0 when set")
     result["optimize"]["population_size"] = population_size
+    result["optimize"]["seed"] = normalize_optional_seed(result["optimize"].get("seed"))
 
     current_limits = deepcopy(result["optimize"].get("limits", []))
     limits_snapshot = deepcopy(current_limits)

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -483,6 +483,7 @@ def get_template_config():
                     "offspring_multiplier": 1,
                     "pareto_max_size": 1000,
                     "population_size": None,
+                    "seed": None,
                     "pymoo": {
                         "algorithm": "auto",
                         "algorithms": {

--- a/src/optimization/backends/deap_backend.py
+++ b/src/optimization/backends/deap_backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import logging
 import multiprocessing
 import os
@@ -28,6 +29,7 @@ from optimization.deap_adapters import (
     cxSimulatedBinaryBoundedWrapper,
     mutPolynomialBoundedWrapper,
 )
+from optimization.random_seed import seed_worker_rngs
 from config.scoring import engine_space_fitness_weights
 
 DEFAULT_DEAP_POPULATION_SIZE = 500
@@ -58,6 +60,12 @@ def _clone_evaluated_individual(individual):
     if hasattr(individual, "evaluation_metrics"):
         clone.evaluation_metrics = deepcopy(individual.evaluation_metrics)
     return clone
+
+
+def _initialize_deap_worker(rng_seed, ignore_sigint_in_worker=None):
+    seed_worker_rngs(rng_seed, context="DEAP optimizer")
+    if ignore_sigint_in_worker is not None:
+        ignore_sigint_in_worker()
 
 
 def run_backend(
@@ -141,9 +149,14 @@ def run_backend(
         toolbox.register("evaluate", evaluator_for_pool.evaluate, overrides_list=overrides_list)
 
         logging.info("Initializing multiprocessing pool. N cpus: %s", config["optimize"]["n_cpus"])
+        worker_initializer = functools.partial(
+            _initialize_deap_worker,
+            config["optimize"].get("seed"),
+            ignore_sigint_in_worker,
+        )
         pool = multiprocessing.Pool(
             processes=config["optimize"]["n_cpus"],
-            initializer=ignore_sigint_in_worker,
+            initializer=worker_initializer,
         )
         toolbox.register("map", pool.map)
         logging.info("Finished initializing multiprocessing pool.")

--- a/src/optimization/backends/pymoo_backend.py
+++ b/src/optimization/backends/pymoo_backend.py
@@ -95,6 +95,7 @@ def _reduce_starting_population(
     payloads: list[dict[str, Any]],
     population_size: int,
     bounds,
+    rng_seed: int | None,
 ) -> np.ndarray:
     if not starting_individuals:
         return _build_random_sampling(bounds, population_size)
@@ -118,7 +119,7 @@ def _reduce_starting_population(
         pop,
         n_survive=population_size,
         algorithm=algorithm,
-        seed=1,
+        seed=rng_seed,
     )
     logging.info(
         "Trimmed starting configs to population size via pymoo %s survival (kept %d)",
@@ -575,6 +576,7 @@ def run_backend(
     try:
         bounds = base_evaluator.bounds
         sig_digits = config["optimize"]["round_to_n_significant_digits"]
+        rng_seed = config["optimize"].get("seed")
         population_plan = _resolve_pymoo_population_plan(
             config,
             n_obj=len(config["optimize"]["scoring"]),
@@ -607,6 +609,7 @@ def run_backend(
             overrides_list,
             len(config["optimize"]["scoring"]),
             evaluator_adapter.has_constraints,
+            rng_seed,
             ignore_sigint_in_worker,
         )
         pool = multiprocessing.Pool(
@@ -683,12 +686,13 @@ def run_backend(
                     payloads=seed_payloads,
                     population_size=population_size,
                     bounds=bounds,
+                    rng_seed=rng_seed,
                 )
         ngen = max(1, int(config["optimize"]["iters"] / population_size))
         logging.info("Starting optimize...")
 
         minimize_kwargs = {
-            "seed": 1,
+            "seed": rng_seed,
             "verbose": False,
             "copy_algorithm": False,
         }

--- a/src/optimization/problem.py
+++ b/src/optimization/problem.py
@@ -12,6 +12,7 @@ from optimization.backend_shared import drain_async_results
 from optimization.bounds import Bound
 from optimization.callback import build_pymoo_record_entry
 from optimization.evaluation_payload import unpack_evaluation_payload
+from optimization.random_seed import seed_worker_rngs
 
 
 _PYMOO_WORKER_EVALUATOR = None
@@ -31,24 +32,35 @@ def _optimize_profile_enabled() -> bool:
     }
 
 
-def initialize_pymoo_worker(
+def _set_pymoo_worker_globals(
     evaluator,
     overrides_list: Sequence[str] | None,
     n_obj: int,
     has_constraints: bool,
-    ignore_sigint_in_worker=None,
 ) -> None:
     global _PYMOO_WORKER_EVALUATOR
     global _PYMOO_WORKER_OVERRIDES_LIST
     global _PYMOO_WORKER_N_OBJ
     global _PYMOO_WORKER_HAS_CONSTRAINTS
 
-    if ignore_sigint_in_worker is not None:
-        ignore_sigint_in_worker()
     _PYMOO_WORKER_EVALUATOR = evaluator
     _PYMOO_WORKER_OVERRIDES_LIST = list(overrides_list or [])
     _PYMOO_WORKER_N_OBJ = int(n_obj)
     _PYMOO_WORKER_HAS_CONSTRAINTS = bool(has_constraints)
+
+
+def initialize_pymoo_worker(
+    evaluator,
+    overrides_list: Sequence[str] | None,
+    n_obj: int,
+    has_constraints: bool,
+    rng_seed: int | None = None,
+    ignore_sigint_in_worker=None,
+) -> None:
+    seed_worker_rngs(rng_seed, context="pymoo optimizer")
+    if ignore_sigint_in_worker is not None:
+        ignore_sigint_in_worker()
+    _set_pymoo_worker_globals(evaluator, overrides_list, n_obj, has_constraints)
 
 
 def _evaluate_pymoo_worker(
@@ -172,7 +184,7 @@ class PymooAsyncRecordingRunner:
 
     def __call__(self, _f, X):
         xs = list(X)
-        initialize_pymoo_worker(
+        _set_pymoo_worker_globals(
             self.evaluator,
             self.overrides_list,
             self.n_obj,

--- a/src/optimization/random_seed.py
+++ b/src/optimization/random_seed.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import logging
+import multiprocessing
+import random
+from typing import Any
+
+import numpy as np
+
+MAX_NUMPY_SEED = 2**32 - 1
+
+
+def normalize_optional_seed(value: Any, *, path: str = "optimize.seed") -> int | None:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"", "none", "null", "auto", "random"}:
+            return None
+        value = int(value)
+    elif value is None:
+        return None
+    else:
+        if isinstance(value, float) and not value.is_integer():
+            raise ValueError(f"{path} must be null or an integer from 0 to {MAX_NUMPY_SEED}")
+        value = int(value)
+    if value < 0 or value > MAX_NUMPY_SEED:
+        raise ValueError(f"{path} must be null or an integer from 0 to {MAX_NUMPY_SEED}")
+    return value
+
+
+def seed_rngs(seed: int | None, *, context: str) -> None:
+    if seed is None:
+        logging.info("%s RNG seed: random", context)
+        return
+    random.seed(seed)
+    np.random.seed(seed)
+    logging.info("%s RNG seed: %d", context, seed)
+
+
+def seed_worker_rngs(base_seed: int | None, *, context: str) -> int:
+    if base_seed is None:
+        seed_sequence = np.random.SeedSequence()
+    else:
+        identity = multiprocessing.current_process()._identity
+        worker_index = int(identity[0]) if identity else 0
+        seed_sequence = np.random.SeedSequence([int(base_seed), worker_index])
+    worker_seed = int(seed_sequence.generate_state(1, dtype=np.uint32)[0])
+    random.seed(worker_seed)
+    np.random.seed(worker_seed)
+    logging.debug("%s RNG worker seed: %d", context, worker_seed)
+    return worker_seed

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -183,6 +183,7 @@ from optimization.bounds import (
 from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, ANCHOR_PLAN_KEY, get_anchor_plan
 from optimization.backend_shared import cancel_pending_async_results, drain_async_results
 from optimization.backends import get_backend_runner
+from optimization.random_seed import seed_rngs
 from optimization.config_adapter import (
     extract_bounds_tuple_list_from_config,
     get_optimization_key_paths,
@@ -3085,6 +3086,7 @@ async def main():
         if checkpoint_path is None:
             checkpoint_path = os.path.join(results_dir, "checkpoint.pkl")
         overrides_list = config.get("optimize", {}).get("enable_overrides", [])
+        seed_rngs(config.get("optimize", {}).get("seed"), context="optimizer")
 
         # Shared state used by workers for duplicate detection
         manager = multiprocessing.Manager()

--- a/tests/optimization/test_backends.py
+++ b/tests/optimization/test_backends.py
@@ -1,5 +1,7 @@
 import argparse
 import copy
+import functools
+from multiprocessing.reduction import ForkingPickler
 
 import pytest
 
@@ -14,6 +16,7 @@ from optimization.backends import get_backend_runner
 from optimization.backends.deap_backend import (
     DEFAULT_DEAP_POPULATION_SIZE,
     _clone_evaluated_individual,
+    _initialize_deap_worker,
     _resolve_deap_population_size,
 )
 from optimization.backends.deap_backend import run_backend as run_deap_backend
@@ -115,6 +118,7 @@ def test_template_defaults_use_null_population_and_pareto_1000():
     assert current["optimize"]["backend"] == "pymoo"
     assert current["optimize"]["population_size"] is None
     assert current["optimize"]["pareto_max_size"] == 1000
+    assert current["optimize"]["seed"] is None
 
 
 def test_format_config_preserves_null_population_size_for_pymoo():
@@ -125,6 +129,27 @@ def test_format_config_preserves_null_population_size_for_pymoo():
     out = format_config(current, verbose=False)
 
     assert out["optimize"]["population_size"] is None
+
+
+def test_format_config_normalizes_optional_optimizer_seed():
+    current = copy.deepcopy(get_template_config())
+    current["optimize"]["seed"] = "123"
+
+    out = format_config(current, verbose=False)
+
+    assert out["optimize"]["seed"] == 123
+
+    current["optimize"]["seed"] = "random"
+    out = format_config(current, verbose=False)
+    assert out["optimize"]["seed"] is None
+
+
+def test_format_config_rejects_negative_optimizer_seed():
+    current = copy.deepcopy(get_template_config())
+    current["optimize"]["seed"] = -1
+
+    with pytest.raises(ValueError, match="optimize.seed must be null"):
+        format_config(current, verbose=False)
 
 
 def test_resolve_deap_population_size_uses_fallback_for_null():
@@ -187,6 +212,10 @@ def test_clone_evaluated_individual_preserves_fitness_and_metrics():
     assert clone.evaluation_metrics == {"nested": {"value": 1}}
     individual.evaluation_metrics["nested"]["value"] = 2
     assert clone.evaluation_metrics == {"nested": {"value": 1}}
+
+
+def test_deap_worker_seed_initializer_is_pickleable():
+    ForkingPickler.dumps(functools.partial(_initialize_deap_worker, None, None))
 
 
 def test_get_backend_runner_resolves_supported_backends():

--- a/tests/optimization/test_problem.py
+++ b/tests/optimization/test_problem.py
@@ -151,6 +151,35 @@ def test_async_recording_runner_records_and_strips_metrics():
     assert recorder.record.call_count == 2
 
 
+def test_async_recording_runner_does_not_reseed_parent_numpy_rng():
+    evaluator = FakeEvaluator(has_constraints=True)
+    recorder = MagicMock()
+    runner = PymooAsyncRecordingRunner(
+        evaluator=evaluator,
+        has_constraints=True,
+        n_obj=2,
+        pool=FakeAsyncPool(),
+        recorder=recorder,
+        template={"optimize": {"backend": "pymoo"}},
+        build_config_fn=lambda vector, overrides_fn, overrides_list, template: {
+            "bot": {"long": {"a": float(vector[0])}},
+            "backtest": {"coins": {"binance": ["BTC/USDT:USDT"]}},
+            **template,
+        },
+        overrides_fn=object(),
+        overrides_list=["x"],
+    )
+    np.random.seed(42)
+    before = np.random.get_state()
+
+    runner(object(), [np.asarray([0.25])])
+
+    after = np.random.get_state()
+    assert before[0] == after[0]
+    assert np.array_equal(before[1], after[1])
+    assert before[2:] == after[2:]
+
+
 def test_async_recording_runner_profiles_record_result_when_enabled(monkeypatch, caplog):
     evaluator = FakeEvaluator(has_constraints=True)
     recorder = MagicMock()

--- a/tests/optimization/test_pymoo_backend.py
+++ b/tests/optimization/test_pymoo_backend.py
@@ -541,7 +541,8 @@ def test_run_backend_evaluates_all_starting_configs_before_trim(monkeypatch):
     captured = {}
 
     def _fake_minimize(problem, algorithm, termination, seed, verbose, **kwargs):
-        del problem, termination, seed, verbose
+        del problem, termination, verbose
+        captured["seed"] = seed
         captured["sampling"] = np.asarray(algorithm.initialization.sampling, dtype=np.float64)
         return None
 
@@ -556,6 +557,7 @@ def test_run_backend_evaluates_all_starting_configs_before_trim(monkeypatch):
                 "population_size": 4,
                 "iters": 8,
                 "n_cpus": 1,
+                "seed": 123,
                 "max_pending_starting_evals_per_cpu": 1,
                 "round_to_n_significant_digits": 4,
                 "scoring": ["adg", "drawdown_worst"],
@@ -589,6 +591,7 @@ def test_run_backend_evaluates_all_starting_configs_before_trim(monkeypatch):
 
     assert result["pool_terminated"] is False
     assert len(recorder.entries) == 6
+    assert captured["seed"] == 123
     assert captured["sampling"].shape == (4, 2)
 
 


### PR DESCRIPTION
## Summary
- add optimize.seed with default null, normalized from null/auto/random or integer values
- keep default optimizer RNG behavior randomized while allowing fixed integer seeds for diagnostics/determinism
- seed parent RNGs before backend setup, seed worker RNGs independently, and pass the configured seed to pymoo instead of hardcoded seed=1

## Tests
- ./venv/bin/python -m pytest tests/optimization/test_backends.py tests/optimization/test_pymoo_backend.py
- ./venv/bin/python -m pytest tests/test_config_pipeline.py
- ./venv/bin/python -m pytest tests/test_config_utils_helpers.py
- ./venv/bin/python -m pytest tests/optimization/test_backends.py tests/optimization/test_pymoo_backend.py tests/test_config_pipeline.py tests/test_config_utils_helpers.py