### PR TITLE
Anchor HSL cooldown at the scope-flattening fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- HSL RED cooldown now anchors at the fill that actually flattened the
+  affected scope, by any means, instead of the latest bot-emitted panic
+  fill. If a position is finished off manually (or by any non-panic close)
+  after the last panic fill, the cooldown window starts at that flattening
+  fill rather than earlier, so cooldowns can no longer expire prematurely
+  for manually-completed flattens.
+
 - Backtest ORANGE `tp_only_with_active_entry_cancellation` now forces flat
   symbols in the affected HSL scope too, blocking initial entries exactly
   like live has since the A2.2 contract change; previously backtests allowed

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -908,6 +908,13 @@ Remaining implementation details:
       already use the latest panic-fill timestamp (the flattening fill for
       bot-flattened episodes); the manual-flatten anchor refinement and the
       incomplete-history policy remain open.
+      Implemented (episode-end anchor): all five live cooldown anchor sites
+      (both supervisors, the check-path finalization, and both
+      repanic-refresh paths) now anchor at the scope's latest fill of any
+      type via `_equity_hard_stop_latest_flatten_fill_timestamp_ms`, falling
+      back to the previous panic-fill anchor and then the caller fallback
+      when no fill evidence exists in the window. Only the incomplete-history
+      policy remains from the #1122 contract.
       Implemented (A2.2 backtest parity): the backtest ORANGE `TpOnly`
       override now forces flat symbols too (`apply_orange_override` has-pos
       gate removed), matching the live overlay since #1098; the orchestrator's

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1757,6 +1757,12 @@ class Passivbot:
     _equity_hard_stop_latest_panic_fill_timestamp_optional_ms = (
         pb_hsl._equity_hard_stop_latest_panic_fill_timestamp_optional_ms
     )
