### PR TITLE
Remove broken unused opt_utils helpers

### DIFF
--- a/src/opt_utils.py
+++ b/src/opt_utils.py
@@ -72,18 +72,6 @@ def calc_dist(p0, p1):
     return math.sqrt(sum((a - b) ** 2 for a, b in zip(p0, p1)))
 
 
-def calc_normalized_dist(point, ideal, w0_min, w0_max, w1_min, w1_max):
-    norm_point = [
-        (p - min_v) / (max_v - min_v) if max_v > min_v else p
-        for p, min_v, max_v in zip(point, mins, maxs)
-    ]
-    norm_ideal = [
-        (i - min_v) / (max_v - min_v) if max_v > min_v else i
-        for i, min_v, max_v in zip(ideal, mins, maxs)
-    ]
-    return math.sqrt(sum((p - i) ** 2 for p, i in zip(norm_point, norm_ideal)))
-
-
 def format_distance(dist: float) -> str:
     """Format distance to fixed-width string for lexicographical sorting."""
     return f"{dist:08.4f}"
@@ -207,21 +195,3 @@ def quantize_floats(obj: Any, sig_digits: int = None, step: float = None) -> Any
         return round_floats_sig_digits(obj, sig_digits)
     else:
         return round_floats_step(obj, step)
-
-
-def enforce_bounds_v2(obj: Any, bounds: Any = None, sig_digits: int = None):
-    """
-    apply floor/ceil capping and rounding to each element in obj
-    obj may be a bot config:
-        - take bounds from config.optimize.bounds
-        - apply to config.bot
-    obj may be a list of floats:
-        - assert len(obj) == len(bounds)
-        - obj is on form [float]
-        - bounds is on form [[float]]
-        - each element of bounds must be len==2 or len==3
-        - bound[0] is lower bound; bound[1] is upper bound
-        - if len bound element == 3, consider bound[2] as step
-        - if len bound element == 2, use sig_digits (raise if missing)
-    """
-    pass


### PR DESCRIPTION
## Summary
- remove calc_normalized_dist, which referenced undefined locals and had no callers
- remove the empty enforce_bounds_v2 stub, which had no callers
- leave the active result-diff and rounding helpers unchanged

## Verification
- rg -n "calc_normalized_dist|enforce_bounds_v2" . -> no matches after removal
- ./venv/bin/python -m pytest tests/test_opt_utils.py
- git diff --check