### PR TITLE
Improve PR review and logging loop workflow

### DIFF
--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -17,6 +17,7 @@ Use this file to decide what to read for a task.
 | Rust/PyO3 build, extension loading, Rust test execution | `build_pitfalls.md` |
 | Logging behavior/levels/tags | `logging_guide.md`, `live_event_registry.md` when touching structured event tags or reason codes |
 | Autonomous PR review loop | `pr_auto_review_loop.md` |
+| Logging-overhaul implementation loop | `../plans/live_logging_overhaul_current_status.md`, then `../plans/live_logging_overhaul_pr_loop_workflow.md`; open the historical progress ledger only when needed |
 | Order logic, risk, Python/Rust boundary | `architecture.md`, `decisions.md`, `features/strategy_runtime.md` when strategy behavior is involved |
 | Code review | `code_review_prompt.md` |
 | Common implementation mistakes | `pitfalls.md` |

--- a/docs/ai/pr_auto_review_loop.md
+++ b/docs/ai/pr_auto_review_loop.md
@@ -1,70 +1,188 @@
 # PR Auto-Review Loop
 
-Use this when acting as an autonomous reviewer for Passivbot PRs targeting
-`v8`.
+Use this workflow when acting as an autonomous reviewer for Passivbot pull
+requests targeting `v8`.
 
-## Scope
+## Authority And Scope
 
-- Review open PRs against `v8`, including logging-overhaul PRs and
-  maintainer-created PRs that are not part of the logging overhaul.
-- Review the current PR head. If the head changes after a review, re-check the
-  delta before approving.
-- Do not implement fixes, push commits, merge PRs, deploy, SSH, or contact
-  exchanges unless explicitly instructed.
+- Review every eligible open PR targeting `v8`, including maintainer-created
+  and non-logging-overhaul PRs.
+- Review the current PR head and current merge base. An approval is valid only
+  for the exact reviewed head SHA.
+- Review code, tests, documentation, PR claims, and repository-policy
+  alignment. Run real backtest, optimize, and fake-live smoke checks when the
+  touched paths make them relevant.
+- Do not implement fixes, push commits, merge, deploy, SSH, signal processes,
+  or contact exchanges unless the maintainer explicitly changes the role.
 
-## Loop Contract
+## Durable Loop
 
-- Use the strongest available self-prompting mechanism in your agent surface:
-  goal mode, scheduled heartbeat, cron, automation, or equivalent.
-- If no durable self-prompting mechanism is available, state that limitation in
-  the thread and perform one complete poll/review pass.
-- Poll cheaply when there is no open work. A one-minute poll interval is fine
-  when each poll is limited to low-token GitHub metadata, such as open PR
-  numbers, head SHAs, review state, and CI state.
-- If each poll requires expensive diff/test context, use a five- to ten-minute
-  interval until a PR head or CI/review state changes.
-- Treat transient network, GitHub, checkout, or tool errors as retryable unless
-  evidence proves otherwise. Record the error briefly, back off, and keep the
-  loop alive.
-- Do not stop the loop after one unexpected disconnect or command failure. On
-  resume, fetch current remote state and continue from GitHub as the source of
-  truth.
-- Stop only when explicitly told to stop, when the goal is complete, or when the
-  same blocker has repeated enough times that your agent's blocked-goal policy
-  requires reporting it.
+Use goal mode, a scheduled heartbeat, cron, an automation, or the strongest
+durable self-prompting mechanism available. The loop must survive an idle
+terminal, one failed poll, a transient disconnect, and an agent restart.
+If no durable mechanism exists, say so in the task, perform one complete
+poll/review pass, and do not claim that continuous monitoring is active.
 
-## Poll Pass
+Persist only compact review state outside the repository, for example under
+`$TMPDIR/passivbot-pr-review-<reviewer>.json`. Store:
 
