### PR TITLE
Use scored Pareto metadata during bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable user-facing changes will be documented in this file.
   evaluator is cleaned up, avoiding attachment churn across evaluations.
 - Pareto pruning now rejects non-finite objective matrices before selecting
   required extremes, preventing NaN values from being retained as best/worst axes.
+- Pareto bootstrap now uses non-empty scoring metadata from existing entries
+  before rebuilding the front, preventing legacy unscored files from forcing
+  minimize-all dominance for scored results.
 - Suite scenarios now reject unknown scenario fields before running, catching
   typos such as `coin` instead of silently ignoring them.
 - Resumed pymoo optimizer checkpoints now refresh the active problem,

--- a/src/pareto_store.py
+++ b/src/pareto_store.py
@@ -234,15 +234,59 @@ class ParetoStore:
         # bootstrap from disk if any
         self._bootstrap_from_disk()
 
+    @staticmethod
+    def _scoring_signature(specs: Sequence[Any]) -> tuple[tuple[str, str], ...]:
+        return tuple((spec.metric, spec.goal) for spec in specs)
+
+    def _apply_entry_scoring_specs(self, entry: dict) -> None:
+        entry_specs = extract_objective_specs(entry)
+        if entry_specs:
+            if self.scoring_specs:
+                if self._scoring_signature(self.scoring_specs) != self._scoring_signature(
+                    entry_specs
+                ):
+                    raise ValueError(
+                        "Pareto entry optimize.scoring differs from store scoring: "
+                        f"{self._scoring_signature(entry_specs)!r} != "
+                        f"{self._scoring_signature(self.scoring_specs)!r}"
+                    )
+                return
+            if self._front:
+                raise ValueError(
+                    "Pareto entry defines optimize.scoring after unscored entries were added; "
+                    "start from a clean pareto directory or ensure all entries include scoring"
+                )
+            self.scoring_specs = entry_specs
+            self.scoring_keys = [spec.metric for spec in entry_specs]
+
+    def _apply_bootstrap_scoring_specs(self, entries: Sequence[tuple[str, dict[str, Any]]]) -> None:
+        bootstrap_specs = None
+        bootstrap_source = None
+        for fp, entry in entries:
+            entry_specs = extract_objective_specs(entry)
+            if not entry_specs:
+                continue
+            if bootstrap_specs is None:
+                bootstrap_specs = entry_specs
+                bootstrap_source = fp
+                continue
+            if self._scoring_signature(bootstrap_specs) != self._scoring_signature(entry_specs):
+                raise ValueError(
+                    "Existing Pareto files have inconsistent optimize.scoring definitions: "
+                    f"{bootstrap_source}: {self._scoring_signature(bootstrap_specs)!r}; "
+                    f"{fp}: {self._scoring_signature(entry_specs)!r}"
+                )
+        if bootstrap_specs and not self.scoring_specs:
+            self.scoring_specs = bootstrap_specs
+            self.scoring_keys = [spec.metric for spec in bootstrap_specs]
+
     def add_entry(self, entry: dict, *, source_path: str | None = None) -> bool:
         """
         Add a new entry, update Pareto front in‑memory.
         Return True if the store actually changed.
         """
         self.n_iters += 1
-        if self.scoring_keys is None:
-            self.scoring_specs = extract_objective_specs(entry)
-            self.scoring_keys = [spec.metric for spec in self.scoring_specs]
+        self._apply_entry_scoring_specs(entry)
         h = calc_hash(entry)
         with self._lock:
             if h in self._entries:  # fast‑dedupe
@@ -380,13 +424,15 @@ class ParetoStore:
                 self._log.error("Could not load existing Pareto file %s: %s", fp, e)
             else:
                 entries.append((fp, entry))
-        bootstrap_specs = None
+        try:
+            self._apply_bootstrap_scoring_specs(entries)
+        except Exception as e:
+            errors.append(str(e))
         for fp, entry in entries:
-            if bootstrap_specs is None:
-                bootstrap_specs = extract_objective_specs(entry)
             try:
                 obj, _ = extract_objectives(
-                    entry, scoring_keys=bootstrap_specs or entry.get("optimize", {}).get("scoring")
+                    entry,
+                    scoring_keys=self.scoring_specs or entry.get("optimize", {}).get("scoring"),
                 )
                 self._validate_objective_vector(obj)
                 violation = extract_violation(entry)
@@ -433,7 +479,8 @@ class ParetoStore:
         maxs = [max(col) for col in zip(*objs)]
 
         metrics = []
-        for i, key in enumerate(self.scoring_keys):
+        scoring_keys = self.scoring_keys or [f"objective_{idx}" for idx in range(len(mins))]
+        for i, key in enumerate(scoring_keys):
             metrics.append(
                 f"{key}:(" f"{pbr.round_dynamic(mins[i], 3)}," f"{pbr.round_dynamic(maxs[i], 3)}),"
             )

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -3028,9 +3028,13 @@ class TestResultRecorder:
         config = load_prepared_config("configs/examples/ema_anchor.json", verbose=False)
         bounds = extract_bounds_tuple_list_from_config(config)
         individual = Candidate(config_to_individual(config, bounds, sig_digits=6))
