### PR TITLE
Emit bounded forager eligibility events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable user-facing changes will be documented in this file.
   stage timings, replay counters, and side-effect counters without contacting
   exchanges or reading/writing live cache and state artifacts.
 
+- Approved and ignored forager-eligibility membership changes now emit bounded
+  `forager.eligibility_changed` structured and monitor events. Each aggregate
+  event identifies the list, add/remove operation, source kind, and per-side
+  count with at most 12 sorted symbols; existing eligibility behavior and text
+  logs are unchanged.
+
 - `passivbot tool crash-finder` can now regenerate scenario suites from an existing
   `crash_clusters.csv` without rescanning local OHLCV data, emit market-wide/coin-focused/single-coin
   filtered suites, merge overlapping stress windows, and add per-coin forced-normal overrides for

--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -53,6 +53,7 @@ across time.
 - `fill.ingested`
 - `fills.refresh_summary`
 - `forager.feature_unavailable`
+- `forager.eligibility_changed`
 - `forager.selection`
 - `health.summary`
 - `market.snapshot_diagnostic_skipped`
@@ -173,6 +174,7 @@ back to exchange-derived replay.
 - `fill_cache_quarantined`
 - `fill_cache_ready`
 - `fill_cache_rebuild_started`
+- `forager_eligibility_membership_changed`
 - `hsl_balance_override_account_level_replay_unsafe`
 - `hsl_history_empty`
 - `hsl_history_inputs_loaded`
@@ -222,6 +224,17 @@ back to exchange-derived replay.
 - `unstuck_status`
 - `warmup_cache_decision`
 - `websocket_reconnect`
+
+## Forager Eligibility Change Events
+
+`forager.eligibility_changed` uses reason code
+`forager_eligibility_membership_changed` for existing approved/ignored membership
+updates. It routes to structured and monitor sinks only, not console or text
+sinks. Its data payload is limited to `source` (`config_sources` or
+`live_value`), `list_kind`, `operation`, and ordered per-pside `changes` rows.
+Each change row contains its total `count` and at most 12 sorted `symbols`; no
+config path, raw source, or full list is retained. Emission is best-effort and
+must not affect eligibility refresh behavior.
 
 Dynamic helpers are part of the same contract:
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,35 +22,39 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1172: `Add offline HSL replay benchmark`
-- Branch: `codex/v8-hsl-replay-benchmark`
+- PR #1173: `Emit bounded forager eligibility events`
+- Branch: `codex/v8-forager-eligibility-events`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
-- Base: `4a00ff171d9a8ef04e4591c797b7ef24952bd175`
-- Scope: bounded deterministic offline benchmark for the current coin-HSL
-  history initializer; no live/runtime HSL behavior change
-- Output: explicit timeline-row and pair-row throughput, profiled timings and
-  counters, deterministic fixture/final-state hashes, and side-effect counters
-- Local validation: focused benchmark plus coin-HSL suites pass (113 tests),
-  direct compact CLI smoke passes, `py_compile` and `git diff --check` pass
-- Independent preflight: green after correcting the pair-row throughput unit
+- Base: `50f1dbaf582828c434f9f3f54ad482140f7deb0e`
+- Scope: bounded structured/monitor-only events for existing approved/ignored
+  forager membership changes; no eligibility, entry-gating, exchange, Rust,
+  order, risk, or HSL behavior change
+- Output: at most four aggregate events per refresh, with fixed source/list/
+  operation fields and at most 12 sorted symbols per pside change row
+- Local validation: focused coin-list/event-route/registry suites and the full
+  fake-live suite pass; a real two-step fake-live run, `py_compile`, and `git
+  diff --check` pass
+- Independent preflight: green; repeated no-op refresh and `live_value` source
+  coverage were added after its residual-risk review
 - Publication state, exact head, mergeability, CI, and current-head review
   verdicts: query live GitHub metadata. Do not encode those transient values in
   the same PR that contains this status file, because every correction would
   create a different head and immediately stale the embedded value.
-- Expected VPS action: none for correctness; optional pull after merge, no bot
-  restart
+- Expected VPS action: pull with autostash, controlled five-bot restart, then
+  immediate and settled bounded smoke reports
 
 Next action:
 
-1. Poll live GitHub metadata for PR #1172's current head, mergeability, CI, and
+1. Poll live GitHub metadata for PR #1173's current head, mergeability, CI, and
    required reviews.
 2. Resolve any verified finding with focused regression coverage.
