### PR TITLE
Align unstuck emission and HSL flat epsilon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live auto-unstuck emission is no longer gated in Python by whether an
+  unstuck order is already resting on the exchange. Rust owns whether an
+  unstuck ideal order is emitted from the realized-PnL cumsum facts; duplicate
+  order risk now rides the same live reconciliation path as every other order
+  type.
+
+- HSL flat detection now uses a shared half-qty-step epsilon where symbol
+  precision is available, including replay cache extension, pside/unified cache
+  synthesis, current-episode proof, and coin replay episode transitions. This
+  keeps dust below half a step from extending or restarting HSL episodes.
+
 - Plan tracker: closed the Python-simplification item, the final open item
   of the risk/unstuck/HSL action plan. Removed live-path policy
   re-decisions: execution type, the redundant unstuck-suppression channel,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -12132,13 +12132,17 @@ class Passivbot:
                         "realized_pnl_by_coin_pside": realized_pnl_coin_pside_window,
                         "is_flat": len(active_symbols) == 0,
                         "is_flat_long": not any(
-                            positions.get(sym, {}).get("long", {}).get("size", 0.0)
-                            > 1e-12
+                            not _is_flat_size(
+                                sym,
+                                positions.get(sym, {}).get("long", {}).get("size", 0.0),
+                            )
                             for sym in positions
                         ),
                         "is_flat_short": not any(
-                            positions.get(sym, {}).get("short", {}).get("size", 0.0)
-                            > 1e-12
+                            not _is_flat_size(
+                                sym,
+                                positions.get(sym, {}).get("short", {}).get("size", 0.0),
+                            )
                             for sym in positions
                         ),
                         "panic_fill_count": int(panic_fill_count),

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11323,6 +11323,14 @@ class Passivbot:
         _safe_float = Passivbot._hsl_fill_safe_float
         _normalize_symbol = self._hsl_normalize_fill_symbol
 
+        def _flat_epsilon(symbol: str) -> float:
+            return pb_hsl._hsl_flat_epsilon(
+                (getattr(self, "qty_steps", None) or {}).get(str(symbol), 0.0)
+            )
+
+        def _is_flat_size(symbol: str, size: float) -> bool:
+            return abs(float(size)) <= _flat_epsilon(symbol)
+
         def _ensure_slot(
             container: Dict[str, Dict[str, Dict[str, float]]], symbol: str
         ):
@@ -11345,7 +11353,11 @@ class Passivbot:
                     if not isinstance(pos, dict):
                         continue
                     size = abs(_safe_float(pos.get("size"), 0.0))
-                    price = _safe_float(pos.get("price"), 0.0) if size > 1e-12 else 0.0
+                    price = (
+                        _safe_float(pos.get("price"), 0.0)
+                        if not _is_flat_size(norm_symbol, size)
+                        else 0.0
+                    )
                     out[(norm_symbol, pside)] = (size, price)
             return out
 
@@ -11364,8 +11376,8 @@ class Passivbot:
                 "events": len(events),
                 "current_position_pairs": sum(
                     1
-                    for size, _price in current_position_state.values()
-                    if size > 1e-12
+                    for (sym, _pside), (size, _price) in current_position_state.items()
+                    if not _is_flat_size(sym, size)
                 ),
             },
             reason_code=ReasonCodes.HSL_HISTORY_INPUTS_LOADED,
