### PR TITLE
HSL: derive replay cooldown/no-restart from canonical RED episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ All notable user-facing changes will be documented in this file.
   Previously such episodes were silently reset with no stop accounting, so a
   restart during an active cooldown (or after a terminal-drawdown episode)
   would resume trading. RED-free ordinary flattenings keep the plain episode
-  reset.
+  reset. The Rust backtest already finalizes cooldown/no-restart for such
+  episodes (its per-episode tier latch keeps the stop path armed after the
+  sample recovers); new Rust regression tests pin that parity for both the
+  pside and coin scopes.
 
 - HSL startup now applies the clarified incomplete-history policy: with
   `restart_after_red_policy=always`, missing pre-episode fill coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live coin-HSL startup replay now derives cooldown and no-restart evidence
+  from canonical reconstructed RED episodes, not only from bot-emitted panic
+  order markers. An episode that crossed RED and was flattened by an ordinary
+  (non-panic) close fill - including a manual close - now latches its
+  cooldown anchored at the scope-flattening fill timestamp and evaluates the
+  no-restart policy at that stop, exactly like a confirmed panic marker.
+  Previously such episodes were silently reset with no stop accounting, so a
+  restart during an active cooldown (or after a terminal-drawdown episode)
+  would resume trading. RED-free ordinary flattenings keep the plain episode
+  reset.
+
 - HSL startup now applies the clarified incomplete-history policy: with
   `restart_after_red_policy=always`, missing pre-episode fill coverage
   degrades to a loud warning when the coin scope's current-episode start is

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -981,9 +981,14 @@ Remaining implementation details:
       flatten fill timestamp and evaluates `restart_after_red_policy` /
       no-restart via the shared Rust predicate at that stop, mirroring the
       confirmed-panic-marker path (source=red_episode_flatten in the
-      reconstruction logs). Broader cross-episode no-restart peak accounting
-      (the backtest's `no_restart_peak_strategy_equity` analogue) remains
-      future work.
+      reconstruction logs). Backtest parity is pre-existing, provided by the
+      backtest's per-episode RED tier latch (step latch_red=true pins the
+      stop path armed after the sample recovers until the episode resets),
+      and is now pinned by Rust regression tests for both the pside and coin
+      scopes (RED seen while open, sample recovered, ordinary flatten ->
+      cooldown). Broader cross-episode no-restart peak accounting in the
+      live replay (the backtest's `no_restart_peak_strategy_equity`
+      analogue) remains future work.
 - [ ] HSL replay performance/readiness slice.
       Persist verified non-authoritative HSL time series/checkpoints, add doctor
       tools, prioritize held scopes, keep timing/source evidence, and move dense

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -975,6 +975,15 @@ Remaining implementation details:
       Partial: historical panic markers now require reconstructed confirmed RED
       tier/score, not raw-only drawdown. Raw RED pending remains diagnostic and
       does not reconstruct a cooldown/no-restart event by itself.
