### PR TITLE
Persist panic flatten markers with the HSL account series

### DIFF
--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -114,6 +114,11 @@ order changes as follows:
 - Rust should be the source of truth for entries, closes, risk, HSL, and
   unstuck. Python should gather exchange data, build Rust payloads, unpack Rust
   ideal orders, and reconcile ideal vs actual exchange orders.
+- Any HSL/risk/unstuck contract shared by live and backtest must be
+  implemented in Rust and consumed by both paths, unless the implementing PR
+  explicitly documents why centralization is infeasible or materially worse.
+  Python-owned live HSL code is limited to exchange data gathering,
+  cache/replay matrix construction, diagnostics, and reconciliation.
 - Statelessness is required. Trading behavior must be reconstructable from
   exchange state plus config. Local caches/checkpoints may improve speed or
   diagnostics, but must not be authoritative trading state.
@@ -985,6 +990,12 @@ Remaining implementation details:
       cached window, beyond the extension end, or from another pair are
       rejected fail-loud so double-counting rejects the cache instead of
       corrupting it.
+      Partial: account-series manifests (schema v4) now persist the replay's
+      panic flatten markers (raw exchange-derived facts: timestamp, minute,
+      pside, symbol) so a future cache-fed replay does not lose in-window
+      cooldown/no-restart evidence. Markers are validated fail-loud (grid
+      alignment, series-span bounds, ascending order, account-kind only) and
+      tamper-checked (missing/invalid/wrong-kind reasons).
 - [ ] Python simplification after Rust owns ideal protective orders and unstuck
       orders.
       Python should reconcile ideal vs actual orders, not re-decide trading

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -37,7 +37,7 @@ _HSL_REPLAY_ACCOUNT_SERIES_FIELDS = ("ts", "pnl")
 _HSL_REPLAY_CACHE_SERIES_KINDS = ("pair_matrix", "account_pnl")
 _HSL_REPLAY_CACHE_ACCOUNT_PSIDE = "account"
 _HSL_REPLAY_CACHE_ACCOUNT_SYMBOL = "__account__"
