### PR TITLE
Update optimizer docs for current v8 behavior

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -604,13 +604,17 @@ Risk should be constrained through canonical `*_strategy_eq` metrics instead. De
     - `adg_strategy_eq`
     - `adg_strategy_eq_w`
     - `mdg_strategy_eq`
-    - `mdg_strategy_eq_w`
+    - `sortino_ratio_strategy_eq`
+    - `volume_pct_per_day_avg`
+    - `sharpe_ratio_strategy_eq`
     - `strategy_eq_recovery_days_max`
     - `position_held_days_max`
     - `drawdown_worst_strategy_eq`
-    - `drawdown_worst_mean_1pct_strategy_eq`
+    - `loss_profit_ratio`
+    - `strategy_eq_underwater_pct_mean`
   - With the default `pymoo` backend, Passivbot uses `nsga2` for `3` or fewer objectives and `nsga3` for `4+` objectives unless explicitly overridden.
-  - Full list of options: `[adg, adg_w, calmar_ratio, calmar_ratio_w, drawdown_worst, drawdown_worst_mean_1pct, equity_balance_diff_neg_max, equity_balance_diff_neg_mean, equity_balance_diff_pos_max, equity_balance_diff_pos_mean, expected_shortfall_1pct, gain, hard_stop_duration_minutes_max, hard_stop_duration_minutes_mean, hard_stop_flatten_time_minutes_mean, hard_stop_halt_to_restart_equity_loss_pct, hard_stop_panic_close_loss_drawdown_pct_max, hard_stop_panic_close_loss_drawdown_pct_mean, hard_stop_panic_close_loss_drawdown_pct_min, hard_stop_panic_close_loss_max, hard_stop_panic_close_loss_sum, hard_stop_post_restart_retrigger_pct, hard_stop_time_in_orange_pct, hard_stop_time_in_red_pct, hard_stop_time_in_yellow_pct, hard_stop_trigger_drawdown_mean, high_exposure_days_max_long, high_exposure_days_max_short, high_exposure_hours_max_long, high_exposure_hours_max_short, loss_profit_ratio, loss_profit_ratio_w, mdg, mdg_w, omega_ratio, omega_ratio_w, peak_recovery_days_equity, peak_recovery_days_pnl, peak_recovery_days_strategy_eq, peak_recovery_hours_equity, peak_recovery_hours_pnl, peak_recovery_hours_strategy_eq, position_held_days_max, position_held_days_mean, position_held_days_median, position_held_hours_max, position_held_hours_mean, position_held_hours_median, position_unchanged_days_max, position_unchanged_hours_max, positions_held_per_day, sharpe_ratio, sharpe_ratio_w, sortino_ratio, sortino_ratio_w, strategy_eq_recovery_days_max, strategy_eq_recovery_days_mean, strategy_eq_recovery_days_mean_worst_1pct, strategy_eq_recovery_days_mean_worst_5pct, strategy_eq_recovery_days_median, strategy_eq_recovery_days_p95, strategy_eq_recovery_days_p99, sterling_ratio, sterling_ratio_w]`
+  - Built-in shorthand metrics and their default goals are registered in
+    `src/config/scoring.py`; see `docs/optimizing.md` for metric descriptions.
   - Suffix `_w` indicates mean across 10 temporal subsets (whole, last_half, last_third, ..., last_tenth) to weigh recent data more heavily.
   - Examples: `["mdg", "sharpe_ratio", "loss_profit_ratio"]`, `["adg", "sortino_ratio", "drawdown_worst"]`, `["sortino_ratio", "omega_ratio", "adg_w", "position_unchanged_hours_max"]`, `["adg_pnl_w", "hard_stop_time_in_red_pct", "hard_stop_panic_close_loss_sum"]`
     - Note: metrics may be suffixed with `_usd` or `_btc` to select denomination. If `config.backtest.btc_collateral_cap` is `0`, BTC values still represent the USD equity translated into BTC terms.

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -130,12 +130,12 @@ The main NSGA-III-specific knob is:
   - Controls how fine the reference-direction grid is.
   - Higher values generate more reference directions, which increases diversity resolution but also
     makes each generation heavier.
-  - With the default 8-objective Passivbot scoring set, common reference-direction counts are:
-    - `n_partitions = 3` -> `120`
-    - `n_partitions = 4` -> `330`
-    - `n_partitions = 5` -> `792`
-  - Default is `"auto"`. For the default 8-objective setup, Passivbot currently resolves that to
-    `n_partitions = 4`, which gives `330` reference directions.
+  - With the default 11-objective Passivbot scoring set, common reference-direction counts are:
+    - `n_partitions = 2` -> `66`
+    - `n_partitions = 3` -> `286`
+    - `n_partitions = 4` -> `1001`
+  - Default is `"auto"`. For the default 11-objective setup, Passivbot currently resolves that to
+    `n_partitions = 3`, which gives `286` reference directions.
   - In auto mode, Passivbot chooses the largest Das-Dennis grid whose reference-direction count
     fits within the resolved NSGA-III population budget. This preserves the NSGA-III invariant that
     `population_size >= reference directions`.
@@ -144,7 +144,7 @@ The main NSGA-III-specific knob is:
   - For `pymoo` + `nsga3`, `null` means “auto”.
   - In that case Passivbot uses the default NSGA-III population budget of `500`, then resolves
     auto reference directions to the finest Das-Dennis grid that fits inside that budget.
