### PR TITLE
HSL: pure pside/unified timeline synthesis with parity trust boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- HSL: new pure, unwired synthesis helper
+  `_hsl_replay_pside_timeline_rows_from_cache` converts persisted held-pair
+  matrices plus the schema-v5 account series into the aggregate timeline
+  rows the pside/unified startup replay consumes, with fail-loud
+  span/continuity/alignment checks. Parity tests prove the synthesized rows
+  equal the authoritative history timeline field-for-field (long and short
+  pairs, realized events on both sides, flatness transitions) and that
+  contract-shaped rows drive the pside/unified initializer to a state
+  identical to authoritative-shaped rows. The helper is not yet consumed:
+  the pside/unified reuse gate is a follow-up slice, and it must prove from
+  fills that cached pairs were the only pairs with in-window positions
+  before trusting these aggregates.
+
 - HSL replay cache schema v5: the persisted account-level realized-PnL
   series now carries per-minute per-pside deltas (`pnl_long`, `pnl_short`)
   alongside the account-level `pnl`, collected from the authoritative

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -1067,6 +1067,16 @@ Remaining implementation details:
       cooldown/no-restart evidence. Markers are validated fail-loud (grid
       alignment, series-span bounds, ascending order, account-kind only) and
       tamper-checked (missing/invalid/wrong-kind reasons).
