### PR TITLE
Reuse pymoo starting seed evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable user-facing changes will be documented in this file.
 - DEAP optimizer generation evaluations now honor
   `optimize.max_pending_starting_evals_per_cpu`, bounding queued offspring
   evaluations with the same memory-control cap used for starting seeds.
+- Pymoo optimizer starting configs now reuse their precomputed seed evaluations
+  during initial population setup instead of backtesting the same seed vectors a
+  second time.
 - Optimizer vector-shape extraction now rejects empty `config.optimize.bounds`
   instead of generating key paths that fail later without matching bounds.
 - Compressed `all_results.bin` optimizer history now preserves deleted keys

--- a/src/optimization/backends/pymoo_backend.py
+++ b/src/optimization/backends/pymoo_backend.py
@@ -105,7 +105,16 @@ def _population_from_payloads(
             [payload.get("G", np.asarray([-1.0], dtype=np.float64)) for payload in payloads],
             dtype=np.float64,
         )
-    return Population.new(*sum(([key, value] for key, value in kwargs.items()), []))
+    return _mark_population_evaluated(
+        Population.new(*sum(([key, value] for key, value in kwargs.items()), []))
+    )
+
+
+def _mark_population_evaluated(population: Population) -> Population:
+    # pymoo's default evaluator requests F/G/H and re-evaluates unless all are marked.
+    for individual in population:
+        individual.evaluated.update(("F", "G", "H"))
+    return population
 
 
 def _reduce_starting_population(
@@ -128,7 +137,12 @@ def _reduce_starting_population(
         array_bytes=int(seed_vectors.nbytes),
     )
     if len(seed_vectors) <= population_size:
-        return _extend_sampling_to_size(seed_vectors, bounds, population_size)
+        pop = _population_from_payloads(
+            seed_vectors,
+            payloads,
+            has_constraints=bool(problem.n_ieq_constr),
+        )
+        return _extend_sampling_to_size(pop, bounds, population_size)
 
     pop = _population_from_payloads(
         seed_vectors,
@@ -147,8 +161,7 @@ def _reduce_starting_population(
         algorithm.__class__.__name__.lower(),
         len(reduced),
     )
-    reduced_vectors = np.asarray(reduced.get("X"), dtype=np.float64)
-    return _extend_sampling_to_size(reduced_vectors, bounds, population_size)
+    return _extend_sampling_to_size(_mark_population_evaluated(reduced), bounds, population_size)
 
 
 def _evaluate_starting_individuals(
@@ -219,7 +232,7 @@ def _evaluate_starting_individuals(
     return slim_payloads
 
 
-def _extend_sampling_to_size(sampling: np.ndarray, bounds, target_size: int) -> np.ndarray:
+def _extend_sampling_to_size(sampling, bounds, target_size: int):
     current_size = int(len(sampling))
     if current_size >= target_size:
         return sampling
@@ -229,7 +242,10 @@ def _extend_sampling_to_size(sampling: np.ndarray, bounds, target_size: int) -> 
     ]
     if not extra:
         return sampling
-    return np.vstack([sampling, np.asarray(extra, dtype=np.float64)])
+    extra_array = np.asarray(extra, dtype=np.float64)
+    if isinstance(sampling, Population):
+        return Population.merge(sampling, Population.new("X", extra_array))
+    return np.vstack([sampling, extra_array])
 
 
 def _resolve_requested_population_size(config: dict[str, Any]) -> int | None:

--- a/tests/optimization/test_backends.py
+++ b/tests/optimization/test_backends.py
@@ -22,6 +22,10 @@ from optimization.backends.deap_backend import (
 )
 from optimization.backends.deap_backend import run_backend as run_deap_backend
 from optimization.backends.pymoo_backend import run_backend as run_pymoo_backend
+from optimization.backends.pymoo_backend import (
+    _population_from_payloads,
+    _reduce_starting_population,
+)
 from optimization.evaluation_payload import apply_evaluation_payload
 
 
@@ -231,6 +235,87 @@ def test_deap_worker_evaluate_uses_initializer_globals():
 
 def test_deap_worker_task_evaluator_is_pickleable_without_bound_evaluator():
     ForkingPickler.dumps(_evaluate_deap_worker)
+
+
+def test_pymoo_reuses_pre_evaluated_starting_seed_payloads():
+    pymoo_minimize = pytest.importorskip("pymoo.optimize").minimize
+    NSGA2 = pytest.importorskip("pymoo.algorithms.moo.nsga2").NSGA2
+    ElementwiseProblem = pytest.importorskip("pymoo.core.problem").ElementwiseProblem
+    np = pytest.importorskip("numpy")
+
+    class CountingProblem(ElementwiseProblem):
+        def __init__(self):
+            super().__init__(
+                n_var=1,
+                n_obj=1,
+                xl=np.asarray([0.0], dtype=np.float64),
+                xu=np.asarray([1.0], dtype=np.float64),
+            )
+            self.calls = []
+
+        def _evaluate(self, x, out, *args, **kwargs):
+            value = float(x[0])
+            self.calls.append(value)
+            out["F"] = np.asarray([value], dtype=np.float64)
+
+    class Bound:
+        low = 0.0
+        high = 1.0
+
+        def __init__(self):
+            self.next_value = 0.8
+
+        def random_on_grid(self):
+            value = self.next_value
+            self.next_value += 0.1
+            return value
+
+    problem = CountingProblem()
+    bounds = [Bound()]
+    seed_vectors = [[0.1], [0.2]]
+    seed_payloads = [
+        {"F": np.asarray([0.1], dtype=np.float64)},
+        {"F": np.asarray([0.2], dtype=np.float64)},
+    ]
+    sampling = _reduce_starting_population(
+        problem=problem,
+        algorithm=NSGA2(pop_size=4, eliminate_duplicates=False),
+        starting_individuals=seed_vectors,
+        payloads=seed_payloads,
+        population_size=4,
+        bounds=bounds,
+        rng_seed=1,
+    )
+    algorithm = NSGA2(pop_size=4, sampling=sampling, eliminate_duplicates=False)
+
+    pymoo_minimize(
+        problem,
+        algorithm,
+        ("n_gen", 1),
+        seed=1,
+        verbose=False,
+        copy_algorithm=False,
+    )
+
+    assert problem.calls == [0.8, 0.9]
+    assert algorithm.evaluator.n_eval == 2
+    assert algorithm.pop.get("F").ravel().tolist() == [0.1, 0.2, 0.8, 0.9]
+
+
+def test_pymoo_seed_population_marks_all_default_evaluator_values():
+    np = pytest.importorskip("numpy")
+
+    pop = _population_from_payloads(
+        np.asarray([[0.1], [0.2]], dtype=np.float64),
+        [
+            {"F": np.asarray([0.1], dtype=np.float64)},
+            {"F": np.asarray([0.2], dtype=np.float64)},
+        ],
+        has_constraints=False,
+    )
+
+    for individual in pop:
+        assert {"F", "G", "H"}.issubset(individual.evaluated)
 
 
 def test_get_backend_runner_resolves_supported_backends():


### PR DESCRIPTION
## Summary
- preserve precomputed pymoo starting-seed objective payloads as evaluated Population entries
- append random fill-in individuals as unevaluated rows so only new random rows are evaluated during initialization
- add regression coverage proving seed rows are not backtested a second time

## Validation
- `./venv/bin/python -m pytest tests/optimization/test_backends.py -q`
- `./venv/bin/python -m py_compile src/optimization/backends/pymoo_backend.py tests/optimization/test_backends.py`
- `git diff --check`