-1. Fetch current `origin/v8`.
-2. List open PRs targeting `v8`.
-3. For each PR, compare the current head SHA, CI status, and latest reviewer
-   state with the last observed state.
-4. If nothing changed, sleep until the next poll.
-5. If a PR is new or changed, create or refresh a clean review worktree and
-   review the current PR head.
+- PR number
+- last observed base and head SHAs
+- last fully reviewed head SHA
+- CI-state digest
+- latest review/comment metadata digest
+- retry count and next retry time
+- last short error classification
+
+Do not store credentials, full comments, diffs, test output, or exchange data in
+the state file. GitHub and the fetched repository remain the sources of truth.
+
+## Cost-Aware Polling
+
+Polling should be deterministic and should not require semantic model work when
+nothing changed.
+
+1. Use one metadata request for open PRs, for example:
+
+   ```bash
+   gh pr list --base v8 --state open --limit 1000 \
+     --json number,title,isDraft,headRefOid,updatedAt,statusCheckRollup
+   ```
+
+2. Compare PR number, head SHA, draft state, update time, and CI summary with the
+   saved state.
+3. Fetch detailed reviews/comments only for a new or changed PR.
+4. Do not fetch the diff, create a worktree, rerun tests, or invoke a strong
+   semantic model for an unchanged head.
+
+Use a one-minute interval only when the scheduler runs the metadata command and
+digest comparison without invoking a model, and wakes an agent only after the
+digest changes. If every heartbeat invokes an agent/model, use at least ten
+minutes even while CI or reviews are pending; pending state alone is not a
+reason for repeated model wakeups. Add small jitter when several reviewers poll
+the same repository.
+
+Where model routing is available:
+
+- use deterministic tooling or the cheapest capable tier for metadata polling
+- use a lower-cost reasoning tier for changed-state triage and test-log summary
+- reserve the strongest tier for full semantic review, trading-critical code,
+  architecture, security, conflicting findings, and final judgment
+
+Do not weaken a high-risk review because a strong model is rate-limited. Keep
+the PR pending and retry later.
+
+## Retry And Recovery
+
+- Treat network, GitHub, checkout, authentication-refresh, subprocess, and
+  temporary rate-limit failures as retryable unless proven persistent.
+- Back off after consecutive failures, for example 1, 2, 5, then 10 minutes,
+  capped at 10 minutes. Reset after a successful poll.
+- A rate-limit response should delay the next metadata poll; it should not end
+  the loop or produce repeated model narration.
+- After reconnect or agent restart, reload compact state, fetch GitHub metadata,
+  and reconcile by PR number and head SHA before doing semantic work.
+- Do not mark the loop blocked after one failure. Escalate only after the same
+  persistent blocker has repeated and no read-only progress remains possible.
+- Stop only when explicitly told to stop, the assigned goal is complete, or the
+  agent's blocked-goal policy requires a final blocked state.
+
+## Review Trigger Rules
+
+Perform a semantic review when:
+
+- a ready-for-review PR is new
+- the head SHA changed
+- the PR was rebased or its effective merge base changed materially
+- the maintainer explicitly requests a re-review
+- new evidence invalidates an earlier conclusion
+
+Do not duplicate a review merely because CI changed from pending to green. Do
+not approve a draft unless explicitly asked. If the head changes after review,
+review the delta from the last reviewed SHA and re-check the integrated full PR
+before posting a new verdict.
+
+## Isolated Checkout
+
+- Work from the reviewer's own clone or clean read-only review worktree, never
+  from the implementer's dirty checkout.
+- Fetch `origin/v8` and the PR head immediately before review.
+- Record the base SHA, head SHA, and merge state used for the review.
+- Never modify the PR branch. Test artifacts belong in temporary directories.
+- Re-check the remote head immediately before posting; discard or clearly mark
+  results if the head changed during review.
+
+## Review Method
+
+1. Read `AGENTS.md`, `docs/ai/principles.yaml`,
+   `docs/ai/error_contract.md`, and task-specific docs from
+   `docs/ai/README.md`.
+2. Read the PR body and classify the scope: docs/tooling, observability
+   producer, runtime behavior, exchange integration, Rust/trading, backtest, or
+   optimizer.
+3. Review the complete diff against the current merge base. Verify that the PR
+   body and docs do not overclaim the actual code surface.
+4. Trace changed behavior through callers and consumers. Do not review an
+   isolated function when safety depends on the full runtime path.
+5. Run validation proportional to risk:
+   - docs/tooling: claim verification, focused tests, compile/lint/diff checks
+   - live observability: event routing, boundedness, redaction, hot-path cost,
+     sink-failure isolation, fake-live where applicable
+   - exchange code: focused connector tests and documented exchange contracts;
+     no real exchange contact without permission
+   - Rust/order/risk/HSL/unstuck: Rust tests, extension rebuild when needed,
+     Python parity tests, and a real bounded backtest/fake-live smoke
+   - backtest/optimize: real short backtest and/or optimize integration smoke
+6. Distinguish PR regressions from failures reproduced on the current base.
+7. Check mergeability and current CI, but do not treat CI as a substitute for
+   semantic review.
 
 ## Review Focus
 
