### PR TITLE
Extract HSL fill-event normalization into reusable methods

### DIFF
--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11093,6 +11093,123 @@ class Passivbot:
 
     # Legacy init_fill_events, update_fill_events, etc. removed - using FillEventsManager
 
+    @staticmethod
+    def _hsl_fill_safe_float(val: Any, default: float = 0.0) -> float:
+        try:
+            if val is None:
+                return default
+            return float(val)
+        except Exception:
+            return default
+
+    def _hsl_normalize_fill_symbol(self, symbol: Any) -> str:
+        sym = str(symbol) if symbol else ""
+        if not sym:
+            return ""
+        if sym in self.c_mults:
+            return sym
+        try:
+            converted = self.get_symbol_id_inv(sym)
+            if converted:
+                return converted
+        except Exception:
+            pass
+        return sym
+
+    @staticmethod
+    def _hsl_fill_action(
+        pside: str, side: str, qty_signed: Optional[float], explicit: Optional[str]
+    ):
+        if explicit in ("increase", "decrease"):
+            return explicit
+        if qty_signed is not None and qty_signed != 0.0:
+            return "increase" if qty_signed > 0 else "decrease"
+        side = side.lower()
+        if pside == "long":
+            return "increase" if side == "buy" else "decrease"
+        return "increase" if side == "sell" else "decrease"
+
+    def _hsl_extract_fill_events(self, source: List[dict]) -> List[dict]:
+        """Normalize raw fill payloads into canonical HSL replay events.
+
+        Shared by the balance/equity replay and (future) cache-extension
+        paths so both consume the same trust-critical normalization.
+        """
+        safe_float = Passivbot._hsl_fill_safe_float
+        out = []
+        for fill in source:
+            ts_raw = fill.get("timestamp")
+            if ts_raw is None:
+                continue
+            try:
+                ts = int(ensure_millis(ts_raw))
+            except Exception:
+                continue
+            symbol = self._hsl_normalize_fill_symbol(fill.get("symbol"))
+            if not symbol:
+                continue
+            pside = str(
+                fill.get("position_side", fill.get("pside", "long"))
+            ).lower()
+            if pside not in ("long", "short"):
+                pside = "long"
+            qty_signed = fill.get("qty_signed")
+            qty_fallback_keys = ("qty", "amount", "size", "contracts")
+            qty_val = safe_float(
+                (
+                    qty_signed
+                    if qty_signed is not None
+                    else next(
+                        (
+                            fill.get(k)
+                            for k in qty_fallback_keys
+                            if fill.get(k) is not None
+                        ),
+                        0.0,
+                    )
+                ),
+                0.0,
+            )
+            qty = abs(qty_val)
+            if qty <= 0.0:
+                continue
+            price_keys = ("price", "avgPrice", "average", "avg_price", "execPrice")
+            price = next(
+                (fill.get(k) for k in price_keys if fill.get(k) is not None), None
+            )
+            if price is None:
+                info = fill.get("info", {})
+                price = (
+                    info.get("avgPrice")
+                    or info.get("execPrice")
+                    or info.get("avg_exec_price")
+                )
+            price = safe_float(price, 0.0)
+            if price <= 0.0:
+                continue
+            pnl_val = safe_float(fill.get("pnl", 0.0), 0.0)
+            fee_paid = signed_fee_paid_from_payload(fill)
+            side = str(fill.get("side", "")).lower()
+            action = Passivbot._hsl_fill_action(
+                pside, side, qty_signed, fill.get("action")
+            )
+            out.append(
+                {
+                    "timestamp": ts,
+                    "symbol": symbol,
+                    "pside": pside,
+                    "qty": qty,
+                    "price": price,
+                    "action": action,
+                    "pnl": pnl_val,
+                    "fee": fee_paid,
+                    "fee_paid": fee_paid,
+                    "pb_order_type": str(fill.get("pb_order_type") or "").lower(),
+                    "c_mult": float(self.c_mults.get(symbol, 1.0)),
+                }
+            )
+        return sorted(out, key=lambda x: x["timestamp"])
+
     async def get_balance_equity_history(
         self,
         fill_events: Optional[List[dict]] = None,
@@ -11141,27 +11258,8 @@ class Passivbot:
                     exc,
                 )
 
