### PR TITLE
Preserve all_results diff deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Compressed `all_results.bin` optimizer history now preserves deleted keys
+  during replay, preventing stale fields such as prior candidate errors from
+  leaking into later entries.
 - Suite scenarios now reject unknown scenario fields before running, catching
   typos such as `coin` instead of silently ignoring them.
 - Optimizer overrides now reject unknown `optimize.enable_overrides` names before

--- a/src/opt_utils.py
+++ b/src/opt_utils.py
@@ -5,6 +5,29 @@ import msgpack
 from typing import Any
 import passivbot_rust as pbr
 
+_DIFF_DELETE_KEY = "__passivbot_diff_delete__"
+_DIFF_DELETE_MARKER = {_DIFF_DELETE_KEY: True}
+
+
+def _is_diff_delete_marker(value: Any) -> bool:
+    return isinstance(value, dict) and value == _DIFF_DELETE_MARKER
+
+
+def _dict_diff(d1: dict, d2: dict) -> dict:
+    diff = {}
+    for k in d1.keys() - d2.keys():
+        diff[k] = _DIFF_DELETE_MARKER.copy()
+    for k in d2:
+        if k not in d1:
+            diff[k] = d2[k]
+        elif isinstance(d2[k], dict) and isinstance(d1.get(k), dict):
+            nested = _dict_diff(d1[k], d2[k])
+            if nested:
+                diff[k] = nested
+        elif d1[k] != d2[k]:
+            diff[k] = d2[k]
+    return diff
+
 
 def dominates(p0, p1):
     better_in_one = False
@@ -83,26 +106,12 @@ def gprint(verbose):
 
 def generate_diffs(dictlist):
     """Yield diffs between consecutive dicts in dictlist, supporting nested dicts."""
-
-    def dict_diff(d1, d2):
-        diff = {}
-        for k in d2:
-            if k not in d1:
-                diff[k] = d2[k]
-            elif isinstance(d2[k], dict) and isinstance(d1.get(k), dict):
-                nested = dict_diff(d1[k], d2[k])
-                if nested:
-                    diff[k] = nested
-            elif d1[k] != d2[k]:
-                diff[k] = d2[k]
-        return diff
-
     prev = {}
     for d in dictlist:
         if not prev:
             yield d
         else:
-            yield dict_diff(prev, d)
+            yield _dict_diff(prev, d)
         prev = d
 
 
@@ -112,6 +121,8 @@ def deep_updated(base, diff):
     for k in keys:
         if k in diff:
             v2 = diff[k]
+            if _is_diff_delete_marker(v2):
+                continue
             if isinstance(v2, dict) and isinstance(base.get(k), dict):
                 out[k] = deep_updated(base[k], v2)
             else:
@@ -123,21 +134,7 @@ def deep_updated(base, diff):
 
 def generate_incremental_diff(prev, current):
     """Return the diff between two dicts."""
-
-    def dict_diff(d1, d2):
-        diff = {}
-        for k in d2:
-            if k not in d1:
-                diff[k] = d2[k]
-            elif isinstance(d2[k], dict) and isinstance(d1.get(k), dict):
-                nested = dict_diff(d1[k], d2[k])
-                if nested:
-                    diff[k] = nested
-            elif d1[k] != d2[k]:
-                diff[k] = d2[k]
-        return diff
-
-    return dict_diff(prev or {}, current)
+    return _dict_diff(prev or {}, current)
 
 
 def apply_diffs(difflist, base=None):

--- a/tests/test_opt_utils.py
+++ b/tests/test_opt_utils.py
@@ -1,0 +1,55 @@
+import msgpack
+
+from opt_utils import apply_diffs, generate_diffs, generate_incremental_diff, load_results
+
+
+def test_incremental_diff_replays_top_level_key_deletions():
+    previous = {"config": {"a": 1}, "metrics": {"error": "bad"}}
+    current = {"config": {"a": 2}}
+
+    diff = generate_incremental_diff(previous, current)
+    replayed = list(apply_diffs([diff], base=previous))[-1]
+
+    assert "metrics" not in replayed
+    assert replayed == current
+
+
+def test_incremental_diff_replays_nested_key_deletions():
+    previous = {
+        "metrics": {
+            "objectives": {"adg": 1.0, "mdg": 2.0},
+            "error": "bad",
+        }
+    }
+    current = {"metrics": {"objectives": {"adg": 1.5}}}
+
+    diff = generate_incremental_diff(previous, current)
+    replayed = list(apply_diffs([diff], base=previous))[-1]
+
+    assert replayed == current
+
+
+def test_load_results_replays_deleted_keys_from_incremental_diffs(tmp_path):
+    first = {"config": {"a": 1}, "metrics": {"error": "bad", "gain": 0.0}}
+    second = {"config": {"a": 2}, "metrics": {"gain": 1.0}}
+    third = {"config": {"a": 3}}
+    second_diff = generate_incremental_diff(first, second)
+    third_diff = generate_incremental_diff(second, third)
+    path = tmp_path / "all_results.bin"
+    packer = msgpack.Packer(use_bin_type=True)
+    with open(path, "wb") as f:
+        f.write(packer.pack(first))
+        f.write(packer.pack(second_diff))
+        f.write(packer.pack(third_diff))
+
+    assert list(load_results(path)) == [first, second, third]
+
+
+def test_generate_diffs_replays_deleted_keys():
+    first = {"a": 1, "stale": {"nested": True}}
+    second = {"a": 2, "stale": {}}
+    third = {"a": 3}
+
+    diffs = list(generate_diffs([first, second, third]))
+
+    assert list(apply_diffs(diffs)) == [first, second, third]


### PR DESCRIPTION
## Summary
- add an explicit deletion marker to compressed optimizer result diffs
- teach all_results replay to remove top-level and nested deleted keys
- share deletion-aware diff logic between generate_diffs and generate_incremental_diff

## Tests
- ./venv/bin/python -m pytest tests/test_opt_utils.py tests/optimization/test_pymoo_backend.py::test_run_backend_writes_readable_result_artifacts tests/optimization/test_optimize.py::test_result_recorder_all_results_write_failure_is_fatal