### PR TITLE
Add HSL replay cache metadata helpers

### DIFF
--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1767,6 +1767,9 @@ class Passivbot:
     _equity_hard_stop_apply_sample = pb_hsl._equity_hard_stop_apply_sample
     _equity_hard_stop_apply_coin_sample = pb_hsl._equity_hard_stop_apply_coin_sample
     _equity_hard_stop_log_transition = pb_hsl._equity_hard_stop_log_transition
+    _hsl_replay_cache_config_digest = pb_hsl._hsl_replay_cache_config_digest
+    _hsl_replay_cache_expected_metadata = pb_hsl._hsl_replay_cache_expected_metadata
+    _hsl_replay_cache_dir = pb_hsl._hsl_replay_cache_dir
     _equity_hard_stop_maybe_emit_raw_red_pending = (
         pb_hsl._equity_hard_stop_maybe_emit_raw_red_pending
     )

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -51,6 +51,18 @@ _HSL_REPLAY_CACHE_REQUIRED_METADATA = (
 )
 
 
+def _hsl_replay_cache_safe_fragment(value: Any) -> str:
+    raw = str(value).strip()
+    out = []
+    for char in raw:
+        if char.isalnum() or char in {"-", "_", "."}:
+            out.append(char)
+        else:
+            out.append("_")
+    safe = "".join(out).strip("._")
+    return safe or "unknown"
+
+
 def _hsl_key_sample(value: Any, *, limit: int = 32) -> list[str]:
     if not isinstance(value, dict):
         return []
@@ -647,6 +659,88 @@ def _normalize_hsl_replay_cache_metadata(metadata: dict[str, Any]) -> dict[str, 
     ):
         out[key] = int(out[key])
     return out
