### PR TITLE
Avoid forced optimizer data pre-copy

### DIFF
--- a/src/optimize.py
+++ b/src/optimize.py
@@ -349,10 +349,10 @@ def _register_exchange_data(
     config["backtest"]["coins"][exchange] = coins
     msss[exchange] = mss
     validate_array(hlcvs, "hlcvs")
-    hlcvs_array = np.array(hlcvs, dtype=np.float64, copy=True, order="C")
+    hlcvs_array = np.asarray(hlcvs, dtype=np.float64, order="C")
     hlcvs_spec, _ = array_manager.create_from(hlcvs_array)
     hlcvs_specs[exchange] = hlcvs_spec
-    btc_usd_array = np.array(btc_usd_prices, dtype=np.float64, copy=True, order="C")
+    btc_usd_array = np.asarray(btc_usd_prices, dtype=np.float64, order="C")
     validate_array(btc_usd_array, f"btc_usd_data for {exchange}", allow_nan=False)
     btc_usd_spec, _ = array_manager.create_from(btc_usd_array)
     btc_usd_specs[exchange] = btc_usd_spec

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -31,6 +31,7 @@ from optimize import (
     _normalize_optional_bool_flag,
     _optimizer_exit_code,
     _record_individual_result,
+    _register_exchange_data,
     _resolve_cli_limits_override,
     _set_candidate_metrics,
     _terminate_optimizer_pool,
@@ -1662,6 +1663,37 @@ class TestValidateArray:
         arr = np.array([])
         with pytest.raises(ValueError, match="is entirely NaN"):
             validate_array(arr, "test_array")
+
+    def test_register_exchange_data_preserves_contiguous_arrays_before_shared_copy(self):
+        class RecordingArrayManager:
+            def __init__(self):
+                self.arrays = []
+
+            def create_from(self, array):
+                self.arrays.append(array)
+                return object(), array
+
+        hlcvs = np.zeros((4, 2, 5), dtype=np.float64, order="C")
+        btc_usd_prices = np.ones(4, dtype=np.float64)
+        timestamps = np.arange(4, dtype=np.int64)
+        mss = {"BTC": {"first_valid_index": 0, "last_valid_index": 3}}
+        config = {"backtest": {"coins": {}, "candle_interval_minutes": 1}}
+        manager = RecordingArrayManager()
+
+        with patch("optimize._stamp_optimizer_warmup"):
+            _register_exchange_data(
+                "binance",
+                (["BTC"], hlcvs, mss, None, None, btc_usd_prices, timestamps),
+                config,
+                msss={},
+                hlcvs_specs={},
+                btc_usd_specs={},
+                timestamps_dict={},
+                array_manager=manager,
+            )
+
+        assert manager.arrays[0] is hlcvs
+        assert manager.arrays[1] is btc_usd_prices
 
 
 class TestApplyPolishBounds:


### PR DESCRIPTION
## Summary
- avoid unconditional pre-copying of optimizer HLCV and BTC arrays before shared-memory registration
- keep dtype/C-order normalization for unsuitable inputs via np.asarray
- add a regression test proving already-contiguous float64 arrays are handed to the shared-array manager by identity

## Tests
- ./venv/bin/python -m pytest tests/optimization/test_optimize.py::TestValidateArray
- ./venv/bin/python -m py_compile src/optimize.py tests/optimization/test_optimize.py
- git diff --check