### PR TITLE
Add health summary scheduling lag telemetry

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,18 +19,18 @@ Last updated: 2026-07-09.
 
 Current `origin/v8` head:
 
-- `46be5b5b` after PR #1147, `Align unstuck emission and HSL flat epsilon`.
+- `58308f32` after PR #1150, `Add resource pressure smoke projection`.
 
 Current logging-overhaul head:
 
-- `1bb6f620` after PR #1149, `Add psutil to live requirements`.
+- `58308f32` after PR #1150, `Add resource pressure smoke projection`.
 
 Current work:
 
-- Branch `codex/v8-smoke-resource-pressure` adds a read-only
-  `live-smoke-report` projection over existing `health.summary`
-  resource-pressure fields so repeated smoke loops can see CPU, memory, RSS,
-  open-FD, and load evidence without a separate performance-report command.
+- Branch `codex/v8-health-loop-lag` adds bounded health-summary scheduling lag
+  telemetry to the existing `health.summary` resource-pressure path and projects
+  it through smoke/performance reports. It does not add exchange calls,
+  order/risk logic, restart orchestration, or trading behavior.
 
 Current review gate:
 
@@ -6873,3 +6873,41 @@ VPS5 deployment status:
 - Expected validation: focused smoke-report resource-pressure tests,
   `py_compile`, `git diff --check`, and the standard added-line
   silent-handling scan.
+- Result: PR #1150 was reviewed by Hermes, Claude Opus 4.8, and Grok 4.5 on
+  current head `c2e68817`, merged to `v8` as `58308f32`, and deployed to VPS5
+  without restarting running bots because the slice was read-only report
+  projection over existing events. VPS5 was pulled to `58308f32` with
+  `--autostash`, preserving a pre-existing local rustfmt-only tracked diff in
+  `passivbot-rust/src/equity_hard_stop_loss.rs`. A settled 2-minute smoke with
+  dropped-unparsed log policy reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, `missing_expected_count=0`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, and event-pipeline dropped/sink
+  errors at zero; non-hard attention remained EMA readiness, one stale dropped
+  traceback sample, and `unstuck.status`. The brief smoke exposed the new
+  `resource_pressure` projection with one reporting bot, `cpu_percent` max
+  `15.1`, RSS total `61177856`, and open FDs total `16`. A focused 30-minute
+  `resource_pressure` section showed four reporting bots, `cpu_percent` max
+  `21.5`, RSS total `363417600`, and open FDs total `61`; the section command
+  exited red only because the report also carried unrelated hard-event and
+  dirty-repository markers.
+
+### Draft Slice: Health Summary Scheduling Lag
+
+- Branch: `codex/v8-health-loop-lag`.
+- Scope: observability producer plus existing smoke/performance report
+  projections for periodic `health.summary` resource-pressure events.
+- Triggering evidence: resource-pressure reports now show CPU/load, memory,
+  RSS, open FDs, event queue depth, dropped event counters, and sink errors, but
+  the performance checklist still lacked loop-lag-style heartbeat evidence.
+  Existing `last_loop_duration_ms` measures the previous cycle body and does
+  not prove whether periodic health summaries themselves are being delayed.
+- Intended result: add non-negative `health_summary_lag_ms` to
+  `health.summary` after the first heartbeat, measuring elapsed time beyond the
+  configured health-summary interval. Project it through
+  `live-performance-report` resource-pressure stats and `live-smoke-report`
+  resource-pressure full/summary/brief output. Do not add exchange calls,
+  monitor files beyond the existing periodic health event, order/risk logic,
+  restart behavior, or trading behavior.
+- Expected validation: focused health-summary payload/scheduler tests, focused
+  smoke/performance resource-pressure tests, `py_compile`, `git diff --check`,
+  and the standard added-line silent-handling scan.

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -364,9 +364,13 @@ classification when enough source events exist.
     process and event-pipeline fields with count, latest, min, mean, median,
     p95, and max values where present. The source payload now includes cached,
     non-blocking process `cpu_percent` when `psutil` is available; the first
