### PR TITLE
Track optimizer audit PR progress

### DIFF
--- a/docs/plans/optimizer_audit_pr_tracker.md
+++ b/docs/plans/optimizer_audit_pr_tracker.md
@@ -1,0 +1,81 @@
+# Optimizer Audit PR Tracker
+
+Tracks the v8 optimizer audit follow-up work as targeted pull requests. Each
+implementation PR should stay narrow, wait for current-head Claude and Hermes
+approval, and merge only after both reviewers approve the same head.
+
+## Review Gate
+
+- Claude approval must mention the PR's current head SHA.
+- Hermes approval must mention the PR's current head SHA.
+- Reviewer findings are addressed on the same PR before merge.
+- Orthogonal follow-up PRs may proceed while earlier PRs wait for reviews.
+
+## Merged
+
+- [x] #1044 - Fix optimizer grid quantization for non-power-of-ten steps.
+- [x] #1045 - Propagate DEAP evaluated vectors back to parent process.
+- [x] #1046 - Harden Pareto store bootstrap and recorder failures.
+- [x] #1047 - Make suite optimizer scenario drops fail loud.
+- [x] #1048 - Add optional optimizer seed control; default remains random.
+- [x] #1049 - Validate optimizer overrides and verify v7 TP grid overrides.
+- [x] #1050 - Preserve anchored fine-tune seed anchor ids.
+- [x] #1051 - Fix optimizer pool shutdown on KeyboardInterrupt.
+- [x] #1052 - Treat suite config as suite mode.
+- [x] #1053 - Preserve suite override aggregate semantics.
+- [x] #1054 - Reject unknown suite scenario keys.
+- [x] #1055 - Honor pymoo resume runtime state changes.
+- [x] #1056 - Preserve deleted keys in compressed all_results deltas.
+- [x] #1057 - Fail loud on unresolved Pareto limit metrics.
+- [x] #1058 - Correct high-priority optimizer documentation drift.
+- [x] #1059 - Close suite evaluator master attachments.
+- [x] #1060 - Remove broken unused opt_utils helpers.
+- [x] #1061 - Reject empty optimizer bounds in config adapter.
+- [x] #1062 - Reject non-finite Pareto prune objectives.
+- [x] #1063 - Clean duplicate ExchangeDataset metadata.
+- [x] #1064 - Remove unused PymooRecorderCallback.
+- [x] #1065 - Remove unused OptimizeOutput.
+- [x] #1066 - Remove unused is_anchored_shape_key.
+- [x] #1067 - Use scored Pareto metadata during bootstrap.
+- [x] #1068 - Remove unused ParetoStore bounds/helper cleanup path.
+- [x] #1069 - Remove duplicate optimize argparse import.
+- [x] #1070 - Remove unused ParetoPoint dataclass.
+- [x] #1071 - Install DEAP evaluator once per worker.
+- [x] #1072 - Avoid forced optimizer data pre-copy.
+- [x] #1073 - Stream resume result validation.
+
+## Open PRs
+
+- [ ] #1074 - Bound DEAP pending offspring evaluations.
+  - Status: mergeable.
+  - Gate: Hermes approved head `6d329686146ece961bf3d706e748851e10097f09`;
+    waiting for fresh Claude approval on that same head.
+- [ ] #1075 - Remove unused opt_utils helpers.
+  - Status: mergeable.
+  - Gate: waiting for Claude and Hermes review on head
+    `65a30da5fcdc999dbafa7581e6710818c7344f0d`.
+- [ ] #1076 - Correct optimizer limit stat docs.
+  - Status: mergeable after rebase repair.
+  - Gate: waiting for Claude and Hermes review on head
+    `7e96a50a0fe9544d1649c66bf7cc034b2cff22bb`.
+
+## Remaining Or Paused Audit Items
+
+- [ ] Pymoo starting-seed double evaluation.
+  - Current note: local probing showed pymoo still evaluates sampled
+    `Population` objects even when `F` and evaluated markers are set. Needs a
+    careful design rather than a drive-by deletion.
+- [ ] ParetoStore add-entry performance.
+  - Current note: exact objective-vector lookup is already in place. Remaining
+    loops are dominance/crowding behavior and need profiling before changing.
+- [ ] Unreachable all_results skip branch cleanup.
+  - Current note: lower-value cleanup in `src/optimize.py`; avoid while #1074
+    touches adjacent optimizer streaming code.
+- [ ] ParetoStore.get_front deletion claim.
+  - Current note: tests still exercise the method; not treated as dead without
+    either removing test need or finding production replacement.
+
+## Out Of Scope For Optimizer Audit PRs
+
+- #1043 - `codex/v8-smoke-cache-health` is unrelated to this optimizer audit
+  tracker and remains ignored here unless explicitly requested.

