### PR TITLE
Add HSL replay phase timing events

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -860,6 +860,9 @@ Remaining implementation details:
       `pnl_cumsum`/`upnl`/equity arrays through a vectorized helper with the
       same continuity/value checks, reducing the need for Python row loops when
       cache reuse is later wired.
+      Partial: coin-HSL replay lifecycle events now split startup timing into
+      history-fetch, pre-replay, replay-loop, and total blocking elapsed fields
+      so future cache-reuse work can prove which phase improved.
 - [ ] Python simplification after Rust owns ideal protective orders and unstuck
       orders.
       Python should reconcile ideal vs actual orders, not re-decide trading

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -3056,7 +3056,8 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             current_balance=self.get_raw_balance(),
             hsl_replay_signal_mode="coin",
         )
-        history_fetch_elapsed_s = max(0.0, time.monotonic() - history_fetch_started_s)
+        history_loaded_s = time.monotonic()
+        history_fetch_elapsed_s = max(0.0, history_loaded_s - history_fetch_started_s)
         check_shutdown("hsl_coin_history_replay_history_loaded")
         panic_flatten_events = history["panic_flatten_events"] if "panic_flatten_events" in history else []
         if panic_flatten_events is None:
@@ -3195,7 +3196,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
         balance = float(self.get_raw_balance())
         rows = 0
         replay_started_s = time.monotonic()
-        pre_replay_elapsed_s = max(0.0, replay_started_s - initialization_started_s)
+        pre_replay_elapsed_s = max(0.0, replay_started_s - history_loaded_s)
         last_progress_log_s = replay_started_s
         replay_symbols = set(symbols)
         active_pairs = [

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -3014,6 +3014,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
     prev_phase = getattr(self, "_log_silence_watchdog_phase", "runtime")
     prev_stage = getattr(self, "_log_silence_watchdog_stage", "idle")
     raise_if_shutdown = getattr(self, "_raise_if_shutdown_requested", None)
+    initialization_started_s = time.monotonic()
 
     def check_shutdown(stage: str) -> None:
         if callable(raise_if_shutdown):
@@ -3050,10 +3051,12 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             status="started",
             reason_code="coin_history_replay",
         )
+        history_fetch_started_s = time.monotonic()
         history = await self.get_balance_equity_history(
             current_balance=self.get_raw_balance(),
             hsl_replay_signal_mode="coin",
         )
+        history_fetch_elapsed_s = max(0.0, time.monotonic() - history_fetch_started_s)
         check_shutdown("hsl_coin_history_replay_history_loaded")
         panic_flatten_events = history["panic_flatten_events"] if "panic_flatten_events" in history else []
         if panic_flatten_events is None:
@@ -3192,6 +3195,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
         balance = float(self.get_raw_balance())
         rows = 0
         replay_started_s = time.monotonic()
+        pre_replay_elapsed_s = max(0.0, replay_started_s - initialization_started_s)
         last_progress_log_s = replay_started_s
         replay_symbols = set(symbols)
         active_pairs = [
@@ -3228,6 +3232,9 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 "fill_events": len(fill_events),
                 "panic_events": len(panic_flatten_events),
                 "skipped_unsupported_symbols": len(skipped_unsupported_symbols),
+                "history_fetch_elapsed_s": round(history_fetch_elapsed_s, 3),
+                "pre_replay_elapsed_s": round(pre_replay_elapsed_s, 3),
+                "elapsed_s": round(pre_replay_elapsed_s, 3),
             },
             status="started",
             reason_code="history_loaded",
@@ -3688,6 +3695,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 log_replay_progress(pair_idx, pside, symbol, applied_rows)
         self._equity_hard_stop_coin_initialized = True
         elapsed_s = max(0.0, time.monotonic() - replay_started_s)
+        total_elapsed_s = max(0.0, time.monotonic() - initialization_started_s)
         rows_per_second = float(rows) / elapsed_s if elapsed_s > 0.0 else None
         skipped_pairs = sum(1 for pair in active_pairs if pair_rows_applied.get(pair, 0) == 0)
         logging.info(
@@ -3715,9 +3723,12 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 "rows_per_second": round(rows_per_second, 3)
                 if rows_per_second is not None
                 else None,
-                "full_elapsed_s": round(elapsed_s, 3),
-                "startup_blocking_elapsed_s": round(elapsed_s, 3),
-                "elapsed_s": round(elapsed_s, 3),
+                "history_fetch_elapsed_s": round(history_fetch_elapsed_s, 3),
+                "pre_replay_elapsed_s": round(pre_replay_elapsed_s, 3),
+                "replay_loop_elapsed_s": round(elapsed_s, 3),
+                "full_elapsed_s": round(total_elapsed_s, 3),
+                "startup_blocking_elapsed_s": round(total_elapsed_s, 3),
+                "elapsed_s": round(total_elapsed_s, 3),
             },
             status="succeeded",
             reason_code="coin_history_replay_completed",
