### PR TITLE
Add pure HSL cache watermark-extension helpers

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -976,6 +976,15 @@ Remaining implementation details:
       metric sequences (across an orange tier transition) when the real coin
       initializer replays synthesized versus authoritative rows. This is the
       trust boundary the read/reuse slice must build on.
+      Partial: pure, unwired watermark-extension helpers
+      (`_hsl_replay_extend_pair_rows`/`_hsl_replay_extend_account_rows`) now
+      extend cached pair/account arrays from the cache watermark to now using
+      post-watermark extracted fills and candle closes, mirroring the
+      authoritative position bookkeeping exactly. Slice-and-extend parity
+      tests prove extension equals a full rebuild to 1e-12; fills inside the
+      cached window, beyond the extension end, or from another pair are
+      rejected fail-loud so double-counting rejects the cache instead of
+      corrupting it.
 - [ ] Python simplification after Rust owns ideal protective orders and unstuck
       orders.
       Python should reconcile ideal vs actual orders, not re-decide trading

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -710,6 +710,205 @@ def _hsl_replay_timeline_rows_from_cache(
     return rows
 
 
+def _hsl_replay_rows_from_arrays(
+    arrays: dict[str, Any], *, series_kind: str
+) -> list[dict[str, Any]]:
+    """Inverse of the arrays builders: expand validated arrays into row dicts."""
+    fields = _hsl_replay_cache_series_fields(series_kind)
+    reasons = _hsl_replay_cache_array_value_reasons(dict(arrays), series_kind=series_kind)
+    if reasons:
+        raise ValueError(
+            f"HSL replay {series_kind} arrays invalid: " + ", ".join(reasons)
+        )
+    row_count = int(len(arrays["ts"]))
+    rows: list[dict[str, Any]] = []
+    for idx in range(row_count):
+        row: dict[str, Any] = {}
+        for field in fields:
+            value = arrays[field][idx]
+            row[field] = int(value) if field == "ts" else float(value)
+        rows.append(row)
+    return rows
+
+
+def _hsl_replay_extension_minutes(
+    watermark_ts: int, end_ts: int
+) -> list[int]:
+    end_minute = int(math.floor(int(end_ts) / _HSL_REPLAY_MATRIX_INTERVAL_MS)) * (
+        _HSL_REPLAY_MATRIX_INTERVAL_MS
+    )
+    if end_minute < int(watermark_ts):
+        raise ValueError(
+            f"HSL cache extension end {end_ts} precedes watermark {watermark_ts}"
+        )
+    return list(
+        range(
+            int(watermark_ts) + _HSL_REPLAY_MATRIX_INTERVAL_MS,
+            end_minute + _HSL_REPLAY_MATRIX_INTERVAL_MS,
+            _HSL_REPLAY_MATRIX_INTERVAL_MS,
+        )
+    )
+
+
+def _hsl_replay_extension_require_fill(fill: Any, watermark_ts: int) -> dict[str, Any]:
+    if not isinstance(fill, dict):
+        raise TypeError(
+            f"HSL cache extension fills must be dicts, got {type(fill).__name__}"
+        )
+    for key in ("timestamp", "qty", "price", "action", "pnl"):
+        if key not in fill:
+            raise ValueError(f"HSL cache extension fill missing required key: {key}")
+    ts = int(fill["timestamp"])
+    if ts < int(watermark_ts) + _HSL_REPLAY_MATRIX_INTERVAL_MS:
+        raise ValueError(
+            "HSL cache extension fill lies inside the cached window "
+            f"(ts={ts}, watermark={watermark_ts}); the cache must be rejected "
+            "instead of double-counting fills"
+        )
+    return fill
+
+
+def _hsl_replay_extend_pair_rows(
+    arrays: dict[str, Any],
+    *,
+    pside: str,
+    symbol: str,
+    fills: list[dict[str, Any]],
+    closes_by_minute: dict[int, float],
+    end_ts: int,
+    c_mult: float,
+) -> list[dict[str, Any]]:
+    """Extend a cached pair matrix from its watermark to `end_ts` (pure).
+
+    Mirrors the authoritative replay's position bookkeeping exactly
+    (`_apply_event` in get_balance_equity_history): increases move the
+    weighted-average entry price, decreases shrink size and zero the price on
+    flat. `fills` must contain only this pair's extracted events strictly
+    after the cached window; anything else is rejected fail-loud because it
+    would double-count or misattribute cached data.
+    """
+    if pside not in ("long", "short"):
+        raise ValueError(f"HSL cache extension pside must be long or short, got {pside!r}")
+    rows = _hsl_replay_rows_from_arrays(arrays, series_kind="pair_matrix")
+    if not rows:
+        raise ValueError(f"HSL cache extension requires non-empty pair arrays for {symbol}")
+    watermark_ts = int(rows[-1]["ts"])
+    minutes = _hsl_replay_extension_minutes(watermark_ts, end_ts)
+    c_mult_f = _finite_hsl_float(c_mult, "c_mult")
+    size = abs(float(rows[-1]["psize"]))
+    pprice = float(rows[-1]["pprice"]) if size > 1e-12 else 0.0
+    last_price = float(rows[-1]["price"])
+    ordered = sorted(
+        (_hsl_replay_extension_require_fill(fill, watermark_ts) for fill in fills),
+        key=lambda fill: int(fill["timestamp"]),
+    )
+    for fill in ordered:
+        if str(fill.get("symbol", symbol)) != symbol or str(
+            fill.get("pside", pside)
+        ) != pside:
+            raise ValueError(
+                "HSL cache extension fill does not belong to pair "
+                f"{pside}:{symbol}: {fill.get('pside')}:{fill.get('symbol')}"
+            )
+    if ordered and int(ordered[-1]["timestamp"]) >= (
+        (minutes[-1] if minutes else watermark_ts) + _HSL_REPLAY_MATRIX_INTERVAL_MS
+    ):
+        raise ValueError(
+            "HSL cache extension fill lies beyond the extension end "
+            f"(ts={ordered[-1]['timestamp']})"
+        )
+    new_rows: list[dict[str, Any]] = []
+    fill_idx = 0
+    for minute in minutes:
+        boundary = minute + _HSL_REPLAY_MATRIX_INTERVAL_MS
+        minute_pnl = 0.0
+        while fill_idx < len(ordered) and int(ordered[fill_idx]["timestamp"]) < boundary:
+            fill = ordered[fill_idx]
+            qty = abs(_finite_hsl_float(fill["qty"], "qty"))
+            fill_price = _finite_hsl_float(fill["price"], "price")
+            minute_pnl += _finite_hsl_float(fill["pnl"], "pnl") + _finite_hsl_float(
+                fill.get("fee", 0.0), "fee"
+            )
+            if str(fill["action"]) == "increase":
+                new_size = size + qty
+                if new_size <= 0.0:
+                    size, pprice = 0.0, 0.0
+                elif size <= 0.0:
+                    size, pprice = new_size, fill_price
+                else:
+                    pprice = max((size * pprice + qty * fill_price) / new_size, 0.0)
+                    size = new_size
+            else:
+                size = max(size - qty, 0.0)
+                if size <= 0.0:
+                    pprice = 0.0
+            fill_idx += 1
+        close = closes_by_minute.get(minute)
+        if close is not None:
+            close_f = _finite_hsl_float(close, "close")
+            if close_f <= 0.0:
+                raise ValueError(
+                    f"HSL cache extension close must be > 0 at {minute}, got {close_f}"
+                )
+            last_price = close_f
+        psize = size if pside == "long" else -size
+        new_rows.append(
+            _hsl_replay_matrix_row(
+                pside=pside,
+                ts=int(minute),
+                price=last_price,
+                psize=psize if size > 1e-12 else 0.0,
+                pprice=pprice if size > 1e-12 else 0.0,
+                pnl=minute_pnl,
+                c_mult=c_mult_f,
+            )
+        )
+    return new_rows
+
+
+def _hsl_replay_extend_account_rows(
+    arrays: dict[str, Any],
+    *,
+    fills: list[dict[str, Any]],
+    end_ts: int,
+) -> list[dict[str, Any]]:
+    """Extend a cached account pnl series from its watermark to `end_ts` (pure).
+
+    `fills` must contain the extracted events for ALL symbols strictly after
+    the cached window; per-minute pnl is the sum of `pnl + fee`, matching the
+    authoritative balance accounting.
+    """
+    rows = _hsl_replay_rows_from_arrays(arrays, series_kind="account_pnl")
+    if not rows:
+        raise ValueError("HSL cache extension requires non-empty account arrays")
+    watermark_ts = int(rows[-1]["ts"])
+    minutes = _hsl_replay_extension_minutes(watermark_ts, end_ts)
+    ordered = sorted(
+        (_hsl_replay_extension_require_fill(fill, watermark_ts) for fill in fills),
+        key=lambda fill: int(fill["timestamp"]),
+    )
+    if ordered and int(ordered[-1]["timestamp"]) >= (
+        (minutes[-1] if minutes else watermark_ts) + _HSL_REPLAY_MATRIX_INTERVAL_MS
+    ):
+        raise ValueError(
+            "HSL cache extension fill lies beyond the extension end "
+            f"(ts={ordered[-1]['timestamp']})"
+        )
+    new_rows: list[dict[str, Any]] = []
+    fill_idx = 0
+    for minute in minutes:
+        boundary = minute + _HSL_REPLAY_MATRIX_INTERVAL_MS
+        minute_pnl = 0.0
+        while fill_idx < len(ordered) and int(ordered[fill_idx]["timestamp"]) < boundary:
+            fill = ordered[fill_idx]
+            minute_pnl += _finite_hsl_float(fill["pnl"], "pnl") + _finite_hsl_float(
+                fill.get("fee", 0.0), "fee"
+            )
+            fill_idx += 1
+        new_rows.append(_hsl_replay_account_series_row(ts=int(minute), pnl=minute_pnl))
+    return new_rows
+
+
 def _hsl_hash_array(array: Any) -> str:
     import numpy as np
 

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -803,9 +803,14 @@ def _hsl_replay_extend_pair_rows(
         key=lambda fill: int(fill["timestamp"]),
     )
     for fill in ordered:
-        if str(fill.get("symbol", symbol)) != symbol or str(
-            fill.get("pside", pside)
-        ) != pside:
+        # Pair identity must be explicit: defaulting a stripped fill to the
+        # target pair would silently apply it to the wrong (or every) pair.
+        if "symbol" not in fill or "pside" not in fill:
+            raise ValueError(
+                "HSL cache extension fill missing pair identity (symbol/pside) "
+                f"for {pside}:{symbol}"
+            )
+        if str(fill["symbol"]) != symbol or str(fill["pside"]) != pside:
             raise ValueError(
                 "HSL cache extension fill does not belong to pair "
                 f"{pside}:{symbol}: {fill.get('pside')}:{fill.get('symbol')}"

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -1799,9 +1799,10 @@ def test_hsl_cache_extension_fail_loud_contracts():
         )
     # Fills with stripped pair identity must reject, never default to the
     # target pair.
-    for missing_key in ("symbol", "pside"):
+    for missing_keys in (("symbol",), ("pside",), ("symbol", "pside")):
         stripped = fill(200_000)
-        del stripped[missing_key]
+        for key in missing_keys:
+            del stripped[key]
         with pytest.raises(ValueError, match="missing pair identity"):
             hsl._hsl_replay_extend_pair_rows(
                 pair, pside="long", symbol="A",

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -1797,6 +1797,16 @@ def test_hsl_cache_extension_fail_loud_contracts():
             pair, pside="long", symbol="A",
             fills=[wrong], closes_by_minute={}, end_ts=240_000, c_mult=1.0,
         )
+    # Fills with stripped pair identity must reject, never default to the
+    # target pair.
+    for missing_key in ("symbol", "pside"):
+        stripped = fill(200_000)
+        del stripped[missing_key]
+        with pytest.raises(ValueError, match="missing pair identity"):
+            hsl._hsl_replay_extend_pair_rows(
+                pair, pside="long", symbol="A",
+                fills=[stripped], closes_by_minute={}, end_ts=240_000, c_mult=1.0,
+            )
     # Zero-length extension is a no-op.
     assert (
         hsl._hsl_replay_extend_pair_rows(

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -1589,6 +1589,231 @@ async def test_hsl_cache_synthesized_replay_reaches_identical_coin_state(monkeyp
     assert state_synth["cooldown_until_ms"] == state_auth["cooldown_until_ms"]
 
 
+async def _run_extension_history(monkeypatch):
+    """Five-minute scenario with a fill after the intended cache watermark."""
+    import numpy as np
+    from unittest.mock import AsyncMock
+
+    import passivbot as passivbot_module
+    from live.event_bus import ListEventSink, LiveEventPipeline
+
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {}}
+    bot.exchange = "kucoin"
+    bot.user = "test_user"
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: 1.0 if key == "pnls_max_lookback_days" else None
+    base_ts = 1_800_000_000_000
+    ts_now = base_ts + 240_000
+    bot.get_exchange_time = lambda: ts_now
+    bot.get_raw_balance = lambda: 100.0
+    bot.get_symbol_id_inv = lambda symbol: symbol
+    symbol = "BTC/USDT:USDT"
+    bot.positions = {
+        symbol: {
+            "long": {"size": 0.9, "price": (0.5 * 100.0 + 0.4 * 99.0) / 0.9},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    bot._pnls_manager = None
+    bot.inverse = False
+    bot._candle_fetch_concurrency = lambda *, context="runtime": 2
+    bot._get_fetch_delay_seconds = lambda: 0.0
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[ListEventSink()],
+        monitor_sinks=[],
+    )
+    bot._live_event_current_cycle_id = "cy_hsl_extension"
+    bot._emit_live_event = Passivbot._emit_live_event.__get__(bot, Passivbot)
+    bot.c_mults = {symbol: 1.0}
+    monkeypatch.setattr(
+        passivbot_module, "compute_psize_pprice", lambda *args, **kwargs: None
+    )
+
+    class _CM:
+        async def get_candles(self, sym, **kwargs):
+            return np.array(
+                [
+                    (base_ts, 99.0, 101.0, 98.0, 100.0, 1.0),
+                    (base_ts + 60_000, 84.0, 100.0, 60.0, 60.0, 1.0),
+                    (base_ts + 120_000, 60.0, 102.0, 60.0, 101.0, 1.0),
+                    (base_ts + 180_000, 99.0, 101.0, 98.0, 99.0, 1.0),
+                    (base_ts + 240_000, 99.0, 104.0, 99.0, 103.0, 1.0),
+                ],
+                dtype=passivbot_module.CANDLE_DTYPE,
+            )
+
+    bot.cm = _CM()
+    fill_events = [
+        {
+            "timestamp": base_ts,
+            "symbol": symbol,
+            "position_side": "long",
+            "side": "buy",
+            "qty": 1.0,
+            "price": 100.0,
+            "pnl": 0.0,
+        },
+        {
+            "timestamp": base_ts + 90_000,
+            "symbol": symbol,
+            "position_side": "long",
+            "side": "sell",
+            "qty": 0.5,
+            "price": 101.0,
+            "pnl": 0.5,
+        },
+        {
+            "timestamp": base_ts + 210_000,
+            "symbol": symbol,
+            "position_side": "long",
+            "side": "buy",
+            "qty": 0.4,
+            "price": 99.0,
+            "pnl": 0.0,
+        },
+    ]
+    history = await bot.get_balance_equity_history(
+        fill_events=fill_events,
+        current_balance=100.0,
+        hsl_replay_signal_mode="coin",
+    )
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+    return history, symbol, base_ts
+
+
+@pytest.mark.asyncio
+async def test_hsl_cache_extension_matches_full_rebuild(monkeypatch):
+    import numpy as np
+
+    history, symbol, base_ts = await _run_extension_history(monkeypatch)
+    watermark_ts = base_ts + 120_000
+    end_ts = base_ts + 240_000
+
+    full_pair_rows = history["hsl_replay_matrices"]["long"][symbol]
+    full_pair = hsl._hsl_replay_matrix_arrays(full_pair_rows)
+    full_account = hsl._hsl_replay_account_series_arrays(
+        history["hsl_replay_account_series"]
+    )
+
+    # Slice the full arrays at the watermark, exactly what a cache written at
+    # that time would contain (collection is deterministic; see parity tests).
+    pair_cut = int(np.searchsorted(full_pair["ts"], watermark_ts, side="right"))
+    cached_pair = {field: arr[:pair_cut] for field, arr in full_pair.items()}
+    account_cut = int(
+        np.searchsorted(full_account["ts"], watermark_ts, side="right")
+    )
+    cached_account = {field: arr[:account_cut] for field, arr in full_account.items()}
+
+    extension_fills = [
+        evt
+        for evt in history["fill_events"]
+        if int(evt["timestamp"]) >= watermark_ts + 60_000
+    ]
+    assert len(extension_fills) == 1
+    closes_by_minute = {base_ts + 180_000: 99.0, base_ts + 240_000: 103.0}
+
+    new_pair_rows = hsl._hsl_replay_extend_pair_rows(
+        cached_pair,
+        pside="long",
+        symbol=symbol,
+        fills=extension_fills,
+        closes_by_minute=closes_by_minute,
+        end_ts=end_ts,
+        c_mult=1.0,
+    )
+    rebuilt_pair = hsl._hsl_replay_matrix_arrays(
+        hsl._hsl_replay_rows_from_arrays(cached_pair, series_kind="pair_matrix")
+        + new_pair_rows
+    )
+    for field in full_pair:
+        np.testing.assert_allclose(
+            rebuilt_pair[field], full_pair[field], rtol=0.0, atol=1e-12
+        )
+
+    new_account_rows = hsl._hsl_replay_extend_account_rows(
+        cached_account,
+        fills=extension_fills,
+        end_ts=end_ts,
+    )
+    rebuilt_account = hsl._hsl_replay_account_series_arrays(
+        hsl._hsl_replay_rows_from_arrays(cached_account, series_kind="account_pnl")
+        + new_account_rows
+    )
+    for field in full_account:
+        np.testing.assert_allclose(
+            rebuilt_account[field], full_account[field], rtol=0.0, atol=1e-12
+        )
+
+
+def test_hsl_cache_extension_fail_loud_contracts():
+    pair = hsl._hsl_replay_matrix_arrays(
+        [
+            hsl._hsl_replay_matrix_row(
+                pside="long", ts=60_000, price=100.0, psize=1.0,
+                pprice=100.0, pnl=0.0, c_mult=1.0,
+            ),
+            hsl._hsl_replay_matrix_row(
+                pside="long", ts=120_000, price=101.0, psize=1.0,
+                pprice=100.0, pnl=0.0, c_mult=1.0,
+            ),
+        ]
+    )
+
+    def fill(ts, action="increase", qty=0.1, price=100.0, pnl=0.0):
+        return {
+            "timestamp": ts,
+            "symbol": "A",
+            "pside": "long",
+            "qty": qty,
+            "price": price,
+            "action": action,
+            "pnl": pnl,
+        }
+
+    # Fill inside the cached window must reject the extension.
+    with pytest.raises(ValueError, match="inside the cached window"):
+        hsl._hsl_replay_extend_pair_rows(
+            pair, pside="long", symbol="A",
+            fills=[fill(150_000)], closes_by_minute={}, end_ts=240_000, c_mult=1.0,
+        )
+    # Fill beyond the extension end must reject.
+    with pytest.raises(ValueError, match="beyond the extension end"):
+        hsl._hsl_replay_extend_pair_rows(
+            pair, pside="long", symbol="A",
+            fills=[fill(400_000)], closes_by_minute={}, end_ts=240_000, c_mult=1.0,
+        )
+    # End before the watermark must reject.
+    with pytest.raises(ValueError, match="precedes watermark"):
+        hsl._hsl_replay_extend_pair_rows(
+            pair, pside="long", symbol="A",
+            fills=[], closes_by_minute={}, end_ts=60_000, c_mult=1.0,
+        )
+    # Fill from another pair must reject.
+    wrong = fill(200_000)
+    wrong["symbol"] = "B"
+    with pytest.raises(ValueError, match="does not belong to pair"):
+        hsl._hsl_replay_extend_pair_rows(
+            pair, pside="long", symbol="A",
+            fills=[wrong], closes_by_minute={}, end_ts=240_000, c_mult=1.0,
+        )
+    # Zero-length extension is a no-op.
+    assert (
+        hsl._hsl_replay_extend_pair_rows(
+            pair, pside="long", symbol="A",
+            fills=[], closes_by_minute={}, end_ts=120_000, c_mult=1.0,
+        )
+        == []
+    )
+    # Missing closes carry the last known price forward.
+    rows = hsl._hsl_replay_extend_pair_rows(
+        pair, pside="long", symbol="A",
+        fills=[], closes_by_minute={}, end_ts=240_000, c_mult=1.0,
+    )
+    assert [row["price"] for row in rows] == [101.0, 101.0]
+    assert [row["psize"] for row in rows] == [1.0, 1.0]
+
+
 def test_hsl_cache_synthesized_rows_fail_loud_on_bad_inputs():
     account = hsl._hsl_replay_account_series_arrays(
         [


### PR DESCRIPTION
Second precursor to the replay-cache reuse gate (after the #1121 parity trust boundary): pure, unwired helpers that extend a valid cache from its watermark to now, so the reuse slice only needs to fetch fills/candles for the gap instead of the full lookback.

Scope (`src/passivbot_hsl.py` + tests, no wiring):

- `_hsl_replay_rows_from_arrays` — validated, kind-aware inverse of the arrays builders, used to compose cached arrays with extension rows.
- `_hsl_replay_extend_pair_rows` — extends a cached pair matrix using the pair's post-watermark extracted fills plus candle closes. Position bookkeeping mirrors the authoritative `_apply_event` exactly (weighted-average entry price on increase; size shrink with price zeroing on flat), prices carry forward through close gaps, per-minute `pnl` is `pnl + fee` like the authoritative accounting.
- `_hsl_replay_extend_account_rows` — extends the account PnL series with per-minute `pnl + fee` sums over all post-watermark fills.
- **Fail-loud contracts**: a fill inside the cached window (double-count hazard), a fill beyond the extension end, a fill from another pair, an extension end before the watermark, or invalid cached arrays all raise — the future reuse gate must treat any of these as cache-reject-and-fall-back, never as repairable.
- **Slice-and-extend parity**: a five-minute scenario (deep dip, partial close, post-watermark re-entry) runs through the **real** collection; cutting the arrays at a watermark and extending with the post-watermark fills/closes rebuilds arrays equal to the full-run arrays to `atol=1e-12` for both series. Combined with #1121's synthesis parity, the full reuse path (load → extend → synthesize → replay) is now parity-proven piecewise before any wiring.

Validation:
- `venv/bin/python -m pytest tests/test_hsl_coin_mode.py tests/test_passivbot_balance_split.py tests/test_unstucking_safeguards.py` — 406 passed
- Full suite: only the 3 known pre-existing out-of-scope failures (pymoo sampling, 2 bitget UTA stubs; see #1116).
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)