### PR TITLE
Use dynamic slots for TWEL overweight repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable user-facing changes will be documented in this file.
 - Rust TWEL auto-reduce now takes priority over same-position auto-unstuck
   reducers in the same ideal-order batch, preventing two reducer closes from
   stacking on one coin+pside when portfolio exposure enforcement is active.
+- Rust TWEL `reduce_overweight` auto-reduce now uses the dynamic currently
+  tradable slot count when deciding which positions are overweight, matching
+  dynamic WEL sizing instead of the configured `n_positions` floor.
 - The Rust orchestrator JSON boundary now rejects invalid account/risk globals
   such as non-positive raw balance, negative realized-loss limits, and negative
   unstuck allowances before risk gates or order planning can silently skip.

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -777,6 +777,10 @@ Remaining implementation details:
       Make `reduce_overweight` use dynamic currently-tradable slot count, keep
       snapped/raw balance separation, and add high-hysteresis warning/preflight
       visibility.
+      Partial: Rust TWEL `reduce_overweight` now uses the dynamic effective
+      slot count when selecting overweight positions, with Rust and
+      orchestrator-JSON regression coverage. Existing raw-balance TWEL reducer
+      and snapped-balance TWEL entry-gate tests remain in place.
 - [ ] Entry cooldown config split design and migration plan.
       Separate simultaneous ladder permission from time-based cooldown.
 - [ ] Canonical HSL equity-history signal design.

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -3300,7 +3300,7 @@ mod core {
                     .global_bot_params
                     .long
                     .total_wallet_exposure_limit,
-                input.global.global_bot_params.long.n_positions,
+                enp_long,
                 input_balance_raw(input),
                 &workspace.twel_positions,
                 input
@@ -3370,7 +3370,7 @@ mod core {
                     .global_bot_params
                     .short
                     .total_wallet_exposure_limit,
-                input.global.global_bot_params.short.n_positions,
+                enp_short,
                 input_balance_raw(input),
                 &workspace.twel_positions,
                 input
@@ -5840,6 +5840,84 @@ mod core {
                 "TWEL enforcer should trigger using raw balance (WE=0.625 > 0.6), \
                  not snapped balance (WE=0.5 < 0.6). Orders: {:?}",
                 out.orders.iter().map(|o| &o.order_type).collect::<Vec<_>>()
+            );
+        }
+
+        #[test]
+        fn twel_reduce_overweight_uses_effective_tradable_slots() {
+            // Configured n_positions=4 but only two symbols are currently eligible.
+            // TWEL target is 0.50, so the dynamic overweight floor is 0.25.
+            // idx0 is exactly at the dynamic floor and less adverse; using the old
+            // configured floor 0.125 would wrongly select idx0 first.
+            let mut sym0 = make_basic_symbol(0);
+            sym0.long.position = Position {
+                size: 2.5,
+                price: 100.0,
+            };
+            sym0.order_book = OrderBook {
+                bid: 100.0,
+                ask: 100.0,
+            };
+            sym0.long.bot_params.wallet_exposure_limit = 0.4;
+            sym0.long.bot_params.risk_wel_enforcer_threshold = 2.0;
+
+            let mut sym1 = make_basic_symbol(1);
+            sym1.long.position = Position {
+                size: 2.6,
+                price: 100.0,
+            };
+            sym1.order_book = OrderBook {
+                bid: 95.0,
+                ask: 95.0,
+            };
+            sym1.long.bot_params.wallet_exposure_limit = 0.4;
+            sym1.long.bot_params.risk_wel_enforcer_threshold = 2.0;
+
+            let mut global_bp = BotParamsPair::default();
+            global_bp.long.total_wallet_exposure_limit = 0.5;
+            global_bp.long.risk_twel_enforcer_threshold = 1.0;
+            global_bp.long.risk_twel_enforcer_policy = TwelEnforcerPolicy::ReduceOverweight;
+            global_bp.long.n_positions = 4;
+
+            let input = OrchestratorInput {
+                balance: 1000.0,
+                balance_raw: 1000.0,
+                timestamp_ms: 0,
+                global: OrchestratorGlobal {
+                    filter_by_min_effective_cost: false,
+                    market_orders_allowed: false,
+                    market_order_near_touch_threshold: 0.001,
+                    market_order_slippage_pct: 0.0,
+                    panic_close_market: false,
+                    auto_unstuck_allowed: Some(true),
+                    unstuck_allowance_long: 0.0,
+                    unstuck_allowance_short: 0.0,
+                    max_realized_loss_pct: 1.0,
+                    realized_pnl_cumsum_max: 0.0,
+                    realized_pnl_cumsum_last: 0.0,
+                    sort_global: true,
+                    global_bot_params: global_bp,
+                    hedge_mode: true,
+                    strategy_kind: StrategyKind::TrailingMartingale,
+                },
+                symbols: vec![sym0, sym1],
+                peek_hints: None,
+                forager_hysteresis: None,
+            };
+            let out = compute_ideal_orders_for_test(&input).unwrap();
+            let twel_closes = out
+                .orders
+                .iter()
+                .filter(|o| o.order_type == OrderType::CloseAutoReduceTwelLong)
+                .collect::<Vec<_>>();
+            assert!(
+                !twel_closes.is_empty(),
+                "TWEL reduce-overweight should still repair total exposure"
+            );
+            assert!(
+                twel_closes.iter().all(|o| o.symbol_idx == 1),
+                "dynamic floor should leave idx0 at WE=0.25 untouched; orders: {:?}",
+                twel_closes
             );
         }
 

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -1654,6 +1654,17 @@ mod core {
         base.max(forced_normals_len)
     }
 
+    fn twel_repair_effective_n_positions(
+        effective_n_positions: usize,
+        open_position_count: usize,
+    ) -> usize {
+        if effective_n_positions > 0 {
+            effective_n_positions
+        } else {
+            open_position_count
+        }
+    }
+
     fn fill_forced_normal_indices(
         symbols: &[SymbolInput],
         pside: PositionSide,
@@ -3288,6 +3299,8 @@ mod core {
                     min_cost: sym.exchange.min_cost,
                 });
             }
