### PR TITLE
Remove unused opt_utils helpers

### DIFF
--- a/src/opt_utils.py
+++ b/src/opt_utils.py
@@ -1,6 +1,3 @@
-import json
-import logging
-import math
 import msgpack
 from typing import Any
 import passivbot_rust as pbr
@@ -29,54 +26,6 @@ def _dict_diff(d1: dict, d2: dict) -> dict:
     return diff
 
 
-def dominates(p0, p1):
-    better_in_one = False
-    for a, b in zip(p0, p1):
-        if a < b:
-            better_in_one = True
-        elif a > b:
-            return False
-    return better_in_one
-
-
-def dominates_d(x, y, higher_is_better):
-    better_in_one = False
-    for xi, yi, hib in zip(x, y, higher_is_better):
-        if hib:
-            if xi > yi:
-                better_in_one = True
-            elif xi < yi:
-                return False
-        else:
-            if xi < yi:
-                better_in_one = True
-            elif xi > yi:
-                return False
-    return better_in_one
-
-
-def update_pareto_front(new_index, new_obj, current_front, objectives_dict, higher_is_better):
-    for idx in current_front:
-        if dominates_d(objectives_dict[idx], new_obj, higher_is_better):
-            return current_front
-    new_front = [
-        idx
-        for idx in current_front
-        if not dominates_d(new_obj, objectives_dict[idx], higher_is_better)
-    ]
-    new_front.append(new_index)
-    return new_front
-
-
-def calc_dist(p0, p1):
-    return math.sqrt(sum((a - b) ** 2 for a, b in zip(p0, p1)))
-
-
-def format_distance(dist: float) -> str:
-    """Format distance to fixed-width string for lexicographical sorting."""
-    return f"{dist:08.4f}"
-
-
 def make_json_serializable(obj):
     if isinstance(obj, dict):
         return {k: make_json_serializable(v) for k, v in obj.items()}
@@ -86,10 +35,6 @@ def make_json_serializable(obj):
         return [make_json_serializable(e) for e in obj]
     else:
         return obj
-
-
-def gprint(verbose):
-    return print if verbose else (lambda *args, **kwargs: None)
 
 
 def generate_diffs(dictlist):


### PR DESCRIPTION
## Summary
- remove unreferenced Pareto/distance/print helpers from opt_utils.py
- drop the now-unused json/logging/math imports
- keep active result diff/replay and rounding helpers unchanged

## Tests
- rg -n "dominates|dominates_d|update_pareto_front|calc_dist|format_distance|gprint|import json|import logging|import math" src/opt_utils.py
- rg -n "from opt_utils import .*\b(dominates|dominates_d|update_pareto_front|calc_dist|format_distance|gprint)\b|opt_utils\.(dominates|dominates_d|update_pareto_front|calc_dist|format_distance|gprint)" src tests
- ./venv/bin/python -m pytest tests/test_opt_utils.py
- ./venv/bin/python -m py_compile src/opt_utils.py
- git diff --check