+
+
+def _hsl_replay_cache_json_digest(payload: Any) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode(
+        "utf-8"
+    )
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _hsl_replay_cache_config_digest(self, pside: str) -> str:
+    if pside not in {"long", "short"}:
+        raise ValueError(f"HSL replay cache pside must be long or short, got {pside!r}")
+    hsl_cfg = getattr(self, "hsl", None)
+    if not isinstance(hsl_cfg, dict) or pside not in hsl_cfg:
+        raise ValueError(f"HSL replay cache requires parsed HSL config for {pside}")
+    payload = {
+        "schema_version": _HSL_REPLAY_CACHE_SCHEMA_VERSION,
+        "signal_mode": self._equity_hard_stop_signal_mode(),
+        "cooldown_position_policy": self._equity_hard_stop_cooldown_position_policy(),
+        "pnls_max_lookback_days": parse_pnls_max_lookback_days(
+            self.live_value("pnls_max_lookback_days"),
+            field_name="live.pnls_max_lookback_days",
+        ).display_value,
+        "pside": pside,
+        "hsl": hsl_cfg[pside],
+        "n_positions": float(self.bot_value(pside, "n_positions")),
+        "total_wallet_exposure_limit": float(
+            self.bot_value(pside, "total_wallet_exposure_limit")
+        ),
+    }
+    return _hsl_replay_cache_json_digest(payload)
+
+
+def _hsl_replay_cache_market_type(self) -> str:
+    for attr in ("market_type", "market"):
+        value = getattr(self, attr, None)
+        if value not in (None, ""):
+            return str(value)
+    config = getattr(self, "config", {})
+    value = get_optional_live_value(config, "market_type", None)
+    if value not in (None, ""):
+        return str(value)
+    return "unknown"
+
+
+def _hsl_replay_cache_expected_metadata(
+    self,
+    pside: str,
+    symbol: str,
+    *,
+    fill_covered_start_ms: int,
+    fill_covered_end_ms: int,
+    candle_covered_start_ms: int,
+    candle_covered_end_ms: int,
+) -> dict[str, Any]:
+    metadata = {
+        "exchange": str(self.exchange),
+        "market_type": _hsl_replay_cache_market_type(self),
+        "user": str(self.user),
+        "config_digest": self._hsl_replay_cache_config_digest(pside),
+        "signal_mode": self._equity_hard_stop_signal_mode(),
+        "pside": str(pside),
+        "symbol": str(symbol),
+        "fill_covered_start_ms": int(fill_covered_start_ms),
+        "fill_covered_end_ms": int(fill_covered_end_ms),
+        "candle_covered_start_ms": int(candle_covered_start_ms),
+        "candle_covered_end_ms": int(candle_covered_end_ms),
+    }
+    return _normalize_hsl_replay_cache_metadata(metadata)
+
+
+def _hsl_replay_cache_dir(self, pside: str, symbol: str, config_digest: str | None = None) -> str:
+    digest = str(config_digest or self._hsl_replay_cache_config_digest(pside))
+    if len(digest) < 16:
+        raise ValueError("HSL replay cache config digest must be at least 16 characters")
+    exchange = _hsl_replay_cache_safe_fragment(getattr(self, "exchange", "unknown"))
+    user = _hsl_replay_cache_safe_fragment(getattr(self, "user", "unknown"))
+    safe_symbol = _hsl_replay_cache_safe_fragment(symbol)
+    return make_get_filepath(
+        "caches/equity_hard_stop/"
+        f"{exchange}/replay_matrix/{user}/{pside}/{safe_symbol}/{digest[:16]}/"
+    )
 
 
 def _write_hsl_replay_matrix_cache(

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -448,6 +448,73 @@ def test_hsl_replay_matrix_cache_try_load_emits_rejected_event(tmp_path):
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_hsl_replay_cache_config_digest_is_stable_and_hsl_scoped():
+    bot = make_coin_bot()
+    digest = hsl._hsl_replay_cache_config_digest(bot, "long")
+
+    bot.config["irrelevant"] = {"changes": "do_not_affect_hsl_replay_cache"}
+    assert hsl._hsl_replay_cache_config_digest(bot, "long") == digest
+
+    bot.hsl["long"]["red_threshold"] = 0.25
+    assert hsl._hsl_replay_cache_config_digest(bot, "long") != digest
+
+    bot = make_coin_bot()
+    original_bot_value = bot.bot_value
+
+    def bot_value(pside, key):
+        if key == "n_positions":
+            return 3
+        return original_bot_value(pside, key)
+
+    bot.bot_value = bot_value
+    assert hsl._hsl_replay_cache_config_digest(bot, "long") != digest
+
+
+def test_hsl_replay_cache_expected_metadata_uses_trust_boundary_fields():
+    bot = make_coin_bot()
+    bot.market_type = "swap"
+
+    metadata = hsl._hsl_replay_cache_expected_metadata(
+        bot,
+        "long",
+        "BTC/USDT:USDT",
+        fill_covered_start_ms=60_000,
+        fill_covered_end_ms=120_000,
+        candle_covered_start_ms=60_000,
+        candle_covered_end_ms=180_000,
+    )
+
+    assert set(metadata) == set(hsl._HSL_REPLAY_CACHE_REQUIRED_METADATA)
+    assert metadata["exchange"] == "test_exchange"
+    assert metadata["market_type"] == "swap"
+    assert metadata["user"] == "test_user"
+    assert metadata["signal_mode"] == "coin"
+    assert metadata["pside"] == "long"
+    assert metadata["symbol"] == "BTC/USDT:USDT"
+    assert metadata["config_digest"] == hsl._hsl_replay_cache_config_digest(bot, "long")
+    assert len(metadata["config_digest"]) == 64
+    assert metadata["fill_covered_start_ms"] == 60_000
+    assert metadata["fill_covered_end_ms"] == 120_000
+    assert metadata["candle_covered_start_ms"] == 60_000
+    assert metadata["candle_covered_end_ms"] == 180_000
+
+
+def test_hsl_replay_cache_dir_is_sanitized_and_digest_scoped():
+    bot = make_coin_bot()
+    bot.exchange = "binance/usdm"
+    bot.user = "user:one"
+    digest = "abcdef0123456789fedcba9876543210abcdef0123456789fedcba9876543210"
+
+    path = hsl._hsl_replay_cache_dir(bot, "long", "BTC/USDT:USDT", config_digest=digest)
+
+    assert "binance_usdm" in path
+    assert "user_one" in path
+    assert "BTC_USDT_USDT" in path
+    assert "abcdef0123456789" in path
+    assert "BTC/USDT:USDT" not in path
+    assert "user:one" not in path
+
+
 def test_hsl_replay_matrix_cache_reports_array_hash_mismatch(tmp_path):
     import numpy as np
 
@@ -645,6 +712,9 @@ def bind_hsl_methods(bot):
         "_equity_hard_stop_infer_coin_replay_contract",
         "_equity_hard_stop_lookback_ms",
         "_equity_hard_stop_log_transition",
+        "_hsl_replay_cache_config_digest",
+        "_hsl_replay_cache_expected_metadata",
+        "_hsl_replay_cache_dir",
         "_equity_hard_stop_build_latch_payload",
         "_equity_hard_stop_check_coin",
         "_equity_hard_stop_clear_coin_runtime_forced_mode",

--- a/tests/test_passivbot_hsl_bindings.py
+++ b/tests/test_passivbot_hsl_bindings.py
@@ -40,4 +40,7 @@ def test_passivbot_uses_passivbot_hsl_module_for_hsl_methods():
         "_equity_hard_stop_run_red_supervisor",
         "_equity_hard_stop_run_coin_red_supervisor",
         "_apply_equity_hard_stop_orange_overlay",
+        "_hsl_replay_cache_config_digest",
+        "_hsl_replay_cache_expected_metadata",
+        "_hsl_replay_cache_dir",
     } <= assigned_names


### PR DESCRIPTION
Adds deterministic helper functions for future HSL replay matrix cache wiring.

Scope:
- Adds cache-safe path fragment normalization.
- Adds a HSL-scoped config digest for replay cache invalidation. The digest includes signal mode, cooldown position policy, lookback, parsed HSL pside config, configured n_positions, and configured total_wallet_exposure_limit.
- Adds expected metadata construction for the existing HSL replay cache manifest trust-boundary fields.
- Adds deterministic replay cache directory construction under the existing equity_hard_stop cache family.
- Does not read, write, or use replay caches in live startup yet; no trading behavior changes.

Validation:
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_hsl_coin_mode.py -k 'hsl_replay_cache_config_digest or hsl_replay_cache_expected_metadata or hsl_replay_cache_dir or hsl_replay_matrix_cache_try_load' -q` — 6 passed
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_hsl_coin_mode.py -k 'hsl_replay_matrix_cache or hsl_replay_cache' -q` — 21 passed
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m compileall src/passivbot_hsl.py tests/test_hsl_coin_mode.py`
- `git diff --check`

This is intended to make the eventual cache read/write wiring PR smaller: it will be able to call tested key/metadata helpers instead of deciding trust-boundary details inline.