### PR TITLE
Pass live TWEL enforcer policy to Rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live TWEL auto-reduce now honors configured
+  `risk_twel_enforcer_policy` when building Rust orchestrator payloads instead
+  of always falling back to `reduce_overweight`, aligning live behavior with
+  backtests for configs using `reduce_portfolio`.
 - Live coin-mode HSL now computes slot drawdown from configured
   `n_positions` and current raw balance only, so TWEL or excess allowance no
   longer makes the configured RED drawdown threshold tolerate a larger

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -735,7 +735,7 @@ Remaining implementation details:
 
 ## Recommended PR Order / Checklist
 
-- [ ] Live `risk_twel_enforcer_policy` plumbing and BotParams coverage tests.
+- [x] Live `risk_twel_enforcer_policy` plumbing and BotParams coverage tests.
       This is the cleanest confirmed live/backtest parity breach.
 - [ ] HSL per-pside panic order type plus Rust enum/default validation.
       Keep market/limit intent side-local unless an explicit emergency global

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -91,6 +91,7 @@ from config.coerce import (
     normalize_hsl_cooldown_position_policy,
     normalize_hsl_signal_mode,
 )
+from config.bot import normalize_twel_enforcer_policy
 from config.strategy import (
     build_runtime_strategy_side,
     get_active_strategy_side,
@@ -13775,6 +13776,7 @@ class Passivbot:
             "n_positions",
             "total_wallet_exposure_limit",
             "risk_twel_enforcer_enabled",
+            "risk_twel_enforcer_policy",
             "risk_twel_enforcer_threshold",
         }
         bool_keys = {
@@ -13785,6 +13787,7 @@ class Passivbot:
             "unstuck_ema_gating_enabled",
         }
         string_keys = {
+            "risk_twel_enforcer_policy",
             "risk_we_excess_allowance_mode",
         }
         strategy_keys = {
@@ -13840,6 +13843,7 @@ class Passivbot:
             "risk_wel_enforcer_enabled",
             "risk_wel_enforcer_threshold",
             "risk_twel_enforcer_enabled",
+            "risk_twel_enforcer_policy",
             "risk_twel_entry_gate_enabled",
             "risk_twel_enforcer_threshold",
             "risk_we_excess_allowance_pct",
@@ -13890,10 +13894,16 @@ class Passivbot:
             elif key in bool_keys:
                 out[out_key] = bool(val)
             elif key in string_keys:
-                out[out_key] = normalize_we_excess_allowance_mode(
-                    val,
-                    path=f"bot.{pside}.risk.we_excess_allowance_mode",
-                )
+                if key == "risk_twel_enforcer_policy":
+                    out[out_key] = normalize_twel_enforcer_policy(
+                        val,
+                        path=f"bot.{pside}.risk.total_exposure_enforcer_policy",
+                    )
+                else:
+                    out[out_key] = normalize_we_excess_allowance_mode(
+                        val,
+                        path=f"bot.{pside}.risk.we_excess_allowance_mode",
+                    )
             else:
                 out[out_key] = float(val or 0.0)
         out.update(

--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -341,6 +341,7 @@ def test_bot_params_to_rust_dict_includes_hsl_fields():
                 "wallet_exposure_limit": 5.0,
                 "risk_entry_cooldown_minutes": 0.0,
                 "risk_wel_enforcer_threshold": 1.0,
+                "risk_twel_enforcer_policy": "REDUCE_PORTFOLIO",
                 "risk_twel_enforcer_threshold": 1.0,
                 "risk_we_excess_allowance_pct": 0.0,
                 "risk_we_excess_allowance_mode": "LEGACY_RAW",
@@ -367,6 +368,7 @@ def test_bot_params_to_rust_dict_includes_hsl_fields():
     assert out["hsl_tier_ratio_orange"] == pytest.approx(0.75)
     assert out["hsl_orange_tier_mode"] == "tp_only_with_active_entry_cancellation"
     assert out["hsl_panic_close_order_type"] == "market"
+    assert out["risk_twel_enforcer_policy"] == "reduce_portfolio"
     assert out["risk_we_excess_allowance_mode"] == "legacy_raw"
     assert "entry_grid_inflation_enabled" not in out
     assert out["forager_score_weights"] == {
@@ -374,6 +376,11 @@ def test_bot_params_to_rust_dict_includes_hsl_fields():
         "ema_readiness": pytest.approx(0.0),
         "volatility": pytest.approx(0.0),
     }
+
+    stub = _Stub()
+    stub.values["risk_twel_enforcer_policy"] = "invalid_policy"
+    with pytest.raises(ValueError, match="total_exposure_enforcer_policy"):
+        Passivbot._bot_params_to_rust_dict(stub, "long", None)
 
 
 def test_bot_params_to_rust_dict_ignores_removed_entry_grid_inflation_flag():
@@ -427,12 +434,15 @@ def test_bot_params_to_rust_dict_ignores_removed_entry_grid_inflation_flag():
                         "risk_wel_enforcer_enabled": True,
                         "risk_wel_enforcer_threshold": 1.0,
                         "risk_twel_enforcer_enabled": True,
+                        "risk_twel_enforcer_policy": "reduce_overweight",
+                        "risk_twel_entry_gate_enabled": True,
                         "risk_twel_enforcer_threshold": 1.0,
                         "risk_we_excess_allowance_pct": 0.0,
                         "risk_we_excess_allowance_mode": "bounded",
                         "unstuck_close_pct": 0.01,
                         "unstuck_ema_dist": 0.0,
                         "unstuck_enabled": True,
+                        "unstuck_ema_gating_enabled": True,
                         "unstuck_loss_allowance_pct": 0.1,
                         "unstuck_threshold": 1.0,
                     },


### PR DESCRIPTION
## Summary
- include risk_twel_enforcer_policy in live Python -> Rust BotParams payloads
- normalize the enum with the existing config validator before Rust parsing
- add fake-live BotParams coverage for reduce_portfolio and invalid policy rejection
- mark the fable-audit B1.1 checklist item complete

## Tests
- PYTHONPATH=/private/tmp/passivbot-fable-hsl-contracts/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_run_fake_live.py::test_bot_params_to_rust_dict_includes_hsl_fields tests/test_run_fake_live.py::test_bot_params_to_rust_dict_ignores_removed_entry_grid_inflation_flag tests/test_orchestrator_json_api.py::test_twel_reduce_portfolio_can_select_underweight_positions tests/test_orchestrator_json_api.py::test_twel_auto_reduce_takes_priority_over_wel_for_same_position
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/passivbot.py tests/test_run_fake_live.py
- PYTHONPATH=/private/tmp/passivbot-fable-hsl-contracts/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_run_fake_live.py
- git diff --check

Reviewer gate: Claude + Hermes final green light and green CI before merge.