### PR TITLE
Bound live executor anomaly diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live executor create/cancel anomalies no longer print raw order dictionaries,
+  exchange responses, exception messages, or tracebacks. Existing bounded
+  structured execution events remain authoritative; when their console
+  projection is unavailable, fallback logs contain only safe count/type/reason
+  context. Exchange behavior is unchanged.
+
 - Live performance timing groups now expose their latest bounded report-safe
   canonical event IDs, including in `operation_durations` and
   `slowest_blockers`, so an operator can correlate a slow row with the

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -111,6 +111,10 @@ Low-balance exposure-increasing create skips are also console-visible through
 `execution.create_skipped`; the legacy `[balance] too low` line is only a
 fallback when the structured event console path is unavailable or explicitly
 disabled.
+Executor create/cancel anomalies are console-visible through bounded structured
+execution events. Legacy fallback logs may retain only counts, sanitized
+symbol/order-type labels, reason codes, and exception types; they must not print
+raw order dictionaries, exchange responses, exception messages, or tracebacks.
 Periodic `health.summary` events are console-visible because they provide a
 compact operator heartbeat covering uptime, loop latency, position counts,
 recent order/fill activity, errors, and resource pressure. Degraded

--- a/docs/plans/live_logging_migration_audit.md
+++ b/docs/plans/live_logging_migration_audit.md
@@ -138,6 +138,11 @@ These are useful for diagnostics but should not stay default INFO console noise:
 - successful cache loads/flushes
 - websocket reconnect debug loops unless user action is needed
 - raw CCXT request/response payloads outside TRACE.
+- executor create/cancel anomaly payloads. Bounded structured execution events
+  are authoritative; text fallback may include only counts, sanitized symbols,
+  order type, reason code, and exception type when the structured console is
+  unavailable. Never print raw order dictionaries, exchange responses, or
+  exception messages from these paths.
 
 Structured events may still retain compact summaries or DEBUG details.
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,34 +15,34 @@ merge, live smoke evidence changes, or new gaps are discovered.
 
 ## Current Status
 
-Last updated: 2026-07-09.
+Last updated: 2026-07-10.
 
 Current `origin/v8` head:
 
-- `a0639806` after PR #1164, `Distinguish recovered config refresh failures`.
+- `5e03df42` after PR #1165, `Expose timing correlation IDs`.
 
 Current logging-overhaul head:
 
-- `a0639806` after PR #1164, `Distinguish recovered config refresh failures`
+- `5e03df42` after PR #1165, `Expose timing correlation IDs`
   (latest merged logging-overhaul slice).
 
 Current work:
 
-- Branch `codex/v8-performance-correlation-ids` adds one bounded report-safe
-  canonical `latest_ids` mapping to each timing group and carries it into
-  `operation_durations` and `slowest_blockers`. This lets operators jump from a
-  slow timing row to the related structured events without exposing free-form
-  payloads. Legacy snapshot IDs follow the existing event-query normalization,
-  and equal-timestamp samples use persistent event sequence/source position.
-  The slice is read-only and does not change event production, exchange calls,
-  order/risk logic, restart orchestration, or trading behavior.
+- Branch `codex/v8-executor-bounded-diagnostics` removes raw order dictionaries,
+  exchange responses, exception messages, and tracebacks from executor
+  anomaly stdout/ERROR paths. Existing structured execution events remain the
+  detailed source; fallback text logs are emitted only when the structured
+  console is unavailable and contain bounded symbol/type/count/reason fields.
+  Exchange calls, result classification, retry/restart behavior, local state,
+  order/risk logic, and trading behavior remain unchanged.
 
 Current review gate:
 
-- Composer has been stopped/retired from this loop. The normal review gate is
-  now Claude Opus 4.8 + Hermes + Grok 4.5 + CI. For low-risk docs/tooling-only
-  slices, a degraded gate may still be used after repeated reviewer absence,
-  but that exception must be called out in the progress evidence.
+- Composer has been stopped/retired from this loop. While Claude Opus 4.8 is
+  rate-limited, the required review gate is Hermes + Grok 4.5 + CI; Claude may
+  rejoin when available. Findings from any additional reviewer still require
+  verification and resolution. A degraded gate after reviewer absence must be
+  explicitly authorized and called out in the progress evidence.
 
 Retuned goal boundary:
 