-3. Merge only after the exact-head gate is satisfied.
+3. Merge only after the exact-head gate is satisfied, then perform the declared
+   VPS5 restart/smoke validation.
 
 ## Deployed Baseline
 
-- Remote `v8`: `4a00ff17`, PR #1170 after workflow-doc PR #1171
+- Remote `v8`: `50f1dbaf`, PR #1172
 - VPS5 repository: `4a00ff17`, PR #1170
 - VPS5 expected bots: five; all are running after the controlled restart
 - Latest immediate and settled smoke: `ok=true`, `hard_failures=0`, all five
@@ -81,12 +85,14 @@ Next action:
 
 ## Next Slice
 
-The offline replay benchmark is the active independent slice. After it merges,
-use its repeatable evidence to choose one review-worthy item from:
+The forager eligibility event producer is the active Phase 5 slice. After it
+merges and is deployed, the next high-value dependent slice is held-position
+protective readiness. Its design must preserve exact HSL reconstruction and
+keep observability events out of the decision authority. Remaining candidates:
 
 - realistic-scale replay fixtures and deeper internal-stage profiling
 - held-position protective-readiness source events and sequencing
-- high-value Phase 5 text-to-event migration
+- unsupported configured-market and stock-perp compatibility events
 - bounded operator tooling improvements sharing one code and validation surface
 
 Do not create progress-only PRs or resume unrelated logging work from stale

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,21 +19,21 @@ Last updated: 2026-07-10.
 
 Current `origin/v8` head:
 
-- `4a00ff17` after PR #1170, `Add structured websocket reconnect events`,
-  following workflow-doc PR #1171.
+- `50f1dbaf` after PR #1172, `Add offline HSL replay benchmark`.
 
 Current logging-overhaul head:
 
-- `4a00ff17` after PR #1170, `Add structured websocket reconnect events`
+- `50f1dbaf` after PR #1172, `Add offline HSL replay benchmark`
   (latest merged logging-overhaul slice).
 
 Current work:
 
-- PR #1172 (`codex/v8-hsl-replay-benchmark`) adds a bounded deterministic offline
-  benchmark for the current coin-HSL replay initializer. It reports explicit
-  timeline-row and pair-row throughput, profiled timings/counters, fixture and
-  final-state hashes, and zero actual live side effects. Realistic-scale
-  fill/row/pair fixtures and deeper internal-stage profiling remain open.
+- PR #1173 (`codex/v8-forager-eligibility-events`) adds bounded
+  `forager.eligibility_changed` structured/monitor events after existing
+  approved/ignored membership mutations and text logs. Payloads contain fixed
+  source/list/operation context plus bounded per-pside count/symbol rows; no
+  eligibility, entry-gating, exchange, Rust, order, risk, or HSL behavior
+  changes.
 
 Current review gate:
 
@@ -64,6 +64,10 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1172 merged to `v8` as `50f1dbaf` after exact-head Hermes and Grok 4.5
+  approvals plus green CI. No VPS pull or restart was required because it added
+  bounded offline benchmark tooling and docs only; VPS5 intentionally remains
+  at the green deployed runtime baseline `4a00ff17`.
 - Repository pulled through PR #1170 at `4a00ff17`, including workflow-doc PR
   #1171. PR #1170 merged after exact-head Hermes and Grok 4.5 approvals plus
   green CI; Claude Opus 4.8 remained explicitly waived while rate-limited.

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -75,6 +75,7 @@ class EventTypes:
     PLANNING_SYMBOL_STATE = "planning.symbol_state"
     FORAGER_SELECTION = "forager.selection"
     FORAGER_FEATURE_UNAVAILABLE = "forager.feature_unavailable"
+    FORAGER_ELIGIBILITY_CHANGED = "forager.eligibility_changed"
     EMA_BUNDLE_STARTED = "ema.bundle.started"
     EMA_BUNDLE_COMPLETED = "ema.bundle.completed"
     EMA_FALLBACK_USED = "ema.fallback_used"
@@ -228,6 +229,9 @@ class ReasonCodes:
     PRE_CREATE_PLANNING_SNAPSHOT_INVALID = "pre_create_planning_snapshot_invalid"
     QUEUE_FULL = "queue_full"
     RANKING_FEATURES_UNAVAILABLE = "ranking_features_unavailable"
