### PR TITLE
Remove duplicate optimize argparse import

### DIFF
--- a/src/optimize.py
+++ b/src/optimize.py
@@ -61,7 +61,6 @@ from backtest import (
     get_backtest_execution_settings,
 )
 import asyncio
-import argparse
 import mmap
 import multiprocessing
 import random


### PR DESCRIPTION
## Summary
- remove the second redundant argparse import from src/optimize.py
- keep the early argparse import used by Rust preflight CLI parsing

## Tests
- rg -n "^import argparse$" src/optimize.py
- ./venv/bin/python -m py_compile src/optimize.py
- git diff --check