### PR TITLE
Add structured websocket reconnect events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ All notable user-facing changes will be documented in this file.
   without rescanning the full minute array for every candle, while preserving the ordered
   high-to-later-low metric.
 
+- Websocket reconnect attempts now emit bounded `websocket.reconnect`
+  structured events with retry timing, fixed reason classification, text-log
+  visibility, traceback cadence, and exception type. Existing reconnect timing,
+  warning throttling, traceback logging, and exchange behavior are unchanged.
+
 - Connector-local exchange-config failure logs in Binance, Bitget, Defx,
   Hyperliquid, KuCoin, and OKX, plus the parent per-symbol retry log, now keep
   bounded operation, symbol, retry, canonical known-code, and exception-type

--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -90,6 +90,7 @@ across time.
 - `trailing.status`
 - `unstuck.selection`
 - `unstuck.status`
+- `websocket.reconnect`
 
 ## HSL Replay Timing Fields
 
@@ -150,6 +151,7 @@ back to exchange-derived replay.
 - `unstuck`
 - `warmup`
 - `wave`
+- `websocket`
 
 ## Reason Codes
 
@@ -219,6 +221,7 @@ back to exchange-derived replay.
 - `unstuck_selection`
 - `unstuck_status`
 - `warmup_cache_decision`
+- `websocket_reconnect`
 
 Dynamic helpers are part of the same contract:
 

--- a/docs/ai/logging_guide.md
+++ b/docs/ai/logging_guide.md
@@ -57,6 +57,12 @@ classifications, and a bounded exception type without rendering exception
 messages or partial response objects. Outer startup/runtime exception logs and
 structured-event error retention follow their separate policies.
 
+Websocket reconnect attempts emit `websocket.reconnect` to the structured and
+monitor sinks while retaining the existing throttled `[ws]` text diagnostics.
+The event records bounded retry, classification, warning-visibility, traceback-
+cadence, and exception-type fields only; it must not retain exception messages,
+tracebacks, exchange payloads, or URLs.
+
 ## Live Event Debug Profiles
 
 Use `logging.live_event_debug_profiles` or the

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,23 +19,20 @@ Last updated: 2026-07-10.
 
 Current `origin/v8` head:
 
-- `8b0869e9` after PR #1168, `Bound exchange config response diagnostics`.
+- `8f836f30` after PR #1169, `Bound exchange config failure diagnostics`.
 
 Current logging-overhaul head:
 
-- `8b0869e9` after PR #1168, `Bound exchange config response diagnostics`
+- `8f836f30` after PR #1169, `Bound exchange config failure diagnostics`
   (latest merged logging-overhaul slice).
 
 Current work:
 
-- Branch `codex/v8-exchange-config-error-diagnostics` removes raw exception
-  messages and partial response objects from the parent per-symbol retry log and
-  connector-local exchange-config logs in Binance, Bitget, Defx, Hyperliquid,
-  KuCoin, and OKX. Logs retain bounded operation, symbol, retry, canonical
-  known-code, and exception-type context. Existing catches, exception
-  propagation, retry/backoff, per-symbol handling, exchange I/O, and trading
-  behavior remain unchanged. Outer startup/runtime exception logs and
-  structured-event error retention remain separate logging-policy work.
+- PR #1170 (`codex/v8-websocket-reconnect-events`) adds a bounded
+  `websocket.reconnect` structured event at the existing throttled reconnect
+  logger. It preserves retry timing, warning throttling, traceback cadence,
+  exchange I/O, and trading behavior. The event excludes exception messages,
+  tracebacks, exchange payloads, and URLs.
 
 Current review gate:
 
@@ -66,6 +63,18 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1169 at `8f836f30`. Connector-local
+  exchange-config failures and the parent per-symbol retry line now retain only
+  bounded operation, symbol, retry, known-code, and exception-type context. The
+  PR merged after current-head Hermes and Grok 4.5 approvals plus green CI;
+  Claude Opus 4.8 was explicitly waived while rate-limited. VPS5 was pulled
+  with autostash, preserving the pre-existing tracked Rust edit and local
+  artifacts. The first exact-pane Ctrl-C grace window stopped Binance, OKX, and
+  Hyperliquid; a second window targeted only KuCoin and GateIO, and no SIGTERM
+  was required. Immediate two-minute and settled five-minute smoke reports were
+  hard-green: `ok=true`, `hard_failures=0`, all five bots matched, zero failed
+  remote/account-critical/fill-refresh calls, and zero text-log hard/attention
+  matches. Four HSL replays remained active, non-stale, and not long-running.
 - Repository pulled through PR #1168 at `8b0869e9`. Successful account-level
   exchange-config responses now use the shared bounded value-safe formatter in
   the CCXT base plus Binance, Bitget, Bybit, KuCoin, and OKX. The PR merged

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -630,8 +630,8 @@ Related detailed plans:
       proving existing queue-overflow observability without live bots,
       exchange calls, or behavior changes.
 