+      Partial: replay cooldown/no-restart evidence is now canonical from
+      reconstructed episodes. An episode with `red_seen_in_episode` that is
+      flattened by an ordinary (non-panic) close fill latches cooldown at the
+      flatten fill timestamp and evaluates `restart_after_red_policy` /
+      no-restart via the shared Rust predicate at that stop, mirroring the
+      confirmed-panic-marker path (source=red_episode_flatten in the
+      reconstruction logs). Broader cross-episode no-restart peak accounting
+      (the backtest's `no_restart_peak_strategy_equity` analogue) remains
+      future work.
 - [ ] HSL replay performance/readiness slice.
       Persist verified non-authoritative HSL time series/checkpoints, add doctor
       tools, prioritize held scopes, keep timing/source evidence, and move dense

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -963,7 +963,7 @@ Remaining implementation details:
       Rust PnL helpers, require contiguous one-minute rows, and recompute
       `pnl_cumsum`/equity from raw minute `pnl` instead of persisting cumulative
       state.
-- [ ] Coin-HSL episode anchoring redesign, including no-restart persistence and
+- [x] Coin-HSL episode anchoring redesign, including no-restart persistence and
       cooldown rules.
       Current panic eligibility should be based on the current trading episode;
       terminal no-restart accounting remains broader.
@@ -986,9 +986,16 @@ Remaining implementation details:
       stop path armed after the sample recovers until the episode resets),
       and is now pinned by Rust regression tests for both the pside and coin
       scopes (RED seen while open, sample recovered, ordinary flatten ->
-      cooldown). Broader cross-episode no-restart peak accounting in the
-      live replay (the backtest's `no_restart_peak_strategy_equity`
-      analogue) remains future work.
+      cooldown). Broader cross-episode no-restart peak accounting needs no
+      further live work, verified 2026-07-08: the pside/unified live replay
+      and forward finalize already maintain the persistent tracker via
+      `_equity_hard_stop_record_no_restart_stop` (max of stop peaks across
+      episodes), and for the coin scope the backtest's tracker is
+      mathematically degenerate - the synthetic per-episode equity is
+      normalized to peak 1.0 and never exceeds it, so
+      `persistent_drawdown_raw` equals the at-stop drawdown ratio, which is
+      exactly what the live coin replay and coin forward finalize evaluate.
+      With that, every sub-item of this tracker entry is implemented.
 - [ ] HSL replay performance/readiness slice.
       Persist verified non-authoritative HSL time series/checkpoints, add doctor
       tools, prioritize held scopes, keep timing/source evidence, and move dense

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -7295,6 +7295,109 @@ mod tests {
     }
 
     #[test]