-- Architecture and intent alignment.
-- Bugs, edge cases, and behavioral regressions.
+- Architecture and stated intent.
+- Bugs, edge cases, concurrency, and behavioral regressions.
 - Trading-critical safety and `docs/ai/error_contract.md` compliance.
-- Rust/Python ownership boundaries, especially order, risk, HSL, and unstuck.
+- Rust/Python ownership boundaries.
 - Stateless restart reproducibility.
-- Test coverage and whether tests prove the intended behavior.
-- Docs and operator-facing clarity.
-- VPS deploy implications and whether restart/smoke evidence is sufficient.
-- Backtest, optimize, fake-live, or real smoke validation when the PR touches
-  relevant paths.
+- Signed quantity, side/position-side, EMA-span, and exchange-contract rules.
+- Test quality: tests must prove the claim rather than only execute the path.
+- Documentation accuracy and user/operator impact.
+- Secret safety, bounded payloads, event volume, retention, and hot-path cost.
+- Incident reconstruction, correlation IDs, reason codes, smoke reports, and
+  VPS deploy/restart implications.
 
-## Review Output
+Avoid style-only findings unless they affect correctness, operations, or
+maintainability.
 
-Post one top-level GitHub PR review or comment:
+## GitHub Output
 
-- Findings first, ordered by severity.
-- Exact file/line references for actionable findings.
-- Commands run and evidence observed.
-- Explicit approval/green-light when clean.
-- Residual risk or untested surface.
+Prefer a formal GitHub review:
 
