### PR TITLE
Bound lower-level order write diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Live executor create/cancel anomalies no longer print raw order dictionaries,
-  exchange responses, exception messages, or tracebacks. Existing bounded
-  structured execution events remain authoritative; when their console
-  projection is unavailable, fallback logs contain only safe count/type/reason
-  context. Exchange behavior is unchanged.
+- Live executor create/cancel anomalies, including lower-level base/CCXT order
+  write failures, no longer print raw order dictionaries, exchange responses,
+  exception messages, or tracebacks. Existing bounded structured execution
+  events remain authoritative; when their console projection is unavailable,
+  fallback logs contain only safe action/symbol/type/reason context. Exchange
+  behavior is unchanged.
 
 - Live performance timing groups now expose their latest bounded report-safe
   canonical event IDs, including in `operation_durations` and

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -115,6 +115,8 @@ Executor create/cancel anomalies are console-visible through bounded structured
 execution events. Legacy fallback logs may retain only counts, sanitized
 symbol/order-type labels, reason codes, and exception types; they must not print
 raw order dictionaries, exchange responses, exception messages, or tracebacks.
+This applies at every order-write layer, including connector/base batch helpers
+that run before the parent executor classifies the result.
 Periodic `health.summary` events are console-visible because they provide a
 compact operator heartbeat covering uptime, loop latency, position counts,
 recent order/fill activity, errors, and resource pressure. Degraded

--- a/docs/plans/live_logging_migration_audit.md
+++ b/docs/plans/live_logging_migration_audit.md
@@ -138,11 +138,12 @@ These are useful for diagnostics but should not stay default INFO console noise:
 - successful cache loads/flushes
 - websocket reconnect debug loops unless user action is needed
 - raw CCXT request/response payloads outside TRACE.
-- executor create/cancel anomaly payloads. Bounded structured execution events
-  are authoritative; text fallback may include only counts, sanitized symbols,
-  order type, reason code, and exception type when the structured console is
-  unavailable. Never print raw order dictionaries, exchange responses, or
-  exception messages from these paths.
+- executor create/cancel anomaly payloads at parent, base, and connector batch
+  layers. Bounded structured execution events are authoritative; text fallback
+  may include only counts, action, sanitized symbols, order type, reason code,
+  and exception type when the structured console is unavailable. Never print
+  raw order dictionaries, exchange responses, or exception messages from these
+  paths.
 
 Structured events may still retain compact summaries or DEBUG details.
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,22 +19,23 @@ Last updated: 2026-07-10.
 
 Current `origin/v8` head:
 
-- `5e03df42` after PR #1165, `Expose timing correlation IDs`.
+- `b1516253` after PR #1166, `Bound live executor anomaly diagnostics`.
 
 Current logging-overhaul head:
 
-- `5e03df42` after PR #1165, `Expose timing correlation IDs`
+- `b1516253` after PR #1166, `Bound live executor anomaly diagnostics`
   (latest merged logging-overhaul slice).
 
 Current work:
 
-- Branch `codex/v8-executor-bounded-diagnostics` removes raw order dictionaries,
-  exchange responses, exception messages, and tracebacks from executor
-  anomaly stdout/ERROR paths. Existing structured execution events remain the
-  detailed source; fallback text logs are emitted only when the structured
-  console is unavailable and contain bounded symbol/type/count/reason fields.
-  Exchange calls, result classification, retry/restart behavior, local state,
-  order/risk logic, and trading behavior remain unchanged.
+- Branch `codex/v8-order-write-bounded-diagnostics` extends the executor
+  diagnostic contract through the lower-level base and CCXT order-write
+  helpers. Error fallbacks contain only bounded action/symbol/type/error-type
+  fields and are suppressed when structured console projection is available;
+  the OKX already-gone cancel race also stops rendering raw exception text.
+  Exchange calls, exception-result propagation, ambiguous classification,
+  retry/restart behavior, local state, order/risk logic, and trading behavior
+  remain unchanged.
 
 Current review gate:
 
