### PR TITLE
Fail loudly on ideal orders without a Rust-supplied execution type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live order conversion no longer re-decides execution type in Python. The
+  Rust orchestrator is the single source of execution-type truth
+  (`should_use_market_execution` owns the panic market-vs-limit choice from
+  `hsl_panic_close_order_type`); the Python fallback that re-derived it for
+  short order tuples was dead on every live path and is replaced by
+  fail-loud validation - a tuple without a valid `limit`/`market`
+  execution type now raises instead of silently defaulting to a limit
+  order, which could have downgraded a panic market close.
+
 - Plan tracker: closed the canonical HSL equity-history signal design item.
   The one-raw-per-minute data-store goal is realized by the shared
   authoritative timeline plus the cache-primitive store (pair matrices +

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -1419,19 +1419,21 @@ def to_executable_orders(
                 logging.debug("duplicate ideal order for %s skipped: %s", symbol, order)
                 continue
             pb_order_type = snake_of(order[3])
-            if len(order) >= 5:
-                execution_type = str(order[4]).lower()
-            else:
-                execution_type = "limit"
-                panic_close_pref = bot._equity_hard_stop_panic_close_order_type(
-                    position_side
+            # The Rust orchestrator is the single source of execution-type
+            # truth (every live path builds 5-tuples from its execution_type
+            # field); a short tuple here means a broken producer, and
+            # silently defaulting could downgrade a panic market close.
+            if len(order) < 5:
+                raise ValueError(
+                    f"ideal order for {symbol} missing execution_type: {order!r}; "
+                    "the Rust orchestrator must supply it"
                 )
-                if "panic" in pb_order_type:
-                    execution_type = (
-                        "market" if panic_close_pref == "market" else "limit"
-                    )
+            execution_type = str(order[4]).lower()
             if execution_type not in {"limit", "market"}:
-                execution_type = "limit"
+                raise ValueError(
+                    f"ideal order for {symbol} has invalid execution_type "
+                    f"{order[4]!r}; expected limit or market"
+                )
             ideal_orders_f[symbol].append(
                 {
                     "symbol": symbol,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -13029,7 +13029,11 @@ class Passivbot:
                 continue
             order_type = str(order["order_type"])
             order_type_id = int(pbr.order_type_snake_to_id(order_type))
-            execution_type = str(order.get("execution_type", "limit"))
+            if "execution_type" not in order:
+                raise ValueError(
+                    f"Rust orchestrator order missing execution_type: {order!r}"
+                )
+            execution_type = str(order["execution_type"])
             ideal_orders.setdefault(symbol, []).append(
                 (
                     float(order["qty"]),
@@ -13755,7 +13759,11 @@ class Passivbot:
                 continue
             order_type = str(o["order_type"])
             order_type_id = int(pbr.order_type_snake_to_id(order_type))
-            execution_type = str(o.get("execution_type", "limit"))
+            if "execution_type" not in o:
+                raise ValueError(
+                    f"Rust orchestrator order missing execution_type: {o!r}"
+                )
+            execution_type = str(o["execution_type"])
             tup = (
                 float(o["qty"]),
                 float(o["price"]),
@@ -15659,7 +15667,11 @@ class Passivbot:
                 continue
             order_type = str(o["order_type"])
             order_type_id = int(pbr.order_type_snake_to_id(order_type))
-            execution_type = str(o.get("execution_type", "limit"))
+            if "execution_type" not in o:
+                raise ValueError(
+                    f"Rust orchestrator order missing execution_type: {o!r}"
+                )
+            execution_type = str(o["execution_type"])
             tup = (
                 float(o["qty"]),
                 float(o["price"]),

--- a/tests/test_order_orchestration.py
+++ b/tests/test_order_orchestration.py
@@ -362,6 +362,34 @@ async def test_calc_orders_allows_panic_close_when_trailing_candles_pending():
 
 
 @pytest.mark.asyncio
+def test_no_silent_execution_type_defaults_in_rust_order_conversion():
+    # Codex P1 regression on the exec-type fail-loud contract: the Rust JSON
+    # conversion sites must not default a missing execution_type (a silent
+    # default upstream would defeat the reconciler's fail-loud guard and
+    # could downgrade a panic market close to a limit order). Any .get with a
+    # default on the execution_type key in the live modules is an offender;
+    # defaultless .get (classification of exchange-side orders) is allowed.
+    import ast
+    from pathlib import Path
+
+    offenders = []
+    for rel in ("src/passivbot.py", "src/live/reconciler.py"):
+        tree = ast.parse(Path(rel).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "get"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and node.args[0].value == "execution_type"
+                and len(node.args) > 1
+            ):
+                offenders.append(f"{rel}:{node.lineno}")
+    assert offenders == [], offenders
+
+
+@pytest.mark.asyncio
 async def test_calc_protective_panic_reconciles_when_active_symbols_stale():
     symbol = "BTC/USDT"
     bot = OrchestrationBot({symbol: 100.0})

--- a/tests/test_order_orchestration.py
+++ b/tests/test_order_orchestration.py
@@ -361,7 +361,6 @@ async def test_calc_orders_allows_panic_close_when_trailing_candles_pending():
     assert [order["pb_order_type"] for order in to_create] == ["close_panic_long"]
 
 
-@pytest.mark.asyncio
 def test_no_silent_execution_type_defaults_in_rust_order_conversion():
     # Codex P1 regression on the exec-type fail-loud contract: the Rust JSON
     # conversion sites must not default a missing execution_type (a silent

--- a/tests/test_order_orchestration.py
+++ b/tests/test_order_orchestration.py
@@ -102,7 +102,7 @@ def test_ema_anchor_limit_orders_route_to_ccxt_post_only_params(
     bot.register_symbol(symbol)
     bot.positions[symbol][position_side]["size"] = position_size
     order_type_id = pbr.order_type_snake_to_id(order_type)
-    ideal_orders = {symbol: [(qty, 100.0, order_type, order_type_id)]}
+    ideal_orders = {symbol: [(qty, 100.0, order_type, order_type_id, "limit")]}
 
     orders_by_symbol, _ = bot._to_executable_orders(ideal_orders, {symbol: 100.0})
     [order] = orders_by_symbol[symbol]

--- a/tests/test_order_price_threshold.py
+++ b/tests/test_order_price_threshold.py
@@ -39,8 +39,8 @@ def test_close_orders_are_not_filtered_by_deprecated_price_distance_gate():
     close_type_id = pbr.order_type_snake_to_id("close_grid_long")
     ideal_orders = {
         symbol: [
-            (0.5, 101.0, "close_grid_long", close_type_id),
-            (0.5, 104.0, "close_grid_long", close_type_id),
+            (0.5, 101.0, "close_grid_long", close_type_id, "limit"),
+            (0.5, 104.0, "close_grid_long", close_type_id, "limit"),
         ]
     }
 

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -2518,23 +2518,35 @@ def test_orange_overlay_tp_only_with_active_entry_cancellation_blocks_initial_en
     assert bot.PB_modes["short"][symbol] == "normal"
 
 
-def test_panic_close_order_type_pref_market_overrides_limit_path():
+def test_executable_orders_take_execution_type_from_rust_only():
+    # The Rust orchestrator is the single source of execution-type truth:
+    # 5-tuple execution_type passes through verbatim, and a short tuple is a
+    # broken producer that must fail loudly rather than silently downgrade a
+    # panic market close to a limit order.
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
     import passivbot_rust as pbr
 
     panic_id = pbr.get_order_id_type_from_string("close_panic_long")
-    ideal_orders = {symbol: [(0.1, 100.0, "close_panic_long", panic_id)]}
     last_prices = {symbol: 100.0}
 
-    _hsl_cfg(bot)["panic_close_order_type"] = "market"
-    orders, _ = bot._to_executable_orders(ideal_orders, last_prices)
-    assert orders[symbol][0]["type"] == "market"
+    for execution_type in ("market", "limit"):
+        ideal_orders = {
+            symbol: [(0.1, 100.0, "close_panic_long", panic_id, execution_type)]
+        }
+        orders, _ = bot._to_executable_orders(ideal_orders, last_prices)
+        assert orders[symbol][0]["type"] == execution_type
 
-    _hsl_cfg(bot)["panic_close_order_type"] = "limit"
-    orders, _ = bot._to_executable_orders(ideal_orders, last_prices)
-    assert orders[symbol][0]["type"] == "limit"
+    with pytest.raises(ValueError, match="missing execution_type"):
+        bot._to_executable_orders(
+            {symbol: [(0.1, 100.0, "close_panic_long", panic_id)]}, last_prices
+        )
+    with pytest.raises(ValueError, match="invalid execution_type"):
+        bot._to_executable_orders(
+            {symbol: [(0.1, 100.0, "close_panic_long", panic_id, "stop")]},
+            last_prices,
+        )
 
 
 def test_hard_stop_apply_sample_delegates_to_rust(monkeypatch):


### PR DESCRIPTION
## Summary

First slice of the "Python simplification" tracker item (Python reconciles ideal vs actual orders; it does not re-decide trading policy Rust owns). This removes a dead, driftable second source of execution-type truth from the live order conversion.

## Rationale (verified)

- The Rust orchestrator owns the execution-type decision: `should_use_market_execution` (passivbot-rust/src/orchestrator.rs:661) makes the panic market-vs-limit choice from `hsl_panic_close_order_type`, and `to_executable_order` returns `execution_type` on every order.
- Every live path builds 5-tuples from that field: the panic supervisor path (src/passivbot.py:13032), the snapshot path (:13758ish), and the main loop all route through `calc_ideal_orders_orchestrator`. The Python fallback in `to_executable_orders` (`len(order) >= 5` else re-derive from HSL config) was unreachable in live operation.
- The fallback was also a silent-downgrade hazard: unknown execution types were coerced to `"limit"`, so an upstream contract break could have turned a panic **market** close into a resting limit order. Per the fail-loud principle for trading-critical paths, short tuples and invalid execution types now raise.

## Changes

- `src/live/reconciler.py`: the fallback branch is replaced by fail-loud validation (missing → `ValueError: missing execution_type`; not in {limit, market} → `ValueError: invalid execution_type`).
- Tests: `test_panic_close_order_type_pref_market_overrides_limit_path` (which pinned the removed Python-side decision) is replaced by `test_executable_orders_take_execution_type_from_rust_only` (pass-through of Rust's execution_type for market and limit + both fail-loud paths); 4-tuple fixtures in the ema-anchor routing and price-threshold tests updated to the 5-tuple contract.

Note: the per-symbol re-sort in `to_executable_orders` is deliberately untouched in this slice — removing it needs an analysis of downstream creation-sequencing assumptions vs Rust's `sort_global`, tracked in the arc notes.

Full local suite green except the 3 known out-of-scope failures.

@vigilpbclaw-hash @claude @codex please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)