### PR TITLE
Bound exchange config failure diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Exchange-config failure logs now keep bounded operation, symbol, retry,
+  canonical known-code, and exception-type context without rendering arbitrary
+  exception messages or partial API responses. Existing connector catches,
+  fail-loud behavior, retries, and per-symbol success/failure handling are
+  unchanged.
+
 - Exchange-config success logs now use one bounded, value-safe formatter across
   the shared CCXT connector and Binance, Bitget, Bybit, KuCoin, and OKX. Raw API
   response values are replaced by canonical status, finite numeric leverage,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Exchange-config failure logs now keep bounded operation, symbol, retry,
-  canonical known-code, and exception-type context without rendering arbitrary
-  exception messages or partial API responses. Existing connector catches,
-  fail-loud behavior, retries, and per-symbol success/failure handling are
-  unchanged.
+- Connector-local exchange-config failure logs in Binance, Bitget, Defx,
+  Hyperliquid, KuCoin, and OKX, plus the parent per-symbol retry log, now keep
+  bounded operation, symbol, retry, canonical known-code, and exception-type
+  context without rendering arbitrary exception messages or partial API
+  responses. Existing connector catches, fail-loud behavior, retries, and
+  per-symbol success/failure handling are unchanged.
 
 - Exchange-config success logs now use one bounded, value-safe formatter across
   the shared CCXT connector and Binance, Bitget, Bybit, KuCoin, and OKX. Raw API

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -51,6 +51,9 @@ Exchange-config response logs at every level must use the shared bounded
 formatter. They may expose only canonical success/unchanged status, finite
 numeric leverage, a bounded numeric response code, or response type/presence;
 they must not render arbitrary response values or full API payloads.
+Exchange-config failure logs may retain bounded operation/symbol/retry context,
+canonical known-code classifications, and a bounded exception type, but must
+not render exception messages or partial response objects.
 
 ## Live Event Debug Profiles
 

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -51,9 +51,11 @@ Exchange-config response logs at every level must use the shared bounded
 formatter. They may expose only canonical success/unchanged status, finite
 numeric leverage, a bounded numeric response code, or response type/presence;
 they must not render arbitrary response values or full API payloads.
-Exchange-config failure logs may retain bounded operation/symbol/retry context,
-canonical known-code classifications, and a bounded exception type, but must
-not render exception messages or partial response objects.
+Connector-local exchange-config failure logs and the parent per-symbol retry
+log retain bounded operation/symbol/retry context, canonical known-code
+classifications, and a bounded exception type without rendering exception
+messages or partial response objects. Outer startup/runtime exception logs and
+structured-event error retention follow their separate policies.
 
 ## Live Event Debug Profiles
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -29,11 +29,13 @@ Current logging-overhaul head:
 Current work:
 
 - Branch `codex/v8-exchange-config-error-diagnostics` removes raw exception
-  messages and partial response objects from parent/connector exchange-config
-  failure logs. Logs retain bounded operation, symbol, retry, canonical
+  messages and partial response objects from the parent per-symbol retry log and
+  connector-local exchange-config logs in Binance, Bitget, Defx, Hyperliquid,
+  KuCoin, and OKX. Logs retain bounded operation, symbol, retry, canonical
   known-code, and exception-type context. Existing catches, exception
   propagation, retry/backoff, per-symbol handling, exchange I/O, and trading
-  behavior remain unchanged.
+  behavior remain unchanged. Outer startup/runtime exception logs and
+  structured-event error retention remain separate logging-policy work.
 
 Current review gate:
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,21 +19,21 @@ Last updated: 2026-07-10.
 
 Current `origin/v8` head:
 
-- `8bb35dea` after PR #1167, `Bound lower-level order write diagnostics`.
+- `8b0869e9` after PR #1168, `Bound exchange config response diagnostics`.
 
 Current logging-overhaul head:
 
-- `8bb35dea` after PR #1167, `Bound lower-level order write diagnostics`
+- `8b0869e9` after PR #1168, `Bound exchange config response diagnostics`
   (latest merged logging-overhaul slice).
 
 Current work:
 
