### PR TITLE
Check Pareto dominance in one pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable user-facing changes will be documented in this file.
 - Pymoo optimizer starting configs now reuse their precomputed seed evaluations
   during initial population setup instead of backtesting the same seed vectors a
   second time.
+- Optimizer Pareto storage now checks candidate/front dominance in a single
+  pass, reducing per-candidate overhead without changing Pareto semantics.
 - Optimizer vector-shape extraction now rejects empty `config.optimize.bounds`
   instead of generating key paths that fail later without matching bounds.
 - Compressed `all_results.bin` optimizer history now preserves deleted keys

--- a/src/pareto_store.py
+++ b/src/pareto_store.py
@@ -277,31 +277,26 @@ class ParetoStore:
                     self._remove_from_front(existing_hash)
             # ────────────────────────────────────────────────────────────────
 
-            # discard if dominated by current front
-            if any(
-                dominates_with_violation(
-                    self._objectives[idx],
-                    self._violations.get(idx, 0.0),
+            dominated = []
+            for idx in self._front:
+                front_obj = self._objectives[idx]
+                front_violation = self._violations.get(idx, 0.0)
+                if dominates_with_violation(
+                    front_obj,
+                    front_violation,
                     obj,
                     violation,
                     objective_specs=self.scoring_specs,
-                )
-                for idx in self._front
-            ):
-                return False
-
-            # remove dominated members
-            dominated = [
-                idx
-                for idx in self._front
+                ):
+                    return False
                 if dominates_with_violation(
                     obj,
                     violation,
-                    self._objectives[idx],
-                    self._violations.get(idx, 0.0),
+                    front_obj,
+                    front_violation,
                     objective_specs=self.scoring_specs,
-                )
-            ]
+                ):
+                    dominated.append(idx)
             for idx in dominated:
                 self._remove_from_front(idx)
 

--- a/tests/test_pareto_extremes.py
+++ b/tests/test_pareto_extremes.py
@@ -120,6 +120,18 @@ def test_pareto_store_persists_candidate_without_extra_rounding(tmp_path):
     assert saved["bot"]["long"]["entry_we_weight"] == 1.384
 
 
+def test_pareto_store_single_pass_drops_and_removes_dominated_entries(tmp_path):
+    store = ParetoStore(directory=str(tmp_path), sig_digits=6, flush_interval=10_000, max_size=50)
+
+    assert store.add_entry(_make_candidate({"metric1": 1.0}))
+    assert not store.add_entry(_make_candidate({"metric1": 2.0}))
+    assert store.add_entry(_make_candidate({"metric1": 0.5}))
+
+    front = store.get_front()
+    assert len(front) == 1
+    assert front[0]["metrics"]["objectives"]["metric1"] == 0.5
+
+
 def test_pareto_store_bootstrap_failure_raises_and_preserves_files(tmp_path):
     pareto_dir = tmp_path / "pareto"
     pareto_dir.mkdir()


### PR DESCRIPTION
## Summary
- combine ParetoStore candidate dominance rejection and dominated-front collection into one pass over the current front
- preserve the same `dominates_with_violation` semantics and removal behavior
- add regression coverage for both dropping dominated candidates and replacing dominated front members

## Validation
- `./venv/bin/python -m pytest tests/test_pareto_extremes.py -q`
- `./venv/bin/python -m py_compile src/pareto_store.py tests/test_pareto_extremes.py`
- `git diff --check`