### PR TITLE
Validate optimizer overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Optimizer overrides now reject unknown `optimize.enable_overrides` names before
+  the run starts, and `forward_tp_grid` / `backward_tp_grid` now reorder
+  `trailing_grid_v7` close-grid markup bounds as intended.
 - Optimizer stepped bounds now stay on the configured grid for fractional steps
   such as `0.25`, `0.125`, and `0.0025`, avoiding off-grid candidate values in
   DEAP, pymoo repair, seed conversion, and result hashing.

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -153,7 +153,7 @@ except ImportError:  # pragma: no cover - allow import in minimal test envs
     tools = algorithms = None
 import math
 import fcntl
-from optimizer_overrides import optimizer_overrides
+from optimizer_overrides import optimizer_overrides, validate_optimizer_overrides
 from opt_utils import make_json_serializable, generate_incremental_diff, round_floats, quantize_floats
 from limit_utils import expand_limit_checks, compute_limit_violation
 from pareto_store import ParetoStore
@@ -2851,6 +2851,7 @@ async def main():
         verbose=False,
         raw_snapshot=raw_snapshot,
     )
+    validate_optimizer_overrides(config.get("optimize", {}).get("enable_overrides", []))
     config_logging_value = get_optional_config_value(config, "logging.level", None)
     effective_log_level = resolve_log_level(args.log_level, config_logging_value, fallback=1)
     if effective_log_level != initial_log_level:

--- a/src/optimizer_overrides.py
+++ b/src/optimizer_overrides.py
@@ -4,6 +4,17 @@ from config.access import require_config_value
 from config.shared_bot import BOT_SHARED_GROUPS
 from config.strategy import DEFAULT_STRATEGY_KIND, normalize_strategy_kind
 
+TRAILING_GRID_V7_STRATEGY_KIND = "trailing_grid_v7"
+
+KNOWN_OPTIMIZER_OVERRIDES = frozenset(
+    {
+        "backward_tp_grid",
+        "forward_tp_grid",
+        "lossless_close_trailing",
+        "mirror_short_from_long",
+    }
+)
+
 
 def _mirror_short_from_long(config):
     strategy_kind = normalize_strategy_kind(config.get("live", {}).get("strategy_kind"))
@@ -26,6 +37,18 @@ def _mirror_short_from_long(config):
     return config
 
 
+def validate_optimizer_overrides(overrides_list):
+    unknown = sorted(
+        {override for override in overrides_list or [] if override not in KNOWN_OPTIMIZER_OVERRIDES}
+    )
+    if unknown:
+        allowed = ", ".join(sorted(KNOWN_OPTIMIZER_OVERRIDES))
+        raise ValueError(
+            f"Unknown optimize.enable_overrides value(s): {', '.join(unknown)}. "
+            f"Allowed values: {allowed}"
+        )
+
+
 def _require_trailing_martingale_side(config, pside):
     strategy_kind = normalize_strategy_kind(config.get("live", {}).get("strategy_kind"))
     if strategy_kind != DEFAULT_STRATEGY_KIND:
@@ -40,10 +63,49 @@ def _require_trailing_martingale_side(config, pside):
     return strategy_cfg
 
 
+def _require_trailing_grid_v7_side(config, pside):
+    strategy_kind = normalize_strategy_kind(config.get("live", {}).get("strategy_kind"))
+    if strategy_kind != TRAILING_GRID_V7_STRATEGY_KIND:
+        raise ValueError(
+            "optimizer override requires live.strategy_kind = "
+            f"{TRAILING_GRID_V7_STRATEGY_KIND!r}; got {strategy_kind!r}"
+        )
+    strategy_cfg = require_config_value(
+        config,
+        f"bot.{pside}.strategy.{TRAILING_GRID_V7_STRATEGY_KIND}",
+    )
+    if not isinstance(strategy_cfg, dict):
+        raise TypeError(
+            f"bot.{pside}.strategy.{TRAILING_GRID_V7_STRATEGY_KIND} must be a dict; "
+            f"got {type(strategy_cfg).__name__}"
+        )
+    return strategy_cfg
+
+
+def _set_trailing_grid_v7_tp_grid_order(config, pside, *, forward: bool):
+    strategy_cfg = _require_trailing_grid_v7_side(config, pside)
+    start = require_config_value(
+        config,
+        f"bot.{pside}.strategy.{TRAILING_GRID_V7_STRATEGY_KIND}.close.grid_markup_start",
+    )
+    end = require_config_value(
+        config,
+        f"bot.{pside}.strategy.{TRAILING_GRID_V7_STRATEGY_KIND}.close.grid_markup_end",
+    )
+    lower = min(start, end)
+    upper = max(start, end)
+    close_cfg = strategy_cfg.setdefault("close", {})
+    close_cfg["grid_markup_start"] = lower if forward else upper
+    close_cfg["grid_markup_end"] = upper if forward else lower
+    return config
+
+
 def optimizer_overrides(overrides_list, config, pside=None):
     if not overrides_list:
         # No overrides to apply
         return config