-    post-start sample is used only to prime the psutil delta and is omitted.
-    Remaining work: loop lag needs a dedicated source event or heartbeat before
-    it can be reported without misleading operators.
+    post-start sample is used only to prime the psutil delta and is omitted. It
+    also includes `health_summary_lag_ms` after the first heartbeat, measuring
+    elapsed time beyond the configured health-summary interval, and smoke
+    reports project the same value in their `resource_pressure` section.
+    Remaining work: a lower-level event-loop lag probe can be added later if
+    operators need sub-heartbeat scheduling latency, but this heartbeat lag now
+    gives bounded non-misleading evidence for delayed health summaries.
 - [ ] Shutdown: signal to exit flag, cancellation request, blocking task names,
   final monitor flush, process exit.
 

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -1339,6 +1339,9 @@ def _console_health_summary(event: LiveEvent) -> list[str]:
     loop_ms = _data_int(data, "last_loop_duration_ms")
     if loop_ms is not None:
         parts.append(f"loop={loop_ms / 1000.0:.1f}s")
+    summary_lag_ms = _data_int(data, "health_summary_lag_ms")
+    if summary_lag_ms:
+        parts.append(f"health_lag={summary_lag_ms / 1000.0:.1f}s")
     long_count = _data_int(data, "positions_long")
     short_count = _data_int(data, "positions_short")
     if long_count is not None or short_count is not None:

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -63,6 +63,7 @@ _RESOURCE_PRESSURE_FIELDS = (
     "cpu_count",
     "uptime_ms",
     "last_loop_duration_ms",
+    "health_summary_lag_ms",
     "errors_last_hour",
     "ws_reconnects",
     "rate_limits",

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -111,6 +111,7 @@ RESOURCE_PRESSURE_FIELDS = (
     "loadavg_1m",
     "loadavg_5m",
     "loadavg_15m",
+    "health_summary_lag_ms",
 )
 HSL_REPLAY_HEALTH_GROUP_LIMIT = 20
 HSL_REPLAY_STALE_ACTIVE_EVENT_AGE_MS = 5 * 60 * 1000
@@ -3023,6 +3024,12 @@ def _summarize_resource_pressure(
                 groups.values(), "open_fds"
             ),
             "latest_loadavg_1m_max": _latest_numeric_max(groups.values(), "loadavg_1m"),
+            "latest_health_summary_lag_ms_max": _latest_numeric_max(
+                groups.values(), "health_summary_lag_ms"
+            ),
+            "latest_health_summary_lag_reporting_bots": _latest_numeric_reporting_bots(
+                groups.values(), "health_summary_lag_ms"
+            ),
             "groups": compact_groups,
         }.items()
         if value is not None
@@ -6522,6 +6529,12 @@ def _summary_limited_groups(
                 "latest_open_fds_reporting_bots"
             ),
             "latest_loadavg_1m_max": summary.get("latest_loadavg_1m_max"),
+            "latest_health_summary_lag_ms_max": summary.get(
+                "latest_health_summary_lag_ms_max"
+            ),
+            "latest_health_summary_lag_reporting_bots": summary.get(
+                "latest_health_summary_lag_reporting_bots"
+            ),
             "hsl_flat_finalization_anchors": summary.get(
                 "hsl_flat_finalization_anchors"
             ),
@@ -7888,6 +7901,12 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
                 resource_pressure.get("latest_open_fds_reporting_bots")
             ),
             "latest_loadavg_1m_max": resource_pressure.get("latest_loadavg_1m_max"),
+            "latest_health_summary_lag_ms_max": resource_pressure.get(
+                "latest_health_summary_lag_ms_max"
+            ),
+            "latest_health_summary_lag_reporting_bots": _count_value(
+                resource_pressure.get("latest_health_summary_lag_reporting_bots")
+            ),
             "event_types": resource_pressure.get("event_types") or {},
         },
         "hsl_replay": _brief_hsl_replay_health(hsl_replay_health),

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1156,6 +1156,7 @@ class Passivbot:
         self._health_ws_reconnects = 0
         self._health_rate_limits = 0
         self._health_last_summary_ms = 0
+        self._health_summary_lag_ms = None
         self._health_summary_interval_ms = 15 * 60 * 1000  # 15 minutes
         self._last_loop_duration_ms = 0
 
@@ -2188,8 +2189,14 @@ class Passivbot:
     def _maybe_log_health_summary(self) -> None:
         """Log periodic health summary if interval has elapsed."""
         now_ms = utc_ms()
-        if (now_ms - self._health_last_summary_ms) < self._health_summary_interval_ms:
+        previous_ms = int(getattr(self, "_health_last_summary_ms", 0) or 0)
+        interval_ms = max(0, int(getattr(self, "_health_summary_interval_ms", 0) or 0))
+        if (now_ms - previous_ms) < interval_ms:
             return
