### PR TITLE
Preserve anchored fine-tune seed ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable user-facing changes will be documented in this file.
 - Optimizer overrides now reject unknown `optimize.enable_overrides` names before
   the run starts, and `forward_tp_grid` / `backward_tp_grid` now reorder
   `trailing_grid_v7` close-grid markup bounds as intended.
+- Anchored fine-tune optimizer seed conversion now preserves each anchor's
+  original id when an earlier starting seed is skipped.
 - Optimizer stepped bounds now stay on the configured grid for fractional steps
   such as `0.25`, `0.125`, and `0.0025`, avoiding off-grid candidate values in
   DEAP, pymoo repair, seed conversion, and result hashing.

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2717,9 +2717,8 @@ def configs_to_individuals_streaming(
         and optimization_shape.key_paths
         and optimization_shape.key_paths[0][0] == ANCHOR_GENE_KEY
     )
-    anchor_count = 0
     clamp_collector = {}
-    for cfg in cfgs:
+    for anchor_idx, cfg in enumerate(cfgs):
         raw_count += 1
         try:
             fcfg = _build_starting_seed_config(cfg)
@@ -2729,7 +2728,7 @@ def configs_to_individuals_streaming(
                 sig_digits,
                 key_paths=key_paths,
                 optimization_shape=optimization_shape,
-                anchor_id=anchor_count if anchored_shape else None,
+                anchor_id=anchor_idx if anchored_shape else None,
                 clamp_context="starting config",
                 source=cfg.get("_starting_config_source", "<memory>")
                 if isinstance(cfg, dict)
@@ -2737,8 +2736,6 @@ def configs_to_individuals_streaming(
                 clamp_collector=clamp_collector,
             )
             inds.add(tuple(individual))
-            if anchored_shape:
-                anchor_count += 1
         except Exception as e:
             logging.warning(f"failed to use starting config as optimizer seed: {e}")
     _flush_seed_bounds_adjustments(clamp_collector)

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -2484,6 +2484,68 @@ class TestApplyFineTuneBounds:
         assert raw_count == 2
         assert sorted(individual[0] for individual in streamed) == [0, 1]
 
+    def test_anchored_seed_stream_preserves_anchor_ids_after_failed_seed(self, caplog):
+        config = {
+            "live": {"strategy_kind": "trailing_martingale"},
+            "optimize": {
+                "bounds": {
+                    "long_n_positions": [1.0, 1.0],
+                    "long_param1": [0.0, 1.0],
+                    "long_total_wallet_exposure_limit": [1.0, 1.0],
+                    "short_n_positions": [0.0, 0.0],
+                    "short_total_wallet_exposure_limit": [0.0, 0.0],
+                },
+                "round_to_n_significant_digits": 6,
+            },
+            "bot": {
+                "long": {
+                    "n_positions": 1.0,
+                    "param1": 0.1,
+                    "total_wallet_exposure_limit": 1.0,
+                },
+                "short": {"n_positions": 0.0, "total_wallet_exposure_limit": 0.0},
+            },
+            ANCHOR_PLAN_KEY: {
+                "anchors": [
+                    {"source": "bad.json", "fixed_values": []},
+                    {"source": "anchor_1.json", "fixed_values": []},
+                    {"source": "anchor_2.json", "fixed_values": []},
+                ],
+                "fixed_keys": [],
+                "key_paths": [["bot", "long", "param1"]],
+                "tunable_keys": ["long_param1"],
+            },
+        }
+        shape = build_optimization_shape(config)
+
+        streamed, raw_count = configs_to_individuals_streaming(
+            [
+                None,
+                {
+                    "bot": deepcopy(config["bot"]),
+                    "_starting_config_source": "anchor_1.json",
+                },
+                {
+                    "bot": {
+                        "long": {
+                            "n_positions": 1.0,
+                            "param1": 0.3,
+                            "total_wallet_exposure_limit": 1.0,
+                        },
+                        "short": {"n_positions": 0.0, "total_wallet_exposure_limit": 0.0},
+                    },
+                    "_starting_config_source": "anchor_2.json",
+                },
+            ],
+            shape.bounds,
+            6,
+            optimization_shape=shape,
+        )
+
+        assert raw_count == 3
+        assert sorted(individual[0] for individual in streamed) == [1, 2]
+        assert "failed to use starting config as optimizer seed" in caplog.text
+
     def test_starting_seed_values_are_clamped_to_base_bounds_with_logging(self, caplog):
         config = {
             "live": {"strategy_kind": "trailing_martingale"},


### PR DESCRIPTION
## Summary\n- preserve anchored fine-tune seed anchor ids by using the input anchor position instead of a success-only counter\n- add a regression where the first anchored seed fails conversion and later seed vectors must keep ids 1 and 2\n- document the user-visible optimizer seed behavior fix\n\n## Validation\n- ./venv/bin/python -m pytest tests/optimization/test_optimize.py::TestApplyFineTuneBounds\n- git diff --check