### PR TITLE
Block initial entries in HSL orange tp-only mode

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -238,6 +238,10 @@ Contract:
 - `pside`: ORANGE blocks all entries for that pside, including initial entries.
 - `coin`: ORANGE blocks entries for that coin+pside, including initial entries.
 
+Implemented: live ORANGE `tp_only_with_active_entry_cancellation` now blocks
+flat initial entries in the affected scope instead of only symbols with an open
+position.
+
 ### A2.3 - Bounded `we_excess` Invalid Base/TWEL
 
 Plan: code fix.

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -14135,12 +14135,7 @@ class Passivbot:
                 if orange_mode == "graceful_stop":
                     return "graceful_stop"
                 if orange_mode == "tp_only_with_active_entry_cancellation":
-                    size = float(
-                        self.positions.get(symbol, {}).get(pside, {}).get("size", 0.0)
-                        or 0.0
-                    )
-                    if size != 0.0:
-                        return "tp_only_with_active_entry_cancellation"
+                    return "tp_only_with_active_entry_cancellation"
 
         runtime_forced = (
             getattr(self, "_runtime_forced_modes", {}).get(pside, {}).get(symbol)

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -3684,7 +3684,7 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
                     self._equity_hard_stop_set_coin_runtime_forced_mode(
                         pside, symbol, "graceful_stop"
                     )
-                elif self._equity_hard_stop_has_open_position_symbol(pside, symbol):
+                elif target == "tp_only_with_active_entry_cancellation":
                     self._equity_hard_stop_set_coin_runtime_forced_mode(
                         pside, symbol, "tp_only_with_active_entry_cancellation"
                     )
@@ -4351,8 +4351,5 @@ def _apply_equity_hard_stop_orange_overlay(self) -> None:
                 if current_mode == "normal":
                     self.PB_modes[pside][symbol] = "graceful_stop"
             else:
-                size = float(self.positions.get(symbol, {}).get(pside, {}).get("size", 0.0) or 0.0)
-                if size == 0.0:
-                    continue
                 if current_mode in ("normal", "graceful_stop"):
                     self.PB_modes[pside][symbol] = "tp_only_with_active_entry_cancellation"

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -2400,7 +2400,25 @@ def test_orange_overlay_graceful_stop_preserves_restrictive_modes():
     assert bot.PB_modes["short"][symbol] == "manual"
 
 
-def test_orange_overlay_tp_only_with_active_entry_cancellation_only_for_open_positions():
+def test_orange_mode_override_blocks_flat_initial_entries():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+
+    _hsl_cfg(bot)["enabled"] = True
+    _hsl_cfg(bot)["orange_tier_mode"] = "tp_only_with_active_entry_cancellation"
+    _hsl_state(bot)["runtime"]._initialized = True
+    _hsl_state(bot)["runtime"]._tier = "orange"
+    _hsl_state(bot)["runtime"]._red_latched = False
+    bot.positions[symbol]["long"]["size"] = 0.0
+
+    assert (
+        bot._orchestrator_mode_override("long", symbol)
+        == "tp_only_with_active_entry_cancellation"
+    )
+
+
+def test_orange_overlay_tp_only_with_active_entry_cancellation_blocks_initial_entries():
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
@@ -2412,7 +2430,7 @@ def test_orange_overlay_tp_only_with_active_entry_cancellation_only_for_open_pos
     _hsl_state(bot)["runtime"]._red_latched = False
     bot.PB_modes["long"][symbol] = "normal"
     bot.PB_modes["short"][symbol] = "normal"
-    bot.positions[symbol]["long"]["size"] = 1.0
+    bot.positions[symbol]["long"]["size"] = 0.0
     bot.positions[symbol]["short"]["size"] = 0.0
 
     bot._apply_equity_hard_stop_orange_overlay()


### PR DESCRIPTION
## Summary
- make live ORANGE tp_only_with_active_entry_cancellation block flat initial entries in the affected HSL scope
- apply the same contract to orchestrator mode overrides, coin-mode runtime forced modes, and the PB-mode orange overlay
- add regressions for flat initial-entry blocking and update the fable-audit plan progress note

## Validation
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_unstucking_safeguards.py::test_orange_mode_override_blocks_flat_initial_entries tests/test_unstucking_safeguards.py::test_orange_overlay_tp_only_with_active_entry_cancellation_blocks_initial_entries tests/test_unstucking_safeguards.py::test_tp_only_with_active_entry_cancellation_filters_entries_but_keeps_entry_cancels -q
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/passivbot.py src/passivbot_hsl.py tests/test_unstucking_safeguards.py
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_run_fake_live.py -q
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_realized_loss_gate.py -q -k "not PrepBacktestArgs"
- git diff --check

Note: full tests/test_unstucking_safeguards.py currently has unrelated current-base fixture failures around dummy total_exposure_enforcer_policy and unified-HSL sample setup. Full tests/test_realized_loss_gate.py currently has unrelated PrepBacktestArgs fixture failures from missing per-side HSL config in those test fixtures.