+    FORAGER_ELIGIBILITY_MEMBERSHIP_CHANGED = (
+        "forager_eligibility_membership_changed"
+    )
     RECENT_EXECUTION = "recent_execution"
     REMOTE_FETCH = "remote_fetch"
     RISK_ENTRY_COOLDOWN_POSITION_DELTA = "entry_cooldown_position_delta"
@@ -378,6 +382,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.PLANNING_SYMBOL_STATE,
     EventTypes.FORAGER_SELECTION,
     EventTypes.FORAGER_FEATURE_UNAVAILABLE,
+    EventTypes.FORAGER_ELIGIBILITY_CHANGED,
     EventTypes.EMA_BUNDLE_STARTED,
     EventTypes.EMA_BUNDLE_COMPLETED,
     EventTypes.EMA_FALLBACK_USED,
@@ -685,6 +690,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
         console=True, text=True, throttle_interval_ms=5 * 60 * 1000
     ),
     EventTypes.FORAGER_FEATURE_UNAVAILABLE: EventRoute(console=False, text=False),
+    EventTypes.FORAGER_ELIGIBILITY_CHANGED: EventRoute(console=False, text=False),
     EventTypes.EMA_BUNDLE_STARTED: EventRoute(console=False, text=False),
     EventTypes.EMA_BUNDLE_COMPLETED: EventRoute(console=False, text=False),
     EventTypes.EMA_FALLBACK_USED: EventRoute(console=False, text=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -2107,6 +2107,66 @@ def emit_forager_feature_unavailable_event(bot: Any, *args: Any, **kwargs: Any) 
         )
 
 
