### PR TITLE
Bound exchange config response diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Exchange-config success logs now use one bounded, value-safe formatter across
+  the shared CCXT connector and Binance, Bitget, Bybit, KuCoin, and OKX. Raw API
+  response values are replaced by canonical status, finite numeric leverage,
+  bounded numeric code, or response type/presence labels; exchange calls and
+  failure behavior are unchanged.
+
 - Live executor create/cancel anomalies, including lower-level base/CCXT order
   write failures, no longer print raw order dictionaries, exchange responses,
   exception messages, or tracebacks. Existing bounded structured execution

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -47,6 +47,11 @@ exists there. Add new registry values before introducing repeated literals. See
 
 Fallbacks in critical paths log warnings with required context from `error_contract.md`.
 
+Exchange-config response logs at every level must use the shared bounded
+formatter. They may expose only canonical success/unchanged status, finite
+numeric leverage, a bounded numeric response code, or response type/presence;
+they must not render arbitrary response values or full API payloads.
+
 ## Live Event Debug Profiles
 
 Use `logging.live_event_debug_profiles` or the

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,23 +19,21 @@ Last updated: 2026-07-10.
 
 Current `origin/v8` head:
 
-- `b1516253` after PR #1166, `Bound live executor anomaly diagnostics`.
+- `8bb35dea` after PR #1167, `Bound lower-level order write diagnostics`.
 
 Current logging-overhaul head:
 
-- `b1516253` after PR #1166, `Bound live executor anomaly diagnostics`
+- `8bb35dea` after PR #1167, `Bound lower-level order write diagnostics`
   (latest merged logging-overhaul slice).
 
 Current work:
 
-- Branch `codex/v8-order-write-bounded-diagnostics` extends the executor
-  diagnostic contract through the lower-level base and CCXT order-write
-  helpers. Error fallbacks contain only bounded action/symbol/type/error-type
-  fields and are suppressed when structured console projection is available;
-  the OKX already-gone cancel race also stops rendering raw exception text.
-  Exchange calls, exception-result propagation, ambiguous classification,
-  retry/restart behavior, local state, order/risk logic, and trading behavior
-  remain unchanged.
+- Branch `codex/v8-exchange-config-response-diagnostics` makes the shared
+  exchange-config response formatter value-safe and applies it to account-level
+  hedge-mode success logs in the shared CCXT connector plus Binance, Bitget,
+  Bybit, KuCoin, and OKX. It changes logging only; exchange calls, response
+  handling, exception propagation, retry/backoff, and trading behavior remain
+  unchanged.
 
 Current review gate:
 
@@ -66,6 +64,18 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1167 at `8bb35dea`. Lower-level base and CCXT
+  order-write failures now fall back to bounded action/symbol/type/error-type
+  context only when structured console projection cannot retain the parent
+  anomaly, and the OKX already-gone cancel race no longer renders raw exception
+  text. The PR merged after current-head Hermes and Grok 4.5 approvals plus
+  green CI; Claude Opus 4.8 was explicitly waived while rate-limited. VPS5 was
+  pulled with `git pull --autostash --ff-only origin v8`, preserving the
+  pre-existing tracked Rust edit and local config/tmp artifacts, and all five
+  configured bots were restarted. A fresh ten-minute smoke on 2026-07-10
+  returned `ok=true`, `hard_failures=0`, all five expected bots matched, zero
+  failed remote/account-critical calls, and zero text-log hard/attention
+  matches. Four HSL replays remained active but non-stale and not long-running.
 - Repository pulled through PR #1166 at `b1516253`.
 - PR #1166 removed raw order dictionaries, exchange responses, exception
   messages, and tracebacks from parent executor anomaly output while preserving

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -733,6 +733,13 @@ Related detailed plans:
       smoke and performance reports so a historical timeout followed by success
       is not presented as unresolved. It does not change verdicts, retries,
       exception propagation, exchange I/O, or trading behavior.
+    - 2026-07-10: Branch
+      `codex/v8-exchange-config-response-diagnostics` replaces raw successful
+      response rendering with one bounded, value-safe formatter across the
+      shared CCXT and account-level connector call sites. Connector-specific
+      failure logs and per-symbol methods that currently swallow exceptions are
+      intentionally unchanged; deciding their propagation contract remains
+      separate trading-critical work.
 
 ## Merged Work Log
 