+        if previous_ms > 0:
+            self._health_summary_lag_ms = max(0, int(now_ms - previous_ms - interval_ms))
+        else:
+            self._health_summary_lag_ms = None
         self._health_last_summary_ms = now_ms
         self._log_health_summary()
 

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -405,6 +405,9 @@ def _build_health_summary_payload(self, *, now_ms: Optional[int] = None) -> dict
         "ws_reconnects": int(self._health_ws_reconnects),
         "rate_limits": int(self._health_rate_limits),
     }
+    summary_lag_ms = getattr(self, "_health_summary_lag_ms", None)
+    if summary_lag_ms is not None:
+        payload["health_summary_lag_ms"] = max(0, int(summary_lag_ms))
     rss = _get_process_rss_bytes()
     if rss is not None:
         payload["rss_bytes"] = int(rss)

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -2820,6 +2820,7 @@ def test_live_performance_report_resource_pressure_from_health_summary(tmp_path)
                     "open_fds": 11,
                     "loadavg_1m": 0.25,
                     "cpu_count": 1,
+                    "health_summary_lag_ms": 0,
                     "event_queue_depth": 3,
                     "event_dropped_total": 1,
                     "event_sink_error_total": 0,
@@ -2842,6 +2843,7 @@ def test_live_performance_report_resource_pressure_from_health_summary(tmp_path)
                     "open_fds": 13,
                     "loadavg_1m": 0.75,
                     "cpu_count": 1,
+                    "health_summary_lag_ms": 2500,
                     "event_queue_depth": 5,
                     "event_dropped_total": 4,
                     "event_sink_error_total": 1,
@@ -2894,6 +2896,15 @@ def test_live_performance_report_resource_pressure_from_health_summary(tmp_path)
     }
     assert group["fields"]["event_queue_depth"]["max"] == 5
     assert group["fields"]["event_queue_depth"]["p95"] == 5
+    assert group["fields"]["health_summary_lag_ms"] == {
+        "latest": 2500,
+        "count": 2,
+        "min": 0,
+        "max": 2500,
+        "mean": 1250,
+        "median": 1250,
+        "p95": 2375,
+    }
     assert group["fields"]["event_dropped_total"]["latest"] == 4
     assert group["fields"]["event_sink_error_total"]["latest"] == 1
     assert group["fields"]["event_degraded_count"]["latest"] == 3

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2244,6 +2244,7 @@ def test_live_smoke_report_summarizes_resource_pressure(tmp_path):
                     "loadavg_1m": 0.75,
                     "loadavg_5m": 0.5,
                     "loadavg_15m": 0.4,
+                    "health_summary_lag_ms": 2500,
                 },
             ),
             _monitor_row(
@@ -2276,6 +2277,7 @@ def test_live_smoke_report_summarizes_resource_pressure(tmp_path):
                     "rss_bytes": 2000,
                     "open_fds": 9,
                     "loadavg_1m": 0.5,
+                    "health_summary_lag_ms": 500,
                 },
             )
         ],
@@ -2299,6 +2301,8 @@ def test_live_smoke_report_summarizes_resource_pressure(tmp_path):
     assert resource["latest_open_fds_total"] == 22
     assert resource["latest_open_fds_reporting_bots"] == 2
     assert resource["latest_loadavg_1m_max"] == 0.75
+    assert resource["latest_health_summary_lag_ms_max"] == 2500
+    assert resource["latest_health_summary_lag_reporting_bots"] == 2
     assert [group["bot"] for group in resource["groups"]] == [
         "okx/okx_01",
         "gateio/gateio_01",
@@ -2312,6 +2316,7 @@ def test_live_smoke_report_summarizes_resource_pressure(tmp_path):
         "loadavg_1m": 0.75,
         "loadavg_5m": 0.5,
         "loadavg_15m": 0.4,
+        "health_summary_lag_ms": 2500,
     }
     assert summary["resource_pressure"]["total"] == 3
     assert summary["resource_pressure"]["groups_truncated"] is True
@@ -2328,6 +2333,8 @@ def test_live_smoke_report_summarizes_resource_pressure(tmp_path):
         "latest_open_fds_total": 22,
         "latest_open_fds_reporting_bots": 2,
         "latest_loadavg_1m_max": 0.75,
+        "latest_health_summary_lag_ms_max": 2500,
+        "latest_health_summary_lag_reporting_bots": 2,
         "event_types": {"health.summary": 3},
     }
     assert "resource_pressure" in section

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1317,6 +1317,7 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
             }
             self._health_start_ms = 100_000
             self._last_loop_duration_ms = 1234
