### PR TITLE
Upgrade crash finder bucketing and scenario suites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -390,6 +390,7 @@ Cargo.lock
 /api-keys.json
 /caches
 /optimize_results
+/crash_finder_results/
 
 # Git worktrees
 .worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool crash-finder` can now regenerate scenario suites from an existing
+  `crash_clusters.csv` without rescanning local OHLCV data, emit market-wide/coin-focused/single-coin
+  filtered suites, merge overlapping stress windows, and add per-coin forced-normal overrides for
+  idiosyncratic non-market-wide crash stress scenarios, capped at two forced coins per scenario.
+  When scanned range metadata is available, generated suites now drop coins with no cached data
+  overlap in the scenario date window. Full discovery now efficiently groups 1m source rows into
+  parameterized crash candles (`1h` by default) without rescanning the full minute array for every
+  candle, while preserving the ordered high-to-later-low metric.
+
 - Connector-local exchange-config failure logs in Binance, Bitget, Defx,
   Hyperliquid, KuCoin, and OKX, plus the parent per-symbol retry log, now keep
   bounded operation, symbol, retry, canonical known-code, and exception-type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ All notable user-facing changes will be documented in this file.
   filtered suites, merge overlapping stress windows, and add per-coin forced-normal overrides for
   idiosyncratic non-market-wide crash stress scenarios, capped at two forced coins per scenario.
   When scanned range metadata is available, generated suites now drop coins with no cached data
-  overlap in the scenario date window. Full discovery now efficiently groups 1m source rows into
-  parameterized crash candles (`1h` by default) without rescanning the full minute array for every
-  candle, while preserving the ordered high-to-later-low metric.
+  overlap in the scenario date window and omit targeted scenarios when no coins remain. Full
+  discovery now efficiently groups 1m source rows into parameterized crash candles (`1h` by default)
+  without rescanning the full minute array for every candle, while preserving the ordered
+  high-to-later-low metric.
 
 - Connector-local exchange-config failure logs in Binance, Bitget, Defx,
   Hyperliquid, KuCoin, and OKX, plus the parent per-symbol retry log, now keep

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -21,6 +21,7 @@ Use this file to decide what to read for a task.
 | Code review | `code_review_prompt.md` |
 | Common implementation mistakes | `pitfalls.md` |
 | Running tools/tests/backtests/optimizer | `commands.md` |
+| Crash discovery and stress-suite generation | `crash_suite_generator.md`, `commands.md` |
 | Feature-specific changes | `features/README.md` + relevant file in `features/` |
 | Deep incident context | `debugging_case_studies.md`, `suite_optimizer_memory_investigation.md` |
 

--- a/docs/ai/crash_suite_generator.md
+++ b/docs/ai/crash_suite_generator.md
@@ -1,0 +1,155 @@
+# Crash Discovery And Stress-Suite Workflow
+
+Use this guide when finding difficult historical periods in the local OHLCV cache or generating
+optimizer/backtest crash suites. The generated artifacts are local research output; keep them under
+`crash_finder_results/<YYYY-MM-DD>_crash_scenarios/` and do not commit them.
+
+## What The Tool Does
+
+`passivbot tool crash-finder` has two distinct modes:
+
+1. Full discovery reads cached 1m candles, builds larger discovery candles, finds crash events,
+   clusters related events, and generates scenario suites.
+2. The `--clusters-csv` fast path regenerates suites from an existing cluster file. It does not read
+   candles and cannot discover a crash added by a recent data download.
+
+After updating candle data, run full discovery if the goal is to find new events. Use the CSV fast
+path only when changing scenario-window, filtering, merging, or override settings while keeping the
+previously discovered events.
+
+## Discovery Semantics
+
+- The cached source is currently required to be `1m` (`--source-timeframe 1m`).
+- `--timeframe` controls the epoch-aligned discovery candle and defaults to `1h`. Durations such as
+  `4h` and `12h` are supported.
+- `1h` is the standard crash-suite horizon. It catches fast idiosyncratic failures such as M while
+  still finding liquidation cascades. Wider candles can find slower moves, but may combine unrelated
+  price action and change cluster timestamps.
+- The default `ordered` metric is the worst high-to-later-low log return inside each discovery
+  candle. Do not replace it with plain candle high/low range: the range cannot tell whether the low
+  happened before the high and creates false crash events.
+- `--threshold` is a log return. For example, `-0.10` is approximately a 9.5% price decline.
+- `--min-valid-minutes` counts valid 1m source rows in a discovery candle. Reconsider this minimum
+  when intentionally using sparse data or much wider candles.
+
+The efficient grouping contract matters. Extract valid source-row indices once, derive contiguous
+bucket boundaries once, then evaluate each compact bucket slice. Do not restore a per-bucket mask
+over the full multi-year minute array; that turns a linear scan into an hours-times-minutes scan.
+
+Full discovery verifies every cache chunk checksum before using it. This is deliberate. A future
+optimization may stream verified monthly chunks instead of materializing one dense symbol range,
+but it must preserve event results, gap handling, source order, and fail-loud integrity checks.
+
+## Refresh Candle Data First
+
+Build the requested coin universe from all scenario files, then update Binance and Bybit separately.
+The downloader's combined-exchange path and each exchange's current market catalog can differ, so
+separate commands make skipped symbols and failures attributable.
+
+```shell
+passivbot download \
+  --symbols BTC,ETH,OM,M \
+  --exchanges binance \
+  --start-date 2021-01-01 \
+  --end-date 2026-07-07
+
+passivbot download \
+  --symbols BTC,ETH,OM,M \
+  --exchanges bybit \
+  --start-date 2021-01-01 \
+  --end-date 2026-07-07
+```
+
+Treat a current-market lookup failure separately from cached-data absence. Exchange symbols may use
+contract aliases such as `1000PEPE`, `1000SHIB`, or `SHIB1000`; use the repository's coin/symbol
+normalization helpers or catalog records instead of guessing `COIN/USDT:USDT`.
+
+After downloading, verify the catalog's actual last timestamp per exchange and normalized coin.
+The requested end date and the downloader's end-exclusive/materialized timestamp are not always
+described identically in logs.
+
+## Standard Full Discovery
+
+Use a dated local output directory. The standard scenario has 14 days of lead-up and 60 days of
+fallout, merges overlapping date windows, and writes filtered suites.
+
+```shell
+passivbot tool crash-finder \
+  --root caches/ohlcvs \
+  --exchange binance \
+  --exchange bybit \
+  --source-timeframe 1m \
+  --timeframe 1h \
+  --threshold -0.10 \
+  --min-valid-minutes 2 \
+  --top-per-coin 20 \
+  --top-clusters 80 \
+  --pre-days 14 \
+  --post-days 60 \
+  --scenario-coin-mode affected \
+  --scenario-kind all \
+  --scenario-force-normal both \
+  --scenario-merge-overlaps \
+  --write-filtered-suites \
+  --output-dir crash_finder_results/$(date +%F)_crash_scenarios
+```
+
+Do not infer that a long first symbol means the run is stuck. Check the log's symbol progress and
+measure a representative single-symbol scan first. The grouping implementation should make the
+event scan linear, but checksum verification and dense range loading still have real cost.
+
+## Fast Suite Regeneration
+
+Use this only when the cluster CSV remains the event source of truth:
+
+```shell
+passivbot tool crash-finder \
+  --clusters-csv crash_finder_results/<source>/crash_clusters.csv \
+  --top-clusters 80 \
+  --pre-days 14 \
+  --post-days 60 \
+  --scenario-coin-mode affected \
+  --scenario-kind all \
+  --scenario-force-normal both \
+  --scenario-merge-overlaps \
+  --write-filtered-suites \
+  --output-dir crash_finder_results/$(date +%F)_crash_scenarios
+```
+
+Keep `scanned_ranges.csv` beside `crash_clusters.csv`. The fast path uses it to remove coins whose
+data does not overlap a scenario window and copies the other scan artifacts when present. Older
+`scanned_ranges.csv` files with `hours_scanned` are accepted as 1h discovery metadata.
+
+## Scenario Requirements
+
+- Market-wide clusters include the affected market coins but never force individual coins to normal
+  mode. The forager should choose naturally during broad market stress.
+- Forced-normal overrides are only for idiosyncratic, non-market-wide crash coins.
+- No scenario may force more than two coins. If overlapping idiosyncratic events would exceed two,
+  emit repeated scenarios for the same window with force targets split into groups of at most two.
+- A scenario coin must have cached data overlapping that scenario's date range on at least one of
+  the scenario's exchanges.
+- Merge scenarios when their 14-day lead-up and 60-day fallout ranges overlap. Preserve the union of
+  eligible coins and exchanges, the outer date range, and the worst-severity label.
+- Keep separate all, market-wide, coin-focused, and strict single-coin suite files when
+  `--write-filtered-suites` is requested.
+
+Event labels use UTC bucket starts. A crash remembered by local calendar date may appear on the next
+UTC date. The M event discussed during initial development is labeled around
+`2026-06-25T00:00:00Z`, although it may be referred to as the June 24 crash locally.
+
+## Validation Checklist
+
+Before reporting a generated suite as complete, verify:
+
+1. Full discovery was run after the latest candle download when new events were expected.
+2. `scan_errors.csv` is reviewed; skipped symbols are not silently treated as successfully scanned.
+3. Every scenario coin overlaps its date range according to `scanned_ranges.csv` or the current
+   catalog.
+4. Market-wide scenarios have no forced-normal overrides.
+5. Every other scenario has at most two forced-normal coins.
+6. The expected known events are present, including M and OM when their data is in scope.
+7. `crash_finder_results/` remains untracked and is absent from the PR diff.
+
+Run `pytest tests/test_crash_finder_tool.py` after changing scanner, clustering, suite, CSV, or CLI
+behavior. Include a bounded real-cache single-symbol smoke scan when changing discovery performance.

--- a/docs/ai/crash_suite_generator.md
+++ b/docs/ai/crash_suite_generator.md
@@ -129,6 +129,8 @@ data does not overlap a scenario window and copies the other scan artifacts when
   emit repeated scenarios for the same window with force targets split into groups of at most two.
 - A scenario coin must have cached data overlapping that scenario's date range on at least one of
   the scenario's exchanges.
+- If data filtering removes every targeted coin, omit that scenario. Never remove the `coins` key
+  and accidentally broaden a targeted scenario to the suite's base coin universe.
 - Merge scenarios when their 14-day lead-up and 60-day fallout ranges overlap. Preserve the union of
   eligible coins and exchanges, the outer date range, and the worst-severity label.
 - Keep separate all, market-wide, coin-focused, and strict single-coin suite files when

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -111,6 +111,63 @@ passivbot tool iterative-history-plot backtests/.../fills.csv
 - `passivbot tool candle-doctor` – Audits legacy `caches/ohlcv/...` shards for corruption, stale index entries, and legacy-format issues; add `--fix` to apply automatic repairs before importing into the v2 store.
 - `passivbot tool migrate-historical-data` – Converts legacy `historical_data/ohlcvs_<exchange>/...` shards into the current `caches/ohlcv/...` layout.
 
+## Crash finder
+
+`passivbot tool crash-finder` builds larger discovery candles from local v2 1m OHLCV data and
+scans them for severe crash windows. The discovery timeframe is parameterized with `--timeframe`
+and defaults to `1h`; `4h` and `12h` are useful alternatives for slower market-wide moves. The
+scanner groups valid source rows once, while retaining their order inside each candle so a low
+before a later high is not misclassified as a crash.
+
+Full scans verify cache chunk checksums and write raw event/cluster CSVs plus
+`backtest.scenarios` suites. Use `--clusters-csv` only to regenerate suites cheaply when event
+discovery does not need to be repeated; this fast path cannot find crashes in newly downloaded
+candles.
+When a sibling `scanned_ranges.csv` is present, suite generation drops coins whose cached data range
+does not overlap the generated scenario date window.
+
+```shell
+passivbot tool crash-finder \
+  --root caches/ohlcvs \
+  --exchange binance \
+  --exchange bybit \
+  --source-timeframe 1m \
+  --timeframe 1h \
+  --threshold -0.10 \
+  --pre-days 14 \
+  --post-days 60 \
+  --scenario-force-normal both \
+  --scenario-merge-overlaps \
+  --write-filtered-suites \
+  --output-dir crash_finder_results/$(date +%F)_crash_scenarios
+
+passivbot tool crash-finder \
+  --clusters-csv crash_finder_results/crash_clusters.csv \
+  --pre-days 14 \
+  --post-days 60 \
+  --scenario-force-normal both \
+  --scenario-merge-overlaps \
+  --write-filtered-suites \
+  --output-dir crash_finder_results/$(date +%F)_crash_scenarios
+```
+
+Useful suite controls:
+
+- `--scenario-kind market-wide` keeps broad market crashes only.
+- `--scenario-kind coin-focused` keeps non-market-wide crashes, including isolated multi-coin
+  clusters such as a DEXE/M event.
+- `--scenario-kind single-coin` keeps strict one-coin crashes only.
+- `--write-filtered-suites` writes all three filtered suites alongside the main suite.
+- `--scenario-force-normal long|short|both` emits per-coin `forced_mode_* = "normal"` overrides
+  only for idiosyncratic non-market-wide crash coins. Market-wide scenario coins are not forced.
+  If a merged scenario would contain more than two forced coins, the tool splits it into repeated
+  scenario windows with at most two forced coins per scenario.
+- `--scenario-merge-overlaps` merges scenarios whose generated date windows overlap, preserving
+  the earliest start, latest end, union of coins, and worst-severity label.
+
+See `docs/ai/crash_suite_generator.md` for the complete discovery, download, generation, and
+validation workflow.
+
 ## Fill Events Tooling
 
 `passivbot tool fill-events-dash` launches a Dash UI for inspecting cached fill-event history,

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -124,7 +124,8 @@ Full scans verify cache chunk checksums and write raw event/cluster CSVs plus
 discovery does not need to be repeated; this fast path cannot find crashes in newly downloaded
 candles.
 When a sibling `scanned_ranges.csv` is present, suite generation drops coins whose cached data range
-does not overlap the generated scenario date window.
+does not overlap the generated scenario date window. A targeted scenario is omitted if no coins
+remain, rather than inheriting the suite's base coin universe.
 
 ```shell
 passivbot tool crash-finder \

