### PR TITLE
Fail loudly on missing Pareto limit metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable user-facing changes will be documented in this file.
 - Compressed `all_results.bin` optimizer history now preserves deleted keys
   during replay, preventing stale fields such as prior candidate errors from
   leaking into later entries.
+- Pareto limit filters now fail loudly when a configured limit metric is missing
+  instead of silently retaining candidates that cannot be checked.
 - Suite scenarios now reject unknown scenario fields before running, catching
   typos such as `coin` instead of silently ignoring them.
 - Resumed pymoo optimizer checkpoints now refresh the active problem,

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -752,6 +752,17 @@ def _resolve_limit_value(
     return None
 
 
+def _format_available_limit_metrics(candidate: ParetoCandidate) -> str:
+    available = sorted(
+        {
+            *candidate.objectives.keys(),
+            *candidate.stats_flat.keys(),
+            *candidate.aggregated_values.keys(),
+        }
+    )
+    return ", ".join(available) if available else "<none>"
+
+
 def _limit_rejects(entry: Mapping[str, Any], value: float) -> bool:
     mode = str(entry.get("penalize_if", "greater_than")).strip().lower()
     if mode == "greater_than":
@@ -802,7 +813,12 @@ def filter_candidates(
         for entry in enabled_limits:
             value = _resolve_limit_value(candidate, entry, aggregate_cfg)
             if value is None:
-                continue
+                metric = str(entry.get("metric", "")).strip() or "<missing>"
+                available = _format_available_limit_metrics(candidate)
+                raise ValueError(
+                    f"Limit metric {metric!r} could not be resolved for "
+                    f"{candidate.path.name}. Available metrics: {available}"
+                )
             if _limit_rejects(entry, value):
                 rejected = True
                 break

--- a/src/pareto_store.py
+++ b/src/pareto_store.py
@@ -33,6 +33,10 @@ from pareto_core import (
 STAT_FIELDS = {"mean", "min", "max", "std"}
 
 
+class LimitMetricError(ValueError):
+    pass
+
+
 def _resolve_aggregate_mode(metric: str, aggregate_cfg: Optional[Dict[str, str]]) -> str:
     return resolve_aggregate_mode(metric, aggregate_cfg)
 
@@ -84,6 +88,24 @@ def _resolve_limit_value(
         field = "mean"
     key = f"{resolved_metric.replace('.', '_')}_{field}"
     return resolve_metric_value(stats_flat, key)
+
+
+def _format_available_limit_metrics(
+    stats_flat: Dict[str, float],
+    aggregated_values: Dict[str, float],
+    objectives: Dict[str, float],
+    metric_map: Dict[str, str],
+) -> str:
+    available = sorted(
+        {
+            *stats_flat.keys(),
+            *aggregated_values.keys(),
+            *objectives.keys(),
+            *metric_map.keys(),
+            *metric_map.values(),
+        }
+    )
+    return ", ".join(available) if available else "<none>"
 
 
 def _suite_metrics_to_stats(
@@ -163,7 +185,13 @@ def _evaluate_limits(
     for spec in specs:
         value = _resolve_limit_value(spec, stats_flat, aggregated_values, objectives, metric_map)
         if value is None:
-            continue
+            available = _format_available_limit_metrics(
+                stats_flat, aggregated_values, objectives, metric_map
+            )
+            raise LimitMetricError(
+                f"Limit metric {spec.metric!r} could not be resolved. "
+                f"Available metrics: {available}"
+            )
         if not spec.op(value, spec.value):
             return False
     return True
@@ -697,6 +725,8 @@ def main():
             if all(v is not None for v in values):
                 points.append((*values, h))
                 filenames[h] = os.path.split(entry_path)[-1]
+        except LimitMetricError:
+            raise
         except Exception as e:
             print(f"Error loading {h}: {e}")
     print(f"Found {len(entries)} Pareto members.")

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -222,6 +222,16 @@ def test_filter_candidates_with_cli_keep_condition(sample_pareto_dir: Path):
     assert sorted(candidate.path.stem for candidate in filtered) == ["a_extreme", "balanced"]
 
 
+def test_filter_candidates_raises_when_limit_metric_is_missing(sample_pareto_dir: Path):
+    _pareto_dir, candidates, _specs = load_candidates(sample_pareto_dir)
+    with pytest.raises(ValueError, match="Limit metric 'missing_metric' could not be resolved"):
+        filter_candidates(
+            candidates,
+            limits_payload=None,
+            limit_entries=["missing_metric>0.0"],
+        )
+
+
 def test_filter_candidates_uses_suite_aggregate_defaults_for_omitted_stat(tmp_path: Path):
     pareto_dir = tmp_path / "run" / "pareto"
     pareto_dir.mkdir(parents=True)

--- a/tests/test_pareto_limits.py
+++ b/tests/test_pareto_limits.py
@@ -1,5 +1,7 @@
 import operator
 
+import pytest
+
 from pareto_store import LimitSpec, _evaluate_limits
 
 
@@ -57,3 +59,15 @@ def test_metric_name_ending_with_suffix_is_not_misparsed():
         "position_unchanged_hours_max_mean": 650.0,
     }
     assert _evaluate_limits(specs, stats_flat, aggregated, {}, {})
+
+
+def test_missing_limit_metric_raises_instead_of_passing():
+    specs = [LimitSpec(metric="missing_metric", field="auto", op=operator.lt, value=800)]
+    with pytest.raises(ValueError, match="Limit metric 'missing_metric' could not be resolved"):
+        _evaluate_limits(
+            specs,
+            {"peak_recovery_hours_pnl_mean": 750.0},
+            {},
+            {},
+            {},
+        )


### PR DESCRIPTION
## Summary
- raise explicit errors when configured Pareto limit metrics cannot be resolved
- include available metric names in store and explorer error messages
- add regression coverage for store and explorer limit filtering

## Tests
- ./venv/bin/python -m pytest tests/test_pareto_limits.py tests/test_pareto_explorer.py