@@ -65,6 +66,22 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1166 at `b1516253`.
+- PR #1166 removed raw order dictionaries, exchange responses, exception
+  messages, and tracebacks from parent executor anomaly output while preserving
+  exchange writes, result classification, ambiguous-order bookkeeping,
+  restart behavior, and state mutation. It merged after current-head Hermes
+  and Grok 4.5 approvals plus green CI; Claude Opus 4.8 was explicitly waived
+  while rate-limited. VPS5 was pulled with `git pull --autostash --ff-only
+  origin v8`, preserving the pre-existing tracked Rust edit and local
+  config/tmp artifacts. All five bots were restarted from
+  `/root/bots_vps5.yaml`; Kucoin required a second exact-pane Ctrl+C, and no
+  broad process-pattern signal was used. Immediate and later smoke reports
+  returned `ok=true`, `hard_failures=0`, all five expected bots matched, and
+  zero failed remote/account-critical calls or text-log hard/attention matches.
+  Four forager bots remained in active, non-stale coin-HSL replay with forward
+  progress, reflecting the known startup-latency gap rather than a #1166
+  regression.
 - Repository pulled through PR #1165 at `5e03df42`.
 - PR #1165 added bounded report-safe latest correlation IDs to performance
   timing groups, `operation_durations`, and `slowest_blockers`, with legacy

--- a/src/exchanges/ccxt_bot.py
+++ b/src/exchanges/ccxt_bot.py
@@ -1133,7 +1133,9 @@ class CCXTBot(Passivbot):
         if any_exceptions:
             for i, result in enumerate(results):
                 if isinstance(result, Exception):
-                    logging.error(f"error executing order {orders[i]}: {result}")
+                    self._log_order_write_failure(
+                        action="create", order=orders[i], error=result
+                    )
             await self.restart_bot_on_too_many_errors()
 
         return results
@@ -1150,7 +1152,9 @@ class CCXTBot(Passivbot):
         if any_exceptions:
             for i, result in enumerate(results):
                 if isinstance(result, Exception):
-                    logging.error(f"error cancelling order {orders[i]}: {result}")
+                    self._log_order_write_failure(
+                        action="cancel", order=orders[i], error=result
+                    )
             await self.restart_bot_on_too_many_errors()
 
         return results

--- a/src/exchanges/ccxt_bot.py
+++ b/src/exchanges/ccxt_bot.py
@@ -1129,14 +1129,12 @@ class CCXTBot(Passivbot):
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
         # Check for exceptions and trigger error handling if needed
-        any_exceptions = any(isinstance(r, Exception) for r in results)
-        if any_exceptions:
-            for i, result in enumerate(results):
-                if isinstance(result, Exception):
-                    self._log_order_write_failure(
-                        action="create", order=orders[i], error=result
-                    )
-            await self.restart_bot_on_too_many_errors()
+        failures = [
+            ("create", orders[i], result)
+            for i, result in enumerate(results)
+            if isinstance(result, Exception)
+        ]
+        await self._handle_order_write_failures(failures)
 
         return results
 
@@ -1148,13 +1146,11 @@ class CCXTBot(Passivbot):
         tasks = [self.execute_cancellation(order) for order in orders]
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        any_exceptions = any(isinstance(r, Exception) for r in results)
-        if any_exceptions:
-            for i, result in enumerate(results):
-                if isinstance(result, Exception):
-                    self._log_order_write_failure(
-                        action="cancel", order=orders[i], error=result
-                    )
-            await self.restart_bot_on_too_many_errors()
+        failures = [
+            ("cancel", orders[i], result)
+            for i, result in enumerate(results)
+            if isinstance(result, Exception)
+        ]
+        await self._handle_order_write_failures(failures)
 
         return results

--- a/src/exchanges/okx.py
+++ b/src/exchanges/okx.py
@@ -192,7 +192,11 @@ class OKXBot(CCXTBot):
         except Exception as e:
             # 51400 = order already cancelled or filled - not an error
             if '"sCode":"51400"' in str(e):
-                logging.info(f"Order already cancelled/filled: {e}")
+                logging.info(
+                    "[order] cancel skipped: %s - order already cancelled or filled | error_type=%s",
+                    self._log_symbol(order.get("symbol")),
+                    type(e).__name__,
+                )
                 return self._ambiguous_cancel_success_result(order)
             raise
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -733,10 +733,15 @@ class Passivbot:
         return value if len(value) <= 64 else f"{value[:64]}..."
 
     def _log_order_write_failure(
-        self, *, action: str, order: Any, error: BaseException
+        self,
+        *,
+        action: str,
+        order: Any,
+        error: BaseException,
+        force: bool = False,
     ) -> None:
         """Emit a bounded fallback when structured execution console is unavailable."""