-16. [ ] Websocket reconnect diagnostics.
-    Status: open.
+16. [x] Websocket reconnect diagnostics.
+    Status: completed by PR #1170.
 
     VPS5 smoke after PR #728 caught a fresh OKX ccxt-pro websocket callback
     traceback after `connection lost ... RequestTimeout`; the bot continued and
@@ -640,6 +640,12 @@ Related detailed plans:
     where practical, or improve smoke classification so known dependency
     callback races are grouped with surrounding reconnect context instead of
     requiring manual log inspection.
+
+    Work log:
+    - 2026-07-10: PR #1170 adds a bounded
+      structured/monitor-only reconnect event at the existing throttled logger.
+      It preserves reconnect control flow and text diagnostics while excluding
+      exception messages, tracebacks, payloads, and URLs from the event.
 
 17. [ ] Forager active-symbol EMA readiness handoff.
     Status: partial. First hardening slice allows active/normal forager symbols

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -86,6 +86,7 @@ class EventTypes:
     CACHE_WARMUP_DECISION = "cache.warmup_decision"
     EXCHANGE_CONFIG_REFRESH = "exchange.config_refresh"
     EXCHANGE_TIME_SYNC = "exchange.time_sync"
+    WEBSOCKET_RECONNECT = "websocket.reconnect"
     REMOTE_CALL_STARTED = "remote_call.started"
     REMOTE_CALL_SUCCEEDED = "remote_call.succeeded"
     REMOTE_CALL_FAILED = "remote_call.failed"
@@ -188,6 +189,7 @@ class EventTags:
     UNSTUCK = "unstuck"
     WARMUP = "warmup"
     WAVE = "wave"
+    WEBSOCKET = "websocket"
 
 
 class ReasonCodes:
@@ -203,6 +205,7 @@ class ReasonCodes:
     EXCHANGE_EXCEPTION = "exchange_exception"
     EXCHANGE_TIME_SYNC = "exchange_time_sync"
     EXCHANGE_TIME_SYNC_UNAVAILABLE = "exchange_time_sync_unavailable"
+    WEBSOCKET_RECONNECT = "websocket_reconnect"
     EXECUTION_LOOP_ERROR_BURST = "execution_loop_error_burst"
     FILL_CACHE_DOCTOR_REPORT = "fill_cache_doctor_report"
     FILL_CACHE_QUARANTINED = "fill_cache_quarantined"
@@ -386,6 +389,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.CACHE_WARMUP_DECISION,
     EventTypes.EXCHANGE_CONFIG_REFRESH,
     EventTypes.EXCHANGE_TIME_SYNC,
+    EventTypes.WEBSOCKET_RECONNECT,
     EventTypes.REMOTE_CALL_STARTED,
     EventTypes.REMOTE_CALL_SUCCEEDED,
     EventTypes.REMOTE_CALL_FAILED,
@@ -692,6 +696,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.CACHE_WARMUP_DECISION: EventRoute(console=False, text=False),
     EventTypes.EXCHANGE_CONFIG_REFRESH: EventRoute(console=False, text=False),
     EventTypes.EXCHANGE_TIME_SYNC: EventRoute(console=False, text=False),
