### PR TITLE
Harden OHLCV gap classification against transient exchange conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Hardened OHLCV gap classification against transient exchange conditions. A
+  persistent gap (missing tail, leading, or internal range) now gets a short
+  one-hour re-verification window on its first observation and keeps the full
+  seven-day window only once the identical gap is observed again at least 30
+  minutes later — so an exchange publishing delay or partial response can no
+  longer silently clip a coin's backtest data for a week. KuCoin pagination
+  holes between pages are now recorded as expiring auto-detected gaps
+  (retried on later fetches) instead of permanent no-trade gaps; holes inside
+  a single exchange response remain verified no-trade minutes.
+
 - Faster backtest startup on hlcvs cache hits: the multi-GB hlcvs artifact is
   now decompressed once instead of twice (manifest verification hands its
   arrays to the loader), array/chunk hashing no longer materializes a full

--- a/docs/plans/backtest_data_integrity_audit_20260709.md
+++ b/docs/plans/backtest_data_integrity_audit_20260709.md
@@ -275,9 +275,18 @@ P-1 (delete the second decompress), P-5's memoryview hash (also in `hash_logical
 ## Suggested action-plan slices (in order)
 
 1. **Quick integrity fix**: I-1 AlphaVantage timezone (one-line + provider conversion tests).
+   DONE — PR #1155.
 2. **Quick perf wins**: P-1 + P-5 memoryview + P-6 + split timers (all low-risk, measurable).
-3. **Gap-classification hardening**: I-4/I-5/I-6 (corroboration separation, expiring reasons,
-   shorter retry for recent tails) + tests.
+   DONE — PR #1158.
+3. **Gap-classification hardening**: I-4/I-5/I-6 — DONE (PR pending). Implemented as
+   graduated retry windows (first observation → 1h re-verification; the full 7d window only
+   for an identical gap re-observed ≥30 min later) rather than temporally separating the
+   short-tail confirmation: the in-run confirm-by-refetch flow is intentional (blocking it
+   would push every first encounter of a delisted coin to the legacy fallback), and a short
+   first-observation retry gives equivalent protection — a false confirm self-heals within
+   the hour instead of clipping data for a week. KuCoin between-page holes now expire
+   (`auto_detected`, retryable) instead of permanent `no_trades`; intra-payload holes stay
+   permanent (exchange-verified in a single response).
 4. **Coverage-loss visibility**: I-2 warning + skip dead fill; I-3 document the synthetic-candle
    model (maintainer decision: keep tradable) + surface per-coin synthetic share.
 5. **Cold-build parallelism**: P-3/P-4/P-7 together (they interlock), fixing I-8 in passing.

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -4249,7 +4249,12 @@ class CandlestickManager:
                     max_step = ONE_MIN_MS
             except Exception:
                 first_ts = last_ts = 0
-            # Record gaps inside payload and between pages as verified no-trade gaps (exchange-provided).
+            # Record intra-payload holes as verified no-trade gaps: the exchange
+            # affirmatively returned the surrounding candles in one response.
+            # Between-page holes are not exchange-verified — a pagination stall
+            # or outage produces the same shape — so they get the expiring
+            # auto-detected classification and are re-verified on later fetches
+            # instead of being permanently masked as no_trades.
             if self._record_payload_gaps_as_known and tf_norm == "1m":
                 try:
                     ts_arr = arr["ts"].astype(np.int64)
@@ -4263,7 +4268,13 @@ class CandlestickManager:
                     if prev_last_ts is not None and first_ts > prev_last_ts + period_ms:
                         gap_start = int(prev_last_ts + period_ms)
                         gap_end = int(first_ts - period_ms)
-                        self._record_verified_gap(symbol, gap_start, gap_end)
+                        self._add_known_gap(
+                            symbol,
+                            gap_start,
+                            gap_end,
+                            reason=GAP_REASON_AUTO,
+                            increment_retry=True,
+                        )
                 except Exception:
                     pass
 

--- a/src/hlcv_preparation.py
+++ b/src/hlcv_preparation.py
@@ -17,7 +17,7 @@ import pandas as pd
 
 from candlestick_manager import CandlestickManager, OhlcvTerminalEmptyPage
 from backtest_dataset_materializer import BacktestDatasetMaterializer, materialize_frames
-from ohlcv_catalog import OhlcvCatalog
+from ohlcv_catalog import KNOWN_GAP_RETRY_MS, OhlcvCatalog
 from ohlcv_legacy_import import import_legacy_range_into_store
 from ohlcv_planner import plan_local_symbol_range
 from ohlcv_store import OhlcvStore, timeframe_to_interval_ms