--- a/docs/plans/optimizer_audit_pr_tracker.md
+++ b/docs/plans/optimizer_audit_pr_tracker.md
@@ -64,13 +64,13 @@ approval, and merge only after both reviewers approve the same head.
 - [ ] #1077 - Track optimizer audit PR progress.
   - Status: mergeable.
   - Gate: waiting for Claude and Hermes review on the current PR head.
+- [ ] #1078 - Reuse pymoo starting seed evaluations.
+  - Status: mergeable.
+  - Gate: waiting for Claude and Hermes review on head
+    `1a288908a02041eac8f4997b122087f2f7105aba`.
 
 ## Remaining Or Paused Audit Items
 
-- [ ] Pymoo starting-seed double evaluation.
-  - Current note: local probing showed pymoo still evaluates sampled
-    `Population` objects even when `F` and evaluated markers are set. Needs a
-    careful design rather than a drive-by deletion.
 - [ ] ParetoStore add-entry performance.
   - Current note: exact objective-vector lookup is already in place. Remaining
     loops are dominance/crowding behavior and need profiling before changing.

--- a/docs/plans/optimizer_audit_pr_tracker.md
+++ b/docs/plans/optimizer_audit_pr_tracker.md
@@ -57,14 +57,14 @@ approval, and merge only after both reviewers approve the same head.
     tracker updates.
 - [ ] #1078 - Reuse pymoo starting seed evaluations.
   - Status: mergeable.
-  - Gate: Hermes approved head
-    `1a288908a02041eac8f4997b122087f2f7105aba`; waiting for Claude approval on
-    that same head.
+  - Gate: rebased onto current `v8` after #1074-#1076 merged; waiting for fresh
+    Claude and Hermes review on head
+    `1bd99a86c9ceb10937fa37e077cb412ff1a00981`.
 - [ ] #1079 - Check Pareto dominance in one pass.
   - Status: mergeable.
-  - Gate: Hermes approved head
-    `ffceb19407b1641fdc63336becc0fb9d07fa8fa1`; waiting for Claude approval on
-    that same head.
+  - Gate: rebased onto current `v8` after #1074-#1076 merged; waiting for fresh
+    Claude and Hermes review on head
+    `f35daa3a93ca54fc85d00a323eabe2e400327f4e`.
 - [ ] #1080 - Remove unused all_results seed skip branch.
   - Status: mergeable.
   - Gate: waiting for Claude and Hermes review on head

--- a/docs/plans/optimizer_audit_pr_tracker.md
+++ b/docs/plans/optimizer_audit_pr_tracker.md
@@ -49,6 +49,7 @@ approval, and merge only after both reviewers approve the same head.
 - [x] #1075 - Remove unused opt_utils helpers.
 - [x] #1076 - Correct optimizer limit stat docs.
 - [x] #1078 - Reuse pymoo starting seed evaluations.
+- [x] #1079 - Check Pareto dominance in one pass.
 - [x] #1080 - Remove unused all_results seed skip branch.
 
 ## Open PRs
@@ -57,17 +58,12 @@ approval, and merge only after both reviewers approve the same head.
   - Status: mergeable.
   - Gate: waiting for Claude and Hermes review on the current PR head after
     tracker updates.
-- [ ] #1079 - Check Pareto dominance in one pass.
-  - Status: mergeable.
-  - Gate: rebased onto current `v8` after #1078 merged; waiting for fresh
-    Claude and Hermes review on head
-    `475cb29a13d058ade04c9d83a54228f9a2522d06`.
 
 ## Remaining Or Paused Audit Items
 
 - [ ] ParetoStore add-entry performance.
-  - Current note: exact objective-vector lookup is already in place, and #1079
-    covers the safe dominance-pass cleanup. Remaining heavier work is
+  - Current note: exact objective-vector lookup is already in place, and merged
+    #1079 covers the safe dominance-pass cleanup. Remaining heavier work is
     synchronous JSON write/profiling-driven behavior and should not be changed
     without measurement.
 - [ ] ParetoStore.get_front deletion claim.