-- Branch `codex/v8-exchange-config-response-diagnostics` makes the shared
-  exchange-config response formatter value-safe and applies it to account-level
-  hedge-mode success logs in the shared CCXT connector plus Binance, Bitget,
-  Bybit, KuCoin, and OKX. It changes logging only; exchange calls, response
-  handling, exception propagation, retry/backoff, and trading behavior remain
-  unchanged.
+- Branch `codex/v8-exchange-config-error-diagnostics` removes raw exception
+  messages and partial response objects from parent/connector exchange-config
+  failure logs. Logs retain bounded operation, symbol, retry, canonical
+  known-code, and exception-type context. Existing catches, exception
+  propagation, retry/backoff, per-symbol handling, exchange I/O, and trading
+  behavior remain unchanged.
 
 Current review gate:
 
@@ -64,6 +64,22 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1168 at `8b0869e9`. Successful account-level
+  exchange-config responses now use the shared bounded value-safe formatter in
+  the CCXT base plus Binance, Bitget, Bybit, KuCoin, and OKX. The PR merged
+  after current-head Hermes and Grok 4.5 approvals plus green CI; Claude Opus
+  4.8 was explicitly waived while rate-limited. VPS5 was pulled with
+  `git pull --autostash --ff-only origin v8`, preserving the pre-existing
+  tracked Rust edit and local config/tmp artifacts. After two exact-pane
+  Ctrl-C grace windows, the four remaining verified HSL-replay PIDs received
+  SIGTERM; the empty tmux session was then reloaded from
+  `/root/bots_vps5.yaml`. Immediate and settled smoke reports returned
+  `ok=true`, `hard_failures=0`, all five expected bots matched, zero failed
+  remote/account-critical calls, zero fill-refresh failures, and zero text-log
+  hard/attention matches. The new KuCoin startup line was observed as
+  `[config] set_position_mode hedged=True result=ok`; the raw response
+  dictionary appeared only in the pre-restart log. Four HSL replays remained
+  active but non-stale and not long-running.
 - Repository pulled through PR #1167 at `8bb35dea`. Lower-level base and CCXT
   order-write failures now fall back to bounded action/symbol/type/error-type
   context only when structured console projection cannot retain the parent

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -740,6 +740,12 @@ Related detailed plans:
       failure logs and per-symbol methods that currently swallow exceptions are
       intentionally unchanged; deciding their propagation contract remains
       separate trading-critical work.
+    - 2026-07-10: Branch `codex/v8-exchange-config-error-diagnostics` bounds
+      parent/connector exchange-config failure logs to operation, symbol,
+      retry, canonical known-code, and exception-type context. Catch/rethrow or
+      swallow behavior remains unchanged. Outer startup/runtime traceback and
+      structured-event raw-error retention are separate logging-policy work;
+      connector propagation semantics remain separate trading-critical work.
 
 ## Merged Work Log
 

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -741,11 +741,13 @@ Related detailed plans:
       intentionally unchanged; deciding their propagation contract remains
       separate trading-critical work.
     - 2026-07-10: Branch `codex/v8-exchange-config-error-diagnostics` bounds
-      parent/connector exchange-config failure logs to operation, symbol,
-      retry, canonical known-code, and exception-type context. Catch/rethrow or
-      swallow behavior remains unchanged. Outer startup/runtime traceback and
-      structured-event raw-error retention are separate logging-policy work;
-      connector propagation semantics remain separate trading-critical work.
+      the parent per-symbol retry log and connector-local exchange-config logs
+      in Binance, Bitget, Defx, Hyperliquid, KuCoin, and OKX to operation,
+      symbol, retry, canonical known-code, and exception-type context.
+      Catch/rethrow or swallow behavior remains unchanged. Outer startup/runtime
+      traceback and structured-event raw-error retention are separate
+      logging-policy work; connector propagation semantics remain separate
+      trading-critical work.
 
 ## Merged Work Log
 

