### PR TITLE
HSL: persist write-only replay cache from pside/unified startup replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- HSL pside/unified startup replay now persists the same write-only replay
+  cache as coin mode after a successful replay (held-pair raw matrices plus
+  the account-level realized-PnL series). The cache config digest includes
+  the HSL signal mode, so caches written by one mode can never be reused by
+  another, and cache-write failures only warn - they never affect the
+  completed replay. The caches are not yet read back on pside/unified boot;
+  the reuse gate for those modes is a follow-up slice.
+
 - Live coin-HSL startup replay now derives cooldown and no-restart evidence
   from canonical reconstructed RED episodes, not only from bot-emitted panic
   order markers. An episode that crossed RED and was flattened by an ordinary

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -1067,6 +1067,13 @@ Remaining implementation details:
       cooldown/no-restart evidence. Markers are validated fail-loud (grid
       alignment, series-span bounds, ascending order, account-kind only) and
       tamper-checked (missing/invalid/wrong-kind reasons).
+      Partial: pside/unified startup replay now persists the same write-only
+      cache as coin mode after a successful replay (held-pair matrices plus
+      the account series; matrix collection in get_balance_equity_history is
+      enabled for all three signal modes). The signal mode is part of the
+      cache config digest, so caches never cross modes. The pside/unified
+      reuse gate (synthesis + parity trust boundary for aggregate rows)
+      remains future work.
       Implemented: live coin-mode startup now attempts cache reuse before the
       full replay. Gates: write-time proven coverage recorded in the manifest
       plus a fresh load-time pnls-manager coverage proof, config-digest

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11760,9 +11760,14 @@ class Passivbot:
 
         # Non-authoritative raw replay matrices (ts, price, psize, pprice, pnl, upnl)
         # for currently held coin+psides. Written to the replay cache after a
-        # successful coin-mode replay; never read back for trading decisions here.
+        # successful HSL replay in any signal mode; never read back for trading
+        # decisions here. The cache config digest includes the signal mode, so
+        # matrices persisted by one mode can never be reused by another.
         replay_matrix_pairs: set[Tuple[str, str]] = set()
