### PR TITLE
Centralize HSL episode finalization in Rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- HSL RED episode finalization now uses one Rust-owned live/backtest contract
+  for caller-supplied persistent no-restart peaks, restart policy, and cooldown
+  deadlines. Coin-mode live restart now retains that no-restart peak like
+  pside live and backtest instead of discarding it with the episode tracker.
+  Python remains responsible for exchange/history proof and supplies the exact
+  scope-flattening fill timestamp; backtests retain the exact configured
+  deadline instead of extending sub-bar cooldowns to a full candle interval.
+
 - Added `passivbot tool hsl-replay-benchmark`, a bounded offline benchmark for
   the current coin-HSL history initializer. It emits deterministic fixture and
   final-state hashes, explicit timeline-row and pair-row throughput, profiled

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,7 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR: pending publication, `Centralize HSL episode finalization in Rust`
+- PR #1174: `Centralize HSL episode finalization in Rust`
 - Branch: `codex/v8-hsl-startup-transition-contract`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
@@ -54,8 +54,7 @@ Estimated completion:
 
 Next action:
 
-1. Publish the PR, then poll its exact head, mergeability, CI, and required
-   reviews.
+1. Poll PR #1174's exact head, mergeability, CI, and required reviews.
 2. Resolve any verified finding with focused regression coverage.
 3. Merge only after the exact-head gate is satisfied, then perform the declared
    VPS5 restart/smoke validation.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,45 +22,55 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1173: `Emit bounded forager eligibility events`
-- Branch: `codex/v8-forager-eligibility-events`
+- PR: pending publication, `Centralize HSL episode finalization in Rust`
+- Branch: `codex/v8-hsl-startup-transition-contract`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
-- Base: `50f1dbaf582828c434f9f3f54ad482140f7deb0e`
-- Scope: bounded structured/monitor-only events for existing approved/ignored
-  forager membership changes; no eligibility, entry-gating, exchange, Rust,
-  order, risk, or HSL behavior change
-- Output: at most four aggregate events per refresh, with fixed source/list/
-  operation fields and at most 12 sorted symbols per pside change row
-- Local validation: focused coin-list/event-route/registry suites and the full
-  fake-live suite pass; a real two-step fake-live run, `py_compile`, and `git
-  diff --check` pass
-- Independent preflight: green; repeated no-op refresh and `live_value` source
-  coverage were added after its residual-risk review
+- Base: `f5395dda4de815bac4f587795a66deda8fb01bc5`
+- Scope: pure Rust post-RED-episode transition shared by backtest and Python
+  live/history replay. It owns caller-supplied persistent no-restart peak/
+  drawdown evaluation, restart policy, explicit disposition, and exact cooldown
+  deadline; coin live restart now retains that peak like pside/backtest. Python still
+  owns exchange/fill-history proof, scope-flat detection, cache/latch I/O,
+  orchestration, and order supervision.
+- Non-goals: no RED trigger/tier math change, no signal-mode denominator
+  change, no replay ordering/background concurrency change, no exchange call,
+  and no new observability event.
+- Local validation: Rust `207/207`; focused Python HSL/replay/binding suites
+  pass; fake-live `29/29`, including seven real end-to-end pside HSL scenario
+  runs; real Binance HSL backtest and four-evaluation optimizer smoke pass;
+  extension source stamp and `git diff --check` pass.
+- Independent preflight: identified an existing coin-mode slot-budget
+  denominator mismatch between live and backtest plus a direct coin fake-live
+  staged-planner epoch failure after panic flatten. Neither is introduced by
+  this transition refactor; both remain focused follow-up work.
 - Publication state, exact head, mergeability, CI, and current-head review
   verdicts: query live GitHub metadata. Do not encode those transient values in
   the same PR that contains this status file, because every correction would
   create a different head and immediately stale the embedded value.
-- Expected VPS action: pull with autostash, controlled five-bot restart, then
-  immediate and settled bounded smoke reports
+- Expected VPS action: pull with autostash, rebuild and verify the Rust
+  extension, controlled five-bot restart, then immediate and settled bounded
+  smoke reports
 
 Next action:
 
-1. Poll live GitHub metadata for PR #1173's current head, mergeability, CI, and
-   required reviews.
+1. Publish the PR, then poll its exact head, mergeability, CI, and required
+   reviews.
 2. Resolve any verified finding with focused regression coverage.
 3. Merge only after the exact-head gate is satisfied, then perform the declared
    VPS5 restart/smoke validation.
 
 ## Deployed Baseline
 
-- Remote `v8`: `50f1dbaf`, PR #1172
-- VPS5 repository: `4a00ff17`, PR #1170
+- Remote `v8`: `f5395dda`, PR #1173
+- VPS5 repository: `f5395dda`, PR #1173
 - VPS5 expected bots: five; all are running after the controlled restart
 - Latest immediate and settled smoke: `ok=true`, `hard_failures=0`, all five
   bots matched, zero failed remote/account-critical/fill-refresh calls, and
   zero text-log hard/attention matches. Four HSL replays remained active but
-  were neither stale nor long-running.
+  were neither stale nor long-running. Five deployed
+  `forager.eligibility_changed` events were observed, one per bot, with bounded
+  source/list/operation/symbol payloads.
 - Known VPS5 tracked edit to preserve:
   `passivbot-rust/src/equity_hard_stop_loss.rs`
 - Preserve local/VPS configs, logs, monitor data, reports, and temporary files
@@ -85,9 +95,11 @@ Next action:
 
 ## Next Slice
 
-The forager eligibility event producer is the active Phase 5 slice. After it
-merges and is deployed, the next high-value dependent slice is held-position
-protective readiness. Its design must preserve exact HSL reconstruction and
+The shared HSL episode-finalization transition is the first prerequisite for
+held-position protective readiness. After it merges and is deployed, reconcile
+the existing coin-mode live/backtest slot-budget denominator mismatch in its
+own behavior PR, then continue with immutable candidate replay and held-first
+protective sequencing. The design must preserve exact HSL reconstruction and
 keep observability events out of the decision authority. Remaining candidates:
 
 - realistic-scale replay fixtures and deeper internal-stage profiling

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,21 +19,21 @@ Last updated: 2026-07-10.
 
 Current `origin/v8` head:
 
-- `50f1dbaf` after PR #1172, `Add offline HSL replay benchmark`.
+- `f5395dda` after PR #1173, `Emit bounded forager eligibility events`.
 
 Current logging-overhaul head:
 
-- `50f1dbaf` after PR #1172, `Add offline HSL replay benchmark`
+- `f5395dda` after PR #1173, `Emit bounded forager eligibility events`
   (latest merged logging-overhaul slice).
 
 Current work:
 
