### PR TITLE
Keep bounded WE excess from using raw invalid budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Bounded `we_excess_allowance_mode` now treats non-positive or non-finite base
+  WEL as zero allowed exposure and non-positive/non-finite TWEL as zero excess
+  headroom instead of falling back to the raw excess percentage.
 - Rust protective reducers now suppress lower-priority same-position ordinary
   close orders in the same ideal-order batch, so panic, TWEL/WEL auto-reduce,
   and auto-unstuck no longer stack with grid/trailing closes for one coin+pside.

--- a/docs/config.bot.md
+++ b/docs/config.bot.md
@@ -19,6 +19,9 @@ Throughout:
 * With the default `we_excess_allowance_mode = "bounded"`,
   `we_excess_effective = min(max(0, risk_we_excess_allowance_pct),
   max(0, total_wallet_exposure_limit / wel_base - 1))`.
+  If `wel_base` is non-positive/non-finite, bounded mode treats the effective
+  allowance and allowed exposure as zero. If `total_wallet_exposure_limit` is
+  non-positive/non-finite, bounded mode grants no excess headroom.
   With `we_excess_allowance_mode = "legacy_raw"`, the raw
   `max(0, risk_we_excess_allowance_pct)` is used instead.
 * `wel_allowed = wel_base * (1 + we_excess_effective)`, so per-position excess allowance never

