### PR TITLE
Fix optimizer interrupt pool shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable user-facing changes will be documented in this file.
   `trailing_grid_v7` close-grid markup bounds as intended.
 - Anchored fine-tune optimizer seed conversion now preserves each anchor's
   original id when an earlier starting seed is skipped.
+- Optimizer SIGINT handling now safely no-ops before a worker pool exists and
+  terminates an active pool without referencing backend-local shutdown state.
 - Optimizer stepped bounds now stay on the configured grid for fractional steps
   such as `0.25`, `0.125`, and `0.0025`, avoiding off-grid candidate values in
   DEAP, pymoo repair, seed conversion, and result hashing.

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -573,6 +573,14 @@ def _optimizer_exit_code(*, interrupted: bool, failed: bool) -> int:
     return 0
 
 
+def _terminate_optimizer_pool(pool, pool_terminated: bool) -> bool:
+    if pool is None or pool_terminated:
+        return pool_terminated
+    logging.info("Terminating worker pool...")
+    pool.terminate()
+    return True
+
+
 def _build_invalid_candidate_metrics(
     scoring_keys: Sequence[str],
     error: str,
@@ -3160,14 +3168,7 @@ async def main():
     except KeyboardInterrupt:
         interrupted = True
         logging.info("SIGINT received; starting graceful shutdown")
-        if "pool" in locals():
-            already = pool_state["terminated"] if "pool_state" in locals() else pool_terminated
-            if not already:
-                logging.info("Terminating worker pool...")
-                pool.terminate()
-                pool_terminated = True
-                if "pool_state" in locals():
-                    pool_state["terminated"] = True
+        pool_terminated = _terminate_optimizer_pool(pool, pool_terminated)
     except Exception as e:
         failed = True
         logging.error(f"An error occurred: {e}")
@@ -3183,9 +3184,7 @@ async def main():
             recorder.close()
         if "pool" in locals() and pool is not None:
             if interrupted and not pool_terminated:
-                logging.info("Terminating worker pool...")
-                pool.terminate()
-                pool_terminated = True
+                pool_terminated = _terminate_optimizer_pool(pool, pool_terminated)
             if pool_terminated or interrupted:
                 logging.info("Joining terminated worker pool...")
             else:

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -32,6 +32,7 @@ from optimize import (
     _record_individual_result,
     _resolve_cli_limits_override,
     _set_candidate_metrics,
+    _terminate_optimizer_pool,
     _format_objectives,
     individual_to_config,
     config_to_individual,
@@ -76,6 +77,24 @@ def test_optimizer_exit_code_reports_fatal_failure():
     assert _optimizer_exit_code(interrupted=False, failed=True) == 1
     assert _optimizer_exit_code(interrupted=True, failed=False) == 130
     assert _optimizer_exit_code(interrupted=True, failed=True) == 130
+
+
+def test_terminate_optimizer_pool_handles_missing_pool():
+    assert _terminate_optimizer_pool(None, False) is False
+
+
+def test_terminate_optimizer_pool_skips_already_terminated_pool():
+    pool = MagicMock()
+
+    assert _terminate_optimizer_pool(pool, True) is True
+    pool.terminate.assert_not_called()
+
+
+def test_terminate_optimizer_pool_terminates_active_pool():
+    pool = MagicMock()
+
+    assert _terminate_optimizer_pool(pool, False) is True
+    pool.terminate.assert_called_once_with()
 
 
 def test_candidate_metrics_sidecars_only_attach_to_objects():


### PR DESCRIPTION
## Summary\n- replace optimizer KeyboardInterrupt pool shutdown logic that referenced backend-local pool_state\n- safely no-op when SIGINT arrives before a worker pool exists\n- share the same terminate helper between interrupt handling and final cleanup\n\n## Validation\n- ./venv/bin/python -m pytest tests/optimization/test_optimize.py::test_optimizer_exit_code_reports_fatal_failure tests/optimization/test_optimize.py::test_terminate_optimizer_pool_handles_missing_pool tests/optimization/test_optimize.py::test_terminate_optimizer_pool_skips_already_terminated_pool tests/optimization/test_optimize.py::test_terminate_optimizer_pool_terminates_active_pool tests/optimization/test_optimize.py::test_optimizer_exit_code_is_nonzero_for_fatal_errors\n- git diff --check