@@ -3728,7 +3739,14 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             EventTypes.HSL_REPLAY_FAILED,
             {
                 "signal_mode": "coin",
-                "elapsed_s": round(time.monotonic() - replay_started_s, 3)
+                "elapsed_s": round(time.monotonic() - initialization_started_s, 3),
+                "history_fetch_elapsed_s": round(history_fetch_elapsed_s, 3)
+                if "history_fetch_elapsed_s" in locals()
+                else None,
+                "pre_replay_elapsed_s": round(pre_replay_elapsed_s, 3)
+                if "pre_replay_elapsed_s" in locals()
+                else None,
+                "replay_loop_elapsed_s": round(time.monotonic() - replay_started_s, 3)
                 if "replay_started_s" in locals()
                 else None,
             },
@@ -3743,7 +3761,14 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             {
                 "signal_mode": "coin",
                 "error_type": type(exc).__name__,
-                "elapsed_s": round(time.monotonic() - replay_started_s, 3)
+                "elapsed_s": round(time.monotonic() - initialization_started_s, 3),
+                "history_fetch_elapsed_s": round(history_fetch_elapsed_s, 3)
+                if "history_fetch_elapsed_s" in locals()
+                else None,
+                "pre_replay_elapsed_s": round(pre_replay_elapsed_s, 3)
+                if "pre_replay_elapsed_s" in locals()
+                else None,
+                "replay_loop_elapsed_s": round(time.monotonic() - replay_started_s, 3)
                 if "replay_started_s" in locals()
                 else None,
             },

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -683,6 +683,10 @@ async def test_coin_hsl_replay_cancels_when_shutdown_requested_after_history_loa
     assert events[0].reason_code == "coin_history_replay"
     assert events[1].status == "failed"
     assert events[1].reason_code == "shutdown_cancelled"
+    assert events[1].data["elapsed_s"] is not None
+    assert events[1].data["history_fetch_elapsed_s"] is not None
+    assert events[1].data["pre_replay_elapsed_s"] is None
+    assert events[1].data["replay_loop_elapsed_s"] is None
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
@@ -758,6 +762,9 @@ async def test_coin_hsl_history_replay_emits_lifecycle_events():
     assert events[1].data["cooldown_pairs"] == 0
     assert events[1].data["required_pairs"] == 1
     assert events[1].data["timeline_rows"] == 2
+    assert events[1].data["history_fetch_elapsed_s"] is not None
+    assert events[1].data["pre_replay_elapsed_s"] is not None
+    assert events[1].data["elapsed_s"] is not None
     assert events[2].status == "succeeded"
     assert events[2].reason_code == "coin_history_replay_completed"
     assert events[2].data["rows"] == 2
@@ -771,8 +778,12 @@ async def test_coin_hsl_history_replay_emits_lifecycle_events():
     assert events[2].data["fill_events"] == 0
     assert events[2].data["panic_events"] == 0
     assert events[2].data["rows_per_second"] is not None
+    assert events[2].data["history_fetch_elapsed_s"] is not None
+    assert events[2].data["pre_replay_elapsed_s"] is not None
+    assert events[2].data["replay_loop_elapsed_s"] is not None
     assert events[2].data["full_elapsed_s"] is not None
     assert events[2].data["startup_blocking_elapsed_s"] is not None
+    assert events[2].data["elapsed_s"] is not None
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -711,6 +711,7 @@ async def test_coin_hsl_history_replay_emits_lifecycle_events():
     bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
 
     async def fake_history(current_balance=None, **kwargs):
+        await asyncio.sleep(0.01)
         return {
             "timeline": [
                 {
@@ -784,6 +785,13 @@ async def test_coin_hsl_history_replay_emits_lifecycle_events():
     assert events[2].data["full_elapsed_s"] is not None
     assert events[2].data["startup_blocking_elapsed_s"] is not None
     assert events[2].data["elapsed_s"] is not None
+    assert events[2].data["history_fetch_elapsed_s"] > 0.0
+    phase_elapsed_s = (
+        events[2].data["history_fetch_elapsed_s"]
+        + events[2].data["pre_replay_elapsed_s"]
+        + events[2].data["replay_loop_elapsed_s"]
+    )
+    assert phase_elapsed_s <= events[2].data["startup_blocking_elapsed_s"] + 0.006
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
## Summary
- add phase timing fields to coin-HSL replay lifecycle events: history fetch, pre-replay preparation, replay loop, and total startup-blocking elapsed
- preserve the existing event flow and trading behavior; this is observability only
- record the partial HSL replay performance/readiness milestone in the fable-audit plan

## Behavior
- No trading behavior change
- Existing hsl.replay.started/progress/completed/failed events remain best-effort
- Failure/cancellation events now report total elapsed even when shutdown occurs before the replay loop starts

## Tests
- ./venv/bin/python -m pytest tests/test_hsl_coin_mode.py -k 'hsl_replay or hsl_coin_history_replay' -q
- ./venv/bin/python -m pytest tests/test_hsl_coin_mode.py -k 'not test_coin_hsl_check_tp_only_orange_skips_flat_symbols' -q
- ./venv/bin/python -m compileall src/passivbot_hsl.py tests/test_hsl_coin_mode.py
- git diff --check