### PR TITLE
Drop live unstuck-allowance inputs; Rust derives the allowance itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- The live path no longer computes unstuck allowances for the Rust
+  orchestrator input. Rust has always derived the unstuck allowance
+  internally from the realized-pnl cumsum facts (risk.rs); the
+  unstuck_allowance_long/short input fields were consumed only as a legacy
+  fallback for the auto_unstuck_allowed flag, which live callers always set
+  explicitly. The fields are now optional (serde defaults) and documented
+  as legacy/diagnostic; live inputs and recorded planning snapshots omit
+  them, removing the last per-cycle duplicate of the allowance formula from
+  the hot path. The monitor still computes allowances on demand for
+  diagnostics. Behavior unchanged.
+
 - Live unstuck-allowance inputs to the Rust orchestrator are no longer
   zeroed while an unstuck order is resting on the exchange. The allowance
   values are pure budget facts derived from fill history; suppression of

--- a/passivbot-rust/src/orchestrator.rs
+++ b/passivbot-rust/src/orchestrator.rs
@@ -307,7 +307,13 @@ mod core {
         pub panic_close_market: bool,
         #[serde(default)]
         pub auto_unstuck_allowed: Option<bool>,
+        /// Legacy/diagnostic only: the unstuck decision derives its allowance
+        /// internally from realized_pnl_cumsum_max/last (risk.rs). These values
+        /// are consumed solely as the fallback for `auto_unstuck_allowed` when
+        /// that flag is absent; explicit-flag callers may omit them.
+        #[serde(default)]
         pub unstuck_allowance_long: f64,
+        #[serde(default)]
         pub unstuck_allowance_short: f64,
         /// Fraction of peak balance that may be realized as drawdown before lossy closes are blocked.
         /// <=0 blocks all lossy closes; >=1 disables gating.

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -12944,8 +12944,6 @@ class Passivbot:
                 ),
                 "panic_close_market": False,
                 "auto_unstuck_allowed": False,
-                "unstuck_allowance_long": 0.0,
-                "unstuck_allowance_short": 0.0,
                 "max_realized_loss_pct": float(Passivbot._live_max_realized_loss_pct(self)),
                 "realized_pnl_cumsum_max": 0.0,
                 "realized_pnl_cumsum_last": 0.0,
@@ -13617,8 +13615,6 @@ class Passivbot:
                 ),
                 "panic_close_market": False,
                 "auto_unstuck_allowed": auto_unstuck_allowed,
-                "unstuck_allowance_long": float(unstuck_allowances.get("long", 0.0)),
-                "unstuck_allowance_short": float(unstuck_allowances.get("short", 0.0)),
                 "max_realized_loss_pct": max_realized_loss_pct,
                 "realized_pnl_cumsum_max": float(
                     realized_pnl_cumsum.get("max", 0.0) or 0.0
@@ -15418,10 +15414,12 @@ class Passivbot:
             self, last_prices, ts=utc_ms(), source=monitor_source
         )
 
-        # The allowance values are pure budget facts; the open-order check
-        # only drives the auto_unstuck_allowed emission gate that Rust owns.
+        # The open-order check drives only the auto_unstuck_allowed emission
+        # gate; Rust derives the actual unstuck allowance internally from the
+        # realized-pnl cumsum facts below, so no allowance values are computed
+        # or passed on this path (the monitor computes them on demand for
+        # diagnostics).
         allow_new_unstuck = not self.has_open_unstuck_order()
-        unstuck_allowances = self._calc_unstuck_allowances_live()
         auto_unstuck_allowed = self._auto_unstuck_allowed_live(allow_new_unstuck)
         realized_pnl_cumsum = self._get_realized_pnl_cumsum_stats()
         now_ms = int(self.get_exchange_time())
@@ -15462,8 +15460,6 @@ class Passivbot:
                 ),
                 "panic_close_market": False,
                 "auto_unstuck_allowed": auto_unstuck_allowed,
