### PR TITLE
Record fill-coverage proof in HSL replay cache metadata

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -870,6 +870,12 @@ Remaining implementation details:
       failures warn and emit `hsl_replay_cache_write_failed` without touching
       replay results; successful writes emit `hsl_replay_cache_written`. The
       cache is still never read for trading decisions.
+      Partial: replay cache manifests (schema v2) now record the pnls-manager
+      fill-coverage proof at write time (`fill_history_scope`,
+      `fill_coverage_proven`) via the canonical coverage-status check, with
+      caller-provided fill events explicitly marked unproven. The future
+      read/reuse slice must gate on a proven manifest plus a fresh coverage
+      proof at load time.
 - [ ] Python simplification after Rust owns ideal protective orders and unstuck
       orders.
       Python should reconcile ideal vs actual orders, not re-decide trading

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11094,6 +11094,7 @@ class Passivbot:
     ) -> Dict[str, Any]:
         """Replay canonical fill events to produce historical balance/equity curves."""
         history_started_s = time.monotonic()
+        external_fill_events = fill_events is not None
         await self.init_pnls()
 
         def _emit_hsl_history_progress(
@@ -12049,6 +12050,19 @@ class Passivbot:
         for (pside, sym), rows in replay_matrix_rows.items():
             if rows:
                 hsl_replay_matrices.setdefault(pside, {})[sym] = rows
+        if external_fill_events:
+            # Caller-provided fills carry no pnls-manager coverage proof.
+            fill_coverage_status: Dict[str, object] = {
+                "ready": False,
+                "reason": "external_fill_events",
+                "history_scope": "unknown",
+            }
+        else:
+            fill_coverage_status = self._pnl_history_coverage_status(
+                start_ms=None if lookback_start is None else int(record_start_ts),
+                end_ms=int(ts_now),
+                lookback=lookback,
+            )
         return {
             "timeline": timeline,
             "panic_flatten_events": panic_flatten_events,
@@ -12060,6 +12074,13 @@ class Passivbot:
             "hsl_replay_matrix_coverage": {
                 "fill_covered_start_ms": int(record_start_ts),
                 "fill_covered_end_ms": int(ts_now),
+                "fill_history_scope": str(
+                    fill_coverage_status.get("history_scope", "unknown") or "unknown"
+                ),
+                "fill_coverage_proven": bool(fill_coverage_status.get("ready", False)),
+                "fill_coverage_reason": str(
+                    fill_coverage_status.get("reason", "unknown") or "unknown"
+                ),
                 "candle_covered_start_ms": int(start_minute),
                 "candle_covered_end_ms": int(end_minute),
             },

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -33,7 +33,7 @@ from utils import make_get_filepath
 _HSL_RISKS_DOC = "docs/equity_hard_stop_loss_risks.md"
 _HSL_REPLAY_MATRIX_INTERVAL_MS = 60_000
 _HSL_REPLAY_MATRIX_RAW_FIELDS = ("ts", "price", "psize", "pprice", "pnl", "upnl")
-_HSL_REPLAY_CACHE_SCHEMA_VERSION = 1
+_HSL_REPLAY_CACHE_SCHEMA_VERSION = 2
 _HSL_REPLAY_CACHE_MATRIX_FILENAME = "hsl_replay_matrix.npz"
 _HSL_REPLAY_CACHE_MANIFEST_FILENAME = "hsl_replay_manifest.json"
 _HSL_REPLAY_CACHE_REQUIRED_METADATA = (
@@ -46,9 +46,12 @@ _HSL_REPLAY_CACHE_REQUIRED_METADATA = (
     "symbol",
     "fill_covered_start_ms",
     "fill_covered_end_ms",
+    "fill_history_scope",
+    "fill_coverage_proven",
     "candle_covered_start_ms",
     "candle_covered_end_ms",
 )
+_HSL_REPLAY_CACHE_FILL_HISTORY_SCOPES = ("unknown", "window", "all")
 
 
 def _hsl_replay_cache_safe_fragment(value: Any) -> str:
@@ -649,6 +652,7 @@ def _normalize_hsl_replay_cache_metadata(metadata: dict[str, Any]) -> dict[str, 
         "signal_mode",
         "pside",
         "symbol",
+        "fill_history_scope",
     ):
         out[key] = str(out[key])
     for key in (
@@ -658,6 +662,16 @@ def _normalize_hsl_replay_cache_metadata(metadata: dict[str, Any]) -> dict[str, 
         "candle_covered_end_ms",
     ):
         out[key] = int(out[key])
+    if out["fill_history_scope"] not in _HSL_REPLAY_CACHE_FILL_HISTORY_SCOPES:
+        raise ValueError(
+            "HSL replay cache metadata fill_history_scope must be one of "
+            f"{_HSL_REPLAY_CACHE_FILL_HISTORY_SCOPES}, got {out['fill_history_scope']!r}"
+        )
+    if not isinstance(out["fill_coverage_proven"], bool):
+        raise ValueError(
+            "HSL replay cache metadata fill_coverage_proven must be a bool, "
+            f"got {type(out['fill_coverage_proven']).__name__}"
+        )
     return out
 
 
@@ -711,6 +725,8 @@ def _hsl_replay_cache_expected_metadata(
     *,
     fill_covered_start_ms: int,
     fill_covered_end_ms: int,
+    fill_history_scope: str,
+    fill_coverage_proven: bool,
     candle_covered_start_ms: int,
     candle_covered_end_ms: int,
 ) -> dict[str, Any]:
@@ -724,6 +740,8 @@ def _hsl_replay_cache_expected_metadata(
         "symbol": str(symbol),
         "fill_covered_start_ms": int(fill_covered_start_ms),
         "fill_covered_end_ms": int(fill_covered_end_ms),
+        "fill_history_scope": str(fill_history_scope),
+        "fill_coverage_proven": bool(fill_coverage_proven),
         "candle_covered_start_ms": int(candle_covered_start_ms),
         "candle_covered_end_ms": int(candle_covered_end_ms),
     }
@@ -1081,6 +1099,8 @@ def _equity_hard_stop_persist_replay_matrices(self, history: dict[str, Any]) -> 
                     symbol,
                     fill_covered_start_ms=int(coverage["fill_covered_start_ms"]),
                     fill_covered_end_ms=int(coverage["fill_covered_end_ms"]),
+                    fill_history_scope=str(coverage["fill_history_scope"]),
+                    fill_coverage_proven=bool(coverage["fill_coverage_proven"]),
                     candle_covered_start_ms=int(coverage["candle_covered_start_ms"]),
                     candle_covered_end_ms=int(coverage["candle_covered_end_ms"]),
                 )

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -741,7 +741,9 @@ def _hsl_replay_cache_expected_metadata(
         "fill_covered_start_ms": int(fill_covered_start_ms),
         "fill_covered_end_ms": int(fill_covered_end_ms),
         "fill_history_scope": str(fill_history_scope),
-        "fill_coverage_proven": bool(fill_coverage_proven),
+        # Passed through raw so the normalizer rejects non-bool proof values
+        # instead of silently blessing truthy garbage as a proven manifest.
+        "fill_coverage_proven": fill_coverage_proven,
         "candle_covered_start_ms": int(candle_covered_start_ms),
         "candle_covered_end_ms": int(candle_covered_end_ms),
     }
@@ -1100,7 +1102,7 @@ def _equity_hard_stop_persist_replay_matrices(self, history: dict[str, Any]) -> 
                     fill_covered_start_ms=int(coverage["fill_covered_start_ms"]),
                     fill_covered_end_ms=int(coverage["fill_covered_end_ms"]),
                     fill_history_scope=str(coverage["fill_history_scope"]),
-                    fill_coverage_proven=bool(coverage["fill_coverage_proven"]),
+                    fill_coverage_proven=coverage["fill_coverage_proven"],
                     candle_covered_start_ms=int(coverage["candle_covered_start_ms"]),
                     candle_covered_end_ms=int(coverage["candle_covered_end_ms"]),
                 )

--- a/tests/test_cache_integrity_doctor.py
+++ b/tests/test_cache_integrity_doctor.py
@@ -85,6 +85,8 @@ def _hsl_replay_cache_metadata():
         "symbol": "BTC/USDT:USDT",
         "fill_covered_start_ms": 60_000,
         "fill_covered_end_ms": 180_000,
+        "fill_history_scope": "window",
+        "fill_coverage_proven": True,
         "candle_covered_start_ms": 60_000,
         "candle_covered_end_ms": 180_000,
     }

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -699,6 +699,54 @@ def test_hsl_replay_cache_persist_matrices_write_failure_is_nonfatal(
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_hsl_replay_cache_writer_rejects_non_bool_coverage_proof(tmp_path, monkeypatch):
+    from live.event_bus import EventTypes, ReasonCodes
+
+    bot, sink = _make_persist_bot(tmp_path, monkeypatch)
+    symbol = "BTC/USDT:USDT"
+
+    with pytest.raises(ValueError, match="fill_coverage_proven"):
+        hsl._hsl_replay_cache_expected_metadata(
+            bot,
+            "long",
+            symbol,
+            fill_covered_start_ms=60_000,
+            fill_covered_end_ms=200_000,
+            fill_history_scope="window",
+            fill_coverage_proven=1,
+            candle_covered_start_ms=60_000,
+            candle_covered_end_ms=180_000,
+        )
+
+    history = {
+        "hsl_replay_matrices": {"long": {symbol: _hsl_cache_rows()}},
+        "hsl_replay_matrix_coverage": {
+            "fill_covered_start_ms": 60_000,
+            "fill_covered_end_ms": 200_000,
+            "fill_history_scope": "window",
+            "fill_coverage_proven": 1,
+            "candle_covered_start_ms": 60_000,
+            "candle_covered_end_ms": 180_000,
+        },
+    }
+
+    written = hsl._equity_hard_stop_persist_replay_matrices(bot, history)
+
+    assert written == 0
+    cache_dir = hsl._hsl_replay_cache_dir(bot, "long", symbol)
+    assert hsl._hsl_replay_cache_validation_reasons(cache_dir) == ["manifest_missing"]
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    failed_events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.HSL_REPLAY_CACHE
+        and event.reason_code == ReasonCodes.HSL_REPLAY_CACHE_WRITE_FAILED
+    ]
+    assert len(failed_events) == 1
+    assert failed_events[0].data["reasons"] == ["write_exception:ValueError"]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_hsl_replay_cache_persist_matrices_skips_missing_coverage(tmp_path, monkeypatch, caplog):
     import logging as logging_module
 

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -194,6 +194,8 @@ def _hsl_cache_metadata(**overrides):
         "symbol": "BTC/USDT:USDT",
         "fill_covered_start_ms": 60_000,
         "fill_covered_end_ms": 180_000,
+        "fill_history_scope": "window",
+        "fill_coverage_proven": True,
         "candle_covered_start_ms": 60_000,
         "candle_covered_end_ms": 180_000,
     }
