### PR TITLE
Summarize resource pressure sample age

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,18 +19,18 @@ Last updated: 2026-07-09.
 
 Current `origin/v8` head:
 
-- `141e88db` after PR #1154, `Add resource pressure sample age reporting`.
+- `4ac5b309` after PR #1156, `Add smoke resource pressure sample age`.
 
 Current logging-overhaul head:
 
-- `141e88db` after PR #1154, `Add resource pressure sample age reporting`.
+- `4ac5b309` after PR #1156, `Add smoke resource pressure sample age`.
 
 Current work:
 
-- Branch `codex/v8-smoke-resource-pressure-age` adds read-only
-  `latest_event_age_ms` freshness metadata to `live-smoke-report`
-  `resource_pressure` groups and brief output. It uses existing
-  `health.summary` event timestamps only and does not add event producers,
+- Branch `codex/v8-resource-pressure-age-aggregate` adds read-only aggregate
+  `latest_event_age_ms_max` and reporting-bot count fields to
+  `live-performance-report` `resource_pressure`, derived from existing
+  per-bot `health.summary` event timestamps. It does not add event producers,
   exchange calls, order/risk logic, restart orchestration, or trading behavior.
 
 Current review gate:
@@ -61,6 +61,24 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1156 at `4ac5b309`.
+- PR #1156 added the read-only smoke-report counterpart for resource-pressure
+  sample age, exposing per-group `latest_event_age_ms`, aggregate
+  `latest_event_age_ms_max`, and reporting-bot count from existing
+  `health.summary` event timestamps. It merged after Hermes approved, Claude
+  Opus 4.8 green-lighted the current head, Grok 4.5 re-approved the rebased
+  head, Codex reviewer posted green, and CI was green. VPS5 was pulled with
+  `git pull --autostash --ff-only origin v8`, preserving the pre-existing
+  tracked Rust-format/local config state. No bot restart was performed because
+  the slice was read-only report projection plus docs. A bounded 2-minute
+  summary smoke reported `ok=true`, `hard_failures=0`, `matched_expected=5`,
+  `missing_expected_count=0`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `logs.hard_matches=0`, and
+  repository head `4ac5b309`. The 2-minute brief resource-pressure window had
+  no health-summary samples, so `latest_event_age_ms_max=null` and
+  `latest_event_age_reporting_bots=0`; a focused 30-minute `resources` section
+  confirmed four reporting bots with `latest_event_age_ms_max=789479` and a
+  sample group age of `583466`.
 - Repository pulled through PR #1154 at `141e88db`.
 - PR #1154 added read-only `latest_event_age_ms` freshness metadata to
   `live-performance-report` `resource_pressure` groups. It merged after Hermes
@@ -6998,6 +7016,31 @@ VPS5 deployment status:
   latest `health.summary` event timestamp. Keep existing field statistics,
   event parsing, monitor writes, console output, smoke-report output, exchange
   calls, restart behavior, order/risk logic, and trading behavior unchanged.
+- Expected validation: focused resource-pressure performance-report tests, full
+  `tests/test_live_performance_report.py`, `py_compile`, `git diff --check`,
+  and the standard added-line silent-handling scan.
+- Result: PR #1154 was reviewed by Hermes, Claude Opus 4.8, Grok 4.5, and
+  Codex on current head, merged to `v8` as `141e88db`, and deployed to VPS5
+  without restarting bots because the slice was read-only report projection.
+  A bounded smoke reported process/repository health green, and a focused
+  30-minute `live-performance-report --section resource_pressure` check proved
+  one Hyperliquid group with `latest_event_age_ms=624447`.
+
+### Draft Slice: Resource Pressure Sample Age Aggregate
+
+- Branch: `codex/v8-resource-pressure-age-aggregate`.
+- Scope: read-only performance-report projection over existing
+  `health.summary` resource-pressure events.
+- Triggering evidence: PR #1154 made per-bot sample age visible in
+  `live-performance-report`, but operators still need a compact top-level
+  maximum age and reporting-bot count to compare the freshness of the whole
+  resource-pressure section without scanning all groups.
+- Intended result: add aggregate `latest_event_age_ms_max` and
+  `latest_event_age_reporting_bots` fields to `live-performance-report`
+  `resource_pressure`, derived from existing per-group ages. Keep existing
+  field statistics, event parsing, monitor writes, console output, smoke-report
+  output, exchange calls, restart behavior, order/risk logic, and trading
+  behavior unchanged.
 - Expected validation: focused resource-pressure performance-report tests, full
   `tests/test_live_performance_report.py`, `py_compile`, `git diff --check`,
   and the standard added-line silent-handling scan.

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -371,7 +371,10 @@ classification when enough source events exist.
     source payload now also includes optional psutil-backed system memory and
     swap totals/usage/percent fields, with smoke reports surfacing max system
     memory percent, minimum available system memory, and max swap percent for