-_HSL_REPLAY_CACHE_SCHEMA_VERSION = 3
+_HSL_REPLAY_CACHE_SCHEMA_VERSION = 4
 _HSL_REPLAY_CACHE_MATRIX_FILENAME = "hsl_replay_matrix.npz"
 _HSL_REPLAY_CACHE_MANIFEST_FILENAME = "hsl_replay_manifest.json"
 _HSL_REPLAY_CACHE_REQUIRED_METADATA = (
@@ -1192,16 +1192,83 @@ def _hsl_replay_cache_account_expected_metadata(
     return _normalize_hsl_replay_cache_metadata(metadata)
 
 
+def _hsl_replay_cache_normalize_panic_events(
+    events: Any, *, start_ts: int, end_ts: int
+) -> list[dict[str, Any]]:
+    """Normalize/validate panic flatten markers persisted with the account series."""
+    if not isinstance(events, list):
+        raise TypeError(
+            f"HSL cache panic_flatten_events must be a list, got {type(events).__name__}"
+        )
+    out: list[dict[str, Any]] = []
+    prev_ts: int | None = None
+    for event in events:
+        if not isinstance(event, dict):
+            raise TypeError(
+                "HSL cache panic_flatten_events entries must be dicts, "
+                f"got {type(event).__name__}"
+            )
+        missing = [
+            key
+            for key in ("timestamp", "minute_timestamp", "pside", "symbol")
+            if event.get(key) is None
+        ]
+        if missing:
+            raise ValueError(
+                f"HSL cache panic_flatten_events entry missing fields: {missing}"
+            )
+        ts = int(event["timestamp"])
+        minute_ts = int(event["minute_timestamp"])
+        pside = str(event["pside"])
+        symbol = str(event["symbol"])
+        if pside not in ("long", "short"):
+            raise ValueError(
+                f"HSL cache panic_flatten_events pside must be long or short, got {pside!r}"
+            )
+        if not symbol:
+            raise ValueError("HSL cache panic_flatten_events symbol must be non-empty")
+        if minute_ts % _HSL_REPLAY_MATRIX_INTERVAL_MS != 0:
+            raise ValueError(
+                f"HSL cache panic_flatten_events minute_timestamp {minute_ts} "
+                "is not minute-aligned"
+            )
+        if minute_ts < int(start_ts) or minute_ts > int(end_ts):
+            raise ValueError(
+                f"HSL cache panic_flatten_events minute_timestamp {minute_ts} lies "
+                f"outside the series span [{start_ts}, {end_ts}]"
+            )
+        if prev_ts is not None and ts < prev_ts:
+            raise ValueError(
+                "HSL cache panic_flatten_events must be ascending by timestamp"
+            )
+        prev_ts = ts
+        out.append(
+            {
+                "timestamp": ts,
+                "minute_timestamp": minute_ts,
+                "pside": pside,
+                "symbol": symbol,
+            }
+        )
+    return out
+
+
 def _write_hsl_replay_matrix_cache(
     cache_dir: str | os.PathLike[str],
     rows: list[dict[str, Any]],
     metadata: dict[str, Any],
     *,
     series_kind: str = "pair_matrix",
+    panic_flatten_events: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     import numpy as np
 
     fields = _hsl_replay_cache_series_fields(series_kind)
+    if series_kind != "account_pnl" and panic_flatten_events is not None:
+        raise ValueError(
+            "HSL cache panic_flatten_events are account-scoped facts; "
+            f"they cannot be persisted with series_kind={series_kind!r}"
+        )
     cache_path = Path(cache_dir)
     cache_path.mkdir(parents=True, exist_ok=True)
     if series_kind == "account_pnl":
@@ -1221,6 +1288,16 @@ def _write_hsl_replay_matrix_cache(
         "metadata": metadata_norm,
         "arrays": _hsl_replay_cache_array_manifest(arrays),
     }
+    if series_kind == "account_pnl":
+        if not len(rows):
+            raise ValueError(
+                "HSL cache account series must be non-empty to scope panic markers"
+            )
+        manifest["panic_flatten_events"] = _hsl_replay_cache_normalize_panic_events(
+            panic_flatten_events if panic_flatten_events is not None else [],
+            start_ts=int(arrays["ts"][0]),
+            end_ts=int(arrays["ts"][-1]),
+        )
     matrix_path = cache_path / _HSL_REPLAY_CACHE_MATRIX_FILENAME
     manifest_path = cache_path / _HSL_REPLAY_CACHE_MANIFEST_FILENAME
     matrix_tmp = matrix_path.with_suffix(matrix_path.suffix + f".{os.getpid()}.tmp")
@@ -1266,6 +1343,20 @@ def _hsl_replay_cache_validation_reasons(
         # A kind/field-list disagreement means the manifest was tampered with
         # or written by an incompatible writer.
         reasons.append("fields_mismatch")
+    if series_kind == "account_pnl":
+        if "panic_flatten_events" not in manifest:
+            reasons.append("panic_events_missing")
+        else:
+            try:
+                _hsl_replay_cache_normalize_panic_events(
+                    manifest.get("panic_flatten_events"),
+                    start_ts=int(manifest.get("start_ts_ms") or 0),
+                    end_ts=int(manifest.get("end_ts_ms") or 0),
+                )
+            except (TypeError, ValueError):
+                reasons.append("panic_events_invalid")
+    elif manifest.get("panic_flatten_events") is not None:
+        reasons.append("panic_events_wrong_kind")
     if str(manifest.get("matrix_file", "")) != _HSL_REPLAY_CACHE_MATRIX_FILENAME:
         reasons.append("matrix_filename_mismatch")
     if int(manifest.get("interval_ms", 0) or 0) != _HSL_REPLAY_MATRIX_INTERVAL_MS:
@@ -1613,8 +1704,15 @@ def _equity_hard_stop_persist_replay_matrices(self, history: dict[str, Any]) -> 
                 candle_covered_start_ms=int(coverage["candle_covered_start_ms"]),
                 candle_covered_end_ms=int(coverage["candle_covered_end_ms"]),
             )
+            panic_events = history.get("panic_flatten_events")
             manifest = _write_hsl_replay_matrix_cache(
-                cache_dir, account_rows, metadata, series_kind="account_pnl"
+                cache_dir,
+                account_rows,
+                metadata,
+                series_kind="account_pnl",
+                panic_flatten_events=(
+                    panic_events if isinstance(panic_events, list) else []
+                ),
             )
         except Exception as exc:
             logging.warning(

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -579,6 +579,100 @@ def test_hsl_replay_account_series_round_trip(tmp_path):
         )
 
 
+def test_hsl_replay_account_series_persists_panic_markers(tmp_path):
+    import json
+
+    metadata = _hsl_cache_metadata(
+        pside=hsl._HSL_REPLAY_CACHE_ACCOUNT_PSIDE,
+        symbol=hsl._HSL_REPLAY_CACHE_ACCOUNT_SYMBOL,
+    )
+    markers = [
+        {
+            "timestamp": 121_500,
+            "minute_timestamp": 120_000,
+            "pside": "long",
+            "symbol": "BTC/USDT:USDT",
+        }
+    ]
+    manifest = hsl._write_hsl_replay_matrix_cache(
+        tmp_path,
+        _hsl_account_series_rows(),
+        metadata,
+        series_kind="account_pnl",
+        panic_flatten_events=markers,
+    )
+
+    assert manifest["panic_flatten_events"] == markers
+    assert (
+        hsl._hsl_replay_cache_validation_reasons(tmp_path, expected_metadata=metadata)
+        == []
+    )
+    loaded_manifest, _arrays = hsl._load_hsl_replay_matrix_cache(
+        tmp_path, expected_metadata=metadata
+    )
+    assert loaded_manifest["panic_flatten_events"] == markers
+
+    # Tampering detection on the persisted manifest.
+    manifest_path = tmp_path / hsl._HSL_REPLAY_CACHE_MANIFEST_FILENAME
+    stored = json.loads(manifest_path.read_text(encoding="utf-8"))
+    stripped = dict(stored)
+    del stripped["panic_flatten_events"]
+    manifest_path.write_text(json.dumps(stripped), encoding="utf-8")
+    assert "panic_events_missing" in hsl._hsl_replay_cache_validation_reasons(tmp_path)
+
+    corrupted = dict(stored, panic_flatten_events=[{"timestamp": 1}])
+    manifest_path.write_text(json.dumps(corrupted), encoding="utf-8")
+    assert "panic_events_invalid" in hsl._hsl_replay_cache_validation_reasons(tmp_path)
+
+
+def test_hsl_replay_cache_panic_markers_fail_loud_contracts(tmp_path):
+    import json
+
+    marker = {
+        "timestamp": 121_500,
+        "minute_timestamp": 120_000,
+        "pside": "long",
+        "symbol": "BTC/USDT:USDT",
+    }
+    account_metadata = _hsl_cache_metadata(
+        pside=hsl._HSL_REPLAY_CACHE_ACCOUNT_PSIDE,
+        symbol=hsl._HSL_REPLAY_CACHE_ACCOUNT_SYMBOL,
+    )
+    # Markers are account-scoped; pair manifests must reject them.
+    with pytest.raises(ValueError, match="account-scoped"):
+        hsl._write_hsl_replay_matrix_cache(
+            tmp_path,
+            _hsl_cache_rows(),
+            _hsl_cache_metadata(),
+            panic_flatten_events=[marker],
+        )
+    # Off-grid minute rejects.
+    with pytest.raises(ValueError, match="not minute-aligned"):
+        hsl._write_hsl_replay_matrix_cache(
+            tmp_path,
+            _hsl_account_series_rows(),
+            account_metadata,
+            series_kind="account_pnl",
+            panic_flatten_events=[dict(marker, minute_timestamp=90_000)],
+        )
+    # Outside the series span rejects.
+    with pytest.raises(ValueError, match="outside the series span"):
+        hsl._write_hsl_replay_matrix_cache(
+            tmp_path,
+            _hsl_account_series_rows(),
+            account_metadata,
+            series_kind="account_pnl",
+            panic_flatten_events=[dict(marker, minute_timestamp=600_000)],
+        )
+    # A pair manifest carrying markers is rejected by the validator.
+    hsl._write_hsl_replay_matrix_cache(tmp_path, _hsl_cache_rows(), _hsl_cache_metadata())
+    manifest_path = tmp_path / hsl._HSL_REPLAY_CACHE_MANIFEST_FILENAME
+    stored = json.loads(manifest_path.read_text(encoding="utf-8"))
+    stored["panic_flatten_events"] = [marker]
+    manifest_path.write_text(json.dumps(stored), encoding="utf-8")
+    assert "panic_events_wrong_kind" in hsl._hsl_replay_cache_validation_reasons(tmp_path)
+
+
 def test_hsl_replay_cache_rejects_series_kind_tampering(tmp_path):
     import json
 
@@ -662,9 +756,18 @@ def test_hsl_replay_cache_persist_matrices_round_trip(tmp_path, monkeypatch):
         "candle_covered_end_ms": 180_000,
     }
     account_rows = _hsl_account_series_rows()
+    panic_markers = [
+        {
+            "timestamp": 121_500,
+            "minute_timestamp": 120_000,
+            "pside": "long",
+            "symbol": symbol,
+        }
+    ]
     history = {
         "hsl_replay_matrices": {"long": {symbol: rows}},
         "hsl_replay_account_series": account_rows,
+        "panic_flatten_events": panic_markers,
         "hsl_replay_matrix_coverage": coverage,
     }
 
@@ -725,6 +828,7 @@ def test_hsl_replay_cache_persist_matrices_round_trip(tmp_path, monkeypatch):
         account_dir, expected_metadata=account_expected
     )
     assert account_manifest["series_kind"] == "account_pnl"
+    assert account_manifest["panic_flatten_events"] == panic_markers
     np.testing.assert_allclose(
         account_arrays["pnl"], [row["pnl"] for row in account_rows]
     )


### PR DESCRIPTION
Third and final precursor to the replay-cache reuse gate. Wiring recon found that `_equity_hard_stop_initialize_coin_from_history` consumes `panic_flatten_events` (derived during the full replay's fill accounting via after-psize flat detection) for cooldown/no-restart reconstruction — a cache-fed replay would silently lose in-window markers. They are raw exchange-derived facts (timestamp, minute, pside, symbol), so they belong in the cache, still write-only.

Scope:

- **Cache schema v4**: account-series manifests always carry `panic_flatten_events` (possibly empty), normalized fail-loud — required fields, `long`/`short` pside, non-empty symbol, minute-grid alignment, series-span bounds, ascending timestamps. Pair manifests must not carry them (`panic_flatten_events` are account-scoped facts; the writer rejects the combination).
- **Validator**: `panic_events_missing` (a v4 account manifest without the field is invalid — this matters because "no field" must never be read as "no panics"), `panic_events_invalid` (corrupted entries), `panic_events_wrong_kind` (markers on a pair manifest). Schema bump v3→v4 rejects all prior caches rather than reinterpreting them; nothing reads caches yet, so only doctor reporting changes.
- **Persist helper** threads `history["panic_flatten_events"]` through to the account write; the end-to-end persist round-trip test verifies the markers land in the manifest and survive the fail-closed loader.
- **Plan doc**: records the strengthened centralization guiding contract (user decision 2026-07-06): any HSL/risk/unstuck contract shared by live and backtest must be implemented in Rust and consumed by both paths unless the implementing PR explicitly documents why centralization is infeasible or materially worse; Python-owned live HSL code is limited to exchange data gathering, cache/replay matrix construction, diagnostics, and reconciliation. Plus the tracker note for this slice.

Validation:
- `venv/bin/python -m pytest tests/test_hsl_coin_mode.py tests/test_passivbot_balance_split.py tests/test_cache_integrity_doctor.py tests/test_unstucking_safeguards.py` — 425 passed
- New tests: marker round-trip through writer/validator/loader with tamper detection (stripped field, corrupted entry); fail-loud contracts (markers on pair kind, off-grid minute, out-of-span minute, wrong-kind manifest tampering); persist wiring carries the history's markers.
- Full suite: only the 3 known pre-existing out-of-scope failures (pymoo sampling, 2 bitget UTA stubs; see #1116).
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)