### PR TITLE
Add health CPU telemetry to performance reports

### DIFF
--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -16,6 +16,7 @@ Use this file to decide what to read for a task.
 | CCXT upgrade / dependency refresh | `ccxt_upgrade_workflow.md`, `exchange_api_quirks.md` |
 | Rust/PyO3 build, extension loading, Rust test execution | `build_pitfalls.md` |
 | Logging behavior/levels/tags | `logging_guide.md`, `live_event_registry.md` when touching structured event tags or reason codes |
+| Autonomous PR review loop | `pr_auto_review_loop.md` |
 | Order logic, risk, Python/Rust boundary | `architecture.md`, `decisions.md`, `features/strategy_runtime.md` when strategy behavior is involved |
 | Code review | `code_review_prompt.md` |
 | Common implementation mistakes | `pitfalls.md` |

--- a/docs/ai/pr_auto_review_loop.md
+++ b/docs/ai/pr_auto_review_loop.md
@@ -1,0 +1,70 @@
+# PR Auto-Review Loop
+
+Use this when acting as an autonomous reviewer for Passivbot PRs targeting
+`v8`.
+
+## Scope
+
+- Review open PRs against `v8`, including logging-overhaul PRs and
+  maintainer-created PRs that are not part of the logging overhaul.
+- Review the current PR head. If the head changes after a review, re-check the
+  delta before approving.
+- Do not implement fixes, push commits, merge PRs, deploy, SSH, or contact
+  exchanges unless explicitly instructed.
+
+## Loop Contract
+
+- Use the strongest available self-prompting mechanism in your agent surface:
+  goal mode, scheduled heartbeat, cron, automation, or equivalent.
+- If no durable self-prompting mechanism is available, state that limitation in
+  the thread and perform one complete poll/review pass.
+- Poll cheaply when there is no open work. A one-minute poll interval is fine
+  when each poll is limited to low-token GitHub metadata, such as open PR
+  numbers, head SHAs, review state, and CI state.
+- If each poll requires expensive diff/test context, use a five- to ten-minute
+  interval until a PR head or CI/review state changes.
+- Treat transient network, GitHub, checkout, or tool errors as retryable unless
+  evidence proves otherwise. Record the error briefly, back off, and keep the
+  loop alive.
+- Do not stop the loop after one unexpected disconnect or command failure. On
+  resume, fetch current remote state and continue from GitHub as the source of
+  truth.
+- Stop only when explicitly told to stop, when the goal is complete, or when the
+  same blocker has repeated enough times that your agent's blocked-goal policy
+  requires reporting it.
+
+## Poll Pass
+
+1. Fetch current `origin/v8`.
+2. List open PRs targeting `v8`.
+3. For each PR, compare the current head SHA, CI status, and latest reviewer
+   state with the last observed state.
+4. If nothing changed, sleep until the next poll.
+5. If a PR is new or changed, create or refresh a clean review worktree and
+   review the current PR head.
+
+## Review Focus
+
+- Architecture and intent alignment.
+- Bugs, edge cases, and behavioral regressions.
+- Trading-critical safety and `docs/ai/error_contract.md` compliance.
+- Rust/Python ownership boundaries, especially order, risk, HSL, and unstuck.
+- Stateless restart reproducibility.
+- Test coverage and whether tests prove the intended behavior.
+- Docs and operator-facing clarity.
+- VPS deploy implications and whether restart/smoke evidence is sufficient.
+- Backtest, optimize, fake-live, or real smoke validation when the PR touches
+  relevant paths.
+
+## Review Output
+
+Post one top-level GitHub PR review or comment:
+
+- Findings first, ordered by severity.
+- Exact file/line references for actionable findings.
+- Commands run and evidence observed.
+- Explicit approval/green-light when clean.
+- Residual risk or untested surface.
+
+Do not recommend merge until the current PR head has green required reviews and
+green CI.