-        if Passivbot._live_event_console_available(self):
+        if not force and Passivbot._live_event_console_available(self):
             return
         symbol = Passivbot._log_symbol(
             order.get("symbol") if isinstance(order, dict) else None
@@ -750,6 +755,29 @@ class Passivbot:
             Passivbot._log_order_type(order),
             type(error).__name__,
         )
+
+    async def _handle_order_write_failures(
+        self, failures: list[tuple[str, Any, BaseException]]
+    ) -> None:
+        """Log bounded fallbacks and preserve restart-budget handling."""
+        if not failures:
+            return
+        for action, order, error in failures:
+            self._log_order_write_failure(
+                action=action, order=order, error=error
+            )
+        try:
+            await self.restart_bot_on_too_many_errors()
+        except BaseException:
+            if Passivbot._live_event_console_available(self):
+                for action, order, error in failures:
+                    self._log_order_write_failure(
+                        action=action,
+                        order=order,
+                        error=error,
+                        force=True,
+                    )
+            raise
 
     @staticmethod
     def _log_symbols(symbols: Iterable[Any], limit: int | None = None) -> str:
@@ -17371,20 +17399,15 @@ class Passivbot:
         if not orders:
             return []
         executions = []
-        any_exceptions = False
+        failures: list[tuple[str, Any, BaseException]] = []
         action = "cancel" if "cancel" in type_ else "create"
         for order in orders:  # sorted by PA dist
             try:
                 task = asyncio.create_task(getattr(self, type_)(order))
                 executions.append((order, task))
             except Exception as e:
-                self._log_order_write_failure(
-                    action=action,
-                    order=order,
-                    error=e,
-                )
+                failures.append((action, order, e))
                 executions.append((order, e))
-                any_exceptions = True
         results = []
         for order, execution in executions:
             if isinstance(execution, Exception):
@@ -17396,15 +17419,9 @@ class Passivbot:
                 result = await execution
                 results.append(result)
             except Exception as e:
-                self._log_order_write_failure(
-                    action=action,
-                    order=order,
-                    error=e,
-                )
+                failures.append((action, order, e))
                 results.append(e)
-                any_exceptions = True
-        if any_exceptions:
-            await self.restart_bot_on_too_many_errors()
+        await self._handle_order_write_failures(failures)
         return results
 
     # Legacy maintain_ohlcvs_1m_REST removed; CandlestickManager handles caching and TTL

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -725,6 +725,33 @@ class Passivbot:
         return symbol_to_coin(sym, verbose=False) or sym
 
     @staticmethod
+    def _log_order_type(order: Any) -> str:
+        """Return a bounded order-type label without decoding raw client ids."""
+        if not isinstance(order, dict):
+            return "unknown"
+        value = str(order.get("pb_order_type") or "unknown")
+        return value if len(value) <= 64 else f"{value[:64]}..."
+
+    def _log_order_write_failure(
+        self, *, action: str, order: Any, error: BaseException
+    ) -> None:
+        """Emit a bounded fallback when structured execution console is unavailable."""
+        if Passivbot._live_event_console_available(self):
+            return
+        symbol = Passivbot._log_symbol(
+            order.get("symbol") if isinstance(order, dict) else None
+        )
+        if len(symbol) > 80:
+            symbol = f"{symbol[:80]}..."
+        logging.error(
+            "[order] write failed | action=%s symbol=%s type=%s error_type=%s",
+            action,
+            symbol,
+            Passivbot._log_order_type(order),
+            type(error).__name__,
+        )
+
+    @staticmethod
     def _log_symbols(symbols: Iterable[Any], limit: int | None = None) -> str:
         """Format a symbol collection for operator-facing logs."""
         vals = [Passivbot._log_symbol(symbol) for symbol in symbols if symbol]
@@ -17345,15 +17372,17 @@ class Passivbot:
             return []
         executions = []
         any_exceptions = False
+        action = "cancel" if "cancel" in type_ else "create"
         for order in orders:  # sorted by PA dist
-            task = None
             try:
                 task = asyncio.create_task(getattr(self, type_)(order))
                 executions.append((order, task))
             except Exception as e:
-                logging.error(f"error executing {type_} {order} {e}")
-                print_async_exception(task)
-                traceback.print_exc()
+                self._log_order_write_failure(
+                    action=action,
+                    order=order,
+                    error=e,
+                )
                 executions.append((order, e))
                 any_exceptions = True
         results = []