@@ -480,6 +482,8 @@ def test_hsl_replay_cache_expected_metadata_uses_trust_boundary_fields():
         "BTC/USDT:USDT",
         fill_covered_start_ms=60_000,
         fill_covered_end_ms=120_000,
+        fill_history_scope="window",
+        fill_coverage_proven=True,
         candle_covered_start_ms=60_000,
         candle_covered_end_ms=180_000,
     )
@@ -495,8 +499,42 @@ def test_hsl_replay_cache_expected_metadata_uses_trust_boundary_fields():
     assert len(metadata["config_digest"]) == 64
     assert metadata["fill_covered_start_ms"] == 60_000
     assert metadata["fill_covered_end_ms"] == 120_000
+    assert metadata["fill_history_scope"] == "window"
+    assert metadata["fill_coverage_proven"] is True
     assert metadata["candle_covered_start_ms"] == 60_000
     assert metadata["candle_covered_end_ms"] == 180_000
+
+
+def test_hsl_replay_cache_metadata_rejects_invalid_coverage_proof_fields():
+    with pytest.raises(ValueError, match="fill_history_scope"):
+        hsl._normalize_hsl_replay_cache_metadata(
+            _hsl_cache_metadata(fill_history_scope="everything")
+        )
+    with pytest.raises(ValueError, match="fill_coverage_proven"):
+        hsl._normalize_hsl_replay_cache_metadata(
+            _hsl_cache_metadata(fill_coverage_proven=1)
+        )
+    # Unproven coverage is valid metadata; the future read slice gates on it.
+    normalized = hsl._normalize_hsl_replay_cache_metadata(
+        _hsl_cache_metadata(fill_coverage_proven=False)
+    )
+    assert normalized["fill_coverage_proven"] is False
+
+
+def test_hsl_replay_cache_validation_flags_missing_coverage_proof_fields(tmp_path):
+    import json
+
+    hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), _hsl_cache_metadata())
+    manifest_path = tmp_path / hsl._HSL_REPLAY_CACHE_MANIFEST_FILENAME
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    del manifest["metadata"]["fill_history_scope"]
+    del manifest["metadata"]["fill_coverage_proven"]
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    reasons = hsl._hsl_replay_cache_validation_reasons(tmp_path)
+
+    assert "metadata_missing_required:fill_history_scope" in reasons
+    assert "metadata_missing_required:fill_coverage_proven" in reasons
 
 
 def test_hsl_replay_cache_dir_is_sanitized_and_digest_scoped():