+            self._health_summary_lag_ms = 2345
             self._monitor_last_equity = 1001.0
             self._health_orders_placed = 5
             self._health_orders_cancelled = 2
@@ -1351,6 +1352,7 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
     payload = FakeBot()._build_health_summary_payload(now_ms=160_000)
 
     assert payload["uptime_ms"] == 60_000
+    assert payload["health_summary_lag_ms"] == 2345
     assert payload["positions_long"] == 1
     assert payload["positions_short"] == 1
     assert payload["rss_bytes"] == 123456
@@ -1498,6 +1500,41 @@ def test_log_health_summary_emits_structured_event(caplog, monkeypatch):
     assert event.data["rss_bytes"] == 987654
     assert event.data["errors_last_hour"] == 1
     assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_maybe_log_health_summary_tracks_scheduler_lag(monkeypatch):
+    import passivbot as pb_mod
+
+    class FakeBot:
+        _maybe_log_health_summary = pb_mod.Passivbot._maybe_log_health_summary
+
+        def __init__(self):
+            self._health_last_summary_ms = 0
+            self._health_summary_interval_ms = 1_000
+            self._health_summary_lag_ms = "unchanged"
+            self.logged = 0
+
+        def _log_health_summary(self):
+            self.logged += 1
+
+    now_values = iter([1_000, 1_750, 2_250])
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: next(now_values))
+    bot = FakeBot()
+
+    bot._maybe_log_health_summary()
+    assert bot.logged == 1
+    assert bot._health_last_summary_ms == 1_000
+    assert bot._health_summary_lag_ms is None
+
+    bot._maybe_log_health_summary()
+    assert bot.logged == 1
+    assert bot._health_last_summary_ms == 1_000
+    assert bot._health_summary_lag_ms is None
+
+    bot._maybe_log_health_summary()
+    assert bot.logged == 2
+    assert bot._health_last_summary_ms == 2_250
+    assert bot._health_summary_lag_ms == 250
 
 
 def test_forager_and_ema_summary_emitters_emit_structured_events():


### PR DESCRIPTION
## Scope

Observability-only live health telemetry and report projection.

## Touched Surfaces

- `health.summary` producer: adds non-negative `health_summary_lag_ms` after the first periodic health heartbeat.
- Live event console projection: shows `health_lag=...s` only when lag is positive.
- `live-performance-report` `resource_pressure`: whitelists and summarizes the new field.
- `live-smoke-report` `resource_pressure`: exposes per-bot latest values plus full/summary/brief aggregate lag counters.
- Progress/readiness docs: records #1150 merge/deploy evidence and updates the resource-pressure checklist.

## Expected VPS Action

Restart required after merge. Running bots must load the new health-summary producer before `health_summary_lag_ms` can appear in live events. No Rust rebuild is required.

## Validation

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/passivbot.py src/passivbot_monitor.py src/live/event_bus.py src/live/performance_report.py src/live/smoke_report.py tests/test_passivbot_monitor.py tests/test_live_performance_report.py tests/test_live_smoke_report.py`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_passivbot_monitor.py::test_build_health_summary_payload_includes_resource_pressure tests/test_passivbot_monitor.py::test_maybe_log_health_summary_tracks_scheduler_lag tests/test_passivbot_monitor.py::test_log_health_summary_emits_structured_event`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_performance_report.py::test_live_performance_report_resource_pressure_from_health_summary tests/test_live_performance_report.py::test_live_performance_report_resource_pressure_whitelists_health_fields tests/test_live_performance_report.py::test_live_performance_report_resource_pressure_summary_is_bounded`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_resource_pressure`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_passivbot_monitor.py`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_performance_report.py`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_smoke_report.py`
- `git diff --check`
- Added-line silent-handling scan over `src tests`: no matches.

## Reviewer Focus

- Confirm `health_summary_lag_ms` is a bounded heartbeat scheduling metric, not a trading gate or lower-level event-loop latency claim.
- Confirm report projections stay whitelisted and do not expose balance/equity/PnL in resource-pressure output.
- Confirm the first heartbeat does not fabricate lag and later lag is clamped non-negative.

## Non-Goals

- No exchange calls, order/risk logic, restart orchestration, Rust changes, or trading behavior changes.
- No dedicated sub-heartbeat asyncio event-loop probe in this slice.
