### PR TITLE
Expose timing correlation IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable user-facing changes will be documented in this file.
 - Live performance timing groups now expose their latest bounded report-safe
   canonical event IDs, including in `operation_durations` and
   `slowest_blockers`, so an operator can correlate a slow row with the
-  structured event stream without exposing free-form event payloads.
+  structured event stream without exposing free-form event payloads. Existing
+  legacy snapshot IDs are normalized consistently with `live-event-query`, and
+  equal-timestamp samples use persistent event ordering.
 
 - Backtests now warn when interior data gaps split a coin's history and real
   data outside the longest contiguous run is excluded from the backtest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live performance timing groups now expose their latest bounded report-safe
+  canonical event IDs, including in `operation_durations` and
+  `slowest_blockers`, so an operator can correlate a slow row with the
+  structured event stream without exposing free-form event payloads.
+
 - Backtests now warn when interior data gaps split a coin's history and real
   data outside the longest contiguous run is excluded from the backtest
   (previously silent). Stock-perps (`xyz:`) coins instead log their

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,21 +19,21 @@ Last updated: 2026-07-09.
 
 Current `origin/v8` head:
 
-- `aff9e864` after PR #1162, `Report exchange config refresh performance`.
+- `a0639806` after PR #1164, `Distinguish recovered config refresh failures`.
 
 Current logging-overhaul head:
 
-- `aff9e864` after PR #1162, `Report exchange config refresh performance`
+- `a0639806` after PR #1164, `Distinguish recovered config refresh failures`
   (latest merged logging-overhaul slice).
 
 Current work:
 
-- Branch `codex/v8-exchange-config-refresh-recovery` adds latest-per-bot status,
-  latest-failed-bot, and recovered-bot aggregates to the existing smoke and
-  performance `exchange.config_refresh` projections. Historical failures remain
-  visible, but a later successful refresh is no longer presented as unresolved.
-  The slice is read-only and does not change smoke verdicts, exchange calls,
-  refresh behavior, order/risk logic, restart orchestration, or trading behavior.
+- Branch `codex/v8-performance-correlation-ids` adds one bounded report-safe
+  canonical `latest_ids` mapping to each timing group and carries it into
+  `operation_durations` and `slowest_blockers`. This lets operators jump from a
+  slow timing row to the related structured events without exposing free-form
+  payloads. The slice is read-only and does not change event production,
+  exchange calls, order/risk logic, restart orchestration, or trading behavior.
 
 Current review gate:
 
@@ -63,6 +63,19 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1164 at `a0639806`.
+- PR #1164 made the smoke and performance `exchange.config_refresh` projections
+  distinguish historical failures from latest unresolved failures and expose
+  recovered-bot counts. It merged after Hermes, Claude Opus 4.8, and Grok 4.5
+  approved the current head and CI was green. VPS5 was pulled with
+  `git pull --autostash --ff-only origin v8`, preserving the pre-existing
+  tracked Rust change and local config/tmp artifacts. No bot restart was
+  performed because the slice was read-only report projection plus docs. The
+  first bounded smoke observed a transient account-critical remote failure; the
+  next bounded query cleared with `ok=true` and `hard_failures=0`. A current
+  focused performance report returned
+  `latest_statuses={"succeeded":4}`, `latest_failed_bots=0`, and no unresolved
+  config-refresh failures.
 - Repository pulled through PR #1162 at `aff9e864`.
 - PR #1162 added bounded `exchange_config_refresh` health and elapsed-timing
   groups to `live-performance-report`, excluding raw exchange error text. It

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -32,8 +32,10 @@ Current work:
   canonical `latest_ids` mapping to each timing group and carries it into
   `operation_durations` and `slowest_blockers`. This lets operators jump from a
   slow timing row to the related structured events without exposing free-form
-  payloads. The slice is read-only and does not change event production,
-  exchange calls, order/risk logic, restart orchestration, or trading behavior.
+  payloads. Legacy snapshot IDs follow the existing event-query normalization,
+  and equal-timestamp samples use persistent event sequence/source position.
+  The slice is read-only and does not change event production, exchange calls,
+  order/risk logic, restart orchestration, or trading behavior.
 
 Current review gate:
 

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -265,7 +265,8 @@ if the final replay result is correct.
    - A follow-up slice added each timing group's latest bounded report-safe
      canonical event IDs to the base timing table, `operation_durations`, and
      `slowest_blockers`, so a slow row can be correlated directly with the
