### PR TITLE
Persist account-level HSL realized-PnL series alongside pair matrices

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -876,6 +876,14 @@ Remaining implementation details:
       caller-provided fill events explicitly marked unproven. The future
       read/reuse slice must gate on a proven manifest plus a fresh coverage
       proof at load time.
+      Partial: cache format (schema v3) now carries a manifest `series_kind`
+      (`pair_matrix` | `account_pnl`), and live coin replay additionally
+      persists the write-only account-level realized-PnL series (`ts`, raw
+      minute `pnl`) alongside held-pair matrices, because per-minute slot
+      budgets need account balance that pair rows cannot provide. Kind/field
+      tampering is rejected (`fields_mismatch`/`series_kind_invalid`). The
+      account series is only written together with at least one pair matrix
+      and remains never read for trading decisions.
 - [ ] Python simplification after Rust owns ideal protective orders and unstuck
       orders.
       Python should reconcile ideal vs actual orders, not re-decide trading

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1770,6 +1770,13 @@ class Passivbot:
     _hsl_replay_cache_config_digest = pb_hsl._hsl_replay_cache_config_digest
     _hsl_replay_cache_expected_metadata = pb_hsl._hsl_replay_cache_expected_metadata
     _hsl_replay_cache_dir = pb_hsl._hsl_replay_cache_dir
+    _hsl_replay_cache_account_config_digest = (
+        pb_hsl._hsl_replay_cache_account_config_digest
+    )
+    _hsl_replay_cache_account_series_dir = pb_hsl._hsl_replay_cache_account_series_dir
+    _hsl_replay_cache_account_expected_metadata = (
+        pb_hsl._hsl_replay_cache_account_expected_metadata
+    )
     _equity_hard_stop_persist_replay_matrices = (
         pb_hsl._equity_hard_stop_persist_replay_matrices
     )
@@ -11703,6 +11710,42 @@ class Passivbot:
         }
         replay_matrix_prev_realized: Dict[Tuple[str, str], float] = {}
         replay_matrix_last_price: Dict[str, float] = {}
+        # Account-level realized-pnl series: pair matrices are only reusable
+        # together with per-minute account balance (slot budgets), which is not
+        # derivable from held-pair rows alone.
+        replay_account_enabled = bool(replay_matrix_pairs)
+        replay_account_rows: List[dict] = []
+        replay_account_prev_balance: Optional[float] = None
+
+        def _collect_account_series_row(minute_ts: int, *, record: bool) -> None:
+            nonlocal replay_account_enabled, replay_account_prev_balance
+            if not replay_account_enabled:
+                return
+            try:
+                balance_now = float(balance)
+                prev = (
+                    balance_now
+                    if replay_account_prev_balance is None
+                    else replay_account_prev_balance
+                )
+                replay_account_prev_balance = balance_now
+                if not record:
+                    return
+                replay_account_rows.append(
+                    pb_hsl._hsl_replay_account_series_row(
+                        ts=int(minute_ts), pnl=balance_now - prev
+                    )
+                )
+            except Exception as exc:
+                replay_account_enabled = False
+                replay_account_rows.clear()
+                logging.warning(
+                    "[risk] HSL account series row build failed; "
+                    "skipping account series cache | ts=%s error=%s: %s",
+                    minute_ts,
+                    type(exc).__name__,
+                    exc,
+                )
 
         def _collect_replay_matrix_rows(minute_ts: int, *, record: bool) -> None:
             # Matrix collection is a passive observer of the replay; any
@@ -11850,6 +11893,8 @@ class Passivbot:
                     pair[1], {"long": 0.0, "short": 0.0}
                 ).get(pair[0], 0.0)
             )
