### PR TITLE
Validate HSL/risk/unstuck numerics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- HSL/risk/unstuck config validation now clamps HSL EMA spans below `1.0`
+  during config preparation and rejects malformed HSL, risk, and unstuck
+  numeric inputs at the Rust orchestrator JSON boundary before order planning.
 - HSL panic close execution now preserves side-local
   `bot.long/short.hsl.panic_close_order_type` in live and backtests; configuring
   one side as `market` no longer market-promotes panic closes for the other side

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -740,7 +740,7 @@ Remaining implementation details:
 - [x] HSL per-pside panic order type plus Rust enum/default validation.
       Keep market/limit intent side-local unless an explicit emergency global
       override is added.
-- [ ] Numeric validation/clamping for HSL EMA spans and risk/unstuck config.
+- [x] Numeric validation/clamping for HSL EMA spans and risk/unstuck config.
       Clamp EMA spans to at least `1.0`; fail loudly or normalize visibly for
       other risk numerics.
 - [ ] Risk-input fail-loud validation boundary.

--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -2467,6 +2467,199 @@ fn validate_hsl_panic_close_order_type_pair(bot_params: &BotParamsPair) -> PyRes
     Ok(())
 }
 
+fn validate_finite_range(
+    path: &str,
+    value: f64,
+    min_value: f64,
+    max_value: Option<f64>,
+    min_inclusive: bool,
+) -> PyResult<()> {
+    if !value.is_finite() {
+        return Err(PyValueError::new_err(format!("{path} must be finite")));
+    }
+    let min_ok = if min_inclusive {
+        value >= min_value
+    } else {
+        value > min_value
+    };
+    if !min_ok {
+        let op = if min_inclusive { ">=" } else { ">" };
+        return Err(PyValueError::new_err(format!(
+            "{path} must be finite and {op} {min_value}"
+        )));
+    }
+    if let Some(max_value) = max_value {
+        if value > max_value {
+            return Err(PyValueError::new_err(format!(
+                "{path} must be finite and <= {max_value}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_hsl_risk_unstuck_bot_params(
+    path_prefix: &str,
+    pside: &str,
+    params: &BotParams,
+) -> PyResult<()> {
+    validate_finite_range(
+        &format!("{path_prefix}.hsl_ema_span_minutes"),
+        params.hsl_ema_span_minutes,
+        1.0,
+        None,
+        true,
+    )?;
+    validate_finite_range(
+        &format!("{path_prefix}.hsl_red_threshold"),
+        params.hsl_red_threshold,
+        0.0,
+        Some(1.0),
+        false,
+    )?;
+    validate_finite_range(
+        &format!("{path_prefix}.hsl_no_restart_drawdown_threshold"),
+        params.hsl_no_restart_drawdown_threshold,
+        0.0,
+        Some(1.0),
+        true,
+    )?;
+    if params.hsl_no_restart_drawdown_threshold < params.hsl_red_threshold {
+        return Err(PyValueError::new_err(format!(
+            "{path_prefix}.hsl_no_restart_drawdown_threshold must be >= {path_prefix}.hsl_red_threshold"
+        )));
+    }
+    validate_finite_range(
+        &format!("{path_prefix}.hsl_cooldown_minutes_after_red"),
+        params.hsl_cooldown_minutes_after_red,
+        0.0,
+        None,
+        true,
+    )?;
+    validate_finite_range(
+        &format!("{path_prefix}.hsl_tier_ratio_yellow"),
+        params.hsl_tier_ratio_yellow,
+        0.0,
+        Some(1.0),
+        true,
+    )?;
+    validate_finite_range(
+        &format!("{path_prefix}.hsl_tier_ratio_orange"),
+        params.hsl_tier_ratio_orange,
+        0.0,
+        Some(1.0),
+        true,
+    )?;
+    if params.hsl_tier_ratio_yellow > params.hsl_tier_ratio_orange {
+        return Err(PyValueError::new_err(format!(
+            "{path_prefix}.hsl_tier_ratio_yellow must be <= {path_prefix}.hsl_tier_ratio_orange"
+        )));
+    }
+    validate_finite_range(
+        &format!("{path_prefix}.risk_entry_cooldown_minutes"),
+        params.risk_entry_cooldown_minutes,
+        0.0,
+        None,
+        true,
+    )?;
+    validate_finite_range(
+        &format!("{path_prefix}.total_wallet_exposure_limit"),
+        params.total_wallet_exposure_limit,
+        0.0,
+        None,
+        true,
+    )?;
+    validate_finite_range(
+        &format!("{path_prefix}.wallet_exposure_limit"),
+        params.wallet_exposure_limit,
+        0.0,
+        None,
+        true,
+    )?;
+    validate_finite_range(
+        &format!("{path_prefix}.risk_wel_enforcer_threshold"),
+        params.risk_wel_enforcer_threshold,
+        0.0,
+        None,
+        true,
+    )?;
+    validate_finite_range(
+        &format!("{path_prefix}.risk_twel_enforcer_threshold"),
+        params.risk_twel_enforcer_threshold,
+        0.0,
+        None,
+        true,
+    )?;
+    validate_finite_range(
+        &format!("{path_prefix}.risk_we_excess_allowance_pct"),
+        params.risk_we_excess_allowance_pct,
+        0.0,
+        None,
+        true,
+    )?;
+    validate_finite_range(
+        &format!("{path_prefix}.unstuck_close_pct"),
+        params.unstuck_close_pct,
+        0.0,
+        Some(1.0),
+        true,
+    )?;
+    validate_finite_range(
+        &format!("{path_prefix}.unstuck_loss_allowance_pct"),
+        params.unstuck_loss_allowance_pct,
+        0.0,
+        None,
+        true,
+    )?;
+    validate_finite_range(
+        &format!("{path_prefix}.unstuck_threshold"),
+        params.unstuck_threshold,
+        0.0,
+        None,
+        true,
+    )?;
+    if !params.unstuck_ema_dist.is_finite() {
+        return Err(PyValueError::new_err(format!(
+            "{path_prefix}.unstuck_ema_dist must be finite"
+        )));
+    }
+    if pside == "long" && params.unstuck_ema_dist <= -1.0 {
+        return Err(PyValueError::new_err(format!(
+            "{path_prefix}.unstuck_ema_dist must be > -1.0"
+        )));
+    }
+    if pside == "short" && params.unstuck_ema_dist >= 1.0 {
+        return Err(PyValueError::new_err(format!(
+            "{path_prefix}.unstuck_ema_dist must be < 1.0"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_hsl_risk_unstuck_orchestrator_input(
+    input: &crate::orchestrator::OrchestratorInput,
+) -> PyResult<()> {
+    validate_hsl_risk_unstuck_bot_params("bot.long", "long", &input.global.global_bot_params.long)?;
+    validate_hsl_risk_unstuck_bot_params(
+        "bot.short",
+        "short",
+        &input.global.global_bot_params.short,
+    )?;
+    for symbol in &input.symbols {
+        validate_hsl_risk_unstuck_bot_params(
+            &format!("symbols[{}].long.bot_params", symbol.symbol_idx),
+            "long",
+            &symbol.long.bot_params,
+        )?;
+        validate_hsl_risk_unstuck_bot_params(
+            &format!("symbols[{}].short.bot_params", symbol.symbol_idx),
+            "short",
+            &symbol.short.bot_params,
+        )?;
+    }
+    Ok(())
+}
+
 fn extract_value<'a, T: pyo3::FromPyObject<'a>>(dict: &'a PyDict, key: &str) -> PyResult<T> {
     dict.get_item(key)
         .map_err(|_| {
@@ -3766,6 +3959,7 @@ pub fn compute_ideal_orders_json(input_json: &str) -> PyResult<String> {
         })?;
     validate_forager_score_weights_pair(&input.global.global_bot_params)?;
     validate_hsl_panic_close_order_type_pair(&input.global.global_bot_params)?;
+    validate_hsl_risk_unstuck_orchestrator_input(&input)?;
 
     let out = crate::orchestrator::compute_ideal_orders(&input).map_err(|e| {
         pyo3::exceptions::PyValueError::new_err(format!(

--- a/src/config/bot.py
+++ b/src/config/bot.py
@@ -363,6 +363,186 @@ def _normalize_cliff_edge_threshold(
     return numeric
 
 
+def _coerce_finite_float(value, *, path: str) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{path} must be numeric") from exc
+    if not math.isfinite(numeric):
+        raise ValueError(f"{path} must be finite")
+    return numeric
+
+
+def _set_grouped_bot_value(
+    result: dict,
+    *,
+    pside: str,
+    flat_key: str,
+    value,
+    tracker: Optional[object],
+) -> None:
+    group_path = FLAT_BOT_KEY_TO_GROUP_PATH.get(flat_key)
+    if group_path is None:
+        result["bot"][pside][flat_key] = value
+        return
+    group_name, local_key = group_path
+    group_cfg = get_bot_group(result["bot"][pside], group_name)
+    if group_cfg:
+        group_cfg[local_key] = value
+    else:
+        result["bot"][pside][flat_key] = value
+
+
+def _normalize_minimum_span(
+    result: dict,
+    *,
+    pside: str,
+    flat_key: str,
+    path: str,
+    verbose: bool,
+    tracker: Optional[object],
+) -> None:
+    raw_value = get_grouped_bot_value(result["bot"][pside], flat_key)
+    numeric = _coerce_finite_float(raw_value, path=path)
+    normalized = max(1.0, numeric)
+    if normalized != numeric:
+        log_config_message(
+            verbose,
+            logging.WARNING,
+            "%s=%s is below minimum EMA span; clamping to %.1f",
+            path,
+            numeric,
+            normalized,
+        )
+        if tracker is not None:
+            group_path = FLAT_BOT_KEY_TO_GROUP_PATH.get(flat_key)
+            if group_path is not None:
+                tracker.update(["bot", pside, *group_path], raw_value, normalized)
+            else:
+                tracker.update(["bot", pside, flat_key], raw_value, normalized)
+    _set_grouped_bot_value(
+        result,
+        pside=pside,
+        flat_key=flat_key,
+        value=normalized,
+        tracker=tracker,
+    )
+
+
+def _validate_ratio(
+    value,
+    *,
+    path: str,
+    min_value: float = 0.0,
+    max_value: float | None = None,
+    min_inclusive: bool = True,
+) -> float:
+    numeric = _coerce_finite_float(value, path=path)
+    if min_inclusive:
+        min_ok = numeric >= min_value
+        min_desc = f">= {min_value}"
+    else:
+        min_ok = numeric > min_value
+        min_desc = f"> {min_value}"
+    if not min_ok:
+        raise ValueError(f"{path} must be finite and {min_desc}")
+    if max_value is not None and numeric > max_value:
+        raise ValueError(f"{path} must be finite and <= {max_value}")
+    return numeric
+
+
+def normalize_hsl_risk_unstuck_numerics(
+    result: dict,
+    *,
+    verbose: bool = True,
+    tracker: Optional[object] = None,
+) -> None:
+    for pside in BOT_POSITION_SIDES:
+        bot_side = result["bot"][pside]
+        hsl_path = f"bot.{pside}.hsl"
+        risk_path = f"bot.{pside}.risk"
+        unstuck_path = f"bot.{pside}.unstuck"
+
+        _normalize_minimum_span(
+            result,
+            pside=pside,
+            flat_key="hsl_ema_span_minutes",
+            path=f"{hsl_path}.ema_span_minutes",
+            verbose=verbose,
+            tracker=tracker,
+        )
+        red_threshold = _validate_ratio(
+            get_grouped_bot_value(bot_side, "hsl_red_threshold"),
+            path=f"{hsl_path}.red_threshold",
+            min_value=0.0,
+            max_value=1.0,
+            min_inclusive=False,
+        )
+        no_restart = _validate_ratio(
+            get_grouped_bot_value(bot_side, "hsl_no_restart_drawdown_threshold"),
+            path=f"{hsl_path}.no_restart_drawdown_threshold",
+            min_value=0.0,
+            max_value=1.0,
+        )
+        if no_restart < red_threshold:
+            log_config_message(
+                verbose,
+                logging.WARNING,
+                "%s.no_restart_drawdown_threshold=%s is below red_threshold=%s; clamping to red_threshold",
+                hsl_path,
+                no_restart,
+                red_threshold,
+            )
+            _set_grouped_bot_value(
+                result,
+                pside=pside,
+                flat_key="hsl_no_restart_drawdown_threshold",
+                value=red_threshold,
+                tracker=tracker,
+            )
+            if tracker is not None:
+                tracker.update(
+                    ["bot", pside, "hsl", "no_restart_drawdown_threshold"],
+                    no_restart,
+                    red_threshold,
+                )
+        _validate_ratio(
+            get_grouped_bot_value(bot_side, "hsl_cooldown_minutes_after_red"),
+            path=f"{hsl_path}.cooldown_minutes_after_red",
+        )
+        tier_ratios = get_grouped_bot_value(bot_side, "hsl_tier_ratios")
+        if not isinstance(tier_ratios, dict):
+            raise TypeError(f"{hsl_path}.tier_ratios must be a dict")
+        yellow = _validate_ratio(
+            tier_ratios.get("yellow"),
+            path=f"{hsl_path}.tier_ratios.yellow",
+            max_value=1.0,
+        )
+        orange = _validate_ratio(
+            tier_ratios.get("orange"),
+            path=f"{hsl_path}.tier_ratios.orange",
+            max_value=1.0,
+        )
+        if yellow > orange:
+            raise ValueError(
+                f"{hsl_path}.tier_ratios.yellow must be <= {hsl_path}.tier_ratios.orange"
+            )
+
+        _validate_ratio(
+            get_grouped_bot_value(bot_side, "risk_we_excess_allowance_pct"),
+            path=f"{risk_path}.we_excess_allowance_pct",
+        )
+        _validate_ratio(
+            get_grouped_bot_value(bot_side, "unstuck_close_pct"),
+            path=f"{unstuck_path}.close_pct",
+            max_value=1.0,
+        )
+        _validate_ratio(
+            get_grouped_bot_value(bot_side, "unstuck_loss_allowance_pct"),
+            path=f"{unstuck_path}.loss_allowance_pct",
+        )
+
+
 def normalize_cliff_edge_thresholds(
     result: dict,
     *,
@@ -833,6 +1013,7 @@ def format_bot_config(
     apply_backward_compatibility_renames(result, verbose=verbose, tracker=tracker)
     ensure_bot_defaults(result, verbose=verbose, tracker=tracker)
     ensure_required_bot_params_present(result)
+    normalize_hsl_risk_unstuck_numerics(result, verbose=verbose, tracker=tracker)
     normalize_cliff_edge_thresholds(result, verbose=verbose, tracker=tracker)
     normalize_bot_forager_config(result, verbose=verbose, tracker=tracker)
     normalize_position_counts(result, tracker=tracker)

--- a/tests/test_config_pipeline.py
+++ b/tests/test_config_pipeline.py
@@ -1887,6 +1887,71 @@ def test_prepare_config_rejects_invalid_staged_live_controls(field, value, match
         prepare_config(source, verbose=False, target="canonical", runtime=None)
 
 
+def test_prepare_config_clamps_hsl_ema_span_to_minimum():
+    source = get_template_config()
+    source["bot"]["long"]["hsl"]["ema_span_minutes"] = 0.25
+
+    prepared = prepare_config(source, verbose=False, target="canonical", runtime=None)
+
+    assert prepared["bot"]["long"]["hsl"]["ema_span_minutes"] == pytest.approx(1.0)
+
+
+def test_prepare_config_clamps_hsl_no_restart_threshold_to_red_threshold():
+    source = get_template_config()
+    source["bot"]["long"]["hsl"]["red_threshold"] = 0.20
+    source["bot"]["long"]["hsl"]["no_restart_drawdown_threshold"] = 0.10
+
+    prepared = prepare_config(source, verbose=False, target="canonical", runtime=None)
+
+    assert prepared["bot"]["long"]["hsl"]["no_restart_drawdown_threshold"] == pytest.approx(0.20)
+
+
+@pytest.mark.parametrize(
+    ("group", "field", "value", "match"),
+    [
+        ("hsl", "red_threshold", 0.0, r"bot\.long\.hsl\.red_threshold must be finite and > 0\.0"),
+        (
+            "hsl",
+            "cooldown_minutes_after_red",
+            -1.0,
+            r"bot\.long\.hsl\.cooldown_minutes_after_red must be finite and >= 0\.0",
+        ),
+        (
+            "hsl",
+            "tier_ratios",
+            {"yellow": 0.9, "orange": 0.8},
+            r"bot\.long\.hsl\.tier_ratios\.yellow must be <= bot\.long\.hsl\.tier_ratios\.orange",
+        ),
+        (
+            "risk",
+            "we_excess_allowance_pct",
+            -0.01,
+            r"bot\.long\.risk\.we_excess_allowance_pct must be finite and >= 0\.0",
+        ),
+        (
+            "unstuck",
+            "close_pct",
+            1.01,
+            r"bot\.long\.unstuck\.close_pct must be finite and <= 1\.0",
+        ),
+        (
+            "unstuck",
+            "loss_allowance_pct",
+            float("nan"),
+            r"bot\.long\.unstuck\.loss_allowance_pct must be finite",
+        ),
+    ],
+)
+def test_prepare_config_rejects_invalid_hsl_risk_unstuck_numerics(
+    group, field, value, match
+):
+    source = get_template_config()
+    source["bot"]["long"][group][field] = value
+
+    with pytest.raises((TypeError, ValueError), match=match):
+        prepare_config(source, verbose=False, target="canonical", runtime=None)
+
+
 def test_prepare_config_preserves_live_candle_budget_controls():
     source = get_template_config()
     source["live"]["defer_broad_candle_warmup"] = False

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -1346,6 +1346,51 @@ def test_panic_close_order_type_rejects_invalid_values():
         compute(pbr, inp)
 
 
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"hsl_ema_span_minutes": 0.5}, r"bot\.long\.hsl_ema_span_minutes"),
+        ({"hsl_red_threshold": 0.0}, r"bot\.long\.hsl_red_threshold"),
+        (
+            {"hsl_red_threshold": 0.2, "hsl_no_restart_drawdown_threshold": 0.1},
+            r"bot\.long\.hsl_no_restart_drawdown_threshold",
+        ),
+        ({"risk_we_excess_allowance_pct": -0.01}, r"bot\.long\.risk_we_excess_allowance_pct"),
+        ({"unstuck_ema_dist": -1.0}, r"bot\.long\.unstuck_ema_dist"),
+    ],
+)
+def test_json_rejects_invalid_global_hsl_risk_unstuck_values(overrides, match):
+    import passivbot_rust as pbr
+
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=bot_params_pair(long_overrides=overrides),
+        symbols=[],
+    )
+
+    with pytest.raises(ValueError, match=match):
+        compute(pbr, inp)
+
+
+def test_json_rejects_invalid_symbol_hsl_risk_unstuck_values():
+    import passivbot_rust as pbr
+
+    inp = make_input(
+        balance=1_000.0,
+        symbols=[
+            make_symbol(
+                0,
+                bid=100.0,
+                ask=101.0,
+                long_bp={"unstuck_close_pct": 1.01},
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match=r"symbols\[0\]\.long\.bot_params\.unstuck_close_pct"):
+        compute(pbr, inp)
+
+
 def test_graceful_stop_blocks_initial_entries_only():
     import passivbot_rust as pbr
 


### PR DESCRIPTION
## Summary
- clamp HSL EMA spans below 1.0 during canonical config preparation
- validate HSL/risk/unstuck numeric contracts in canonical config preparation
- reject malformed global and per-symbol BotParams at the Rust orchestrator JSON boundary before order planning

## Validation
- maturin develop --release --manifest-path passivbot-rust/Cargo.toml
- cargo check --manifest-path passivbot-rust/Cargo.toml
- python -m py_compile src/config/bot.py tests/test_config_pipeline.py tests/test_orchestrator_json_api.py
- pytest tests/test_orchestrator_json_api.py::test_json_rejects_invalid_global_hsl_risk_unstuck_values tests/test_orchestrator_json_api.py::test_json_rejects_invalid_symbol_hsl_risk_unstuck_values tests/test_orchestrator_json_api.py::test_panic_close_order_type_is_side_local tests/test_orchestrator_json_api.py::test_panic_mode_emits_close_panic_long tests/test_config_pipeline.py::test_prepare_config_clamps_hsl_ema_span_to_minimum tests/test_config_pipeline.py::test_prepare_config_clamps_hsl_no_restart_threshold_to_red_threshold tests/test_config_pipeline.py::test_prepare_config_rejects_invalid_hsl_risk_unstuck_numerics -q
- git diff --check