### PR TITLE
Prioritize TWEL over same-position unstuck reducers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Rust TWEL auto-reduce now takes priority over same-position auto-unstuck
+  reducers in the same ideal-order batch, preventing two reducer closes from
+  stacking on one coin+pside when portfolio exposure enforcement is active.
 - The Rust orchestrator JSON boundary now rejects invalid account/risk globals
   such as non-positive raw balance, negative realized-loss limits, and negative
   unstuck allowances before risk gates or order planning can silently skip.

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -752,6 +752,8 @@ Remaining implementation details:
       Priority is HSL panic, WEL/TWEL reducer, auto-unstuck, then any other
       close order, with bid/ask-reachable reducers prioritized before farther
       passive closes.
+      Partial: TWEL auto-reduce now removes same-position WEL and auto-unstuck
+      reducers before insertion, with long/short JSON API regression coverage.
 - [ ] Contract docs batch: unstuck min-qty overshoot, inherited lookbacks,
       HSL/config-change risks, statelessness, `pnls_max_lookback_days`, and
       HSL-enabled startup warning.

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -3257,8 +3257,12 @@ mod core {
             );
             for (idx, order) in actions {
                 if let Some(s) = per_long.get_mut(idx).and_then(|v| v.as_mut()) {
-                    s.closes
-                        .retain(|o| o.order_type != OrderType::CloseAutoReduceWelLong);
+                    s.closes.retain(|o| {
+                        !matches!(
+                            o.order_type,
+                            OrderType::CloseAutoReduceWelLong | OrderType::CloseUnstuckLong
+                        )
+                    });
                     s.closes.push(IdealOrder {
                         symbol_idx: idx,
                         pside: PositionSide::Long,
@@ -3323,8 +3327,12 @@ mod core {
             );
             for (idx, order) in actions {
                 if let Some(s) = per_short.get_mut(idx).and_then(|v| v.as_mut()) {
-                    s.closes
-                        .retain(|o| o.order_type != OrderType::CloseAutoReduceWelShort);
+                    s.closes.retain(|o| {
+                        !matches!(
+                            o.order_type,
+                            OrderType::CloseAutoReduceWelShort | OrderType::CloseUnstuckShort
+                        )
+                    });
                     s.closes.push(IdealOrder {
                         symbol_idx: idx,
                         pside: PositionSide::Short,

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -2161,6 +2161,74 @@ def test_twel_auto_reduce_takes_priority_over_wel_for_same_position():
     assert "close_auto_reduce_wel_long" not in order_types
 
 
+def test_twel_auto_reduce_takes_priority_over_unstuck_for_same_position():
+    import passivbot_rust as pbr
+
+    long_bp = {
+        "wallet_exposure_limit": 0.4,
+        "risk_wel_enforcer_enabled": False,
+        "total_wallet_exposure_limit": 0.5,
+        "risk_twel_enforcer_policy": "reduce_portfolio",
+        "risk_twel_enforcer_threshold": 1.0,
+        "n_positions": 1,
+        "unstuck_close_pct": 0.5,
+        "unstuck_threshold": 0.001,
+        "unstuck_ema_dist": 0.0,
+        "unstuck_loss_allowance_pct": 0.01,
+    }
+    global_bp = bot_params_pair(long_overrides=long_bp)
+    sym = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        long_pos_size=6.0,
+        long_pos_price=100.0,
+        long_bp=long_bp,
+    )
+    inp = make_input(balance=1_000.0, global_bp=global_bp, symbols=[sym])
+    inp["global"]["unstuck_allowance_long"] = 1e9
+
+    out = compute(pbr, inp)
+    order_types = [o["order_type"] for o in out["orders"]]
+
+    assert "close_auto_reduce_twel_long" in order_types
+    assert "close_unstuck_long" not in order_types
+
+
+def test_twel_auto_reduce_takes_priority_over_short_unstuck_for_same_position():
+    import passivbot_rust as pbr
+
+    short_bp = {
+        "wallet_exposure_limit": 0.4,
+        "risk_wel_enforcer_enabled": False,
+        "total_wallet_exposure_limit": 0.5,
+        "risk_twel_enforcer_policy": "reduce_portfolio",
+        "risk_twel_enforcer_threshold": 1.0,
+        "n_positions": 1,
+        "unstuck_close_pct": 0.5,
+        "unstuck_threshold": 0.001,
+        "unstuck_ema_dist": 0.0,
+        "unstuck_loss_allowance_pct": 0.01,
+    }
+    global_bp = bot_params_pair(short_overrides=short_bp)
+    sym = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        short_pos_size=-6.0,
+        short_pos_price=100.0,
+        short_bp=short_bp,
+    )
+    inp = make_input(balance=1_000.0, global_bp=global_bp, symbols=[sym])
+    inp["global"]["unstuck_allowance_short"] = 1e9
+
+    out = compute(pbr, inp)
+    order_types = [o["order_type"] for o in out["orders"]]
+
+    assert "close_auto_reduce_twel_short" in order_types
+    assert "close_unstuck_short" not in order_types
+
+
 def test_twel_auto_reduce_includes_managed_modes_and_excludes_manual_panic():
     import passivbot_rust as pbr
 


### PR DESCRIPTION
## Summary
- make Rust TWEL auto-reduce remove same-position WEL and auto-unstuck reducers before insertion
- add long and short JSON API regressions proving TWEL does not stack with auto-unstuck on the same coin+pside
- record the partial reducer-priority progress and changelog entry

## Validation
- maturin develop --release --manifest-path passivbot-rust/Cargo.toml
- cargo check --manifest-path passivbot-rust/Cargo.toml
- python -m pytest tests/test_orchestrator_json_api.py::test_twel_auto_reduce_takes_priority_over_wel_for_same_position tests/test_orchestrator_json_api.py::test_twel_auto_reduce_takes_priority_over_unstuck_for_same_position tests/test_orchestrator_json_api.py::test_twel_auto_reduce_takes_priority_over_short_unstuck_for_same_position tests/test_orchestrator_json_api.py::test_unstuck_is_added_in_addition_to_close_grid_and_capped tests/test_orchestrator_json_api.py::test_twel_enforcer_emits_auto_reduce -q
- git diff --check