+    fn hard_stop_red_seen_episode_recovered_before_flatten_sets_cooldown() {
+        // B2.1: RED is seen mid-episode while the position is open, the sample
+        // recovers before the position flattens, and the stop must still
+        // finalize into cooldown accounting once the scope is flat.
+        let hlcvs = Array3::from_shape_vec((5, 1, 4), vec![1.0; 5 * 1 * 4]).unwrap();
+        let btc_usd_prices =
+            Array1::from_vec(vec![20_000.0, 20_000.0, 20_000.0, 20_000.0, 20_000.0]);
+
+        let mut bp_pair = BotParamsPair::default();
+        bp_pair.long.n_positions = 1;
+        bp_pair.long.ema_span_0 = 10.0;
+        bp_pair.long.ema_span_1 = 20.0;
+
+        let mut hs = EquityHardStopLossConfig::default();
+        hs.enabled = true;
+        hs.red_threshold = 0.1;
+        hs.ema_span_minutes = 1.0;
+        hs.cooldown_minutes_after_red = 5.0;
+        hs.signal_mode = "unified".to_string();
+
+        let backtest_params = BacktestParams {
+            starting_balance: 1000.0,
+            maker_fee: 0.0,
+            taker_fee: 0.00055,
+            coins: vec!["TEST".to_string()],
+            active_coin_indices: None,
+            first_timestamp_ms: 0,
+            requested_start_timestamp_ms: 0,
+            first_valid_indices: vec![0],
+            last_valid_indices: vec![4],
+            warmup_minutes: vec![0],
+            trade_start_indices: vec![0],
+            global_warmup_bars: 0,
+            btc_collateral_cap: 0.0,
+            btc_collateral_ltv_cap: None,
+            metrics_only: true,
+            skip_btc_analysis: false,
+            filter_by_min_effective_cost: false,
+            dynamic_wel_by_tradability: true,
+            hedge_mode: true,
+            max_realized_loss_pct: 1.0,
+            pnls_max_lookback_days: 30.0,
+            liquidation_threshold: 0.05,
+            equity_hard_stop_loss: hs,
+            market_orders_allowed: false,
+            market_order_near_touch_threshold: 0.001,
+            market_order_slippage_pct: 0.0005,
+            forager_score_hysteresis_pct: 0.0,
+            candle_interval_minutes: 1,
+        };
+
+        let mut bt = Backtest::new(
+            hlcvs.view(),
+            btc_usd_prices.view(),
+            vec![bp_pair],
+            vec![ExchangeParams::default()],
+            &backtest_params,
+        );
+
+        bt.positions.long[0] = Position {
+            size: 1.0,
+            price: 100.0,
+        };
+
+        bt.balance.usd_total_balance = 100.0;
+        bt.equities.timestamps_ms.push(0);
+        bt.equities.usd_total_equity.push(100.0);
+        bt.update_hard_stop_state(0).unwrap();
+
+        // RED while the position is open: no flat confirmations accumulate.
+        bt.equities.timestamps_ms.push(60_000);
+        bt.equities.usd_total_equity.push(80.0);
+        bt.update_hard_stop_state(1).unwrap();
+        assert!(!bt.hard_stop_pside[LONG].halted);
+
+        // Sample recovers below RED while still open; red_seen persists.
+        bt.equities.timestamps_ms.push(120_000);
+        bt.equities.usd_total_equity.push(96.0);
+        bt.update_hard_stop_state(2).unwrap();
+        assert!(!bt.hard_stop_pside[LONG].halted);
+        // The tier stays latched Red for the episode, but the SAMPLE recovered.
+        assert!(!bt.hard_stop_pside[LONG].red_active_now);
+
+        // Position flattens by an ordinary close (no panic): the recovered
+        // episode must still finalize into a cooldown stop.
+        bt.positions.long[0] = Position::default();
+        bt.equities.timestamps_ms.push(180_000);
+        bt.equities.usd_total_equity.push(96.0);
+        bt.update_hard_stop_state(3).unwrap();
+
+        bt.equities.timestamps_ms.push(240_000);
+        bt.equities.usd_total_equity.push(96.0);
+        bt.update_hard_stop_state(4).unwrap();
+
+        assert!(bt.hard_stop_pside[LONG].halted);
+        assert!(!bt.hard_stop_pside[LONG].no_restart_latched);
+        assert_eq!(
+            bt.hard_stop_pside[LONG].cooldown_until_ms,
+            Some(180_000 + 300_000)
+        );
+    }
+
+    #[test]
     fn hard_stop_unified_signal_feeds_same_equity_to_both_psides() {
         let hlcvs = Array3::from_shape_vec((1, 1, 4), vec![90.0; 1 * 1 * 4]).unwrap();
         let btc_usd_prices = Array1::from_vec(vec![20_000.0]);
@@ -7377,6 +7480,122 @@ mod tests {
         bt_unified.update_hard_stop_state_pside(0, SHORT).unwrap();
         assert_eq!(bt_unified.strategy_equity_series_pside[LONG][0], 90.0);
         assert_eq!(bt_unified.strategy_equity_series_pside[SHORT][0], 90.0);
+    }
+
+    #[test]
+    fn hard_stop_coin_red_seen_episode_recovered_before_flatten_sets_cooldown() {
+        // B2.1 parity pin (coin scope): RED is seen mid-episode while the coin
+        // position is open, the sample recovers before the position flattens,
+        // and the stop must still finalize into cooldown accounting once flat.
+        let hlcvs = Array3::from_shape_vec((5, 1, 4), vec![100.0; 5 * 1 * 4]).unwrap();
+        let btc_usd_prices =
+            Array1::from_vec(vec![20_000.0, 20_000.0, 20_000.0, 20_000.0, 20_000.0]);
+
+        let mut bp_pair = BotParamsPair::default();
+        bp_pair.long.n_positions = 4;
+        bp_pair.long.total_wallet_exposure_limit = 4.0;
+        bp_pair.long.wallet_exposure_limit = 1.0;
+        bp_pair.long.ema_span_0 = 10.0;
+        bp_pair.long.ema_span_1 = 20.0;
+        bp_pair.long.hsl_enabled = true;
+        bp_pair.long.hsl_red_threshold = 0.5;
+        bp_pair.long.hsl_ema_span_minutes = 1.0;
+        bp_pair.long.hsl_tier_ratio_yellow = 0.5;
+        bp_pair.long.hsl_tier_ratio_orange = 0.75;
+        bp_pair.long.hsl_cooldown_minutes_after_red = 5.0;
+
+        let mut hs = EquityHardStopLossConfig::default();
+        hs.enabled = true;
+        hs.signal_mode = "coin".to_string();
+        hs.red_threshold = 0.5;
+        hs.ema_span_minutes = 1.0;
+        hs.cooldown_minutes_after_red = 5.0;
+
+        let backtest_params = BacktestParams {
+            starting_balance: 100.0,
+            maker_fee: 0.0,
+            taker_fee: 0.00055,
+            coins: vec!["A".to_string()],
+            active_coin_indices: None,
+            first_timestamp_ms: 0,
+            requested_start_timestamp_ms: 0,
+            first_valid_indices: vec![0],
+            last_valid_indices: vec![4],
+            warmup_minutes: vec![0],
+            trade_start_indices: vec![0],
+            global_warmup_bars: 0,
+            btc_collateral_cap: 0.0,
+            btc_collateral_ltv_cap: None,
+            metrics_only: true,
+            skip_btc_analysis: false,
+            filter_by_min_effective_cost: false,
+            dynamic_wel_by_tradability: false,
+            hedge_mode: true,
+            max_realized_loss_pct: 1.0,
+            pnls_max_lookback_days: 30.0,
+            liquidation_threshold: 0.05,
+            equity_hard_stop_loss: hs,
+            market_orders_allowed: false,
+            market_order_near_touch_threshold: 0.001,
+            market_order_slippage_pct: 0.0005,
+            forager_score_hysteresis_pct: 0.0,
+            candle_interval_minutes: 1,
+        };
+
+        let mut bt = Backtest::new(
+            hlcvs.view(),
+            btc_usd_prices.view(),
+            vec![bp_pair],
+            vec![ExchangeParams::default()],
+            &backtest_params,
+        );
+
+        bt.positions.long[0] = Position {
+            size: 1.0,
+            price: 100.0,
+        };
+        bt.balance.usd_total_balance = 100.0;
+
+        // slot budget = balance * TWEL / n_positions = 100 * 4 / 4 = 100;
+        // RED at drawdown >= 50.
+        bt.record_coin_rolling_pnl(0, 0, LONG, 0.0);
+        bt.equities.timestamps_ms.push(0);
+        bt.equities.usd_total_equity.push(100.0);
+        bt.update_hard_stop_state_coin(0, 0, LONG).unwrap();
+
+        // RED while the coin position is open: no flat confirmations.
+        bt.record_coin_rolling_pnl(1, 0, LONG, -60.0);
+        bt.equities.timestamps_ms.push(60_000);
+        bt.equities.usd_total_equity.push(100.0);
+        bt.update_hard_stop_state_coin(1, 0, LONG).unwrap();
+        assert!(!bt.hard_stop_coin[LONG][0].halted);
+        assert_eq!(bt.hard_stop_coin[LONG][0].tier, ehsl::HardStopTier::Red);
+        assert!(bt.hard_stop_coin[LONG][0].red_active_now);
+
+        // Sample recovers (pnl claws back) while still open; red_seen persists.
+        bt.record_coin_rolling_pnl(2, 0, LONG, 55.0);
+        bt.equities.timestamps_ms.push(120_000);
+        bt.equities.usd_total_equity.push(100.0);
+        bt.update_hard_stop_state_coin(2, 0, LONG).unwrap();
+        assert!(!bt.hard_stop_coin[LONG][0].halted);
+        assert!(!bt.hard_stop_coin[LONG][0].red_active_now);
+
+        // Ordinary flatten (no panic): recovered episode must still cool down.
+        bt.positions.long[0] = Position::default();
+        bt.equities.timestamps_ms.push(180_000);
+        bt.equities.usd_total_equity.push(100.0);
+        bt.update_hard_stop_state_coin(3, 0, LONG).unwrap();
+
+        bt.equities.timestamps_ms.push(240_000);
+        bt.equities.usd_total_equity.push(100.0);
+        bt.update_hard_stop_state_coin(4, 0, LONG).unwrap();
+
+        assert!(bt.hard_stop_coin[LONG][0].halted);
+        assert!(!bt.hard_stop_coin[LONG][0].no_restart_latched);
+        assert_eq!(
+            bt.hard_stop_coin[LONG][0].cooldown_until_ms,
+            Some(180_000 + 300_000)
+        );
     }
 
     #[test]

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -4915,9 +4915,21 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     if replay_is_nonflat:
                         replay_was_nonflat = True
                     if marker is None:
-                        if replay_flattened_this_row:
-                            # Ordinary, non-panic flattening ends the current coin episode.
-                            # Cooldown/no-restart accounting remains driven by panic markers.
+                        if not replay_flattened_this_row:
+                            continue
+                        if bool(metrics.get("red_seen_in_episode")):
+                            # The episode crossed RED and ended by an ordinary
+                            # (non-panic) scope-flattening fill. Per the B2.1
+                            # contract, cooldown/no-restart evidence is canonical
+                            # from the reconstructed episode, not from bot panic
+                            # markers; anchor the stop at the flatten fill.
+                            stop_ts = int(replay_flattened_at_ms)
+                            stop_source = "red_episode_flatten"
+                            replay_was_nonflat = False
+                            replay_flattened_at_ms = None
+                        else:
+                            # Ordinary, non-panic flattening of a RED-free episode
+                            # just ends the episode with no stop accounting.
                             reset_ts = int(replay_flattened_at_ms) + 1
                             state["pnl_reset_timestamp_ms"] = reset_ts
                             reset_baseline_realized = abs_realized
@@ -4932,23 +4944,25 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                                 int(replay_flattened_at_ms),
                             )
                             replay_flattened_at_ms = None
