### PR TITLE
Remove unused all_results seed skip branch

### DIFF
--- a/src/optimize.py
+++ b/src/optimize.py
@@ -2534,9 +2534,6 @@ def extract_configs(path):
 def iter_extract_configs(path):
     if not os.path.exists(path):
         return
-    if path.endswith("_all_results.bin"):
-        logging.info(f"Skipping {path}")
-        return
     if path.endswith(".json"):
         try:
             raw = load_hjson_config(path, log_errors=False)

--- a/tests/optimization/test_optimize.py
+++ b/tests/optimization/test_optimize.py
@@ -2732,15 +2732,6 @@ class TestExtractConfigs:
         result = extract_configs("/nonexistent/path")
         assert result == []
 
-    def test_all_results_bin_skipped(self):
-        with tempfile.NamedTemporaryFile(suffix="_all_results.bin", delete=False) as f:
-            path = f.name
-        try:
-            result = extract_configs(path)
-            assert result == []
-        finally:
-            os.unlink(path)
-
     def test_json_file_loaded(self):
         from config_utils import get_template_config
 


### PR DESCRIPTION
## Summary
- remove the starting-config extractor branch that special-cased paths ending `_all_results.bin`
- remove the unit test that existed only to preserve that obsolete branch
- leave JSON and `_pareto.txt` starting-config extraction behavior unchanged

## Validation
- `./venv/bin/python -m pytest tests/optimization/test_optimize.py::TestExtractConfigs tests/optimization/test_optimize.py::TestGetStartingConfigs -q`
- `./venv/bin/python -m py_compile src/optimize.py tests/optimization/test_optimize.py`
- `git diff --check`
- `rg -n "_all_results\\.bin|test_all_results_bin_skipped" src/optimize.py tests/optimization/test_optimize.py` returned no matches