### PR TITLE
Add HSL replay cache status events

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -61,6 +61,7 @@ across time.
 - `hsl.raw_red_pending`
 - `hsl.red_finalized_without_order`
 - `hsl.red_triggered`
+- `hsl.replay.cache`
 - `hsl.replay.completed`
 - `hsl.replay.failed`
 - `hsl.replay.progress`
@@ -89,6 +90,15 @@ across time.
 - `trailing.status`
 - `unstuck.selection`
 - `unstuck.status`
+
+## HSL Replay Timing Fields
+
+For `hsl.replay.completed`, `full_elapsed_s`, `startup_blocking_elapsed_s`, and
+`elapsed_s` measure total blocking startup time for the replay. Use
+`replay_loop_elapsed_s` for the replay-loop-only duration. Cache status events
+use `hsl.replay.cache` with `cache_status=hit|miss|rejected`; misses and
+rejections are non-authoritative performance-cache outcomes and should fall
+back to exchange-derived replay.
 
 ## Event Tags
 

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -126,6 +126,7 @@ class EventTypes:
     HSL_REPLAY_PROGRESS = "hsl.replay.progress"
     HSL_REPLAY_COMPLETED = "hsl.replay.completed"
     HSL_REPLAY_FAILED = "hsl.replay.failed"
+    HSL_REPLAY_CACHE = "hsl.replay.cache"
     HSL_RED_TRIGGERED = "hsl.red_triggered"
     HSL_RED_FINALIZED_WITHOUT_ORDER = "hsl.red_finalized_without_order"
     HSL_COOLDOWN_STARTED = "hsl.cooldown_started"
@@ -240,6 +241,9 @@ class ReasonCodes:
         "hsl_price_history_symbol_fetch_completed"
     )
     HSL_PRICE_HISTORY_SYMBOL_FETCH_STARTED = "hsl_price_history_symbol_fetch_started"