+            let twel_effective_n_positions =
+                twel_repair_effective_n_positions(enp_long, workspace.twel_positions.len());
             let actions = calc_twel_enforcer_actions(
                 LONG,
                 input
@@ -3300,7 +3313,7 @@ mod core {
                     .global_bot_params
                     .long
                     .total_wallet_exposure_limit,
-                enp_long,
+                twel_effective_n_positions,
                 input_balance_raw(input),
                 &workspace.twel_positions,
                 input
@@ -3358,6 +3371,8 @@ mod core {
                     min_cost: sym.exchange.min_cost,
                 });
             }
+            let twel_effective_n_positions =
+                twel_repair_effective_n_positions(enp_short, workspace.twel_positions.len());
             let actions = calc_twel_enforcer_actions(
                 SHORT,
                 input
@@ -3370,7 +3385,7 @@ mod core {
                     .global_bot_params
                     .short
                     .total_wallet_exposure_limit,
-                enp_short,
+                twel_effective_n_positions,
                 input_balance_raw(input),
                 &workspace.twel_positions,
                 input
@@ -5918,6 +5933,80 @@ mod core {
                 twel_closes.iter().all(|o| o.symbol_idx == 1),
                 "dynamic floor should leave idx0 at WE=0.25 untouched; orders: {:?}",
                 twel_closes
+            );
+        }
+
+        #[test]
+        fn twel_reduce_overweight_repairs_when_no_symbols_eligible() {
+            // No symbols are eligible for new entries, but held positions still need
+            // protective TWEL repair. The enforcer should fall back to the current
+            // open-position count instead of no-oping on effective_n_positions=0.
+            let mut sym0 = make_basic_symbol(0);
+            sym0.tradable = false;
+            sym0.long.position = Position {
+                size: 2.6,
+                price: 100.0,
+            };
+            sym0.order_book = OrderBook {
+                bid: 100.0,
+                ask: 100.0,
+            };
+            sym0.long.bot_params.wallet_exposure_limit = 0.4;
+            sym0.long.bot_params.risk_wel_enforcer_threshold = 2.0;
+
+            let mut sym1 = make_basic_symbol(1);
+            sym1.tradable = false;
+            sym1.long.position = Position {
+                size: 2.6,
+                price: 100.0,
+            };
+            sym1.order_book = OrderBook {
+                bid: 95.0,
+                ask: 95.0,
+            };
+            sym1.long.bot_params.wallet_exposure_limit = 0.4;
+            sym1.long.bot_params.risk_wel_enforcer_threshold = 2.0;
+
+            let mut global_bp = BotParamsPair::default();
+            global_bp.long.total_wallet_exposure_limit = 0.5;
+            global_bp.long.risk_twel_enforcer_threshold = 1.0;
+            global_bp.long.risk_twel_enforcer_policy = TwelEnforcerPolicy::ReduceOverweight;
+            global_bp.long.n_positions = 4;
+
+            let input = OrchestratorInput {
+                balance: 1000.0,
+                balance_raw: 1000.0,
+                timestamp_ms: 0,
+                global: OrchestratorGlobal {
+                    filter_by_min_effective_cost: false,
+                    market_orders_allowed: false,
+                    market_order_near_touch_threshold: 0.001,
+                    market_order_slippage_pct: 0.0,
+                    panic_close_market: false,
+                    auto_unstuck_allowed: Some(true),
+                    unstuck_allowance_long: 0.0,
+                    unstuck_allowance_short: 0.0,
+                    max_realized_loss_pct: 1.0,
+                    realized_pnl_cumsum_max: 0.0,
+                    realized_pnl_cumsum_last: 0.0,
+                    sort_global: true,
+                    global_bot_params: global_bp,
+                    hedge_mode: true,
+                    strategy_kind: StrategyKind::TrailingMartingale,
+                },
+                symbols: vec![sym0, sym1],
+                peek_hints: None,
+                forager_hysteresis: None,
+            };
+            let out = compute_ideal_orders_for_test(&input).unwrap();
+            let twel_closes = out
+                .orders
+                .iter()
+                .filter(|o| o.order_type == OrderType::CloseAutoReduceTwelLong)
+                .collect::<Vec<_>>();
+            assert!(
+                !twel_closes.is_empty(),
+                "TWEL reduce-overweight should still repair held positions when eligibility is zero"
             );
         }
 

--- a/passivbot-rust/src/risk.rs
+++ b/passivbot-rust/src/risk.rs
@@ -624,7 +624,7 @@ pub fn calc_twel_enforcer_actions(
     pside: usize,
     threshold: f64,
     total_wallet_exposure_limit: f64,
-    configured_n_positions: usize,
+    effective_n_positions: usize,
     balance: f64,
     positions: &[TwelEnforcerInputPosition],
     policy: TwelEnforcerPolicy,
@@ -633,7 +633,7 @@ pub fn calc_twel_enforcer_actions(
     if threshold <= 0.0
         || total_wallet_exposure_limit <= 0.0
         || balance <= 0.0
-        || configured_n_positions == 0
+        || effective_n_positions == 0
         || !threshold.is_finite()
         || !total_wallet_exposure_limit.is_finite()
         || !balance.is_finite()
@@ -772,7 +772,7 @@ pub fn calc_twel_enforcer_actions(
         return Vec::new();
     }
 
-    let overweight_target = limit / configured_n_positions as f64;
+    let overweight_target = limit / effective_n_positions as f64;
     let mut candidates: Vec<Candidate> = valid_positions
         .into_iter()
         .filter(|candidate| match policy {

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -1100,6 +1100,55 @@ def test_twel_reduce_overweight_uses_effective_tradable_slots():
     assert {order["symbol_idx"] for order in twel_closes} == {1}
 
 
+def test_twel_reduce_overweight_repairs_when_no_symbols_eligible():
+    import passivbot_rust as pbr
+
+    global_bp = bot_params_pair(
+        long_overrides={
+            "n_positions": 4,
+            "total_wallet_exposure_limit": 0.5,
+            "risk_twel_enforcer_threshold": 1.0,
+            "risk_twel_enforcer_policy": "reduce_overweight",
+        }
+    )
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=global_bp,
+        symbols=[
+            make_symbol(
+                0,
+                bid=100.0,
+                ask=100.0,
+                tradable=False,
+                long_pos_size=2.6,
+                long_pos_price=100.0,
+                long_bp={
+                    "wallet_exposure_limit": 0.4,
+                    "risk_wel_enforcer_threshold": 2.0,
+                },
+            ),
+            make_symbol(
+                1,
+                bid=95.0,
+                ask=95.0,
+                tradable=False,
+                long_pos_size=2.6,
+                long_pos_price=100.0,
+                long_bp={
+                    "wallet_exposure_limit": 0.4,
+                    "risk_wel_enforcer_threshold": 2.0,
+                },
+            ),
+        ],
+    )
+
+    out = compute(pbr, inp)
+    twel_closes = [
+        order for order in out["orders"] if order["order_type"] == "close_auto_reduce_twel_long"
+    ]
+    assert twel_closes
+
+
 def test_ema_anchor_volatility_weights_widen_quotes():
     import passivbot_rust as pbr
 

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -1052,6 +1052,54 @@ def test_ema_anchor_respects_runtime_budget_for_base_clip_size():
     assert out["orders"][0]["qty"] == pytest.approx(0.3)
 
 
+def test_twel_reduce_overweight_uses_effective_tradable_slots():
+    import passivbot_rust as pbr
+
+    global_bp = bot_params_pair(
+        long_overrides={
+            "n_positions": 4,
+            "total_wallet_exposure_limit": 0.5,
+            "risk_twel_enforcer_threshold": 1.0,
+            "risk_twel_enforcer_policy": "reduce_overweight",
+        }
+    )
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=global_bp,
+        symbols=[
+            make_symbol(
+                0,
+                bid=100.0,
+                ask=100.0,
+                long_pos_size=2.5,
+                long_pos_price=100.0,
+                long_bp={
+                    "wallet_exposure_limit": 0.4,
+                    "risk_wel_enforcer_threshold": 2.0,
+                },
+            ),
+            make_symbol(
+                1,
+                bid=95.0,
+                ask=95.0,
+                long_pos_size=2.6,
+                long_pos_price=100.0,
+                long_bp={
+                    "wallet_exposure_limit": 0.4,
+                    "risk_wel_enforcer_threshold": 2.0,
+                },
+            ),
+        ],
+    )
+
+    out = compute(pbr, inp)
+    twel_closes = [
+        order for order in out["orders"] if order["order_type"] == "close_auto_reduce_twel_long"
+    ]
+    assert twel_closes
+    assert {order["symbol_idx"] for order in twel_closes} == {1}
+
+
 def test_ema_anchor_volatility_weights_widen_quotes():
     import passivbot_rust as pbr
 


### PR DESCRIPTION
## Summary
- make Rust TWEL reduce_overweight use computed effective tradable slots instead of configured n_positions
- add Rust and orchestrator-JSON regressions for selecting the correct overweight position
- document the behavior in CHANGELOG and mark the fable-audit tracker item partially complete

## Validation
- cargo fmt --manifest-path passivbot-rust/Cargo.toml
- cargo check --manifest-path passivbot-rust/Cargo.toml
- VIRTUAL_ENV=/Users/eiriknarjord/repos/passivbot-2/venv PATH=/Users/eiriknarjord/repos/passivbot-2/venv/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Users/eiriknarjord/.local/bin:/Users/eiriknarjord/.codex/tmp/arg0/codex-arg0hxCI0Y:/Users/eiriknarjord/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/eiriknarjord/.grok/bin:/opt/homebrew/opt/tcl-tk/bin:/Users/eiriknarjord/repos/autonomi/target/release/:/Users/eiriknarjord/.modular/pkg/packages.modular.com_mojo/bin:/Users/eiriknarjord/.pyenv/shims:/Users/eiriknarjord/.cargo/bin:/Applications/Codex.app/Contents/Resources /Users/eiriknarjord/repos/passivbot-2/venv/bin/maturin develop --release
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_orchestrator_json_api.py::test_twel_reduce_overweight_uses_effective_tradable_slots tests/test_orchestrator_json_api.py::test_panic_close_order_type_is_side_local tests/test_orchestrator_json_api.py::test_json_rejects_invalid_global_hsl_risk_unstuck_values -q
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall tests/test_orchestrator_json_api.py
- git diff --check

Note: local cargo test --lib for this PyO3 crate is still blocked by the known macOS Python-symbol linker issue; cargo check plus maturin/pytest passed.