### PR TITLE
HSL: derive pside/unified replay cooldown/no-restart from canonical RED episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- HSL pside/unified startup replay now derives cooldown and no-restart
+  evidence from canonical reconstructed RED episodes, matching the coin-mode
+  behavior shipped earlier: an episode that crossed RED and was flattened by
+  an ordinary (non-panic) close now latches its cooldown anchored at the
+  scope-flattening fill (falling back to the flatten row minute when no fill
+  evidence exists) and evaluates restart_after_red_policy/no-restart at that
+  stop via the persistent cross-episode tracker. Previously such episodes
+  were silently dropped, so a restart during an active cooldown resumed
+  trading. RED-free ordinary flattenings now perform a plain episode reset
+  (clearing the episode's RED memory) instead of carrying state into the
+  next episode.
+
 - HSL: new pure, unwired synthesis helper
   `_hsl_replay_pside_timeline_rows_from_cache` converts persisted held-pair
   matrices plus the schema-v5 account series into the aggregate timeline

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -996,6 +996,14 @@ Remaining implementation details:
       `persistent_drawdown_raw` equals the at-stop drawdown ratio, which is
       exactly what the live coin replay and coin forward finalize evaluate.
       With that, every sub-item of this tracker entry is implemented.
+      Implemented (pside/unified parity, 2026-07-08): the pside/unified
+      startup replay now applies the same canonical RED-episode accounting
+      as coin replay - ordinary scope-flattening of a red_seen_in_episode
+      episode latches cooldown at the flatten fill (row-minute fallback) and
+      evaluates no-restart via the persistent tracker; RED-free flattenings
+      reset the episode state. Flatness comes from the timeline's
+      is_flat/is_flat_{pside} flags (rows without the flags conservatively
+      skip transition detection).
 - [ ] HSL replay performance/readiness slice.
       Persist verified non-authoritative HSL time series/checkpoints, add doctor
       tools, prioritize held scopes, keep timing/source evidence, and move dense

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import bisect
 import math
 import os
 import time
@@ -4418,6 +4419,15 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                     state["pending_red_since_ms"] = int(current_metrics["timestamp_ms"])
                 continue
             ignored_panic_marker_timestamps: set[int] = set()
+            scope_flat_key = "is_flat" if signal_mode == "unified" else f"is_flat_{pside}"
+            scope_fill_ts = sorted(
+                _equity_hard_stop_fill_timestamp_ms(fill)
+                for fill in fill_events
+                if signal_mode == "unified"
+                or _equity_hard_stop_fill_pside(fill) == pside
+            )
+            scope_was_nonflat = False
+            prev_recorded_ts: Optional[int] = None
             for row in timeline:
                 if not isinstance(row, dict):
                     continue
@@ -4455,7 +4465,17 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                     latch_red=False,
                 )
                 n_rows[pside] += 1
+                row_flat = row.get(scope_flat_key)
+                scope_flattened_this_row = (
+                    isinstance(row_flat, bool) and row_flat and scope_was_nonflat
+                )
+                if isinstance(row_flat, bool):
+                    scope_was_nonflat = not row_flat
+                row_prev_recorded_ts = prev_recorded_ts
+                prev_recorded_ts = ts
                 panic_flatten_marker = panic_flatten_events_by_key.get((pside, ts))
+                stop_ts: Optional[int] = None
+                stop_source = "panic_fill_flatten"
                 if panic_flatten_marker is not None:
                     marker_ts = int(panic_flatten_marker["timestamp"])
                     if not _equity_hard_stop_replay_marker_confirms_red(current_metrics):
@@ -4472,6 +4492,40 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                             float(current_metrics["red_threshold"]),
                         )
                         continue
+                    stop_ts = marker_ts
+                elif scope_flattened_this_row:
+                    if bool(current_metrics.get("red_seen_in_episode")):
+                        # B2.1: the episode crossed RED and ended by an ordinary
+                        # (non-panic) scope-flattening fill; cooldown/no-restart
+                        # evidence is canonical from the reconstructed episode.
+                        # Anchor at the latest scope fill inside the flatten
+                        # window, falling back to the row minute.
+                        boundary = ts + 60_000
+                        window_start = (
+                            row_prev_recorded_ts
+                            if row_prev_recorded_ts is not None
+                            else ts - 60_000
+                        )
+                        idx = bisect.bisect_left(scope_fill_ts, boundary)
+                        anchor = None
+                        if idx > 0 and scope_fill_ts[idx - 1] > window_start:
+                            anchor = int(scope_fill_ts[idx - 1])
+                        stop_ts = anchor if anchor is not None else int(ts)
+                        stop_source = "red_episode_flatten"
+                    else:
+                        # Ordinary flatten of a RED-free episode: plain episode
+                        # reset with no stop accounting.
+                        self._equity_hard_stop_reset_after_restart(pside)
+                        state = self._hsl_state(pside)
+                        logging.info(
+                            "[risk] HSL[%s] replay reset current episode after flat row | ts=%s",
+                            pside,
+                            int(ts),
+                        )
+                        continue
+                if stop_ts is None:
+                    continue
+                if True:
                     state["pending_red_since_ms"] = int(ts)
                     stop_drawdown_raw = float(current_metrics["drawdown_raw"])
                     (
@@ -4491,10 +4545,10 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                     )
                     cooldown_until_ms = None
                     if not no_restart_latched and cooldown_ms > 0:
