### PR TITLE
Close suite evaluator master attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable user-facing changes will be documented in this file.
   leaking into later entries.
 - Pareto limit filters now fail loudly when a configured limit metric is missing
   instead of silently retaining candidates that cannot be checked.
+- Suite optimizer workers now close lazy-slicing master shared-memory attachments when the
+  evaluator is cleaned up, avoiding attachment churn across evaluations.
 - Suite scenarios now reject unknown scenario fields before running, catching
   typos such as `coin` instead of silently ignoring them.
 - Resumed pymoo optimizer checkpoints now refresh the active problem,

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2140,17 +2140,27 @@ class SuiteEvaluator:
         return build_evaluation_payload(objectives, total_penalty, metrics_payload, individual)
 
     def __del__(self):
-        for ctx in self.contexts:
-            for attachment in ctx.attachments.get("hlcvs", {}).values():
+        self.close()
+
+    def close(self):
+        for ctx in getattr(self, "contexts", []):
+            attachments = getattr(ctx, "attachments", {}) or {}
+            for attachment_map in attachments.values():
+                for attachment in attachment_map.values():
+                    try:
+                        attachment.close()
+                    except Exception:
+                        pass
+                attachment_map.clear()
+        for attachment_map in getattr(self, "_master_attachments", {}).values():
+            for attachment in attachment_map.values():
                 try:
                     attachment.close()
                 except Exception:
                     pass
-            for attachment in ctx.attachments.get("btc", {}).values():
-                try:
-                    attachment.close()
-                except Exception:
-                    pass
+            attachment_map.clear()
+        for array_map in getattr(self, "_master_arrays", {}).values():
+            array_map.clear()
 
 
 def add_extra_options(parser, *, help_all: bool):

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -583,6 +583,19 @@ def _terminate_optimizer_pool(pool, pool_terminated: bool) -> bool:
     return True
 
 
+def _close_evaluator_for_pool(evaluator_for_pool) -> bool:
+    close = getattr(evaluator_for_pool, "close", None)
+    if not callable(close):
+        return False
+    logging.info("Closing evaluator resources...")
+    try:
+        close()
+    except Exception:
+        logging.exception("Failed to close evaluator resources")
+        return False
+    return True
+
+
 def _suite_config_implies_suite_mode(args) -> bool:
     return bool(getattr(args, "suite_config", None)) and getattr(args, "suite", None) is None
 
@@ -3218,6 +3231,8 @@ async def main():
                 manager.shutdown()
             except Exception:
                 logging.exception("Failed to shut down multiprocessing manager")
+        if "evaluator_for_pool" in locals():
+            _close_evaluator_for_pool(evaluator_for_pool)
         if "array_manager" in locals():
             logging.info("Releasing shared memory...")
             try:

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -26,6 +26,7 @@ from optimize import (
     _analysis_indicates_liquidation,
     _canonicalize_optimizer_individual,
     _clear_candidate_metrics,
+    _close_evaluator_for_pool,
     _looks_like_bool_token,
     _normalize_optional_bool_flag,
     _optimizer_exit_code,
@@ -96,6 +97,19 @@ def test_terminate_optimizer_pool_terminates_active_pool():
 
     assert _terminate_optimizer_pool(pool, False) is True
     pool.terminate.assert_called_once_with()
+
+
+def test_close_evaluator_for_pool_calls_close_when_available():
+    evaluator = MagicMock()
+
+    assert _close_evaluator_for_pool(evaluator) is True
+    evaluator.close.assert_called_once_with()
+
+
+def test_close_evaluator_for_pool_skips_plain_evaluator():
+    evaluator = object()
+
+    assert _close_evaluator_for_pool(evaluator) is False
 
 
 def test_suite_config_implies_suite_mode_when_suite_flag_omitted():

--- a/tests/optimization/test_optimize_suite_contexts.py
+++ b/tests/optimization/test_optimize_suite_contexts.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
@@ -9,6 +11,14 @@ from suite_runner import ExchangeDataset
 class _NoSharedArrayManager:
     def create_from(self, _array):
         raise AssertionError("test dataset should use lazy master specs")
+
+
+class _FakeAttachment:
+    def __init__(self):
+        self.closed = 0
+
+    def close(self):
+        self.closed += 1
 
 
 def _make_lazy_dataset(
@@ -98,6 +108,44 @@ async def test_prepare_suite_contexts_keeps_directional_scenarios_with_default_s
     )
 
     assert [ctx.label for ctx in contexts] == ["base", "long_only", "short_only"]
+
+
+def test_suite_evaluator_close_releases_context_and_master_attachments():
+    from optimize import SuiteEvaluator
+
+    context_hlcvs = _FakeAttachment()
+    context_btc = _FakeAttachment()
+    master_hlcvs = _FakeAttachment()
+    master_btc = _FakeAttachment()
+
+    evaluator = object.__new__(SuiteEvaluator)
+    evaluator.contexts = [
+        SimpleNamespace(
+            attachments={
+                "hlcvs": {"binance": context_hlcvs},
+                "btc": {"binance": context_btc},
+            }
+        )
+    ]
+    evaluator._master_attachments = {
+        "hlcvs": {"master-hlcvs": master_hlcvs},
+        "btc": {"master-btc": master_btc},
+    }
+    evaluator._master_arrays = {
+        "hlcvs": {"master-hlcvs": np.empty((1,))},
+        "btc": {"master-btc": np.empty((1,))},
+    }
+
+    evaluator.close()
+    evaluator.close()
+
+    assert context_hlcvs.closed == 1
+    assert context_btc.closed == 1
+    assert master_hlcvs.closed == 1
+    assert master_btc.closed == 1
+    assert evaluator.contexts[0].attachments == {"hlcvs": {}, "btc": {}}
+    assert evaluator._master_attachments == {"hlcvs": {}, "btc": {}}
+    assert evaluator._master_arrays == {"hlcvs": {}, "btc": {}}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add an explicit idempotent SuiteEvaluator.close() cleanup path
- close and clear lazy-slicing master shared-memory attachments as well as per-context attachments
- add regression coverage for context and master attachment cleanup

## Tests
- ./venv/bin/python -m pytest tests/optimization/test_optimize_suite_contexts.py
- git diff --check