### PR TITLE
Prune lower-priority closes when reducers exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Rust protective reducers now suppress lower-priority same-position ordinary
+  close orders in the same ideal-order batch, so panic, TWEL/WEL auto-reduce,
+  and auto-unstuck no longer stack with grid/trailing closes for one coin+pside.
 - Rust WEL auto-reduce now takes priority over same-position auto-unstuck
   reducers in the same ideal-order batch, matching the documented reducer
   priority before auto-unstuck is admitted.

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -756,6 +756,9 @@ Remaining implementation details:
       reducers before insertion, with long/short JSON API regression coverage.
       Partial: auto-unstuck admission now skips same-position panic, TWEL, or
       WEL reducers already queued, with long/short WEL regression coverage.
+      Partial: protective reducers now prune lower-priority same-position
+      ordinary closes before size trimming; ordinary strategy-only close
+      multiplicity is intentionally unchanged.
 - [ ] Contract docs batch: unstuck min-qty overshoot, inherited lookbacks,
       HSL/config-change risks, statelessness, `pnls_max_lookback_days`, and
       HSL-enabled startup warning.

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -534,6 +534,35 @@ mod core {
         )
     }
 
+    fn close_reducer_priority(order_type: OrderType, pside: PositionSide) -> Option<u8> {
+        match (pside, order_type) {
+            (PositionSide::Long, OrderType::ClosePanicLong)
+            | (PositionSide::Short, OrderType::ClosePanicShort) => Some(0),
+            (PositionSide::Long, OrderType::CloseAutoReduceTwelLong)
+            | (PositionSide::Long, OrderType::CloseAutoReduceWelLong)
+            | (PositionSide::Short, OrderType::CloseAutoReduceTwelShort)
+            | (PositionSide::Short, OrderType::CloseAutoReduceWelShort) => Some(1),
+            (PositionSide::Long, OrderType::CloseUnstuckLong)
+            | (PositionSide::Short, OrderType::CloseUnstuckShort) => Some(2),
+            _ if is_close_order_type(order_type) => Some(3),
+            _ => None,
+        }
+    }
+
+    fn prune_lower_priority_closes(orders: &mut Vec<IdealOrder>, pside: PositionSide) {
+        let highest = orders
+            .iter()
+            .filter_map(|order| close_reducer_priority(order.order_type, pside))
+            .min();
+        if let Some(priority) = highest {
+            if priority < 3 {
+                orders.retain(|order| {
+                    close_reducer_priority(order.order_type, pside).unwrap_or(3) == priority
+                });
+            }
+        }
+    }
+
     fn current_market_price(order_book: &OrderBook) -> f64 {
         if order_book.bid.is_finite()
             && order_book.ask.is_finite()
@@ -3377,6 +3406,7 @@ mod core {
         // Trim closes per symbol to position size (furthest-first).
         for s in per_long.iter_mut().filter_map(|v| v.as_mut()) {
             let sym = &input.symbols[s.symbol_idx];
+            prune_lower_priority_closes(&mut s.closes, PositionSide::Long);
             trim_closes_to_position(
                 PositionSide::Long,
                 &mut s.closes,
@@ -3387,6 +3417,7 @@ mod core {
         }
         for s in per_short.iter_mut().filter_map(|v| v.as_mut()) {
             let sym = &input.symbols[s.symbol_idx];
+            prune_lower_priority_closes(&mut s.closes, PositionSide::Short);
             trim_closes_to_position(
                 PositionSide::Short,
                 &mut s.closes,

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -1579,7 +1579,7 @@ def test_json_output_is_deterministic():
     assert out1 == out2
 
 
-def test_unstuck_is_added_in_addition_to_close_grid_and_capped():
+def test_unstuck_takes_priority_over_close_grid_and_is_capped():
     import passivbot_rust as pbr
 
     balance = 1_000.0
@@ -1615,7 +1615,7 @@ def test_unstuck_is_added_in_addition_to_close_grid_and_capped():
     out = compute(pbr, inp)
     order_types = [o["order_type"] for o in out["orders"]]
     assert "close_unstuck_long" in order_types
-    assert "close_grid_long" in order_types
+    assert "close_grid_long" not in order_types
 
     closes = [
         o
@@ -2192,6 +2192,7 @@ def test_wel_auto_reduce_takes_priority_over_unstuck_for_same_position():
 
     assert "close_auto_reduce_wel_long" in order_types
     assert "close_unstuck_long" not in order_types
+    assert "close_grid_long" not in order_types
 
 
 def test_wel_auto_reduce_takes_priority_over_short_unstuck_for_same_position():
@@ -2225,6 +2226,7 @@ def test_wel_auto_reduce_takes_priority_over_short_unstuck_for_same_position():
 
     assert "close_auto_reduce_wel_short" in order_types
     assert "close_unstuck_short" not in order_types
+    assert "close_grid_short" not in order_types
 
 
 def test_twel_auto_reduce_takes_priority_over_unstuck_for_same_position():
@@ -2259,6 +2261,7 @@ def test_twel_auto_reduce_takes_priority_over_unstuck_for_same_position():
 
     assert "close_auto_reduce_twel_long" in order_types
     assert "close_unstuck_long" not in order_types
+    assert "close_grid_long" not in order_types
 
 
 def test_twel_auto_reduce_takes_priority_over_short_unstuck_for_same_position():
@@ -2293,6 +2296,7 @@ def test_twel_auto_reduce_takes_priority_over_short_unstuck_for_same_position():
 
     assert "close_auto_reduce_twel_short" in order_types
     assert "close_unstuck_short" not in order_types
+    assert "close_grid_short" not in order_types
 
 
 def test_twel_auto_reduce_includes_managed_modes_and_excludes_manual_panic():


### PR DESCRIPTION
## Summary
- add Rust close-priority pruning before size trimming so panic, TWEL/WEL auto-reduce, and auto-unstuck suppress lower-priority same-position ordinary closes
- update JSON API regressions to prove unstuck/WEL/TWEL reducers do not stack with grid closes on the same coin+pside
- record the reducer-priority progress and changelog entry

## Validation
- maturin develop --release --manifest-path passivbot-rust/Cargo.toml
- python -m pytest tests/test_orchestrator_json_api.py::test_unstuck_takes_priority_over_close_grid_and_is_capped tests/test_orchestrator_json_api.py::test_wel_auto_reduce_takes_priority_over_unstuck_for_same_position tests/test_orchestrator_json_api.py::test_wel_auto_reduce_takes_priority_over_short_unstuck_for_same_position tests/test_orchestrator_json_api.py::test_twel_auto_reduce_takes_priority_over_unstuck_for_same_position tests/test_orchestrator_json_api.py::test_twel_auto_reduce_takes_priority_over_short_unstuck_for_same_position tests/test_orchestrator_json_api.py::test_twel_auto_reduce_takes_priority_over_wel_for_same_position tests/test_orchestrator_json_api.py::test_long_grid_close_uses_position_price_anchor tests/test_orchestrator_json_api.py::test_short_grid_close_uses_position_price_anchor -q
- cargo check --manifest-path passivbot-rust/Cargo.toml
- python -m py_compile tests/test_orchestrator_json_api.py
- git diff --check