-                        continue
-                    stop_ts = int(marker["timestamp"])
-                    if not _equity_hard_stop_replay_marker_confirms_red(metrics):
-                        ignored_panic_marker_timestamps.add(stop_ts)
-                        logging.warning(
-                            "[risk] HSL[%s:%s] ignored historical coin panic marker without reconstructed RED | "
-                            "stop_ts=%s drawdown_raw=%.6f drawdown_ema=%.6f drawdown_score=%.6f "
-                            "red_threshold=%.6f source=panic_fill_flatten",
-                            pside,
-                            symbol,
-                            stop_ts,
-                            float(metrics["drawdown_raw"]),
-                            float(metrics["drawdown_ema"]),
-                            float(metrics["drawdown_score"]),
-                            float(metrics["red_threshold"]),
-                        )
-                        continue
+                            continue
+                    else:
+                        stop_ts = int(marker["timestamp"])
+                        stop_source = "panic_fill_flatten"
+                        if not _equity_hard_stop_replay_marker_confirms_red(metrics):
+                            ignored_panic_marker_timestamps.add(stop_ts)
+                            logging.warning(
+                                "[risk] HSL[%s:%s] ignored historical coin panic marker without reconstructed RED | "
+                                "stop_ts=%s drawdown_raw=%.6f drawdown_ema=%.6f drawdown_score=%.6f "
+                                "red_threshold=%.6f source=panic_fill_flatten",
+                                pside,
+                                symbol,
+                                stop_ts,
+                                float(metrics["drawdown_raw"]),
+                                float(metrics["drawdown_ema"]),
+                                float(metrics["drawdown_score"]),
+                                float(metrics["red_threshold"]),
+                            )
+                            continue
                     stop_drawdown_raw = float(metrics["drawdown_raw"])
                     no_restart_latched = _equity_hard_stop_no_restart_latched(
                         cfg, stop_drawdown_raw, float(metrics["drawdown_ema"])
@@ -4991,11 +5005,12 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         )
                         logging.critical(
                             "[risk] HSL[%s:%s] reconstructed terminal coin RED stop from exchange-derived history | "
-                            "stop_ts=%s drawdown_raw=%.6f",
+                            "stop_ts=%s drawdown_raw=%.6f source=%s",
                             pside,
                             symbol,
                             stop_ts,
                             stop_drawdown_raw,
+                            stop_source,
                         )
                         break
                     state["halted"] = True