--- a/src/tools/crash_finder.py
+++ b/src/tools/crash_finder.py
@@ -5,6 +5,8 @@ import csv
 import hashlib
 import json
 import logging
+import re
+import shutil
 import sqlite3
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime, timedelta
@@ -53,7 +55,8 @@ class ScannedRange:
     first_iso: str
     last_iso: str
     valid_rows: int
-    hours_scanned: int
+    scan_timeframe: str
+    buckets_scanned: int
     events_found: int
 
 
@@ -75,14 +78,15 @@ class CrashEvent:
     exchange: str
     symbol: str
     coin: str
+    timeframe: str
     timestamp: int
     timestamp_iso: str
     valid_minutes: int
     range_log: float
     ordered_high_to_later_low_log: float
     prev_close_low_log: float | None
-    hour_high: float
-    hour_low: float
+    bucket_high: float
+    bucket_low: float
     previous_close: float | None
 
 
@@ -103,6 +107,14 @@ class CrashCluster:
     market_wide: bool
 
 
+@dataclass(frozen=True)
+class CoinDataRange:
+    exchange: str
+    coin: str
+    first_ts: int
+    last_ts: int
+
+
 def _ts_to_iso(ts_ms: int) -> str:
     return datetime.fromtimestamp(int(ts_ms) / 1000, tz=UTC).isoformat().replace("+00:00", "Z")
 
@@ -120,7 +132,7 @@ def _connect(db_path: Path) -> sqlite3.Connection:
 def load_symbol_ranges(
     root: Path,
     *,
-    exchange: str | None,
+    exchanges: Sequence[str] | None,
     timeframe: str,
     symbols: Sequence[str] | None,
 ) -> list[SymbolRange]:
@@ -129,9 +141,10 @@ def load_symbol_ranges(
         raise FileNotFoundError(f"v2 OHLCV catalog not found: {db_path}")
     filters = ["timeframe = ?", "first_ts IS NOT NULL", "last_ts IS NOT NULL"]
     params: list[Any] = [timeframe]
-    if exchange:
-        filters.append("exchange = ?")
-        params.append(exchange)
+    if exchanges:
+        placeholders = ",".join("?" for _ in exchanges)
+        filters.append(f"exchange IN ({placeholders})")
+        params.extend(exchanges)
     if symbols:
         placeholders = ",".join("?" for _ in symbols)
         filters.append(f"symbol IN ({placeholders})")
@@ -183,6 +196,36 @@ def _worst_ordered_high_to_later_low_log(high: np.ndarray, low: np.ndarray) -> f
     prefix_high = np.maximum.accumulate(high)
     ratios = low / prefix_high
     return float(np.log(np.min(ratios)))
+
+
+def _duration_timeframe_to_ms(timeframe: str) -> int:
+    normalized = str(timeframe).strip().lower()
+    match = re.fullmatch(r"([1-9][0-9]*)([mhd])", normalized)
+    if match is None:
+        raise ValueError(
+            f"unsupported scan timeframe {timeframe!r}; expected a positive duration such as "
+            "1h, 4h, or 12h"
+        )
+    count = int(match.group(1))
+    unit_ms = {"m": 60_000, "h": HOUR_MS, "d": 24 * HOUR_MS}[match.group(2)]
+    return count * unit_ms
+
+
+def _group_valid_rows_by_bucket(
+    timestamps: np.ndarray,
+    usable: np.ndarray,
+    bucket_ms: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Return valid row indices and contiguous group metadata in one linear pass."""
+    valid_indices = np.flatnonzero(usable)
+    if len(valid_indices) == 0:
+        empty = np.empty(0, dtype=np.int64)
+        return valid_indices, empty, empty, empty
+    valid_bucket_ids = timestamps[valid_indices] // bucket_ms
+    split_points = np.flatnonzero(np.diff(valid_bucket_ids)) + 1
+    starts = np.concatenate((np.array([0], dtype=np.int64), split_points))
+    ends = np.concatenate((split_points, np.array([len(valid_indices)], dtype=np.int64)))
+    return valid_indices, valid_bucket_ids[starts], starts, ends
 
 
 def _compute_chunk_checksum_readonly(body_path: str, valid_path: str) -> str:
@@ -277,6 +320,8 @@ def scan_symbol(
     symbol_range: SymbolRange,
     *,
     interval_ms: int,
+    scan_timeframe: str,
+    bucket_ms: int,
     min_valid_minutes: int,
     threshold: float,
     rank_metric: str,
@@ -303,35 +348,38 @@ def scan_symbol(
             first_iso=_ts_to_iso(start_ts),
             last_iso=_ts_to_iso(end_ts),
             valid_rows=0,
-            hours_scanned=0,
+            scan_timeframe=scan_timeframe,
+            buckets_scanned=0,
             events_found=0,
         )
         return [], scanned
 
-    hour_ids = data.timestamps // HOUR_MS
-    unique_hours = np.unique(hour_ids[usable])
+    valid_indices, bucket_ids, bucket_starts, bucket_ends = _group_valid_rows_by_bucket(
+        data.timestamps,
+        usable,
+        bucket_ms,
+    )
     events: list[CrashEvent] = []
     prev_close: float | None = None
     coin = symbol_to_coin(symbol_range.symbol, verbose=False)
 
-    for hour_id in unique_hours:
-        hour_mask = usable & (hour_ids == hour_id)
-        indices = np.flatnonzero(hour_mask)
+    for bucket_id, bucket_start, bucket_end in zip(bucket_ids, bucket_starts, bucket_ends):
+        indices = valid_indices[bucket_start:bucket_end]
         if len(indices) < min_valid_minutes:
             if len(indices):
                 prev_close = float(data.values[indices[-1], 2])
             continue
-        hour_values = data.values[indices]
-        high = np.asarray(hour_values[:, 0], dtype=np.float64)
-        low = np.asarray(hour_values[:, 1], dtype=np.float64)
-        close = np.asarray(hour_values[:, 2], dtype=np.float64)
-        hour_high = float(np.max(high))
-        hour_low = float(np.min(low))
-        range_log = float(np.log(hour_low / hour_high))
+        bucket_values = data.values[indices]
+        high = np.asarray(bucket_values[:, 0], dtype=np.float64)
+        low = np.asarray(bucket_values[:, 1], dtype=np.float64)
+        close = np.asarray(bucket_values[:, 2], dtype=np.float64)
+        bucket_high = float(np.max(high))
+        bucket_low = float(np.min(low))
+        range_log = float(np.log(bucket_low / bucket_high))
         ordered_log = _worst_ordered_high_to_later_low_log(high, low)
         prev_close_low_log = None
         if prev_close is not None and np.isfinite(prev_close) and prev_close > 0.0:
-            prev_close_low_log = float(np.log(hour_low / prev_close))
+            prev_close_low_log = float(np.log(bucket_low / prev_close))
         if rank_metric == "range":
             threshold_value = range_log
         elif rank_metric == "prev-close":
@@ -339,20 +387,21 @@ def scan_symbol(
         else:
             threshold_value = ordered_log
         if threshold_value <= threshold:
-            event_ts = int(hour_id * HOUR_MS)
+            event_ts = int(bucket_id * bucket_ms)
             events.append(
                 CrashEvent(
                     exchange=symbol_range.exchange,
                     symbol=symbol_range.symbol,
                     coin=coin,
+                    timeframe=scan_timeframe,
                     timestamp=event_ts,
                     timestamp_iso=_ts_to_iso(event_ts),
                     valid_minutes=int(len(indices)),
                     range_log=range_log,
                     ordered_high_to_later_low_log=ordered_log,
                     prev_close_low_log=prev_close_low_log,
-                    hour_high=hour_high,
-                    hour_low=hour_low,
+                    bucket_high=bucket_high,
+                    bucket_low=bucket_low,
                     previous_close=prev_close,
                 )
             )
@@ -367,7 +416,8 @@ def scan_symbol(
         first_iso=_ts_to_iso(start_ts),
         last_iso=_ts_to_iso(end_ts),
         valid_rows=valid_count,
-        hours_scanned=int(len(unique_hours)),
+        scan_timeframe=scan_timeframe,
+        buckets_scanned=int(len(bucket_ids)),
         events_found=len(events),
     )
     return events, scanned
@@ -482,10 +532,17 @@ def build_suite_payload(
     post_days: int,
     top_clusters: int,
     coin_mode: str,
+    scenario_kind: str,
+    force_normal: str,
+    merge_overlaps: bool,
     all_scanned_coins: Sequence[str],
+    coin_data_ranges: Sequence[CoinDataRange] | None = None,
 ) -> dict[str, Any]:
-    selected = list(clusters[:top_clusters] if top_clusters > 0 else clusters)
-    scenarios = []
+    selected = _filter_clusters_by_scenario_kind(
+        list(clusters[:top_clusters] if top_clusters > 0 else clusters),
+        scenario_kind,
+    )
+    scenario_specs = []
     all_coins = sorted(dict.fromkeys(all_scanned_coins))
     for cluster in selected:
         event_dt = datetime.fromtimestamp(cluster.timestamp / 1000, tz=UTC)
@@ -497,16 +554,30 @@ def build_suite_payload(
             coins = []
         else:
             coins = list(cluster.affected_coins)
-        scenario: dict[str, Any] = {
-            "label": cluster.label,
-            "start_date": start_dt.strftime("%Y-%m-%d"),
-            "end_date": end_dt.strftime("%Y-%m-%d"),
-        }
-        if coins:
-            scenario["coins"] = coins
-        if cluster.exchanges:
-            scenario["exchanges"] = list(cluster.exchanges)
-        scenarios.append(scenario)
+        force_coins = list(cluster.affected_coins) if coins and not cluster.market_wide else []
+        scenario_specs.append(
+            {
+                "label": cluster.label,
+                "start_dt": start_dt,
+                "end_dt": end_dt,
+                "coins": coins,
+                "force_coins": force_coins,
+                "exchanges": list(cluster.exchanges),
+                "severity": cluster.severity,
+                "market_wide": cluster.market_wide,
+            }
+        )
+    if merge_overlaps:
+        scenario_specs = _merge_overlapping_scenario_specs(scenario_specs)
+    scenarios = []
+    for spec in scenario_specs:
+        scenarios.extend(
+            _scenario_spec_to_payload_items(
+                spec,
+                force_normal=force_normal,
+                coin_data_ranges=coin_data_ranges,
+            )
+        )
     return {
         "backtest": {
             "suite_enabled": True,
@@ -514,6 +585,164 @@ def build_suite_payload(
             "aggregate": {"default": "mean"},
         }
     }
+
+
+def _filter_clusters_by_scenario_kind(
+    clusters: Sequence[CrashCluster],
+    scenario_kind: str,
+) -> list[CrashCluster]:
+    if scenario_kind == "all":
+        return list(clusters)
+    if scenario_kind == "market-wide":
+        return [cluster for cluster in clusters if cluster.market_wide]
+    if scenario_kind == "coin-focused":
+        return [cluster for cluster in clusters if not cluster.market_wide]
+    if scenario_kind == "single-coin":
+        return [
+            cluster
+            for cluster in clusters
+            if not cluster.market_wide and cluster.affected_coin_count == 1
+        ]
+    raise ValueError(f"unknown scenario kind: {scenario_kind}")
+
+
+def _merge_overlapping_scenario_specs(scenario_specs: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    if not scenario_specs:
+        return []
+    merged: list[dict[str, Any]] = []
+    for spec in sorted(scenario_specs, key=lambda item: (item["start_dt"], item["severity"])):
+        if not merged or spec["start_dt"] > merged[-1]["end_dt"]:
+            merged.append({**spec, "labels": [spec["label"]]})
+            continue
+        current = merged[-1]
+        current["end_dt"] = max(current["end_dt"], spec["end_dt"])
+        current["coins"] = sorted(dict.fromkeys([*current["coins"], *spec["coins"]]))
+        current["force_coins"] = sorted(
+            dict.fromkeys([*current["force_coins"], *spec["force_coins"]])
+        )
+        current["exchanges"] = sorted(dict.fromkeys([*current["exchanges"], *spec["exchanges"]]))
+        current["market_wide"] = bool(current["market_wide"] or spec["market_wide"])
+        current["labels"].append(spec["label"])
+        if spec["severity"] < current["severity"]:
+            current["severity"] = spec["severity"]
+            current["label"] = spec["label"]
+    return merged
+
+
+def _scenario_spec_to_payload_items(
+    spec: dict[str, Any],
+    *,
+    force_normal: str,
+    coin_data_ranges: Sequence[CoinDataRange] | None = None,
+) -> list[dict[str, Any]]:
+    label = str(spec["label"])
+    labels = spec.get("labels") or [label]
+    if len(labels) > 1:
+        label = f"{label}_combined_{len(labels)}"
+    coins = _filter_coins_with_data(
+        spec["coins"],
+        start_dt=spec["start_dt"],
+        end_dt=spec["end_dt"],
+        exchanges=spec["exchanges"],
+        coin_data_ranges=coin_data_ranges,
+    )
+    force_coins = [coin for coin in spec["force_coins"] if coin in coins]
+    force_groups = _force_coin_groups(force_coins, force_normal=force_normal)
+    if not force_groups:
+        return [
+            _scenario_payload_item(
+                spec,
+                label=label,
+                coins=coins,
+                force_coins=[],
+                force_normal=force_normal,
+            )
+        ]
+    multiple_groups = len(force_groups) > 1
+    scenarios = []
+    for force_group in force_groups:
+        group_label = label
+        if multiple_groups:
+            suffix = "_".join(_sanitize_label_piece(coin) for coin in force_group)
+            group_label = f"{label}_force_{suffix}"
+        scenarios.append(
+            _scenario_payload_item(
+                spec,
+                label=group_label,
+                coins=coins,
+                force_coins=force_group,
+                force_normal=force_normal,
+            )
+        )
+    return scenarios
+
+
+def _scenario_payload_item(
+    spec: dict[str, Any],
+    *,
+    label: str,
+    coins: Sequence[str],
+    force_coins: Sequence[str],
+    force_normal: str,
+) -> dict[str, Any]:
+    scenario: dict[str, Any] = {
+        "label": label,
+        "start_date": spec["start_dt"].strftime("%Y-%m-%d"),
+        "end_date": spec["end_dt"].strftime("%Y-%m-%d"),
+    }
+    if coins:
+        scenario["coins"] = list(coins)
+    if spec["exchanges"]:
+        scenario["exchanges"] = list(spec["exchanges"])
+    overrides = _forced_normal_overrides(force_coins, force_normal=force_normal)
+    if overrides:
+        scenario["overrides"] = {"coin_overrides": overrides}
+    return scenario
+
+
+def _filter_coins_with_data(
+    coins: Sequence[str],
+    *,
+    start_dt: datetime,
+    end_dt: datetime,
+    exchanges: Sequence[str],
+    coin_data_ranges: Sequence[CoinDataRange] | None,
+) -> list[str]:
+    unique = sorted(dict.fromkeys(coins))
+    if coin_data_ranges is None:
+        return unique
+    start_ms = int(datetime(start_dt.year, start_dt.month, start_dt.day, tzinfo=UTC).timestamp() * 1000)
+    end_ms = int(datetime(end_dt.year, end_dt.month, end_dt.day, tzinfo=UTC).timestamp() * 1000)
+    exchange_filter = set(exchanges)
+    filtered = []
+    for coin in unique:
+        if any(
+            item.coin == coin
+            and (not exchange_filter or item.exchange in exchange_filter)
+            and item.first_ts < end_ms
+            and item.last_ts >= start_ms
+            for item in coin_data_ranges
+        ):
+            filtered.append(coin)
+    return filtered
+
+
+def _force_coin_groups(coins: Sequence[str], *, force_normal: str) -> list[list[str]]:
+    if force_normal == "none":
+        return []
+    unique = sorted(dict.fromkeys(coins))
+    return [unique[idx : idx + 2] for idx in range(0, len(unique), 2)]
+
+
+def _forced_normal_overrides(coins: Sequence[str], *, force_normal: str) -> dict[str, Any]:
+    if force_normal == "none" or not coins:
+        return {}
+    live_payload: dict[str, str] = {}
+    if force_normal in {"long", "both"}:
+        live_payload["forced_mode_long"] = "normal"
+    if force_normal in {"short", "both"}:
+        live_payload["forced_mode_short"] = "normal"
+    return {coin: {"live": dict(live_payload)} for coin in sorted(dict.fromkeys(coins))}
 
 
 def _write_csv(path: Path, rows: Sequence[dict[str, Any]], fieldnames: Sequence[str]) -> None:
@@ -525,6 +754,78 @@ def _write_csv(path: Path, rows: Sequence[dict[str, Any]], fieldnames: Sequence[
             writer.writerow(row)
 
 
+def _parse_csv_list(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _parse_csv_bool(value: str | None) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes"}
+
+
+def load_clusters_csv(path: Path) -> list[CrashCluster]:
+    with path.open("r", newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    clusters = []
+    for row in rows:
+        coins = _parse_csv_list(row.get("affected_coins"))
+        exchanges = _parse_csv_list(row.get("exchanges"))
+        clusters.append(
+            CrashCluster(
+                label=str(row["label"]),
+                timestamp=int(row["timestamp"]),
+                timestamp_iso=str(row["timestamp_iso"]),
+                start_ts=int(row["start_ts"]),
+                end_ts=int(row["end_ts"]),
+                start_iso=str(row["start_iso"]),
+                end_iso=str(row["end_iso"]),
+                severity=float(row["severity"]),
+                event_count=int(row["event_count"]),
+                affected_coin_count=int(row.get("affected_coin_count") or len(coins)),
+                affected_coins=coins,
+                exchanges=exchanges,
+                market_wide=_parse_csv_bool(row.get("market_wide")),
+            )
+        )
+    return sorted(clusters, key=lambda item: (item.severity, item.timestamp))
+
+
+def load_scanned_ranges_csv(path: Path) -> list[ScannedRange]:
+    with path.open("r", newline="", encoding="utf-8") as fh:
+        rows = list(csv.DictReader(fh))
+    scanned = []
+    for row in rows:
+        scanned.append(
+            ScannedRange(
+                exchange=str(row["exchange"]),
+                timeframe=str(row["timeframe"]),
+                symbol=str(row["symbol"]),
+                first_ts=int(row["first_ts"]),
+                last_ts=int(row["last_ts"]),
+                first_iso=str(row["first_iso"]),
+                last_iso=str(row["last_iso"]),
+                valid_rows=int(row["valid_rows"]),
+                scan_timeframe=str(row.get("scan_timeframe") or "1h"),
+                buckets_scanned=int(row.get("buckets_scanned") or row.get("hours_scanned") or 0),
+                events_found=int(row["events_found"]),
+            )
+        )
+    return scanned
+
+
+def coin_data_ranges_from_scanned(scanned: Sequence[ScannedRange]) -> list[CoinDataRange]:
+    return [
+        CoinDataRange(
+            exchange=item.exchange,
+            coin=symbol_to_coin(item.symbol, verbose=False),
+            first_ts=item.first_ts,
+            last_ts=item.last_ts,
+        )
+        for item in scanned
+    ]
+
+
 def write_outputs(
     output_dir: Path,
     *,
@@ -533,6 +834,7 @@ def write_outputs(
     scanned: Sequence[ScannedRange],
     scan_errors: Sequence[ScanError],
     suite_payload: dict[str, Any],
+    extra_suite_payloads: dict[str, dict[str, Any]] | None = None,
 ) -> dict[str, str]:
     output_dir.mkdir(parents=True, exist_ok=True)
     event_rows = [asdict(event) for event in events]
@@ -574,36 +876,206 @@ def write_outputs(
     _write_csv(scanned_path, scanned_rows, list(ScannedRange.__dataclass_fields__.keys()))
     _write_csv(scan_errors_path, scan_error_rows, list(ScanError.__dataclass_fields__.keys()))
     suite_path.write_text(json.dumps(suite_payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
-    return {
+    output_paths = {
         "events_csv": str(events_path),
         "clusters_csv": str(clusters_path),
         "scanned_ranges_csv": str(scanned_path),
         "scan_errors_csv": str(scan_errors_path),
         "suite_hjson": str(suite_path),
     }
+    for suffix, payload in (extra_suite_payloads or {}).items():
+        extra_path = output_dir / f"crash_scenarios_{suffix}.hjson"
+        extra_path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+        output_paths[f"suite_{suffix}_hjson"] = str(extra_path)
+    return output_paths
+
+
+def write_cluster_suite_outputs(
+    output_dir: Path,
+    *,
+    clusters_csv: Path,
+    clusters: Sequence[CrashCluster],
+    suite_payload: dict[str, Any],
+    extra_suite_payloads: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, str]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cluster_rows = [
+        {
+            **asdict(cluster),
+            "affected_coins": ",".join(cluster.affected_coins),
+            "exchanges": ",".join(cluster.exchanges),
+        }
+        for cluster in clusters
+    ]
+    clusters_path = output_dir / "crash_clusters.csv"
+    suite_path = output_dir / "crash_scenarios.hjson"
+    _write_csv(
+        clusters_path,
+        cluster_rows,
+        [
+            "label",
+            "timestamp",
+            "timestamp_iso",
+            "start_ts",
+            "end_ts",
+            "start_iso",
+            "end_iso",
+            "severity",
+            "event_count",
+            "affected_coin_count",
+            "affected_coins",
+            "exchanges",
+            "market_wide",
+        ],
+    )
+    suite_path.write_text(json.dumps(suite_payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+    output_paths = {
+        "clusters_csv": str(clusters_path),
+        "suite_hjson": str(suite_path),
+    }
+    for suffix, payload in (extra_suite_payloads or {}).items():
+        extra_path = output_dir / f"crash_scenarios_{suffix}.hjson"
+        extra_path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+        output_paths[f"suite_{suffix}_hjson"] = str(extra_path)
+
+    source_dir = clusters_csv.parent
+    for name, key in [
+        ("crash_events.csv", "events_csv"),
+        ("scanned_ranges.csv", "scanned_ranges_csv"),
+        ("scan_errors.csv", "scan_errors_csv"),
+    ]:
+        source = source_dir / name
+        if not source.exists():
+            continue
+        target = output_dir / name
+        if source.resolve() != target.resolve():
+            shutil.copy2(source, target)
+        output_paths[key] = str(target)
+    return output_paths
+
+
+def _build_suite_payloads_from_clusters(
+    clusters: Sequence[CrashCluster],
+    args: argparse.Namespace,
+    all_scanned_coins: Sequence[str] | None = None,
+    coin_data_ranges: Sequence[CoinDataRange] | None = None,
+) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    scanned_coins = sorted(
+        dict.fromkeys(
+            all_scanned_coins
+            if all_scanned_coins is not None
+            else [coin for cluster in clusters for coin in cluster.affected_coins]
+        )
+    )
+    suite_payload = build_suite_payload(
+        clusters,
+        pre_days=args.pre_days,
+        post_days=args.post_days,
+        top_clusters=0,
+        coin_mode=args.scenario_coin_mode,
+        scenario_kind=args.scenario_kind,
+        force_normal=args.scenario_force_normal,
+        merge_overlaps=args.scenario_merge_overlaps,
+        all_scanned_coins=scanned_coins,
+        coin_data_ranges=coin_data_ranges,
+    )
+    extra_suite_payloads = {}
+    if args.write_filtered_suites:
+        for kind, suffix in [
+            ("market-wide", "market_wide"),
+            ("coin-focused", "coin_focused"),
+            ("single-coin", "single_coin"),
+        ]:
+            extra_suite_payloads[suffix] = build_suite_payload(
+                clusters,
+                pre_days=args.pre_days,
+                post_days=args.post_days,
+                top_clusters=0,
+                coin_mode=args.scenario_coin_mode,
+                scenario_kind=kind,
+                force_normal=args.scenario_force_normal,
+                merge_overlaps=args.scenario_merge_overlaps,
+                all_scanned_coins=scanned_coins,
+                coin_data_ranges=coin_data_ranges,
+            )
+    return suite_payload, extra_suite_payloads
+
+
+def run_from_clusters_csv(args: argparse.Namespace) -> dict[str, Any]:
+    clusters_csv = Path(args.clusters_csv).expanduser()
+    clusters = load_clusters_csv(clusters_csv)
+    selected_clusters = list(clusters[: args.top_clusters] if args.top_clusters > 0 else clusters)
+    scanned_ranges_path = clusters_csv.parent / "scanned_ranges.csv"
+    scanned_ranges = load_scanned_ranges_csv(scanned_ranges_path) if scanned_ranges_path.exists() else []
+    suite_payload, extra_suite_payloads = _build_suite_payloads_from_clusters(
+        selected_clusters,
+        args,
+        all_scanned_coins=(
+            sorted({symbol_to_coin(item.symbol, verbose=False) for item in scanned_ranges})
+            if scanned_ranges
+            else None
+        ),
+        coin_data_ranges=coin_data_ranges_from_scanned(scanned_ranges) if scanned_ranges else None,
+    )
+    output_paths = None
+    if args.output_dir:
+        output_paths = write_cluster_suite_outputs(
+            Path(args.output_dir).expanduser(),
+            clusters_csv=clusters_csv,
+            clusters=selected_clusters,
+            suite_payload=suite_payload,
+            extra_suite_payloads=extra_suite_payloads,
+        )
+        logging.info("[crash-finder] wrote suite outputs from %s to %s", clusters_csv, args.output_dir)
+    return {
+        "clusters_csv": str(clusters_csv),
+        "clusters_loaded": len(clusters),
+        "clusters_selected": len(selected_clusters),
+        "scanned_ranges_loaded": len(scanned_ranges),
+        "clusters": [asdict(item) for item in selected_clusters],
+        "suite": suite_payload,
+        "output_paths": output_paths,
+    }
 
 
 def run_scan(args: argparse.Namespace) -> dict[str, Any]:
+    if args.clusters_csv:
+        return run_from_clusters_csv(args)
     root = Path(args.root).expanduser()
-    interval_ms = timeframe_to_interval_ms(args.timeframe)
+    source_timeframe = str(args.source_timeframe).strip().lower()
+    scan_timeframe = str(args.timeframe).strip().lower()
+    interval_ms = timeframe_to_interval_ms(source_timeframe)
     if interval_ms != 60_000:
-        raise ValueError("first iteration supports scanning 1m cache data only")
+        raise ValueError("crash discovery currently requires 1m source cache data")
+    bucket_ms = _duration_timeframe_to_ms(scan_timeframe)
+    if bucket_ms < interval_ms or bucket_ms % interval_ms != 0:
+        raise ValueError(
+            f"scan timeframe {scan_timeframe!r} must be an integer multiple of source timeframe "
+            f"{source_timeframe!r}"
+        )
+    if args.min_valid_minutes <= 0:
+        raise ValueError("min-valid-minutes must be positive")
+    exchanges = sorted(
+        dict.fromkeys(str(exchange).strip().lower() for exchange in (args.exchange or []))
+    )
     symbols = args.symbol or None
     symbol_ranges = load_symbol_ranges(
         root,
-        exchange=args.exchange,
-        timeframe=args.timeframe,
+        exchanges=exchanges or None,
+        timeframe=source_timeframe,
         symbols=symbols,
     )
     if not symbol_ranges:
         raise ValueError("no matching cached OHLCV symbols found")
 
     logging.info(
-        "[crash-finder] scanning %d cached symbol range(s) root=%s timeframe=%s exchange=%s",
+        "[crash-finder] scanning %d cached symbol range(s) root=%s source_timeframe=%s "
+        "scan_timeframe=%s exchange=%s",
         len(symbol_ranges),
         root,
-        args.timeframe,
-        args.exchange or "all",
+        source_timeframe,
+        scan_timeframe,
+        ",".join(exchanges) if exchanges else "all",
     )
     catalog = OhlcvCatalog(_db_path(root))
     all_events: list[CrashEvent] = []
@@ -623,6 +1095,8 @@ def run_scan(args: argparse.Namespace) -> dict[str, Any]:
                 catalog,
                 symbol_range,
                 interval_ms=interval_ms,
+                scan_timeframe=scan_timeframe,
+                bucket_ms=bucket_ms,
                 min_valid_minutes=args.min_valid_minutes,
                 threshold=args.threshold,
                 rank_metric=args.rank_metric,
@@ -654,11 +1128,12 @@ def run_scan(args: argparse.Namespace) -> dict[str, Any]:
             scan_errors.append(scan_error)
             continue
         logging.info(
-            "[crash-finder] scanned %s %s valid_rows=%d hours=%d events=%d",
+            "[crash-finder] scanned %s %s valid_rows=%d timeframe=%s buckets=%d events=%d",
             scanned.exchange,
             scanned.symbol,
             scanned.valid_rows,
-            scanned.hours_scanned,
+            scanned.scan_timeframe,
+            scanned.buckets_scanned,
             scanned.events_found,
         )
         all_events.extend(events)
@@ -679,13 +1154,11 @@ def run_scan(args: argparse.Namespace) -> dict[str, Any]:
     if args.top_clusters > 0:
         clusters = clusters[: args.top_clusters]
     scanned_coins = sorted({symbol_to_coin(item.symbol, verbose=False) for item in scanned_ranges})
-    suite_payload = build_suite_payload(
+    suite_payload, extra_suite_payloads = _build_suite_payloads_from_clusters(
         clusters,
-        pre_days=args.pre_days,
-        post_days=args.post_days,
-        top_clusters=0,
-        coin_mode=args.scenario_coin_mode,
+        args,
         all_scanned_coins=scanned_coins,
+        coin_data_ranges=coin_data_ranges_from_scanned(scanned_ranges),
     )
 
     output_paths = None
@@ -697,12 +1170,15 @@ def run_scan(args: argparse.Namespace) -> dict[str, Any]:
             scanned=scanned_ranges,
             scan_errors=scan_errors,
             suite_payload=suite_payload,
+            extra_suite_payloads=extra_suite_payloads,
         )
         logging.info("[crash-finder] wrote outputs to %s", args.output_dir)
 
     return {
         "root": str(root),
-        "timeframe": args.timeframe,
+        "source_timeframe": source_timeframe,
+        "timeframe": scan_timeframe,
+        "exchanges": exchanges,
         "rank_metric": args.rank_metric,
         "threshold": args.threshold,
         "symbols_attempted": len(symbol_ranges),
@@ -726,18 +1202,40 @@ def build_parser() -> argparse.ArgumentParser:
         description="Scan local v2 OHLCV cache data for the worst historical crash windows.",
     )
     parser.add_argument("--root", default=str(DEFAULT_ROOT), help="v2 OHLCV cache root.")
-    parser.add_argument("--exchange", help="Restrict scan to one exchange.")
+    parser.add_argument(
+        "--clusters-csv",
+        help="Build scenario suites from an existing crash_clusters.csv instead of scanning OHLCV.",
+    )
+    parser.add_argument(
+        "--exchange",
+        action="append",
+        help="Restrict discovery to an exchange; repeat to scan multiple exchanges.",
+    )
     parser.add_argument("--symbol", action="append", help="Restrict scan to one symbol; repeatable.")
-    parser.add_argument("--timeframe", default="1m", help="Cache timeframe to scan (default: 1m).")
+    parser.add_argument(
+        "--source-timeframe",
+        default="1m",
+        help="Cached source candle timeframe (default and currently required: 1m).",
+    )
+    parser.add_argument(
+        "--timeframe",
+        default="1h",
+        help="Crash discovery candle timeframe built from source candles (default: 1h).",
+    )
     parser.add_argument(
         "--threshold",
         type=float,
         default=-0.10,
-        help="Only keep hourly crash candidates at or below this log-return severity.",
+        help="Only keep crash candidates at or below this log-return severity.",
     )
     parser.add_argument("--top-per-coin", type=int, default=10)
     parser.add_argument("--top-clusters", type=int, default=30)
-    parser.add_argument("--min-valid-minutes", type=int, default=2)
+    parser.add_argument(
+        "--min-valid-minutes",
+        type=int,
+        default=2,
+        help="Minimum valid 1m source rows required in a discovery candle.",
+    )
     parser.add_argument("--dedupe-coin-window-hours", type=float, default=6.0)
     parser.add_argument("--cluster-window-hours", type=float, default=6.0)
     parser.add_argument("--min-market-wide-coins", type=int, default=3)
@@ -754,6 +1252,31 @@ def build_parser() -> argparse.ArgumentParser:
         choices=("affected", "all-scanned", "none"),
         default="affected",
         help="Which coins to place in generated backtest scenarios.",
+    )
+    parser.add_argument(
+        "--scenario-kind",
+        choices=("all", "market-wide", "coin-focused", "single-coin"),
+        default="all",
+        help="Which crash clusters to include in generated backtest scenarios.",
+    )
+    parser.add_argument(
+        "--scenario-force-normal",
+        choices=("none", "long", "short", "both"),
+        default="none",
+        help=(
+            "Emit forced_mode_* = normal overrides for idiosyncratic non-market-wide "
+            "crash coins, with at most two forced coins per scenario."
+        ),
+    )
+    parser.add_argument(
+        "--scenario-merge-overlaps",
+        action="store_true",
+        help="Merge scenarios whose pre/post crash date windows overlap.",
+    )
+    parser.add_argument(
+        "--write-filtered-suites",
+        action="store_true",
+        help="Also write market-wide, coin-focused, and single-coin suite files.",
     )
     parser.add_argument("--output-dir", help="Write CSV outputs and crash_scenarios.hjson here.")
     parser.add_argument(
@@ -776,17 +1299,25 @@ def _configure_logging(level: str) -> None:
     logging.basicConfig(
         level=getattr(logging, level.upper()),
         format="%(asctime)s %(levelname)s %(message)s",
+        force=True,
     )
 
 
 def _print_text_summary(payload: dict[str, Any]) -> None:
-    print(
-        "Scanned "
-        f"{payload['symbols_scanned']}/{payload['symbols_attempted']} symbol range(s); "
-        f"skipped {payload['symbols_failed']}; "
-        f"selected {payload['events_selected']} event(s), "
-        f"{payload['clusters_selected']} cluster(s)."
-    )
+    if "symbols_scanned" in payload:
+        print(
+            "Scanned "
+            f"{payload['symbols_scanned']}/{payload['symbols_attempted']} symbol range(s); "
+            f"skipped {payload['symbols_failed']}; "
+            f"selected {payload['events_selected']} event(s), "
+            f"{payload['clusters_selected']} cluster(s)."
+        )
+    else:
+        print(
+            "Loaded "
+            f"{payload['clusters_selected']}/{payload['clusters_loaded']} cluster(s) "
+            f"from {payload['clusters_csv']}."
+        )
     if payload.get("output_paths"):
         print("Outputs:")
         for key, value in payload["output_paths"].items():

--- a/src/tools/crash_finder.py
+++ b/src/tools/crash_finder.py
@@ -617,11 +617,13 @@ def _merge_overlapping_scenario_specs(scenario_specs: Sequence[dict[str, Any]]) 
         current = merged[-1]
         current["end_dt"] = max(current["end_dt"], spec["end_dt"])
         current["coins"] = sorted(dict.fromkeys([*current["coins"], *spec["coins"]]))
-        current["force_coins"] = sorted(
-            dict.fromkeys([*current["force_coins"], *spec["force_coins"]])
-        )
         current["exchanges"] = sorted(dict.fromkeys([*current["exchanges"], *spec["exchanges"]]))
         current["market_wide"] = bool(current["market_wide"] or spec["market_wide"])
+        current["force_coins"] = (
+            []
+            if current["market_wide"]
+            else sorted(dict.fromkeys([*current["force_coins"], *spec["force_coins"]]))
+        )
         current["labels"].append(spec["label"])
         if spec["severity"] < current["severity"]:
             current["severity"] = spec["severity"]
@@ -646,7 +648,16 @@ def _scenario_spec_to_payload_items(
         exchanges=spec["exchanges"],
         coin_data_ranges=coin_data_ranges,
     )
-    force_coins = [coin for coin in spec["force_coins"] if coin in coins]
+    if spec["coins"] and not coins:
+        logging.warning(
+            "[crash-finder] omitted targeted scenario %s because none of its coins overlap the "
+            "scenario data window",
+            label,
+        )
+        return []
+    force_coins = (
+        [] if spec["market_wide"] else [coin for coin in spec["force_coins"] if coin in coins]
+    )
     force_groups = _force_coin_groups(force_coins, force_normal=force_normal)
     if not force_groups:
         return [
@@ -719,7 +730,7 @@ def _filter_coins_with_data(
         if any(
             item.coin == coin
             and (not exchange_filter or item.exchange in exchange_filter)
-            and item.first_ts < end_ms
+            and item.first_ts <= end_ms
             and item.last_ts >= start_ms
             for item in coin_data_ranges
         ):

--- a/tests/test_crash_finder_tool.py
+++ b/tests/test_crash_finder_tool.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import logging
+from datetime import UTC, datetime
 
 import numpy as np
 
@@ -17,6 +19,18 @@ def _write_hour(store: OhlcvStore, exchange: str, symbol: str, hour_ts: int, low
         close = max(float(low), 1.0)
         values.append([high, float(low), close, 1.0])
     store.write_rows(exchange, "1m", symbol, timestamps, np.asarray(values, dtype=np.float32))
+
+
+def test_crash_finder_defaults_to_hourly_discovery_from_minute_candles():
+    args = crash_finder.build_parser().parse_args(
+        ["--exchange", "binance", "--exchange", "bybit"]
+    )
+
+    assert args.source_timeframe == "1m"
+    assert args.timeframe == "1h"
+    assert args.exchange == ["binance", "bybit"]
+    assert crash_finder._duration_timeframe_to_ms("4h") == 4 * HOUR_MS
+    assert crash_finder._duration_timeframe_to_ms("12h") == 12 * HOUR_MS
 
 
 def test_crash_finder_identifies_clusters_and_writes_outputs(tmp_path, capsys):
@@ -66,6 +80,8 @@ def test_crash_finder_identifies_clusters_and_writes_outputs(tmp_path, capsys):
         assert item["first_iso"]
         assert item["last_iso"]
         assert item["valid_rows"] > 0
+        assert item["scan_timeframe"] == "1h"
+        assert item["buckets_scanned"] > 0
 
     assert (out_dir / "crash_events.csv").exists()
     assert (out_dir / "crash_clusters.csv").exists()
@@ -105,11 +121,99 @@ def test_ordered_metric_does_not_treat_low_before_high_as_crash(tmp_path):
                 "2",
                 "--rank-metric",
                 "ordered",
+                "--timeframe",
+                "4h",
             ]
         )
     )
 
     assert payload["events_selected"] == 0
+
+
+def test_larger_scan_timeframe_combines_source_minutes_across_hour_boundary(tmp_path):
+    root = tmp_path / "ohlcvs"
+    catalog = OhlcvCatalog(root / "catalog.sqlite")
+    store = OhlcvStore(root, catalog)
+    four_hour_start = month_start_ts(2025, 5) + 8 * HOUR_MS
+    timestamps = np.asarray(
+        [four_hour_start + 59 * 60_000, four_hour_start + 60 * 60_000],
+        dtype=np.int64,
+    )
+    values = np.asarray(
+        [
+            [100.0, 100.0, 100.0, 1.0],
+            [50.0, 50.0, 50.0, 1.0],
+        ],
+        dtype=np.float32,
+    )
+    store.write_rows("binance", "1m", "CROSS/USDT:USDT", timestamps, values)
+
+    one_hour = crash_finder.run_scan(
+        crash_finder.build_parser().parse_args(
+            [
+                "--root",
+                str(root),
+                "--timeframe",
+                "1h",
+                "--threshold",
+                "-0.50",
+                "--min-valid-minutes",
+                "1",
+            ]
+        )
+    )
+    four_hours = crash_finder.run_scan(
+        crash_finder.build_parser().parse_args(
+            [
+                "--root",
+                str(root),
+                "--timeframe",
+                "4h",
+                "--threshold",
+                "-0.50",
+                "--min-valid-minutes",
+                "1",
+            ]
+        )
+    )
+
+    assert one_hour["events_selected"] == 0
+    assert one_hour["scanned_ranges"][0]["buckets_scanned"] == 2
+    assert four_hours["events_selected"] == 1
+    assert four_hours["scanned_ranges"][0]["buckets_scanned"] == 1
+    event = four_hours["events"][0]
+    assert event["timeframe"] == "4h"
+    assert event["timestamp"] == four_hour_start
+    assert event["valid_minutes"] == 2
+    assert event["bucket_high"] == 100.0
+    assert event["bucket_low"] == 50.0
+
+
+def test_full_scan_all_scanned_coin_mode_keeps_non_crashing_scanned_coins(tmp_path):
+    root = tmp_path / "ohlcvs"
+    catalog = OhlcvCatalog(root / "catalog.sqlite")
+    store = OhlcvStore(root, catalog)
+    base = month_start_ts(2025, 6) + 4 * HOUR_MS
+    _write_hour(store, "binance", "BTC/USDT:USDT", base, [99, 97, 90, 80, 70])
+    _write_hour(store, "binance", "XRP/USDT:USDT", base, [99, 98, 97, 96, 95])
+
+    payload = crash_finder.run_scan(
+        crash_finder.build_parser().parse_args(
+            [
+                "--root",
+                str(root),
+                "--threshold",
+                "-0.20",
+                "--min-valid-minutes",
+                "2",
+                "--scenario-coin-mode",
+                "all-scanned",
+            ]
+        )
+    )
+
+    scenario = payload["suite"]["backtest"]["scenarios"][0]
+    assert scenario["coins"] == ["BTC", "XRP"]
 
 
 def test_crash_finder_skips_symbol_with_missing_checksum(tmp_path):
@@ -149,6 +253,311 @@ def test_crash_finder_skips_symbol_with_missing_checksum(tmp_path):
     assert "checksum missing" in payload["scan_errors"][0]["message"]
     assert payload["events_selected"] == 1
     assert (out_dir / "scan_errors.csv").exists()
+
+
+def test_suite_builder_merges_overlaps_and_forces_normal():
+    market_ts = int(datetime(2025, 10, 10, 21, tzinfo=UTC).timestamp() * 1000)
+    coin_ts = int(datetime(2025, 9, 29, 17, tzinfo=UTC).timestamp() * 1000)
+    clusters = [
+        crash_finder.CrashCluster(
+            label="crash_2025_10_10_21_market_wide",
+            timestamp=market_ts,
+            timestamp_iso="2025-10-10T21:00:00Z",
+            start_ts=market_ts,
+            end_ts=market_ts,
+            start_iso="2025-10-10T21:00:00Z",
+            end_iso="2025-10-10T21:00:00Z",
+            severity=-1.0,
+            event_count=4,
+            affected_coin_count=3,
+            affected_coins=["BTC", "M", "OM"],
+            exchanges=["binance", "bybit"],
+            market_wide=True,
+        ),
+        crash_finder.CrashCluster(
+            label="crash_2025_09_29_17_dexe_m",
+            timestamp=coin_ts,
+            timestamp_iso="2025-09-29T17:00:00Z",
+            start_ts=coin_ts,
+            end_ts=coin_ts,
+            start_iso="2025-09-29T17:00:00Z",
+            end_iso="2025-09-29T17:00:00Z",
+            severity=-0.5,
+            event_count=2,
+            affected_coin_count=2,
+            affected_coins=["DEXE", "M"],
+            exchanges=["binance"],
+            market_wide=False,
+        ),
+    ]
+
+    payload = crash_finder.build_suite_payload(
+        clusters,
+        pre_days=14,
+        post_days=60,
+        top_clusters=0,
+        coin_mode="affected",
+        scenario_kind="all",
+        force_normal="long",
+        merge_overlaps=True,
+        all_scanned_coins=[],
+    )
+
+    scenarios = payload["backtest"]["scenarios"]
+    assert len(scenarios) == 1
+    scenario = scenarios[0]
+    assert scenario["label"] == "crash_2025_10_10_21_market_wide_combined_2"
+    assert scenario["start_date"] == "2025-09-15"
+    assert scenario["end_date"] == "2025-12-09"
+    assert scenario["coins"] == ["BTC", "DEXE", "M", "OM"]
+    assert sorted(scenario["overrides"]["coin_overrides"]) == ["DEXE", "M"]
+    assert scenario["overrides"]["coin_overrides"]["M"] == {
+        "live": {"forced_mode_long": "normal"}
+    }
+
+
+def test_suite_builder_can_filter_market_wide_clusters():
+    base = month_start_ts(2025, 4)
+    clusters = [
+        crash_finder.CrashCluster(
+            label="crash_market",
+            timestamp=base,
+            timestamp_iso="2025-04-01T00:00:00Z",
+            start_ts=base,
+            end_ts=base,
+            start_iso="2025-04-01T00:00:00Z",
+            end_iso="2025-04-01T00:00:00Z",
+            severity=-0.4,
+            event_count=4,
+            affected_coin_count=4,
+            affected_coins=["BTC", "ETH", "SOL", "XRP"],
+            exchanges=["binance"],
+            market_wide=True,
+        ),
+        crash_finder.CrashCluster(
+            label="crash_om",
+            timestamp=base + HOUR_MS,
+            timestamp_iso="2025-04-01T01:00:00Z",
+            start_ts=base + HOUR_MS,
+            end_ts=base + HOUR_MS,
+            start_iso="2025-04-01T01:00:00Z",
+            end_iso="2025-04-01T01:00:00Z",
+            severity=-0.9,
+            event_count=1,
+            affected_coin_count=1,
+            affected_coins=["OM"],
+            exchanges=["binance"],
+            market_wide=False,
+        ),
+    ]
+
+    payload = crash_finder.build_suite_payload(
+        clusters,
+        pre_days=14,
+        post_days=60,
+        top_clusters=0,
+        coin_mode="affected",
+        scenario_kind="market-wide",
+        force_normal="none",
+        merge_overlaps=False,
+        all_scanned_coins=[],
+    )
+
+    scenarios = payload["backtest"]["scenarios"]
+    assert [scenario["label"] for scenario in scenarios] == ["crash_market"]
+
+
+def test_suite_builder_splits_merged_idiosyncratic_force_targets_into_pairs():
+    base_ts = int(datetime(2025, 4, 13, 18, tzinfo=UTC).timestamp() * 1000)
+    clusters = []
+    for idx, coin in enumerate(["OM", "DEXE", "M"]):
+        ts = base_ts + idx * HOUR_MS
+        clusters.append(
+            crash_finder.CrashCluster(
+                label=f"crash_2025_04_13_{18 + idx:02d}_{coin.lower()}",
+                timestamp=ts,
+                timestamp_iso="2025-04-13T18:00:00Z",
+                start_ts=ts,
+                end_ts=ts,
+                start_iso="2025-04-13T18:00:00Z",
+                end_iso="2025-04-13T18:00:00Z",
+                severity=-1.0 + idx * 0.1,
+                event_count=1,
+                affected_coin_count=1,
+                affected_coins=[coin],
+                exchanges=["binance"],
+                market_wide=False,
+            )
+        )
+
+    payload = crash_finder.build_suite_payload(
+        clusters,
+        pre_days=14,
+        post_days=60,
+        top_clusters=0,
+        coin_mode="affected",
+        scenario_kind="coin-focused",
+        force_normal="both",
+        merge_overlaps=True,
+        all_scanned_coins=[],
+    )
+
+    scenarios = payload["backtest"]["scenarios"]
+    assert len(scenarios) == 2
+    forced_groups = [
+        sorted(scenario["overrides"]["coin_overrides"])
+        for scenario in scenarios
+        if scenario.get("overrides")
+    ]
+    assert forced_groups == [["DEXE", "M"], ["OM"]]
+    assert all(len(group) <= 2 for group in forced_groups)
+    assert all(scenario["coins"] == ["DEXE", "M", "OM"] for scenario in scenarios)
+
+
+def test_suite_builder_filters_coins_without_data_in_scenario_window():
+    event_ts = int(datetime(2026, 6, 25, tzinfo=UTC).timestamp() * 1000)
+    cluster = crash_finder.CrashCluster(
+        label="crash_2026_06_25_00_m_legacy",
+        timestamp=event_ts,
+        timestamp_iso="2026-06-25T00:00:00Z",
+        start_ts=event_ts,
+        end_ts=event_ts,
+        start_iso="2026-06-25T00:00:00Z",
+        end_iso="2026-06-25T00:00:00Z",
+        severity=-1.0,
+        event_count=2,
+        affected_coin_count=2,
+        affected_coins=["LEGACY", "M"],
+        exchanges=["binance"],
+        market_wide=False,
+    )
+
+    payload = crash_finder.build_suite_payload(
+        [cluster],
+        pre_days=14,
+        post_days=60,
+        top_clusters=0,
+        coin_mode="affected",
+        scenario_kind="coin-focused",
+        force_normal="both",
+        merge_overlaps=False,
+        all_scanned_coins=[],
+        coin_data_ranges=[
+            crash_finder.CoinDataRange(
+                exchange="binance",
+                coin="LEGACY",
+                first_ts=int(datetime(2025, 1, 1, tzinfo=UTC).timestamp() * 1000),
+                last_ts=int(datetime(2025, 2, 1, tzinfo=UTC).timestamp() * 1000),
+            ),
+            crash_finder.CoinDataRange(
+                exchange="binance",
+                coin="M",
+                first_ts=int(datetime(2026, 6, 1, tzinfo=UTC).timestamp() * 1000),
+                last_ts=int(datetime(2026, 6, 29, tzinfo=UTC).timestamp() * 1000),
+            ),
+        ],
+    )
+
+    scenario = payload["backtest"]["scenarios"][0]
+    assert scenario["coins"] == ["M"]
+    assert sorted(scenario["overrides"]["coin_overrides"]) == ["M"]
+
+
+def test_clusters_csv_fast_path_copies_source_scan_artifacts(tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    clusters_csv = source_dir / "crash_clusters.csv"
+    clusters_csv.write_text(
+        "\n".join(
+            [
+                "label,timestamp,timestamp_iso,start_ts,end_ts,start_iso,end_iso,severity,event_count,affected_coin_count,affected_coins,exchanges,market_wide",
+                "crash_2025_04_13_18_om,1744567200000,2025-04-13T18:00:00Z,1744567200000,1744567200000,2025-04-13T18:00:00Z,2025-04-13T18:00:00Z,-1.0,1,1,OM,binance,False",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    for name in ["crash_events.csv", "scan_errors.csv"]:
+        (source_dir / name).write_text(f"source {name}\n", encoding="utf-8")
+    (source_dir / "scanned_ranges.csv").write_text(
+        "\n".join(
+            [
+                "exchange,timeframe,symbol,first_ts,last_ts,first_iso,last_iso,valid_rows,hours_scanned,events_found",
+                "binance,1m,OM/USDT:USDT,1740000000000,1750000000000,2025-02-19T21:20:00Z,2025-06-15T15:06:40Z,1,1,1",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    out_dir = tmp_path / "out"
+    payload = crash_finder.run_scan(
+        crash_finder.build_parser().parse_args(
+            [
+                "--clusters-csv",
+                str(clusters_csv),
+                "--pre-days",
+                "14",
+                "--post-days",
+                "60",
+                "--scenario-force-normal",
+                "both",
+                "--output-dir",
+                str(out_dir),
+            ]
+        )
+    )
+
+    assert payload["clusters_loaded"] == 1
+    assert (out_dir / "crash_clusters.csv").exists()
+    assert (out_dir / "crash_scenarios.hjson").exists()
+    for name in ["crash_events.csv", "scan_errors.csv"]:
+        assert (out_dir / name).read_text(encoding="utf-8") == f"source {name}\n"
+    assert (out_dir / "scanned_ranges.csv").read_text(encoding="utf-8").startswith(
+        "exchange,timeframe,symbol"
+    )
+    suite_payload = json.loads((out_dir / "crash_scenarios.hjson").read_text(encoding="utf-8"))
+    scenario = suite_payload["backtest"]["scenarios"][0]
+    assert scenario["start_date"] == "2025-03-30"
+    assert scenario["end_date"] == "2025-06-12"
+    assert scenario["overrides"]["coin_overrides"]["OM"]["live"] == {
+        "forced_mode_long": "normal",
+        "forced_mode_short": "normal",
+    }
+
+
+def test_clusters_csv_fast_path_does_not_create_empty_scan_artifacts(tmp_path):
+    clusters_csv = tmp_path / "crash_clusters.csv"
+    clusters_csv.write_text(
+        "\n".join(
+            [
+                "label,timestamp,timestamp_iso,start_ts,end_ts,start_iso,end_iso,severity,event_count,affected_coin_count,affected_coins,exchanges,market_wide",
+                "crash_2025_04_13_18_om,1744567200000,2025-04-13T18:00:00Z,1744567200000,1744567200000,2025-04-13T18:00:00Z,2025-04-13T18:00:00Z,-1.0,1,1,OM,binance,False",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    out_dir = tmp_path / "out"
+    payload = crash_finder.run_scan(
+        crash_finder.build_parser().parse_args(
+            ["--clusters-csv", str(clusters_csv), "--output-dir", str(out_dir)]
+        )
+    )
+
+    assert "events_csv" not in (payload["output_paths"] or {})
+    assert not (out_dir / "crash_events.csv").exists()
+    assert not (out_dir / "scanned_ranges.csv").exists()
+    assert not (out_dir / "scan_errors.csv").exists()
+
+
+def test_logging_configuration_honors_requested_level_with_existing_handlers():
+    logging.basicConfig(level=logging.INFO, force=True)
+
+    crash_finder._configure_logging("warning")
+
+    assert logging.getLogger().level == logging.WARNING
 
 
 HOUR_MS = 60 * 60_000

--- a/tests/test_crash_finder_tool.py
+++ b/tests/test_crash_finder_tool.py
@@ -255,7 +255,7 @@ def test_crash_finder_skips_symbol_with_missing_checksum(tmp_path):
     assert (out_dir / "scan_errors.csv").exists()
 
 
-def test_suite_builder_merges_overlaps_and_forces_normal():
+def test_suite_builder_merged_market_wide_scenario_suppresses_forced_normal():
     market_ts = int(datetime(2025, 10, 10, 21, tzinfo=UTC).timestamp() * 1000)
     coin_ts = int(datetime(2025, 9, 29, 17, tzinfo=UTC).timestamp() * 1000)
     clusters = [
@@ -310,10 +310,7 @@ def test_suite_builder_merges_overlaps_and_forces_normal():
     assert scenario["start_date"] == "2025-09-15"
     assert scenario["end_date"] == "2025-12-09"
     assert scenario["coins"] == ["BTC", "DEXE", "M", "OM"]
-    assert sorted(scenario["overrides"]["coin_overrides"]) == ["DEXE", "M"]
-    assert scenario["overrides"]["coin_overrides"]["M"] == {
-        "live": {"forced_mode_long": "normal"}
-    }
+    assert "overrides" not in scenario
 
 
 def test_suite_builder_can_filter_market_wide_clusters():
@@ -461,6 +458,127 @@ def test_suite_builder_filters_coins_without_data_in_scenario_window():
     scenario = payload["backtest"]["scenarios"][0]
     assert scenario["coins"] == ["M"]
     assert sorted(scenario["overrides"]["coin_overrides"]) == ["M"]
+
+
+def test_suite_builder_skips_targeted_scenario_when_all_coins_are_filtered(caplog):
+    event_ts = int(datetime(2026, 6, 25, tzinfo=UTC).timestamp() * 1000)
+    cluster = crash_finder.CrashCluster(
+        label="crash_2026_06_25_00_legacy",
+        timestamp=event_ts,
+        timestamp_iso="2026-06-25T00:00:00Z",
+        start_ts=event_ts,
+        end_ts=event_ts,
+        start_iso="2026-06-25T00:00:00Z",
+        end_iso="2026-06-25T00:00:00Z",
+        severity=-1.0,
+        event_count=1,
+        affected_coin_count=1,
+        affected_coins=["LEGACY"],
+        exchanges=["binance"],
+        market_wide=False,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        payload = crash_finder.build_suite_payload(
+            [cluster],
+            pre_days=14,
+            post_days=60,
+            top_clusters=0,
+            coin_mode="affected",
+            scenario_kind="coin-focused",
+            force_normal="both",
+            merge_overlaps=False,
+            all_scanned_coins=[],
+            coin_data_ranges=[
+                crash_finder.CoinDataRange(
+                    exchange="binance",
+                    coin="LEGACY",
+                    first_ts=int(datetime(2025, 1, 1, tzinfo=UTC).timestamp() * 1000),
+                    last_ts=int(datetime(2025, 2, 1, tzinfo=UTC).timestamp() * 1000),
+                )
+            ],
+        )
+
+    assert payload["backtest"]["scenarios"] == []
+    assert "omitted targeted scenario crash_2026_06_25_00_legacy" in caplog.text
+
+
+def test_suite_builder_none_coin_mode_keeps_inherit_base_scenario():
+    event_ts = int(datetime(2026, 6, 25, tzinfo=UTC).timestamp() * 1000)
+    cluster = crash_finder.CrashCluster(
+        label="crash_2026_06_25_00_m",
+        timestamp=event_ts,
+        timestamp_iso="2026-06-25T00:00:00Z",
+        start_ts=event_ts,
+        end_ts=event_ts,
+        start_iso="2026-06-25T00:00:00Z",
+        end_iso="2026-06-25T00:00:00Z",
+        severity=-1.0,
+        event_count=1,
+        affected_coin_count=1,
+        affected_coins=["M"],
+        exchanges=["binance"],
+        market_wide=False,
+    )
+
+    payload = crash_finder.build_suite_payload(
+        [cluster],
+        pre_days=14,
+        post_days=60,
+        top_clusters=0,
+        coin_mode="none",
+        scenario_kind="coin-focused",
+        force_normal="both",
+        merge_overlaps=False,
+        all_scanned_coins=[],
+        coin_data_ranges=[],
+    )
+
+    scenario = payload["backtest"]["scenarios"][0]
+    assert "coins" not in scenario
+    assert "overrides" not in scenario
+
+
+def test_suite_builder_includes_coin_with_data_exactly_on_end_date():
+    event_ts = int(datetime(2026, 6, 25, tzinfo=UTC).timestamp() * 1000)
+    end_ts = int(datetime(2026, 8, 24, tzinfo=UTC).timestamp() * 1000)
+    cluster = crash_finder.CrashCluster(
+        label="crash_2026_06_25_00_end",
+        timestamp=event_ts,
+        timestamp_iso="2026-06-25T00:00:00Z",
+        start_ts=event_ts,
+        end_ts=event_ts,
+        start_iso="2026-06-25T00:00:00Z",
+        end_iso="2026-06-25T00:00:00Z",
+        severity=-1.0,
+        event_count=1,
+        affected_coin_count=1,
+        affected_coins=["END"],
+        exchanges=["binance"],
+        market_wide=False,
+    )
+
+    payload = crash_finder.build_suite_payload(
+        [cluster],
+        pre_days=14,
+        post_days=60,
+        top_clusters=0,
+        coin_mode="affected",
+        scenario_kind="coin-focused",
+        force_normal="none",
+        merge_overlaps=False,
+        all_scanned_coins=[],
+        coin_data_ranges=[
+            crash_finder.CoinDataRange(
+                exchange="binance",
+                coin="END",
+                first_ts=end_ts,
+                last_ts=end_ts,
+            )
+        ],
+    )
+
+    assert payload["backtest"]["scenarios"][0]["coins"] == ["END"]
 
 
 def test_clusters_csv_fast_path_copies_source_scan_artifacts(tmp_path):

--- a/tests/test_crash_finder_tool.py
+++ b/tests/test_crash_finder_tool.py
@@ -61,6 +61,7 @@ def test_crash_finder_identifies_clusters_and_writes_outputs(tmp_path, capsys):
                 "2",
                 "--top-clusters",
                 "10",
+                "--write-filtered-suites",
                 "--output-dir",
                 str(out_dir),
                 "--json",
@@ -87,6 +88,8 @@ def test_crash_finder_identifies_clusters_and_writes_outputs(tmp_path, capsys):
     assert (out_dir / "crash_clusters.csv").exists()
     assert (out_dir / "scanned_ranges.csv").exists()
     assert (out_dir / "scan_errors.csv").exists()
+    for suffix in ["market_wide", "coin_focused", "single_coin"]:
+        assert (out_dir / f"crash_scenarios_{suffix}.hjson").exists()
     suite_payload = json.loads((out_dir / "crash_scenarios.hjson").read_text(encoding="utf-8"))
     scenarios = suite_payload["backtest"]["scenarios"]
     assert len(scenarios) == 2
@@ -362,6 +365,58 @@ def test_suite_builder_can_filter_market_wide_clusters():
 
     scenarios = payload["backtest"]["scenarios"]
     assert [scenario["label"] for scenario in scenarios] == ["crash_market"]
+
+
+def test_suite_builder_can_filter_strict_single_coin_clusters():
+    base = month_start_ts(2025, 4)
+    clusters = [
+        crash_finder.CrashCluster(
+            label="crash_om",
+            timestamp=base,
+            timestamp_iso="2025-04-01T00:00:00Z",
+            start_ts=base,
+            end_ts=base,
+            start_iso="2025-04-01T00:00:00Z",
+            end_iso="2025-04-01T00:00:00Z",
+            severity=-0.9,
+            event_count=1,
+            affected_coin_count=1,
+            affected_coins=["OM"],
+            exchanges=["binance"],
+            market_wide=False,
+        ),
+        crash_finder.CrashCluster(
+            label="crash_dexe_m",
+            timestamp=base + HOUR_MS,
+            timestamp_iso="2025-04-01T01:00:00Z",
+            start_ts=base + HOUR_MS,
+            end_ts=base + HOUR_MS,
+            start_iso="2025-04-01T01:00:00Z",
+            end_iso="2025-04-01T01:00:00Z",
+            severity=-0.8,
+            event_count=2,
+            affected_coin_count=2,
+            affected_coins=["DEXE", "M"],
+            exchanges=["binance"],
+            market_wide=False,
+        ),
+    ]
+
+    payload = crash_finder.build_suite_payload(
+        clusters,
+        pre_days=14,
+        post_days=60,
+        top_clusters=0,
+        coin_mode="affected",
+        scenario_kind="single-coin",
+        force_normal="none",
+        merge_overlaps=False,
+        all_scanned_coins=[],
+    )
+
+    scenarios = payload["backtest"]["scenarios"]
+    assert [scenario["label"] for scenario in scenarios] == ["crash_om"]
+    assert scenarios[0]["coins"] == ["OM"]
 
 
 def test_suite_builder_splits_merged_idiosyncratic_force_targets_into_pairs():


### PR DESCRIPTION
## Summary

- build parameterized crash-discovery candles from 1m cache data, defaulting to 1h, with one linear bucket-grouping pass while preserving ordered high-to-later-low semantics
- add repeatable exchange filters, filtered/merged suites, idiosyncratic forced-normal overrides capped at two coins, data-window filtering, and fast suite regeneration from existing clusters
- document the full download, discovery, regeneration, validation, and artifact-handling workflow for users and future AI agents
- ignore local crash_finder_results artifacts

## Validation

- `pytest -q tests/test_crash_finder_tool.py` (13 passed)
- real-cache AAVE 1h scan: about 5.5 seconds versus about 140 seconds before the grouping fix
- full Binance + Bybit 1h discovery: 111/123 ranges scanned, 12 legacy checksum failures reported, 1,739 events selected, 80 clusters retained
- generated suites validated with zero out-of-window coins, at most two forced-normal coins per scenario, and zero forced overrides in the market-wide suite
- M remains the second-worst cluster at `2026-06-25T00:00:00Z`

Generated CSV/HJSON/notes artifacts are local and are not included in this PR.