+    HSL_REPLAY_CACHE_HIT = "hsl_replay_cache_hit"
+    HSL_REPLAY_CACHE_MISS = "hsl_replay_cache_miss"
+    HSL_REPLAY_CACHE_REJECTED = "hsl_replay_cache_rejected"
     HSL_RAW_RED_PENDING_EMA_CONFIRMATION = "hsl_raw_red_pending_ema_confirmation"
     HSL_RED_FINALIZED_WITHOUT_EXCHANGE_ORDER = (
         "hsl_red_finalized_without_exchange_order"
@@ -417,6 +421,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.HSL_REPLAY_PROGRESS,
     EventTypes.HSL_REPLAY_COMPLETED,
     EventTypes.HSL_REPLAY_FAILED,
+    EventTypes.HSL_REPLAY_CACHE,
     EventTypes.HSL_RED_TRIGGERED,
     EventTypes.HSL_RED_FINALIZED_WITHOUT_ORDER,
     EventTypes.HSL_COOLDOWN_STARTED,
@@ -729,6 +734,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.HSL_REPLAY_PROGRESS: EventRoute(console=False, text=False),
     EventTypes.HSL_REPLAY_COMPLETED: EventRoute(console=False, text=False),
     EventTypes.HSL_REPLAY_FAILED: EventRoute(console=False, text=False),
+    EventTypes.HSL_REPLAY_CACHE: EventRoute(console=False, text=False),
     EventTypes.HSL_RED_TRIGGERED: EventRoute(console=False, text=False),
     EventTypes.HSL_RED_FINALIZED_WITHOUT_ORDER: EventRoute(console=False, text=False),
     EventTypes.HSL_COOLDOWN_STARTED: EventRoute(console=False, text=False),

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -814,6 +814,145 @@ def _load_hsl_replay_matrix_cache(
     return manifest, arrays
 
 
+def _hsl_replay_cache_status_data(
+    *,
+    cache_status: str,
+    elapsed_s: float,
+    reasons: list[str] | None = None,
+    manifest: dict[str, Any] | None = None,
+    expected_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "cache_status": str(cache_status),
+        "schema_version": _HSL_REPLAY_CACHE_SCHEMA_VERSION,
+        "matrix_file": _HSL_REPLAY_CACHE_MATRIX_FILENAME,
+        "manifest_file": _HSL_REPLAY_CACHE_MANIFEST_FILENAME,
+        "elapsed_s": round(max(0.0, float(elapsed_s)), 3),
+    }
+    metadata = manifest.get("metadata") if isinstance(manifest, dict) else expected_metadata
+    if isinstance(metadata, dict):
+        for key in ("signal_mode", "pside", "symbol"):
+            value = metadata.get(key)
+            if value is not None:
+                data[key] = str(value)
+    if isinstance(manifest, dict):
+        for key in ("row_count", "start_ts_ms", "end_ts_ms", "interval_ms"):
+            value = manifest.get(key)
+            if value is not None:
+                data[key] = int(value)
+    if reasons:
+        bounded_reasons = [str(reason) for reason in reasons[:8]]
+        data["reasons"] = bounded_reasons
+        data["reason_count"] = int(len(reasons))
+        data["reasons_truncated"] = bool(len(reasons) > len(bounded_reasons))
+    else:
+        data["reason_count"] = 0
+        data["reasons_truncated"] = False
+    return data
+
+
+def _try_load_hsl_replay_matrix_cache(
+    self,
+    cache_dir: str | os.PathLike[str],
+    *,
+    expected_metadata: dict[str, Any] | None = None,
+    pside: str | None = None,
+    symbol: str | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    started_s = time.monotonic()
+    try:
+        reasons = _hsl_replay_cache_validation_reasons(
+            cache_dir,
+            expected_metadata=expected_metadata,
+        )
+    except Exception as exc:
+        elapsed_s = time.monotonic() - started_s
+        _emit_hsl_replay_event(
+            self,
+            EventTypes.HSL_REPLAY_CACHE,
+            _hsl_replay_cache_status_data(
+                cache_status="rejected",
+                elapsed_s=elapsed_s,
+                reasons=[f"validation_exception:{type(exc).__name__}"],
+                expected_metadata=expected_metadata,
+            ),
+            pside=pside,
+            symbol=symbol,
+            level="debug",
+            status="skipped",
+            reason_code=ReasonCodes.HSL_REPLAY_CACHE_REJECTED,
+        )
+        return None
+    if reasons:
+        elapsed_s = time.monotonic() - started_s
+        cache_status = "miss" if reasons == ["manifest_missing"] else "rejected"
+        reason_code = (
+            ReasonCodes.HSL_REPLAY_CACHE_MISS
+            if cache_status == "miss"
+            else ReasonCodes.HSL_REPLAY_CACHE_REJECTED
+        )
+        _emit_hsl_replay_event(
+            self,
+            EventTypes.HSL_REPLAY_CACHE,
+            _hsl_replay_cache_status_data(
+                cache_status=cache_status,
+                elapsed_s=elapsed_s,
+                reasons=reasons,
+                expected_metadata=expected_metadata,
+            ),
+            pside=pside,
+            symbol=symbol,
+            level="debug",
+            status="skipped",
+            reason_code=reason_code,
+        )
+        return None
+    try:
+        import numpy as np
+
+        cache_path = Path(cache_dir)
+        manifest = json.loads(
+            (cache_path / _HSL_REPLAY_CACHE_MANIFEST_FILENAME).read_text(encoding="utf-8")
+        )
+        with np.load(cache_path / _HSL_REPLAY_CACHE_MATRIX_FILENAME, allow_pickle=False) as loaded:
+            arrays = {field: loaded[field].copy() for field in _HSL_REPLAY_MATRIX_RAW_FIELDS}
+    except Exception as exc:
+        elapsed_s = time.monotonic() - started_s
+        _emit_hsl_replay_event(
+            self,
+            EventTypes.HSL_REPLAY_CACHE,
+            _hsl_replay_cache_status_data(
+                cache_status="rejected",
+                elapsed_s=elapsed_s,
+                reasons=[f"load_exception:{type(exc).__name__}"],
+                expected_metadata=expected_metadata,
+            ),
+            pside=pside,
+            symbol=symbol,
+            level="debug",
+            status="skipped",
+            reason_code=ReasonCodes.HSL_REPLAY_CACHE_REJECTED,
+        )
+        return None
+    elapsed_s = time.monotonic() - started_s
+    _emit_hsl_replay_event(
+        self,
+        EventTypes.HSL_REPLAY_CACHE,
+        _hsl_replay_cache_status_data(
+            cache_status="hit",
+            elapsed_s=elapsed_s,
+            manifest=manifest,
+            expected_metadata=expected_metadata,
+        ),
+        pside=pside,
+        symbol=symbol,
+        level="debug",
+        status="succeeded",
+        reason_code=ReasonCodes.HSL_REPLAY_CACHE_HIT,
+    )
+    return manifest, arrays
+
+
 def _hsl_psides(self) -> tuple[str, str]:
     return ("long", "short")
 

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -330,6 +330,124 @@ def test_hsl_replay_matrix_cache_load_rejects_metadata_mismatch(tmp_path):
         )
 
 
+def test_hsl_replay_matrix_cache_try_load_emits_hit_event(tmp_path):
+    import numpy as np
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
+
+    metadata = _hsl_cache_metadata()
+    written_manifest = hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), metadata)
+    bot = FakeHslBot()
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._live_event_current_cycle_id = "cy_hsl_cache"
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+
+    loaded = hsl._try_load_hsl_replay_matrix_cache(
+        bot,
+        tmp_path,
+        expected_metadata=metadata,
+        pside="long",
+        symbol=metadata["symbol"],
+    )
+
+    assert loaded is not None
+    manifest, arrays = loaded
+    assert manifest == written_manifest
+    np.testing.assert_array_equal(arrays["ts"], np.array([60_000, 120_000, 180_000]))
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [event for event in sink.events if event.event_type == EventTypes.HSL_REPLAY_CACHE]
+    assert len(events) == 1
+    event = events[0]
+    assert event.status == "succeeded"
+    assert event.reason_code == ReasonCodes.HSL_REPLAY_CACHE_HIT
+    assert event.cycle_id == "cy_hsl_cache"
+    assert event.pside == "long"
+    assert event.symbol == metadata["symbol"]
+    assert event.data["cache_status"] == "hit"
+    assert event.data["row_count"] == 3
+    assert event.data["start_ts_ms"] == 60_000
+    assert event.data["end_ts_ms"] == 180_000
+    assert event.data["reason_count"] == 0
+    assert "cache_dir" not in event.data
+    assert "path" not in event.data
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_hsl_replay_matrix_cache_try_load_emits_miss_event(tmp_path):
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
+
+    metadata = _hsl_cache_metadata()
+    bot = FakeHslBot()
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+
+    loaded = hsl._try_load_hsl_replay_matrix_cache(
+        bot,
+        tmp_path,
+        expected_metadata=metadata,
+        pside="long",
+        symbol=metadata["symbol"],
+    )
+
+    assert loaded is None
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [event for event in sink.events if event.event_type == EventTypes.HSL_REPLAY_CACHE]
+    assert len(events) == 1
+    event = events[0]
+    assert event.status == "skipped"
+    assert event.reason_code == ReasonCodes.HSL_REPLAY_CACHE_MISS
+    assert event.data["cache_status"] == "miss"
+    assert event.data["reasons"] == ["manifest_missing"]
+    assert event.data["reason_count"] == 1
+    assert "cache_dir" not in event.data
+    assert "path" not in event.data
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_hsl_replay_matrix_cache_try_load_emits_rejected_event(tmp_path):
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
+
+    metadata = _hsl_cache_metadata()
+    hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), metadata)
+    bot = FakeHslBot()
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+
+    loaded = hsl._try_load_hsl_replay_matrix_cache(
+        bot,
+        tmp_path,
+        expected_metadata=_hsl_cache_metadata(config_digest="other_cfg_hash"),
+        pside="long",
+        symbol=metadata["symbol"],
+    )
+
+    assert loaded is None
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [event for event in sink.events if event.event_type == EventTypes.HSL_REPLAY_CACHE]
+    assert len(events) == 1
+    event = events[0]
+    assert event.status == "skipped"
+    assert event.reason_code == ReasonCodes.HSL_REPLAY_CACHE_REJECTED
+    assert event.data["cache_status"] == "rejected"
+    assert event.data["reasons"] == ["metadata_mismatch:config_digest"]
+    assert event.data["reason_count"] == 1
+    assert "other_cfg_hash" not in str(event.data)
+    assert "cache_dir" not in event.data
+    assert "path" not in event.data
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_hsl_replay_matrix_cache_reports_array_hash_mismatch(tmp_path):
     import numpy as np
 


