### PR TITLE
Add HSL metric-level regression tests for all signal modes

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -205,6 +205,13 @@ Plan: tests/investigation first.
 Add metric-level regression tests for pside, unified, and coin HSL before
 changing metric semantics.
 
+Partial: `tests/test_hsl_metric_regression.py` now pins hand-computed
+drawdown/tier ladders for all three signal modes, the pside scoped-signal and
+baseline-minus-total-realized contracts, unified-mode `unrealized_pnl_total`
+fail-loud requirement, the coin slot-budget denominator (exposure-knob
+invariance, `n_positions` sensitivity, non-positive input rejection), red
+latching across recovery, and the runtime's first-sample peak anchoring.
+
 ### A2.1 - Coin-Mode `hsl_no_restart_drawdown_threshold`
 
 Plan: code/design plus docs.

--- a/tests/test_hsl_metric_regression.py
+++ b/tests/test_hsl_metric_regression.py
@@ -1,0 +1,284 @@
+"""Metric-level regression pins for HSL signal modes (action plan A1.6).
+
+These tests freeze the numeric drawdown/tier semantics of the three HSL signal
+modes with hand-computed fixtures so future refactors (canonical equity-history
+redesign, replay-cache reuse) cannot silently change metric meaning.
+
+All fixtures use ema_span_minutes=1.0 so drawdown_ema == drawdown_raw ==
+drawdown_score and expected values stay hand-checkable.
+"""
+
+from types import MethodType
+
+import pytest
+
+pbr = pytest.importorskip("passivbot_rust", reason="passivbot_rust extension not available")
+hsl = pytest.importorskip("passivbot_hsl", reason="live HSL dependencies not available")
+
+
+_BOUND_METHODS = (
+    "_hsl_psides",
+    "_hsl_state",
+    "_hsl_coin_state",
+    "_equity_hard_stop_make_state",
+    "_equity_hard_stop_signal_mode",
+    "_equity_hard_stop_signal_values",
+    "_equity_hard_stop_lookback_ms",
+    "_equity_hard_stop_apply_sample",
+    "_equity_hard_stop_apply_coin_metrics_sample",
+    "_equity_hard_stop_runtime_tier",
+    "_equity_hard_stop_runtime_red_latched",
+)
+
+
+class _MetricBot:
+    pass
+
+
+def _make_bot(signal_mode, *, n_positions=4.0, red_threshold=0.2):
+    bot = _MetricBot()
+    for name in _BOUND_METHODS:
+        setattr(bot, name, MethodType(getattr(hsl, name), bot))
+    bot.config = {
+        "live": {
+            "hsl_signal_mode": signal_mode,
+            "pnls_max_lookback_days": 30.0,
+        }
+    }
+    bot.live_value = lambda key: bot.config["live"][key]
+    bot.bot_value = lambda pside, key: {"n_positions": n_positions}[key]
+    side_cfg = {
+        "enabled": True,
+        "red_threshold": red_threshold,
+        "tier_ratios": {"yellow": 0.5, "orange": 0.75},
+        "ema_span_minutes": 1.0,
+        "cooldown_minutes_after_red": 5.0,
+        "no_restart_drawdown_threshold": 0.9,
+        "restart_after_red_policy": "threshold",
+        "orange_tier_mode": "tp_only_with_active_entry_cancellation",
+        "panic_close_order_type": "market",
+    }
+    bot.hsl = {"long": dict(side_cfg), "short": dict(side_cfg)}
+    bot._equity_hard_stop = {
+        "long": bot._equity_hard_stop_make_state(),
+        "short": bot._equity_hard_stop_make_state(),
+    }
+    bot._equity_hard_stop_coin = {"long": {}, "short": {}}
+    return bot
+
+
+def test_unified_metrics_pin_drawdown_and_tier_ladder():
+    # red_threshold 0.2, ratios 0.5/0.75 -> yellow at 0.10, orange at 0.15.
+    bot = _make_bot("unified")
+
+    def sample(ts, balance, realized_total, upnl_total):
+        return bot._equity_hard_stop_apply_sample(
+            "long",
+            ts,
+            balance,
+            realized_total,
+            0.0,
+            0.0,
+            unrealized_pnl_total=upnl_total,
+            latch_red=False,
+        )
+
+    m = sample(60_000, 100.0, 0.0, 0.0)
+    assert m["signal_mode"] == "unified"
+    assert m["baseline_balance"] == pytest.approx(100.0)
+    assert m["strategy_equity"] == pytest.approx(100.0)
+    assert m["drawdown_raw"] == pytest.approx(0.0)
+    assert m["tier"] == "green"
+
+    m = sample(120_000, 100.0, 0.0, 10.0)
+    assert m["strategy_equity"] == pytest.approx(110.0)
+    assert m["drawdown_raw"] == pytest.approx(0.0)
+    assert m["tier"] == "green"
+
+    m = sample(180_000, 100.0, 0.0, -6.0)
+    assert m["strategy_equity"] == pytest.approx(94.0)
+    # Peak equity 110 -> (110 - 94) / 110.
+    assert m["drawdown_raw"] == pytest.approx(16.0 / 110.0)
+    assert m["drawdown_ema"] == pytest.approx(m["drawdown_raw"])
+    assert m["drawdown_score"] == pytest.approx(m["drawdown_raw"])
+    assert m["tier"] == "yellow"
+
+    # Realized losses move balance but keep baseline anchored.
+    m = sample(240_000, 92.0, -8.0, 0.0)
+    assert m["baseline_balance"] == pytest.approx(100.0)
+    assert m["strategy_equity"] == pytest.approx(92.0)
+    assert m["drawdown_raw"] == pytest.approx(18.0 / 110.0)
+    assert m["tier"] == "orange"
+
+    m = sample(300_000, 92.0, -8.0, -14.0)
+    assert m["strategy_equity"] == pytest.approx(78.0)
+    assert m["drawdown_raw"] == pytest.approx(32.0 / 110.0)
+    assert m["tier"] == "red"
+
+
+def test_pside_metrics_use_scoped_signal_and_ignore_unified_upnl():
+    bot = _make_bot("pside")
+
+    def sample(ts, balance, realized_total, realized_pside, upnl_pside):
+        return bot._equity_hard_stop_apply_sample(
+            "long",
+            ts,
+            balance,
+            realized_total,
+            realized_pside,
+            upnl_pside,
+            # Pside mode must not require the unified total.
+            unrealized_pnl_total=None,
+            latch_red=False,
+        )
+
+    m = sample(60_000, 100.0, 0.0, 0.0, 0.0)
+    assert m["signal_mode"] == "pside"
+    assert m["strategy_equity"] == pytest.approx(100.0)
+    assert m["tier"] == "green"
+
+    m = sample(120_000, 100.0, 0.0, 0.0, 10.0)
+    assert m["strategy_equity"] == pytest.approx(110.0)
+    assert m["tier"] == "green"
+
+    m = sample(180_000, 100.0, 0.0, 0.0, -6.0)
+    assert m["strategy_equity"] == pytest.approx(94.0)
+    assert m["drawdown_raw"] == pytest.approx(16.0 / 110.0)
+    assert m["tier"] == "yellow"
+
+
+def test_pside_baseline_subtracts_total_realized_before_adding_scoped_signal():
+    # Contract pin: baseline_balance = balance - realized_pnl_total even in
+    # pside mode, so scoped equity = balance - r_total + r_pside + u_pside.
+    bot = _make_bot("pside")
+    m = bot._equity_hard_stop_apply_sample(
+        "long",
+        60_000,
+        100.0,
+        20.0,
+        -5.0,
+        0.0,
+        latch_red=False,
+    )
+    assert m["baseline_balance"] == pytest.approx(80.0)
+    assert m["strategy_equity"] == pytest.approx(75.0)
+
+
+def test_unified_mode_requires_unrealized_pnl_total():
+    bot = _make_bot("unified")
+    with pytest.raises(ValueError, match="unrealized_pnl_total"):
+        bot._equity_hard_stop_apply_sample(
+            "long", 60_000, 100.0, 0.0, 0.0, 0.0, latch_red=False
+        )
+
+
+def test_coin_metrics_pin_slot_budget_drawdown_ladder():
+    # balance 100 / n_positions 4 -> slot budget 25.
+    bot = _make_bot("coin")
+    symbol = "A"
+
+    def sample(ts, peak_realized, last_realized, upnl):
+        return bot._equity_hard_stop_apply_coin_metrics_sample(
+            "long",
+            symbol,
+            ts,
+            100.0,
+            peak_realized,
+            last_realized,
+            upnl,
+            latch_red=False,
+        )
+
+    m = sample(60_000, 0.0, 0.0, 0.0)
+    assert m["signal_mode"] == "coin"
+    assert m["slot_budget"] == pytest.approx(25.0)
+    assert m["drawdown_usd"] == pytest.approx(0.0)
+    assert m["drawdown_raw"] == pytest.approx(0.0)
+    assert m["tier"] == "green"
+
+    m = sample(120_000, 0.0, 0.0, -3.0)
+    assert m["drawdown_usd"] == pytest.approx(3.0)
+    assert m["drawdown_raw"] == pytest.approx(3.0 / 25.0)
+    assert m["tier"] == "yellow"
+
+    # Realized recovery shrinks the drawdown again while unlatched.
+    m = sample(180_000, 2.0, 2.0, -2.0)
+    assert m["drawdown_usd"] == pytest.approx(2.0)
+    assert m["drawdown_raw"] == pytest.approx(2.0 / 25.0)
+    assert m["tier"] == "green"
+
+    m = sample(240_000, 2.0, -1.0, -2.5)
+    assert m["drawdown_usd"] == pytest.approx(5.5)
+    assert m["drawdown_raw"] == pytest.approx(5.5 / 25.0)
+    assert m["tier"] == "red"
+
+
+def test_coin_drawdown_scales_with_n_positions_not_wallet_exposure():
+    # A3.4 contract: coin HSL sensitivity is anchored to the configured slot
+    # count. Raising exposure limits must not change the drawdown percentage,
+    # while changing n_positions must.
+    def coin_drawdown(bot):
+        # Warm up with a zero-drawdown sample: the runtime anchors its peak on
+        # the first observed sample, mirroring replay priming.
+        bot._equity_hard_stop_apply_coin_metrics_sample(
+            "long", "A", 60_000, 100.0, 0.0, 0.0, 0.0, latch_red=False
+        )
+        return bot._equity_hard_stop_apply_coin_metrics_sample(
+            "long", "A", 120_000, 100.0, 0.0, 0.0, -3.0, latch_red=False
+        )["drawdown_raw"]
+
+    base_bot = _make_bot("coin", n_positions=4.0)
+    baseline = coin_drawdown(base_bot)
+    assert baseline == pytest.approx(3.0 / 25.0)
+
+    boosted_bot = _make_bot("coin", n_positions=4.0)
+    boosted_bot.hsl["long"]["red_threshold"] = 0.2
+    # Simulate a config with much larger exposure allowances; the metric layer
+    # never consults them, so any exposure knob is invisible here by design.
+    boosted_bot.config["bot"] = {
+        "long": {"total_wallet_exposure_limit": 10.0, "we_excess_allowance_pct": 5.0}
+    }
+    assert coin_drawdown(boosted_bot) == pytest.approx(baseline)
+
+    fewer_slots_bot = _make_bot("coin", n_positions=2.0)
+    assert coin_drawdown(fewer_slots_bot) == pytest.approx(3.0 / 50.0)
+
+
+def test_coin_metrics_reject_nonpositive_slot_inputs():
+    bot = _make_bot("coin", n_positions=0.0)
+    with pytest.raises(ValueError, match="n_positions"):
+        bot._equity_hard_stop_apply_coin_metrics_sample(
+            "long", "A", 60_000, 100.0, 0.0, 0.0, 0.0, latch_red=False
+        )
+    bot = _make_bot("coin")
+    with pytest.raises(ValueError, match="balance"):
+        bot._equity_hard_stop_apply_coin_metrics_sample(
+            "long", "A", 60_000, 0.0, 0.0, 0.0, 0.0, latch_red=False
+        )
+
+
+def test_red_latching_holds_tier_after_recovery():
+    bot = _make_bot("unified")
+
+    def sample(ts, upnl_total, *, latch_red):
+        return bot._equity_hard_stop_apply_sample(
+            "long",
+            ts,
+            100.0,
+            0.0,
+            0.0,
+            0.0,
+            unrealized_pnl_total=upnl_total,
+            latch_red=latch_red,
+        )
+
+    sample(60_000, 10.0, latch_red=True)
+    m = sample(120_000, -15.0, latch_red=True)
+    # Peak 110, equity 85 -> drawdown 25/110 > red threshold 0.2.
+    assert m["tier"] == "red"
+    assert bot._equity_hard_stop_runtime_red_latched("long") is True
+
+    # Full recovery does not clear a latched red tier.
+    m = sample(180_000, 12.0, latch_red=True)
+    assert m["drawdown_raw"] == pytest.approx(0.0)
+    assert m["tier"] == "red"