-                "unstuck_allowance_long": float(unstuck_allowances.get("long", 0.0)),
-                "unstuck_allowance_short": float(unstuck_allowances.get("short", 0.0)),
                 "max_realized_loss_pct": max_realized_loss_pct,
                 "realized_pnl_cumsum_max": float(
                     realized_pnl_cumsum.get("max", 0.0) or 0.0
@@ -15722,7 +15718,6 @@ class Passivbot:
                 "user": str(self.config_get(["live", "user"]) or ""),
                 "active_symbols": list(symbols),
                 "auto_unstuck_allowed": auto_unstuck_allowed,
-                "unstuck_allowances": unstuck_allowances,
                 "realized_pnl_cumsum": realized_pnl_cumsum,
                 "last_increase_fill_timestamps": last_increase_fill_timestamps,
                 "planning_snapshot": (

--- a/tests/test_orchestrator_integration.py
+++ b/tests/test_orchestrator_integration.py
@@ -516,6 +516,25 @@ class TestOrchestratorOrderAccuracy:
             if "unstuck" in o.get("order_type", "").lower()
         ] == []
 
+        # The allowance input fields are legacy/diagnostic: omitting them
+        # entirely parses (serde defaults) and emission is governed by the
+        # explicit flag plus the realized-pnl cumsum facts alone.
+        omitted_input = stuck_input()
+        del omitted_input["global"]["unstuck_allowance_long"]
+        del omitted_input["global"]["unstuck_allowance_short"]
+        omitted_input["global"]["auto_unstuck_allowed"] = True
+        omitted = compute(pbr, omitted_input)
+        assert (
+            len(
+                [
+                    o
+                    for o in omitted["orders"]
+                    if "unstuck" in o.get("order_type", "").lower()
+                ]
+            )
+            == 1
+        )
+
     def test_trailing_entry_logic(self):
         """Test trailing entry logic."""
         import passivbot_rust as pbr

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -6107,7 +6107,7 @@ async def test_protective_panic_orchestrator_payload_omits_ema_dependencies(monk
         "m1": {"close": [], "log_range": [], "volume": []},
         "h1": {"close": [], "log_range": [], "volume": []},
     }
-    assert captured["input"]["global"]["unstuck_allowance_long"] == 0.0
+    assert "unstuck_allowance_long" not in captured["input"]["global"]
     assert captured["input"]["global"]["realized_pnl_cumsum_last"] == 0.0
     assert pb_mod.Passivbot._protective_panic_target_psides_by_symbol(FakeBot()) == {
         symbol: {"long"}

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1333,8 +1333,10 @@ async def test_existing_unstuck_blocks_new(monkeypatch):
 
     payload = json.loads(captured["input"])
     assert payload["global"]["auto_unstuck_allowed"] is False
-    assert payload["global"]["unstuck_allowance_long"] == 0.0
-    assert payload["global"]["unstuck_allowance_short"] == 0.0
+    # Allowance values are no longer passed: Rust derives the unstuck
+    # allowance internally from the realized-pnl cumsum facts.
+    assert "unstuck_allowance_long" not in payload["global"]
+    assert "unstuck_allowance_short" not in payload["global"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Slice 4 of the Python-simplification arc (after #1142, #1143). Verified before changing: **Rust has always derived the unstuck allowance internally** — `risk.rs:calc_unstucking_action_with_position_allowances` computes `calc_auto_unstuck_allowance(balance, pct×TWEL, cumsum_max, cumsum_last)` from the realized-pnl cumsum facts already in the global input. The `unstuck_allowance_long/short` input fields were consumed only by input validation and as the legacy fallback for `auto_unstuck_allowed` when that flag is absent — and live callers always set the flag explicitly (pinned in #1143).

## Changes

- **Rust**: the two fields get `#[serde(default)]` plus a doc comment marking them legacy/diagnostic (decision uses cumsum facts; values matter only for the flag-absent fallback). Backtest builds the struct directly — unaffected.
- **Python live**: the hot path no longer calls `pbr.calc_auto_unstuck_allowance` at all — the last per-cycle duplicate of the allowance formula (`pct × TWEL` composition included) is gone. Live global inputs and recorded planning snapshots omit the fields; the panic path's explicit zeros are removed. The from-snapshot flag fallback still honors old recordings that carry `unstuck_allowances`. The monitor computes allowances on demand for diagnostics (unchanged), as does the unstuck-selection log line.
- Behavior unchanged: Rust's decision inputs (flag + cumsum facts + per-symbol bot params) are identical before and after.

## Pins

- Rust JSON gate test now also proves **omitted** allowance fields parse (serde defaults) with emission governed by the explicit flag + cumsum facts alone (deterministic stuck-long fixture).
- Input-shape pins updated from `== 0.0` to key-absent in the existing unstuck-blocks-new and panic-payload tests.
- Full cargo suite 204/204; full local pytest green except the 3 known out-of-scope failures (fake-live suite included in the affected-suite run).

@vigilpbclaw-hash @claude @codex please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)