--- a/docs/plans/live_logging_overhaul_pr_loop_workflow.md
+++ b/docs/plans/live_logging_overhaul_pr_loop_workflow.md
@@ -1,0 +1,102 @@
+# Live Logging Overhaul PR Loop Workflow
+
+This note defines the resumed logging-overhaul implementation loop. It
+complements:
+
+- `docs/plans/live_logging_overhaul_plan.md`
+- `docs/plans/live_logging_overhaul_progress.md`
+- `docs/plans/live_performance_readiness_goals.md`
+- `docs/plans/live_ops_improvement_backlog.md`
+
+## Roles
+
+- Codex owns implementation, local validation, PR creation, review iteration,
+  merge to `v8` after the gate is satisfied, VPS5 deploy/smoke when appropriate,
+  and progress evidence updates.
+- Hermes, Claude Opus, Grok, and any additional reviewer agents review the
+  current PR delta. Reviewers do not implement fixes or merge. Reusable
+  reviewer-loop instructions live in `docs/ai/pr_auto_review_loop.md`.
+- Maintainer-created PRs may also enter the same review loop. It is OK for
+  reviewers to review non-logging-overhaul PRs when they target `v8`.
+
+## PR Scope
+
+- Prefer review-worthy slices over progress-only PRs.
+- Keep each PR tied to one behavior/tooling/docs purpose and one validation
+  story.
+- Split PRs for behavior, restart/deploy behavior, exchange contact, HSL/risk,
+  Rust extension behavior, and read-only report/tooling changes.
+- Start dependent work only after its dependency is merged to `v8`; parallel PRs
+  should be orthogonal.
+
+## PR Body Contract
+
+Every implementation PR should state:
+
+- scope category: `read-only tooling`, `observability producer`, `runtime behavior`,
+  `restart/deploy behavior`, or `trading-path`
+- expected behavior impact
+- expected VPS action: no restart, restart required, or observe only
+- validation commands and results
+- reviewer-specific notes for subtle contracts
+
+## Review Gate
+
+- Merge only after current-head green reviews from required reviewers and green
+  CI.
+- If the PR head changes after a review, require delta re-review for the new
+  head before merging.
+- For low-risk read-only tooling/docs PRs, use a degraded gate only when a
+  reviewer is unavailable and the PR explicitly justifies that choice.
+
+## Reviewer Output Contract
+
+Ask reviewers to post one top-level PR review/comment with:
+
+- findings first, ordered by severity
+- exact file/line references for actionable findings
+- commands run and evidence observed
+- explicit approval/green-light when clean
+- residual risk or untested surface
+
+Reviewer focus areas:
+
+- architecture and intent alignment
+- trading-critical safety and error-contract compliance
+- Rust/Python ownership boundaries
+- statelessness and restart reproducibility
+- tests that prove the claimed behavior
+- operator usefulness in smoke, incident-bundle, debug-profile, and VPS workflows
+- VPS deploy implications and whether restart/smoke evidence is sufficient
+
+## Implementation Loop
+
+1. Fetch current `origin/v8` and inspect open PRs/branches.
+2. Reconcile `docs/plans/live_logging_overhaul_progress.md` against GitHub and
+   VPS state before choosing the next slice.
+3. Create a clean branch/worktree for the chosen slice when the main checkout is
+   dirty.
+4. Implement the narrow slice, update tests, and update progress docs only when
+   the PR includes a real review-worthy code/tool/docs change.
+5. Run targeted validation, `git diff --check`, and broader/fake-live/VPS tests
+   when relevant.
+6. Open the PR with the body contract above.
+7. Wait for reviewer and CI feedback.
+8. Apply narrow fixes for findings, push, and wait for delta re-review.
+9. Merge only after the gate is satisfied.
+10. Pull `v8` locally. Deploy to VPS5 according to the PR's declared deploy
+    impact, restart bots only when the change requires running processes to load
+    new code, and run bounded smoke/incident checks.
+11. Record compact evidence in the progress ledger: PR, scope, validation,
+    review gate, merge SHA, VPS action, smoke result, and remaining gap.
+
+## VPS Policy
+
+- Read-only tooling/report changes usually require pull plus bounded smoke, not
+  bot restart.
+- Producer/event payload changes require restart and observation.
+- Runtime behavior, exchange contact, order/risk, and Rust changes require
+  restart and observation.
+- For Rust-touching deploys, rebuild and verify the extension before restarting.
+- VPS actions must be explicit and evidence-driven; do not perform broad process
+  kills or live-bot actions outside the declared deploy plan.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -6789,3 +6789,22 @@ VPS5 deployment status:
    becomes the higher leverage next step.
 7. Continue cache-doctor refinements in separate adjacent PRs: deeper metadata
    compatibility checks and synthetic/no-trade assumptions.
