### PR TITLE
HSL replay cache schema v5: per-pside pnl in the account series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- HSL replay cache schema v5: the persisted account-level realized-PnL
+  series now carries per-minute per-pside deltas (`pnl_long`, `pnl_short`)
+  alongside the account-level `pnl`, collected from the authoritative
+  per-pside running totals during the history replay and reproduced exactly
+  by the watermark-extension helper (which now requires an explicit position
+  side on every extension fill and rejects the cache otherwise). This is
+  groundwork for the future pside/unified cache-reuse gate, whose timeline
+  synthesis needs per-pside realized PnL. Existing v4 caches fail schema
+  validation and are rebuilt by the next full replay, by design.
+
 - HSL pside/unified startup replay now persists the same write-only replay
   cache as coin mode after a successful replay (held-pair raw matrices plus
   the account-level realized-PnL series). The cache config digest includes

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -1067,6 +1067,15 @@ Remaining implementation details:
       cooldown/no-restart evidence. Markers are validated fail-loud (grid
       alignment, series-span bounds, ascending order, account-kind only) and
       tamper-checked (missing/invalid/wrong-kind reasons).
+      Partial: cache schema v5 extends the account series with per-minute
+      per-pside realized deltas (`pnl_long`/`pnl_short`), collected from the
+      authoritative per-pside running totals and reproduced by the
+      watermark-extension helper with strict fill-pside attribution
+      (missing pside rejects the cache). Needed because the future
+      pside/unified timeline synthesis must reconstruct
+      `realized_pnl_long/short`, which held-pair matrices alone cannot
+      provide. v4 caches are invalidated by the schema bump and rebuilt on
+      the next full replay.
       Partial: pside/unified startup replay now persists the same write-only
       cache as coin mode after a successful replay (held-pair matrices plus
       the account series; matrix collection in get_balance_equity_history is

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11784,24 +11784,39 @@ class Passivbot:
         replay_account_enabled = bool(replay_matrix_pairs)
         replay_account_rows: List[dict] = []
         replay_account_prev_balance: Optional[float] = None
+        replay_account_prev_realized_pside: Optional[Dict[str, float]] = None
 
         def _collect_account_series_row(minute_ts: int, *, record: bool) -> None:
             nonlocal replay_account_enabled, replay_account_prev_balance
+            nonlocal replay_account_prev_realized_pside
             if not replay_account_enabled:
                 return
             try:
                 balance_now = float(balance)
+                realized_pside_now = {
+                    "long": float(realized_pnl_pside_running["long"]),
+                    "short": float(realized_pnl_pside_running["short"]),
+                }
                 prev = (
                     balance_now
                     if replay_account_prev_balance is None
                     else replay_account_prev_balance
                 )
+                prev_pside = (
+                    realized_pside_now
+                    if replay_account_prev_realized_pside is None
+                    else replay_account_prev_realized_pside
+                )
                 replay_account_prev_balance = balance_now
+                replay_account_prev_realized_pside = realized_pside_now
                 if not record:
                     return
                 replay_account_rows.append(
                     pb_hsl._hsl_replay_account_series_row(
-                        ts=int(minute_ts), pnl=balance_now - prev
+                        ts=int(minute_ts),
+                        pnl=balance_now - prev,
+                        pnl_long=realized_pside_now["long"] - prev_pside["long"],
+                        pnl_short=realized_pside_now["short"] - prev_pside["short"],
                     )
                 )
             except Exception as exc:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11978,6 +11978,10 @@ class Passivbot:
             )
         if replay_account_enabled:
             replay_account_prev_balance = float(balance)
