### PR TITLE
Pin HSL replay matrix row contract

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -818,6 +818,12 @@ Remaining implementation details:
       Align coin, pside, and unified around one raw per-minute `pnl + upnl`
       data-store model, keep scoped modes on base slot-budget-style
       normalization, and add sample-parity tests before changing semantics.
+      Partial: live HSL now has pure replay-matrix helpers that build
+      non-authoritative raw rows (`ts`, `price`, `psize`, `pprice`, `pnl`,
+      `upnl`) from authoritative candle/fill inputs, derive UPnL through the
+      Rust PnL helpers, require contiguous one-minute rows, and recompute
+      `pnl_cumsum`/equity from raw minute `pnl` instead of persisting cumulative
+      state.
 - [ ] Coin-HSL episode anchoring redesign, including no-restart persistence and
       cooldown rules.
       Current panic eligibility should be based on the current trading episode;

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -29,6 +29,8 @@ from utils import make_get_filepath
 
 
 _HSL_RISKS_DOC = "docs/equity_hard_stop_loss_risks.md"
+_HSL_REPLAY_MATRIX_INTERVAL_MS = 60_000
+_HSL_REPLAY_MATRIX_RAW_FIELDS = ("ts", "price", "psize", "pprice", "pnl", "upnl")
 
 
 def _hsl_key_sample(value: Any, *, limit: int = 32) -> list[str]:
@@ -370,6 +372,92 @@ def _calc_hsl_pnl(position_side, entry_price, close_price, qty, c_mult):
             return pbr.calc_pnl_long(entry_price, close_price, qty, c_mult)
         return pbr.calc_pnl_short(entry_price, close_price, qty, c_mult)
     return pbr.calc_pnl_long(entry_price, close_price, qty, c_mult)
+
+
+def _finite_hsl_float(value: Any, field_name: str) -> float:
+    out = float(value)
+    if not math.isfinite(out):
+        raise ValueError(f"HSL replay matrix field {field_name} must be finite, got {out}")
+    return out
+
+
+def _hsl_replay_matrix_row(
+    *,
+    pside: str,
+    ts: int,
+    price: float,
+    psize: float,
+    pprice: float,
+    pnl: float,
+    c_mult: float,
+) -> dict[str, float | int]:
+    """Build one non-authoritative cache row from authoritative candles/fills."""
+    if pside not in {"long", "short"}:
+        raise ValueError(f"HSL replay matrix pside must be long or short, got {pside!r}")
+    ts_int = int(ts)
+    if ts_int < 0:
+        raise ValueError(f"HSL replay matrix ts must be >= 0, got {ts_int}")
+    price_f = _finite_hsl_float(price, "price")
+    psize_f = _finite_hsl_float(psize, "psize")
+    pprice_f = _finite_hsl_float(pprice, "pprice")
+    pnl_f = _finite_hsl_float(pnl, "pnl")
+    c_mult_f = _finite_hsl_float(c_mult, "c_mult")
+    if price_f <= 0.0:
+        raise ValueError(f"HSL replay matrix price must be > 0, got {price_f}")
+    if c_mult_f <= 0.0:
+        raise ValueError(f"HSL replay matrix c_mult must be > 0, got {c_mult_f}")
+    if abs(psize_f) <= 0.0:
+        upnl = 0.0
+    else:
+        if pprice_f <= 0.0:
+            raise ValueError(
+                f"HSL replay matrix pprice must be > 0 for non-flat rows, got {pprice_f}"
+            )
+        qty = abs(psize_f)
+        upnl = float(_calc_hsl_pnl(pside, pprice_f, price_f, qty, c_mult_f))
+    return {
+        "ts": ts_int,
+        "price": price_f,
+        "psize": psize_f,
+        "pprice": pprice_f,
+        "pnl": pnl_f,
+        "upnl": upnl,
+    }
+
+
+def _hsl_replay_matrix_derived_series(
+    rows: list[dict[str, Any]], *, base_equity: float
+) -> list[dict[str, float | int]]:
+    """Derive cumulative PnL/equity without treating persisted raw PnL as cumulative."""
+    base_equity_f = _finite_hsl_float(base_equity, "base_equity")
+    if base_equity_f <= 0.0:
+        raise ValueError(f"HSL replay matrix base_equity must be > 0, got {base_equity_f}")
+    out: list[dict[str, float | int]] = []
+    pnl_cumsum = 0.0
+    prev_ts: int | None = None
+    for row in rows:
+        missing = [field for field in _HSL_REPLAY_MATRIX_RAW_FIELDS if field not in row]
+        if missing:
+            raise ValueError(f"HSL replay matrix row missing fields: {missing}")
+        ts = int(row["ts"])
+        if prev_ts is not None and ts - prev_ts != _HSL_REPLAY_MATRIX_INTERVAL_MS:
+            raise ValueError(
+                "HSL replay matrix rows must be contiguous 1m samples; "
+                f"got previous_ts={prev_ts} ts={ts}"
+            )
+        pnl = _finite_hsl_float(row["pnl"], "pnl")
+        upnl = _finite_hsl_float(row["upnl"], "upnl")
+        pnl_cumsum += pnl
+        out.append(
+            {
+                "ts": ts,
+                "pnl_cumsum": float(pnl_cumsum),
+                "upnl": upnl,
+                "equity": float(base_equity_f + pnl_cumsum + upnl),
+            }
+        )
+        prev_ts = ts
+    return out
 
 
 def _hsl_psides(self) -> tuple[str, str]:

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -92,6 +92,97 @@ def test_parse_hsl_config_warns_about_history_reinterpretation(caplog):
     assert any("HSL mode changes" in message for message in messages)
 
 
