### PR TITLE
Add HSL replay cache manifest validation

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -842,6 +842,12 @@ Remaining implementation details:
       computation away from Python primitive loops. First persisted format
       should be `.npz` arrays plus JSON metadata unless implementation evidence
       shows a better dependency-free option.
+      Partial: pure live-HSL cache helpers now write the raw replay matrix as
+      `hsl_replay_matrix.npz` plus `hsl_replay_manifest.json`, including schema
+      version, fixed one-minute interval, row/time bounds, trust-boundary
+      metadata, per-array dtype/shape/SHA-256, and explicit validation reason
+      codes for reuse rejection. The cache remains unwired and
+      non-authoritative.
 - [ ] Python simplification after Rust owns ideal protective orders and unstuck
       orders.
       Python should reconcile ideal vs actual orders, not re-decide trading

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -483,6 +483,16 @@ def _hsl_replay_matrix_arrays(rows: list[dict[str, Any]]) -> dict[str, Any]:
 
     # Reuse the derived-series validation path for raw fields and 1m continuity.
     _hsl_replay_matrix_derived_series(rows, base_equity=1.0)
+    for row in rows:
+        price = _finite_hsl_float(row["price"], "price")
+        psize = _finite_hsl_float(row["psize"], "psize")
+        pprice = _finite_hsl_float(row["pprice"], "pprice")
+        if price <= 0.0:
+            raise ValueError(f"HSL replay matrix price must be > 0, got {price}")
+        if abs(psize) > 0.0 and pprice <= 0.0:
+            raise ValueError(
+                f"HSL replay matrix pprice must be > 0 for non-flat rows, got {pprice}"
+            )
     return {
         "ts": np.asarray([int(row["ts"]) for row in rows], dtype=np.int64),
         "price": np.asarray([float(row["price"]) for row in rows], dtype=np.float64),
@@ -515,6 +525,33 @@ def _hsl_replay_cache_array_manifest(arrays: dict[str, Any]) -> dict[str, dict[s
         }
         for field in _HSL_REPLAY_MATRIX_RAW_FIELDS
     }
+
+
+def _hsl_replay_cache_array_value_reasons(arrays: dict[str, Any]) -> list[str]:
+    import numpy as np
+
+    reasons: list[str] = []
+    required = set(_HSL_REPLAY_MATRIX_RAW_FIELDS)
+    if set(arrays) != required:
+        return reasons
+    row_count = int(len(arrays["ts"]))
+    for field in _HSL_REPLAY_MATRIX_RAW_FIELDS:
+        if len(arrays[field]) != row_count:
+            reasons.append(f"array_length_mismatch:{field}")
+    if reasons:
+        return reasons
+    ts = arrays["ts"]
+    if row_count and (not bool(np.all(np.isfinite(ts))) or int(ts[0]) < 0):
+        reasons.append("timestamp_invalid")
+    for field in ("price", "psize", "pprice", "pnl", "upnl"):
+        if not bool(np.all(np.isfinite(arrays[field]))):
+            reasons.append(f"array_nonfinite:{field}")
+    if row_count and bool(np.any(arrays["price"] <= 0.0)):
+        reasons.append("price_nonpositive")
+    nonflat = np.abs(arrays["psize"]) > 0.0
+    if row_count and bool(np.any(nonflat & (arrays["pprice"] <= 0.0))):
+        reasons.append("nonflat_pprice_nonpositive")
+    return reasons
 
 
 def _normalize_hsl_replay_cache_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
@@ -614,11 +651,25 @@ def _hsl_replay_cache_validation_reasons(
         except Exception:
             reasons.append("expected_metadata_invalid")
     metadata = manifest.get("metadata")
+    metadata_norm = None
     if not isinstance(metadata, dict):
         reasons.append("metadata_missing")
-    elif expected_norm is not None:
+    else:
+        try:
+            metadata_norm = _normalize_hsl_replay_cache_metadata(metadata)
+        except ValueError:
+            missing_fields = [
+                key for key in _HSL_REPLAY_CACHE_REQUIRED_METADATA if metadata.get(key) is None
+            ]
+            if missing_fields:
+                reasons.extend(f"metadata_missing_required:{key}" for key in missing_fields)
+            else:
+                reasons.append("metadata_invalid")
+        except Exception:
+            reasons.append("metadata_invalid")
+    if metadata_norm is not None and expected_norm is not None:
         for key, value in expected_norm.items():
-            if metadata.get(key) != value:
+            if metadata_norm.get(key) != value:
                 reasons.append(f"metadata_mismatch:{key}")
     try:
         loaded_npz = np.load(matrix_path, allow_pickle=False)
@@ -651,6 +702,7 @@ def _hsl_replay_cache_validation_reasons(
             row_count = int(len(loaded_arrays["ts"]))
             if row_count != int(manifest.get("row_count", -1)):
                 reasons.append("row_count_mismatch")
+            reasons.extend(_hsl_replay_cache_array_value_reasons(loaded_arrays))
             if row_count:
                 diffs = np.diff(loaded_arrays["ts"])
                 if diffs.size and not bool(np.all(diffs == _HSL_REPLAY_MATRIX_INTERVAL_MS)):

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -720,18 +720,28 @@ def _hsl_replay_cache_validation_reasons(
             if _hsl_hash_array(arr) != str(entry.get("sha256")):
                 reasons.append(f"array_hash_mismatch:{field}")
         if set(loaded_arrays) == set(_HSL_REPLAY_MATRIX_RAW_FIELDS):
-            row_count = int(len(loaded_arrays["ts"]))
-            if row_count != int(manifest.get("row_count", -1)):
+            value_reasons = _hsl_replay_cache_array_value_reasons(loaded_arrays)
+            reasons.extend(value_reasons)
+            ts_array = np.asarray(loaded_arrays["ts"])
+            ts_valid_for_time_checks = (
+                ts_array.ndim == 1
+                and np.issubdtype(ts_array.dtype, np.number)
+                and bool(np.all(np.isfinite(ts_array)))
+            )
+            row_count = int(len(ts_array)) if ts_valid_for_time_checks else None
+            if row_count is not None and row_count != int(manifest.get("row_count", -1)):
                 reasons.append("row_count_mismatch")
-            reasons.extend(_hsl_replay_cache_array_value_reasons(loaded_arrays))
             if row_count:
-                diffs = np.diff(loaded_arrays["ts"])
+                diffs = np.diff(ts_array)
                 if diffs.size and not bool(np.all(diffs == _HSL_REPLAY_MATRIX_INTERVAL_MS)):
                     reasons.append("timestamp_not_contiguous")
-                if int(loaded_arrays["ts"][0]) != manifest.get("start_ts_ms"):
-                    reasons.append("start_ts_mismatch")
-                if int(loaded_arrays["ts"][-1]) != manifest.get("end_ts_ms"):
-                    reasons.append("end_ts_mismatch")
+                try:
+                    if int(ts_array[0]) != manifest.get("start_ts_ms"):
+                        reasons.append("start_ts_mismatch")
+                    if int(ts_array[-1]) != manifest.get("end_ts_ms"):
+                        reasons.append("end_ts_mismatch")
+                except (TypeError, ValueError, OverflowError):
+                    reasons.append("timestamp_invalid")
     return reasons
 
 

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import math
@@ -8,6 +9,7 @@ import os
 import time
 import traceback
 from collections import deque
+from pathlib import Path
 from typing import Any, Optional
 
 import passivbot_rust as pbr
@@ -31,6 +33,22 @@ from utils import make_get_filepath
 _HSL_RISKS_DOC = "docs/equity_hard_stop_loss_risks.md"
 _HSL_REPLAY_MATRIX_INTERVAL_MS = 60_000
 _HSL_REPLAY_MATRIX_RAW_FIELDS = ("ts", "price", "psize", "pprice", "pnl", "upnl")
+_HSL_REPLAY_CACHE_SCHEMA_VERSION = 1
+_HSL_REPLAY_CACHE_MATRIX_FILENAME = "hsl_replay_matrix.npz"
+_HSL_REPLAY_CACHE_MANIFEST_FILENAME = "hsl_replay_manifest.json"
+_HSL_REPLAY_CACHE_REQUIRED_METADATA = (
+    "exchange",
+    "market_type",
+    "user",
+    "config_digest",
+    "signal_mode",
+    "pside",
+    "symbol",
+    "fill_covered_start_ms",
+    "fill_covered_end_ms",
+    "candle_covered_start_ms",
+    "candle_covered_end_ms",
+)
 
 
 def _hsl_key_sample(value: Any, *, limit: int = 32) -> list[str]:
@@ -458,6 +476,190 @@ def _hsl_replay_matrix_derived_series(
         )
         prev_ts = ts
     return out
+
+
+def _hsl_replay_matrix_arrays(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    import numpy as np
+
+    # Reuse the derived-series validation path for raw fields and 1m continuity.
+    _hsl_replay_matrix_derived_series(rows, base_equity=1.0)
+    return {
+        "ts": np.asarray([int(row["ts"]) for row in rows], dtype=np.int64),
+        "price": np.asarray([float(row["price"]) for row in rows], dtype=np.float64),
+        "psize": np.asarray([float(row["psize"]) for row in rows], dtype=np.float64),
+        "pprice": np.asarray([float(row["pprice"]) for row in rows], dtype=np.float64),
+        "pnl": np.asarray([float(row["pnl"]) for row in rows], dtype=np.float64),
+        "upnl": np.asarray([float(row["upnl"]) for row in rows], dtype=np.float64),
+    }
+
+
+def _hsl_hash_array(array: Any) -> str:
+    import numpy as np
+
+    arr = np.ascontiguousarray(np.asarray(array))
+    hasher = hashlib.sha256()
+    hasher.update(str(arr.dtype).encode("utf-8"))
+    hasher.update(b"\0")
+    hasher.update(json.dumps(list(arr.shape), separators=(",", ":")).encode("utf-8"))
+    hasher.update(b"\0")
+    hasher.update(arr.tobytes(order="C"))
+    return hasher.hexdigest()
+
+
+def _hsl_replay_cache_array_manifest(arrays: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        field: {
+            "sha256": _hsl_hash_array(arrays[field]),
+            "shape": [int(x) for x in arrays[field].shape],
+            "dtype": str(arrays[field].dtype),
+        }
+        for field in _HSL_REPLAY_MATRIX_RAW_FIELDS
+    }
+
+
+def _normalize_hsl_replay_cache_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(metadata, dict):
+        raise TypeError(f"HSL replay cache metadata must be a dict, got {type(metadata).__name__}")
+    missing = [key for key in _HSL_REPLAY_CACHE_REQUIRED_METADATA if metadata.get(key) is None]
+    if missing:
+        raise ValueError(f"HSL replay cache metadata missing required fields: {missing}")
+    out = dict(metadata)
+    for key in (
+        "exchange",
+        "market_type",
+        "user",
+        "config_digest",
+        "signal_mode",
+        "pside",
+        "symbol",
+    ):
+        out[key] = str(out[key])
+    for key in (
+        "fill_covered_start_ms",
+        "fill_covered_end_ms",
+        "candle_covered_start_ms",
+        "candle_covered_end_ms",
+    ):
+        out[key] = int(out[key])
+    return out
+
+
+def _write_hsl_replay_matrix_cache(
+    cache_dir: str | os.PathLike[str],
+    rows: list[dict[str, Any]],
+    metadata: dict[str, Any],
+) -> dict[str, Any]:
+    import numpy as np
+
+    cache_path = Path(cache_dir)
+    cache_path.mkdir(parents=True, exist_ok=True)
+    arrays = _hsl_replay_matrix_arrays(rows)
+    metadata_norm = _normalize_hsl_replay_cache_metadata(metadata)
+    manifest = {
+        "schema_version": _HSL_REPLAY_CACHE_SCHEMA_VERSION,
+        "matrix_file": _HSL_REPLAY_CACHE_MATRIX_FILENAME,
+        "row_count": int(len(rows)),
+        "fields": list(_HSL_REPLAY_MATRIX_RAW_FIELDS),
+        "interval_ms": _HSL_REPLAY_MATRIX_INTERVAL_MS,
+        "start_ts_ms": int(arrays["ts"][0]) if len(rows) else None,
+        "end_ts_ms": int(arrays["ts"][-1]) if len(rows) else None,
+        "metadata": metadata_norm,
+        "arrays": _hsl_replay_cache_array_manifest(arrays),
+    }
+    matrix_path = cache_path / _HSL_REPLAY_CACHE_MATRIX_FILENAME
+    manifest_path = cache_path / _HSL_REPLAY_CACHE_MANIFEST_FILENAME
+    matrix_tmp = matrix_path.with_suffix(matrix_path.suffix + f".{os.getpid()}.tmp")
+    manifest_tmp = manifest_path.with_suffix(manifest_path.suffix + f".{os.getpid()}.tmp")
+    np.savez(matrix_tmp, **arrays)
+    # numpy appends .npz when the provided filename does not already end with it.
+    actual_matrix_tmp = matrix_tmp if matrix_tmp.exists() else Path(str(matrix_tmp) + ".npz")
+    os.replace(actual_matrix_tmp, matrix_path)
+    manifest_tmp.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(manifest_tmp, manifest_path)
+    return manifest
+
+
+def _hsl_replay_cache_validation_reasons(
+    cache_dir: str | os.PathLike[str],
+    *,
+    expected_metadata: dict[str, Any] | None = None,
+) -> list[str]:
+    import numpy as np
+
+    cache_path = Path(cache_dir)
+    manifest_path = cache_path / _HSL_REPLAY_CACHE_MANIFEST_FILENAME
+    matrix_path = cache_path / _HSL_REPLAY_CACHE_MATRIX_FILENAME
+    if not manifest_path.exists():
+        return ["manifest_missing"]
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except Exception:
+        return ["manifest_unreadable"]
+    reasons: list[str] = []
+    if not isinstance(manifest, dict):
+        return ["manifest_not_object"]
+    if int(manifest.get("schema_version", 0) or 0) != _HSL_REPLAY_CACHE_SCHEMA_VERSION:
+        reasons.append("schema_version_mismatch")
+    if str(manifest.get("matrix_file", "")) != _HSL_REPLAY_CACHE_MATRIX_FILENAME:
+        reasons.append("matrix_filename_mismatch")
+    if int(manifest.get("interval_ms", 0) or 0) != _HSL_REPLAY_MATRIX_INTERVAL_MS:
+        reasons.append("interval_mismatch")
+    if not matrix_path.exists():
+        reasons.append("matrix_missing")
+        return reasons
+    expected_norm = None
+    if expected_metadata is not None:
+        try:
+            expected_norm = _normalize_hsl_replay_cache_metadata(expected_metadata)
+        except Exception:
+            reasons.append("expected_metadata_invalid")
+    metadata = manifest.get("metadata")
+    if not isinstance(metadata, dict):
+        reasons.append("metadata_missing")
+    elif expected_norm is not None:
+        for key, value in expected_norm.items():
+            if metadata.get(key) != value:
+                reasons.append(f"metadata_mismatch:{key}")
+    try:
+        loaded_npz = np.load(matrix_path, allow_pickle=False)
+    except Exception:
+        reasons.append("matrix_unreadable")
+        return reasons
+    with loaded_npz as loaded:
+        arrays_manifest = manifest.get("arrays")
+        if not isinstance(arrays_manifest, dict):
+            reasons.append("arrays_manifest_missing")
+            arrays_manifest = {}
+        loaded_arrays: dict[str, Any] = {}
+        for field in _HSL_REPLAY_MATRIX_RAW_FIELDS:
+            if field not in loaded:
+                reasons.append(f"array_missing:{field}")
+                continue
+            arr = loaded[field]
+            loaded_arrays[field] = arr
+            entry = arrays_manifest.get(field)
+            if not isinstance(entry, dict):
+                reasons.append(f"array_manifest_missing:{field}")
+                continue
+            if str(arr.dtype) != str(entry.get("dtype")):
+                reasons.append(f"array_dtype_mismatch:{field}")
+            if [int(x) for x in arr.shape] != list(entry.get("shape", [])):
+                reasons.append(f"array_shape_mismatch:{field}")
+            if _hsl_hash_array(arr) != str(entry.get("sha256")):
+                reasons.append(f"array_hash_mismatch:{field}")
+        if set(loaded_arrays) == set(_HSL_REPLAY_MATRIX_RAW_FIELDS):
+            row_count = int(len(loaded_arrays["ts"]))
+            if row_count != int(manifest.get("row_count", -1)):
+                reasons.append("row_count_mismatch")
+            if row_count:
+                diffs = np.diff(loaded_arrays["ts"])
+                if diffs.size and not bool(np.all(diffs == _HSL_REPLAY_MATRIX_INTERVAL_MS)):
+                    reasons.append("timestamp_not_contiguous")
+                if int(loaded_arrays["ts"][0]) != manifest.get("start_ts_ms"):
+                    reasons.append("start_ts_mismatch")
+                if int(loaded_arrays["ts"][-1]) != manifest.get("end_ts_ms"):
+                    reasons.append("end_ts_mismatch")
+    return reasons
 
 
 def _hsl_psides(self) -> tuple[str, str]:

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -527,6 +527,17 @@ def _hsl_replay_cache_array_manifest(arrays: dict[str, Any]) -> dict[str, dict[s
     }
 
 
+def _hsl_replay_cache_array_dtype_is_valid(field: str, dtype: Any) -> bool:
+    import numpy as np
+
+    np_dtype = np.dtype(dtype)
+    if np.issubdtype(np_dtype, np.complexfloating):
+        return False
+    if field == "ts":
+        return bool(np.issubdtype(np_dtype, np.integer))
+    return bool(np.issubdtype(np_dtype, np.integer) or np.issubdtype(np_dtype, np.floating))
+
+
 def _hsl_replay_cache_array_value_reasons(arrays: dict[str, Any]) -> list[str]:
     import numpy as np
 
@@ -551,7 +562,7 @@ def _hsl_replay_cache_array_value_reasons(arrays: dict[str, Any]) -> list[str]:
     numeric_arrays: dict[str, Any] = {}
     for field in _HSL_REPLAY_MATRIX_RAW_FIELDS:
         arr = np.asarray(arrays[field])
-        if arr.ndim != 1 or not np.issubdtype(arr.dtype, np.number):
+        if arr.ndim != 1 or not _hsl_replay_cache_array_dtype_is_valid(field, arr.dtype):
             reasons.append(f"array_value_invalid:{field}")
             continue
         numeric_arrays[field] = arr
@@ -725,7 +736,7 @@ def _hsl_replay_cache_validation_reasons(
             ts_array = np.asarray(loaded_arrays["ts"])
             ts_valid_for_time_checks = (
                 ts_array.ndim == 1
-                and np.issubdtype(ts_array.dtype, np.number)
+                and _hsl_replay_cache_array_dtype_is_valid("ts", ts_array.dtype)
                 and bool(np.all(np.isfinite(ts_array)))
             )
             row_count = int(len(ts_array)) if ts_valid_for_time_checks else None

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -534,23 +534,44 @@ def _hsl_replay_cache_array_value_reasons(arrays: dict[str, Any]) -> list[str]:
     required = set(_HSL_REPLAY_MATRIX_RAW_FIELDS)
     if set(arrays) != required:
         return reasons
-    row_count = int(len(arrays["ts"]))
+    try:
+        row_count = int(len(arrays["ts"]))
+    except TypeError:
+        return ["array_value_invalid:ts"]
     for field in _HSL_REPLAY_MATRIX_RAW_FIELDS:
-        if len(arrays[field]) != row_count:
+        try:
+            field_len = int(len(arrays[field]))
+        except TypeError:
+            reasons.append(f"array_value_invalid:{field}")
+            continue
+        if field_len != row_count:
             reasons.append(f"array_length_mismatch:{field}")
     if reasons:
         return reasons
-    ts = arrays["ts"]
-    if row_count and (not bool(np.all(np.isfinite(ts))) or int(ts[0]) < 0):
-        reasons.append("timestamp_invalid")
-    for field in ("price", "psize", "pprice", "pnl", "upnl"):
-        if not bool(np.all(np.isfinite(arrays[field]))):
-            reasons.append(f"array_nonfinite:{field}")
-    if row_count and bool(np.any(arrays["price"] <= 0.0)):
+    numeric_arrays: dict[str, Any] = {}
+    for field in _HSL_REPLAY_MATRIX_RAW_FIELDS:
+        arr = np.asarray(arrays[field])
+        if arr.ndim != 1 or not np.issubdtype(arr.dtype, np.number):
+            reasons.append(f"array_value_invalid:{field}")
+            continue
+        numeric_arrays[field] = arr
+        try:
+            if not bool(np.all(np.isfinite(arr))):
+                reasons.append(f"array_nonfinite:{field}")
+        except (TypeError, ValueError):
+            reasons.append(f"array_value_invalid:{field}")
+    if "ts" in numeric_arrays and row_count:
+        try:
+            if int(numeric_arrays["ts"][0]) < 0:
+                reasons.append("timestamp_invalid")
+        except (TypeError, ValueError, OverflowError):
+            reasons.append("timestamp_invalid")
+    if "price" in numeric_arrays and row_count and bool(np.any(numeric_arrays["price"] <= 0.0)):
         reasons.append("price_nonpositive")
-    nonflat = np.abs(arrays["psize"]) > 0.0
-    if row_count and bool(np.any(nonflat & (arrays["pprice"] <= 0.0))):
-        reasons.append("nonflat_pprice_nonpositive")
+    if {"psize", "pprice"}.issubset(numeric_arrays) and row_count:
+        nonflat = np.abs(numeric_arrays["psize"]) > 0.0
+        if bool(np.any(nonflat & (numeric_arrays["pprice"] <= 0.0))):
+            reasons.append("nonflat_pprice_nonpositive")
     return reasons
 
 

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -337,6 +337,34 @@ def test_hsl_replay_matrix_cache_validation_reports_non_numeric_array_without_ra
     assert "array_value_invalid:price" in reasons
 
 
+def test_hsl_replay_matrix_cache_validation_rejects_complex_arrays_with_matching_manifest(
+    tmp_path,
+):
+    import json
+    import numpy as np
+
+    metadata = _hsl_cache_metadata()
+    hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), metadata)
+    matrix_path = tmp_path / hsl._HSL_REPLAY_CACHE_MATRIX_FILENAME
+    manifest_path = tmp_path / hsl._HSL_REPLAY_CACHE_MANIFEST_FILENAME
+    with np.load(matrix_path, allow_pickle=False) as loaded:
+        arrays = {field: loaded[field].copy() for field in hsl._HSL_REPLAY_MATRIX_RAW_FIELDS}
+    arrays["ts"] = arrays["ts"].astype(np.complex128) + 1j
+    arrays["price"] = arrays["price"].astype(np.complex128) + 1j
+    np.savez(matrix_path, **arrays)
+    manifest = json.loads(manifest_path.read_text())
+    manifest["arrays"] = hsl._hsl_replay_cache_array_manifest(arrays)
+    manifest_path.write_text(json.dumps(manifest, sort_keys=True))
+
+    reasons = hsl._hsl_replay_cache_validation_reasons(
+        tmp_path,
+        expected_metadata=metadata,
+    )
+
+    assert "array_value_invalid:ts" in reasons
+    assert "array_value_invalid:price" in reasons
+
+
 @pytest.mark.parametrize("bad_ts_kind", ["strings", "scalar", "two_dim"])
 def test_hsl_replay_matrix_cache_validation_reports_corrupt_ts_without_raising(
     tmp_path, bad_ts_kind

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -183,6 +183,110 @@ def test_hsl_replay_matrix_derived_series_requires_contiguous_minutes():
         hsl._hsl_replay_matrix_derived_series(rows, base_equity=1_000.0)
 
 
+def _hsl_cache_metadata(**overrides):
+    metadata = {
+        "exchange": "binance",
+        "market_type": "swap",
+        "user": "test_user",
+        "config_digest": "cfg_hash",
+        "signal_mode": "coin",
+        "pside": "long",
+        "symbol": "BTC/USDT:USDT",
+        "fill_covered_start_ms": 60_000,
+        "fill_covered_end_ms": 180_000,
+        "candle_covered_start_ms": 60_000,
+        "candle_covered_end_ms": 180_000,
+    }
+    metadata.update(overrides)
+    return metadata
+
+
+def _hsl_cache_rows():
+    return [
+        hsl._hsl_replay_matrix_row(
+            pside="long",
+            ts=60_000,
+            price=100.0,
+            psize=1.0,
+            pprice=100.0,
+            pnl=0.0,
+            c_mult=1.0,
+        ),
+        hsl._hsl_replay_matrix_row(
+            pside="long",
+            ts=120_000,
+            price=90.0,
+            psize=1.0,
+            pprice=100.0,
+            pnl=-2.0,
+            c_mult=1.0,
+        ),
+        hsl._hsl_replay_matrix_row(
+            pside="long",
+            ts=180_000,
+            price=95.0,
+            psize=0.0,
+            pprice=0.0,
+            pnl=3.0,
+            c_mult=1.0,
+        ),
+    ]
+
+
+def test_hsl_replay_matrix_cache_round_trips_with_manifest(tmp_path):
+    metadata = _hsl_cache_metadata()
+
+    manifest = hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), metadata)
+
+    assert manifest["schema_version"] == hsl._HSL_REPLAY_CACHE_SCHEMA_VERSION
+    assert manifest["matrix_file"] == hsl._HSL_REPLAY_CACHE_MATRIX_FILENAME
+    assert manifest["row_count"] == 3
+    assert manifest["metadata"] == metadata
+    assert hsl._hsl_replay_cache_validation_reasons(
+        tmp_path,
+        expected_metadata=metadata,
+    ) == []
+
+
+def test_hsl_replay_matrix_cache_reports_metadata_mismatch(tmp_path):
+    metadata = _hsl_cache_metadata()
+    hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), metadata)
+
+    reasons = hsl._hsl_replay_cache_validation_reasons(
+        tmp_path,
+        expected_metadata=_hsl_cache_metadata(config_digest="other_cfg_hash"),
+    )
+
+    assert reasons == ["metadata_mismatch:config_digest"]
+
+
+def test_hsl_replay_matrix_cache_reports_array_hash_mismatch(tmp_path):
+    import numpy as np
+
+    metadata = _hsl_cache_metadata()
+    hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), metadata)
+    matrix_path = tmp_path / hsl._HSL_REPLAY_CACHE_MATRIX_FILENAME
+    with np.load(matrix_path, allow_pickle=False) as loaded:
+        arrays = {field: loaded[field].copy() for field in hsl._HSL_REPLAY_MATRIX_RAW_FIELDS}
+    arrays["pnl"][1] = -99.0
+    np.savez(matrix_path, **arrays)
+
+    reasons = hsl._hsl_replay_cache_validation_reasons(
+        tmp_path,
+        expected_metadata=metadata,
+    )
+
+    assert "array_hash_mismatch:pnl" in reasons
+
+
+def test_hsl_replay_matrix_cache_requires_trust_boundary_metadata(tmp_path):
+    metadata = _hsl_cache_metadata()
+    metadata.pop("config_digest")
+
+    with pytest.raises(ValueError, match="metadata missing required fields"):
+        hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), metadata)
+
+
 def bind_hsl_methods(bot):
     for name in (
         "_hsl_psides",

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -316,6 +316,27 @@ def test_hsl_replay_matrix_cache_validation_reports_semantically_invalid_raw_val
     assert "nonflat_pprice_nonpositive" in reasons
 
 
+def test_hsl_replay_matrix_cache_validation_reports_non_numeric_array_without_raising(tmp_path):
+    import numpy as np
+
+    metadata = _hsl_cache_metadata()
+    hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), metadata)
+    matrix_path = tmp_path / hsl._HSL_REPLAY_CACHE_MATRIX_FILENAME
+    with np.load(matrix_path, allow_pickle=False) as loaded:
+        arrays = {field: loaded[field].copy() for field in hsl._HSL_REPLAY_MATRIX_RAW_FIELDS}
+    arrays["price"] = np.array(["bad", "bad", "bad"], dtype="<U3")
+    np.savez(matrix_path, **arrays)
+
+    reasons = hsl._hsl_replay_cache_validation_reasons(
+        tmp_path,
+        expected_metadata=metadata,
+    )
+
+    assert "array_dtype_mismatch:price" in reasons
+    assert "array_hash_mismatch:price" in reasons
+    assert "array_value_invalid:price" in reasons
+
+
 def test_hsl_replay_matrix_cache_requires_trust_boundary_metadata(tmp_path):
     metadata = _hsl_cache_metadata()
     metadata.pop("config_digest")

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -279,12 +279,64 @@ def test_hsl_replay_matrix_cache_reports_array_hash_mismatch(tmp_path):
     assert "array_hash_mismatch:pnl" in reasons
 
 