@@ -3415,6 +3415,37 @@ async def _fetch_coin_range_into_v2_store(
     )
 
 
+# A persistent gap keeps the full KNOWN_GAP_RETRY_MS window only once the
+# identical gap has been observed on two fetches separated in time; a single
+# observation could be an exchange publishing delay, an outage, or a transient
+# partial response, so it gets a short re-verification window instead.
+GAP_FIRST_OBSERVATION_RETRY_MS = 60 * 60 * 1000
+GAP_CORROBORATION_MIN_SEPARATION_MS = 30 * 60 * 1000
+
+
+def _gap_observation_corroborated(
+    catalog: OhlcvCatalog,
+    *,
+    exchange: str,
+    timeframe: str,
+    symbol: str,
+    start_ts: int,
+    end_ts: int,
+    reason: str,
+    now_ms: int,
+) -> bool:
+    for gap in catalog.get_gaps(exchange, timeframe, symbol, start_ts, end_ts):
+        if int(gap.start_ts) != int(start_ts) or int(gap.end_ts) != int(end_ts):
+            continue
+        if str(gap.reason) != str(reason):
+            continue
+        if gap.last_attempt_at is None:
+            continue
+        if now_ms - int(gap.last_attempt_at) >= GAP_CORROBORATION_MIN_SEPARATION_MS:
+            return True
+    return False
+
+
 def _mark_sparse_fetch_gaps(
     *,
     catalog: OhlcvCatalog,
@@ -3451,9 +3482,21 @@ def _mark_sparse_fetch_gaps(
                 gaps.append((gap_start, gap_end, "internal_gap"))
     if mark_trailing_unavailable and trailing_note and last_ts < int(request_end_ts):
         gaps.append((last_ts + interval_ms, int(request_end_ts), "trailing_unavailable"))
+    now_ms = int(utc_ms())
     for gap_start, gap_end, reason in gaps:
         if gap_end < gap_start:
             continue
+        corroborated = _gap_observation_corroborated(
+            catalog,
+            exchange=exchange,
+            timeframe=timeframe,
+            symbol=symbol,
+            start_ts=gap_start,
+            end_ts=gap_end,
+            reason=reason,
+            now_ms=now_ms,
+        )
+        retry_window_ms = KNOWN_GAP_RETRY_MS if corroborated else GAP_FIRST_OBSERVATION_RETRY_MS
         catalog.mark_gap(
             exchange=exchange,
             timeframe=timeframe,
@@ -3463,6 +3506,7 @@ def _mark_sparse_fetch_gaps(
             reason=reason,
             persistent=True,
             retry_count=int(attempt),
+            next_retry_at=now_ms + retry_window_ms,
             note=trailing_note if reason == "trailing_unavailable" and trailing_note else "confirmed_by_v2_fetch",
         )
 

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -1805,3 +1805,53 @@ async def test_force_refetch_gaps_clears_gaps(tmp_path):
 
     # Gap should be cleared
     assert len(cm._get_known_gaps(symbol)) == 0
+
+
+def test_kucoin_between_page_holes_recorded_as_expiring_auto_gaps(tmp_path):
+    """Intra-payload holes are exchange-verified no-trade minutes (the exchange
+    returned the surrounding candles in one response) and stay permanent.
+    Between-page holes are indistinguishable from a pagination stall or outage,
+    so they must be recorded with the expiring auto_detected classification and
+    remain retryable instead of being permanently masked as no_trades."""
+
+    class _Ex:
+        id = "kucoinfutures"
+
+    cm = CandlestickManager(
+        exchange=_Ex(), exchange_name="kucoin", cache_dir=str(tmp_path / "caches")
+    )
+    assert cm._record_payload_gaps_as_known
+
+    base = _floor_minute(int(time.time() * 1000)) - 100 * ONE_MIN_MS
+
+    def t(i):
+        return base + i * ONE_MIN_MS
+
+    def row(i):
+        return [t(i), 100.0, 101.0, 99.0, 100.5, 5.0]
+
+    pages = [
+        [row(0), row(1), row(3)],  # intra-payload hole at minute 2
+        [row(6), row(7)],  # between-page hole covering minutes 4-5
+    ]
+
+    async def fake_once(symbol, since_ms, limit, end_exclusive_ms=None, timeframe=None, *, tf=None):
+        return pages.pop(0) if pages else []
+
+    cm._ccxt_fetch_ohlcv_once = fake_once
+    arr = asyncio.run(cm._fetch_ohlcv_paginated("ETH/USDT:USDT", t(0), t(8)))
+    assert arr.shape[0] == 5
+
+    gaps = cm._get_known_gaps_enhanced("ETH/USDT:USDT")
+    by_range = {(int(g["start_ts"]), int(g["end_ts"])): g for g in gaps}
+    assert set(by_range) == {(t(2), t(2)), (t(4), t(5))}
+
+    intra = by_range[(t(2), t(2))]
+    assert intra["reason"] == "no_trades"
+    assert int(intra["retry_count"]) >= _GAP_MAX_RETRIES
+    assert not cm._should_retry_gap(intra)
+
+    between = by_range[(t(4), t(5))]
+    assert between["reason"] == "auto_detected"
+    assert int(between["retry_count"]) < _GAP_MAX_RETRIES
+    assert cm._should_retry_gap(between)

--- a/tests/test_ohlcv_v2_prepare.py
+++ b/tests/test_ohlcv_v2_prepare.py
@@ -3570,3 +3570,125 @@ async def test_corrupt_chunk_failed_repair_preserves_existing_rows(tmp_path):
     finally:
         del body
         del valid
+
+
+def test_mark_sparse_fetch_gaps_graduated_retry_windows(tmp_path):
+    """A gap's first observation gets a short re-verification window; only a
+    re-observation separated in time earns the full KNOWN_GAP_RETRY_MS window.
+    Guards against a transient outage or publishing delay masking data for
+    the full retry period on a single sighting."""
+    from hlcv_preparation import (
+        GAP_CORROBORATION_MIN_SEPARATION_MS,
+        GAP_FIRST_OBSERVATION_RETRY_MS,
+        KNOWN_GAP_RETRY_MS,
+        _mark_sparse_fetch_gaps,
+    )
+    from utils import utc_ms
+
+    catalog = OhlcvCatalog(tmp_path / "caches" / "ohlcvs" / "catalog.sqlite")
+    start_ts = month_start_ts(2026, 4)
+    request_end_ts = start_ts + 9 * 60_000
+    # Rows with an internal hole (minute 2 missing) and a missing tail.
+    ts = np.array(
+        [start_ts, start_ts + 60_000, start_ts + 3 * 60_000, start_ts + 4 * 60_000],
+        dtype=np.int64,
+    )
+
+    def mark():
+        _mark_sparse_fetch_gaps(
+            catalog=catalog,
+            exchange="kucoin",
+            timeframe="1m",
+            symbol="ETH/USDT:USDT",
+            request_start_ts=start_ts,
+            request_end_ts=request_end_ts,
+            ts=ts,
+            attempt=1,
+            leading_reason="leading_unavailable",
+            trailing_note="short_tail_return test",
+        )
+
+    mark()
+    now_ms = int(utc_ms())
+    gaps = catalog.get_gaps("kucoin", "1m", "ETH/USDT:USDT", start_ts, request_end_ts)
+    assert {gap.reason for gap in gaps} == {"internal_gap", "trailing_unavailable"}
+    for gap in gaps:
+        assert gap.persistent
+        # First observation: short window, far below the corroborated one.
+        assert gap.next_retry_at <= now_ms + GAP_FIRST_OBSERVATION_RETRY_MS + 5_000
+        assert gap.next_retry_at < now_ms + KNOWN_GAP_RETRY_MS // 2
+
+    # Re-marking immediately (same run / seconds apart) must NOT extend the window.
+    mark()
+    gaps = catalog.get_gaps("kucoin", "1m", "ETH/USDT:USDT", start_ts, request_end_ts)
+    for gap in gaps:
+        assert gap.next_retry_at < now_ms + KNOWN_GAP_RETRY_MS // 2
+
+    # Backdate the recorded observations beyond the corroboration separation,
+    # then re-mark: the identical gaps are now corroborated -> full window.
+    import sqlite3
+
+    with sqlite3.connect(catalog.db_path) as conn:
+        conn.execute(
+            "UPDATE gaps SET last_attempt_at = last_attempt_at - ?",
+            (GAP_CORROBORATION_MIN_SEPARATION_MS + 60_000,),
+        )
+    mark()
+    now_ms = int(utc_ms())
+    gaps = catalog.get_gaps("kucoin", "1m", "ETH/USDT:USDT", start_ts, request_end_ts)
+    for gap in gaps:
+        assert gap.next_retry_at > now_ms + KNOWN_GAP_RETRY_MS - 60_000
+
+
+@pytest.mark.asyncio
+async def test_confirmed_short_tail_gap_gets_short_first_retry_window(tmp_path):
+    """The in-run short-tail confirmation writes a truncated dataset; its
+    trailing gap must carry the short first-observation retry window so a
+    false confirm (exchange publishing delay) self-heals quickly instead of
+    clipping recent-end backtests for the full KNOWN_GAP_RETRY_MS."""
+    from hlcv_preparation import GAP_FIRST_OBSERVATION_RETRY_MS, KNOWN_GAP_RETRY_MS
+    from utils import utc_ms
+
+    catalog = OhlcvCatalog(tmp_path / "caches" / "ohlcvs" / "catalog.sqlite")
+    store = OhlcvStore(tmp_path / "caches" / "ohlcvs", catalog)
+    start_ts = month_start_ts(2026, 4)
+    end_ts = start_ts + 5 * 60_000
+
+    class FakeOhlcvManager:
+        gap_tolerance_ohlcvs_minutes = 0.0
+        cm = None
+
+        def update_timestamp_range(self, new_start_ts, new_end_ts):
+            self.start_ts = int(new_start_ts)
+            self.end_ts = int(new_end_ts)
+
+        async def fetch_ohlcvs_for_v2_store(self, coin, *, start_ts, end_ts):
+            return pd.DataFrame(
+                {
+                    "timestamp": np.array([start_ts, start_ts + 60_000], dtype=np.int64),
+                    "high": np.array([101.0, 102.0], dtype=np.float32),
+                    "low": np.array([99.0, 100.0], dtype=np.float32),
+                    "close": np.array([100.0, 101.0], dtype=np.float32),
+                    "volume": np.array([10.0, 11.0], dtype=np.float32),
+                }
+            )
+
+    manager = FakeOhlcvManager()
+    for _ in range(2):
+        result = await _fetch_coin_range_into_v2_store(
+            om=manager,
+            catalog=catalog,
+            store=store,
+            exchange="bybit",
+            coin="ETH",
+            symbol="ETH/USDT:USDT",
+            start_ts=start_ts,
+            end_ts=end_ts,
+        )
+
+    assert result.ok
+    now_ms = int(utc_ms())
+    gaps = catalog.get_gaps("bybit", "1m", "ETH/USDT:USDT", start_ts, end_ts)
+    assert [gap.reason for gap in gaps] == ["trailing_unavailable"]
+    assert gaps[0].next_retry_at <= now_ms + GAP_FIRST_OBSERVATION_RETRY_MS + 5_000
+    assert gaps[0].next_retry_at < now_ms + KNOWN_GAP_RETRY_MS // 2


### PR DESCRIPTION
## Summary

Slice 3 of the backtest data audit action plan (findings I-4/I-5/I-6, docs/plans/backtest_data_integrity_audit_20260709.md).

### Graduated persistent-gap retry windows (I-4, I-5)
A persistent gap's **first observation** now gets a **1-hour** re-verification window (`GAP_FIRST_OBSERVATION_RETRY_MS`); the full **7-day** window (`KNOWN_GAP_RETRY_MS`) applies only once the identical gap — same span and reason — is re-observed **≥30 minutes later** (`GAP_CORROBORATION_MIN_SEPARATION_MS`). Previously a single sighting locked in 7 days, so an exchange publishing delay or a transient partial response silently clipped a coin's backtest coverage for a week (recent-end tails were the worst case: the audit found the existing "two-attempt corroboration" is satisfied by an *immediate in-run refetch*, providing no real temporal protection).

**Design note — why not temporal separation on the confirmation itself:** the in-run confirm-by-refetch flow is intentional; requiring separated attempts would push every *first* encounter of a genuinely delisted coin into the legacy fallback path for the whole prep. The short first-observation window achieves the same protection with zero control-flow change: a false confirm self-heals within the hour via the existing retryable-persistent-gap refetch + `clear_gap_range` path.

### KuCoin between-page holes now expire (I-6)
Holes **between pagination pages** are recorded as expiring `auto_detected` gaps (retryable, persistent-with-expiry after max retries) instead of permanent never-retried `no_trades` — a pagination stall or outage is indistinguishable from a genuine no-trade span. Holes **inside a single response** remain verified `no_trades` minutes: the exchange affirmatively returned the surrounding candles in one payload.

## Test plan
- New: graduated-window transitions in `test_ohlcv_v2_prepare.py` (first marking → short window; same-run re-mark stays short; corroborated re-mark after backdated separation → 7d) and end-to-end short-tail confirmation carrying the short window.
- New: real pagination-loop test in `test_candlestick_manager.py` asserting intra-payload holes stay `no_trades`/non-retryable while between-page holes become `auto_detected`/retryable.
- Affected suites: 210 passed, 2 skipped (v2 prepare/foundation, hlcv preparation, candlestick manager + locking, cache integrity doctor).
- Full suite: 100% complete, 0 failures, pytest exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)