### PR TITLE
Stop zeroing unstuck allowances while an unstuck order is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live unstuck-allowance inputs to the Rust orchestrator are no longer
+  zeroed while an unstuck order is resting on the exchange. The allowance
+  values are pure budget facts derived from fill history; suppression of
+  new unstuck emission rides solely on the existing auto_unstuck_allowed
+  flag, which the Rust orchestrator consumes as the sole gate. Behavior is
+  unchanged (Rust emitted no unstuck either way); this removes a redundant
+  second suppression channel that made the allowance inputs diverge from
+  the backtest for reasons unrelated to budget.
+
 - Live order conversion no longer re-decides execution type in Python. The
   Rust orchestrator is the single source of execution-type truth
   (`should_use_market_execution` owns the panic market-vs-limit choice from

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -10423,9 +10423,15 @@ class Passivbot:
                 self._log_fill_event(event),
             )
 
-    def _calc_unstuck_allowances(self, allow_new_unstuck: bool) -> dict[str, float]:
-        """Calculate unstuck allowances using FillEventsManager data."""
-        if not allow_new_unstuck or self._pnls_manager is None:
+    def _calc_unstuck_allowances(self) -> dict[str, float]:
+        """Calculate unstuck allowances using FillEventsManager data.
+
+        Pure budget math from fill history; whether an unstuck order may be
+        emitted this cycle is a separate decision carried by the
+        auto_unstuck_allowed flag, which the Rust orchestrator consumes as
+        the sole emission gate.
+        """
+        if self._pnls_manager is None:
             return {"long": 0.0, "short": 0.0}
 
         start_ms = self._pnls_lookback_start_ms()
@@ -13516,11 +13522,9 @@ class Passivbot:
             return mode
         return "graceful_stop"
 
-    def _calc_unstuck_allowances_live(
-        self, allow_new_unstuck: bool
-    ) -> dict[str, float]:
+    def _calc_unstuck_allowances_live(self) -> dict[str, float]:
         """Calculate unstuck allowances using FillEventsManager."""
-        return self._calc_unstuck_allowances(allow_new_unstuck)
+        return self._calc_unstuck_allowances()
 
     def _auto_unstuck_allowed_live(self, allow_new_unstuck: bool) -> bool:
         if not allow_new_unstuck or self._pnls_manager is None:
@@ -15414,10 +15418,10 @@ class Passivbot:
             self, last_prices, ts=utc_ms(), source=monitor_source
         )
 
+        # The allowance values are pure budget facts; the open-order check
+        # only drives the auto_unstuck_allowed emission gate that Rust owns.
         allow_new_unstuck = not self.has_open_unstuck_order()
-        unstuck_allowances = self._calc_unstuck_allowances_live(
-            allow_new_unstuck=allow_new_unstuck
-        )
+        unstuck_allowances = self._calc_unstuck_allowances_live()
         auto_unstuck_allowed = self._auto_unstuck_allowed_live(allow_new_unstuck)
         realized_pnl_cumsum = self._get_realized_pnl_cumsum_stats()
         now_ms = int(self.get_exchange_time())

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -717,7 +717,9 @@ async def _build_monitor_forager_section(self) -> dict[str, dict]:
 
 def _build_monitor_unstuck_section(self) -> dict[str, Any]:
     has_open = bool(self.has_open_unstuck_order())