+def test_hsl_replay_matrix_cache_write_rejects_semantically_invalid_raw_values(tmp_path):
+    rows = _hsl_cache_rows()
+    rows[0] = dict(rows[0], price=float("nan"))
+
+    with pytest.raises(ValueError, match="price"):
+        hsl._write_hsl_replay_matrix_cache(tmp_path, rows, _hsl_cache_metadata())
+
+    rows = _hsl_cache_rows()
+    rows[0] = dict(rows[0], pprice=0.0)
+
+    with pytest.raises(ValueError, match="pprice"):
+        hsl._write_hsl_replay_matrix_cache(tmp_path, rows, _hsl_cache_metadata())
+
+
+def test_hsl_replay_matrix_cache_validation_reports_semantically_invalid_raw_values(tmp_path):
+    import numpy as np
+
+    metadata = _hsl_cache_metadata()
+    hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), metadata)
+    matrix_path = tmp_path / hsl._HSL_REPLAY_CACHE_MATRIX_FILENAME
+    with np.load(matrix_path, allow_pickle=False) as loaded:
+        arrays = {field: loaded[field].copy() for field in hsl._HSL_REPLAY_MATRIX_RAW_FIELDS}
+    arrays["price"][0] = float("nan")
+    arrays["pprice"][1] = 0.0
+    np.savez(matrix_path, **arrays)
+
+    reasons = hsl._hsl_replay_cache_validation_reasons(
+        tmp_path,
+        expected_metadata=metadata,
+    )
+
+    assert "array_hash_mismatch:price" in reasons
+    assert "array_nonfinite:price" in reasons
+    assert "array_hash_mismatch:pprice" in reasons
+    assert "nonflat_pprice_nonpositive" in reasons
+
+
 def test_hsl_replay_matrix_cache_requires_trust_boundary_metadata(tmp_path):
     metadata = _hsl_cache_metadata()
     metadata.pop("config_digest")
 
     with pytest.raises(ValueError, match="metadata missing required fields"):
         hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), metadata)
