### PR TITLE
Remove unused ParetoPoint dataclass

### DIFF
--- a/src/pareto_core.py
+++ b/src/pareto_core.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
@@ -8,13 +7,6 @@ import numpy as np
 
 from config.scoring import ObjectiveSpec, dominates_objectives, extract_objective_specs, from_engine_value
 from config.metrics import canonicalize_metric_name, resolve_metric_value
-
-
-@dataclass(frozen=True)
-class ParetoPoint:
-    hash_id: str
-    objectives: Tuple[float, ...]
-    violation: float = 0.0
 
 
 def _canonicalized_objective_map(objectives_map: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- remove the unreferenced ParetoPoint dataclass from pareto_core
- remove the now-unused dataclass import

## Tests
- rg -n "ParetoPoint|from dataclasses import dataclass" src/pareto_core.py src tests
- ./venv/bin/python -m pytest tests/test_pareto_core.py tests/test_pareto_extremes.py
- ./venv/bin/python -m py_compile src/pareto_core.py
- git diff --check