--- a/docs/plans/optimizer_audit_pr_tracker.md
+++ b/docs/plans/optimizer_audit_pr_tracker.md
@@ -59,13 +59,14 @@ approval, and merge only after both reviewers approve the same head.
     that same head.
 - [ ] #1076 - Correct optimizer limit stat docs.
   - Status: mergeable after rebase repair.
-  - Gate: stale Hermes review correctly found the branch was stacked on #1075;
-    branch was rebased onto `origin/v8` and now contains only
-    `docs/configuration.md`. Waiting for fresh Claude and Hermes review on head
-    `7e96a50a0fe9544d1649c66bf7cc034b2cff22bb`.
+  - Gate: Hermes approved repaired head
+    `7e96a50a0fe9544d1649c66bf7cc034b2cff22bb`; waiting for Claude approval on
+    that same head.
 - [ ] #1077 - Track optimizer audit PR progress.
   - Status: mergeable.
-  - Gate: waiting for Claude and Hermes review on the current PR head.
+  - Gate: Hermes approved older head
+    `3a87beb82ac9076307ab7cc91128a0e9fc6a711f`; waiting for Claude and fresh
+    Hermes review on the current PR head after tracker updates.
 - [ ] #1078 - Reuse pymoo starting seed evaluations.
   - Status: mergeable.
   - Gate: waiting for Claude and Hermes review on head

--- a/docs/plans/optimizer_audit_pr_tracker.md
+++ b/docs/plans/optimizer_audit_pr_tracker.md
@@ -48,6 +48,7 @@ approval, and merge only after both reviewers approve the same head.
 - [x] #1074 - Bound DEAP pending offspring evaluations.
 - [x] #1075 - Remove unused opt_utils helpers.
 - [x] #1076 - Correct optimizer limit stat docs.
+- [x] #1078 - Reuse pymoo starting seed evaluations.
 - [x] #1080 - Remove unused all_results seed skip branch.
 
 ## Open PRs
@@ -56,16 +57,12 @@ approval, and merge only after both reviewers approve the same head.
   - Status: mergeable.
   - Gate: waiting for Claude and Hermes review on the current PR head after
     tracker updates.
-- [ ] #1078 - Reuse pymoo starting seed evaluations.
-  - Status: mergeable.
-  - Gate: rebased onto current `v8` after #1074-#1076 merged; waiting for fresh
-    Claude and Hermes review on head
-    `1bd99a86c9ceb10937fa37e077cb412ff1a00981`.
 - [ ] #1079 - Check Pareto dominance in one pass.
   - Status: mergeable.
-  - Gate: rebased onto current `v8` after #1074-#1076 merged; waiting for fresh
+  - Gate: rebased onto current `v8` after #1078 merged; waiting for fresh
     Claude and Hermes review on head
-    `f35daa3a93ca54fc85d00a323eabe2e400327f4e`.
+    `475cb29a13d058ade04c9d83a54228f9a2522d06`.
+
 ## Remaining Or Paused Audit Items
 
 - [ ] ParetoStore add-entry performance.

--- a/docs/plans/optimizer_audit_pr_tracker.md
+++ b/docs/plans/optimizer_audit_pr_tracker.md
@@ -68,12 +68,18 @@ approval, and merge only after both reviewers approve the same head.
   - Status: mergeable.
   - Gate: waiting for Claude and Hermes review on head
     `1a288908a02041eac8f4997b122087f2f7105aba`.
+- [ ] #1079 - Check Pareto dominance in one pass.
+  - Status: mergeable.
+  - Gate: waiting for Claude and Hermes review on head
+    `ffceb19407b1641fdc63336becc0fb9d07fa8fa1`.
 
 ## Remaining Or Paused Audit Items
 
 - [ ] ParetoStore add-entry performance.
-  - Current note: exact objective-vector lookup is already in place. Remaining
-    loops are dominance/crowding behavior and need profiling before changing.
+  - Current note: exact objective-vector lookup is already in place, and #1079
+    covers the safe dominance-pass cleanup. Remaining heavier work is
+    synchronous JSON write/profiling-driven behavior and should not be changed
+    without measurement.
 - [ ] Unreachable all_results skip branch cleanup.
   - Current note: lower-value cleanup in `src/optimize.py`; avoid while #1074
     touches adjacent optimizer streaming code.