+    _equity_hard_stop_latest_flatten_fill_timestamp_ms = (
+        pb_hsl._equity_hard_stop_latest_flatten_fill_timestamp_ms
+    )
+    _equity_hard_stop_latest_flatten_fill_timestamp_optional_ms = (
+        pb_hsl._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms
+    )
     _get_exchange_fee_rates = pb_hsl._get_exchange_fee_rates
     _orchestrator_exchange_params = pb_hsl._orchestrator_exchange_params
     _equity_hard_stop_realized_pnl_now = pb_hsl._equity_hard_stop_realized_pnl_now

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -2617,6 +2617,60 @@ def _equity_hard_stop_latest_panic_fill_timestamp_ms(
     return int(self.get_exchange_time())
 
 
+def _equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
+    self,
+    pside: str,
+    *,
+    symbol: Optional[str] = None,
+    since_ms: Optional[int] = None,
+) -> Optional[int]:
+    """Latest fill timestamp for the scope, regardless of order type.
+
+    B2.1 contract: the episode ends (and cooldown anchors) at the fill that
+    makes the scoped position set flat, by any means - not only bot-emitted
+    panic fills. Once the scope is flat, its latest fill is that flattening
+    fill.
+    """
+    latest_ts: Optional[int] = None
+    if self._pnls_manager is not None:
+        for event in self._pnls_manager.get_events():
+            if _equity_hard_stop_fill_pside(event) != pside:
+                continue
+            if symbol is not None and _equity_hard_stop_fill_symbol(event) != symbol:
+                continue
+            event_ts = _equity_hard_stop_fill_timestamp_ms(event)
+            if since_ms is not None and event_ts < int(since_ms):
+                continue
+            latest_ts = event_ts if latest_ts is None else max(latest_ts, event_ts)
+    return latest_ts
+
+
+def _equity_hard_stop_latest_flatten_fill_timestamp_ms(
+    self,
+    pside: str,
+    *,
+    symbol: Optional[str] = None,
+    since_ms: Optional[int] = None,
+    fallback_ms: Optional[int] = None,
+) -> int:
+    latest_ts = _equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
+        self,
+        pside,
+        symbol=symbol,
+        since_ms=since_ms,
+    )
+    if latest_ts is not None:
+        return int(latest_ts)
+    # No fill evidence inside the window: fall back to the latest panic fill
+    # (pre-refinement anchor), then the caller-provided fallback.
+    return self._equity_hard_stop_latest_panic_fill_timestamp_ms(
+        pside,
+        symbol=symbol,
+        since_ms=since_ms,
+        fallback_ms=fallback_ms,
+    )
+
+
 def _equity_hard_stop_latest_panic_fill_timestamp_optional_ms(
     self,
     pside: str,
@@ -3587,7 +3641,7 @@ async def _equity_hard_stop_refresh_cooldown_after_repanic(self, pside: str, now
     previous_stop_ts = None
     if state.get("last_stop_event") is not None:
         previous_stop_ts = int(state["last_stop_event"]["stop_event_timestamp_ms"]) + 1
-    stop_ts_ms = self._equity_hard_stop_latest_panic_fill_timestamp_ms(
+    stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_ms(
         pside,
         since_ms=previous_stop_ts,
         fallback_ms=now_ms,
@@ -3652,7 +3706,7 @@ async def _equity_hard_stop_refresh_coin_cooldown_after_repanic(
     previous_stop_ts = None
     if state.get("last_stop_event") is not None:
         previous_stop_ts = int(state["last_stop_event"]["stop_event_timestamp_ms"]) + 1
-    stop_ts_ms = self._equity_hard_stop_latest_panic_fill_timestamp_ms(
+    stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_ms(
         pside,
         symbol=symbol,
         since_ms=previous_stop_ts,
@@ -5527,7 +5581,7 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
                     )
                 )
                 if not has_position and entry_orders == 0 and nonpanic_close_orders == 0:
-                    stop_ts_ms = self._equity_hard_stop_latest_panic_fill_timestamp_ms(
+                    stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_ms(
                         pside,
                         symbol=symbol,
                         since_ms=state.get("pending_red_since_ms"),
@@ -6084,7 +6138,7 @@ async def _equity_hard_stop_run_red_supervisor(self) -> None:
                 n_positions = self._equity_hard_stop_count_open_positions(pside)
                 entry_orders, nonpanic_close_orders = self._equity_hard_stop_count_blocking_open_orders(pside)
                 if n_positions == 0 and entry_orders == 0 and nonpanic_close_orders == 0:
-                    stop_ts_ms = self._equity_hard_stop_latest_panic_fill_timestamp_ms(
+                    stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_ms(
                         pside,
                         since_ms=state.get("pending_red_since_ms"),
                         fallback_ms=int(self.get_exchange_time()),
@@ -6211,7 +6265,7 @@ async def _equity_hard_stop_run_coin_red_supervisor(self) -> None:
                     self._equity_hard_stop_count_blocking_open_orders_symbol(pside, symbol)
                 )
                 if not has_position and entry_orders == 0 and nonpanic_close_orders == 0:
-                    stop_ts_ms = self._equity_hard_stop_latest_panic_fill_timestamp_ms(
+                    stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_ms(
                         pside,
                         symbol=symbol,
                         since_ms=state.get("pending_red_since_ms"),

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -858,6 +858,44 @@ def test_forced_mode_refresher_preserves_paused_red(monkeypatch):
     )
 
 
+def test_cooldown_anchor_uses_scope_flattening_fill():
+    # B2.1: cooldown anchors at the fill that flattened the scope, by any
+    # means. A manual close after the last panic fill must win; with no fills
+    # in the window the panic-fill fallback and then the caller fallback hold.
+    bot = make_coin_bot()
+    events = [
+        SimpleNamespace(
+            position_side="long", symbol="A", timestamp=120_500,
+            pb_order_type="close_panic_long",
+        ),
+        SimpleNamespace(
+            position_side="long", symbol="A", timestamp=150_000,
+            pb_order_type="close_manual_long",
+        ),
+    ]
+    bot._pnls_manager = SimpleNamespace(get_events=lambda: events)
+    assert (
+        bot._equity_hard_stop_latest_flatten_fill_timestamp_ms(
+            "long", symbol="A", since_ms=60_000, fallback_ms=999_000
+        )
+        == 150_000
+    )
+    # Window that excludes both fills: caller fallback.
+    assert (
+        bot._equity_hard_stop_latest_flatten_fill_timestamp_ms(
+            "long", symbol="A", since_ms=200_000, fallback_ms=999_000
+        )
+        == 999_000
+    )
+    # Other-pair fills never leak into the anchor.
+    assert (
+        bot._equity_hard_stop_latest_flatten_fill_timestamp_ms(
+            "long", symbol="B", since_ms=60_000, fallback_ms=999_000
+        )
+        == 999_000
+    )
+
+
 def test_red_paused_forced_modes_block_entries_without_panic():
     bot = make_coin_bot()
     bot.positions = {"A": {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}}
@@ -1368,6 +1406,7 @@ def bind_hsl_methods(bot):
         "_try_load_hsl_replay_matrix_cache",
         "_equity_hard_stop_try_reuse_replay_cache",
         "_equity_hard_stop_set_red_paused_runtime_forced_modes",
+        "_equity_hard_stop_latest_flatten_fill_timestamp_ms",
         "_equity_hard_stop_refresh_halted_runtime_forced_modes",
         "_equity_hard_stop_set_red_runtime_forced_modes",
         "_equity_hard_stop_runtime_red_latched",

--- a/tests/test_passivbot_hsl_bindings.py
+++ b/tests/test_passivbot_hsl_bindings.py
@@ -50,4 +50,5 @@ def test_passivbot_uses_passivbot_hsl_module_for_hsl_methods():
         "_try_load_hsl_replay_matrix_cache",
         "_equity_hard_stop_try_reuse_replay_cache",
         "_equity_hard_stop_set_red_paused_runtime_forced_modes",
+        "_equity_hard_stop_latest_flatten_fill_timestamp_ms",
     } <= assigned_names


### PR DESCRIPTION
Third behavior slice of the #1122 episode/RED contract (B2.1 item 4): **cooldown anchors at the fill that flattened the scope, by any means** — not at the latest bot-emitted panic fill. Previously, a position finished off manually (or by any non-panic close) after the last panic fill anchored cooldown at the earlier panic fill, starting — and therefore expiring — the window prematurely.

Scope:
- New `_equity_hard_stop_latest_flatten_fill_timestamp_ms` (+ optional variant): the scope's latest fill of any type within the window — once the scope is flat, that is by definition the flattening fill. Layered fallback keeps anchors monotone on missing data: no fill evidence in window → the previous panic-fill anchor → the caller fallback (exchange now).
- All five live cooldown anchor sites switched: both RED supervisors, the check-path finalization for recovered episodes (#1129), and both repanic-refresh paths. For bot-flattened episodes the anchor is unchanged (the panic fill *is* the latest fill); the behavior delta is exactly the manual-completion case.
- Replay-side marker anchoring is deliberately unchanged — episode reconstruction from the canonical series owns that per B2.7.
- Bound on `Passivbot`, pinned in the AST + fake-bot binding tests.

Evidence: regression pins the manual-close-after-panic anchor, window-exclusion fallback, and pair isolation; 213+ passed across the HSL suites; full suite shows only the 3 known pre-existing out-of-scope failures (see #1116); CHANGELOG entry; `git diff --check` clean.

With this, only the incomplete-history startup policy remains from the #1122 contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)