+
+
+def test_hsl_replay_matrix_cache_validation_requires_manifest_trust_boundary_metadata(tmp_path):
+    import json
+
+    metadata = _hsl_cache_metadata()
+    hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), metadata)
+    manifest_path = tmp_path / hsl._HSL_REPLAY_CACHE_MANIFEST_FILENAME
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["metadata"].pop("config_digest")
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    reasons = hsl._hsl_replay_cache_validation_reasons(tmp_path)
+
+    assert reasons == ["metadata_missing_required:config_digest"]
 
 
 def bind_hsl_methods(bot):

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -337,6 +337,34 @@ def test_hsl_replay_matrix_cache_validation_reports_non_numeric_array_without_ra
     assert "array_value_invalid:price" in reasons
 
 
+@pytest.mark.parametrize("bad_ts_kind", ["strings", "scalar", "two_dim"])
+def test_hsl_replay_matrix_cache_validation_reports_corrupt_ts_without_raising(
+    tmp_path, bad_ts_kind
+):
+    import numpy as np
+
+    metadata = _hsl_cache_metadata()
+    hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), metadata)
+    matrix_path = tmp_path / hsl._HSL_REPLAY_CACHE_MATRIX_FILENAME
+    with np.load(matrix_path, allow_pickle=False) as loaded:
+        arrays = {field: loaded[field].copy() for field in hsl._HSL_REPLAY_MATRIX_RAW_FIELDS}
+    if bad_ts_kind == "strings":
+        arrays["ts"] = np.array(["bad", "bad", "bad"], dtype="<U3")
+    elif bad_ts_kind == "scalar":
+        arrays["ts"] = np.array(0)
+    else:
+        arrays["ts"] = np.array([[60_000], [120_000], [180_000]])
+    np.savez(matrix_path, **arrays)
+
+    reasons = hsl._hsl_replay_cache_validation_reasons(
+        tmp_path,
+        expected_metadata=metadata,
+    )
+
+    assert "array_value_invalid:ts" in reasons
+    assert any(reason.startswith("array_hash_mismatch:ts") for reason in reasons)
+
+
 def test_hsl_replay_matrix_cache_requires_trust_boundary_metadata(tmp_path):
     metadata = _hsl_cache_metadata()
     metadata.pop("config_digest")


### PR DESCRIPTION
## Summary
- add pure HSL replay cache helpers for hsl_replay_matrix.npz plus hsl_replay_manifest.json
- include schema version, fixed interval, row/time bounds, trust-boundary metadata, and per-array dtype/shape/SHA-256
- return explicit validation reason codes for cache rejection; helpers remain unwired and non-authoritative

## Validation
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_hsl_coin_mode.py::test_hsl_replay_matrix_cache_round_trips_with_manifest tests/test_hsl_coin_mode.py::test_hsl_replay_matrix_cache_reports_metadata_mismatch tests/test_hsl_coin_mode.py::test_hsl_replay_matrix_cache_reports_array_hash_mismatch tests/test_hsl_coin_mode.py::test_hsl_replay_matrix_cache_requires_trust_boundary_metadata -q
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_hsl_coin_mode.py -k 'not test_coin_hsl_check_tp_only_orange_skips_flat_symbols' -q
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/passivbot_hsl.py tests/test_hsl_coin_mode.py
- git diff --check