+    EventTypes.WEBSOCKET_RECONNECT: EventRoute(console=False, text=False),
     EventTypes.REMOTE_CALL_STARTED: EventRoute(console=False),
     EventTypes.REMOTE_CALL_SUCCEEDED: EventRoute(console=False),
     EventTypes.REMOTE_CALL_FAILED: EventRoute(console=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -616,6 +616,51 @@ def emit_exchange_time_sync_event(bot: Any, *args: Any, **kwargs: Any) -> None:
         logging.debug("[event] failed to emit exchange time-sync event: %s", exc)
 
 
+def _emit_websocket_reconnect_event_unchecked(
+    bot: Any,
+    *,
+    reconnect_no: int,
+    retry_delay_s: float,
+    reason: str,
+    warning_visible: bool,
+    traceback_emitted: bool,
+    exc: BaseException | None = None,
+    rate_limited: bool = False,
+) -> None:
+    reason_value = str(reason or "connection_lost")
+    if reason_value not in {"connection_lost", "rate_limited", "time_sync"}:
+        reason_value = "other"
+    data = {
+        "reconnect_no": max(0, int(reconnect_no or 0)),
+        "retry_delay_ms": max(0, int(round(float(retry_delay_s or 0.0) * 1000))),
+        "reason": reason_value,
+        "rate_limited": bool(rate_limited),
+        "warning_visible": bool(warning_visible),
+        "traceback_emitted": bool(traceback_emitted),
+    }
+    if exc is not None:
+        data["error_type"] = type(exc).__name__
+    _safe_emit(
+        bot,
+        EventTypes.WEBSOCKET_RECONNECT,
+        level="warning" if warning_visible else "debug",
+        component="exchange.websocket",
+        tags=(EventTags.EXCHANGE, EventTags.WEBSOCKET),
+        cycle_id=current_live_event_cycle_id(bot),
+        status="degraded",
+        reason_code=ReasonCodes.WEBSOCKET_RECONNECT,
+        data=data,
+    )
+
+
+def emit_websocket_reconnect_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+    """Best-effort bounded visibility for websocket reconnect attempts."""
+    try:
+        _emit_websocket_reconnect_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug("[event] failed to emit websocket reconnect event: %s", exc)
+
+
 def _emit_exchange_config_refresh_event_unchecked(
     bot: Any,
     *,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -615,6 +615,9 @@ class Passivbot:
     _emit_exchange_config_refresh_event = (
         live_event_emitters.emit_exchange_config_refresh_event
     )
+    _emit_websocket_reconnect_event = (
+        live_event_emitters.emit_websocket_reconnect_event
+    )
     _emit_execution_confirmation_requested_event = (
         live_event_emitters.emit_execution_confirmation_requested_event
     )
@@ -5939,11 +5942,10 @@ class Passivbot:
         reconnect_no = int(reconnect_no or 0)
         retry_delay_s = max(0.0, float(retry_delay_s or 0.0))
         reason = str(reason or "connection_lost")
-        level = (
-            logging.WARNING
-            if Passivbot._should_log_ws_reconnect_warning(self, reconnect_no)
-            else logging.DEBUG
+        warning_visible = Passivbot._should_log_ws_reconnect_warning(
+            self, reconnect_no
         )
+        level = logging.WARNING if warning_visible else logging.DEBUG
         if rate_limited:
             logging.log(
                 level,
@@ -5962,6 +5964,7 @@ class Passivbot:
                 retry_delay_s,
                 exc_name,
             )
+        traceback_emitted = False
         if exc is not None:
             logging.debug(
                 "[ws] %s: reconnect reason=%s exception=%s", exchange, reason, exc
@@ -5971,6 +5974,7 @@ class Passivbot:
                 getattr(self, "_ws_reconnect_traceback_last_ms", 0) or 0
             )
             if reconnect_no <= 1 or now_ms - last_traceback_ms >= 15 * 60 * 1000:
+                traceback_emitted = True
                 self._ws_reconnect_traceback_last_ms = now_ms
                 logging.debug(
                     "[ws] %s: reconnect traceback follows (throttled)", exchange
@@ -5980,6 +5984,15 @@ class Passivbot:
                         traceback.format_exception(type(exc), exc, exc.__traceback__)
                     )
                 )
+        self._emit_websocket_reconnect_event(
+            reconnect_no=reconnect_no,
+            retry_delay_s=retry_delay_s,
+            reason=reason,
+            warning_visible=warning_visible,
+            traceback_emitted=traceback_emitted,
+            exc=exc,
+            rate_limited=rate_limited,
+        )
 
     def _handle_candle_disk_load_event(self, payload: dict[str, Any]) -> None:
         """Emit summarized candle disk-load events without flooding monitor storage."""

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -242,6 +242,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.CACHE_FLUSH_COMPLETED,
         EventTypes.CACHE_WARMUP_DECISION,
         EventTypes.EXCHANGE_CONFIG_REFRESH,
+        EventTypes.WEBSOCKET_RECONNECT,
         EventTypes.FILLS_REFRESH_SUMMARY,
         EventTypes.PLANNING_DEFER_SUMMARY,
         EventTypes.PLANNING_SYMBOL_STATE,

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -384,6 +384,7 @@ async def test_init_pnls_emits_cache_ready_event(monkeypatch):
     route = DEFAULT_ROUTES[EventTypes.FILLS_REFRESH_SUMMARY]
     assert route.console is False
     assert route.text is False
+
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
@@ -2781,6 +2782,79 @@ def test_ws_reconnect_warning_logs_are_throttled(monkeypatch, caplog):
         logging.DEBUG,
         logging.DEBUG,
     ]
+
+
+def test_ws_reconnect_emits_bounded_structured_event(monkeypatch, caplog):
+    sink = ListEventSink()
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "kucoin"
+    bot._live_event_current_cycle_id = "cy_ws"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    now_ms = [1_000]
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now_ms[0])
+
+    with caplog.at_level(logging.DEBUG):
+        Passivbot._log_ws_reconnect(
+            bot,
+            reconnect_no=1,
+            retry_delay_s=1.25,
+            reason="time_sync",
+            exc=TimeoutError("api_key=SECRET ping timeout"),
+        )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.WEBSOCKET_RECONNECT
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.level == "warning"
+    assert event.component == "exchange.websocket"
+    assert event.tags == (EventTags.EXCHANGE, EventTags.WEBSOCKET)
+    assert event.cycle_id == "cy_ws"
+    assert event.status == "degraded"
+    assert event.reason_code == ReasonCodes.WEBSOCKET_RECONNECT
+    assert event.data == {
+        "reconnect_no": 1,
+        "retry_delay_ms": 1_250,
+        "reason": "time_sync",
+        "rate_limited": False,
+        "warning_visible": True,
+        "traceback_emitted": True,
+        "error_type": "TimeoutError",
+    }
+    assert "SECRET" not in json.dumps(event.to_dict())
+    route = DEFAULT_ROUTES[EventTypes.WEBSOCKET_RECONNECT]
+    assert route.structured is True
+    assert route.monitor is True
+    assert route.console is False
+    assert route.text is False
+
+    Passivbot._log_ws_reconnect(
+        bot,
+        reconnect_no=4,
+        retry_delay_s=2.5,
+        reason="rate_limited",
+        rate_limited=True,
+    )
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    rate_limit_event = sink.events[-1]
+    assert rate_limit_event.event_type == EventTypes.WEBSOCKET_RECONNECT
+    assert rate_limit_event.level == "debug"
+    assert rate_limit_event.data == {
+        "reconnect_no": 4,
+        "retry_delay_ms": 2_500,
+        "reason": "rate_limited",
+        "rate_limited": True,
+        "warning_visible": False,
+        "traceback_emitted": False,
+    }
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