@@ -17367,10 +17396,12 @@ class Passivbot:
                 result = await execution
                 results.append(result)
             except Exception as e:
-                logging.error(f"error executing {type_} {execution} {e}")
-                print_async_exception(result)
+                self._log_order_write_failure(
+                    action=action,
+                    order=order,
+                    error=e,
+                )
                 results.append(e)
-                traceback.print_exc()
                 any_exceptions = True
         if any_exceptions:
             await self.restart_bot_on_too_many_errors()
@@ -17673,8 +17704,6 @@ class Passivbot:
                     order.get("id", "?")[:12],
                 )
                 return self._ambiguous_cancel_success_result(order)
-            logging.error(f"error cancelling order {order} {e}")
-            print_async_exception(executed)
             raise
 
     async def execute_cancellations(self, orders: [dict]) -> [dict]:

--- a/tests/exchanges/test_ccxt_bot.py
+++ b/tests/exchanges/test_ccxt_bot.py
@@ -434,6 +434,117 @@ class TestCCXTBotUpdateExchangeConfigBySymbols:
             await bot.update_exchange_config_by_symbols(["BTC/USDT:USDT"])
 
 
+class TestCCXTBotBatchOrderDiagnostics:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("batch_method", "single_method", "action"),
+        [
+            ("execute_orders", "execute_order", "create"),
+            ("execute_cancellations", "execute_cancellation", "cancel"),
+        ],
+    )
+    async def test_bounds_failures_and_preserves_restart(
+        self, batch_method, single_method, action, caplog, capsys
+    ):
+        from exchanges.ccxt_bot import CCXTBot
+
+        bot = CCXTBot.__new__(CCXTBot)
+        bot.live_event_console_enabled = False
+        bot._live_event_pipeline = None
+        setattr(
+            bot,
+            single_method,
+            AsyncMock(
+                side_effect=RuntimeError(
+                    "exchange write failed Authorization: Bearer RAW_WRITE_SECRET"
+                )
+            ),
+        )
+        bot.restart_bot_on_too_many_errors = AsyncMock()
+        order = {
+            "id": "order-1",
+            "symbol": "BTC/USDT:USDT",
+            "pb_order_type": "entry_grid_normal_long",
+            "raw_payload": "RAW_ORDER_SECRET",
+        }
+
+        with caplog.at_level(logging.ERROR):
+            results = await getattr(bot, batch_method)([order])
+
+        assert len(results) == 1
+        assert isinstance(results[0], RuntimeError)
+        bot.restart_bot_on_too_many_errors.assert_awaited_once()
+        captured = capsys.readouterr()
+        rendered = captured.out + captured.err + caplog.text
+        assert "RAW_WRITE_SECRET" not in rendered
+        assert "RAW_ORDER_SECRET" not in rendered
+        assert "Authorization" not in rendered
+        assert "raw_payload" not in rendered
+        assert (
+            f"[order] write failed | action={action} symbol=BTC "
+            "type=entry_grid_normal_long error_type=RuntimeError"
+        ) in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_structured_console_suppresses_fallback(self, caplog):
+        from exchanges.ccxt_bot import CCXTBot
+
+        bot = CCXTBot.__new__(CCXTBot)
+        bot.live_event_console_enabled = True
+        bot._live_event_pipeline = object()
+        bot.execute_order = AsyncMock(side_effect=RuntimeError("RAW_SUPPRESSED_SECRET"))
+        bot.restart_bot_on_too_many_errors = AsyncMock()
+
+        with caplog.at_level(logging.ERROR):
+            results = await bot.execute_orders(
+                [
+                    {
+                        "symbol": "ETH/USDT:USDT",
+                        "pb_order_type": "close_grid_long",
+                    }
+                ]
+            )
+
+        assert len(results) == 1
+        assert isinstance(results[0], RuntimeError)
+        bot.restart_bot_on_too_many_errors.assert_awaited_once()
+        assert "write failed" not in caplog.text
+        assert "RAW_SUPPRESSED_SECRET" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_base_sequential_writer_bounds_failure(self, caplog, capsys):
+        from passivbot import Passivbot
+
+        bot = Passivbot.__new__(Passivbot)
+        bot.live_event_console_enabled = False
+        bot._live_event_pipeline = None
+        bot.execute_order = AsyncMock(
+            side_effect=RuntimeError("sequential failed apiKey=RAW_SEQUENTIAL_SECRET")
+        )
+        bot.restart_bot_on_too_many_errors = AsyncMock()
+        order = {
+            "symbol": "SOL/USDT:USDT",
+            "pb_order_type": "entry_grid_normal_long",
+            "private": "RAW_SEQUENTIAL_ORDER_SECRET",
+        }
+
+        with caplog.at_level(logging.ERROR):
+            results = await bot.execute_multiple([order], "execute_order")
+
+        assert len(results) == 1
+        assert isinstance(results[0], RuntimeError)
+        bot.restart_bot_on_too_many_errors.assert_awaited_once()
+        captured = capsys.readouterr()
+        rendered = captured.out + captured.err + caplog.text
+        assert "RAW_SEQUENTIAL_SECRET" not in rendered
+        assert "RAW_SEQUENTIAL_ORDER_SECRET" not in rendered
+        assert "Traceback" not in rendered
+        assert (
+            "[order] write failed | action=create symbol=SOL "
+            "type=entry_grid_normal_long error_type=RuntimeError"
+        ) in caplog.text
+
+
 class TestCCXTBotExecuteCancellation:
     """Tests for execute_cancellation."""
 
