### PR TITLE
Validate suite scenario keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Suite scenarios now reject unknown scenario fields before running, catching
+  typos such as `coin` instead of silently ignoring them.
 - Optimizer overrides now reject unknown `optimize.enable_overrides` names before
   the run starts, and `forward_tp_grid` / `backward_tp_grid` now reorder
   `trailing_grid_v7` close-grid markup bounds as intended.

--- a/src/suite_runner.py
+++ b/src/suite_runner.py
@@ -42,6 +42,19 @@ from ohlcv_utils import align_and_aggregate_hlcvs
 from shared_arrays import SharedArraySpec
 from metrics_schema import flatten_metric_stats, merge_suite_payload
 
+_SCENARIO_KEYS = frozenset(
+    {
+        "label",
+        "start_date",
+        "end_date",
+        "coins",
+        "ignored_coins",
+        "exchanges",
+        "coin_sources",
+        "overrides",
+    }
+)
+
 # --------------------------------------------------------------------------- #
 # Data containers
 # --------------------------------------------------------------------------- #
@@ -481,6 +494,16 @@ def build_scenarios(
 
     scenarios: List[SuiteScenario] = []
     for idx, raw in enumerate(scenarios_cfg, 1):
+        scenario_path = f"config.backtest.scenarios[{idx - 1}]"
+        if not isinstance(raw, dict):
+            raise ValueError(f"{scenario_path} must be a mapping.")
+        unknown_keys = sorted(set(raw) - _SCENARIO_KEYS)
+        if unknown_keys:
+            allowed = ", ".join(sorted(_SCENARIO_KEYS))
+            raise ValueError(
+                f"{scenario_path} contains unknown key(s): {', '.join(unknown_keys)}. "
+                f"Allowed keys: {allowed}."
+            )
         exchanges_value = raw.get("exchanges")
         coin_sources_value = raw.get("coin_sources")
 

--- a/tests/test_suite_runner.py
+++ b/tests/test_suite_runner.py
@@ -104,6 +104,54 @@ def test_build_scenarios_inherits_exchanges_from_defaults():
     assert scenarios[0].exchanges == ["kucoin"]
 
 
+def test_build_scenarios_accepts_documented_scenario_keys():
+    suite_cfg = {
+        "scenarios": [
+            {
+                "label": "full",
+                "start_date": "2021-01-01",
+                "end_date": "2021-01-31",
+                "coins": ["BTC"],
+                "ignored_coins": ["ETH"],
+                "exchanges": "binance",
+                "coin_sources": {"BTC": "binance"},
+                "overrides": {"bot.long.risk.n_positions": 1},
+            }
+        ]
+    }
+
+    scenarios, _ = build_scenarios(suite_cfg)
+
+    assert scenarios[0].label == "full"
+    assert scenarios[0].exchanges == ["binance"]
+    assert scenarios[0].coins == ["BTC"]
+    assert scenarios[0].ignored_coins == ["ETH"]
+    assert scenarios[0].coin_sources == {"BTC": "binance"}
+    assert scenarios[0].overrides == {"bot.long.risk.n_positions": 1}
+
+
+def test_build_scenarios_rejects_unknown_scenario_keys():
+    suite_cfg = {
+        "scenarios": [
+            {
+                "label": "typo",
+                "coin": ["BTC"],
+            }
+        ]
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=r"config\.backtest\.scenarios\[0\] contains unknown key\(s\): coin",
+    ):
+        build_scenarios(suite_cfg)
+
+
+def test_build_scenarios_rejects_non_mapping_scenarios():
+    with pytest.raises(ValueError, match=r"config\.backtest\.scenarios\[0\] must be a mapping"):
+        build_scenarios({"scenarios": ["not-a-mapping"]})
+
+
 def test_apply_scenario_filters_unavailable_coins():
     base_config = {
         "backtest": {


### PR DESCRIPTION
## Summary
- reject non-mapping suite scenario entries before scenario construction
- reject unknown suite scenario keys with the scenario index and allowed key list
- cover the documented accepted scenario-key surface and typo rejection

## Tests
- ./venv/bin/python -m pytest tests/test_suite_runner.py::test_build_scenarios_basic tests/test_suite_runner.py::test_build_scenarios_handles_exchanges_and_coin_sources tests/test_suite_runner.py::test_build_scenarios_normalizes_coins_and_coin_sources tests/test_suite_runner.py::test_build_scenarios_inherits_exchanges_from_defaults tests/test_suite_runner.py::test_build_scenarios_accepts_documented_scenario_keys tests/test_suite_runner.py::test_build_scenarios_rejects_unknown_scenario_keys tests/test_suite_runner.py::test_build_scenarios_rejects_non_mapping_scenarios tests/test_suite_config_sources.py
- ./venv/bin/python -m pytest tests/test_suite_runner.py