@@ -5010,12 +5025,13 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         )
                         logging.critical(
                             "[risk] HSL[%s:%s] reconstructed active coin RED cooldown from exchange-derived history | "
-                            "remaining_time=%s",
+                            "remaining_time=%s source=%s",
                             pside,
                             symbol,
                             _equity_hard_stop_format_remaining_time(
                                 (cooldown_until_ms - now_ms) / 1000.0
                             ),
+                            stop_source,
                         )
                         continue
                     self._equity_hard_stop_reset_coin_after_restart(pside, symbol)

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -3264,6 +3264,172 @@ def test_coin_hsl_live_slot_budget_ignores_twel(total_wallet_exposure_limit):
     assert metrics["drawdown_raw"] == pytest.approx(0.5)
 
 
+def _red_episode_history(symbol, *, flatten_pnl, rows_upnl, flatten_ts=150_000):
+    """History where a coin episode enters at 60_000, draws down, and is
+    flattened by an ORDINARY close fill (no panic_flatten_events)."""
+    timeline = []
+    realized = 0.0
+    for idx, upnl in enumerate(rows_upnl):
+        ts = 60_000 * (idx + 1)
+        if flatten_ts < ts + 60_000:
+            realized = flatten_pnl
+        timeline.append(
+            {
+                "timestamp": ts,
+                "balance": 100.0,
+                "realized_pnl": realized,
+                "realized_pnl_by_coin_pside": {symbol: {"long": realized, "short": 0.0}},
+                "unrealized_pnl_by_coin_pside": {symbol: {"long": upnl, "short": 0.0}},
+            }
+        )
+    fills = [
+        {
+            "timestamp": 60_000,
+            "symbol": symbol,
+            "pside": "long",
+            "action": "increase",
+            "qty": 1.0,
+            "pnl": 0.0,
+        },
+        {
+            "timestamp": flatten_ts,
+            "symbol": symbol,
+            "pside": "long",
+            "action": "decrease",
+            "qty": 1.0,
+            "pnl": flatten_pnl,
+        },
+    ]
+    return {"timeline": timeline, "panic_flatten_events": [], "fill_events": fills}
+
+
+def _flat_position_bot(symbol):
+    bot = make_coin_bot()
+    bot.positions = {
+        symbol: {"long": {"size": 0.0, "price": 0.0}, "short": {"size": 0.0, "price": 0.0}}
+    }
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_replay_latches_cooldown_from_red_episode_ordinary_flatten():
+    # Episode crosses RED (drawdown 0.6 >= 0.5) and is flattened at 150_000 by an
+    # ordinary close with no panic marker: cooldown must anchor at the flatten fill.
+    symbol = "A"
+    bot = _flat_position_bot(symbol)
+    bot.get_exchange_time = lambda: 180_000
+
+    async def fake_history(current_balance=None, **kwargs):
+        return _red_episode_history(symbol, flatten_pnl=-30.0, rows_upnl=[0.0, 0.0])
+
+    bot.get_balance_equity_history = fake_history
+
+    await bot._equity_hard_stop_initialize_coin_from_history()
+
+    state = bot._hsl_coin_state("long", symbol)
+    assert state["halted"] is True
+    assert state["no_restart_latched"] is False
+    assert state["cooldown_until_ms"] == 150_000 + 300_000
+    assert state["last_stop_event"]["stop_event_timestamp_ms"] == 150_000
+    assert state["pnl_reset_timestamp_ms"] == 150_001
+    assert bot._runtime_forced_modes["long"][symbol] == "graceful_stop"
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_replay_latches_no_restart_from_red_episode_ordinary_flatten():
+    # Same shape but the episode drawdown (1.6) breaches the no-restart threshold
+    # (0.9) under policy=threshold: terminal halt, no cooldown.
+    symbol = "A"
+    bot = _flat_position_bot(symbol)
+    bot.get_exchange_time = lambda: 180_000
+
+    async def fake_history(current_balance=None, **kwargs):
+        return _red_episode_history(symbol, flatten_pnl=-80.0, rows_upnl=[0.0, 0.0])
+
+    bot.get_balance_equity_history = fake_history
+
+    await bot._equity_hard_stop_initialize_coin_from_history()
+
+    state = bot._hsl_coin_state("long", symbol)
+    assert state["halted"] is True
+    assert state["no_restart_latched"] is True
+    assert state["cooldown_until_ms"] is None
+    assert bot._runtime_forced_modes["long"][symbol] == "graceful_stop"
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_replay_never_policy_latches_no_restart_on_red_episode():
+    symbol = "A"
+    bot = _flat_position_bot(symbol)
+    bot.hsl["long"]["restart_after_red_policy"] = "never"
+    bot.get_exchange_time = lambda: 180_000
+
+    async def fake_history(current_balance=None, **kwargs):
+        return _red_episode_history(symbol, flatten_pnl=-30.0, rows_upnl=[0.0, 0.0])
+
+    bot.get_balance_equity_history = fake_history
+
+    await bot._equity_hard_stop_initialize_coin_from_history()
+
+    state = bot._hsl_coin_state("long", symbol)
+    assert state["halted"] is True
+    assert state["no_restart_latched"] is True
+    assert state["cooldown_until_ms"] is None
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_replay_red_recovered_before_ordinary_flatten_still_cools_down():
+    # RED is seen mid-episode (row 120_000, drawdown 0.6) but the current sample
+    # has recovered by the flatten row: red_seen_in_episode still activates
+    # cooldown, and no-restart is evaluated on at-flatten drawdown (small), so
+    # the halt is a cooldown, not terminal.
+    symbol = "A"
+    bot = _flat_position_bot(symbol)
+    bot.get_exchange_time = lambda: 300_000
+
+    async def fake_history(current_balance=None, **kwargs):
+        return _red_episode_history(
+            symbol,
+            flatten_pnl=-1.0,
+            rows_upnl=[0.0, -30.0, -1.0, 0.0],
+            flatten_ts=210_000,
+        )
+
+    bot.get_balance_equity_history = fake_history
+
+    await bot._equity_hard_stop_initialize_coin_from_history()
+
+    state = bot._hsl_coin_state("long", symbol)
+    assert state["halted"] is True
+    assert state["no_restart_latched"] is False
+    assert state["cooldown_until_ms"] == 210_000 + 300_000
+    assert state["last_stop_event"]["stop_event_timestamp_ms"] == 210_000
+    assert bot._runtime_forced_modes["long"][symbol] == "graceful_stop"
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_replay_red_free_ordinary_flatten_resets_without_stop():
+    # Control: an episode that never saw RED and flattens ordinarily keeps the
+    # existing plain episode reset with no cooldown/no-restart accounting.
+    symbol = "A"
+    bot = _flat_position_bot(symbol)
+    bot.get_exchange_time = lambda: 180_000
+
+    async def fake_history(current_balance=None, **kwargs):
+        return _red_episode_history(symbol, flatten_pnl=-1.0, rows_upnl=[0.0, 0.0])
+
+    bot.get_balance_equity_history = fake_history
+
+    await bot._equity_hard_stop_initialize_coin_from_history()
+
+    state = bot._hsl_coin_state("long", symbol)
+    assert state["halted"] is False
+    assert state["no_restart_latched"] is False
+    assert state["cooldown_until_ms"] is None
+    assert state["last_stop_event"] is None
+    assert symbol not in bot._runtime_forced_modes["long"]
+
+
 @pytest.mark.asyncio
 async def test_coin_hsl_history_replay_does_not_latch_recovered_red_without_panic_marker():
     bot = make_coin_bot()
