### PR TITLE
Warn about HSL history reinterpretation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- HSL-enabled startup and live-config preflight now surface a history
+  reinterpretation caveat and point operators to a dedicated HSL risks doc for
+  deposits, withdrawals, balance overrides, and HSL config changes.
 - Rust close-reducer pruning now keeps only the closest-to-fill reducer when
   multiple same-priority protective reducers target one coin+pside in the same
   ideal-order batch; ordinary grid/trailing close ladders remain preserved.

--- a/docs/equity_hard_stop_loss_risks.md
+++ b/docs/equity_hard_stop_loss_risks.md
@@ -1,0 +1,42 @@
+# Equity Hard Stop Loss Risks
+
+Hard stop loss (HSL) is reconstructed from exchange state plus config. Local
+files may speed replay or improve diagnostics, but they are not authoritative
+trading state. A fresh VPS with the same exchange account and config must be
+able to reconstruct the same HSL decision.
+
+## History Reinterpretation
+
+HSL replay does not infer user intent behind account transfers or config
+changes. The following can reinterpret historical drawdown:
+
+- deposits and withdrawals
+- balance overrides
+- switching `live.hsl_signal_mode`
+- enabling HSL on an account with existing fill history
+- changing `bot.long/short.risk.total_wallet_exposure_limit`
+- changing `bot.long/short.risk.n_positions`
+- changing HSL thresholds, cooldown, or restart policy
+
+This is intentional. The bot should not guess whether a balance change was a
+transfer, a realized trading result, or an operator baseline reset. Treat HSL
+config changes on live accounts as risk changes, not harmless formatting edits.
+
+## Practical Guidance
+
+- Run `passivbot tool live-config-preflight` before enabling or changing HSL.
+- Use `passivbot tool hsl-startup-preview` where available to inspect
+  reconstructed HSL state before live trading.
+- Be extra cautious when enabling HSL on an account that was previously traded
+  without HSL.
+- If account deposits or withdrawals happened inside the HSL lookback window,
+  review reconstructed drawdown before trusting startup behavior.
+- Do not use `live.balance_override` with account-level HSL modes
+  (`unified` or `pside`). Use `coin` mode or remove the override.
+
+## Current Limitation
+
+HSL replay currently models fills, positions, prices, and current balance. It
+does not build a separate authoritative transfer ledger. Future diagnostics may
+detect suspicious balance jumps, but trading behavior should remain derived
+from exchange state plus config unless an explicit stateless contract is added.

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -28,6 +28,9 @@ from passivbot_exceptions import RestartBotException
 from utils import make_get_filepath
 
 
+_HSL_RISKS_DOC = "docs/equity_hard_stop_loss_risks.md"
+
+
 def _hsl_key_sample(value: Any, *, limit: int = 32) -> list[str]:
     if not isinstance(value, dict):
         return []
@@ -506,6 +509,13 @@ def _parse_hsl_config(self) -> dict[str, dict[str, Any]]:
             "restart_after_red_policy": restart_after_red_policy,
         }
         if enabled:
+            logging.warning(
+                "[risk] HSL[%s] enabled; review %s. Deposits, withdrawals, "
+                "balance overrides, HSL mode changes, and HSL budget/threshold "
+                "changes can reinterpret reconstructed history.",
+                pside,
+                _HSL_RISKS_DOC,
+            )
             logging.info(
                 "[risk] HSL[%s] enabled | red_threshold=%.6f ema_span_minutes=%.3f "
                 "cooldown_minutes_after_red=%.3f "

--- a/src/tools/live_config_preflight.py
+++ b/src/tools/live_config_preflight.py
@@ -14,6 +14,7 @@ from live.smoke_report import _user_safe_display_path
 DEFAULT_SAMPLE_SIZE = 8
 HIGH_BALANCE_HYSTERESIS_WARNING_PCT = 0.05
 DEFAULT_HSL_SIGNAL_MODE = "coin"
+HSL_RISKS_DOC = "docs/equity_hard_stop_loss_risks.md"
 SIDES = ("long", "short")
 _MISSING = object()
 CACHE_LIVE_KEYS = (
@@ -722,6 +723,17 @@ def _cache_readiness_report(
     if _any_hsl_enabled(hsl_sides):
         hsl["evidence"].append(
             {"code": "hsl_enabled", "message": "one or more HSL sides are enabled"}
+        )
+        hsl["evidence"].append(
+            {
+                "code": "hsl_history_reinterpretation_caveat",
+                "doc": HSL_RISKS_DOC,
+                "message": (
+                    "HSL reconstructs history from exchange state plus config; deposits, "
+                    "withdrawals, balance overrides, HSL mode changes, and HSL budget/"
+                    "threshold changes can reinterpret historical drawdown"
+                ),
+            }
         )
         signal_mode = _effective_hsl_signal_mode(live)
         if (

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -60,6 +60,38 @@ def test_hsl_signal_mode_requires_normalized_live_config():
         hsl._equity_hard_stop_signal_mode(bot)
 
 
+def test_parse_hsl_config_warns_about_history_reinterpretation(caplog):
+    bot = FakeHslBot(config={"live": {"hsl_signal_mode": "coin"}})
+    values = {
+        "hsl_enabled": True,
+        "hsl_red_threshold": 0.05,
+        "hsl_ema_span_minutes": 120.0,
+        "hsl_cooldown_minutes_after_red": 60.0,
+        "hsl_no_restart_drawdown_threshold": 0.08,
+        "hsl_tier_ratios": {"yellow": 0.5, "orange": 0.75},
+        "hsl_tier_ratios.yellow": 0.5,
+        "hsl_tier_ratios.orange": 0.75,
+        "hsl_orange_tier_mode": "tp_only_with_active_entry_cancellation",
+        "hsl_panic_close_order_type": "limit",
+        "hsl_restart_after_red_policy": "threshold",
+    }
+    bot._hsl_psides = lambda: ["long"]
+    bot._equity_hard_stop_signal_mode = MethodType(
+        hsl._equity_hard_stop_signal_mode,
+        bot,
+    )
+    bot.bot_value = lambda pside, key: values[key]
+
+    with caplog.at_level(logging.WARNING):
+        parsed = hsl._parse_hsl_config(bot)
+
+    assert parsed["long"]["enabled"] is True
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("docs/equity_hard_stop_loss_risks.md" in message for message in messages)
+    assert any("Deposits, withdrawals" in message for message in messages)
+    assert any("HSL mode changes" in message for message in messages)
+
+
 def bind_hsl_methods(bot):
     for name in (
         "_hsl_psides",

--- a/tests/test_live_config_preflight.py
+++ b/tests/test_live_config_preflight.py
@@ -85,6 +85,19 @@ def test_live_config_preflight_reports_risk_relevant_shape_and_bounds_symbols(tm
     assert report["hsl"]["sides"]["long"]["enabled"] is True
     assert report["hsl"]["sides"]["long"]["red_threshold"] == 0.05
     assert report["hsl"]["sides"]["short"]["enabled"] is False
+    hsl_evidence = report["cache"]["readiness"]["surfaces"]["hsl"]["evidence"]
+    assert {
+        item["code"]
+        for item in hsl_evidence
+    } >= {"hsl_enabled", "hsl_history_reinterpretation_caveat"}
+    caveat = next(
+        item
+        for item in hsl_evidence
+        if item["code"] == "hsl_history_reinterpretation_caveat"
+    )
+    assert caveat["doc"] == "docs/equity_hard_stop_loss_risks.md"
+    assert "deposits" in caveat["message"]
+    assert "HSL mode changes" in caveat["message"]
     assert report["universe"]["approved_coins"]["long"] == {
         "count": 4,
         "mode": "list",


### PR DESCRIPTION
## Summary
- add a dedicated HSL risks doc covering stateless replay, transfers, balance overrides, and config-change reinterpretation
- emit a startup warning when HSL is enabled, pointing to the doc
- add live-config-preflight HSL evidence for the same caveat

## Tests
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_config_preflight.py tests/test_hsl_coin_mode.py::test_parse_hsl_config_warns_about_history_reinterpretation -q
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/passivbot_hsl.py src/tools/live_config_preflight.py
- git diff --check