-                        cooldown_until_ms = marker_ts + cooldown_ms
+                        cooldown_until_ms = stop_ts + cooldown_ms
                     payload = self._equity_hard_stop_build_latch_payload(
                         pside,
-                        stop_event_timestamp_ms=marker_ts,
+                        stop_event_timestamp_ms=stop_ts,
                         balance=float(row["balance"]),
                         realized_pnl_total=float(row["realized_pnl"]),
                         realized_pnl=float(row[f"realized_pnl_{pside}"]),
@@ -4522,14 +4576,15 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                         "[risk] HSL[%s] replay found finalized RED stop in exchange-derived history | "
                         "stop_ts=%s drawdown_raw=%.6f no_restart_drawdown_raw=%.6f "
                         "no_restart_latched=%s cooldown_until_ms=%s diagnostic=%s "
-                        "source=panic_fill_flatten",
+                        "source=%s",
                         pside,
-                        marker_ts,
+                        stop_ts,
                         stop_drawdown_raw,
                         no_restart_drawdown_raw,
                         state["no_restart_latched"],
                         cooldown_until_ms if cooldown_until_ms is not None else "none",
                         latch_path,
+                        stop_source,
                     )
                     if state["no_restart_latched"]:
                         break

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -3169,6 +3169,114 @@ def _pside_state_snapshot(bot):
     }
 
 
+def _red_flatten_bot(monkeypatch, *, rows, fills=(), policy="threshold",
+                     no_restart_threshold=0.9, now_ms=361_000):
+    cfg = _dummy_config()
+    cfg["live"]["hsl_signal_mode"] = "unified"
+    bot = _make_dummy_bot(cfg)
+    _hsl_cfg(bot)["enabled"] = True
+    _hsl_cfg(bot)["red_threshold"] = 0.1
+    _hsl_cfg(bot)["ema_span_minutes"] = 1.0
+    _hsl_cfg(bot)["cooldown_minutes_after_red"] = 5.0
+    _hsl_cfg(bot)["no_restart_drawdown_threshold"] = no_restart_threshold
+    _hsl_cfg(bot)["restart_after_red_policy"] = policy
+    bot.balance = rows[-1]["balance"]
+    bot.get_exchange_time = lambda: now_ms
+
+    async def fake_history(*, current_balance=None, **kwargs):
+        return {
+            "timeline": list(rows),
+            "panic_flatten_events": [],
+            "fill_events": list(fills),
+        }
+
+    monkeypatch.setattr(bot, "get_balance_equity_history", fake_history)
+    monkeypatch.setattr(
+        bot, "_equity_hard_stop_write_latch", lambda pside, payload: "/tmp/x.json"
+    )
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_pside_replay_red_episode_ordinary_flatten_latches_cooldown(monkeypatch):
+    # RED seen mid-episode; ordinary flatten with a scope fill inside the
+    # flatten window anchors the cooldown at that fill.
+    rows = _pside_parity_timeline()
+    fills = [
+        {
+            "timestamp": 195_000,
+            "symbol": "XMR/USDT:USDT",
+            "position_side": "long",
+            "side": "sell",
+            "qty": 1.0,
+            "price": 90.0,
+            "pnl": -15.0,
+        }
+    ]
+    # Flatten row is at 181_000; the fill at 195_000 is inside [181_000, 241_000).
+    rows[-1]["timestamp"] = 241_000
+    bot = _red_flatten_bot(monkeypatch, rows=rows, fills=fills, now_ms=400_000)
+
+    await bot._equity_hard_stop_initialize_from_history()
+
+    state = _hsl_state(bot)
+    assert state["halted"] is True
+    assert state["no_restart_latched"] is False
+    assert state["cooldown_until_ms"] == 195_000 + 300_000
+    assert state["last_stop_event"]["stop_event_timestamp_ms"] == 195_000
+
+
+@pytest.mark.asyncio
+async def test_pside_replay_red_episode_flatten_latches_terminal_by_threshold(
+    monkeypatch,
+):
+    bot = _red_flatten_bot(
+        monkeypatch, rows=_pside_parity_timeline(), no_restart_threshold=0.12
+    )
+
+    await bot._equity_hard_stop_initialize_from_history()
+
+    state = _hsl_state(bot)
+    assert state["halted"] is True
+    assert state["no_restart_latched"] is True
+    assert state["cooldown_until_ms"] is None
+
+
+@pytest.mark.asyncio
+async def test_pside_replay_never_policy_latches_terminal_on_red_episode(monkeypatch):
+    bot = _red_flatten_bot(monkeypatch, rows=_pside_parity_timeline(), policy="never")
+
+    await bot._equity_hard_stop_initialize_from_history()
+
+    state = _hsl_state(bot)
+    assert state["halted"] is True
+    assert state["no_restart_latched"] is True
+    assert state["cooldown_until_ms"] is None
+
+
+@pytest.mark.asyncio
+async def test_pside_replay_red_free_flatten_resets_without_stop(monkeypatch):
+    # Control: drawdown stays below RED (0.05 < 0.1); the ordinary flatten is a
+    # plain episode reset with no stop accounting.
+    rows = _pside_parity_timeline()
+    for row in rows:
+        if row["unrealized_pnl_long"] == -12.0:
+            row["unrealized_pnl_long"] = -5.0
+        if row["realized_pnl"] == -15.0:
+            row["balance"] = 95.0
+            row["realized_pnl"] = -5.0
+            row["realized_pnl_long"] = -5.0
+    bot = _red_flatten_bot(monkeypatch, rows=rows)
+
+    await bot._equity_hard_stop_initialize_from_history()
+
+    state = _hsl_state(bot)
+    assert state["halted"] is False
+    assert state["no_restart_latched"] is False
+    assert state["cooldown_until_ms"] is None
+    assert state["last_stop_event"] is None
+
+
 @pytest.mark.asyncio
 async def test_pside_initializer_state_parity_on_contract_shaped_rows(monkeypatch):
     # Trust boundary: rows carrying ONLY the synthesis contract fields must
