### PR TITLE
Add resource pressure to live smoke reports

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,24 +19,25 @@ Last updated: 2026-07-09.
 
 Current `origin/v8` head:
 
-- `63c60022` after PR #1148, `Add health CPU telemetry to performance reports`.
+- `46be5b5b` after PR #1147, `Align unstuck emission and HSL flat epsilon`.
 
 Current logging-overhaul head:
 
-- `63c60022` after PR #1148, `Add health CPU telemetry to performance reports`.
+- `1bb6f620` after PR #1149, `Add psutil to live requirements`.
 
 Current work:
 
-- Branch `codex/v8-live-psutil-requirement` makes `psutil` part of the live
-  install so the deployed health-summary RSS, memory-percent, open-FD, and new
-  CPU-percent probes are available in standard live environments.
+- Branch `codex/v8-smoke-resource-pressure` adds a read-only
+  `live-smoke-report` projection over existing `health.summary`
+  resource-pressure fields so repeated smoke loops can see CPU, memory, RSS,
+  open-FD, and load evidence without a separate performance-report command.
 
 Current review gate:
 
 - Composer has been stopped/retired from this loop. The normal review gate is
-  now Claude + Hermes + Cursor + CI. For low-risk docs/tooling-only slices, a
-  degraded gate may still be used after repeated reviewer absence, but that
-  exception must be called out in the progress evidence.
+  now Claude Opus 4.8 + Hermes + Grok 4.5 + CI. For low-risk docs/tooling-only
+  slices, a degraded gate may still be used after repeated reviewer absence,
+  but that exception must be called out in the progress evidence.
 
 Retuned goal boundary:
 
@@ -6839,3 +6840,36 @@ VPS5 deployment status:
 - Expected validation: requirement parsing/import smoke, focused health-summary
   CPU probe tests, `py_compile` for the touched live monitor/report modules if
   needed, `git diff --check`, and the standard added-line silent-handling scan.
+- Result: PR #1149 was reviewed by Hermes, Claude Opus 4.8, and Grok 4.5 on
+  current head `16c05d8`, merged to `v8` as `1bb6f620`, and deployed to VPS5.
+  The VPS5 checkout was pulled to `1bb6f620`, the live venv installed
+  `psutil==5.9.8` from `requirements-live.txt`, and the five configured bots
+  were restarted from `/root/bots_vps5.yaml`. A 2-minute post-restart smoke
+  reported `ok=true`, `hard_failures=0`, `matched_expected=5`,
+  `missing_expected_count=0`, `remote_calls.failed=0`, and
+  `account_critical_remote_calls.failed=0`, with only non-hard EMA readiness,
+  state refresh-progress, and active HSL replay attention. A focused
+  `health.summary` query then showed `cpu_percent=3.9` for
+  `hyperliquid/hyperliquid_tradfi`, and a 30-minute
+  `live-performance-report --section resource_pressure` showed
+  `cpu_percent.latest=20.4`, `count=2`, and no event-pipeline drops or sink
+  errors.
+
+### Draft Slice: Resource Pressure Smoke Projection
+
+- Branch: `codex/v8-smoke-resource-pressure`.
+- Scope: read-only smoke-report projection over existing periodic
+  `health.summary` resource-pressure fields.
+- Triggering evidence: PRs #1148 and #1149 made CPU, memory, RSS, open-FD, and
+  load evidence available in deployed `health.summary` events and
+  `live-performance-report --section resource_pressure`, but standard repeated
+  smoke loops still did not expose those process-pressure signals directly.
+- Intended result: add `resource_pressure` to full and summary smoke reports,
+  plus a compact `resource_pressure` brief projection and `resources` section
+  alias, using only existing `health.summary` events. Keep output bounded to
+  per-bot latest values and aggregate latest max/total counters. Do not add
+  event producers, exchange calls, monitor writes, console routing, restart
+  behavior, order/risk logic, or trading behavior.
+- Expected validation: focused smoke-report resource-pressure tests,
+  `py_compile`, `git diff --check`, and the standard added-line
+  silent-handling scan.

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -102,6 +102,16 @@ EMA_READINESS_REASON_SYMBOL_SAMPLE_LIMIT = 8
 STAGED_READINESS_GROUP_LIMIT = 20
 STAGED_READINESS_VALUE_LIMIT = 8
 EVENT_PIPELINE_HEALTH_GROUP_LIMIT = 20