--- a/docs/plans/optimizer_audit_pr_tracker.md
+++ b/docs/plans/optimizer_audit_pr_tracker.md
@@ -75,6 +75,10 @@ approval, and merge only after both reviewers approve the same head.
   - Status: mergeable.
   - Gate: waiting for Claude and Hermes review on head
     `ffceb19407b1641fdc63336becc0fb9d07fa8fa1`.
+- [ ] #1080 - Remove unused all_results seed skip branch.
+  - Status: mergeable.
+  - Gate: waiting for Claude and Hermes review on head
+    `1826e53bc1ca6f5bf6333a282545defcc6c59c13`.
 
 ## Remaining Or Paused Audit Items
 
@@ -83,9 +87,6 @@ approval, and merge only after both reviewers approve the same head.
     covers the safe dominance-pass cleanup. Remaining heavier work is
     synchronous JSON write/profiling-driven behavior and should not be changed
     without measurement.
-- [ ] Unreachable all_results skip branch cleanup.
-  - Current note: lower-value cleanup in `src/optimize.py`; avoid while #1074
-    touches adjacent optimizer streaming code.
 - [ ] ParetoStore.get_front deletion claim.
   - Current note: tests still exercise the method; not treated as dead without
     either removing test need or finding production replacement.

--- a/docs/plans/optimizer_audit_pr_tracker.md
+++ b/docs/plans/optimizer_audit_pr_tracker.md
@@ -66,15 +66,18 @@ approval, and merge only after both reviewers approve the same head.
   - Status: mergeable.
   - Gate: Hermes approved older head
     `3a87beb82ac9076307ab7cc91128a0e9fc6a711f`; waiting for Claude and fresh
-    Hermes review on the current PR head after tracker updates.
+    Hermes review on current head `9288b038ecc8babba4afc5e99ba7bc9a0c83e093`
+    after tracker updates.
 - [ ] #1078 - Reuse pymoo starting seed evaluations.
   - Status: mergeable.
-  - Gate: waiting for Claude and Hermes review on head
-    `1a288908a02041eac8f4997b122087f2f7105aba`.
+  - Gate: Hermes approved head
+    `1a288908a02041eac8f4997b122087f2f7105aba`; waiting for Claude approval on
+    that same head.
 - [ ] #1079 - Check Pareto dominance in one pass.
   - Status: mergeable.
-  - Gate: waiting for Claude and Hermes review on head
-    `ffceb19407b1641fdc63336becc0fb9d07fa8fa1`.
+  - Gate: Hermes approved head
+    `ffceb19407b1641fdc63336becc0fb9d07fa8fa1`; waiting for Claude approval on
+    that same head.
 - [ ] #1080 - Remove unused all_results seed skip branch.
   - Status: mergeable.
   - Gate: waiting for Claude and Hermes review on head

--- a/docs/plans/optimizer_audit_pr_tracker.md
+++ b/docs/plans/optimizer_audit_pr_tracker.md
@@ -45,29 +45,16 @@ approval, and merge only after both reviewers approve the same head.
 - [x] #1071 - Install DEAP evaluator once per worker.
 - [x] #1072 - Avoid forced optimizer data pre-copy.
 - [x] #1073 - Stream resume result validation.
+- [x] #1074 - Bound DEAP pending offspring evaluations.
+- [x] #1075 - Remove unused opt_utils helpers.
+- [x] #1076 - Correct optimizer limit stat docs.
 
 ## Open PRs
 
-- [ ] #1074 - Bound DEAP pending offspring evaluations.
-  - Status: mergeable.
-  - Gate: Hermes approved head `6d329686146ece961bf3d706e748851e10097f09`;
-    waiting for fresh Claude approval on that same head.
-- [ ] #1075 - Remove unused opt_utils helpers.
-  - Status: mergeable.
-  - Gate: Hermes approved head
-    `65a30da5fcdc999dbafa7581e6710818c7344f0d`; waiting for Claude approval on
-    that same head.
-- [ ] #1076 - Correct optimizer limit stat docs.
-  - Status: mergeable after rebase repair.
-  - Gate: Hermes approved repaired head
-    `7e96a50a0fe9544d1649c66bf7cc034b2cff22bb`; waiting for Claude approval on
-    that same head.
 - [ ] #1077 - Track optimizer audit PR progress.
   - Status: mergeable.
