### PR TITLE
Reject empty optimizer bounds in config adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Optimizer vector-shape extraction now rejects empty `config.optimize.bounds`
+  instead of generating key paths that fail later without matching bounds.
 - Compressed `all_results.bin` optimizer history now preserves deleted keys
   during replay, preventing stale fields such as prior candidate errors from
   leaking into later entries.

--- a/src/optimization/config_adapter.py
+++ b/src/optimization/config_adapter.py
@@ -19,7 +19,6 @@ from config.schema import get_template_config
 from config.strategy import normalize_strategy_kind
 from config.strategy_spec import (
     get_strategy_spec,
-    strategy_field_names_by_side,
     strategy_optimize_key_path_map,
 )
 from optimization.bounds import Bound
@@ -52,14 +51,19 @@ def _flatten_bounds_for_config(config: dict, optimize_bounds: dict) -> dict:
     return flat_bounds
 
 
+def _flatten_required_optimize_bounds(config: dict) -> dict:
+    raw_bounds = config.get("optimize", {}).get("bounds")
+    if not isinstance(raw_bounds, dict):
+        raise TypeError("config.optimize.bounds must be a non-empty dict")
+    optimize_bounds = _flatten_bounds_for_config(config, raw_bounds)
+    if not optimize_bounds:
+        raise ValueError("config.optimize.bounds must contain at least one optimizer bound")
+    return optimize_bounds
+
+
 def _strategy_path_map(config: dict) -> dict[str, Tuple[str, ...]]:
     strategy_kind = normalize_strategy_kind(config.get("live", {}).get("strategy_kind"))
     return strategy_optimize_key_path_map(strategy_kind)
-
-
-def _strategy_field_names_by_side(config: dict) -> dict[str, set[str]]:
-    strategy_kind = normalize_strategy_kind(config.get("live", {}).get("strategy_kind"))
-    return strategy_field_names_by_side(strategy_kind)
 
 
 def resolve_optimization_bound_path(config: dict, bound_key: str) -> Tuple[str, ...] | None:
@@ -123,41 +127,9 @@ def get_optimization_key_paths(config) -> List[Tuple[str, Tuple[str, ...]]]:
     if bot_config is None:
         bot_config = template["bot"]
     strategy_kind = normalize_strategy_kind(config.get("live", {}).get("strategy_kind"))
-    strategy_fields = _strategy_field_names_by_side(config)
     strategy_path_map = _strategy_path_map(config)
-    optimize_bounds = _flatten_bounds_for_config(config, config.get("optimize", {}).get("bounds", {}))
+    optimize_bounds = _flatten_required_optimize_bounds(config)
     validate_optimize_bounds_against_bot_config(config, optimize_bounds)
-    if not optimize_bounds:
-        for pside in ("long", "short"):
-            scalar_paths: dict[str, Tuple[str, ...]] = {}
-            pside_cfg = flatten_shared_bot_side(bot_config.get(pside, {}))
-            for key in sorted(pside_cfg):
-                value = pside_cfg[key]
-                if key in strategy_fields.get(pside, set()):
-                    continue
-                if isinstance(value, bool) or not isinstance(value, (int, float)):
-                    continue
-                resolved = resolve_optimizer_key_path(config, f"{pside}_{key}") or ("bot", pside, key)
-                scalar_paths[key] = resolved
-            for key, path in strategy_path_map.items():
-                if not key.startswith(f"{pside}_"):
-                    continue
-                local_key = key.split("_", 1)[1]
-                current = config
-                found = True
-                for part in path:
-                    if not isinstance(current, dict) or part not in current:
-                        found = False
-                        break
-                    current = current[part]
-                if not found:
-                    continue
-                if isinstance(current, bool) or not isinstance(current, (int, float)):
-                    continue
-                scalar_paths[local_key] = path
-            for key in sorted(scalar_paths):
-                key_paths.append((f"{pside}_{key}", scalar_paths[key]))
-        return key_paths
     for bound_key in sorted(optimize_bounds):
         if not isinstance(bound_key, str):
             continue
