### PR TITLE
Persist HSL replay matrices after successful coin replay

### DIFF
--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -183,6 +183,8 @@ back to exchange-derived replay.
 - `hsl_replay_cache_hit`
 - `hsl_replay_cache_miss`
 - `hsl_replay_cache_rejected`
+- `hsl_replay_cache_write_failed`
+- `hsl_replay_cache_written`
 - `hsl_timeline_replay_completed`
 - `hsl_timeline_replay_started`
 - `initial_entry_distance_gate`

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -863,6 +863,13 @@ Remaining implementation details:
       Partial: coin-HSL replay lifecycle events now split startup timing into
       history-fetch, pre-replay, replay-loop, and total blocking elapsed fields
       so future cache-reuse work can prove which phase improved.
+      Partial: live coin-HSL replay now persists write-only raw replay matrices
+      for currently held coin+psides (`.npz` plus manifest, linear markets
+      only) after a successful replay, keyed by the tested cache-dir/config
+      digest helpers with fill/candle coverage metadata. Per-pair write
+      failures warn and emit `hsl_replay_cache_write_failed` without touching
+      replay results; successful writes emit `hsl_replay_cache_written`. The
+      cache is still never read for trading decisions.
 - [ ] Python simplification after Rust owns ideal protective orders and unstuck
       orders.
       Python should reconcile ideal vs actual orders, not re-decide trading

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -244,6 +244,8 @@ class ReasonCodes:
     HSL_REPLAY_CACHE_HIT = "hsl_replay_cache_hit"
     HSL_REPLAY_CACHE_MISS = "hsl_replay_cache_miss"
     HSL_REPLAY_CACHE_REJECTED = "hsl_replay_cache_rejected"
