### PR TITLE
Report HSL replay cache validity in doctor

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -848,6 +848,10 @@ Remaining implementation details:
       metadata, per-array dtype/shape/SHA-256, and explicit validation reason
       codes for reuse rejection. The cache remains unwired and
       non-authoritative.
+      Partial: `cache-integrity-doctor` now discovers HSL replay manifests,
+      runs the replay-cache validator, reports valid/invalid cache counts and
+      validation reason counts under risk metadata, and emits warning issues
+      for caches that must be rebuilt rather than reused.
 - [ ] Python simplification after Rust owns ideal protective orders and unstuck
       orders.
       Python should reconcile ideal vs actual orders, not re-decide trading

--- a/src/tools/cache_integrity_doctor.py
+++ b/src/tools/cache_integrity_doctor.py
@@ -258,6 +258,10 @@ def _metadata_summary_entry() -> dict[str, Any]:
         "no_trade_known_gap_count": 0,
         "unclassified_known_gap_count": 0,
         "hsl_artifact_count": 0,
+        "hsl_replay_cache_count": 0,
+        "hsl_replay_cache_valid_count": 0,
+        "hsl_replay_cache_invalid_count": 0,
+        "hsl_replay_cache_reason_counts": Counter(),
         "first_event_ms": None,
         "last_event_ms": None,
         "covered_start_ms": None,
@@ -862,6 +866,62 @@ def _summarize_risk_ndjson_payload(path: Path) -> dict[str, Any] | None:
     return out
 
 
+def _inspect_hsl_replay_cache_manifest(path: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    out = _metadata_summary_entry()
+    out["artifact_count"] = 1
+    out["metadata_file_count"] = 1
+    out["hsl_artifact_count"] = 1
+    out["hsl_replay_cache_count"] = 1
+    sample = {
+        "path": str(path),
+        "kind": "hsl_replay_cache_manifest",
+        "hsl_related": True,
+    }
+    issues: list[dict[str, Any]] = []
+    try:
+        from passivbot_hsl import _hsl_replay_cache_validation_reasons
+    except Exception as exc:
+        out["hsl_replay_cache_invalid_count"] = 1
+        reason = "validator_unavailable"
+        out["hsl_replay_cache_reason_counts"][reason] += 1
+        sample["valid"] = False
+        sample["reasons"] = [reason]
+        issues.append(
+            _issue(
+                "warning",
+                "hsl_replay_cache_validation_unavailable",
+                path,
+                f"could not import HSL replay cache validator: {type(exc).__name__}",
+                family="risk",
+            )
+        )
+    else:
+        try:
+            reasons = list(_hsl_replay_cache_validation_reasons(path.parent))
+        except Exception as exc:
+            reasons = [f"validator_failed:{type(exc).__name__}"]
+        if reasons:
+            out["hsl_replay_cache_invalid_count"] = 1
+            for reason in reasons:
+                out["hsl_replay_cache_reason_counts"][str(reason)] += 1
+            sample["valid"] = False
+            sample["reasons"] = [str(reason) for reason in reasons[:MAX_METADATA_ARTIFACT_SAMPLES]]
+            issues.append(
+                _issue(
+                    "warning",
+                    "hsl_replay_cache_invalid",
+                    path,
+                    "HSL replay cache is not safely reusable: " + ", ".join(sample["reasons"]),
+                    family="risk",
+                )
+            )
+        else:
+            out["hsl_replay_cache_valid_count"] = 1
+            sample["valid"] = True
+    _add_limited_sample(out["artifact_samples"], sample, MAX_METADATA_ARTIFACT_SAMPLES)
+    return out, issues
+
+
 def _inspect_metadata_artifact(path: Path, family: str) -> dict[str, Any] | None:
     suffix = path.suffix.lower()
     if suffix == ".json":
@@ -899,10 +959,16 @@ def _merge_metadata(summary: dict[str, Any], artifact: dict[str, Any]) -> None:
         "unclassified_known_gap_count",
         "timestamp_field_count",
         "hsl_artifact_count",
+        "hsl_replay_cache_count",
+        "hsl_replay_cache_valid_count",
+        "hsl_replay_cache_invalid_count",
     ):
         metadata[key] += int(artifact[key])
     metadata["history_scope_counts"].update(artifact["history_scope_counts"])
     metadata["known_gap_reason_counts"].update(artifact["known_gap_reason_counts"])