-Do not recommend merge until the current PR head has green required reviews and
-green CI.
+- `APPROVE` when clean
+- `REQUEST_CHANGES` for actionable findings
+- `COMMENT` only for clarification or when the reviewer shares the author
+  account and GitHub forbids self-approval
+
+When formal review is unavailable, post one structured top-level comment. Every
+verdict must include:
+
+- reviewer identity
+- PR number
+- reviewed base and head SHAs
+- scope: full review or exact delta
+- decision: `approve`, `request changes`, or `needs clarification`
+- findings first, ordered by severity, with exact file/line references
+- commands run and observed results
+- base-only failures or environmental limitations
+- residual risk and untested surfaces
+
+An approval comment must say explicitly that it is green for the named head
+SHA. Never state that a PR is merge-ready unless all configured reviewers and
+CI are green on that same head.
+
+## State After Review
+
+After posting, save the reviewed head SHA and return to metadata-only polling.
+If the author pushes a fix, review the delta, rerun affected validation, inspect
+the integrated result, and supersede the earlier verdict. Do not keep posting
+unchanged approvals or status comments.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -1,0 +1,99 @@
+# Live Logging Overhaul Current Status
+
+Updated: 2026-07-10.
+
+This is the compact operational source for the active logging-overhaul loop.
+Read it before the historical progress ledger. Update it whenever the active
+PR, head SHA, review gate, deployed SHA, VPS state, or next action changes.
+
+## Goal
+
+Deliver bounded, correlated, operator-useful live observability through small
+reviewable PRs, current-head review gates, and evidence-based VPS5 validation.
+Rust remains the trading-logic authority; observability must not become a
+trading control plane.
+
+Estimated completion:
+
+- core event/observability architecture: about 85%
+- original logging migration: about 70%
+- expanded logging, performance-readiness, restart, and ops scope: about 65%
+  overall, with substantial uncertainty from the intentionally growing backlog
+
+## Active Runtime PR
+
+- PR #1170: `Add structured websocket reconnect events`
+- Branch: `codex/v8-websocket-reconnect-events`
+- Head: `40ad4a774b775a35ee1d0fcdcc0e11d985b79b33`
+- Current `origin/v8`: `b7c514c0a44931ee09832bc934dce1d48705a38b`
+  after PR #1163
+- Scope: bounded structured/monitor-only websocket reconnect producer; no
+  reconnect or trading behavior change
+- CI: green on the current head
+- Reviews: the prior `CHANGELOG.md` conflict findings are resolved; current-head
+  Hermes and Grok delta reviews are pending
+- Gate: not yet satisfied; GitHub reports `CLEAN`, but prior reviews apply to
+  the superseded head
+- State: runtime loop resumed; docs-only workflow PR #1171 remains orthogonal
+
+Next action after the maintainer resumes the loop:
+
+1. Wait for current-head Hermes and Grok delta reviews.
+2. Reconfirm current `origin/v8`, mergeability, head SHA, reviews, and CI.
+3. Merge PR #1170 only after the current-head gate is satisfied.
+4. Pull VPS5 with autostash while preserving local artifacts.
+5. Restart the five configured bots because #1170 adds a live producer.
+6. Run immediate and settled bounded smoke checks without inducing a websocket
+   or exchange failure.
+7. Record merge/deploy evidence here and in the historical ledger.
+
+## Deployed Baseline
+
+- Remote `v8`: `b7c514c0`, PR #1163
+- VPS5 repository: `8f836f30`, PR #1169
+- VPS5 expected bots: five; all were running after the latest restart
+- Latest immediate and settled smoke: `ok=true`, `hard_failures=0`, all five
+  bots matched, zero failed remote/account-critical/fill-refresh calls, and
+  zero text-log hard/attention matches
+- Known VPS5 tracked edit to preserve:
+  `passivbot-rust/src/equity_hard_stop_loss.rs`
+- Preserve local/VPS configs, logs, monitor data, reports, and temporary files
+
+## Review Gate
+
+- Normal gate: all reviewers currently designated by the maintainer plus green
+  CI on the exact head SHA.
+- Temporary gate while Claude is rate-limited: Hermes + Grok 4.5 + green CI.
+- Findings from any additional reviewer must still be verified and resolved.
+- Any pushed delta requires current-head re-review.
+
+## Agent Routing
+
+- Sol: architecture, high-risk implementation, finding adjudication, merge,
+  VPS signals/restart, and incident judgment.
+- Terra: isolated low/medium-risk docs, tests, report/query tooling, and bounded
+  observability implementation with explicit file scope.
+- Luna or deterministic automation: metadata polling, state-change detection,
+  CI/reviewer summaries, and read-only output parsing.
+- Parallel PRs must be orthogonal. Dependent work waits for merge to `v8`.
+
+## Next Slice
+
+Do not start a dependent runtime slice until PR #1170 is merged and deployed.
+After deployment, choose one review-worthy item from:
+
+- high-value Phase 5 text-to-event migration
+- missing performance/readiness source events that unblock measurement
+- bounded operator tooling improvements sharing one code and validation surface
+
+Do not create progress-only PRs or resume unrelated logging work from stale
+worktrees.
+
+## References
+
+- Operating workflow: `live_logging_overhaul_pr_loop_workflow.md`
+- Architecture: `live_logging_overhaul_plan.md`
+- Historical evidence: `live_logging_overhaul_progress.md`
+- Performance goals: `live_performance_readiness_goals.md`
+- Operational backlog: `live_ops_improvement_backlog.md`
+- Reviewer loop: `../ai/pr_auto_review_loop.md`

--- a/docs/plans/live_logging_overhaul_pr_loop_workflow.md
+++ b/docs/plans/live_logging_overhaul_pr_loop_workflow.md
@@ -1,102 +1,184 @@
 # Live Logging Overhaul PR Loop Workflow
 
-This note defines the resumed logging-overhaul implementation loop. It
-complements:
+This is the operating workflow for the logging/observability implementation
+loop. Read `live_logging_overhaul_current_status.md` first. Use
+`live_logging_overhaul_progress.md` only for historical evidence.
 
-- `docs/plans/live_logging_overhaul_plan.md`
-- `docs/plans/live_logging_overhaul_progress.md`
-- `docs/plans/live_performance_readiness_goals.md`
-- `docs/plans/live_ops_improvement_backlog.md`
+Architecture and backlog references:
 