### PR DESCRIPTION
Adds a bot-scoped, best-effort HSL replay matrix cache status wrapper plus registry entries for `hsl.replay.cache`.

Scope:
- Adds `EventTypes.HSL_REPLAY_CACHE` and cache hit/miss/rejected reason codes.
- Adds `_try_load_hsl_replay_matrix_cache()`, which emits bounded cache status events and returns `None` on miss/reject so future callers can rebuild from authoritative exchange data.
- Does not wire cache use into HSL startup yet; no trading behavior changes.
- Updates `docs/ai/live_event_registry.md` with the cache event and the replay elapsed field definition from #1113.

Validation:
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_hsl_coin_mode.py -k 'hsl_replay_matrix_cache_try_load or hsl_replay_matrix_cache_load or hsl_replay_matrix_derived_arrays' -q` — 9 passed
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py -q` — 56 passed
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_hsl_coin_mode.py -k 'not test_coin_hsl_check_tp_only_orange_skips_flat_symbols' -q` — 71 passed, with existing passivbot_rust unraisable warnings
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/passivbot_hsl.py src/live/event_bus.py tests/test_hsl_coin_mode.py`
- `git diff --check`

Known unrelated current-v8 issue:
- Full `tests/test_hsl_coin_mode.py -q` still fails at `test_coin_hsl_check_tp_only_orange_skips_flat_symbols`; this branch did not touch that path.