### PR TITLE
Enable optimizer suite configs by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable user-facing changes will be documented in this file.
   original id when an earlier starting seed is skipped.
 - Optimizer SIGINT handling now safely no-ops before a worker pool exists and
   terminates an active pool without referencing backend-local shutdown state.
+- `passivbot optimize --suite-config` now enables suite mode when `--suite` is
+  omitted, while explicit `--suite n` still disables suite mode.
 - Optimizer stepped bounds now stay on the configured grid for fractional steps
   such as `0.25`, `0.125`, and `0.0025`, avoiding off-grid candidate values in
   DEAP, pymoo repair, seed conversion, and result hashing.

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -581,6 +581,10 @@ def _terminate_optimizer_pool(pool, pool_terminated: bool) -> bool:
     return True
 
 
+def _suite_config_implies_suite_mode(args) -> bool:
+    return bool(getattr(args, "suite_config", None)) and getattr(args, "suite", None) is None
+
+
 def _build_invalid_candidate_metrics(
     scoring_keys: Sequence[str],
     error: str,
@@ -2915,6 +2919,8 @@ async def main():
     if args.suite_config:
         logging.info("loading suite config %s", args.suite_config)
         suite_override = load_suite_override_config(args.suite_config)
+        if _suite_config_implies_suite_mode(args):
+            recursive_config_update(config, "backtest.suite_enabled", True, verbose=True)
     suite_cfg = extract_suite_config(config, suite_override)
 
     # Handle --scenarios filter (implies --suite y)

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -33,6 +33,7 @@ from optimize import (
     _resolve_cli_limits_override,
     _set_candidate_metrics,
     _terminate_optimizer_pool,
+    _suite_config_implies_suite_mode,
     _format_objectives,
     individual_to_config,
     config_to_individual,
@@ -95,6 +96,38 @@ def test_terminate_optimizer_pool_terminates_active_pool():
 
     assert _terminate_optimizer_pool(pool, False) is True
     pool.terminate.assert_called_once_with()
+
+
+def test_suite_config_implies_suite_mode_when_suite_flag_omitted():
+    args = argparse.Namespace(suite_config="suite.json", suite=None)
+
+    assert _suite_config_implies_suite_mode(args) is True
+
+
+@pytest.mark.parametrize("suite_value", [False, True])
+def test_suite_config_does_not_override_explicit_suite_flag(suite_value):
+    args = argparse.Namespace(suite_config="suite.json", suite=suite_value)
+
+    assert _suite_config_implies_suite_mode(args) is False
+
+
+def test_missing_suite_config_does_not_imply_suite_mode():
+    args = argparse.Namespace(suite_config=None, suite=None)
+
+    assert _suite_config_implies_suite_mode(args) is False
+
+
+def test_suite_config_activation_enables_extracted_suite_config():
+    args = argparse.Namespace(suite_config="suite.json", suite=None)
+    config = get_template_config()
+    suite_override = {"scenarios": [{"label": "stress"}]}
+
+    if _suite_config_implies_suite_mode(args):
+        optimize.recursive_config_update(config, "backtest.suite_enabled", True, verbose=False)
+    suite_cfg = optimize.extract_suite_config(config, suite_override)
+
+    assert suite_cfg["enabled"] is True
+    assert suite_cfg["scenarios"] == [{"label": "stress"}]
 
 
 def test_candidate_metrics_sidecars_only_attach_to_objects():


### PR DESCRIPTION
## Summary\n- make passivbot optimize --suite-config imply suite mode when --suite is omitted\n- preserve explicit --suite y/n precedence, so --suite n still disables suite mode\n- add targeted tests for CLI precedence and extracted suite activation\n\n## Validation\n- ./venv/bin/python -m pytest tests/optimization/test_optimize.py::test_suite_config_implies_suite_mode_when_suite_flag_omitted tests/optimization/test_optimize.py::test_suite_config_does_not_override_explicit_suite_flag tests/optimization/test_optimize.py::test_missing_suite_config_does_not_imply_suite_mode tests/optimization/test_optimize.py::test_suite_config_activation_enables_extracted_suite_config tests/test_suite_config_sources.py tests/test_config_optimize_suite.py\n- git diff --check