### PR TITLE
HSL: incomplete-history policy with per-run override (final #1122 item)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- HSL startup now applies the clarified incomplete-history policy: with
+  `restart_after_red_policy=always`, missing pre-episode fill coverage
+  degrades to a loud warning when the coin scope's current-episode start is
+  provable from covered fills (the `always` policy ignores historical
+  no-restart evidence); `threshold` and `never` still require full
+  configured lookback coverage. A new dangerous per-run CLI flag
+  `--hsl-accept-incomplete-history` lets an operator explicitly start on
+  incomplete evidence for any policy, with a critical startup banner and
+  per-use critical logs warning that panic/cooldown/no-restart may be wrong.
+  Corrupt (pending/degraded) PnL data still always hard-fails.
+
 - HSL RED cooldown now anchors at the fill that actually flattened the
   affected scope, by any means, instead of the latest bot-emitted panic
   fill. If a position is finished off manually (or by any non-panic close)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ All notable user-facing changes will be documented in this file.
   `--hsl-accept-incomplete-history` lets an operator explicitly start on
   incomplete evidence for any policy, with a critical startup banner and
   per-use critical logs warning that panic/cooldown/no-restart may be wrong.
-  Corrupt (pending/degraded) PnL data still always hard-fails.
+  The override is enforced as per-run only: values persisted in config
+  files are stripped at load time (with a critical log) before CLI
+  overrides are applied, so it can never survive a restart. Corrupt
+  (pending/degraded) PnL data still always hard-fails.
 
 - HSL RED cooldown now anchors at the fill that actually flattened the
   affected scope, by any means, instead of the latest bot-emitted panic

--- a/docs/equity_hard_stop_loss_risks.md
+++ b/docs/equity_hard_stop_loss_risks.md
@@ -51,5 +51,7 @@ and `never` require full configured lookback coverage.
 `--hsl-accept-incomplete-history` is a dangerous per-run CLI flag that starts
 the bot on incomplete HSL evidence for any policy. While it is active,
 panic, cooldown, and no-restart decisions may be wrong. Pass it on the
-command line for the specific run that needs it; do not persist it in config
-files.
+command line for the specific run that needs it. Persisting it in config
+files does not work: any `hsl_accept_incomplete_history: true` found in a
+config file is stripped at load time with a critical log, before CLI
+overrides are applied, so the waiver can never survive a restart.

--- a/docs/equity_hard_stop_loss_risks.md
+++ b/docs/equity_hard_stop_loss_risks.md
@@ -40,3 +40,16 @@ HSL replay currently models fills, positions, prices, and current balance. It
 does not build a separate authoritative transfer ledger. Future diagnostics may
 detect suspicious balance jumps, but trading behavior should remain derived
 from exchange state plus config unless an explicit stateless contract is added.
+
+## Incomplete fill history and the override flag
+
+With `restart_after_red_policy=always`, HSL startup tolerates missing
+pre-episode fill coverage when the current episode is provable from covered
+fills, because `always` ignores historical no-restart evidence. `threshold`
+and `never` require full configured lookback coverage.
+
+`--hsl-accept-incomplete-history` is a dangerous per-run CLI flag that starts
+the bot on incomplete HSL evidence for any policy. While it is active,
+panic, cooldown, and no-restart decisions may be wrong. Pass it on the
+command line for the specific run that needs it; do not persist it in config
+files.

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -915,6 +915,17 @@ Remaining implementation details:
       back to the previous panic-fill anchor and then the caller fallback
       when no fill evidence exists in the window. Only the incomplete-history
       policy remains from the #1122 contract.
+      Implemented (incomplete-history policy): HSL coverage assertions now
+      accept an explicit allow_incomplete waiver that converts
+      coverage-category failures into critical logs (corrupt pending/degraded
+      PnL still hard-fails). Waivers are granted only by the per-run
+      `live.hsl_accept_incomplete_history` CLI override (critical startup
+      banner + per-use critical logs) or by `restart_after_red_policy=always`
+      when the coin scope's current-episode start is provable from covered
+      fills (reversed running-size reconstruction from the live position;
+      ambiguity is unprovable). pside/unified scopes stay strict, which is
+      conservative-compliant with the contract's "not necessarily block"
+      wording. With this, every #1122 contract item is implemented.
       Implemented (A2.2 backtest parity): the backtest ORANGE `TpOnly`
       override now forces flat symbols too (`apply_orange_override` has-pos
       gate removed), matching the live overlay since #1098; the orchestrator's

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,4 +1,9 @@
-from .load import load_input_config, load_prepared_config, prepare_config
+from .load import (
+    load_input_config,
+    load_prepared_config,
+    prepare_config,
+    strip_persisted_hsl_incomplete_history_override,
+)
 from .normalize import normalize_config
 from .overrides import parse_overrides
 from .parse import load_raw_config
@@ -19,5 +24,6 @@ __all__ = [
     "parse_overrides",
     "prepare_config",
     "project_config",
+    "strip_persisted_hsl_incomplete_history_override",
     "validate_config",
 ]

--- a/src/config/load.py
+++ b/src/config/load.py
@@ -8,6 +8,26 @@ from .runtime_compile import compile_runtime_config
 from .schema import get_template_config
 
 
+def strip_persisted_hsl_incomplete_history_override(source: dict, config_path: str) -> None:
+    """live.hsl_accept_incomplete_history waives the HSL fail-closed coverage
+    contract and must only ever be granted by the CLI flag of the current
+    invocation; a value persisted in a config file is stripped here, before
+    CLI overrides are applied, so it can never survive a restart."""
+    containers = [source]
+    live = source.get("live")
+    if isinstance(live, dict):
+        containers.append(live)
+    for container in containers:
+        if container.get("hsl_accept_incomplete_history"):
+            logging.critical(
+                "[risk] ignoring hsl_accept_incomplete_history=true persisted in %s: "
+                "this override is per-run CLI-only (--hsl-accept-incomplete-history) "
+                "and persisted values are stripped to keep HSL coverage fail-closed",
+                config_path or "<config>",
+            )
+            container.pop("hsl_accept_incomplete_history", None)
+
+
 def load_input_config(
     config_path: str | None, *, log_info: bool = True
 ) -> tuple[dict, str, dict]:
@@ -15,6 +35,7 @@ def load_input_config(
         if log_info:
             logging.info("loading config %s", config_path)
         source = load_raw_config(config_path)
+        strip_persisted_hsl_incomplete_history_override(source, config_path)
         return source, config_path, deepcopy(source)
     if log_info:
         logging.info("loading schema defaults from src/config/schema.py")

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -399,6 +399,7 @@ def get_template_config():
                 "forced_mode_long": "",
                 "forced_mode_short": "",
                 "hedge_mode": False,
+                "hsl_accept_incomplete_history": False,
                 "hsl_position_during_cooldown_policy": "panic",
                 "hsl_signal_mode": "coin",
                 "ignored_coins": {

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -274,6 +274,14 @@ FIELD_RUNTIME_RULES = {
             "optimize": "Backtest Runtime",
         },
     },
+    "live.hsl_accept_incomplete_history": {
+        "owner": "live",
+        "consumed_by": {"live"},
+        "cli_exposed_on": {"live"},
+        "help_group": {
+            "live": "Behavior",
+        },
+    },
     "live.hsl_signal_mode": {
         "owner": "live",
         "consumed_by": {"live", "backtest", "optimize"},
@@ -1085,6 +1093,15 @@ RESERVED_CLI_ARGS = {
             "optimize": "Backtest Runtime",
         },
         "help": "How far into the past to fetch realized PnL history: 0=minimal lookback, positive=float days, 'all'=full history.",
+    },
+    "live.hsl_accept_incomplete_history": {
+        "visible": ["--hsl-accept-incomplete-history"],
+        "hidden": [
+            "--live.hsl_accept_incomplete_history",
+            "--live_hsl_accept_incomplete_history",
+        ],
+        "action": "store_true",
+        "default": None,
     },
     "live.hsl_signal_mode": {
         "visible": ["--hsl-signal-mode"],

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -1102,6 +1102,11 @@ RESERVED_CLI_ARGS = {
         ],
         "action": "store_true",
         "default": None,
+        "help": (
+            "DANGEROUS per-run override: start despite incomplete HSL fill-history "
+            "evidence (panic/cooldown/no-restart may be wrong). Per-invocation only; "
+            "values persisted in config files are ignored."
+        ),
     },
     "live.hsl_signal_mode": {
         "visible": ["--hsl-signal-mode"],
@@ -1786,20 +1791,30 @@ def add_reserved_arguments(
             else parser
         )
 
-        register_kwargs = dict(
-            type=spec["type"],
-            dest=config_key,
-            required=False,
-            default=None,
-            metavar=spec["metavar"],
-            help=(
-                spec["help"]
-                if help_all or visible_group is not None or command is None
-                else argparse.SUPPRESS
-            ),
+        help_text = (
+            spec["help"]
+            if help_all or visible_group is not None or command is None
+            else argparse.SUPPRESS
         )
-        if "choices" in spec:
-            register_kwargs["choices"] = spec["choices"]
+        if spec.get("action") == "store_true":
+            register_kwargs = dict(
+                action="store_true",
+                dest=config_key,
+                required=False,
+                default=spec.get("default"),
+                help=help_text,
+            )
+        else:
+            register_kwargs = dict(
+                type=spec["type"],
+                dest=config_key,
+                required=False,
+                default=None,
+                metavar=spec["metavar"],
+                help=help_text,
+            )
+            if "choices" in spec:
+                register_kwargs["choices"] = spec["choices"]
 
         _register_argument(
             container,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1631,8 +1631,17 @@ class Passivbot:
         start_ms: Optional[int],
         end_ms: Optional[int] = None,
         require_coverage: bool = True,
+        allow_incomplete: bool = False,
     ) -> None:
-        """Fail before risk gates consume incomplete realized-PnL history."""
+        """Fail before risk gates consume incomplete realized-PnL history.
+
+        `allow_incomplete=True` (B2.1 incomplete-history policy: the `always`
+        restart policy with a proven current episode, or the explicit per-run
+        operator override) converts coverage-category failures into a loud
+        critical log and proceeds. Pending or degraded PnL data still raises:
+        corrupt evidence is never acceptable, only provably-incomplete
+        evidence can be waived.
+        """
         self._assert_no_pending_pnl_events(events, context=context)
         degraded = [
             event
@@ -1649,6 +1658,27 @@ class Passivbot:
             )
         if not require_coverage or self._pnls_manager is None:
             return
+        try:
+            self._assert_pnl_history_coverage_for_risk(
+                context=context, start_ms=start_ms, end_ms=end_ms
+            )
+        except (RuntimeError, FillHistoryCoverageUnavailable) as exc:
+            if not allow_incomplete:
+                raise
+            logging.critical(
+                "[risk] %s: proceeding on INCOMPLETE fill history by explicit "
+                "policy/override; panic/cooldown/no-restart may be wrong | %s",
+                context,
+                exc,
+            )
+
+    def _assert_pnl_history_coverage_for_risk(
+        self,
+        *,
+        context: str,
+        start_ms: Optional[int],
+        end_ms: Optional[int] = None,
+    ) -> None:
         cache = getattr(self._pnls_manager, "cache", None)
         if cache is None:
             raise RuntimeError(
@@ -1766,6 +1796,12 @@ class Passivbot:
     _get_exchange_fee_rates = pb_hsl._get_exchange_fee_rates
     _orchestrator_exchange_params = pb_hsl._orchestrator_exchange_params
     _equity_hard_stop_realized_pnl_now = pb_hsl._equity_hard_stop_realized_pnl_now
+    _equity_hard_stop_coverage_allow_incomplete = (
+        pb_hsl._equity_hard_stop_coverage_allow_incomplete
+    )
+    _equity_hard_stop_coin_episode_start_covered = (
+        pb_hsl._equity_hard_stop_coin_episode_start_covered
+    )
     _equity_hard_stop_coin_realized_pnl_peak_last = (
         pb_hsl._equity_hard_stop_coin_realized_pnl_peak_last
     )

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -2197,6 +2197,17 @@ def _parse_hsl_config(self) -> dict[str, dict[str, Any]]:
                 pside,
                 _HSL_RISKS_DOC,
             )
+            live_cfg = self.config.get("live") if isinstance(self.config, dict) else None
+            if isinstance(live_cfg, dict) and bool(
+                live_cfg.get("hsl_accept_incomplete_history", False)
+            ):
+                logging.critical(
+                    "[risk] HSL[%s] hsl_accept_incomplete_history OVERRIDE is "
+                    "active: HSL evidence incomplete; panic/cooldown/no-restart "
+                    "may be wrong. This is a dangerous per-run flag - do not "
+                    "persist it in config files.",
+                    pside,
+                )
             logging.info(
                 "[risk] HSL[%s] enabled | red_threshold=%.6f ema_span_minutes=%.3f "
                 "cooldown_minutes_after_red=%.3f "
@@ -2781,6 +2792,69 @@ def _orchestrator_exchange_params(self, symbol: str) -> dict:
     }
 
 
+def _equity_hard_stop_coin_episode_start_covered(self, pside: str, symbol: str) -> bool:
+    """Whether covered fills prove the coin scope's current-episode start.
+
+    Walks the pair's covered fills backward from the current exchange
+    position; if the reversed running size reaches flat inside coverage, the
+    episode boundary is provable from available evidence. Ambiguous fills
+    (unknown action/qty) make the reconstruction unprovable.
+    """
+    if self._pnls_manager is None:
+        return False
+    slot = (self.positions or {}).get(symbol, {}).get(pside, {})
+    size = abs(float(slot.get("size", 0.0) or 0.0))
+    if size <= 1e-12:
+        # Flat scope: the current episode is empty; nothing to reconstruct.
+        return True
+    replay_events, ambiguous = _equity_hard_stop_coin_replay_events(
+        list(self._pnls_manager.get_events()), pside, symbol
+    )
+    if ambiguous:
+        return False
+    running = size
+    for _ts, action, qty in reversed(replay_events):
+        running = running - qty if action == "increase" else running + qty
+        if running <= 1e-12:
+            return True
+    return False
+
+
+def _equity_hard_stop_coverage_allow_incomplete(
+    self, pside: str, symbol: Optional[str] = None
+) -> bool:
+    """B2.1 incomplete-history policy (#1122).
+
+    Coverage-category failures on HSL PnL inputs may be waived only when:
+    - the explicit per-run operator override is active
+      (`live.hsl_accept_incomplete_history`), or
+    - `restart_after_red_policy=always` for the scope AND the coin scope's
+      current-episode start is provable from covered fills (the `always`
+      policy ignores the historical no-restart evidence, so pre-episode
+      history may degrade to a warning). `threshold`/`never` always require
+      full configured lookback coverage; pside/unified scopes stay strict.
+    """
+    config = getattr(self, "config", None)
+    if isinstance(config, dict):
+        live_cfg = config.get("live")
+        if isinstance(live_cfg, dict) and bool(
+            live_cfg.get("hsl_accept_incomplete_history", False)
+        ):
+            return True
+    if symbol is None:
+        return False
+    hsl_cfg = getattr(self, "hsl", None)
+    if not isinstance(hsl_cfg, dict) or pside not in hsl_cfg:
+        return False
+    policy = normalize_hsl_restart_after_red_policy(
+        hsl_cfg[pside].get("restart_after_red_policy", "threshold"),
+        path="hsl.restart_after_red_policy",
+    )
+    if policy != "always":
+        return False
+    return self._equity_hard_stop_coin_episode_start_covered(pside, symbol)
+
+
 def _equity_hard_stop_realized_pnl_now(self, pside: Optional[str] = None) -> float:
     if self._pnls_manager is None:
         return 0.0
@@ -2799,6 +2873,9 @@ def _equity_hard_stop_realized_pnl_now(self, pside: Optional[str] = None) -> flo
         events,
         context="equity hard stop realized PnL",
         start_ms=start_ms,
+        allow_incomplete=self._equity_hard_stop_coverage_allow_incomplete(
+            pside if pside is not None else "long"
+        ),
     )
     for event in events:
         realized += float(getattr(event, "pnl", 0.0) or 0.0)
@@ -2829,6 +2906,9 @@ def _equity_hard_stop_coin_realized_pnl_peak_last(
         events,
         context="coin HSL realized PnL",
         start_ms=start_ms,
+        allow_incomplete=self._equity_hard_stop_coverage_allow_incomplete(
+            pside, symbol
+        ),
     )
     events.sort(key=_equity_hard_stop_fill_timestamp_ms)
     current = 0.0

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -858,6 +858,119 @@ def test_forced_mode_refresher_preserves_paused_red(monkeypatch):
     )
 
 
+def _incomplete_history_bot(*, policy="threshold", override=False, fills=(), position_size=1.0):
+    bot = make_coin_bot()
+    bot.hsl["long"]["restart_after_red_policy"] = policy
+    if override:
+        bot.config["live"]["hsl_accept_incomplete_history"] = True
+    bot.positions = {
+        "A": {"long": {"size": position_size, "price": 100.0}, "short": {"size": 0.0}}
+    }
+
+    class _Cache:
+        def load_metadata(self):
+            return {"covered_start_ms": 0, "oldest_event_ts": 1}
+
+        def get_covered_start_ms(self):
+            return 0
+
+        def get_history_scope(self):
+            return "window"
+
+    class _Manager:
+        cache = _Cache()
+
+        def __init__(self, events):
+            self._events = list(events)
+
+        def get_events(self, start_ms=None):
+            if start_ms is None:
+                return list(self._events)
+            return [
+                e for e in self._events if getattr(e, "timestamp", 0) >= start_ms
+            ]
+
+        def get_history_scope(self):
+            return "window"
+
+    bot._pnls_manager = _Manager(fills)
+    return bot
+
+
+def _episode_fill(ts, action, qty):
+    return SimpleNamespace(
+        position_side="long",
+        symbol="A",
+        timestamp=ts,
+        action=action,
+        qty=qty,
+        pnl=0.0,
+    )
+
+
+def test_incomplete_history_policy_gates_hsl_coverage(caplog):
+    import logging as logging_module
+
+    # Coverage is unproven in every case below (covered_start_ms=0, window).
+    # Fills reconstruct the current episode: flat -> 1.0 long.
+    episode_fills = [_episode_fill(60_000, "increase", 1.0)]
+
+    # threshold: hard-fail preserved.
+    bot = _incomplete_history_bot(policy="threshold", fills=episode_fills)
+    with pytest.raises(Exception):
+        bot._equity_hard_stop_coin_realized_pnl_peak_last("long", "A", 120_000)
+
+    # never: hard-fail preserved.
+    bot = _incomplete_history_bot(policy="never", fills=episode_fills)
+    with pytest.raises(Exception):
+        bot._equity_hard_stop_coin_realized_pnl_peak_last("long", "A", 120_000)
+
+    # always + provable episode start: proceeds with a critical log.
+    bot = _incomplete_history_bot(policy="always", fills=episode_fills)
+    with caplog.at_level(logging_module.CRITICAL):
+        peak, last = bot._equity_hard_stop_coin_realized_pnl_peak_last(
+            "long", "A", 120_000
+        )
+    assert "INCOMPLETE fill history" in caplog.text
+    caplog.clear()
+
+    # always + unprovable episode (fills never reach flat): hard-fail.
+    partial_fills = [_episode_fill(60_000, "increase", 0.4)]
+    bot = _incomplete_history_bot(policy="always", fills=partial_fills)
+    with pytest.raises(Exception):
+        bot._equity_hard_stop_coin_realized_pnl_peak_last("long", "A", 120_000)
+
+    # Explicit per-run override: proceeds loudly regardless of policy.
+    bot = _incomplete_history_bot(
+        policy="never", override=True, fills=partial_fills
+    )
+    with caplog.at_level(logging_module.CRITICAL):
+        bot._equity_hard_stop_coin_realized_pnl_peak_last("long", "A", 120_000)
+    assert "INCOMPLETE fill history" in caplog.text
+
+
+def test_coin_episode_start_covered_reconstruction():
+    # Flat scope: trivially provable.
+    bot = _incomplete_history_bot(fills=(), position_size=0.0)
+    assert bot._equity_hard_stop_coin_episode_start_covered("long", "A") is True
+    # Covered fills reconstruct back to flat: provable.
+    bot = _incomplete_history_bot(
+        fills=[
+            _episode_fill(60_000, "increase", 0.6),
+            _episode_fill(120_000, "increase", 0.4),
+        ]
+    )
+    assert bot._equity_hard_stop_coin_episode_start_covered("long", "A") is True
+    # Fills do not explain the position: unprovable.
+    bot = _incomplete_history_bot(fills=[_episode_fill(60_000, "increase", 0.4)])
+    assert bot._equity_hard_stop_coin_episode_start_covered("long", "A") is False
+    # Ambiguous fill (unknown action) poisons the reconstruction.
+    ambiguous = _episode_fill(60_000, "increase", 1.0)
+    ambiguous.action = "unknown"
+    bot = _incomplete_history_bot(fills=[ambiguous])
+    assert bot._equity_hard_stop_coin_episode_start_covered("long", "A") is False
+
+
 def test_cooldown_anchor_uses_scope_flattening_fill():
     # B2.1: cooldown anchors at the fill that flattened the scope, by any
     # means. A manual close after the last panic fill must win; with no fills
@@ -1407,6 +1520,8 @@ def bind_hsl_methods(bot):
         "_equity_hard_stop_try_reuse_replay_cache",
         "_equity_hard_stop_set_red_paused_runtime_forced_modes",
         "_equity_hard_stop_latest_flatten_fill_timestamp_ms",
+        "_equity_hard_stop_coverage_allow_incomplete",
+        "_equity_hard_stop_coin_episode_start_covered",
         "_equity_hard_stop_refresh_halted_runtime_forced_modes",
         "_equity_hard_stop_set_red_runtime_forced_modes",
         "_equity_hard_stop_runtime_red_latched",
@@ -1437,6 +1552,7 @@ def bind_hsl_methods(bot):
         "_pnl_gap_overlaps",
         "_pnl_event_preview",
         "_assert_pnl_history_safe_for_risk",
+        "_assert_pnl_history_coverage_for_risk",
     ):
         setattr(bot, name, MethodType(getattr(Passivbot, name), bot))
 

--- a/tests/test_hsl_incomplete_history_override.py
+++ b/tests/test_hsl_incomplete_history_override.py
@@ -1,0 +1,79 @@
+"""Pure-Python tests for the per-run-only enforcement of
+live.hsl_accept_incomplete_history (no passivbot_rust required).
+
+The flag waives the HSL fail-closed coverage contract, so a value persisted
+in a config file must never survive a restart: load_input_config strips it
+(with a critical log) before CLI overrides are applied, and only the CLI
+flag of the current invocation can re-enable it.
+"""
+
+import json
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from config.load import (  # noqa: E402
+    load_input_config,
+    strip_persisted_hsl_incomplete_history_override,
+)
+
+
+def test_persisted_nested_true_is_stripped_with_critical_log(caplog):
+    source = {"live": {"hsl_accept_incomplete_history": True, "leverage": 10}}
+    with caplog.at_level(logging.CRITICAL):
+        strip_persisted_hsl_incomplete_history_override(source, "cfg.json")
+    assert "hsl_accept_incomplete_history" not in source["live"]
+    assert source["live"]["leverage"] == 10
+    assert "per-run CLI-only" in caplog.text
+    assert "cfg.json" in caplog.text
+
+
+def test_persisted_flat_true_is_stripped_with_critical_log(caplog):
+    source = {"hsl_accept_incomplete_history": True}
+    with caplog.at_level(logging.CRITICAL):
+        strip_persisted_hsl_incomplete_history_override(source, "cfg.json")
+    assert "hsl_accept_incomplete_history" not in source
+    assert "per-run CLI-only" in caplog.text
+
+
+def test_persisted_false_is_left_untouched_silently(caplog):
+    # A persisted False matches the schema default and poses no risk;
+    # leaving it in place keeps _raw snapshots faithful to the file.
+    source = {"live": {"hsl_accept_incomplete_history": False}}
+    with caplog.at_level(logging.CRITICAL):
+        strip_persisted_hsl_incomplete_history_override(source, "cfg.json")
+    assert source["live"]["hsl_accept_incomplete_history"] is False
+    assert caplog.text == ""
+
+
+def test_load_input_config_strips_persisted_override(tmp_path, caplog):
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(
+        json.dumps({"live": {"hsl_accept_incomplete_history": True}})
+    )
+    with caplog.at_level(logging.CRITICAL):
+        source, base_path, raw_snapshot = load_input_config(
+            str(cfg_path), log_info=False
+        )
+    assert "hsl_accept_incomplete_history" not in source["live"]
+    assert "hsl_accept_incomplete_history" not in raw_snapshot["live"]
+    assert "per-run CLI-only" in caplog.text
+
+
+def test_cli_override_survives_because_it_is_applied_after_load(tmp_path):
+    from config_utils import update_config_with_args
+
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(
+        json.dumps({"live": {"hsl_accept_incomplete_history": True}})
+    )
+    source, _, _ = load_input_config(str(cfg_path), log_info=False)
+    assert "hsl_accept_incomplete_history" not in source["live"]
+    args = SimpleNamespace(**{"live.hsl_accept_incomplete_history": True})
+    update_config_with_args(
+        source, args, allowed_keys={"live.hsl_accept_incomplete_history"}
+    )
+    assert source["live"]["hsl_accept_incomplete_history"] is True

--- a/tests/test_passivbot_hsl_bindings.py
+++ b/tests/test_passivbot_hsl_bindings.py
@@ -51,4 +51,6 @@ def test_passivbot_uses_passivbot_hsl_module_for_hsl_methods():
         "_equity_hard_stop_try_reuse_replay_cache",
         "_equity_hard_stop_set_red_paused_runtime_forced_modes",
         "_equity_hard_stop_latest_flatten_fill_timestamp_ms",
+        "_equity_hard_stop_coverage_allow_incomplete",
+        "_equity_hard_stop_coin_episode_start_covered",
     } <= assigned_names


