### PR TITLE
Validate orchestrator risk inputs in core

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -149,6 +149,11 @@ Required risk inputs should be validated at the Rust/orchestrator boundary and
 fail loudly. Do not rely on `log::error!` inside individual calculators as the
 safety mechanism.
 
+Implemented: Rust orchestrator core and PyO3 JSON entrypoints now reject
+invalid account/risk globals before realized-loss or unstuck gates can
+silently skip. Coverage includes non-positive raw balance and realized-PnL
+peak/current inconsistencies.
+
 ### A1.3 - Pside HSL Side-Local Equity <= 0
 
 Plan: code/design plus docs.
@@ -747,11 +752,12 @@ Remaining implementation details:
 - [x] Numeric validation/clamping for HSL EMA spans and risk/unstuck config.
       Clamp EMA spans to at least `1.0`; fail loudly or normalize visibly for
       other risk numerics.
-- [ ] Risk-input fail-loud validation boundary.
+- [x] Risk-input fail-loud validation boundary.
       Invalid balance, position, exchange params, PnL stats, or active gate
       inputs must not disable risk gates permissively.
-      Partial: Rust orchestrator JSON now rejects invalid account/risk globals
-      before realized-loss or unstuck gates can silently skip.
+      Implemented: Rust core and JSON API validation reject invalid account/risk
+      globals before realized-loss or unstuck gates can silently skip, including
+      non-positive raw balance and realized-PnL peak/current inconsistencies.
 - [ ] Rust reducer priority: one reducer per coin+pside per ideal-order batch.
       Priority is HSL panic, WEL/TWEL reducer, auto-unstuck, then any other
       close order, with bid/ask-reachable reducers prioritized before farther

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -415,6 +415,65 @@ mod core {
         }
     }
 