+            replay_account_prev_realized_pside = {
+                "long": float(realized_pnl_pside_running["long"]),
+                "short": float(realized_pnl_pside_running["short"]),
+            }
         record_start_realized_pnl_pside = {
             "long": float(realized_pnl_pside_running["long"]),
             "short": float(realized_pnl_pside_running["short"]),

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -33,11 +33,11 @@ from utils import make_get_filepath
 _HSL_RISKS_DOC = "docs/equity_hard_stop_loss_risks.md"
 _HSL_REPLAY_MATRIX_INTERVAL_MS = 60_000
 _HSL_REPLAY_MATRIX_RAW_FIELDS = ("ts", "price", "psize", "pprice", "pnl", "upnl")
-_HSL_REPLAY_ACCOUNT_SERIES_FIELDS = ("ts", "pnl")
+_HSL_REPLAY_ACCOUNT_SERIES_FIELDS = ("ts", "pnl", "pnl_long", "pnl_short")
 _HSL_REPLAY_CACHE_SERIES_KINDS = ("pair_matrix", "account_pnl")
 _HSL_REPLAY_CACHE_ACCOUNT_PSIDE = "account"
 _HSL_REPLAY_CACHE_ACCOUNT_SYMBOL = "__account__"
-_HSL_REPLAY_CACHE_SCHEMA_VERSION = 4
+_HSL_REPLAY_CACHE_SCHEMA_VERSION = 5
 _HSL_REPLAY_CACHE_MATRIX_FILENAME = "hsl_replay_matrix.npz"
 _HSL_REPLAY_CACHE_MANIFEST_FILENAME = "hsl_replay_manifest.json"
 _HSL_REPLAY_CACHE_REQUIRED_METADATA = (
@@ -462,12 +462,24 @@ def _hsl_replay_matrix_row(
     }
 
 
-def _hsl_replay_account_series_row(*, ts: int, pnl: float) -> dict[str, float | int]:
-    """Build one non-authoritative account-level realized-PnL row."""
+def _hsl_replay_account_series_row(
+    *, ts: int, pnl: float, pnl_long: float, pnl_short: float
+) -> dict[str, float | int]:
+    """Build one non-authoritative account-level realized-PnL row.
+
+    `pnl` is the per-minute account-level delta (balance accounting, fees
+    included); `pnl_long`/`pnl_short` are the per-minute per-pside realized
+    deltas needed by the future pside/unified timeline synthesis.
+    """
     ts_int = int(ts)
     if ts_int < 0:
         raise ValueError(f"HSL account series ts must be >= 0, got {ts_int}")
-    return {"ts": ts_int, "pnl": _finite_hsl_float(pnl, "pnl")}
+    return {
+        "ts": ts_int,
+        "pnl": _finite_hsl_float(pnl, "pnl"),
+        "pnl_long": _finite_hsl_float(pnl_long, "pnl_long"),
+        "pnl_short": _finite_hsl_float(pnl_short, "pnl_short"),
+    }
 
 
 def _hsl_replay_account_series_arrays(rows: list[dict[str, Any]]) -> dict[str, Any]:
@@ -486,11 +498,19 @@ def _hsl_replay_account_series_arrays(rows: list[dict[str, Any]]) -> dict[str, A
                 "HSL account series rows must be contiguous 1m samples; "
                 f"got previous_ts={prev_ts} ts={ts}"
             )
-        _finite_hsl_float(row["pnl"], "pnl")
+        for field in _HSL_REPLAY_ACCOUNT_SERIES_FIELDS:
+            if field != "ts":
+                _finite_hsl_float(row[field], field)
         prev_ts = ts
     return {
         "ts": np.asarray([int(row["ts"]) for row in rows], dtype=np.int64),
         "pnl": np.asarray([float(row["pnl"]) for row in rows], dtype=np.float64),
+        "pnl_long": np.asarray(
+            [float(row["pnl_long"]) for row in rows], dtype=np.float64
+        ),
+        "pnl_short": np.asarray(
+            [float(row["pnl_short"]) for row in rows], dtype=np.float64
+        ),
     }
 
 
@@ -904,13 +924,32 @@ def _hsl_replay_extend_account_rows(
     for minute in minutes:
         boundary = minute + _HSL_REPLAY_MATRIX_INTERVAL_MS
         minute_pnl = 0.0
+        minute_pnl_pside = {"long": 0.0, "short": 0.0}
         while fill_idx < len(ordered) and int(ordered[fill_idx]["timestamp"]) < boundary:
             fill = ordered[fill_idx]
-            minute_pnl += _finite_hsl_float(fill["pnl"], "pnl") + _finite_hsl_float(
+            fill_pnl = _finite_hsl_float(fill["pnl"], "pnl") + _finite_hsl_float(
                 fill.get("fee", 0.0), "fee"
             )
+            minute_pnl += fill_pnl
+            # Strict pside attribution: the permissive accessor's default of
+            # "long" would silently corrupt per-pside evidence here.
+            raw_pside = fill.get("position_side", fill.get("pside"))
+            pside = str(raw_pside).lower() if raw_pside is not None else None
+            if pside not in minute_pnl_pside:
+                raise ValueError(
+                    "HSL account series extension fill has no usable position "
+                    f"side (ts={fill['timestamp']}); the cache must be rejected"
+                )
+            minute_pnl_pside[pside] += fill_pnl
             fill_idx += 1
-        new_rows.append(_hsl_replay_account_series_row(ts=int(minute), pnl=minute_pnl))
+        new_rows.append(
+            _hsl_replay_account_series_row(
+                ts=int(minute),
+                pnl=minute_pnl,
+                pnl_long=minute_pnl_pside["long"],
+                pnl_short=minute_pnl_pside["short"],
+            )
+        )
     return new_rows
 
 

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -539,9 +539,9 @@ def test_hsl_replay_cache_validation_flags_missing_coverage_proof_fields(tmp_pat
 
 def _hsl_account_series_rows():
     return [
-        hsl._hsl_replay_account_series_row(ts=60_000, pnl=0.0),
-        hsl._hsl_replay_account_series_row(ts=120_000, pnl=-2.5),
-        hsl._hsl_replay_account_series_row(ts=180_000, pnl=1.0),
+        hsl._hsl_replay_account_series_row(ts=60_000, pnl=0.0, pnl_long=0.0, pnl_short=0.0),
+        hsl._hsl_replay_account_series_row(ts=120_000, pnl=-2.5, pnl_long=-2.5, pnl_short=0.0),
+        hsl._hsl_replay_account_series_row(ts=180_000, pnl=1.0, pnl_long=1.0, pnl_short=0.0),
     ]
 
 
@@ -558,7 +558,7 @@ def test_hsl_replay_account_series_round_trip(tmp_path):
     )
 
     assert manifest["series_kind"] == "account_pnl"
-    assert manifest["fields"] == ["ts", "pnl"]
+    assert manifest["fields"] == ["ts", "pnl", "pnl_long", "pnl_short"]
     assert (
         hsl._hsl_replay_cache_validation_reasons(tmp_path, expected_metadata=metadata)
         == []
@@ -566,15 +566,15 @@ def test_hsl_replay_account_series_round_trip(tmp_path):
     loaded_manifest, arrays = hsl._load_hsl_replay_matrix_cache(
         tmp_path, expected_metadata=metadata
     )
-    assert set(arrays) == {"ts", "pnl"}
+    assert set(arrays) == {"ts", "pnl", "pnl_long", "pnl_short"}
     np.testing.assert_array_equal(arrays["ts"], np.array([60_000, 120_000, 180_000]))
     np.testing.assert_allclose(arrays["pnl"], [0.0, -2.5, 1.0])
 
     with pytest.raises(ValueError, match="contiguous"):
         hsl._hsl_replay_account_series_arrays(
             [
-                hsl._hsl_replay_account_series_row(ts=60_000, pnl=0.0),
-                hsl._hsl_replay_account_series_row(ts=240_000, pnl=1.0),
+                hsl._hsl_replay_account_series_row(ts=60_000, pnl=0.0, pnl_long=0.0, pnl_short=0.0),
+                hsl._hsl_replay_account_series_row(ts=240_000, pnl=1.0, pnl_long=1.0, pnl_short=0.0),
             ]
         )
 
@@ -2182,6 +2182,41 @@ async def test_hsl_cache_extension_matches_full_rebuild(monkeypatch):
         )
 
 
+def test_hsl_account_extension_requires_fill_pside():
+    account = hsl._hsl_replay_account_series_arrays(
+        [
+            hsl._hsl_replay_account_series_row(
+                ts=60_000, pnl=0.0, pnl_long=0.0, pnl_short=0.0
+            ),
+        ]
+    )
+    fill = {
+        "timestamp": 130_000,
+        "qty": 1.0,
+        "price": 100.0,
+        "action": "decrease",
+        "pnl": -2.0,
+        "position_side": "short",
+    }
+    rows = hsl._hsl_replay_extend_account_rows(
+        dict(account), fills=[fill], end_ts=180_000
+    )
+    # Watermark 60_000, end 180_000 -> extension minutes [120_000, 180_000];
+    # the fill at 130_000 lands in the first extension minute.
+    assert [row["ts"] for row in rows] == [120_000, 180_000]
+    assert [row["pnl_short"] for row in rows] == [-2.0, 0.0]
+    assert all(row["pnl_long"] == 0.0 for row in rows)
+    assert [row["pnl"] for row in rows] == [-2.0, 0.0]
+
+    # A fill without a usable position side must reject the cache, not guess.
+    anonymous = dict(fill)
+    del anonymous["position_side"]
+    with pytest.raises(ValueError, match="no usable position side"):
+        hsl._hsl_replay_extend_account_rows(
+            dict(account), fills=[anonymous], end_ts=180_000
+        )
+
+
 def test_hsl_cache_extension_fail_loud_contracts():
     pair = hsl._hsl_replay_matrix_arrays(
         [
@@ -2701,8 +2736,8 @@ async def test_hsl_cache_reuse_falls_back_on_missing_or_incompatible_cache(
 def test_hsl_cache_synthesized_rows_fail_loud_on_bad_inputs():
     account = hsl._hsl_replay_account_series_arrays(
         [
-            hsl._hsl_replay_account_series_row(ts=60_000, pnl=0.0),
-            hsl._hsl_replay_account_series_row(ts=120_000, pnl=0.5),
+            hsl._hsl_replay_account_series_row(ts=60_000, pnl=0.0, pnl_long=0.0, pnl_short=0.0),
+            hsl._hsl_replay_account_series_row(ts=120_000, pnl=0.5, pnl_long=0.5, pnl_short=0.0),
         ]
     )
     pair = hsl._hsl_replay_matrix_arrays(
@@ -2740,8 +2775,8 @@ def test_hsl_cache_synthesized_rows_fail_loud_on_bad_inputs():
     # the coin metrics layer requires balance > 0.
     deep_loss_account = hsl._hsl_replay_account_series_arrays(
         [
-            hsl._hsl_replay_account_series_row(ts=60_000, pnl=0.0),
-            hsl._hsl_replay_account_series_row(ts=120_000, pnl=250.0),
+            hsl._hsl_replay_account_series_row(ts=60_000, pnl=0.0, pnl_long=0.0, pnl_short=0.0),
+            hsl._hsl_replay_account_series_row(ts=120_000, pnl=250.0, pnl_long=250.0, pnl_short=0.0),
         ]
     )
     with pytest.raises(ValueError, match="finite and > 0"):
@@ -2836,8 +2871,8 @@ async def test_coin_hsl_history_replay_persists_replay_matrices(tmp_path, monkey
             "fill_events": [],
             "hsl_replay_matrices": {"long": {symbol: matrix_rows}},
             "hsl_replay_account_series": [
-                hsl._hsl_replay_account_series_row(ts=60_000, pnl=0.0),
-                hsl._hsl_replay_account_series_row(ts=120_000, pnl=1.0),
+                hsl._hsl_replay_account_series_row(ts=60_000, pnl=0.0, pnl_long=0.0, pnl_short=0.0),
+                hsl._hsl_replay_account_series_row(ts=120_000, pnl=1.0, pnl_long=1.0, pnl_short=0.0),
             ],
             "hsl_replay_matrix_coverage": coverage,
         }

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1575,6 +1575,100 @@ async def test_balance_equity_history_paces_replay_candle_fetches(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_balance_equity_history_first_minute_realized_pnl_attributes_pside(
+    monkeypatch,
+):
+    # Codex P1 regression on schema v5: with lookback "all" the record window
+    # starts at the first minute; a realized fill inside that minute must land
+    # in pnl_long/pnl_short exactly like in pnl (the per-pside baseline must be
+    # seeded alongside the balance baseline, pre-fill).
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {}}
+    bot.exchange = "kucoin"
+    bot.user = "test_user"
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
+    base_ts = 1_800_000_000_000
+    ts_now = base_ts + 120_000
+    bot.get_exchange_time = lambda: ts_now
+    bot.get_raw_balance = lambda: 101.0
+    bot.get_symbol_id_inv = lambda symbol: symbol
+    symbol = "BTC/USDT:USDT"
+    bot.positions = {
+        symbol: {
+            "long": {"size": 0.5, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    bot._pnls_manager = None
+    bot.inverse = False
+    bot._candle_fetch_concurrency = lambda *, context="runtime": 2
+    bot._get_fetch_delay_seconds = lambda: 0.0
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[ListEventSink()],
+        monitor_sinks=[],
+    )
+    bot._live_event_current_cycle_id = "cy_hsl_first_minute_pnl"
+    bot._emit_live_event = Passivbot._emit_live_event.__get__(bot, Passivbot)
+    bot.c_mults = {symbol: 1.0}
+    monkeypatch.setattr(
+        passivbot_module, "compute_psize_pprice", lambda *args, **kwargs: None
+    )
+
+    class _CM:
+        async def get_candles(self, sym, **kwargs):
+            return np.array(
+                [
+                    (base_ts, 99.0, 101.0, 98.0, 100.0, 1.0),
+                    (base_ts + 60_000, 100.0, 102.0, 99.0, 101.0, 1.0),
+                    (base_ts + 120_000, 101.0, 103.0, 100.0, 102.0, 1.0),
+                ],
+                dtype=passivbot_module.CANDLE_DTYPE,
+            )
+
+    bot.cm = _CM()
+    fill_events = [
+        {
+            "timestamp": base_ts,
+            "symbol": symbol,
+            "position_side": "long",
+            "side": "buy",
+            "qty": 1.0,
+            "price": 100.0,
+            "pnl": 0.0,
+        },
+        {
+            # Realized close inside the FIRST minute of the record window.
+            "timestamp": base_ts + 1_000,
+            "symbol": symbol,
+            "position_side": "long",
+            "side": "sell",
+            "qty": 0.5,
+            "price": 102.0,
+            "pnl": 1.0,
+        },
+    ]
+
+    history = await bot.get_balance_equity_history(
+        fill_events=fill_events,
+        current_balance=101.0,
+        hsl_replay_signal_mode="unified",
+    )
+
+    account_rows = history["hsl_replay_account_series"]
+    assert account_rows, "account series must be collected"
+    first = account_rows[0]
+    assert first["pnl"] == pytest.approx(1.0)
+    assert first["pnl_long"] == pytest.approx(1.0)
+    assert first["pnl_short"] == 0.0
+    for row in account_rows[1:]:
+        assert row["pnl"] == 0.0
+        assert row["pnl_long"] == 0.0
+        assert row["pnl_short"] == 0.0
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
 async def test_balance_equity_history_builds_replay_matrices_for_held_pairs(monkeypatch):
     bot = Passivbot.__new__(Passivbot)
     bot.config = {"live": {}}

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1670,6 +1670,11 @@ async def test_balance_equity_history_builds_replay_matrices_for_held_pairs(monk
     # other recorded minute has zero account-level realized pnl.
     assert [row["pnl"] for row in account_rows[-3:]] == [0.0, 0.5, 0.0]
     assert sum(row["pnl"] for row in account_rows) == pytest.approx(0.5)
+    # Schema v5: per-minute per-pside realized deltas. The fixture's only
+    # realized event is the long partial close (+0.5).
+    assert [row["pnl_long"] for row in account_rows[-3:]] == [0.0, 0.5, 0.0]
+    assert all(row["pnl_short"] == 0.0 for row in account_rows)
+    assert sum(row["pnl_long"] for row in account_rows) == pytest.approx(0.5)
 
     coverage = history["hsl_replay_matrix_coverage"]
     assert coverage["candle_covered_start_ms"] <= base_ts


### PR DESCRIPTION
## Summary

Groundwork slice for the pside/unified cache-reuse gate (follow-up to #1135). The future pside/unified timeline synthesis must reconstruct `realized_pnl_long/short`, which held-pair matrices alone cannot provide — so the persisted account-level series now carries per-minute per-pside realized deltas.

## Changes

- `_HSL_REPLAY_ACCOUNT_SERIES_FIELDS` → `("ts", "pnl", "pnl_long", "pnl_short")`; `_HSL_REPLAY_CACHE_SCHEMA_VERSION` → 5. Existing v4 caches fail schema validation and are rebuilt by the next full replay, by design (fail-closed; reuse falls back to the authoritative full replay).
- `src/passivbot.py` collection: `_collect_account_series_row` derives the per-pside deltas from the authoritative `realized_pnl_pside_running` totals, mirroring the existing balance-delta pattern.
- `_hsl_replay_extend_account_rows` (watermark extension) reproduces the fields from post-watermark fills with **strict** pside attribution: a fill without an explicit `position_side`/`pside` raises and rejects the cache. The permissive shared accessor (`_equity_hard_stop_fill_pside`, which silently defaults to `"long"`) is deliberately not used there — a silent default would corrupt per-pside evidence.
- Row builder and arrays builder validate all v5 fields finite; array manifest/hash/tamper machinery picks the new fields up generically.

## Tests

- History-fetch regression pins the collected per-pside deltas (long partial close → `pnl_long` `[0, 0.5, 0]`, `pnl_short` all zero).
- The existing slice-and-extend parity test now proves the new fields to 1e-12 automatically (it compares **all** account array fields against a full rebuild).
- New extension test pins short-side attribution and the fail-loud missing-pside rejection.
- Round-trip fields/arrays pins updated to the v5 field set; all touched suites green (427 passed), full local suite green except the 3 known out-of-scope failures.

@vigilpbclaw-hash @claude @codex please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)