### PR TITLE
Validate active risk slot budgets

### DIFF
--- a/src/config/bot.py
+++ b/src/config/bot.py
@@ -134,13 +134,20 @@ def validate_bot_config(result: dict) -> None:
             path=f"bot.{pside}.risk.total_exposure_enforcer_policy",
         )
         twel = float(get_grouped_bot_value(bot_side, "total_wallet_exposure_limit"))
-        n_positions = int(round(float(get_grouped_bot_value(bot_side, "n_positions"))))
-        twel_enabled = bool(get_grouped_bot_value(bot_side, "risk_twel_enforcer_enabled"))
+        raw_n_positions = get_grouped_bot_value(bot_side, "n_positions")
+        try:
+            n_positions_value = float(raw_n_positions)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(f"bot.{pside}.risk.n_positions must be numeric") from exc
+        if not math.isfinite(n_positions_value) or n_positions_value < 0.0:
+            raise ValueError(f"bot.{pside}.risk.n_positions must be finite and >= 0")
+        n_positions = int(round(n_positions_value))
         if twel < 0.0 or not math.isfinite(twel):
             raise ValueError(f"bot.{pside}.risk.total_wallet_exposure_limit must be finite and >= 0.0")
-        if twel > 0.0 and (entry_gate_enabled or twel_enabled) and n_positions <= 0:
+        if twel > 0.0 and n_positions <= 0:
             raise ValueError(
-                f"bot.{pside}.risk.n_positions must be > 0 when TWEL entry gate or enforcer is enabled"
+                f"bot.{pside}.risk.n_positions must be > 0 when "
+                f"bot.{pside}.risk.total_wallet_exposure_limit is > 0"
             )
         _validate_bool(
             get_grouped_bot_value(bot_side, "unstuck_enabled"),
@@ -784,9 +791,12 @@ def normalize_position_counts(result: dict, *, tracker: Optional[object] = None)
         if current is None:
             continue
         try:
-            rounded = int(round(float(current)))
+            current_value = float(current)
         except (TypeError, ValueError) as exc:
             raise TypeError(f"bot.{pside}.n_positions must be numeric") from exc
+        if not math.isfinite(current_value) or current_value < 0.0:
+            raise ValueError(f"bot.{pside}.risk.n_positions must be finite and >= 0")
+        rounded = int(round(current_value))
         if tracker is not None and current != rounded:
             tracker.update(["bot", pside, "risk", "n_positions"], current, rounded)
         risk_cfg["n_positions"] = rounded

--- a/tests/test_config_pipeline.py
+++ b/tests/test_config_pipeline.py
@@ -1477,6 +1477,35 @@ def test_prepare_config_rejects_negative_entry_cooldown_minutes():
         prepare_config(source, verbose=False, target="canonical", runtime=None)
 
 
+def test_prepare_config_rejects_positive_twel_with_zero_positions():
+    source = get_template_config()
+    risk = source["bot"]["long"]["risk"]
+    risk["total_wallet_exposure_limit"] = 1.0
+    risk["n_positions"] = 0
+    risk["total_exposure_entry_gate_enabled"] = False
+    risk["total_exposure_enforcer_enabled"] = False
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"bot\.long\.risk\.n_positions must be > 0 when "
+            r"bot\.long\.risk\.total_wallet_exposure_limit is > 0"
+        ),
+    ):
+        prepare_config(source, verbose=False, target="canonical", runtime=None)
+
+
+@pytest.mark.parametrize("n_positions", [-1, -0.1])
+def test_prepare_config_rejects_negative_positions_even_when_side_disabled(n_positions):
+    source = get_template_config()
+    risk = source["bot"]["short"]["risk"]
+    risk["total_wallet_exposure_limit"] = 0.0
+    risk["n_positions"] = n_positions
+
+    with pytest.raises(ValueError, match=r"bot\.short\.risk\.n_positions"):
+        prepare_config(source, verbose=False, target="canonical", runtime=None)
+
+
 def test_prepare_config_normalizes_we_excess_allowance_mode_and_runtime_flattening():
     source = get_template_config()
     source["bot"]["long"]["risk"]["we_excess_allowance_mode"] = "LEGACY_RAW"


### PR DESCRIPTION
## Summary
- reject config sides with positive total_wallet_exposure_limit but non-positive n_positions regardless of TWEL gate/enforcer flags
- reject negative/non-finite n_positions clearly before runtime budget derivation
- preserve zero-TWEL disabled side behavior

## Tests
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_config_pipeline.py -q
- git diff --check