### PR TITLE
Close canonical HSL equity-history signal design tracker item (docs-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Plan tracker: closed the canonical HSL equity-history signal design item.
+  The one-raw-per-minute data-store goal is realized by the shared
+  authoritative timeline plus the cache-primitive store (pair matrices +
+  per-pside account series) consumed by all three signal modes, with
+  sample-parity tests at every trust boundary; the originally sketched five
+  named dataframes are superseded by these primitives. Docs-only change.
+
 - Plan tracker: closed the HSL replay performance/readiness item. All
   sub-items are implemented (persisted npz+manifest checkpoints with
   watermark extension for all three signal modes, fail-closed reuse gates,

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -953,10 +953,24 @@ Remaining implementation details:
 - [x] `live.hsl_signal_mode` runtime/default alignment.
       Runtime paths should require normalized `live.hsl_signal_mode`, while
       raw-config diagnostics should report the schema default `coin`.
-- [ ] Canonical HSL equity-history signal design.
+- [x] Canonical HSL equity-history signal design.
       Align coin, pside, and unified around one raw per-minute `pnl + upnl`
       data-store model, keep scoped modes on base slot-budget-style
       normalization, and add sample-parity tests before changing semantics.
+      Closure assessment (2026-07-08): all three goals are realized, with
+      the originally sketched five named dataframes superseded by the
+      cache-primitive store. One raw per-minute model now feeds every mode:
+      the authoritative `get_balance_equity_history` builds a single
+      timeline from one fill/candle replay regardless of signal mode, and
+      the persisted store is one primitive set (pair matrices
+      `ts/price/psize/pprice/pnl/upnl` plus the v5 account series
+      `ts/pnl/pnl_long/pnl_short`) from which coin AND pside/unified
+      timelines are synthesized. Scoped modes keep base slot-budget
+      normalization (resolved decision, pinned by tests). Sample-parity
+      tests exist at every trust boundary: coin synthesis row parity,
+      pside/unified field-for-field and initializer state parity, and
+      slice-and-extend 1e-12 parity for cached arrays. No semantics were
+      changed without a parity pin, which was the item's core demand.
       Partial: live HSL now has pure replay-matrix helpers that build
       non-authoritative raw rows (`ts`, `price`, `psize`, `pprice`, `pnl`,
       `upnl`) from authoritative candle/fill inputs, derive UPnL through the


### PR DESCRIPTION
## Summary

Docs-only closure of the "Canonical HSL equity-history signal design" tracker item, companion to #1140. Each of the item's three goals is verifiably met:

1. **One raw per-minute `pnl + upnl` data-store model across coin/pside/unified**: the authoritative `get_balance_equity_history` builds a single timeline from one fill/candle replay regardless of signal mode, and the persisted store is one primitive set — pair matrices (`ts/price/psize/pprice/pnl/upnl`) plus the schema-v5 account series (`ts/pnl/pnl_long/pnl_short`) — from which both the coin timeline (#1116-era synthesis) and the pside/unified timeline (#1137) are synthesized. The originally sketched five named dataframes (`df_hsl_unified`, `df_hsl_long_agg`, …) are superseded by these primitives.
2. **Scoped modes keep base slot-budget-style normalization**: resolved decision, implemented and pinned (`slot_budget = balance × TWEL / n_positions`, no eff_WEL scaling).
3. **Sample-parity tests before changing semantics**: parity pins exist at every trust boundary — coin synthesis row parity + initializer state parity, pside/unified field-for-field parity + initializer state parity, and slice-and-extend 1e-12 parity for cached arrays. No semantics changed without a parity pin, which was the item's core demand.

With this and #1140, the only remaining open tracker item is "Python simplification after Rust owns ideal protective orders and unstuck orders", plus the flat-detection-tolerance design detail.

If maintainers prefer the five-dataframe surface as a distinct deliverable, happy to reopen with that as a concrete slice instead.

@vigilpbclaw-hash @claude @codex please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)