+    metadata["hsl_replay_cache_reason_counts"].update(
+        artifact["hsl_replay_cache_reason_counts"]
+    )
     for key in ("first_event_ms", "covered_start_ms"):
         value = artifact[key]
         if value is not None and (metadata[key] is None or int(value) < int(metadata[key])):
@@ -933,10 +999,16 @@ def _merge_finalized_metadata(summary: dict[str, Any], metadata_report: dict[str
         "unclassified_known_gap_count",
         "timestamp_field_count",
         "hsl_artifact_count",
+        "hsl_replay_cache_count",
+        "hsl_replay_cache_valid_count",
+        "hsl_replay_cache_invalid_count",
     ):
         metadata[key] += int(metadata_report[key])
     metadata["history_scope_counts"].update(metadata_report["history_scope_counts"])
     metadata["known_gap_reason_counts"].update(metadata_report["known_gap_reason_counts"])
+    metadata["hsl_replay_cache_reason_counts"].update(
+        metadata_report["hsl_replay_cache_reason_counts"]
+    )
     for key in ("first_event_ms", "covered_start_ms"):
         value = metadata_report[key]
         if value is not None and (metadata[key] is None or int(value) < int(metadata[key])):
@@ -969,6 +1041,9 @@ def _finalize_metadata(
     known_gap_count = int(metadata["known_gap_count"])
     no_trade_known_gap_count = int(metadata["no_trade_known_gap_count"])
     hsl_artifact_count = int(metadata["hsl_artifact_count"])
+    hsl_replay_cache_count = int(metadata["hsl_replay_cache_count"])
+    hsl_replay_cache_valid_count = int(metadata["hsl_replay_cache_valid_count"])
+    hsl_replay_cache_invalid_count = int(metadata["hsl_replay_cache_invalid_count"])
     if artifact_count == 0:
         compatibility = "no_local_metadata"
     elif issue_count:
@@ -994,7 +1069,11 @@ def _finalize_metadata(
         compatibility = "local_state_observed"
     hsl_compatibility = None
     if family == "risk":
-        if hsl_artifact_count and int(metadata["timestamp_field_count"]):
+        if hsl_replay_cache_invalid_count:
+            hsl_compatibility = "hsl_replay_cache_invalid"
+        elif hsl_replay_cache_valid_count:
+            hsl_compatibility = "hsl_replay_cache_valid"
+        elif hsl_artifact_count and int(metadata["timestamp_field_count"]):
             hsl_compatibility = "hsl_state_with_timestamps"
         elif hsl_artifact_count:
             hsl_compatibility = "hsl_state_without_timestamps"
@@ -1014,6 +1093,12 @@ def _finalize_metadata(
         "no_trade_known_gap_count": no_trade_known_gap_count,
         "unclassified_known_gap_count": int(metadata["unclassified_known_gap_count"]),
         "hsl_artifact_count": hsl_artifact_count,
+        "hsl_replay_cache_count": hsl_replay_cache_count,
+        "hsl_replay_cache_valid_count": hsl_replay_cache_valid_count,
+        "hsl_replay_cache_invalid_count": hsl_replay_cache_invalid_count,
+        "hsl_replay_cache_reason_counts": dict(
+            sorted(metadata["hsl_replay_cache_reason_counts"].items())
+        ),
         "hsl_compatibility": hsl_compatibility,
         "first_event_ms": metadata["first_event_ms"],
         "last_event_ms": metadata["last_event_ms"],
@@ -1410,9 +1495,15 @@ def _scan_root(root: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
                         family=family,
                     )
                 )
-        metadata_artifact = _inspect_metadata_artifact(entry, family)
-        if metadata_artifact is not None:
+        if family == "risk" and entry.name == "hsl_replay_manifest.json":
+            metadata_artifact, hsl_cache_issues = _inspect_hsl_replay_cache_manifest(entry)
             _merge_metadata(family_summary, metadata_artifact)
+            family_summary["issue_count"] += len(hsl_cache_issues)
+            issues.extend(hsl_cache_issues)
+        else:
+            metadata_artifact = _inspect_metadata_artifact(entry, family)
+            if metadata_artifact is not None:
+                _merge_metadata(family_summary, metadata_artifact)
     summary["by_extension"] = dict(sorted(by_extension.items()))
     summary["by_family"] = _finalize_family_summary(by_family)
     summary["warm_cache_readiness"] = _build_warm_cache_readiness(summary["by_family"])

--- a/tests/test_cache_integrity_doctor.py
+++ b/tests/test_cache_integrity_doctor.py
@@ -66,6 +66,79 @@ def test_cache_integrity_report_summarizes_cache_families(tmp_path):
     assert issue["family"] == "candles"
 
 
+def _hsl_replay_cache_rows():
+    return [
+        {"ts": 60_000, "price": 100.0, "psize": 0.0, "pprice": 0.0, "pnl": 0.0, "upnl": 0.0},
+        {"ts": 120_000, "price": 101.0, "psize": 1.0, "pprice": 100.0, "pnl": 0.5, "upnl": 1.0},
+        {"ts": 180_000, "price": 102.0, "psize": 1.0, "pprice": 100.0, "pnl": 0.0, "upnl": 2.0},
+    ]
+
+
+def _hsl_replay_cache_metadata():
+    return {
+        "exchange": "binance",
+        "market_type": "swap",
+        "user": "user_01",
+        "config_digest": "cfg_digest",
+        "signal_mode": "coin",
+        "pside": "long",
+        "symbol": "BTC/USDT:USDT",
+        "fill_covered_start_ms": 60_000,
+        "fill_covered_end_ms": 180_000,
+        "candle_covered_start_ms": 60_000,
+        "candle_covered_end_ms": 180_000,
+    }
+
+
+def test_cache_integrity_report_validates_hsl_replay_cache(tmp_path):
+    import passivbot_hsl as hsl
+
+    cache_dir = tmp_path / "caches" / "equity_hard_stop" / "binance" / "user_01" / "BTC"
+    hsl._write_hsl_replay_matrix_cache(
+        cache_dir,
+        _hsl_replay_cache_rows(),
+        _hsl_replay_cache_metadata(),
+    )
+
+    report = build_cache_integrity_report([tmp_path / "caches"])
+
+    risk = report["summary"]["by_family"]["risk"]
+    metadata = risk["metadata"]
+    assert metadata["hsl_replay_cache_count"] == 1
+    assert metadata["hsl_replay_cache_valid_count"] == 1
+    assert metadata["hsl_replay_cache_invalid_count"] == 0
+    assert metadata["hsl_replay_cache_reason_counts"] == {}
+    assert metadata["hsl_compatibility"] == "hsl_replay_cache_valid"
+    assert report["issues"] == []
+
+
+def test_cache_integrity_report_flags_invalid_hsl_replay_cache(tmp_path):
+    import passivbot_hsl as hsl
+
+    cache_dir = tmp_path / "caches" / "equity_hard_stop" / "binance" / "user_01" / "BTC"
+    hsl._write_hsl_replay_matrix_cache(
+        cache_dir,
+        _hsl_replay_cache_rows(),
+        _hsl_replay_cache_metadata(),
+    )
+    (cache_dir / hsl._HSL_REPLAY_CACHE_MATRIX_FILENAME).unlink()
+
+    report = build_cache_integrity_report([tmp_path / "caches"])
+
+    risk = report["summary"]["by_family"]["risk"]
+    metadata = risk["metadata"]
+    assert metadata["hsl_replay_cache_count"] == 1
+    assert metadata["hsl_replay_cache_valid_count"] == 0
+    assert metadata["hsl_replay_cache_invalid_count"] == 1
+    assert metadata["hsl_replay_cache_reason_counts"] == {"matrix_missing": 1}
+    assert metadata["hsl_compatibility"] == "hsl_replay_cache_invalid"
+    assert report["ok"] is True
+    issue = next(item for item in report["issues"] if item["code"] == "hsl_replay_cache_invalid")
+    assert issue["severity"] == "warning"
+    assert issue["family"] == "risk"
+    assert "matrix_missing" in issue["message"]
+
+
 def test_cache_integrity_report_summarizes_candle_coverage_windows_and_gaps(tmp_path):
     root = tmp_path / "caches"
     month_dir = root / "ohlcv" / "data" / "binance" / "1m" / "BTC_USDT" / "2026"


### PR DESCRIPTION
## Summary
- extend cache-integrity-doctor risk metadata with HSL replay cache valid/invalid counters and validation reason counts
- discover hsl_replay_manifest.json and run the existing fail-closed replay-cache validator read-only
- record invalid/unavailable HSL replay cache validation as warning issues, not trading blockers
- update the fable-audit action plan progress note for the HSL replay performance/readiness slice

## Validation
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_cache_integrity_doctor.py -q
- /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/tools/cache_integrity_doctor.py tests/test_cache_integrity_doctor.py
- git diff --check

## Scope
Read-only tooling/docs only. No live trading behavior, HSL replay behavior, or cache reuse wiring changes.