### PR TITLE
Repair stale hard_stop cargo tests to current B2.1/A2.2 contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Repaired three stale Rust hard_stop unit tests that pinned pre-B2.1/A2.2
+  mode-override behavior and were never run by CI: ORANGE tp-only now forces
+  flat sides too (A2.2), and RED only authorizes panic while the current
+  sample is actively RED - a recovered sample downgrades to tp-only (B2.1
+  red split). The repaired red test now pins both branches; no behavior
+  changes.
+
 - HSL startup now applies the clarified incomplete-history policy: with
   `restart_after_red_policy=always`, missing pre-episode fill coverage
   degrades to a loud warning when the coin scope's current-episode start is

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -6458,11 +6458,16 @@ mod tests {
             input.symbols[0].long.mode,
             Some(orchestrator::TradingMode::TpOnly)
         );
-        assert_eq!(input.symbols[0].short.mode, None);
+        // A2.2: ORANGE tp-only blocks initial entries, so the flat side is
+        // forced too.
+        assert_eq!(
+            input.symbols[0].short.mode,
+            Some(orchestrator::TradingMode::TpOnly)
+        );
     }
 
     #[test]
-    fn hard_stop_orange_tp_only_leaves_flat_sides_unchanged() {
+    fn hard_stop_orange_tp_only_forces_flat_sides() {
         let hlcvs = Array3::from_shape_vec((2, 1, 4), vec![1.0; 2 * 1 * 4]).unwrap();
         let btc_usd_prices = Array1::from_vec(vec![20_000.0, 20_000.0]);
 
@@ -6518,9 +6523,17 @@ mod tests {
         );
         bt.hard_stop_tier = ehsl::HardStopTier::Orange;
 
+        // A2.2: ORANGE tp-only blocks initial entries in the affected scope,
+        // so flat sides are forced to TpOnly instead of left unchanged.
         let input = bt.get_orchestrator_input_cached(1, None, None);
-        assert_eq!(input.symbols[0].long.mode, None);
-        assert_eq!(input.symbols[0].short.mode, None);
+        assert_eq!(
+            input.symbols[0].long.mode,
+            Some(orchestrator::TradingMode::TpOnly)
+        );
+        assert_eq!(
+            input.symbols[0].short.mode,
+            Some(orchestrator::TradingMode::TpOnly)
+        );
     }
 
     #[test]
@@ -6577,12 +6590,29 @@ mod tests {
             vec![ExchangeParams::default()],
             &backtest_params,
         );
-        bt.hard_stop_tier = ehsl::HardStopTier::Red;
         bt.positions.long[0] = Position {
             size: 1.0,
             price: 100.0,
         };
 
+        // B2.1 red split: RED tier with the current sample recovered
+        // (red_active_now false) blocks entries without authorizing panic.
+        bt.hard_stop_tier = ehsl::HardStopTier::Red;
+        let input = bt.get_orchestrator_input_cached(1, None, None);
+        assert_eq!(
+            input.symbols[0].long.mode,
+            Some(orchestrator::TradingMode::TpOnly)
+        );
+        assert_eq!(
+            input.symbols[0].short.mode,
+            Some(orchestrator::TradingMode::TpOnly)
+        );
+
+        // Only an actively-RED sample authorizes panic on all sides.
+        for pside in [LONG, SHORT] {
+            bt.hard_stop_pside[pside].tier = ehsl::HardStopTier::Red;
+            bt.hard_stop_pside[pside].red_active_now = true;
+        }
         let input = bt.get_orchestrator_input_cached(1, None, None);
         assert_eq!(
             input.symbols[0].long.mode,


### PR DESCRIPTION
## Summary

Follow-up flagged in the PR #1133 discussion: three Rust `hard_stop` unit tests failed under `cargo test --no-default-features` on clean v8. CI never runs cargo tests (workflow is a no-op), so they silently rotted when the B2.1 red split (#1129/#1130) and A2.2 ORANGE parity landed. Test-only changes — no behavior changes.

- `hard_stop_orange_overrides_to_tp_only` — expected the flat short side to stay `None`; per A2.2, ORANGE tp-only blocks initial entries, so flat sides are forced to `TpOnly` too (the `apply_orange_override` has-pos gate was removed in the A2.2 parity slice). Expectation updated.
- `hard_stop_orange_tp_only_leaves_flat_sides_unchanged` — pinned exactly the removed behavior; renamed to `hard_stop_orange_tp_only_forces_flat_sides`, both sides expected `TpOnly`.
- `hard_stop_red_forces_panic_on_all_sides` — set only the legacy display tier (`bt.hard_stop_tier = Red`); since the B2.1 red split gates panic emission on `red_active_now` (which legacy-alias hydration correctly does not arm), that setup now yields `TpOnly` by design. The test now pins **both** branches: recovered RED (tier red, `red_active_now` false) downgrades to TpOnly on all sides — the first Rust-level pin of this branch — and actively-RED runtimes (`red_active_now = true`) force Panic on all sides.

## Verification

- `cargo test --no-default-features`: **202 passed, 0 failed** — the full Rust suite is green for the first time.
- Extension rebuilt and stamped; full local pytest suite green except the 3 known out-of-scope failures (pymoo sampling, 2 bitget UTA stubs).

@vigilpbclaw-hash @claude @codex please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)