@@ -4086,9 +4252,12 @@ async def test_coin_hsl_history_replay_allows_flat_realized_only_rows():
 
 @pytest.mark.asyncio
 async def test_coin_hsl_history_replay_resets_current_episode_after_nonpanic_flatten():
+    # The episode stays below RED (drawdown 0.6 < 0.7): an ordinary flatten is a
+    # plain episode reset. RED-crossing episodes now latch cooldown/no-restart
+    # instead (see test_coin_hsl_replay_latches_cooldown_from_red_episode_*).
     bot = make_coin_bot()
     symbol = "A"
-    bot.hsl["long"]["red_threshold"] = 0.2
+    bot.hsl["long"]["red_threshold"] = 0.7
     bot.positions = {
         symbol: {"long": {"size": 1.0, "price": 100.0}, "short": {"size": 0.0}}
     }


### PR DESCRIPTION
## Summary

Closes the remaining gap in the "Coin-HSL episode anchoring redesign" tracker item: **terminal no-restart/cooldown accounting from canonical RED timestamps**.

Live coin-HSL startup replay derived cooldown/no-restart state only from bot-emitted panic order markers (`panic_flatten_events` / panic `pb_order_type` fills). An episode that crossed RED and was flattened by an **ordinary (non-panic) close fill** — including a manual close — was silently reset with no stop accounting (`red_seen_in_episode` was computed every replay row but never consulted), so a restart during an active cooldown, or after a terminal-drawdown episode, resumed trading. The Rust backtest halts at the RED flatten regardless of order type, and the B2.1 contract says cooldown activates for any episode with `red_seen_in_episode`, anchored at the scope-flattening fill.