+      Partial: a pure, unwired `_hsl_replay_pside_timeline_rows_from_cache`
+      now synthesizes the aggregate pside/unified timeline rows (balance,
+      windowed realized_pnl and per-pside realized, per-pside upnl and
+      flatness from signed pair psize) from held-pair matrices plus the v5
+      account series, with the same fail-loud span/continuity checks as the
+      coin synthesis. Field-for-field parity against the authoritative
+      timeline and initializer state parity on contract-shaped rows are
+      pinned. Documented precondition for the future reuse gate: cached
+      pairs must be proven (from fills) to be the only pairs with in-window
+      positions, else full replay.
       Partial: cache schema v5 extends the account series with per-minute
       per-pside realized deltas (`pnl_long`/`pnl_short`), collected from the
       authoritative per-pside running totals and reproduced by the

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -730,6 +730,142 @@ def _hsl_replay_timeline_rows_from_cache(
     return rows
 
 
+def _hsl_replay_pside_timeline_rows_from_cache(
+    pair_arrays: dict[tuple[str, str], dict[str, Any]],
+    account_arrays: dict[str, Any],
+    *,
+    current_balance: float,
+) -> list[dict[str, Any]]:
+    """Synthesize pside/unified-replay timeline rows from persisted cache arrays.
+
+    Pure and unwired: the trust-boundary conversion a future pside/unified
+    reuse slice would feed into `_equity_hard_stop_initialize_from_history`.
+    Each row carries exactly the aggregate fields that initializer consumes:
+    `timestamp`, `balance`, `realized_pnl`, `realized_pnl_long`,
+    `realized_pnl_short`, `unrealized_pnl_long`, `unrealized_pnl_short`,
+    `is_flat`, `is_flat_long`, `is_flat_short`.
+
+    CRITICAL precondition (enforced by the future reuse gate, not here): the
+    cached pairs must be the ONLY pairs that held positions anywhere in the
+    covered window. Unrealized-PnL and flatness aggregates are summed from
+    cached pair matrices alone, so any uncached pair with an in-window
+    position makes them wrong; the reuse gate must prove pair completeness
+    from fills (mirroring the coin-mode flat-pair rejection) or force a full
+    replay. Realized aggregates come from the schema-v5 account series
+    (`pnl_long`/`pnl_short`) and are anchored at the series start like the
+    authoritative record-window anchor. Fail-loud on any input that cannot
+    prove equivalence.
+    """
+    import numpy as np
+
+    balance_f = _finite_hsl_float(current_balance, "current_balance")
+    if balance_f <= 0.0:
+        raise ValueError(f"current_balance must be > 0, got {balance_f}")
+    account_reasons = _hsl_replay_cache_array_value_reasons(
+        dict(account_arrays), series_kind="account_pnl"
+    )
+    if account_reasons:
+        raise ValueError(
+            "HSL cache account arrays invalid: " + ", ".join(account_reasons)
+        )
+    account_ts = np.asarray(account_arrays["ts"], dtype=np.int64)
+    if account_ts.size == 0:
+        raise ValueError("HSL cache account arrays must not be empty")
+    if account_ts.size > 1 and not bool(
+        np.all(np.diff(account_ts) == _HSL_REPLAY_MATRIX_INTERVAL_MS)
+    ):
+        raise ValueError("HSL cache account arrays invalid: timestamp_not_contiguous")
+    account_pnl = np.asarray(account_arrays["pnl"], dtype=np.float64)
+    account_cumsum = np.cumsum(account_pnl, dtype=np.float64)
+    pside_cumsum = {
+        "long": np.cumsum(
+            np.asarray(account_arrays["pnl_long"], dtype=np.float64), dtype=np.float64
+        ),
+        "short": np.cumsum(
+            np.asarray(account_arrays["pnl_short"], dtype=np.float64), dtype=np.float64
+        ),
+    }
+    # Anchor the balance series so its final minute equals the current balance,
+    # mirroring how the authoritative replay back-computes its baseline.
+    balances = balance_f - (float(account_cumsum[-1]) - account_cumsum)
+    if not bool(np.all(np.isfinite(balances))) or bool(np.any(balances <= 0.0)):
+        raise ValueError(
+            "HSL cache-derived balance series must be finite and > 0 for every minute"
+        )
+    start_ts = int(account_ts[0])
+    end_ts = int(account_ts[-1])
+    n_rows = int(len(account_ts))
+    upnl_by_minute = {
+        "long": np.zeros(n_rows, dtype=np.float64),
+        "short": np.zeros(n_rows, dtype=np.float64),
+    }
+    nonflat_by_minute = {
+        "long": np.zeros(n_rows, dtype=bool),
+        "short": np.zeros(n_rows, dtype=bool),
+    }
+    for pair, arrays in pair_arrays.items():
+        pside, symbol = pair
+        if pside not in ("long", "short"):
+            raise ValueError(f"HSL cache pair pside must be long or short, got {pside!r}")
+        pair_reasons = _hsl_replay_cache_array_value_reasons(
+            dict(arrays), series_kind="pair_matrix"
+        )
+        if pair_reasons:
+            raise ValueError(
+                f"HSL cache pair arrays invalid for {pside}:{symbol}: "
+                + ", ".join(pair_reasons)
+            )
+        pair_ts = np.asarray(arrays["ts"], dtype=np.int64)
+        if pair_ts.size == 0:
+            raise ValueError(f"HSL cache pair arrays empty for {pside}:{symbol}")
+        if pair_ts.size > 1 and not bool(
+            np.all(np.diff(pair_ts) == _HSL_REPLAY_MATRIX_INTERVAL_MS)
+        ):
+            raise ValueError(
+                f"HSL cache pair arrays invalid for {pside}:{symbol}: "
+                "timestamp_not_contiguous"
+            )
+        pair_start = int(pair_ts[0])
+        pair_end = int(pair_ts[-1])
+        if pair_start < start_ts or pair_end > end_ts:
+            raise ValueError(
+                f"HSL cache pair series for {pside}:{symbol} spans "
+                f"[{pair_start}, {pair_end}] outside account span "
+                f"[{start_ts}, {end_ts}]"
+            )
+        if (pair_start - start_ts) % _HSL_REPLAY_MATRIX_INTERVAL_MS != 0:
+            raise ValueError(
+                f"HSL cache pair series for {pside}:{symbol} is not aligned to "
+                "the account minute grid"
+            )
+        offset = (pair_start - start_ts) // _HSL_REPLAY_MATRIX_INTERVAL_MS
+        pair_upnl = np.asarray(arrays["upnl"], dtype=np.float64)
+        # Pair matrices store signed position size (shorts are negative).
+        pair_psize = np.asarray(arrays["psize"], dtype=np.float64)
+        span = slice(offset, offset + len(pair_ts))
+        upnl_by_minute[pside][span] += pair_upnl
+        nonflat_by_minute[pside][span] |= np.abs(pair_psize) > 1e-12
+    rows: list[dict[str, Any]] = []
+    for idx in range(n_rows):
+        flat_long = not bool(nonflat_by_minute["long"][idx])
+        flat_short = not bool(nonflat_by_minute["short"][idx])
+        rows.append(
+            {
+                "timestamp": int(account_ts[idx]),
+                "balance": float(balances[idx]),
+                "realized_pnl": float(account_cumsum[idx]),
+                "realized_pnl_long": float(pside_cumsum["long"][idx]),
+                "realized_pnl_short": float(pside_cumsum["short"][idx]),
+                "unrealized_pnl_long": float(upnl_by_minute["long"][idx]),
+                "unrealized_pnl_short": float(upnl_by_minute["short"][idx]),
+                "is_flat": flat_long and flat_short,
+                "is_flat_long": flat_long,
+                "is_flat_short": flat_short,
+            }
+        )
+    return rows
+
+
 def _hsl_replay_rows_from_arrays(
     arrays: dict[str, Any], *, series_kind: str
 ) -> list[dict[str, Any]]:

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -776,14 +776,29 @@ def _hsl_replay_pside_timeline_rows_from_cache(
     ):
         raise ValueError("HSL cache account arrays invalid: timestamp_not_contiguous")
     account_pnl = np.asarray(account_arrays["pnl"], dtype=np.float64)
+    pnl_long = np.asarray(account_arrays["pnl_long"], dtype=np.float64)
+    pnl_short = np.asarray(account_arrays["pnl_short"], dtype=np.float64)
+    # The authoritative writer accumulates the identical pnl+fee per fill into
+    # both the balance stream and the per-pside totals, so per minute
+    # pnl == pnl_long + pnl_short must hold; anything else is a malformed or
+    # internally inconsistent v5 series and must be rejected, not synthesized.
+    pside_sum = pnl_long + pnl_short
+    tolerance = 1e-9 * np.maximum(
+        1.0, np.maximum(np.abs(account_pnl), np.abs(pside_sum))
+    )
+    mismatch = np.abs(account_pnl - pside_sum) > tolerance
+    if bool(np.any(mismatch)):
+        idx = int(np.argmax(mismatch))
+        raise ValueError(
+            "HSL cache account arrays invalid: pnl_pside_sum_mismatch at "
+            f"ts={int(np.asarray(account_arrays['ts'], dtype=np.int64)[idx])} "
+            f"(pnl={float(account_pnl[idx])!r}, "
+            f"pnl_long+pnl_short={float(pside_sum[idx])!r})"
+        )
     account_cumsum = np.cumsum(account_pnl, dtype=np.float64)
     pside_cumsum = {
-        "long": np.cumsum(
-            np.asarray(account_arrays["pnl_long"], dtype=np.float64), dtype=np.float64
-        ),
-        "short": np.cumsum(
-            np.asarray(account_arrays["pnl_short"], dtype=np.float64), dtype=np.float64
-        ),
+        "long": np.cumsum(pnl_long, dtype=np.float64),
+        "short": np.cumsum(pnl_short, dtype=np.float64),
     }
     # Anchor the balance series so its final minute equals the current balance,
     # mirroring how the authoritative replay back-computes its baseline.

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1574,7 +1574,6 @@ async def test_balance_equity_history_paces_replay_candle_fetches(monkeypatch):
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
-@pytest.mark.asyncio
 def test_pside_timeline_synthesis_rejects_inconsistent_pside_pnl():
     # Codex P1: the trust boundary must reject a v5 account series whose
     # account-level pnl and per-pside pnl describe different realized streams.

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1575,6 +1575,35 @@ async def test_balance_equity_history_paces_replay_candle_fetches(monkeypatch):
 
 
 @pytest.mark.asyncio
+def test_pside_timeline_synthesis_rejects_inconsistent_pside_pnl():
+    # Codex P1: the trust boundary must reject a v5 account series whose
+    # account-level pnl and per-pside pnl describe different realized streams.
+    account_arrays = passivbot_module.pb_hsl._hsl_replay_account_series_arrays(
+        [
+            passivbot_module.pb_hsl._hsl_replay_account_series_row(
+                ts=60_000, pnl=10.0, pnl_long=3.0, pnl_short=0.0
+            )
+        ]
+    )
+    with pytest.raises(ValueError, match="pnl_pside_sum_mismatch"):
+        passivbot_module.pb_hsl._hsl_replay_pside_timeline_rows_from_cache(
+            {}, account_arrays, current_balance=100.0
+        )
+    # A consistent series passes.
+    consistent = passivbot_module.pb_hsl._hsl_replay_account_series_arrays(
+        [
+            passivbot_module.pb_hsl._hsl_replay_account_series_row(
+                ts=60_000, pnl=3.0, pnl_long=3.0, pnl_short=0.0
+            )
+        ]
+    )
+    rows = passivbot_module.pb_hsl._hsl_replay_pside_timeline_rows_from_cache(
+        {}, consistent, current_balance=100.0
+    )
+    assert rows[0]["realized_pnl"] == rows[0]["realized_pnl_long"] == 3.0
+
+
+@pytest.mark.asyncio
 async def test_pside_timeline_synthesis_matches_authoritative_rows(monkeypatch):
     # Trust boundary for the future pside/unified reuse gate: rows synthesized
     # from the persisted cache arrays must equal the authoritative timeline

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1575,6 +1575,173 @@ async def test_balance_equity_history_paces_replay_candle_fetches(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_pside_timeline_synthesis_matches_authoritative_rows(monkeypatch):
+    # Trust boundary for the future pside/unified reuse gate: rows synthesized
+    # from the persisted cache arrays must equal the authoritative timeline
+    # field-for-field on every aggregate field the pside/unified initializer
+    # consumes, for every covered minute.
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {}}
+    bot.exchange = "kucoin"
+    bot.user = "test_user"
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
+    base_ts = 1_800_000_000_000
+    ts_now = base_ts + 180_000
+    bot.get_exchange_time = lambda: ts_now
+    bot.get_raw_balance = lambda: 100.5
+    bot.get_symbol_id_inv = lambda symbol: symbol
+    sym_long = "BTC/USDT:USDT"
+    sym_short = "ETH/USDT:USDT"
+    bot.positions = {
+        sym_long: {
+            "long": {"size": 0.5, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        },
+        sym_short: {
+            "long": {"size": 0.0, "price": 0.0},
+            "short": {"size": 1.0, "price": 50.0},
+        },
+    }
+    bot._pnls_manager = None
+    bot.inverse = False
+    bot._candle_fetch_concurrency = lambda *, context="runtime": 2
+    bot._get_fetch_delay_seconds = lambda: 0.0
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[ListEventSink()],
+        monitor_sinks=[],
+    )
+    bot._live_event_current_cycle_id = "cy_hsl_pside_parity"
+    bot._emit_live_event = Passivbot._emit_live_event.__get__(bot, Passivbot)
+    bot.c_mults = {sym_long: 1.0, sym_short: 1.0}
+    monkeypatch.setattr(
+        passivbot_module, "compute_psize_pprice", lambda *args, **kwargs: None
+    )
+
+    candles = {
+        sym_long: np.array(
+            [
+                (base_ts, 99.0, 101.0, 98.0, 100.0, 1.0),
+                (base_ts + 60_000, 100.0, 102.0, 99.0, 101.0, 1.0),
+                (base_ts + 120_000, 101.0, 103.0, 100.0, 102.0, 1.0),
+                (base_ts + 180_000, 102.0, 104.0, 101.0, 103.0, 1.0),
+            ],
+            dtype=passivbot_module.CANDLE_DTYPE,
+        ),
+        sym_short: np.array(
+            [
+                (base_ts, 49.0, 51.0, 48.0, 50.0, 1.0),
+                (base_ts + 60_000, 50.0, 52.0, 49.0, 49.0, 1.0),
+                (base_ts + 120_000, 49.0, 51.0, 48.0, 48.0, 1.0),
+                (base_ts + 180_000, 48.0, 50.0, 47.0, 47.0, 1.0),
+            ],
+            dtype=passivbot_module.CANDLE_DTYPE,
+        ),
+    }
+
+    class _CM:
+        async def get_candles(self, sym, **kwargs):
+            return candles[sym]
+
+    bot.cm = _CM()
+    fill_events = [
+        {
+            "timestamp": base_ts,
+            "symbol": sym_long,
+            "position_side": "long",
+            "side": "buy",
+            "qty": 1.0,
+            "price": 100.0,
+            "pnl": 0.0,
+        },
+        {
+            "timestamp": base_ts + 30_000,
+            "symbol": sym_short,
+            "position_side": "short",
+            "side": "sell",
+            "qty": 1.0,
+            "price": 50.0,
+            "pnl": 0.0,
+        },
+        {
+            # Long partial close, realized +1.0 inside the second minute.
+            "timestamp": base_ts + 90_000,
+            "symbol": sym_long,
+            "position_side": "long",
+            "side": "sell",
+            "qty": 0.5,
+            "price": 102.0,
+            "pnl": 1.0,
+        },
+        {
+            # Short add, realized -0.5 fee-like loss inside the third minute.
+            "timestamp": base_ts + 150_000,
+            "symbol": sym_short,
+            "position_side": "short",
+            "side": "buy",
+            "qty": 0.0,
+            "price": 48.0,
+            "pnl": -0.5,
+        },
+    ]
+
+    history = await bot.get_balance_equity_history(
+        fill_events=fill_events,
+        current_balance=100.5,
+        hsl_replay_signal_mode="unified",
+    )
+
+    matrices = history["hsl_replay_matrices"]
+    assert set(matrices.get("long", {})) == {sym_long}
+    assert set(matrices.get("short", {})) == {sym_short}
+    pair_arrays = {
+        (pside, sym): passivbot_module.pb_hsl._hsl_replay_matrix_arrays(rows)
+        for pside, by_sym in matrices.items()
+        for sym, rows in by_sym.items()
+    }
+    account_arrays = passivbot_module.pb_hsl._hsl_replay_account_series_arrays(
+        history["hsl_replay_account_series"]
+    )
+
+    synthesized = passivbot_module.pb_hsl._hsl_replay_pside_timeline_rows_from_cache(
+        pair_arrays,
+        account_arrays,
+        current_balance=100.5,
+    )
+
+    authoritative = {int(row["timestamp"]): row for row in history["timeline"]}
+    contract_fields = (
+        "balance",
+        "realized_pnl",
+        "realized_pnl_long",
+        "realized_pnl_short",
+        "unrealized_pnl_long",
+        "unrealized_pnl_short",
+        "is_flat",
+        "is_flat_long",
+        "is_flat_short",
+    )
+    assert synthesized, "synthesis must produce rows"
+    compared = 0
+    for row in synthesized:
+        auth = authoritative.get(int(row["timestamp"]))
+        if auth is None:
+            continue
+        compared += 1
+        assert set(row) == {"timestamp", *contract_fields}
+        for field in contract_fields:
+            if isinstance(auth[field], bool):
+                assert row[field] == auth[field], (row["timestamp"], field)
+            else:
+                assert row[field] == pytest.approx(auth[field], abs=1e-9), (
+                    row["timestamp"],
+                    field,
+                )
+    assert compared >= 4
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
 async def test_balance_equity_history_first_minute_realized_pnl_attributes_pside(
     monkeypatch,
 ):

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -3117,6 +3117,108 @@ async def test_hard_stop_finalize_red_stop_uses_persistent_no_restart_peak(monke
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def _pside_parity_timeline():
+    # Nontrivial path: drawdown into RED territory, partial recovery, flatten.
+    rows = []
+    specs = [
+        # (minute, balance, r_pnl, r_long, r_short, u_long, u_short, flat_l, flat_s)
+        (0, 100.0, 0.0, 0.0, 0.0, 0.0, 0.0, False, True),
+        (1, 100.0, 0.0, 0.0, 0.0, -12.0, 0.0, False, True),
+        (2, 100.0, 0.0, 0.0, 0.0, -6.0, 0.0, False, True),
+        (3, 85.0, -15.0, -15.0, 0.0, 0.0, 0.0, True, True),
+    ]
+    for minute, balance, r, rl, rs, ul, us, fl, fs in specs:
+        rows.append(
+            {
+                "timestamp": 1_000 + minute * 60_000,
+                "balance": balance,
+                "realized_pnl": r,
+                "realized_pnl_long": rl,
+                "realized_pnl_short": rs,
+                "unrealized_pnl_long": ul,
+                "unrealized_pnl_short": us,
+                "is_flat": fl and fs,
+                "is_flat_long": fl,
+                "is_flat_short": fs,
+            }
+        )
+    return rows
+
+
+def _pside_state_snapshot(bot):
+    state = _hsl_state(bot)
+    metrics = state.get("last_metrics") or {}
+    return {
+        "halted": state["halted"],
+        "no_restart_latched": state["no_restart_latched"],
+        "cooldown_until_ms": state["cooldown_until_ms"],
+        "pnl_reset_timestamp_ms": state.get("pnl_reset_timestamp_ms"),
+        "pending_red_since_ms": state.get("pending_red_since_ms"),
+        "metrics": {
+            key: metrics.get(key)
+            for key in (
+                "timestamp_ms",
+                "tier",
+                "drawdown_raw",
+                "drawdown_ema",
+                "drawdown_score",
+                "strategy_equity",
+                "peak_strategy_equity",
+            )
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_pside_initializer_state_parity_on_contract_shaped_rows(monkeypatch):
+    # Trust boundary: rows carrying ONLY the synthesis contract fields must
+    # drive _equity_hard_stop_initialize_from_history to a state identical to
+    # authoritative-shaped rows (which carry extra fields like equity,
+    # unrealized_pnl, per-coin dicts, panic_fill_count) with equal values.
+    contract_rows = _pside_parity_timeline()
+    authoritative_rows = []
+    for row in contract_rows:
+        full = dict(row)
+        upnl = row["unrealized_pnl_long"] + row["unrealized_pnl_short"]
+        full["unrealized_pnl"] = upnl
+        full["equity"] = row["balance"] + upnl
+        full["unrealized_pnl_by_coin_pside"] = {}
+        full["realized_pnl_by_coin_pside"] = {}
+        full["panic_fill_count"] = 0
+        authoritative_rows.append(full)
+
+    snapshots = []
+    for timeline in (contract_rows, authoritative_rows):
+        cfg = _dummy_config()
+        cfg["live"]["hsl_signal_mode"] = "unified"
+        bot = _make_dummy_bot(cfg)
+        _hsl_cfg(bot)["enabled"] = True
+        _hsl_cfg(bot)["red_threshold"] = 0.1
+        _hsl_cfg(bot)["ema_span_minutes"] = 1.0
+        _hsl_cfg(bot)["cooldown_minutes_after_red"] = 5.0
+        _hsl_cfg(bot)["no_restart_drawdown_threshold"] = 0.9
+        bot.balance = 85.0
+        bot.get_exchange_time = lambda: 361_000
+
+        async def fake_history(*, current_balance=None, _rows=timeline, **kwargs):
+            return {"timeline": list(_rows), "panic_flatten_events": []}
+
+        monkeypatch.setattr(bot, "get_balance_equity_history", fake_history)
+        await bot._equity_hard_stop_initialize_from_history()
+        snapshots.append(_pside_state_snapshot(bot))
+
+    assert snapshots[0] == snapshots[1]
+    # Nontriviality: the replay crossed RED mid-window (row 1: -12 upnl on a
+    # 100 balance vs red_threshold 0.1) and the final live sample applied.
+    # Recovered mid-replay RED without a panic marker intentionally does not
+    # latch on this path (pinned by
+    # test_hard_stop_initialize_from_history_does_not_latch_recovered_red_without_panic_marker),
+    # so the final state is green - what matters here is that both row shapes
+    # walked the identical path to it.
+    assert snapshots[0]["metrics"]["timestamp_ms"] == 361_000
+    assert snapshots[0]["metrics"]["strategy_equity"] == pytest.approx(85.0)
+
+
 def _minimal_pside_history():
     return {
         "timeline": [


### PR DESCRIPTION
## Summary

Third slice of the pside/unified replay-cache arc (#1135 write-only persistence → #1136 schema v5 per-pside pnl → this). Adds the pure, **unwired** synthesis helper `_hsl_replay_pside_timeline_rows_from_cache` plus the parity trust boundary the future reuse gate must build on — mirroring how the coin arc landed its synthesis slice.

## Changes

- `src/passivbot_hsl.py`: `_hsl_replay_pside_timeline_rows_from_cache(pair_arrays, account_arrays, *, current_balance)` synthesizes the exact aggregate row contract `_equity_hard_stop_initialize_from_history` consumes (`timestamp`, `balance`, `realized_pnl`, `realized_pnl_long/short`, `unrealized_pnl_long/short`, `is_flat`, `is_flat_long/short`):
  - balance anchored so the final minute equals the current balance (same convention as the coin synthesis);
  - per-pside realized cumsums from the schema-v5 `pnl_long`/`pnl_short` arrays;
  - per-pside upnl sums and flatness from cached pair matrices — psize is **signed** (shorts negative), so flatness uses `abs(psize) > 1e-12` (the parity test caught this during development);
  - the same fail-loud span/continuity/grid-alignment validations as the coin synthesis.
- **Documented critical precondition** (docstring + tracker): the future reuse gate must prove from fills that cached pairs were the ONLY pairs with in-window positions before trusting the upnl/flatness aggregates — mirroring coin-mode flat-pair rejection — else force full replay. Nothing is wired in this slice.

## Tests

- `test_pside_timeline_synthesis_matches_authoritative_rows`: field-for-field equality against the real `get_balance_equity_history` timeline (unified mode; one long + one short pair; realized events on both sides; flatness transitions on both psides; exact contract key-set pin).
- `test_pside_initializer_state_parity_on_contract_shaped_rows`: rows carrying only the contract fields drive the pside/unified initializer to a state identical to authoritative-shaped rows (extra fields present), through a mid-replay RED crossing with pinned final sample.

Full local suite green except the 3 known out-of-scope failures.

## Noted follow-up (tracked)

While building the state-parity fixture: the pside/unified replay still derives cooldown/no-restart only from panic markers — a RED-seen episode flattened by an ordinary close is dropped (pinned by an existing test). That is the pside analogue of the #1133 coin fix and is queued as its own slice.

@vigilpbclaw-hash @claude @codex please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)