### PR DESCRIPTION
Action plan A1.6 (tests first): pins the numeric drawdown/tier semantics of unified, pside, and coin HSL with hand-computed fixtures, so the upcoming canonical equity-history redesign (B1.2) and replay-cache reuse (B2.1b) cannot silently change metric meaning. Tests + plan-doc note only; no src changes.

New `tests/test_hsl_metric_regression.py` (self-contained fixture binding the module helpers, all fixtures use `ema_span_minutes=1.0` so raw == ema == score and every expected value is hand-checkable):

- **Unified ladder**: equity 100 → 110 → 94 → 92 → 78 against peak 110 pins drawdowns 16/110, 18/110, 32/110 crossing yellow (0.10) / orange (0.15) / red (0.20) exactly; baseline stays anchored at `balance − realized_total` when realized losses move the balance.
- **Pside**: scoped realized+UPnL drive the metrics with `unrealized_pnl_total=None` accepted (not required in pside mode), plus an explicit pin of the baseline interaction — scoped equity = `balance − r_total + r_pside + u_pside` (documented as a contract, since baseline subtracts *total* realized even in pside mode).
- **Unified fail-loud**: omitting `unrealized_pnl_total` raises.
- **Coin ladder**: `drawdown = max(0, peak_realized − (last_realized + upnl)) / (balance / n_positions)` pinned through green→yellow→green→red including realized recovery shrinking the drawdown while unlatched.
- **A3.4 invariance**: exposure knobs (TWEL / we-excess) are invisible to the coin metric layer — same inputs, same drawdown — while halving `n_positions` halves the denominator. Non-positive `n_positions`/balance rejected.
- **Latching**: red holds through full recovery once latched; and the runtime's first-sample peak anchoring (replay priming) is documented via a warmup tick in the invariance probe.

Validation:
- `venv/bin/python -m pytest tests/test_hsl_metric_regression.py tests/test_hsl_coin_mode.py tests/test_unstucking_safeguards.py tests/test_equity_hard_stop_rolling_peak.py` — 209 passed
- Orthogonal to the open replay-cache PR #1119 (new file; no shared hunks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)