- Category: `observability producer`
- Add a bounded `websocket.reconnect` structured event at the existing websocket reconnect logger.
- Register the event type, tag, reason code, and structured/monitor-only route.
- Record the completed PR #1169 VPS5 deployment evidence.

## Behavior impact

- No trading, exchange I/O, retry timing, backoff, warning-throttle, traceback-cadence, or reconnect control-flow changes.
- Existing `[ws]` text diagnostics remain unchanged.
- Structured payloads retain only reconnect number, retry delay, fixed reason classification, warning selection, traceback cadence, rate-limit status, and exception type.
- Exception messages, tracebacks, exchange payloads, and URLs are excluded from the event.

## VPS action

Restart required after merge because this adds a live event producer. Then run bounded immediate and settled smoke checks; do not deliberately induce exchange/websocket failures.

## Validation

- Repo-venv `pytest -q tests/test_passivbot_balance_split.py tests/test_live_event_bus.py tests/exchanges/test_ccxt_bot_hooks.py tests/exchanges/test_ccxt_bot.py`: 380 passed.
- Repo-venv `pytest -q tests/test_run_fake_live.py`: 29 passed.
- Real two-step minimal fake-live run completed successfully.
- Repo-venv `py_compile` on touched Python modules/tests passed.
- `git diff --check` passed.

## Review notes

Please verify that event emission remains best-effort and cannot alter reconnect behavior, that the structured route does not duplicate console/text output, and that no free-form exception or payload data enters the event. Temporary required gate is Hermes + Grok 4.5 + green CI while Claude Opus 4.8 is rate-limited; any additional findings still require resolution.