--- a/src/exchanges/binance.py
+++ b/src/exchanges/binance.py
@@ -545,12 +545,20 @@ class BinanceBot(CCXTBot):
                 res = await coros_to_call_lev[symbol]
                 to_print += f"leverage={format_exchange_config_response(res)} "
             except Exception as e:
-                logging.error(f"{log_symbol}: error setting leverage {e}")
+                logging.error(
+                    "[config] %s leverage update failed | %s",
+                    log_symbol,
+                    self._format_exchange_config_error(e),
+                )
             try:
                 res_margin = await coros_to_call_margin_mode[symbol]
                 to_print += f"margin={format_exchange_config_response(res_margin)}"
             except Exception as e:
-                logging.error(f"{log_symbol}: error setting cross mode {e}")
+                logging.error(
+                    "[config] %s cross-margin update failed | %s",
+                    log_symbol,
+                    self._format_exchange_config_error(e),
+                )
             if to_print:
                 logging.info(f"{log_symbol}: {to_print}")
 
@@ -562,9 +570,12 @@ class BinanceBot(CCXTBot):
             )
         except Exception as e:
             if '"code":-4059' in str(e):
-                logging.debug("[config] hedge mode unchanged: %s", e)
+                logging.debug("[config] hedge mode unchanged | code=-4059")
             else:
-                logging.error("[config] error setting hedge mode: %s", e)
+                logging.error(
+                    "[config] hedge mode update failed | %s",
+                    self._format_exchange_config_error(e),
+                )
                 raise
 
     def format_custom_id_single(self, order_type_id: int) -> str:

--- a/src/exchanges/bitget.py
+++ b/src/exchanges/bitget.py
@@ -733,13 +733,22 @@ class BitgetBot(CCXTBot):
                         )
                     )
                 except Exception as e:
-                    logging.error(f"{log_symbol}: error setting {margin_mode} mode {e}")
+                    logging.error(
+                        "[config] %s %s-margin task creation failed | %s",
+                        log_symbol,
+                        margin_mode,
+                        self._format_exchange_config_error(e),
+                    )
             try:
                 coros_to_call_lev[symbol] = asyncio.create_task(
                     self.cca.set_leverage(self._calc_leverage_for_symbol(symbol), symbol=symbol)
                 )
             except Exception as e:
-                logging.error(f"{log_symbol}: error setting leverage {e}")
+                logging.error(
+                    "[config] %s leverage task creation failed | %s",
+                    log_symbol,
+                    self._format_exchange_config_error(e),
+                )
         for symbol in symbols:
             log_symbol = symbol_to_coin(symbol, verbose=False) or symbol
             res = None
@@ -748,7 +757,11 @@ class BitgetBot(CCXTBot):
                 res = await coros_to_call_lev[symbol]
                 to_print += f"leverage={format_exchange_config_response(res)} "
             except Exception as e:
-                logging.error(f"{log_symbol} error setting leverage {e}")
+                logging.error(
+                    "[config] %s leverage update failed | %s",
+                    log_symbol,
+                    self._format_exchange_config_error(e),
+                )
             res = None
             if symbol in coros_to_call_margin_mode:
                 try:
@@ -756,7 +769,10 @@ class BitgetBot(CCXTBot):
                     to_print += f"margin={format_exchange_config_response(res)}"
                 except Exception as e:
                     logging.error(
-                        f"{log_symbol} error setting {self._get_margin_mode_for_symbol(symbol)} mode {e}"
+                        "[config] %s %s-margin update failed | %s",
+                        log_symbol,
+                        self._get_margin_mode_for_symbol(symbol),
+                        self._format_exchange_config_error(e),
                     )
             if to_print:
                 logging.info(f"{log_symbol}: {to_print}")
@@ -801,7 +817,10 @@ class BitgetBot(CCXTBot):
                 "[config] set hedge mode response: %s", format_exchange_config_response(res)
             )
         except Exception as e:
-            logging.error("[config] error setting hedge mode: %s %s", e, res)
+            logging.error(
+                "[config] hedge mode update failed | %s",
+                self._format_exchange_config_error(e),
+            )
             raise
 
     def format_custom_id_single(self, order_type_id: int) -> str:

--- a/src/exchanges/defx.py
+++ b/src/exchanges/defx.py
@@ -9,7 +9,7 @@ import asyncio
 from copy import deepcopy
 
 import passivbot_rust as pbr
-from exchanges.ccxt_bot import CCXTBot
+from exchanges.ccxt_bot import CCXTBot, format_exchange_config_response
 from passivbot import logging
 from utils import utc_ms
 
@@ -176,21 +176,33 @@ class DefxBot(CCXTBot):
                     ),
                     "symbol": symbol,
                 }
-                logging.debug(f"update_exchange_config_by_symbols {params}")
+                logging.debug(
+                    "[config] %s leverage task requested | leverage=%d",
+                    symbol,
+                    params["leverage"],
+                )
                 coros_to_call_leverage[symbol] = asyncio.create_task(self.cca.set_leverage(**params))
             except Exception as e:
-                logging.error(f"{symbol}: error setting leverage {e}")
+                logging.error(
+                    "[config] %s leverage task creation failed | %s",
+                    symbol,
+                    self._format_exchange_config_error(e),
+                )
         for symbol in symbols:
             res = None
             to_print = ""
             try:
                 res = await coros_to_call_leverage[symbol]
-                to_print += f"set leverage {res}"
+                to_print = f"set_leverage {format_exchange_config_response(res)}"
             except Exception as e:
                 if '"code":"59107"' in str(e):
-                    to_print += f" cross mode and leverage: {res} {e}"
+                    to_print = "set_leverage ok (unchanged) code=59107"
                 else:
-                    logging.error(f"{symbol} error setting leverage {res} {e}")
+                    logging.error(
+                        "[config] %s leverage update failed | %s",
+                        symbol,
+                        self._format_exchange_config_error(e),
+                    )
             if to_print:
-                logging.info(f"{symbol}: {to_print}")
+                logging.info("[config] %s: %s", symbol, to_print)
         return

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -1295,10 +1295,19 @@ class HyperliquidBot(CCXTBot):
                         to_print = f"margin=ok (unchanged, {margin_mode})"
                     else:
                         log_symbol = symbol_to_coin(symbol, verbose=False) or symbol
-                        logging.error(f"{log_symbol} error setting {margin_mode} mode {e}")
+                        logging.error(
+                            "[config] %s %s-margin update failed | %s",
+                            log_symbol,
+                            margin_mode,
+                            self._format_exchange_config_error(e),
+                        )
             except Exception as e:
                 log_symbol = symbol_to_coin(symbol, verbose=False) or symbol
-                logging.error(f"{log_symbol}: error setting margin mode and leverage {e}")
+                logging.error(
+                    "[config] %s margin/leverage preparation failed | %s",
+                    log_symbol,
+                    self._format_exchange_config_error(e),
+                )
             if to_print:
                 log_symbol = symbol_to_coin(symbol, verbose=False) or symbol
                 logging.debug(f"{log_symbol}: {to_print}")

--- a/src/exchanges/kucoin.py
+++ b/src/exchanges/kucoin.py
@@ -541,7 +541,10 @@ class KucoinBot(CCXTBot):
             else:
                 raise NotImplementedError("set_position_mode not supported by current KuCoin client")
         except Exception as e:
-            logging.error(f"set_position_mode hedged=True not applied: {e}")
+            logging.error(
+                "[config] set_position_mode hedged=True not applied | %s",
+                self._format_exchange_config_error(e),
+            )
             raise
 
     async def update_exchange_config_by_symbols(self, symbols):
@@ -562,7 +565,11 @@ class KucoinBot(CCXTBot):
                     )
                 )
             except Exception as e:
-                logging.warning(f"{log_symbol}: error set_margin_mode {e}")
+                logging.warning(
+                    "[config] %s set_margin_mode task creation failed | %s",
+                    log_symbol,
+                    self._format_exchange_config_error(e),
+                )
         for symbol, task_name, task in coros_to_call:
             log_symbol = symbol_to_coin(symbol, verbose=False) or symbol
             res = None
@@ -571,7 +578,12 @@ class KucoinBot(CCXTBot):
                 res = await task
                 to_print += f"{task_name}={format_exchange_config_response(res)}"
             except Exception as e:
-                logging.warning(f"{log_symbol} error {task_name} {e}")
+                logging.warning(
+                    "[config] %s %s failed | %s",
+                    log_symbol,
+                    task_name,
+                    self._format_exchange_config_error(e),
+                )
             if to_print:
                 logging.info(f"{log_symbol}: {to_print}")
 
@@ -592,7 +604,11 @@ class KucoinBot(CCXTBot):
             except ValueError:
                 raise
             except Exception as e:
-                logging.warning(f"{log_symbol}: error preparing set_leverage {e}")
+                logging.warning(
+                    "[config] %s set_leverage task creation failed | %s",
+                    log_symbol,
+                    self._format_exchange_config_error(e),
+                )
         for symbol, task_name, task in coros_to_call:
             log_symbol = symbol_to_coin(symbol, verbose=False) or symbol
             res = None
@@ -601,6 +617,11 @@ class KucoinBot(CCXTBot):
                 res = await task
                 to_print += f"{task_name}={format_exchange_config_response(res)}"
             except Exception as e:
-                logging.warning(f"{log_symbol} error {task_name} {e}")
+                logging.warning(
+                    "[config] %s %s failed | %s",
+                    log_symbol,
+                    task_name,
+                    self._format_exchange_config_error(e),
+                )
             if to_print:
                 logging.info(f"{log_symbol}: {to_print}")

--- a/src/exchanges/okx.py
+++ b/src/exchanges/okx.py
@@ -233,7 +233,12 @@ class OKXBot(CCXTBot):
                     )
                 )
             except Exception as e:
-                logging.error(f"{log_symbol}: error setting {margin_mode} mode and leverage {e}")
+                logging.error(
+                    "[config] %s %s-margin task creation failed | %s",
+                    log_symbol,
+                    margin_mode,
+                    self._format_exchange_config_error(e),
+                )
         for symbol in symbols:
             log_symbol = symbol_to_coin(symbol, verbose=False) or symbol
             res = None
@@ -251,7 +256,11 @@ class OKXBot(CCXTBot):
                     )
                     continue
                 else:
-                    logging.error(f"{log_symbol} error setting cross mode {e}")
+                    logging.error(
+                        "[config] %s cross-margin update failed | %s",
+                        log_symbol,
+                        self._format_exchange_config_error(e),
+                    )
             if to_print:
                 logging.info(f"{log_symbol}: {to_print}")
 
@@ -271,7 +280,7 @@ class OKXBot(CCXTBot):
         except Exception as e:
             err_str = str(e)
             if '"code":"59000"' in err_str:
-                logging.info("[config] hedge mode update skipped: %s", e)
+                logging.info("[config] hedge mode update skipped | code=59000")
             elif '"code":"51039"' in err_str or '"code":"51000"' in err_str:
                 # Cannot switch to dual/hedge (often due to PM or open orders/positions).
                 self.okx_dual_side = False

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -7601,6 +7601,19 @@ class Passivbot:
             return False
         return True
 
+    @staticmethod
+    def _format_exchange_config_error(exc: BaseException) -> str:
+        """Return a bounded error-type label without rendering exception values."""
+        error_type = type(exc).__name__
+        if (
+            not error_type
+            or len(error_type) > 40
+            or not error_type.isascii()
+            or not error_type.replace("_", "").isalnum()
+        ):
+            error_type = "Exception"
+        return f"error_type={error_type}"
+
     async def update_exchange_configs(self, symbols=None):
         """Ensure exchange-specific settings are initialised for all active symbols."""
         if not hasattr(self, "already_updated_exchange_config_symbols"):
