### PR TITLE
Pin dynamic WEL expansion contract

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -792,7 +792,7 @@ Remaining implementation details:
       finalization now use the explicit policy, with `threshold` as the
       behavior-preserving default and config/JSON validation for invalid
       values.
-- [ ] Dynamic WEL and snapped/raw balance docs/tests.
+- [x] Dynamic WEL and snapped/raw balance docs/tests.
       Make `reduce_overweight` use dynamic currently-tradable slot count, keep
       snapped/raw balance separation, and add high-hysteresis warning/preflight
       visibility.
@@ -803,6 +803,8 @@ Remaining implementation details:
       reports `balance_hysteresis_snap_pct` and warns when it is invalid or
       above `0.05`; docs now spell out snapped-balance sizing/gating versus
       raw-balance exposure-repair surfaces.
+      Implemented: JSON API coverage now pins both shrinking and expanding
+      currently-tradable universes for `reduce_overweight`.
 - [x] Entry cooldown design and migration plan.
       `entry_cooldown_minutes` is the sole ladder/cooldown control. Zero
       cooldown with entry retracement disabled may stage multiple

--- a/tests/test_orchestrator_json_api.py
+++ b/tests/test_orchestrator_json_api.py
@@ -1195,6 +1195,54 @@ def test_twel_reduce_overweight_uses_effective_tradable_slots():
     assert {order["symbol_idx"] for order in twel_closes} == {1}
 
 
+def test_twel_reduce_overweight_relaxes_floor_when_tradable_slots_expand():
+    import passivbot_rust as pbr
+
+    global_bp = bot_params_pair(
+        long_overrides={
+            "n_positions": 4,
+            "total_wallet_exposure_limit": 0.5,
+            "risk_twel_enforcer_threshold": 1.0,
+            "risk_twel_enforcer_policy": "reduce_overweight",
+        }
+    )
+    common_bp = {
+        "wallet_exposure_limit": 0.4,
+        "risk_wel_enforcer_threshold": 2.0,
+    }
+    inp = make_input(
+        balance=1_000.0,
+        global_bp=global_bp,
+        symbols=[
+            make_symbol(
+                0,
+                bid=100.0,
+                ask=100.0,
+                long_pos_size=2.5,
+                long_pos_price=100.0,
+                long_bp=common_bp,
+            ),
+            make_symbol(
+                1,
+                bid=95.0,
+                ask=95.0,
+                long_pos_size=2.6,
+                long_pos_price=100.0,
+                long_bp=common_bp,
+            ),
+            make_symbol(2, bid=100.0, ask=100.0, long_bp=common_bp),
+            make_symbol(3, bid=100.0, ask=100.0, long_bp=common_bp),
+        ],
+    )
+
+    out = compute(pbr, inp)
+    twel_closes = [
+        order for order in out["orders"] if order["order_type"] == "close_auto_reduce_twel_long"
+    ]
+    assert twel_closes
+    assert {order["symbol_idx"] for order in twel_closes} == {0}
+
+
 def test_twel_reduce_overweight_repairs_when_no_symbols_eligible():
     import passivbot_rust as pbr
 


### PR DESCRIPTION
Summary:
- add JSON API regression coverage for reduce_overweight when the currently-tradable universe expands
- prove expanded tradable slots relax the dynamic per-slot floor, making a previously-at-floor position eligible for TWEL repair
- mark the dynamic WEL/snapped-vs-raw checklist item complete; production behavior is unchanged

Validation:
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_orchestrator_json_api.py::test_twel_reduce_overweight_uses_effective_tradable_slots tests/test_orchestrator_json_api.py::test_twel_reduce_overweight_relaxes_floor_when_tradable_slots_expand tests/test_orchestrator_json_api.py::test_twel_reduce_overweight_repairs_when_no_symbols_eligible -q
- git diff --check