### PR TITLE
Install DEAP evaluator once per worker

### DIFF
--- a/src/optimization/backends/deap_backend.py
+++ b/src/optimization/backends/deap_backend.py
@@ -7,7 +7,7 @@ import os
 import pickle
 import random
 from copy import deepcopy
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 
 import numpy as np
 
@@ -33,6 +33,8 @@ from optimization.random_seed import seed_worker_rngs
 from config.scoring import engine_space_fitness_weights
 
 DEFAULT_DEAP_POPULATION_SIZE = 500
+_DEAP_WORKER_EVALUATOR = None
+_DEAP_WORKER_OVERRIDES_LIST: list[Any] = []
 
 
 def _resolve_deap_population_size(config: dict[str, Any]) -> int:
@@ -62,10 +64,30 @@ def _clone_evaluated_individual(individual):
     return clone
 
 
-def _initialize_deap_worker(rng_seed, ignore_sigint_in_worker=None):
+def _set_deap_worker_globals(evaluator, overrides_list: Sequence[Any] | None) -> None:
+    global _DEAP_WORKER_EVALUATOR
+    global _DEAP_WORKER_OVERRIDES_LIST
+
+    _DEAP_WORKER_EVALUATOR = evaluator
+    _DEAP_WORKER_OVERRIDES_LIST = list(overrides_list or [])
+
+
+def _initialize_deap_worker(
+    rng_seed,
+    ignore_sigint_in_worker=None,
+    evaluator=None,
+    overrides_list: Sequence[Any] | None = None,
+):
     seed_worker_rngs(rng_seed, context="DEAP optimizer")
     if ignore_sigint_in_worker is not None:
         ignore_sigint_in_worker()
+    _set_deap_worker_globals(evaluator, overrides_list)
+
+
+def _evaluate_deap_worker(individual):
+    if _DEAP_WORKER_EVALUATOR is None:
+        raise RuntimeError("DEAP worker evaluator not initialized")
+    return _DEAP_WORKER_EVALUATOR.evaluate(individual, _DEAP_WORKER_OVERRIDES_LIST)
 
 
 def run_backend(
@@ -146,13 +168,15 @@ def run_backend(
             bounds=bounds,
         )
         toolbox.register("select", tools.selNSGA2)
-        toolbox.register("evaluate", evaluator_for_pool.evaluate, overrides_list=overrides_list)
+        toolbox.register("evaluate", _evaluate_deap_worker)
 
         logging.info("Initializing multiprocessing pool. N cpus: %s", config["optimize"]["n_cpus"])
         worker_initializer = functools.partial(
             _initialize_deap_worker,
             config["optimize"].get("seed"),
             ignore_sigint_in_worker,
+            evaluator_for_pool,
+            overrides_list,
         )
         pool = multiprocessing.Pool(
             processes=config["optimize"]["n_cpus"],

--- a/tests/optimization/test_backends.py
+++ b/tests/optimization/test_backends.py
@@ -16,6 +16,7 @@ from optimization.backends import get_backend_runner
 from optimization.backends.deap_backend import (
     DEFAULT_DEAP_POPULATION_SIZE,
     _clone_evaluated_individual,
+    _evaluate_deap_worker,
     _initialize_deap_worker,
     _resolve_deap_population_size,
 )
@@ -216,6 +217,20 @@ def test_clone_evaluated_individual_preserves_fitness_and_metrics():
 
 def test_deap_worker_seed_initializer_is_pickleable():
     ForkingPickler.dumps(functools.partial(_initialize_deap_worker, None, None))
+
+
+def test_deap_worker_evaluate_uses_initializer_globals():
+    class Evaluator:
+        def evaluate(self, individual, overrides_list):
+            return tuple(individual), tuple(overrides_list)
+
+    _initialize_deap_worker(None, None, Evaluator(), ["override.a"])
+
+    assert _evaluate_deap_worker([1.0, 2.0]) == ((1.0, 2.0), ("override.a",))
+
+
+def test_deap_worker_task_evaluator_is_pickleable_without_bound_evaluator():
+    ForkingPickler.dumps(_evaluate_deap_worker)
 
 
 def test_get_backend_runner_resolves_supported_backends():


### PR DESCRIPTION
## Summary
- install the DEAP evaluator and overrides into worker globals from the pool initializer
- register a module-level DEAP evaluation function so per-task payloads no longer carry a bound evaluator method
- add focused tests for the initializer/global evaluation path and task-function picklability

## Tests
- ./venv/bin/python -m pytest tests/optimization/test_backends.py
- ./venv/bin/python -m py_compile src/optimization/backends/deap_backend.py tests/optimization/test_backends.py
- git diff --check