-        def _safe_float(val: Any, default: float = 0.0) -> float:
-            try:
-                if val is None:
-                    return default
-                return float(val)
-            except Exception:
-                return default
-
-        def _normalize_symbol(symbol: Any) -> str:
-            sym = str(symbol) if symbol else ""
-            if not sym:
-                return ""
-            if sym in self.c_mults:
-                return sym
-            try:
-                converted = self.get_symbol_id_inv(sym)
-                if converted:
-                    return converted
-            except Exception:
-                pass
-            return sym
+        _safe_float = Passivbot._hsl_fill_safe_float
+        _normalize_symbol = self._hsl_normalize_fill_symbol
 
         def _ensure_slot(
             container: Dict[str, Dict[str, Dict[str, float]]], symbol: str
@@ -11173,90 +11271,6 @@ class Passivbot:
                 }
             return container[symbol]
 
-        def _determine_action(
-            pside: str, side: str, qty_signed: Optional[float], explicit: Optional[str]
-        ):
-            if explicit in ("increase", "decrease"):
-                return explicit
-            if qty_signed is not None and qty_signed != 0.0:
-                return "increase" if qty_signed > 0 else "decrease"
-            side = side.lower()
-            if pside == "long":
-                return "increase" if side == "buy" else "decrease"
-            return "increase" if side == "sell" else "decrease"
-
-        def _extract_events(source: List[dict]) -> List[dict]:
-            out = []
-            for fill in source:
-                ts_raw = fill.get("timestamp")
-                if ts_raw is None:
-                    continue
-                try:
-                    ts = int(ensure_millis(ts_raw))
-                except Exception:
-                    continue
-                symbol = _normalize_symbol(fill.get("symbol"))
-                if not symbol:
-                    continue
-                pside = str(
-                    fill.get("position_side", fill.get("pside", "long"))
-                ).lower()
-                if pside not in ("long", "short"):
-                    pside = "long"
-                qty_signed = fill.get("qty_signed")
-                qty_fallback_keys = ("qty", "amount", "size", "contracts")
-                qty_val = _safe_float(
-                    (
-                        qty_signed
-                        if qty_signed is not None
-                        else next(
-                            (
-                                fill.get(k)
-                                for k in qty_fallback_keys
-                                if fill.get(k) is not None
-                            ),
-                            0.0,
-                        )
-                    ),
-                    0.0,
-                )
-                qty = abs(qty_val)
-                if qty <= 0.0:
-                    continue
-                price_keys = ("price", "avgPrice", "average", "avg_price", "execPrice")
-                price = next(
-                    (fill.get(k) for k in price_keys if fill.get(k) is not None), None
-                )
-                if price is None:
-                    info = fill.get("info", {})
-                    price = (
-                        info.get("avgPrice")
-                        or info.get("execPrice")
-                        or info.get("avg_exec_price")
-                    )
-                price = _safe_float(price, 0.0)
-                if price <= 0.0:
-                    continue
-                pnl_val = _safe_float(fill.get("pnl", 0.0), 0.0)
-                fee_paid = signed_fee_paid_from_payload(fill)
-                side = str(fill.get("side", "")).lower()
-                action = _determine_action(pside, side, qty_signed, fill.get("action"))
-                out.append(
-                    {
-                        "timestamp": ts,
-                        "symbol": symbol,
-                        "pside": pside,
-                        "qty": qty,
-                        "price": price,
-                        "action": action,
-                        "pnl": pnl_val,
-                        "fee": fee_paid,
-                        "fee_paid": fee_paid,
-                        "pb_order_type": str(fill.get("pb_order_type") or "").lower(),
-                        "c_mult": float(self.c_mults.get(symbol, 1.0)),
-                    }
-                )
-            return sorted(out, key=lambda x: x["timestamp"])
 
         def _current_position_state() -> Dict[Tuple[str, str], Tuple[float, float]]:
             out: Dict[Tuple[str, str], Tuple[float, float]] = {}
@@ -11279,7 +11293,7 @@ class Passivbot:
             else:
                 fill_events = []
 
