### PR TITLE
Add explicit HSL restart policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ All notable user-facing changes will be documented in this file.
   `bot.long/short.hsl.panic_close_order_type` in live and backtests; configuring
   one side as `market` no longer market-promotes panic closes for the other side
   when that side is configured as `limit`.
+- HSL restart behavior after RED is now controlled by explicit
+  `bot.long/short.hsl.restart_after_red_policy` values: `threshold` preserves
+  the previous no-restart-threshold behavior, `never` makes any RED terminal,
+  and `always` restarts after cooldown while disabling the no-restart safety
+  latch for that HSL scope.
 - Live TWEL auto-reduce now honors configured
   `risk_twel_enforcer_policy` when building Rust orchestrator payloads instead
   of always falling back to `reduce_overweight`, aligning live behavior with

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -765,10 +765,14 @@ Remaining implementation details:
 - [x] Contract docs batch: unstuck min-qty overshoot, inherited lookbacks,
       HSL/config-change risks, statelessness, `pnls_max_lookback_days`, and
       HSL-enabled startup warning.
-- [ ] HSL restart policy enum.
+- [x] HSL restart policy enum.
       Add `restart_after_red_policy = always | threshold | never`, scoped by
       HSL signal mode, and migrate no-restart semantics onto that explicit
       surface.
+      Implemented: Python live HSL replay/finalization and Rust backtest HSL
+      finalization now use the explicit policy, with `threshold` as the
+      behavior-preserving default and config/JSON validation for invalid
+      values.
 - [ ] Dynamic WEL and snapped/raw balance docs/tests.
       Make `reduce_overweight` use dynamic currently-tradable slot count, keep
       snapped/raw balance separation, and add high-hysteresis warning/preflight

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -440,6 +440,22 @@ struct HardStopStopSnapshot {
     drawdown_raw: f64,
 }
 
