### PR TITLE
Authorize HSL panic orders from red_active_now only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- HSL panic orders are now authorized only while the CURRENT drawdown sample
+  is in RED (`red_active_now`), in both live and backtest. Previously a
+  latched RED episode kept emitting panic closes until the scope was flat
+  even after the drawdown recovered; now a recovered sample pauses panic
+  emission for the remainder of the episode while entries stay blocked
+  (`tp_only_with_active_entry_cancellation`), and panic resumes if RED
+  re-activates. Flat-scope stop finalization, cooldown, and no-restart
+  accounting are unchanged and still use the episode's RED evidence.
+
 - The HSL no-restart (permanent halt) trigger now evaluates
   `max(drawdown_raw, drawdown_ema)` against
   `hsl_no_restart_drawdown_threshold` in both live and backtest, instead of

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -898,6 +898,20 @@ Remaining implementation details:
       this slice: the tier latch still pins display red; the follow-up slice
       rewires panic authorization to consume `red_active_now` only and moves
       the cooldown anchor to the scoped episode-end fill timestamp.
+      Implemented (panic authorization): live coin and unified/pside RED
+      supervisors now refresh a sample each cycle and emit panic modes only
+      while `red_active_now`; a recovered sample downgrades the scope to
+      `tp_only_with_active_entry_cancellation` for the remainder of the
+      episode and re-engages panic if RED re-activates. Backtest parity: the
+      pside/coin mode overrides gate `TradingMode::Panic` on the runtime's
+      latest `red_active_now` and fall back to tp-only. Live stop anchors
+      already use the latest panic-fill timestamp (the flattening fill for
+      bot-flattened episodes); the manual-flatten anchor refinement and the
+      incomplete-history policy remain open.
+      Observed while implementing (pre-existing, not this slice): the
+      backtest ORANGE `TpOnly` override still skips flat symbols
+      (`apply_orange_override` has-pos gate), which diverges from the
+      live A2.2 contract; needs its own parity fix.
 - [x] Dynamic WEL and snapped/raw balance docs/tests.
       Make `reduce_overweight` use dynamic currently-tradable slot count, keep
       snapped/raw balance separation, and add high-hysteresis warning/preflight

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -460,6 +460,10 @@ fn hsl_no_restart_latched(
 struct HardStopPsideRuntime {
     state: Option<ehsl::HardStopState>,
     tier: ehsl::HardStopTier,
+    // B2.1 red split: whether the LATEST sample crossed RED. Only this may
+    // authorize panic-mode order emission; a latched red tier alone keeps
+    // entry blocking but no new panic orders.
+    red_active_now: bool,
     rolling_peak_strategy_pnl: VecDeque<(u64, f64)>,
     halted: bool,
     no_restart_latched: bool,
@@ -3248,7 +3252,15 @@ impl<'a> Backtest<'a> {
         }
         match runtime.tier {
             ehsl::HardStopTier::Red => {
-                *mode = Some(orchestrator::TradingMode::Panic);
+                if runtime.red_active_now {
+                    *mode = Some(orchestrator::TradingMode::Panic);
+                } else {
+                    // B2.1 red split: RED seen this episode but the current
+                    // sample recovered. Block entries for the remainder of
+                    // the episode without authorizing new panic orders,
+                    // matching the live supervisor's paused-red mode.
+                    *mode = Some(orchestrator::TradingMode::TpOnly);
+                }
             }
             ehsl::HardStopTier::Orange => {
                 let target = self.hard_stop_orange_target_mode_pside(pside);
@@ -3280,7 +3292,15 @@ impl<'a> Backtest<'a> {
         }
         match runtime.tier {
             ehsl::HardStopTier::Red => {
-                *mode = Some(orchestrator::TradingMode::Panic);
+                if runtime.red_active_now {
+                    *mode = Some(orchestrator::TradingMode::Panic);
+                } else {
+                    // B2.1 red split: RED seen this episode but the current
+                    // sample recovered. Block entries for the remainder of
+                    // the episode without authorizing new panic orders,
+                    // matching the live supervisor's paused-red mode.
+                    *mode = Some(orchestrator::TradingMode::TpOnly);
+                }
             }
             ehsl::HardStopTier::Orange => {
                 let target = self.hard_stop_orange_target_mode_pside(pside);
@@ -3568,6 +3588,7 @@ impl<'a> Backtest<'a> {
         let runtime = &mut self.hard_stop_pside[pside];
         let prev_tier = runtime.tier;
         runtime.tier = step.tier;
+        runtime.red_active_now = step.red_active_now;
 
         if step.tier == ehsl::HardStopTier::Red {
             if prev_tier != ehsl::HardStopTier::Red {
@@ -3765,6 +3786,7 @@ impl<'a> Backtest<'a> {
         let runtime = &mut self.hard_stop_coin[pside][idx];
         let prev_tier = runtime.tier;
         runtime.tier = step.tier;
+        runtime.red_active_now = step.red_active_now;
 
         if step.tier == ehsl::HardStopTier::Red {
             if prev_tier != ehsl::HardStopTier::Red {

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1855,6 +1855,9 @@ class Passivbot:
     _equity_hard_stop_set_red_runtime_forced_modes = (
         pb_hsl._equity_hard_stop_set_red_runtime_forced_modes
     )
+    _equity_hard_stop_set_red_paused_runtime_forced_modes = (
+        pb_hsl._equity_hard_stop_set_red_paused_runtime_forced_modes
+    )
     _equity_hard_stop_set_coin_runtime_forced_mode = (
         pb_hsl._equity_hard_stop_set_coin_runtime_forced_mode
     )

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -5505,7 +5505,17 @@ def _equity_hard_stop_coin_needs_panic_supervision(
     if not self._equity_hard_stop_enabled(pside):
         return False
     if state["runtime"].red_latched() and not state["halted"]:
-        return True
+        # B2.1 contract (clarified 2026-07-06): only the CURRENT sample being
+        # in RED may authorize new panic orders. A latched tier with a
+        # recovered sample keeps the episode's entry blocking (forced-mode
+        # downgrade handled by the supervisor) but must not keep submitting
+        # panic orders.
+        last_metrics = state.get("last_metrics")
+        if last_metrics is None:
+            # No sample yet against the latched state: stay protective until
+            # the next sample proves recovery.
+            return True
+        return bool(last_metrics.get("red_active_now", True))
     return bool(state["halted"] and state["cooldown_repanic_reset_pending"])
 
 
@@ -5534,6 +5544,31 @@ def _equity_hard_stop_set_red_runtime_forced_modes(self, pside: str) -> None:
             previous_modes=previous,
             modes=forced,
             reason_code="hsl_red_runtime_forced_modes",
+        )
+
+
+def _equity_hard_stop_set_red_paused_runtime_forced_modes(self, pside: str) -> None:
+    """Episode entry blocking without panic emission (B2.1 red split).
+
+    Used while a red-seen episode is still open but the current sample is no
+    longer in RED: entries stay cancelled/blocked, normal closes may proceed,
+    and no new panic orders are authorized.
+    """
+    previous = dict(getattr(self, "_runtime_forced_modes", {}).get(pside, {}) or {})
+    forced = {}
+    symbols = set(self.positions.keys()) | set(self.open_orders.keys()) | set(self.active_symbols)
+    for symbol in symbols:
+        forced[symbol] = "tp_only_with_active_entry_cancellation"
+    self._runtime_forced_modes[pside] = forced
+    if previous != forced:
+        _emit_runtime_forced_mode_changed_event(
+            self,
+            pside=pside,
+            action="replace",
+            symbols=forced.keys(),
+            previous_modes=previous,
+            modes=forced,
+            reason_code="hsl_red_paused_runtime_forced_modes",
         )
 
 
@@ -6029,7 +6064,50 @@ async def _equity_hard_stop_run_red_supervisor(self) -> None:
             if not active_red_psides:
                 return
             for pside in active_red_psides:
-                self._equity_hard_stop_set_red_runtime_forced_modes(pside)
+                # B2.1 contract: refresh the sample so recovery is observable
+                # mid-supervision; only red_active_now authorizes continued
+                # panic emission for the episode. Any refresh failure keeps
+                # panic modes: recovery must be PROVEN by a fresh sample.
+                metrics = None
+                try:
+                    signal_mode = self._equity_hard_stop_signal_mode()
+                    upnl_total = (
+                        float(await self._calc_upnl_sum_strict())
+                        if signal_mode == "unified"
+                        else None
+                    )
+                    metrics = self._equity_hard_stop_apply_sample(
+                        pside,
+                        int(self.get_exchange_time()),
+                        float(self.get_raw_balance()),
+                        float(self._equity_hard_stop_realized_pnl_now()),
+                        float(self._equity_hard_stop_realized_pnl_now(pside)),
+                        float(await self._calc_upnl_sum_strict(pside)),
+                        unrealized_pnl_total=upnl_total,
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    logging.warning(
+                        "[risk] HSL[%s] RED supervisor sample refresh failed; "
+                        "keeping panic modes (recovery must be proven) | "
+                        "error=%s: %s",
+                        pside,
+                        type(exc).__name__,
+                        exc,
+                    )
+                if metrics is not None and not bool(
+                    metrics.get("red_active_now", True)
+                ):
+                    logging.info(
+                        "[risk] HSL[%s] RED no longer active on current sample; "
+                        "pausing panic emission for the remainder of the episode "
+                        "(entries stay blocked)",
+                        pside,
+                    )
+                    self._equity_hard_stop_set_red_paused_runtime_forced_modes(pside)
+                else:
+                    self._equity_hard_stop_set_red_runtime_forced_modes(pside)
             self._equity_hard_stop_refresh_halted_runtime_forced_modes()
             try:
                 to_cancel, to_create = (
@@ -6105,7 +6183,51 @@ async def _equity_hard_stop_run_coin_red_supervisor(self) -> None:
                             nonpanic_close_orders=nonpanic_close_orders,
                         )
                 else:
-                    self._equity_hard_stop_set_coin_runtime_forced_mode(pside, symbol, "panic")
+                    # B2.1 contract: refresh the sample so recovery is
+                    # observable mid-supervision; only red_active_now may
+                    # authorize continued panic emission. A recovered sample
+                    # inside a red-seen episode keeps entry blocking without
+                    # new panic orders; supervision re-engages if RED
+                    # re-activates. Any refresh failure keeps panic modes:
+                    # recovery must be PROVEN by a fresh sample.
+                    metrics = None
+                    try:
+                        metrics = self._equity_hard_stop_apply_coin_sample(
+                            pside,
+                            symbol,
+                            int(self.get_exchange_time()),
+                            float(self.get_raw_balance()),
+                            float(await self._calc_upnl_sum_strict(pside, symbol)),
+                        )
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as exc:
+                        logging.warning(
+                            "[risk] HSL[%s:%s] RED supervisor sample refresh "
+                            "failed; keeping panic mode (recovery must be "
+                            "proven) | error=%s: %s",
+                            pside,
+                            symbol,
+                            type(exc).__name__,
+                            exc,
+                        )
+                    if metrics is not None and not bool(
+                        metrics.get("red_active_now", True)
+                    ):
+                        logging.info(
+                            "[risk] HSL[%s:%s] RED no longer active on current "
+                            "sample; pausing panic emission for the remainder "
+                            "of the episode (entries stay blocked)",
+                            pside,
+                            symbol,
+                        )
+                        self._equity_hard_stop_set_coin_runtime_forced_mode(
+                            pside, symbol, "tp_only_with_active_entry_cancellation"
+                        )
+                    else:
+                        self._equity_hard_stop_set_coin_runtime_forced_mode(
+                            pside, symbol, "panic"
+                        )
             active = [
                 (pside, symbol)
                 for pside in self._hsl_psides()

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -3925,7 +3925,17 @@ def _equity_hard_stop_refresh_halted_runtime_forced_modes(self) -> None:
             continue
         state = self._hsl_state(pside)
         if self._equity_hard_stop_runtime_red_latched(pside) and not state["halted"]:
-            self._equity_hard_stop_set_red_runtime_forced_modes(pside)
+            # B2.1 red split: a latched episode whose CURRENT sample has
+            # recovered stays entry-blocked without panic authorization; the
+            # centralized refresher must not overwrite the paused state back
+            # to panic. Unknown/missing sample stays protective (panic).
+            last_metrics = state.get("last_metrics")
+            if last_metrics is not None and not bool(
+                last_metrics.get("red_active_now", True)
+            ):
+                self._equity_hard_stop_set_red_paused_runtime_forced_modes(pside)
+            else:
+                self._equity_hard_stop_set_red_runtime_forced_modes(pside)
             continue
         if not state["halted"]:
             self._equity_hard_stop_clear_runtime_forced_modes(pside)
@@ -5494,6 +5504,55 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
                     self._equity_hard_stop_set_coin_runtime_forced_mode(
                         pside, symbol, "tp_only_with_active_entry_cancellation"
                     )
+            if (
+                state["runtime"].red_latched()
+                and not state["halted"]
+                and not bool(metrics.get("red_active_now", True))
+            ):
+                # B2.1 red split: the episode saw RED but the current sample
+                # recovered, so panic supervision is disengaged. The regular
+                # check path owns the paused episode: keep entries blocked and
+                # perform the flat-confirmation/finalization the supervisor
+                # would otherwise do, so cooldown/no-restart accounting can
+                # never be skipped just because RED recovered before flat.
+                self._equity_hard_stop_set_coin_runtime_forced_mode(
+                    pside, symbol, "tp_only_with_active_entry_cancellation"
+                )
+                has_position = self._equity_hard_stop_has_open_position_symbol(
+                    pside, symbol
+                )
+                entry_orders, nonpanic_close_orders = (
+                    self._equity_hard_stop_count_blocking_open_orders_symbol(
+                        pside, symbol
+                    )
+                )
+                if not has_position and entry_orders == 0 and nonpanic_close_orders == 0:
+                    stop_ts_ms = self._equity_hard_stop_latest_panic_fill_timestamp_ms(
+                        pside,
+                        symbol=symbol,
+                        since_ms=state.get("pending_red_since_ms"),
+                        fallback_ms=ts_ms,
+                    )
+                    state["pending_stop_event"] = (
+                        await self._equity_hard_stop_compute_coin_stop_event(
+                            pside, symbol, stop_ts_ms
+                        )
+                    )
+                    state["red_flat_confirmations"] += 1
+                else:
+                    state["red_flat_confirmations"] = 0
+                    state["pending_stop_event"] = None
+                if state["red_flat_confirmations"] >= 2:
+                    await self._equity_hard_stop_finalize_coin_red_stop(
+                        pside,
+                        symbol,
+                        state["pending_stop_event"],
+                        finalized_without_order=True,
+                        flat_confirmations=state["red_flat_confirmations"],
+                        entry_orders=entry_orders,
+                        nonpanic_close_orders=nonpanic_close_orders,
+                    )
+                    state = self._hsl_coin_state(pside, symbol)
             self._equity_hard_stop_emit_coin_status(pside, symbol, metrics)
             out[f"{pside}:{symbol}"] = metrics
     return out if out else None

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -703,6 +703,64 @@ def test_hsl_replay_cache_account_digest_scoped_to_lookback():
     assert hsl._hsl_replay_cache_account_config_digest(bot) != digest
 
 
+def test_coin_panic_supervision_requires_red_active_now():
+    # B2.1 red split: a latched red episode authorizes panic supervision only
+    # while the CURRENT sample is in RED.
+    bot = make_coin_bot()
+    symbol = "A"
+    state = bot._hsl_coin_state("long", symbol)
+    state["runtime"].apply_sample(
+        timestamp_ms=60_000, equity=100.0, peak_strategy_equity=100.0,
+        red_threshold=0.2, ema_span_minutes=1.0,
+        tier_ratio_yellow=0.5, tier_ratio_orange=0.75, latch_red=True,
+    )
+    state["runtime"].apply_sample(
+        timestamp_ms=120_000, equity=70.0, peak_strategy_equity=100.0,
+        red_threshold=0.2, ema_span_minutes=1.0,
+        tier_ratio_yellow=0.5, tier_ratio_orange=0.75, latch_red=True,
+    )
+    assert state["runtime"].red_latched() is True
+
+    # No metrics yet against the latched state: stay protective.
+    state["last_metrics"] = None
+    assert (
+        bot._equity_hard_stop_coin_needs_panic_supervision("long", symbol, state)
+        is True
+    )
+    # Current sample in RED: panic authorized.
+    state["last_metrics"] = {"red_active_now": True}
+    assert (
+        bot._equity_hard_stop_coin_needs_panic_supervision("long", symbol, state)
+        is True
+    )
+    # Current sample recovered: no new panic orders for this episode.
+    state["last_metrics"] = {"red_active_now": False}
+    assert (
+        bot._equity_hard_stop_coin_needs_panic_supervision("long", symbol, state)
+        is False
+    )
+    # Halted repanic-reset supervision is unaffected by the split.
+    state["halted"] = True
+    state["cooldown_repanic_reset_pending"] = True
+    assert (
+        bot._equity_hard_stop_coin_needs_panic_supervision("long", symbol, state)
+        is True
+    )
+
+
+def test_red_paused_forced_modes_block_entries_without_panic():
+    bot = make_coin_bot()
+    bot.positions = {"A": {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}}
+    bot.open_orders = {"B": []}
+    bot.active_symbols = ["C"]
+
+    bot._equity_hard_stop_set_red_paused_runtime_forced_modes("long")
+
+    forced = bot._runtime_forced_modes["long"]
+    assert set(forced) == {"A", "B", "C"}
+    assert set(forced.values()) == {"tp_only_with_active_entry_cancellation"}
+
+
 def test_hsl_replay_cache_dir_is_sanitized_and_digest_scoped():
     bot = make_coin_bot()
     bot.exchange = "binance/usdm"
@@ -1198,6 +1256,7 @@ def bind_hsl_methods(bot):
         "_equity_hard_stop_persist_replay_matrices",
         "_try_load_hsl_replay_matrix_cache",
         "_equity_hard_stop_try_reuse_replay_cache",
+        "_equity_hard_stop_set_red_paused_runtime_forced_modes",
         "_equity_hard_stop_build_latch_payload",
         "_equity_hard_stop_check_coin",
         "_equity_hard_stop_clear_coin_runtime_forced_mode",

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -748,6 +748,116 @@ def test_coin_panic_supervision_requires_red_active_now():
     )
 
 
+@pytest.mark.asyncio
+async def test_recovered_red_episode_finalizes_from_check_path():
+    # Codex blocker regression on the red split: RED latches, the sample
+    # recovers while the position is open (panic pauses, tp-only holds), the
+    # position later flattens normally, and the episode MUST still be
+    # finalized (halt + cooldown) by the regular check path without RED ever
+    # re-activating and without the panic supervisor running.
+    bot = make_coin_bot()
+    symbol = "A"
+    bot.positions = {
+        symbol: {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}
+    }
+    bot.open_orders = {}
+    bot.active_symbols = [symbol]
+    upnl_box = {"value": 0.0}
+
+    async def calc_upnl(pside=None, sym=None):
+        return upnl_box["value"]
+
+    bot._calc_upnl_sum_strict = calc_upnl
+    now_box = {"ts": 60_000}
+    bot.get_exchange_time = lambda: now_box["ts"]
+
+    # Warmup green sample, then crash through RED (slot budget 50, red 0.5).
+    await bot._equity_hard_stop_check_coin()
+    now_box["ts"] = 120_000
+    upnl_box["value"] = -30.0
+    out = await bot._equity_hard_stop_check_coin()
+    state = bot._hsl_coin_state("long", symbol)
+    assert out[f"long:{symbol}"]["tier"] == "red"
+    assert state["runtime"].red_latched() is True
+    assert bot._runtime_forced_modes["long"][symbol] == "panic"
+
+    # Recovery while the position is still open: panic pauses, tp-only holds,
+    # and the panic supervisor is NOT needed.
+    now_box["ts"] = 180_000
+    upnl_box["value"] = 0.0
+    out = await bot._equity_hard_stop_check_coin()
+    state = bot._hsl_coin_state("long", symbol)
+    assert out[f"long:{symbol}"]["red_active_now"] is False
+    assert (
+        bot._runtime_forced_modes["long"][symbol]
+        == "tp_only_with_active_entry_cancellation"
+    )
+    assert (
+        bot._equity_hard_stop_coin_needs_panic_supervision("long", symbol, state)
+        is False
+    )
+    assert state["halted"] is False
+
+    # The position closes normally under tp-only; two check cycles confirm
+    # flat and finalize the episode: halt + cooldown, no RED re-activation.
+    bot.positions = {
+        symbol: {"long": {"size": 0.0, "price": 0.0}, "short": {"size": 0.0}}
+    }
+    bot.active_symbols = []
+    now_box["ts"] = 240_000
+    await bot._equity_hard_stop_check_coin()
+    state = bot._hsl_coin_state("long", symbol)
+    assert state["red_flat_confirmations"] == 1
+    assert state["halted"] is False
+    now_box["ts"] = 300_000
+    await bot._equity_hard_stop_check_coin()
+    state = bot._hsl_coin_state("long", symbol)
+    assert state["halted"] is True
+    assert state["cooldown_until_ms"] is not None
+
+
+def test_forced_mode_refresher_preserves_paused_red(monkeypatch):
+    # Hermes finding on the red split: the centralized refresher used to
+    # overwrite the paused tp-only modes back to panic for any latched
+    # non-halted pside. It must derive panic vs paused from the latest
+    # sample's red_active_now, staying protective when no sample exists.
+    bot = make_coin_bot()
+    bot.positions = {"A": {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}}
+    bot.open_orders = {}
+    bot.active_symbols = ["A"]
+    state = bot._hsl_state("long")
+    state["runtime"].apply_sample(
+        timestamp_ms=60_000, equity=100.0, peak_strategy_equity=100.0,
+        red_threshold=0.2, ema_span_minutes=1.0,
+        tier_ratio_yellow=0.5, tier_ratio_orange=0.75, latch_red=True,
+    )
+    state["runtime"].apply_sample(
+        timestamp_ms=120_000, equity=70.0, peak_strategy_equity=100.0,
+        red_threshold=0.2, ema_span_minutes=1.0,
+        tier_ratio_yellow=0.5, tier_ratio_orange=0.75, latch_red=True,
+    )
+    assert state["runtime"].red_latched() is True
+
+    # No sample recorded: protective panic.
+    state["last_metrics"] = None
+    bot._equity_hard_stop_refresh_halted_runtime_forced_modes()
+    assert bot._runtime_forced_modes["long"]["A"] == "panic"
+
+    # Active sample: panic.
+    state["last_metrics"] = {"red_active_now": True}
+    bot._equity_hard_stop_refresh_halted_runtime_forced_modes()
+    assert bot._runtime_forced_modes["long"]["A"] == "panic"
+
+    # Recovered sample: the paused tp-only modes survive the refresher.
+    state["last_metrics"] = {"red_active_now": False}
+    bot._equity_hard_stop_set_red_paused_runtime_forced_modes("long")
+    bot._equity_hard_stop_refresh_halted_runtime_forced_modes()
+    assert (
+        bot._runtime_forced_modes["long"]["A"]
+        == "tp_only_with_active_entry_cancellation"
+    )
+
+
 def test_red_paused_forced_modes_block_entries_without_panic():
     bot = make_coin_bot()
     bot.positions = {"A": {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}}
@@ -1242,6 +1352,7 @@ def bind_hsl_methods(bot):
         "_equity_hard_stop_coin_symbols",
         "_equity_hard_stop_handle_coin_position_during_cooldown",
         "_equity_hard_stop_has_open_position_symbol",
+        "_equity_hard_stop_count_blocking_open_orders_symbol",
         "_equity_hard_stop_history_coin_value",
         "_equity_hard_stop_initialize_coin_from_history",
         "_equity_hard_stop_infer_coin_replay_contract",
@@ -1257,6 +1368,11 @@ def bind_hsl_methods(bot):
         "_try_load_hsl_replay_matrix_cache",
         "_equity_hard_stop_try_reuse_replay_cache",
         "_equity_hard_stop_set_red_paused_runtime_forced_modes",
+        "_equity_hard_stop_refresh_halted_runtime_forced_modes",
+        "_equity_hard_stop_set_red_runtime_forced_modes",
+        "_equity_hard_stop_runtime_red_latched",
+        "_equity_hard_stop_clear_runtime_forced_modes",
+        "_equity_hard_stop_halted_mode",
         "_equity_hard_stop_build_latch_payload",
         "_equity_hard_stop_check_coin",
         "_equity_hard_stop_clear_coin_runtime_forced_mode",

--- a/tests/test_passivbot_hsl_bindings.py
+++ b/tests/test_passivbot_hsl_bindings.py
@@ -49,4 +49,5 @@ def test_passivbot_uses_passivbot_hsl_module_for_hsl_methods():
         "_equity_hard_stop_persist_replay_matrices",
         "_try_load_hsl_replay_matrix_cache",
         "_equity_hard_stop_try_reuse_replay_cache",
+        "_equity_hard_stop_set_red_paused_runtime_forced_modes",
     } <= assigned_names


### PR DESCRIPTION
Second behavior slice of the clarified episode/RED contract (#1122, plan B2.1), building on the #1128 red-split groundwork: **a latched RED episode no longer keeps emitting panic closes until flat** — panic emission is authorized only while the *current* drawdown sample is in RED, in both live and backtest.

**Live**:
- `_equity_hard_stop_coin_needs_panic_supervision` consumes the latest sample's `red_active_now` when latched; no sample yet against a latched state stays protective.
- Both RED supervisors (coin + unified/pside) refresh a metrics sample each cycle. A recovered sample downgrades the scope's forced modes to `tp_only_with_active_entry_cancellation` for the remainder of the episode — entries stay blocked (A2.2 semantics), normal closes proceed, no new panic orders — and panic re-engages if RED re-activates (contract point 5: partial flatten + recovery must not keep panicking). **Any refresh failure keeps panic modes with a warning**: recovery must be *proven* by a fresh sample, so degradation is always in the protective direction (this is also exercised by the orchestration test's minimal fixture).
- Flat-scope stop finalization, cooldown, and no-restart accounting are unchanged — they use the episode's RED evidence (`red_seen_in_episode` / latch), not the moment-to-moment signal.
- New pside-wide `_equity_hard_stop_set_red_paused_runtime_forced_modes`, bound on `Passivbot` and pinned in the AST + fake-bot binding tests.

**Backtest parity**: `HardStopPsideRuntime` records the latest step's `red_active_now` (from the shared runtime step introduced in #1128); the pside and coin mode overrides emit `TradingMode::Panic` only while it is true, falling back to `TpOnly` for the rest of a latched red episode.

**Deliberately unchanged / recorded**: the live stop anchor already uses the latest panic-fill timestamp (the flattening fill for bot-flattened episodes); the manual-flatten anchor refinement and the incomplete-history policy remain tracked as follow-ups. The tracker also records a **pre-existing** backtest ORANGE flat-symbol parity gap observed while implementing (`apply_orange_override`'s has-pos gate diverges from the live A2.2 contract) for its own fix — intentionally not bundled here.

Evidence:
- Predicate pins: no-metrics → protective; active → authorize; recovered → pause; halted repanic-reset unaffected. Paused-mode helper coverage (position/order/active symbols all forced tp-only).
- 251 passed across the affected suites; full suite shows only the 3 known pre-existing out-of-scope failures (see #1116); extension rebuilt fingerprint-stamped before runs.
- CHANGELOG entry (user-facing behavior change in a risk gate, both live and backtest).
- `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)