### PR TITLE
Wire HSL replay cache reuse into live coin startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live coin-mode HSL startup can now reuse its persisted replay cache: when
+  the cached series pass every trust gate (proven fill coverage at write and
+  load time, config digest identity, watermark agreement, gap extension from
+  exchange fills/candles, and current-position reconciliation), the bot
+  replays from the cache plus the gap instead of re-fetching the full
+  lookback. Any gate failure falls back to the full exchange-derived replay;
+  the cache never becomes authoritative trading state, and a fresh VPS
+  reconstructs identical decisions.
 - HSL-enabled startup and live-config preflight now surface a history
   reinterpretation caveat and point operators to a dedicated HSL risks doc for
   deposits, withdrawals, balance overrides, and HSL config changes.

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -996,6 +996,16 @@ Remaining implementation details:
       cooldown/no-restart evidence. Markers are validated fail-loud (grid
       alignment, series-span bounds, ascending order, account-kind only) and
       tamper-checked (missing/invalid/wrong-kind reasons).
+      Implemented: live coin-mode startup now attempts cache reuse before the
+      full replay. Gates: write-time proven coverage recorded in the manifest
+      plus a fresh load-time pnls-manager coverage proof, config-digest
+      identity, account/pair watermark agreement, gap extension from
+      exchange fills/candles (panic fills inside the gap force full replay),
+      and current-position reconciliation within qty-step tolerance. Any
+      rejection or unexpected error falls back to the authoritative full
+      replay; the completed event now reports `cache_reused` alongside phase
+      timings. End-to-end test proves the cache-fed boot reaches state
+      identical to the full replay with the full fetch provably skipped.
 - [ ] Python simplification after Rust owns ideal protective orders and unstuck
       orders.
       Python should reconcile ideal vs actual orders, not re-decide trading

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1780,6 +1780,10 @@ class Passivbot:
     _equity_hard_stop_persist_replay_matrices = (
         pb_hsl._equity_hard_stop_persist_replay_matrices
     )
