### PR TITLE
Distinguish recovered config refresh failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -670,6 +670,9 @@ All notable user-facing changes will be documented in this file.
   `passivbot tool live-performance-report`, projecting existing structured
   refresh success/failure events without copying raw exchange error text or
   making new exchange calls.
+- Exchange-config refresh summaries in `live-smoke-report` and
+  `live-performance-report` now distinguish historical failures from each
+  bot's latest status and count recovered bots after a later successful refresh.
 - Improved cold `passivbot backtest` materialization by batching legacy OHLCV
   imports by month, vectorizing chunk writes, staging HLCV cache writes with
   rollback on publish failure, and honoring Ctrl+C between expensive

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,21 +19,21 @@ Last updated: 2026-07-09.
 
 Current `origin/v8` head:
 
-- `aa9e6623` after PR #1161, `Summarize event pipeline resource pressure`.
+- `aff9e864` after PR #1162, `Report exchange config refresh performance`.
 
 Current logging-overhaul head:
 
-- `aa9e6623` after PR #1161, `Summarize event pipeline resource pressure`
+- `aff9e864` after PR #1162, `Report exchange config refresh performance`
   (latest merged logging-overhaul slice).
 
 Current work:
 
-- Branch `codex/v8-performance-exchange-config-refresh` adds a read-only,
-  bounded `exchange_config_refresh` health and timing projection to
-  `live-performance-report`, derived from existing structured
-  `exchange.config_refresh` events. It excludes raw error text and does not add
-  event producers, exchange calls, refresh behavior, order/risk logic, restart
-  orchestration, or trading behavior.
+- Branch `codex/v8-exchange-config-refresh-recovery` adds latest-per-bot status,
+  latest-failed-bot, and recovered-bot aggregates to the existing smoke and
+  performance `exchange.config_refresh` projections. Historical failures remain
+  visible, but a later successful refresh is no longer presented as unresolved.
+  The slice is read-only and does not change smoke verdicts, exchange calls,
+  refresh behavior, order/risk logic, restart orchestration, or trading behavior.
 
 Current review gate:
 
@@ -63,6 +63,20 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1162 at `aff9e864`.
+- PR #1162 added bounded `exchange_config_refresh` health and elapsed-timing
+  groups to `live-performance-report`, excluding raw exchange error text. It
+  merged after Hermes, Claude Opus 4.8, and Grok 4.5 approved the current head
+  and CI was green. VPS5 was pulled with `git pull --autostash --ff-only origin
+  v8`, preserving the pre-existing tracked Rust change and local config/tmp
+  artifacts. No bot restart was performed because the slice was read-only
+  report projection plus docs. A fresh one-minute smoke reported `ok=true`,
+  `hard_failures=0`, `matched_expected=5`, `missing_expected_count=0`, and zero
+  failed remote/account-critical calls. A bounded 24-hour focused report scanned
+  24 event files and returned `ok=true`, `error_count=0`, with 14 real refresh
+  events across all five bots: 13 succeeded and one Kucoin `RequestTimeout`.
+  Kucoin subsequently succeeded, Binance had three successes, and no raw error
+  text appeared. GateIO had the slowest observed refresh at `max_ms=78920`.
 - Repository pulled through PR #1161 at `aa9e6623`.
 - PR #1161 added top-level event-pipeline queue, drop, sink-error, degraded,
   and unhealthy-bot aggregates to `live-performance-report`

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -670,10 +670,11 @@ Related detailed plans:
       remain unavailable instead of receiving synthetic ranking tails.
 
 18. [ ] Binance hourly hedge-mode/config refresh traceback classification.
-    Status: structured event plus smoke projection merged; a performance-report
-    projection is in the current logging-overhaul slice. Live emission evidence
-    and smoke/report classification remain open after a restarted process has
-    crossed an hourly maintenance refresh.
+    Status: structured event, smoke projection, performance projection, and live
+    hourly emission evidence are complete. The historical Binance `-4084`
+    classification remains open only if it recurs; current live evidence shows
+    successful Binance refreshes. The current logging slice makes recovered
+    failures explicit without changing smoke verdicts.
 
     VPS5 smoke after PR #892 deployed to `v8@7e7ce16f` returned hard-red from
     a non-risk text-log traceback in the Binance bot while all five live
