### PR TITLE
Add smoke resource pressure sample age

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,19 @@ Last updated: 2026-07-09.
 
 Current `origin/v8` head:
 
-- `84191c02` after PR #1153, `Keep missing resource pressure minima null`.
+- `141e88db` after PR #1154, `Add resource pressure sample age reporting`.
 
 Current logging-overhaul head:
 
-- `84191c02` after PR #1153, `Keep missing resource pressure minima null`.
+- `141e88db` after PR #1154, `Add resource pressure sample age reporting`.
 
 Current work:
 
-- Branch `codex/v8-resource-pressure-event-age` adds read-only
-  `latest_event_age_ms` freshness metadata to `live-performance-report`
-  `resource_pressure` groups. It uses existing `health.summary` event
-  timestamps only and does not add event producers, exchange calls, order/risk
-  logic, restart orchestration, or trading behavior.
+- Branch `codex/v8-smoke-resource-pressure-age` adds read-only
+  `latest_event_age_ms` freshness metadata to `live-smoke-report`
+  `resource_pressure` groups and brief output. It uses existing
+  `health.summary` event timestamps only and does not add event producers,
+  exchange calls, order/risk logic, restart orchestration, or trading behavior.
 
 Current review gate:
 
@@ -61,6 +61,23 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1154 at `141e88db`.
+- PR #1154 added read-only `latest_event_age_ms` freshness metadata to
+  `live-performance-report` `resource_pressure` groups. It merged after Hermes
+  approved, Claude Opus 4.8 green-lighted the current head, Cursor/Grok
+  approved, Codex reviewer posted green, and CI was green. VPS5 was pulled with
+  `git pull --autostash --ff-only origin v8` to preserve the pre-existing
+  tracked Rust-format/local config state. No bot restart was performed because
+  the slice was read-only report projection plus docs. A bounded 2-minute smoke
+  with supervisor process check reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, `missing_expected_count=0`,
+  `remote_calls.failed=0`, `account_critical_remote_calls.failed=0`,
+  `logs.hard_matches=0`, and repository head `141e88db`. Non-hard attention
+  remained active HSL replay and EMA readiness evidence. The short smoke window
+  contained no `health.summary` resource-pressure samples; a focused 30-minute
+  `live-performance-report --section resource_pressure` check reported
+  `ok=true`, `resource_pressure.total=2`, `resource_pressure.bots=1`, and
+  `latest_event_age_ms=624447` on the Hyperliquid resource-pressure group.
 - Repository pulled through PR #1153 at `84191c02`.
 - PR #1153 kept no-data `live-smoke-report --brief` resource-pressure minimum
   fields as null/absent instead of coercing them to zero. It merged after

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -2993,10 +2993,55 @@ def _latest_numeric_reporting_bots(groups: Iterable[dict[str, Any]], field: str)
     return sum(1 for group in groups if _latest_numeric_value(group, field) is not None)
 
 
+def _resource_pressure_event_age_ms(
+    group: dict[str, Any],
+    *,
+    report_ts_ms: int,
+) -> int | None:
+    ts = _non_negative_int(group.get("latest_ts"))
+    if ts is None:
+        return None
+    return int(max(0, int(report_ts_ms) - int(ts)))
+
+
+def _resource_pressure_latest_age_max(
+    groups: Iterable[dict[str, Any]],
+) -> int | None:
+    values = [
+        int(value)
+        for group in groups
+        if (value := _non_negative_int(group.get("latest_event_age_ms"))) is not None
+    ]
+    if not values:
+        return None
+    return max(values)
+
+
+def _resource_pressure_age_reporting_bots(
+    groups: Iterable[dict[str, Any]],
+) -> int:
+    return sum(
+        1
+        for group in groups
+        if _non_negative_int(group.get("latest_event_age_ms")) is not None
+    )
+
+
 def _summarize_resource_pressure(
     groups: dict[tuple[Any, ...], dict[str, Any]],
     event_type_counts: Counter[str],
+    *,
+    report_ts_ms: int | None = None,
 ) -> dict[str, Any]:
+    if report_ts_ms is None:
+        report_ts_ms = utc_ms()
+    for group in groups.values():
+        age_ms = _resource_pressure_event_age_ms(
+            group,
+            report_ts_ms=int(report_ts_ms),
+        )
+        if age_ms is not None:
+            group["latest_event_age_ms"] = int(age_ms)
     ordered = sorted(
         groups.values(),
         key=lambda item: (
@@ -3066,6 +3111,12 @@ def _summarize_resource_pressure(
             ),
             "latest_health_summary_lag_reporting_bots": _latest_numeric_reporting_bots(
                 groups.values(), "health_summary_lag_ms"
+            ),
+            "latest_event_age_ms_max": _resource_pressure_latest_age_max(
+                groups.values()
+            ),
+            "latest_event_age_reporting_bots": _resource_pressure_age_reporting_bots(
+                groups.values()
             ),
             "groups": compact_groups,
         }.items()
@@ -6013,6 +6064,7 @@ def _scan_events(
         "resource_pressure": _summarize_resource_pressure(
             resource_pressure_groups,
             resource_pressure_event_type_counts,
+            report_ts_ms=report_ts_ms,
         ),
         "hsl_replay_health": _summarize_hsl_replay_health(
             hsl_replay_health_groups,
@@ -6582,6 +6634,10 @@ def _summary_limited_groups(
             ),
             "latest_health_summary_lag_reporting_bots": summary.get(
                 "latest_health_summary_lag_reporting_bots"
+            ),
+            "latest_event_age_ms_max": summary.get("latest_event_age_ms_max"),
+            "latest_event_age_reporting_bots": summary.get(
+                "latest_event_age_reporting_bots"
             ),
             "hsl_flat_finalization_anchors": summary.get(
                 "hsl_flat_finalization_anchors"
@@ -7967,6 +8023,12 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             ),
             "latest_health_summary_lag_reporting_bots": _count_value(
                 resource_pressure.get("latest_health_summary_lag_reporting_bots")
+            ),
+            "latest_event_age_ms_max": resource_pressure.get(
+                "latest_event_age_ms_max"
+            ),
+            "latest_event_age_reporting_bots": _count_value(
+                resource_pressure.get("latest_event_age_reporting_bots")
             ),
             "event_types": resource_pressure.get("event_types") or {},
         },

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2204,7 +2204,8 @@ def test_live_smoke_report_summarizes_event_pipeline_health(tmp_path):
     }
 
 
-def test_live_smoke_report_summarizes_resource_pressure(tmp_path):
+def test_live_smoke_report_summarizes_resource_pressure(tmp_path, monkeypatch):
+    monkeypatch.setattr(smoke_report_module, "utc_ms", lambda: 5000)
     okx_events = tmp_path / "monitor" / "okx" / "okx_01" / "events"
     gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
     _write_ndjson(
@@ -2320,11 +2321,14 @@ def test_live_smoke_report_summarizes_resource_pressure(tmp_path):
     assert resource["latest_loadavg_1m_max"] == 0.75
     assert resource["latest_health_summary_lag_ms_max"] == 2500
     assert resource["latest_health_summary_lag_reporting_bots"] == 2
+    assert resource["latest_event_age_ms_max"] == 3500
+    assert resource["latest_event_age_reporting_bots"] == 2
     assert [group["bot"] for group in resource["groups"]] == [
         "okx/okx_01",
         "gateio/gateio_01",
     ]
     assert resource["groups"][0]["latest_ids"] == {"cycle_id": "okx_latest"}
+    assert resource["groups"][0]["latest_event_age_ms"] == 3000
     assert resource["groups"][0]["latest_values"] == {
         "cpu_percent": 12.25,
         "memory_percent": 11.5,
@@ -2344,6 +2348,7 @@ def test_live_smoke_report_summarizes_resource_pressure(tmp_path):
     assert summary["resource_pressure"]["total"] == 3
     assert summary["resource_pressure"]["groups_truncated"] is True
     assert summary["resource_pressure"]["groups"][0]["bot"] == "okx/okx_01"
+    assert summary["resource_pressure"]["groups"][0]["latest_event_age_ms"] == 3000
     assert brief["resource_pressure"] == {
         "total": 3,
         "bots": 2,
@@ -2363,6 +2368,8 @@ def test_live_smoke_report_summarizes_resource_pressure(tmp_path):
         "latest_loadavg_1m_max": 0.75,
         "latest_health_summary_lag_ms_max": 2500,
         "latest_health_summary_lag_reporting_bots": 2,
+        "latest_event_age_ms_max": 3500,
+        "latest_event_age_reporting_bots": 2,
         "event_types": {"health.summary": 3},
     }
     assert "resource_pressure" in section
@@ -2376,7 +2383,10 @@ def test_live_smoke_report_resource_pressure_brief_keeps_missing_min_as_null(tmp
     pressure = report["resource_pressure"]
     assert pressure["total"] == 0
     assert "latest_system_memory_available_bytes_min" not in pressure
+    assert "latest_event_age_ms_max" not in pressure
     assert brief["resource_pressure"]["latest_system_memory_available_bytes_min"] is None
+    assert brief["resource_pressure"]["latest_event_age_ms_max"] is None
+    assert brief["resource_pressure"]["latest_event_age_reporting_bots"] == 0
 
 
 def test_live_smoke_report_event_pipeline_health_aggregates_multi_bot_queue_overflow(tmp_path):


### PR DESCRIPTION
## Summary
- add `latest_event_age_ms` freshness metadata to `live-smoke-report` resource-pressure groups using existing `health.summary` event timestamps
- project max sample age and reporting-bot count through summary-limited groups and `--brief`
- reconcile the logging progress ledger through PR #1154 and record this branch as the active smoke freshness slice

## Scope
- observability-only / tooling-only

## Touched surfaces
- `src/live/smoke_report.py` resource-pressure scan summary and brief projection
- `tests/test_live_smoke_report.py` resource-pressure regression coverage
- `docs/plans/live_logging_overhaul_progress.md` progress ledger

## Expected VPS action
- no restart expected
- after merge: pull `v8` on VPS5 and run bounded smoke/report checks; this does not change event producers, exchange calls, order/risk logic, restart orchestration, or trading behavior

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_smoke_report.py::test_live_smoke_report_summarizes_resource_pressure tests/test_live_smoke_report.py::test_live_smoke_report_resource_pressure_brief_keeps_missing_min_as_null`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_smoke_report.py`
- `git diff --check`
- touched-file silent-handling scan: only pre-existing `src/live/smoke_report.py` patterns matched; no new unsafe fallback added

## Reviewer focus
- confirm this remains read-only report projection with no live behavior or trading-path impact
- confirm stale/missing resource-pressure samples remain explicit: no sample age is emitted when no latest `health.summary` sample exists, and `--brief` keeps max age null/reporting bots zero
- confirm the field naming is consistent with PR #1154 performance-report resource-pressure freshness

## Non-goals
- no new health-summary event producer fields
- no exchange/API contact
- no bot restart behavior
- no change to HSL/risk/unstuck/order logic