@@ -546,6 +584,8 @@ def test_hsl_replay_cache_persist_matrices_round_trip(tmp_path, monkeypatch):
     coverage = {
         "fill_covered_start_ms": 60_000,
         "fill_covered_end_ms": 200_000,
+        "fill_history_scope": "window",
+        "fill_coverage_proven": True,
         "candle_covered_start_ms": 60_000,
         "candle_covered_end_ms": 180_000,
     }
@@ -563,6 +603,8 @@ def test_hsl_replay_cache_persist_matrices_round_trip(tmp_path, monkeypatch):
         symbol,
         fill_covered_start_ms=coverage["fill_covered_start_ms"],
         fill_covered_end_ms=coverage["fill_covered_end_ms"],
+        fill_history_scope=coverage["fill_history_scope"],
+        fill_coverage_proven=coverage["fill_coverage_proven"],
         candle_covered_start_ms=coverage["candle_covered_start_ms"],
         candle_covered_end_ms=coverage["candle_covered_end_ms"],
     )
@@ -625,6 +667,8 @@ def test_hsl_replay_cache_persist_matrices_write_failure_is_nonfatal(
         "hsl_replay_matrix_coverage": {
             "fill_covered_start_ms": 60_000,
             "fill_covered_end_ms": 200_000,
+            "fill_history_scope": "window",
+            "fill_coverage_proven": True,
             "candle_covered_start_ms": 60_000,
             "candle_covered_end_ms": 180_000,
         },
@@ -1188,6 +1232,8 @@ async def test_coin_hsl_history_replay_persists_replay_matrices(tmp_path, monkey
     coverage = {
         "fill_covered_start_ms": 0,
         "fill_covered_end_ms": 180_000,
+        "fill_history_scope": "all",
+        "fill_coverage_proven": True,
         "candle_covered_start_ms": 60_000,
         "candle_covered_end_ms": 120_000,
     }
@@ -1235,6 +1281,8 @@ async def test_coin_hsl_history_replay_persists_replay_matrices(tmp_path, monkey
         symbol,
         fill_covered_start_ms=coverage["fill_covered_start_ms"],
         fill_covered_end_ms=coverage["fill_covered_end_ms"],
+        fill_history_scope=coverage["fill_history_scope"],
+        fill_coverage_proven=coverage["fill_coverage_proven"],
         candle_covered_start_ms=coverage["candle_covered_start_ms"],
         candle_covered_end_ms=coverage["candle_covered_end_ms"],
     )

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1608,6 +1608,10 @@ async def test_balance_equity_history_builds_replay_matrices_for_held_pairs(monk
     assert coverage["candle_covered_end_ms"] == base_ts + 120_000
     assert coverage["fill_covered_start_ms"] <= base_ts
     assert coverage["fill_covered_end_ms"] == ts_now
+    # Caller-provided fill events carry no pnls-manager coverage proof.
+    assert coverage["fill_history_scope"] == "unknown"
+    assert coverage["fill_coverage_proven"] is False
+    assert coverage["fill_coverage_reason"] == "external_fill_events"
 
     # Non-coin signal modes must not build matrices.
     history_unified = await bot.get_balance_equity_history(
@@ -1631,6 +1635,99 @@ async def test_balance_equity_history_builds_replay_matrices_for_held_pairs(monk
     )
     assert history_degraded["hsl_replay_matrices"] == {}
     assert len(history_degraded["timeline"]) == len(history["timeline"])
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_balance_equity_history_records_pnls_manager_coverage_proof(monkeypatch):
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {}}
+    bot.exchange = "kucoin"
+    bot.user = "test_user"
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: 1.0 if key == "pnls_max_lookback_days" else None
+    base_ts = 1_800_000_000_000
+    ts_now = base_ts + 120_000
+    bot.get_exchange_time = lambda: ts_now
+    bot.get_raw_balance = lambda: 100.0
+    bot.get_symbol_id_inv = lambda symbol: symbol
+    symbol = "BTC/USDT:USDT"
+    bot.positions = {
+        symbol: {
+            "long": {"size": 1.0, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    bot.inverse = False
+    bot._candle_fetch_concurrency = lambda *, context="runtime": 2
+    bot._get_fetch_delay_seconds = lambda: 0.0
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[ListEventSink()],
+        monitor_sinks=[],
+    )
+    bot._live_event_current_cycle_id = "cy_hsl_history_build"
+    bot._emit_live_event = Passivbot._emit_live_event.__get__(bot, Passivbot)
+    bot.c_mults = {symbol: 1.0}
+    monkeypatch.setattr(
+        passivbot_module, "compute_psize_pprice", lambda *args, **kwargs: None
+    )
+
+    class _CM:
+        async def get_candles(self, sym, **kwargs):
+            return np.array(
+                [
+                    (base_ts, 99.0, 101.0, 98.0, 100.0, 1.0),
+                    (base_ts + 60_000, 100.0, 102.0, 99.0, 101.0, 1.0),
+                    (base_ts + 120_000, 101.0, 103.0, 100.0, 102.0, 1.0),
+                ],
+                dtype=passivbot_module.CANDLE_DTYPE,
+            )
+
+    bot.cm = _CM()
+
+    class _StubEvent:
+        def to_dict(self):
+            return {
+                "timestamp": base_ts,
+                "symbol": symbol,
+                "position_side": "long",
+                "side": "buy",
+                "qty": 1.0,
+                "price": 100.0,
+                "pnl": 0.0,
+            }
+
+    class _StubCache:
+        def load_metadata(self):
+            return {"covered_start_ms": 1, "oldest_event_ts": base_ts}
+
+        def get_covered_start_ms(self):
+            return 1
+
+        def get_history_scope(self):
+            return "all"
+
+    class _StubPnlsManager:
+        cache = _StubCache()
+
+        def get_events(self):
+            return [_StubEvent()]
+
+        def get_history_scope(self):
+            return "all"
+
+    bot._pnls_manager = _StubPnlsManager()
+
+    history = await bot.get_balance_equity_history(
+        current_balance=100.0,
+        hsl_replay_signal_mode="coin",
+    )
+
+    coverage = history["hsl_replay_matrix_coverage"]
+    assert coverage["fill_history_scope"] == "all"
+    assert coverage["fill_coverage_proven"] is True
+    assert coverage["fill_coverage_reason"] == "full_history"
+    assert set(history["hsl_replay_matrices"]) == {"long"}
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
Precursor to HSL replay-cache reuse (action plan B2.1b). Both #1117 reviews flagged that the manifest's `fill_covered_start_ms`/`fill_covered_end_ms` describe the replay window consumed, not a completeness proof. This slice records the pnls-manager coverage proof in the manifest at write time so the future read slice has something trustworthy to gate on. Still write-only: nothing reads the cache, no trading behavior change.

Scope:

- `src/passivbot.py` (`get_balance_equity_history`): computes the canonical `_pnl_history_coverage_status` (the same known-gap-aware check risk consumers use) for the replay window and returns `fill_history_scope`, `fill_coverage_proven`, and `fill_coverage_reason` in `hsl_replay_matrix_coverage`. Caller-provided `fill_events` are explicitly marked unproven with reason `external_fill_events` — they carry no pnls-manager proof.
- `src/passivbot_hsl.py`: cache manifest metadata (schema **v2**) gains required trust-boundary fields `fill_history_scope` (validated against `unknown`/`window`/`all`) and `fill_coverage_proven` (strict bool — `1` is rejected). The persist helper threads them through from the coverage payload.
- Schema bump rationale: v1 manifests lack the proof fields; bumping to v2 makes the shared validator reject them (`schema_version_mismatch`) rather than reinterpret. Since nothing reads caches yet, the only observable effect is `cache-integrity-doctor` flagging v1 caches for rebuild, which is the correct message.
- Unproven coverage is still written and recorded honestly (`fill_coverage_proven: false`) — the write path stays non-authoritative and non-gating. The read slice must require a proven manifest **plus** a fresh coverage proof at load time (noted in the action-plan tracker, updated here).

Validation:
- `venv/bin/python -m pytest tests/test_hsl_coin_mode.py tests/test_passivbot_balance_split.py tests/test_unstucking_safeguards.py tests/test_passivbot_hsl_bindings.py tests/test_live_event_registry_docs.py` — 401 passed; `tests/test_cache_integrity_doctor.py` — 17 passed
- New tests: metadata normalization strictness (invalid scope value, non-bool proven, unproven-but-valid False); validator emits `metadata_missing_required:fill_history_scope`/`:fill_coverage_proven` for stripped manifests; coverage payload marks external fills unproven; a pnls-manager stub with `history_scope=all` yields `fill_coverage_proven: true` / `full_history` end-to-end through the matrix build.
- Full suite: only the 3 known pre-existing out-of-scope failures (pymoo sampling, 2 bitget UTA stubs; see #1116).
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)