@@ -722,12 +723,16 @@ Related detailed plans:
       `exchange.config_refresh` events. This is not yet proof that the Binance
       `-4084` maintenance traceback is fixed or classified, because no sampled
       window has proven an hourly refresh occurrence after restart.
-    - 2026-07-09: Branch `codex/v8-performance-exchange-config-refresh` adds a
-      bounded `live-performance-report` health and elapsed-timing projection
-      over existing `exchange.config_refresh` events. It excludes raw error
-      text and does not change refresh retries, exception propagation, smoke
-      verdicts, exchange I/O, or trading behavior. Live hourly emission
-      evidence remains the prerequisite for any later classification change.
+    - 2026-07-09: PR #1162 added a bounded `live-performance-report` health and
+      elapsed-timing projection over existing `exchange.config_refresh` events.
+      Post-deploy VPS evidence found 14 real hourly refresh events across all
+      five bots: 13 succeeded and one Kucoin timeout was followed by success;
+      Binance had three successes. No live `-4084` recurrence was observed.
+    - 2026-07-09: Branch `codex/v8-exchange-config-refresh-recovery` adds
+      latest-per-bot status, latest-failed-bot, and recovered-bot aggregates to
+      smoke and performance reports so a historical timeout followed by success
+      is not presented as unresolved. It does not change verdicts, retries,
+      exception propagation, exchange I/O, or trading behavior.
 
 ## Merged Work Log
 

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -833,10 +833,10 @@ Each slice should update this checklist with its result.
      summary explaining the slowest startup and cycle blockers from local
      monitor data only.
    - Status: resource-pressure groups now expose process, sample-age, queue,
-     drop, sink-error, degraded, and unhealthy-bot aggregates. The current
-     `codex/v8-performance-exchange-config-refresh` slice adds bounded
-     exchange-config refresh success/failure groups and elapsed timings from
-     existing `exchange.config_refresh` events without adding exchange calls.
+     drop, sink-error, degraded, and unhealthy-bot aggregates. PR #1162 added
+     bounded exchange-config refresh success/failure groups and elapsed timings
+     from existing `exchange.config_refresh` events. The current recovery slice
+     distinguishes historical failures from each bot's latest observed status.
 
 2. [ ] HSL replay benchmark/profiling slice.
    - Add an offline deterministic benchmark or fixture path for coin-mode HSL

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -2845,11 +2845,13 @@ class _ExchangeConfigRefreshAccumulator:
     def __init__(self) -> None:
         self.groups: dict[tuple[str, str, str, str, str], dict[str, Any]] = {}
         self.event_types: Counter[str] = Counter()
+        self.event_index = 0
 
     def add(self, *, row: dict[str, Any], live_event: dict[str, Any]) -> None:
         event_type = str(live_event.get("event_type") or row.get("kind") or "")
         if event_type not in _EXCHANGE_CONFIG_REFRESH_EVENT_TYPES:
             return
+        self.event_index += 1
         data = live_event.get("data") if isinstance(live_event.get("data"), dict) else {}
         bot = _bot_key(row, live_event)
         status = str(live_event.get("status") or "unknown")
@@ -2869,10 +2871,12 @@ class _ExchangeConfigRefreshAccumulator:
                 "count": 0,
                 "latest_ts": None,
                 "latest_data": {},
+                "_latest_position": None,
             }
             self.groups[key] = group
         group["count"] = int(group.get("count") or 0) + 1
         ts = _record_ts(row)
+        position = (int(ts) if ts is not None else -1, self.event_index)
         latest_changed = ts is None or group.get("latest_ts") is None
         if ts is not None and group.get("latest_ts") is not None:
             latest_changed = int(ts) >= int(group["latest_ts"])
@@ -2891,6 +2895,10 @@ class _ExchangeConfigRefreshAccumulator:
             if started_ms is not None:
                 latest_data["started_ms"] = started_ms
             group["latest_data"] = latest_data
+        if group.get("_latest_position") is None or position >= tuple(
+            group["_latest_position"]
+        ):
+            group["_latest_position"] = position
         self.event_types[event_type] += 1
 
     def to_dict(self, *, group_limit: int = GROUP_LIMIT) -> dict[str, Any]:
@@ -2908,23 +2916,46 @@ class _ExchangeConfigRefreshAccumulator:
             {
                 key: value
                 for key, value in group.items()
-                if value not in (None, {}, [])
+                if not key.startswith("_") and value not in (None, {}, [])
             }
             for group in ordered[: max(0, int(group_limit))]
         ]
         status_counts: Counter[str] = Counter()
         failed_bots: set[str] = set()
+        latest_by_bot: dict[str, dict[str, Any]] = {}
         for group in self.groups.values():
             count = int(group.get("count") or 0)
             status = str(group.get("status") or "unknown")
             status_counts[status] += count
-            if status == "failed" and group.get("bot") not in (None, ""):
-                failed_bots.add(str(group["bot"]))
+            bot = str(group.get("bot") or "")
+            if status == "failed" and bot:
+                failed_bots.add(bot)
+            if not bot:
+                continue
+            current = latest_by_bot.get(bot)
+            if current is None or tuple(group["_latest_position"]) > tuple(
+                current["_latest_position"]
+            ):
+                latest_by_bot[bot] = group
+        latest_status_counts = Counter(
+            str(group.get("status") or "unknown") for group in latest_by_bot.values()
+        )
+        latest_failed_bots = {
+            bot
+            for bot, group in latest_by_bot.items()
+            if str(group.get("status") or "unknown") == "failed"
+        }
+        recovered_bots = {
+            bot
+            for bot, group in latest_by_bot.items()
+            if bot in failed_bots
+            and str(group.get("status") or "unknown") == "succeeded"
+        }
         total = sum(int(group.get("count") or 0) for group in self.groups.values())
         failed = int(status_counts.get("failed", 0))
         return {
             "total": int(total),
-            "bots": len({str(group.get("bot")) for group in self.groups.values()}),
+            "bots": len(latest_by_bot),
             "succeeded": int(status_counts.get("succeeded", 0)),
             "failed": failed,
             "failure_pct": (
@@ -2932,6 +2963,9 @@ class _ExchangeConfigRefreshAccumulator:
             ),
             "failed_bots": len(failed_bots),
             "statuses": dict(status_counts.most_common()),
+            "latest_statuses": dict(latest_status_counts.most_common()),
+            "latest_failed_bots": len(latest_failed_bots),
+            "recovered_bots": len(recovered_bots),
             "event_types": dict(self.event_types.most_common()),
             "groups_truncated": len(ordered) > int(group_limit),
             "groups": compact_groups,

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -2424,12 +2424,48 @@ def _summarize_exchange_config_refresh_health(
     ]
     status_counts: Counter[str] = Counter()
     failed_bots: set[str] = set()
+    latest_by_bot: dict[str, dict[str, Any]] = {}
     for group in groups.values():
         count = int(group.get("count") or 0)
         status = str(group.get("status") or "unknown")
         status_counts[status] += count
-        if status == "failed" and count > 0 and group.get("bot") not in (None, ""):
-            failed_bots.add(str(group.get("bot")))
+        bot = str(group.get("bot") or "")
+        if status == "failed" and count > 0 and bot:
+            failed_bots.add(bot)
+        if not bot:
+            continue
+        current = latest_by_bot.get(bot)
+        current_key = (
+            _sort_event_position_key(
+                ts=current.get("latest_ts"),
+                seq=current.get("latest_seq"),
+                path=current.get("latest_path") or "",
+                line_no=int(current.get("latest_line") or 0),
+            )
+            if current is not None
+            else None
+        )
+        group_key = _sort_event_position_key(
+            ts=group.get("latest_ts"),
+            seq=group.get("latest_seq"),
+            path=group.get("latest_path") or "",
+            line_no=int(group.get("latest_line") or 0),
+        )
+        if current_key is None or group_key > current_key:
+            latest_by_bot[bot] = group
+    latest_status_counts = Counter(
+        str(group.get("status") or "unknown") for group in latest_by_bot.values()
+    )
+    latest_failed_bots = {
+        bot
+        for bot, group in latest_by_bot.items()
+        if str(group.get("status") or "unknown") == "failed"
+    }
+    recovered_bots = {
+        bot
+        for bot, group in latest_by_bot.items()
+        if bot in failed_bots and str(group.get("status") or "unknown") == "succeeded"
+    }
     total = sum(int(group.get("count", 0)) for group in groups.values())
     failed = int(status_counts.get("failed", 0))
     return {
@@ -2440,8 +2476,11 @@ def _summarize_exchange_config_refresh_health(
         "groups_truncated": len(ordered) > EXCHANGE_CONFIG_REFRESH_HEALTH_GROUP_LIMIT,
         "event_types": dict(event_type_counts.most_common()),
         "statuses": dict(status_counts.most_common()),
-        "bots": len({group.get("bot") for group in groups.values()}),
+        "latest_statuses": dict(latest_status_counts.most_common()),
+        "bots": len(latest_by_bot),
         "failed_bots": len(failed_bots),
+        "latest_failed_bots": len(latest_failed_bots),
+        "recovered_bots": len(recovered_bots),
         "groups": compact_groups,
     }
 
@@ -7949,6 +7988,15 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             "failure_pct": exchange_config_refresh_health.get("failure_pct"),
             "failed_bots": _count_value(
                 exchange_config_refresh_health.get("failed_bots")
+            ),
+            "latest_failed_bots": _count_value(
+                exchange_config_refresh_health.get("latest_failed_bots")
+            ),
+            "recovered_bots": _count_value(
+                exchange_config_refresh_health.get("recovered_bots")
+            ),
+            "latest_statuses": (
+                exchange_config_refresh_health.get("latest_statuses") or {}
             ),
             "event_types": exchange_config_refresh_health.get("event_types") or {},
         },

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -3098,7 +3098,10 @@ def test_live_performance_report_exchange_config_refresh_health(tmp_path):
     assert refresh["failure_pct"] == 50.0
     assert refresh["bots"] == 1
     assert refresh["failed_bots"] == 1
+    assert refresh["latest_failed_bots"] == 1
+    assert refresh["recovered_bots"] == 0
     assert refresh["statuses"] == {"succeeded": 1, "failed": 1}
+    assert refresh["latest_statuses"] == {"failed": 1}
     assert refresh["event_types"] == {"exchange.config_refresh": 2}
     assert refresh["groups"][0]["status"] == "failed"
     assert refresh["groups"][0]["latest_data"] == {
@@ -3128,6 +3131,49 @@ def test_live_performance_report_exchange_config_refresh_health(tmp_path):
     assert summary["operation_durations"]["operation_category_counts"][
         "exchange_config_refresh"
     ] == 1
+
+
+def test_live_performance_report_marks_recovered_exchange_config_refresh_bot(tmp_path):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="exchange.config_refresh",
+                seq=1,
+                ts=1000,
+                exchange="kucoin",
+                user="kucoin_01",
+                status="failed",
+                reason_code="exchange_config_refresh_failed",
+                data={
+                    "operation": "init_markets",
+                    "elapsed_ms": 33915,
+                    "error_type": "RequestTimeout",
+                },
+            ),
+            _monitor_row(
+                event_type="exchange.config_refresh",
+                seq=2,
+                ts=2000,
+                exchange="kucoin",
+                user="kucoin_01",
+                status="succeeded",
+                reason_code="exchange_config_refresh",
+                data={"operation": "init_markets", "elapsed_ms": 6331},
+            ),
+        ],
+    )
+
+    refresh = build_live_performance_report(tmp_path / "monitor")[
+        "exchange_config_refresh"
+    ]
+
+    assert refresh["failed"] == 1
+    assert refresh["failed_bots"] == 1
+    assert refresh["latest_statuses"] == {"succeeded": 1}
+    assert refresh["latest_failed_bots"] == 0
+    assert refresh["recovered_bots"] == 1
 
 
 def test_live_performance_report_exchange_config_refresh_summary_is_bounded(tmp_path):

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1414,6 +1414,9 @@ def test_live_smoke_report_brief_summary_projects_top_level_counters(tmp_path):
         "failed": 0,
         "failure_pct": 0,
         "failed_bots": 0,