+
+    validate_optimizer_overrides(overrides_list)
 
     for override in overrides_list:
         if override == "mirror_short_from_long":
@@ -67,17 +129,9 @@ def optimizer_overrides(overrides_list, config, pside=None):
             strategy_cfg.setdefault("close", {})["threshold_base_pct"] = max(threshold, retracement)
 
         elif override == "forward_tp_grid":
-            _require_trailing_martingale_side(config, pside)
+            config = _set_trailing_grid_v7_tp_grid_order(config, pside, forward=True)
 
         elif override == "backward_tp_grid":
-            _require_trailing_martingale_side(config, pside)
-
-        elif override == "example":
-            # Logic for override 'example'
-            pass
-
-        else:
-            print(f"Unknown override: {override}")
-            return config
+            config = _set_trailing_grid_v7_tp_grid_order(config, pside, forward=False)
 
     return config

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -1051,10 +1051,46 @@ class TestIndividualToConfig:
         assert strategy["close"]["threshold_base_pct"] == pytest.approx(0.004)
         assert strategy["close"]["retracement_base_pct"] == pytest.approx(0.004)
 
-    def test_trailing_martingale_overrides_reject_non_trailing_martingale_strategy(self):
+    def test_optimizer_overrides_reject_unknown_names(self):
+        with pytest.raises(ValueError, match="Unknown optimize.enable_overrides value"):
+            optimize.validate_optimizer_overrides(["mirror_short_from_long", "typo_override"])
+
+    @pytest.mark.parametrize(
+        ("override", "expected_start", "expected_end"),
+        [
+            ("forward_tp_grid", 0.001, 0.01),
+            ("backward_tp_grid", 0.01, 0.001),
+        ],
+    )
+    def test_trailing_grid_v7_tp_grid_overrides_reorder_close_markup(
+        self, override, expected_start, expected_end
+    ):
+        config = {
+            "live": {"strategy_kind": "trailing_grid_v7"},
+            "bot": {
+                "long": {
+                    "strategy": {
+                        "trailing_grid_v7": {
+                            "close": {
+                                "grid_markup_start": 0.01,
+                                "grid_markup_end": 0.001,
+                            }
+                        }
+                    }
+                }
+            },
+        }
+
+        result = optimize.optimizer_overrides([override], deepcopy(config), "long")
+        close = result["bot"]["long"]["strategy"]["trailing_grid_v7"]["close"]
+
+        assert close["grid_markup_start"] == pytest.approx(expected_start)
+        assert close["grid_markup_end"] == pytest.approx(expected_end)
+
+    def test_trailing_grid_v7_tp_grid_overrides_reject_other_strategies(self):
         config = load_prepared_config("configs/examples/ema_anchor.json", verbose=False)
 
-        with pytest.raises(ValueError, match="live.strategy_kind = 'trailing_martingale'"):
+        with pytest.raises(ValueError, match="live.strategy_kind = 'trailing_grid_v7'"):
             optimize.optimizer_overrides(["forward_tp_grid"], deepcopy(config), "long")
 
     def test_accepts_precomputed_key_paths(self):


### PR DESCRIPTION
## Summary\n- reject unknown optimize.enable_overrides names before optimize startup and from direct override calls\n- restore trailing_grid_v7 forward_tp_grid / backward_tp_grid behavior by ordering close grid markup start/end\n- keep TP-grid overrides v7-only; trailing_martingale users should express forward/backward grids through threshold_we_weight bounds\n\n## Validation\n- ./venv/bin/python -m pytest tests/optimization/test_optimize.py::TestIndividualToConfig tests/optimization/test_optimizer_warmup.py\n- git diff --check