@@ -11475,7 +11487,7 @@ class Passivbot:
         current_position_symbols = {
             symbol
             for (symbol, _pside), (size, _price) in current_position_state.items()
-            if size > 1e-12
+            if not _is_flat_size(symbol, size)
         }
         symbols = {
             evt["symbol"]
@@ -11711,7 +11723,7 @@ class Passivbot:
         record_start_realized_pnl_pside = {"long": 0.0, "short": 0.0}
         record_start_realized_pnl_coin_pside: Dict[str, Dict[str, float]] = {}
         actual_symbol_pside_flat = {
-            (sym, ps): size <= 1e-12
+            (sym, ps): _is_flat_size(sym, size)
             for (sym, ps), (size, _price) in current_position_state.items()
         }
         last_event_ts_by_symbol_pside = {
@@ -11735,7 +11747,7 @@ class Passivbot:
                 return True
             if "size" not in pside_position:
                 return True
-            return float(pside_position["size"]) <= 1e-12
+            return _is_flat_size(symbol, float(pside_position["size"]))
 
         def _apply_event(evt: dict):
             slot = _ensure_slot(positions, evt["symbol"])[evt["pside"]]
@@ -11758,11 +11770,12 @@ class Passivbot:
                 slot["size"] = max(slot["size"] - qty, 0.0)
                 if slot["size"] <= 0.0:
                     slot["price"] = 0.0
-            has_pos = slot["size"] > 1e-12
+            has_pos = not _is_flat_size(evt["symbol"], slot["size"])
             if has_pos:
                 active_symbols.add(evt["symbol"])
             elif not any(
-                positions[evt["symbol"]][ps]["size"] > 1e-12 for ps in ("long", "short")
+                not _is_flat_size(evt["symbol"], positions[evt["symbol"]][ps]["size"])
+                for ps in ("long", "short")
             ):
                 active_symbols.discard(evt["symbol"])
 
@@ -11784,7 +11797,7 @@ class Passivbot:
             replay_matrix_pairs = {
                 (pside, sym)
                 for (sym, pside), (size, _price) in current_position_state.items()
-                if size > 1e-12 and sym in price_replay_symbols
+                if not _is_flat_size(sym, size) and sym in price_replay_symbols
             }
         replay_matrix_rows: Dict[Tuple[str, str], List[dict]] = {
             pair: [] for pair in replay_matrix_pairs
@@ -11874,7 +11887,7 @@ class Passivbot:
                         continue
                     slot = positions.get(sym, {}).get(pside, {})
                     size = float(slot.get("size", 0.0) or 0.0)
-                    if size > 1e-12:
+                    if not _is_flat_size(sym, size):
                         psize = size if pside == "long" else -size
                         pprice = float(slot.get("price", 0.0) or 0.0)
                     else:
@@ -11946,7 +11959,8 @@ class Passivbot:
                 == evt["timestamp"]
             )
             if authoritative_symbol_flat_override and (
-                not math.isfinite(after_psize) or after_psize > 1e-12
+                not math.isfinite(after_psize)
+                or not _is_flat_size(evt["symbol"], after_psize)
             ):
                 logging.warning(
                     "[risk] balance-equity replay trusting current flat %s symbol state over residual panic replay size | timestamp=%s replay_after_psize=%s symbol=%s",
@@ -11960,7 +11974,7 @@ class Passivbot:
                     Passivbot._log_symbol(evt["symbol"]),
                 )
             if (
-                (math.isfinite(after_psize) and after_psize <= 1e-12)
+                (math.isfinite(after_psize) and _is_flat_size(evt["symbol"], after_psize))
                 or authoritative_symbol_flat_override
                 or _symbol_pside_is_flat(evt["symbol"], evt["pside"])
             ):
@@ -13524,8 +13538,8 @@ class Passivbot:
         """Calculate unstuck allowances using FillEventsManager."""
         return self._calc_unstuck_allowances()
 
-    def _auto_unstuck_allowed_live(self, allow_new_unstuck: bool) -> bool:
-        if not allow_new_unstuck or self._pnls_manager is None:
+    def _auto_unstuck_allowed_live(self) -> bool:
+        if self._pnls_manager is None:
             return False
         start_ms = self._pnls_lookback_start_ms()
         events = self._get_effective_pnl_events()
@@ -13534,7 +13548,7 @@ class Passivbot:
             context="auto unstuck realized PnL",
             start_ms=start_ms,
         )
-        return bool(events)
+        return True
 
     def _calc_orchestrator_unstuck_allowance_for_symbol(
         self, pside: str, symbol: str, realized_pnl_cumsum: dict
@@ -15414,13 +15428,10 @@ class Passivbot:
             self, last_prices, ts=utc_ms(), source=monitor_source
         )
 
-        # The open-order check drives only the auto_unstuck_allowed emission
-        # gate; Rust derives the actual unstuck allowance internally from the
-        # realized-pnl cumsum facts below, so no allowance values are computed
-        # or passed on this path (the monitor computes them on demand for
-        # diagnostics).
-        allow_new_unstuck = not self.has_open_unstuck_order()
-        auto_unstuck_allowed = self._auto_unstuck_allowed_live(allow_new_unstuck)
+        # Python only proves the realized-PnL inputs are safe to expose; Rust
+        # owns unstuck emission from the cumsum facts below, and duplicate
+        # order risk rides normal live reconciliation like any other order.
+        auto_unstuck_allowed = self._auto_unstuck_allowed_live()
         realized_pnl_cumsum = self._get_realized_pnl_cumsum_stats()
         now_ms = int(self.get_exchange_time())
         fill_increase_timestamps = self._get_last_increase_fill_timestamps(

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -69,6 +69,20 @@ def _hsl_flat_epsilon(qty_step: Any = 0.0) -> float:
     return max(1e-12, step * 0.5)
 
 
+def _hsl_qty_step_for_symbol(self: Any, symbol: Any) -> float:
+    qty_steps = getattr(self, "qty_steps", None)
+    if not isinstance(qty_steps, dict):
+        return 0.0
+    try:
+        value = qty_steps.get(symbol)
+        if value is None:
+            value = qty_steps.get(str(symbol))
+        step = abs(float(value or 0.0))
+    except (TypeError, ValueError):
+        return 0.0
+    return step if math.isfinite(step) else 0.0
+
+
 def _hsl_replay_cache_safe_fragment(value: Any) -> str:
     raw = str(value).strip()
     out = []
@@ -2069,7 +2083,7 @@ async def _hsl_replay_load_extend_and_reconcile_cache(
             closes_by_minute=closes_by_symbol.get(symbol, {}),
             end_ts=end_minute,
             c_mult=float(self.c_mults.get(symbol, 1.0)),
-            qty_step=float(self.qty_steps.get(symbol, 0.0) or 0.0),
+            qty_step=_hsl_qty_step_for_symbol(self, symbol),
         )
         extended_pairs[(pside, symbol)] = (
             _hsl_replay_rows_from_arrays(arrays, series_kind="pair_matrix") + new_rows
@@ -2091,7 +2105,7 @@ async def _hsl_replay_load_extend_and_reconcile_cache(
         slot = (self.positions or {}).get(symbol, {}).get(pside, {})
         current_size = abs(float(slot.get("size", 0.0) or 0.0))
         current_signed = current_size if pside == "long" else -current_size
-        tolerance = max(float(self.qty_steps.get(symbol, 0.0) or 0.0), 1e-9)
+        tolerance = max(_hsl_qty_step_for_symbol(self, symbol), 1e-9)
         if abs(extended_psize - current_signed) > tolerance:
             logging.warning(
                 "[risk] HSL replay cache reuse rejected: extended %s:%s position "
@@ -2206,7 +2220,7 @@ async def _equity_hard_stop_try_reuse_pside_replay_cache(
         _hsl_replay_account_series_arrays(account_rows),
         current_balance=float(self.get_raw_balance()),
         qty_step_by_pair={
-            pair: float(self.qty_steps.get(pair[1], 0.0) or 0.0)
+            pair: _hsl_qty_step_for_symbol(self, pair[1])
             for pair in core["extended_pairs"]
         },
     )
@@ -3121,7 +3135,7 @@ def _equity_hard_stop_coin_episode_start_covered(self, pside: str, symbol: str) 
         return False
     slot = (self.positions or {}).get(symbol, {}).get(pside, {})
     size = abs(float(slot.get("size", 0.0) or 0.0))
-    qty_step = float(self.qty_steps.get(symbol, 0.0) or 0.0)
+    qty_step = _hsl_qty_step_for_symbol(self, symbol)
     flat_epsilon = _hsl_flat_epsilon(qty_step)
     if size <= flat_epsilon:
         # Flat scope: the current episode is empty; nothing to reconstruct.
@@ -5171,11 +5185,12 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 require_coin_timeline_fields = (pside, symbol) in required_replay_pairs
                 required_start_ts = required_replay_start_ts.get((pside, symbol))
                 seen_coin_timeline_fields = False
+                qty_step = _hsl_qty_step_for_symbol(self, symbol)
                 replay_events, replay_ambiguous = _equity_hard_stop_coin_replay_events(
                     fill_events,
                     pside,
                     symbol,
-                    qty_step=float(self.qty_steps.get(symbol, 0.0) or 0.0),
+                    qty_step=qty_step,
                 )
 
                 def reset_rolling_window() -> None:
@@ -5186,7 +5201,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
 
                 replay_event_idx = 0
                 replay_size = 0.0
-                flat_epsilon = _hsl_flat_epsilon(self.qty_steps.get(symbol, 0.0))
+                flat_epsilon = _hsl_flat_epsilon(qty_step)
                 replay_was_nonflat = False
                 replay_flattened_at_ms: Optional[int] = None
                 ignored_panic_marker_timestamps: set[int] = set()

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -59,6 +59,16 @@ _HSL_REPLAY_CACHE_REQUIRED_METADATA = (
 _HSL_REPLAY_CACHE_FILL_HISTORY_SCOPES = ("unknown", "window", "all")
 
 
+def _hsl_flat_epsilon(qty_step: Any = 0.0) -> float:
+    try:
+        step = abs(float(qty_step or 0.0))
+    except (TypeError, ValueError):
+        step = 0.0
+    if not math.isfinite(step):
+        step = 0.0
+    return max(1e-12, step * 0.5)
+
+
 def _hsl_replay_cache_safe_fragment(value: Any) -> str:
     raw = str(value).strip()
     out = []
@@ -736,6 +746,7 @@ def _hsl_replay_pside_timeline_rows_from_cache(
     account_arrays: dict[str, Any],
     *,
     current_balance: float,
+    qty_step_by_pair: dict[tuple[str, str], float] | None = None,
 ) -> list[dict[str, Any]]:
     """Synthesize pside/unified-replay timeline rows from persisted cache arrays.
 
@@ -860,7 +871,10 @@ def _hsl_replay_pside_timeline_rows_from_cache(
         pair_psize = np.asarray(arrays["psize"], dtype=np.float64)
         span = slice(offset, offset + len(pair_ts))
         upnl_by_minute[pside][span] += pair_upnl
-        nonflat_by_minute[pside][span] |= np.abs(pair_psize) > 1e-12
+        flat_epsilon = _hsl_flat_epsilon(
+            (qty_step_by_pair or {}).get((pside, symbol), 0.0)
+        )
+        nonflat_by_minute[pside][span] |= np.abs(pair_psize) > flat_epsilon
     rows: list[dict[str, Any]] = []
     for idx in range(n_rows):
         flat_long = not bool(nonflat_by_minute["long"][idx])
@@ -949,6 +963,7 @@ def _hsl_replay_extend_pair_rows(
     closes_by_minute: dict[int, float],
     end_ts: int,
     c_mult: float,
+    qty_step: float = 0.0,
 ) -> list[dict[str, Any]]:
     """Extend a cached pair matrix from its watermark to `end_ts` (pure).
 
@@ -967,8 +982,9 @@ def _hsl_replay_extend_pair_rows(
     watermark_ts = int(rows[-1]["ts"])
     minutes = _hsl_replay_extension_minutes(watermark_ts, end_ts)
     c_mult_f = _finite_hsl_float(c_mult, "c_mult")
+    flat_epsilon = _hsl_flat_epsilon(qty_step)
     size = abs(float(rows[-1]["psize"]))
-    pprice = float(rows[-1]["pprice"]) if size > 1e-12 else 0.0
+    pprice = float(rows[-1]["pprice"]) if size > flat_epsilon else 0.0
     last_price = float(rows[-1]["price"])
     ordered = sorted(
         (_hsl_replay_extension_require_fill(fill, watermark_ts) for fill in fills),
@@ -1034,8 +1050,8 @@ def _hsl_replay_extend_pair_rows(
                 pside=pside,
                 ts=int(minute),
                 price=last_price,
-                psize=psize if size > 1e-12 else 0.0,
-                pprice=pprice if size > 1e-12 else 0.0,
+                psize=psize if size > flat_epsilon else 0.0,
+                pprice=pprice if size > flat_epsilon else 0.0,
                 pnl=minute_pnl,
                 c_mult=c_mult_f,
             )
@@ -2053,6 +2069,7 @@ async def _hsl_replay_load_extend_and_reconcile_cache(
             closes_by_minute=closes_by_symbol.get(symbol, {}),
             end_ts=end_minute,
             c_mult=float(self.c_mults.get(symbol, 1.0)),
+            qty_step=float(self.qty_steps.get(symbol, 0.0) or 0.0),
         )
         extended_pairs[(pside, symbol)] = (
             _hsl_replay_rows_from_arrays(arrays, series_kind="pair_matrix") + new_rows
@@ -2188,6 +2205,10 @@ async def _equity_hard_stop_try_reuse_pside_replay_cache(
         },
         _hsl_replay_account_series_arrays(account_rows),
         current_balance=float(self.get_raw_balance()),
+        qty_step_by_pair={
+            pair: float(self.qty_steps.get(pair[1], 0.0) or 0.0)
+            for pair in core["extended_pairs"]
+        },
     )
     return self._hsl_reuse_assemble_history(core, timeline, now_ms)
 
@@ -3100,18 +3121,20 @@ def _equity_hard_stop_coin_episode_start_covered(self, pside: str, symbol: str) 
         return False
     slot = (self.positions or {}).get(symbol, {}).get(pside, {})
     size = abs(float(slot.get("size", 0.0) or 0.0))
-    if size <= 1e-12:
+    qty_step = float(self.qty_steps.get(symbol, 0.0) or 0.0)
+    flat_epsilon = _hsl_flat_epsilon(qty_step)
+    if size <= flat_epsilon:
         # Flat scope: the current episode is empty; nothing to reconstruct.
         return True
     replay_events, ambiguous = _equity_hard_stop_coin_replay_events(
-        list(self._pnls_manager.get_events()), pside, symbol
+        list(self._pnls_manager.get_events()), pside, symbol, qty_step=qty_step
     )
     if ambiguous:
         return False
     running = size
     for _ts, action, qty in reversed(replay_events):
         running = running - qty if action == "increase" else running + qty
-        if running <= 1e-12:
+        if running <= flat_epsilon:
             return True
     return False
 
@@ -3576,11 +3599,12 @@ def _equity_hard_stop_fill_replay_qty(fill: Any) -> Optional[float]:
 
 
 def _equity_hard_stop_coin_replay_events(
-    fill_events: list[Any], pside: str, symbol: str
+    fill_events: list[Any], pside: str, symbol: str, *, qty_step: float = 0.0
 ) -> tuple[list[tuple[int, str, float]], bool]:
     replay_events: list[tuple[int, str, float]] = []
     ambiguous = False
     replay_size = 0.0
+    flat_epsilon = _hsl_flat_epsilon(qty_step)
     for event in fill_events:
         if _equity_hard_stop_fill_pside(event) != pside:
             continue
@@ -3599,7 +3623,7 @@ def _equity_hard_stop_coin_replay_events(
         if action == "increase":
             replay_size += qty
         else:
-            if qty > replay_size + 1e-12:
+            if qty > replay_size + flat_epsilon:
                 ambiguous = True
             replay_size = max(0.0, replay_size - qty)
     return replay_events, ambiguous
@@ -5148,7 +5172,10 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 required_start_ts = required_replay_start_ts.get((pside, symbol))
                 seen_coin_timeline_fields = False
                 replay_events, replay_ambiguous = _equity_hard_stop_coin_replay_events(
-                    fill_events, pside, symbol
+                    fill_events,
+                    pside,
+                    symbol,
+                    qty_step=float(self.qty_steps.get(symbol, 0.0) or 0.0),
                 )
 
                 def reset_rolling_window() -> None:
@@ -5159,6 +5186,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
 
                 replay_event_idx = 0
                 replay_size = 0.0
+                flat_epsilon = _hsl_flat_epsilon(self.qty_steps.get(symbol, 0.0))
                 replay_was_nonflat = False
                 replay_flattened_at_ms: Optional[int] = None
                 ignored_panic_marker_timestamps: set[int] = set()
@@ -5174,7 +5202,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                             replay_size += qty
                         else:
                             replay_size = max(0.0, replay_size - qty)
-                            if replay_size <= 1e-12:
+                            if replay_size <= flat_epsilon:
                                 replay_flattened_at_ms = int(event_ts)
                         replay_event_idx += 1
                     return float(replay_size)
@@ -5255,7 +5283,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         ),
                     )
                     if not has_unrealized and require_coin_timeline_value:
-                        if replay_ambiguous or replay_position_size > 1e-12:
+                        if replay_ambiguous or replay_position_size > flat_epsilon:
                             if not require_coin_timeline_fields:
                                 continue
                             current_upnl = _equity_hard_stop_history_coin_value(
@@ -5292,7 +5320,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     applied_rows += 1
                     rows += 1
                     pair_rows_applied[(pside, symbol)] = int(applied_rows)
-                    replay_is_nonflat = replay_position_size > 1e-12
+                    replay_is_nonflat = replay_position_size > flat_epsilon
                     replay_flattened_this_row = (
                         not replay_ambiguous
                         and replay_was_nonflat

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1602,6 +1602,41 @@ def test_pside_timeline_synthesis_rejects_inconsistent_pside_pnl():
     assert rows[0]["realized_pnl"] == rows[0]["realized_pnl_long"] == 3.0
 
 
+def test_pside_timeline_synthesis_uses_qty_step_flat_epsilon():
+    account_arrays = passivbot_module.pb_hsl._hsl_replay_account_series_arrays(
+        [
+            passivbot_module.pb_hsl._hsl_replay_account_series_row(
+                ts=60_000, pnl=0.0, pnl_long=0.0, pnl_short=0.0
+            )
+        ]
+    )
+    pair_arrays = {
+        ("long", "BTC/USDT:USDT"): passivbot_module.pb_hsl._hsl_replay_matrix_arrays(
+            [
+                passivbot_module.pb_hsl._hsl_replay_matrix_row(
+                    pside="long",
+                    ts=60_000,
+                    price=100.0,
+                    psize=0.004,
+                    pprice=100.0,
+                    pnl=0.0,
+                    c_mult=1.0,
+                )
+            ]
+        )
+    }
+
+    rows = passivbot_module.pb_hsl._hsl_replay_pside_timeline_rows_from_cache(
+        pair_arrays,
+        account_arrays,
+        current_balance=100.0,
+        qty_step_by_pair={("long", "BTC/USDT:USDT"): 0.01},
+    )
+
+    assert rows[0]["is_flat"] is True
+    assert rows[0]["is_flat_long"] is True
+
+
 @pytest.mark.asyncio
 async def test_pside_timeline_synthesis_matches_authoritative_rows(monkeypatch):
     # Trust boundary for the future pside/unified reuse gate: rows synthesized
@@ -5620,11 +5655,10 @@ async def test_update_effective_min_cost_uses_executable_min_qty():
     assert bot.effective_min_cost[symbol] == pytest.approx(88.165)
 
 
-def test_unstuck_allowances_stay_real_while_unstuck_order_is_open(monkeypatch):
-    # The allowance values are pure budget facts; an open unstuck order must
-    # not zero them. Suppression of new unstuck emission rides solely on the
-    # auto_unstuck_allowed flag, which the Rust orchestrator consumes as the
-    # sole gate (pinned in test_auto_unstuck_allowed_flag_is_sole_emission_gate).
+def test_open_unstuck_order_does_not_gate_live_unstuck_emission(monkeypatch):
+    # Rust owns auto-unstuck emission from the realized-PnL cumsum facts. A
+    # resting unstuck order must not add a Python-only suppression path; any
+    # duplicate-order risk rides normal order reconciliation.
     import passivbot as pb_mod
 
     bot = Passivbot.__new__(Passivbot)
@@ -5655,8 +5689,8 @@ def test_unstuck_allowances_stay_real_while_unstuck_order_is_open(monkeypatch):
     out = bot._calc_unstuck_allowances()
     assert out["long"] == pytest.approx(77.0)
 
-    # The emission gate is still off while the order is open.
-    assert bot._auto_unstuck_allowed_live(allow_new_unstuck=False) is False
+    # The emission input stays available while the order is open.
+    assert bot._auto_unstuck_allowed_live() is True
 
 
 def _make_unstuck_custom_id() -> str:

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -1638,6 +1638,88 @@ def test_pside_timeline_synthesis_uses_qty_step_flat_epsilon():
 
 
 @pytest.mark.asyncio
+async def test_authoritative_pside_timeline_uses_qty_step_flat_epsilon(monkeypatch):
+    bot = Passivbot.__new__(Passivbot)
+    bot.config = {"live": {}}
+    bot.exchange = "kucoin"
+    bot.user = "test_user"
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
+    base_ts = 1_800_000_000_000
+    ts_now = base_ts + 60_000
+    bot.get_exchange_time = lambda: ts_now
+    bot.get_raw_balance = lambda: 100.0
+    bot.get_symbol_id_inv = lambda symbol: symbol
+    symbol = "BTC/USDT:USDT"
+    bot.positions = {
+        symbol: {
+            "long": {"size": 0.004, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    bot.qty_steps = {symbol: 0.01}
+    bot._pnls_manager = None
+    bot.inverse = False
+    bot._candle_fetch_concurrency = lambda *, context="runtime": 2
+    bot._get_fetch_delay_seconds = lambda: 0.0
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[ListEventSink()],
+        monitor_sinks=[],
+    )
+    bot._live_event_current_cycle_id = "cy_hsl_authoritative_flat_epsilon"
+    bot._emit_live_event = Passivbot._emit_live_event.__get__(bot, Passivbot)
+    bot.c_mults = {symbol: 1.0}
+    monkeypatch.setattr(
+        passivbot_module, "compute_psize_pprice", lambda *args, **kwargs: None
+    )
+
+    class _CM:
+        async def get_candles(self, sym, **kwargs):
+            assert sym == symbol
+            return np.array(
+                [
+                    (base_ts, 99.0, 101.0, 98.0, 100.0, 1.0),
+                    (base_ts + 60_000, 100.0, 102.0, 99.0, 101.0, 1.0),
+                ],
+                dtype=passivbot_module.CANDLE_DTYPE,
+            )
+
+    bot.cm = _CM()
+    fill_events = [
+        {
+            "timestamp": base_ts,
+            "symbol": symbol,
+            "position_side": "long",
+            "side": "buy",
+            "qty": 0.01,
+            "price": 100.0,
+            "pnl": 0.0,
+        },
+        {
+            "timestamp": base_ts + 1_000,
+            "symbol": symbol,
+            "position_side": "long",
+            "side": "sell",
+            "qty": 0.006,
+            "price": 100.0,
+            "pnl": 0.0,
+        },
+    ]
+
+    history = await bot.get_balance_equity_history(
+        fill_events=fill_events,
+        current_balance=100.0,
+        hsl_replay_signal_mode="unified",
+    )
+
+    first = history["timeline"][0]
+    assert first["is_flat"] is True
+    assert first["is_flat_long"] is True
+    assert first["is_flat_short"] is True
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
 async def test_pside_timeline_synthesis_matches_authoritative_rows(monkeypatch):
     # Trust boundary for the future pside/unified reuse gate: rows synthesized
     # from the persisted cache arrays must equal the authoritative timeline

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1272,13 +1272,17 @@ def _make_order(
 
 
 @pytest.mark.asyncio
-async def test_existing_unstuck_blocks_new(monkeypatch):
+async def test_existing_unstuck_order_does_not_block_rust_emission(monkeypatch):
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
     import passivbot_rust as pbr
 
-    # Pretend an unstuck order is already live on the exchange
+    bot._pnls_manager = _DummyPnlsManager([_DummyFillEvent(symbol, "long", 120_000)])
+    monkeypatch.setattr(bot, "_pnls_lookback_start_ms", lambda: None)
+    monkeypatch.setattr(bot, "_assert_pnl_history_safe_for_risk", lambda *a, **k: None)
+
+    # Pretend an unstuck order is already live on the exchange.
     bot.open_orders[symbol] = [
         {
             "symbol": symbol,
@@ -1287,9 +1291,12 @@ async def test_existing_unstuck_blocks_new(monkeypatch):
             "qty": 0.1,
             "price": 100.0,
             "reduce_only": True,
-            "custom_id": "0x1234existing",
+            "custom_id": bot.format_custom_id_single(
+                pbr.get_order_id_type_from_string("close_unstuck_long")
+            ),
         }
     ]
+    assert bot.has_open_unstuck_order() is True
 
     bot.markets_dict = {symbol: _active_market()}
     bot.effective_min_cost = {symbol: 1.0}
@@ -1332,7 +1339,7 @@ async def test_existing_unstuck_blocks_new(monkeypatch):
     await bot.calc_ideal_orders_orchestrator()
 
     payload = json.loads(captured["input"])
-    assert payload["global"]["auto_unstuck_allowed"] is False
+    assert payload["global"]["auto_unstuck_allowed"] is True
     # Allowance values are no longer passed: Rust derives the unstuck
     # allowance internally from the realized-pnl cumsum facts.
     assert "unstuck_allowance_long" not in payload["global"]


### PR DESCRIPTION
## Summary
- remove the Python open-unstuck-order suppression path from live auto-unstuck emission; Python now only validates realized-PnL history before Rust owns emission
- centralize HSL flat detection on half qty step where symbol precision is available, including authoritative replay, cache extension, pside/unified synthesis, and coin replay transitions
- update regressions and changelog for the new ownership contract

## Tests
- PYTHONPATH=/private/tmp/passivbot-unstuck-flat/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_passivbot_balance_split.py::test_open_unstuck_order_does_not_gate_live_unstuck_emission tests/test_passivbot_balance_split.py::test_pside_timeline_synthesis_uses_qty_step_flat_epsilon tests/test_passivbot_balance_split.py::test_pside_timeline_synthesis_matches_authoritative_rows tests/test_hsl_coin_mode.py::test_hsl_cache_extension_matches_full_rebuild tests/test_hsl_coin_mode.py::test_hsl_cache_extension_fail_loud_contracts tests/test_unstucking_safeguards.py::test_existing_unstuck_order_does_not_block_rust_emission tests/test_orchestrator_integration.py::TestOrchestratorOrderAccuracy::test_auto_unstuck_allowed_flag_is_sole_emission_gate tests/test_orchestrator_json_api.py::test_auto_unstuck_allowed_gate_blocks_symbol_allowance
- python -m py_compile src/passivbot.py src/passivbot_hsl.py tests/test_passivbot_balance_split.py tests/test_unstucking_safeguards.py tests/test_hsl_coin_mode.py
- git diff --check