-- PR #1173 (`codex/v8-forager-eligibility-events`) adds bounded
-  `forager.eligibility_changed` structured/monitor events after existing
-  approved/ignored membership mutations and text logs. Payloads contain fixed
-  source/list/operation context plus bounded per-pside count/symbol rows; no
-  eligibility, entry-gating, exchange, Rust, order, risk, or HSL behavior
-  changes.
+- Branch `codex/v8-hsl-startup-transition-contract` centralizes post-RED
+  episode finalization in a pure Rust transition used by backtest and Python
+  live/history replay. It owns caller-supplied persistent no-restart peak/
+  drawdown evaluation, policy, disposition, and exact cooldown deadline;
+  coin live restart retains that peak like pside/backtest. Trigger math, history proof,
+  replay scheduling, exchange I/O, and order supervision are unchanged.
 
 Current review gate:
 
@@ -64,6 +64,16 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1173 merged to `v8` as `f5395dda` after exact-head Hermes and Grok 4.5
+  approvals plus green CI. VPS5 pulled with autostash, preserving the known
+  tracked Rust edit and local artifacts, then all five bots restarted from
+  `/root/bots_vps5.yaml`. KuCoin and GateIO required a second exact-pane
+  Ctrl-C. Immediate and settled smoke reports returned `ok=true`,
+  `hard_failures=0`, all five bots matched, zero failed
+  remote/account-critical/fill-refresh calls, and zero text-log hard/attention
+  matches. Four HSL replays remained active but non-stale and not long-running.
+  A direct deployed query returned five bounded
+  `forager.eligibility_changed` events, one per bot.
 - PR #1172 merged to `v8` as `50f1dbaf` after exact-head Hermes and Grok 4.5
   approvals plus green CI. No VPS pull or restart was required because it added
   bounded offline benchmark tooling and docs only; VPS5 intentionally remains

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -154,6 +154,14 @@ Related detailed plans:
      timestamp/nonce recovery by classifying same-cycle successful
      `exchange.time_sync` as recovered problem evidence instead of a persistent
      hard failure.
+   - 2026-07-10: The held-readiness prerequisite audit found that live coin HSL
+     normalizes drawdown by `balance / n_positions`, while the Rust backtest
+     uses `balance * total_wallet_exposure_limit / n_positions`. The live
+     contract and metric regression explicitly make sensitivity independent of
+     exposure limits, so reconcile the backtest denominator in a focused
+     parity PR before using full-replay equivalence as the held-readiness gate.
+     The current prerequisite branch separately centralizes post-episode
+     no-restart/cooldown finalization in Rust without changing trigger math.
 
 1. [x] Incident bundle generator.
    Status: initial implementation plus trace-report integration merged.
@@ -629,6 +637,13 @@ Related detailed plans:
       multi-bot event-pipeline queue/drop/sink-error health aggregation,
       proving existing queue-overflow observability without live bots,
       exchange calls, or behavior changes.
+    - 2026-07-10: A direct two-step coin-HSL fake-live run reached RED, posted
+      and filled the panic close, then failed the next cycle because the staged
+      planner still considered `balance,fills,open_orders,positions` missing
+      for the new epoch before market-snapshot refresh. The existing 29-test
+      fake-live suite and seven pside HSL end-to-end scenarios remain green;
+      add a dedicated coin-mode post-panic scenario and fix the epoch handoff
+      separately from HSL episode-finalization math.
 
 16. [x] Websocket reconnect diagnostics.
     Status: completed by PR #1170.

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -869,6 +869,13 @@ Each slice should update this checklist with its result.
      emit explicit `hsl_protective_*` state events.
    - Acceptance: held-pair state matches existing full replay in tests, and a
      held late-sorting symbol is no longer delayed by broad flat-symbol replay.
+   - Status: the first prerequisite centralizes post-RED episode finalization
+     in Rust for backtest and Python live/history replay, including persistent
+     no-restart peak/drawdown evaluation, explicit disposition, exact cooldown
+     deadline, and coin-live retention of the persistent peak across restart.
+     Independent preflight also found an existing coin-mode slot-budget
+     denominator mismatch between live and backtest; reconcile that in a
+     focused parity PR before relying on held-pair equivalence.
 
 4. [ ] Full replay lower-complexity slice.
    - Replace avoidable nested scans and repeated fill/timeline work with exact

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -441,21 +441,6 @@ struct HardStopStopSnapshot {
     drawdown_ema: f64,
 }
 
-fn hsl_no_restart_latched(
-    restart_after_red_policy: &str,
-    persistent_drawdown_raw: f64,
-    drawdown_ema: f64,
-    no_restart_drawdown_threshold: f64,
-) -> Result<bool, String> {
-    // Shared live/backtest contract: max(raw, ema) trips the permanent halt.
-    ehsl::no_restart_triggered(
-        restart_after_red_policy,
-        persistent_drawdown_raw,
-        drawdown_ema,
-        no_restart_drawdown_threshold,
-    )
-}
-
 #[derive(Debug, Clone, Default)]
 struct HardStopPsideRuntime {
     state: Option<ehsl::HardStopState>,
@@ -3665,33 +3650,21 @@ impl<'a> Backtest<'a> {
                         }
                         runtime.last_restart_ts_ms = None;
                     }