-## Roles
+- `live_logging_overhaul_plan.md`
+- `live_performance_readiness_goals.md`
+- `live_ops_improvement_backlog.md`
+- `../ai/pr_auto_review_loop.md`
 
-- Codex owns implementation, local validation, PR creation, review iteration,
-  merge to `v8` after the gate is satisfied, VPS5 deploy/smoke when appropriate,
-  and progress evidence updates.
-- Hermes, Claude Opus, Grok, and any additional reviewer agents review the
-  current PR delta. Reviewers do not implement fixes or merge. Reusable
-  reviewer-loop instructions live in `docs/ai/pr_auto_review_loop.md`.
-- Maintainer-created PRs may also enter the same review loop. It is OK for
-  reviewers to review non-logging-overhaul PRs when they target `v8`.
+## Goal
+
+Deliver bounded, correlated, operator-useful live observability through
+reviewable PRs, current-head review gates, and evidence-based VPS5 validation,
+without moving trading decisions out of Rust or making observability a trading
+control plane.
+
+## Tiered Ownership
+
+Use the cheapest capable execution tier and reserve the strongest reasoning
+tier for consequential decisions.
+
+### Sol: Lead And Safety Owner
+
+- Select architecture and PR boundaries.
+- Own trading-critical, exchange-contract, Rust, risk/HSL/unstuck, security,
+  concurrency, and live-runtime decisions.
+- Adjudicate reviewer findings and conflicting evidence.
+- Inspect delegated diffs and validation before publication.
+- Decide merge readiness and perform or authorize VPS signals/restarts.
+- Interpret incidents and choose the next dependent slice.
+
+### Terra: Scoped Implementation Worker
+
+- Implement straightforward docs, tests, report projections, query/tooling
+  changes, and bounded observability producers with an explicit file scope.
+- Run local validation and return a clean commit/diff plus evidence.
+- Work only in an isolated branch/worktree.
+- Do not merge, deploy, SSH, signal processes, or broaden scope.
+
+### Luna: Polling And Read-Only Triage
+
+- Poll low-token GitHub metadata and notify Sol only when state changes.
+- Summarize CI/reviewer findings, current head/base, and merge state.
+- Run read-only branch checks and parse test, smoke, incident, and performance
+  outputs.
+- Do not edit, approve on Sol's behalf, merge, deploy, SSH, or signal processes.
+
+If these tiers are unavailable, preserve the role boundaries with deterministic
+commands and direct Sol work. Do not spend strong-model context on unchanged
+polls.
+
+## Delegation Contract
+
+Every delegated task must state:
+
+- objective and non-goals
+- base SHA and branch/worktree
+- allowed files and ownership boundary
+- forbidden actions, especially merge/SSH/live exchange/process signals
+- required tests and evidence
+- expected return: findings, diff/commit, validation, and residual risk
+
+Parallel work is allowed only for orthogonal PRs. Work that depends on another
+PR must wait until that PR is merged to `v8`. Sol reviews every delegated diff
+before push or merge.
+
+## Current State And History
+
+- `live_logging_overhaul_current_status.md` is the compact operational source
+  for the active PR, review gate, deployed SHA, VPS state, and next action.
+- `live_logging_overhaul_progress.md` is append-only historical evidence. Do not
+  load or rewrite the entire ledger during routine polls.
+- Update the compact status whenever the active PR, head SHA, gate, deploy
+  state, or next action changes.
+- Append one compact historical entry after merge/deploy. Archive older ledger
+  sections in a separate docs-only slice when size materially impairs use.
 
 ## PR Scope
 
-- Prefer review-worthy slices over progress-only PRs.
-- Keep each PR tied to one behavior/tooling/docs purpose and one validation
-  story.
-- Split PRs for behavior, restart/deploy behavior, exchange contact, HSL/risk,
-  Rust extension behavior, and read-only report/tooling changes.
-- Start dependent work only after its dependency is merged to `v8`; parallel PRs
-  should be orthogonal.
+- Prefer one coherent behavior/tooling/docs purpose and one validation story.
+- Combine adjacent low-risk report or query fields when they share the same
+  producer, consumer, and test surface.
+- Avoid progress-only PRs and excessively small projection PRs.
+- Split changes at safety boundaries: trading behavior, exchange contact,
+  Rust/PyO3, HSL/risk, sink/backpressure, raw retention, restart behavior, and
+  read-only tooling.
+- Keep dependent work serial. Use parallel PRs only when they are truly
+  orthogonal and merge-order independent.
+
+Use a draft PR while implementation or author validation is incomplete. Mark it
+ready only after the branch is clean, the PR body is accurate, and required
+author tests pass.
 
 ## PR Body Contract
 
