### PR TITLE
Repair silently broken risk/HSL regression tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -393,3 +393,6 @@ Cargo.lock
 
 # Git worktrees
 .worktrees/
+
+# Fake-live/monitor test artifacts
+/monitor/

--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -180,6 +180,9 @@ back to exchange-derived replay.
 - `hsl_price_history_symbol_fetch_started`
 - `hsl_raw_red_pending_ema_confirmation`
 - `hsl_red_finalized_without_exchange_order`
+- `hsl_replay_cache_hit`
+- `hsl_replay_cache_miss`
+- `hsl_replay_cache_rejected`
 - `hsl_timeline_replay_completed`
 - `hsl_timeline_replay_started`
 - `initial_entry_distance_gate`

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -2845,6 +2845,11 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
     try:
         self._equity_hard_stop_reset_state()
         signal_mode = self._equity_hard_stop_signal_mode()
+        if signal_mode not in ("unified", "pside"):
+            raise ValueError(
+                "HSL initialize_from_history requires signal_mode unified or pside, "
+                f"got {signal_mode!r}; coin mode must use the coin history initializer"
+            )
         lookback = parse_pnls_max_lookback_days(
             self.live_value("pnls_max_lookback_days"),
             field_name="live.pnls_max_lookback_days",

--- a/tests/test_entries_sizing.py
+++ b/tests/test_entries_sizing.py
@@ -19,7 +19,7 @@ def _calc_next_entry_short(**kwargs):
 
 
 @pytest.mark.skipif(pbr is None or pbr_is_stub, reason="passivbot_rust extension not available")
-def test_initial_entry_qty_long_respects_min_qty_and_allowance():
+def test_initial_entry_qty_long_uses_base_wel_without_runtime_excess():
     params = dict(
         qty_step=0.01,
         price_step=0.1,
@@ -54,7 +54,10 @@ def test_initial_entry_qty_long_respects_min_qty_and_allowance():
     qty, price, order_type = _calc_next_entry_long(**params)
     assert order_type == "entry_initial_normal_long"
 
-    allowed = params["wallet_exposure_limit"] * (1.0 + params["risk_we_excess_allowance_pct"])
+    # Excess allowance is applied upstream (orchestrator/backtest) through the
+    # runtime effective wallet exposure limit; the standalone entry calculator
+    # sizes off the base limit it receives.
+    allowed = params["wallet_exposure_limit"]
     target_cost = params["balance"] * allowed * params["entry_initial_qty_pct"]
     expected_qty = pbr.round_(
         pbr.cost_to_qty(target_cost, price, params["c_mult"]), params["qty_step"]
@@ -64,7 +67,7 @@ def test_initial_entry_qty_long_respects_min_qty_and_allowance():
 
 
 @pytest.mark.skipif(pbr is None or pbr_is_stub, reason="passivbot_rust extension not available")
-def test_initial_entry_qty_short_respects_allowance():
+def test_initial_entry_qty_short_uses_base_wel_without_runtime_excess():
     params = dict(
         qty_step=0.01,
         price_step=0.1,
@@ -99,7 +102,10 @@ def test_initial_entry_qty_short_respects_allowance():
     qty, price, order_type = _calc_next_entry_short(**params)
     assert order_type == "entry_initial_normal_short"
 
-    allowed = params["wallet_exposure_limit"] * (1.0 + params["risk_we_excess_allowance_pct"])
+    # Excess allowance is applied upstream (orchestrator/backtest) through the
+    # runtime effective wallet exposure limit; the standalone entry calculator
+    # sizes off the base limit it receives.
+    allowed = params["wallet_exposure_limit"]
     target_cost = params["balance"] * allowed * params["entry_initial_qty_pct"]
     expected_qty = pbr.round_(
         pbr.cost_to_qty(target_cost, price, params["c_mult"]), params["qty_step"]

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -2449,7 +2449,7 @@ async def test_coin_hsl_check_preserves_cooldown_policy_forced_mode(policy, expe
 
 
 @pytest.mark.asyncio
-async def test_coin_hsl_check_tp_only_orange_skips_flat_symbols():
+async def test_coin_hsl_check_tp_only_orange_blocks_flat_initial_entries():
     bot = make_coin_bot()
     open_symbol = "A"
     flat_symbol = "B"
@@ -2473,4 +2473,7 @@ async def test_coin_hsl_check_tp_only_orange_skips_flat_symbols():
         bot._runtime_forced_modes["long"][open_symbol]
         == "tp_only_with_active_entry_cancellation"
     )
-    assert flat_symbol not in bot._runtime_forced_modes["long"]
+    assert (
+        bot._runtime_forced_modes["long"][flat_symbol]
+        == "tp_only_with_active_entry_cancellation"
+    )

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1386,7 +1386,15 @@ async def test_balance_equity_history_paces_replay_candle_fetches(monkeypatch):
     bot.get_exchange_time = lambda: base_ts + 120_000
     bot.get_raw_balance = lambda: 100.0
     bot.get_symbol_id_inv = lambda symbol: symbol
-    bot.positions = {}
+    # Coin-mode price replay only fetches candles for held or panic symbols,
+    # so hold a long position in every replayed symbol.
+    bot.positions = {
+        symbol: {
+            "long": {"size": 1.0, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+        for symbol in ("BTC/USDT:USDT", "ETH/USDT:USDT", "SOL/USDT:USDT")
+    }
     bot._pnls_manager = None
     bot.inverse = False
     bot._candle_fetch_concurrency = lambda *, context="runtime": 2

--- a/tests/test_realized_loss_gate.py
+++ b/tests/test_realized_loss_gate.py
@@ -846,6 +846,7 @@ class TestPrepBacktestArgsMaxRealizedLossPct:
             "hsl_tier_ratios": {"yellow": 0.5, "orange": 0.75},
             "hsl_orange_tier_mode": "tp_only_with_active_entry_cancellation",
             "hsl_panic_close_order_type": "market",
+            "hsl_restart_after_red_policy": "threshold",
         }
         hsl_short = deepcopy(hsl_long)
         config = {
@@ -874,6 +875,7 @@ class TestPrepBacktestArgsMaxRealizedLossPct:
             "live": {
                 "approved_coins": {"long": ["BTC"], "short": []},
                 "hedge_mode": True,
+                "hsl_signal_mode": "coin",
                 "max_realized_loss_pct": 1.0,
                 "pnls_max_lookback_days": 30.0,
             },
@@ -926,6 +928,7 @@ class TestPrepBacktestArgsEquityHardStopLoss:
             "hsl_tier_ratios": {"yellow": 0.5, "orange": 0.75},
             "hsl_orange_tier_mode": "tp_only_with_active_entry_cancellation",
             "hsl_panic_close_order_type": "market",
+            "hsl_restart_after_red_policy": "threshold",
         }
         hsl_short = deepcopy(hsl_long)
         config = {
@@ -954,6 +957,7 @@ class TestPrepBacktestArgsEquityHardStopLoss:
             "live": {
                 "approved_coins": {"long": ["BTC"], "short": []},
                 "hedge_mode": True,
+                "hsl_signal_mode": "coin",
                 "max_realized_loss_pct": 1.0,
                 "pnls_max_lookback_days": 30.0,
             },

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -524,7 +524,6 @@ def _make_dummy_bot(config, *, last_price=100.0):
                 "ema_span_1": 2.0,
                 "entry_volatility_ema_span_1h": 0.0,
                 "entry_volatility_ema_span_1m": 60.0,
-        "entry_volatility_ema_span_1m": 60.0,
                 "entry_grid_spacing_pct": 0.0,
                 "entry_initial_qty_pct": 0.0,
                 "entry_grid_double_down_factor": 1.0,
@@ -555,7 +554,11 @@ def _make_dummy_bot(config, *, last_price=100.0):
             self._bot_value_defaults = {
                 "n_positions": 0,
                 "total_wallet_exposure_limit": 0.0,
+                "risk_twel_enforcer_policy": "reduce_overweight",
                 "risk_twel_enforcer_threshold": 0.0,
+                "hsl_restart_after_red_policy": "threshold",
+                "hsl_orange_tier_mode": "tp_only_with_active_entry_cancellation",
+                "hsl_panic_close_order_type": "limit",
                 "filter_volume_ema_span_1m": 0.0,
                 "filter_volatility_ema_span_1m": 0.0,
                 "forager_volume_drop_pct": 0.0,
@@ -3076,6 +3079,7 @@ async def test_hard_stop_finalize_red_stop_uses_persistent_no_restart_peak(monke
 @pytest.mark.asyncio
 async def test_hard_stop_initialize_from_history_terminal_stop_sets_latch(monkeypatch):
     cfg = _dummy_config()
+    cfg["live"]["hsl_signal_mode"] = "unified"
     bot = _make_dummy_bot(cfg)
     _hsl_cfg(bot)["enabled"] = True
     _hsl_cfg(bot)["red_threshold"] = 0.05
@@ -3160,6 +3164,7 @@ async def test_hard_stop_initialize_from_history_does_not_latch_recovered_red_wi
     monkeypatch,
 ):
     cfg = _dummy_config()
+    cfg["live"]["hsl_signal_mode"] = "unified"
     bot = _make_dummy_bot(cfg)
     _hsl_cfg(bot)["enabled"] = True
     _hsl_cfg(bot)["red_threshold"] = 0.05
@@ -3230,6 +3235,7 @@ async def test_hard_stop_initialize_from_history_reconstructs_active_cooldown_wi
     monkeypatch,
 ):
     cfg = _dummy_config()
+    cfg["live"]["hsl_signal_mode"] = "unified"
     bot = _make_dummy_bot(cfg)
     _hsl_cfg(bot)["enabled"] = True
     _hsl_cfg(bot)["red_threshold"] = 0.05
@@ -3410,6 +3416,7 @@ async def test_hard_stop_initialize_from_history_replay_cooldown_resets_cycle(
     monkeypatch,
 ):
     cfg = _dummy_config()
+    cfg["live"]["hsl_signal_mode"] = "unified"
     bot = _make_dummy_bot(cfg)
     _hsl_cfg(bot)["enabled"] = True
     _hsl_cfg(bot)["red_threshold"] = 0.05
@@ -3526,11 +3533,12 @@ async def test_hard_stop_initialize_from_history_preserves_no_restart_peak_acros
     monkeypatch,
 ):
     cfg = _dummy_config()
+    cfg["live"]["hsl_signal_mode"] = "unified"
     bot = _make_dummy_bot(cfg)
     _hsl_cfg(bot)["enabled"] = True
     _hsl_cfg(bot)["red_threshold"] = 0.04
     _hsl_cfg(bot)["ema_span_minutes"] = 1.0
-    _hsl_cfg(bot)["cooldown_minutes_after_red"] = 1.0
+    _hsl_cfg(bot)["cooldown_minutes_after_red"] = 0.5
     _hsl_cfg(bot)["no_restart_drawdown_threshold"] = 0.2
     bot.balance = 86.0
     bot._live_values["execution_delay_seconds"] = 60.0
@@ -3638,10 +3646,10 @@ async def test_hard_stop_initialize_from_history_preserves_no_restart_peak_acros
     assert _hsl_state(bot)["no_restart_peak_strategy_equity"] == pytest.approx(110.0)
     assert len(captured) == 2
     assert captured[0][1]["no_restart_latched"] is False
-    assert captured[0][1]["cooldown_until_ms"] == 181_500
+    assert captured[0][1]["cooldown_until_ms"] == 151_500
     assert captured[1][1]["no_restart_latched"] is True
     assert captured[1][1]["cooldown_until_ms"] is None
-    assert captured[1][1]["drawdown_raw"] == pytest.approx(0.0)
+    assert captured[1][1]["drawdown_raw"] == pytest.approx(1.0 - 86.0 / 90.0)
     assert captured[1][1]["no_restart_drawdown_raw"] == pytest.approx(
         1.0 - 86.0 / 110.0
     )
@@ -4178,6 +4186,7 @@ async def test_hard_stop_initialize_from_history_resets_after_panic_marker_same_
     monkeypatch,
 ):
     cfg = _dummy_config()
+    cfg["live"]["hsl_signal_mode"] = "unified"
     bot = _make_dummy_bot(cfg)
     _hsl_cfg(bot)["enabled"] = True
     _hsl_cfg(bot)["red_threshold"] = 0.05
@@ -4286,6 +4295,7 @@ async def test_hard_stop_initialize_from_history_normal_policy_replays_from_entr
     monkeypatch,
 ):
     cfg = _dummy_config()
+    cfg["live"]["hsl_signal_mode"] = "unified"
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
     _hsl_cfg(bot)["enabled"] = True
@@ -4407,6 +4417,7 @@ async def test_hard_stop_initialize_from_history_unresolved_panic_residue_stays_
     monkeypatch,
 ):
     cfg = _dummy_config()
+    cfg["live"]["hsl_signal_mode"] = "unified"
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
     _hsl_cfg(bot)["enabled"] = True
@@ -4484,6 +4495,22 @@ async def test_hard_stop_initialize_from_history_unresolved_panic_residue_stays_
     assert _hsl_state(bot)["cooldown_unresolved_residue"] is True
     assert _hsl_state(bot)["cooldown_until_ms"] == 241_500
     assert bot._equity_hard_stop_halted_mode("long", symbol) == "panic"
+
+
+@pytest.mark.asyncio
+async def test_hard_stop_initialize_from_history_rejects_coin_signal_mode(monkeypatch):
+    cfg = _dummy_config()
+    cfg["live"]["hsl_signal_mode"] = "coin"
+    bot = _make_dummy_bot(cfg)
+    _hsl_cfg(bot)["enabled"] = True
+
+    async def fake_history(*, current_balance=None, **kwargs):
+        raise AssertionError("history must not be fetched for coin signal mode")
+
+    monkeypatch.setattr(bot, "get_balance_equity_history", fake_history)
+
+    with pytest.raises(ValueError, match="unified or pside"):
+        await bot._equity_hard_stop_initialize_from_history()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Repairs the risk/unstuck/HSL regression-test surfaces that broke silently as intentional behavior changes landed on v8. The repo's GitHub CI workflow is a no-op (`run: 'true'`), so none of these were caught at merge time; they were found by running the full suite locally while working the fable-audit action plan.

Baseline before this PR (fresh `origin/v8`, rebuilt Rust extension): **26 failing tests** across 6 files. After this PR: **3 known failures remain**, all out of scope (listed at the bottom).

Scope (mostly test-only; one small fail-loud guard and one doc parity fix):

- `tests/test_hsl_coin_mode.py`: `test_coin_hsl_check_tp_only_orange_skips_flat_symbols` still pinned the pre-#1098 contract. Rewritten as `..._blocks_flat_initial_entries` pinning the A2.2 contract: ORANGE `tp_only_with_active_entry_cancellation` also forces the mode for flat symbols in scope, blocking initial entries.
- `tests/test_unstucking_safeguards.py`:
  - DummyBot fixture predated the strict string bot params; `bot_value`/`bp` neutral `0.0` fallbacks now fail the strict normalizers. Added string defaults for `risk_twel_enforcer_policy`, `hsl_restart_after_red_policy`, `hsl_orange_tier_mode`, `hsl_panic_close_order_type`; removed a duplicated misindented `_bp_defaults` line (merge artifact).
  - Eight unified-path `initialize_from_history` tests inherited the template `hsl_signal_mode=coin` default (C1 alignment) and died mid-replay; they now pin `hsl_signal_mode="unified"` explicitly, matching sibling tests.
  - `..._preserves_no_restart_peak_across_replay_reset` expected pre-#1107 semantics where a panic marker alone reconstructed a RED stop. Re-authored with a shorter cooldown so the second episode has a pre-drop sample and reconstructs a *confirmed* RED per the #1107 contract; the test still proves its core point — the no-restart peak (110) survives episode resets.
- `src/passivbot_hsl.py`: `_equity_hard_stop_initialize_from_history` now fails loudly when invoked with `signal_mode=coin` (which must use the coin initializer) instead of surfacing a misleading mid-replay "unified signal mode requires unrealized_pnl_total" error. Production dispatch already routes coin mode to the coin initializer, so no live behavior change; new regression test.
- `tests/test_realized_loss_gate.py`: prep-backtest-args fixtures predated the HSL restart-policy enum (now part of `HSL_PSIDE_KEYS`) and the required `live.hsl_signal_mode` key. 8 tests restored.
- `tests/test_entries_sizing.py`: the two initial-entry tests pinned the removed implicit `risk_we_excess_allowance_pct` scaling inside `calc_next_entry_*`. Excess allowance is now applied upstream via the runtime effective wallet exposure limit (`RuntimeOrderContext`); the standalone calculator sizes off base WEL. Renamed and re-asserted.
- `tests/test_passivbot_balance_split.py`: the replay-fetch pacing test predated #989's narrowing of coin-mode price replay to held/panic symbols; the bot now holds positions in the replayed symbols so pacing is still exercised.
- `docs/ai/live_event_registry.md`: added missing `hsl_replay_cache_hit`/`miss`/`rejected` reason codes (from the #1111/#1114 replay-cache events) to restore registry/doc parity.
- `.gitignore`: ignore `monitor/`, where fake-live tests write runtime artifacts.

Validation:
- `venv/bin/python -m pytest tests/test_realized_loss_gate.py tests/test_entries_sizing.py tests/test_passivbot_balance_split.py tests/test_live_event_registry_docs.py tests/test_unstucking_safeguards.py tests/test_hsl_coin_mode.py tests/test_passivbot_hsl_bindings.py` — 440 passed
- Full-suite run: `venv/bin/python -m pytest tests/ -q` — only the 3 known out-of-scope failures below remain (26 before this PR)
- Rust extension rebuilt and fingerprint-stamped via `rust_utils.recompile_rust()` before test runs.

Known remaining failures (out of scope for this PR, not introduced by it):
- `tests/optimization/test_pymoo_backend.py::test_run_backend_evaluates_all_starting_configs_before_trim` — `algorithm.initialization.sampling` now yields pymoo `Individual` objects; `np.asarray(..., dtype=float)` in the test raises. Optimizer scope.
- `tests/test_exchange_config_updates.py` (2 bitget cases) — the bitget bot now runs UTA account-mode detection (`private_uta_get_v3_account_assets`) before `set_position_mode`; the test stubs lack that attribute. Exchange scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