+    fn validate_account_risk_inputs(input: &OrchestratorInput) -> Result<(), OrchestratorError> {
+        if !(input.balance.is_finite() && input.balance > 0.0) {
+            return Err(OrchestratorError::NonFiniteInput {
+                field: "balance",
+                symbol_idx: None,
+            });
+        }
+        let balance_raw = input_balance_raw(input);
+        if !(balance_raw.is_finite() && balance_raw > 0.0) {
+            return Err(OrchestratorError::NonFiniteInput {
+                field: "balance_raw",
+                symbol_idx: None,
+            });
+        }
+        if !(input.global.max_realized_loss_pct.is_finite()
+            && input.global.max_realized_loss_pct >= 0.0)
+        {
+            return Err(OrchestratorError::NonFiniteInput {
+                field: "global.max_realized_loss_pct",
+                symbol_idx: None,
+            });
+        }
+        if !input.global.realized_pnl_cumsum_max.is_finite() {
+            return Err(OrchestratorError::NonFiniteInput {
+                field: "global.realized_pnl_cumsum_max",
+                symbol_idx: None,
+            });
+        }
+        if !input.global.realized_pnl_cumsum_last.is_finite() {
+            return Err(OrchestratorError::NonFiniteInput {
+                field: "global.realized_pnl_cumsum_last",
+                symbol_idx: None,
+            });
+        }
+        if input.global.realized_pnl_cumsum_max < input.global.realized_pnl_cumsum_last {
+            return Err(OrchestratorError::NonFiniteInput {
+                field: "global.realized_pnl_cumsum_max_lt_last",
+                symbol_idx: None,
+            });
+        }
+        if !(input.global.unstuck_allowance_long.is_finite()
+            && input.global.unstuck_allowance_long >= 0.0)
+        {
+            return Err(OrchestratorError::NonFiniteInput {
+                field: "global.unstuck_allowance_long",
+                symbol_idx: None,
+            });
+        }
+        if !(input.global.unstuck_allowance_short.is_finite()
+            && input.global.unstuck_allowance_short >= 0.0)
+        {
+            return Err(OrchestratorError::NonFiniteInput {
+                field: "global.unstuck_allowance_short",
+                symbol_idx: None,
+            });
+        }
+        Ok(())
+    }
+
     fn cooldown_delay_ms(cooldown_minutes: f64) -> u64 {
         if !cooldown_minutes.is_finite() || cooldown_minutes <= 0.0 {
             0
@@ -2367,18 +2426,7 @@ mod core {
         input: &OrchestratorInput,
         workspace: &mut OrchestratorWorkspace,
     ) -> Result<OrchestratorOutput, OrchestratorError> {
-        if !input.balance.is_finite() {
-            return Err(OrchestratorError::NonFiniteInput {
-                field: "balance",
-                symbol_idx: None,
-            });
-        }
-        if input.balance_raw.is_infinite() {
-            return Err(OrchestratorError::NonFiniteInput {
-                field: "balance_raw",
-                symbol_idx: None,
-            });
-        }
+        validate_account_risk_inputs(input)?;
         let mut diagnostics = OrchestratorDiagnostics::default();
 
         // Validate invariants:
@@ -5739,7 +5787,7 @@ mod core {
         }
 
         #[test]
-        fn realized_loss_gate_non_positive_balance_raw_returns_early() {
+        fn account_risk_validation_rejects_non_positive_balance_raw() {
             for raw_balance in [0.0, -1.0] {
                 let mut sym = make_basic_symbol(0);
                 sym.long.position = Position {
@@ -5784,20 +5832,37 @@ mod core {
                     peek_hints: None,
                     forager_hysteresis: None,
                 };
-                let out = compute_ideal_orders_for_test(&input).unwrap();
-                assert!(
-                    out.orders
-                        .iter()
-                        .any(|o| o.order_type == OrderType::CloseAutoReduceWelLong),
-                    "expected non-positive balance_raw={} to early-return and keep close order",
-                    raw_balance
-                );
-                assert!(
-                    out.diagnostics.loss_gate_blocks.is_empty(),
-                    "expected non-positive balance_raw={} to skip loss-gate diagnostics",
-                    raw_balance
+                assert_eq!(
+                    compute_ideal_orders_for_test(&input).unwrap_err(),
+                    OrchestratorError::NonFiniteInput {
+                        field: "balance_raw",
+                        symbol_idx: None,
+                    }
                 );
             }
+        }
+
+        #[test]
+        fn account_risk_validation_rejects_pnl_peak_below_current() {
+            let mut input = OrchestratorInput {
+                balance: 1000.0,
+                balance_raw: 1000.0,
+                timestamp_ms: 0,
+                global: make_basic_global(),
+                symbols: vec![make_basic_symbol(0)],
+                peek_hints: None,
+                forager_hysteresis: None,
+            };
+            input.global.realized_pnl_cumsum_max = 5.0;
+            input.global.realized_pnl_cumsum_last = 10.0;
+
+            assert_eq!(
+                compute_ideal_orders_for_test(&input).unwrap_err(),
+                OrchestratorError::NonFiniteInput {
+                    field: "global.realized_pnl_cumsum_max_lt_last",
+                    symbol_idx: None,
+                }
+            );
         }
 
         #[test]

--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -2730,6 +2730,11 @@ fn validate_orchestrator_account_risk_inputs(
             return Err(PyValueError::new_err(format!("{path} must be finite")));
         }
     }
+    if input.global.realized_pnl_cumsum_max < input.global.realized_pnl_cumsum_last {
+        return Err(PyValueError::new_err(
+            "global.realized_pnl_cumsum_max must be >= global.realized_pnl_cumsum_last",
+        ));
+    }
     validate_finite_range(
         "global.unstuck_allowance_long",
         input.global.unstuck_allowance_long,

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -2797,6 +2797,13 @@ def test_balance_raw_absent_falls_back_to_balance():
             lambda inp: inp["global"].__setitem__("unstuck_allowance_short", -1.0),
             r"global\.unstuck_allowance_short must be finite and >= 0",
         ),
+        (
+            lambda inp: (
+                inp["global"].__setitem__("realized_pnl_cumsum_max", 5.0),
+                inp["global"].__setitem__("realized_pnl_cumsum_last", 10.0),
+            ),
+            r"global\.realized_pnl_cumsum_max must be >= global\.realized_pnl_cumsum_last",
+        ),
     ],
 )
 def test_json_rejects_invalid_account_risk_globals(mutator, match):


### PR DESCRIPTION
## Summary
- validate account/risk globals at the Rust orchestrator core boundary before realized-loss or unstuck gates run
- keep PyO3 JSON validation aligned, including rejecting realized_pnl_cumsum_max < realized_pnl_cumsum_last
- update the fable-audit action plan progress for A1.2

## Validation
- cargo fmt --manifest-path passivbot-rust/Cargo.toml -- --check
- cargo check --manifest-path passivbot-rust/Cargo.toml
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_orchestrator_json_api.py -q
- cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features
- git diff --check