--- a/src/exchanges/binance.py
+++ b/src/exchanges/binance.py
@@ -557,7 +557,9 @@ class BinanceBot(CCXTBot):
     async def update_exchange_config(self):
         try:
             res = await self.cca.set_position_mode(True)
-            logging.debug("[config] set hedge mode response: %s", res)
+            logging.debug(
+                "[config] set hedge mode response: %s", format_exchange_config_response(res)
+            )
         except Exception as e:
             if '"code":-4059' in str(e):
                 logging.debug("[config] hedge mode unchanged: %s", e)

--- a/src/exchanges/bitget.py
+++ b/src/exchanges/bitget.py
@@ -797,7 +797,9 @@ class BitgetBot(CCXTBot):
         res = None
         try:
             res = await self.cca.set_position_mode(True)
-            logging.debug("[config] set hedge mode response: %s", res)
+            logging.debug(
+                "[config] set hedge mode response: %s", format_exchange_config_response(res)
+            )
         except Exception as e:
             logging.error("[config] error setting hedge mode: %s %s", e, res)
             raise

--- a/src/exchanges/bybit.py
+++ b/src/exchanges/bybit.py
@@ -538,4 +538,6 @@ class BybitBot(CCXTBot):
                 logging.debug("[config] hedge mode already set (not modified)")
                 return
             raise
-        logging.debug("[config] set hedge mode response: %s", res)
+        logging.debug(
+            "[config] set hedge mode response: %s", format_exchange_config_response(res)
+        )

--- a/src/exchanges/ccxt_bot.py
+++ b/src/exchanges/ccxt_bot.py
@@ -45,46 +45,51 @@ from config.access import get_optional_live_value, require_live_value
 assert_correct_ccxt_version(ccxt=ccxt_async)
 
 
-def format_exchange_config_response(res: dict) -> str:
-    """Format exchange config API response (leverage, margin mode) concisely.
-
-    Instead of logging full JSON like:
-        {'symbol': 'ADAUSDT', 'leverage': '10', 'maxNotionalValue': '10000000'}
-    Returns:
-        'ok' or 'leverage=10x' or error message
-    """
+def format_exchange_config_response(res: object) -> str:
+    """Return a bounded, value-safe summary of an exchange config response."""
     if not isinstance(res, dict):
-        return str(res)[:50]
+        return f"result_type={type(res).__name__[:40]}"
 
-    # Check for success indicators
-    code = res.get("code") or res.get("retCode")
-    msg = res.get("msg") or res.get("retMsg") or res.get("message", "")
-    status = res.get("status", "")
+    code = res.get("code")
+    if code is None:
+        code = res.get("retCode")
+    status = res.get("status")
 
-    # Success cases
-    if code in (0, "0", "200000", 200000):
-        return "ok"
-    if status == "ok":
+    if code in (0, "0", "200000", 200000) or status == "ok":
         return "ok"
 
-    # "No need to change" is success
-    if "no need" in str(msg).lower():
+    msg = res.get("msg")
+    if msg is None:
+        msg = res.get("retMsg")
+    if msg is None:
+        msg = res.get("message")
+    if isinstance(msg, str) and "no need" in msg.lower():
         return "ok (unchanged)"
 
-    # Extract useful info
-    leverage = res.get("leverage") or res.get("lever")
-    if leverage:
-        return f"leverage={leverage}x"
+    leverage = res.get("leverage")
+    if leverage is None:
+        leverage = res.get("lever")
+    if isinstance(leverage, (int, float, str)) and not isinstance(leverage, bool):
+        try:
+            leverage_value = float(leverage)
+        except (TypeError, ValueError, OverflowError):
+            leverage_value = None
+        if leverage_value is not None and math.isfinite(leverage_value):
+            return f"leverage={leverage_value:g}x"
 
-    # Error cases - show code and message
-    if code and msg:
-        return f"code={code}: {msg[:40]}"
-    if msg:
-        return msg[:50]
-
-    # Fallback: truncated string
-    s = str(res)
-    return s[:60] + "..." if len(s) > 60 else s
+    if isinstance(code, int) and not isinstance(code, bool):
+        return f"code={code}"
+    if (
+        isinstance(code, str)
+        and len(code) <= 12
+        and code.removeprefix("-").isdigit()
+    ):
+        return f"code={code}"
+    if code is not None:
+        return "code_present"
+    if msg is not None:
+        return "message_present"
+    return "response=dict"
 
 
 class CCXTBot(Passivbot):
