### PR TITLE
Use max(raw, ema) for the HSL no-restart trigger in Rust and live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- The HSL no-restart (permanent halt) trigger now evaluates
+  `max(drawdown_raw, drawdown_ema)` against
+  `hsl_no_restart_drawdown_threshold` in both live and backtest, instead of
+  raw drawdown only. The permanent halt is intentionally conservative: it now
+  also trips on sustained smoothed damage even when the instantaneous
+  drawdown at the stop sample has partially recovered. The RED/panic-now
+  trigger is unchanged (`min(raw, ema)` crossing `hsl_red_threshold`).
 - Live coin-mode HSL startup can now reuse its persisted replay cache: when
   the cached series pass every trust gate (proven fill coverage at write and
   load time, config digest identity, watermark agreement, gap extension from

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -881,6 +881,15 @@ Remaining implementation details:
       finalization now use the explicit policy, with `threshold` as the
       behavior-preserving default and config/JSON validation for invalid
       values.
+      Implemented (B2.1 contract, 2026-07-06 clarification): the no-restart
+      trigger is now the shared Rust predicate
+      `ehsl::no_restart_triggered(policy, drawdown_raw, drawdown_ema,
+      threshold)` using `max(raw, ema)`, consumed by both the Rust backtest
+      finalization (stop snapshots now carry the smoothed drawdown) and
+      Python live finalize paths via PyO3, per the centralization guiding
+      contract. The RED/panic-now tier score was verified to already use
+      `min(raw, ema)` in the shared runtime and is pinned by regression
+      tests rather than changed.
 - [x] Dynamic WEL and snapped/raw balance docs/tests.
       Make `reduce_overweight` use dynamic currently-tradable slot count, keep
       snapped/raw balance separation, and add high-hysteresis warning/preflight

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -438,22 +438,22 @@ struct HardStopStopSnapshot {
     equity: f64,
     peak_strategy_equity: f64,
     drawdown_raw: f64,
+    drawdown_ema: f64,
 }
 
 fn hsl_no_restart_latched(
     restart_after_red_policy: &str,
     persistent_drawdown_raw: f64,
+    drawdown_ema: f64,
     no_restart_drawdown_threshold: f64,
 ) -> Result<bool, String> {
-    match restart_after_red_policy {
-        "always" => Ok(false),
-        "threshold" => Ok(persistent_drawdown_raw >= no_restart_drawdown_threshold),
-        "never" => Ok(true),
-        raw => Err(format!(
-            "hsl_restart_after_red_policy must be one of always, threshold, never; got {:?}",
-            raw
-        )),
-    }
+    // Shared live/backtest contract: max(raw, ema) trips the permanent halt.
+    ehsl::no_restart_triggered(
+        restart_after_red_policy,
+        persistent_drawdown_raw,
+        drawdown_ema,
+        no_restart_drawdown_threshold,
+    )
 }
 
 #[derive(Debug, Clone, Default)]
@@ -3125,6 +3125,7 @@ impl<'a> Backtest<'a> {
                     state.last_minute = Some(current_minute.saturating_sub(1));
                     state.cached_step.get_or_insert(ehsl::HardStopStep {
                         drawdown_raw: state.drawdown_ema.max(0.0),
+                        drawdown_ema: state.drawdown_ema.max(0.0),
                         drawdown_score: state.drawdown_ema.max(0.0),
                         tier: state.tier,
                         changed: false,
@@ -3593,6 +3594,7 @@ impl<'a> Backtest<'a> {
                         equity: strategy_equity,
                         peak_strategy_equity,
                         drawdown_raw: step.drawdown_raw,
+                        drawdown_ema: step.drawdown_ema.max(0.0),
                     });
                 }
                 if runtime.flat_confirmations >= 2 {
@@ -3601,6 +3603,7 @@ impl<'a> Backtest<'a> {
                         equity: strategy_equity,
                         peak_strategy_equity,
                         drawdown_raw: step.drawdown_raw,
+                        drawdown_ema: step.drawdown_ema.max(0.0),
                     });
                     runtime.last_stop = Some(stop_snapshot);
                     runtime.pending_stop = None;
@@ -3651,6 +3654,7 @@ impl<'a> Backtest<'a> {
                     if hsl_no_restart_latched(
                         hsl_restart_after_red_policy.as_str(),
                         persistent_drawdown_raw,
+                        stop_snapshot.drawdown_ema,
                         hsl_no_restart_drawdown_threshold,
                     )? {
                         runtime.no_restart_latched = true;
@@ -3787,6 +3791,7 @@ impl<'a> Backtest<'a> {
                         equity: synthetic_equity,
                         peak_strategy_equity: 1.0,
                         drawdown_raw: step.drawdown_raw,
+                        drawdown_ema: step.drawdown_ema.max(0.0),
                     });
                 }
                 if runtime.flat_confirmations >= 2 {
@@ -3795,6 +3800,7 @@ impl<'a> Backtest<'a> {
                         equity: synthetic_equity,
                         peak_strategy_equity: 1.0,
                         drawdown_raw: step.drawdown_raw,
+                        drawdown_ema: step.drawdown_ema.max(0.0),
                     });
                     runtime.last_stop = Some(stop_snapshot);
                     runtime.pending_stop = None;
@@ -3841,6 +3847,7 @@ impl<'a> Backtest<'a> {
                     if hsl_no_restart_latched(
                         hsl_restart_after_red_policy.as_str(),
                         persistent_drawdown_raw,
+                        stop_snapshot.drawdown_ema,
                         hsl_no_restart_drawdown_threshold,
                     )? {
                         runtime.no_restart_latched = true;
@@ -8120,11 +8127,13 @@ mod tests {
 
     #[test]
     fn hard_stop_restart_after_red_policy_controls_terminal_latch() {
-        assert!(!hsl_no_restart_latched("always", 1.0, 0.10).unwrap());
-        assert!(!hsl_no_restart_latched("threshold", 0.09, 0.10).unwrap());
-        assert!(hsl_no_restart_latched("threshold", 0.10, 0.10).unwrap());
-        assert!(hsl_no_restart_latched("never", 0.0, 0.10).unwrap());
-        assert!(hsl_no_restart_latched("sometimes", 1.0, 0.10).is_err());
+        assert!(!hsl_no_restart_latched("always", 1.0, 1.0, 0.10).unwrap());
+        assert!(!hsl_no_restart_latched("threshold", 0.09, 0.05, 0.10).unwrap());
+        assert!(hsl_no_restart_latched("threshold", 0.10, 0.0, 0.10).unwrap());
+        // Sustained smoothed damage trips the halt even when raw recovered.
+        assert!(hsl_no_restart_latched("threshold", 0.02, 0.11, 0.10).unwrap());
+        assert!(hsl_no_restart_latched("never", 0.0, 0.0, 0.10).unwrap());
+        assert!(hsl_no_restart_latched("sometimes", 1.0, 1.0, 0.10).is_err());
     }
 
     #[test]

--- a/passivbot-rust/src/equity_hard_stop_loss.rs
+++ b/passivbot-rust/src/equity_hard_stop_loss.rs
@@ -74,6 +74,7 @@ pub struct HardStopState {
 #[derive(Debug, Clone, Copy)]
 pub struct HardStopStep {
     pub drawdown_raw: f64,
+    pub drawdown_ema: f64,
     pub drawdown_score: f64,
     pub tier: HardStopTier,
     pub changed: bool,
@@ -135,6 +136,31 @@ impl RollingPeakTracker {
         }
         self.peaks.push_back((timestamp_ms, equity));
         Ok(self.peaks.front().map(|(_, eq)| *eq).unwrap_or(equity))
+    }
+}
+
+/// Whether the permanent no-restart halt trips for a finalized RED stop.
+///
+/// Contract (fable audit plan, clarified 2026-07-06): the no-restart trigger
+/// is conservative and uses `max(drawdown_raw, drawdown_ema)` so it catches
+/// either catastrophic instantaneous damage or sustained smoothed damage,
+/// while the RED/panic-now tier score stays `min(raw, ema)`.
+pub fn no_restart_triggered(
+    restart_after_red_policy: &str,
+    drawdown_raw: f64,
+    drawdown_ema: f64,
+    no_restart_drawdown_threshold: f64,
+) -> Result<bool, String> {
+    match restart_after_red_policy {
+        "always" => Ok(false),
+        "threshold" => {
+            Ok(drawdown_raw.max(drawdown_ema) >= no_restart_drawdown_threshold)
+        }
+        "never" => Ok(true),
+        raw => Err(format!(
+            "hsl_restart_after_red_policy must be one of always, threshold, never; got {:?}",
+            raw
+        )),
     }
 }
 
@@ -213,6 +239,7 @@ pub fn step_with_peak_strategy_equity_latch(
         };
         let step = HardStopStep {
             drawdown_raw: 0.0,
+            drawdown_ema: state.drawdown_ema.max(0.0),
             drawdown_score: 0.0,
             tier: state.tier,
             changed: state.tier != prev_tier,
@@ -281,6 +308,7 @@ pub fn step_with_peak_strategy_equity_latch(
     state.last_minute = Some(current_minute);
     let step = HardStopStep {
         drawdown_raw,
+        drawdown_ema: state.drawdown_ema.max(0.0),
         drawdown_score,
         tier: state.tier,
         changed: state.tier != prev_tier,

--- a/passivbot-rust/src/lib.rs
+++ b/passivbot-rust/src/lib.rs
@@ -68,6 +68,7 @@ fn passivbot_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(gate_entries_by_twel_py, m)?)?;
     m.add_function(wrap_pyfunction!(calc_unstucking_close_py, m)?)?;
     m.add_function(wrap_pyfunction!(trailing_bundle_default_py, m)?)?;
+    m.add_function(wrap_pyfunction!(hsl_no_restart_triggered, m)?)?;
     m.add_function(wrap_pyfunction!(update_trailing_bundle_py, m)?)?;
     m.add_function(wrap_pyfunction!(equity_hard_stop_step_py, m)?)?;
     m.add_function(wrap_pyfunction!(select_coin_indices_py, m)?)?;

--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -520,6 +520,22 @@ pub fn trailing_bundle_default_py() -> (f64, f64, f64, f64) {
 }
 
 #[pyfunction]
+pub fn hsl_no_restart_triggered(
+    restart_after_red_policy: &str,
+    drawdown_raw: f64,
+    drawdown_ema: f64,
+    no_restart_drawdown_threshold: f64,
+) -> PyResult<bool> {
+    ehsl::no_restart_triggered(
+        restart_after_red_policy,
+        drawdown_raw,
+        drawdown_ema,
+        no_restart_drawdown_threshold,
+    )
+    .map_err(pyo3::exceptions::PyValueError::new_err)
+}
+
+#[pyfunction]
 #[pyo3(signature = (highs, lows, closes, bundle=None))]
 pub fn update_trailing_bundle_py(
     highs: PyReadonlyArray1<'_, f64>,

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -2218,16 +2218,27 @@ def _parse_hsl_config(self) -> dict[str, dict[str, Any]]:
     return out
 
 
-def _equity_hard_stop_no_restart_latched(cfg: dict[str, Any], drawdown_raw: float) -> bool:
+def _equity_hard_stop_no_restart_latched(
+    cfg: dict[str, Any], drawdown_raw: float, drawdown_ema: float
+) -> bool:
+    """Shared live/backtest no-restart trigger, owned by Rust.
+
+    Contract (fable audit plan, clarified 2026-07-06): the permanent halt is
+    conservative and trips on max(drawdown_raw, drawdown_ema), catching either
+    catastrophic instantaneous damage or sustained smoothed damage.
+    """
     policy = normalize_hsl_restart_after_red_policy(
         cfg.get("restart_after_red_policy", "threshold"),
         path="hsl.restart_after_red_policy",
     )
-    if policy == "always":
-        return False
-    if policy == "never":
-        return True
-    return bool(float(drawdown_raw) >= float(cfg["no_restart_drawdown_threshold"]))
+    return bool(
+        pbr.hsl_no_restart_triggered(
+            policy,
+            float(drawdown_raw),
+            float(drawdown_ema),
+            float(cfg["no_restart_drawdown_threshold"]),
+        )
+    )
 
 
 def _equity_hard_stop_enabled(self, pside: Optional[str] = None) -> bool:
@@ -4133,7 +4144,9 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                         },
                     )
                     no_restart_latched = _equity_hard_stop_no_restart_latched(
-                        cfg, no_restart_drawdown_raw
+                        cfg,
+                        no_restart_drawdown_raw,
+                        float(current_metrics["drawdown_ema"]),
                     )
                     cooldown_until_ms = None
                     if not no_restart_latched and cooldown_ms > 0:
@@ -4790,7 +4803,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         continue
                     stop_drawdown_raw = float(metrics["drawdown_raw"])
                     no_restart_latched = _equity_hard_stop_no_restart_latched(
-                        cfg, stop_drawdown_raw
+                        cfg, stop_drawdown_raw, float(metrics["drawdown_ema"])
                     )
                     cooldown_until_ms = None
                     if not no_restart_latched and cooldown_ms > 0:
@@ -5696,7 +5709,9 @@ async def _equity_hard_stop_finalize_red_stop(
         no_restart_peak_strategy_equity,
         no_restart_drawdown_raw,
     ) = self._equity_hard_stop_record_no_restart_stop(pside, stop_event)
-    no_restart_latched = _equity_hard_stop_no_restart_latched(cfg, no_restart_drawdown_raw)
+    no_restart_latched = _equity_hard_stop_no_restart_latched(
+        cfg, no_restart_drawdown_raw, float(stop_event["drawdown_ema"])
+    )
     cooldown_ms = int(round(cooldown_minutes * 60_000.0)) if cooldown_minutes > 0.0 else 0
     cooldown_until_ms = None if no_restart_latched or cooldown_ms <= 0 else int(stop_ts_ms + cooldown_ms)
     payload = self._equity_hard_stop_build_latch_payload(
@@ -5837,7 +5852,9 @@ async def _equity_hard_stop_finalize_coin_red_stop(
     else:
         stop_ts_ms = int(stop_event["stop_event_timestamp_ms"])
     cooldown_minutes = float(cfg["cooldown_minutes_after_red"])
-    no_restart_latched = _equity_hard_stop_no_restart_latched(cfg, stop_event["drawdown_raw"])
+    no_restart_latched = _equity_hard_stop_no_restart_latched(
+        cfg, stop_event["drawdown_raw"], float(stop_event["drawdown_ema"])
+    )
     cooldown_ms = int(round(cooldown_minutes * 60_000.0)) if cooldown_minutes > 0.0 else 0
     cooldown_until_ms = None if no_restart_latched or cooldown_ms <= 0 else int(stop_ts_ms + cooldown_ms)
     payload = self._equity_hard_stop_build_latch_payload(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,6 +65,25 @@ def _install_passivbot_rust_stub():
     )
     stub.calc_min_entry_qty = lambda *args, **kwargs: 0.0
     stub.calc_min_entry_qty_py = stub.calc_min_entry_qty
+
+    def _hsl_no_restart_triggered(
+        restart_after_red_policy, drawdown_raw, drawdown_ema, no_restart_drawdown_threshold
+    ):
+        # Mirrors ehsl::no_restart_triggered exactly (max(raw, ema) contract).
+        if restart_after_red_policy == "always":
+            return False
+        if restart_after_red_policy == "threshold":
+            return max(float(drawdown_raw), float(drawdown_ema)) >= float(
+                no_restart_drawdown_threshold
+            )
+        if restart_after_red_policy == "never":
+            return True
+        raise ValueError(
+            "hsl_restart_after_red_policy must be one of always, threshold, never; "
+            f"got {restart_after_red_policy!r}"
+        )
+
+    stub.hsl_no_restart_triggered = _hsl_no_restart_triggered
     stub.round_ = _round
     stub.round_dn = _round_dn
     stub.round_up = _round_up

--- a/tests/test_hsl_metric_regression.py
+++ b/tests/test_hsl_metric_regression.py
@@ -257,6 +257,82 @@ def test_coin_metrics_reject_nonpositive_slot_inputs():
         )
 
 
+def test_no_restart_trigger_uses_max_of_raw_and_ema():
+    # Contract (plan B2.1, clarified 2026-07-06): the permanent no-restart
+    # halt trips on max(drawdown_raw, drawdown_ema) — conservative, catching
+    # catastrophic instantaneous damage OR sustained smoothed damage — while
+    # the RED/panic-now tier score stays min(raw, ema).
+    cfg = {
+        "restart_after_red_policy": "threshold",
+        "no_restart_drawdown_threshold": 0.2,
+    }
+    assert hsl._equity_hard_stop_no_restart_latched(cfg, 0.25, 0.05) is True
+    # Sustained smoothed damage trips the halt even after raw recovered.
+    assert hsl._equity_hard_stop_no_restart_latched(cfg, 0.05, 0.25) is True
+    assert hsl._equity_hard_stop_no_restart_latched(cfg, 0.15, 0.19) is False
+    assert (
+        hsl._equity_hard_stop_no_restart_latched(
+            dict(cfg, restart_after_red_policy="always"), 1.0, 1.0
+        )
+        is False
+    )
+    assert (
+        hsl._equity_hard_stop_no_restart_latched(
+            dict(cfg, restart_after_red_policy="never"), 0.0, 0.0
+        )
+        is True
+    )
+    with pytest.raises(ValueError):
+        hsl._equity_hard_stop_no_restart_latched(
+            dict(cfg, restart_after_red_policy="sometimes"), 1.0, 1.0
+        )
+
+
+def test_red_tier_score_is_min_of_raw_and_ema():
+    # Pin the existing Rust runtime semantics as the #1122 RED contract:
+    # min(raw, ema) must cross red_threshold, so a raw flash-crash spike with
+    # a calm EMA does not trigger RED, and a stale high EMA after recovery
+    # does not either.
+    bot = _make_bot("unified")
+
+    def sample(ts, upnl_total):
+        return bot._equity_hard_stop_apply_sample(
+            "long",
+            ts,
+            100.0,
+            0.0,
+            0.0,
+            0.0,
+            unrealized_pnl_total=upnl_total,
+            latch_red=False,
+        )
+
+    slow_bot = _make_bot("unified")
+    slow_bot.hsl["long"]["ema_span_minutes"] = 60.0
+
+    def slow_sample(ts, upnl_total):
+        return slow_bot._equity_hard_stop_apply_sample(
+            "long",
+            ts,
+            100.0,
+            0.0,
+            0.0,
+            0.0,
+            unrealized_pnl_total=upnl_total,
+            latch_red=False,
+        )
+
+    slow_sample(60_000, 10.0)
+    # Raw crashes 30/110 > red 0.2 but the 60m EMA stays calm: no RED.
+    m = slow_sample(120_000, -20.0)
+    assert m["drawdown_raw"] > m["red_threshold"]
+    assert m["drawdown_ema"] < m["red_threshold"]
+    assert m["drawdown_score"] == pytest.approx(
+        min(m["drawdown_raw"], m["drawdown_ema"])
+    )
+    assert m["tier"] != "red"
+
+
 def test_red_latching_holds_tier_after_recovery():
     bot = _make_bot("unified")
 

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -20,6 +20,25 @@ def _make_mock_pbr():
 
     module.get_strategy_kinds = _get_strategy_kinds
 
+    def _hsl_no_restart_triggered(
+        restart_after_red_policy, drawdown_raw, drawdown_ema, no_restart_drawdown_threshold
+    ):
+        # Mirrors ehsl::no_restart_triggered exactly (max(raw, ema) contract).
+        if restart_after_red_policy == "always":
+            return False
+        if restart_after_red_policy == "threshold":
+            return max(float(drawdown_raw), float(drawdown_ema)) >= float(
+                no_restart_drawdown_threshold
+            )
+        if restart_after_red_policy == "never":
+            return True
+        raise ValueError(
+            "hsl_restart_after_red_policy must be one of always, threshold, never; "
+            f"got {restart_after_red_policy!r}"
+        )
+
+    module.hsl_no_restart_triggered = _hsl_no_restart_triggered
+
     class _EquityHardStopRollingPeak:
         def __init__(self):
             self._peaks = []


### PR DESCRIPTION
First behavior slice of the clarified episode/RED/no-restart contract (#1122, plan B2.1). The permanent no-restart halt now trips on `max(drawdown_raw, drawdown_ema) >= hsl_no_restart_drawdown_threshold` in **both** live and backtest; previously both evaluated raw drawdown only, under-triggering whenever sustained smoothed damage exceeded the instantaneous drawdown at the stop sample (e.g., deep drawdown with partial recovery right before the scope flattened). The RED/panic-now trigger is **unchanged**: recon showed the shared Rust runtime already implements the contract's `min(raw, ema)` tier score — this PR pins that with a regression test instead of touching it.

Centralization (per the guiding contract added in #1124): the predicate is owned by Rust and consumed by both paths —

- `ehsl::no_restart_triggered(policy, drawdown_raw, drawdown_ema, threshold)` in the shared `equity_hard_stop_loss` module, with the policy semantics unchanged (`always` → never latch, `never` → always latch, `threshold` → the max comparison).
- Backtest: `hsl_no_restart_latched` delegates to it; `HardStopStep` and the backtest stop snapshots now carry `drawdown_ema` (populated from the shared runtime state at snapshot time), and both evaluation sites (pside and coin paths) pass it. Rust unit tests updated, including the decisive `("threshold", raw=0.02, ema=0.11, thr=0.10) → latched` case.
- Live: exposed as `pbr.hsl_no_restart_triggered` via PyO3; `_equity_hard_stop_no_restart_latched` delegates, and all four finalize/latch call sites pass the matching `drawdown_ema` from their metrics/stop events (coin metrics finalize, stop-metrics finalize, recorded no-restart stop, coin stop event).

Tests/evidence:
- PyO3 predicate verified end-to-end after a fingerprint-stamped rebuild (all policies + invalid-policy ValueError).
- New contract pins in `tests/test_hsl_metric_regression.py`: max-trigger semantics across the three policies (including ema-trips-while-raw-recovered), and the RED `min(raw, ema)` pin — a raw flash-crash spike against a calm 60m EMA must not trigger RED (cites the #1122 rationale; users wanting raw sensitivity set `hsl_ema_span_minutes=1`).
- `venv/bin/python -m pytest tests/test_hsl_coin_mode.py tests/test_unstucking_safeguards.py tests/test_equity_hard_stop_rolling_peak.py tests/test_hsl_metric_regression.py` — 232 passed; full suite shows only the 3 known pre-existing out-of-scope failures (see #1116).
- CHANGELOG entry (user-facing behavior change: backtest results and live no-restart decisions can differ where ema > raw at the stop).
- `git diff --check` — clean.

Remaining #1122 contract items (separate PRs, tracked): red_active_now vs red_seen_in_episode supervision split, episode-end cooldown anchor, incomplete-history startup policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)