### PR TITLE
Pin reducer reachability priority

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -767,7 +767,7 @@ Remaining implementation details:
       Implemented: Rust core and JSON API validation reject invalid account/risk
       globals before realized-loss or unstuck gates can silently skip, including
       non-positive raw balance and realized-PnL peak/current inconsistencies.
-- [ ] Rust reducer priority: one reducer per coin+pside per ideal-order batch.
+- [x] Rust reducer priority: one reducer per coin+pside per ideal-order batch.
       Priority is HSL panic, WEL/TWEL reducer, auto-unstuck, then any other
       close order, with bid/ask-reachable reducers prioritized before farther
       passive closes.
@@ -778,9 +778,9 @@ Remaining implementation details:
       Partial: protective reducers now prune lower-priority same-position
       ordinary closes before size trimming; ordinary strategy-only close
       multiplicity is intentionally unchanged.
-      Remaining: keep or split out explicit bid/ask-reachable reducer ordering
-      if future review finds the existing close trimming/order sorting is not
-      sufficient.
+      Implemented: same-priority reducer pruning now has long/short regression
+      coverage proving bid/ask-reachable reducers win before farther passive
+      reducers.
 - [x] Contract docs batch: unstuck min-qty overshoot, inherited lookbacks,
       HSL/config-change risks, statelessness, `pnls_max_lookback_days`, and
       HSL-enabled startup warning.

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -4282,6 +4282,66 @@ mod core {
         }
 
         #[test]
+        fn close_pruning_prefers_reachable_long_reducer_with_same_priority() {
+            let order_book = OrderBook {
+                bid: 100.0,
+                ask: 101.0,
+            };
+            let mut closes = vec![
+                IdealOrder {
+                    symbol_idx: 0,
+                    pside: PositionSide::Long,
+                    qty: -0.3,
+                    price: 101.1,
+                    order_type: OrderType::CloseAutoReduceTwelLong,
+                },
+                IdealOrder {
+                    symbol_idx: 0,
+                    pside: PositionSide::Long,
+                    qty: -0.3,
+                    price: 100.9,
+                    order_type: OrderType::CloseAutoReduceWelLong,
+                },
+            ];
+
+            prune_lower_priority_closes(&mut closes, PositionSide::Long, &order_book);
+
+            assert_eq!(closes.len(), 1);
+            assert_eq!(closes[0].order_type, OrderType::CloseAutoReduceWelLong);
+            assert!((closes[0].price - 100.9).abs() < 1e-12);
+        }
+
+        #[test]
+        fn close_pruning_prefers_reachable_short_reducer_with_same_priority() {
+            let order_book = OrderBook {
+                bid: 100.0,
+                ask: 101.0,
+            };
+            let mut closes = vec![
+                IdealOrder {
+                    symbol_idx: 0,
+                    pside: PositionSide::Short,
+                    qty: 0.3,
+                    price: 99.9,
+                    order_type: OrderType::CloseAutoReduceTwelShort,
+                },
+                IdealOrder {
+                    symbol_idx: 0,
+                    pside: PositionSide::Short,
+                    qty: 0.3,
+                    price: 100.1,
+                    order_type: OrderType::CloseAutoReduceWelShort,
+                },
+            ];
+
+            prune_lower_priority_closes(&mut closes, PositionSide::Short, &order_book);
+
+            assert_eq!(closes.len(), 1);
+            assert_eq!(closes[0].order_type, OrderType::CloseAutoReduceWelShort);
+            assert!((closes[0].price - 100.1).abs() < 1e-12);
+        }
+
+        #[test]
         fn close_pruning_preserves_ordinary_close_ladder() {
             let order_book = OrderBook {
                 bid: 100.0,


### PR DESCRIPTION
Summary:
- add Rust regression coverage proving same-priority long/short reducers prefer bid/ask-reachable orders before farther passive reducers
- mark the reducer-priority fable-audit checklist item complete
- no trading behavior change intended; this pins the existing signed price-diff pruning contract

Validation:
- RUSTFLAGS='-L /Users/eiriknarjord/.pyenv/versions/3.12.3/lib -l python3.12' DYLD_LIBRARY_PATH=/Users/eiriknarjord/.pyenv/versions/3.12.3/lib cargo test -p passivbot_rust close_pruning -- --nocapture
- cargo check -p passivbot_rust
- git diff --check

Note: plain cargo test hit local macOS PyO3 linker/runtime issues without explicit libpython binding; the command above uses the local Python 3.12 dylib.