### PR TITLE
Add resource pressure sample age reporting

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,18 +19,19 @@ Last updated: 2026-07-09.
 
 Current `origin/v8` head:
 
-- `80ea2ea2` after PR #1152, `Add system memory health telemetry`.
+- `84191c02` after PR #1153, `Keep missing resource pressure minima null`.
 
 Current logging-overhaul head:
 
-- `80ea2ea2` after PR #1152, `Add system memory health telemetry`.
+- `84191c02` after PR #1153, `Keep missing resource pressure minima null`.
 
 Current work:
 
-- Branch `codex/v8-resource-pressure-null-min` keeps no-data
-  `live-smoke-report --brief` resource-pressure minimum fields as null/absent
-  instead of coercing them to zero. It does not add event producers, exchange
-  calls, order/risk logic, restart orchestration, or trading behavior.
+- Branch `codex/v8-resource-pressure-event-age` adds read-only
+  `latest_event_age_ms` freshness metadata to `live-performance-report`
+  `resource_pressure` groups. It uses existing `health.summary` event
+  timestamps only and does not add event producers, exchange calls, order/risk
+  logic, restart orchestration, or trading behavior.
 
 Current review gate:
 
@@ -60,6 +61,20 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1153 at `84191c02`.
+- PR #1153 kept no-data `live-smoke-report --brief` resource-pressure minimum
+  fields as null/absent instead of coercing them to zero. It merged after
+  Hermes approved, Claude Opus 4.8 green-lighted the current head, Cursor/Grok
+  approved, and CI was green. VPS5 was pulled with `git pull --autostash
+  --ff-only origin v8` to preserve the pre-existing tracked Rust-format/local
+  config state. No bot restart was performed because the slice was read-only
+  report projection plus docs. A bounded 2-minute smoke with supervisor process
+  check reported `ok=true`, `hard_failures=0`, `matched_expected=5`,
+  `missing_expected_count=0`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `logs.hard_matches=0`, and
+  repository head `84191c02`. Non-hard attention remained active HSL replay and
+  EMA readiness evidence; the short smoke window contained no
+  `health.summary` resource-pressure samples, so `resource_pressure.total=0`.
 - Repository pulled through PR #1152 at `80ea2ea2`.
 - PR #1152 added optional psutil-backed system memory and swap pressure fields
   to existing `health.summary` events and projected them through
@@ -6948,4 +6963,24 @@ VPS5 deployment status:
   restart behavior, or trading behavior.
 - Expected validation: focused health-summary payload/scheduler tests, focused
   smoke/performance resource-pressure tests, `py_compile`, `git diff --check`,
+  and the standard added-line silent-handling scan.
+
+### Draft Slice: Resource Pressure Sample Age
+
+- Branch: `codex/v8-resource-pressure-event-age`.
+- Scope: read-only performance-report projection over existing
+  `health.summary` resource-pressure events.
+- Triggering evidence: PRs #1148 through #1153 made resource-pressure values
+  available and visible in performance/smoke reports, but
+  `live-performance-report --section resource_pressure` exposed only each bot's
+  `latest_ts`, not a directly comparable age. During bounded post-deploy smoke
+  windows, operators need to distinguish recent pressure samples from stale or
+  absent samples without manually subtracting timestamps.
+- Intended result: add `latest_event_age_ms` to each performance-report
+  `resource_pressure` group, derived from the report timestamp and the group's
+  latest `health.summary` event timestamp. Keep existing field statistics,
+  event parsing, monitor writes, console output, smoke-report output, exchange
+  calls, restart behavior, order/risk logic, and trading behavior unchanged.
+- Expected validation: focused resource-pressure performance-report tests, full
+  `tests/test_live_performance_report.py`, `py_compile`, `git diff --check`,
   and the standard added-line silent-handling scan.

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -2637,10 +2637,19 @@ class _ResourcePressureAccumulator:
         }
         return out
 
-    def to_dict(self, *, group_limit: int = GROUP_LIMIT) -> dict[str, Any]:
+    def to_dict(
+        self,
+        *,
+        group_limit: int = GROUP_LIMIT,
+        report_ts_ms: int | None = None,
+    ) -> dict[str, Any]:
         groups = []
         for bot, state in self.bots.items():
             latest = state.get("latest") if isinstance(state.get("latest"), dict) else {}
+            latest_ts = state.get("latest_ts")
+            latest_event_age_ms = None
+            if report_ts_ms is not None and latest_ts is not None:
+                latest_event_age_ms = max(0, int(report_ts_ms) - int(latest_ts))
             fields = {}
             for key in _RESOURCE_PRESSURE_FIELDS:
                 values = state["values"].get(key) if isinstance(state.get("values"), dict) else []