-    allowances_live = self._calc_unstuck_allowances_live(allow_new_unstuck=not has_open)
+    # Allowances are pure budget facts and stay real while an unstuck order
+    # is open; has_open is reported alongside so the monitor shows both.
+    allowances_live = self._calc_unstuck_allowances_live()
     out: dict[str, Any] = {
         "has_open_order": has_open,
         "open_orders": [],

--- a/tests/test_orchestrator_integration.py
+++ b/tests/test_orchestrator_integration.py
@@ -470,6 +470,52 @@ class TestOrchestratorOrderAccuracy:
         # At minimum, we should get valid output without errors
         assert isinstance(out["orders"], list)
 
+    def test_auto_unstuck_allowed_flag_is_sole_emission_gate(self):
+        """auto_unstuck_allowed=false suppresses unstuck emission even with
+        positive allowances - the live open-order suppression rides this flag
+        alone, so allowance values stay pure budget facts."""
+        import passivbot_rust as pbr
+
+        def stuck_input():
+            inp = make_input(
+                balance=1_000.0,
+                symbols=[
+                    make_symbol(
+                        0,
+                        bid=80.0,
+                        ask=80.0,
+                        long_pos_size=5.0,
+                        long_pos_price=100.0,
+                        long_bp={
+                            "unstuck_threshold": 0.1,
+                            "unstuck_loss_allowance_pct": 0.05,
+                            "unstuck_close_pct": 0.5,
+                            "unstuck_ema_dist": -0.05,
+                        },
+                    )
+                ],
+            )
+            inp["global"]["unstuck_allowance_long"] = 50.0
+            inp["global"]["max_realized_loss_pct"] = 1.0
+            return inp
+
+        baseline = compute(pbr, stuck_input())
+        baseline_unstuck = [
+            o
+            for o in baseline["orders"]
+            if "unstuck" in o.get("order_type", "").lower()
+        ]
+        assert len(baseline_unstuck) == 1, baseline_unstuck
+
+        suppressed_input = stuck_input()
+        suppressed_input["global"]["auto_unstuck_allowed"] = False
+        suppressed = compute(pbr, suppressed_input)
+        assert [
+            o
+            for o in suppressed["orders"]
+            if "unstuck" in o.get("order_type", "").lower()
+        ] == []
+
     def test_trailing_entry_logic(self):
         """Test trailing entry logic."""
         import passivbot_rust as pbr

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -5620,6 +5620,56 @@ async def test_update_effective_min_cost_uses_executable_min_qty():
     assert bot.effective_min_cost[symbol] == pytest.approx(88.165)
 
 
+def test_unstuck_allowances_stay_real_while_unstuck_order_is_open(monkeypatch):
+    # The allowance values are pure budget facts; an open unstuck order must
+    # not zero them. Suppression of new unstuck emission rides solely on the
+    # auto_unstuck_allowed flag, which the Rust orchestrator consumes as the
+    # sole gate (pinned in test_auto_unstuck_allowed_flag_is_sole_emission_gate).
+    import passivbot as pb_mod
+
+    bot = Passivbot.__new__(Passivbot)
+    bot.balance = 100.0
+    bot.balance_raw = 200.0
+    bot._pnls_manager = types.SimpleNamespace(
+        get_events=lambda: [
+            types.SimpleNamespace(pnl=10.0, fee_paid=-1.0),
+        ],
+        cache=_SafeRiskCache(),
+        get_history_scope=lambda: "all",
+    )
+    bot.bot_value = lambda pside, key: {
+        "unstuck_loss_allowance_pct": 0.2 if pside == "long" else 0.0,
+        "total_wallet_exposure_limit": 0.5,
+    }.get(key, 0.0)
+    monkeypatch.setattr(
+        pb_mod.pbr, "calc_auto_unstuck_allowance", lambda *a: 77.0
+    )
+    # An unstuck order is live on the exchange.
+    bot.open_orders = {
+        "BTC/USDT:USDT": [
+            {"custom_id": _make_unstuck_custom_id()},
+        ]
+    }
+    assert bot.has_open_unstuck_order() is True
+
+    out = bot._calc_unstuck_allowances()
+    assert out["long"] == pytest.approx(77.0)
+
+    # The emission gate is still off while the order is open.
+    assert bot._auto_unstuck_allowed_live(allow_new_unstuck=False) is False
+
+
+def _make_unstuck_custom_id() -> str:
+    import passivbot as pb_mod
+
+    bot = Passivbot.__new__(Passivbot)
+    bot.broker_code = ""
+    bot.custom_id_max_length = 36
+    return bot.format_custom_id_single(
+        pb_mod.pbr.get_order_id_type_from_string("close_unstuck_long")
+    )
+
+
 def test_unstuck_allowance_routes_raw_balance_to_rust(monkeypatch):
     import passivbot as pb_mod
 
@@ -5656,7 +5706,7 @@ def test_unstuck_allowance_routes_raw_balance_to_rust(monkeypatch):
         pb_mod.pbr, "calc_auto_unstuck_allowance", fake_calc_auto_unstuck_allowance
     )
 
