### PR TITLE
Keep missing resource pressure minima null

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,18 @@ Last updated: 2026-07-09.
 
 Current `origin/v8` head:
 
-- `1a624989` after PR #1151, `Add health summary scheduling lag telemetry`.
+- `80ea2ea2` after PR #1152, `Add system memory health telemetry`.
 
 Current logging-overhaul head:
 
-- `1a624989` after PR #1151, `Add health summary scheduling lag telemetry`.
+- `80ea2ea2` after PR #1152, `Add system memory health telemetry`.
 
 Current work:
 
-- Branch `codex/v8-health-system-memory` adds optional psutil-backed system
-  memory and swap pressure fields to the existing `health.summary`
-  resource-pressure path and projects them through smoke/performance reports.
-  It does not add exchange calls, order/risk logic, restart orchestration, or
-  trading behavior.
+- Branch `codex/v8-resource-pressure-null-min` keeps no-data
+  `live-smoke-report --brief` resource-pressure minimum fields as null/absent
+  instead of coercing them to zero. It does not add event producers, exchange
+  calls, order/risk logic, restart orchestration, or trading behavior.
 
 Current review gate:
 
@@ -61,6 +60,25 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1152 at `80ea2ea2`.
+- PR #1152 added optional psutil-backed system memory and swap pressure fields
+  to existing `health.summary` events and projected them through
+  smoke/performance `resource_pressure` output. It merged after Claude Opus 4.8
+  green-lighted the current head, Hermes approved, Cursor/Grok approved, and CI
+  was green. VPS5 was pulled with `git pull --autostash --ff-only origin v8`
+  to preserve the pre-existing tracked Rust-format/local config state, then
+  bots were restarted from `/root/bots_vps5.yaml` because the slice changed the
+  live health-summary producer. All five old bot processes required exact
+  live-process SIGTERM after two Ctrl-C grace windows; `tmuxp load -d
+  /root/bots_vps5.yaml` started all five configured bots. Immediate 2-minute
+  smoke reported `ok=true`, `hard_failures=0`, `matched_expected=5`,
+  `remote_calls.failed=0`, `account_critical_remote_calls.failed=0`,
+  `fill_refresh.failed=0`, `logs.hard_matches=0`, and repository head
+  `80ea2ea2`. A focused 5-minute `resource_pressure` smoke also reported
+  `ok=true`, `hard_failures=0`, one `health.summary` event, and live projected
+  host pressure fields: `latest_system_memory_percent_max=96.4`,
+  `latest_system_memory_available_bytes_min=35811328`, and
+  `latest_swap_percent_max=49`.
 - Repository pulled through PR #1151 at `1a624989`.
 - PR #1151 added bounded health-summary scheduling lag telemetry to existing
   `health.summary` events and projected it through smoke/performance

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -7942,8 +7942,8 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             "latest_system_memory_reporting_bots": _count_value(
                 resource_pressure.get("latest_system_memory_reporting_bots")
             ),
-            "latest_system_memory_available_bytes_min": _count_value(
-                resource_pressure.get("latest_system_memory_available_bytes_min")
+            "latest_system_memory_available_bytes_min": resource_pressure.get(
+                "latest_system_memory_available_bytes_min"
             ),
             "latest_swap_percent_max": resource_pressure.get("latest_swap_percent_max"),
             "latest_swap_reporting_bots": _count_value(

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2369,6 +2369,16 @@ def test_live_smoke_report_summarizes_resource_pressure(tmp_path):
     assert "resource_pressure" in available_live_smoke_report_sections(report)
 
 
+def test_live_smoke_report_resource_pressure_brief_keeps_missing_min_as_null(tmp_path):
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    brief = summarize_live_smoke_report_brief(report)
+
+    pressure = report["resource_pressure"]
+    assert pressure["total"] == 0
+    assert "latest_system_memory_available_bytes_min" not in pressure
+    assert brief["resource_pressure"]["latest_system_memory_available_bytes_min"] is None
+
+
 def test_live_smoke_report_event_pipeline_health_aggregates_multi_bot_queue_overflow(tmp_path):
     okx_events = tmp_path / "monitor" / "okx" / "okx_01" / "events"
     gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"


### PR DESCRIPTION
Scope: read-only smoke-report projection fix plus progress evidence.\n\nTouched surfaces:\n- Keeps missing live-smoke-report --brief resource_pressure latest_system_memory_available_bytes_min as null instead of coercing missing data to 0.\n- Adds a regression for no-health-summary/no-resource-pressure windows.\n- Records PR #1152 merge and VPS5 deploy/smoke evidence in the logging-overhaul progress ledger.\n\nExpected VPS action: no restart. This is report-only tooling plus docs; after merge, pull v8 and run bounded smoke if useful.\n\nValidation run:\n- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py\n- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_resource_pressure tests/test_live_smoke_report.py::test_live_smoke_report_resource_pressure_brief_keeps_missing_min_as_null\n- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_smoke_report.py\n- git diff --check\n- added-line silent-handling scan over src/tests: no matches\n\nReviewer focus requests:\n- Confirm no-data minimum memory telemetry is not misrepresented as 0 bytes in brief output.\n- Confirm this is report-only and cannot affect live trading behavior.\n- Check the progress-ledger deploy evidence for #1152 is factual and concise.\n\nKnown non-goals:\n- No event producer changes.\n- No exchange calls.\n- No order/risk/HSL/unstuck behavior.\n- No console warnings or thresholds.\n