@@ -65,6 +65,21 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1165 at `5e03df42`.
+- PR #1165 added bounded report-safe latest correlation IDs to performance
+  timing groups, `operation_durations`, and `slowest_blockers`, with legacy
+  snapshot-ID normalization and stable persistent event ordering. It merged
+  after current-head Hermes, Claude Opus 4.8, Grok 4.5, and Codex reviews were
+  green and CI passed. VPS5 was pulled with
+  `git pull --autostash --ff-only origin v8`, preserving the pre-existing
+  tracked Rust edit and local config/tmp artifacts. No bot restart was
+  performed because the slice was read-only report projection. The first
+  two-minute smoke caught a Kucoin account-state `RequestTimeout` and degraded
+  cycle; a fresh one-minute smoke cleared with `ok=true`, `hard_failures=0`,
+  all five bots matched, and zero failed remote/account-critical calls. A
+  bounded 180-minute real-monitor report returned `ok=true`,
+  `error_count=0`, and 78 of 80 displayed groups carried `latest_ids` in each
+  of the performance, operation-duration, and blocker projections.
 - Repository pulled through PR #1164 at `a0639806`.
 - PR #1164 made the smoke and performance `exchange.config_refresh` projections
   distinguish historical failures from latest unresolved failures and expose

--- a/src/live/executor.py
+++ b/src/live/executor.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 import logging
 import math
 import sys
-import traceback
 from collections import defaultdict
 
 from passivbot_exceptions import RestartBotException
 from live.event_bus import EventTypes, ReasonCodes
-from procedures import print_async_exception
 from pure_funcs import shorten_custom_id
 from utils import utc_ms as _utils_utc_ms
 
@@ -29,6 +27,11 @@ def _utc_ms() -> int:
     if module is not None and hasattr(module, "utc_ms"):
         return int(module.utc_ms())
     return int(_utils_utc_ms())
+
+
+def _live_event_console_available(bot, passivbot_cls) -> bool:
+    checker = getattr(passivbot_cls, "_live_event_console_available", None)
+    return bool(checker(bot)) if callable(checker) else False
 
 
 def _order_is_reduce_only(order: dict) -> bool:
@@ -156,14 +159,22 @@ async def execute_order_plan(
     for elm in to_cancel:
         key = str(elm["price"]) + str(elm["qty"])
         if key in seen:
-            logging.debug("duplicate cancel candidate: %s", elm)
+            logging.debug(
+                "[order] duplicate cancel candidate | symbol=%s type=%s",
+                passivbot_cls._log_symbol(elm.get("symbol")),
+                _order_pb_type(elm),
+            )
         seen.add(key)
 
     seen = set()
     for elm in to_create:
         key = str(elm["price"]) + str(elm["qty"])
         if key in seen:
-            logging.debug("duplicate create candidate: %s", elm)
+            logging.debug(
+                "[order] duplicate create candidate | symbol=%s type=%s",
+                passivbot_cls._log_symbol(elm.get("symbol")),
+                _order_pb_type(elm),
+            )
         seen.add(key)
     low_balance = False
     if not bot.debug_mode:
@@ -201,13 +212,7 @@ async def execute_order_plan(
                         "allowed_protective_create": len(to_create),
                     },
                 )