+    _try_load_hsl_replay_matrix_cache = pb_hsl._try_load_hsl_replay_matrix_cache
+    _equity_hard_stop_try_reuse_replay_cache = (
+        pb_hsl._equity_hard_stop_try_reuse_replay_cache
+    )
     _equity_hard_stop_maybe_emit_raw_red_pending = (
         pb_hsl._equity_hard_stop_maybe_emit_raw_red_pending
     )

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -1609,6 +1609,282 @@ def _try_load_hsl_replay_matrix_cache(
     return manifest, arrays
 
 
+def _hsl_replay_cache_read_manifest_window(
+    cache_dir: str | os.PathLike[str],
+) -> dict[str, Any] | None:
+    """Best-effort read of a manifest's recorded coverage window and scope.
+
+    The reader cannot predict the write-time coverage window, so expected
+    metadata takes those fields from the manifest itself (tautological
+    comparison) while identity fields and the coverage proof stay strict.
+    Returns None when no readable manifest exists (a cache miss).
+    """
+    manifest_path = Path(cache_dir) / _HSL_REPLAY_CACHE_MANIFEST_FILENAME
+    if not manifest_path.exists():
+        return None
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        metadata = manifest.get("metadata") or {}
+        return {
+            "fill_covered_start_ms": int(metadata["fill_covered_start_ms"]),
+            "fill_covered_end_ms": int(metadata["fill_covered_end_ms"]),
+            "fill_history_scope": str(metadata["fill_history_scope"]),
+            "candle_covered_start_ms": int(metadata["candle_covered_start_ms"]),
+            "candle_covered_end_ms": int(metadata["candle_covered_end_ms"]),
+        }
+    except Exception:
+        # Unreadable manifests are handled (and evented) by the validator.
+        return {}
+
+
+async def _equity_hard_stop_try_reuse_replay_cache(
+    self, now_ms: int
+) -> dict[str, Any] | None:
+    """Attempt to reconstruct the coin-replay history from persisted caches.
+
+    Returns a history payload equivalent to `get_balance_equity_history()`
+    output for the coin replay, or None when the cache must not be used, in
+    which case the caller falls back to the full exchange-derived replay.
+    Every rejection is observable through the cache hit/miss/rejected events
+    emitted by the loader or a warning here. The cache never becomes
+    authoritative: reuse requires a proven write-time fill-coverage flag, a
+    fresh load-time coverage proof, digest identity, watermark agreement,
+    gap extension from exchange fills/candles, and current-position
+    compatibility; any failure falls back.
+    """
+    if self._equity_hard_stop_signal_mode() != "coin":
+        return None
+    if bool(getattr(self, "inverse", False)):
+        return None
+    manager = getattr(self, "_pnls_manager", None)
+    if manager is None:
+        return None
+    held_pairs: list[tuple[str, str]] = []
+    for symbol, slots in (self.positions or {}).items():
+        if not isinstance(slots, dict):
+            continue
+        for pside in self._hsl_psides():
+            if not self._equity_hard_stop_coin_active_pside(pside):
+                continue
+            if self._equity_hard_stop_has_open_position_symbol(pside, str(symbol)):
+                if not self._equity_hard_stop_symbol_supported_for_coin_replay(
+                    str(symbol)
+                ):
+                    return None
+                held_pairs.append((pside, str(symbol)))
+    if not held_pairs:
+        return None
+
+    lookback = parse_pnls_max_lookback_days(
+        self.live_value("pnls_max_lookback_days"),
+        field_name="live.pnls_max_lookback_days",
+    )
+    lookback_start = lookback.balance_history_start_ms(int(now_ms))
+    coverage_status = self._pnl_history_coverage_status(
+        start_ms=None if lookback_start is None else int(lookback_start),
+        end_ms=int(now_ms),
+        lookback=lookback,
+    )
+    if not bool(coverage_status.get("ready", False)):
+        logging.info(
+            "[risk] HSL replay cache reuse skipped: fill coverage not proven at load "
+            "| reason=%s",
+            str(coverage_status.get("reason", "unknown")),
+        )
+        return None
+
+    def expected_from_window(window: dict[str, Any], *, account: bool, pside: str = "", symbol: str = ""):
+        if window.get("fill_history_scope") not in ("window", "all"):
+            return None
+        kwargs = {
+            "fill_covered_start_ms": window["fill_covered_start_ms"],
+            "fill_covered_end_ms": window["fill_covered_end_ms"],
+            "fill_history_scope": window["fill_history_scope"],
+            # Strict: only caches written from proven fills are reusable.
+            "fill_coverage_proven": True,
+            "candle_covered_start_ms": window["candle_covered_start_ms"],
+            "candle_covered_end_ms": window["candle_covered_end_ms"],
+        }
+        if account:
+            return self._hsl_replay_cache_account_expected_metadata(**kwargs)
+        return self._hsl_replay_cache_expected_metadata(pside, symbol, **kwargs)
+
+    account_dir = self._hsl_replay_cache_account_series_dir()
+    account_window = _hsl_replay_cache_read_manifest_window(account_dir)
+    if account_window is None or not account_window:
+        return None
+    account_expected = expected_from_window(account_window, account=True)
+    if account_expected is None:
+        return None
+    account_loaded = self._try_load_hsl_replay_matrix_cache(
+        account_dir,
+        expected_metadata=account_expected,
+        pside=_HSL_REPLAY_CACHE_ACCOUNT_PSIDE,
+        symbol=_HSL_REPLAY_CACHE_ACCOUNT_SYMBOL,
+    )
+    if account_loaded is None:
+        return None
+    account_manifest, account_arrays = account_loaded
+    watermark_ts = int(account_manifest["end_ts_ms"])
+
+    pair_arrays_by_pair: dict[tuple[str, str], dict[str, Any]] = {}
+    for pside, symbol in held_pairs:
+        pair_dir = self._hsl_replay_cache_dir(pside, symbol)
+        pair_window = _hsl_replay_cache_read_manifest_window(pair_dir)
+        if pair_window is None or not pair_window:
+            return None
+        pair_expected = expected_from_window(
+            pair_window, account=False, pside=pside, symbol=symbol
+        )
+        if pair_expected is None:
+            return None
+        pair_loaded = self._try_load_hsl_replay_matrix_cache(
+            pair_dir,
+            expected_metadata=pair_expected,
+            pside=pside,
+            symbol=symbol,
+        )
+        if pair_loaded is None:
+            return None
+        pair_manifest, pair_arrays = pair_loaded
+        if int(pair_manifest["end_ts_ms"]) != watermark_ts:
+            logging.warning(
+                "[risk] HSL replay cache reuse rejected: pair %s:%s watermark %s "
+                "disagrees with account watermark %s",
+                pside,
+                symbol,
+                pair_manifest["end_ts_ms"],
+                watermark_ts,
+            )
+            return None
+        pair_arrays_by_pair[(pside, symbol)] = pair_arrays
+
+    raw_fills = [event.to_dict() for event in manager.get_events()]
+    extracted = self._hsl_extract_fill_events(raw_fills)
+    gap_floor = watermark_ts + _HSL_REPLAY_MATRIX_INTERVAL_MS
+    gap_fills = [event for event in extracted if int(event["timestamp"]) >= gap_floor]
+    if any(
+        "panic" in str(event.get("pb_order_type") or "") for event in gap_fills
+    ):
+        # Gap panic markers need flat-detection state this slice does not
+        # reconstruct; the full replay derives them authoritatively.
+        logging.info(
+            "[risk] HSL replay cache reuse skipped: panic fill inside the "
+            "extension gap; falling back to full replay"
+        )
+        return None
+
+    closes_by_symbol: dict[str, dict[int, float]] = {}
+    end_minute = int(math.floor(int(now_ms) / _HSL_REPLAY_MATRIX_INTERVAL_MS)) * (
+        _HSL_REPLAY_MATRIX_INTERVAL_MS
+    )
+    if end_minute > watermark_ts:
+        for _pside, symbol in held_pairs:
+            if symbol in closes_by_symbol:
+                continue
+            candles = await self.cm.get_candles(
+                symbol,
+                start_ts=watermark_ts,
+                end_ts=end_minute,
+                strict=False,
+                timeframe="1m",
+            )
+            closes: dict[int, float] = {}
+            for row in candles:
+                closes[int(row["ts"])] = float(row["c"])
+            closes_by_symbol[symbol] = closes
+
+    extended_pairs: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for (pside, symbol), arrays in pair_arrays_by_pair.items():
+        pair_gap_fills = [
+            event
+            for event in gap_fills
+            if str(event["symbol"]) == symbol and str(event["pside"]) == pside
+        ]
+        new_rows = _hsl_replay_extend_pair_rows(
+            arrays,
+            pside=pside,
+            symbol=symbol,
+            fills=pair_gap_fills,
+            closes_by_minute=closes_by_symbol.get(symbol, {}),
+            end_ts=end_minute,
+            c_mult=float(self.c_mults.get(symbol, 1.0)),
+        )
+        extended_pairs[(pside, symbol)] = (
+            _hsl_replay_rows_from_arrays(arrays, series_kind="pair_matrix") + new_rows
+        )
+    account_new_rows = _hsl_replay_extend_account_rows(
+        account_arrays,
+        fills=gap_fills,
+        end_ts=end_minute,
+    )
+    account_rows = (
+        _hsl_replay_rows_from_arrays(account_arrays, series_kind="account_pnl")
+        + account_new_rows
+    )
+
+    # Current-position compatibility: the extended series' final position must
+    # reconcile with the exchange state or the cache is stale/incomplete.
+    for (pside, symbol), rows in extended_pairs.items():
+        extended_psize = float(rows[-1]["psize"])
+        slot = (self.positions or {}).get(symbol, {}).get(pside, {})
+        current_size = abs(float(slot.get("size", 0.0) or 0.0))
+        current_signed = current_size if pside == "long" else -current_size
+        tolerance = max(float(self.qty_steps.get(symbol, 0.0) or 0.0), 1e-9)
+        if abs(extended_psize - current_signed) > tolerance:
+            logging.warning(
+                "[risk] HSL replay cache reuse rejected: extended %s:%s position "
+                "%.12f does not reconcile with exchange position %.12f "
+                "(tolerance %.12f)",
+                pside,
+                symbol,
+                extended_psize,
+                current_signed,
+                tolerance,
+            )
+            return None
+
+    current_balance = float(self.get_raw_balance())
+    timeline = _hsl_replay_timeline_rows_from_cache(
+        {
+            pair: _hsl_replay_matrix_arrays(rows)
+            for pair, rows in extended_pairs.items()
+        },
+        _hsl_replay_account_series_arrays(account_rows),
+        current_balance=current_balance,
+    )
+    panic_flatten_events = list(account_manifest.get("panic_flatten_events") or [])
+    return {
+        "timeline": timeline,
+        "panic_flatten_events": panic_flatten_events,
+        "fill_events": extracted,
+        "hsl_replay_matrices": _hsl_reuse_group_matrices(extended_pairs),
+        "hsl_replay_account_series": account_rows,
+        "hsl_replay_matrix_coverage": {
+            "fill_covered_start_ms": int(
+                account_expected["fill_covered_start_ms"]
+            ),
+            "fill_covered_end_ms": int(now_ms),
+            "fill_history_scope": str(coverage_status.get("history_scope", "unknown")),
+            "fill_coverage_proven": bool(coverage_status.get("ready", False)),
+            "fill_coverage_reason": str(coverage_status.get("reason", "unknown")),
+            "candle_covered_start_ms": int(
+                account_expected["candle_covered_start_ms"]
+            ),
+            "candle_covered_end_ms": int(end_minute),
+        },
+    }
+
+
+def _hsl_reuse_group_matrices(
+    extended_pairs: dict[tuple[str, str], list[dict[str, Any]]],
+) -> dict[str, dict[str, list[dict[str, Any]]]]:
+    out: dict[str, dict[str, list[dict[str, Any]]]] = {}
+    for (pside, symbol), rows in extended_pairs.items():
+        out.setdefault(pside, {})[symbol] = rows
+    return out
+
+
 def _equity_hard_stop_persist_replay_matrices(self, history: dict[str, Any]) -> int:
     """Persist non-authoritative raw replay matrices after a successful coin replay.
 
@@ -3997,10 +4273,35 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             reason_code="coin_history_replay",
         )
         history_fetch_started_s = time.monotonic()
-        history = await self.get_balance_equity_history(
-            current_balance=self.get_raw_balance(),
-            hsl_replay_signal_mode="coin",
-        )
+        history = None
+        cache_reused = False
+        try:
+            history = await self._equity_hard_stop_try_reuse_replay_cache(
+                int(self.get_exchange_time())
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # Reuse is an accelerator; any unexpected failure must fall back
+            # to the authoritative full replay, never abort startup.
+            logging.warning(
+                "[risk] HSL replay cache reuse failed; falling back to full "
+                "replay | error=%s: %s",
+                type(exc).__name__,
+                exc,
+            )
+            history = None
+        if history is not None:
+            cache_reused = True
+            logging.info(
+                "[risk] HSL coin replay reusing persisted cache | timeline_rows=%d",
+                len(history.get("timeline") or []),
+            )
+        else:
+            history = await self.get_balance_equity_history(
+                current_balance=self.get_raw_balance(),
+                hsl_replay_signal_mode="coin",
+            )
         history_loaded_s = time.monotonic()
         history_fetch_elapsed_s = max(0.0, history_loaded_s - history_fetch_started_s)
         check_shutdown("hsl_coin_history_replay_history_loaded")
@@ -4675,6 +4976,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 "full_elapsed_s": round(total_elapsed_s, 3),
                 "startup_blocking_elapsed_s": round(total_elapsed_s, 3),
                 "elapsed_s": round(total_elapsed_s, 3),
+                "cache_reused": bool(cache_reused),
             },
             status="succeeded",
             reason_code="coin_history_replay_completed",

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -1727,6 +1727,29 @@ async def _equity_hard_stop_try_reuse_replay_cache(
     account_manifest, account_arrays = account_loaded
     watermark_ts = int(account_manifest["end_ts_ms"])
 
+    # Flat-pair cooldown safety: the replay treats every supported panic
+    # marker as a required replay pair, but this slice only loads matrices
+    # for currently held pairs. A marker for a supported flat coin would
+    # therefore demand per-coin timeline values the synthesized rows cannot
+    # provide, aborting startup mid-replay instead of falling back. Reject
+    # reuse up front so the authoritative full replay reconstructs that
+    # flat-pair cooldown.
+    held_pair_set = set(held_pairs)
+    for marker in account_manifest.get("panic_flatten_events") or []:
+        marker_pside = str(marker.get("pside", ""))
+        marker_symbol = str(marker.get("symbol", ""))
+        if not self._equity_hard_stop_symbol_supported_for_coin_replay(marker_symbol):
+            continue
+        if (marker_pside, marker_symbol) not in held_pair_set:
+            logging.info(
+                "[risk] HSL replay cache reuse skipped: cached panic marker for "
+                "flat pair %s:%s is not covered by a held-pair matrix; falling "
+                "back to full replay for cooldown reconstruction",
+                marker_pside,
+                marker_symbol,
+            )
+            return None
+
     pair_arrays_by_pair: dict[tuple[str, str], dict[str, Any]] = {}
     for pside, symbol in held_pairs:
         pair_dir = self._hsl_replay_cache_dir(pside, symbol)

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -1196,6 +1196,8 @@ def bind_hsl_methods(bot):
         "_hsl_replay_cache_account_series_dir",
         "_hsl_replay_cache_account_expected_metadata",
         "_equity_hard_stop_persist_replay_matrices",
+        "_try_load_hsl_replay_matrix_cache",
+        "_equity_hard_stop_try_reuse_replay_cache",
         "_equity_hard_stop_build_latch_payload",
         "_equity_hard_stop_check_coin",
         "_equity_hard_stop_clear_coin_runtime_forced_mode",
@@ -1927,6 +1929,402 @@ def test_hsl_cache_extension_fail_loud_contracts():
     )
     assert [row["price"] for row in rows] == [101.0, 101.0]
     assert [row["psize"] for row in rows] == [1.0, 1.0]
+
+
+def _bind_reuse_support(bot, tmp_path, monkeypatch, *, fills, covered_start_ms=1):
+    """Equip a fake coin bot with everything the cache-reuse path consumes."""
+    from unittest.mock import AsyncMock
+
+    def fake_get_filepath(rel):
+        path = tmp_path / rel
+        path.mkdir(parents=True, exist_ok=True)
+        return f"{path}/"
+
+    monkeypatch.setattr(hsl, "make_get_filepath", fake_get_filepath)
+    bot.market_type = "swap"
+    bot.qty_steps = {}
+    bot.init_pnls = AsyncMock()
+    bot._pnl_history_coverage_status = MethodType(
+        Passivbot._pnl_history_coverage_status, bot
+    )
+    bot._pnl_blocking_known_gaps = MethodType(Passivbot._pnl_blocking_known_gaps, bot)
+    bot._pnl_gap_is_confirmed_legitimate = Passivbot._pnl_gap_is_confirmed_legitimate
+    bot._pnl_gap_overlaps = Passivbot._pnl_gap_overlaps
+    bot._hsl_extract_fill_events = MethodType(Passivbot._hsl_extract_fill_events, bot)
+    bot._hsl_normalize_fill_symbol = MethodType(
+        Passivbot._hsl_normalize_fill_symbol, bot
+    )
+    bot.get_symbol_id_inv = lambda sym: sym
+
+    class _StubEvent:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def to_dict(self):
+            return dict(self._payload)
+
+    class _StubCache:
+        def load_metadata(self):
+            return {"covered_start_ms": covered_start_ms, "oldest_event_ts": 1}
+
+        def get_covered_start_ms(self):
+            return covered_start_ms
+
+        def get_history_scope(self):
+            return "all"
+
+    class _StubPnlsManager:
+        cache = _StubCache()
+
+        def get_events(self):
+            return [_StubEvent(payload) for payload in fills]
+
+        def get_history_scope(self):
+            return "all"
+
+    bot._pnls_manager = _StubPnlsManager()
+    return bot
+
+
+_REUSE_BASE_TS = 1_800_000_000_000
+_REUSE_SYMBOL = "BTC/USDT:USDT"
+
+
+def _reuse_fill(offset_ms, *, side, qty, price, pnl=0.0, pb_order_type=""):
+    return {
+        "timestamp": _REUSE_BASE_TS + offset_ms,
+        "symbol": _REUSE_SYMBOL,
+        "position_side": "long",
+        "side": side,
+        "qty": qty,
+        "price": price,
+        "pnl": pnl,
+        "pb_order_type": pb_order_type,
+    }
+
+
+_REUSE_PREFIX_FILLS = [
+    _reuse_fill(0, side="buy", qty=1.0, price=100.0),
+    _reuse_fill(90_000, side="sell", qty=0.5, price=101.0, pnl=0.5),
+]
+_REUSE_GAP_FILL = _reuse_fill(210_000, side="buy", qty=0.4, price=99.0)
+_REUSE_CANDLES = [
+    (_REUSE_BASE_TS, 99.0, 101.0, 98.0, 100.0, 1.0),
+    (_REUSE_BASE_TS + 60_000, 84.0, 100.0, 60.0, 60.0, 1.0),
+    (_REUSE_BASE_TS + 120_000, 60.0, 102.0, 60.0, 101.0, 1.0),
+    (_REUSE_BASE_TS + 180_000, 99.0, 101.0, 98.0, 99.0, 1.0),
+    (_REUSE_BASE_TS + 240_000, 99.0, 104.0, 99.0, 103.0, 1.0),
+]
+
+
+async def _reuse_collection_history(monkeypatch, *, n_minutes, fills, positions):
+    """Run the real manager-backed collection over the first n scenario minutes."""
+    import numpy as np
+    from unittest.mock import AsyncMock
+
+    import passivbot as passivbot_module
+    from live.event_bus import ListEventSink, LiveEventPipeline
+
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {}}
+    bot.exchange = "test_exchange"
+    bot.user = "test_user"
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: 1.0 if key == "pnls_max_lookback_days" else None
+    ts_now = _REUSE_BASE_TS + (n_minutes - 1) * 60_000
+    bot.get_exchange_time = lambda: ts_now
+    bot.get_raw_balance = lambda: 100.0
+    bot.get_symbol_id_inv = lambda symbol: symbol
+    bot.positions = positions
+    bot.inverse = False
+    bot._candle_fetch_concurrency = lambda *, context="runtime": 2
+    bot._get_fetch_delay_seconds = lambda: 0.0
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[ListEventSink()], monitor_sinks=[]
+    )
+    bot._live_event_current_cycle_id = "cy_reuse_collect"
+    bot._emit_live_event = Passivbot._emit_live_event.__get__(bot, Passivbot)
+    bot.c_mults = {_REUSE_SYMBOL: 1.0}
+    monkeypatch.setattr(
+        passivbot_module, "compute_psize_pprice", lambda *args, **kwargs: None
+    )
+
+    class _CM:
+        async def get_candles(self, sym, **kwargs):
+            return np.array(
+                _REUSE_CANDLES[:n_minutes], dtype=passivbot_module.CANDLE_DTYPE
+            )
+
+    bot.cm = _CM()
+
+    class _StubEvent:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def to_dict(self):
+            return dict(self._payload)
+
+    class _StubCache:
+        def load_metadata(self):
+            return {"covered_start_ms": 1, "oldest_event_ts": 1}
+
+        def get_covered_start_ms(self):
+            return 1
+
+        def get_history_scope(self):
+            return "all"
+
+    class _StubPnlsManager:
+        cache = _StubCache()
+
+        def __init__(self, payloads):
+            self._payloads = payloads
+
+        def get_events(self):
+            return [_StubEvent(p) for p in self._payloads]
+
+        def get_history_scope(self):
+            return "all"
+
+    bot._pnls_manager = _StubPnlsManager(fills)
+    history = await bot.get_balance_equity_history(
+        current_balance=100.0,
+        hsl_replay_signal_mode="coin",
+    )
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+    return history
+
+
+def _make_reuse_bot(tmp_path, monkeypatch, *, fills, exchange_now, positions):
+    import numpy as np
+
+    import passivbot as passivbot_module
+
+    bot = make_coin_bot()
+    bot.exchange = "test_exchange"
+    bot.positions = positions
+    bot.c_mults = {_REUSE_SYMBOL: 1.0}
+    bot.get_exchange_time = lambda: exchange_now
+    _bind_reuse_support(bot, tmp_path, monkeypatch, fills=fills)
+
+    class _GapCM:
+        async def get_candles(self, sym, *, start_ts, end_ts, **kwargs):
+            rows = [
+                row
+                for row in _REUSE_CANDLES
+                if start_ts <= row[0] <= end_ts
+            ]
+            return np.array(rows, dtype=passivbot_module.CANDLE_DTYPE)
+
+    bot.cm = _GapCM()
+
+    async def calc_upnl(pside=None, symbol=None):
+        # Final close 103 vs pprice (0.5*100 + 0.4*99)/0.9.
+        pprice = (0.5 * 100.0 + 0.4 * 99.0) / 0.9
+        return (103.0 - pprice) * 0.9
+
+    bot._calc_upnl_sum_strict = calc_upnl
+
+    def fail_full_replay(*args, **kwargs):
+        raise AssertionError("cache reuse must not fall back in this scenario")
+
+    bot._fail_full_replay = fail_full_replay
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_hsl_cache_reuse_reaches_state_identical_to_full_replay(
+    tmp_path, monkeypatch
+):
+    prefix_positions = {
+        _REUSE_SYMBOL: {
+            "long": {"size": 0.5, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    final_positions = {
+        _REUSE_SYMBOL: {
+            "long": {"size": 0.9, "price": (0.5 * 100.0 + 0.4 * 99.0) / 0.9},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    all_fills = _REUSE_PREFIX_FILLS + [_REUSE_GAP_FILL]
+    exchange_now = _REUSE_BASE_TS + 240_000
+
+    # Boot 1: full replay over the prefix window writes the cache.
+    prefix_history = await _reuse_collection_history(
+        monkeypatch, n_minutes=3, fills=_REUSE_PREFIX_FILLS, positions=prefix_positions
+    )
+    writer_bot = make_coin_bot()
+    writer_bot.exchange = "test_exchange"
+    _bind_reuse_support(writer_bot, tmp_path, monkeypatch, fills=_REUSE_PREFIX_FILLS)
+    assert writer_bot._equity_hard_stop_persist_replay_matrices(prefix_history) == 2
+
+    # Boot 2: cache-fed replay over the full window; full fetch must not run.
+    reuse_bot = _make_reuse_bot(
+        tmp_path,
+        monkeypatch,
+        fills=all_fills,
+        exchange_now=exchange_now,
+        positions=final_positions,
+    )
+    reuse_bot.get_balance_equity_history = reuse_bot._fail_full_replay
+    await reuse_bot._equity_hard_stop_initialize_coin_from_history()
+    assert getattr(reuse_bot, "_equity_hard_stop_coin_initialized", False) is True
+
+    # Boot 3 (control): authoritative full replay over the full window.
+    full_history = await _reuse_collection_history(
+        monkeypatch, n_minutes=5, fills=all_fills, positions=final_positions
+    )
+    control_bot = _make_reuse_bot(
+        tmp_path,
+        monkeypatch,
+        fills=all_fills,
+        exchange_now=exchange_now,
+        positions=final_positions,
+    )
+
+    async def full_fetch(current_balance=None, **kwargs):
+        return full_history
+
+    control_bot.get_balance_equity_history = full_fetch
+    await control_bot._equity_hard_stop_initialize_coin_from_history()
+
+    state_reuse = reuse_bot._hsl_coin_state("long", _REUSE_SYMBOL)
+    state_control = control_bot._hsl_coin_state("long", _REUSE_SYMBOL)
+    metrics_reuse = state_reuse["last_metrics"]
+    metrics_control = state_control["last_metrics"]
+    assert metrics_reuse is not None and metrics_control is not None
+    assert metrics_reuse["tier"] == metrics_control["tier"]
+    for key in (
+        "balance",
+        "slot_budget",
+        "drawdown_usd",
+        "drawdown_raw",
+        "drawdown_ema",
+        "drawdown_score",
+        "unrealized_pnl",
+    ):
+        assert metrics_reuse[key] == pytest.approx(metrics_control[key], abs=1e-9)
+    assert state_reuse["halted"] == state_control["halted"]
+    assert state_reuse["cooldown_until_ms"] == state_control["cooldown_until_ms"]
+
+
+@pytest.mark.asyncio
+async def test_hsl_cache_reuse_falls_back_on_missing_or_incompatible_cache(
+    tmp_path, monkeypatch
+):
+    final_positions = {
+        _REUSE_SYMBOL: {
+            "long": {"size": 0.9, "price": (0.5 * 100.0 + 0.4 * 99.0) / 0.9},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    all_fills = _REUSE_PREFIX_FILLS + [_REUSE_GAP_FILL]
+    exchange_now = _REUSE_BASE_TS + 240_000
+
+    # No cache on disk: reuse returns None (miss) and the caller falls back.
+    bot = _make_reuse_bot(
+        tmp_path,
+        monkeypatch,
+        fills=all_fills,
+        exchange_now=exchange_now,
+        positions=final_positions,
+    )
+    assert (
+        await bot._equity_hard_stop_try_reuse_replay_cache(exchange_now) is None
+    )
+
+    # Write a valid cache, then break each reuse gate in turn.
+    prefix_positions = {
+        _REUSE_SYMBOL: {
+            "long": {"size": 0.5, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    prefix_history = await _reuse_collection_history(
+        monkeypatch, n_minutes=3, fills=_REUSE_PREFIX_FILLS, positions=prefix_positions
+    )
+    writer_bot = make_coin_bot()
+    writer_bot.exchange = "test_exchange"
+    _bind_reuse_support(writer_bot, tmp_path, monkeypatch, fills=_REUSE_PREFIX_FILLS)
+    assert writer_bot._equity_hard_stop_persist_replay_matrices(prefix_history) == 2
+
+    # Sanity: the intact cache is reusable.
+    bot = _make_reuse_bot(
+        tmp_path,
+        monkeypatch,
+        fills=all_fills,
+        exchange_now=exchange_now,
+        positions=final_positions,
+    )
+    assert (
+        await bot._equity_hard_stop_try_reuse_replay_cache(exchange_now) is not None
+    )
+
+    # HSL config change rotates the digest: rejected.
+    bot = _make_reuse_bot(
+        tmp_path,
+        monkeypatch,
+        fills=all_fills,
+        exchange_now=exchange_now,
+        positions=final_positions,
+    )
+    bot.hsl["long"]["red_threshold"] = 0.31
+    assert (
+        await bot._equity_hard_stop_try_reuse_replay_cache(exchange_now) is None
+    )
+
+    # Positions that do not reconcile with the extended series: rejected.
+    bot = _make_reuse_bot(
+        tmp_path,
+        monkeypatch,
+        fills=all_fills,
+        exchange_now=exchange_now,
+        positions={
+            _REUSE_SYMBOL: {
+                "long": {"size": 5.0, "price": 100.0},
+                "short": {"size": 0.0, "price": 0.0},
+            }
+        },
+    )
+    assert (
+        await bot._equity_hard_stop_try_reuse_replay_cache(exchange_now) is None
+    )
+
+    # A panic fill inside the gap: skipped (full replay owns marker derivation).
+    panic_fills = _REUSE_PREFIX_FILLS + [
+        dict(_REUSE_GAP_FILL, pb_order_type="close_panic_long")
+    ]
+    bot = _make_reuse_bot(
+        tmp_path,
+        monkeypatch,
+        fills=panic_fills,
+        exchange_now=exchange_now,
+        positions=final_positions,
+    )
+    assert (
+        await bot._equity_hard_stop_try_reuse_replay_cache(exchange_now) is None
+    )
+
+    # Unproven load-time coverage: skipped.
+    bot = _make_reuse_bot(
+        tmp_path,
+        monkeypatch,
+        fills=all_fills,
+        exchange_now=exchange_now,
+        positions=final_positions,
+    )
+    bot._pnls_manager.cache.get_history_scope = lambda: "window"
+    bot._pnls_manager.get_history_scope = lambda: "window"
+    bot._pnls_manager.cache.get_covered_start_ms = lambda: 0
+    bot._pnls_manager.cache.load_metadata = lambda: {
+        "covered_start_ms": 0,
+        "oldest_event_ts": 1,
+    }
+    assert (
+        await bot._equity_hard_stop_try_reuse_replay_cache(exchange_now) is None
+    )
 
 
 def test_hsl_cache_synthesized_rows_fail_loud_on_bad_inputs():

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -2307,6 +2307,47 @@ async def test_hsl_cache_reuse_falls_back_on_missing_or_incompatible_cache(
         await bot._equity_hard_stop_try_reuse_replay_cache(exchange_now) is None
     )
 
+    # A cached panic marker for a supported flat coin whose pair matrix is
+    # not loaded must reject reuse (full replay owns flat-pair cooldown
+    # reconstruction) instead of aborting startup mid-replay.
+    flat_symbol = "ETH/USDT:USDT"
+    marker_history = dict(prefix_history)
+    marker_history["panic_flatten_events"] = [
+        {
+            "timestamp": _REUSE_BASE_TS + 500,
+            "minute_timestamp": _REUSE_BASE_TS,
+            "pside": "long",
+            "symbol": flat_symbol,
+        }
+    ]
+    writer_bot = make_coin_bot()
+    writer_bot.exchange = "test_exchange"
+    _bind_reuse_support(writer_bot, tmp_path, monkeypatch, fills=_REUSE_PREFIX_FILLS)
+    assert writer_bot._equity_hard_stop_persist_replay_matrices(marker_history) == 2
+    bot = _make_reuse_bot(
+        tmp_path,
+        monkeypatch,
+        fills=all_fills,
+        exchange_now=exchange_now,
+        positions=final_positions,
+    )
+    # The flat marker symbol is supported for coin replay but not held.
+    bot.c_mults[flat_symbol] = 1.0
+    assert (
+        await bot._equity_hard_stop_try_reuse_replay_cache(exchange_now) is None
+    )
+    # With the marker symbol unsupported, the marker is ignored by the full
+    # replay too, so reuse remains allowed.
+    del bot.c_mults[flat_symbol]
+    assert (
+        await bot._equity_hard_stop_try_reuse_replay_cache(exchange_now) is not None
+    )
+    # Restore the marker-free cache for the remaining gate checks.
+    writer_bot = make_coin_bot()
+    writer_bot.exchange = "test_exchange"
+    _bind_reuse_support(writer_bot, tmp_path, monkeypatch, fills=_REUSE_PREFIX_FILLS)
+    assert writer_bot._equity_hard_stop_persist_replay_matrices(prefix_history) == 2
+
     # Unproven load-time coverage: skipped.
     bot = _make_reuse_bot(
         tmp_path,

--- a/tests/test_passivbot_hsl_bindings.py
+++ b/tests/test_passivbot_hsl_bindings.py
@@ -47,4 +47,6 @@ def test_passivbot_uses_passivbot_hsl_module_for_hsl_methods():
         "_hsl_replay_cache_account_series_dir",
         "_hsl_replay_cache_account_expected_metadata",
         "_equity_hard_stop_persist_replay_matrices",
+        "_try_load_hsl_replay_matrix_cache",
+        "_equity_hard_stop_try_reuse_replay_cache",
     } <= assigned_names


### PR DESCRIPTION
The first behavior-bearing slice of the replay-cache work (B2.1b), composing the six merged precursors: metadata/digests (#1115/#1118), write persistence (#1117), account series (#1119), synthesis parity (#1121), extension parity (#1123), persisted panic markers (#1124), and shared fill extraction (#1125).

**What changes**: live coin-mode HSL startup calls `_equity_hard_stop_try_reuse_replay_cache` before `get_balance_equity_history`. On success, the replay history is reconstructed from the persisted caches plus only the watermark→now gap; on any gate failure or unexpected error, it falls back to the authoritative full replay (shutdown cancellation still propagates). The reused history flows through the **same** downstream code: the existing replay loop via the parity-proven synthesizer, the persisted panic markers from the account manifest, and the unchanged re-persist path that refreshes the cache.

**Reuse gates (each individually tested to fall back)**:
1. Write-time `fill_coverage_proven=true` in the manifest **and** a fresh load-time `_pnl_history_coverage_status` proof — both required, per the #1118 contract.
2. Expected-metadata identity through the fail-closed loader: coverage window/scope come from the manifest itself (tautological compare — the reader cannot predict write-time windows) while exchange/user/market_type/config-digest/signal-mode are enforced strictly, `fill_coverage_proven` must equal `true`, and scope must not be `unknown`.
3. Account and every held-pair watermark must agree.
4. Gap fills come from the pnls manager through the shared #1125 extraction; gap candles are fetched only for the watermark gap. A panic fill inside the gap forces the full replay (marker derivation needs flat-detection state the reuse path does not reconstruct — deliberately conservative).
5. The extended series' final position must reconcile with current exchange positions within qty-step tolerance.

**Statelessness**: unchanged — the cache accelerates, never decides. A fresh VPS (no cache) takes the full-replay path and reaches identical state; the end-to-end test proves the two paths are state-identical.

**Evidence**:
- End-to-end identity test: boot 1 full-replays a prefix window and persists; boot 2 reuses over the extended window with `get_balance_equity_history` replaced by a raiser (proving the full fetch is skipped) and reaches coin state identical to a control full replay (tier, drawdowns, balance, upnl to 1e-9, halted/cooldown equal).
- Rejection tests: cache miss, HSL config change (digest rotation), irreconcilable positions, panic fill in the gap, unproven load-time coverage — each returns None and falls back.
- Fixed along the way: `_try_load_hsl_replay_matrix_cache` was never bound on `Passivbot` (unwired scaffolding); it and the new reuse method are now bound and pinned in the AST test + fake-bot bind list.
- `HSL_REPLAY_COMPLETED` now reports `cache_reused` for boot-timing evidence (plan requirement: prove the checkpoint actually speeds boot).
- CHANGELOG entry (user-facing behavior change) + tracker update.
- 429 passed across the six HSL/replay/doctor test files; full suite shows only the 3 known pre-existing out-of-scope failures (see #1116). `git diff --check` clean.

**Known conservative limitations (intentional, documented here)**: reuse requires all held pairs cached with agreeing watermarks; gap panic fills, inverse markets, and non-coin signal modes always take the full replay. Flat-pair cooldown reconstruction still relies on the persisted markers plus fill-derived contracts exactly as the full replay does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)