-  - For the default 8-objective setup, that means `population_size = 500` with `330` reference
+  - For the default 11-objective setup, that means `population_size = 500` with `286` reference
     directions.
   - For a 10-objective setup, auto keeps `population_size = 500` and uses `220` reference
     directions (`n_partitions = 3`) because the next grid would require `715` reference directions.
@@ -241,7 +241,7 @@ Algorithm selection under the default `auto` mode:
 - `1` to `3` objectives -> `nsga2`
 - `4+` objectives -> `nsga3`
 
-That means the default 8-objective Passivbot template uses `nsga3`, while small custom scoring
+That means the default 11-objective Passivbot template uses `nsga3`, while small custom scoring
 lists automatically fall back to `nsga2`.
 
 ### Candle Interval
@@ -460,10 +460,6 @@ Contents:
 - `pareto/`: JSON files for Pareto-optimal configurations
   - Named `{hash}.json`
   - Files are added/removed over time as the Pareto front updates and is pruned to `optimize.pareto_max_size`
-- `index.json`: List of Pareto member hashes
-
-Each recorded result now also includes runtime provenance so later replay mismatches can be
-diagnosed directly from the artifact.
 
 ## Analyzing Results
 
@@ -547,7 +543,8 @@ objects. Each object describes when to penalize a result:
 - `value`: numeric threshold for `<`/`>` limits.
 - `range`: `[low, high]` for the range-based operators.
 - Optional `stat`: override the statistic to compare against (`min`, `max`, `mean`, `std`).
-  The default is `_max` for `>` checks, `_min` for `<` checks, and `_mean` for range checks.
+  Without `stat`, Passivbot resolves the metric through `backtest.aggregate`: first a
+  metric-specific aggregate rule, then `backtest.aggregate.default`, then `mean`.
 
 Example:
 
@@ -596,9 +593,11 @@ Semantics:
   `<=`, `==`). Explicit JSON/HJSON limit objects still use direct `penalize_if` semantics.
 - `--clear-limits` starts from an empty limit list before any `--limits` or `--limit` entries are applied.
 
-Penalties are added to every objective as a positive modifier; they do not disqualify a config but will push it far from the Pareto front when violated. Metric names may include `_usd` / `_btc` suffixes to lock a denomination; when omitted, USD is assumed.
-
-Pareto logging also includes the top violated constraints and their penalties so you can see which limits are driving a bad candidate.
+Limit violations do not disqualify a config. They produce positive penalty scores in optimizer
+engine space: if a limit metric matches a configured scoring metric, the penalty replaces that
+objective's engine score for the candidate; unmatched/global penalties affect every objective.
+Metric names may include `_usd` / `_btc` suffixes to lock a denomination; when omitted, USD is
+assumed.
 
 ## Performance Metrics
 
@@ -616,8 +615,9 @@ over all exchanges before scoring.
   exchanges in the run. The scoring logic uses the mean (`{metric}_mean`).
 - Internally, Passivbot converts all objectives into optimizer engine space where lower is better,
   so both the `deap` and `pymoo` backends receive consistent minimization-style values.
-- Penalties from `optimize.limits` are added to every objective when a bound is violated,
-  turning constraint breaches into very poor scores.
+- Penalties from `optimize.limits` replace affected engine objective scores when a bound is
+  violated, turning constraint breaches into very poor scores while preserving the raw metrics
+  stored for inspection.
 - Metrics are emitted with both USD and BTC suffixes (for example, `adg_usd` and `adg_btc`).
 - `_btc` metrics use BTC-denominated balance/equity as the numeraire even when
   `backtest.btc_collateral_cap = 0`, so they can be used to compare strategy performance against
@@ -704,20 +704,16 @@ for config in load_results("optimize_results/.../all_results.bin"):
 
 ### Monitoring Optimizer Memory Usage
 
-The script `tools/profile_optimizer_memory.py` (requires `psutil`) can be used to launch
-two optimizer runs with different CPU counts and record both process RSS and system-wide
-memory pressure. This is useful when validating that shared-memory datasets are behaving
-as expected on a given machine.
+The script `src/tools/capture_optimize_memory.py` samples an active optimizer process tree and
+host memory state into a JSON report. This is useful when validating that shared-memory datasets
+are behaving as expected on a given machine.
 
 ```bash
-python tools/profile_optimizer_memory.py \
-  --coins BTC ETH XRP SOL \
-  --iters 20 \
-  --population-size 12 \
-  --cpus 2 6
+PYTHONPATH=src python3 src/tools/capture_optimize_memory.py --wait --output tmp/optimize_memory.json
 ```
 
-The script writes raw samples and a summary to `tmp/optimizer_mem_profiles/`.
+Use `--pid <pid>` to monitor a specific optimizer process instead of waiting for the newest
+matching process.
 
 ### Profiling Suite Optimizer Evaluation
 


### PR DESCRIPTION
## Summary
- update default optimizer objective count and NSGA-III reference-direction examples for the current 11-objective template
- remove stale Pareto artifact/provenance claims and correct limit penalty/stat semantics
- replace the removed memory profiler command with the current capture_optimize_memory tool
- point shorthand scoring options at the source-of-truth registry instead of a stale duplicated list

## Verification
- rg for stale phrases: 8-objective, profile_optimizer_memory, index.json, runtime provenance, top violated constraints, added to every objective
- git diff --check