+        if replay_account_enabled:
+            replay_account_prev_balance = float(balance)
         record_start_realized_pnl_pside = {
             "long": float(realized_pnl_pside_running["long"]),
             "short": float(realized_pnl_pside_running["short"]),
@@ -11988,6 +12033,9 @@ class Passivbot:
             _collect_replay_matrix_rows(
                 int(minute), record=minute >= record_start_minute
             )
+            _collect_account_series_row(
+                int(minute), record=minute >= record_start_minute
+            )
             minute += ONE_MIN_MS
 
         if not timeline:
@@ -12071,6 +12119,9 @@ class Passivbot:
             "equities": equities,
             "metadata": metadata,
             "hsl_replay_matrices": hsl_replay_matrices,
+            "hsl_replay_account_series": (
+                replay_account_rows if hsl_replay_matrices else []
+            ),
             "hsl_replay_matrix_coverage": {
                 "fill_covered_start_ms": int(record_start_ts),
                 "fill_covered_end_ms": int(ts_now),

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -33,7 +33,11 @@ from utils import make_get_filepath
 _HSL_RISKS_DOC = "docs/equity_hard_stop_loss_risks.md"
 _HSL_REPLAY_MATRIX_INTERVAL_MS = 60_000
 _HSL_REPLAY_MATRIX_RAW_FIELDS = ("ts", "price", "psize", "pprice", "pnl", "upnl")
-_HSL_REPLAY_CACHE_SCHEMA_VERSION = 2
+_HSL_REPLAY_ACCOUNT_SERIES_FIELDS = ("ts", "pnl")
+_HSL_REPLAY_CACHE_SERIES_KINDS = ("pair_matrix", "account_pnl")
+_HSL_REPLAY_CACHE_ACCOUNT_PSIDE = "account"
+_HSL_REPLAY_CACHE_ACCOUNT_SYMBOL = "__account__"
+_HSL_REPLAY_CACHE_SCHEMA_VERSION = 3
 _HSL_REPLAY_CACHE_MATRIX_FILENAME = "hsl_replay_matrix.npz"
 _HSL_REPLAY_CACHE_MANIFEST_FILENAME = "hsl_replay_manifest.json"
 _HSL_REPLAY_CACHE_REQUIRED_METADATA = (
@@ -458,6 +462,38 @@ def _hsl_replay_matrix_row(
     }
 
 
+def _hsl_replay_account_series_row(*, ts: int, pnl: float) -> dict[str, float | int]:
+    """Build one non-authoritative account-level realized-PnL row."""
+    ts_int = int(ts)
+    if ts_int < 0:
+        raise ValueError(f"HSL account series ts must be >= 0, got {ts_int}")
+    return {"ts": ts_int, "pnl": _finite_hsl_float(pnl, "pnl")}
+
+
+def _hsl_replay_account_series_arrays(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    import numpy as np
+
+    prev_ts: int | None = None
+    for row in rows:
+        missing = [field for field in _HSL_REPLAY_ACCOUNT_SERIES_FIELDS if field not in row]
+        if missing:
+            raise ValueError(f"HSL account series row missing fields: {missing}")
+        ts = int(row["ts"])
+        if ts < 0:
+            raise ValueError(f"HSL account series ts must be >= 0, got {ts}")
+        if prev_ts is not None and ts - prev_ts != _HSL_REPLAY_MATRIX_INTERVAL_MS:
+            raise ValueError(
+                "HSL account series rows must be contiguous 1m samples; "
+                f"got previous_ts={prev_ts} ts={ts}"
+            )
+        _finite_hsl_float(row["pnl"], "pnl")
+        prev_ts = ts
+    return {
+        "ts": np.asarray([int(row["ts"]) for row in rows], dtype=np.int64),
+        "pnl": np.asarray([float(row["pnl"]) for row in rows], dtype=np.float64),
+    }
+
+
 def _hsl_replay_matrix_derived_series(
     rows: list[dict[str, Any]], *, base_equity: float
 ) -> list[dict[str, float | int]]:
@@ -574,7 +610,7 @@ def _hsl_replay_cache_array_manifest(arrays: dict[str, Any]) -> dict[str, dict[s
             "shape": [int(x) for x in arrays[field].shape],
             "dtype": str(arrays[field].dtype),
         }
-        for field in _HSL_REPLAY_MATRIX_RAW_FIELDS
+        for field in sorted(arrays)
     }
 
 
@@ -589,18 +625,32 @@ def _hsl_replay_cache_array_dtype_is_valid(field: str, dtype: Any) -> bool:
     return bool(np.issubdtype(np_dtype, np.integer) or np.issubdtype(np_dtype, np.floating))
 
 
-def _hsl_replay_cache_array_value_reasons(arrays: dict[str, Any]) -> list[str]:
+def _hsl_replay_cache_series_fields(series_kind: str) -> tuple[str, ...]:
+    if series_kind == "pair_matrix":
+        return _HSL_REPLAY_MATRIX_RAW_FIELDS
+    if series_kind == "account_pnl":
+        return _HSL_REPLAY_ACCOUNT_SERIES_FIELDS
+    raise ValueError(
+        "HSL replay cache series_kind must be one of "
+        f"{_HSL_REPLAY_CACHE_SERIES_KINDS}, got {series_kind!r}"
+    )
+
+
+def _hsl_replay_cache_array_value_reasons(
+    arrays: dict[str, Any], *, series_kind: str = "pair_matrix"
+) -> list[str]:
     import numpy as np
 
+    fields = _hsl_replay_cache_series_fields(series_kind)
     reasons: list[str] = []
-    required = set(_HSL_REPLAY_MATRIX_RAW_FIELDS)
+    required = set(fields)
     if set(arrays) != required:
         return reasons
     try:
         row_count = int(len(arrays["ts"]))
     except TypeError:
         return ["array_value_invalid:ts"]
-    for field in _HSL_REPLAY_MATRIX_RAW_FIELDS:
+    for field in fields:
         try:
             field_len = int(len(arrays[field]))
         except TypeError:
@@ -611,7 +661,7 @@ def _hsl_replay_cache_array_value_reasons(arrays: dict[str, Any]) -> list[str]:
     if reasons:
         return reasons
     numeric_arrays: dict[str, Any] = {}
-    for field in _HSL_REPLAY_MATRIX_RAW_FIELDS:
+    for field in fields:
         arr = np.asarray(arrays[field])
         if arr.ndim != 1 or not _hsl_replay_cache_array_dtype_is_valid(field, arr.dtype):
             reasons.append(f"array_value_invalid:{field}")
@@ -763,22 +813,84 @@ def _hsl_replay_cache_dir(self, pside: str, symbol: str, config_digest: str | No
     )
 
 
+def _hsl_replay_cache_account_config_digest(self) -> str:
+    """Digest over the inputs that change how the account pnl series is built."""
+    payload = {
+        "schema_version": _HSL_REPLAY_CACHE_SCHEMA_VERSION,
+        "series_kind": "account_pnl",
+        "pnls_max_lookback_days": parse_pnls_max_lookback_days(
+            self.live_value("pnls_max_lookback_days"),
+            field_name="live.pnls_max_lookback_days",
+        ).display_value,
+    }
+    return _hsl_replay_cache_json_digest(payload)
+
+
+def _hsl_replay_cache_account_series_dir(self, config_digest: str | None = None) -> str:
+    digest = str(config_digest or self._hsl_replay_cache_account_config_digest())
+    if len(digest) < 16:
+        raise ValueError("HSL replay cache account digest must be at least 16 characters")
+    exchange = _hsl_replay_cache_safe_fragment(getattr(self, "exchange", "unknown"))
+    user = _hsl_replay_cache_safe_fragment(getattr(self, "user", "unknown"))
+    return make_get_filepath(
+        "caches/equity_hard_stop/"
+        f"{exchange}/replay_matrix/{user}/{_HSL_REPLAY_CACHE_ACCOUNT_PSIDE}/"
+        f"{_HSL_REPLAY_CACHE_ACCOUNT_SYMBOL}/{digest[:16]}/"
+    )
+
+
+def _hsl_replay_cache_account_expected_metadata(
+    self,
+    *,
+    fill_covered_start_ms: int,
+    fill_covered_end_ms: int,
+    fill_history_scope: str,
+    fill_coverage_proven: bool,
+    candle_covered_start_ms: int,
+    candle_covered_end_ms: int,
+) -> dict[str, Any]:
+    metadata = {
+        "exchange": str(self.exchange),
+        "market_type": _hsl_replay_cache_market_type(self),
+        "user": str(self.user),
+        "config_digest": self._hsl_replay_cache_account_config_digest(),
+        "signal_mode": self._equity_hard_stop_signal_mode(),
+        "pside": _HSL_REPLAY_CACHE_ACCOUNT_PSIDE,
+        "symbol": _HSL_REPLAY_CACHE_ACCOUNT_SYMBOL,
+        "fill_covered_start_ms": int(fill_covered_start_ms),
+        "fill_covered_end_ms": int(fill_covered_end_ms),
+        "fill_history_scope": str(fill_history_scope),
+        # Raw pass-through: the normalizer rejects non-bool proof values.
+        "fill_coverage_proven": fill_coverage_proven,
+        "candle_covered_start_ms": int(candle_covered_start_ms),
+        "candle_covered_end_ms": int(candle_covered_end_ms),
+    }
+    return _normalize_hsl_replay_cache_metadata(metadata)
+
+
 def _write_hsl_replay_matrix_cache(
     cache_dir: str | os.PathLike[str],
     rows: list[dict[str, Any]],
     metadata: dict[str, Any],
+    *,
+    series_kind: str = "pair_matrix",
 ) -> dict[str, Any]:
     import numpy as np
 
+    fields = _hsl_replay_cache_series_fields(series_kind)
     cache_path = Path(cache_dir)
     cache_path.mkdir(parents=True, exist_ok=True)
-    arrays = _hsl_replay_matrix_arrays(rows)
+    if series_kind == "account_pnl":
+        arrays = _hsl_replay_account_series_arrays(rows)
+    else:
+        arrays = _hsl_replay_matrix_arrays(rows)
     metadata_norm = _normalize_hsl_replay_cache_metadata(metadata)
     manifest = {
         "schema_version": _HSL_REPLAY_CACHE_SCHEMA_VERSION,
+        "series_kind": str(series_kind),
         "matrix_file": _HSL_REPLAY_CACHE_MATRIX_FILENAME,
         "row_count": int(len(rows)),
-        "fields": list(_HSL_REPLAY_MATRIX_RAW_FIELDS),
+        "fields": list(fields),
         "interval_ms": _HSL_REPLAY_MATRIX_INTERVAL_MS,
         "start_ts_ms": int(arrays["ts"][0]) if len(rows) else None,
         "end_ts_ms": int(arrays["ts"][-1]) if len(rows) else None,
@@ -819,6 +931,17 @@ def _hsl_replay_cache_validation_reasons(
         return ["manifest_not_object"]
     if int(manifest.get("schema_version", 0) or 0) != _HSL_REPLAY_CACHE_SCHEMA_VERSION:
         reasons.append("schema_version_mismatch")
+    series_kind = str(manifest.get("series_kind", "") or "")
+    if series_kind not in _HSL_REPLAY_CACHE_SERIES_KINDS:
+        reasons.append("series_kind_invalid")
+        # Field-set checks below need a concrete kind; a wrong-kind manifest is
+        # already invalid, so validate the arrays against the pair layout.
+        series_kind = "pair_matrix"
+    series_fields = _hsl_replay_cache_series_fields(series_kind)
+    if list(manifest.get("fields") or []) != list(series_fields):
+        # A kind/field-list disagreement means the manifest was tampered with
+        # or written by an incompatible writer.
+        reasons.append("fields_mismatch")
     if str(manifest.get("matrix_file", "")) != _HSL_REPLAY_CACHE_MATRIX_FILENAME:
         reasons.append("matrix_filename_mismatch")
     if int(manifest.get("interval_ms", 0) or 0) != _HSL_REPLAY_MATRIX_INTERVAL_MS:
@@ -864,7 +987,7 @@ def _hsl_replay_cache_validation_reasons(
             reasons.append("arrays_manifest_missing")
             arrays_manifest = {}
         loaded_arrays: dict[str, Any] = {}
-        for field in _HSL_REPLAY_MATRIX_RAW_FIELDS:
+        for field in series_fields:
             if field not in loaded:
                 reasons.append(f"array_missing:{field}")
                 continue
@@ -880,8 +1003,10 @@ def _hsl_replay_cache_validation_reasons(
                 reasons.append(f"array_shape_mismatch:{field}")
             if _hsl_hash_array(arr) != str(entry.get("sha256")):
                 reasons.append(f"array_hash_mismatch:{field}")
-        if set(loaded_arrays) == set(_HSL_REPLAY_MATRIX_RAW_FIELDS):
-            value_reasons = _hsl_replay_cache_array_value_reasons(loaded_arrays)
+        if set(loaded_arrays) == set(series_fields):
+            value_reasons = _hsl_replay_cache_array_value_reasons(
+                loaded_arrays, series_kind=series_kind
+            )
             reasons.extend(value_reasons)
             ts_array = np.asarray(loaded_arrays["ts"])
             ts_valid_for_time_checks = (
@@ -923,8 +1048,9 @@ def _load_hsl_replay_matrix_cache(
     manifest = json.loads(
         (cache_path / _HSL_REPLAY_CACHE_MANIFEST_FILENAME).read_text(encoding="utf-8")
     )
+    fields = _hsl_replay_cache_series_fields(str(manifest.get("series_kind", "")))
     with np.load(cache_path / _HSL_REPLAY_CACHE_MATRIX_FILENAME, allow_pickle=False) as loaded:
-        arrays = {field: loaded[field].copy() for field in _HSL_REPLAY_MATRIX_RAW_FIELDS}
+        arrays = {field: loaded[field].copy() for field in fields}
     return manifest, arrays
 
 
@@ -1028,8 +1154,9 @@ def _try_load_hsl_replay_matrix_cache(
         manifest = json.loads(
             (cache_path / _HSL_REPLAY_CACHE_MANIFEST_FILENAME).read_text(encoding="utf-8")
         )
+        fields = _hsl_replay_cache_series_fields(str(manifest.get("series_kind", "")))
         with np.load(cache_path / _HSL_REPLAY_CACHE_MATRIX_FILENAME, allow_pickle=False) as loaded:
-            arrays = {field: loaded[field].copy() for field in _HSL_REPLAY_MATRIX_RAW_FIELDS}
+            arrays = {field: loaded[field].copy() for field in fields}
     except Exception as exc:
         elapsed_s = time.monotonic() - started_s
         _emit_hsl_replay_event(
@@ -1142,6 +1269,62 @@ def _equity_hard_stop_persist_replay_matrices(self, history: dict[str, Any]) -> 
                 ),
                 pside=pside,
                 symbol=symbol,
+                level="debug",
+                status="succeeded",
+                reason_code=ReasonCodes.HSL_REPLAY_CACHE_WRITTEN,
+            )
+    account_rows = history.get("hsl_replay_account_series")
+    if written and isinstance(account_rows, list) and account_rows:
+        # Pair matrices are only reusable together with the account-level pnl
+        # series (per-minute slot budgets need the account balance), so persist
+        # it alongside them under the same guarded, write-only contract.
+        started_s = time.monotonic()
+        try:
+            cache_dir = self._hsl_replay_cache_account_series_dir()
+            metadata = self._hsl_replay_cache_account_expected_metadata(
+                fill_covered_start_ms=int(coverage["fill_covered_start_ms"]),
+                fill_covered_end_ms=int(coverage["fill_covered_end_ms"]),
+                fill_history_scope=str(coverage["fill_history_scope"]),
+                fill_coverage_proven=coverage["fill_coverage_proven"],
+                candle_covered_start_ms=int(coverage["candle_covered_start_ms"]),
+                candle_covered_end_ms=int(coverage["candle_covered_end_ms"]),
+            )
+            manifest = _write_hsl_replay_matrix_cache(
+                cache_dir, account_rows, metadata, series_kind="account_pnl"
+            )
+        except Exception as exc:
+            logging.warning(
+                "[risk] HSL account series replay cache write failed | rows=%d error=%s: %s",
+                len(account_rows),
+                type(exc).__name__,
+                exc,
+            )
+            _emit_hsl_replay_event(
+                self,
+                EventTypes.HSL_REPLAY_CACHE,
+                _hsl_replay_cache_status_data(
+                    cache_status="write_failed",
+                    elapsed_s=time.monotonic() - started_s,
+                    reasons=[f"write_exception:{type(exc).__name__}"],
+                ),
+                pside=_HSL_REPLAY_CACHE_ACCOUNT_PSIDE,
+                symbol=_HSL_REPLAY_CACHE_ACCOUNT_SYMBOL,
+                level="warning",
+                status="failed",
+                reason_code=ReasonCodes.HSL_REPLAY_CACHE_WRITE_FAILED,
+            )
+        else:
+            written += 1
+            _emit_hsl_replay_event(
+                self,
+                EventTypes.HSL_REPLAY_CACHE,
+                _hsl_replay_cache_status_data(
+                    cache_status="written",
+                    elapsed_s=time.monotonic() - started_s,
+                    manifest=manifest,
+                ),
+                pside=_HSL_REPLAY_CACHE_ACCOUNT_PSIDE,
+                symbol=_HSL_REPLAY_CACHE_ACCOUNT_SYMBOL,
                 level="debug",
                 status="succeeded",
                 reason_code=ReasonCodes.HSL_REPLAY_CACHE_WRITTEN,

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -537,6 +537,78 @@ def test_hsl_replay_cache_validation_flags_missing_coverage_proof_fields(tmp_pat
     assert "metadata_missing_required:fill_coverage_proven" in reasons
 
 
+def _hsl_account_series_rows():
+    return [
+        hsl._hsl_replay_account_series_row(ts=60_000, pnl=0.0),
+        hsl._hsl_replay_account_series_row(ts=120_000, pnl=-2.5),
+        hsl._hsl_replay_account_series_row(ts=180_000, pnl=1.0),
+    ]
+
+
+def test_hsl_replay_account_series_round_trip(tmp_path):
+    import numpy as np
+
+    metadata = _hsl_cache_metadata(
+        pside=hsl._HSL_REPLAY_CACHE_ACCOUNT_PSIDE,
+        symbol=hsl._HSL_REPLAY_CACHE_ACCOUNT_SYMBOL,
+    )
+    rows = _hsl_account_series_rows()
+    manifest = hsl._write_hsl_replay_matrix_cache(
+        tmp_path, rows, metadata, series_kind="account_pnl"
+    )
+
+    assert manifest["series_kind"] == "account_pnl"
+    assert manifest["fields"] == ["ts", "pnl"]
+    assert (
+        hsl._hsl_replay_cache_validation_reasons(tmp_path, expected_metadata=metadata)
+        == []
+    )
+    loaded_manifest, arrays = hsl._load_hsl_replay_matrix_cache(
+        tmp_path, expected_metadata=metadata
+    )
+    assert set(arrays) == {"ts", "pnl"}
+    np.testing.assert_array_equal(arrays["ts"], np.array([60_000, 120_000, 180_000]))
+    np.testing.assert_allclose(arrays["pnl"], [0.0, -2.5, 1.0])
+
+    with pytest.raises(ValueError, match="contiguous"):
+        hsl._hsl_replay_account_series_arrays(
+            [
+                hsl._hsl_replay_account_series_row(ts=60_000, pnl=0.0),
+                hsl._hsl_replay_account_series_row(ts=240_000, pnl=1.0),
+            ]
+        )
+
+
+def test_hsl_replay_cache_rejects_series_kind_tampering(tmp_path):
+    import json
+
+    hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), _hsl_cache_metadata())
+    manifest_path = tmp_path / hsl._HSL_REPLAY_CACHE_MANIFEST_FILENAME
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    tampered = dict(manifest, series_kind="account_pnl")
+    manifest_path.write_text(json.dumps(tampered), encoding="utf-8")
+    assert "fields_mismatch" in hsl._hsl_replay_cache_validation_reasons(tmp_path)
+
+    stripped = dict(manifest)
+    del stripped["series_kind"]
+    manifest_path.write_text(json.dumps(stripped), encoding="utf-8")
+    assert "series_kind_invalid" in hsl._hsl_replay_cache_validation_reasons(tmp_path)
+
+
+def test_hsl_replay_cache_account_digest_scoped_to_lookback():
+    bot = make_coin_bot()
+    digest = hsl._hsl_replay_cache_account_config_digest(bot)
+    assert len(digest) == 64
+
+    bot.config["irrelevant"] = {"changes": "ignored"}
+    bot.hsl["long"]["red_threshold"] = 0.33
+    assert hsl._hsl_replay_cache_account_config_digest(bot) == digest
+
+    bot.config["live"]["pnls_max_lookback_days"] = 7.0
+    assert hsl._hsl_replay_cache_account_config_digest(bot) != digest
+
+
 def test_hsl_replay_cache_dir_is_sanitized_and_digest_scoped():
     bot = make_coin_bot()
     bot.exchange = "binance/usdm"
@@ -589,14 +661,16 @@ def test_hsl_replay_cache_persist_matrices_round_trip(tmp_path, monkeypatch):
         "candle_covered_start_ms": 60_000,
         "candle_covered_end_ms": 180_000,
     }
+    account_rows = _hsl_account_series_rows()
     history = {
         "hsl_replay_matrices": {"long": {symbol: rows}},
+        "hsl_replay_account_series": account_rows,
         "hsl_replay_matrix_coverage": coverage,
     }
 
     written = hsl._equity_hard_stop_persist_replay_matrices(bot, history)
 
-    assert written == 1
+    assert written == 2
     expected_metadata = hsl._hsl_replay_cache_expected_metadata(
         bot,
         "long",
@@ -631,6 +705,30 @@ def test_hsl_replay_cache_persist_matrices_round_trip(tmp_path, monkeypatch):
     np.testing.assert_allclose(arrays["pnl"], [row["pnl"] for row in rows])
     np.testing.assert_allclose(arrays["upnl"], [row["upnl"] for row in rows])
 
+    account_expected = hsl._hsl_replay_cache_account_expected_metadata(
+        bot,
+        fill_covered_start_ms=coverage["fill_covered_start_ms"],
+        fill_covered_end_ms=coverage["fill_covered_end_ms"],
+        fill_history_scope=coverage["fill_history_scope"],
+        fill_coverage_proven=coverage["fill_coverage_proven"],
+        candle_covered_start_ms=coverage["candle_covered_start_ms"],
+        candle_covered_end_ms=coverage["candle_covered_end_ms"],
+    )
+    account_dir = hsl._hsl_replay_cache_account_series_dir(bot)
+    assert (
+        hsl._hsl_replay_cache_validation_reasons(
+            account_dir, expected_metadata=account_expected
+        )
+        == []
+    )
+    account_manifest, account_arrays = hsl._load_hsl_replay_matrix_cache(
+        account_dir, expected_metadata=account_expected
+    )
+    assert account_manifest["series_kind"] == "account_pnl"
+    np.testing.assert_allclose(
+        account_arrays["pnl"], [row["pnl"] for row in account_rows]
+    )
+
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     cache_events = [
         event for event in sink.events if event.event_type == EventTypes.HSL_REPLAY_CACHE
@@ -640,7 +738,11 @@ def test_hsl_replay_cache_persist_matrices_round_trip(tmp_path, monkeypatch):
         for event in cache_events
         if event.reason_code == ReasonCodes.HSL_REPLAY_CACHE_WRITTEN
     ]
-    assert len(written_events) == 1
+    assert len(written_events) == 2
+    assert [(event.pside, event.symbol) for event in written_events] == [
+        ("long", symbol),
+        (hsl._HSL_REPLAY_CACHE_ACCOUNT_PSIDE, hsl._HSL_REPLAY_CACHE_ACCOUNT_SYMBOL),
+    ]
     event = written_events[0]
     assert event.status == "succeeded"
     assert event.pside == "long"
@@ -744,6 +846,31 @@ def test_hsl_replay_cache_writer_rejects_non_bool_coverage_proof(tmp_path, monke
     ]
     assert len(failed_events) == 1
     assert failed_events[0].data["reasons"] == ["write_exception:ValueError"]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_hsl_replay_cache_persist_skips_account_series_without_pair_writes(
+    tmp_path, monkeypatch
+):
+    bot, sink = _make_persist_bot(tmp_path, monkeypatch)
+    history = {
+        "hsl_replay_matrices": {},
+        "hsl_replay_account_series": _hsl_account_series_rows(),
+        "hsl_replay_matrix_coverage": {
+            "fill_covered_start_ms": 60_000,
+            "fill_covered_end_ms": 200_000,
+            "fill_history_scope": "window",
+            "fill_coverage_proven": True,
+            "candle_covered_start_ms": 60_000,
+            "candle_covered_end_ms": 180_000,
+        },
+    }
+
+    written = hsl._equity_hard_stop_persist_replay_matrices(bot, history)
+
+    assert written == 0
+    account_dir = hsl._hsl_replay_cache_account_series_dir(bot)
+    assert hsl._hsl_replay_cache_validation_reasons(account_dir) == ["manifest_missing"]
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
@@ -961,6 +1088,9 @@ def bind_hsl_methods(bot):
         "_hsl_replay_cache_config_digest",
         "_hsl_replay_cache_expected_metadata",
         "_hsl_replay_cache_dir",
+        "_hsl_replay_cache_account_config_digest",
+        "_hsl_replay_cache_account_series_dir",
+        "_hsl_replay_cache_account_expected_metadata",
         "_equity_hard_stop_persist_replay_matrices",
         "_equity_hard_stop_build_latch_payload",
         "_equity_hard_stop_check_coin",
@@ -1315,6 +1445,10 @@ async def test_coin_hsl_history_replay_persists_replay_matrices(tmp_path, monkey
             "panic_flatten_events": [],
             "fill_events": [],
             "hsl_replay_matrices": {"long": {symbol: matrix_rows}},
+            "hsl_replay_account_series": [
+                hsl._hsl_replay_account_series_row(ts=60_000, pnl=0.0),
+                hsl._hsl_replay_account_series_row(ts=120_000, pnl=1.0),
+            ],
             "hsl_replay_matrix_coverage": coverage,
         }
 
@@ -1341,6 +1475,22 @@ async def test_coin_hsl_history_replay_persists_replay_matrices(tmp_path, monkey
         )
         == []
     )
+    account_expected = hsl._hsl_replay_cache_account_expected_metadata(
+        bot,
+        fill_covered_start_ms=coverage["fill_covered_start_ms"],
+        fill_covered_end_ms=coverage["fill_covered_end_ms"],
+        fill_history_scope=coverage["fill_history_scope"],
+        fill_coverage_proven=coverage["fill_coverage_proven"],
+        candle_covered_start_ms=coverage["candle_covered_start_ms"],
+        candle_covered_end_ms=coverage["candle_covered_end_ms"],
+    )
+    account_dir = hsl._hsl_replay_cache_account_series_dir(bot)
+    assert (
+        hsl._hsl_replay_cache_validation_reasons(
+            account_dir, expected_metadata=account_expected
+        )
+        == []
+    )
 
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     replay_events = [
@@ -1358,8 +1508,8 @@ async def test_coin_hsl_history_replay_persists_replay_matrices(tmp_path, monkey
         and event.reason_code == ReasonCodes.HSL_REPLAY_CACHE_WRITTEN
     ]
     assert len(completed_idx) == 1
-    assert len(written_idx) == 1
-    assert written_idx[0] > completed_idx[0]
+    assert len(written_idx) == 2
+    assert all(idx > completed_idx[0] for idx in written_idx)
     written_event = replay_events[written_idx[0]]
     assert written_event.status == "succeeded"
     assert written_event.pside == "long"

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1602,6 +1602,17 @@ async def test_balance_equity_history_builds_replay_matrices_for_held_pairs(monk
     assert [row["pnl"] for row in rows] == [0.0, 0.5, 0.0]
     assert [row["upnl"] for row in rows] == [0.0, 0.5, 1.0]
 
+    account_rows = history["hsl_replay_account_series"]
+    assert len(account_rows) >= 3
+    account_ts = [row["ts"] for row in account_rows]
+    assert account_ts == sorted(account_ts)
+    assert all(b - a == 60_000 for a, b in zip(account_ts, account_ts[1:]))
+    assert account_ts[-3:] == [base_ts, base_ts + 60_000, base_ts + 120_000]
+    # The partial close realized +0.5 inside the second-to-last minute; every
+    # other recorded minute has zero account-level realized pnl.
+    assert [row["pnl"] for row in account_rows[-3:]] == [0.0, 0.5, 0.0]
+    assert sum(row["pnl"] for row in account_rows) == pytest.approx(0.5)
+
     coverage = history["hsl_replay_matrix_coverage"]
     assert coverage["candle_covered_start_ms"] <= base_ts
     assert coverage["candle_covered_start_ms"] % 60_000 == 0
@@ -1620,6 +1631,7 @@ async def test_balance_equity_history_builds_replay_matrices_for_held_pairs(monk
         hsl_replay_signal_mode="unified",
     )
     assert history_unified["hsl_replay_matrices"] == {}
+    assert history_unified["hsl_replay_account_series"] == []
 
     # A failing matrix row build must drop the pair's cache, not the replay.
     def raising_row_builder(**kwargs):
@@ -1634,6 +1646,7 @@ async def test_balance_equity_history_builds_replay_matrices_for_held_pairs(monk
         hsl_replay_signal_mode="coin",
     )
     assert history_degraded["hsl_replay_matrices"] == {}
+    assert history_degraded["hsl_replay_account_series"] == []
     assert len(history_degraded["timeline"]) == len(history["timeline"])
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 

--- a/tests/test_passivbot_hsl_bindings.py
+++ b/tests/test_passivbot_hsl_bindings.py
@@ -43,5 +43,8 @@ def test_passivbot_uses_passivbot_hsl_module_for_hsl_methods():
         "_hsl_replay_cache_config_digest",
         "_hsl_replay_cache_expected_metadata",
         "_hsl_replay_cache_dir",
+        "_hsl_replay_cache_account_config_digest",
+        "_hsl_replay_cache_account_series_dir",
+        "_hsl_replay_cache_account_expected_metadata",
         "_equity_hard_stop_persist_replay_matrices",
     } <= assigned_names


### PR DESCRIPTION
Third write-only slice of the HSL replay cache work (action plan B2.1b), unblocking future reuse: cache-reuse recon showed `_equity_hard_stop_apply_coin_metrics_sample` consumes **per-minute account balance** (`slot_budget = balance / n_positions`), which held-pair matrices cannot provide — flat-symbol PnL and fees also move the account balance. This persists the missing account-level series. Still write-only: nothing reads the cache, no trading behavior change.

Scope:

- **Cache format schema v3** (`src/passivbot_hsl.py`): manifests carry `series_kind` (`pair_matrix` | `account_pnl`). The account series stores only raw per-minute facts (`ts`, minute `pnl`); balance is recomputable downstream as `pnl_cumsum` anchored to current balance (B1.2 step 5) — no cumulative or authoritative state persisted, consistent with the statelessness contract.
- **Trust boundary**: the shared validator derives the expected field set from `series_kind`, rejects unknown kinds (`series_kind_invalid`), and rejects kind/field-list disagreement (`fields_mismatch`) — without the latter, flipping `series_kind` in a pair manifest would revalidate against the reduced account layout, since pair npz files contain `ts`+`pnl` too. Loaders return the kind's field set.
- **Account-scoped identity**: digest over schema + series kind + `pnls_max_lookback_days` (HSL threshold changes intentionally do not invalidate the account series — it is fills-only), cache path under `.../{user}/account/__account__/{digest16}/`, and an expected-metadata builder with the same raw-pass-through `fill_coverage_proven` strictness as #1118.
- **Collection** (`src/passivbot.py`): the coin-mode minute loop tracks the account balance delta per recorded minute under the same guarded passive-observer contract as pair rows (any failure drops the series with a warning, never the replay). The series is returned/persisted only together with at least one pair matrix, since it is only useful in combination.
- Bindings for the three new instance helpers pinned in the AST test and fake-bot bind list.

Validation:
- `venv/bin/python -m pytest tests/test_hsl_coin_mode.py tests/test_passivbot_balance_split.py tests/test_cache_integrity_doctor.py tests/test_passivbot_hsl_bindings.py tests/test_unstucking_safeguards.py tests/test_live_event_registry_docs.py` — 423 passed
- New tests: account row/arrays contiguity validation; account round-trip through the fail-closed validator/loader; series-kind tampering rejection (both flipped and stripped); account digest scoping (irrelevant HSL threshold change → stable, lookback change → rebuild); minute-loop pnl attribution (partial close lands in exactly its own minute, zero elsewhere, sum matches); persist round-trip with ordered written events (pair then account, both after `HSL_REPLAY_COMPLETED`); account-alone skip; degraded-path coupling (dropped pair matrices suppress the account series).
- Full suite: only the 3 known pre-existing out-of-scope failures (pymoo sampling, 2 bitget UTA stubs; see #1116).
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)