-Every implementation PR should state:
+State:
 
-- scope category: `read-only tooling`, `observability producer`, `runtime behavior`,
-  `restart/deploy behavior`, or `trading-path`
+- scope category: `docs`, `read-only tooling`, `observability producer`,
+  `runtime behavior`, `restart/deploy behavior`, or `trading-path`
+- touched surfaces and explicit non-goals
 - expected behavior impact
-- expected VPS action: no restart, restart required, or observe only
+- expected VPS action: none, pull/observe, or restart/smoke
 - validation commands and results
-- reviewer-specific notes for subtle contracts
+- reviewer focus requests and known residual risk
 
 ## Review Gate
 
-- Merge only after current-head green reviews from required reviewers and green
-  CI.
-- If the PR head changes after a review, require delta re-review for the new
-  head before merging.
-- For low-risk read-only tooling/docs PRs, use a degraded gate only when a
-  reviewer is unavailable and the PR explicitly justifies that choice.
+- Merge only after every currently required reviewer and CI are green on the
+  exact current head SHA.
+- Prefer formal GitHub reviews or commit-bound checks. If GitHub forbids
+  self-approval, accept a structured comment only when it names the reviewer,
+  verdict, and exact head SHA.
+- A head change invalidates prior approval unless the reviewer explicitly
+  carries it to the new head after delta/integrated review.
+- Findings from optional reviewers still require verification and resolution.
+- Use a degraded gate only with explicit maintainer authorization and record it
+  in the PR and historical evidence.
 
-## Reviewer Output Contract
+## Cost-Aware Waiting
 
-Ask reviewers to post one top-level PR review/comment with:
-
-- findings first, ordered by severity
-- exact file/line references for actionable findings
-- commands run and evidence observed
-- explicit approval/green-light when clean
-- residual risk or untested surface
-
-Reviewer focus areas:
-
-- architecture and intent alignment
-- trading-critical safety and error-contract compliance
-- Rust/Python ownership boundaries
-- statelessness and restart reproducibility
-- tests that prove the claimed behavior
-- operator usefulness in smoke, incident-bundle, debug-profile, and VPS workflows
-- VPS deploy implications and whether restart/smoke evidence is sufficient
+- Use deterministic metadata polling and a compact state digest as defined in
+  `docs/ai/pr_auto_review_loop.md`.
+- Poll every minute only when the scheduler computes the digest without a model
+  and wakes an agent only after a change. If every heartbeat consumes model
+  context, use at least ten minutes; pending CI/reviews do not justify faster
+  model wakeups.
+- Wake Sol only for a new PR/head, a reviewer finding, a completed gate, a
+  persistent blocker, or a deploy decision.
+- Transient GitHub, network, rate-limit, or tool errors back off and retry; they
+  do not end the goal.
 
 ## Implementation Loop
 
