### PR TITLE
Skip auto-unstuck when WEL reducer is queued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Rust WEL auto-reduce now takes priority over same-position auto-unstuck
+  reducers in the same ideal-order batch, matching the documented reducer
+  priority before auto-unstuck is admitted.
 - Rust TWEL auto-reduce now takes priority over same-position auto-unstuck
   reducers in the same ideal-order batch, preventing two reducer closes from
   stacking on one coin+pside when portfolio exposure enforcement is active.

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -754,6 +754,8 @@ Remaining implementation details:
       passive closes.
       Partial: TWEL auto-reduce now removes same-position WEL and auto-unstuck
       reducers before insertion, with long/short JSON API regression coverage.
+      Partial: auto-unstuck admission now skips same-position panic, TWEL, or
+      WEL reducers already queued, with long/short WEL regression coverage.
 - [ ] Contract docs batch: unstuck min-qty overshoot, inherited lookbacks,
       HSL/config-change risks, statelessness, `pnls_max_lookback_days`, and
       HSL-enabled startup warning.

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -514,6 +514,18 @@ mod core {
         )
     }
 
+    fn is_higher_priority_reducer_than_unstuck(order_type: OrderType, pside: PositionSide) -> bool {
+        matches!(
+            (pside, order_type),
+            (PositionSide::Long, OrderType::ClosePanicLong)
+                | (PositionSide::Long, OrderType::CloseAutoReduceTwelLong)
+                | (PositionSide::Long, OrderType::CloseAutoReduceWelLong)
+                | (PositionSide::Short, OrderType::ClosePanicShort)
+                | (PositionSide::Short, OrderType::CloseAutoReduceTwelShort)
+                | (PositionSide::Short, OrderType::CloseAutoReduceWelShort)
+        )
+    }
+
     fn is_twel_close_order_type(order_type: OrderType, pside: PositionSide) -> bool {
         matches!(
             (pside, order_type),
@@ -3189,12 +3201,26 @@ mod core {
                 match ideal.pside {
                     PositionSide::Long => {
                         if let Some(s) = per_long.get_mut(idx).and_then(|v| v.as_mut()) {
-                            s.closes.push(ideal);
+                            if !s.closes.iter().any(|o| {
+                                is_higher_priority_reducer_than_unstuck(
+                                    o.order_type,
+                                    PositionSide::Long,
+                                )
+                            }) {
+                                s.closes.push(ideal);
+                            }
                         }
                     }
                     PositionSide::Short => {
                         if let Some(s) = per_short.get_mut(idx).and_then(|v| v.as_mut()) {
-                            s.closes.push(ideal);
+                            if !s.closes.iter().any(|o| {
+                                is_higher_priority_reducer_than_unstuck(
+                                    o.order_type,
+                                    PositionSide::Short,
+                                )
+                            }) {
+                                s.closes.push(ideal);
+                            }
                         }
                     }
                 }

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -2161,6 +2161,72 @@ def test_twel_auto_reduce_takes_priority_over_wel_for_same_position():
     assert "close_auto_reduce_wel_long" not in order_types
 
 
+def test_wel_auto_reduce_takes_priority_over_unstuck_for_same_position():
+    import passivbot_rust as pbr
+
+    long_bp = {
+        "wallet_exposure_limit": 0.4,
+        "risk_wel_enforcer_threshold": 1.0,
+        "risk_twel_enforcer_enabled": False,
+        "total_wallet_exposure_limit": 1.0,
+        "n_positions": 1,
+        "unstuck_close_pct": 0.5,
+        "unstuck_threshold": 0.001,
+        "unstuck_ema_dist": 0.0,
+        "unstuck_loss_allowance_pct": 0.01,
+    }
+    global_bp = bot_params_pair(long_overrides=long_bp)
+    sym = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        long_pos_size=6.0,
+        long_pos_price=100.0,
+        long_bp=long_bp,
+    )
+    inp = make_input(balance=1_000.0, global_bp=global_bp, symbols=[sym])
+    inp["global"]["unstuck_allowance_long"] = 1e9
+
+    out = compute(pbr, inp)
+    order_types = [o["order_type"] for o in out["orders"]]
+
+    assert "close_auto_reduce_wel_long" in order_types
+    assert "close_unstuck_long" not in order_types
+
+
+def test_wel_auto_reduce_takes_priority_over_short_unstuck_for_same_position():
+    import passivbot_rust as pbr
+
+    short_bp = {
+        "wallet_exposure_limit": 0.4,
+        "risk_wel_enforcer_threshold": 1.0,
+        "risk_twel_enforcer_enabled": False,
+        "total_wallet_exposure_limit": 1.0,
+        "n_positions": 1,
+        "unstuck_close_pct": 0.5,
+        "unstuck_threshold": 0.001,
+        "unstuck_ema_dist": 0.0,
+        "unstuck_loss_allowance_pct": 0.01,
+    }
+    global_bp = bot_params_pair(short_overrides=short_bp)
+    sym = make_symbol(
+        0,
+        bid=100.0,
+        ask=100.0,
+        short_pos_size=-6.0,
+        short_pos_price=100.0,
+        short_bp=short_bp,
+    )
+    inp = make_input(balance=1_000.0, global_bp=global_bp, symbols=[sym])
+    inp["global"]["unstuck_allowance_short"] = 1e9
+
+    out = compute(pbr, inp)
+    order_types = [o["order_type"] for o in out["orders"]]
+
+    assert "close_auto_reduce_wel_short" in order_types
+    assert "close_unstuck_short" not in order_types
+
+
 def test_twel_auto_reduce_takes_priority_over_unstuck_for_same_position():
     import passivbot_rust as pbr
 


### PR DESCRIPTION
## Summary
- skip auto-unstuck admission for a coin+pside when a higher-priority panic, TWEL, or WEL reducer is already queued
- add long and short JSON API regressions proving WEL does not stack with auto-unstuck on the same position
- record partial reducer-priority progress and changelog entry

## Validation
- maturin develop --release --manifest-path passivbot-rust/Cargo.toml
- cargo check --manifest-path passivbot-rust/Cargo.toml
- python -m pytest tests/test_orchestrator_json_api.py::test_wel_auto_reduce_takes_priority_over_unstuck_for_same_position tests/test_orchestrator_json_api.py::test_wel_auto_reduce_takes_priority_over_short_unstuck_for_same_position tests/test_orchestrator_json_api.py::test_twel_auto_reduce_takes_priority_over_unstuck_for_same_position tests/test_orchestrator_json_api.py::test_twel_auto_reduce_takes_priority_over_short_unstuck_for_same_position tests/test_orchestrator_json_api.py::test_unstuck_is_added_in_addition_to_close_grid_and_capped tests/test_orchestrator_json_api.py::test_twel_auto_reduce_takes_priority_over_wel_for_same_position -q
- cargo check --manifest-path passivbot-rust/Cargo.toml
- git diff --check