+def _emit_forager_eligibility_changed_event_unchecked(
+    bot: Any,
+    *,
+    source: str,
+    list_kind: str,
+    operation: str,
+    changes: dict[str, set[str]],
+) -> None:
+    if source not in {"config_sources", "live_value"}:
+        raise ValueError(f"unsupported forager eligibility source {source!r}")
+    if list_kind not in {"approved_coins", "ignored_coins"}:
+        raise ValueError(f"unsupported forager eligibility list kind {list_kind!r}")
+    if operation not in {"added", "removed"}:
+        raise ValueError(f"unsupported forager eligibility operation {operation!r}")
+    pside_changes = []
+    for pside in ("long", "short"):
+        symbols = changes.get(pside)
+        if not symbols:
+            continue
+        ordered_symbols = sorted(str(symbol) for symbol in symbols)
+        pside_changes.append(
+            {
+                "pside": pside,
+                "count": len(ordered_symbols),
+                "symbols": ordered_symbols[:12],
+            }
+        )
+    if not pside_changes:
+        return
+    _safe_emit(
+        bot,
+        EventTypes.FORAGER_ELIGIBILITY_CHANGED,
+        level="info",
+        component="forager.eligibility",
+        tags=(EventTags.FORAGER, EventTags.REFRESH),
+        cycle_id=current_live_event_cycle_id(bot),
+        status="succeeded",
+        reason_code=ReasonCodes.FORAGER_ELIGIBILITY_MEMBERSHIP_CHANGED,
+        data={
+            "source": source,
+            "list_kind": list_kind,
+            "operation": operation,
+            "changes": pside_changes,
+        },
+    )
+
+
+def emit_forager_eligibility_changed_event(
+    bot: Any, *args: Any, **kwargs: Any
+) -> None:
+    try:
+        _emit_forager_eligibility_changed_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.FORAGER_ELIGIBILITY_CHANGED,
+            exc,
+        )
+
+
 def _emit_forager_selection_event_unchecked(
     bot: Any,
     *,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -662,6 +662,9 @@ class Passivbot:
     _emit_forager_feature_unavailable_event = (
         live_event_emitters.emit_forager_feature_unavailable_event
     )
+    _emit_forager_eligibility_changed_event = (
+        live_event_emitters.emit_forager_eligibility_changed_event
+    )
     _emit_forager_selection_event = live_event_emitters.emit_forager_selection_event
     _emit_ema_bundle_started_event = live_event_emitters.emit_ema_bundle_started_event
     _emit_ema_bundle_completed_event = live_event_emitters.emit_ema_bundle_completed_event
@@ -17546,14 +17549,17 @@ class Passivbot:
         try:
             added_summary = {}
             removed_summary = {}
+            source_by_list_kind = {}
             for k in ("approved_coins", "ignored_coins"):
                 if not hasattr(self, k):
                     setattr(self, k, {"long": set(), "short": set()})
                 config_sources = self.config.get("_coins_sources", {})
                 if k in config_sources:
                     raw_source = config_sources[k]
+                    source_by_list_kind[k] = "config_sources"
                 else:
                     raw_source = self.live_value(k)
+                    source_by_list_kind[k] = "live_value"
                 parsed = normalize_coins_source(
                     raw_source, allow_all=(k == "approved_coins")
                 )
@@ -17636,6 +17642,18 @@ class Passivbot:
                     if parts:
                         logging.info(
                             "removed from ignored_coins | %s", " | ".join(parts)
+                        )
+            for list_kind in ("approved_coins", "ignored_coins"):
+                for operation, summary in (
+                    ("added", added_summary.get(list_kind, {})),
+                    ("removed", removed_summary.get(list_kind, {})),
+                ):
+                    if summary:
+                        self._emit_forager_eligibility_changed_event(
+                            source=source_by_list_kind[list_kind],
+                            list_kind=list_kind,
+                            operation=operation,
+                            changes=summary,
                         )
             try:
                 if not getattr(self, "_stock_perps_warning_logged", False):

--- a/tests/test_live_coin_lists.py
+++ b/tests/test_live_coin_lists.py
@@ -2,6 +2,7 @@ import logging
 
 import pytest
 
+from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
 from passivbot import Passivbot
 
 
@@ -168,3 +169,155 @@ def test_refresh_approved_ignored_coin_lists_supports_migrated_global_all():
 
     assert bot.approved_coins["long"] == {"AAA/USDT:USDT", "BBB/USDT:USDT"}
     assert bot.approved_coins["short"] == {"AAA/USDT:USDT", "BBB/USDT:USDT"}
+
+
+def _make_eligibility_event_bot():
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "bitget"
+    bot.user = "bitget_01"
+    bot.bot_id = "bot_1"
+    bot.eligible_symbols = {
+        f"A{index:02d}/USDT:USDT" for index in range(14)
+    } | {"SHORT/USDT:USDT", "IGNORED/USDT:USDT"}
+    bot.approved_coins = {
+        "long": {"OLD/USDT:USDT"},
+        "short": {"OLD_SHORT/USDT:USDT"},
+    }
+    bot.ignored_coins = {
+        "long": {"OLD_IGNORED/USDT:USDT"},
+        "short": set(),
+    }
+    bot.approved_coins_minus_ignored_coins = {"long": set(), "short": set()}
+    bot._disabled_psides_logged = set()
+    bot._unsupported_coin_warnings = set()
+    bot._last_coin_symbol_warning_counts = {
+        "symbol_to_coin_fallbacks": 0,
+        "coin_to_symbol_fallbacks": 0,
+    }
+    bot.config = {
+        "_coins_sources": {
+            "approved_coins": {
+                "long": [f"A{index:02d}" for index in range(14)],
+                "short": ["SHORT"],
+            },
+            "ignored_coins": {"long": ["IGNORED"], "short": []},
+        },
+        "live": {},
+    }
+    bot.coin_to_symbol = lambda coin, verbose=True: f"{coin}/USDT:USDT"
+    bot.is_pside_enabled = lambda _pside: True
+    bot.live_value = lambda key: bot.config["live"][key]
+    bot._filter_approved_symbols = lambda _pside, symbols: symbols
+    return bot
+
+
+def test_refresh_approved_ignored_coin_lists_emits_bounded_aggregate_events(caplog):
+    bot = _make_eligibility_event_bot()
+    structured = ListEventSink()
+    monitor = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[structured], monitor_sinks=[monitor]
+    )
+
+    with caplog.at_level(logging.INFO):
+        bot.refresh_approved_ignored_coins_lists()
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in structured.events
+        if event.event_type == EventTypes.FORAGER_ELIGIBILITY_CHANGED
+    ]
+    assert len(events) == 4
+    assert monitor.events == events
+    assert all(
+        event.reason_code == ReasonCodes.FORAGER_ELIGIBILITY_MEMBERSHIP_CHANGED
+        for event in events
+    )
+    assert all(
+        set(event.data) == {"source", "list_kind", "operation", "changes"}
+        for event in events
+    )
+    assert all(event.data["source"] == "config_sources" for event in events)
+
+    approved_added = next(
+        event
+        for event in events
+        if event.data["list_kind"] == "approved_coins"
+        and event.data["operation"] == "added"
+    )
+    assert approved_added.data["changes"] == [
+        {
+            "pside": "long",
+            "count": 14,
+            "symbols": [f"A{index:02d}/USDT:USDT" for index in range(12)],
+        },
+        {"pside": "short", "count": 1, "symbols": ["SHORT/USDT:USDT"]},
+    ]
+    assert all(
+        change["symbols"] == sorted(change["symbols"])
+        and len(change["symbols"]) <= 12
+        for event in events
+        for change in event.data["changes"]
+    )
+    assert any("added to approved_coins" in record.message for record in caplog.records)
+    assert any("removed from ignored_coins" in record.message for record in caplog.records)
+
+    bot.refresh_approved_ignored_coins_lists()
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert len(
+        [
+            event
+            for event in structured.events
+            if event.event_type == EventTypes.FORAGER_ELIGIBILITY_CHANGED
+        ]
+    ) == 4
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_refresh_approved_ignored_coin_lists_labels_live_value_source():
+    bot = _make_eligibility_event_bot()
+    bot.config = {
+        "_coins_sources": {},
+        "live": {
+            "approved_coins": {
+                "long": [f"A{index:02d}" for index in range(14)],
+                "short": ["SHORT"],
+            },
+            "ignored_coins": {"long": ["IGNORED"], "short": []},
+        },
+    }
+    structured = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(structured_sinks=[structured])
+
+    bot.refresh_approved_ignored_coins_lists()
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in structured.events
+        if event.event_type == EventTypes.FORAGER_ELIGIBILITY_CHANGED
+    ]
+    assert len(events) == 4
+    assert all(event.data["source"] == "live_value" for event in events)
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_refresh_approved_ignored_coin_lists_ignores_event_emission_failure(caplog):
+    bot = _make_eligibility_event_bot()
+
+    def fail_emit(*_args, **_kwargs):
+        raise RuntimeError("event sink unavailable")
+
+    bot._emit_live_event = fail_emit
+
+    with caplog.at_level(logging.INFO):
+        bot.refresh_approved_ignored_coins_lists()
+
+    assert bot.approved_coins["long"] == {
+        f"A{index:02d}/USDT:USDT" for index in range(14)
+    }
+    assert bot.approved_coins["short"] == {"SHORT/USDT:USDT"}
+    assert bot.ignored_coins == {"long": {"IGNORED/USDT:USDT"}, "short": set()}
+    assert any("added to approved_coins" in record.message for record in caplog.records)
+    assert any("removed from ignored_coins" in record.message for record in caplog.records)

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -231,6 +231,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.DATA_PACKET_UPDATED].console is False
     for event_type in (
         EventTypes.FORAGER_FEATURE_UNAVAILABLE,
+        EventTypes.FORAGER_ELIGIBILITY_CHANGED,
         EventTypes.ACTION_PLANNED,
         EventTypes.EMA_BUNDLE_STARTED,
         EventTypes.EMA_BUNDLE_COMPLETED,


### PR DESCRIPTION
## Scope

Add bounded structured observability for existing approved/ignored forager membership changes.

- at most four aggregate events per refresh: approved/ignored x added/removed
- per-side total counts with at most 12 sorted symbols
- fixed source, list-kind, operation, component, reason, and tags
- structured and monitor sinks only; existing text logs remain unchanged
- best-effort emission after existing membership mutation

## Non-goals

- no eligibility calculation, entry gating, graceful-stop, or `auto_gs` changes
- no exchange calls, Rust/order/risk/HSL behavior changes, or new console noise
- no config paths, raw source content, or full coin lists in events

## Validation

- focused coin-list/event-route/registry suites: passed
- `tests/test_run_fake_live.py`: 29 passed
- real two-step minimal fake-live invocation: completed successfully
- repeated identical refresh: emits no additional event
- `live_value` and config-source labels covered
- event-pipeline failure regression: mutation and existing text logging continue
- independent Terra preflight: green; identified coverage gaps were added
- `py_compile` and `git diff --check origin/v8...HEAD`: passed

## Deployment

This adds a live producer without changing trading behavior. After merge, VPS5 requires a controlled five-bot restart plus immediate and settled bounded smoke validation.