+        "latest_failed_bots": 0,
+        "recovered_bots": 0,
+        "latest_statuses": {},
         "event_types": {},
     }
     assert brief["staged_readiness"] == {
@@ -2076,8 +2079,11 @@ def test_live_smoke_report_summarizes_exchange_config_refresh_health(tmp_path):
     assert health["failure_pct"] == 50.0
     assert health["bots"] == 1
     assert health["failed_bots"] == 1
+    assert health["latest_failed_bots"] == 1
+    assert health["recovered_bots"] == 0
     assert health["event_types"] == {"exchange.config_refresh": 2}
     assert health["statuses"] == {"succeeded": 1, "failed": 1}
+    assert health["latest_statuses"] == {"failed": 1}
     assert health["groups"][0]["status"] == "failed"
     assert health["groups"][0]["latest_data"] == {
         "context": "maintain_hourly_cycle",
@@ -2103,8 +2109,57 @@ def test_live_smoke_report_summarizes_exchange_config_refresh_health(tmp_path):
         "failed": 1,
         "failure_pct": 50.0,
         "failed_bots": 1,
+        "latest_failed_bots": 1,
+        "recovered_bots": 0,
+        "latest_statuses": {"failed": 1},
         "event_types": {"exchange.config_refresh": 2},
     }
+
+
+def test_live_smoke_report_marks_recovered_exchange_config_refresh_bot(tmp_path):
+    events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="exchange.config_refresh",
+                seq=1,
+                ts=1000,
+                exchange="kucoin",
+                user="kucoin_01",
+                status="failed",
+                reason_code="exchange_config_refresh_failed",
+                data={
+                    "operation": "init_markets",
+                    "elapsed_ms": 33915,
+                    "error_type": "RequestTimeout",
+                },
+            ),
+            _monitor_row(
+                event_type="exchange.config_refresh",
+                seq=2,
+                ts=2000,
+                exchange="kucoin",
+                user="kucoin_01",
+                status="succeeded",
+                reason_code="exchange_config_refresh",
+                data={"operation": "init_markets", "elapsed_ms": 6331},
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    health = report["exchange_config_refresh_health"]
+    brief = summarize_live_smoke_report_brief(report)["exchange_config_refresh"]
+
+    assert health["failed"] == 1
+    assert health["failed_bots"] == 1
+    assert health["latest_statuses"] == {"succeeded": 1}
+    assert health["latest_failed_bots"] == 0
+    assert health["recovered_bots"] == 1
+    assert brief["latest_statuses"] == {"succeeded": 1}
+    assert brief["latest_failed_bots"] == 0
+    assert brief["recovered_bots"] == 1
 
 
 def test_live_smoke_report_summarizes_event_pipeline_health(tmp_path):


### PR DESCRIPTION
Scope: observability-only

Touched surfaces:
- live-smoke-report exchange_config_refresh_health and brief projections
- live-performance-report exchange_config_refresh projection
- focused smoke/performance report tests
- CHANGELOG and live logging/performance/backlog evidence

Behavior:
- keeps historical succeeded/failed totals and failed_bots unchanged
- adds latest_statuses, latest_failed_bots, and recovered_bots from each bots latest observed refresh event
- makes a failed refresh followed by success explicitly recovered

Expected VPS action: pull plus bounded smoke/performance report validation; no bot restart. Existing events are sufficient.

Validation run:
- branch based on v8 aff9e864 after merged PR #1162
- py_compile passed
- focused recovery and existing config-refresh tests passed: 5 passed
- full tests/test_live_smoke_report.py passed: 74 passed
- full tests/test_live_performance_report.py passed: 67 passed
- git diff --check passed
- added-line silent-handling scan found no trading-critical fallback patterns

Triggering live evidence:
- PR #1162 post-deploy report found 14 real hourly refresh events across five bots: 13 succeeded and one Kucoin RequestTimeout
- Kucoin later succeeded, but historical failed_bots alone did not express that recovery
- Binance had three successful refreshes and no observed -4084 recurrence

Reviewer focus:
- verify latest event ordering is deterministic per bot
- verify historical failure totals remain unchanged
- verify recovered_bots requires a historical failure plus latest succeeded status
- verify output remains bounded and redacted
- verify smoke verdict and exchange behavior are untouched

Non-goals:
- no event producer or registry changes
- no smoke verdict changes
- no exchange calls, retry policy, exception propagation, or refresh behavior changes
- no Rust, order, risk, HSL, unstuck, restart, backtest, optimize, or trading behavior changes

Merge gate: Hermes + Claude Opus 4.8 + Grok 4.5 current-head green reviews plus green CI.