@@ -197,7 +169,7 @@ def extract_bounds_tuple_list_from_config(config) -> List[Bound]:
         - single value: fixed parameter (low=high, step=None)
     """
     bounds = []
-    optimize_bounds = _flatten_bounds_for_config(config, config["optimize"]["bounds"])
+    optimize_bounds = _flatten_required_optimize_bounds(config)
     key_paths = get_optimization_key_paths(config)
     bot_config = config.get("bot")
     if bot_config is None:

--- a/tests/optimization/test_config_adapter.py
+++ b/tests/optimization/test_config_adapter.py
@@ -91,7 +91,7 @@ class TestConfigAdapter:
         assert ("long_hsl_red_threshold", ("bot", "long", "hsl_red_threshold")) in key_paths
         assert ("short_hsl_ema_span_minutes", ("bot", "short", "hsl_ema_span_minutes")) in key_paths
 
-    def test_get_optimization_key_paths_skips_missing_side_configs(self):
+    def test_get_optimization_key_paths_rejects_empty_bounds(self):
         config = {
             "bot": {
                 "long": {
@@ -102,12 +102,14 @@ class TestConfigAdapter:
             "optimize": {"bounds": {}},
         }
 
-        key_paths = get_optimization_key_paths(config)
-
-        assert key_paths == [
-            ("long_a", ("bot", "long", "a")),
-            ("long_b", ("bot", "long", "b")),
-        ]
+        with pytest.raises(
+            ValueError, match="config.optimize.bounds must contain at least one optimizer bound"
+        ):
+            get_optimization_key_paths(config)
+        with pytest.raises(
+            ValueError, match="config.optimize.bounds must contain at least one optimizer bound"
+        ):
+            extract_bounds_tuple_list_from_config(config)
 
     @pytest.mark.parametrize(
         ("bound_key", "bound_value", "expected"),

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -69,6 +69,10 @@ from config.parse import load_raw_config
 from config.schema import get_template_config
 
 
+def _toy_optimize_bounds(*keys):
+    return {"bounds": {key: [0.0, 1000.0] for key in keys}}
+
+
 def test_worker_initializer_is_pickleable_for_spawn():
     ForkingPickler.dumps(ignore_sigint_in_worker)
 
@@ -737,7 +741,13 @@ class TestIndividualToConfig:
             "bot": {
                 "long": {"param1": 0.0, "param2": 0.0},
                 "short": {"param1": 0.0, "param2": 0.0},
-            }
+            },
+            "optimize": _toy_optimize_bounds(
+                "long_param1",
+                "long_param2",
+                "short_param1",
+                "short_param2",
+            ),
         }
         overrides_list = []
         mock_overrides = lambda x, y, z: y
@@ -756,7 +766,13 @@ class TestIndividualToConfig:
             "bot": {
                 "long": {"z_param": 0.0, "a_param": 0.0},
                 "short": {"z_param": 0.0, "a_param": 0.0},
-            }
+            },
+            "optimize": _toy_optimize_bounds(
+                "long_a_param",
+                "long_z_param",
+                "short_a_param",
+                "short_z_param",
+            ),
         }
         overrides_list = []
         mock_overrides = lambda x, y, z: y
@@ -776,7 +792,12 @@ class TestIndividualToConfig:
                 "long": {"param1": 99.0, "param2": 99.0},
                 "short": {"param1": 99.0, "param2": 99.0},
             },
-            "optimize": {"bounds": {}},
+            "optimize": _toy_optimize_bounds(
+                "long_param1",
+                "long_param2",
+                "short_param1",
+                "short_param2",
+            ),
         }
         original_template = deepcopy(template)
         overrides_list = []
@@ -1204,7 +1225,13 @@ class TestIndividualToConfig:
             "bot": {
                 "long": {"z_param": 0.0, "a_param": 0.0},
                 "short": {"z_param": 0.0, "a_param": 0.0},
-            }
+            },
+            "optimize": _toy_optimize_bounds(
+                "long_a_param",
+                "long_z_param",
+                "short_a_param",
+                "short_z_param",
+            ),
         }
         key_paths = get_optimization_key_paths(template)
 
@@ -1434,7 +1461,13 @@ class TestConfigToIndividual:
             "bot": {
                 "long": {"param1": 1.5, "param2": 2.5},
                 "short": {"param1": 3.5, "param2": 4.5},
-            }
+            },
+            "optimize": _toy_optimize_bounds(
+                "long_param1",
+                "long_param2",
+                "short_param1",
+                "short_param2",
+            ),
         }
         bounds = [Bound(0.0, 10.0) for _ in range(4)]
         sig_digits = 6
@@ -1454,7 +1487,12 @@ class TestConfigToIndividual:
                 "long": {"z_param": 100.0, "a_param": 200.0},
                 "short": {"z_param": 300.0, "a_param": 400.0},
             },
-            "optimize": {"bounds": {}},
+            "optimize": _toy_optimize_bounds(
+                "long_a_param",
+                "long_z_param",
+                "short_a_param",
+                "short_z_param",
+            ),
         }
         bounds = [Bound(0.0, 1000.0)] * 4
         sig_digits = 6


### PR DESCRIPTION
## Summary
- make optimizer vector-shape extraction reject missing or empty optimize.bounds up front
- remove the generated key-path fallback that had no matching Bound entries downstream
- update config-adapter coverage for the fail-loud empty-bounds behavior

## Tests
- ./venv/bin/python -m pytest tests/optimization/test_config_adapter.py tests/optimization/test_optimize.py::TestConfigsToIndividuals tests/optimization/test_optimize.py::test_resume_config_mismatches_rejects_changed_optimize_bounds
- git diff --check