### PR TITLE
Reject invalid orchestrator risk globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- The Rust orchestrator JSON boundary now rejects invalid account/risk globals
+  such as non-positive raw balance, negative realized-loss limits, and negative
+  unstuck allowances before risk gates or order planning can silently skip.
 - HSL/risk/unstuck config validation now clamps HSL EMA spans below `1.0`
   during config preparation and rejects malformed HSL, risk, and unstuck
   numeric inputs at the Rust orchestrator JSON boundary before order planning.

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -746,6 +746,8 @@ Remaining implementation details:
 - [ ] Risk-input fail-loud validation boundary.
       Invalid balance, position, exchange params, PnL stats, or active gate
       inputs must not disable risk gates permissively.
+      Partial: Rust orchestrator JSON now rejects invalid account/risk globals
+      before realized-loss or unstuck gates can silently skip.
 - [ ] Rust reducer priority: one reducer per coin+pside per ideal-order batch.
       Priority is HSL panic, WEL/TWEL reducer, auto-unstuck, then any other
       close order, with bid/ask-reachable reducers prioritized before farther

--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -2660,6 +2660,54 @@ fn validate_hsl_risk_unstuck_orchestrator_input(
     Ok(())
 }
 
+fn validate_orchestrator_account_risk_inputs(
+    input: &crate::orchestrator::OrchestratorInput,
+) -> PyResult<()> {
+    validate_finite_range("balance", input.balance, 0.0, None, false)?;
+    let balance_raw = if input.balance_raw.is_finite() {
+        input.balance_raw
+    } else {
+        input.balance
+    };
+    validate_finite_range("balance_raw", balance_raw, 0.0, None, false)?;
+    validate_finite_range(
+        "global.max_realized_loss_pct",
+        input.global.max_realized_loss_pct,
+        0.0,
+        None,
+        true,
+    )?;
+    for (path, value) in [
+        (
+            "global.realized_pnl_cumsum_max",
+            input.global.realized_pnl_cumsum_max,
+        ),
+        (
+            "global.realized_pnl_cumsum_last",
+            input.global.realized_pnl_cumsum_last,
+        ),
+    ] {
+        if !value.is_finite() {
+            return Err(PyValueError::new_err(format!("{path} must be finite")));
+        }
+    }
+    validate_finite_range(
+        "global.unstuck_allowance_long",
+        input.global.unstuck_allowance_long,
+        0.0,
+        None,
+        true,
+    )?;
+    validate_finite_range(
+        "global.unstuck_allowance_short",
+        input.global.unstuck_allowance_short,
+        0.0,
+        None,
+        true,
+    )?;
+    Ok(())
+}
+
 fn extract_value<'a, T: pyo3::FromPyObject<'a>>(dict: &'a PyDict, key: &str) -> PyResult<T> {
     dict.get_item(key)
         .map_err(|_| {
@@ -3957,6 +4005,7 @@ pub fn compute_ideal_orders_json(input_json: &str) -> PyResult<String> {
                 e
             ))
         })?;
+    validate_orchestrator_account_risk_inputs(&input)?;
     validate_forager_score_weights_pair(&input.global.global_bot_params)?;
     validate_hsl_panic_close_order_type_pair(&input.global.global_bot_params)?;
     validate_hsl_risk_unstuck_orchestrator_input(&input)?;

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -2450,8 +2450,39 @@ def test_balance_raw_absent_falls_back_to_balance():
     assert isinstance(out, dict)
 
 
-def test_balance_raw_zero_gate_returns_early():
-    """When balance_raw is 0.0, the loss gate returns early (non-positive guard)."""
+@pytest.mark.parametrize(
+    ("mutator", "match"),
+    [
+        (lambda inp: inp.__setitem__("balance", 0.0), r"balance must be finite and > 0"),
+        (
+            lambda inp: inp["global"].__setitem__("max_realized_loss_pct", -0.01),
+            r"global\.max_realized_loss_pct must be finite and >= 0",
+        ),
+        (
+            lambda inp: inp["global"].__setitem__("unstuck_allowance_long", -1.0),
+            r"global\.unstuck_allowance_long must be finite and >= 0",
+        ),
+        (
+            lambda inp: inp["global"].__setitem__("unstuck_allowance_short", -1.0),
+            r"global\.unstuck_allowance_short must be finite and >= 0",
+        ),
+    ],
+)
+def test_json_rejects_invalid_account_risk_globals(mutator, match):
+    import passivbot_rust as pbr
+
+    inp = make_input(
+        balance=1_000.0,
+        symbols=[make_symbol(0, bid=100.0, ask=100.0)],
+    )
+    mutator(inp)
+
+    with pytest.raises(ValueError, match=match):
+        compute(pbr, inp)
+
+
+def test_balance_raw_zero_rejected():
+    """Non-positive balance_raw is rejected instead of disabling realized-loss gates."""
     import passivbot_rust as pbr
 
     long_bp = {}
@@ -2474,14 +2505,12 @@ def test_balance_raw_zero_gate_returns_early():
     inp["global"]["realized_pnl_cumsum_max"] = 10.0
     inp["global"]["realized_pnl_cumsum_last"] = 5.0
 
-    out = compute(pbr, inp)
-    # Gate skips with non-positive balance_raw, close orders should still appear
-    close_orders = [o for o in out["orders"] if o["order_type"].startswith("close_")]
-    assert len(close_orders) > 0
+    with pytest.raises(ValueError, match=r"balance_raw must be finite and > 0"):
+        compute(pbr, inp)
 
 
-def test_balance_raw_negative_gate_returns_early():
-    """When balance_raw is -1.0, the loss gate returns early (non-positive guard)."""
+def test_balance_raw_negative_rejected():
+    """Negative balance_raw is rejected instead of disabling realized-loss gates."""
     import passivbot_rust as pbr
 
     long_bp = {}
@@ -2504,10 +2533,8 @@ def test_balance_raw_negative_gate_returns_early():
     inp["global"]["realized_pnl_cumsum_max"] = 10.0
     inp["global"]["realized_pnl_cumsum_last"] = 5.0
 
-    out = compute(pbr, inp)
-    # Gate skips with negative balance_raw, close orders should still appear
-    close_orders = [o for o in out["orders"] if o["order_type"].startswith("close_")]
-    assert len(close_orders) > 0
+    with pytest.raises(ValueError, match=r"balance_raw must be finite and > 0"):
+        compute(pbr, inp)
 
 
 def test_balance_raw_inf_rejected():


### PR DESCRIPTION
## Summary
- reject non-positive balance/effective balance_raw at the Rust orchestrator JSON boundary
- reject negative realized-loss limits and negative unstuck allowances before risk gates/order planning
- preserve missing balance_raw fallback to balance

## Validation
- maturin develop --release --manifest-path passivbot-rust/Cargo.toml
- cargo check --manifest-path passivbot-rust/Cargo.toml
- python -m py_compile tests/test_orchestrator_json_api.py
- pytest tests/test_orchestrator_json_api.py::test_balance_raw_absent_falls_back_to_balance tests/test_orchestrator_json_api.py::test_json_rejects_invalid_account_risk_globals tests/test_orchestrator_json_api.py::test_balance_raw_zero_rejected tests/test_orchestrator_json_api.py::test_balance_raw_negative_rejected tests/test_orchestrator_json_api.py::test_realized_loss_gate_uses_balance_raw -q
- git diff --check