-    out = bot._calc_unstuck_allowances(allow_new_unstuck=True)
+    out = bot._calc_unstuck_allowances()
 
     assert out["long"] == pytest.approx(123.45)
     assert out["short"] == pytest.approx(0.0)
@@ -5709,7 +5759,7 @@ def test_unstuck_allowance_uses_only_configured_pnl_lookback(monkeypatch):
         pb_mod.pbr, "calc_auto_unstuck_allowance", fake_calc_auto_unstuck_allowance
     )
 
-    out = bot._calc_unstuck_allowances(allow_new_unstuck=True)
+    out = bot._calc_unstuck_allowances()
 
     assert out["long"] == pytest.approx(10.0)
     assert len(calls) == 1
@@ -5745,7 +5795,7 @@ def test_unstuck_allowance_blocks_degraded_synthetic_pnl():
     bot.bot_value = bot_value
 
     with pytest.raises(RuntimeError, match="degraded realized PnL"):
-        bot._calc_unstuck_allowances(allow_new_unstuck=True)
+        bot._calc_unstuck_allowances()
 
 
 @pytest.mark.asyncio

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -4831,8 +4831,9 @@ async def test_build_monitor_snapshot_includes_market_forager_unstuck_and_recent
                 }
             return {"status": "disabled"}
 
-        def _calc_unstuck_allowances_live(self, allow_new_unstuck):
-            return {"long": 0.0 if not allow_new_unstuck else 1.0, "short": 0.0}
+        def _calc_unstuck_allowances_live(self):
+            # Allowances are pure budget facts, real even with an open unstuck order.
+            return {"long": 1.0, "short": 0.0}
 
         async def build_forager_candidate_payload(
             self,


### PR DESCRIPTION
## Summary

Slice 2 of the Python-simplification arc (after #1142). The live path suppressed new unstuck emission through **two redundant channels**: zeroing the allowance inputs AND setting `auto_unstuck_allowed=false`. Rust consumes the flag as its sole gate (`orchestrator.rs:3294-3297`; the allowance>0 fallback applies only when the flag is absent), so the zeroing changed nothing in Rust's decision while making the allowance values fed to Rust diverge from the backtest's derivation for reasons unrelated to budget. Behavior is unchanged; the redundant channel is removed.

## Changes

- `_calc_unstuck_allowances` (and its live wrapper) is now pure budget math from fill history — the `allow_new_unstuck` parameter is gone. The pnl-history fail-loud checks stay.
- The open-order check (`has_open_unstuck_order`) now drives only the `auto_unstuck_allowed` flag, which keeps its own pnl-history safety gating (`_auto_unstuck_allowed_live`).

## Pins

- **Rust JSON API** (`test_auto_unstuck_allowed_flag_is_sole_emission_gate`): a deterministically stuck long emits exactly one `close_unstuck_long` with a positive allowance; the same input with `auto_unstuck_allowed=false` emits none. The flag's sole-gate role was previously untested (the existing unstuck test asserts only "valid output").
- **Python** (`test_unstuck_allowances_stay_real_while_unstuck_order_is_open`): with a resting unstuck order detected from `open_orders` custom IDs, allowances stay real and the emission gate stays off.

## Maintainer question (observed while verifying, not changed here)

The reconciler has no unstuck-retention logic: while an unstuck order rests, the ideal set contains no unstuck (flag off), so `calc_orders_to_cancel_and_create` cancels the resting order, and the next cycle may re-emit one — a potential create/cancel oscillation for unstuck orders that don't fill within a cycle. This PR preserves that behavior exactly (it predates the change and is orthogonal to which channel carries the suppression). If it's unintended, the fix direction would be Rust re-emitting the incumbent unstuck (identity passed like forager incumbents) so reconciliation keeps it — happy to take that as a follow-up slice on maintainer confirmation.

Full local suite green except the 3 known out-of-scope failures.

@vigilpbclaw-hash @claude @codex please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)