+fn hsl_no_restart_latched(
+    restart_after_red_policy: &str,
+    persistent_drawdown_raw: f64,
+    no_restart_drawdown_threshold: f64,
+) -> Result<bool, String> {
+    match restart_after_red_policy {
+        "always" => Ok(false),
+        "threshold" => Ok(persistent_drawdown_raw >= no_restart_drawdown_threshold),
+        "never" => Ok(true),
+        raw => Err(format!(
+            "hsl_restart_after_red_policy must be one of always, threshold, never; got {:?}",
+            raw
+        )),
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 struct HardStopPsideRuntime {
     state: Option<ehsl::HardStopState>,
@@ -1011,6 +1027,7 @@ impl<'a> Backtest<'a> {
             bp.hsl_ema_span_minutes = common_hsl.ema_span_minutes;
             bp.hsl_cooldown_minutes_after_red = common_hsl.cooldown_minutes_after_red;
             bp.hsl_no_restart_drawdown_threshold = common_hsl.no_restart_drawdown_threshold;
+            bp.hsl_restart_after_red_policy = common_hsl.restart_after_red_policy.clone();
             bp.hsl_tier_ratio_yellow = common_hsl.tier_ratios.yellow;
             bp.hsl_tier_ratio_orange = common_hsl.tier_ratios.orange;
             bp.hsl_orange_tier_mode = common_hsl.orange_tier_mode.clone();
@@ -3497,6 +3514,7 @@ impl<'a> Backtest<'a> {
         let hsl_tier_ratio_orange = cfg.hsl_tier_ratio_orange;
         let hsl_no_restart_drawdown_threshold =
             cfg.hsl_no_restart_drawdown_threshold.max(hsl_red_threshold);
+        let hsl_restart_after_red_policy = cfg.hsl_restart_after_red_policy.clone();
         let hsl_cooldown_minutes_after_red = cfg.hsl_cooldown_minutes_after_red;
         if !(hsl_no_restart_drawdown_threshold.is_finite()
             && hsl_red_threshold.is_finite()
@@ -3630,7 +3648,11 @@ impl<'a> Backtest<'a> {
                         - stop_snapshot.equity
                             / runtime.no_restart_peak_strategy_equity.max(f64::EPSILON))
                     .max(0.0);
-                    if persistent_drawdown_raw >= hsl_no_restart_drawdown_threshold {
+                    if hsl_no_restart_latched(
+                        hsl_restart_after_red_policy.as_str(),
+                        persistent_drawdown_raw,
+                        hsl_no_restart_drawdown_threshold,
+                    )? {
                         runtime.no_restart_latched = true;
                         runtime.cooldown_until_ms = None;
                     } else {
@@ -3695,6 +3717,7 @@ impl<'a> Backtest<'a> {
         let hsl_tier_ratio_orange = cfg.hsl_tier_ratio_orange;
         let hsl_no_restart_drawdown_threshold =
             cfg.hsl_no_restart_drawdown_threshold.max(hsl_red_threshold);
+        let hsl_restart_after_red_policy = cfg.hsl_restart_after_red_policy.clone();
         let hsl_cooldown_minutes_after_red = cfg.hsl_cooldown_minutes_after_red;
         if !(hsl_no_restart_drawdown_threshold.is_finite()
             && hsl_red_threshold.is_finite()
@@ -3815,7 +3838,11 @@ impl<'a> Backtest<'a> {
                         - stop_snapshot.equity
                             / runtime.no_restart_peak_strategy_equity.max(f64::EPSILON))
                     .max(0.0);
-                    if persistent_drawdown_raw >= hsl_no_restart_drawdown_threshold {
+                    if hsl_no_restart_latched(
+                        hsl_restart_after_red_policy.as_str(),
+                        persistent_drawdown_raw,
+                        hsl_no_restart_drawdown_threshold,
+                    )? {
                         runtime.no_restart_latched = true;
                         runtime.cooldown_until_ms = None;
                     } else {
@@ -8089,6 +8116,15 @@ mod tests {
         assert!(bt.hard_stop_no_restart_latched);
         assert_eq!(bt.hard_stop_cooldown_until_ms, None);
         assert!(!bt.try_restart_after_hard_stop(10_000_000));
+    }
+
+    #[test]
+    fn hard_stop_restart_after_red_policy_controls_terminal_latch() {
+        assert!(!hsl_no_restart_latched("always", 1.0, 0.10).unwrap());
+        assert!(!hsl_no_restart_latched("threshold", 0.09, 0.10).unwrap());
+        assert!(hsl_no_restart_latched("threshold", 0.10, 0.10).unwrap());
+        assert!(hsl_no_restart_latched("never", 0.0, 0.10).unwrap());
+        assert!(hsl_no_restart_latched("sometimes", 1.0, 0.10).is_err());
     }
 
     #[test]

--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -1931,6 +1931,17 @@ fn backtest_params_from_dict(dict: &PyDict) -> PyResult<BacktestParams> {
                 signal_mode
             )));
         }
+        let restart_after_red_policy =
+            extract_optional_string(cfg, "restart_after_red_policy", "threshold")?;
+        match restart_after_red_policy.as_str() {
+            "always" | "threshold" | "never" => {}
+            raw => {
+                return Err(PyValueError::new_err(format!(
+                    "{key}.restart_after_red_policy must be one of {{always, threshold, never}}, got {:?}",
+                    raw
+                )));
+            }
+        }
         Ok(EquityHardStopLossConfig {
             enabled: extract_value(cfg, "enabled")?,
             signal_mode,
@@ -1938,6 +1949,7 @@ fn backtest_params_from_dict(dict: &PyDict) -> PyResult<BacktestParams> {
             ema_span_minutes: extract_value(cfg, "ema_span_minutes")?,
             cooldown_minutes_after_red: extract_value(cfg, "cooldown_minutes_after_red")?,
             no_restart_drawdown_threshold: extract_value(cfg, "no_restart_drawdown_threshold")?,
+            restart_after_red_policy,
             tier_ratios: EquityHardStopLossTierRatios {
                 yellow: extract_value(ratios, "yellow")?,
                 orange: extract_value(ratios, "orange")?,
@@ -2301,6 +2313,8 @@ fn bot_params_from_dict(dict: &PyDict) -> PyResult<BotParams> {
         extract_value(dict, "hsl_cooldown_minutes_after_red")?;
     let hsl_no_restart_drawdown_threshold: f64 =
         extract_value(dict, "hsl_no_restart_drawdown_threshold")?;
+    let hsl_restart_after_red_policy: String =
+        extract_optional_string(dict, "hsl_restart_after_red_policy", "threshold")?;
     let hsl_tier_ratios = dict
         .get_item("hsl_tier_ratios")?
         .ok_or_else(|| PyValueError::new_err("position missing 'hsl_tier_ratios'"))?
@@ -2386,6 +2400,7 @@ fn bot_params_from_dict(dict: &PyDict) -> PyResult<BotParams> {
         hsl_ema_span_minutes,
         hsl_cooldown_minutes_after_red,
         hsl_no_restart_drawdown_threshold,
+        hsl_restart_after_red_policy,
         hsl_tier_ratio_yellow,
         hsl_tier_ratio_orange,
         hsl_orange_tier_mode,
@@ -2467,6 +2482,21 @@ fn validate_hsl_panic_close_order_type_pair(bot_params: &BotParamsPair) -> PyRes
     Ok(())
 }
 
+fn validate_hsl_restart_after_red_policy_pair(bot_params: &BotParamsPair) -> PyResult<()> {
+    for (pside, params) in [("long", &bot_params.long), ("short", &bot_params.short)] {
+        match params.hsl_restart_after_red_policy.as_str() {
+            "always" | "threshold" | "never" => {}
+            raw => {
+                return Err(PyValueError::new_err(format!(
+                    "bot.{pside}.hsl_restart_after_red_policy must be one of: always, threshold, never; got {:?}",
+                    raw
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 fn validate_finite_range(
     path: &str,
     value: f64,
@@ -2528,6 +2558,15 @@ fn validate_hsl_risk_unstuck_bot_params(
         return Err(PyValueError::new_err(format!(
             "{path_prefix}.hsl_no_restart_drawdown_threshold must be >= {path_prefix}.hsl_red_threshold"
         )));
+    }
+    match params.hsl_restart_after_red_policy.as_str() {
+        "always" | "threshold" | "never" => {}
+        raw => {
+            return Err(PyValueError::new_err(format!(
+                "{path_prefix}.hsl_restart_after_red_policy must be one of: always, threshold, never; got {:?}",
+                raw
+            )));
+        }
     }
     validate_finite_range(
         &format!("{path_prefix}.hsl_cooldown_minutes_after_red"),
@@ -4008,6 +4047,7 @@ pub fn compute_ideal_orders_json(input_json: &str) -> PyResult<String> {
     validate_orchestrator_account_risk_inputs(&input)?;
     validate_forager_score_weights_pair(&input.global.global_bot_params)?;
     validate_hsl_panic_close_order_type_pair(&input.global.global_bot_params)?;
+    validate_hsl_restart_after_red_policy_pair(&input.global.global_bot_params)?;
     validate_hsl_risk_unstuck_orchestrator_input(&input)?;
 
     let out = crate::orchestrator::compute_ideal_orders(&input).map_err(|e| {

--- a/passivbot-rust/src/types.rs
+++ b/passivbot-rust/src/types.rs
@@ -276,6 +276,7 @@ pub struct EquityHardStopLossConfig {
     pub ema_span_minutes: f64,
     pub cooldown_minutes_after_red: f64,
     pub no_restart_drawdown_threshold: f64,
+    pub restart_after_red_policy: String,
     pub tier_ratios: EquityHardStopLossTierRatios,
     pub orange_tier_mode: String,
     #[allow(dead_code)]
@@ -292,6 +293,7 @@ impl Default for EquityHardStopLossConfig {
             ema_span_minutes: 60.0,
             cooldown_minutes_after_red: 0.0,
             no_restart_drawdown_threshold: 1.0,
+            restart_after_red_policy: "threshold".to_string(),
             tier_ratios: EquityHardStopLossTierRatios::default(),
             orange_tier_mode: "tp_only_with_active_entry_cancellation".to_string(),
             panic_close_order_type: "market".to_string(),
@@ -428,6 +430,10 @@ fn default_hsl_cooldown_minutes_after_red() -> f64 {
 
 fn default_hsl_no_restart_drawdown_threshold() -> f64 {
     1.0
+}
+
+fn default_hsl_restart_after_red_policy() -> String {
+    "threshold".to_string()
 }
 
 fn default_hsl_tier_ratio_yellow() -> f64 {
@@ -578,6 +584,8 @@ pub struct BotParams {
     pub hsl_cooldown_minutes_after_red: f64,
     #[serde(default = "default_hsl_no_restart_drawdown_threshold")]
     pub hsl_no_restart_drawdown_threshold: f64,
+    #[serde(default = "default_hsl_restart_after_red_policy")]
+    pub hsl_restart_after_red_policy: String,
     #[serde(default = "default_hsl_tier_ratio_yellow")]
     pub hsl_tier_ratio_yellow: f64,
     #[serde(default = "default_hsl_tier_ratio_orange")]
@@ -648,6 +656,7 @@ impl Default for BotParams {
             hsl_ema_span_minutes: default_hsl_ema_span_minutes(),
             hsl_cooldown_minutes_after_red: default_hsl_cooldown_minutes_after_red(),
             hsl_no_restart_drawdown_threshold: default_hsl_no_restart_drawdown_threshold(),
+            hsl_restart_after_red_policy: default_hsl_restart_after_red_policy(),
             hsl_tier_ratio_yellow: default_hsl_tier_ratio_yellow(),
             hsl_tier_ratio_orange: default_hsl_tier_ratio_orange(),
             hsl_orange_tier_mode: default_hsl_orange_tier_mode(),

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -63,7 +63,7 @@ from config.access import (
 )
 from config.pnl_lookback import parse_pnls_max_lookback_days
 from config.metrics import ANALYSIS_SHARED_KEYS
-from config.coerce import normalize_hsl_signal_mode
+from config.coerce import normalize_hsl_restart_after_red_policy, normalize_hsl_signal_mode
 from config.overrides import parse_overrides
 from config.shared_bot import flatten_shared_bot_side
 from config.strategy import (
@@ -259,6 +259,10 @@ def _resolve_backtest_hsl_configs(config: dict) -> tuple[dict, dict]:
             ),
             "no_restart_drawdown_threshold": float(
                 pside_cfg["hsl_no_restart_drawdown_threshold"]
+            ),
+            "restart_after_red_policy": normalize_hsl_restart_after_red_policy(
+                pside_cfg["hsl_restart_after_red_policy"],
+                path="bot.<pside>.hsl.restart_after_red_policy",
             ),
             "tier_ratios": {
                 "yellow": float(pside_cfg["hsl_tier_ratios"]["yellow"]),
@@ -2259,6 +2263,10 @@ def prep_backtest_args(
             tier_ratio_orange = float(tier_ratios["orange"])
             orange_tier_mode = str(cfg["orange_tier_mode"])
             panic_close_order_type = str(cfg["panic_close_order_type"])
+            restart_after_red_policy = normalize_hsl_restart_after_red_policy(
+                cfg.get("restart_after_red_policy", "threshold"),
+                path=f"{path_prefix}.restart_after_red_policy",
+            )
             if enabled and red_threshold <= 0.0:
                 raise ValueError(
                     f"{path_prefix}.red_threshold must be > 0.0 when enabled"
@@ -2305,6 +2313,7 @@ def prep_backtest_args(
                 "ema_span_minutes": ema_span_minutes,
                 "cooldown_minutes_after_red": cooldown_minutes_after_red,
                 "no_restart_drawdown_threshold": no_restart_drawdown_threshold,
+                "restart_after_red_policy": restart_after_red_policy,
                 "tier_ratios": {
                     "yellow": tier_ratio_yellow,
                     "orange": tier_ratio_orange,

--- a/src/config/bot.py
+++ b/src/config/bot.py
@@ -19,6 +19,7 @@ from .shared_bot import (
 )
 from .schema import get_template_config
 from .access import require_config_dict
+from .coerce import normalize_hsl_restart_after_red_policy
 from .tree_ops import add_missing_keys_recursively
 from risk_limits import normalize_we_excess_allowance_mode
 
@@ -527,6 +528,27 @@ def normalize_hsl_risk_unstuck_numerics(
             raise ValueError(
                 f"{hsl_path}.tier_ratios.yellow must be <= {hsl_path}.tier_ratios.orange"
             )
+        restart_after_red_policy = normalize_hsl_restart_after_red_policy(
+            get_grouped_bot_value(bot_side, "hsl_restart_after_red_policy"),
+            path=f"{hsl_path}.restart_after_red_policy",
+        )
+        if tracker is not None:
+            current_restart_policy = get_grouped_bot_value(
+                bot_side, "hsl_restart_after_red_policy"
+            )
+            if current_restart_policy != restart_after_red_policy:
+                tracker.update(
+                    ["bot", pside, "hsl", "restart_after_red_policy"],
+                    current_restart_policy,
+                    restart_after_red_policy,
+                )
+        _set_grouped_bot_value(
+            result,
+            pside=pside,
+            flat_key="hsl_restart_after_red_policy",
+            value=restart_after_red_policy,
+            tracker=None,
+        )
 
         _validate_ratio(
             get_grouped_bot_value(bot_side, "risk_we_excess_allowance_pct"),

--- a/src/config/coerce.py
+++ b/src/config/coerce.py
@@ -13,6 +13,7 @@ HSL_COOLDOWN_POSITION_POLICIES = (
     "graceful_stop",
     "manual",
 )
+HSL_RESTART_AFTER_RED_POLICIES = ("always", "threshold", "never")
 HSL_SIGNAL_MODES = ("coin", "pside", "unified")
 MONITOR_BOOL_KEYS = (
     "enabled",
@@ -47,6 +48,16 @@ def normalize_hsl_signal_mode(value, path: str = "live.hsl_signal_mode") -> str:
         allowed = ", ".join(HSL_SIGNAL_MODES)
         raise ValueError(f"{path} must be one of {{{allowed}}}, got {mode!r}")
     return mode
+
+
+def normalize_hsl_restart_after_red_policy(
+    value, path: str = "bot.<pside>.hsl.restart_after_red_policy"
+) -> str:
+    policy = "threshold" if value is None else str(value)
+    if policy not in HSL_RESTART_AFTER_RED_POLICIES:
+        allowed = ", ".join(HSL_RESTART_AFTER_RED_POLICIES)
+        raise ValueError(f"{path} must be one of {{{allowed}}}, got {policy!r}")
+    return policy
 
 
 def normalize_monitor_config(config: dict) -> None:

--- a/src/config/migrations/trailing_grid_v7.py
+++ b/src/config/migrations/trailing_grid_v7.py
@@ -147,6 +147,7 @@ V7_INSERTED_DEFAULT_SHARED_FLAT_KEYS = (
     "hsl_orange_tier_mode",
     "hsl_panic_close_order_type",
     "hsl_red_threshold",
+    "hsl_restart_after_red_policy",
     "hsl_tier_ratios",
     "unstuck_close_pct",
     "unstuck_ema_dist",

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -29,6 +29,7 @@ def _get_shared_bot_defaults():
                 "orange_tier_mode": "tp_only_with_active_entry_cancellation",
                 "panic_close_order_type": "limit",
                 "red_threshold": 0.025,
+                "restart_after_red_policy": "threshold",
                 "tier_ratios": {
                     "orange": 0.75,
                     "yellow": 0.5
@@ -75,6 +76,7 @@ def _get_shared_bot_defaults():
                 "orange_tier_mode": "tp_only_with_active_entry_cancellation",
                 "panic_close_order_type": "limit",
                 "red_threshold": 0.01,
+                "restart_after_red_policy": "threshold",
                 "tier_ratios": {
                     "orange": 0.75,
                     "yellow": 0.5
@@ -473,7 +475,9 @@ def get_template_config():
                     "fixed_params": [],
                     "fixed_runtime_overrides": {
                         "bot.long.hsl.no_restart_drawdown_threshold": 1,
-                        "bot.short.hsl.no_restart_drawdown_threshold": 1
+                        "bot.long.hsl.restart_after_red_policy": "threshold",
+                        "bot.short.hsl.no_restart_drawdown_threshold": 1,
+                        "bot.short.hsl.restart_after_red_policy": "threshold"
                     },
                     "iters": 200000,
                     "mutation_eta": 20,

--- a/src/config/shared_bot.py
+++ b/src/config/shared_bot.py
@@ -33,6 +33,7 @@ BOT_GROUP_FIELD_MAP = {
         "orange_tier_mode": "hsl_orange_tier_mode",
         "panic_close_order_type": "hsl_panic_close_order_type",
         "red_threshold": "hsl_red_threshold",
+        "restart_after_red_policy": "hsl_restart_after_red_policy",
         "tier_ratios": "hsl_tier_ratios",
     },
     "unstuck": {

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -22,11 +22,13 @@ from config.bot import (
 from config.load import load_prepared_config as staged_load_prepared_config
 from config.coerce import (
     HSL_COOLDOWN_POSITION_POLICIES,
+    HSL_RESTART_AFTER_RED_POLICIES,
     HSL_SIGNAL_MODES,
     MONITOR_BOOL_KEYS,
     PYMOO_ALGORITHMS,
     PYMOO_REF_DIR_METHODS,
     normalize_hsl_cooldown_position_policy,
+    normalize_hsl_restart_after_red_policy,
     normalize_hsl_signal_mode,
 )
 from config.hydrate import (
@@ -144,6 +146,7 @@ HSL_PSIDE_KEYS = (
     "hsl_ema_span_minutes",
     "hsl_cooldown_minutes_after_red",
     "hsl_no_restart_drawdown_threshold",
+    "hsl_restart_after_red_policy",
     "hsl_orange_tier_mode",
     "hsl_panic_close_order_type",
     "hsl_tier_ratios",
@@ -353,6 +356,30 @@ OPTIMIZE_FIXED_BOT_RUNTIME_CLI_ARGS = {
         "commands": {"optimize"},
         "choices": ["limit", "market"],
         "help": "Override bot.short.hsl.panic_close_order_type for this optimize run.",
+    },
+    "bot.long.hsl.restart_after_red_policy": {
+        "visible": ["--bot.long.hsl.restart_after_red_policy"],
+        "hidden": [
+            "--bot.long.hsl_restart_after_red_policy",
+            "--bot_long_hsl_restart_after_red_policy",
+        ],
+        "type": normalize_hsl_restart_after_red_policy,
+        "metavar": "POLICY",
+        "commands": {"optimize"},
+        "choices": tuple(HSL_RESTART_AFTER_RED_POLICIES),
+        "help": "Override bot.long.hsl.restart_after_red_policy for this optimize run.",
+    },
+    "bot.short.hsl.restart_after_red_policy": {
+        "visible": ["--bot.short.hsl.restart_after_red_policy"],
+        "hidden": [
+            "--bot.short.hsl_restart_after_red_policy",
+            "--bot_short_hsl_restart_after_red_policy",
+        ],
+        "type": normalize_hsl_restart_after_red_policy,
+        "metavar": "POLICY",
+        "commands": {"optimize"},
+        "choices": tuple(HSL_RESTART_AFTER_RED_POLICIES),
+        "help": "Override bot.short.hsl.restart_after_red_policy for this optimize run.",
     },
 }
 
@@ -1457,6 +1484,10 @@ for _pside in ("long", "short"):
             f"bot.{_pside}.hsl.no_restart_drawdown_threshold": (
                 f"Terminal {_pside} HSL drawdown threshold. Values below "
                 "red_threshold are clamped up to red_threshold."
+            ),
+            f"bot.{_pside}.hsl.restart_after_red_policy": (
+                f"Restart policy after {_pside} HSL RED. Allowed values: "
+                "always, threshold, or never."
             ),
             f"bot.{_pside}.hsl.tier_ratios.yellow": (
                 f"Multiplier of red_threshold used for the {_pside} YELLOW HSL tier."

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -89,6 +89,7 @@ from config.access import (
 )
 from config.coerce import (
     normalize_hsl_cooldown_position_policy,
+    normalize_hsl_restart_after_red_policy,
     normalize_hsl_signal_mode,
 )
 from config.bot import normalize_twel_enforcer_policy
@@ -13906,6 +13907,10 @@ class Passivbot:
                 ),
                 "hsl_no_restart_drawdown_threshold": float(
                     self.bot_value(pside, "hsl_no_restart_drawdown_threshold")
+                ),
+                "hsl_restart_after_red_policy": normalize_hsl_restart_after_red_policy(
+                    self.bot_value(pside, "hsl_restart_after_red_policy"),
+                    path=f"bot.{pside}.hsl_restart_after_red_policy",
                 ),
                 "hsl_tier_ratio_yellow": float(
                     self.bot_value(pside, "hsl_tier_ratios.yellow")

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -18,6 +18,7 @@ from config.access import (
 )
 from config.coerce import (
     normalize_hsl_cooldown_position_policy,
+    normalize_hsl_restart_after_red_policy,
     normalize_hsl_signal_mode,
 )
 from config.pnl_lookback import parse_pnls_max_lookback_days
@@ -457,6 +458,10 @@ def _parse_hsl_config(self) -> dict[str, dict[str, Any]]:
         ratio_orange = float(self.bot_value(pside, "hsl_tier_ratios.orange"))
         orange_tier_mode = str(self.bot_value(pside, "hsl_orange_tier_mode"))
         panic_close_order_type = str(self.bot_value(pside, "hsl_panic_close_order_type"))
+        restart_after_red_policy = normalize_hsl_restart_after_red_policy(
+            self.bot_value(pside, "hsl_restart_after_red_policy"),
+            path=f"bot.{pside}.hsl_restart_after_red_policy",
+        )
 
         if enabled and red_threshold <= 0.0:
             raise ValueError(f"bot.{pside}.hsl_red_threshold must be > 0.0 when enabled")
@@ -498,6 +503,7 @@ def _parse_hsl_config(self) -> dict[str, dict[str, Any]]:
             "tier_ratios": {"yellow": ratio_yellow, "orange": ratio_orange},
             "orange_tier_mode": orange_tier_mode,
             "panic_close_order_type": panic_close_order_type,
+            "restart_after_red_policy": restart_after_red_policy,
         }
         if enabled:
             logging.info(
@@ -505,7 +511,7 @@ def _parse_hsl_config(self) -> dict[str, dict[str, Any]]:
                 "cooldown_minutes_after_red=%.3f "
                 "no_restart_drawdown_threshold=%.6f signal_mode=%s "
                 "yellow_ratio=%.3f orange_ratio=%.3f "
-                "orange_mode=%s panic_close=%s",
+                "orange_mode=%s panic_close=%s restart_after_red=%s",
                 pside,
                 red_threshold,
                 ema_span_minutes,
@@ -516,8 +522,21 @@ def _parse_hsl_config(self) -> dict[str, dict[str, Any]]:
                 ratio_orange,
                 orange_tier_mode,
                 panic_close_order_type,
+                restart_after_red_policy,
             )
     return out
+
+
+def _equity_hard_stop_no_restart_latched(cfg: dict[str, Any], drawdown_raw: float) -> bool:
+    policy = normalize_hsl_restart_after_red_policy(
+        cfg.get("restart_after_red_policy", "threshold"),
+        path="hsl.restart_after_red_policy",
+    )
+    if policy == "always":
+        return False
+    if policy == "never":
+        return True
+    return bool(float(drawdown_raw) >= float(cfg["no_restart_drawdown_threshold"]))
 
 
 def _equity_hard_stop_enabled(self, pside: Optional[str] = None) -> bool:
@@ -2312,7 +2331,6 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
             cfg = self.hsl[pside]
             contract = replay_contracts[pside]
             cooldown_minutes = float(cfg["cooldown_minutes_after_red"])
-            no_restart_drawdown_threshold = float(cfg["no_restart_drawdown_threshold"])
             cooldown_ms = int(round(cooldown_minutes * 60_000.0)) if cooldown_minutes > 0.0 else 0
             if contract["intervention_entry_ts"] is not None and contract["policy"] == "normal":
                 self._equity_hard_stop_reset_after_restart(pside)
@@ -2420,8 +2438,8 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                             "peak_strategy_equity": float(current_metrics["peak_strategy_equity"]),
                         },
                     )
-                    no_restart_latched = bool(
-                        no_restart_drawdown_raw >= no_restart_drawdown_threshold
+                    no_restart_latched = _equity_hard_stop_no_restart_latched(
+                        cfg, no_restart_drawdown_raw
                     )
                     cooldown_until_ms = None
                     if not no_restart_latched and cooldown_ms > 0:
@@ -2825,7 +2843,6 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             cfg = self.hsl[pside]
             cooldown_minutes = float(cfg["cooldown_minutes_after_red"])
             cooldown_ms = int(round(cooldown_minutes * 60_000.0)) if cooldown_minutes > 0.0 else 0
-            no_restart_drawdown_threshold = float(cfg["no_restart_drawdown_threshold"])
             for symbol in sorted(replay_symbols):
                 check_shutdown("hsl_coin_history_replay_pair")
                 pair_idx += 1
@@ -3014,7 +3031,9 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         )
                         continue
                     stop_drawdown_raw = float(metrics["drawdown_raw"])
-                    no_restart_latched = bool(stop_drawdown_raw >= no_restart_drawdown_threshold)
+                    no_restart_latched = _equity_hard_stop_no_restart_latched(
+                        cfg, stop_drawdown_raw
+                    )
                     cooldown_until_ms = None
                     if not no_restart_latched and cooldown_ms > 0:
                         cooldown_until_ms = stop_ts + cooldown_ms
@@ -3888,7 +3907,7 @@ async def _equity_hard_stop_finalize_red_stop(
         no_restart_peak_strategy_equity,
         no_restart_drawdown_raw,
     ) = self._equity_hard_stop_record_no_restart_stop(pside, stop_event)
-    no_restart_latched = bool(no_restart_drawdown_raw >= no_restart_drawdown_threshold)
+    no_restart_latched = _equity_hard_stop_no_restart_latched(cfg, no_restart_drawdown_raw)
     cooldown_ms = int(round(cooldown_minutes * 60_000.0)) if cooldown_minutes > 0.0 else 0
     cooldown_until_ms = None if no_restart_latched or cooldown_ms <= 0 else int(stop_ts_ms + cooldown_ms)
     payload = self._equity_hard_stop_build_latch_payload(
@@ -4029,8 +4048,7 @@ async def _equity_hard_stop_finalize_coin_red_stop(
     else:
         stop_ts_ms = int(stop_event["stop_event_timestamp_ms"])
     cooldown_minutes = float(cfg["cooldown_minutes_after_red"])
-    no_restart_drawdown_threshold = float(cfg["no_restart_drawdown_threshold"])
-    no_restart_latched = bool(stop_event["drawdown_raw"] >= no_restart_drawdown_threshold)
+    no_restart_latched = _equity_hard_stop_no_restart_latched(cfg, stop_event["drawdown_raw"])
     cooldown_ms = int(round(cooldown_minutes * 60_000.0)) if cooldown_minutes > 0.0 else 0
     cooldown_until_ms = None if no_restart_latched or cooldown_ms <= 0 else int(stop_ts_ms + cooldown_ms)
     payload = self._equity_hard_stop_build_latch_payload(

--- a/src/tools/hsl_startup_preview.py
+++ b/src/tools/hsl_startup_preview.py
@@ -112,6 +112,7 @@ def _hsl_side_config(config: dict[str, Any], pside: str) -> dict[str, Any]:
             ("red_threshold", "hsl_red_threshold"),
             ("cooldown_minutes_after_red", "hsl_cooldown_minutes_after_red"),
             ("no_restart_drawdown_threshold", "hsl_no_restart_drawdown_threshold"),
+            ("restart_after_red_policy", "hsl_restart_after_red_policy"),
             ("ema_span_minutes", "hsl_ema_span_minutes"),
             ("tier_ratios", "hsl_tier_ratios"),
             ("orange_tier_mode", "hsl_orange_tier_mode"),

--- a/src/tools/live_config_preflight.py
+++ b/src/tools/live_config_preflight.py
@@ -272,6 +272,7 @@ def _hsl_side_report(side_config: dict[str, Any]) -> dict[str, Any]:
             ("red_threshold", "hsl_red_threshold"),
             ("cooldown_minutes_after_red", "hsl_cooldown_minutes_after_red"),
             ("no_restart_drawdown_threshold", "hsl_no_restart_drawdown_threshold"),
+            ("restart_after_red_policy", "hsl_restart_after_red_policy"),
             ("ema_span_minutes", "hsl_ema_span_minutes"),
             ("tier_ratios", "hsl_tier_ratios"),
             ("orange_tier_mode", "hsl_orange_tier_mode"),

--- a/tests/test_config_utils_helpers.py
+++ b/tests/test_config_utils_helpers.py
@@ -10,7 +10,7 @@ import pytest
 
 from cli_utils import build_command_parser, expand_help_all_argv, help_all_requested
 from config import load_input_config, prepare_config
-from config.coerce import normalize_hsl_signal_mode
+from config.coerce import normalize_hsl_restart_after_red_policy, normalize_hsl_signal_mode
 from config.project import project_config
 from config.runtime_compile import compile_runtime_config
 from config.validate import validate_config
@@ -65,6 +65,13 @@ def test_load_input_config_without_path_uses_schema_defaults():
 
 def test_hsl_signal_mode_accepts_coin():
     assert normalize_hsl_signal_mode("coin") == "coin"
+
+
+def test_hsl_restart_after_red_policy_normalizes_default_and_rejects_invalid():
+    assert normalize_hsl_restart_after_red_policy(None) == "threshold"
+    assert normalize_hsl_restart_after_red_policy("always") == "always"
+    with pytest.raises(ValueError, match="restart_after_red_policy"):
+        normalize_hsl_restart_after_red_policy("sometimes")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -137,6 +137,7 @@ def make_coin_bot(policy="panic"):
             "ema_span_minutes": 1.0,
             "cooldown_minutes_after_red": 5.0,
             "no_restart_drawdown_threshold": 0.9,
+            "restart_after_red_policy": "threshold",
             "orange_tier_mode": "tp_only_with_active_entry_cancellation",
             "panic_close_order_type": "market",
         },
@@ -147,6 +148,7 @@ def make_coin_bot(policy="panic"):
             "ema_span_minutes": 1.0,
             "cooldown_minutes_after_red": 5.0,
             "no_restart_drawdown_threshold": 0.9,
+            "restart_after_red_policy": "threshold",
             "orange_tier_mode": "tp_only_with_active_entry_cancellation",
             "panic_close_order_type": "market",
         },
@@ -1028,11 +1030,22 @@ async def test_coin_hsl_history_replay_rebases_lookback_window_realized_points()
     assert state["last_metrics"]["drawdown_raw"] == pytest.approx(0.70)
 
 
+@pytest.mark.parametrize(
+    ("restart_after_red_policy", "expected_latched", "expected_cooldown_until_ms"),
+    [
+        ("threshold", True, None),
+        ("always", False, 420_500),
+        ("never", True, None),
+    ],
+)
 @pytest.mark.asyncio
-async def test_coin_hsl_history_replay_uses_stop_drawdown_for_no_restart():
+async def test_coin_hsl_history_replay_honors_restart_after_red_policy(
+    restart_after_red_policy, expected_latched, expected_cooldown_until_ms
+):
     bot = make_coin_bot()
     symbol = "A"
     bot.hsl["long"]["no_restart_drawdown_threshold"] = 0.7
+    bot.hsl["long"]["restart_after_red_policy"] = restart_after_red_policy
 
     async def fake_history(current_balance=None, **kwargs):
         return {
@@ -1076,8 +1089,8 @@ async def test_coin_hsl_history_replay_uses_stop_drawdown_for_no_restart():
 
     state = bot._hsl_coin_state("long", symbol)
     assert state["halted"] is True
-    assert state["no_restart_latched"] is True
-    assert state["cooldown_until_ms"] is None
+    assert state["no_restart_latched"] is expected_latched
+    assert state["cooldown_until_ms"] == expected_cooldown_until_ms
     assert state["last_stop_event"]["drawdown_raw"] == pytest.approx(1.0)
 
 

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -1355,6 +1355,7 @@ def test_panic_close_order_type_rejects_invalid_values():
             {"hsl_red_threshold": 0.2, "hsl_no_restart_drawdown_threshold": 0.1},
             r"bot\.long\.hsl_no_restart_drawdown_threshold",
         ),
+        ({"hsl_restart_after_red_policy": "sometimes"}, r"bot\.long\.hsl_restart_after_red_policy"),
         ({"risk_we_excess_allowance_pct": -0.01}, r"bot\.long\.risk_we_excess_allowance_pct"),
         ({"unstuck_ema_dist": -1.0}, r"bot\.long\.unstuck_ema_dist"),
     ],

--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -333,6 +333,7 @@ def test_bot_params_to_rust_dict_includes_hsl_fields():
                 "hsl_ema_span_minutes": 1.0,
                 "hsl_cooldown_minutes_after_red": 1.0,
                 "hsl_no_restart_drawdown_threshold": 0.9,
+                "hsl_restart_after_red_policy": "threshold",
                 "hsl_tier_ratios": {"yellow": 0.5, "orange": 0.75},
                 "hsl_orange_tier_mode": "tp_only_with_active_entry_cancellation",
                 "hsl_panic_close_order_type": "market",
@@ -366,6 +367,7 @@ def test_bot_params_to_rust_dict_includes_hsl_fields():
     assert out["hsl_red_threshold"] == pytest.approx(0.05)
     assert out["hsl_tier_ratio_yellow"] == pytest.approx(0.5)
     assert out["hsl_tier_ratio_orange"] == pytest.approx(0.75)
+    assert out["hsl_restart_after_red_policy"] == "threshold"
     assert out["hsl_orange_tier_mode"] == "tp_only_with_active_entry_cancellation"
     assert out["hsl_panic_close_order_type"] == "market"
     assert out["risk_twel_enforcer_policy"] == "reduce_portfolio"
@@ -424,6 +426,7 @@ def test_bot_params_to_rust_dict_ignores_removed_entry_grid_inflation_flag():
                         "hsl_ema_span_minutes": 1.0,
                         "hsl_cooldown_minutes_after_red": 1.0,
                         "hsl_no_restart_drawdown_threshold": 0.9,
+                        "hsl_restart_after_red_policy": "threshold",
                         "hsl_tier_ratios": {"yellow": 0.5, "orange": 0.75},
                         "hsl_orange_tier_mode": "tp_only_with_active_entry_cancellation",
                         "hsl_panic_close_order_type": "market",


### PR DESCRIPTION
## Summary
- add explicit HSL restart-after-RED policy: always, threshold, never
- keep threshold as behavior-preserving default across config hydration, live payloads, and Rust backtest config
- route Python live HSL replay/finalization and Rust backtest HSL finalization through the explicit policy
- update startup/preflight HSL reports and fable-audit tracker

## Validation
- VIRTUAL_ENV=/Users/eiriknarjord/repos/passivbot-2/venv PATH=/Users/eiriknarjord/repos/passivbot-2/venv/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/eiriknarjord/.local/bin:/Users/eiriknarjord/.codex/tmp/arg0/codex-arg0hxCI0Y:/Users/eiriknarjord/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/eiriknarjord/.grok/bin:/opt/homebrew/opt/tcl-tk/bin:/Users/eiriknarjord/repos/autonomi/target/release/:/Users/eiriknarjord/.modular/pkg/packages.modular.com_mojo/bin:/Users/eiriknarjord/.pyenv/shims:/Users/eiriknarjord/.cargo/bin:/Applications/Codex.app/Contents/Resources /Users/eiriknarjord/repos/passivbot-2/venv/bin/maturin develop --release
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/passivbot_hsl.py src/passivbot.py src/backtest.py src/config src/config_utils.py src/tools/hsl_startup_preview.py src/tools/live_config_preflight.py
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_config_utils_helpers.py::test_hsl_restart_after_red_policy_normalizes_default_and_rejects_invalid tests/test_config_utils_helpers.py::test_load_input_config_without_path_uses_schema_defaults tests/test_hsl_coin_mode.py::test_coin_hsl_history_replay_honors_restart_after_red_policy tests/test_orchestrator_json_api.py::test_json_rejects_invalid_global_hsl_risk_unstuck_values tests/test_run_fake_live.py::test_bot_params_to_rust_dict_includes_hsl_fields -q
- cargo check --manifest-path passivbot-rust/Cargo.toml
- git diff --check

Note: cargo test --lib for this PyO3 crate still hits the known macOS Python-symbol linker issue; cargo check and maturin rebuild are green.