### PR TITLE
Clean duplicate exchange dataset metadata

### DIFF
--- a/src/suite_runner.py
+++ b/src/suite_runner.py
@@ -611,7 +611,6 @@ def filter_coins_by_exchange_assignment(
 
 
 @dataclass
-@dataclass
 class ExchangeDataset:
     exchange: str
     coins: List[str]
@@ -623,8 +622,6 @@ class ExchangeDataset:
     btc_usd_prices: np.ndarray
     timestamps: Optional[np.ndarray]
     cache_dir: str
-    hlcvs_spec: Optional[SharedArraySpec] = None
-    btc_spec: Optional[SharedArraySpec] = None
     hlcvs_spec: Optional[SharedArraySpec] = None
     btc_spec: Optional[SharedArraySpec] = None
 


### PR DESCRIPTION
## Summary
- remove the duplicate @dataclass decorator on suite_runner.ExchangeDataset
- remove duplicate hlcvs_spec and btc_spec field declarations

## Verification
- ./venv/bin/python -m pytest tests/test_suite_runner.py
- git diff --check