### PR TITLE
Reject non-finite Pareto prune objectives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable user-facing changes will be documented in this file.
   instead of silently retaining candidates that cannot be checked.
 - Suite optimizer workers now close lazy-slicing master shared-memory attachments when the
   evaluator is cleaned up, avoiding attachment churn across evaluations.
+- Pareto pruning now rejects non-finite objective matrices before selecting
+  required extremes, preventing NaN values from being retained as best/worst axes.
 - Suite scenarios now reject unknown scenario fields before running, catching
   typos such as `coin` instead of silently ignoring them.
 - Resumed pymoo optimizer checkpoints now refresh the active problem,

--- a/src/pareto_core.py
+++ b/src/pareto_core.py
@@ -150,6 +150,13 @@ def prune_front_with_extremes(
         return []
     objs = [objectives_map[idx] for idx in front_hashes]
     arr = np.asarray(objs, dtype=float)
+    if not np.all(np.isfinite(arr)):
+        row, col = np.argwhere(~np.isfinite(arr))[0]
+        raise ValueError(
+            "Pareto objective matrix contains non-finite value "
+            f"for {front_hashes[int(row)]!r} at objective index {int(col)}: "
+            f"{arr[int(row), int(col)]!r}"
+        )
     required: set[str] = set()
     for dim in range(arr.shape[1]):
         min_idx = int(np.argmin(arr[:, dim]))

--- a/tests/test_pareto_core.py
+++ b/tests/test_pareto_core.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from config.scoring import ObjectiveSpec
 from pareto_core import (
@@ -55,6 +56,19 @@ def test_prune_preserves_extremes_and_uses_crowding():
     arr = np.array([objectives[k] for k in front])
     cds = crowding_distances(arr)
     assert cds.shape[0] == len(front)
+
+
+def test_prune_rejects_nonfinite_objectives_before_selecting_extremes():
+    front = ["nan", "a", "b"]
+    objectives = {
+        "nan": (np.nan, 0.5),
+        "a": (0.1, 0.4),
+        "b": (0.2, 0.3),
+    }
+    violations = {k: 0.0 for k in front}
+
+    with pytest.raises(ValueError, match="non-finite value"):
+        prune_front_with_extremes(front, objectives, violations, max_size=2)
 
 
 def test_compute_ideal_weighted_respects_mixed_objective_goals():

--- a/tests/test_pareto_extremes.py
+++ b/tests/test_pareto_extremes.py
@@ -140,3 +140,17 @@ def test_pareto_store_rejects_missing_objective_values(tmp_path):
 
     with pytest.raises(ValueError, match="missing or non-numeric"):
         store.add_entry(entry)
+
+
+def test_pareto_store_rejects_nan_objective_values(tmp_path):
+    entry = {
+        "metrics": {
+            "objectives": {"metric1": math.nan},
+            "constraint_violation": 0.0,
+        },
+        "optimize": {"scoring": ["metric1"]},
+    }
+    store = ParetoStore(directory=str(tmp_path), sig_digits=6, flush_interval=10_000, max_size=50)
+
+    with pytest.raises(ValueError, match="non-finite"):
+        store.add_entry(entry)


### PR DESCRIPTION
## Summary
- reject non-finite objective matrices before Pareto pruning selects required extremes
- add core regression coverage for NaN objectives in prune_front_with_extremes
- add store regression coverage confirming NaN objectives fail before entering the front

## Tests
- ./venv/bin/python -m pytest tests/test_pareto_core.py tests/test_pareto_extremes.py
- git diff --check