-        events = _extract_events(fill_events)
+        events = self._hsl_extract_fill_events(fill_events)
         current_position_state = _current_position_state()
         _emit_hsl_history_progress(
             "history_inputs_loaded",

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1374,6 +1374,64 @@ def test_candle_fetch_concurrency_is_conservative_for_history_replay():
     assert bot._candle_fetch_concurrency(context="history_replay") == 7
 
 
+def test_hsl_extract_fill_events_normalization():
+    bot = Passivbot.__new__(Passivbot)
+    bot.c_mults = {"BTC/USDT:USDT": 2.0}
+    bot.get_symbol_id_inv = (
+        lambda sym: "BTC/USDT:USDT" if sym == "BTCUSDT" else ""
+    )
+
+    events = bot._hsl_extract_fill_events(
+        [
+            {
+                "timestamp": 1_800_000_061_000,
+                "symbol": "BTCUSDT",
+                "position_side": "long",
+                "side": "buy",
+                "qty": 1.0,
+                "price": 100.0,
+                "pnl": 0.0,
+            },
+            {
+                "timestamp": 1_800_000_060_000,
+                "symbol": "BTC/USDT:USDT",
+                "pside": "short",
+                "side": "buy",
+                "amount": 2.0,
+                "avgPrice": 50.0,
+                "pnl": -1.0,
+            },
+            {
+                "timestamp": 1_800_000_062_000,
+                "symbol": "BTC/USDT:USDT",
+                "qty_signed": -0.5,
+                "price": 10.0,
+            },
+            # Missing timestamp, missing symbol, zero qty, zero price: skipped.
+            {"symbol": "BTC/USDT:USDT", "qty": 1.0, "price": 1.0},
+            {"timestamp": 1_800_000_063_000, "symbol": "", "qty": 1.0, "price": 1.0},
+            {"timestamp": 1_800_000_064_000, "symbol": "BTC/USDT:USDT", "qty": 0.0, "price": 1.0},
+            {"timestamp": 1_800_000_065_000, "symbol": "BTC/USDT:USDT", "qty": 1.0, "price": 0.0},
+        ]
+    )
+
+    assert [event["timestamp"] for event in events] == [1_800_000_060_000, 1_800_000_061_000, 1_800_000_062_000]
+    by_ts = {event["timestamp"]: event for event in events}
+    # Exchange-id symbols normalize through get_symbol_id_inv.
+    assert by_ts[1_800_000_061_000]["symbol"] == "BTC/USDT:USDT"
+    assert by_ts[1_800_000_061_000]["action"] == "increase"
+    assert by_ts[1_800_000_061_000]["c_mult"] == 2.0
+    # qty/price fallbacks (amount/avgPrice); short buy reduces.
+    assert by_ts[1_800_000_060_000]["qty"] == 2.0
+    assert by_ts[1_800_000_060_000]["price"] == 50.0
+    assert by_ts[1_800_000_060_000]["pside"] == "short"
+    assert by_ts[1_800_000_060_000]["action"] == "decrease"
+    # Signed qty decides the action and qty is stored unsigned.
+    assert by_ts[1_800_000_062_000]["qty"] == 0.5
+    assert by_ts[1_800_000_062_000]["action"] == "decrease"
+    assert all("fee" in event and "pb_order_type" in event for event in events)
+
+
 @pytest.mark.asyncio
 async def test_balance_equity_history_paces_replay_candle_fetches(monkeypatch):
     bot = Passivbot.__new__(Passivbot)


### PR DESCRIPTION
Behavior-neutral refactor ahead of the replay-cache reuse wiring (parallel to #1124; different files, no shared hunks). The trust-critical fill normalization lived in closures inside `get_balance_equity_history`; the reuse path must apply the identical normalization to post-watermark gap fills, and duplicating it would fork the trust boundary.

Scope (`src/passivbot.py` + one test):

- `_hsl_extract_fill_events`, `_hsl_normalize_fill_symbol`, `_hsl_fill_action`, `_hsl_fill_safe_float` are now `Passivbot` methods with bodies moved **verbatim** from the closures. The remaining in-function uses of `_safe_float`/`_normalize_symbol` (progress payloads, position state, price handling) delegate to the methods via local aliases, so there is exactly one implementation.
- Direct unit coverage of the extraction contract (previously only testable through the full replay): exchange-id symbol normalization via `get_symbol_id_inv`, qty fallback chain (`qty_signed` → `qty`/`amount`/`size`/`contracts`), price fallback chain (`price` → `avgPrice`/`average`/… → `info`), signed-qty and side-based action inference (short buy → decrease), unsigned qty storage, `c_mult` stamping, and the skip rules (missing timestamp/symbol, zero qty/price).

Behavior neutrality evidence: the 200+ `get_balance_equity_history` tests in `test_passivbot_balance_split.py` (including the matrix-collection and pacing tests) pass unchanged — 203 passed; `tests/test_hsl_coin_mode.py` + `tests/test_unstucking_safeguards.py` — 204 passed. Full suite: only the 3 known pre-existing out-of-scope failures (see #1116). `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)