@@ -3209,14 +3317,13 @@ async def test_pside_initializer_state_parity_on_contract_shaped_rows(monkeypatc
 
     assert snapshots[0] == snapshots[1]
     # Nontriviality: the replay crossed RED mid-window (row 1: -12 upnl on a
-    # 100 balance vs red_threshold 0.1) and the final live sample applied.
-    # Recovered mid-replay RED without a panic marker intentionally does not
-    # latch on this path (pinned by
-    # test_hard_stop_initialize_from_history_does_not_latch_recovered_red_without_panic_marker),
-    # so the final state is green - what matters here is that both row shapes
-    # walked the identical path to it.
-    assert snapshots[0]["metrics"]["timestamp_ms"] == 361_000
-    assert snapshots[0]["metrics"]["strategy_equity"] == pytest.approx(85.0)
+    # 100 balance vs red_threshold 0.1) and the episode flattened ordinarily at
+    # row 3, so the canonical RED-episode accounting latches an active cooldown
+    # anchored at the flatten row (no fill evidence in this fixture).
+    assert snapshots[0]["halted"] is True
+    assert snapshots[0]["no_restart_latched"] is False
+    assert snapshots[0]["cooldown_until_ms"] == 181_000 + 300_000
+    assert snapshots[0]["metrics"]["timestamp_ms"] == 181_000
 
 
 def _minimal_pside_history():


### PR DESCRIPTION
## Summary

Pside/unified analogue of #1133 (queued as a follow-up in the #1137 discussion). The pside/unified startup replay derived cooldown/no-restart evidence only from panic markers — an episode that crossed RED and was flattened by an **ordinary (non-panic) close** was silently dropped, so a restart during an active cooldown (or after a terminal-drawdown episode) resumed trading. The B2.1 contract activates cooldown for any `red_seen_in_episode` episode, anchored at the scope-flattening fill, in **all** scopes; the Rust backtest already behaves this way (parity pinned in #1133 for the pside runtime).

## Changes (`src/passivbot_hsl.py`, `_equity_hard_stop_initialize_from_history` row loop)

- Scope flatness is tracked from the timeline's `is_flat` (unified) / `is_flat_{pside}` (pside) flags; rows without the flags conservatively skip transition detection (no crash on reduced histories).
- A RED-seen ordinary scope-flattening enters the **same stop-latch path** as a confirmed panic marker: `stop_ts` = latest scope fill inside the flatten window (`bisect` over the history's fill timestamps, window bounded by the previous recorded row; falls back to the flatten row minute when no fill evidence exists), cooldown = `stop_ts + cooldown_ms`, and no-restart evaluated via the persistent cross-episode tracker (`_equity_hard_stop_record_no_restart_stop`) exactly like the marker path.
- RED-free ordinary flattenings perform a plain episode reset (`_equity_hard_stop_reset_after_restart`), clearing the episode's RED memory instead of carrying `red_seen_in_episode` into the next episode.
- Reconstruction logs carry `source=red_episode_flatten` vs `source=panic_fill_flatten`.

## Tests

Four-scenario matrix in `tests/test_unstucking_safeguards.py` (the three latch tests **fail on the unmodified replay**; the control passes both ways):
- fill-anchored cooldown latch (`stop_ts` = the scope fill at 195_000, not the row minute);
- terminal no-restart when the stop drawdown breaches the threshold (policy=threshold);
- terminal no-restart under policy=never on any RED episode;
- RED-free ordinary flatten resets without stop accounting.

The #1137 state-parity test's RED-crossing fixture now latches under the new contract; its expectations pin that outcome (parity across row shapes still asserted). The existing `does_not_latch_recovered_red_without_panic_marker` pin still holds — its scope never flattens, and a held recovered-RED episode must indeed not latch.

Full local suite green except the 3 known out-of-scope failures.

@vigilpbclaw-hash @claude @codex please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)