--- a/docs/min_effective_cost.md
+++ b/docs/min_effective_cost.md
@@ -21,7 +21,7 @@ For most perpetuals, `initial_notional ≈ balance * effective_wel * strategy_in
 With:
 - `balance`: current account balance in quote currency (e.g., USDT/USDC).
 - `twel = total_wallet_exposure_limit`: side-level cap; divided by `n_positions` to get per-position WE.
-- `we_allowance`: optional headroom multiplier on per-position WEL. With the default `we_excess_allowance_mode = "bounded"`, this is `min(max(0, risk_we_excess_allowance_pct), max(0, twel / wallet_exposure_limit - 1))`, capped so a single symbol cannot exceed the side-level TWEL. With `we_excess_allowance_mode = "legacy_raw"`, this is the raw `max(0, risk_we_excess_allowance_pct)` and may exceed that cap.
+- `we_allowance`: optional headroom multiplier on per-position WEL. With the default `we_excess_allowance_mode = "bounded"`, this is `min(max(0, risk_we_excess_allowance_pct), max(0, twel / wallet_exposure_limit - 1))`, capped so a single symbol cannot exceed the side-level TWEL. If `wallet_exposure_limit` is non-positive/non-finite, bounded mode treats both the allowance and allowed exposure as zero; if `twel` is non-positive/non-finite, bounded mode grants no excess headroom. With `we_excess_allowance_mode = "legacy_raw"`, this is the raw `max(0, risk_we_excess_allowance_pct)` and may exceed that cap.
 - `effective_wel = wallet_exposure_limit * (1 + we_allowance)`.
 - `strategy_initial_sizing_fraction`: fraction of the per-position exposure used for the first
   order. For `live.strategy_kind = "trailing_martingale"`, this is

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -250,6 +250,11 @@ Bounded mode should not degrade to raw semantics when base/TWEL is invalid.
 Return zero for explicitly disabled/no-budget contexts and fail validation for
 active configs with invalid limits.
 
+Implemented: Rust bounded `we_excess` now returns zero allowed exposure for
+non-positive/non-finite base WEL and zero excess headroom for
+non-positive/non-finite TWEL instead of falling back to the raw excess
+percentage. `legacy_raw` remains intentionally raw.
+
 ### A3.1 - Reducer Stacking
 
 Plan: Rust-side code fix.

--- a/docs/risk_management.md
+++ b/docs/risk_management.md
@@ -127,6 +127,11 @@ With the default `we_excess_allowance_mode = "bounded"`, the raw excess is cappe
 
 `effective_limit = wallet_exposure_limit * (1 + effective_we_excess_allowance_pct)`
 
+If `wallet_exposure_limit` is non-positive or non-finite, bounded mode treats
+the effective excess allowance and effective limit as zero. If
+`total_wallet_exposure_limit` is non-positive or non-finite, bounded mode
+grants no excess headroom.
+
 Set `we_excess_allowance_mode = "legacy_raw"` only when intentionally preserving v7-style behavior where the configured excess percentage is used raw and may expand one symbol above side TWEL.
 
 * **Example:** If WEL is `0.20` and allowance is `0.10` (10%), the position can grow to `0.22` before the bot considers it "full."

--- a/passivbot-rust/src/entries.rs
+++ b/passivbot-rust/src/entries.rs
@@ -25,8 +25,12 @@ pub fn effective_we_excess_allowance_pct(bot_params: &BotParams, base_limit: f64
     if bot_params.risk_we_excess_allowance_mode == WeExcessAllowanceMode::LegacyRaw {
         return raw;
     }
-    if base_limit <= 0.0 || bot_params.total_wallet_exposure_limit <= 0.0 {
-        return raw;
+    if !(base_limit.is_finite()
+        && base_limit > 0.0
+        && bot_params.total_wallet_exposure_limit.is_finite()
+        && bot_params.total_wallet_exposure_limit > 0.0)
+    {
+        return 0.0;
     }
     let max_effective = (bot_params.total_wallet_exposure_limit / base_limit - 1.0).max(0.0);
     raw.min(max_effective)
@@ -37,8 +41,8 @@ pub fn wallet_exposure_limit_with_allowance_from_base(
     base_limit: f64,
 ) -> f64 {
     let base = base_limit;
-    if base <= 0.0 {
-        base
+    if !(base.is_finite() && base > 0.0) {
+        0.0
     } else {
         base * (1.0 + effective_we_excess_allowance_pct(bot_params, base))
     }
@@ -1168,6 +1172,34 @@ mod tests {
         assert_eq!(
             wallet_exposure_limit_with_allowance_from_base(&bot, 0.5),
             0.75
+        );
+    }
+
+    #[test]
+    fn test_bounded_we_excess_invalid_budget_returns_zero_not_raw() {
+        let mut bot = BotParams {
+            total_wallet_exposure_limit: 1.0,
+            risk_we_excess_allowance_pct: 1.5,
+            risk_we_excess_allowance_mode: WeExcessAllowanceMode::Bounded,
+            ..Default::default()
+        };
+
+        assert_eq!(effective_we_excess_allowance_pct(&bot, 0.0), 0.0);
+        assert_eq!(
+            wallet_exposure_limit_with_allowance_from_base(&bot, 0.0),
+            0.0
+        );
+        assert_eq!(effective_we_excess_allowance_pct(&bot, f64::NAN), 0.0);
+        assert_eq!(
+            wallet_exposure_limit_with_allowance_from_base(&bot, f64::NAN),
+            0.0
+        );
+
+        bot.total_wallet_exposure_limit = 0.0;
+        assert_eq!(effective_we_excess_allowance_pct(&bot, 0.5), 0.0);
+        assert_eq!(
+            wallet_exposure_limit_with_allowance_from_base(&bot, 0.5),
+            0.5
         );
     }
 


### PR DESCRIPTION
## Summary
- make bounded we_excess return zero excess headroom when base WEL/TWEL is non-positive or non-finite, instead of falling back to the raw configured excess
- keep legacy_raw intentionally raw
- document the bounded invalid-budget behavior and update the fable-audit plan note

## Validation
- cargo fmt --manifest-path passivbot-rust/Cargo.toml -- --check
- cargo check --manifest-path passivbot-rust/Cargo.toml
- cargo test --manifest-path passivbot-rust/Cargo.toml entries::tests:: --no-default-features
- cargo test --manifest-path passivbot-rust/Cargo.toml --no-default-features
- git diff --check