### PR DESCRIPTION
## Summary

Implements the incomplete-history policy from the clarified HSL episode/RED/no-restart contract (#1122, point 6) — the final remaining item of that contract.

- `_assert_pnl_history_safe_for_risk` gains an `allow_incomplete` waiver: coverage checks are extracted into `_assert_pnl_history_coverage_for_risk`, and when a waiver is active a coverage failure degrades to `logging.critical("[risk] ...: proceeding on INCOMPLETE fill history by explicit policy/override; panic/cooldown/no-restart may be wrong | ...")` instead of raising. Corrupt data (pending/degraded PnL events) still **always** hard-fails — the waiver applies only to coverage.
- Waivers are granted by `_equity_hard_stop_coverage_allow_incomplete(pside, symbol)`:
  - `restart_after_red_policy=always`, coin scope only, and only when `_equity_hard_stop_coin_episode_start_covered` proves the current episode start from covered fills (walks covered fills backward from the live position via reversed running-size reconstruction; flat scope is trivially proven; any ambiguity → unprovable → strict). Rationale: `always` never consults historical no-restart evidence, so only current-episode data is load-bearing.
  - The new per-run CLI flag `--hsl-accept-incomplete-history` (`live.hsl_accept_incomplete_history`, default false), which proceeds loudly for **any** policy and scope, with a critical startup banner ("HSL evidence incomplete; panic/cooldown/no-restart may be wrong ... do not persist it in config files") plus the per-use critical logs.
- `threshold`/`never` policies and pside/unified scopes remain fully strict (conservative-compliant with the contract's "not necessarily block" wording).
- Config plumbing: schema default, FIELD_RUNTIME_RULES, CLI arg map.
- Bindings: class-block bindings in `src/passivbot.py`, AST bindings test, fake-bot bind list.

## Tests

- `test_incomplete_history_policy_gates_hsl_coverage`: threshold/never still raise on unproven coverage; always+proven episode proceeds with critical log; always+unproven raises; override proceeds loudly regardless of policy.
- `test_coin_episode_start_covered_reconstruction`: flat → proven; covered fills reaching flat → proven; fills not explaining position → unprovable; ambiguous action → unprovable.
- Full local suite green except the 3 known out-of-scope failures (pymoo sampling, 2 bitget UTA stubs).

## Docs

CHANGELOG entry, plan tracker updated (all #1122 contract items now implemented), `docs/equity_hard_stop_loss_risks.md` section on the override instructing CLI-only per-run use.

@vigilpbclaw-hash @claude @codex please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)