### PR TITLE
Bound DEAP pending offspring evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- DEAP optimizer generation evaluations now honor
+  `optimize.max_pending_starting_evals_per_cpu`, bounding queued offspring
+  evaluations with the same memory-control cap used for starting seeds.
 - Optimizer vector-shape extraction now rejects empty `config.optimize.bounds`
   instead of generating key paths that fail later without matching bounds.
 - Compressed `all_results.bin` optimizer history now preserves deleted keys

--- a/docs/optimizing.md
+++ b/docs/optimizing.md
@@ -368,8 +368,8 @@ be constrained through `drawdown_worst_strategy_eq`, `drawdown_worst_ema_strateg
 `drawdown_worst_mean_1pct_strategy_eq`, `drawdown_worst_mean_1pct_ema_strategy_eq`, and
 `strategy_eq_recovery_days_max` instead of being prematurely truncated.
 
-When you provide many starting configs, optimizer now also bounds how many seed evaluations may be
-in flight at once:
+When you provide many starting configs, optimizer bounds how many seed evaluations may be in flight
+at once. For the DEAP backend, the same cap also applies to generation offspring evaluations:
 
 ```json
 "optimize": {
@@ -383,9 +383,9 @@ Effective cap:
 - All provided starting configs are still evaluated before the optimizer trims them down to the
   backend's initial population.
 
-This is mainly a memory-control knob for large seed pools, especially in suite mode where each
-candidate returns a larger metrics payload. Lower it first if the VPS spikes RAM during initial
-seed evaluation.
+This is mainly a memory-control knob for large seed pools and DEAP generation batches, especially
+in suite mode where each candidate returns a larger metrics payload. Lower it first if the VPS
+spikes RAM during seed or offspring evaluation.
 
 ### Optimizer Suites
 

--- a/src/optimization/backends/deap_backend.py
+++ b/src/optimization/backends/deap_backend.py
@@ -343,6 +343,11 @@ def run_backend(
             start_gen=start_gen,
             logbook=logbook,
             checkpoint_path=checkpoint_path,
+            max_pending_evals=max(
+                1,
+                int(config["optimize"]["n_cpus"])
+                * int(config["optimize"].get("max_pending_starting_evals_per_cpu", 1)),
+            ),
         )
         logging.info("Optimization complete.")
         return {

--- a/src/optimize.py
+++ b/src/optimize.py
@@ -180,7 +180,7 @@ from optimization.bounds import (
     round_to_sig_digits,
 )
 from optimization.fine_tune_anchors import ANCHOR_GENE_KEY, ANCHOR_PLAN_KEY, get_anchor_plan
-from optimization.backend_shared import cancel_pending_async_results, drain_async_results
+from optimization.backend_shared import cancel_pending_async_results, stream_async_results
 from optimization.backends import get_backend_runner
 from optimization.random_seed import seed_rngs
 from optimization.config_adapter import (
@@ -957,6 +957,7 @@ def ea_mu_plus_lambda_stream(
     start_gen=1,
     logbook=None,
     checkpoint_path=None,
+    max_pending_evals=None,
 ):
     import pickle
     if logbook is None:
@@ -973,9 +974,6 @@ def ea_mu_plus_lambda_stream(
         if not individuals:
             return 0
         logging.debug("Evaluating %d candidates", len(individuals))
-        pending = {}
-        for idx, ind in enumerate(individuals):
-            pending[pool.apply_async(toolbox.evaluate, (ind,))] = idx
 
         completed = {"count": 0}
 
@@ -1023,11 +1021,13 @@ def ea_mu_plus_lambda_stream(
                 logging.info("Terminating worker pool immediately due to interrupt...")
                 pool.terminate()
                 pool_state["terminated"] = True
-        drain_async_results(
-            pending,
+        stream_async_results(
+            enumerate(individuals),
+            submit=lambda item: (pool.apply_async(toolbox.evaluate, (item[1],)), item[0]),
             poll_interval_seconds=0.1,
             on_result=_on_result,
             on_interrupt=_on_interrupt,
+            max_pending=max_pending_evals,
         )
 
         total_evals += completed["count"]

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -13,6 +13,7 @@ import json
 import logging
 from multiprocessing.reduction import ForkingPickler
 import tempfile
+from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
 from unittest.mock import Mock, MagicMock, patch
@@ -37,6 +38,7 @@ from optimize import (
     _terminate_optimizer_pool,
     _suite_config_implies_suite_mode,
     _format_objectives,
+    ea_mu_plus_lambda_stream,
     individual_to_config,
     config_to_individual,
     validate_array,
@@ -212,6 +214,65 @@ def test_deap_evaluation_payload_accepts_legacy_tuple_payload_without_mutating_v
     assert individual.fitness.constraint_violation == 2.0
     assert individual.constraint_violation == 2.0
     assert metrics is None
+
+
+def test_deap_evolution_forwards_max_pending_to_stream(monkeypatch):
+    class Fitness:
+        def __init__(self):
+            self.values = ()
+            self.constraint_violation = 0.0
+
+        @property
+        def valid(self):
+            return bool(self.values)
+
+    class Candidate(list):
+        def __init__(self, values):
+            super().__init__(values)
+            self.fitness = Fitness()
+
+    captured = {}
+
+    def fake_stream(items, *, submit, on_result, max_pending=None, **_kwargs):
+        captured["max_pending"] = max_pending
+        for idx, individual in items:
+            on_result(
+                idx,
+                build_evaluation_payload(
+                    (0.1,),
+                    0.0,
+                    {"liquidated": False},
+                    individual,
+                ),
+            )
+        return 1
+
+    monkeypatch.setattr(optimize, "stream_async_results", fake_stream)
+    monkeypatch.setattr(optimize, "_record_individual_result", lambda *args, **kwargs: None)
+    population = [Candidate([1.0])]
+
+    ea_mu_plus_lambda_stream(
+        population,
+        toolbox=object(),
+        mu=1,
+        lambda_=1,
+        cxpb=0.0,
+        mutpb=0.0,
+        ngen=1,
+        stats=None,
+        halloffame=None,
+        verbose=False,
+        recorder=MagicMock(),
+        evaluator_config={"bot": {}, "backtest": {}, "optimize": {}},
+        overrides_list=[],
+        pool=object(),
+        duplicate_counter=defaultdict(int),
+        pool_state={"terminated": False},
+        max_pending_evals=3,
+    )
+
+    assert captured["max_pending"] == 3
+    assert population[0].fitness.valid
 
 
 class TestApplyConfigOverrides:


### PR DESCRIPTION
## Summary
- stream DEAP generation evaluations through the shared async backpressure helper
- cap pending generation evaluations with the same n_cpus * max_pending_starting_evals_per_cpu setting used for starting configs
- add a focused unit test that pins the max_pending handoff into stream_async_results

## Tests
- ./venv/bin/python -m pytest tests/optimization/test_optimize.py::test_deap_evolution_forwards_max_pending_to_stream tests/optimization/test_backends.py
- ./venv/bin/python -m py_compile src/optimize.py src/optimization/backends/deap_backend.py tests/optimization/test_optimize.py
- git diff --check