@@ -7655,10 +7668,10 @@ class Passivbot:
                         )
                         break
                     logging.warning(
-                        "[config] exchange config update failed for %s; retrying in %.1fs: %s",
+                        "[config] exchange config update failed | symbol=%s retry_in=%.1fs %s",
                         symbol,
                         backoff_s,
-                        e,
+                        Passivbot._format_exchange_config_error(e),
                     )
                 else:
                     if self._shutdown_requested():

--- a/tests/test_exchange_config_updates.py
+++ b/tests/test_exchange_config_updates.py
@@ -127,6 +127,57 @@ def test_format_exchange_config_error_is_bounded_and_value_safe():
     )
 
 
+def make_defx_config_bot(cca):
+    from exchanges.defx import DefxBot
+
+    bot = DefxBot.__new__(DefxBot)
+    bot.cca = cca
+    bot.max_leverage = {"BTC/USDC:USDC": 10}
+    bot.config_get = lambda path, *, symbol=None: 5
+    bot.get_wallet_exposure_limit = lambda pside, symbol: 1.0
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_defx_exchange_config_response_is_value_safe(caplog):
+    class SuccessfulCCA:
+        async def set_leverage(self, **params):
+            return {"leverage": params["leverage"], "apiKey": "SECRET"}
+
+    bot = make_defx_config_bot(SuccessfulCCA())
+
+    with caplog.at_level(logging.INFO):
+        await bot.update_exchange_config_by_symbols(["BTC/USDC:USDC"])
+
+    assert "set_leverage leverage=2x" in caplog.text
+    assert "SECRET" not in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (RuntimeError("SECRET"), "error_type=RuntimeError"),
+        (
+            RuntimeError('{"code":"59107","msg":"SECRET"}'),
+            "set_leverage ok (unchanged) code=59107",
+        ),
+    ],
+)
+async def test_defx_exchange_config_failure_is_value_safe(caplog, error, expected):
+    class FailingCCA:
+        async def set_leverage(self, **_params):
+            raise error
+
+    bot = make_defx_config_bot(FailingCCA())
+
+    with caplog.at_level(logging.INFO):
+        await bot.update_exchange_config_by_symbols(["BTC/USDC:USDC"])
+
+    assert expected in caplog.text
+    assert "SECRET" not in caplog.text
+
+
 @pytest.mark.asyncio
 async def test_update_exchange_configs_does_not_mark_invalid_kucoin_leverage_cap(
     monkeypatch,

--- a/tests/test_exchange_config_updates.py
+++ b/tests/test_exchange_config_updates.py
@@ -70,7 +70,7 @@ def make_kucoin_config_bot():
 
 
 @pytest.mark.asyncio
-async def test_update_exchange_configs_marks_only_successful_symbols(monkeypatch):
+async def test_update_exchange_configs_marks_only_successful_symbols(monkeypatch, caplog):
     import passivbot as pb_mod
 
     class FakeBot:
@@ -88,7 +88,7 @@ async def test_update_exchange_configs_marks_only_successful_symbols(monkeypatch
             symbol = symbols[0]
             self.calls.append(symbol)
             if symbol == "A":
-                raise Exception("boom")
+                raise RuntimeError("SECRET")
 
         _is_rate_limit_like_exception = pb_mod.Passivbot._is_rate_limit_like_exception
         _exchange_config_backoff_seconds = pb_mod.Passivbot._exchange_config_backoff_seconds
@@ -101,13 +101,30 @@ async def test_update_exchange_configs_marks_only_successful_symbols(monkeypatch
     monkeypatch.setattr(asyncio, "sleep", fake_sleep)
 
     bot = FakeBot()
-    await pb_mod.Passivbot.update_exchange_configs(bot)
+    with caplog.at_level(logging.WARNING):
+        await pb_mod.Passivbot.update_exchange_configs(bot)
 
     assert bot.calls == ["A", "B"]
     assert bot.already_updated_exchange_config_symbols == {"B"}
     assert bot._exchange_config_retry_attempts["A"] == 1
     assert bot._exchange_config_retry_after_ms["A"] > 0
     assert bot._health_rate_limits == 0
+    assert "error_type=RuntimeError" in caplog.text
+    assert "SECRET" not in caplog.text
+
+
+def test_format_exchange_config_error_is_bounded_and_value_safe():
+    import passivbot as pb_mod
+
+    assert (
+        pb_mod.Passivbot._format_exchange_config_error(RuntimeError("SECRET"))
+        == "error_type=RuntimeError"
+    )
+    unsafe_type = type("SECRET" * 20, (Exception,), {})
+    assert (
+        pb_mod.Passivbot._format_exchange_config_error(unsafe_type("SECRET"))
+        == "error_type=Exception"
+    )
 
 
 @pytest.mark.asyncio
@@ -329,17 +346,23 @@ async def test_update_exchange_configs_stops_after_shutdown_signal(monkeypatch):
         ("exchanges.kucoin", "KucoinBot"),
     ],
 )
-async def test_exchange_update_config_reraises_hedge_mode_failures(module_name, class_name):
+async def test_exchange_update_config_reraises_hedge_mode_failures(
+    module_name, class_name, caplog
+):
     module = __import__(module_name, fromlist=[class_name])
     bot_cls = getattr(module, class_name)
     bot = bot_cls.__new__(bot_cls)
-    bot.cca = SimpleNamespace(set_position_mode=AsyncMock(side_effect=RuntimeError("boom")))
+    bot.cca = SimpleNamespace(set_position_mode=AsyncMock(side_effect=RuntimeError("SECRET")))
     if class_name == "BitgetBot":
         # Bitget probes the UTA account mode before setting hedge mode.
         bot.cca.private_uta_get_v3_account_assets = AsyncMock(return_value={"code": "00000"})
 
-    with pytest.raises(RuntimeError, match="boom"):
-        await bot.update_exchange_config()
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError, match="SECRET"):
+            await bot.update_exchange_config()
+
+    assert "error_type=RuntimeError" in caplog.text
+    assert "SECRET" not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -367,15 +390,21 @@ async def test_exchange_update_config_accepts_live_same_mode_success(
 
 
 @pytest.mark.asyncio
-async def test_binance_update_config_accepts_already_hedged_response():
+async def test_binance_update_config_accepts_already_hedged_response(caplog):
     from exchanges.binance import BinanceBot
 
     bot = BinanceBot.__new__(BinanceBot)
     bot.cca = SimpleNamespace(
-        set_position_mode=AsyncMock(side_effect=Exception('{"code":-4059,"msg":"No need"}'))
+        set_position_mode=AsyncMock(
+            side_effect=Exception('{"code":-4059,"msg":"No need SECRET"}')
+        )
     )
 
-    await bot.update_exchange_config()
+    with caplog.at_level(logging.DEBUG):
+        await bot.update_exchange_config()
+
+    assert "hedge mode unchanged | code=-4059" in caplog.text
+    assert "SECRET" not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -448,6 +477,29 @@ async def test_okx_update_config_reraises_unknown_hedge_mode_failure():
 
     with pytest.raises(RuntimeError, match="hedge boom"):
         await bot.update_exchange_config()
+
+
+@pytest.mark.asyncio
+async def test_okx_update_config_bounds_known_skip_diagnostic(caplog):
+    from exchanges.okx import OKXBot
+
+    bot = OKXBot.__new__(OKXBot)
+    bot.okx_dual_side = True
+    bot.hedge_mode = True
+    bot.cca = SimpleNamespace(
+        private_get_account_config=AsyncMock(
+            return_value={"data": [{"posMode": "long_short_mode"}]}
+        ),
+        set_position_mode=AsyncMock(
+            side_effect=RuntimeError('{"code":"59000","msg":"SECRET"}')
+        ),
+    )
+
+    with caplog.at_level(logging.INFO):
+        await bot.update_exchange_config()
+
+    assert "hedge mode update skipped | code=59000" in caplog.text
+    assert "SECRET" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_kucoin_exchange_config.py
+++ b/tests/test_kucoin_exchange_config.py
@@ -279,6 +279,28 @@ async def test_update_exchange_config_by_symbols_treats_missing_max_leverage_as_
 
 
 @pytest.mark.asyncio
+async def test_update_exchange_config_by_symbols_bounds_failure_logs(caplog):
+    class FailingCCA:
+        async def set_margin_mode(self, **_params):
+            raise RuntimeError("SECRET_MARGIN")
+
+        async def set_leverage(self, **_params):
+            raise ValueError("SECRET_LEVERAGE")
+
+    bot = make_bot()
+    bot.cca = FailingCCA()
+    bot.max_leverage = {"BTC/USDT:USDT": 10}
+    bot.config_get = lambda path, *, symbol=None: 5
+
+    with caplog.at_level(logging.WARNING):
+        await bot.update_exchange_config_by_symbols(["BTC/USDT:USDT"])
+
+    assert "error_type=RuntimeError" in caplog.text
+    assert "error_type=ValueError" in caplog.text
+    assert "SECRET" not in caplog.text
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("raw_max_leverage", ["bad", 0, -1, math.inf, math.nan])
 async def test_update_exchange_config_by_symbols_rejects_invalid_max_leverage(
     raw_max_leverage,


### PR DESCRIPTION
## Scope

Category: **observability producer**.

Replace raw exception-message and partial-response rendering in the parent per-symbol retry log and connector-local exchange-config logs for Binance, Bitget, Defx, Hyperliquid, KuCoin, and OKX. Defx success responses now also use the bounded shared response formatter. Update the policy and user-facing claims to this exact surface, and record PR #1168 merge/deploy evidence.

## Behavior impact

Logging only. `Passivbot._format_exchange_config_error()` emits one bounded ASCII exception-type label. Generic migrated failure logs no longer include `str(exc)` or partial responses; known-code detection still inspects the original exception and renders only the canonical code. Every catch, rethrow, swallow, retry/backoff, exchange call, state mutation, and trading decision is unchanged.

Outer startup/runtime exception logs, structured-event raw-error retention, and connector propagation semantics are explicitly separate work and are no longer covered by the policy/changelog claim in this PR.

## VPS action

Restart required after merge because running bots must load the parent/connector logging changes. Deploy with the established autostash-preserving workflow, restart only the five configured bots, and verify settled smoke. No exchange failure will be induced.

## Validation

- `python -m pytest -q tests/exchanges tests/test_exchange_config_updates.py tests/test_kucoin_exchange_config.py tests/test_init_markets_retry.py` - 198 passed
- `python -m pytest -q -m fake_live tests/test_run_fake_live.py` - 21 passed
- real two-step fake-live minimal scenario - completed successfully on the initial head
- `python -m compileall -q src/passivbot.py src/exchanges tests/test_exchange_config_updates.py tests/test_kucoin_exchange_config.py tests/test_init_markets_retry.py` - passed
- `git diff --check` and all-connector raw config-response interpolation scan - clean

Backtest/optimizer smokes are not applicable to this logging-only live connector slice.

## Review gate

Per maintainer direction while Claude Opus 4.8 is rate-limited: current-head Hermes + Grok 4.5 approvals and green CI are required. Findings from any additional reviewer still require resolution.

## Reviewer notes

- Delta `4ff18fe89` addresses the Codex finding by covering Defx and narrowing the policy/changelog to connector-local plus parent per-symbol retry logs.
- Rate-limit detection and known Binance/OKX/Hyperliquid/Defx code classification still inspect original exception strings before rendering canonical labels.
- Regression tests inject `SECRET` into propagated, swallowed, known-code, and Defx response/error values and assert it does not reach captured migrated logs.
- The existing per-symbol connector swallow behavior is deliberately preserved and remains tracked as separate trading-critical contract work.