+RESOURCE_PRESSURE_GROUP_LIMIT = 20
+RESOURCE_PRESSURE_FIELDS = (
+    "cpu_percent",
+    "memory_percent",
+    "rss_bytes",
+    "open_fds",
+    "loadavg_1m",
+    "loadavg_5m",
+    "loadavg_15m",
+)
 HSL_REPLAY_HEALTH_GROUP_LIMIT = 20
 HSL_REPLAY_STALE_ACTIVE_EVENT_AGE_MS = 5 * 60 * 1000
 HSL_REPLAY_LONG_RUNNING_ACTIVE_MS = 10 * 60 * 1000
@@ -2849,6 +2859,176 @@ def _summarize_event_pipeline_health(
     }
 
 
+def _resource_pressure_group(
+    *,
+    bot_key: str,
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+    path: Path,
+    line_no: int,
+) -> dict[str, Any] | None:
+    data = live_event.get("data")
+    payload = data if isinstance(data, dict) else {}
+    latest_values: dict[str, int | float] = {}
+    for key in RESOURCE_PRESSURE_FIELDS:
+        value = _numeric_value(payload.get(key))
+        if value is None or float(value) < 0.0:
+            continue
+        latest_values[key] = value
+    if not latest_values:
+        return None
+    ids = _event_ids(live_event)
+    return {
+        "bot": bot_key,
+        "count": 1,
+        "latest_ts": row.get("ts"),
+        "latest_seq": row.get("seq"),
+        "latest_path": str(path),
+        "latest_line": int(line_no),
+        "latest_values": latest_values,
+        "latest_ids": {
+            key: ids.get(key)
+            for key in ("cycle_id", "snapshot_id", "plan_id", "action_id")
+            if ids.get(key) is not None
+        },
+    }
+
+
+def _merge_resource_pressure_group(
+    groups: dict[tuple[Any, ...], dict[str, Any]],
+    group: dict[str, Any],
+) -> None:
+    key = (group.get("bot"),)
+    existing = groups.get(key)
+    if existing is None:
+        groups[key] = group
+        return
+    existing["count"] = int(existing["count"]) + 1
+    current_key = _sort_event_position_key(
+        ts=group.get("latest_ts"),
+        seq=group.get("latest_seq"),
+        path=group.get("latest_path") or "",
+        line_no=int(group.get("latest_line") or 0),
+    )
+    existing_key = _sort_event_position_key(
+        ts=existing.get("latest_ts"),
+        seq=existing.get("latest_seq"),
+        path=existing.get("latest_path") or "",
+        line_no=int(existing.get("latest_line") or 0),
+    )
+    if current_key > existing_key:
+        for field in (
+            "latest_ts",
+            "latest_seq",
+            "latest_path",
+            "latest_line",
+            "latest_values",
+            "latest_ids",
+        ):
+            existing[field] = group.get(field)
+
+
+def _latest_numeric_value(group: dict[str, Any], field: str) -> int | float | None:
+    values = group.get("latest_values")
+    if not isinstance(values, dict):
+        return None
+    return _numeric_value(values.get(field))
+
+
+def _latest_numeric_sum(groups: Iterable[dict[str, Any]], field: str) -> int | float:
+    total = 0.0
+    integral = True
+    for group in groups:
+        value = _latest_numeric_value(group, field)
+        if value is None:
+            continue
+        numeric = float(value)
+        total += numeric
+        integral = integral and numeric.is_integer()
+    if integral:
+        return int(total)
+    return round(total, 6)
+
+
+def _latest_numeric_max(
+    groups: Iterable[dict[str, Any]], field: str
+) -> int | float | None:
+    values = [
+        float(value)
+        for group in groups
+        if (value := _latest_numeric_value(group, field)) is not None
+    ]
+    if not values:
+        return None
+    out = max(values)
+    if out.is_integer():
+        return int(out)
+    return round(out, 6)
+
+
+def _latest_numeric_reporting_bots(groups: Iterable[dict[str, Any]], field: str) -> int:
+    return sum(1 for group in groups if _latest_numeric_value(group, field) is not None)
+
+
+def _summarize_resource_pressure(
+    groups: dict[tuple[Any, ...], dict[str, Any]],
+    event_type_counts: Counter[str],
+) -> dict[str, Any]:
+    ordered = sorted(
+        groups.values(),
+        key=lambda item: (
+            -float(_latest_numeric_value(item, "cpu_percent") or 0.0),
+            -float(_latest_numeric_value(item, "memory_percent") or 0.0),
+            -float(_latest_numeric_value(item, "rss_bytes") or 0.0),
+            -int(_non_negative_int(item.get("latest_ts")) or 0),
+            str(item.get("bot") or ""),
+        ),
+    )
+    compact_groups = [
+        {
+            key: value
+            for key, value in group.items()
+            if key not in {"latest_path", "latest_line", "latest_seq"}
+            and value not in (None, {}, [])
+        }
+        for group in ordered[:RESOURCE_PRESSURE_GROUP_LIMIT]
+    ]
+    return {
+        key: value
+        for key, value in {
+            "total": sum(int(group["count"]) for group in groups.values()),
+            "bots": len({group.get("bot") for group in groups.values()}),
+            "groups_truncated": len(ordered) > RESOURCE_PRESSURE_GROUP_LIMIT,
+            "event_types": dict(event_type_counts.most_common()),
+            "latest_cpu_percent_max": _latest_numeric_max(
+                groups.values(), "cpu_percent"
+            ),
+            "latest_cpu_reporting_bots": _latest_numeric_reporting_bots(
+                groups.values(), "cpu_percent"
+            ),
+            "latest_memory_percent_max": _latest_numeric_max(
+                groups.values(), "memory_percent"
+            ),
+            "latest_memory_reporting_bots": _latest_numeric_reporting_bots(
+                groups.values(), "memory_percent"
+            ),
+            "latest_rss_bytes_total": _latest_numeric_sum(
+                groups.values(), "rss_bytes"
+            ),
+            "latest_rss_reporting_bots": _latest_numeric_reporting_bots(
+                groups.values(), "rss_bytes"
+            ),
+            "latest_open_fds_total": _latest_numeric_sum(groups.values(), "open_fds"),
+            "latest_open_fds_reporting_bots": _latest_numeric_reporting_bots(
+                groups.values(), "open_fds"
+            ),
+            "latest_loadavg_1m_max": _latest_numeric_max(groups.values(), "loadavg_1m"),
+            "groups": compact_groups,
+        }.items()
+        if value is not None
+    }
+
+
 def _risk_event_group(
     *,
     bot_key: str,
@@ -5335,6 +5515,8 @@ def _scan_events(
     staged_readiness_event_type_counts: Counter[str] = Counter()
     event_pipeline_health_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     event_pipeline_health_event_type_counts: Counter[str] = Counter()
+    resource_pressure_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
+    resource_pressure_event_type_counts: Counter[str] = Counter()
     hsl_replay_health_groups: dict[str, dict[str, Any]] = {}
     hsl_replay_health_event_type_counts: Counter[str] = Counter()
     risk_event_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -5599,6 +5781,19 @@ def _scan_events(
                                 event_pipeline_health_groups,
                                 event_pipeline_health_group,
                             )
+                        resource_pressure_group = _resource_pressure_group(
+                            bot_key=bot_key,
+                            row=row,
+                            live_event=live_event,
+                            path=path,
+                            line_no=line_no,
+                        )
+                        if resource_pressure_group is not None:
+                            resource_pressure_event_type_counts[str(event_type)] += 1
+                            _merge_resource_pressure_group(
+                                resource_pressure_groups,
+                                resource_pressure_group,
+                            )
                     if event_type in HSL_REPLAY_EVENT_TYPES:
                         hsl_replay_health_event_type_counts[str(event_type)] += 1
                         _merge_hsl_replay_group(
@@ -5770,6 +5965,10 @@ def _scan_events(
         "event_pipeline_health": _summarize_event_pipeline_health(
             event_pipeline_health_groups,
             event_pipeline_health_event_type_counts,
+        ),
+        "resource_pressure": _summarize_resource_pressure(
+            resource_pressure_groups,
+            resource_pressure_event_type_counts,
         ),
         "hsl_replay_health": _summarize_hsl_replay_health(
             hsl_replay_health_groups,
@@ -6201,6 +6400,7 @@ def build_live_smoke_report(
         ],
         "staged_readiness_health": event_scan["staged_readiness_health"],
         "event_pipeline_health": event_scan["event_pipeline_health"],
+        "resource_pressure": event_scan["resource_pressure"],
         "hsl_replay_health": event_scan["hsl_replay_health"],
         "risk_events": event_scan["risk_events"],
         "shutdown_events": event_scan["shutdown_events"],
@@ -6309,6 +6509,19 @@ def _summary_limited_groups(
                 "latest_worker_not_alive_count"
             ),
             "latest_stopping_count": summary.get("latest_stopping_count"),
+            "latest_cpu_percent_max": summary.get("latest_cpu_percent_max"),
+            "latest_cpu_reporting_bots": summary.get("latest_cpu_reporting_bots"),
+            "latest_memory_percent_max": summary.get("latest_memory_percent_max"),
+            "latest_memory_reporting_bots": summary.get(
+                "latest_memory_reporting_bots"
+            ),
+            "latest_rss_bytes_total": summary.get("latest_rss_bytes_total"),
+            "latest_rss_reporting_bots": summary.get("latest_rss_reporting_bots"),
+            "latest_open_fds_total": summary.get("latest_open_fds_total"),
+            "latest_open_fds_reporting_bots": summary.get(
+                "latest_open_fds_reporting_bots"
+            ),
+            "latest_loadavg_1m_max": summary.get("latest_loadavg_1m_max"),
             "hsl_flat_finalization_anchors": summary.get(
                 "hsl_flat_finalization_anchors"
             ),
@@ -6494,6 +6707,11 @@ def summarize_live_smoke_report(
         if isinstance(report.get("event_pipeline_health"), dict)
         else {}
     )
+    resource_pressure = (
+        report.get("resource_pressure")
+        if isinstance(report.get("resource_pressure"), dict)
+        else {}
+    )
     hsl_replay_health = (
         report.get("hsl_replay_health")
         if isinstance(report.get("hsl_replay_health"), dict)
@@ -6670,6 +6888,10 @@ def summarize_live_smoke_report(
         ),
         "event_pipeline_health": _summary_limited_groups(
             event_pipeline_health,
+            limit=max_groups,
+        ),
+        "resource_pressure": _summary_limited_groups(
+            resource_pressure,
             limit=max_groups,
         ),
         "hsl_replay_health": _summary_limited_groups(
@@ -7362,6 +7584,11 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         if isinstance(report.get("event_pipeline_health"), dict)
         else {}
     )
+    resource_pressure = (
+        report.get("resource_pressure")
+        if isinstance(report.get("resource_pressure"), dict)
+        else {}
+    )
     hsl_replay_health = (
         report.get("hsl_replay_health")
         if isinstance(report.get("hsl_replay_health"), dict)
@@ -7635,6 +7862,34 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             ),
             "event_types": event_pipeline_health.get("event_types") or {},
         },
+        "resource_pressure": {
+            "total": _count_value(resource_pressure.get("total")),
+            "bots": _count_value(resource_pressure.get("bots")),
+            "latest_cpu_percent_max": resource_pressure.get("latest_cpu_percent_max"),
+            "latest_cpu_reporting_bots": _count_value(
+                resource_pressure.get("latest_cpu_reporting_bots")
+            ),
+            "latest_memory_percent_max": resource_pressure.get(
+                "latest_memory_percent_max"
+            ),
+            "latest_memory_reporting_bots": _count_value(
+                resource_pressure.get("latest_memory_reporting_bots")
+            ),
+            "latest_rss_bytes_total": _count_value(
+                resource_pressure.get("latest_rss_bytes_total")
+            ),
+            "latest_rss_reporting_bots": _count_value(
+                resource_pressure.get("latest_rss_reporting_bots")
+            ),
+            "latest_open_fds_total": _count_value(
+                resource_pressure.get("latest_open_fds_total")
+            ),
+            "latest_open_fds_reporting_bots": _count_value(
+                resource_pressure.get("latest_open_fds_reporting_bots")
+            ),
+            "latest_loadavg_1m_max": resource_pressure.get("latest_loadavg_1m_max"),
+            "event_types": resource_pressure.get("event_types") or {},
+        },
         "hsl_replay": _brief_hsl_replay_health(hsl_replay_health),
         "risk_events": risk_events_brief,
         "shutdown_events": {
@@ -7670,6 +7925,7 @@ SMOKE_REPORT_SECTION_ALIASES: dict[str, tuple[str, ...]] = {
     "fill_refresh": ("fill_refresh_health",),
     "hsl_replay": ("hsl_replay_health",),
     "remote_calls": ("remote_call_health", "remote_call_timings"),
+    "resources": ("resource_pressure",),
     "staged_readiness": ("staged_readiness_health",),
 }
 

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2204,6 +2204,136 @@ def test_live_smoke_report_summarizes_event_pipeline_health(tmp_path):
     }
 
 
+def test_live_smoke_report_summarizes_resource_pressure(tmp_path):
+    okx_events = tmp_path / "monitor" / "okx" / "okx_01" / "events"
+    gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        okx_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="health.summary",
+                exchange="okx",
+                user="okx_01",
+                seq=1,
+                ts=1000,
+                level="debug",
+                reason_code="periodic_health_summary",
+                ids={"cycle_id": "okx_old"},
+                data={
+                    "cpu_percent": 5.5,
+                    "memory_percent": 10.25,
+                    "rss_bytes": 1000,
+                    "open_fds": 11,
+                    "loadavg_1m": 0.25,
+                },
+            ),
+            _monitor_row(
+                event_type="health.summary",
+                exchange="okx",
+                user="okx_01",
+                seq=2,
+                ts=2000,
+                level="debug",
+                reason_code="periodic_health_summary",
+                ids={"cycle_id": "okx_latest"},
+                data={
+                    "cpu_percent": 12.25,
+                    "memory_percent": 11.5,
+                    "rss_bytes": 1500,
+                    "open_fds": 13,
+                    "loadavg_1m": 0.75,
+                    "loadavg_5m": 0.5,
+                    "loadavg_15m": 0.4,
+                },
+            ),
+            _monitor_row(
+                event_type="health.summary",
+                exchange="okx",
+                user="okx_01",
+                seq=3,
+                ts=3000,
+                level="debug",
+                reason_code="periodic_health_summary",
+                ids={"cycle_id": "okx_ignored"},
+                data={"event_queue_depth": 1},
+            ),
+        ],
+    )
+    _write_ndjson(
+        gateio_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="health.summary",
+                exchange="gateio",
+                user="gateio_01",
+                seq=4,
+                ts=1500,
+                level="debug",
+                reason_code="periodic_health_summary",
+                ids={"cycle_id": "gateio_latest"},
+                data={
+                    "memory_percent": 7.5,
+                    "rss_bytes": 2000,
+                    "open_fds": 9,
+                    "loadavg_1m": 0.5,
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    summary = summarize_live_smoke_report(report, max_groups=1)
+    brief = summarize_live_smoke_report_brief(report)
+    section = project_live_smoke_report_sections(report, ["resources"])
+
+    resource = report["resource_pressure"]
+    assert resource["total"] == 3
+    assert resource["bots"] == 2
+    assert resource["event_types"] == {"health.summary": 3}
+    assert resource["latest_cpu_percent_max"] == 12.25
+    assert resource["latest_cpu_reporting_bots"] == 1
+    assert resource["latest_memory_percent_max"] == 11.5
+    assert resource["latest_memory_reporting_bots"] == 2
+    assert resource["latest_rss_bytes_total"] == 3500
+    assert resource["latest_rss_reporting_bots"] == 2
+    assert resource["latest_open_fds_total"] == 22
+    assert resource["latest_open_fds_reporting_bots"] == 2
+    assert resource["latest_loadavg_1m_max"] == 0.75
+    assert [group["bot"] for group in resource["groups"]] == [
+        "okx/okx_01",
+        "gateio/gateio_01",
+    ]
+    assert resource["groups"][0]["latest_ids"] == {"cycle_id": "okx_latest"}
+    assert resource["groups"][0]["latest_values"] == {
+        "cpu_percent": 12.25,
+        "memory_percent": 11.5,
+        "rss_bytes": 1500,
+        "open_fds": 13,
+        "loadavg_1m": 0.75,
+        "loadavg_5m": 0.5,
+        "loadavg_15m": 0.4,
+    }
+    assert summary["resource_pressure"]["total"] == 3
+    assert summary["resource_pressure"]["groups_truncated"] is True
+    assert summary["resource_pressure"]["groups"][0]["bot"] == "okx/okx_01"
+    assert brief["resource_pressure"] == {
+        "total": 3,
+        "bots": 2,
+        "latest_cpu_percent_max": 12.25,
+        "latest_cpu_reporting_bots": 1,
+        "latest_memory_percent_max": 11.5,
+        "latest_memory_reporting_bots": 2,
+        "latest_rss_bytes_total": 3500,
+        "latest_rss_reporting_bots": 2,
+        "latest_open_fds_total": 22,
+        "latest_open_fds_reporting_bots": 2,
+        "latest_loadavg_1m_max": 0.75,
+        "event_types": {"health.summary": 3},
+    }
+    assert "resource_pressure" in section
+    assert "resource_pressure" in available_live_smoke_report_sections(report)
+
+
 def test_live_smoke_report_event_pipeline_health_aggregates_multi_bot_queue_overflow(tmp_path):
     okx_events = tmp_path / "monitor" / "okx" / "okx_01" / "events"
     gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"


### PR DESCRIPTION
## Scope

Read-only observability slice for the logging overhaul. This adds a bounded resource_pressure projection to live-smoke-report using existing health.summary events.

Touched surfaces:
- src/live/smoke_report.py: full, summary, brief, and section projection for CPU, memory, RSS, open-FD, and load evidence.
- tests/test_live_smoke_report.py: resource-pressure report/summary/brief/section regression.
- docs/plans/live_logging_overhaul_progress.md: progress evidence and next-slice ledger update.

## Non-goals

No event producers, exchange calls, monitor writes, console routing, restart behavior, order/risk logic, or trading behavior changed.

## Validation

- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_smoke_report.py
- git diff --check origin/v8...HEAD
- added-line silent-handling scan over the touched files: no matches

## Reviewer Focus

Please check bounded aggregation semantics, value filtering, section alias behavior, summary/brief shape stability, and that this stays read-only with no trading or producer-side behavior changes.

## Expected VPS Action After Merge

Pull v8 on VPS5 and run a bounded live-smoke-report resource_pressure check. No bot restart is expected for this read-only report slice.