-     structured event stream without exposing free-form payloads.
+     structured event stream without exposing free-form payloads. It preserves
+     legacy snapshot-ID query compatibility and stable persistent event ordering.
    - A follow-up slice corrected `snapshot_to_rust` correlation: planning
      snapshot epochs are not live event cycle IDs, so legacy/current
      `snapshot.built` events without envelope cycle IDs are matched to the

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -262,6 +262,10 @@ if the final replay result is correct.
      existing startup, cycle, state-refresh, remote-call, HSL replay, cache,
      decision-boundary, input-staleness, execution, and shutdown timing groups
      into one bounded report section.
+   - A follow-up slice added each timing group's latest bounded report-safe
+     canonical event IDs to the base timing table, `operation_durations`, and
+     `slowest_blockers`, so a slow row can be correlated directly with the
+     structured event stream without exposing free-form payloads.
    - A follow-up slice corrected `snapshot_to_rust` correlation: planning
      snapshot epochs are not live event cycle IDs, so legacy/current
      `snapshot.built` events without envelope cycle IDs are matched to the
@@ -347,8 +351,11 @@ classification when enough source events exist.
     that normalizes existing duration/staleness groups from performance,
     decision-boundary, input-staleness, execution, and shutdown sections into
     one sortable table with operation category, timing kind, trading impact, and
-    blocking scope. Remaining work: source events for event-pipeline overhead
-    and complete stage coverage where the live loop does not yet emit timings.
+    blocking scope. Timing groups, the normalized table, and ranked
+    `slowest_blockers` also include the latest bounded report-safe canonical
+    event IDs for direct event-stream correlation. Remaining work: source events
+    for event-pipeline overhead and complete stage coverage where the live loop
+    does not yet emit timings.
 - [ ] Exchange writes: create/cancel/close/panic write latency, exchange
   response latency, ambiguous write rate, confirmation latency.
   - Status: partial. The report now derives order-wave total duration,

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -296,6 +296,8 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   `operation_durations`/`slowest_blockers` projections include one bounded `latest_ids` mapping
   of report-safe canonical event-envelope IDs when available (excluding per-action IDs),
   allowing direct correlation with `live-event-query` without exposing free-form payloads.
+  The mapping uses the same legacy snapshot-ID normalization as `live-event-query` and
+  selects the latest sample by stable event position (`ts`, `seq`, path, and line).
   The `operation_durations` section
   collates startup, cycle, state-refresh, remote-call, HSL replay, cache, decision-boundary,
   input-staleness, fill-refresh, execution, and shutdown timing groups into one bounded table with operation

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -292,7 +292,11 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   The startup-readiness section summarizes latest per-bot startup phase timings and HSL
   replay state from existing lifecycle/replay events. The `slowest_blockers` section ranks
   non-diagnostic timing and staleness groups by observed duration so the largest trading-impact
-  delays are visible without scanning every timing group. The `operation_durations` section
+  delays are visible without scanning every timing group. Base timing groups and their
+  `operation_durations`/`slowest_blockers` projections include one bounded `latest_ids` mapping
+  of report-safe canonical event-envelope IDs when available (excluding per-action IDs),
+  allowing direct correlation with `live-event-query` without exposing free-form payloads.
+  The `operation_durations` section
   collates startup, cycle, state-refresh, remote-call, HSL replay, cache, decision-boundary,
   input-staleness, fill-refresh, execution, and shutdown timing groups into one bounded table with operation
   category, trading-impact, blocking-scope, and timing-kind counters. The `resource_pressure` section

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -16,11 +16,12 @@ from live.event_bus import (
 )
 from live.event_file_rows import event_file_rows
 from live.event_query import (
+    _event_ids,
     _limit_recent_event_files_per_bot,
     _recent_event_file_sort_key,
     discover_event_files_with_metadata,
 )
-from live.smoke_report import _user_safe_display_path
+from live.smoke_report import _sort_event_position_key, _user_safe_display_path
 
 
 GROUP_LIMIT = 80
