### PR TITLE
Reset coin HSL episode after nonpanic flatten

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -820,6 +820,11 @@ Remaining implementation details:
       cooldown rules.
       Current panic eligibility should be based on the current trading episode;
       terminal no-restart accounting remains broader.
+      Partial: live coin-HSL replay now resets current-episode realized-PnL
+      and runtime drawdown state when fill replay proves a coin+pside flattened
+      by an ordinary, non-panic close before a later re-entry. Panic-marker
+      cooldown/no-restart handling is unchanged; broader terminal no-restart
+      accounting from canonical RED timestamps remains future work.
 - [ ] HSL replay performance/readiness slice.
       Persist verified non-authoritative HSL time series/checkpoints, add doctor
       tools, prioritize held scopes, keep timing/source evidence, and move dense
@@ -830,8 +835,11 @@ Remaining implementation details:
       orders.
       Python should reconcile ideal vs actual orders, not re-decide trading
       policy where Rust can own it.
-- [ ] Dead legacy HSL cleanup after parity tests cover active
+- [x] Dead legacy HSL cleanup after parity tests cover active
       `src/passivbot_hsl.py`.
+      Implemented: removed shadowed legacy HSL method definitions from
+      `src/passivbot.py`; active behavior is bound from `src/passivbot_hsl.py`
+      with an AST regression guard.
 
 ## Non-Goals For First PRs
 

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -2893,10 +2893,12 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
 
                 replay_event_idx = 0
                 replay_size = 0.0
+                replay_was_nonflat = False
+                replay_flattened_at_ms: Optional[int] = None
                 ignored_panic_marker_timestamps: set[int] = set()
 
                 def replay_size_at(row_ts_ms: int) -> float:
-                    nonlocal replay_event_idx, replay_size
+                    nonlocal replay_event_idx, replay_size, replay_flattened_at_ms
                     boundary_ts_ms = int(row_ts_ms) + 60_000
                     while replay_event_idx < len(replay_events):
                         event_ts, action, qty = replay_events[replay_event_idx]
@@ -2906,6 +2908,8 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                             replay_size += qty
                         else:
                             replay_size = max(0.0, replay_size - qty)
+                            if replay_size <= 1e-12:
+                                replay_flattened_at_ms = int(event_ts)
                         replay_event_idx += 1
                     return float(replay_size)
 
@@ -2948,6 +2952,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     )
                     if not require_coin_timeline_value:
                         continue
+                    replay_position_size = replay_size_at(ts)
                     abs_realized = _equity_hard_stop_history_coin_value(
                         row,
                         "realized_pnl_by_coin_pside",
@@ -2984,7 +2989,6 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         ),
                     )
                     if not has_unrealized and require_coin_timeline_value:
-                        replay_position_size = replay_size_at(ts)
                         if replay_ambiguous or replay_position_size > 1e-12:
                             if not require_coin_timeline_fields:
                                 continue
@@ -3022,7 +3026,34 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     applied_rows += 1
                     rows += 1
                     pair_rows_applied[(pside, symbol)] = int(applied_rows)
+                    replay_is_nonflat = replay_position_size > 1e-12
+                    replay_flattened_this_row = (
+                        not replay_ambiguous
+                        and replay_was_nonflat
+                        and not replay_is_nonflat
+                        and replay_flattened_at_ms is not None
+                        and replay_flattened_at_ms < ts + 60_000
+                    )
+                    if replay_is_nonflat:
+                        replay_was_nonflat = True
                     if marker is None:
+                        if replay_flattened_this_row:
+                            # Ordinary, non-panic flattening ends the current coin episode.
+                            # Cooldown/no-restart accounting remains driven by panic markers.
+                            reset_ts = int(replay_flattened_at_ms) + 1
+                            state["pnl_reset_timestamp_ms"] = reset_ts
+                            reset_baseline_realized = abs_realized
+                            self._equity_hard_stop_reset_coin_after_restart(pside, symbol)
+                            state = self._hsl_coin_state(pside, symbol)
+                            reset_rolling_window()
+                            replay_was_nonflat = False
+                            logging.info(
+                                "[risk] HSL[%s:%s] replay reset current episode after flat fill | flat_ts=%s",
+                                pside,
+                                symbol,
+                                int(replay_flattened_at_ms),
+                            )
+                            replay_flattened_at_ms = None
                         continue
                     stop_ts = int(marker["timestamp"])
                     if not _equity_hard_stop_replay_marker_confirms_red(metrics):

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -1474,6 +1474,96 @@ async def test_coin_hsl_history_replay_allows_flat_realized_only_rows():
 
 
 @pytest.mark.asyncio
