### PR TITLE
Add HSL replay-cache parity trust boundary

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -884,6 +884,14 @@ Remaining implementation details:
       tampering is rejected (`fields_mismatch`/`series_kind_invalid`). The
       account series is only written together with at least one pair matrix
       and remains never read for trading decisions.
+      Partial: a pure, unwired `_hsl_replay_timeline_rows_from_cache` now
+      synthesizes coin-replay timeline rows from persisted pair+account
+      arrays with fail-loud span/continuity/balance checks, and parity tests
+      prove row equality against the authoritative
+      `get_balance_equity_history` timeline plus identical per-sample coin
+      metric sequences (across an orange tier transition) when the real coin
+      initializer replays synthesized versus authoritative rows. This is the
+      trust boundary the read/reuse slice must build on.
 - [ ] Python simplification after Rust owns ideal protective orders and unstuck
       orders.
       Python should reconcile ideal vs actual orders, not re-decide trading

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -590,6 +590,118 @@ def _hsl_replay_matrix_derived_arrays(
     }
 
 
+def _hsl_replay_timeline_rows_from_cache(
+    pair_arrays: dict[tuple[str, str], dict[str, Any]],
+    account_arrays: dict[str, Any],
+    *,
+    current_balance: float,
+) -> list[dict[str, Any]]:
+    """Synthesize coin-replay timeline rows from persisted cache arrays.
+
+    Pure and unwired: this is the trust-boundary conversion a future reuse
+    slice would feed into the existing coin replay loop, so its output must be
+    row-for-row equivalent to the authoritative `get_balance_equity_history`
+    timeline for the covered pairs. Fail-loud on any input that cannot prove
+    that equivalence. Per-pair realized values are cumulative from each pair's
+    matrix start; the replay windowing consumes differences, so a constant
+    anchor offset versus the authoritative timeline is harmless by contract.
+    """
+    import numpy as np
+
+    balance_f = _finite_hsl_float(current_balance, "current_balance")
+    if balance_f <= 0.0:
+        raise ValueError(f"current_balance must be > 0, got {balance_f}")
+    account_reasons = _hsl_replay_cache_array_value_reasons(
+        dict(account_arrays), series_kind="account_pnl"
+    )
+    if account_reasons:
+        raise ValueError(
+            "HSL cache account arrays invalid: " + ", ".join(account_reasons)
+        )
+    account_ts = np.asarray(account_arrays["ts"], dtype=np.int64)
+    if account_ts.size == 0:
+        raise ValueError("HSL cache account arrays must not be empty")
+    if account_ts.size > 1 and not bool(
+        np.all(np.diff(account_ts) == _HSL_REPLAY_MATRIX_INTERVAL_MS)
+    ):
+        raise ValueError("HSL cache account arrays invalid: timestamp_not_contiguous")
+    account_pnl = np.asarray(account_arrays["pnl"], dtype=np.float64)
+    account_cumsum = np.cumsum(account_pnl, dtype=np.float64)
+    # Anchor the balance series so its final minute equals the current balance,
+    # mirroring how the authoritative replay back-computes its baseline.
+    balances = balance_f - (float(account_cumsum[-1]) - account_cumsum)
+    if not bool(np.all(np.isfinite(balances))) or bool(np.any(balances <= 0.0)):
+        raise ValueError(
+            "HSL cache-derived balance series must be finite and > 0 for every minute"
+        )
+    start_ts = int(account_ts[0])
+    end_ts = int(account_ts[-1])
+    realized_by_minute: list[dict[str, dict[str, float]]] = [
+        {} for _ in range(len(account_ts))
+    ]
+    unrealized_by_minute: list[dict[str, dict[str, float]]] = [
+        {} for _ in range(len(account_ts))
+    ]
+    for pair, arrays in pair_arrays.items():
+        pside, symbol = pair
+        if pside not in ("long", "short"):
+            raise ValueError(f"HSL cache pair pside must be long or short, got {pside!r}")
+        pair_reasons = _hsl_replay_cache_array_value_reasons(
+            dict(arrays), series_kind="pair_matrix"
+        )
+        if pair_reasons:
+            raise ValueError(
+                f"HSL cache pair arrays invalid for {pside}:{symbol}: "
+                + ", ".join(pair_reasons)
+            )
+        pair_ts = np.asarray(arrays["ts"], dtype=np.int64)
+        if pair_ts.size == 0:
+            raise ValueError(f"HSL cache pair arrays empty for {pside}:{symbol}")
+        if pair_ts.size > 1 and not bool(
+            np.all(np.diff(pair_ts) == _HSL_REPLAY_MATRIX_INTERVAL_MS)
+        ):
+            raise ValueError(
+                f"HSL cache pair arrays invalid for {pside}:{symbol}: "
+                "timestamp_not_contiguous"
+            )
+        pair_start = int(pair_ts[0])
+        pair_end = int(pair_ts[-1])
+        if pair_start < start_ts or pair_end > end_ts:
+            raise ValueError(
+                f"HSL cache pair series for {pside}:{symbol} spans "
+                f"[{pair_start}, {pair_end}] outside account span "
+                f"[{start_ts}, {end_ts}]"
+            )
+        if (pair_start - start_ts) % _HSL_REPLAY_MATRIX_INTERVAL_MS != 0:
+            raise ValueError(
+                f"HSL cache pair series for {pside}:{symbol} is not aligned to "
+                "the account minute grid"
+            )
+        offset = (pair_start - start_ts) // _HSL_REPLAY_MATRIX_INTERVAL_MS
+        pair_cumsum = np.cumsum(
+            np.asarray(arrays["pnl"], dtype=np.float64), dtype=np.float64
+        )
+        pair_upnl = np.asarray(arrays["upnl"], dtype=np.float64)
+        for idx in range(len(pair_ts)):
+            realized_by_minute[offset + idx].setdefault(symbol, {})[pside] = float(
+                pair_cumsum[idx]
+            )
+            unrealized_by_minute[offset + idx].setdefault(symbol, {})[pside] = float(
+                pair_upnl[idx]
+            )
+    rows: list[dict[str, Any]] = []
+    for idx in range(len(account_ts)):
+        rows.append(
+            {
+                "timestamp": int(account_ts[idx]),
+                "balance": float(balances[idx]),
+                "realized_pnl_by_coin_pside": realized_by_minute[idx],
+                "unrealized_pnl_by_coin_pside": unrealized_by_minute[idx],
+            }
+        )
+    return rows
+
+
 def _hsl_hash_array(array: Any) -> str:
     import numpy as np
 

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -599,12 +599,19 @@ def _hsl_replay_timeline_rows_from_cache(
     """Synthesize coin-replay timeline rows from persisted cache arrays.
 
     Pure and unwired: this is the trust-boundary conversion a future reuse
-    slice would feed into the existing coin replay loop, so its output must be
-    row-for-row equivalent to the authoritative `get_balance_equity_history`
-    timeline for the covered pairs. Fail-loud on any input that cannot prove
-    that equivalence. Per-pair realized values are cumulative from each pair's
-    matrix start; the replay windowing consumes differences, so a constant
-    anchor offset versus the authoritative timeline is harmless by contract.
+    slice would feed into the existing coin replay loop. The output is an
+    explicit coin-replay row contract, not the full unified timeline shape:
+    each row carries exactly `timestamp`, `balance`, `realized_pnl`
+    (account-level, anchored at the series start like the authoritative
+    record-window anchor), `realized_pnl_by_coin_pside`, and
+    `unrealized_pnl_by_coin_pside` — the fields the coin replay loop and its
+    stop/latch payloads consume. Values must equal the authoritative
+    `get_balance_equity_history` timeline for the covered pairs; consumers
+    that need additional unified-timeline fields must fail loudly rather than
+    assume this shape. Fail-loud on any input that cannot prove equivalence.
+    Per-pair realized values are cumulative from each pair's matrix start; the
+    replay windowing consumes differences, so a constant anchor offset versus
+    the authoritative timeline is harmless by contract.
     """
     import numpy as np
 
@@ -695,6 +702,7 @@ def _hsl_replay_timeline_rows_from_cache(
             {
                 "timestamp": int(account_ts[idx]),
                 "balance": float(balances[idx]),
+                "realized_pnl": float(account_cumsum[idx]),
                 "realized_pnl_by_coin_pside": realized_by_minute[idx],
                 "unrealized_pnl_by_coin_pside": unrealized_by_minute[idx],
             }

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -1360,6 +1360,276 @@ async def test_coin_hsl_history_replay_emits_lifecycle_events():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+async def _run_parity_history(monkeypatch):
+    """Run the real coin-mode collection over a small two-close scenario."""
+    import numpy as np
+    from unittest.mock import AsyncMock
+
+    import passivbot as passivbot_module
+    from live.event_bus import ListEventSink, LiveEventPipeline
+
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {}}
+    bot.exchange = "kucoin"
+    bot.user = "test_user"
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: 1.0 if key == "pnls_max_lookback_days" else None
+    base_ts = 1_800_000_000_000
+    ts_now = base_ts + 120_000
+    bot.get_exchange_time = lambda: ts_now
+    bot.get_raw_balance = lambda: 100.0
+    bot.get_symbol_id_inv = lambda symbol: symbol
+    symbol = "BTC/USDT:USDT"
+    bot.positions = {
+        symbol: {
+            "long": {"size": 0.5, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    bot._pnls_manager = None
+    bot.inverse = False
+    bot._candle_fetch_concurrency = lambda *, context="runtime": 2
+    bot._get_fetch_delay_seconds = lambda: 0.0
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[ListEventSink()],
+        monitor_sinks=[],
+    )
+    bot._live_event_current_cycle_id = "cy_hsl_parity"
+    bot._emit_live_event = Passivbot._emit_live_event.__get__(bot, Passivbot)
+    bot.c_mults = {symbol: 1.0}
+    monkeypatch.setattr(
+        passivbot_module, "compute_psize_pprice", lambda *args, **kwargs: None
+    )
+
+    class _CM:
+        async def get_candles(self, sym, **kwargs):
+            return np.array(
+                [
+                    (base_ts, 99.0, 101.0, 98.0, 100.0, 1.0),
+                    (base_ts + 60_000, 84.0, 100.0, 60.0, 60.0, 1.0),
+                    (base_ts + 120_000, 60.0, 102.0, 60.0, 101.0, 1.0),
+                ],
+                dtype=passivbot_module.CANDLE_DTYPE,
+            )
+
+    bot.cm = _CM()
+    fill_events = [
+        {
+            "timestamp": base_ts,
+            "symbol": symbol,
+            "position_side": "long",
+            "side": "buy",
+            "qty": 1.0,
+            "price": 100.0,
+            "pnl": 0.0,
+        },
+        {
+            "timestamp": base_ts + 90_000,
+            "symbol": symbol,
+            "position_side": "long",
+            "side": "sell",
+            "qty": 0.5,
+            "price": 101.0,
+            "pnl": 0.5,
+        },
+    ]
+    history = await bot.get_balance_equity_history(
+        fill_events=fill_events,
+        current_balance=100.0,
+        hsl_replay_signal_mode="coin",
+    )
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+    return history, symbol
+
+
+@pytest.mark.asyncio
+async def test_hsl_cache_synthesized_rows_match_authoritative_timeline(monkeypatch):
+    history, symbol = await _run_parity_history(monkeypatch)
+    pair_arrays = hsl._hsl_replay_matrix_arrays(
+        history["hsl_replay_matrices"]["long"][symbol]
+    )
+    account_arrays = hsl._hsl_replay_account_series_arrays(
+        history["hsl_replay_account_series"]
+    )
+
+    synthesized = hsl._hsl_replay_timeline_rows_from_cache(
+        {("long", symbol): pair_arrays},
+        account_arrays,
+        current_balance=100.0,
+    )
+
+    timeline_by_ts = {int(row["timestamp"]): row for row in history["timeline"]}
+    assert len(synthesized) == len(history["timeline"])
+    seen_pair_values = 0
+    for row in synthesized:
+        auth = timeline_by_ts[row["timestamp"]]
+        assert row["balance"] == pytest.approx(auth["balance"], abs=1e-9)
+        synth_realized = row["realized_pnl_by_coin_pside"].get(symbol, {}).get("long")
+        synth_upnl = row["unrealized_pnl_by_coin_pside"].get(symbol, {}).get("long")
+        auth_realized = (
+            auth.get("realized_pnl_by_coin_pside", {}).get(symbol, {}).get("long")
+        )
+        auth_upnl = (
+            auth.get("unrealized_pnl_by_coin_pside", {}).get(symbol, {}).get("long")
+        )
+        if auth_realized is not None:
+            seen_pair_values += 1
+            assert synth_realized == pytest.approx(auth_realized, abs=1e-9)
+            assert synth_upnl == pytest.approx(auth_upnl, abs=1e-9)
+        elif synth_realized is not None:
+            # Collection may start pair rows at the first candle, before the
+            # pair's first fill; those extra rows must be exactly neutral.
+            assert synth_realized == 0.0
+            assert synth_upnl == 0.0
+    # The scenario's fill minutes must actually have been compared.
+    assert seen_pair_values >= 2
+
+
+@pytest.mark.asyncio
+async def test_hsl_cache_synthesized_replay_reaches_identical_coin_state(monkeypatch):
+    history, symbol = await _run_parity_history(monkeypatch)
+    pair_arrays = hsl._hsl_replay_matrix_arrays(
+        history["hsl_replay_matrices"]["long"][symbol]
+    )
+    account_arrays = hsl._hsl_replay_account_series_arrays(
+        history["hsl_replay_account_series"]
+    )
+    synthesized = hsl._hsl_replay_timeline_rows_from_cache(
+        {("long", symbol): pair_arrays},
+        account_arrays,
+        current_balance=100.0,
+    )
+    end_ts = int(history["timeline"][-1]["timestamp"])
+
+    async def run_replay(timeline):
+        bot = make_coin_bot()
+        bot.positions = {
+            symbol: {
+                "long": {"size": 0.5, "price": 100.0},
+                "short": {"size": 0.0, "price": 0.0},
+            }
+        }
+        bot.c_mults = {symbol: 1.0}
+        bot.get_exchange_time = lambda: end_ts
+
+        async def fake_history(current_balance=None, **kwargs):
+            return {
+                "timeline": timeline,
+                "panic_flatten_events": [],
+                "fill_events": history["fill_events"],
+            }
+
+        bot.get_balance_equity_history = fake_history
+        samples = []
+        original_apply = bot._equity_hard_stop_apply_coin_metrics_sample
+
+        def recording_apply(*args, **kwargs):
+            metrics = original_apply(*args, **kwargs)
+            samples.append(
+                (
+                    metrics["timestamp_ms"],
+                    metrics["tier"],
+                    round(metrics["drawdown_raw"], 12),
+                    round(metrics["drawdown_score"], 12),
+                    round(metrics["balance"], 9),
+                    round(metrics["unrealized_pnl"], 9),
+                )
+            )
+            return metrics
+
+        bot._equity_hard_stop_apply_coin_metrics_sample = recording_apply
+        await bot._equity_hard_stop_initialize_coin_from_history()
+        return bot, samples
+
+    bot_auth, samples_auth = await run_replay(history["timeline"])
+    bot_synth, samples_synth = await run_replay(synthesized)
+
+    # The scenario dips through the orange tier mid-replay, so the sequences
+    # prove parity across tier transitions rather than only green states.
+    auth_tiers = {tier for _, tier, *_ in samples_auth}
+    assert "orange" in auth_tiers
+    # The synthesized replay may include extra leading neutral samples (pair
+    # rows can start at the first candle, before the first fill); after
+    # aligning on the authoritative sample timestamps the sequences must match
+    # exactly.
+    auth_ts = {sample[0] for sample in samples_auth}
+    assert [s for s in samples_synth if s[0] in auth_ts] == samples_auth
+    extra = [s for s in samples_synth if s[0] not in auth_ts]
+    assert all(tier == "green" and dd == 0.0 for _, tier, dd, *_ in extra)
+
+    state_auth = bot_auth._hsl_coin_state("long", symbol)
+    state_synth = bot_synth._hsl_coin_state("long", symbol)
+    metrics_auth = state_auth["last_metrics"]
+    metrics_synth = state_synth["last_metrics"]
+    assert metrics_auth is not None and metrics_synth is not None
+    for key in ("tier", "timestamp_ms"):
+        assert metrics_synth[key] == metrics_auth[key]
+    for key in (
+        "balance",
+        "slot_budget",
+        "drawdown_usd",
+        "drawdown_raw",
+        "drawdown_ema",
+        "drawdown_score",
+        "unrealized_pnl",
+    ):
+        assert metrics_synth[key] == pytest.approx(metrics_auth[key], abs=1e-9)
+    assert state_synth["halted"] == state_auth["halted"]
+    assert state_synth["cooldown_until_ms"] == state_auth["cooldown_until_ms"]
+
+
+def test_hsl_cache_synthesized_rows_fail_loud_on_bad_inputs():
+    account = hsl._hsl_replay_account_series_arrays(
+        [
+            hsl._hsl_replay_account_series_row(ts=60_000, pnl=0.0),
+            hsl._hsl_replay_account_series_row(ts=120_000, pnl=0.5),
+        ]
+    )
+    pair = hsl._hsl_replay_matrix_arrays(
+        [
+            hsl._hsl_replay_matrix_row(
+                pside="long", ts=60_000, price=100.0, psize=1.0,
+                pprice=100.0, pnl=0.0, c_mult=1.0,
+            ),
+            hsl._hsl_replay_matrix_row(
+                pside="long", ts=120_000, price=101.0, psize=1.0,
+                pprice=100.0, pnl=0.5, c_mult=1.0,
+            ),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="current_balance"):
+        hsl._hsl_replay_timeline_rows_from_cache(
+            {("long", "A"): pair}, account, current_balance=0.0
+        )
+
+    out_of_span = hsl._hsl_replay_matrix_arrays(
+        [
+            hsl._hsl_replay_matrix_row(
+                pside="long", ts=180_000, price=100.0, psize=1.0,
+                pprice=100.0, pnl=0.0, c_mult=1.0,
+            ),
+        ]
+    )
+    with pytest.raises(ValueError, match="outside account span"):
+        hsl._hsl_replay_timeline_rows_from_cache(
+            {("long", "A"): out_of_span}, account, current_balance=100.0
+        )
+
+    # A synthesized balance dipping to <= 0 anywhere must be rejected because
+    # the coin metrics layer requires balance > 0.
+    deep_loss_account = hsl._hsl_replay_account_series_arrays(
+        [
+            hsl._hsl_replay_account_series_row(ts=60_000, pnl=0.0),
+            hsl._hsl_replay_account_series_row(ts=120_000, pnl=250.0),
+        ]
+    )
+    with pytest.raises(ValueError, match="finite and > 0"):
+        hsl._hsl_replay_timeline_rows_from_cache(
+            {}, deep_loss_account, current_balance=100.0
+        )
+
+
 @pytest.mark.asyncio
 async def test_coin_hsl_history_replay_persists_replay_matrices(tmp_path, monkeypatch):
     from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -1462,8 +1462,19 @@ async def test_hsl_cache_synthesized_rows_match_authoritative_timeline(monkeypat
     assert len(synthesized) == len(history["timeline"])
     seen_pair_values = 0
     for row in synthesized:
+        # The synthesized rows expose an explicit coin-replay row contract.
+        assert set(row) == {
+            "timestamp",
+            "balance",
+            "realized_pnl",
+            "realized_pnl_by_coin_pside",
+            "unrealized_pnl_by_coin_pside",
+        }
         auth = timeline_by_ts[row["timestamp"]]
         assert row["balance"] == pytest.approx(auth["balance"], abs=1e-9)
+        # Account-level realized pnl feeds stop/latch payload diagnostics and
+        # must match the authoritative record-window value exactly.
+        assert row["realized_pnl"] == pytest.approx(auth["realized_pnl"], abs=1e-9)
         synth_realized = row["realized_pnl_by_coin_pside"].get(symbol, {}).get("long")
         synth_upnl = row["unrealized_pnl_by_coin_pside"].get(symbol, {}).get("long")
         auth_realized = (


### PR DESCRIPTION
The parity slice the plan requires before any cache reuse ("read/extend/reuse behavior only after trust-boundary tests are strong"). Introduces the pure, still-unwired conversion the read slice will consume, and proves — with product code on both sides — that cache-derived replay is indistinguishable from the authoritative one.

Scope:

- `src/passivbot_hsl.py`: new pure `_hsl_replay_timeline_rows_from_cache(pair_arrays, account_arrays, *, current_balance)` synthesizes coin-replay timeline rows from persisted arrays. Balance is anchored so the final minute equals current balance (mirroring the authoritative baseline back-computation); per-pair realized values are cumulative from matrix start — the replay windowing consumes differences, so a constant anchor offset is harmless by contract, and the docstring says so. Fail-loud on: invalid arrays (kind-aware value checks), non-contiguous timestamps, pair spans outside the account span, minute-grid misalignment, and any synthesized balance ≤ 0 (the coin metric layer requires balance > 0).
- Parity test 1 (row level): a two-fill scenario (buy, deep dip to 60, partial close, recovery) runs through the **real** `get_balance_equity_history` collection; rows synthesized from the returned matrices/account series match the authoritative timeline value-for-value (balance, scoped realized, upnl) wherever the pair exists, and any earlier synthesized-only entries (pair rows may start at the first candle, before the first fill) are exactly neutral.
- Parity test 2 (state level): the **real** `_equity_hard_stop_initialize_coin_from_history` replays both timelines on two coin bots with a per-sample recorder; the aligned metric sequences (timestamp, tier, drawdown_raw/score, balance, upnl) are **identical across an orange tier transition**, extra leading synthesized samples must be green/zero, and final metrics + halted/cooldown state are equal.
- Fail-loud tests for bad inputs.

Nothing is wired: `git grep` shows the new helper has no caller outside tests. The read slice (next) will feed this synthesizer through the existing initializer loop, gated on proven manifests + fresh coverage proof + watermark extension, per the gate notes on #1118/#1119.

Validation:
- `venv/bin/python -m pytest tests/test_hsl_coin_mode.py tests/test_passivbot_balance_split.py tests/test_unstucking_safeguards.py` — 404 passed
- Full suite: only the 3 known pre-existing out-of-scope failures (pymoo sampling, 2 bitget UTA stubs; see #1116).
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)