-                    runtime.no_restart_peak_strategy_equity = runtime
-                        .no_restart_peak_strategy_equity
-                        .max(stop_snapshot.peak_strategy_equity)
-                        .max(stop_snapshot.equity);
-                    let persistent_drawdown_raw = (1.0
-                        - stop_snapshot.equity
-                            / runtime.no_restart_peak_strategy_equity.max(f64::EPSILON))
-                    .max(0.0);
-                    if hsl_no_restart_latched(
+                    let finalization = ehsl::evaluate_red_episode_finalization(
                         hsl_restart_after_red_policy.as_str(),
-                        persistent_drawdown_raw,
+                        stop_snapshot.timestamp_ms,
+                        stop_snapshot.equity,
+                        stop_snapshot.peak_strategy_equity,
+                        runtime.no_restart_peak_strategy_equity,
                         stop_snapshot.drawdown_ema,
+                        hsl_red_threshold,
                         hsl_no_restart_drawdown_threshold,
-                    )? {
-                        runtime.no_restart_latched = true;
-                        runtime.cooldown_until_ms = None;
-                    } else {
-                        let cooldown_minutes = hsl_cooldown_minutes_after_red;
-                        if cooldown_minutes.is_finite() && cooldown_minutes > 0.0 {
-                            let cooldown_ms = ((cooldown_minutes * 60_000.0).round() as u64)
-                                .max(self.interval_ms);
-                            runtime.cooldown_until_ms =
-                                Some(stop_snapshot.timestamp_ms.saturating_add(cooldown_ms));
-                        } else {
-                            runtime.cooldown_until_ms = None;
-                        }
-                    }
+                        hsl_cooldown_minutes_after_red,
+                    )?;
+                    runtime.no_restart_peak_strategy_equity =
+                        finalization.no_restart_peak_strategy_equity;
+                    runtime.no_restart_latched = finalization.no_restart_latched;
+                    runtime.cooldown_until_ms = finalization.cooldown_until_ms;
                     self.hard_stop_plot_events_pside[pside].push(HardStopPlotEvent {
                         kind: "halt".to_string(),
                         timestamp_ms: stop_snapshot.timestamp_ms,
@@ -3859,33 +3832,21 @@ impl<'a> Backtest<'a> {
                         }
                         runtime.last_restart_ts_ms = None;
                     }
-                    runtime.no_restart_peak_strategy_equity = runtime
-                        .no_restart_peak_strategy_equity
-                        .max(stop_snapshot.peak_strategy_equity)
-                        .max(stop_snapshot.equity);
-                    let persistent_drawdown_raw = (1.0
-                        - stop_snapshot.equity
-                            / runtime.no_restart_peak_strategy_equity.max(f64::EPSILON))
-                    .max(0.0);
-                    if hsl_no_restart_latched(
+                    let finalization = ehsl::evaluate_red_episode_finalization(
                         hsl_restart_after_red_policy.as_str(),
-                        persistent_drawdown_raw,
+                        stop_snapshot.timestamp_ms,
+                        stop_snapshot.equity,
+                        stop_snapshot.peak_strategy_equity,
+                        runtime.no_restart_peak_strategy_equity,
                         stop_snapshot.drawdown_ema,
+                        hsl_red_threshold,
                         hsl_no_restart_drawdown_threshold,
-                    )? {
-                        runtime.no_restart_latched = true;
-                        runtime.cooldown_until_ms = None;
-                    } else {
-                        let cooldown_minutes = hsl_cooldown_minutes_after_red;
-                        if cooldown_minutes.is_finite() && cooldown_minutes > 0.0 {
-                            let cooldown_ms = ((cooldown_minutes * 60_000.0).round() as u64)
-                                .max(self.interval_ms);
-                            runtime.cooldown_until_ms =
-                                Some(stop_snapshot.timestamp_ms.saturating_add(cooldown_ms));
-                        } else {
-                            runtime.cooldown_until_ms = None;
-                        }
-                    }
+                        hsl_cooldown_minutes_after_red,
+                    )?;
+                    runtime.no_restart_peak_strategy_equity =
+                        finalization.no_restart_peak_strategy_equity;
+                    runtime.no_restart_latched = finalization.no_restart_latched;
+                    runtime.cooldown_until_ms = finalization.cooldown_until_ms;
                     self.hard_stop_plot_events_pside[pside].push(HardStopPlotEvent {
                         kind: "halt".to_string(),
                         timestamp_ms: stop_snapshot.timestamp_ms,
@@ -8407,13 +8368,13 @@ mod tests {
         Backtest::apply_orange_override(&mut manual, orchestrator::TradingMode::TpOnly);
         assert!(matches!(manual, Some(orchestrator::TradingMode::Manual)));
 
-        assert!(!hsl_no_restart_latched("always", 1.0, 1.0, 0.10).unwrap());
-        assert!(!hsl_no_restart_latched("threshold", 0.09, 0.05, 0.10).unwrap());
-        assert!(hsl_no_restart_latched("threshold", 0.10, 0.0, 0.10).unwrap());
+        assert!(!ehsl::no_restart_triggered("always", 1.0, 1.0, 0.10).unwrap());
+        assert!(!ehsl::no_restart_triggered("threshold", 0.09, 0.05, 0.10).unwrap());
+        assert!(ehsl::no_restart_triggered("threshold", 0.10, 0.0, 0.10).unwrap());
         // Sustained smoothed damage trips the halt even when raw recovered.
-        assert!(hsl_no_restart_latched("threshold", 0.02, 0.11, 0.10).unwrap());
-        assert!(hsl_no_restart_latched("never", 0.0, 0.0, 0.10).unwrap());
-        assert!(hsl_no_restart_latched("sometimes", 1.0, 1.0, 0.10).is_err());
+        assert!(ehsl::no_restart_triggered("threshold", 0.02, 0.11, 0.10).unwrap());
+        assert!(ehsl::no_restart_triggered("never", 0.0, 0.0, 0.10).unwrap());
+        assert!(ehsl::no_restart_triggered("sometimes", 1.0, 1.0, 0.10).is_err());
     }
 
     #[test]

--- a/passivbot-rust/src/equity_hard_stop_loss.rs
+++ b/passivbot-rust/src/equity_hard_stop_loss.rs
@@ -162,15 +162,127 @@ pub fn no_restart_triggered(
 ) -> Result<bool, String> {
     match restart_after_red_policy {
         "always" => Ok(false),
-        "threshold" => {
-            Ok(drawdown_raw.max(drawdown_ema) >= no_restart_drawdown_threshold)
-        }
+        "threshold" => Ok(drawdown_raw.max(drawdown_ema) >= no_restart_drawdown_threshold),
         "never" => Ok(true),
         raw => Err(format!(
             "hsl_restart_after_red_policy must be one of always, threshold, never; got {:?}",
             raw
         )),
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RedEpisodeFinalization {
+    pub no_restart_peak_strategy_equity: f64,
+    pub no_restart_drawdown_raw: f64,
+    pub no_restart_latched: bool,
+    pub cooldown_until_ms: Option<u64>,
+    pub disposition: RedEpisodeDisposition,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RedEpisodeDisposition {
+    NoRestart,
+    Cooldown,
+    HaltedNoCooldown,
+}
+
+impl RedEpisodeDisposition {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NoRestart => "no_restart",
+            Self::Cooldown => "cooldown",
+            Self::HaltedNoCooldown => "halted_no_cooldown",
+        }
+    }
+}
+
+/// Evaluate the state transition after a RED episode has fully flattened.
+///
+/// The caller owns exchange/history proof and supplies the previous
+/// no-restart peak for the applicable lookback. This pure transition owns the
+/// shared live/backtest policy math. A positive configured cooldown is rounded
+/// to milliseconds with a canonical 1 ms floor; bar backtests observe the
+/// exact deadline on their next available sample instead of redefining it.
+pub fn evaluate_red_episode_finalization(
+    restart_after_red_policy: &str,
+    stop_timestamp_ms: u64,
+    stop_equity: f64,
+    stop_peak_strategy_equity: f64,
+    previous_no_restart_peak_strategy_equity: f64,
+    drawdown_ema: f64,
+    red_threshold: f64,
+    no_restart_drawdown_threshold: f64,
+    cooldown_minutes_after_red: f64,
+) -> Result<RedEpisodeFinalization, String> {
+    if !stop_equity.is_finite() || stop_equity <= 0.0 {
+        return Err("stop_equity must be finite and > 0".to_string());
+    }
+    if !stop_peak_strategy_equity.is_finite() || stop_peak_strategy_equity <= 0.0 {
+        return Err("stop_peak_strategy_equity must be finite and > 0".to_string());
+    }
+    if stop_peak_strategy_equity + f64::EPSILON < stop_equity {
+        return Err("stop_peak_strategy_equity must be >= stop_equity".to_string());
+    }
+    if !previous_no_restart_peak_strategy_equity.is_finite()
+        || previous_no_restart_peak_strategy_equity < 0.0
+    {
+        return Err("previous_no_restart_peak_strategy_equity must be finite and >= 0".to_string());
+    }
+    if !drawdown_ema.is_finite() || drawdown_ema < 0.0 {
+        return Err("drawdown_ema must be finite and >= 0".to_string());
+    }
+    if !red_threshold.is_finite() || red_threshold <= 0.0 {
+        return Err("red_threshold must be finite and > 0".to_string());
+    }
+    if !no_restart_drawdown_threshold.is_finite()
+        || !(red_threshold <= no_restart_drawdown_threshold && no_restart_drawdown_threshold <= 1.0)
+    {
+        return Err(
+            "no_restart_drawdown_threshold must be finite and satisfy red_threshold <= threshold <= 1"
+                .to_string(),
+        );
+    }
+    if !cooldown_minutes_after_red.is_finite() || cooldown_minutes_after_red < 0.0 {
+        return Err("cooldown_minutes_after_red must be finite and >= 0".to_string());
+    }
+
+    let no_restart_peak_strategy_equity = previous_no_restart_peak_strategy_equity
+        .max(stop_peak_strategy_equity)
+        .max(stop_equity);
+    let no_restart_drawdown_raw =
+        (1.0 - stop_equity / no_restart_peak_strategy_equity.max(f64::EPSILON)).max(0.0);
+    let no_restart_latched = no_restart_triggered(
+        restart_after_red_policy,
+        no_restart_drawdown_raw,
+        drawdown_ema,
+        no_restart_drawdown_threshold,
+    )?;
+    let cooldown_until_ms = if no_restart_latched || cooldown_minutes_after_red <= 0.0 {
+        None
+    } else {
+        let cooldown_ms_f64 = (cooldown_minutes_after_red * 60_000.0).round();
+        if !cooldown_ms_f64.is_finite() || cooldown_ms_f64 > u64::MAX as f64 {
+            return Err("cooldown_minutes_after_red is too large".to_string());
+        }
+        let cooldown_ms = (cooldown_ms_f64 as u64).max(1);
+        Some(stop_timestamp_ms.saturating_add(cooldown_ms))
+    };
+    let disposition = if no_restart_latched {
+        RedEpisodeDisposition::NoRestart
+    } else if cooldown_until_ms.is_some() {
+        RedEpisodeDisposition::Cooldown
+    } else {
+        RedEpisodeDisposition::HaltedNoCooldown
+    };
+
+    Ok(RedEpisodeFinalization {
+        no_restart_peak_strategy_equity,
+        no_restart_drawdown_raw,
+        no_restart_latched,
+        cooldown_until_ms,
+        disposition,
+    })
 }
 
 #[allow(dead_code)] // Kept as a convenience helper for callers that want internal peak tracking.
@@ -349,18 +461,16 @@ mod tests {
             ema_span_minutes: 1.0,
             tier_ratios: HardStopTierRatios::default(),
         };
-        let s = step_with_peak_strategy_equity_latch(
-            &mut state, config, 100.0, 100.0, 60_000, true,
-        )
-        .unwrap();
+        let s =
+            step_with_peak_strategy_equity_latch(&mut state, config, 100.0, 100.0, 60_000, true)
+                .unwrap();
         assert!(!s.red_active_now);
         assert!(!state.red_seen_in_episode);
 
         // Crash through RED with latching on.
-        let s = step_with_peak_strategy_equity_latch(
-            &mut state, config, 70.0, 100.0, 120_000, true,
-        )
-        .unwrap();
+        let s =
+            step_with_peak_strategy_equity_latch(&mut state, config, 70.0, 100.0, 120_000, true)
+                .unwrap();
         assert!(s.red_active_now);
         assert!(state.red_seen_in_episode);
         assert!(state.red_latched);
@@ -368,10 +478,9 @@ mod tests {
 
         // Full recovery: latch pins the tier, but the current sample is no
         // longer RED, and the episode memory persists.
-        let s = step_with_peak_strategy_equity_latch(
-            &mut state, config, 100.0, 100.0, 180_000, true,
-        )
-        .unwrap();
+        let s =
+            step_with_peak_strategy_equity_latch(&mut state, config, 100.0, 100.0, 180_000, true)
+                .unwrap();
         assert!(!s.red_active_now);
         assert!(state.red_seen_in_episode);
         assert_eq!(s.tier, HardStopTier::Red);
@@ -392,23 +501,121 @@ mod tests {
             ema_span_minutes: 1.0,
             tier_ratios: HardStopTierRatios::default(),
         };
-        step_with_peak_strategy_equity_latch(
-            &mut state, config, 100.0, 100.0, 60_000, false,
-        )
-        .unwrap();
-        let s = step_with_peak_strategy_equity_latch(
-            &mut state, config, 70.0, 100.0, 120_000, false,
-        )
-        .unwrap();
+        step_with_peak_strategy_equity_latch(&mut state, config, 100.0, 100.0, 60_000, false)
+            .unwrap();
+        let s =
+            step_with_peak_strategy_equity_latch(&mut state, config, 70.0, 100.0, 120_000, false)
+                .unwrap();
         assert!(s.red_active_now);
         assert!(!state.red_latched);
-        let s = step_with_peak_strategy_equity_latch(
-            &mut state, config, 100.0, 100.0, 180_000, false,
-        )
-        .unwrap();
+        let s =
+            step_with_peak_strategy_equity_latch(&mut state, config, 100.0, 100.0, 180_000, false)
+                .unwrap();
         assert!(!s.red_active_now);
         assert!(state.red_seen_in_episode);
         assert_ne!(s.tier, HardStopTier::Red);
+    }
+
+    #[test]
+    fn red_episode_finalization_uses_persistent_peak_and_fill_timestamp() {
+        let out = evaluate_red_episode_finalization(
+            "threshold",
+            125_500,
+            70.0,
+            80.0,
+            100.0,
+            0.10,
+            0.20,
+            0.25,
+            5.0,
+        )
+        .unwrap();
+        assert!((out.no_restart_peak_strategy_equity - 100.0).abs() < 1e-12);
+        assert!((out.no_restart_drawdown_raw - 0.30).abs() < 1e-12);
+        assert!(out.no_restart_latched);
+        assert_eq!(out.cooldown_until_ms, None);
+        assert_eq!(out.disposition, RedEpisodeDisposition::NoRestart);
+
+        let restartable = evaluate_red_episode_finalization(
+            "threshold",
+            125_500,
+            90.0,
+            100.0,
+            0.0,
+            0.10,
+            0.20,
+            0.25,
+            5.0,
+        )
+        .unwrap();
+        assert!(!restartable.no_restart_latched);
+        assert_eq!(restartable.cooldown_until_ms, Some(425_500));
+        assert_eq!(restartable.disposition, RedEpisodeDisposition::Cooldown);
+    }
+
+    #[test]
+    fn red_episode_finalization_honors_policy_and_canonical_minimum() {
+        let always = evaluate_red_episode_finalization(
+            "always", 1_000, 1.0, 1.0, 0.0, 1.0, 0.25, 0.5, 0.000_001,
+        )
+        .unwrap();
+        assert!(!always.no_restart_latched);
+        assert_eq!(always.cooldown_until_ms, Some(1_001));
+
+        let halted_no_cooldown =
+            evaluate_red_episode_finalization("always", 1_000, 1.0, 1.0, 0.0, 0.0, 0.25, 0.5, 0.0)
+                .unwrap();
+        assert_eq!(
+            halted_no_cooldown.disposition,
+            RedEpisodeDisposition::HaltedNoCooldown
+        );
+        assert_eq!(halted_no_cooldown.cooldown_until_ms, None);
+
+        let never =
+            evaluate_red_episode_finalization("never", 1_000, 1.0, 1.0, 0.0, 0.0, 0.25, 0.5, 5.0)
+                .unwrap();
+        assert!(never.no_restart_latched);
+        assert_eq!(never.cooldown_until_ms, None);
+    }
+
+    #[test]
+    fn red_episode_finalization_rejects_invalid_inputs() {
+        assert!(evaluate_red_episode_finalization(
+            "threshold",
+            1_000,
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.25,
+            0.5,
+            5.0,
+        )
+        .is_err());
+        assert!(evaluate_red_episode_finalization(
+            "threshold",
+            1_000,
+            1.0,
+            1.0,
+            0.0,
+            f64::NAN,
+            0.25,
+            0.5,
+            5.0,
+        )
+        .is_err());
+        assert!(evaluate_red_episode_finalization(
+            "sometimes",
+            1_000,
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0.25,
+            0.5,
+            5.0,
+        )
+        .is_err());
     }
 
     fn cfg() -> HardStopConfig {

--- a/passivbot-rust/src/lib.rs
+++ b/passivbot-rust/src/lib.rs
@@ -69,6 +69,7 @@ fn passivbot_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(calc_unstucking_close_py, m)?)?;
     m.add_function(wrap_pyfunction!(trailing_bundle_default_py, m)?)?;
     m.add_function(wrap_pyfunction!(hsl_no_restart_triggered, m)?)?;
+    m.add_function(wrap_pyfunction!(hsl_red_episode_finalization, m)?)?;
     m.add_function(wrap_pyfunction!(update_trailing_bundle_py, m)?)?;
     m.add_function(wrap_pyfunction!(equity_hard_stop_step_py, m)?)?;
     m.add_function(wrap_pyfunction!(select_coin_indices_py, m)?)?;

--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -542,6 +542,55 @@ pub fn hsl_no_restart_triggered(
 }
 
 #[pyfunction]
+#[pyo3(signature = (
+    *,
+    restart_after_red_policy,
+    stop_timestamp_ms,
+    stop_equity,
+    stop_peak_strategy_equity,
+    previous_no_restart_peak_strategy_equity,
+    drawdown_ema,
+    red_threshold,
+    no_restart_drawdown_threshold,
+    cooldown_minutes_after_red
+))]
+pub fn hsl_red_episode_finalization(
+    py: Python<'_>,
+    restart_after_red_policy: &str,
+    stop_timestamp_ms: u64,
+    stop_equity: f64,
+    stop_peak_strategy_equity: f64,
+    previous_no_restart_peak_strategy_equity: f64,
+    drawdown_ema: f64,
+    red_threshold: f64,
+    no_restart_drawdown_threshold: f64,
+    cooldown_minutes_after_red: f64,
+) -> PyResult<Py<PyDict>> {
+    let result = ehsl::evaluate_red_episode_finalization(
+        restart_after_red_policy,
+        stop_timestamp_ms,
+        stop_equity,
+        stop_peak_strategy_equity,
+        previous_no_restart_peak_strategy_equity,
+        drawdown_ema,
+        red_threshold,
+        no_restart_drawdown_threshold,
+        cooldown_minutes_after_red,
+    )
+    .map_err(PyValueError::new_err)?;
+    let out = PyDict::new_bound(py);
+    out.set_item(
+        "no_restart_peak_strategy_equity",
+        result.no_restart_peak_strategy_equity,
+    )?;
+    out.set_item("no_restart_drawdown_raw", result.no_restart_drawdown_raw)?;
+    out.set_item("no_restart_latched", result.no_restart_latched)?;
+    out.set_item("cooldown_until_ms", result.cooldown_until_ms)?;
+    out.set_item("disposition", result.disposition.as_str())?;
+    Ok(out.unbind())
+}
+
+#[pyfunction]
 #[pyo3(signature = (highs, lows, closes, bundle=None))]
 pub fn update_trailing_bundle_py(
     highs: PyReadonlyArray1<'_, f64>,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1902,7 +1902,9 @@ class Passivbot:
         pb_hsl._equity_hard_stop_format_remaining_time
     )
     _equity_hard_stop_build_latch_payload = pb_hsl._equity_hard_stop_build_latch_payload
-    _equity_hard_stop_record_no_restart_stop = pb_hsl._equity_hard_stop_record_no_restart_stop
+    _equity_hard_stop_red_episode_finalization = (
+        pb_hsl._equity_hard_stop_red_episode_finalization
+    )
     _equity_hard_stop_compute_stop_event = pb_hsl._equity_hard_stop_compute_stop_event
     _equity_hard_stop_compute_coin_stop_event = (
         pb_hsl._equity_hard_stop_compute_coin_stop_event

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -3886,35 +3886,43 @@ def _equity_hard_stop_build_latch_payload(
     }
 
 
-def _equity_hard_stop_record_no_restart_stop(
-    self, pside: str, stop_event: dict
-) -> tuple[float, float]:
-    state = self._hsl_state(pside)
-    equity = float(stop_event["equity"])
-    peak_strategy_equity = float(stop_event["peak_strategy_equity"])
-    if not math.isfinite(equity) or equity <= 0.0:
-        raise RuntimeError(f"invalid HSL[{pside}] stop equity for no-restart latch: {equity}")
-    if not math.isfinite(peak_strategy_equity) or peak_strategy_equity <= 0.0:
-        raise RuntimeError(
-            f"invalid HSL[{pside}] stop peak_strategy_equity for no-restart latch: {peak_strategy_equity}"
-        )
-    no_restart_peak_strategy_equity = max(
-        float(state.get("no_restart_peak_strategy_equity", 0.0) or 0.0),
-        peak_strategy_equity,
-        equity,
+def _equity_hard_stop_red_episode_finalization(
+    self,
+    pside: str,
+    stop_event: dict,
+    stop_event_timestamp_ms: int,
+    *,
+    symbol: Optional[str] = None,
+) -> dict[str, Any]:
+    """Apply Rust-owned post-episode restart/cooldown policy math."""
+    state = self._hsl_coin_state(pside, symbol) if symbol else self._hsl_state(pside)
+    cfg = self.hsl[pside]
+    policy = normalize_hsl_restart_after_red_policy(
+        cfg.get("restart_after_red_policy", "threshold"),
+        path="hsl.restart_after_red_policy",
     )
-    if (
-        not math.isfinite(no_restart_peak_strategy_equity)
-        or no_restart_peak_strategy_equity <= 0.0
-    ):
-        raise RuntimeError(
-            f"invalid HSL[{pside}] no_restart_peak_strategy_equity: {no_restart_peak_strategy_equity}"
-        )
-    state["no_restart_peak_strategy_equity"] = no_restart_peak_strategy_equity
-    no_restart_drawdown_raw = max(
-        0.0, 1.0 - equity / max(no_restart_peak_strategy_equity, 1e-12)
+    result = pbr.hsl_red_episode_finalization(
+        restart_after_red_policy=policy,
+        stop_timestamp_ms=int(stop_event_timestamp_ms),
+        stop_equity=float(stop_event["equity"]),
+        stop_peak_strategy_equity=float(stop_event["peak_strategy_equity"]),
+        previous_no_restart_peak_strategy_equity=float(
+            state.get("no_restart_peak_strategy_equity", 0.0) or 0.0
+        ),
+        drawdown_ema=float(stop_event["drawdown_ema"]),
+        red_threshold=float(cfg["red_threshold"]),
+        no_restart_drawdown_threshold=float(cfg["no_restart_drawdown_threshold"]),
+        cooldown_minutes_after_red=float(cfg["cooldown_minutes_after_red"]),
     )
-    return float(no_restart_peak_strategy_equity), float(no_restart_drawdown_raw)
+    if not isinstance(result, dict):
+        raise TypeError(
+            "passivbot_rust.hsl_red_episode_finalization() must return a dict, "
+            f"got {type(result).__name__}"
+        )
+    state["no_restart_peak_strategy_equity"] = float(
+        result["no_restart_peak_strategy_equity"]
+    )
+    return result
 
 
 async def _equity_hard_stop_compute_stop_event(self, pside: str, stop_event_ts_ms: int) -> dict:
@@ -4541,10 +4549,7 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
             if not self._equity_hard_stop_enabled(pside):
                 continue
             state = self._hsl_state(pside)
-            cfg = self.hsl[pside]
             contract = replay_contracts[pside]
-            cooldown_minutes = float(cfg["cooldown_minutes_after_red"])
-            cooldown_ms = int(round(cooldown_minutes * 60_000.0)) if cooldown_minutes > 0.0 else 0
             if contract["intervention_entry_ts"] is not None and contract["policy"] == "normal":
                 self._equity_hard_stop_reset_after_restart(pside)
                 n_rows[pside] = self._equity_hard_stop_replay_from_boundary(
@@ -4694,24 +4699,23 @@ async def _equity_hard_stop_initialize_from_history(self) -> None:
                 if True:
                     state["pending_red_since_ms"] = int(ts)
                     stop_drawdown_raw = float(current_metrics["drawdown_raw"])
-                    (
-                        no_restart_peak_strategy_equity,
-                        no_restart_drawdown_raw,
-                    ) = self._equity_hard_stop_record_no_restart_stop(
+                    finalization = self._equity_hard_stop_red_episode_finalization(
                         pside,
                         {
                             "equity": float(current_metrics["strategy_equity"]),
                             "peak_strategy_equity": float(current_metrics["peak_strategy_equity"]),
+                            "drawdown_ema": float(current_metrics["drawdown_ema"]),
                         },
+                        stop_ts,
                     )
-                    no_restart_latched = _equity_hard_stop_no_restart_latched(
-                        cfg,
-                        no_restart_drawdown_raw,
-                        float(current_metrics["drawdown_ema"]),
+                    no_restart_peak_strategy_equity = float(
+                        finalization["no_restart_peak_strategy_equity"]
                     )
-                    cooldown_until_ms = None
-                    if not no_restart_latched and cooldown_ms > 0:
-                        cooldown_until_ms = stop_ts + cooldown_ms
+                    no_restart_drawdown_raw = float(
+                        finalization["no_restart_drawdown_raw"]
+                    )
+                    no_restart_latched = bool(finalization["no_restart_latched"])
+                    cooldown_until_ms = finalization["cooldown_until_ms"]
                     payload = self._equity_hard_stop_build_latch_payload(
                         pside,
                         stop_event_timestamp_ms=stop_ts,
@@ -5154,9 +5158,6 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             check_shutdown("hsl_coin_history_replay_pside")
             if not self._equity_hard_stop_coin_active_pside(pside):
                 continue
-            cfg = self.hsl[pside]
-            cooldown_minutes = float(cfg["cooldown_minutes_after_red"])
-            cooldown_ms = int(round(cooldown_minutes * 60_000.0)) if cooldown_minutes > 0.0 else 0
             for symbol in sorted(replay_symbols):
                 check_shutdown("hsl_coin_history_replay_pair")
                 pair_idx += 1
@@ -5395,12 +5396,18 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                             )
                             continue
                     stop_drawdown_raw = float(metrics["drawdown_raw"])
-                    no_restart_latched = _equity_hard_stop_no_restart_latched(
-                        cfg, stop_drawdown_raw, float(metrics["drawdown_ema"])
+                    finalization = self._equity_hard_stop_red_episode_finalization(
+                        pside,
+                        {
+                            "equity": float(metrics["equity"]),
+                            "peak_strategy_equity": float(metrics["peak_strategy_equity"]),
+                            "drawdown_ema": float(metrics["drawdown_ema"]),
+                        },
+                        stop_ts,
+                        symbol=symbol,
                     )
-                    cooldown_until_ms = None
-                    if not no_restart_latched and cooldown_ms > 0:
-                        cooldown_until_ms = stop_ts + cooldown_ms
+                    no_restart_latched = bool(finalization["no_restart_latched"])
+                    cooldown_until_ms = finalization["cooldown_until_ms"]
                     state["last_stop_event"] = self._equity_hard_stop_build_latch_payload(
                         pside,
                         symbol=symbol,
@@ -5419,6 +5426,12 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         drawdown_score=float(metrics["drawdown_score"]),
                         no_restart_latched=no_restart_latched,
                         cooldown_until_ms=cooldown_until_ms,
+                        no_restart_peak_strategy_equity=float(
+                            finalization["no_restart_peak_strategy_equity"]
+                        ),
+                        no_restart_drawdown_raw=float(
+                            finalization["no_restart_drawdown_raw"]
+                        ),
                     )
                     state["pnl_reset_timestamp_ms"] = stop_ts + 1
                     state["pending_red_since_ms"] = None
@@ -5852,9 +5865,13 @@ def _equity_hard_stop_coin_symbols(self) -> set[str]:
 def _equity_hard_stop_reset_coin_after_restart(self, pside: str, symbol: str) -> None:
     state = self._hsl_coin_state(pside, symbol)
     reset_ts = state.get("pnl_reset_timestamp_ms")
+    no_restart_peak_strategy_equity = float(
+        state.get("no_restart_peak_strategy_equity", 0.0) or 0.0
+    )
     state.clear()
     state.update(self._equity_hard_stop_make_state())
     state["pnl_reset_timestamp_ms"] = reset_ts
+    state["no_restart_peak_strategy_equity"] = no_restart_peak_strategy_equity
     self._equity_hard_stop_clear_coin_runtime_forced_mode(pside, symbol)
 
 
@@ -6382,17 +6399,18 @@ async def _equity_hard_stop_finalize_red_stop(
         stop_event = await self._equity_hard_stop_compute_stop_event(pside, stop_ts_ms)
     else:
         stop_ts_ms = int(stop_event["stop_event_timestamp_ms"])
-    cooldown_minutes = float(cfg["cooldown_minutes_after_red"])
     no_restart_drawdown_threshold = float(cfg["no_restart_drawdown_threshold"])
-    (
-        no_restart_peak_strategy_equity,
-        no_restart_drawdown_raw,
-    ) = self._equity_hard_stop_record_no_restart_stop(pside, stop_event)
-    no_restart_latched = _equity_hard_stop_no_restart_latched(
-        cfg, no_restart_drawdown_raw, float(stop_event["drawdown_ema"])
+    finalization = self._equity_hard_stop_red_episode_finalization(
+        pside,
+        stop_event,
+        stop_ts_ms,
     )
-    cooldown_ms = int(round(cooldown_minutes * 60_000.0)) if cooldown_minutes > 0.0 else 0
-    cooldown_until_ms = None if no_restart_latched or cooldown_ms <= 0 else int(stop_ts_ms + cooldown_ms)
+    no_restart_peak_strategy_equity = float(
+        finalization["no_restart_peak_strategy_equity"]
+    )
+    no_restart_drawdown_raw = float(finalization["no_restart_drawdown_raw"])
+    no_restart_latched = bool(finalization["no_restart_latched"])
+    cooldown_until_ms = finalization["cooldown_until_ms"]
     payload = self._equity_hard_stop_build_latch_payload(
         pside,
         stop_event_timestamp_ms=stop_ts_ms,
@@ -6509,7 +6527,6 @@ async def _equity_hard_stop_finalize_coin_red_stop(
     nonpanic_close_orders: int | None = None,
 ) -> None:
     state = self._hsl_coin_state(pside, symbol)
-    cfg = self.hsl[pside]
     stop_ts_ms = int(self.get_exchange_time())
     stop_event_anchor_source = "provided_stop_event"
     stop_event_anchor_fallback_used = False
@@ -6530,12 +6547,14 @@ async def _equity_hard_stop_finalize_coin_red_stop(
         stop_event = await self._equity_hard_stop_compute_coin_stop_event(pside, symbol, stop_ts_ms)
     else:
         stop_ts_ms = int(stop_event["stop_event_timestamp_ms"])
-    cooldown_minutes = float(cfg["cooldown_minutes_after_red"])
-    no_restart_latched = _equity_hard_stop_no_restart_latched(
-        cfg, stop_event["drawdown_raw"], float(stop_event["drawdown_ema"])
+    finalization = self._equity_hard_stop_red_episode_finalization(
+        pside,
+        stop_event,
+        stop_ts_ms,
+        symbol=symbol,
     )
-    cooldown_ms = int(round(cooldown_minutes * 60_000.0)) if cooldown_minutes > 0.0 else 0
-    cooldown_until_ms = None if no_restart_latched or cooldown_ms <= 0 else int(stop_ts_ms + cooldown_ms)
+    no_restart_latched = bool(finalization["no_restart_latched"])
+    cooldown_until_ms = finalization["cooldown_until_ms"]
     payload = self._equity_hard_stop_build_latch_payload(
         pside,
         symbol=symbol,
@@ -6554,6 +6573,10 @@ async def _equity_hard_stop_finalize_coin_red_stop(
         drawdown_score=float(stop_event["drawdown_score"]),
         no_restart_latched=no_restart_latched,
         cooldown_until_ms=cooldown_until_ms,
+        no_restart_peak_strategy_equity=float(
+            finalization["no_restart_peak_strategy_equity"]
+        ),
+        no_restart_drawdown_raw=float(finalization["no_restart_drawdown_raw"]),
     )
     state["last_stop_event"] = payload
     state["halted"] = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,54 @@ def _install_passivbot_rust_stub():
         )
 
     stub.hsl_no_restart_triggered = _hsl_no_restart_triggered
+
+    def _hsl_red_episode_finalization(
+        *,
+        restart_after_red_policy,
+        stop_timestamp_ms,
+        stop_equity,
+        stop_peak_strategy_equity,
+        previous_no_restart_peak_strategy_equity,
+        drawdown_ema,
+        red_threshold,
+        no_restart_drawdown_threshold,
+        cooldown_minutes_after_red,
+    ):
+        if not (0.0 < float(red_threshold) <= float(no_restart_drawdown_threshold) <= 1.0):
+            raise ValueError(
+                "no_restart_drawdown_threshold must satisfy red_threshold <= threshold <= 1"
+            )
+        peak = max(
+            float(previous_no_restart_peak_strategy_equity),
+            float(stop_peak_strategy_equity),
+            float(stop_equity),
+        )
+        raw = max(0.0, 1.0 - float(stop_equity) / peak)
+        no_restart = _hsl_no_restart_triggered(
+            restart_after_red_policy,
+            raw,
+            drawdown_ema,
+            no_restart_drawdown_threshold,
+        )
+        cooldown_until_ms = None
+        if not no_restart and float(cooldown_minutes_after_red) > 0.0:
+            cooldown_ms = max(1, round(float(cooldown_minutes_after_red) * 60_000.0))
+            cooldown_until_ms = int(stop_timestamp_ms) + int(cooldown_ms)
+        return {
+            "no_restart_peak_strategy_equity": peak,
+            "no_restart_drawdown_raw": raw,
+            "no_restart_latched": no_restart,
+            "cooldown_until_ms": cooldown_until_ms,
+            "disposition": (
+                "no_restart"
+                if no_restart
+                else "cooldown"
+                if cooldown_until_ms is not None
+                else "halted_no_cooldown"
+            ),
+        }
+
+    stub.hsl_red_episode_finalization = _hsl_red_episode_finalization
     stub.round_ = _round
     stub.round_dn = _round_dn
     stub.round_up = _round_up

--- a/tests/test_equity_hard_stop_rolling_peak.py
+++ b/tests/test_equity_hard_stop_rolling_peak.py
@@ -12,6 +12,32 @@ pbr_is_stub = bool(getattr(pbr, "__is_stub__", False)) if pbr is not None else F
     pbr is None or pbr_is_stub,
     reason="passivbot_rust extension not available",
 )
+def test_red_episode_finalization_binding_returns_explicit_disposition():
+    out = pbr.hsl_red_episode_finalization(
+        restart_after_red_policy="threshold",
+        stop_timestamp_ms=125_500,
+        stop_equity=90.0,
+        stop_peak_strategy_equity=100.0,
+        previous_no_restart_peak_strategy_equity=120.0,
+        drawdown_ema=0.10,
+        red_threshold=0.20,
+        no_restart_drawdown_threshold=0.90,
+        cooldown_minutes_after_red=5.0,
+    )
+
+    assert out == {
+        "no_restart_peak_strategy_equity": pytest.approx(120.0),
+        "no_restart_drawdown_raw": pytest.approx(0.25),
+        "no_restart_latched": False,
+        "cooldown_until_ms": 425_500,
+        "disposition": "cooldown",
+    }
+
+
+@pytest.mark.skipif(
+    pbr is None or pbr_is_stub,
+    reason="passivbot_rust extension not available",
+)
 def test_equity_hard_stop_rolling_peak_accepts_negative_values():
     tracker = pbr.EquityHardStopRollingPeak()
 

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -1511,7 +1511,7 @@ def bind_hsl_methods(bot):
         "_equity_hard_stop_apply_sample",
         "_equity_hard_stop_reset_state",
         "_equity_hard_stop_reset_after_restart",
-        "_equity_hard_stop_record_no_restart_stop",
+        "_equity_hard_stop_red_episode_finalization",
         "_equity_hard_stop_validate_balance_source_for_history_replay",
         "_equity_hard_stop_balance_override_active",
         "_equity_hard_stop_position_symbols",
@@ -1646,6 +1646,21 @@ def make_coin_bot(policy="panic"):
 
 def test_passivbot_binds_coin_hsl_replay_support_helper():
     assert hasattr(Passivbot, "_equity_hard_stop_symbol_supported_for_coin_replay")
+
+
+def test_coin_hsl_restart_reset_preserves_persistent_no_restart_peak():
+    bot = make_coin_bot()
+    state = bot._hsl_coin_state("long", "BTC/USDT:USDT")
+    state["no_restart_peak_strategy_equity"] = 1.25
+    state["pnl_reset_timestamp_ms"] = 123_456
+    state["halted"] = True
+
+    bot._equity_hard_stop_reset_coin_after_restart("long", "BTC/USDT:USDT")
+
+    state = bot._hsl_coin_state("long", "BTC/USDT:USDT")
+    assert state["no_restart_peak_strategy_equity"] == pytest.approx(1.25)
+    assert state["pnl_reset_timestamp_ms"] == 123_456
+    assert state["halted"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_hsl_metric_regression.py
+++ b/tests/test_hsl_metric_regression.py
@@ -28,6 +28,7 @@ _BOUND_METHODS = (
     "_equity_hard_stop_apply_coin_metrics_sample",
     "_equity_hard_stop_runtime_tier",
     "_equity_hard_stop_runtime_red_latched",
+    "_equity_hard_stop_red_episode_finalization",
 )
 
 
@@ -286,6 +287,29 @@ def test_no_restart_trigger_uses_max_of_raw_and_ema():
         hsl._equity_hard_stop_no_restart_latched(
             dict(cfg, restart_after_red_policy="sometimes"), 1.0, 1.0
         )
+
+
+def test_red_episode_finalization_uses_rust_owned_persistent_peak_and_deadline():
+    bot = _make_bot("unified")
+    state = bot._hsl_state("long")
+    state["no_restart_peak_strategy_equity"] = 120.0
+
+    out = bot._equity_hard_stop_red_episode_finalization(
+        "long",
+        {
+            "equity": 90.0,
+            "peak_strategy_equity": 100.0,
+            "drawdown_ema": 0.10,
+        },
+        125_500,
+    )
+
+    assert out["no_restart_peak_strategy_equity"] == pytest.approx(120.0)
+    assert out["no_restart_drawdown_raw"] == pytest.approx(0.25)
+    assert out["no_restart_latched"] is False
+    assert out["cooldown_until_ms"] == 425_500
+    assert out["disposition"] == "cooldown"
+    assert state["no_restart_peak_strategy_equity"] == pytest.approx(120.0)
 
 
 def test_red_tier_score_is_min_of_raw_and_ema():


### PR DESCRIPTION
## Summary\n- centralize post-RED HSL episode finalization in a pure Rust transition shared by backtest and Python live/history replay\n- make persistent no-restart peak/drawdown, restart policy, disposition, and exact cooldown deadline one contract\n- retain the coin-live persistent no-restart peak across episode restart, matching pside live and backtest\n\n## Ownership boundary\nRust owns the shared policy math. Python still owns exchange/fill-history proof, scope-flat detection, cache and latch I/O, orchestration, and order supervision.\n\n## Non-goals\n- no RED trigger or tier-math change\n- no coin signal denominator change\n- no replay ordering or background-concurrency change\n- no exchange behavior or new observability event\n\n## Validation\n- cargo test --no-default-features: 207 passed\n- cargo check --tests\n- focused Rust HSL tests: 17 passed\n- focused Python HSL/replay/binding suites: 138 passed\n- fake-live regression suite: 29 passed, including seven pside HSL end-to-end scenarios\n- real Binance BTC HSL backtest, 2026-06-01 through 2026-06-03\n- real four-evaluation optimizer smoke\n- release extension rebuilt and source stamp verified\n- cargo fmt --check\n- git diff --check\n\n## Reviewer focus\n- exact flatten-fill timestamp anchoring and sub-bar cooldown semantics\n- persistent no-restart peak lifecycle across pside/coin and live/backtest\n- max(raw, EMA) no-restart policy parity\n- PyO3 validation and error propagation\n- caller/owner boundary for history proof and flat detection\n\n## Known follow-ups\nAn existing coin-mode slot-budget denominator mismatch between live and backtest, and a direct coin fake-live staged-planner epoch failure after panic flatten, are recorded separately. Neither is changed by this PR.\n\n## VPS after merge\nPull with autostash, preserve the known tracked Rust edit and local artifacts, rebuild and source-stamp the Rust extension, restart the five declared bots, then run immediate and settled bounded smoke checks.