### PR TITLE
Refresh trailing martingale default config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ All notable user-facing changes will be documented in this file.
   the hot path. The monitor still computes allowances on demand for
   diagnostics. Behavior unchanged.
 
+- Optimizer defaults now keep HSL restarts enabled by setting
+  `bot.long/short.hsl.restart_after_red_policy=always` in
+  `optimize.fixed_runtime_overrides` instead of forcing
+  `no_restart_drawdown_threshold=1`. This avoids permanent optimizer halts
+  while preserving the live/default no-restart threshold values for configs
+  that use `restart_after_red_policy=threshold`.
+
 - Live unstuck-allowance inputs to the Rust orchestrator are no longer
   zeroed while an unstuck order is resting on the exchange. The allowance
   values are pure budget facts derived from fill history; suppression of

--- a/configs/examples/default_trailing_martingale_long.json
+++ b/configs/examples/default_trailing_martingale_long.json
@@ -160,29 +160,30 @@
     "bot": {
         "long": {
             "forager": {
-                "score_weights": {"ema_readiness": 0.08, "volatility": 0.48, "volume": 0.44},
-                "volatility_ema_span_1m": 661.0,
-                "volume_drop_pct": 0.06,
-                "volume_ema_span_1m": 2369.0
+                "score_weights": {"ema_readiness": 0.2, "volatility": 0.34, "volume": 0.46},
+                "volatility_ema_span_1m": 187.0,
+                "volume_drop_pct": 0.02,
+                "volume_ema_span_1m": 1280.0
             },
             "hsl": {
-                "cooldown_minutes_after_red": 3981.0,
-                "ema_span_minutes": 644.0,
+                "cooldown_minutes_after_red": 4041.0,
+                "ema_span_minutes": 639.0,
                 "enabled": false,
                 "no_restart_drawdown_threshold": 1,
                 "orange_tier_mode": "tp_only_with_active_entry_cancellation",
                 "panic_close_order_type": "limit",
-                "red_threshold": 0.025,
+                "red_threshold": 0.117,
+                "restart_after_red_policy": "threshold",
                 "tier_ratios": {"orange": 0.75, "yellow": 0.5}
             },
             "risk": {
-                "entry_cooldown_minutes": 7.1,
+                "entry_cooldown_minutes": 7.3,
                 "n_positions": 5.0,
                 "position_exposure_enforcer_enabled": false,
                 "position_exposure_enforcer_threshold": 1.0,
                 "total_exposure_enforcer_enabled": true,
                 "total_exposure_enforcer_policy": "reduce_overweight",
-                "total_exposure_enforcer_threshold": 1.004,
+                "total_exposure_enforcer_threshold": 1.002,
                 "total_exposure_entry_gate_enabled": true,
                 "total_wallet_exposure_limit": 1.5,
                 "we_excess_allowance_mode": "bounded",
@@ -191,42 +192,42 @@
             "strategy": {
                 "trailing_martingale": {
                     "close": {
-                        "qty_pct": 0.4,
+                        "qty_pct": 0.22,
                         "retracement_base_pct": 0.0001,
-                        "retracement_volatility_1h_weight": 0.93,
-                        "retracement_volatility_1m_weight": 1.33,
-                        "threshold_base_pct": -0.0138,
-                        "threshold_volatility_1h_weight": 0.02,
-                        "threshold_volatility_1m_weight": 7.58,
-                        "threshold_we_weight": 0.0142
+                        "retracement_volatility_1h_weight": 5.8,
+                        "retracement_volatility_1m_weight": 39.03,
+                        "threshold_base_pct": -0.0179,
+                        "threshold_volatility_1h_weight": 0.13,
+                        "threshold_volatility_1m_weight": 7.94,
+                        "threshold_we_weight": 0.0148
                     },
-                    "ema_span_0": 200.0,
-                    "ema_span_1": 150.0,
+                    "ema_span_0": 130.0,
+                    "ema_span_1": 130.0,
                     "entry": {
-                        "double_down_factor": 0.39,
+                        "double_down_factor": 0.68,
                         "ema_gate_mode": "all",
-                        "initial_ema_dist": 0.0193,
-                        "initial_qty_pct": 0.0703,
-                        "retracement_base_pct": 0.0006,
-                        "retracement_volatility_1h_weight": 6.24,
-                        "retracement_volatility_1m_weight": 24.21,
-                        "retracement_we_weight": 2.984,
-                        "threshold_base_pct": 0.032,
-                        "threshold_volatility_1h_weight": 1.71,
-                        "threshold_volatility_1m_weight": 35.44,
-                        "threshold_we_weight": 4.821
+                        "initial_ema_dist": 0.0184,
+                        "initial_qty_pct": 0.0673,
+                        "retracement_base_pct": 0.0011,
+                        "retracement_volatility_1h_weight": 13.35,
+                        "retracement_volatility_1m_weight": 18.54,
+                        "retracement_we_weight": 4.575,
+                        "threshold_base_pct": 0.0248,
+                        "threshold_volatility_1h_weight": 1.64,
+                        "threshold_volatility_1m_weight": 35.21,
+                        "threshold_we_weight": 4.107
                     },
-                    "volatility_ema_span_1h": 672.0,
-                    "volatility_ema_span_1m": 1049.0
+                    "volatility_ema_span_1h": 1537.0,
+                    "volatility_ema_span_1m": 1425.0
                 }
             },
             "unstuck": {
-                "close_pct": 0.028,
-                "ema_dist": -0.086,
+                "close_pct": 0.024,
+                "ema_dist": -0.1238,
                 "ema_gating_enabled": true,
                 "enabled": true,
-                "loss_allowance_pct": 0.0065,
-                "threshold": 0.46
+                "loss_allowance_pct": 0.0063,
+                "threshold": 0.432
             }
         },
         "short": {
@@ -244,6 +245,7 @@
                 "orange_tier_mode": "tp_only_with_active_entry_cancellation",
                 "panic_close_order_type": "limit",
                 "red_threshold": 0.01,
+                "restart_after_red_policy": "threshold",
                 "tier_ratios": {"orange": 0.75, "yellow": 0.5}
             },
             "risk": {
@@ -411,6 +413,7 @@
         "forced_mode_long": "",
         "forced_mode_short": "",
         "hedge_mode": false,
+        "hsl_accept_incomplete_history": false,
         "hsl_position_during_cooldown_policy": "panic",
         "hsl_signal_mode": "coin",
         "ignored_coins": {"long": [], "short": []},
@@ -603,8 +606,8 @@
         "enable_overrides": [],
         "fixed_params": [],
         "fixed_runtime_overrides": {
-            "bot.long.hsl.no_restart_drawdown_threshold": 1,
-            "bot.short.hsl.no_restart_drawdown_threshold": 1
+            "bot.long.hsl.restart_after_red_policy": "always",
+            "bot.short.hsl.restart_after_red_policy": "always"
         },
         "iters": 200000,
         "limits": [
@@ -633,7 +636,9 @@
             "algorithm": "auto",
             "algorithms": {
                 "nsga2": {},
-                "nsga3": {"ref_dirs": {"method": "das_dennis", "n_partitions": "auto"}}
+                "nsga3": {
+                    "ref_dirs": {"method": "das_dennis", "n_partitions": "auto"}
+                }
             },
             "shared": {
                 "crossover_eta": 20.0,
@@ -657,6 +662,7 @@
             {"goal": "min", "metric": "loss_profit_ratio"},
             {"goal": "min", "metric": "strategy_eq_underwater_pct_mean"}
         ],
+        "seed": null,
         "write_all_results": true
     }
 }

--- a/passivbot-rust/src/strategies/spec.rs
+++ b/passivbot-rust/src/strategies/spec.rs
@@ -52,7 +52,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "ema_span_0",
         path: &["ema_span_0"],
-        long_default: 200.0,
+        long_default: 130.0,
         short_default: 60.0,
         long_bounds: &[100.0, 2880.0, 10.0],
         short_bounds: &[100.0, 2880.0, 10.0],
@@ -60,7 +60,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "ema_span_1",
         path: &["ema_span_1"],
-        long_default: 150.0,
+        long_default: 130.0,
         short_default: 60.0,
         long_bounds: &[100.0, 2880.0, 10.0],
         short_bounds: &[100.0, 2880.0, 10.0],
@@ -68,7 +68,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "volatility_ema_span_1h",
         path: &["volatility_ema_span_1h"],
-        long_default: 672.0,
+        long_default: 1537.0,
         short_default: 672.0,
         long_bounds: &[168.0, 2016.0, 1.0],
         short_bounds: &[168.0, 2016.0, 1.0],
@@ -76,7 +76,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "volatility_ema_span_1m",
         path: &["volatility_ema_span_1m"],
-        long_default: 1049.0,
+        long_default: 1425.0,
         short_default: 5.0,
         long_bounds: &[5.0, 1440.0, 1.0],
         short_bounds: &[5.0, 1440.0, 1.0],
@@ -84,7 +84,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_double_down_factor",
         path: &["entry", "double_down_factor"],
-        long_default: 0.39,
+        long_default: 0.68,
         short_default: 0.2,
         long_bounds: &[0.2, 1.0, 0.01],
         short_bounds: &[0.2, 1.0, 0.01],
@@ -92,7 +92,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_initial_qty_pct",
         path: &["entry", "initial_qty_pct"],
-        long_default: 0.0703,
+        long_default: 0.0673,
         short_default: 0.005,
         long_bounds: &[0.005, 0.1, 0.0001],
         short_bounds: &[0.005, 0.1, 0.0001],
@@ -100,7 +100,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_initial_ema_dist",
         path: &["entry", "initial_ema_dist"],
-        long_default: 0.0193,
+        long_default: 0.0184,
         short_default: -0.1,
         long_bounds: &[-0.1, 0.02, 0.0001],
         short_bounds: &[-0.1, 0.02, 0.0001],
@@ -108,7 +108,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_threshold_base_pct",
         path: &["entry", "threshold_base_pct"],
-        long_default: 0.032,
+        long_default: 0.0248,
         short_default: 0.001,
         long_bounds: &[0.001, 0.035, 0.0001],
         short_bounds: &[0.001, 0.035, 0.0001],
@@ -116,7 +116,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_threshold_we_weight",
         path: &["entry", "threshold_we_weight"],
-        long_default: 4.821,
+        long_default: 4.107,
         short_default: 0.0,
         long_bounds: &[0.0, 5.0, 0.001],
         short_bounds: &[0.0, 5.0, 0.001],
@@ -124,7 +124,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_threshold_volatility_1h_weight",
         path: &["entry", "threshold_volatility_1h_weight"],
-        long_default: 1.71,
+        long_default: 1.64,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -132,7 +132,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_threshold_volatility_1m_weight",
         path: &["entry", "threshold_volatility_1m_weight"],
-        long_default: 35.44,
+        long_default: 35.21,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -140,7 +140,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_retracement_base_pct",
         path: &["entry", "retracement_base_pct"],
-        long_default: 0.0006,
+        long_default: 0.0011,
         short_default: -0.01,
         long_bounds: &[0.0001, 0.01, 0.0001],
         short_bounds: &[0.0001, 0.01, 0.0001],
@@ -148,7 +148,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_retracement_we_weight",
         path: &["entry", "retracement_we_weight"],
-        long_default: 2.984,
+        long_default: 4.575,
         short_default: 0.0,
         long_bounds: &[0.0, 5.0, 0.001],
         short_bounds: &[0.0, 5.0, 0.001],
@@ -156,7 +156,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_retracement_volatility_1h_weight",
         path: &["entry", "retracement_volatility_1h_weight"],
-        long_default: 6.24,
+        long_default: 13.35,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -164,7 +164,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_retracement_volatility_1m_weight",
         path: &["entry", "retracement_volatility_1m_weight"],
-        long_default: 24.21,
+        long_default: 18.54,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -172,7 +172,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_qty_pct",
         path: &["close", "qty_pct"],
-        long_default: 0.4,
+        long_default: 0.22,
         short_default: 0.05,
         long_bounds: &[0.05, 1.0, 0.01],
         short_bounds: &[0.05, 1.0, 0.01],
@@ -180,7 +180,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_threshold_base_pct",
         path: &["close", "threshold_base_pct"],
-        long_default: -0.0138,
+        long_default: -0.0179,
         short_default: -0.02,
         long_bounds: &[-0.02, 0.02, 0.0001],
         short_bounds: &[-0.02, 0.02, 0.0001],
@@ -188,7 +188,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_threshold_we_weight",
         path: &["close", "threshold_we_weight"],
-        long_default: 0.0142,
+        long_default: 0.0148,
         short_default: -0.1,
         long_bounds: &[-0.1, 0.1, 0.0001],
         short_bounds: &[-0.1, 0.1, 0.0001],
@@ -196,7 +196,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_threshold_volatility_1h_weight",
         path: &["close", "threshold_volatility_1h_weight"],
-        long_default: 0.02,
+        long_default: 0.13,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -204,7 +204,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_threshold_volatility_1m_weight",
         path: &["close", "threshold_volatility_1m_weight"],
-        long_default: 7.58,
+        long_default: 7.94,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -220,7 +220,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_retracement_volatility_1h_weight",
         path: &["close", "retracement_volatility_1h_weight"],
-        long_default: 0.93,
+        long_default: 5.8,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -228,7 +228,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_retracement_volatility_1m_weight",
         path: &["close", "retracement_volatility_1m_weight"],
-        long_default: 1.33,
+        long_default: 39.03,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -13,22 +13,22 @@ def _get_shared_bot_defaults():
         "long": {
             "forager": {
                 "score_weights": {
-                    "ema_readiness": 0.08,
-                    "volatility": 0.48,
-                    "volume": 0.44
+                    "ema_readiness": 0.2,
+                    "volatility": 0.34,
+                    "volume": 0.46
                 },
-                "volatility_ema_span_1m": 661.0,
-                "volume_drop_pct": 0.06,
-                "volume_ema_span_1m": 2369.0
+                "volatility_ema_span_1m": 187.0,
+                "volume_drop_pct": 0.02,
+                "volume_ema_span_1m": 1280.0
             },
             "hsl": {
-                "cooldown_minutes_after_red": 3981.0,
-                "ema_span_minutes": 644.0,
+                "cooldown_minutes_after_red": 4041.0,
+                "ema_span_minutes": 639.0,
                 "enabled": False,
                 "no_restart_drawdown_threshold": 1,
                 "orange_tier_mode": "tp_only_with_active_entry_cancellation",
                 "panic_close_order_type": "limit",
-                "red_threshold": 0.025,
+                "red_threshold": 0.117,
                 "restart_after_red_policy": "threshold",
                 "tier_ratios": {
                     "orange": 0.75,
@@ -36,25 +36,25 @@ def _get_shared_bot_defaults():
                 }
             },
             "risk": {
-                "entry_cooldown_minutes": 7.1,
+                "entry_cooldown_minutes": 7.3,
                 "n_positions": 5.0,
                 "position_exposure_enforcer_enabled": False,
                 "position_exposure_enforcer_threshold": 1.0,
                 "total_exposure_enforcer_enabled": True,
                 "total_exposure_enforcer_policy": "reduce_overweight",
-                "total_exposure_enforcer_threshold": 1.004,
+                "total_exposure_enforcer_threshold": 1.002,
                 "total_exposure_entry_gate_enabled": True,
                 "total_wallet_exposure_limit": 1.5,
                 "we_excess_allowance_mode": "bounded",
                 "we_excess_allowance_pct": 0.5
             },
             "unstuck": {
-                "close_pct": 0.028,
-                "ema_dist": -0.086,
+                "close_pct": 0.024,
+                "ema_dist": -0.1238,
                 "ema_gating_enabled": True,
                 "enabled": True,
-                "loss_allowance_pct": 0.0065,
-                "threshold": 0.46
+                "loss_allowance_pct": 0.0063,
+                "threshold": 0.432
             }
         },
         "short": {
@@ -475,10 +475,8 @@ def get_template_config():
                     "enable_overrides": [],
                     "fixed_params": [],
                     "fixed_runtime_overrides": {
-                        "bot.long.hsl.no_restart_drawdown_threshold": 1,
-                        "bot.long.hsl.restart_after_red_policy": "threshold",
-                        "bot.short.hsl.no_restart_drawdown_threshold": 1,
-                        "bot.short.hsl.restart_after_red_policy": "threshold"
+                        "bot.long.hsl.restart_after_red_policy": "always",
+                        "bot.short.hsl.restart_after_red_policy": "always"
                     },
                     "iters": 200000,
                     "mutation_eta": 20,


### PR DESCRIPTION
Summary:\n- Refresh bot.long schema defaults and trailing_martingale long strategy defaults from tmp/canon_candidate.json.\n- Regenerate configs/examples/default_trailing_martingale_long.json from the refreshed template.\n- Update optimize.fixed_runtime_overrides to use restart_after_red_policy=always instead of forcing no_restart_drawdown_threshold=1, with changelog reasoning.\n\nValidation:\n- schema/example override and bot.long candidate assertions\n- ./venv/bin/python -m pytest tests/test_config_utils_helpers.py::test_hsl_restart_after_red_policy_normalizes_default_and_rejects_invalid tests/test_config_utils_helpers.py::test_default_example_config_loads_with_grouped_shape_and_live_execution_settings tests/optimization/test_optimize.py::TestIndividualToConfig::test_applies_optimize_fixed_runtime_overrides_without_mutating_template -q\n- ./venv/bin/python -m py_compile src/config/schema.py src/optimize.py src/optimization/warmup.py\n- cargo check --release