### PR TITLE
Require confirmed RED for HSL replay markers

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -827,6 +827,9 @@ Remaining implementation details:
       by an ordinary, non-panic close before a later re-entry. Panic-marker
       cooldown/no-restart handling is unchanged; broader terminal no-restart
       accounting from canonical RED timestamps remains future work.
+      Partial: historical panic markers now require reconstructed confirmed RED
+      tier/score, not raw-only drawdown. Raw RED pending remains diagnostic and
+      does not reconstruct a cooldown/no-restart event by itself.
 - [ ] HSL replay performance/readiness slice.
       Persist verified non-authoritative HSL time series/checkpoints, add doctor
       tools, prioritize held scopes, keep timing/source evidence, and move dense

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -633,7 +633,6 @@ def _equity_hard_stop_format_remaining_time(seconds: float) -> str:
 
 def _equity_hard_stop_replay_marker_confirms_red(metrics: dict) -> bool:
     try:
-        drawdown_raw = float(metrics["drawdown_raw"])
         drawdown_score = float(metrics["drawdown_score"])
         red_threshold = float(metrics["red_threshold"])
     except (KeyError, TypeError, ValueError) as exc:
@@ -642,7 +641,6 @@ def _equity_hard_stop_replay_marker_confirms_red(metrics: dict) -> bool:
     return (
         str(metrics.get("tier")) == "red"
         or drawdown_score >= threshold
-        or drawdown_raw >= threshold
     )
 
 

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -1197,6 +1197,76 @@ async def test_coin_hsl_history_replay_ignores_panic_marker_without_reconstructe
 
 
 @pytest.mark.asyncio
+async def test_coin_hsl_history_replay_ignores_raw_red_pending_panic_marker(caplog):
+    bot = make_coin_bot()
+    symbol = "A"
+    bot.hsl["long"]["ema_span_minutes"] = 100.0
+    writes = []
+    bot._equity_hard_stop_write_latch = (
+        lambda pside, payload, symbol=None: writes.append((pside, symbol, payload))
+        or "/tmp/hsl_coin_raw_pending_ignored.json"
+    )
+
+    async def fake_history(current_balance=None, **kwargs):
+        return {
+            "timeline": [
+                {
+                    "timestamp": 60_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {symbol: {"long": 0.0, "short": 0.0}},
+                    "unrealized_pnl_by_coin_pside": {symbol: {"long": 0.0, "short": 0.0}},
+                },
+                {
+                    "timestamp": 120_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {symbol: {"long": 0.0, "short": 0.0}},
+                    "unrealized_pnl_by_coin_pside": {symbol: {"long": -80.0, "short": 0.0}},
+                },
+            ],
+            "panic_flatten_events": [
+                {
+                    "timestamp": 120_500,
+                    "minute_timestamp": 120_000,
+                    "pside": "long",
+                    "symbol": symbol,
+                }
+            ],
+            "fill_events": [
+                {
+                    "timestamp": 120_500,
+                    "symbol": symbol,
+                    "pside": "long",
+                    "action": "decrease",
+                    "qty": 1.0,
+                    "pb_order_type": "close_panic_long",
+                }
+            ],
+        }
+
+    bot.get_balance_equity_history = fake_history
+    bot.get_exchange_time = lambda: 180_000
+
+    with caplog.at_level(logging.WARNING):
+        await bot._equity_hard_stop_initialize_coin_from_history()
+
+    state = bot._hsl_coin_state("long", symbol)
+    assert state["halted"] is False
+    assert state["cooldown_until_ms"] is None
+    assert state["last_stop_event"] is None
+    assert state["runtime"].red_latched() is False
+    assert writes == []
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "ignored historical coin panic marker without reconstructed RED" in message
+        and "drawdown_raw=1.000000" in message
+        and "drawdown_score=0.019802" in message
+        for message in messages
+    )
+
+
+@pytest.mark.asyncio
 async def test_coin_hsl_history_replay_requires_coin_timeline_fields():
     bot = make_coin_bot()
     symbol = "A"

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1169,6 +1169,47 @@ def test_hsl_replay_marker_confirmation_fails_loudly_on_incomplete_metrics():
         )
 
 
+def test_hsl_replay_marker_confirmation_requires_confirmed_red_not_raw_only():
+    import passivbot_hsl
+
+    assert (
+        passivbot_hsl._equity_hard_stop_replay_marker_confirms_red(
+            {
+                "tier": "orange",
+                "drawdown_raw": 0.20,
+                "drawdown_ema": 0.05,
+                "drawdown_score": 0.05,
+                "red_threshold": 0.10,
+            }
+        )
+        is False
+    )
+    assert (
+        passivbot_hsl._equity_hard_stop_replay_marker_confirms_red(
+            {
+                "tier": "red",
+                "drawdown_raw": 0.20,
+                "drawdown_ema": 0.05,
+                "drawdown_score": 0.05,
+                "red_threshold": 0.10,
+            }
+        )
+        is True
+    )
+    assert (
+        passivbot_hsl._equity_hard_stop_replay_marker_confirms_red(
+            {
+                "tier": "orange",
+                "drawdown_raw": 0.20,
+                "drawdown_ema": 0.10,
+                "drawdown_score": 0.10,
+                "red_threshold": 0.10,
+            }
+        )
+        is True
+    )
+
+
 def _make_order(
     symbol="TEST/USDT",
     *,


### PR DESCRIPTION
Summary:
- require historical HSL panic markers to match reconstructed confirmed RED tier/score, not raw-only drawdown
- add helper and coin-HSL replay regressions proving raw RED pending remains diagnostic and does not reconstruct cooldown/no-restart by itself
- update the fable-audit action plan with this partial coin-HSL episode/no-restart contract slice

Validation:
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_hsl_coin_mode.py::test_coin_hsl_history_replay_does_not_latch_recovered_red_without_panic_marker tests/test_hsl_coin_mode.py::test_coin_hsl_history_replay_honors_restart_after_red_policy tests/test_hsl_coin_mode.py::test_coin_hsl_history_replay_ignores_panic_marker_without_reconstructed_red tests/test_hsl_coin_mode.py::test_coin_hsl_history_replay_ignores_raw_red_pending_panic_marker tests/test_unstucking_safeguards.py::test_hsl_replay_marker_confirmation_fails_loudly_on_incomplete_metrics tests/test_unstucking_safeguards.py::test_hsl_replay_marker_confirmation_requires_confirmed_red_not_raw_only -q
- git diff --check