-            live_event_console_available = False
-            live_event_console_available_fn = getattr(
-                passivbot_cls, "_live_event_console_available", None
-            )
-            if callable(live_event_console_available_fn):
-                live_event_console_available = bool(live_event_console_available_fn(bot))
-            if not live_event_console_available:
+            if not _live_event_console_available(bot, passivbot_cls):
                 logging.info(
                     "[balance] too low: %.2f %s; skipped %d exposure-increasing order creates; "
                     "allowing %d cancellations and %d protective creates",
@@ -219,8 +224,8 @@ async def execute_order_plan(
                 )
     if bot.debug_mode:
         if to_cancel:
-            print(
-                f"would cancel {len(to_cancel)} order{'s' if len(to_cancel) > 1 else ''}"
+            logging.info(
+                "[order] debug mode would cancel orders | count=%d", len(to_cancel)
             )
     else:
         cancel_started_ms = _utc_ms()
@@ -234,8 +239,8 @@ async def execute_order_plan(
             order_wave["cancel_posted"] = len(res or [])
     if bot.debug_mode:
         if to_create:
-            print(
-                f"would create {len(to_create)} order{'s' if len(to_create) > 1 else ''}"
+            logging.info(
+                "[order] debug mode would create orders | count=%d", len(to_create)
             )
     else:
         to_create_mod = []
@@ -390,9 +395,12 @@ async def execute_order_plan(
             except RestartBotException:
                 raise
             except Exception as exc:
-                logging.error(f"error executing orders {to_create_mod} {exc}")
-                print_async_exception(res)
-                traceback.print_exc()
+                if not _live_event_console_available(bot, passivbot_cls):
+                    logging.error(
+                        "[order] create batch raised before completion | count=%d error_type=%s",
+                        len(to_create_mod),
+                        type(exc).__name__,
+                    )
                 await bot.restart_bot_on_too_many_errors()
     if to_cancel or to_create:
         bot.execution_scheduled = True
@@ -497,11 +505,6 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
             )
         return []
     if len(orders) != len(res):
-        print(
-            f"debug unequal lengths execute_orders_parent: "
-            f"{len(orders)} orders, {len(res)} executions",
-            res,
-        )
         for idx, order in enumerate(orders):
             passivbot_cls._emit_execution_order_event(
                 bot,
@@ -523,18 +526,25 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
                 status="create_response_partial",
                 reason=ReasonCodes.LENGTH_MISMATCH,
             )
+        if not _live_event_console_available(bot, passivbot_cls):
+            logging.warning(
+                "[order] create response count mismatch | requested=%d returned=%d",
+                len(orders),
+                len(res),
+            )
         return []
     to_return = []
     for idx, (ex, order) in enumerate(zip(res, orders)):
         if not bot.did_create_order(ex):
             if isinstance(ex, Exception):
+                reason_code = "result_exception"
                 passivbot_cls._emit_execution_order_event(
                     bot,
                     event_type=EventTypes.EXECUTION_AMBIGUOUS,
                     order=order,
                     action="create",
                     status="degraded",
-                    reason_code="result_exception",
+                    reason_code=reason_code,
                     level="warning",
                     index=idx,
                     wave=wave,
@@ -546,7 +556,7 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
                     order,
                     emitted_ts=emitted_ts,
                     status="create_error_ambiguous",
-                    reason="result_exception",
+                    reason=reason_code,
                     error=ex,
                 )
             else:
@@ -568,18 +578,29 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
                     wave=wave,
                     result=ex if isinstance(ex, dict) else None,
                 )
-            print(f"debug did_create_order false {ex}")
+            if not _live_event_console_available(bot, passivbot_cls):
+                logging.warning(
+                    "[order] create not acknowledged | symbol=%s type=%s reason=%s error_type=%s",
+                    passivbot_cls._log_symbol(order.get("symbol")),
+                    bot._resolve_pb_order_type(order),
+                    reason_code,
+                    type(ex).__name__ if isinstance(ex, BaseException) else "",
+                )
             continue
-        debug_prints = {}
+        normalized_fields: dict[str, list[str]] = {}
         for key in order:
             if key not in ex:
-                debug_prints.setdefault("missing", []).append((key, order[key]))
+                normalized_fields.setdefault("missing", []).append(str(key))
                 ex[key] = order[key]
             elif ex[key] is None:
-                debug_prints.setdefault("is_none", []).append((key, order[key]))
+                normalized_fields.setdefault("is_none", []).append(str(key))
                 ex[key] = order[key]
-        if debug_prints and bot.debug_mode:
-            print("debug create_orders", debug_prints)
+        if normalized_fields and bot.debug_mode:
+            logging.debug(
+                "[order] normalized create response fields | missing_keys=%s none_keys=%s",
+                sorted(normalized_fields.get("missing", []))[:12],
+                sorted(normalized_fields.get("is_none", []))[:12],
+            )
         passivbot_cls._record_emitted_order_custom_id(bot, ex, emitted_ts=emitted_ts)
         bot.add_to_recent_order_executions(ex)
         passivbot_cls._emit_execution_order_event(
@@ -624,7 +645,10 @@ async def execute_cancellations_parent(bot, orders: list[dict]) -> list[dict]:
             rest = [x for x in orders if not x["reduce_only"]]
             orders = (reduce_only_orders + rest)[:max_cancellations]
         except Exception as exc:
-            logging.error(f"debug filter cancellations {exc}")
+            logging.error(
+                "[order] cancellation priority filtering failed; using input order | error_type=%s",
+                type(exc).__name__,
+            )
             orders = orders[:max_cancellations]
     grouped_orders: dict[str, list[dict]] = defaultdict(list)
     for order in orders:
@@ -686,11 +710,12 @@ async def execute_cancellations_parent(bot, orders: list[dict]) -> list[dict]:
                 extra={"response_count": len(res), "request_count": len(orders)},
             )
             bot.state_change_detected_by_symbol.add(order["symbol"])
-        print(
-            f"debug unequal lengths execute_cancellations_parent: "
-            f"{len(orders)} orders, {len(res)} executions",
-            res,
-        )
+        if not _live_event_console_available(bot, passivbot_cls):
+            logging.warning(
+                "[order] cancel response count mismatch | requested=%d returned=%d",
+                len(orders),
+                len(res),
+            )
         return []
     for idx, (ex, order) in enumerate(zip(res, orders)):
         if not bot.did_cancel_order(ex, order):
@@ -708,23 +733,33 @@ async def execute_cancellations_parent(bot, orders: list[dict]) -> list[dict]:
                 result=ex if isinstance(ex, dict) else None,
                 error=ex if isinstance(ex, BaseException) else None,
             )
-            print(f"debug did_cancel_order false {ex} {order}")
+            if not _live_event_console_available(bot, passivbot_cls):
+                logging.warning(
+                    "[order] cancel not acknowledged | symbol=%s type=%s error_type=%s",
+                    passivbot_cls._log_symbol(order.get("symbol")),
+                    bot._resolve_pb_order_type(order),
+                    type(ex).__name__ if isinstance(ex, BaseException) else "",
+                )
             continue
         ambiguous_terminal_state = (
             bot._cancel_result_requires_full_authoritative_confirmation(ex)
         )
         if ambiguous_terminal_state:
             bot.state_change_detected_by_symbol.add(order["symbol"])
-        debug_prints = {}
+        normalized_fields: dict[str, list[str]] = {}
         for key in order:
             if key not in ex:
-                debug_prints.setdefault("missing", []).append((key, order[key]))
+                normalized_fields.setdefault("missing", []).append(str(key))
                 ex[key] = order[key]
             elif ex[key] is None:
-                debug_prints.setdefault("is_none", []).append((key, order[key]))
+                normalized_fields.setdefault("is_none", []).append(str(key))
                 ex[key] = order[key]
-        if debug_prints and bot.debug_mode:
-            print("debug cancel_orders", debug_prints)
+        if normalized_fields and bot.debug_mode:
+            logging.debug(
+                "[order] normalized cancel response fields | missing_keys=%s none_keys=%s",
+                sorted(normalized_fields.get("missing", []))[:12],
+                sorted(normalized_fields.get("is_none", []))[:12],
+            )
         if ambiguous_terminal_state:
             passivbot_cls._emit_execution_order_event(
                 bot,

--- a/tests/test_foreign_passivbot_detection.py
+++ b/tests/test_foreign_passivbot_detection.py
@@ -104,7 +104,9 @@ async def test_execute_orders_parent_tracks_acknowledged_custom_id():
 
 
 @pytest.mark.asyncio
-async def test_execute_orders_parent_tracks_ambiguous_create_error_custom_id():
+async def test_execute_orders_parent_tracks_ambiguous_create_error_custom_id(
+    caplog, capsys
+):
     import passivbot as pb_mod
 
     class FakeBot:
@@ -152,7 +154,7 @@ async def test_execute_orders_parent_tracks_ambiguous_create_error_custom_id():
             return None
 
         async def execute_orders(self, orders):
-            return [TimeoutError("create timed out")]
+            return [TimeoutError("create timed out apiKey=RAW_CREATE_SECRET")]
 
         def did_create_order(self, executed):
             return False
@@ -173,7 +175,8 @@ async def test_execute_orders_parent_tracks_ambiguous_create_error_custom_id():
         "pb_order_type": "entry_grid_normal_long",
     }
 
-    res = await pb_mod.Passivbot.execute_orders_parent(bot, [order])
+    with caplog.at_level(logging.WARNING):
+        res = await pb_mod.Passivbot.execute_orders_parent(bot, [order])
 
     assert res == []
     assert len(bot.orders_emitted_to_exchange) == 1
@@ -186,10 +189,18 @@ async def test_execute_orders_parent_tracks_ambiguous_create_error_custom_id():
     assert bot._health_orders_placed == 0
     assert len(bot.recent_order_executions) == 1
     assert bot.recent_order_executions[0]["custom_id"] == custom_id
+    captured = capsys.readouterr()
+    rendered = captured.out + captured.err + caplog.text
+    assert "RAW_CREATE_SECRET" not in rendered
+    assert "create timed out" not in rendered
+    assert "create not acknowledged" in caplog.text
+    assert "error_type=TimeoutError" in caplog.text
 
 
 @pytest.mark.asyncio
-async def test_execute_orders_parent_does_not_throttle_rejected_create_response():
+async def test_execute_orders_parent_does_not_throttle_rejected_create_response(
+    caplog, capsys
+):
     import passivbot as pb_mod
 
     class FakeBot:
@@ -238,7 +249,14 @@ async def test_execute_orders_parent_does_not_throttle_rejected_create_response(
             return None
 
         async def execute_orders(self, orders):
-            return [{"id": "reject-1", "status": "rejected", **orders[0]}]
+            return [
+                {
+                    "id": "reject-1",
+                    "status": "rejected",
+                    "raw_error": "Authorization: Bearer RAW_REJECT_SECRET",
+                    **orders[0],
+                }
+            ]
 
         def add_new_order(self, order, source="POST"):
             raise AssertionError("rejected creates must not be added locally")
@@ -255,11 +273,17 @@ async def test_execute_orders_parent_does_not_throttle_rejected_create_response(
         "pb_order_type": "close_grid_long",
     }
 
-    res = await pb_mod.Passivbot.execute_orders_parent(bot, [order])
+    with caplog.at_level(logging.WARNING):
+        res = await pb_mod.Passivbot.execute_orders_parent(bot, [order])
 
     assert res == []
     assert bot.recent_order_executions == []
     assert bot._health_orders_placed == 0
+    captured = capsys.readouterr()
+    rendered = captured.out + captured.err + caplog.text
+    assert "RAW_REJECT_SECRET" not in rendered
+    assert "raw_error" not in rendered
+    assert "reason=terminal_rejection" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -331,6 +355,82 @@ async def test_execute_orders_parent_tracks_hard_failed_create_as_ambiguous():
 
 
 @pytest.mark.asyncio
+async def test_execute_order_plan_bounds_raised_create_exception_diagnostics(
+    monkeypatch, caplog, capsys
+):
+    import passivbot as pb_mod
+
+    async def keep_fresh_creations(_bot, orders):
+        return orders
+
+    monkeypatch.setattr(
+        pb_mod.Passivbot,
+        "_filter_fresh_market_snapshot_creations",
+        keep_fresh_creations,
+    )
+
+    class FakeBot:
+        debug_mode = False
+        balance_threshold = 0.0
+        quote = "USDT"
+        stop_signal_received = False
+        state_change_detected_by_symbol = set()
+        _shutdown_requested = pb_mod.Passivbot._shutdown_requested
+
+        def __init__(self):
+            self.restart_called = False
+            self.execution_scheduled = False
+
+        def get_raw_balance(self):
+            return 100.0
+
+        async def execute_cancellations_parent(self, orders):
+            assert orders == []
+            return []
+
+        def order_was_recently_updated(self, order):
+            return 0
+
+        async def execute_orders_parent(self, orders):
+            raise RuntimeError(
+                "exchange create failed Authorization: Bearer RAW_BATCH_SECRET"
+            )
+
+        async def restart_bot_on_too_many_errors(self):
+            self.restart_called = True
+
+        def _resolve_pb_order_type(self, order):
+            return str(order.get("pb_order_type") or "")
+
+    bot = FakeBot()
+    order = {
+        "symbol": "TON/USDT:USDT",
+        "side": "buy",
+        "position_side": "long",
+        "qty": 25.0,
+        "price": 2.495,
+        "reduce_only": False,
+        "custom_id": _pb_custom_id("entry_grid_normal_long", "batchfail"),
+        "pb_order_type": "entry_grid_normal_long",
+    }
+
+    with caplog.at_level(logging.ERROR):
+        await pb_mod.Passivbot.execute_order_plan_to_exchange(
+            bot, [], [order], configure_creations=False
+        )
+
+    assert bot.restart_called is True
+    assert bot.execution_scheduled is True
+    captured = capsys.readouterr()
+    rendered = captured.out + captured.err + caplog.text
+    assert "RAW_BATCH_SECRET" not in rendered
+    assert "Authorization" not in rendered
+    assert "Traceback" not in rendered
+    assert "create batch raised before completion" in caplog.text
+    assert "count=1 error_type=RuntimeError" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_execute_orders_parent_tracks_empty_create_response_as_ambiguous():
     import passivbot as pb_mod
 
@@ -397,7 +497,9 @@ async def test_execute_orders_parent_tracks_empty_create_response_as_ambiguous()
 
 
 @pytest.mark.asyncio
-async def test_execute_orders_parent_tracks_partial_create_response_as_ambiguous():
+async def test_execute_orders_parent_tracks_partial_create_response_as_ambiguous(
+    caplog, capsys
+):
     import passivbot as pb_mod
 
     class FakeBot:
@@ -441,7 +543,13 @@ async def test_execute_orders_parent_tracks_partial_create_response_as_ambiguous
             return None
 
         async def execute_orders(self, orders):
-            return [{"id": "only-first", **orders[0]}]
+            return [
+                {
+                    "id": "only-first",
+                    "raw_response": "api_key=RAW_PARTIAL_SECRET",
+                    **orders[0],
+                }
+            ]
 
     bot = FakeBot()
     orders = [
@@ -467,7 +575,8 @@ async def test_execute_orders_parent_tracks_partial_create_response_as_ambiguous
         },
     ]
 
-    res = await pb_mod.Passivbot.execute_orders_parent(bot, orders)
+    with caplog.at_level(logging.WARNING):
+        res = await pb_mod.Passivbot.execute_orders_parent(bot, orders)
 
     assert res == []
     assert len(bot.recent_order_executions) == 2
@@ -475,6 +584,89 @@ async def test_execute_orders_parent_tracks_partial_create_response_as_ambiguous
         "create_response_partial",
         "create_response_partial",
     ]
+    captured = capsys.readouterr()
+    rendered = captured.out + captured.err + caplog.text
+    assert "RAW_PARTIAL_SECRET" not in rendered
+    assert "raw_response" not in rendered
+    assert "create response count mismatch | requested=2 returned=1" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_execute_cancellations_parent_bounds_partial_response_diagnostics(
+    caplog, capsys
+):
+    import passivbot as pb_mod
+
+    class FakeBot:
+        debug_mode = False
+
+        def __init__(self):
+            self._health_orders_cancelled = 0
+            self._order_wave_in_progress = None
+            self.state_change_detected_by_symbol = set()
+
+        def live_value(self, key):
+            assert key == "max_n_cancellations_per_batch"
+            return 5
+
+        def add_to_recent_order_cancellations(self, order):
+            return None
+
+        def log_order_action(self, *args, **kwargs):
+            return None
+
+        def _log_order_action_summary(self, *args, **kwargs):
+            return None
+
+        async def execute_cancellations(self, orders):
+            return [
+                {
+                    "status": "success",
+                    "raw_response": "apiKey=RAW_CANCEL_SECRET",
+                    **orders[0],
+                }
+            ]
+
+        def _resolve_pb_order_type(self, order):
+            return str(order.get("pb_order_type") or "")
+
+    bot = FakeBot()
+    orders = [
+        {
+            "id": "cancel-1",
+            "symbol": "BTC/USDT:USDT",
+            "side": "buy",
+            "position_side": "long",
+            "qty": 0.01,
+            "price": 100000.0,
+            "reduce_only": True,
+            "pb_order_type": "close_grid_long",
+        },
+        {
+            "id": "cancel-2",
+            "symbol": "ETH/USDT:USDT",
+            "side": "sell",
+            "position_side": "short",
+            "qty": 0.1,
+            "price": 3000.0,
+            "reduce_only": True,
+            "pb_order_type": "close_grid_short",
+        },
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        res = await pb_mod.Passivbot.execute_cancellations_parent(bot, orders)
+
+    assert res == []
+    assert bot.state_change_detected_by_symbol == {
+        "BTC/USDT:USDT",
+        "ETH/USDT:USDT",
+    }
+    captured = capsys.readouterr()
+    rendered = captured.out + captured.err + caplog.text
+    assert "RAW_CANCEL_SECRET" not in rendered
+    assert "raw_response" not in rendered
+    assert "cancel response count mismatch | requested=2 returned=1" in caplog.text
 
 
 def _make_detection_bot(now_ts: int, start_ts: int):


### PR DESCRIPTION
## Summary

- remove raw order dictionaries, exchange responses, exception messages, and tracebacks from live executor anomaly output
- keep existing structured execution events authoritative; emit only bounded fallback fields when structured console projection is unavailable
- preserve exchange calls, result classification, ambiguous-order bookkeeping, restart behavior, authoritative-confirmation requests, and order state mutation
- record the merged PR #1165 VPS/report evidence and the temporary Hermes + Grok + CI review gate while Claude is rate-limited

## Contract

This is an observability-only cleanup. It does not change order generation, create/cancel submission, retries, throttling, result acceptance, restart policy, risk logic, or exchange behavior.

Safe fallback fields are limited to counts, sanitized symbol/order-type labels, reason codes, and exception types. Detailed bounded context remains available through the existing structured execution events.

## Validation

- `pytest -q tests/test_foreign_passivbot_detection.py` (18 passed)
- `pytest -q tests/test_exchange_config_updates.py` (27 passed)
- `pytest -q tests/test_order_orchestration.py` (31 passed)
- `pytest -q tests/test_passivbot_monitor.py` (76 passed)
- `pytest -q tests/test_passivbot_balance_split.py::test_ambiguous_cancel_forces_full_authoritative_confirmation`
- `pytest -q tests/test_run_fake_live.py -m fake_live` (21 passed)
- real two-step fake-live CLI smoke: `minimal.hjson`, completed successfully
- Python compile check for the executor and regression test
- `git diff --check`

Regression coverage injects secret-bearing create exceptions, terminal rejections, partial create responses, and partial cancel responses and proves raw payload/message/traceback text is absent while existing recovery and state semantics remain intact.

## Review Gate

Required for this PR while Claude Opus 4.8 is rate-limited: Hermes + Grok 4.5 + green CI. Findings from any additional reviewer still require resolution and current-head re-review.