+
+### Draft Slice: Health Summary CPU Percent
+
+- Branch: `codex/v8-health-cpu-percent`.
+- Scope: observability producer plus existing performance-report projection for
+  periodic `health.summary` resource-pressure events.
+- Triggering evidence: `live-performance-report` already summarizes
+  `resource_pressure`, and the performance readiness plan calls for CPU/load,
+  RSS, open-FD, event queue, and monitor sink telemetry. RSS, memory percent,
+  load averages, open FDs, and event-pipeline counters were already emitted, but
+  process CPU percent was still absent from the source event.
+- Intended result: add a non-blocking process `cpu_percent` probe when `psutil`
+  is available, include it in `health.summary`, and aggregate it through the
+  existing `resource_pressure` performance report field. Do not add exchange
+  calls, monitor writes beyond the existing periodic health event, console
+  routing changes, order/risk logic, restart behavior, or trading behavior.
+- Expected validation: focused health-summary payload test, focused
+  live-performance-report resource-pressure test, `py_compile`, `git diff
+  --check`, and the standard added-line silent-handling scan.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -6801,11 +6801,11 @@ VPS5 deployment status:
   load averages, open FDs, and event-pipeline counters were already emitted, but
   process CPU percent was still absent from the source event.
 - Intended result: add a cached, non-blocking process `cpu_percent` probe when
-  `psutil` is available, include it in `health.summary`, and aggregate it
-  through the existing `resource_pressure` performance report field. Do not add
-  exchange calls, monitor writes beyond the existing periodic health event,
-  console routing changes, order/risk logic, restart behavior, or trading
-  behavior.
+  `psutil` is available, omit the first priming sample, include subsequent
+  samples in `health.summary`, and aggregate them through the existing
+  `resource_pressure` performance report field. Do not add exchange calls,
+  monitor writes beyond the existing periodic health event, console routing
+  changes, order/risk logic, restart behavior, or trading behavior.
 - Expected validation: focused health-summary payload test, focused
   live-performance-report resource-pressure test, `py_compile`, `git diff
   --check`, and the standard added-line silent-handling scan.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -6800,11 +6800,12 @@ VPS5 deployment status:
   RSS, open-FD, event queue, and monitor sink telemetry. RSS, memory percent,
   load averages, open FDs, and event-pipeline counters were already emitted, but
   process CPU percent was still absent from the source event.
-- Intended result: add a non-blocking process `cpu_percent` probe when `psutil`
-  is available, include it in `health.summary`, and aggregate it through the
-  existing `resource_pressure` performance report field. Do not add exchange
-  calls, monitor writes beyond the existing periodic health event, console
-  routing changes, order/risk logic, restart behavior, or trading behavior.
+- Intended result: add a cached, non-blocking process `cpu_percent` probe when
+  `psutil` is available, include it in `health.summary`, and aggregate it
+  through the existing `resource_pressure` performance report field. Do not add
+  exchange calls, monitor writes beyond the existing periodic health event,
+  console routing changes, order/risk logic, restart behavior, or trading
+  behavior.
 - Expected validation: focused health-summary payload test, focused
   live-performance-report resource-pressure test, `py_compile`, `git diff
   --check`, and the standard added-line silent-handling scan.

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -362,8 +362,10 @@ classification when enough source events exist.
   - Status: partial. Existing `health.summary` events are summarized by
     `live-performance-report` as `resource_pressure`, including whitelisted
     process and event-pipeline fields with count, latest, min, mean, median,
-    p95, and max values where present. Remaining work: CPU percent and loop lag
-    need source event support if they are not already emitted by the active bot.
+    p95, and max values where present. The source payload now includes
+    non-blocking process `cpu_percent` when `psutil` is available. Remaining
+    work: loop lag needs a dedicated source event or heartbeat before it can be
+    reported without misleading operators.
 - [ ] Shutdown: signal to exit flag, cancellation request, blocking task names,
   final monitor flush, process exit.
 
