### PR TITLE
Add offline HSL replay benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool hsl-replay-benchmark`, a bounded offline benchmark for
+  the current coin-HSL history initializer. It emits deterministic fixture and
+  final-state hashes, explicit timeline-row and pair-row throughput, profiled
+  stage timings, replay counters, and side-effect counters without contacting
+  exchanges or reading/writing live cache and state artifacts.
+
 - `passivbot tool crash-finder` can now regenerate scenario suites from an existing
   `crash_clusters.csv` without rescanning local OHLCV data, emit market-wide/coin-focused/single-coin
   filtered suites, merge overlapping stress windows, and add per-coin forced-normal overrides for

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -20,41 +20,43 @@ Estimated completion:
 - expanded logging, performance-readiness, restart, and ops scope: about 65%
   overall, with substantial uncertainty from the intentionally growing backlog
 
-## Active Runtime PR
+## Active Review Slice
 
-- PR #1170: `Add structured websocket reconnect events`
-- Branch: `codex/v8-websocket-reconnect-events`
-- Head: `40ad4a774b775a35ee1d0fcdcc0e11d985b79b33`
-- Current `origin/v8`: `b7c514c0a44931ee09832bc934dce1d48705a38b`
-  after PR #1163
-- Scope: bounded structured/monitor-only websocket reconnect producer; no
-  reconnect or trading behavior change
-- CI: green on the current head
-- Reviews: the prior `CHANGELOG.md` conflict findings are resolved; current-head
-  Hermes and Grok delta reviews are pending
-- Gate: not yet satisfied; GitHub reports `CLEAN`, but prior reviews apply to
-  the superseded head
-- State: runtime loop resumed; docs-only workflow PR #1171 remains orthogonal
+- PR #1172: `Add offline HSL replay benchmark`
+- Branch: `codex/v8-hsl-replay-benchmark`
+- Head: query live GitHub metadata; this commit cannot embed its own final SHA
+  without making that value stale
+- Base: `4a00ff171d9a8ef04e4591c797b7ef24952bd175`
+- Scope: bounded deterministic offline benchmark for the current coin-HSL
+  history initializer; no live/runtime HSL behavior change
+- Output: explicit timeline-row and pair-row throughput, profiled timings and
+  counters, deterministic fixture/final-state hashes, and side-effect counters
+- Local validation: focused benchmark plus coin-HSL suites pass (113 tests),
+  direct compact CLI smoke passes, `py_compile` and `git diff --check` pass
+- Independent preflight: green after correcting the pair-row throughput unit
+- Publication state, exact head, mergeability, CI, and current-head review
+  verdicts: query live GitHub metadata. Do not encode those transient values in
+  the same PR that contains this status file, because every correction would
+  create a different head and immediately stale the embedded value.
+- Expected VPS action: none for correctness; optional pull after merge, no bot
+  restart
 
-Next action after the maintainer resumes the loop:
+Next action:
 
-1. Wait for current-head Hermes and Grok delta reviews.
-2. Reconfirm current `origin/v8`, mergeability, head SHA, reviews, and CI.
-3. Merge PR #1170 only after the current-head gate is satisfied.
-4. Pull VPS5 with autostash while preserving local artifacts.
-5. Restart the five configured bots because #1170 adds a live producer.
-6. Run immediate and settled bounded smoke checks without inducing a websocket
-   or exchange failure.
-7. Record merge/deploy evidence here and in the historical ledger.
+1. Poll live GitHub metadata for PR #1172's current head, mergeability, CI, and
+   required reviews.
+2. Resolve any verified finding with focused regression coverage.
+3. Merge only after the exact-head gate is satisfied.
 
 ## Deployed Baseline
 
-- Remote `v8`: `b7c514c0`, PR #1163
-- VPS5 repository: `8f836f30`, PR #1169
-- VPS5 expected bots: five; all were running after the latest restart
+- Remote `v8`: `4a00ff17`, PR #1170 after workflow-doc PR #1171
+- VPS5 repository: `4a00ff17`, PR #1170
+- VPS5 expected bots: five; all are running after the controlled restart
 - Latest immediate and settled smoke: `ok=true`, `hard_failures=0`, all five
   bots matched, zero failed remote/account-critical/fill-refresh calls, and
-  zero text-log hard/attention matches
+  zero text-log hard/attention matches. Four HSL replays remained active but
+  were neither stale nor long-running.
 - Known VPS5 tracked edit to preserve:
   `passivbot-rust/src/equity_hard_stop_loss.rs`
 - Preserve local/VPS configs, logs, monitor data, reports, and temporary files
@@ -79,11 +81,12 @@ Next action after the maintainer resumes the loop:
 
 ## Next Slice
 
-Do not start a dependent runtime slice until PR #1170 is merged and deployed.
-After deployment, choose one review-worthy item from:
+The offline replay benchmark is the active independent slice. After it merges,
+use its repeatable evidence to choose one review-worthy item from:
 
+- realistic-scale replay fixtures and deeper internal-stage profiling
+- held-position protective-readiness source events and sequencing
 - high-value Phase 5 text-to-event migration
-- missing performance/readiness source events that unblock measurement
 - bounded operator tooling improvements sharing one code and validation surface
 
 Do not create progress-only PRs or resume unrelated logging work from stale

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,20 +19,21 @@ Last updated: 2026-07-10.
 
 Current `origin/v8` head:
 
-- `8f836f30` after PR #1169, `Bound exchange config failure diagnostics`.
+- `4a00ff17` after PR #1170, `Add structured websocket reconnect events`,
+  following workflow-doc PR #1171.
 
 Current logging-overhaul head:
 
-- `8f836f30` after PR #1169, `Bound exchange config failure diagnostics`
+- `4a00ff17` after PR #1170, `Add structured websocket reconnect events`
   (latest merged logging-overhaul slice).
 
 Current work:
 
-- PR #1170 (`codex/v8-websocket-reconnect-events`) adds a bounded
-  `websocket.reconnect` structured event at the existing throttled reconnect
-  logger. It preserves retry timing, warning throttling, traceback cadence,
-  exchange I/O, and trading behavior. The event excludes exception messages,
-  tracebacks, exchange payloads, and URLs.
+- PR #1172 (`codex/v8-hsl-replay-benchmark`) adds a bounded deterministic offline
+  benchmark for the current coin-HSL replay initializer. It reports explicit
+  timeline-row and pair-row throughput, profiled timings/counters, fixture and
+  final-state hashes, and zero actual live side effects. Realistic-scale
+  fill/row/pair fixtures and deeper internal-stage profiling remain open.
 
 Current review gate:
 
@@ -63,6 +64,17 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- Repository pulled through PR #1170 at `4a00ff17`, including workflow-doc PR
+  #1171. PR #1170 merged after exact-head Hermes and Grok 4.5 approvals plus
+  green CI; Claude Opus 4.8 remained explicitly waived while rate-limited.
+  VPS5 was pulled with autostash, preserving the known tracked Rust edit and
+  local config/tmp artifacts. Four bots stopped after the first exact-pane
+  Ctrl-C; KuCoin stopped after a second exact-pane Ctrl-C. The empty session was
+  reloaded from `/root/bots_vps5.yaml`. Immediate two-minute and settled
+  five-minute smoke reports returned `ok=true`, `hard_failures=0`, all five
+  bots matched, zero failed remote/account-critical/fill-refresh calls, and
+  zero text-log hard/attention matches. Four HSL replays remained active but
+  were neither stale nor long-running.
 - Repository pulled through PR #1169 at `8f836f30`. Connector-local
   exchange-config failures and the parent per-symbol retry line now retain only
   bounded operation, symbol, retry, known-code, and exception-type context. The

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -93,8 +93,14 @@ slices.
 - [ ] Confirm whether all needed data was already cached in the slow Binance
   XLM incident path; if yes, explain exactly why local replay still took about
   27 minutes.
-- [ ] Add an offline deterministic fixture so rows/s, stage timings, and
+- [x] Add an offline deterministic fixture so rows/s, stage timings, and
   equivalence can be checked without live exchange access.
+  - Result: `passivbot tool hsl-replay-benchmark` replays a bounded in-memory
+    coin-HSL fixture through the current initializer, with distinct profiled
+    timeline-rows/s and pair-rows/s, per-stage timing, counter, fixture-hash,
+    final-state-hash, and side-effect-counter output. Realistic-scale
+    fill/row/pair fixtures and deeper internal-stage profiling remain part of
+    the open benchmark slice.
 - [ ] Acceptance: before optimizing, the report identifies the dominant cost
   category and provides a repeatable local benchmark.
 
@@ -853,8 +859,10 @@ Each slice should update this checklist with its result.
      contacting exchanges or changing live behavior.
    - Status: first report slices add `hsl_replay_profile` from existing live
      events, including per-bot replay records plus aggregate stage/status
-     counters for active/completed/failed replay state. Offline deterministic
-     replay fixtures and internal stage profiling remain open.
+     counters for active/completed/failed replay state. The bounded offline
+     deterministic fixture now covers repeatable elapsed/throughput and state
+     equivalence checks; realistic-scale fixtures and deeper internal-stage
+     profiling remain open.
 
 3. [ ] Held-position protective readiness slice.
    - Classify currently held `coin+pside` pairs before unrelated flat pairs and

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -205,6 +205,12 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   local HSL status/cooldown observations when present, while explicitly marking current
   drawdown and startup panic-order prediction unavailable unless a future slice adds safe
   local replay inputs.
+- `passivbot tool hsl-replay-benchmark` runs a bounded deterministic in-memory fixture through
+  the current coin-HSL history replay initializer. It reports machine-readable stage timings,
+  profiled timeline-rows/s and pair-rows/s, replay counters, fixture and final-state hashes,
+  and side-effect counters. It never contacts an
+  exchange or reads/writes live cache, monitor, latch, or state artifacts. Use
+  `--minutes`, `--symbols`, and `--iterations` to change only the bounded synthetic workload.
 - `passivbot tool live-event-query` validates and queries local structured monitor event
   segments. It is read-only and does not contact exchanges. Use `--event-type`,
   `--level`, `--cycle-id`, ID filters, `--symbol`, `--pside`, `--tag`,

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -119,6 +119,10 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "tools.hsl_startup_preview",
         "read-only offline HSL startup preview",
     ),
+    "hsl-replay-benchmark": CommandSpec(
+        "tools.hsl_replay_benchmark",
+        "benchmark the offline coin-HSL replay hot path",
+    ),
     "live-smoke-report": CommandSpec(
         "tools.live_smoke_report",
         "summarize local live monitor events and text logs",

--- a/src/tools/hsl_replay_benchmark.py
+++ b/src/tools/hsl_replay_benchmark.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import time
+from collections import defaultdict
+from typing import Any
+
+import passivbot_rust as pbr
+
+from passivbot import Passivbot
+
+
+BENCHMARK_SCHEMA_VERSION = 1
+DEFAULT_MINUTES = 240
+DEFAULT_SYMBOLS = 8
+DEFAULT_ITERATIONS = 1
+MAX_MINUTES = 1_440
+MAX_SYMBOLS = 32
+MAX_ITERATIONS = 20
+
+
+def _fixture_symbol(index: int) -> str:
+    return f"HSLBENCH{index:02d}/USDT:USDT"
+
+
+def build_coin_hsl_history_fixture(minutes: int, symbols: int) -> dict[str, Any]:
+    """Build a bounded, deterministic coin-HSL history with one active long per symbol."""
+    if not 1 <= int(minutes) <= MAX_MINUTES:
+        raise ValueError(f"minutes must be between 1 and {MAX_MINUTES}")
+    if not 1 <= int(symbols) <= MAX_SYMBOLS:
+        raise ValueError(f"symbols must be between 1 and {MAX_SYMBOLS}")
+
+    names = [_fixture_symbol(index) for index in range(int(symbols))]
+    timeline: list[dict[str, Any]] = []
+    fill_events: list[dict[str, Any]] = []
+    for symbol_index, symbol in enumerate(names):
+        fill_events.append(
+            {
+                "timestamp": 1,
+                "symbol": symbol,
+                "pside": "long",
+                "action": "increase",
+                "qty": 1.0,
+                "id": f"fixture-open-{symbol_index}",
+            }
+        )
+    for minute in range(1, int(minutes) + 1):
+        realized_by_symbol: dict[str, dict[str, float]] = {}
+        unrealized_by_symbol: dict[str, dict[str, float]] = {}
+        total_realized = 0.0
+        for symbol_index, symbol in enumerate(names):
+            realized = float((minute * (symbol_index + 3)) % 19) / 100.0
+            unrealized = -float((minute + symbol_index * 5) % 11) / 100.0
+            realized_by_symbol[symbol] = {"long": realized}
+            unrealized_by_symbol[symbol] = {"long": unrealized}
+            total_realized += realized
+        timeline.append(
+            {
+                "timestamp": minute * 60_000,
+                "balance": 1_000.0,
+                "realized_pnl": total_realized,
+                "realized_pnl_by_coin_pside": realized_by_symbol,
+                "unrealized_pnl_by_coin_pside": unrealized_by_symbol,
+            }
+        )
+    return {
+        "timeline": timeline,
+        "fill_events": fill_events,
+        "panic_flatten_events": [],
+    }
+
+
+def _fixture_digest(history: dict[str, Any]) -> str:
+    encoded = json.dumps(history, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _make_offline_replay_bot(history: dict[str, Any], timings: dict[str, dict[str, int]]) -> Passivbot:
+    """Create an uninitialized bot that can only replay supplied in-memory history."""
+    bot = Passivbot.__new__(Passivbot)
+    symbols = sorted(history["timeline"][0]["realized_pnl_by_coin_pside"])
+    now_ms = int(history["timeline"][-1]["timestamp"])
+    side_effects = {
+        "network_calls": 0,
+        "cache_reads": 0,
+        "cache_writes": 0,
+        "latch_writes": 0,
+        "latch_removals": 0,
+        "monitor_events": 0,
+    }
+
+    bot.user = "offline_hsl_replay_benchmark"
+    bot.exchange = "offline"
+    bot.market_type = "swap"
+    bot._equity_hard_stop = {
+        "long": bot._equity_hard_stop_make_state(),
+        "short": bot._equity_hard_stop_make_state(),
+    }
+    bot._equity_hard_stop_coin = {"long": {}, "short": {}}
+    bot._runtime_forced_modes = {"long": {}, "short": {}}
+    bot._pnls_manager = None
+    bot.positions = {
+        symbol: {
+            "long": {"size": 1.0, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+        for symbol in symbols
+    }
+    bot.open_orders = {}
+    bot.active_symbols = []
+    bot.fetched_positions = []
+    bot.c_mults = {}
+    bot.qty_steps = {}
+    bot.config = {
+        "live": {
+            "hsl_signal_mode": "coin",
+            "hsl_position_during_cooldown_policy": "panic",
+            "pnls_max_lookback_days": 30.0,
+        }
+    }
+    bot.hsl = {
+        "long": {
+            "enabled": True,
+            "red_threshold": 0.95,
+            "tier_ratios": {"yellow": 0.5, "orange": 0.75},
+            "ema_span_minutes": 15.0,
+            "cooldown_minutes_after_red": 5.0,
+            "no_restart_drawdown_threshold": 1.0,
+            "restart_after_red_policy": "threshold",
+            "orange_tier_mode": "tp_only_with_active_entry_cancellation",
+            "panic_close_order_type": "market",
+        },
+        "short": {
+            "enabled": False,
+            "red_threshold": 0.95,
+            "tier_ratios": {"yellow": 0.5, "orange": 0.75},
+            "ema_span_minutes": 15.0,
+            "cooldown_minutes_after_red": 5.0,
+            "no_restart_drawdown_threshold": 1.0,
+            "restart_after_red_policy": "threshold",
+            "orange_tier_mode": "tp_only_with_active_entry_cancellation",
+            "panic_close_order_type": "market",
+        },
+    }
+    bot.get_raw_balance = lambda: 1_000.0
+    bot.get_exchange_time = lambda: now_ms
+    bot.live_value = lambda key: bot.config["live"][key]
+    bot._equity_hard_stop_realized_pnl_now = lambda pside=None: 0.0
+    bot.bot_value = lambda pside, key: {
+        "n_positions": len(symbols),
+        "total_wallet_exposure_limit": 1.0,
+    }[key]
+
+    async def history_provider(current_balance=None, **kwargs):
+        started_ns = time.perf_counter_ns()
+        try:
+            return history
+        finally:
+            timings["history_load"]["calls"] += 1
+            timings["history_load"]["elapsed_ns"] += time.perf_counter_ns() - started_ns
+
+    async def no_cache_reuse(*_args, **_kwargs):
+        timings["cache_reuse_skipped"]["calls"] += 1
+        return None
+
+    async def current_upnl(*_args, **_kwargs):
+        started_ns = time.perf_counter_ns()
+        try:
+            return 0.0
+        finally:
+            timings["current_upnl"]["calls"] += 1
+            timings["current_upnl"]["elapsed_ns"] += time.perf_counter_ns() - started_ns
+
+    def skip_cache_persist(*_args, **_kwargs):
+        timings["cache_persist_skipped"]["calls"] += 1
+        return 0
+
+    def skip_latch_write(*_args, **_kwargs):
+        side_effects["latch_writes"] += 1
+        return None
+
+    def skip_latch_remove(*_args, **_kwargs):
+        side_effects["latch_removals"] += 1
+
+    original_apply_metrics = bot._equity_hard_stop_apply_coin_metrics_sample
+
+    def profile_coin_metrics_sample(*args, **kwargs):
+        started_ns = time.perf_counter_ns()
+        try:
+            return original_apply_metrics(*args, **kwargs)
+        finally:
+            timings["coin_metrics_sample"]["calls"] += 1
+            timings["coin_metrics_sample"]["elapsed_ns"] += time.perf_counter_ns() - started_ns
+
+    bot.get_balance_equity_history = history_provider
+    bot._equity_hard_stop_try_reuse_replay_cache = no_cache_reuse
+    bot._calc_upnl_sum_strict = current_upnl
+    bot._equity_hard_stop_persist_replay_matrices = skip_cache_persist
+    bot._equity_hard_stop_write_latch = skip_latch_write
+    bot._equity_hard_stop_remove_latch_file = skip_latch_remove
+    bot._equity_hard_stop_apply_coin_metrics_sample = profile_coin_metrics_sample
+    bot._offline_hsl_benchmark_side_effects = side_effects
+    return bot
+
+
+def _state_digest(bot: Passivbot) -> str:
+    state_projection = []
+    for pside, symbols in sorted(bot._equity_hard_stop_coin.items()):
+        for symbol, state in sorted(symbols.items()):
+            metrics = state.get("last_metrics") or {}
+            state_projection.append(
+                {
+                    "pside": pside,
+                    "symbol": symbol,
+                    "halted": bool(state["halted"]),
+                    "no_restart_latched": bool(state["no_restart_latched"]),
+                    "cooldown_until_ms": state["cooldown_until_ms"],
+                    "tier": metrics.get("tier"),
+                    "drawdown_raw": metrics.get("drawdown_raw"),
+                    "drawdown_ema": metrics.get("drawdown_ema"),
+                    "drawdown_score": metrics.get("drawdown_score"),
+                }
+            )
+    encoded = json.dumps(state_projection, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+async def run_hsl_replay_benchmark(
+    *, minutes: int = DEFAULT_MINUTES, symbols: int = DEFAULT_SYMBOLS, iterations: int = DEFAULT_ITERATIONS
+) -> dict[str, Any]:
+    if getattr(pbr, "__is_stub__", False):
+        raise RuntimeError("passivbot_rust extension is required for hsl-replay-benchmark")
+    if not 1 <= int(iterations) <= MAX_ITERATIONS:
+        raise ValueError(f"iterations must be between 1 and {MAX_ITERATIONS}")
+
+    history = build_coin_hsl_history_fixture(minutes=minutes, symbols=symbols)
+    timing_totals: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    state_digests: list[str] = []
+    side_effect_totals: dict[str, int] = defaultdict(int)
+    full_replay_elapsed_ns = 0
+    for _ in range(int(iterations)):
+        bot = _make_offline_replay_bot(history, timing_totals)
+        started_ns = time.perf_counter_ns()
+        previous_logging_disable = logging.root.manager.disable
+        logging.disable(logging.CRITICAL)
+        try:
+            await bot._equity_hard_stop_initialize_coin_from_history()
+        finally:
+            logging.disable(previous_logging_disable)
+        full_replay_elapsed_ns += time.perf_counter_ns() - started_ns
+        state_digests.append(_state_digest(bot))
+        for key, value in bot._offline_hsl_benchmark_side_effects.items():
+            side_effect_totals[key] += int(value)
+    if len(set(state_digests)) != 1:
+        raise RuntimeError("offline coin-HSL replay produced non-deterministic final state")
+
+    expected_replay_samples = int(minutes) * int(symbols) * int(iterations)
+    expected_current_samples = int(symbols) * int(iterations)
+    actual_sample_calls = int(timing_totals["coin_metrics_sample"]["calls"])
+    elapsed_seconds = max(full_replay_elapsed_ns, 1) / 1_000_000_000.0
+    replay_rows = int(minutes) * int(iterations)
+    return {
+        "schema_version": BENCHMARK_SCHEMA_VERSION,
+        "kind": "hsl_replay_benchmark",
+        "offline": True,
+        "fixture": {
+            "minutes": int(minutes),
+            "symbols": int(symbols),
+            "timeline_rows": len(history["timeline"]),
+            "fill_events": len(history["fill_events"]),
+            "panic_events": len(history["panic_flatten_events"]),
+            "sha256": _fixture_digest(history),
+        },
+        "counters": {
+            "iterations": int(iterations),
+            "active_pairs": int(symbols) * int(iterations),
+            "expected_replay_samples": expected_replay_samples,
+            "expected_current_samples": expected_current_samples,
+            "coin_metrics_sample_calls": actual_sample_calls,
+            "replay_samples_applied": actual_sample_calls - expected_current_samples,
+        },
+        "timings": {
+            stage: {"calls": int(values["calls"]), "elapsed_ns": int(values["elapsed_ns"])}
+            for stage, values in sorted(timing_totals.items())
+        }
+        | {
+            "full_replay": {
+                "calls": int(iterations),
+                "elapsed_ns": int(full_replay_elapsed_ns),
+            }
+        },
+        "throughput": {
+            "timeline_rows_per_second": replay_rows / elapsed_seconds,
+            "pair_rows_per_second": expected_replay_samples / elapsed_seconds,
+        },
+        "determinism": {"final_state_sha256": state_digests[0]},
+        "side_effects": dict(sorted(side_effect_totals.items())),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a bounded in-memory benchmark of the coin-HSL replay hot path. "
+            "It never contacts exchanges or reads/writes live cache or state."
+        )
+    )
+    parser.add_argument("--minutes", type=int, default=DEFAULT_MINUTES, help=f"Fixture minutes (1-{MAX_MINUTES}).")
+    parser.add_argument("--symbols", type=int, default=DEFAULT_SYMBOLS, help=f"Fixture symbols (1-{MAX_SYMBOLS}).")
+    parser.add_argument(
+        "--iterations", type=int, default=DEFAULT_ITERATIONS, help=f"Replay iterations (1-{MAX_ITERATIONS})."
+    )
+    parser.add_argument("--compact", action="store_true", help="Emit compact single-line JSON.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        report = asyncio.run(
+            run_hsl_replay_benchmark(
+                minutes=int(args.minutes),
+                symbols=int(args.symbols),
+                iterations=int(args.iterations),
+            )
+        )
+    except ValueError as exc:
+        build_parser().error(str(exc))
+    print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_hsl_replay_benchmark.py
+++ b/tests/test_hsl_replay_benchmark.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+
+import pytest
+
+from passivbot_cli import main as cli_main
+from tools import hsl_replay_benchmark
+
+
+pbr = pytest.importorskip("passivbot_rust", reason="passivbot_rust extension not available")
+if bool(getattr(pbr, "__is_stub__", False)):
+    pytest.skip("passivbot_rust extension not available", allow_module_level=True)
+
+
+def _without_elapsed_ns(value):
+    if isinstance(value, dict):
+        return {
+            key: _without_elapsed_ns(item)
+            for key, item in value.items()
+            if key not in {"elapsed_ns", "throughput"}
+        }
+    if isinstance(value, list):
+        return [_without_elapsed_ns(item) for item in value]
+    return value
+
+
+def test_hsl_replay_benchmark_is_deterministic_and_has_no_side_effects():
+    first = asyncio.run(
+        hsl_replay_benchmark.run_hsl_replay_benchmark(minutes=4, symbols=2, iterations=2)
+    )
+    second = asyncio.run(
+        hsl_replay_benchmark.run_hsl_replay_benchmark(minutes=4, symbols=2, iterations=2)
+    )
+
+    assert first["offline"] is True
+    assert first["fixture"]["timeline_rows"] == 4
+    assert first["fixture"]["fill_events"] == 2
+    assert first["counters"] == {
+        "iterations": 2,
+        "active_pairs": 4,
+        "expected_replay_samples": 16,
+        "expected_current_samples": 4,
+        "coin_metrics_sample_calls": 20,
+        "replay_samples_applied": 16,
+    }
+    assert first["timings"]["history_load"]["calls"] == 2
+    assert first["timings"]["coin_metrics_sample"]["calls"] == 20
+    assert first["timings"]["current_upnl"]["calls"] == 4
+    assert first["timings"]["cache_reuse_skipped"]["calls"] == 2
+    assert first["timings"]["cache_persist_skipped"]["calls"] == 2
+    assert first["throughput"]["timeline_rows_per_second"] > 0.0
+    assert first["throughput"]["pair_rows_per_second"] == pytest.approx(
+        first["throughput"]["timeline_rows_per_second"] * 2
+    )
+    assert first["side_effects"] == {
+        "cache_reads": 0,
+        "cache_writes": 0,
+        "latch_removals": 0,
+        "latch_writes": 0,
+        "monitor_events": 0,
+        "network_calls": 0,
+    }
+    assert _without_elapsed_ns(first) == _without_elapsed_ns(second)
+
+
+def test_hsl_replay_benchmark_main_emits_json(capsys):
+    assert hsl_replay_benchmark.main(["--minutes", "2", "--symbols", "1", "--compact"]) == 0
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["kind"] == "hsl_replay_benchmark"
+    assert report["fixture"]["timeline_rows"] == 2
+
+
+def test_hsl_replay_benchmark_tool_dispatch_forwards_module_and_prog(monkeypatch):
+    captured = {}
+
+    def fake_invoke_module_main(module_name):
+        captured["module_name"] = module_name
+        captured["argv"] = sys.argv[:]
+        captured["prog_env"] = os.environ.get("PASSIVBOT_CLI_PROG")
+        return True, 0
+
+    monkeypatch.setattr(cli_main, "_invoke_module_main", fake_invoke_module_main)
+    monkeypatch.setattr(cli_main, "_missing_full_install_markers", lambda: [])
+
+    assert cli_main.main(["tool", "hsl-replay-benchmark", "--minutes", "10"]) == 0
+
+    assert captured == {
+        "module_name": "tools.hsl_replay_benchmark",
+        "argv": ["passivbot tool hsl-replay-benchmark", "--minutes", "10"],
+        "prog_env": "passivbot tool hsl-replay-benchmark",
+    }


### PR DESCRIPTION
## Scope

Add a bounded deterministic offline benchmark for the current coin-HSL history initializer.

- synthetic in-memory history with configurable minutes, symbols, and iterations
- explicit timeline-row and pair-row throughput
- profiled stage timings and replay counters
- deterministic fixture and final-state hashes
- side-effect counters with exchange/live cache/state collaborators stubbed
- unified CLI registration and operator docs
- compact status and historical evidence for merged/deployed PRs #1170 and #1171

## Non-goals

- no live/runtime HSL behavior changes
- no exchange or network calls
- no live cache, latch, monitor, or state writes
- no optimization of the replay path yet
- no claim that the bounded fixture represents realistic fill density or full internal-stage profiling

## Validation

- `pytest -q tests/test_hsl_replay_benchmark.py tests/test_hsl_coin_mode.py`: 113 passed
- direct compact CLI smoke: 240 minutes, 8 symbols, 2 iterations; deterministic hashes; zero actual live side effects
- independent Terra preflight: initial pair-row unit finding fixed; delta green
- `py_compile`: passed
- `git diff --check origin/v8...HEAD`: passed
- touched-area silent-handling audit: no matches

## Deployment

Read-only offline tooling. No VPS deploy or bot restart is required for correctness.