@@ -2655,7 +2664,8 @@ class _ResourcePressureAccumulator:
             group = {
                 "bot": bot,
                 "count": int(state.get("count") or 0),
-                "latest_ts": state.get("latest_ts"),
+                "latest_ts": latest_ts,
+                "latest_event_age_ms": latest_event_age_ms,
                 "fields": fields,
                 "latest_event_pipeline_stopping": latest.get("event_pipeline_stopping"),
                 "latest_event_pipeline_worker_alive": latest.get(
@@ -3910,7 +3920,10 @@ def build_live_performance_report(
         "cache_warmup": cache_warmup.to_dict(group_limit=group_limit),
         "fill_refresh": fill_refresh.to_dict(group_limit=group_limit),
         "forager_ema_readiness": forager_ema_readiness.to_dict(group_limit=group_limit),
-        "resource_pressure": resource_pressure.to_dict(group_limit=group_limit),
+        "resource_pressure": resource_pressure.to_dict(
+            group_limit=group_limit,
+            report_ts_ms=report_ts_ms,
+        ),
         "shutdown_latency": shutdown_latency.to_dict(group_limit=group_limit),
         "execution_timing": execution_timing.to_dict(group_limit=group_limit),
         "account_state_changes": account_state_changes.to_dict(group_limit=group_limit),

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -2803,7 +2803,8 @@ def test_live_performance_report_risk_activity_summary_is_bounded(tmp_path):
     assert summary["risk_activity"]["bots_truncated"] is True
 
 
-def test_live_performance_report_resource_pressure_from_health_summary(tmp_path):
+def test_live_performance_report_resource_pressure_from_health_summary(tmp_path, monkeypatch):
+    monkeypatch.setattr(performance_report_module, "utc_ms", lambda: 5000)
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(
         events_dir / "current.ndjson",
@@ -2879,6 +2880,7 @@ def test_live_performance_report_resource_pressure_from_health_summary(tmp_path)
     assert group["bot"] == "binance/binance_01"
     assert group["count"] == 2
     assert group["latest_ts"] == 2000
+    assert group["latest_event_age_ms"] == 3000
     assert group["fields"]["rss_bytes"] == {
         "latest": 1500,
         "count": 2,
@@ -3012,6 +3014,7 @@ def test_live_performance_report_resource_pressure_summary_is_bounded(tmp_path):
     assert len(summary["resource_pressure"]["groups"]) == 1
     assert summary["resource_pressure"]["groups_truncated"] is True
     assert summary["resource_pressure"]["groups"][0]["bot"] == "okx/okx_faisal"
+    assert "latest_event_age_ms" in summary["resource_pressure"]["groups"][0]
 
 
 def test_live_performance_report_shutdown_latency_from_lifecycle_events(tmp_path):


### PR DESCRIPTION
Scope: read-only performance-report projection plus progress evidence.\n\nTouched surfaces:\n- Adds latest_event_age_ms to each live-performance-report resource_pressure group, derived from the report timestamp and the group latest health.summary timestamp.\n- Keeps resource-pressure parsing, existing field statistics, monitor writes, smoke-report output, event producers, and live behavior unchanged.\n- Records PR #1153 merge plus VPS5 pull/smoke evidence and documents this new draft slice in the logging-overhaul progress ledger.\n\nExpected VPS action: no restart. This is report-only tooling plus docs; after merge, pull v8 and run a bounded smoke if useful.\n\nValidation run:\n- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/performance_report.py tests/test_live_performance_report.py\n- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_performance_report.py::test_live_performance_report_resource_pressure_from_health_summary tests/test_live_performance_report.py::test_live_performance_report_resource_pressure_summary_is_bounded\n- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_performance_report.py\n- git diff --check\n- added-line silent-handling scan over src/tests: no matches\n\nReviewer focus requests:\n- Confirm latest_event_age_ms is derived-only and cannot affect live trading behavior.\n- Confirm the field helps distinguish stale resource-pressure samples from recent samples without changing existing resource-pressure statistics.\n- Check the progress-ledger #1153 deploy evidence and current-slice scope for factual accuracy.\n\nKnown non-goals:\n- No event producer changes.\n- No exchange calls.\n- No monitor writes or smoke-report output changes.\n- No order/risk/HSL/unstuck behavior.\n- No restart orchestration or console routing changes.