+        scoring_keys = config["optimize"]["scoring"]
+        objectives = {
+            item["metric"] if isinstance(item, dict) else item: 0.5 for item in scoring_keys
+        }
 
         individual.evaluation_metrics = {
-            "objectives": {"metric1": 0.5},
+            "objectives": objectives,
             "constraint_violation": 0.0,
         }
 
@@ -3039,7 +3043,7 @@ class TestResultRecorder:
                 results_dir=tmpdir,
                 sig_digits=6,
                 flush_interval=60,
-                scoring_keys=["metric1"],
+                scoring_keys=scoring_keys,
                 compress=False,
                 write_all_results=False,
                 bounds=None,
@@ -3072,10 +3076,14 @@ class TestResultRecorder:
         template = load_prepared_config("configs/examples/ema_anchor.json", verbose=False)
         bounds = extract_bounds_tuple_list_from_config(template)
         vector = config_to_individual(template, bounds, sig_digits=6)
+        scoring_keys = template["optimize"]["scoring"]
+        objectives = {
+            item["metric"] if isinstance(item, dict) else item: 0.5 for item in scoring_keys
+        }
 
         entry = build_pymoo_record_entry(
             vector=vector,
-            metrics={"objectives": {"metric1": 0.5}, "constraint_violation": 0.0},
+            metrics={"objectives": objectives, "constraint_violation": 0.0},
             template=template,
             build_config_fn=individual_to_config,
             overrides_fn=optimize.optimizer_overrides,
@@ -3087,7 +3095,7 @@ class TestResultRecorder:
                 results_dir=tmpdir,
                 sig_digits=6,
                 flush_interval=60,
-                scoring_keys=["metric1"],
+                scoring_keys=scoring_keys,
                 compress=False,
                 write_all_results=False,
                 bounds=bounds,

--- a/tests/test_pareto_extremes.py
+++ b/tests/test_pareto_extremes.py
@@ -20,6 +20,20 @@ def _make_candidate(w_values, violation=0.0):
     }
 
 
+def _make_adg_candidate(value, *, include_scoring=True):
+    candidate = {
+        "metrics": {
+            "objectives": {"adg_strategy_eq": value},
+            "constraint_violation": 0.0,
+        },
+    }
+    if include_scoring:
+        candidate["optimize"] = {
+            "scoring": [{"metric": "adg_strategy_eq", "goal": "max"}],
+        }
+    return candidate
+
+
 @pytest.mark.parametrize("sig_digits", [6])
 def test_pareto_front_retains_per_metric_extremes(sig_digits, tmp_path):
     random.seed(42)
@@ -126,6 +140,36 @@ def test_pareto_store_flush_does_not_delete_files_that_were_never_loaded(tmp_pat
     store.flush_now()
 
     assert unknown.exists()
+
+
+def test_pareto_store_bootstrap_uses_nonempty_scoring_from_later_file(tmp_path):
+    pareto_dir = tmp_path / "pareto"
+    pareto_dir.mkdir()
+    first_without_scoring = pareto_dir / "000_without_scoring.json"
+    later_with_scoring = pareto_dir / "001_with_scoring.json"
+    first_without_scoring.write_text(
+        json.dumps(_make_adg_candidate(1.0, include_scoring=False)),
+        encoding="utf-8",
+    )
+    later_with_scoring.write_text(
+        json.dumps(_make_adg_candidate(2.0, include_scoring=True)),
+        encoding="utf-8",
+    )
+
+    store = ParetoStore(directory=str(tmp_path), sig_digits=6, flush_interval=10_000, max_size=50)
+
+    front = store.get_front()
+    assert store.scoring_keys == ["adg_strategy_eq"]
+    assert len(front) == 1
+    assert front[0]["metrics"]["objectives"]["adg_strategy_eq"] == 2.0
+
+
+def test_pareto_store_rejects_scored_entry_after_unscored_front(tmp_path):
+    store = ParetoStore(directory=str(tmp_path), sig_digits=6, flush_interval=10_000, max_size=50)
+    assert store.add_entry(_make_adg_candidate(1.0, include_scoring=False))
+
+    with pytest.raises(ValueError, match="after unscored entries"):
+        store.add_entry(_make_adg_candidate(2.0, include_scoring=True))
 
 
 def test_pareto_store_rejects_missing_objective_values(tmp_path):


### PR DESCRIPTION
## Summary
- scan existing Pareto entries for a non-empty optimize.scoring definition before rebuilding the front
- avoid freezing empty scoring metadata from the first glob-ordered file
- fail loudly if a scored entry is added after an unscored front has already been built

## Verification
- ./venv/bin/python -m pytest tests/test_pareto_extremes.py tests/test_pareto_core.py
- git diff --check