@@ -39,6 +40,8 @@ _PERFORMANCE_REPORT_ID_KEY_ALLOWLIST = frozenset(
 _PERFORMANCE_REPORT_ID_KEYS = tuple(
     key for key in LIVE_EVENT_ID_KEYS if key in _PERFORMANCE_REPORT_ID_KEY_ALLOWLIST
 )
+_PERFORMANCE_REPORT_SOURCE_PATH_KEY = "_performance_report_source_path"
+_PERFORMANCE_REPORT_SOURCE_LINE_KEY = "_performance_report_source_line"
 _PERFORMANCE_REPORT_SECTION_BASE_KEYS = (
     "ok",
     "root",
@@ -439,15 +442,30 @@ def _safe_label(value: Any, *, max_len: int = 120) -> str | None:
 
 
 def _bounded_event_ids(live_event: dict[str, Any]) -> dict[str, str]:
-    ids = live_event.get("ids")
-    if not isinstance(ids, dict):
-        return {}
+    ids = _event_ids(live_event)
     out: dict[str, str] = {}
     for key in _PERFORMANCE_REPORT_ID_KEYS:
         value = _safe_label(ids.get(key), max_len=160)
         if value is not None:
             out[key] = value
     return out
+
+
+def _metric_event_position(row: dict[str, Any]) -> tuple[int, int, str, int] | None:
+    timestamp_ms = _record_ts(row)
+    if timestamp_ms is None:
+        return None
+    line_no = row.get(_PERFORMANCE_REPORT_SOURCE_LINE_KEY)
+    try:
+        normalized_line_no = int(line_no)
+    except (TypeError, ValueError):
+        normalized_line_no = 0
+    return _sort_event_position_key(
+        ts=timestamp_ms,
+        seq=row.get("seq"),
+        path=row.get(_PERFORMANCE_REPORT_SOURCE_PATH_KEY) or "",
+        line_no=normalized_line_no,
+    )
 
 
 def _elapsed_s_to_ms(value: Any) -> int | None:
@@ -501,8 +519,7 @@ class _MetricGroup:
         self.symbols: Counter[str] = Counter()
         self.latest_ts: int | None = None
         self.latest_ids: dict[str, str] = {}
-        self._latest_position: tuple[int, int] | None = None
-        self._event_index = 0
+        self._latest_position: tuple[int, int, str, int] | None = None
 
     def add(
         self,
@@ -511,7 +528,6 @@ class _MetricGroup:
         row: dict[str, Any],
         live_event: dict[str, Any],
     ) -> None:
-        self._event_index += 1
         self.values.append(int(value_ms))
         status = live_event.get("status")
         if status is not None:
@@ -525,11 +541,12 @@ class _MetricGroup:
         ts = _record_ts(row)
         if ts is not None and (self.latest_ts is None or ts > self.latest_ts):
             self.latest_ts = ts
-        if ts is not None:
-            position = (int(ts), self._event_index)
-            if self._latest_position is None or position >= self._latest_position:
-                self._latest_position = position
-                self.latest_ids = _bounded_event_ids(live_event)
+        position = _metric_event_position(row)
+        if position is not None and (
+            self._latest_position is None or position >= self._latest_position
+        ):
+            self._latest_position = position
+            self.latest_ids = _bounded_event_ids(live_event)
 
     def to_dict(self) -> dict[str, Any]:
         values = sorted(self.values)
@@ -4048,6 +4065,8 @@ def build_live_performance_report(
                 }
             )
             return
+        row[_PERFORMANCE_REPORT_SOURCE_PATH_KEY] = str(path)
+        row[_PERFORMANCE_REPORT_SOURCE_LINE_KEY] = int(line_no)
         live_event = _live_event_payload(row)
         if live_event is None:
             legacy_events += 1

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from live.event_bus import (
     LIVE_EVENT_DEBUG_PROFILES,
+    LIVE_EVENT_ID_KEYS,
     LIVE_EVENT_MONITOR_PAYLOAD_KEY,
     utc_ms,
 )
@@ -24,6 +25,20 @@ from live.smoke_report import _user_safe_display_path
 
 GROUP_LIMIT = 80
 SUMMARY_GROUP_LIMIT = 12
+_PERFORMANCE_REPORT_ID_KEY_ALLOWLIST = frozenset(
+    {
+        "bot_id",
+        "cycle_id",
+        "snapshot_id",
+        "plan_id",
+        "order_wave_id",
+        "remote_call_id",
+        "remote_call_group_id",
+    }
+)
+_PERFORMANCE_REPORT_ID_KEYS = tuple(
+    key for key in LIVE_EVENT_ID_KEYS if key in _PERFORMANCE_REPORT_ID_KEY_ALLOWLIST
+)
 _PERFORMANCE_REPORT_SECTION_BASE_KEYS = (
     "ok",
     "root",
@@ -423,6 +438,18 @@ def _safe_label(value: Any, *, max_len: int = 120) -> str | None:
     return text
 
 
+def _bounded_event_ids(live_event: dict[str, Any]) -> dict[str, str]:
+    ids = live_event.get("ids")
+    if not isinstance(ids, dict):
+        return {}
+    out: dict[str, str] = {}
+    for key in _PERFORMANCE_REPORT_ID_KEYS:
+        value = _safe_label(ids.get(key), max_len=160)
+        if value is not None:
+            out[key] = value
+    return out
+
+
 def _elapsed_s_to_ms(value: Any) -> int | None:
     number = _finite_float(value)
     if number is None or number < 0:
@@ -473,6 +500,9 @@ class _MetricGroup:
         self.reason_codes: Counter[str] = Counter()
         self.symbols: Counter[str] = Counter()
         self.latest_ts: int | None = None
+        self.latest_ids: dict[str, str] = {}
+        self._latest_position: tuple[int, int] | None = None
+        self._event_index = 0
 
     def add(
         self,
@@ -481,6 +511,7 @@ class _MetricGroup:
         row: dict[str, Any],
         live_event: dict[str, Any],
     ) -> None:
+        self._event_index += 1
         self.values.append(int(value_ms))
         status = live_event.get("status")
         if status is not None:
@@ -494,6 +525,11 @@ class _MetricGroup:
         ts = _record_ts(row)
         if ts is not None and (self.latest_ts is None or ts > self.latest_ts):
             self.latest_ts = ts
+        if ts is not None:
+            position = (int(ts), self._event_index)
+            if self._latest_position is None or position >= self._latest_position:
+                self._latest_position = position
+                self.latest_ids = _bounded_event_ids(live_event)
 
     def to_dict(self) -> dict[str, Any]:
         values = sorted(self.values)
@@ -514,6 +550,7 @@ class _MetricGroup:
                 "median_ms": int(round(statistics.median(values))) if values else None,
                 "p95_ms": _percentile(values, 0.95),
                 "latest_ts": self.latest_ts,
+                "latest_ids": self.latest_ids,
                 "statuses": dict(sorted(self.statuses.items())),
                 "reason_codes": dict(sorted(self.reason_codes.items())),
                 "symbols_sample": [
@@ -3468,6 +3505,7 @@ def _slowest_blockers(
                     "median_ms",
                     "p95_ms",
                     "latest_ts",
+                    "latest_ids",
                     "statuses",
                     "reason_codes",
                     "symbols_sample",
@@ -3562,6 +3600,7 @@ def _operation_duration_table(
                     "median_ms",
                     "p95_ms",
                     "latest_ts",
+                    "latest_ids",
                     "statuses",
                     "reason_codes",
                     "symbols_sample",

--- a/tests/test_live_incident_bundle.py
+++ b/tests/test_live_incident_bundle.py
@@ -641,6 +641,9 @@ def test_live_incident_bundle_collects_hashes_snapshots_events_and_window(tmp_pa
         "failed": 1,
         "failure_pct": 100.0,
         "failed_bots": 1,
+        "latest_statuses": {"failed": 1},
+        "latest_failed_bots": 1,
+        "recovered_bots": 0,
         "event_types": {"exchange.config_refresh": 1},
     }
     assert report["smoke_report"]["staged_readiness"] == {

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -447,6 +447,119 @@ def test_live_performance_report_slowest_blockers_summary_is_bounded(tmp_path):
     assert summary["slowest_blockers"]["groups"][0]["operation"] == "state_refresh.wall"
 
 
+def test_live_performance_report_timing_groups_include_latest_safe_ids(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1", "plan_id": "plan_1"},
+                data={"elapsed_ms": 1000},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=2,
+                ts=2000,
+                ids={
+                    "bot_id": "binance_01",
+                    "cycle_id": "cy_2",
+                    "snapshot_id": "snapshot_2",
+                    "plan_id": "plan_2",
+                    "action_id": "action_2",
+                    "order_wave_id": "wave_2",
+                    "remote_call_id": "rc_2",
+                    "remote_call_group_id": "rcg_2",
+                },
+                data={"elapsed_ms": 2000},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    summary = summarize_live_performance_report(report)
+    expected_ids = {
+        "bot_id": "binance_01",
+        "cycle_id": "cy_2",
+        "snapshot_id": "snapshot_2",
+        "plan_id": "plan_2",
+        "order_wave_id": "wave_2",
+        "remote_call_id": "rc_2",
+        "remote_call_group_id": "rcg_2",
+    }
+
+    performance_group = next(
+        group
+        for group in report["performance"]["groups"]
+        if group["operation"] == "cycle.elapsed"
+    )
+    duration_group = next(
+        group
+        for group in report["operation_durations"]["groups"]
+        if group["operation"] == "cycle.elapsed"
+    )
+    blocker_group = next(
+        group
+        for group in report["slowest_blockers"]["groups"]
+        if group["operation"] == "cycle.elapsed"
+    )
+    summary_duration_group = next(
+        group
+        for group in summary["operation_durations"]["groups"]
+        if group["operation"] == "cycle.elapsed"
+    )
+    summary_blocker_group = next(
+        group
+        for group in summary["slowest_blockers"]["groups"]
+        if group["operation"] == "cycle.elapsed"
+    )
+
+    assert performance_group["latest_ids"] == expected_ids
+    assert duration_group["latest_ids"] == expected_ids
+    assert blocker_group["latest_ids"] == expected_ids
+    assert summary_duration_group["latest_ids"] == expected_ids
+    assert summary_blocker_group["latest_ids"] == expected_ids
+    rendered = json.dumps(report, sort_keys=True)
+    assert "action_2" not in rendered
+
+
+def test_live_performance_report_latest_ids_do_not_stick_to_newer_sample(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1"},
+                data={"elapsed_ms": 1000},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=2,
+                ts=2000,
+                data={"elapsed_ms": 2000},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    groups = [
+        next(
+            group
+            for group in report[section]["groups"]
+            if group["operation"] == "cycle.elapsed"
+        )
+        for section in ("performance", "operation_durations", "slowest_blockers")
+    ]
+
+    assert all(group["latest_ts"] == 2000 for group in groups)
+    assert all("latest_ids" not in group for group in groups)
+
+
 def test_live_performance_report_decision_boundary_lag(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -560,6 +560,89 @@ def test_live_performance_report_latest_ids_do_not_stick_to_newer_sample(tmp_pat
     assert all("latest_ids" not in group for group in groups)
 
 
+def test_live_performance_report_latest_ids_use_persistent_event_position(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=2,
+                ts=1000,
+                ids={"cycle_id": "cy_2", "plan_id": "plan_2"},
+                data={"elapsed_ms": 2000},
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_1", "plan_id": "plan_1"},
+                data={"elapsed_ms": 1000},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    summary = summarize_live_performance_report(report)
+    expected_ids = {"cycle_id": "cy_2", "plan_id": "plan_2"}
+    groups = [
+        next(
+            group
+            for group in section["groups"]
+            if group["operation"] == "cycle.elapsed"
+        )
+        for section in (
+            report["performance"],
+            report["operation_durations"],
+            report["slowest_blockers"],
+            summary["operation_durations"],
+            summary["slowest_blockers"],
+        )
+    ]
+
+    assert all(group["latest_ts"] == 1000 for group in groups)
+    assert all(group["latest_ids"] == expected_ids for group in groups)
+
+
+def test_live_performance_report_latest_ids_normalize_legacy_snapshot_id(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=1,
+                ts=1000,
+                data={
+                    "snapshot_id": "snap_legacy",
+                    "surface_ages": [{"name": "balance", "age_ms": 500}],
+                },
+            )
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    summary = summarize_live_performance_report(report)
+    expected_ids = {"snapshot_id": "snap_legacy"}
+    groups = [
+        next(
+            group
+            for group in section["groups"]
+            if group["operation"] == "input_staleness.surface.balance"
+        )
+        for section in (
+            report["input_staleness"],
+            report["operation_durations"],
+            report["slowest_blockers"],
+            summary["input_staleness"],
+            summary["operation_durations"],
+            summary["slowest_blockers"],
+        )
+    ]
+
+    assert all(group["latest_ids"] == expected_ids for group in groups)
+
+
 def test_live_performance_report_decision_boundary_lag(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- expose one bounded report-safe latest event-ID mapping on performance timing groups
- carry those IDs into `operation_durations` and `slowest_blockers` for direct `live-event-query` correlation
- preserve the existing no-per-action-ID contract and correct the stale incident-bundle expectation from PR #1164
- update operator docs, performance goals, changelog, and the logging progress ledger

## Contract
Read-only report projection only. No event producers, exchange I/O, order/risk behavior, restart orchestration, or live trading behavior change. No bot restart is required after deployment.

## Validation
- `python -m pytest -q tests/test_live_performance_report.py tests/test_live_incident_bundle.py`
- `python -m py_compile src/live/performance_report.py tests/test_live_performance_report.py tests/test_live_incident_bundle.py`
- `git diff --check`
- added-line silent-handling scan: clean