@@ -464,18 +575,35 @@ class TestCCXTBotExecuteCancellation:
         assert not any(record.levelname == "ERROR" for record in caplog.records)
 
     @pytest.mark.asyncio
-    async def test_unexpected_cancel_error_propagates(self):
+    async def test_unexpected_cancel_error_propagates_without_raw_output(
+        self, caplog, capsys
+    ):
         from exchanges.ccxt_bot import CCXTBot
 
         bot = CCXTBot.__new__(CCXTBot)
         bot.exchange = "bybit"
         bot.cca = MagicMock()
-        bot.cca.cancel_order = AsyncMock(side_effect=Exception("simulated network outage"))
-
-        with pytest.raises(Exception, match="simulated network outage"):
-            await bot.execute_cancellation(
-                {"id": "abc123def456", "symbol": "SUI/USDT:USDT"}
+        bot.cca.cancel_order = AsyncMock(
+            side_effect=Exception(
+                "simulated network outage Authorization: Bearer RAW_CANCEL_SECRET"
             )
+        )
+
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(Exception, match="simulated network outage"):
+                await bot.execute_cancellation(
+                    {
+                        "id": "abc123def456",
+                        "symbol": "SUI/USDT:USDT",
+                        "raw_payload": "RAW_CANCEL_ORDER_SECRET",
+                    }
+                )
+
+        captured = capsys.readouterr()
+        rendered = captured.out + captured.err + caplog.text
+        assert "RAW_CANCEL_SECRET" not in rendered
+        assert "RAW_CANCEL_ORDER_SECRET" not in rendered
+        assert "simulated network outage" not in rendered
 
     def test_cross_only_blocks_isolated_only_symbol_for_entries(self, caplog):
         from exchanges.ccxt_bot import CCXTBot

--- a/tests/exchanges/test_ccxt_bot.py
+++ b/tests/exchanges/test_ccxt_bot.py
@@ -512,6 +512,45 @@ class TestCCXTBotBatchOrderDiagnostics:
         assert "RAW_SUPPRESSED_SECRET" not in caplog.text
 
     @pytest.mark.asyncio
+    async def test_restart_raise_forces_bounded_fallback(
+        self, caplog, capsys
+    ):
+        from exchanges.ccxt_bot import CCXTBot
+        from passivbot_exceptions import RestartBotException
+
+        bot = CCXTBot.__new__(CCXTBot)
+        bot.live_event_console_enabled = True
+        bot._live_event_pipeline = object()
+        bot.execute_order = AsyncMock(
+            side_effect=RuntimeError("write failed apiKey=RAW_RESTART_WRITE_SECRET")
+        )
+        bot.restart_bot_on_too_many_errors = AsyncMock(
+            side_effect=RestartBotException(
+                "restart failed Authorization: Bearer RAW_RESTART_SECRET"
+            )
+        )
+        order = {
+            "symbol": "XRP/USDT:USDT",
+            "pb_order_type": "entry_grid_normal_long",
+            "private": "RAW_RESTART_ORDER_SECRET",
+        }
+
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(RestartBotException, match="restart failed"):
+                await bot.execute_orders([order])
+
+        bot.restart_bot_on_too_many_errors.assert_awaited_once()
+        captured = capsys.readouterr()
+        rendered = captured.out + captured.err + caplog.text
+        assert "RAW_RESTART_WRITE_SECRET" not in rendered
+        assert "RAW_RESTART_SECRET" not in rendered
+        assert "RAW_RESTART_ORDER_SECRET" not in rendered
+        assert (
+            "[order] write failed | action=create symbol=XRP "
+            "type=entry_grid_normal_long error_type=RuntimeError"
+        ) in caplog.text
+
+    @pytest.mark.asyncio
     async def test_base_sequential_writer_bounds_failure(self, caplog, capsys):
         from passivbot import Passivbot
 

--- a/tests/test_exchange_config_updates.py
+++ b/tests/test_exchange_config_updates.py
@@ -473,6 +473,38 @@ async def test_okx_update_config_verified_net_mode_fails_loudly():
 
 
 @pytest.mark.asyncio
+async def test_okx_already_gone_cancel_does_not_log_raw_exception(caplog, capsys):
+    from exchanges.okx import OKXBot
+
+    bot = OKXBot.__new__(OKXBot)
+    bot.cca = SimpleNamespace(
+        cancel_order=AsyncMock(
+            side_effect=Exception(
+                '{"sCode":"51400","apiKey":"RAW_OKX_CANCEL_SECRET"}'
+            )
+        )
+    )
+    order = {
+        "id": "order-1",
+        "symbol": "BTC/USDT:USDT",
+        "raw_payload": "RAW_OKX_ORDER_SECRET",
+    }
+
+    with caplog.at_level(logging.INFO):
+        result = await bot.execute_cancellation(order)
+
+    assert result["status"] == "success"
+    assert result["_passivbot_cancel_requires_full_authoritative_confirmation"] is True
+    captured = capsys.readouterr()
+    rendered = captured.out + captured.err + caplog.text
+    assert "RAW_OKX_CANCEL_SECRET" not in rendered
+    assert "RAW_OKX_ORDER_SECRET" not in rendered
+    assert "sCode" not in rendered
+    assert "cancel skipped: BTC" in caplog.text
+    assert "error_type=Exception" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_execute_to_exchange_stops_after_exchange_config_shutdown():
     import passivbot as pb_mod
 


### PR DESCRIPTION
## Summary

- extend the bounded executor diagnostic contract through base and CCXT create/cancel batch writers
- suppress duplicate lower-level fallback logs when structured live-event console projection is active
- stop rendering raw OKX `51400` already-gone cancel exceptions while preserving the successful ambiguous-confirmation result
- record PR #1166 merge/deploy/restart evidence in the logging progress ledger

## Contract

This is observability-only. Exchange calls, order payloads, concurrent/sequential execution, exception-result propagation, result classification, ambiguous-order bookkeeping, authoritative confirmation, restart behavior, local state mutation, and trading/risk behavior are unchanged.

When structured console projection is unavailable, lower-level write failures emit only bounded `action`, symbol, order type, and exception type. Raw order dictionaries, exchange responses, exception messages, and tracebacks are not rendered.

If restart-budget handling raises before the parent executor can emit its structured result event, the lower layer emits one forced bounded fallback before propagating the restart. Otherwise it stays silent under structured console projection to avoid duplicate output.

## Validation

- `pytest -q tests/exchanges/test_ccxt_bot.py tests/test_exchange_config_updates.py` (71 passed)
- `pytest -q tests/test_foreign_passivbot_detection.py` (18 passed)
- `pytest -q tests/test_passivbot_monitor.py` (76 passed)
- `pytest -q tests/test_order_orchestration.py` (31 passed)
- `pytest -q tests/exchanges/test_ccxt_bot_hooks.py` (57 passed)
- `pytest -q tests/test_run_fake_live.py -m fake_live` (21 passed)
- real two-step fake-live CLI smoke with `minimal.hjson` completed successfully
- Python compile check for all touched Python files
- `git diff --check`
- added-line silent-handling scan: no new unobserved exception fallback

Regression tests inject secret-bearing create/cancel exceptions and raw order fields, prove that fallback output is bounded or suppressed, and verify that restart calls, exception results, propagation, and OKX already-gone success semantics remain intact.

## Review Gate

Required while Claude Opus 4.8 is rate-limited: Hermes + Grok 4.5 + green CI. Findings from any additional reviewer still require resolution and current-head re-review.