## Change (src/passivbot_hsl.py, replay row loop)

- An ordinary scope-flattening fill of an episode with `red_seen_in_episode` now enters the **same stop-latch path as a confirmed panic marker**: `stop_ts` = flatten fill timestamp (B2.1 episode end), cooldown = `stop_ts + cooldown_ms`, and `restart_after_red_policy`/no-restart evaluated at that stop via the shared Rust `ehsl::no_restart_triggered` predicate (max(raw, ema) at the flatten sample). Latch payload, pnl-reset boundary, forced `graceful_stop`, and elapsed-cooldown restart behave identically to the panic-marker path.
- RED-free ordinary flattenings keep the existing plain episode reset.
- Reconstruction logs now carry `source=red_episode_flatten` vs `source=panic_fill_flatten`.
- `red_seen_in_episode` comes from the shared Rust runtime (confirmed min(raw, ema) RED semantics), so the decision predicate stays centralized in Rust; the Python change is replay/reconciliation orchestration, per the centralization guiding contract.

## Tests

Five new replay tests (all four latch scenarios **fail without the fix**; the control passes):
- cooldown latch anchored at the flatten fill, active at boot → halted + `graceful_stop`;
- terminal no-restart when the at-flatten drawdown breaches the threshold (policy=threshold);
- terminal no-restart under policy=never on any RED episode;
- RED recovered before the flatten still activates cooldown (red_seen drives it; no-restart evaluated on recovered at-flatten drawdown → not terminal);
- RED-free ordinary flatten keeps the plain reset (no stop state).

The existing `test_coin_hsl_history_replay_resets_current_episode_after_nonpanic_flatten` deliberately pinned the old semantics (threshold lowered so its episode crossed RED yet still reset); its episode now stays below RED, preserving its purpose of pinning the reset boundary and re-entry behavior.

Full local suite green except the 3 known out-of-scope failures (pymoo sampling, 2 bitget UTA stubs).

## Notes / future work

Broader cross-episode no-restart peak accounting (the backtest's `no_restart_peak_strategy_equity` analogue) remains future work, noted in the tracker. Backtest-side cooldown for RED-recovered-then-ordinarily-flattened episodes is a possible parity follow-up (live forward path and now replay follow the contract; the backtest only accumulates flat confirmations while in RED).

@vigilpbclaw-hash @claude @codex please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)