-  - Gate: Hermes approved older head
-    `3a87beb82ac9076307ab7cc91128a0e9fc6a711f`; waiting for Claude and fresh
-    Hermes review on current head `9288b038ecc8babba4afc5e99ba7bc9a0c83e093`
-    after tracker updates.
+  - Gate: waiting for Claude and Hermes review on the current PR head after
+    tracker updates.
 - [ ] #1078 - Reuse pymoo starting seed evaluations.
   - Status: mergeable.
   - Gate: Hermes approved head

--- a/docs/plans/optimizer_audit_pr_tracker.md
+++ b/docs/plans/optimizer_audit_pr_tracker.md
@@ -48,6 +48,7 @@ approval, and merge only after both reviewers approve the same head.
 - [x] #1074 - Bound DEAP pending offspring evaluations.
 - [x] #1075 - Remove unused opt_utils helpers.
 - [x] #1076 - Correct optimizer limit stat docs.
+- [x] #1080 - Remove unused all_results seed skip branch.
 
 ## Open PRs
 
@@ -65,11 +66,6 @@ approval, and merge only after both reviewers approve the same head.
   - Gate: rebased onto current `v8` after #1074-#1076 merged; waiting for fresh
     Claude and Hermes review on head
     `f35daa3a93ca54fc85d00a323eabe2e400327f4e`.
-- [ ] #1080 - Remove unused all_results seed skip branch.
-  - Status: mergeable.
-  - Gate: waiting for Claude and Hermes review on head
-    `1826e53bc1ca6f5bf6333a282545defcc6c59c13`.
-
 ## Remaining Or Paused Audit Items
 
 - [ ] ParetoStore add-entry performance.

--- a/docs/plans/optimizer_audit_pr_tracker.md
+++ b/docs/plans/optimizer_audit_pr_tracker.md
@@ -8,7 +8,9 @@ approval, and merge only after both reviewers approve the same head.
 
 - Claude approval must mention the PR's current head SHA.
 - Hermes approval must mention the PR's current head SHA.
-- Reviewer findings are addressed on the same PR before merge.
+- Reviewer findings are addressed on the same PR before merge, and the follow-up
+  fix delta must itself receive current-head Claude and Hermes greenlight before
+  merging.
 - Orthogonal follow-up PRs may proceed while earlier PRs wait for reviews.
 
 ## Merged

--- a/docs/plans/optimizer_audit_pr_tracker.md
+++ b/docs/plans/optimizer_audit_pr_tracker.md
@@ -52,12 +52,18 @@ approval, and merge only after both reviewers approve the same head.
     waiting for fresh Claude approval on that same head.
 - [ ] #1075 - Remove unused opt_utils helpers.
   - Status: mergeable.
-  - Gate: waiting for Claude and Hermes review on head
-    `65a30da5fcdc999dbafa7581e6710818c7344f0d`.
+  - Gate: Hermes approved head
+    `65a30da5fcdc999dbafa7581e6710818c7344f0d`; waiting for Claude approval on
+    that same head.
 - [ ] #1076 - Correct optimizer limit stat docs.
   - Status: mergeable after rebase repair.
-  - Gate: waiting for Claude and Hermes review on head
+  - Gate: stale Hermes review correctly found the branch was stacked on #1075;
+    branch was rebased onto `origin/v8` and now contains only
+    `docs/configuration.md`. Waiting for fresh Claude and Hermes review on head
     `7e96a50a0fe9544d1649c66bf7cc034b2cff22bb`.
+- [ ] #1077 - Track optimizer audit PR progress.
+  - Status: mergeable.
+  - Gate: waiting for Claude and Hermes review on the current PR head.
 
 ## Remaining Or Paused Audit Items
 


### PR DESCRIPTION
## Summary
- add a durable optimizer audit PR checklist under `docs/plans/optimizer_audit_pr_tracker.md`
- record merged optimizer audit PRs, currently open PR review gates, and paused remaining audit items
- document the current-head Claude/Hermes merge gate used for this optimizer audit loop

## Validation
- `git diff --cached --check` before commit
- staged diff contained only `docs/plans/optimizer_audit_pr_tracker.md`