### PR TITLE
Add psutil to live requirements

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,24 +15,21 @@ merge, live smoke evidence changes, or new gaps are discovered.
 
 ## Current Status
 
-Last updated: 2026-07-03.
+Last updated: 2026-07-09.
 
 Current `origin/v8` head:
 
-- `06f04070` after PR #1042, `Add cache live-event debug profile`.
+- `63c60022` after PR #1148, `Add health CPU telemetry to performance reports`.
 
 Current logging-overhaul head:
 
-- `06f04070` after PR #1042, `Add cache live-event debug profile`.
+- `63c60022` after PR #1148, `Add health CPU telemetry to performance reports`.
 
 Current work:
 
-- Branch `codex/v8-smoke-cache-health` adds a read-only `cache_health` smoke
-  report projection over existing cache load, flush, and warmup-decision events.
-  It lets restart/warm-cache smoke loops see cache reuse, cold-path, load, and
-  flush counters without running a separate performance report. It does not add
-  event producers, exchange calls, cache behavior, startup behavior, console
-  routing, order/risk logic, or trading behavior.
+- Branch `codex/v8-live-psutil-requirement` makes `psutil` part of the live
+  install so the deployed health-summary RSS, memory-percent, open-FD, and new
+  CPU-percent probes are available in standard live environments.
 
 Current review gate:
 
@@ -6809,3 +6806,36 @@ VPS5 deployment status:
 - Expected validation: focused health-summary payload test, focused
   live-performance-report resource-pressure test, `py_compile`, `git diff
   --check`, and the standard added-line silent-handling scan.
+- Result: PR #1148 was reviewed by Hermes, Claude Opus 4.8, and Grok 4.5 on
+  current head `5dc295f8`, merged to `v8` as `63c60022`, and deployed to VPS5.
+  Because it changed the live `health.summary` producer, VPS5 was pulled to
+  `63c60022` and the five configured bots were restarted from
+  `/root/bots_vps5.yaml`. The first bounded smoke was hard-red from a transient
+  Kucoin account-critical balance `RequestTimeout`; a later 2-minute smoke
+  reported `ok=true`, `hard_failures=0`, `matched_expected=5`,
+  `missing_expected_count=0`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, and only non-hard EMA readiness plus
+  one active Kucoin HSL replay attention item. A focused 10-minute
+  `resource_pressure` report returned `ok=true` with health summaries from three
+  bots and no event-pipeline drops or sink errors, but VPS5's live venv did not
+  have `psutil`, so `cpu_percent` was omitted. That packaging gap is being
+  handled by the follow-up live requirement slice.
+
+### Draft Slice: Live psutil Requirement
+
+- Branch: `codex/v8-live-psutil-requirement`.
+- Scope: live packaging plus progress evidence.
+- Triggering evidence: PR #1148 added a cached CPU-percent probe and the
+  existing health summary already had optional `psutil`-backed RSS,
+  memory-percent, and open-FD probes. VPS5 deploy proved the live venv installed
+  from `requirements-live.txt` lacks `psutil`, so those probes safely return
+  `None` and the new `cpu_percent` field is not emitted in standard live
+  installs.
+- Intended result: include the already-pinned `psutil` dependency in
+  `requirements-live.txt` so fresh live installs and refreshed VPS live envs can
+  emit the resource-pressure probes. Do not change health-summary fallback
+  behavior, event schemas, monitor routing, console output, exchange calls,
+  order/risk logic, restart behavior, or trading behavior.
+- Expected validation: requirement parsing/import smoke, focused health-summary
+  CPU probe tests, `py_compile` for the touched live monitor/report modules if
+  needed, `git diff --check`, and the standard added-line silent-handling scan.

--- a/requirements-live.txt
+++ b/requirements-live.txt
@@ -12,3 +12,5 @@ sortedcontainers==2.4.0
 portalocker==3.2.0
 tqdm==4.66.5
 openpyxl==3.1.5
+psutil==5.9.8; python_version < "3.14"
+psutil==7.2.2; python_version >= "3.14"

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _requirements(path: str) -> set[str]:
+    rows: set[str] = set()
+    for raw_line in (ROOT / path).read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if line:
+            rows.add(line)
+    return rows
+
+
+def test_live_requirements_include_psutil_for_health_telemetry():
+    requirements = _requirements("requirements-live.txt")
+
+    assert 'psutil==5.9.8; python_version < "3.14"' in requirements
+    assert 'psutil==7.2.2; python_version >= "3.14"' in requirements


### PR DESCRIPTION
## Scope

observability packaging + progress evidence

## Touched Surfaces

- `requirements-live.txt`: adds the already-pinned `psutil` versions from the full install to the live install.
- `tests/test_requirements.py`: locks that live health telemetry keeps `psutil` in live requirements.
- `docs/plans/live_logging_overhaul_progress.md`: records #1148 merge/deploy/smoke evidence and the VPS5 packaging gap that triggered this slice.

## Rationale

PR #1148 added cached process CPU telemetry to `health.summary` when `psutil` is available. VPS5 deploy proved `/root/passivbot/venv` was installed from live requirements and has no `psutil`, so the probe safely returned `None` and `cpu_percent` was omitted. Existing health probes for RSS, memory percent, and open FDs are also `psutil`-backed, so the live install should include the dependency.

## Expected VPS Action

After merge: pull `v8`, refresh the VPS5 live venv dependency install so `psutil` is present, restart the five configured bots from `/root/bots_vps5.yaml`, then run bounded smoke plus a focused `resource_pressure` performance report to confirm `cpu_percent` appears.

## Validation

- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_requirements.py tests/test_passivbot_monitor.py::test_process_cpu_percent_reuses_psutil_process` -> 2 passed
- `git diff --check`
- added-line silent-handling scan over changed files -> no matches

## Reviewer Focus

- Confirm `psutil` belongs in live requirements rather than remaining full-only.
- Confirm the progress evidence accurately distinguishes #1148 deploy success from the remaining VPS dependency gap.
- Confirm this does not change health-summary fallback behavior, event schema, exchange calls, order/risk logic, or trading behavior.

## Non-Goals

- No code-path changes to `health.summary`.
- No monitor/event routing changes.
- No VPS dependency install or bot restart before this PR is reviewed and merged.