-    quick operator scans.
+    quick operator scans. Performance reports expose per-bot
+    `latest_event_age_ms` plus an aggregate maximum age and reporting-bot count
+    so stale resource-pressure samples are visible without manual timestamp
+    subtraction.
     Remaining work: a lower-level event-loop lag probe can be added later if
     operators need sub-heartbeat scheduling latency, but the heartbeat lag now
     gives bounded non-misleading evidence for delayed health summaries.

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -2694,13 +2694,22 @@ class _ResourcePressureAccumulator:
             ),
         )
         limit = max(0, int(group_limit))
-        return {
+        age_values = [
+            int(group["latest_event_age_ms"])
+            for group in groups
+            if group.get("latest_event_age_ms") is not None
+        ]
+        out = {
             "total": sum(int(group.get("count") or 0) for group in groups),
             "bots": len(groups),
             "event_types": dict(self.event_types.most_common()),
             "groups_truncated": len(groups) > limit,
             "groups": groups[:limit],
         }
+        if age_values:
+            out["latest_event_age_ms_max"] = max(age_values)
+        out["latest_event_age_reporting_bots"] = len(age_values)
+        return out
 
 
 class _ShutdownLatencyAccumulator:

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -2877,6 +2877,8 @@ def test_live_performance_report_resource_pressure_from_health_summary(tmp_path,
     assert pressure["total"] == 2
     assert pressure["bots"] == 1
     assert pressure["event_types"] == {"health.summary": 2}
+    assert pressure["latest_event_age_ms_max"] == 3000
+    assert pressure["latest_event_age_reporting_bots"] == 1
     assert group["bot"] == "binance/binance_01"
     assert group["count"] == 2
     assert group["latest_ts"] == 2000
@@ -2983,7 +2985,8 @@ def test_live_performance_report_resource_pressure_whitelists_health_fields(tmp_
     assert "raw-payload" not in rendered
 
 
-def test_live_performance_report_resource_pressure_summary_is_bounded(tmp_path):
+def test_live_performance_report_resource_pressure_summary_is_bounded(tmp_path, monkeypatch):
+    monkeypatch.setattr(performance_report_module, "utc_ms", lambda: 5000)
     events_dir = tmp_path / "monitor" / "mixed" / "events"
     _write_ndjson(
         events_dir / "current.ndjson",
@@ -3011,10 +3014,14 @@ def test_live_performance_report_resource_pressure_summary_is_bounded(tmp_path):
     summary = summarize_live_performance_report(report, group_limit=1)
 
     assert report["resource_pressure"]["bots"] == 2
+    assert report["resource_pressure"]["latest_event_age_ms_max"] == 4000
+    assert report["resource_pressure"]["latest_event_age_reporting_bots"] == 2
     assert len(summary["resource_pressure"]["groups"]) == 1
     assert summary["resource_pressure"]["groups_truncated"] is True
     assert summary["resource_pressure"]["groups"][0]["bot"] == "okx/okx_faisal"
     assert "latest_event_age_ms" in summary["resource_pressure"]["groups"][0]
+    assert summary["resource_pressure"]["latest_event_age_ms_max"] == 4000
+    assert summary["resource_pressure"]["latest_event_age_reporting_bots"] == 2
 
 
 def test_live_performance_report_shutdown_latency_from_lifecycle_events(tmp_path):


### PR DESCRIPTION
scope: tooling-only / observability-only

Touched surfaces:
- `src/live/performance_report.py` resource_pressure report projection
- `tests/test_live_performance_report.py` resource-pressure coverage
- `docs/plans/live_logging_overhaul_progress.md` and `docs/plans/live_performance_readiness_goals.md` progress/readiness notes

Expected VPS action: pull plus bounded smoke after merge; no bot restart. This is read-only report projection over existing `health.summary` monitor events.

What changed:
- Add top-level `resource_pressure.latest_event_age_ms_max` to `live-performance-report`, derived from already-computed per-bot sample ages.
- Add `resource_pressure.latest_event_age_reporting_bots` as a count of bots with age evidence.
- Keep max-age absent when no age exists; the reporting-bot count is zero in that case.

Validation run:
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/performance_report.py tests/test_live_performance_report.py`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_performance_report.py::test_live_performance_report_resource_pressure_from_health_summary tests/test_live_performance_report.py::test_live_performance_report_resource_pressure_summary_is_bounded` - 2 passed
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_performance_report.py` - 64 passed
- `git diff --check`
- added-line silent-handling scan over `src`/`tests` for `except Exception`, `return_exceptions=True`, and neutral `.get(..., default)` patterns - no matches

Reviewer focus:
- Null/count semantics for no sample-age evidence.
- Whether this stays report-only and does not widen the pending smoke-report PR #1156.
- Progress/readiness ledger wording around current parallel PR state.

Known non-goals:
- No event producers, exchange calls, monitor writes, console routing, smoke-report changes, restart orchestration, order/risk/HSL/unstuck behavior, Rust changes, backtest, optimize, or trading behavior.