### PR TITLE
Correct optimizer limit stat docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -641,7 +641,7 @@ Any metric listed above can be used when defining limits. Currency-specific metr
 - `value`: numeric threshold for `<`/`>` modes.
 - `range`: two-value list `[low, high]` for the range modes.
 - Optional `enabled`: set to `false` to disable a default limit without deleting it. This prevents config normalization from re-adding that metric's default limit later.
-- Optional `stat`: when you want to compare against a specific statistic (`min`, `max`, `mean`, `std`). The default is `_max` for `>` checks, `_min` for `<` checks, and `_mean` for range checks.
+- Optional `stat`: when you want to compare against a specific statistic (`min`, `max`, `mean`, `std`). If omitted, Passivbot uses the metric's `backtest.aggregate` rule, then `backtest.aggregate.default`, then `mean`.
 
 #### Format
 


### PR DESCRIPTION
## Summary
- update docs/configuration.md to match current optimizer limit stat resolution
- document explicit stat -> metric aggregate -> aggregate default -> mean behavior
- remove stale wording that claimed > defaults to max and < defaults to min

## Tests
- rg -n "Optional \2215145894 336 crw-rw-rw- 1 root wheel 50331650 0 "Jul  4 14:37:10 2026" "Jul  4 14:44:10 2026" "Jul  4 14:44:10 2026" "Dec 31 19:00:00 1969" 65536 0 0 (stdin)|resolve_limit_stat|_max for|_min for|aggregate\.default" docs/configuration.md docs/optimizing.md src/config/limits.py
- git diff --check