### PR TITLE
Add fail-closed HSL replay cache loader

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -852,6 +852,10 @@ Remaining implementation details:
       runs the replay-cache validator, reports valid/invalid cache counts and
       validation reason counts under risk metadata, and emits warning issues
       for caches that must be rebuilt rather than reused.
+      Partial: pure live-HSL cache helpers now include a fail-closed loader
+      that validates manifest metadata and array hashes before returning copied
+      manifest/array data for future replay reuse. The loader remains unwired
+      and non-authoritative.
 - [ ] Python simplification after Rust owns ideal protective orders and unstuck
       orders.
       Python should reconcile ideal vs actual orders, not re-decide trading

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -756,6 +756,28 @@ def _hsl_replay_cache_validation_reasons(
     return reasons
 
 
+def _load_hsl_replay_matrix_cache(
+    cache_dir: str | os.PathLike[str],
+    *,
+    expected_metadata: dict[str, Any] | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    import numpy as np
+
+    reasons = _hsl_replay_cache_validation_reasons(
+        cache_dir,
+        expected_metadata=expected_metadata,
+    )
+    if reasons:
+        raise ValueError("HSL replay cache validation failed: " + ", ".join(reasons))
+    cache_path = Path(cache_dir)
+    manifest = json.loads(
+        (cache_path / _HSL_REPLAY_CACHE_MANIFEST_FILENAME).read_text(encoding="utf-8")
+    )
+    with np.load(cache_path / _HSL_REPLAY_CACHE_MATRIX_FILENAME, allow_pickle=False) as loaded:
+        arrays = {field: loaded[field].copy() for field in _HSL_REPLAY_MATRIX_RAW_FIELDS}
+    return manifest, arrays
+
+
 def _hsl_psides(self) -> tuple[str, str]:
     return ("long", "short")
 

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -260,6 +260,34 @@ def test_hsl_replay_matrix_cache_reports_metadata_mismatch(tmp_path):
     assert reasons == ["metadata_mismatch:config_digest"]
 
 
+def test_hsl_replay_matrix_cache_load_returns_manifest_and_arrays(tmp_path):
+    import numpy as np
+
+    metadata = _hsl_cache_metadata()
+    written_manifest = hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), metadata)
+
+    manifest, arrays = hsl._load_hsl_replay_matrix_cache(
+        tmp_path,
+        expected_metadata=metadata,
+    )
+
+    assert manifest == written_manifest
+    assert set(arrays) == set(hsl._HSL_REPLAY_MATRIX_RAW_FIELDS)
+    np.testing.assert_array_equal(arrays["ts"], np.array([60_000, 120_000, 180_000]))
+    np.testing.assert_allclose(arrays["pnl"], np.array([0.0, -2.0, 3.0]))
+
+
+def test_hsl_replay_matrix_cache_load_rejects_metadata_mismatch(tmp_path):
+    metadata = _hsl_cache_metadata()
+    hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), metadata)
+
+    with pytest.raises(ValueError, match="metadata_mismatch:config_digest"):
+        hsl._load_hsl_replay_matrix_cache(
+            tmp_path,
+            expected_metadata=_hsl_cache_metadata(config_digest="other_cfg_hash"),
+        )
+
+
 def test_hsl_replay_matrix_cache_reports_array_hash_mismatch(tmp_path):
     import numpy as np
 
@@ -277,6 +305,21 @@ def test_hsl_replay_matrix_cache_reports_array_hash_mismatch(tmp_path):
     )
 
     assert "array_hash_mismatch:pnl" in reasons
+
+
+def test_hsl_replay_matrix_cache_load_rejects_corrupt_matrix(tmp_path):
+    import numpy as np
+
+    metadata = _hsl_cache_metadata()
+    hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), metadata)
+    matrix_path = tmp_path / hsl._HSL_REPLAY_CACHE_MATRIX_FILENAME
+    with np.load(matrix_path, allow_pickle=False) as loaded:
+        arrays = {field: loaded[field].copy() for field in hsl._HSL_REPLAY_MATRIX_RAW_FIELDS}
+    arrays["pnl"][1] = -99.0
+    np.savez(matrix_path, **arrays)
+
+    with pytest.raises(ValueError, match="array_hash_mismatch:pnl"):
+        hsl._load_hsl_replay_matrix_cache(tmp_path, expected_metadata=metadata)
 
 
 def test_hsl_replay_matrix_cache_write_rejects_semantically_invalid_raw_values(tmp_path):


### PR DESCRIPTION
## Summary
- add a private HSL replay matrix cache loader that validates manifest metadata and array hashes before returning cached data
- return copied manifest/array data only after validation succeeds; corrupt or mismatched caches raise with existing reason codes
- record the partial HSL replay performance/readiness milestone in the fable-audit plan

## Behavior
- Observability/performance plumbing only; loader remains unwired from live trading decisions
- Cache remains non-authoritative and fail-closed

## Tests
- ./venv/bin/python -m pytest tests/test_hsl_coin_mode.py -k hsl_replay_matrix_cache -q
- ./venv/bin/python -m pytest tests/test_hsl_coin_mode.py -k 'not test_coin_hsl_check_tp_only_orange_skips_flat_symbols' -q
- ./venv/bin/python -m compileall src/passivbot_hsl.py tests/test_hsl_coin_mode.py
- git diff --check