### PR TITLE
Close Python-simplification tracker item (docs-only) - final action-plan item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Plan tracker: closed the Python-simplification item, the final open item
+  of the risk/unstuck/HSL action plan. Removed live-path policy
+  re-decisions: execution type, the redundant unstuck-suppression channel,
+  and the per-cycle unstuck-allowance computation. The remaining
+  Python-side order handling is documented as intentionally Python-owned
+  reconciliation or live-only execution/data guards. Docs-only change.
+
 - The live path no longer computes unstuck allowances for the Rust
   orchestrator input. Rust has always derived the unstuck allowance
   internally from the realized-pnl cumsum facts (risk.rs); the

--- a/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
+++ b/docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md
@@ -1151,10 +1151,36 @@ Remaining implementation details:
       replay; the completed event now reports `cache_reused` alongside phase
       timings. End-to-end test proves the cache-fed boot reaches state
       identical to the full replay with the full fetch provably skipped.
-- [ ] Python simplification after Rust owns ideal protective orders and unstuck
+- [x] Python simplification after Rust owns ideal protective orders and unstuck
       orders.
       Python should reconcile ideal vs actual orders, not re-decide trading
       policy where Rust can own it.
+      Closure assessment (2026-07-08): the live path was audited end to end
+      for policy re-decisions layered on the Rust orchestrator's output.
+      Removed re-decisions: execution type (the Rust orchestrator is the
+      single source of truth, fail-loud end to end, silent limit-downgrade
+      hazard eliminated); the redundant unstuck-suppression channel
+      (auto_unstuck_allowed is the sole emission gate; allowances no longer
+      zeroed by an open-order check); and the per-cycle unstuck-allowance
+      computation (Rust always derived the allowance internally from the
+      realized-pnl cumsum facts; the input fields are now optional and
+      documented legacy/diagnostic).
+      Verified as intentionally Python-owned per the guiding contract
+      (reconciliation, live-only execution economics, or live-data guards
+      with no backtest analog): the reconciler's mode cancel-retention
+      filters (the two tp_only variants produce identical Rust ideal orders
+      and differ only in which ACTUAL orders reconciliation retains);
+      reduce-only qty clamps and the over-subscription trim (a response to
+      live exchange-position drift Rust cannot observe, trimming
+      farthest-first consistently with Rust's keep-nearest reducer
+      priority); the initial-entry distance gate; entry-cooldown
+      delta-guard anchors; the trailing-unavailable reconciliation filter;
+      executor-time safety guards; and exchange data gathering.
+      Still-open acknowledged detail (from Remaining implementation
+      details): the exact flat-detection tolerance for episode-end fills
+      (qty-step epsilon versus exchange dust) remains a design refinement -
+      current code uses 1e-12 in replay flatness and qty-step tolerance in
+      cache-reuse position reconciliation.
 - [x] Dead legacy HSL cleanup after parity tests cover active
       `src/passivbot_hsl.py`.
       Implemented: removed shadowed legacy HSL method definitions from


### PR DESCRIPTION
## Summary

Docs-only closure of "Python simplification after Rust owns ideal protective orders and unstuck orders" — the **final open item** of docs/plans/risk_unstuck_hsl_fable_audit_action_plan_20260702.md.

The live path was audited end to end for policy re-decisions layered on the Rust orchestrator's output (scoping report in the PR #1142-#1144 series):

**Removed re-decisions** (merged):
- #1142 — execution type: Rust is the single fail-loud source of truth; the silent panic-market→limit downgrade hazard is eliminated (AST pin prevents regression).
- #1143 — the redundant unstuck-suppression channel: `auto_unstuck_allowed` is the sole emission gate; allowance inputs stopped being zeroed by an open-order check.
- #1144 — the per-cycle unstuck-allowance computation: Rust always derived the allowance internally from cumsum facts; the input fields are optional and documented legacy/diagnostic.

**Verified as intentionally Python-owned** per the guiding contract (reconciliation, live-only execution economics, live-data guards with no backtest analog):
- reconciler mode cancel-retention filters — the two `tp_only` variants produce **identical** Rust ideal orders and differ only in which actual orders reconciliation retains, so a Rust mode variant would centralize nothing;
- reduce-only qty clamps and the over-subscription trim — a response to live exchange-position drift Rust cannot observe, trimming farthest-first consistently with Rust's keep-nearest reducer priority;
- initial-entry distance gate, entry-cooldown delta-guard anchors, trailing-unavailable filter, executor-time guards, exchange data gathering.

**Still-open acknowledged detail**: the exact flat-detection tolerance for episode-end fills (qty-step epsilon vs exchange dust) is recorded as a design refinement, not silently closed.

With this, every tracker item in the action plan is closed. Two observations remain posed to maintainers from earlier PRs: the unstuck create/cancel oscillation question (#1143) and first-boot replay vectorization contingent on production timings (#1140).

@vigilpbclaw-hash @claude @codex please review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)