### PR TITLE
Keep HSL panic close order type side-local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- HSL panic close execution now preserves side-local
+  `bot.long/short.hsl.panic_close_order_type` in live and backtests; configuring
+  one side as `market` no longer market-promotes panic closes for the other side
+  when that side is configured as `limit`.
 - Live TWEL auto-reduce now honors configured
   `risk_twel_enforcer_policy` when building Rust orchestrator payloads instead
   of always falling back to `reduce_overweight`, aligning live behavior with

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -737,7 +737,7 @@ Remaining implementation details:
 
 - [x] Live `risk_twel_enforcer_policy` plumbing and BotParams coverage tests.
       This is the cleanest confirmed live/backtest parity breach.
-- [ ] HSL per-pside panic order type plus Rust enum/default validation.
+- [x] HSL per-pside panic order type plus Rust enum/default validation.
       Keep market/limit intent side-local unless an explicit emergency global
       override is added.
 - [ ] Numeric validation/clamping for HSL EMA spans and risk/unstuck config.

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -1548,11 +1548,7 @@ impl<'a> Backtest<'a> {
                     .backtest_params
                     .market_order_near_touch_threshold,
                 market_order_slippage_pct: self.backtest_params.market_order_slippage_pct,
-                panic_close_market: self
-                    .backtest_params
-                    .equity_hard_stop_loss
-                    .panic_close_order_type
-                    == "market",
+                panic_close_market: false,
                 auto_unstuck_allowed: Some(true),
                 unstuck_allowance_long: long_allowance,
                 unstuck_allowance_short: short_allowance,

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -4098,26 +4098,41 @@ mod core {
         }
 
         #[test]
-        fn panic_close_respects_panic_close_market_flag() {
+        fn panic_close_respects_side_local_hsl_order_type() {
             let mut global = make_basic_global();
+            global.global_bot_params.long.hsl_enabled = true;
+            global.global_bot_params.long.hsl_panic_close_order_type = "market".to_string();
+            global.global_bot_params.short.hsl_enabled = true;
+            global.global_bot_params.short.hsl_panic_close_order_type = "limit".to_string();
             let order_book = OrderBook {
                 bid: 100.0,
                 ask: 100.0,
             };
-            let order = IdealOrder {
+            let long_order = IdealOrder {
                 symbol_idx: 0,
                 pside: PositionSide::Long,
                 qty: -1.0,
                 price: 50.0,
                 order_type: OrderType::ClosePanicLong,
             };
+            let short_order = IdealOrder {
+                symbol_idx: 0,
+                pside: PositionSide::Short,
+                qty: 1.0,
+                price: 150.0,
+                order_type: OrderType::ClosePanicShort,
+            };
             assert_eq!(
-                to_executable_order(order.clone(), &global, &order_book).execution_type,
+                to_executable_order(long_order.clone(), &global, &order_book).execution_type,
+                ExecutionType::Market
+            );
+            assert_eq!(
+                to_executable_order(short_order.clone(), &global, &order_book).execution_type,
                 ExecutionType::Limit
             );
             global.panic_close_market = true;
             assert_eq!(
-                to_executable_order(order, &global, &order_book).execution_type,
+                to_executable_order(short_order, &global, &order_book).execution_type,
                 ExecutionType::Market
             );
         }

--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -2452,6 +2452,21 @@ fn validate_forager_score_weights_pair(bot_params: &BotParamsPair) -> PyResult<(
     Ok(())
 }
 
+fn validate_hsl_panic_close_order_type_pair(bot_params: &BotParamsPair) -> PyResult<()> {
+    for (pside, params) in [("long", &bot_params.long), ("short", &bot_params.short)] {
+        match params.hsl_panic_close_order_type.as_str() {
+            "market" | "limit" => {}
+            raw => {
+                return Err(PyValueError::new_err(format!(
+                    "bot.{pside}.hsl_panic_close_order_type must be one of: market, limit; got {:?}",
+                    raw
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 fn extract_value<'a, T: pyo3::FromPyObject<'a>>(dict: &'a PyDict, key: &str) -> PyResult<T> {
     dict.get_item(key)
         .map_err(|_| {
@@ -3750,6 +3765,7 @@ pub fn compute_ideal_orders_json(input_json: &str) -> PyResult<String> {
             ))
         })?;
     validate_forager_score_weights_pair(&input.global.global_bot_params)?;
+    validate_hsl_panic_close_order_type_pair(&input.global.global_bot_params)?;
 
     let out = crate::orchestrator::compute_ideal_orders(&input).map_err(|e| {
         pyo3::exceptions::PyValueError::new_err(format!(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -13642,18 +13642,6 @@ class Passivbot:
 
         if not hasattr(self, "effective_min_cost") or self.effective_min_cost is None:
             self.effective_min_cost = {}
-        target_psides = {
-            pside for psides in target_psides_by_symbol.values() for pside in psides
-        }
-        panic_close_market = bool(
-            any(
-                Passivbot._equity_hard_stop_panic_close_order_type(self, pside)
-                == "market"
-                for pside in target_psides
-                if Passivbot._equity_hard_stop_enabled(self, pside)
-            )
-        )
-        input_dict["global"]["panic_close_market"] = panic_close_market
         for symbol in symbols:
             idx = symbol_to_idx[symbol]
             snap = market_snapshots.get(symbol)
@@ -14304,14 +14292,7 @@ class Passivbot:
                 "market_order_near_touch_threshold": float(
                     self.live_value("market_order_near_touch_threshold")
                 ),
-                "panic_close_market": bool(
-                    any(
-                        Passivbot._equity_hard_stop_panic_close_order_type(self, pside)
-                        == "market"
-                        for pside in ("long", "short")
-                        if Passivbot._equity_hard_stop_enabled(self, pside)
-                    )
-                ),
+                "panic_close_market": False,
                 "auto_unstuck_allowed": auto_unstuck_allowed,
                 "unstuck_allowance_long": float(unstuck_allowances.get("long", 0.0)),
                 "unstuck_allowance_short": float(unstuck_allowances.get("short", 0.0)),
@@ -16152,14 +16133,7 @@ class Passivbot:
                 "market_order_near_touch_threshold": float(
                     self.live_value("market_order_near_touch_threshold")
                 ),
-                "panic_close_market": bool(
-                    any(
-                        Passivbot._equity_hard_stop_panic_close_order_type(self, pside)
-                        == "market"
-                        for pside in ("long", "short")
-                        if Passivbot._equity_hard_stop_enabled(self, pside)
-                    )
-                ),
+                "panic_close_market": False,
                 "auto_unstuck_allowed": auto_unstuck_allowed,
                 "unstuck_allowance_long": float(unstuck_allowances.get("long", 0.0)),
                 "unstuck_allowance_short": float(unstuck_allowances.get("short", 0.0)),

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -1295,6 +1295,57 @@ def test_panic_mode_emits_close_panic_long():
     assert o["qty"] < 0.0
 
 
+def test_panic_close_order_type_is_side_local():
+    import passivbot_rust as pbr
+
+    global_bp = bot_params_pair(
+        long_overrides={"hsl_enabled": True, "hsl_panic_close_order_type": "market"},
+        short_overrides={
+            "hsl_enabled": True,
+            "hsl_panic_close_order_type": "limit",
+            "n_positions": 1,
+            "total_wallet_exposure_limit": 1.0,
+        },
+    )
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=global_bp,
+        symbols=[
+            make_symbol(
+                0,
+                bid=95.0,
+                ask=95.0,
+                long_mode="panic",
+                short_mode="panic",
+                long_pos_size=1.5,
+                long_pos_price=100.0,
+                short_pos_size=-1.5,
+                short_pos_price=100.0,
+            )
+        ],
+    )
+
+    out = compute(pbr, inp)
+    by_pside = {o["pside"]: o for o in out["orders"]}
+
+    assert by_pside["long"]["order_type"] == "close_panic_long"
+    assert by_pside["long"]["execution_type"] == "market"
+    assert by_pside["short"]["order_type"] == "close_panic_short"
+    assert by_pside["short"]["execution_type"] == "limit"
+
+
+def test_panic_close_order_type_rejects_invalid_values():
+    import passivbot_rust as pbr
+
+    global_bp = bot_params_pair(
+        long_overrides={"hsl_panic_close_order_type": "iceberg"},
+    )
+    inp = make_input(balance=1_000.0, global_bp=global_bp, symbols=[])
+
+    with pytest.raises(ValueError, match="hsl_panic_close_order_type"):
+        compute(pbr, inp)
+
+
 def test_graceful_stop_blocks_initial_entries_only():
     import passivbot_rust as pbr
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -5452,7 +5452,7 @@ async def test_protective_panic_orchestrator_payload_omits_ema_dependencies(monk
     rust_symbol = captured["input"]["symbols"][0]
     assert rust_symbol["long"]["mode"] == "panic"
     assert rust_symbol["short"]["mode"] == "manual"
-    assert captured["input"]["global"]["panic_close_market"] is True
+    assert captured["input"]["global"]["panic_close_market"] is False
     assert len(captured["input"]["symbols"]) == 1
     assert rust_symbol["emas"] == {
         "m1": {"close": [], "log_range": [], "volume": []},


### PR DESCRIPTION
## Summary
- stop live and backtest inputs from setting the implicit global panic_close_market override from any side configured as market
- preserve side-local HSL panic execution through bot.long/short.hsl.panic_close_order_type
- add Rust JSON-boundary validation for hsl_panic_close_order_type values
- add JSON API/live payload regression tests and update the fable-audit checklist

## Tests
- VIRTUAL_ENV=/Users/eiriknarjord/repos/passivbot-2/venv PATH=/Users/eiriknarjord/repos/passivbot-2/venv/bin:$PATH /Users/eiriknarjord/repos/passivbot-2/venv/bin/maturin develop --release --manifest-path passivbot-rust/Cargo.toml
- PYTHONPATH=/private/tmp/passivbot-fable-hsl-contracts/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_orchestrator_json_api.py::test_panic_close_order_type_is_side_local tests/test_orchestrator_json_api.py::test_panic_close_order_type_rejects_invalid_values tests/test_passivbot_balance_split.py::test_protective_panic_orchestrator_payload_omits_ema_dependencies tests/test_orchestrator_json_api.py::test_panic_mode_emits_close_panic_long
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/passivbot.py tests/test_orchestrator_json_api.py tests/test_passivbot_balance_split.py
- git diff --check

Note: direct cargo test of the Rust unit target hit the local macOS PyO3 test-linking issue (undefined Python symbols). The modified extension was instead built successfully with maturin and exercised through the JSON API tests.

Reviewer gate: Claude + Hermes final green light and green CI before merge.