@@ -750,6 +752,11 @@ Trading-impact labels:
 - [ ] Add low-overhead process resource snapshots to the performance report.
   - CPU percent, RSS, open file descriptors if available, event queue depth,
     and monitor sink backlog.
+  - Status: partial. Periodic `health.summary` now emits RSS, memory percent,
+    non-blocking process CPU percent, open FDs, load averages, and event-pipeline
+    queue/drop/sink counters where available; `live-performance-report`
+    aggregates those fields under `resource_pressure`. Loop lag and explicit
+    sink backlog remain open source-event gaps.
 
 - [ ] Identify CPU-bound Python loops.
   - HSL replay is currently the obvious case. Other candidates are EMA

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -362,10 +362,11 @@ classification when enough source events exist.
   - Status: partial. Existing `health.summary` events are summarized by
     `live-performance-report` as `resource_pressure`, including whitelisted
     process and event-pipeline fields with count, latest, min, mean, median,
-    p95, and max values where present. The source payload now includes
-    non-blocking process `cpu_percent` when `psutil` is available. Remaining
-    work: loop lag needs a dedicated source event or heartbeat before it can be
-    reported without misleading operators.
+    p95, and max values where present. The source payload now includes cached,
+    non-blocking process `cpu_percent` when `psutil` is available; the first
+    post-start sample is used only to prime the psutil delta and is omitted.
+    Remaining work: loop lag needs a dedicated source event or heartbeat before
+    it can be reported without misleading operators.
 - [ ] Shutdown: signal to exit flag, cancellation request, blocking task names,
   final monitor flush, process exit.
 
@@ -753,10 +754,11 @@ Trading-impact labels:
   - CPU percent, RSS, open file descriptors if available, event queue depth,
     and monitor sink backlog.
   - Status: partial. Periodic `health.summary` now emits RSS, memory percent,