+def test_hsl_replay_matrix_row_derives_upnl_from_rust_pnl_helpers():
+    long_row = hsl._hsl_replay_matrix_row(
+        pside="long",
+        ts=60_000,
+        price=90.0,
+        psize=2.0,
+        pprice=100.0,
+        pnl=-3.0,
+        c_mult=1.0,
+    )
+    short_row = hsl._hsl_replay_matrix_row(
+        pside="short",
+        ts=60_000,
+        price=110.0,
+        psize=-2.0,
+        pprice=100.0,
+        pnl=4.0,
+        c_mult=1.0,
+    )
+
+    assert set(long_row) == set(hsl._HSL_REPLAY_MATRIX_RAW_FIELDS)
+    assert long_row["upnl"] == pytest.approx(pbr.calc_pnl_long(100.0, 90.0, 2.0, 1.0))
+    assert short_row["upnl"] == pytest.approx(pbr.calc_pnl_short(100.0, 110.0, 2.0, 1.0))
+    assert long_row["pnl"] == pytest.approx(-3.0)
+    assert short_row["pnl"] == pytest.approx(4.0)
+
+
+def test_hsl_replay_matrix_derived_series_keeps_persisted_pnl_raw():
+    rows = [
+        hsl._hsl_replay_matrix_row(
+            pside="long",
+            ts=60_000,
+            price=100.0,
+            psize=1.0,
+            pprice=100.0,
+            pnl=5.0,
+            c_mult=1.0,
+        ),
+        hsl._hsl_replay_matrix_row(
+            pside="long",
+            ts=120_000,
+            price=90.0,
+            psize=1.0,
+            pprice=100.0,
+            pnl=-2.0,
+            c_mult=1.0,
+        ),
+        hsl._hsl_replay_matrix_row(
+            pside="long",
+            ts=180_000,
+            price=105.0,
+            psize=0.0,
+            pprice=0.0,
+            pnl=7.0,
+            c_mult=1.0,
+        ),
+    ]
+
+    derived = hsl._hsl_replay_matrix_derived_series(rows, base_equity=1_000.0)
+
+    assert [row["pnl"] for row in rows] == [5.0, -2.0, 7.0]
+    assert [row["pnl_cumsum"] for row in derived] == pytest.approx([5.0, 3.0, 10.0])
+    assert [row["equity"] for row in derived] == pytest.approx([1005.0, 993.0, 1010.0])
+
+
+def test_hsl_replay_matrix_derived_series_requires_contiguous_minutes():
+    rows = [
+        hsl._hsl_replay_matrix_row(
+            pside="long",
+            ts=60_000,
+            price=100.0,
+            psize=0.0,
+            pprice=0.0,
+            pnl=0.0,
+            c_mult=1.0,
+        ),
+        hsl._hsl_replay_matrix_row(
+            pside="long",
+            ts=180_000,
+            price=100.0,
+            psize=0.0,
+            pprice=0.0,
+            pnl=0.0,
+            c_mult=1.0,
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="contiguous 1m samples"):
+        hsl._hsl_replay_matrix_derived_series(rows, base_equity=1_000.0)
+
+
 def bind_hsl_methods(bot):
     for name in (
         "_hsl_psides",


### PR DESCRIPTION
## Summary
- add pure live-HSL replay matrix helpers for non-authoritative raw rows
- derive UPnL through Rust PnL helpers and derive pnl_cumsum/equity from raw minute PnL
- record the fable-audit progress note for the canonical HSL signal design

## Validation
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_hsl_coin_mode.py::test_hsl_replay_matrix_row_derives_upnl_from_rust_pnl_helpers tests/test_hsl_coin_mode.py::test_hsl_replay_matrix_derived_series_keeps_persisted_pnl_raw tests/test_hsl_coin_mode.py::test_hsl_replay_matrix_derived_series_requires_contiguous_minutes -q
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_hsl_coin_mode.py -k 'not test_coin_hsl_check_tp_only_orange_skips_flat_symbols' -q
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/passivbot_hsl.py tests/test_hsl_coin_mode.py
- git diff --check