### PR TITLE
Preserve aggregate for partial suite overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable user-facing changes will be documented in this file.
   terminates an active pool without referencing backend-local shutdown state.
 - `passivbot optimize --suite-config` now enables suite mode when `--suite` is
   omitted, while explicit `--suite n` still disables suite mode.
+- Partial suite override files that define scenarios without `aggregate` now
+  preserve the base config's `backtest.aggregate` instead of resetting to mean.
 - Optimizer stepped bounds now stay on the configured grid for fractional steps
   such as `0.25`, `0.125`, and `0.0025`, avoiding off-grid candidate values in
   DEAP, pymoo repair, seed conversion, and result hashing.

--- a/src/suite_runner.py
+++ b/src/suite_runner.py
@@ -167,8 +167,9 @@ def _suite_override_from_section(section: Dict[str, Any], *, source_label: str) 
         raise ValueError(f"Suite config {source_label} field 'scenarios' must be a list.")
     suite_override: Dict[str, Any] = {
         "scenarios": deepcopy(scenarios),
-        "aggregate": deepcopy(section.get("aggregate", {"default": "mean"})),
     }
+    if "aggregate" in section:
+        suite_override["aggregate"] = deepcopy(section["aggregate"])
     for key in ("exchanges", "volume_normalization"):
         if key in section:
             suite_override[key] = deepcopy(section[key])

--- a/tests/test_suite_config_sources.py
+++ b/tests/test_suite_config_sources.py
@@ -76,6 +76,46 @@ def test_optimizer_suite_config_override_accepts_partial_backtest_scenarios(tmp_
     assert suite_cfg["scenarios"] == override_cfg["backtest"]["scenarios"]
 
 
+def test_partial_backtest_suite_config_preserves_base_aggregate(tmp_path: Path):
+    base_cfg = get_template_config()
+    base_cfg["backtest"]["suite_enabled"] = True
+    base_cfg["backtest"]["scenarios"] = [{"label": "base_scenario"}]
+    base_cfg["backtest"]["aggregate"] = {"default": "max", "adg": "median"}
+
+    override_cfg = {
+        "backtest": {
+            "scenarios": [{"label": "stress_window"}],
+        }
+    }
+
+    config_path = tmp_path / "base.json"
+    suite_path = tmp_path / "partial_suite.hjson"
+    config_path.write_text(json.dumps(base_cfg))
+    suite_path.write_text(json.dumps(override_cfg))
+
+    suite_cfg = ensure_suite_config(config_path, suite_path)
+    assert suite_cfg["aggregate"] == {"default": "max", "adg": "median"}
+    assert suite_cfg["scenarios"] == override_cfg["backtest"]["scenarios"]
+
+
+def test_partial_top_level_suite_config_preserves_base_aggregate(tmp_path: Path):
+    base_cfg = get_template_config()
+    base_cfg["backtest"]["suite_enabled"] = True
+    base_cfg["backtest"]["scenarios"] = [{"label": "base_scenario"}]
+    base_cfg["backtest"]["aggregate"] = {"default": "max", "adg": "median"}
+
+    override_cfg = {"scenarios": [{"label": "top_level_stress"}]}
+
+    config_path = tmp_path / "base.json"
+    suite_path = tmp_path / "partial_suite.hjson"
+    config_path.write_text(json.dumps(base_cfg))
+    suite_path.write_text(json.dumps(override_cfg))
+
+    suite_cfg = ensure_suite_config(config_path, suite_path)
+    assert suite_cfg["aggregate"] == {"default": "max", "adg": "median"}
+    assert suite_cfg["scenarios"] == override_cfg["scenarios"]
+
+
 def test_optimizer_suite_legacy_override_format(tmp_path: Path):
     """Test that legacy backtest.suite format in override config still works."""
     base_cfg = get_template_config()


### PR DESCRIPTION
## Summary\n- stop injecting aggregate={default: mean} for partial suite override files that only define scenarios\n- preserve the base config's backtest.aggregate unless the suite override explicitly defines aggregate\n- add regressions for partial backtest.scenarios and top-level scenarios override files\n\n## Validation\n- ./venv/bin/python -m pytest tests/test_suite_config_sources.py tests/test_suite_runner.py::test_extract_suite_config_merges_override\n- git diff --check