### PR TITLE
Refresh pymoo resume runtime state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable user-facing changes will be documented in this file.
 
 - Suite scenarios now reject unknown scenario fields before running, catching
   typos such as `coin` instead of silently ignoring them.
+- Resumed pymoo optimizer checkpoints now refresh the active problem,
+  termination target, and checkpoint callback before continuing, so increasing
+  `optimize.iters` on resume takes effect.
 - Optimizer overrides now reject unknown `optimize.enable_overrides` names before
   the run starts, and `forward_tp_grid` / `backward_tp_grid` now reorder
   `trailing_grid_v7` close-grid markup bounds as intended.

--- a/src/optimization/backends/pymoo_backend.py
+++ b/src/optimization/backends/pymoo_backend.py
@@ -69,6 +69,27 @@ def _build_random_sampling(bounds, population_size: int) -> np.ndarray:
     return np.asarray(population, dtype=np.float64)
 
 
+def _prepare_resumed_algorithm(
+    algorithm,
+    *,
+    problem,
+    termination,
+    seed: int | None,
+    callback,
+) -> None:
+    saved_random_state = getattr(algorithm, "random_state", None)
+    algorithm.has_terminated = False
+    algorithm.setup(
+        problem,
+        termination=termination,
+        seed=seed,
+        verbose=False,
+        callback=callback,
+    )
+    if saved_random_state is not None:
+        algorithm.random_state = saved_random_state
+
+
 def _population_from_payloads(
     vectors: np.ndarray,
     payloads: list[dict[str, Any]],
@@ -634,6 +655,12 @@ def run_backend(
             elementwise_runner=runner,
         )
 
+        ngen = max(1, int(config["optimize"]["iters"] / population_size))
+        termination = get_termination("n_gen", ngen)
+        checkpoint_callback = (
+            PymooCheckpointCallback(checkpoint_path) if checkpoint_path is not None else None
+        )
+
         algorithm = None
         if resume:
             if checkpoint_path is None:
@@ -643,17 +670,13 @@ def run_backend(
             logging.info(f"Loading PyMoo checkpoint from {checkpoint_path}...")
             with open(checkpoint_path, "rb") as f:
                 algorithm = pickle.load(f)
-            algorithm.has_terminated = False
-
-            # Restore the active runner (pool) and evaluator
-            if hasattr(algorithm, "problem"):
-                algorithm.problem.elementwise_runner = runner
-                if hasattr(algorithm.problem, "evaluator_adapter"):
-                    algorithm.problem.evaluator_adapter.evaluator = evaluator_for_pool
-            if hasattr(algorithm, "evaluator") and hasattr(algorithm.evaluator, "problem"):
-                algorithm.evaluator.problem.elementwise_runner = runner
-                if hasattr(algorithm.evaluator.problem, "evaluator_adapter"):
-                    algorithm.evaluator.problem.evaluator_adapter.evaluator = evaluator_for_pool
+            _prepare_resumed_algorithm(
+                algorithm,
+                problem=problem,
+                termination=termination,
+                seed=rng_seed,
+                callback=checkpoint_callback,
+            )
 
         if algorithm is None:
             algorithm = _build_algorithm(
@@ -688,7 +711,6 @@ def run_backend(
                     bounds=bounds,
                     rng_seed=rng_seed,
                 )
-        ngen = max(1, int(config["optimize"]["iters"] / population_size))
         logging.info("Starting optimize...")
 
         minimize_kwargs = {
@@ -696,13 +718,13 @@ def run_backend(
             "verbose": False,
             "copy_algorithm": False,
         }
-        if checkpoint_path is not None:
-            minimize_kwargs["callback"] = PymooCheckpointCallback(checkpoint_path)
+        if checkpoint_callback is not None:
+            minimize_kwargs["callback"] = checkpoint_callback
 
         pymoo_minimize(
             problem,
             algorithm,
-            get_termination("n_gen", ngen),
+            termination,
             **minimize_kwargs
         )
         logging.info("Optimization complete.")

--- a/tests/optimization/test_pymoo_backend.py
+++ b/tests/optimization/test_pymoo_backend.py
@@ -595,6 +595,91 @@ def test_run_backend_evaluates_all_starting_configs_before_trim(monkeypatch):
     assert captured["sampling"].shape == (4, 2)
 
 
+def test_run_backend_refreshes_pymoo_resume_runtime_state(monkeypatch, tmp_path):
+    monkeypatch.setattr(pymoo_backend.multiprocessing, "Pool", FakePool)
+    checkpoint_path = tmp_path / "checkpoint.pkl"
+    stale_algorithm = _build_nsga3_algorithm(population_size=4, n_obj=2)
+    stale_algorithm.setup(
+        TinyManyObjectiveProblem(n_obj=2),
+        termination=pymoo_backend.get_termination("n_gen", 1),
+        seed=7,
+        verbose=True,
+        callback=pymoo_backend.Callback(),
+    )
+    saved_random_state = copy.deepcopy(stale_algorithm.random_state.bit_generator.state)
+    with open(checkpoint_path, "wb") as f:
+        pickle.dump(stale_algorithm, f, protocol=pickle.HIGHEST_PROTOCOL)
+
+    captured = {}
+
+    def _fake_minimize(problem, algorithm, termination, seed, verbose, **kwargs):
+        captured["problem"] = problem
+        captured["algorithm"] = algorithm
+        captured["termination"] = termination
+        captured["seed"] = seed
+        captured["verbose"] = verbose
+        captured["kwargs"] = kwargs
+        return None
+
+    monkeypatch.setattr(pymoo_backend, "pymoo_minimize", _fake_minimize)
+    evaluator = FakeEvaluator(["adg", "drawdown_worst"])
+
+    result = pymoo_backend.run_backend(
+        config={
+            "optimize": {
+                "backend": "pymoo",
+                "population_size": 4,
+                "iters": 20,
+                "seed": 99,
+                "n_cpus": 1,
+                "round_to_n_significant_digits": 4,
+                "scoring": ["adg", "drawdown_worst"],
+                "pymoo": {
+                    "algorithm": "nsga3",
+                    "shared": {
+                        "crossover_prob_var": 0.5,
+                        "crossover_eta": 20.0,
+                        "mutation_eta": 20.0,
+                        "mutation_prob_var": 0.5,
+                        "eliminate_duplicates": True,
+                    },
+                },
+            }
+        },
+        evaluator=evaluator,
+        evaluator_for_pool=evaluator,
+        recorder=FakeRecorder(),
+        overrides_list=[],
+        duplicate_counter={},
+        starting_configs_path=None,
+        constraint_fitness_cls=None,
+        ignore_sigint_in_worker=_ignore_sigint,
+        get_starting_configs=_get_starting_configs,
+        configs_to_individuals=_configs_to_individuals,
+        record_individual_result=None,
+        run_evolution=None,
+        build_config_fn=_build_config,
+        overrides_fn=_noop_overrides,
+        checkpoint_path=str(checkpoint_path),
+        resume=True,
+    )
+
+    resumed_algorithm = captured["algorithm"]
+    assert captured["problem"] is resumed_algorithm.problem
+    assert resumed_algorithm.problem.elementwise_runner.recorder.__class__ is FakeRecorder
+    assert resumed_algorithm.termination.n_max_gen == 5
+    assert captured["termination"].n_max_gen == 5
+    assert isinstance(resumed_algorithm.callback, pymoo_backend.PymooCheckpointCallback)
+    assert isinstance(captured["kwargs"]["callback"], pymoo_backend.PymooCheckpointCallback)
+    assert resumed_algorithm.seed == 99
+    assert captured["seed"] == 99
+    assert captured["verbose"] is False
+    assert resumed_algorithm.has_terminated is False
+    assert resumed_algorithm.random_state.bit_generator.state == saved_random_state
+    result["pool"].close()
+    result["pool"].join()
+
+
 def test_starting_payloads_are_slimmed_after_recording(monkeypatch):
     monkeypatch.setattr(pymoo_backend.multiprocessing, "Pool", FakePool)
     evaluator = FakeEvaluator(["adg", "drawdown_worst"])


### PR DESCRIPTION
## Summary
- prepare loaded pymoo checkpoint algorithms with the current problem, termination, checkpoint callback, and minimize seed before resume
- preserve checkpointed RNG generator state when rebinding runtime-only setup state
- reuse the same termination/callback objects for fresh and resumed minimize calls

## Tests
- ./venv/bin/python -m pytest tests/optimization/test_pymoo_backend.py
- ./venv/bin/python -m pytest tests/optimization/test_pymoo_integration.py tests/optimization/test_optimize.py::test_require_resume_checkpoint_rejects_missing_checkpoint tests/optimization/test_optimize.py::test_require_resume_checkpoint_rejects_empty_checkpoint tests/optimization/test_optimize.py::test_validate_resume_results_counts_entries