### PR TITLE
Add vectorized HSL replay cache derivation

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -856,6 +856,10 @@ Remaining implementation details:
       that validates manifest metadata and array hashes before returning copied
       manifest/array data for future replay reuse. The loader remains unwired
       and non-authoritative.
+      Partial: raw replay arrays can now be converted to derived
+      `pnl_cumsum`/`upnl`/equity arrays through a vectorized helper with the
+      same continuity/value checks, reducing the need for Python row loops when
+      cache reuse is later wired.
 - [ ] Python simplification after Rust owns ideal protective orders and unstuck
       orders.
       Python should reconcile ideal vs actual orders, not re-decide trading

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -503,6 +503,42 @@ def _hsl_replay_matrix_arrays(rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _hsl_replay_matrix_derived_arrays(
+    arrays: dict[str, Any], *, base_equity: float
+) -> dict[str, Any]:
+    import numpy as np
+
+    if not isinstance(arrays, dict):
+        raise TypeError(f"HSL replay matrix arrays must be a dict, got {type(arrays).__name__}")
+    expected = set(_HSL_REPLAY_MATRIX_RAW_FIELDS)
+    actual = set(arrays)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise ValueError(
+            "HSL replay matrix arrays must contain exactly the raw fields; "
+            f"missing={missing} extra={extra}"
+        )
+    base_equity_f = _finite_hsl_float(base_equity, "base_equity")
+    if base_equity_f <= 0.0:
+        raise ValueError(f"HSL replay matrix base_equity must be > 0, got {base_equity_f}")
+    reasons = _hsl_replay_cache_array_value_reasons(arrays)
+    if reasons:
+        raise ValueError("HSL replay matrix arrays invalid: " + ", ".join(reasons))
+    ts = np.asarray(arrays["ts"], dtype=np.int64)
+    if len(ts) > 1 and not bool(np.all(np.diff(ts) == _HSL_REPLAY_MATRIX_INTERVAL_MS)):
+        raise ValueError("HSL replay matrix arrays invalid: timestamp_not_contiguous")
+    pnl = np.asarray(arrays["pnl"], dtype=np.float64)
+    upnl = np.asarray(arrays["upnl"], dtype=np.float64)
+    pnl_cumsum = np.cumsum(pnl, dtype=np.float64)
+    return {
+        "ts": ts.copy(),
+        "pnl_cumsum": pnl_cumsum,
+        "upnl": upnl.copy(),
+        "equity": base_equity_f + pnl_cumsum + upnl,
+    }
+
+
 def _hsl_hash_array(array: Any) -> str:
     import numpy as np
 

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -248,6 +248,48 @@ def test_hsl_replay_matrix_cache_round_trips_with_manifest(tmp_path):
     ) == []
 
 
+def test_hsl_replay_matrix_derived_arrays_matches_row_series():
+    import numpy as np
+
+    rows = _hsl_cache_rows()
+    arrays = hsl._hsl_replay_matrix_arrays(rows)
+    derived_arrays = hsl._hsl_replay_matrix_derived_arrays(arrays, base_equity=1_000.0)
+    derived_rows = hsl._hsl_replay_matrix_derived_series(rows, base_equity=1_000.0)
+
+    np.testing.assert_array_equal(
+        derived_arrays["ts"],
+        np.array([row["ts"] for row in derived_rows], dtype=np.int64),
+    )
+    np.testing.assert_allclose(
+        derived_arrays["pnl_cumsum"],
+        np.array([row["pnl_cumsum"] for row in derived_rows]),
+    )
+    np.testing.assert_allclose(
+        derived_arrays["upnl"],
+        np.array([row["upnl"] for row in derived_rows]),
+    )
+    np.testing.assert_allclose(
+        derived_arrays["equity"],
+        np.array([row["equity"] for row in derived_rows]),
+    )
+
+
+def test_hsl_replay_matrix_derived_arrays_rejects_missing_field():
+    arrays = hsl._hsl_replay_matrix_arrays(_hsl_cache_rows())
+    arrays.pop("upnl")
+
+    with pytest.raises(ValueError, match="missing=\\['upnl'\\]"):
+        hsl._hsl_replay_matrix_derived_arrays(arrays, base_equity=1_000.0)
+
+
+def test_hsl_replay_matrix_derived_arrays_rejects_timestamp_gap():
+    arrays = hsl._hsl_replay_matrix_arrays(_hsl_cache_rows())
+    arrays["ts"][1] += hsl._HSL_REPLAY_MATRIX_INTERVAL_MS
+
+    with pytest.raises(ValueError, match="timestamp_not_contiguous"):
+        hsl._hsl_replay_matrix_derived_arrays(arrays, base_equity=1_000.0)
+
+
 def test_hsl_replay_matrix_cache_reports_metadata_mismatch(tmp_path):
     metadata = _hsl_cache_metadata()
     hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), metadata)


### PR DESCRIPTION
## Summary
- add a pure helper that derives HSL replay pnl_cumsum, upnl, and equity arrays directly from raw replay cache arrays
- reuse the existing raw-array value checks and require contiguous 1m timestamps before deriving series data
- record the partial HSL replay performance/readiness milestone in the fable-audit plan

## Behavior
- Performance/readiness scaffolding only; helper remains unwired from live trading decisions
- Cache remains non-authoritative and invalid arrays fail closed

## Tests
- ./venv/bin/python -m pytest tests/test_hsl_coin_mode.py -k 'hsl_replay_matrix' -q
- ./venv/bin/python -m pytest tests/test_hsl_coin_mode.py -k 'not test_coin_hsl_check_tp_only_orange_skips_flat_symbols' -q
- ./venv/bin/python -m compileall src/passivbot_hsl.py tests/test_hsl_coin_mode.py
- git diff --check