### PR TITLE
Report exchange config refresh performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -666,6 +666,10 @@ All notable user-facing changes will be documented in this file.
   `health.summary` process and event-pipeline fields with count, min, mean,
   median, p95, max, and latest values without raw account or financial
   payloads.
+- Added `exchange_config_refresh` summaries and elapsed timing groups to
+  `passivbot tool live-performance-report`, projecting existing structured
+  refresh success/failure events without copying raw exchange error text or
+  making new exchange calls.
 - Improved cold `passivbot backtest` materialization by batching legacy OHLCV
   imports by month, vectorizing chunk writes, staging HLCV cache writes with
   rollback on publish failure, and honoring Ctrl+C between expensive

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,21 +19,21 @@ Last updated: 2026-07-09.
 
 Current `origin/v8` head:
 
-- `14d521fd` after PR #1160, `Surface interior coverage loss and stock-perps
-  synthetic-candle share`.
+- `aa9e6623` after PR #1161, `Summarize event pipeline resource pressure`.
 
 Current logging-overhaul head:
 
-- `441d9fe5` after PR #1157, `Summarize resource pressure sample age` (latest
-  merged logging-overhaul slice).
+- `aa9e6623` after PR #1161, `Summarize event pipeline resource pressure`
+  (latest merged logging-overhaul slice).
 
 Current work:
 
-- Branch `codex/v8-resource-pressure-pipeline-summary` adds read-only
-  aggregate event-pipeline health counters to `live-performance-report`
-  `resource_pressure`, derived from existing per-bot `health.summary`
-  queue/drop/sink/worker fields. It does not add event producers, exchange
-  calls, order/risk logic, restart orchestration, or trading behavior.
+- Branch `codex/v8-performance-exchange-config-refresh` adds a read-only,
+  bounded `exchange_config_refresh` health and timing projection to
+  `live-performance-report`, derived from existing structured
+  `exchange.config_refresh` events. It excludes raw error text and does not add
+  event producers, exchange calls, refresh behavior, order/risk logic, restart
+  orchestration, or trading behavior.
 
 Current review gate:
 
@@ -63,6 +63,22 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1161 at `aa9e6623`.
+- PR #1161 added top-level event-pipeline queue, drop, sink-error, degraded,
+  and unhealthy-bot aggregates to `live-performance-report`
+  `resource_pressure`. It merged after Hermes, Claude Opus 4.8, and Grok 4.5
+  approved the current head and CI was green. VPS5 was pulled with
+  `git pull --autostash --ff-only origin v8`, preserving the pre-existing
+  tracked Rust change and local config/tmp artifacts. No bot restart was
+  performed because the slice was read-only report projection plus docs. The
+  first bounded two-minute smoke saw one recovered Kucoin balance
+  `RequestTimeout`: the same group already had a later successful balance
+  fetch. A fresh one-minute smoke then reported `ok=true`, `hard_failures=0`,
+  `matched_expected=5`, `missing_expected_count=0`,
+  `remote_calls.failed=0`, `account_critical_remote_calls.failed=0`, and
+  `logs.hard_matches=0`. A focused 30-minute `resource_pressure` report
+  returned `ok=true`, `error_count=0`, `resource_bots=4`, queue depth `0`,
+  zero drop/sink/degraded counters, and zero unhealthy bots.
 - Repository pulled through PR #1157 at `441d9fe5`.
 - PR #1157 added read-only aggregate resource-pressure sample-age fields to
   `live-performance-report`, exposing `latest_event_age_ms_max` and

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -670,9 +670,10 @@ Related detailed plans:
       remain unavailable instead of receiving synthetic ranking tails.
 
 18. [ ] Binance hourly hedge-mode/config refresh traceback classification.
-    Status: structured event plus smoke projection merged; live emission
-    evidence and smoke/report classification remain open after a restarted
-    process has crossed an hourly maintenance refresh.
+    Status: structured event plus smoke projection merged; a performance-report
+    projection is in the current logging-overhaul slice. Live emission evidence
+    and smoke/report classification remain open after a restarted process has
+    crossed an hourly maintenance refresh.
 
     VPS5 smoke after PR #892 deployed to `v8@7e7ce16f` returned hard-red from
     a non-risk text-log traceback in the Binance bot while all five live
@@ -721,6 +722,12 @@ Related detailed plans:
       `exchange.config_refresh` events. This is not yet proof that the Binance
       `-4084` maintenance traceback is fixed or classified, because no sampled
       window has proven an hourly refresh occurrence after restart.
+    - 2026-07-09: Branch `codex/v8-performance-exchange-config-refresh` adds a
+      bounded `live-performance-report` health and elapsed-timing projection
+      over existing `exchange.config_refresh` events. It excludes raw error
+      text and does not change refresh retries, exception propagation, smoke
+      verdicts, exchange I/O, or trading behavior. Live hourly emission
+      evidence remains the prerequisite for any later classification change.
 
 ## Merged Work Log
 

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -832,6 +832,11 @@ Each slice should update this checklist with its result.
    - Acceptance: `passivbot tool live-performance-report` can produce a bounded
      summary explaining the slowest startup and cycle blockers from local
      monitor data only.
+   - Status: resource-pressure groups now expose process, sample-age, queue,
+     drop, sink-error, degraded, and unhealthy-bot aggregates. The current
+     `codex/v8-performance-exchange-config-refresh` slice adds bounded
+     exchange-config refresh success/failure groups and elapsed timings from
+     existing `exchange.config_refresh` events without adding exchange calls.
 
 2. [ ] HSL replay benchmark/profiling slice.
    - Add an offline deterministic benchmark or fixture path for coin-mode HSL

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -282,6 +282,15 @@ _FILL_REFRESH_NUMERIC_FIELDS = (
     "degraded_events_after",
     "legacy_files_quarantined",
 )
+_EXCHANGE_CONFIG_REFRESH_EVENT_TYPES = {
+    "exchange.config_refresh",
+}
+_SAFE_LABEL_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyz"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "0123456789"
+    "._:-/"
+)
 
 
 def _open_text(path: Path):
@@ -399,6 +408,19 @@ def _safe_string_list(value: Any, *, limit: int = 12) -> list[str]:
         if len(out) >= int(limit):
             break
     return out
+
+
+def _safe_label(value: Any, *, max_len: int = 120) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if len(text) > int(max_len):
+        text = text[: int(max_len)]
+    if any(char not in _SAFE_LABEL_CHARS for char in text):
+        return None
+    return text
 
 
 def _elapsed_s_to_ms(value: Any) -> int | None:
@@ -2819,6 +2841,103 @@ class _ShutdownLatencyAccumulator:
         }
 
 
+class _ExchangeConfigRefreshAccumulator:
+    def __init__(self) -> None:
+        self.groups: dict[tuple[str, str, str, str, str], dict[str, Any]] = {}
+        self.event_types: Counter[str] = Counter()
+
+    def add(self, *, row: dict[str, Any], live_event: dict[str, Any]) -> None:
+        event_type = str(live_event.get("event_type") or row.get("kind") or "")
+        if event_type not in _EXCHANGE_CONFIG_REFRESH_EVENT_TYPES:
+            return
+        data = live_event.get("data") if isinstance(live_event.get("data"), dict) else {}
+        bot = _bot_key(row, live_event)
+        status = str(live_event.get("status") or "unknown")
+        reason_code = str(live_event.get("reason_code") or "unknown")
+        operation = _safe_label(data.get("operation"), max_len=80) or "unknown"
+        error_type = _safe_label(data.get("error_type"), max_len=80) or ""
+        key = (bot, status, reason_code, operation, error_type)
+        group = self.groups.get(key)
+        if group is None:
+            group = {
+                "bot": bot,
+                "event_type": event_type,
+                "status": status,
+                "reason_code": reason_code,
+                "level": live_event.get("level"),
+                "component": live_event.get("component"),
+                "count": 0,
+                "latest_ts": None,
+                "latest_data": {},
+            }
+            self.groups[key] = group
+        group["count"] = int(group.get("count") or 0) + 1
+        ts = _record_ts(row)
+        latest_changed = ts is None or group.get("latest_ts") is None
+        if ts is not None and group.get("latest_ts") is not None:
+            latest_changed = int(ts) >= int(group["latest_ts"])
+        if ts is not None and latest_changed:
+            group["latest_ts"] = int(ts)
+        if latest_changed:
+            latest_data: dict[str, Any] = {}
+            for label_key in ("context", "operation", "error_type"):
+                label = _safe_label(data.get(label_key), max_len=80)
+                if label:
+                    latest_data[label_key] = label
+            elapsed_ms = _non_negative_ms(data.get("elapsed_ms"))
+            if elapsed_ms is not None:
+                latest_data["elapsed_ms"] = elapsed_ms
+            started_ms = _non_negative_ms(data.get("started_ms"))
+            if started_ms is not None:
+                latest_data["started_ms"] = started_ms
+            group["latest_data"] = latest_data
+        self.event_types[event_type] += 1
+
+    def to_dict(self, *, group_limit: int = GROUP_LIMIT) -> dict[str, Any]:
+        ordered = sorted(
+            self.groups.values(),
+            key=lambda item: (
+                -int(item.get("latest_ts") or 0),
+                -int(item.get("count") or 0),
+                str(item.get("bot") or ""),
+                str(item.get("status") or ""),
+                str(item.get("reason_code") or ""),
+            ),
+        )
+        compact_groups = [
+            {
+                key: value
+                for key, value in group.items()
+                if value not in (None, {}, [])
+            }
+            for group in ordered[: max(0, int(group_limit))]
+        ]
+        status_counts: Counter[str] = Counter()
+        failed_bots: set[str] = set()
+        for group in self.groups.values():
+            count = int(group.get("count") or 0)
+            status = str(group.get("status") or "unknown")
+            status_counts[status] += count
+            if status == "failed" and group.get("bot") not in (None, ""):
+                failed_bots.add(str(group["bot"]))
+        total = sum(int(group.get("count") or 0) for group in self.groups.values())
+        failed = int(status_counts.get("failed", 0))
+        return {
+            "total": int(total),
+            "bots": len({str(group.get("bot")) for group in self.groups.values()}),
+            "succeeded": int(status_counts.get("succeeded", 0)),
+            "failed": failed,
+            "failure_pct": (
+                _rounded_float((failed / total) * 100.0, 3) if total else None
+            ),
+            "failed_bots": len(failed_bots),
+            "statuses": dict(status_counts.most_common()),
+            "event_types": dict(self.event_types.most_common()),
+            "groups_truncated": len(ordered) > int(group_limit),
+            "groups": compact_groups,
+        }
+
+
 class _ExecutionTimingAccumulator:
     def __init__(self) -> None:
         self.accumulator = _PerformanceAccumulator()
@@ -3357,6 +3476,7 @@ def _operation_category(operation: Any) -> str:
         ("input_staleness.", "input_staleness"),
         ("execution.", "execution"),
         ("order_wave.", "execution"),
+        ("exchange_config_refresh.", "exchange_config_refresh"),
         ("shutdown.", "shutdown"),
         ("cycle.", "cycle"),
     ):
@@ -3519,6 +3639,8 @@ def _trading_impact_for_event(event_type: str, operation: str) -> str:
         return "blocks_or_delays_hsl_readiness"
     if event_type == "bot.startup_timing":
         return "blocks_startup_readiness"
+    if event_type == "exchange.config_refresh":
+        return "exchange_io"
     return "observability"
 
 
@@ -3644,6 +3766,18 @@ def _add_event_timings(
             live_event=live_event,
             operation=operation,
             value_ms=value_ms,
+            trading_impact=_trading_impact_for_event(event_type, operation),
+        )
+        return
+
+    if event_type == "exchange.config_refresh":
+        operation = _safe_label(data.get("operation"), max_len=80) or "unknown"
+        operation = f"exchange_config_refresh.{operation}"
+        accumulator.add(
+            row=row,
+            live_event=live_event,
+            operation=operation,
+            value_ms=_non_negative_ms(data.get("elapsed_ms")),
             trading_impact=_trading_impact_for_event(event_type, operation),
         )
 
@@ -3799,6 +3933,7 @@ def build_live_performance_report(
     forager_ema_readiness = _ForagerEmaReadinessAccumulator()
     resource_pressure = _ResourcePressureAccumulator()
     shutdown_latency = _ShutdownLatencyAccumulator()
+    exchange_config_refresh = _ExchangeConfigRefreshAccumulator()
     execution_timing = _ExecutionTimingAccumulator()
     account_state_changes = _AccountStateChangeAccumulator()
     risk_activity = _RiskActivityAccumulator()
@@ -3893,6 +4028,7 @@ def build_live_performance_report(
         forager_ema_readiness.add(row=row, live_event=live_event)
         resource_pressure.add(row=row, live_event=live_event)
         shutdown_latency.add(row=row, live_event=live_event)
+        exchange_config_refresh.add(row=row, live_event=live_event)
         execution_timing.add(
             row=row,
             live_event=live_event,
@@ -3986,6 +4122,9 @@ def build_live_performance_report(
             report_ts_ms=report_ts_ms,
         ),
         "shutdown_latency": shutdown_latency.to_dict(group_limit=group_limit),
+        "exchange_config_refresh": exchange_config_refresh.to_dict(
+            group_limit=group_limit
+        ),
         "execution_timing": execution_timing.to_dict(group_limit=group_limit),
         "account_state_changes": account_state_changes.to_dict(group_limit=group_limit),
         "risk_activity": risk_activity.to_dict(group_limit=group_limit),
@@ -4169,6 +4308,17 @@ def summarize_live_performance_report(
         if len(shutdown_groups) > max(0, int(group_limit)):
             shutdown_latency["groups_truncated"] = True
         summary["shutdown_latency"] = shutdown_latency
+    if isinstance(report.get("exchange_config_refresh"), dict):
+        exchange_config_refresh = dict(report["exchange_config_refresh"])
+        refresh_groups = (
+            exchange_config_refresh.get("groups")
+            if isinstance(exchange_config_refresh.get("groups"), list)
+            else []
+        )
+        exchange_config_refresh["groups"] = refresh_groups[: max(0, int(group_limit))]
+        if len(refresh_groups) > max(0, int(group_limit)):
+            exchange_config_refresh["groups_truncated"] = True
+        summary["exchange_config_refresh"] = exchange_config_refresh
     if isinstance(report.get("execution_timing"), dict):
         execution_timing = dict(report["execution_timing"])
         execution_groups = (

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -3047,6 +3047,129 @@ def test_live_performance_report_resource_pressure_summary_is_bounded(tmp_path, 
     assert summary["resource_pressure"]["event_pipeline_unhealthy_bots"] == 2
 
 
+def test_live_performance_report_exchange_config_refresh_health(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="exchange.config_refresh",
+                seq=1,
+                ts=1000,
+                component="exchange.config_refresh",
+                status="succeeded",
+                reason_code="exchange_config_refresh",
+                ids={"cycle_id": "cy_cfg_1"},
+                data={
+                    "context": "maintain_hourly_cycle",
+                    "operation": "init_markets",
+                    "started_ms": 900,
+                    "elapsed_ms": 100,
+                },
+            ),
+            _monitor_row(
+                event_type="exchange.config_refresh",
+                seq=2,
+                ts=2000,
+                component="exchange.config_refresh",
+                status="failed",
+                level="warning",
+                reason_code="exchange_config_refresh_failed",
+                ids={"cycle_id": "cy_cfg_2"},
+                data={
+                    "context": "maintain_hourly_cycle",
+                    "operation": "init_markets",
+                    "started_ms": 1800,
+                    "elapsed_ms": 200,
+                    "error_type": "ExchangeError",
+                    "error": "binanceusdm apiKey=supersecret code=-4084",
+                },
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    summary = summarize_live_performance_report(report)
+
+    refresh = report["exchange_config_refresh"]
+    assert refresh["total"] == 2
+    assert refresh["succeeded"] == 1
+    assert refresh["failed"] == 1
+    assert refresh["failure_pct"] == 50.0
+    assert refresh["bots"] == 1
+    assert refresh["failed_bots"] == 1
+    assert refresh["statuses"] == {"succeeded": 1, "failed": 1}
+    assert refresh["event_types"] == {"exchange.config_refresh": 2}
+    assert refresh["groups"][0]["status"] == "failed"
+    assert refresh["groups"][0]["latest_data"] == {
+        "context": "maintain_hourly_cycle",
+        "operation": "init_markets",
+        "error_type": "ExchangeError",
+        "elapsed_ms": 200,
+        "started_ms": 1800,
+    }
+    rendered = json.dumps(refresh, sort_keys=True)
+    assert "supersecret" not in rendered
+    assert "apiKey" not in rendered
+    assert "code=-4084" not in rendered
+
+    groups = {
+        group["operation"]: group
+        for group in report["operation_durations"]["groups"]
+        if group["operation"].startswith("exchange_config_refresh.")
+    }
+    assert groups["exchange_config_refresh.init_markets"]["trading_impact"] == "exchange_io"
+    assert groups["exchange_config_refresh.init_markets"]["max_ms"] == 200
+    assert summary["exchange_config_refresh"]["total"] == 2
+    assert summary["exchange_config_refresh"]["statuses"] == {
+        "succeeded": 1,
+        "failed": 1,
+    }
+    assert summary["operation_durations"]["operation_category_counts"][
+        "exchange_config_refresh"
+    ] == 1
+
+
+def test_live_performance_report_exchange_config_refresh_summary_is_bounded(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="exchange.config_refresh",
+                seq=1,
+                ts=1000,
+                exchange="binance",
+                user="binance_01",
+                data={"operation": "init_markets", "elapsed_ms": 100},
+            ),
+            _monitor_row(
+                event_type="exchange.config_refresh",
+                seq=2,
+                ts=2000,
+                exchange="okx",
+                user="okx_faisal",
+                status="failed",
+                reason_code="exchange_config_refresh_failed",
+                data={"operation": "set_position_mode", "elapsed_ms": 300},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    summary = summarize_live_performance_report(report, group_limit=1)
+
+    assert report["exchange_config_refresh"]["total"] == 2
+    assert report["exchange_config_refresh"]["bots"] == 2
+    assert len(summary["exchange_config_refresh"]["groups"]) == 1
+    assert summary["exchange_config_refresh"]["groups_truncated"] is True
+    assert summary["exchange_config_refresh"]["groups"][0]["bot"] == "okx/okx_faisal"
+    assert summary["operation_durations"]["total_groups"] >= 2
+    assert summary["operation_durations"]["operation_category_counts"][
+        "exchange_config_refresh"
+    ] == 2
+
+
 def test_live_performance_report_shutdown_latency_from_lifecycle_events(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
Scope: observability-only

Touched surfaces:
- src/live/performance_report.py: adds bounded exchange_config_refresh health groups and elapsed timing categories from existing exchange.config_refresh events
- tests/test_live_performance_report.py: covers aggregation, bounded summaries, operation timing, and raw-error exclusion
- CHANGELOG.md and live logging/performance/backlog plans: record the new report surface and PR #1161 deploy evidence

Expected VPS action: pull plus bounded report/smoke validation; no bot restart. The producer and running-process behavior are unchanged.

Validation run:
- branch rebased onto v8 aa9e6623 after merged PR #1161
- git diff --check passed
- py_compile passed
- focused exchange-config-refresh tests passed: 2 passed
- full tests/test_live_performance_report.py passed: 66 passed
- bounded local-artifact CLI smoke with --section exchange_config_refresh returned ok=true, error_count=0, and the expected empty section for a window with no matching events
- silent-handling scan found only non-critical diagnostic aggregation/sorting defaults

Reviewer focus:
- confirm the projection remains bounded and excludes free-text data.error
- confirm status/reason/operation timing aggregation is correct across bot groups
- confirm operation_durations classifies refresh timing as exchange_io without changing any trading or refresh decision
- confirm progress evidence accurately records the recovered Kucoin timeout seen after PR #1161 deploy

Non-goals:
- no event producer or registry changes
- no exchange calls, retries, exception propagation, or maintenance refresh behavior changes
- no smoke verdict or log classification changes
- no Rust, order, risk, HSL, unstuck, restart, backtest, optimize, or trading behavior changes

Merge gate: Hermes + Claude Opus 4.8 + Grok 4.5 current-head green reviews plus green CI.