### PR TITLE
Force flat symbols in backtest ORANGE tp-only scope (A2.2 parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Backtest ORANGE `tp_only_with_active_entry_cancellation` now forces flat
+  symbols in the affected HSL scope too, blocking initial entries exactly
+  like live has since the A2.2 contract change; previously backtests allowed
+  new initial entries during ORANGE for symbols without a position, so
+  backtest results could overstate entry activity near the orange tier.
+
 - HSL panic orders are now authorized only while the CURRENT drawdown sample
   is in RED (`red_active_now`), in both live and backtest. Previously a
   latched RED episode kept emitting panic closes until the scope was flat

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -908,10 +908,11 @@ Remaining implementation details:
       already use the latest panic-fill timestamp (the flattening fill for
       bot-flattened episodes); the manual-flatten anchor refinement and the
       incomplete-history policy remain open.
-      Observed while implementing (pre-existing, not this slice): the
-      backtest ORANGE `TpOnly` override still skips flat symbols
-      (`apply_orange_override` has-pos gate), which diverges from the
-      live A2.2 contract; needs its own parity fix.
+      Implemented (A2.2 backtest parity): the backtest ORANGE `TpOnly`
+      override now forces flat symbols too (`apply_orange_override` has-pos
+      gate removed), matching the live overlay since #1098; the orchestrator's
+      `TpOnly` generates no entries and no flat-symbol closes, so the forced
+      mode is safe for flat scopes.
 - [x] Dynamic WEL and snapped/raw balance docs/tests.
       Make `reduce_overweight` use dynamic currently-tradable slot count, keep
       snapped/raw balance separation, and add high-hysteresis warning/preflight

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -3246,7 +3246,7 @@ impl<'a> Backtest<'a> {
             if pos.size != 0.0 {
                 *mode = Some(orchestrator::TradingMode::Panic);
             } else {
-                Self::apply_orange_override(mode, orchestrator::TradingMode::GracefulStop, false);
+                Self::apply_orange_override(mode, orchestrator::TradingMode::GracefulStop);
             }
             return;
         }
@@ -3264,7 +3264,7 @@ impl<'a> Backtest<'a> {
             }
             ehsl::HardStopTier::Orange => {
                 let target = self.hard_stop_orange_target_mode_pside(pside);
-                Self::apply_orange_override(mode, target, pos.size != 0.0);
+                Self::apply_orange_override(mode, target);
             }
             _ => {}
         }
@@ -3286,7 +3286,7 @@ impl<'a> Backtest<'a> {
             if pos.size != 0.0 {
                 *mode = Some(orchestrator::TradingMode::Panic);
             } else {
-                Self::apply_orange_override(mode, orchestrator::TradingMode::GracefulStop, false);
+                Self::apply_orange_override(mode, orchestrator::TradingMode::GracefulStop);
             }
             return;
         }
@@ -3304,7 +3304,7 @@ impl<'a> Backtest<'a> {
             }
             ehsl::HardStopTier::Orange => {
                 let target = self.hard_stop_orange_target_mode_pside(pside);
-                Self::apply_orange_override(mode, target, pos.size != 0.0);
+                Self::apply_orange_override(mode, target);
             }
             _ => {}
         }
@@ -3314,7 +3314,6 @@ impl<'a> Backtest<'a> {
     fn apply_orange_override(
         mode: &mut Option<orchestrator::TradingMode>,
         target: orchestrator::TradingMode,
-        has_pos: bool,
     ) {
         use orchestrator::TradingMode::*;
         match target {
@@ -3323,9 +3322,10 @@ impl<'a> Backtest<'a> {
                 _ => {}
             },
             TpOnly => {
-                if !has_pos {
-                    return;
-                }
+                // A2.2 contract: ORANGE tp-only blocks initial entries in the
+                // affected scope, so flat symbols are forced too (TpOnly
+                // generates no entries and no closes without a position),
+                // matching the live overlay since #1098.
                 match mode {
                     None | Some(Normal) | Some(GracefulStop) => *mode = Some(TpOnly),
                     _ => {}
@@ -8150,6 +8150,14 @@ mod tests {
 
     #[test]
     fn hard_stop_restart_after_red_policy_controls_terminal_latch() {
+        // A2.2 parity: ORANGE tp-only forces flat symbols too.
+        let mut mode: Option<orchestrator::TradingMode> = None;
+        Backtest::apply_orange_override(&mut mode, orchestrator::TradingMode::TpOnly);
+        assert!(matches!(mode, Some(orchestrator::TradingMode::TpOnly)));
+        let mut manual = Some(orchestrator::TradingMode::Manual);
+        Backtest::apply_orange_override(&mut manual, orchestrator::TradingMode::TpOnly);
+        assert!(matches!(manual, Some(orchestrator::TradingMode::Manual)));
+
         assert!(!hsl_no_restart_latched("always", 1.0, 1.0, 0.10).unwrap());
         assert!(!hsl_no_restart_latched("threshold", 0.09, 0.05, 0.10).unwrap());
         assert!(hsl_no_restart_latched("threshold", 0.10, 0.0, 0.10).unwrap());


### PR DESCRIPTION
Fixes the pre-existing live/backtest parity gap recorded in the tracker while implementing #1129: the backtest's `apply_orange_override` skipped flat symbols for the `TpOnly` target (`if !has_pos { return; }`), so backtests allowed new **initial entries during ORANGE** for symbols without a position — while live has blocked them since the A2.2 contract change (#1098, ORANGE `tp_only_with_active_entry_cancellation` blocks initial entries in the affected scope). Backtest results could therefore overstate entry activity near the orange tier relative to live behavior.

**Change**: the has-pos gate is removed — ORANGE tp-only now forces flat symbols too, in both the pside and coin override paths. Safety argument (documented in-code): the orchestrator's `TpOnly` mode `should_generate_entries → false` unconditionally and `should_generate_closes → has_pos`, so the forced mode is inert for flat scopes beyond blocking initial entries — exactly the live overlay semantics. Mode precedence is unchanged (Manual/Panic are never overridden); GracefulStop targets keep their existing semantics.

Evidence:
- Rust unit test pins flat-symbol forcing (`None → Some(TpOnly)`) and manual-mode precedence (`Manual` untouched).
- Full suite after a fingerprint-stamped rebuild: only the 3 known pre-existing out-of-scope failures (see #1116).
- CHANGELOG entry (backtest behavior change).
- `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)