@@ -508,7 +513,9 @@ class CCXTBot(Passivbot):
         res = await self.cca.set_position_mode(True)
         elapsed_ms = (time.time() - t0) * 1000
         logging.debug("[config] %s: set_position_mode completed in %.1fms", self.exchange, elapsed_ms)
-        logging.debug("[config] set hedge mode response: %s", res)
+        logging.debug(
+            "[config] set hedge mode response: %s", format_exchange_config_response(res)
+        )
 
     def _should_set_margin_mode(self, symbol: str) -> bool:
         """Hook: Should we call set_margin_mode for this symbol?

--- a/src/exchanges/ccxt_bot.py
+++ b/src/exchanges/ccxt_bot.py
@@ -77,7 +77,11 @@ def format_exchange_config_response(res: object) -> str:
         if leverage_value is not None and math.isfinite(leverage_value):
             return f"leverage={leverage_value:g}x"
 
-    if isinstance(code, int) and not isinstance(code, bool):
+    if (
+        isinstance(code, int)
+        and not isinstance(code, bool)
+        and -999_999_999_999 <= code <= 999_999_999_999
+    ):
         return f"code={code}"
     if (
         isinstance(code, str)

--- a/src/exchanges/kucoin.py
+++ b/src/exchanges/kucoin.py
@@ -534,7 +534,10 @@ class KucoinBot(CCXTBot):
             # Hedge mode enabled so both long/short can coexist.
             if hasattr(self.cca, "set_position_mode"):
                 res = await self.cca.set_position_mode(True)
-                logging.info(f"set_position_mode hedged=True {res}")
+                logging.info(
+                    "[config] set_position_mode hedged=True result=%s",
+                    format_exchange_config_response(res),
+                )
             else:
                 raise NotImplementedError("set_position_mode not supported by current KuCoin client")
         except Exception as e:

--- a/src/exchanges/okx.py
+++ b/src/exchanges/okx.py
@@ -265,7 +265,9 @@ class OKXBot(CCXTBot):
             )
         try:
             res = await self.cca.set_position_mode(True)
-            logging.debug("[config] set hedge mode response: %s", res)
+            logging.debug(
+                "[config] set hedge mode response: %s", format_exchange_config_response(res)
+            )
         except Exception as e:
             err_str = str(e)
             if '"code":"59000"' in err_str:

--- a/tests/exchanges/test_ccxt_bot.py
+++ b/tests/exchanges/test_ccxt_bot.py
@@ -14,6 +14,7 @@ import pytest
         ({"message": "No need SECRET"}, "ok (unchanged)"),
         ({"leverage": "10", "secret": "SECRET"}, "leverage=10x"),
         ({"code": "51039", "msg": "SECRET"}, "code=51039"),
+        ({"code": 10**100, "msg": "SECRET"}, "code_present"),
         ({"code": "unsafe SECRET", "msg": "SECRET"}, "code_present"),
         ({"msg": "SECRET"}, "message_present"),
         ({"apiKey": "SECRET"}, "response=dict"),

--- a/tests/exchanges/test_ccxt_bot.py
+++ b/tests/exchanges/test_ccxt_bot.py
@@ -1,7 +1,43 @@
 # tests/exchanges/test_ccxt_bot.py
 import logging
+import math
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from unittest.mock import MagicMock, patch, AsyncMock
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        ({"code": "200000", "data": {"apiKey": "SECRET"}}, "ok"),
+        ({"status": "ok", "message": "SECRET"}, "ok"),
+        ({"message": "No need SECRET"}, "ok (unchanged)"),
+        ({"leverage": "10", "secret": "SECRET"}, "leverage=10x"),
+        ({"code": "51039", "msg": "SECRET"}, "code=51039"),
+        ({"code": "unsafe SECRET", "msg": "SECRET"}, "code_present"),
+        ({"msg": "SECRET"}, "message_present"),
+        ({"apiKey": "SECRET"}, "response=dict"),
+        ("SECRET", "result_type=str"),
+    ],
+)
+def test_format_exchange_config_response_is_value_safe(response, expected):
+    from exchanges.ccxt_bot import format_exchange_config_response
+
+    rendered = format_exchange_config_response(response)
+
+    assert rendered == expected
+    assert len(rendered) <= 64
+    assert "SECRET" not in rendered
+
+
+@pytest.mark.parametrize("leverage", [True, math.nan, math.inf, "not-a-number SECRET"])
+def test_format_exchange_config_response_rejects_non_numeric_leverage(leverage):
+    from exchanges.ccxt_bot import format_exchange_config_response
+
+    rendered = format_exchange_config_response({"leverage": leverage, "secret": "SECRET"})
+
+    assert rendered == "response=dict"
+    assert "SECRET" not in rendered
 
 
 class TestCCXTBotSessionCreation:
@@ -284,7 +320,7 @@ class TestCCXTBotUpdateExchangeConfig:
     """Tests for update_exchange_config."""
 
     @pytest.mark.asyncio
-    async def test_update_exchange_config_sets_hedge_mode(self):
+    async def test_update_exchange_config_sets_hedge_mode(self, caplog):
         """Test that hedge mode is set when exchange supports it."""
         from exchanges.ccxt_bot import CCXTBot
 
@@ -293,11 +329,16 @@ class TestCCXTBotUpdateExchangeConfig:
 
         bot.cca = MagicMock()
         bot.cca.has = {"setPositionMode": True}
-        bot.cca.set_position_mode = AsyncMock(return_value={"result": "success"})
+        bot.cca.set_position_mode = AsyncMock(
+            return_value={"result": "success", "apiKey": "SECRET"}
+        )
 
-        await bot.update_exchange_config()
+        with caplog.at_level(logging.DEBUG):
+            await bot.update_exchange_config()
 
         bot.cca.set_position_mode.assert_called_once_with(True)
+        assert "set hedge mode response: response=dict" in caplog.text
+        assert "SECRET" not in caplog.text
 
     @pytest.mark.asyncio
     async def test_update_exchange_config_skips_when_unsupported(self):

--- a/tests/test_kucoin_exchange_config.py
+++ b/tests/test_kucoin_exchange_config.py
@@ -25,7 +25,7 @@ class DummyCCA:
 
     async def set_position_mode(self, hedged):
         self.position_mode_calls.append(hedged)
-        return {"code": "200000", "hedged": hedged}
+        return {"code": "200000", "hedged": hedged, "apiKey": "SECRET"}
 
     async def set_margin_mode(self, **params):
         self.margin_calls.append(params)
@@ -177,7 +177,8 @@ async def test_update_exchange_config_sets_position_mode_when_supported(caplog):
     bot = make_bot()
     await bot.update_exchange_config()
     assert bot.cca.position_mode_calls == [True]
-    assert "set_position_mode hedged=True" in caplog.text
+    assert "set_position_mode hedged=True result=ok" in caplog.text
+    assert "SECRET" not in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

Category: **observability producer**.

Make successful exchange-config response rendering bounded and value-safe across the shared CCXT connector and Binance, Bitget, Bybit, KuCoin, and OKX account-level hedge-mode logs. Update the logging policy, progress ledger, backlog boundary, and changelog.

## Behavior impact

Logging only. The shared formatter emits canonical success/unchanged status, finite numeric leverage, a bounded numeric code, or response type/presence labels. It never renders arbitrary response values or full API payloads. Exchange calls, response handling, exception propagation, retries/backoff, and trading behavior are unchanged. Connector-specific failure logging and per-symbol methods that currently swallow exceptions remain separate trading-critical contract work.

## VPS action

Restart required after merge because running bots must load the changed connector code. Deploy with the established autostash-preserving workflow, restart the five configured VPS5 bots, and verify bounded startup/config logs plus a settled smoke report.

## Validation

- `python -m pytest -q tests/exchanges tests/test_exchange_config_updates.py tests/test_kucoin_exchange_config.py` - 184 passed
- `python -m pytest -q -m fake_live tests/test_run_fake_live.py` - 21 passed
- real two-step fake-live minimal scenario - completed successfully
- `python -m compileall -q src/exchanges tests/exchanges/test_ccxt_bot.py tests/test_kucoin_exchange_config.py` - passed
- focused formatter/KuCoin suite - 73 passed
- `git diff --check` and raw-success-response scans - clean

Backtest/optimizer smokes are not applicable to this logging-only connector slice.

## Review gate

Per maintainer direction while Claude Opus 4.8 is rate-limited: current-head Hermes + Grok 4.5 approvals and green CI are required. Findings from any additional reviewer still require resolution.

## Reviewer notes

- The formatter may inspect a message only to classify the established `no need` success case; message content is never returned.
- Every rendered form is capped at 64 characters by construction and regression tests inject secret markers into nested and top-level values.
- Error-path semantics and raw exception logs are intentionally outside this PR.