-    non-blocking process CPU percent, open FDs, load averages, and event-pipeline
-    queue/drop/sink counters where available; `live-performance-report`
-    aggregates those fields under `resource_pressure`. Loop lag and explicit
-    sink backlog remain open source-event gaps.
+    cached non-blocking process CPU percent after the first priming sample,
+    open FDs, load averages, and event-pipeline queue/drop/sink counters where
+    available; `live-performance-report` aggregates those fields under
+    `resource_pressure`. Loop lag and explicit sink backlog remain open
+    source-event gaps.
 
 - [ ] Identify CPU-bound Python loops.
   - HSL replay is currently the obvious case. Other candidates are EMA

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -55,6 +55,7 @@ _BLOCKING_SCOPE_BY_IMPACT = {
 _RESOURCE_PRESSURE_FIELDS = (
     "rss_bytes",
     "memory_percent",
+    "cpu_percent",
     "open_fds",
     "loadavg_1m",
     "loadavg_5m",

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -78,6 +78,8 @@ def _get_process_cpu_percent() -> Optional[float]:
     try:
         if _PROCESS_CPU_PERCENT_PROBE is None:
             _PROCESS_CPU_PERCENT_PROBE = psutil.Process(os.getpid())
+            _PROCESS_CPU_PERCENT_PROBE.cpu_percent(interval=None)
+            return None
         return float(_PROCESS_CPU_PERCENT_PROBE.cpu_percent(interval=None))
     except error_types as exc:
         _PROCESS_CPU_PERCENT_PROBE = None

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -33,6 +33,8 @@ try:
 except Exception:
     resource = None
 
+_PROCESS_CPU_PERCENT_PROBE: Any = None
+
 
 def _get_process_rss_bytes() -> Optional[int]:
     """Return current process RSS in bytes or None if unavailable."""
@@ -68,13 +70,17 @@ def _get_process_cpu_percent() -> Optional[float]:
     """Return non-blocking process CPU percentage when psutil is available."""
     if psutil is None:
         return None
+    global _PROCESS_CPU_PERCENT_PROBE
     error_types = (OSError, RuntimeError, ValueError, AttributeError)
     psutil_error = getattr(psutil, "Error", None)
     if isinstance(psutil_error, type):
         error_types = error_types + (psutil_error,)
     try:
-        return float(psutil.Process(os.getpid()).cpu_percent(interval=None))
+        if _PROCESS_CPU_PERCENT_PROBE is None:
+            _PROCESS_CPU_PERCENT_PROBE = psutil.Process(os.getpid())
+        return float(_PROCESS_CPU_PERCENT_PROBE.cpu_percent(interval=None))
     except error_types as exc:
+        _PROCESS_CPU_PERCENT_PROBE = None
         logging.debug("[monitor] cpu percent probe unavailable: %s", exc)
     return None
 

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -64,6 +64,21 @@ def _get_process_memory_percent() -> Optional[float]:
     return None
 
 
+def _get_process_cpu_percent() -> Optional[float]:
+    """Return non-blocking process CPU percentage when psutil is available."""
+    if psutil is None:
+        return None
+    error_types = (OSError, RuntimeError, ValueError, AttributeError)
+    psutil_error = getattr(psutil, "Error", None)
+    if isinstance(psutil_error, type):
+        error_types = error_types + (psutil_error,)
+    try:
+        return float(psutil.Process(os.getpid()).cpu_percent(interval=None))
+    except error_types as exc:
+        logging.debug("[monitor] cpu percent probe unavailable: %s", exc)
+    return None
+
+
 def _get_open_fd_count() -> Optional[int]:
     """Return current open file descriptor count when the platform exposes it."""
     try:
@@ -388,6 +403,9 @@ def _build_health_summary_payload(self, *, now_ms: Optional[int] = None) -> dict
     mem_pct = _get_process_memory_percent()
     if mem_pct is not None and math.isfinite(mem_pct):
         payload["memory_percent"] = float(mem_pct)
+    cpu_pct = _get_process_cpu_percent()
+    if cpu_pct is not None and math.isfinite(cpu_pct):
+        payload["cpu_percent"] = max(0.0, float(cpu_pct))
     open_fds = _get_open_fd_count()
     if open_fds is not None:
         payload["open_fds"] = int(open_fds)

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -2816,6 +2816,7 @@ def test_live_performance_report_resource_pressure_from_health_summary(tmp_path)
                 data={
                     "rss_bytes": 1000,
                     "memory_percent": 5.5,
+                    "cpu_percent": 12.0,
                     "open_fds": 11,
                     "loadavg_1m": 0.25,
                     "cpu_count": 1,
@@ -2837,6 +2838,7 @@ def test_live_performance_report_resource_pressure_from_health_summary(tmp_path)
                 data={
                     "rss_bytes": 1500,
                     "memory_percent": 6.5,
+                    "cpu_percent": 24.0,
                     "open_fds": 13,
                     "loadavg_1m": 0.75,
                     "cpu_count": 1,
@@ -2880,6 +2882,15 @@ def test_live_performance_report_resource_pressure_from_health_summary(tmp_path)
         "mean": 6,
         "median": 6,
         "p95": 6.45,
+    }
+    assert group["fields"]["cpu_percent"] == {
+        "latest": 24,
+        "count": 2,
+        "min": 12,
+        "max": 24,
+        "mean": 18,
+        "median": 18,
+        "p95": 23,
     }
     assert group["fields"]["event_queue_depth"]["max"] == 5
     assert group["fields"]["event_queue_depth"]["p95"] == 5

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1371,6 +1371,46 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
     assert payload["event_pipeline_worker_alive"] is True
 
 
+def test_process_cpu_percent_reuses_psutil_process(monkeypatch):
+    import passivbot as pb_mod
+
+    calls = []
+
+    class FakeProcess:
+        def __init__(self, pid):
+            self.pid = pid
+            self.samples = [0.0, 42.5]
+
+        def cpu_percent(self, *, interval=None):
+            calls.append((self.pid, interval, id(self)))
+            return self.samples.pop(0)
+
+    class FakePsutil:
+        Error = RuntimeError
+
+        def __init__(self):
+            self.processes = []
+
+        def Process(self, pid):
+            process = FakeProcess(pid)
+            self.processes.append(process)
+            return process
+
+    fake_psutil = FakePsutil()
+    monkeypatch.setattr(pb_mod.pb_monitor, "psutil", fake_psutil)
+    monkeypatch.setattr(pb_mod.pb_monitor, "_PROCESS_CPU_PERCENT_PROBE", None)
+    monkeypatch.setattr(pb_mod.pb_monitor.os, "getpid", lambda: 12345)
+
+    assert pb_mod.pb_monitor._get_process_cpu_percent() == 0.0
+    assert pb_mod.pb_monitor._get_process_cpu_percent() == 42.5
+
+    assert len(fake_psutil.processes) == 1
+    assert calls == [
+        (12345, None, id(fake_psutil.processes[0])),
+        (12345, None, id(fake_psutil.processes[0])),
+    ]
+
+
 def test_log_health_summary_emits_structured_event(caplog, monkeypatch):
     import passivbot as pb_mod
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1335,6 +1335,7 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
 
     monkeypatch.setattr(pb_mod.pb_monitor, "_get_process_rss_bytes", lambda: 123456)
     monkeypatch.setattr(pb_mod.pb_monitor, "_get_process_memory_percent", lambda: 12.5)
+    monkeypatch.setattr(pb_mod.pb_monitor, "_get_process_cpu_percent", lambda: 34.25)
     monkeypatch.setattr(pb_mod.pb_monitor, "_get_open_fd_count", lambda: 42)
     monkeypatch.setattr(
         pb_mod.pb_monitor,
@@ -1354,6 +1355,7 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
     assert payload["positions_short"] == 1
     assert payload["rss_bytes"] == 123456
     assert payload["memory_percent"] == 12.5
+    assert payload["cpu_percent"] == 34.25
     assert payload["open_fds"] == 42
     assert payload["loadavg_1m"] == 1.5
     assert payload["loadavg_5m"] == 1.25

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1401,7 +1401,7 @@ def test_process_cpu_percent_reuses_psutil_process(monkeypatch):
     monkeypatch.setattr(pb_mod.pb_monitor, "_PROCESS_CPU_PERCENT_PROBE", None)
     monkeypatch.setattr(pb_mod.pb_monitor.os, "getpid", lambda: 12345)
 
-    assert pb_mod.pb_monitor._get_process_cpu_percent() == 0.0
+    assert pb_mod.pb_monitor._get_process_cpu_percent() is None
     assert pb_mod.pb_monitor._get_process_cpu_percent() == 42.5
 
     assert len(fake_psutil.processes) == 1


### PR DESCRIPTION
## Scope

Category: observability producer + read-only reporting/docs.

This PR adds non-blocking process CPU percent telemetry to the existing periodic
health summary payload when `psutil` is available, then lets the existing
`live-performance-report` `resource_pressure` section aggregate the new
`cpu_percent` field. It also adds durable PR-loop/reviewer-loop docs for the
resumed logging-overhaul workflow.

## Behavior impact

- Adds optional `health.summary.data.cpu_percent`.
- Adds `cpu_percent` to `live-performance-report.resource_pressure` when
  present.
- No exchange calls, order/risk logic, HSL/unstuck behavior, startup behavior,
  or console routing changes.
- Existing bots need a restart after merge before they emit the new field.

## VPS action

After merge: pull `v8` on VPS5, restart bots to load the producer payload
change, then run bounded smoke/performance-report checks. No VPS action before
merge.

## Validation

- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_passivbot_monitor.py::test_build_health_summary_payload_includes_resource_pressure tests/test_live_performance_report.py::test_live_performance_report_resource_pressure_from_health_summary tests/test_live_performance_report.py::test_live_performance_report_resource_pressure_whitelists_health_fields`
  -> 3 passed
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_passivbot_monitor.py`
  -> 74 passed
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_performance_report.py`
  -> 64 passed
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/passivbot_monitor.py src/live/performance_report.py`
  -> passed
- `git diff --check` -> passed
- Added-line silent-handling scan over touched files -> no matches

## Reviewer notes

Please review the CPU probe as low-overhead and nonblocking: it uses
`psutil.Process(...).cpu_percent(interval=None)` and skips the field when
unavailable. Loop-lag telemetry remains intentionally out of scope because it
needs a dedicated heartbeat/source event to avoid a misleading payload field.