+    HSL_REPLAY_CACHE_WRITTEN = "hsl_replay_cache_written"
+    HSL_REPLAY_CACHE_WRITE_FAILED = "hsl_replay_cache_write_failed"
     HSL_RAW_RED_PENDING_EMA_CONFIRMATION = "hsl_raw_red_pending_ema_confirmation"
     HSL_RED_FINALIZED_WITHOUT_EXCHANGE_ORDER = (
         "hsl_red_finalized_without_exchange_order"

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1770,6 +1770,9 @@ class Passivbot:
     _hsl_replay_cache_config_digest = pb_hsl._hsl_replay_cache_config_digest
     _hsl_replay_cache_expected_metadata = pb_hsl._hsl_replay_cache_expected_metadata
     _hsl_replay_cache_dir = pb_hsl._hsl_replay_cache_dir
+    _equity_hard_stop_persist_replay_matrices = (
+        pb_hsl._equity_hard_stop_persist_replay_matrices
+    )
     _equity_hard_stop_maybe_emit_raw_red_pending = (
         pb_hsl._equity_hard_stop_maybe_emit_raw_red_pending
     )
@@ -11684,6 +11687,79 @@ class Passivbot:
         last_price: Dict[str, float] = {}
         pre_window_events_applied = 0
 
+        # Non-authoritative raw replay matrices (ts, price, psize, pprice, pnl, upnl)
+        # for currently held coin+psides. Written to the replay cache after a
+        # successful coin-mode replay; never read back for trading decisions here.
+        replay_matrix_pairs: set[Tuple[str, str]] = set()
+        if str(hsl_replay_signal_mode or "").lower() == "coin" and not self.inverse:
+            replay_matrix_pairs = {
+                (pside, sym)
+                for (sym, pside), (size, _price) in current_position_state.items()
+                if size > 1e-12 and sym in price_replay_symbols
+            }
+        replay_matrix_rows: Dict[Tuple[str, str], List[dict]] = {
+            pair: [] for pair in replay_matrix_pairs
+        }
+        replay_matrix_prev_realized: Dict[Tuple[str, str], float] = {}
+        replay_matrix_last_price: Dict[str, float] = {}
+
+        def _collect_replay_matrix_rows(minute_ts: int, *, record: bool) -> None:
+            for pair in list(replay_matrix_rows):
+                pside, sym = pair
+                running = float(
+                    realized_pnl_coin_pside_running.get(
+                        sym, {"long": 0.0, "short": 0.0}
+                    ).get(pside, 0.0)
+                )
+                # Track the running realized value every minute so the first
+                # persisted row's pnl covers only its own minute.
+                minute_pnl = running - replay_matrix_prev_realized.get(pair, running)
+                replay_matrix_prev_realized[pair] = running
+                mprice = price_lookup.get(sym, {}).get(minute_ts)
+                if mprice is not None and mprice > 0.0:
+                    replay_matrix_last_price[sym] = float(mprice)
+                else:
+                    mprice = replay_matrix_last_price.get(sym)
+                if not record:
+                    continue
+                if mprice is None or mprice <= 0.0:
+                    if replay_matrix_rows[pair]:
+                        # A gap after rows started would break 1m continuity;
+                        # drop the pair rather than persist an unprovable series.
+                        del replay_matrix_rows[pair]
+                    continue
+                slot = positions.get(sym, {}).get(pside, {})
+                size = float(slot.get("size", 0.0) or 0.0)
+                if size > 1e-12:
+                    psize = size if pside == "long" else -size
+                    pprice = float(slot.get("price", 0.0) or 0.0)
+                else:
+                    psize = 0.0
+                    pprice = 0.0
+                try:
+                    replay_matrix_rows[pair].append(
+                        pb_hsl._hsl_replay_matrix_row(
+                            pside=pside,
+                            ts=int(minute_ts),
+                            price=float(mprice),
+                            psize=psize,
+                            pprice=pprice,
+                            pnl=minute_pnl,
+                            c_mult=float(self.c_mults.get(sym, 1.0)),
+                        )
+                    )
+                except Exception as exc:
+                    del replay_matrix_rows[pair]
+                    logging.warning(
+                        "[risk] HSL[%s:%s] replay matrix row build failed; "
+                        "skipping cache for this pair | ts=%s error=%s: %s",
+                        pside,
+                        Passivbot._log_symbol(sym),
+                        minute_ts,
+                        type(exc).__name__,
+                        exc,
+                    )
+
         history_minutes = int(max(0, (end_minute - start_minute) // ONE_MIN_MS)) + 1
         _emit_hsl_history_progress(
             "timeline_replay_started",
@@ -11764,6 +11840,12 @@ class Passivbot:
             event_idx += 1
             pre_window_events_applied += 1
         record_start_balance = float(balance)
+        for pair in replay_matrix_rows:
+            replay_matrix_prev_realized[pair] = float(
+                realized_pnl_coin_pside_running.get(
+                    pair[1], {"long": 0.0, "short": 0.0}
+                ).get(pair[0], 0.0)
+            )
         record_start_realized_pnl_pside = {
             "long": float(realized_pnl_pside_running["long"]),
             "short": float(realized_pnl_pside_running["short"]),
@@ -11899,6 +11981,9 @@ class Passivbot:
                         "panic_fill_count": int(panic_fill_count),
                     }
                 )
+            _collect_replay_matrix_rows(
+                int(minute), record=minute >= record_start_minute
+            )
             minute += ONE_MIN_MS
 
         if not timeline:
@@ -11957,6 +12042,10 @@ class Passivbot:
             status="succeeded",
             reason_code=ReasonCodes.HSL_TIMELINE_REPLAY_COMPLETED,
         )
+        hsl_replay_matrices: Dict[str, Dict[str, List[dict]]] = {}
+        for (pside, sym), rows in replay_matrix_rows.items():
+            if rows:
+                hsl_replay_matrices.setdefault(pside, {})[sym] = rows
         return {
             "timeline": timeline,
             "panic_flatten_events": panic_flatten_events,
@@ -11964,6 +12053,13 @@ class Passivbot:
             "balances": balances,
             "equities": equities,
             "metadata": metadata,
+            "hsl_replay_matrices": hsl_replay_matrices,
+            "hsl_replay_matrix_coverage": {
+                "fill_covered_start_ms": int(record_start_ts),
+                "fill_covered_end_ms": int(ts_now),
+                "candle_covered_start_ms": int(start_minute),
+                "candle_covered_end_ms": int(end_minute),
+            },
         }
 
     async def update_open_orders(self):

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11704,39 +11704,42 @@ class Passivbot:
         replay_matrix_last_price: Dict[str, float] = {}
 
         def _collect_replay_matrix_rows(minute_ts: int, *, record: bool) -> None:
+            # Matrix collection is a passive observer of the replay; any
+            # per-pair failure drops that pair's cache and must never
+            # propagate into the replay itself.
             for pair in list(replay_matrix_rows):
                 pside, sym = pair
-                running = float(
-                    realized_pnl_coin_pside_running.get(
-                        sym, {"long": 0.0, "short": 0.0}
-                    ).get(pside, 0.0)
-                )
-                # Track the running realized value every minute so the first
-                # persisted row's pnl covers only its own minute.
-                minute_pnl = running - replay_matrix_prev_realized.get(pair, running)
-                replay_matrix_prev_realized[pair] = running
-                mprice = price_lookup.get(sym, {}).get(minute_ts)
-                if mprice is not None and mprice > 0.0:
-                    replay_matrix_last_price[sym] = float(mprice)
-                else:
-                    mprice = replay_matrix_last_price.get(sym)
-                if not record:
-                    continue
-                if mprice is None or mprice <= 0.0:
-                    if replay_matrix_rows[pair]:
-                        # A gap after rows started would break 1m continuity;
-                        # drop the pair rather than persist an unprovable series.
-                        del replay_matrix_rows[pair]
-                    continue
-                slot = positions.get(sym, {}).get(pside, {})
-                size = float(slot.get("size", 0.0) or 0.0)
-                if size > 1e-12:
-                    psize = size if pside == "long" else -size
-                    pprice = float(slot.get("price", 0.0) or 0.0)
-                else:
-                    psize = 0.0
-                    pprice = 0.0
                 try:
+                    running = float(
+                        realized_pnl_coin_pside_running.get(
+                            sym, {"long": 0.0, "short": 0.0}
+                        ).get(pside, 0.0)
+                    )
+                    # Track the running realized value every minute so the first
+                    # persisted row's pnl covers only its own minute.
+                    minute_pnl = running - replay_matrix_prev_realized.get(pair, running)
+                    replay_matrix_prev_realized[pair] = running
+                    mprice = price_lookup.get(sym, {}).get(minute_ts)
+                    if mprice is not None and mprice > 0.0:
+                        replay_matrix_last_price[sym] = float(mprice)
+                    else:
+                        mprice = replay_matrix_last_price.get(sym)
+                    if not record:
+                        continue
+                    if mprice is None or mprice <= 0.0:
+                        if replay_matrix_rows[pair]:
+                            # A gap after rows started would break 1m continuity;
+                            # drop the pair rather than persist an unprovable series.
+                            del replay_matrix_rows[pair]
+                        continue
+                    slot = positions.get(sym, {}).get(pside, {})
+                    size = float(slot.get("size", 0.0) or 0.0)
+                    if size > 1e-12:
+                        psize = size if pside == "long" else -size
+                        pprice = float(slot.get("price", 0.0) or 0.0)
+                    else:
+                        psize = 0.0
+                        pprice = 0.0
                     replay_matrix_rows[pair].append(
                         pb_hsl._hsl_replay_matrix_row(
                             pside=pside,
@@ -11749,7 +11752,7 @@ class Passivbot:
                         )
                     )
                 except Exception as exc:
-                    del replay_matrix_rows[pair]
+                    replay_matrix_rows.pop(pair, None)
                     logging.warning(
                         "[risk] HSL[%s:%s] replay matrix row build failed; "
                         "skipping cache for this pair | ts=%s error=%s: %s",

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -1047,6 +1047,86 @@ def _try_load_hsl_replay_matrix_cache(
     return manifest, arrays
 
 
+def _equity_hard_stop_persist_replay_matrices(self, history: dict[str, Any]) -> int:
+    """Persist non-authoritative raw replay matrices after a successful coin replay.
+
+    Write-only cache population: nothing here is read back for trading decisions.
+    Per-pair failures are logged and emitted as events but never raised, because
+    the cache is a performance aid, not trading state.
+    """
+    matrices = history.get("hsl_replay_matrices")
+    coverage = history.get("hsl_replay_matrix_coverage")
+    if not isinstance(matrices, dict) or not matrices:
+        return 0
+    if not isinstance(coverage, dict):
+        logging.warning(
+            "[risk] HSL replay cache write skipped: history missing matrix coverage metadata"
+        )
+        return 0
+    written = 0
+    for pside in sorted(matrices):
+        by_symbol = matrices.get(pside)
+        if not isinstance(by_symbol, dict):
+            continue
+        for symbol in sorted(by_symbol):
+            rows = by_symbol[symbol]
+            started_s = time.monotonic()
+            try:
+                config_digest = self._hsl_replay_cache_config_digest(pside)
+                cache_dir = self._hsl_replay_cache_dir(
+                    pside, symbol, config_digest=config_digest
+                )
+                metadata = self._hsl_replay_cache_expected_metadata(
+                    pside,
+                    symbol,
+                    fill_covered_start_ms=int(coverage["fill_covered_start_ms"]),
+                    fill_covered_end_ms=int(coverage["fill_covered_end_ms"]),
+                    candle_covered_start_ms=int(coverage["candle_covered_start_ms"]),
+                    candle_covered_end_ms=int(coverage["candle_covered_end_ms"]),
+                )
+                manifest = _write_hsl_replay_matrix_cache(cache_dir, rows, metadata)
+            except Exception as exc:
+                logging.warning(
+                    "[risk] HSL[%s:%s] replay cache write failed | rows=%d error=%s: %s",
+                    pside,
+                    symbol,
+                    len(rows) if isinstance(rows, list) else -1,
+                    type(exc).__name__,
+                    exc,
+                )
+                _emit_hsl_replay_event(
+                    self,
+                    EventTypes.HSL_REPLAY_CACHE,
+                    _hsl_replay_cache_status_data(
+                        cache_status="write_failed",
+                        elapsed_s=time.monotonic() - started_s,
+                        reasons=[f"write_exception:{type(exc).__name__}"],
+                    ),
+                    pside=pside,
+                    symbol=symbol,
+                    level="warning",
+                    status="failed",
+                    reason_code=ReasonCodes.HSL_REPLAY_CACHE_WRITE_FAILED,
+                )
+                continue
+            written += 1
+            _emit_hsl_replay_event(
+                self,
+                EventTypes.HSL_REPLAY_CACHE,
+                _hsl_replay_cache_status_data(
+                    cache_status="written",
+                    elapsed_s=time.monotonic() - started_s,
+                    manifest=manifest,
+                ),
+                pside=pside,
+                symbol=symbol,
+                level="debug",
+                status="succeeded",
+                reason_code=ReasonCodes.HSL_REPLAY_CACHE_WRITTEN,
+            )
+    return written
+
+
 def _hsl_psides(self) -> tuple[str, str]:
     return ("long", "short")
 
@@ -3972,6 +4052,18 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             status="succeeded",
             reason_code="coin_history_replay_completed",
         )
+        try:
+            self._equity_hard_stop_persist_replay_matrices(history)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # Cache persistence is a performance aid; a failure here must
+            # never invalidate the completed replay.
+            logging.warning(
+                "[risk] HSL replay cache persistence failed | error=%s: %s",
+                type(exc).__name__,
+                exc,
+            )
     except asyncio.CancelledError:
         _emit_hsl_replay_event(
             self,

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -515,6 +515,160 @@ def test_hsl_replay_cache_dir_is_sanitized_and_digest_scoped():
     assert "user:one" not in path
 
 
+def _make_persist_bot(tmp_path, monkeypatch):
+    from live.event_bus import ListEventSink, LiveEventPipeline
+
+    def fake_get_filepath(rel):
+        path = tmp_path / rel
+        path.mkdir(parents=True, exist_ok=True)
+        return f"{path}/"
+
+    monkeypatch.setattr(hsl, "make_get_filepath", fake_get_filepath)
+    bot = make_coin_bot()
+    bot.market_type = "swap"
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._live_event_current_cycle_id = "cy_hsl_cache_write"
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+    return bot, sink
+
+
+def test_hsl_replay_cache_persist_matrices_round_trip(tmp_path, monkeypatch):
+    import numpy as np
+    from live.event_bus import EventTypes, ReasonCodes
+
+    bot, sink = _make_persist_bot(tmp_path, monkeypatch)
+    symbol = "BTC/USDT:USDT"
+    rows = _hsl_cache_rows()
+    coverage = {
+        "fill_covered_start_ms": 60_000,
+        "fill_covered_end_ms": 200_000,
+        "candle_covered_start_ms": 60_000,
+        "candle_covered_end_ms": 180_000,
+    }
+    history = {
+        "hsl_replay_matrices": {"long": {symbol: rows}},
+        "hsl_replay_matrix_coverage": coverage,
+    }
+
+    written = hsl._equity_hard_stop_persist_replay_matrices(bot, history)
+
+    assert written == 1
+    expected_metadata = hsl._hsl_replay_cache_expected_metadata(
+        bot,
+        "long",
+        symbol,
+        fill_covered_start_ms=coverage["fill_covered_start_ms"],
+        fill_covered_end_ms=coverage["fill_covered_end_ms"],
+        candle_covered_start_ms=coverage["candle_covered_start_ms"],
+        candle_covered_end_ms=coverage["candle_covered_end_ms"],
+    )
+    cache_dir = hsl._hsl_replay_cache_dir(bot, "long", symbol)
+    assert (
+        hsl._hsl_replay_cache_validation_reasons(
+            cache_dir, expected_metadata=expected_metadata
+        )
+        == []
+    )
+    loaded = hsl._try_load_hsl_replay_matrix_cache(
+        bot,
+        cache_dir,
+        expected_metadata=expected_metadata,
+        pside="long",
+        symbol=symbol,
+    )
+    assert loaded is not None
+    manifest, arrays = loaded
+    assert manifest["row_count"] == len(rows)
+    np.testing.assert_array_equal(
+        arrays["ts"], np.array([row["ts"] for row in rows], dtype=np.int64)
+    )
+    np.testing.assert_allclose(arrays["pnl"], [row["pnl"] for row in rows])
+    np.testing.assert_allclose(arrays["upnl"], [row["upnl"] for row in rows])
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    cache_events = [
+        event for event in sink.events if event.event_type == EventTypes.HSL_REPLAY_CACHE
+    ]
+    written_events = [
+        event
+        for event in cache_events
+        if event.reason_code == ReasonCodes.HSL_REPLAY_CACHE_WRITTEN
+    ]
+    assert len(written_events) == 1
+    event = written_events[0]
+    assert event.status == "succeeded"
+    assert event.pside == "long"
+    assert event.symbol == symbol
+    assert event.data["cache_status"] == "written"
+    assert event.data["row_count"] == len(rows)
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_hsl_replay_cache_persist_matrices_write_failure_is_nonfatal(
+    tmp_path, monkeypatch, caplog
+):
+    import logging as logging_module
+
+    from live.event_bus import EventTypes, ReasonCodes
+
+    bot, sink = _make_persist_bot(tmp_path, monkeypatch)
+    symbol = "BTC/USDT:USDT"
+    rows = _hsl_cache_rows()
+    # Break 1m continuity so the fail-loud writer rejects the rows.
+    rows[-1] = dict(rows[-1], ts=rows[-1]["ts"] + 60_000)
+    history = {
+        "hsl_replay_matrices": {"long": {symbol: rows}},
+        "hsl_replay_matrix_coverage": {
+            "fill_covered_start_ms": 60_000,
+            "fill_covered_end_ms": 200_000,
+            "candle_covered_start_ms": 60_000,
+            "candle_covered_end_ms": 180_000,
+        },
+    }
+
+    with caplog.at_level(logging_module.WARNING):
+        written = hsl._equity_hard_stop_persist_replay_matrices(bot, history)
+
+    assert written == 0
+    assert "replay cache write failed" in caplog.text
+    cache_dir = hsl._hsl_replay_cache_dir(bot, "long", symbol)
+    assert hsl._hsl_replay_cache_validation_reasons(cache_dir) == ["manifest_missing"]
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    failed_events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.HSL_REPLAY_CACHE
+        and event.reason_code == ReasonCodes.HSL_REPLAY_CACHE_WRITE_FAILED
+    ]
+    assert len(failed_events) == 1
+    event = failed_events[0]
+    assert event.status == "failed"
+    assert event.pside == "long"
+    assert event.symbol == symbol
+    assert event.data["cache_status"] == "write_failed"
+    assert event.data["reasons"] == ["write_exception:ValueError"]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_hsl_replay_cache_persist_matrices_skips_missing_coverage(tmp_path, monkeypatch, caplog):
+    import logging as logging_module
+
+    bot, _sink = _make_persist_bot(tmp_path, monkeypatch)
+    history = {"hsl_replay_matrices": {"long": {"BTC/USDT:USDT": _hsl_cache_rows()}}}
+
+    with caplog.at_level(logging_module.WARNING):
+        written = hsl._equity_hard_stop_persist_replay_matrices(bot, history)
+
+    assert written == 0
+    assert "missing matrix coverage metadata" in caplog.text
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_hsl_replay_matrix_cache_reports_array_hash_mismatch(tmp_path):
     import numpy as np
 
@@ -715,6 +869,7 @@ def bind_hsl_methods(bot):
         "_hsl_replay_cache_config_digest",
         "_hsl_replay_cache_expected_metadata",
         "_hsl_replay_cache_dir",
+        "_equity_hard_stop_persist_replay_matrices",
         "_equity_hard_stop_build_latch_payload",
         "_equity_hard_stop_check_coin",
         "_equity_hard_stop_clear_coin_runtime_forced_mode",
@@ -980,6 +1135,140 @@ async def test_coin_hsl_history_replay_emits_lifecycle_events():
         + events[2].data["replay_loop_elapsed_s"]
     )
     assert phase_elapsed_s <= events[2].data["startup_blocking_elapsed_s"] + 0.006
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_history_replay_persists_replay_matrices(tmp_path, monkeypatch):
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
+
+    def fake_get_filepath(rel):
+        path = tmp_path / rel
+        path.mkdir(parents=True, exist_ok=True)
+        return f"{path}/"
+
+    monkeypatch.setattr(hsl, "make_get_filepath", fake_get_filepath)
+    bot = make_coin_bot()
+    bot.market_type = "swap"
+    symbol = "A"
+    bot.positions = {
+        symbol: {
+            "long": {"size": 1.0, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    sink = ListEventSink()
+    bot._live_event_current_cycle_id = "cy_hsl_replay"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+
+    matrix_rows = [
+        hsl._hsl_replay_matrix_row(
+            pside="long",
+            ts=60_000,
+            price=100.0,
+            psize=1.0,
+            pprice=101.0,
+            pnl=0.0,
+            c_mult=1.0,
+        ),
+        hsl._hsl_replay_matrix_row(
+            pside="long",
+            ts=120_000,
+            price=99.5,
+            psize=1.0,
+            pprice=101.0,
+            pnl=1.0,
+            c_mult=1.0,
+        ),
+    ]
+    coverage = {
+        "fill_covered_start_ms": 0,
+        "fill_covered_end_ms": 180_000,
+        "candle_covered_start_ms": 60_000,
+        "candle_covered_end_ms": 120_000,
+    }
+
+    async def fake_history(current_balance=None, **kwargs):
+        return {
+            "timeline": [
+                {
+                    "timestamp": 60_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {
+                        symbol: {"long": 0.0, "short": 0.0}
+                    },
+                    "unrealized_pnl_by_coin_pside": {
+                        symbol: {"long": -1.0, "short": 0.0}
+                    },
+                },
+                {
+                    "timestamp": 120_000,
+                    "balance": 100.0,
+                    "realized_pnl": 1.0,
+                    "realized_pnl_by_coin_pside": {
+                        symbol: {"long": 1.0, "short": 0.0}
+                    },
+                    "unrealized_pnl_by_coin_pside": {
+                        symbol: {"long": -0.5, "short": 0.0}
+                    },
+                },
+            ],
+            "panic_flatten_events": [],
+            "fill_events": [],
+            "hsl_replay_matrices": {"long": {symbol: matrix_rows}},
+            "hsl_replay_matrix_coverage": coverage,
+        }
+
+    bot.get_balance_equity_history = fake_history
+
+    await bot._equity_hard_stop_initialize_coin_from_history()
+
+    assert getattr(bot, "_equity_hard_stop_coin_initialized", False) is True
+    expected_metadata = hsl._hsl_replay_cache_expected_metadata(
+        bot,
+        "long",
+        symbol,
+        fill_covered_start_ms=coverage["fill_covered_start_ms"],
+        fill_covered_end_ms=coverage["fill_covered_end_ms"],
+        candle_covered_start_ms=coverage["candle_covered_start_ms"],
+        candle_covered_end_ms=coverage["candle_covered_end_ms"],
+    )
+    cache_dir = hsl._hsl_replay_cache_dir(bot, "long", symbol)
+    assert (
+        hsl._hsl_replay_cache_validation_reasons(
+            cache_dir, expected_metadata=expected_metadata
+        )
+        == []
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    replay_events = [
+        event for event in sink.events if event.event_type.startswith("hsl.replay.")
+    ]
+    completed_idx = [
+        idx
+        for idx, event in enumerate(replay_events)
+        if event.event_type == EventTypes.HSL_REPLAY_COMPLETED
+    ]
+    written_idx = [
+        idx
+        for idx, event in enumerate(replay_events)
+        if event.event_type == EventTypes.HSL_REPLAY_CACHE
+        and event.reason_code == ReasonCodes.HSL_REPLAY_CACHE_WRITTEN
+    ]
+    assert len(completed_idx) == 1
+    assert len(written_idx) == 1
+    assert written_idx[0] > completed_idx[0]
+    written_event = replay_events[written_idx[0]]
+    assert written_event.status == "succeeded"
+    assert written_event.pside == "long"
+    assert written_event.symbol == symbol
+    assert written_event.data["row_count"] == 2
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1517,6 +1517,109 @@ async def test_balance_equity_history_paces_replay_candle_fetches(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_balance_equity_history_builds_replay_matrices_for_held_pairs(monkeypatch):
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {}}
+    bot.exchange = "kucoin"
+    bot.user = "test_user"
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: 1.0 if key == "pnls_max_lookback_days" else None
+    base_ts = 1_800_000_000_000
+    ts_now = base_ts + 120_000
+    bot.get_exchange_time = lambda: ts_now
+    bot.get_raw_balance = lambda: 100.0
+    bot.get_symbol_id_inv = lambda symbol: symbol
+    symbol = "BTC/USDT:USDT"
+    bot.positions = {
+        symbol: {
+            "long": {"size": 0.5, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    bot._pnls_manager = None
+    bot.inverse = False
+    bot._candle_fetch_concurrency = lambda *, context="runtime": 2
+    bot._get_fetch_delay_seconds = lambda: 0.0
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[ListEventSink()],
+        monitor_sinks=[],
+    )
+    bot._live_event_current_cycle_id = "cy_hsl_history_build"
+    bot._emit_live_event = Passivbot._emit_live_event.__get__(bot, Passivbot)
+    bot.c_mults = {symbol: 1.0}
+    monkeypatch.setattr(
+        passivbot_module, "compute_psize_pprice", lambda *args, **kwargs: None
+    )
+
+    class _CM:
+        async def get_candles(self, sym, **kwargs):
+            return np.array(
+                [
+                    (base_ts, 99.0, 101.0, 98.0, 100.0, 1.0),
+                    (base_ts + 60_000, 100.0, 102.0, 99.0, 101.0, 1.0),
+                    (base_ts + 120_000, 101.0, 103.0, 100.0, 102.0, 1.0),
+                ],
+                dtype=passivbot_module.CANDLE_DTYPE,
+            )
+
+    bot.cm = _CM()
+    fill_events = [
+        {
+            "timestamp": base_ts,
+            "symbol": symbol,
+            "position_side": "long",
+            "side": "buy",
+            "qty": 1.0,
+            "price": 100.0,
+            "pnl": 0.0,
+        },
+        {
+            "timestamp": base_ts + 90_000,
+            "symbol": symbol,
+            "position_side": "long",
+            "side": "sell",
+            "qty": 0.5,
+            "price": 101.0,
+            "pnl": 0.5,
+        },
+    ]
+
+    history = await bot.get_balance_equity_history(
+        fill_events=fill_events,
+        current_balance=100.0,
+        hsl_replay_signal_mode="coin",
+    )
+
+    matrices = history["hsl_replay_matrices"]
+    assert set(matrices) == {"long"}
+    assert set(matrices["long"]) == {symbol}
+    rows = matrices["long"][symbol]
+    assert [row["ts"] for row in rows] == [base_ts, base_ts + 60_000, base_ts + 120_000]
+    assert [row["price"] for row in rows] == [100.0, 101.0, 102.0]
+    assert [row["psize"] for row in rows] == [1.0, 0.5, 0.5]
+    assert [row["pprice"] for row in rows] == [100.0, 100.0, 100.0]
+    # Raw minute pnl: the partial close realized +0.5 inside the second minute.
+    assert [row["pnl"] for row in rows] == [0.0, 0.5, 0.0]
+    assert [row["upnl"] for row in rows] == [0.0, 0.5, 1.0]
+
+    coverage = history["hsl_replay_matrix_coverage"]
+    assert coverage["candle_covered_start_ms"] <= base_ts
+    assert coverage["candle_covered_start_ms"] % 60_000 == 0
+    assert coverage["candle_covered_end_ms"] == base_ts + 120_000
+    assert coverage["fill_covered_start_ms"] <= base_ts
+    assert coverage["fill_covered_end_ms"] == ts_now
+
+    # Non-coin signal modes must not build matrices.
+    history_unified = await bot.get_balance_equity_history(
+        fill_events=fill_events,
+        current_balance=100.0,
+        hsl_replay_signal_mode="unified",
+    )
+    assert history_unified["hsl_replay_matrices"] == {}
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
 async def test_balance_equity_history_clamps_finite_replay_to_lookback_after_state_seed(
     monkeypatch,
 ):

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1616,6 +1616,21 @@ async def test_balance_equity_history_builds_replay_matrices_for_held_pairs(monk
         hsl_replay_signal_mode="unified",
     )
     assert history_unified["hsl_replay_matrices"] == {}
+
+    # A failing matrix row build must drop the pair's cache, not the replay.
+    def raising_row_builder(**kwargs):
+        raise ValueError("synthetic matrix row failure")
+
+    monkeypatch.setattr(
+        passivbot_module.pb_hsl, "_hsl_replay_matrix_row", raising_row_builder
+    )
+    history_degraded = await bot.get_balance_equity_history(
+        fill_events=fill_events,
+        current_balance=100.0,
+        hsl_replay_signal_mode="coin",
+    )
+    assert history_degraded["hsl_replay_matrices"] == {}
+    assert len(history_degraded["timeline"]) == len(history["timeline"])
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 

--- a/tests/test_passivbot_hsl_bindings.py
+++ b/tests/test_passivbot_hsl_bindings.py
@@ -43,4 +43,5 @@ def test_passivbot_uses_passivbot_hsl_module_for_hsl_methods():
         "_hsl_replay_cache_config_digest",
         "_hsl_replay_cache_expected_metadata",
         "_hsl_replay_cache_dir",
+        "_equity_hard_stop_persist_replay_matrices",
     } <= assigned_names


### PR DESCRIPTION
Wires the write side of the HSL replay cache (action plan B2.1b, next dependent slice after #1115). The cache is populated but still never read: replay behavior and trading decisions are unchanged.

Scope:

- `src/passivbot.py` (`get_balance_equity_history`): when invoked with `hsl_replay_signal_mode="coin"` on linear markets, builds raw non-authoritative replay matrix rows (`ts`, `price`, `psize`, `pprice`, `pnl`, `upnl`) for **currently held coin+psides** during the existing minute loop, via the fail-loud pure row builder from #1108/#1115:
  - `pnl` is the raw per-minute realized delta of the coin+pside running realized PnL (prev-value tracking starts at the record-window baseline so the first row covers exactly its own minute).
  - `psize`/`pprice` come from the replayed position state at each minute's end (signed psize; flat rows are `0.0/0.0`).
  - `price` is the minute's candle close, carried forward through no-price minutes once seen; pairs whose series would break one-minute continuity (no price yet at record start is fine, a later gap is not) are dropped rather than persisted.
  - Inverse markets are excluded because the pure UPnL helper (`pbr.calc_pnl_long/short`) does not model inverse contracts, while the timeline's own UPnL does.
  - Matrices and fill/candle coverage bounds are returned as `history["hsl_replay_matrices"]` / `history["hsl_replay_matrix_coverage"]`.
- `src/passivbot_hsl.py`: new `_equity_hard_stop_persist_replay_matrices` writes each pair's matrix through the tested helpers (`_hsl_replay_cache_config_digest` → `_hsl_replay_cache_dir` → `_hsl_replay_cache_expected_metadata` → `_write_hsl_replay_matrix_cache`). Called after `HSL_REPLAY_COMPLETED` in the coin initializer, wrapped so cache persistence can never invalidate a completed replay (CancelledError still propagates for shutdown).
- Observability: successful writes emit `hsl.replay.cache` with new reason code `hsl_replay_cache_written` (debug level); failures warn and emit `hsl_replay_cache_write_failed` per pair, then continue. Registry doc updated (parity test covers it).
- Bindings: the new instance helper is bound on `Passivbot`, pinned in the AST bindings test, and added to the fake-bot bind list (the #1115 lesson).

Statelessness contract: the persisted matrices are raw per-minute facts only — no cumulative PnL, equity, drawdown, RED/cooldown/no-restart state — and nothing reads them yet. A fresh VPS reconstructs identical trading decisions from exchange state plus config. The read/extend/reuse slice comes separately once these trust-boundary writes have soaked.

Coverage-metadata caveat for the future read slice (intentional, documented here so reviewers don't treat it as hidden): `fill_covered_start_ms`/`fill_covered_end_ms` record the replay window actually consumed (record-window start, exchange now), not a pnls-manager coverage proof. The reuse slice must gate on proven coverage (`history_scope=all`/`covered_start_ms`) before trusting these bounds, per the error contract.

Validation:
- `venv/bin/python -m pytest tests/test_hsl_coin_mode.py tests/test_passivbot_balance_split.py tests/test_passivbot_hsl_bindings.py tests/test_live_event_registry_docs.py tests/test_unstucking_safeguards.py tests/test_realized_loss_gate.py` — 442 passed
- New tests: matrix construction from candle/fill replay (pnl attribution across a partial close, psize/pprice tracking, price carry-forward, coin-mode gating with unified-mode returning no matrices); persist round-trip validated by the fail-closed validator and loader (`validation_reasons == []`, arrays equal); write-failure non-fatality with `hsl_replay_cache_write_failed` event evidence; missing-coverage skip; end-to-end coin-initializer wiring proving the cache appears after `HSL_REPLAY_COMPLETED`.
- Full suite: `venv/bin/python -m pytest tests/ -q` — only the 3 known pre-existing out-of-scope failures (pymoo sampling, 2 bitget UTA stubs; see #1116)
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