-        if str(hsl_replay_signal_mode or "").lower() == "coin" and not self.inverse:
+        if (
+            str(hsl_replay_signal_mode or "").lower() in ("coin", "pside", "unified")
+            and not self.inverse
+        ):
             replay_matrix_pairs = {
                 (pside, sym)
                 for (sym, pside), (size, _price) in current_position_state.items()

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -1909,7 +1909,10 @@ def _hsl_reuse_group_matrices(
 
 
 def _equity_hard_stop_persist_replay_matrices(self, history: dict[str, Any]) -> int:
-    """Persist non-authoritative raw replay matrices after a successful coin replay.
+    """Persist non-authoritative raw replay matrices after a successful HSL replay.
+
+    Called by the coin and pside/unified startup initializers alike; the cache
+    config digest includes the signal mode, so caches never cross modes.
 
     Write-only cache population: nothing here is read back for trading decisions.
     Per-pair failures are logged and emitted as events but never raised, because
@@ -4408,6 +4411,18 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
             if current_metrics["tier"] == "red":
                 state["pending_red_since_ms"] = int(current_metrics["timestamp_ms"])
         self._equity_hard_stop_refresh_halted_runtime_forced_modes()
+        try:
+            self._equity_hard_stop_persist_replay_matrices(history)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # Cache persistence is a performance aid; a failure here must
+            # never invalidate the completed replay.
+            logging.warning(
+                "[risk] HSL replay cache persistence failed | error=%s: %s",
+                type(exc).__name__,
+                exc,
+            )
     finally:
         if hasattr(self, "_set_log_silence_watchdog_context"):
             self._set_log_silence_watchdog_context(phase=prev_phase, stage=prev_stage)

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1682,14 +1682,25 @@ async def test_balance_equity_history_builds_replay_matrices_for_held_pairs(monk
     assert coverage["fill_coverage_proven"] is False
     assert coverage["fill_coverage_reason"] == "external_fill_events"
 
-    # Non-coin signal modes must not build matrices.
-    history_unified = await bot.get_balance_equity_history(
+    # pside/unified signal modes now build the same held-pair matrices and
+    # account series (write-only cache population; the cache config digest
+    # includes the signal mode, so caches never cross modes).
+    for other_mode in ("unified", "pside"):
+        history_other = await bot.get_balance_equity_history(
+            fill_events=fill_events,
+            current_balance=100.0,
+            hsl_replay_signal_mode=other_mode,
+        )
+        assert history_other["hsl_replay_matrices"] == matrices, other_mode
+        assert history_other["hsl_replay_account_series"] == account_rows, other_mode
+
+    # A replay fetch with no signal mode must not build matrices.
+    history_no_mode = await bot.get_balance_equity_history(
         fill_events=fill_events,
         current_balance=100.0,
-        hsl_replay_signal_mode="unified",
     )
-    assert history_unified["hsl_replay_matrices"] == {}
-    assert history_unified["hsl_replay_account_series"] == []
+    assert history_no_mode["hsl_replay_matrices"] == {}
+    assert history_no_mode["hsl_replay_account_series"] == []
 
     # A failing matrix row build must drop the pair's cache, not the replay.
     def raising_row_builder(**kwargs):

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -3117,6 +3117,85 @@ async def test_hard_stop_finalize_red_stop_uses_persistent_no_restart_peak(monke
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def _minimal_pside_history():
+    return {
+        "timeline": [
+            {
+                "timestamp": 1_000,
+                "balance": 100.0,
+                "realized_pnl": 0.0,
+                "realized_pnl_long": 0.0,
+                "realized_pnl_short": 0.0,
+                "unrealized_pnl_long": 0.0,
+                "unrealized_pnl_short": 0.0,
+                "is_flat": True,
+                "is_flat_long": True,
+                "is_flat_short": True,
+            }
+        ],
+        "panic_flatten_events": [],
+        "hsl_replay_matrices": {"long": {"XMR/USDT:USDT": [{"ts": 0}]}},
+        "hsl_replay_account_series": [{"ts": 0, "pnl": 0.0}],
+        "hsl_replay_matrix_coverage": {"fill_coverage_proven": False},
+    }
+
+
+@pytest.mark.asyncio
+async def test_hard_stop_initialize_from_history_persists_replay_cache(monkeypatch):
+    cfg = _dummy_config()
+    cfg["live"]["hsl_signal_mode"] = "unified"
+    bot = _make_dummy_bot(cfg)
+    _hsl_cfg(bot)["enabled"] = True
+    bot.balance = 100.0
+
+    history = _minimal_pside_history()
+
+    async def fake_history(*, current_balance=None, **kwargs):
+        return history
+
+    persisted = []
+    monkeypatch.setattr(bot, "get_balance_equity_history", fake_history)
+    monkeypatch.setattr(
+        bot,
+        "_equity_hard_stop_persist_replay_matrices",
+        lambda h: persisted.append(h) or 1,
+    )
+
+    await bot._equity_hard_stop_initialize_from_history()
+
+    assert persisted == [history]
+
+
+@pytest.mark.asyncio
+async def test_hard_stop_initialize_from_history_survives_cache_persist_failure(
+    monkeypatch, caplog
+):
+    cfg = _dummy_config()
+    cfg["live"]["hsl_signal_mode"] = "unified"
+    bot = _make_dummy_bot(cfg)
+    _hsl_cfg(bot)["enabled"] = True
+    bot.balance = 100.0
+
+    async def fake_history(*, current_balance=None, **kwargs):
+        return _minimal_pside_history()
+
+    def failing_persist(history):
+        raise RuntimeError("synthetic cache write failure")
+
+    monkeypatch.setattr(bot, "get_balance_equity_history", fake_history)
+    monkeypatch.setattr(
+        bot, "_equity_hard_stop_persist_replay_matrices", failing_persist
+    )
+
+    import logging as logging_module
+
+    with caplog.at_level(logging_module.WARNING):
+        await bot._equity_hard_stop_initialize_from_history()
+
+    assert "HSL replay cache persistence failed" in caplog.text
+    assert _hsl_state(bot)["halted"] is False
+
+
 @pytest.mark.asyncio
 async def test_hard_stop_initialize_from_history_terminal_stop_sets_latch(monkeypatch):
     cfg = _dummy_config()


### PR DESCRIPTION
## Summary

First slice extending the B2.1b replay-cache arc beyond coin mode. Pside/unified startup replay persisted nothing — `get_balance_equity_history` collected replay matrices only when `hsl_replay_signal_mode == "coin"` — so every pside/unified restart pays the full history fetch + replay. This slice is **write-only**, mirroring how the coin arc landed (write → parity → reuse): the caches are never read back in these modes yet.

## Changes

- `src/passivbot.py`: matrix collection (held-pair raw matrices `ts/price/psize/pprice/pnl/upnl` + account-level realized-PnL series) is enabled for all three HSL signal modes (still linear-only, held pairs only). A fetch with no signal mode still collects nothing.
- `src/passivbot_hsl.py`: `_equity_hard_stop_initialize_from_history` (pside/unified initializer) persists after a successful replay via the same never-raise `_equity_hard_stop_persist_replay_matrices` guard as the coin initializer; a cache-write failure warns and never touches the completed replay. Helper docstring updated.
- Mode isolation is pre-existing: `_hsl_replay_cache_config_digest` includes `signal_mode`, so caches written by one mode can never validate for another mode's boot.

## Tests

- History-fetch regression (`tests/test_passivbot_balance_split.py`): pside and unified fetches now collect matrices and account series **identical** to the coin fetch on the same fills; a mode-less fetch still collects nothing; existing degraded-path expectations unchanged.
- Two initializer wiring tests (`tests/test_unstucking_safeguards.py`): persist is called exactly once with the fetched history; a synthetic persist failure logs the warning and leaves HSL state intact.

Full local suite green except the 3 known out-of-scope failures (pymoo sampling, 2 bitget UTA stubs); extension rebuilt and stamped.

## Follow-up

The pside/unified reuse gate (aggregate-row synthesis + parity trust boundary, then the load-time gates mirroring the coin mode's coverage/watermark/position checks) is the next slice, tracked in the plan.

@vigilpbclaw-hash @claude @codex please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)