+async def test_coin_hsl_history_replay_resets_current_episode_after_nonpanic_flatten():
+    bot = make_coin_bot()
+    symbol = "A"
+    bot.hsl["long"]["red_threshold"] = 0.2
+    bot.positions = {
+        symbol: {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}
+    }
+    bot.get_exchange_time = lambda: 300_000
+    fill_events = [
+        {
+            "timestamp": 60_500,
+            "symbol": symbol,
+            "pside": "long",
+            "action": "increase",
+            "qty": 1.0,
+            "price": 100.0,
+            "pnl": 0.0,
+        },
+        {
+            "timestamp": 180_500,
+            "symbol": symbol,
+            "pside": "long",
+            "action": "decrease",
+            "qty": 1.0,
+            "price": 80.0,
+            "pnl": -20.0,
+            "pb_order_type": "close_grid_long",
+        },
+        {
+            "timestamp": 240_500,
+            "symbol": symbol,
+            "pside": "long",
+            "action": "increase",
+            "qty": 1.0,
+            "price": 100.0,
+            "pnl": 0.0,
+        },
+    ]
+
+    async def fake_history(current_balance=None, **kwargs):
+        return {
+            "timeline": [
+                {
+                    "timestamp": 60_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {symbol: {"long": 0.0, "short": 0.0}},
+                    "unrealized_pnl_by_coin_pside": {symbol: {"long": 0.0, "short": 0.0}},
+                },
+                {
+                    "timestamp": 120_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {symbol: {"long": 0.0, "short": 0.0}},
+                    "unrealized_pnl_by_coin_pside": {symbol: {"long": -30.0, "short": 0.0}},
+                },
+                {
+                    "timestamp": 180_000,
+                    "balance": 80.0,
+                    "realized_pnl": -20.0,
+                    "realized_pnl_by_coin_pside": {symbol: {"long": -20.0, "short": 0.0}},
+                    "unrealized_pnl_by_coin_pside": {},
+                },
+                {
+                    "timestamp": 240_000,
+                    "balance": 80.0,
+                    "realized_pnl": -20.0,
+                    "realized_pnl_by_coin_pside": {symbol: {"long": -20.0, "short": 0.0}},
+                    "unrealized_pnl_by_coin_pside": {symbol: {"long": 0.0, "short": 0.0}},
+                },
+            ],
+            "panic_flatten_events": [],
+            "fill_events": fill_events,
+        }
+
+    bot.get_balance_equity_history = fake_history
+
+    await bot._equity_hard_stop_initialize_coin_from_history()
+
+    state = bot._hsl_coin_state("long", symbol)
+    assert state["pnl_reset_timestamp_ms"] == 180_501
+    assert state["halted"] is False
+    assert state["last_stop_event"] is None
+    assert state["last_metrics"]["timestamp_ms"] == 300_000
+    assert state["last_metrics"]["tier"] == "green"
+    assert state["last_metrics"]["drawdown_raw"] == pytest.approx(0.0)
+    assert bot._runtime_forced_modes == {"long": {}, "short": {}}
+
+
+@pytest.mark.asyncio
 async def test_coin_hsl_history_replay_requires_upnl_for_carry_in_decrease():
     bot = make_coin_bot()
     symbol = "A"


### PR DESCRIPTION
Summary:
- reset live coin-HSL current-episode realized-PnL and runtime drawdown when fill replay proves an ordinary non-panic flatten before a later re-entry
- keep panic-marker cooldown/no-restart handling unchanged
- update the fable-audit action plan with this partial coin-HSL episode-anchoring slice

Validation:
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/passivbot_hsl.py tests/test_hsl_coin_mode.py
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_hsl_coin_mode.py::test_coin_hsl_history_replay_resets_current_episode_after_nonpanic_flatten -q
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_hsl_coin_mode.py -q -k 'not test_coin_hsl_check_tp_only_orange_skips_flat_symbols'
- git diff --check

Note: full tests/test_hsl_coin_mode.py still has the known origin/v8 baseline failure test_coin_hsl_check_tp_only_orange_skips_flat_symbols, reproduced before this PR.