### PR TITLE
Summarize event pipeline resource pressure

### DIFF
--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,21 @@ Last updated: 2026-07-09.
 
 Current `origin/v8` head:
 
-- `4ac5b309` after PR #1156, `Add smoke resource pressure sample age`.
+- `14d521fd` after PR #1160, `Surface interior coverage loss and stock-perps
+  synthetic-candle share`.
 
 Current logging-overhaul head:
 
-- `4ac5b309` after PR #1156, `Add smoke resource pressure sample age`.
+- `441d9fe5` after PR #1157, `Summarize resource pressure sample age` (latest
+  merged logging-overhaul slice).
 
 Current work:
 
-- Branch `codex/v8-resource-pressure-age-aggregate` adds read-only aggregate
-  `latest_event_age_ms_max` and reporting-bot count fields to
-  `live-performance-report` `resource_pressure`, derived from existing
-  per-bot `health.summary` event timestamps. It does not add event producers,
-  exchange calls, order/risk logic, restart orchestration, or trading behavior.
+- Branch `codex/v8-resource-pressure-pipeline-summary` adds read-only
+  aggregate event-pipeline health counters to `live-performance-report`
+  `resource_pressure`, derived from existing per-bot `health.summary`
+  queue/drop/sink/worker fields. It does not add event producers, exchange
+  calls, order/risk logic, restart orchestration, or trading behavior.
 
 Current review gate:
 
@@ -61,6 +63,24 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1157 at `441d9fe5`.
+- PR #1157 added read-only aggregate resource-pressure sample-age fields to
+  `live-performance-report`, exposing `latest_event_age_ms_max` and
+  `latest_event_age_reporting_bots` from existing per-bot `health.summary`
+  timestamps. It merged after Hermes approved the current head, Claude Opus
+  4.8 green-lighted the rebased head, Grok 4.5 re-approved the current head,
+  Codex reviewer posted green, and CI was green. VPS5 was pulled with
+  `git pull --autostash --ff-only origin v8`, preserving the pre-existing
+  tracked Rust-format/local config state. No bot restart was performed because
+  the slice was read-only report projection plus docs. A bounded 2-minute
+  summary smoke reported `ok=true`, `hard_failures=0`, `matched_expected=5`,
+  `missing_expected_count=0`, `remote_calls.failed=0`,
+  `account_critical_remote_calls.failed=0`, `logs.hard_matches=0`, and
+  repository head `441d9fe5`. A focused 30-minute `resource_pressure` report
+  on VPS5 monitor data reported `ok=true`, `error_count=0`,
+  `resource_total=9`, `resource_bots=5`,
+  `latest_event_age_ms_max=872783`, and
+  `latest_event_age_reporting_bots=5`.
 - Repository pulled through PR #1156 at `4ac5b309`.
 - PR #1156 added the read-only smoke-report counterpart for resource-pressure
   sample age, exposing per-group `latest_event_age_ms`, aggregate

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -374,7 +374,10 @@ classification when enough source events exist.
     quick operator scans. Performance reports expose per-bot
     `latest_event_age_ms` plus an aggregate maximum age and reporting-bot count
     so stale resource-pressure samples are visible without manual timestamp
-    subtraction.
+    subtraction. Performance reports also expose aggregate latest event-pipeline
+    queue/drop/sink/degraded counters and unhealthy-bot count, so operators can
+    see whether observability itself is backed up or dropping data without
+    opening every per-bot group.
     Remaining work: a lower-level event-loop lag probe can be added later if
     operators need sub-heartbeat scheduling latency, but the heartbeat lag now
     gives bounded non-misleading evidence for delayed health summaries.

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -2699,10 +2699,62 @@ class _ResourcePressureAccumulator:
             for group in groups
             if group.get("latest_event_age_ms") is not None
         ]
+        def latest_field_int(group: dict[str, Any], field: str) -> int | None:
+            fields = group.get("fields")
+            if not isinstance(fields, dict):
+                return None
+            stats = fields.get(field)
+            if not isinstance(stats, dict):
+                return None
+            value = stats.get("latest")
+            if value is None:
+                return None
+            return int(value)
+
+        latest_queue_depths = [
+            value
+            for group in groups
+            for value in [latest_field_int(group, "event_queue_depth")]
+            if value is not None
+        ]
+        dropped_total_latest_sum = sum(
+            value
+            for group in groups
+            for value in [latest_field_int(group, "event_dropped_total")]
+            if value is not None
+        )
+        sink_error_total_latest_sum = sum(
+            value
+            for group in groups
+            for value in [latest_field_int(group, "event_sink_error_total")]
+            if value is not None
+        )
+        degraded_count_latest_sum = sum(
+            value
+            for group in groups
+            for value in [latest_field_int(group, "event_degraded_count")]
+            if value is not None
+        )
+        unhealthy_bots = sum(
+            1
+            for group in groups
+            if group.get("latest_event_pipeline_stopping") is True
+            or group.get("latest_event_pipeline_worker_alive") is False
+            or (latest_field_int(group, "event_dropped_total") or 0) > 0
+            or (latest_field_int(group, "event_sink_error_total") or 0) > 0
+            or (latest_field_int(group, "event_degraded_count") or 0) > 0
+        )
         out = {
             "total": sum(int(group.get("count") or 0) for group in groups),
             "bots": len(groups),
             "event_types": dict(self.event_types.most_common()),
+            "latest_event_queue_depth_max": max(latest_queue_depths)
+            if latest_queue_depths
+            else None,
+            "latest_event_dropped_total_sum": dropped_total_latest_sum,
+            "latest_event_sink_error_total_sum": sink_error_total_latest_sum,
+            "latest_event_degraded_count_sum": degraded_count_latest_sum,
+            "event_pipeline_unhealthy_bots": unhealthy_bots,
             "groups_truncated": len(groups) > limit,
             "groups": groups[:limit],
         }

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -2879,6 +2879,11 @@ def test_live_performance_report_resource_pressure_from_health_summary(tmp_path,
     assert pressure["event_types"] == {"health.summary": 2}
     assert pressure["latest_event_age_ms_max"] == 3000
     assert pressure["latest_event_age_reporting_bots"] == 1
+    assert pressure["latest_event_queue_depth_max"] == 5
+    assert pressure["latest_event_dropped_total_sum"] == 4
+    assert pressure["latest_event_sink_error_total_sum"] == 1
+    assert pressure["latest_event_degraded_count_sum"] == 3
+    assert pressure["event_pipeline_unhealthy_bots"] == 1
     assert group["bot"] == "binance/binance_01"
     assert group["count"] == 2
     assert group["latest_ts"] == 2000
@@ -2997,7 +3002,12 @@ def test_live_performance_report_resource_pressure_summary_is_bounded(tmp_path, 
                 ts=1000,
                 exchange="binance",
                 user="binance_01",
-                data={"rss_bytes": 1000, "event_queue_depth": 1},
+                data={
+                    "rss_bytes": 1000,
+                    "event_queue_depth": 1,
+                    "event_dropped_total": 1,
+                    "event_pipeline_worker_alive": True,
+                },
             ),
             _monitor_row(
                 event_type="health.summary",
@@ -3005,7 +3015,12 @@ def test_live_performance_report_resource_pressure_summary_is_bounded(tmp_path, 
                 ts=2000,
                 exchange="okx",
                 user="okx_faisal",
-                data={"rss_bytes": 2000, "event_queue_depth": 2},
+                data={
+                    "rss_bytes": 2000,
+                    "event_queue_depth": 2,
+                    "event_dropped_total": 0,
+                    "event_pipeline_worker_alive": False,
+                },
             ),
         ],
     )
@@ -3016,12 +3031,20 @@ def test_live_performance_report_resource_pressure_summary_is_bounded(tmp_path, 
     assert report["resource_pressure"]["bots"] == 2
     assert report["resource_pressure"]["latest_event_age_ms_max"] == 4000
     assert report["resource_pressure"]["latest_event_age_reporting_bots"] == 2
+    assert report["resource_pressure"]["latest_event_queue_depth_max"] == 2
+    assert report["resource_pressure"]["latest_event_dropped_total_sum"] == 1
+    assert report["resource_pressure"]["latest_event_sink_error_total_sum"] == 0
+    assert report["resource_pressure"]["latest_event_degraded_count_sum"] == 0
+    assert report["resource_pressure"]["event_pipeline_unhealthy_bots"] == 2
     assert len(summary["resource_pressure"]["groups"]) == 1
     assert summary["resource_pressure"]["groups_truncated"] is True
-    assert summary["resource_pressure"]["groups"][0]["bot"] == "okx/okx_faisal"
+    assert summary["resource_pressure"]["groups"][0]["bot"] == "binance/binance_01"
     assert "latest_event_age_ms" in summary["resource_pressure"]["groups"][0]
     assert summary["resource_pressure"]["latest_event_age_ms_max"] == 4000
     assert summary["resource_pressure"]["latest_event_age_reporting_bots"] == 2
+    assert summary["resource_pressure"]["latest_event_queue_depth_max"] == 2
+    assert summary["resource_pressure"]["latest_event_dropped_total_sum"] == 1
+    assert summary["resource_pressure"]["event_pipeline_unhealthy_bots"] == 2
 
 
 def test_live_performance_report_shutdown_latency_from_lifecycle_events(tmp_path):


### PR DESCRIPTION
## Scope
observability-only

## Touched surfaces
- `src/live/performance_report.py`
- `tests/test_live_performance_report.py`
- `docs/plans/live_logging_overhaul_progress.md`
- `docs/plans/live_performance_readiness_goals.md`

## What changed
- Adds top-level `resource_pressure` aggregates in `live-performance-report` from existing per-bot `health.summary` fields:
  - `latest_event_queue_depth_max`
  - `latest_event_dropped_total_sum`
  - `latest_event_sink_error_total_sum`
  - `latest_event_degraded_count_sum`
  - `event_pipeline_unhealthy_bots`
- Keeps per-bot groups unchanged and bounded by the existing group limit.
- Carries #1157 merge/deploy evidence into the progress ledger.

## Expected VPS action
No restart. If merged, pull `v8` on VPS5 and run bounded smoke/report checks only. This is read-only report projection over existing monitor events.

## Validation run
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/performance_report.py tests/test_live_performance_report.py`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_performance_report.py::test_live_performance_report_resource_pressure_from_health_summary tests/test_live_performance_report.py::test_live_performance_report_resource_pressure_summary_is_bounded` - passed
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_performance_report.py` - 64 passed
- `git diff --check origin/v8...HEAD` - passed
- Added-line silent-handling scan over `src`/`tests` for `except Exception`, `return_exceptions=True`, and neutral `.get(..., default)` patterns - no matches

## Reviewer focus
- Confirm this remains diagnostics/report-only and does not alter event producers, exchange I/O, order/risk/HSL/unstuck behavior, or restart behavior.
- Check that aggregate counters are derived from the same whitelisted `health.summary` fields already exposed in per-bot groups.
- Check summary truncation still keeps top-level aggregate evidence.

## Non-goals
- No new health-summary fields.
- No event-bus producer changes.
- No smoke-report projection changes in this slice.
- No trading-path, Rust, backtest, or optimize behavior changes.