-1. Fetch current `origin/v8` and inspect open PRs/branches.
-2. Reconcile `docs/plans/live_logging_overhaul_progress.md` against GitHub and
-   VPS state before choosing the next slice.
-3. Create a clean branch/worktree for the chosen slice when the main checkout is
-   dirty.
-4. Implement the narrow slice, update tests, and update progress docs only when
-   the PR includes a real review-worthy code/tool/docs change.
-5. Run targeted validation, `git diff --check`, and broader/fake-live/VPS tests
-   when relevant.
-6. Open the PR with the body contract above.
-7. Wait for reviewer and CI feedback.
-8. Apply narrow fixes for findings, push, and wait for delta re-review.
-9. Merge only after the gate is satisfied.
-10. Pull `v8` locally. Deploy to VPS5 according to the PR's declared deploy
-    impact, restart bots only when the change requires running processes to load
-    new code, and run bounded smoke/incident checks.
-11. Record compact evidence in the progress ledger: PR, scope, validation,
-    review gate, merge SHA, VPS action, smoke result, and remaining gap.
+1. Read the compact current-status file and fetch current `origin/v8`.
+2. Reconcile the active PR/head/gate from GitHub. Read historical progress only
+   when evidence is needed.
+3. Select one review-worthy slice. Route routine scoped work to Terra when
+   available; keep high-risk work with Sol.
+4. Create a clean branch/worktree. Preserve unrelated tracked and untracked
+   artifacts in the main checkout and on VPS5.
+5. Implement and validate proportionally. Use real fake-live, backtest, or
+   optimize smokes when touched behavior warrants them.
+6. Open a draft PR if work remains; otherwise open ready with the PR body
+   contract.
+7. Let Luna/deterministic polling monitor GitHub. Sol does not wait in a
+   high-cost semantic loop.
+8. Verify every finding against the current branch. Apply the narrow fix,
+   rerun affected tests, push, and require current-head delta review.
+9. Re-fetch `origin/v8`, verify mergeability, gate SHAs, and CI immediately
+   before merge.
+10. Merge only after the gate is satisfied. Update local state.
+11. Deploy according to the declared impact. Sol retains control of actual VPS
+    signals/restarts; read-only preflight and output parsing may be delegated.
+12. Run immediate and settled bounded smoke checks and leave expected bots
+    running.
+13. Update compact status, then append concise merge/deploy evidence to the
+    historical ledger.
 
 ## VPS Policy
 
+- Docs-only changes require no VPS action.
 - Read-only tooling/report changes usually require pull plus bounded smoke, not
   bot restart.
-- Producer/event payload changes require restart and observation.
-- Runtime behavior, exchange contact, order/risk, and Rust changes require
-  restart and observation.
-- For Rust-touching deploys, rebuild and verify the extension before restarting.
-- VPS actions must be explicit and evidence-driven; do not perform broad process
-  kills or live-bot actions outside the declared deploy plan.
+- Producer/event payload, console/text projection, startup/shutdown, live-loop,
+  Rust, exchange-call, and trading-path changes normally require restart and
+  observation.
+- For Rust changes, rebuild and verify the extension before restart.
+- Use exact verified process/session targets. Do not use broad process-pattern
+  signals.
+- Preserve known tracked edits and all local configs, logs, monitor data,
+  reports, and temporary artifacts.
+
+## Goal Health
+
+- Keep the active goal objective short and point it to this workflow plus the
+  compact status file.
+- Do not mark the goal blocked for a single approval, network, quota, or tool
+  failure. Back off and continue with available read-only work.
+- Mark blocked only after the same persistent condition repeats and no useful
+  progress remains possible under the goal policy.


### PR DESCRIPTION
## Scope

- Category: `docs`
- Rewrite the reusable autonomous PR reviewer loop.
- Add tiered Sol/Terra/Luna ownership to the logging-overhaul implementation loop.
- Add a compact current-status source so routine work does not load the historical progress ledger.
- Update the AI docs router.

## Behavior impact

No runtime, trading, exchange, event, test, packaging, or configuration behavior changes.

The workflow now requires deterministic change-only polling, durable external state, rate-limit/disconnect recovery, isolated reviewer clones/worktrees, current-head verdicts, proportional real smoke validation, formal reviews where possible, draft PRs during incomplete work, and strong-model escalation only for semantic/high-risk work.

## Non-goals

- No merge or deploy of PR #1170.
- No restart of the logging implementation loop.
- No GitHub App, branch-protection, scheduler, or VPS configuration changes.

## VPS action

None. This is documentation-only.

## Validation

- `git diff --check`: passed.
- Referenced documentation paths: verified present.
- Non-ASCII scan of touched docs: clean.
- Documented `gh pr list --base v8 --state open --json number,title,isDraft,headRefOid,updatedAt,statusCheckRollup` poll command: executed successfully against the repository.

## Review focus

Please check for contradictory role boundaries, unsafe delegation, stale gate claims, polling loops that could still waste model tokens, failure modes that could silently stop monitoring, and any instruction that would let a reviewer edit/merge/deploy or contact exchanges.

This PR is orthogonal to open runtime PR #1170 and does not change its reviewed head.
