### PR TITLE
Align coin HSL denominator across runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Coin-mode HSL drawdown normalization now uses one Rust-owned live/backtest
+  contract: account balance divided by the applicable slot count. TWEL still
+  enables the side but no longer scales the HSL denominator, so increasing an
+  exposure allowance cannot silently weaken the configured RED threshold.
+
 - HSL RED episode finalization now uses one Rust-owned live/backtest contract
   for caller-supplied persistent no-restart peaks, restart policy, and cooldown
   deadlines. Coin-mode live restart now retains that no-restart peak like

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -182,8 +182,8 @@ Signal mode:
 3. `live.hsl_signal_mode = "coin"` (default)
    - each `coin+pside` controller uses realized PnL drawdown inside `live.pnls_max_lookback_days` plus current UPnL
    - RED panic-closes only the affected `coin+pside`
-   - live denominator is `balance * total_wallet_exposure_limit / config.n_positions`; runtime effective position count and WE-excess allowance are intentionally not included
-   - backtests use configured `n_positions` when `backtest.dynamic_wel_by_tradability=false`, and the effective tradability-aware denominator when it is `true`
+   - live denominator is `balance / config.n_positions`; TWEL and WE-excess allowance are intentionally not included
+   - backtests use `balance / configured_n_positions` when `backtest.dynamic_wel_by_tradability=false`, and `balance / effective_tradability_aware_n_positions` when it is `true`; TWEL does not scale either denominator
 
 Backtest-specific note:
 

--- a/docs/equity_hard_stop_loss.md
+++ b/docs/equity_hard_stop_loss.md
@@ -52,7 +52,8 @@ Use `pside` when:
 
 1. realized net PnL is tracked per `coin+pside` inside `live.pnls_max_lookback_days`
 2. the peak realized cumsum in that window is compared to `last_realized_cumsum + current_upnl`
-3. the resulting drawdown is divided by `balance * total_wallet_exposure_limit / config.n_positions`
+3. the resulting drawdown is divided by `balance / config.n_positions`; TWEL
+   controls whether the side is active but does not scale HSL sensitivity
 4. live uses `config.n_positions` directly, not runtime effective position count, so adding/removing active symbols does not silently change HSL sensitivity
 5. RED affects only the stopped `coin+pside`; other coins on the same `pside` continue normally
 
@@ -89,9 +90,14 @@ of a rebased strategy-equity curve:
 peak_realized = max(realized_pnl_cumsum for coin+pside inside lookback)
 last_realized = last(realized_pnl_cumsum for coin+pside inside lookback)
 drawdown_usd = max(0.0, peak_realized - (last_realized + current_upnl))
-slot_budget = balance * total_wallet_exposure_limit / config.n_positions
+slot_budget = balance / applicable_n_positions
 drawdown_raw = drawdown_usd / slot_budget
 ```
+
+Live uses configured `n_positions`. Backtests use configured slots normally and
+effective tradability-aware slots when `backtest.dynamic_wel_by_tradability` is
+enabled. TWEL controls whether the side is active but does not scale either HSL
+denominator.
 
 This avoids false triggers caused only by collateral price moves when strategy PnL itself has not deteriorated.
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,7 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR: pending publication, `Align coin-HSL denominator across live and backtest`
+- PR #1175: `Align coin-HSL denominator across live and backtest`
 - Branch: `codex/v8-hsl-coin-denominator-parity`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
@@ -51,9 +51,8 @@ Estimated completion:
 
 Next action:
 
-1. Complete Rust/PyO3/Python, fake-live, real backtest, and optimizer validation.
-2. Publish a review-ready PR and resolve every verified finding with focused
-   regression coverage.
+1. Poll PR #1175's exact head, mergeability, CI, and required reviews.
+2. Resolve every verified finding with focused regression coverage.
 3. Merge only after the exact-head gate is satisfied, then perform the declared
    VPS5 restart/smoke validation.
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,28 +22,25 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1174: `Centralize HSL episode finalization in Rust`
-- Branch: `codex/v8-hsl-startup-transition-contract`
+- PR: pending publication, `Align coin-HSL denominator across live and backtest`
+- Branch: `codex/v8-hsl-coin-denominator-parity`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
-- Base: `f5395dda4de815bac4f587795a66deda8fb01bc5`
-- Scope: pure Rust post-RED-episode transition shared by backtest and Python
-  live/history replay. It owns caller-supplied persistent no-restart peak/
-  drawdown evaluation, restart policy, explicit disposition, and exact cooldown
-  deadline; coin live restart now retains that peak like pside/backtest. Python still
-  owns exchange/fill-history proof, scope-flat detection, cache/latch I/O,
-  orchestration, and order supervision.
-- Non-goals: no RED trigger/tier math change, no signal-mode denominator
-  change, no replay ordering/background concurrency change, no exchange call,
-  and no new observability event.
-- Local validation: Rust `207/207`; focused Python HSL/replay/binding suites
-  pass; fake-live `29/29`, including seven real end-to-end pside HSL scenario
-  runs; real Binance HSL backtest and four-evaluation optimizer smoke pass;
-  extension source stamp and `git diff --check` pass.
-- Independent preflight: identified an existing coin-mode slot-budget
-  denominator mismatch between live and backtest plus a direct coin fake-live
-  staged-planner epoch failure after panic flatten. Neither is introduced by
-  this transition refactor; both remain focused follow-up work.
+- Base: `61fbd0eb14efe8a3b77535b461eb1bf7c936fe41`
+- Scope: one Rust-owned coin-HSL drawdown primitive shared by Python live/replay
+  and Rust backtest. Slot budget is balance divided by the caller's applicable
+  slot count; TWEL remains an activation/validation input but cannot scale HSL
+  sensitivity.
+- Non-goals: no TWEL activation change, no dynamic-tradability slot-count
+  change, no RED tier/EMA/finalization change, no replay ordering change, no
+  exchange call, and no new observability event.
+- Local validation: Rust `209/209` plus default-feature test compilation pass;
+  focused Python HSL/replay/binding suites `139/139`; fake-live `29/29`; real
+  Binance BTC backtest and pymoo optimizer smoke pass; extension source stamp,
+  `py_compile`, `cargo fmt --check`, and `git diff --check` pass.
+- Independent preflight: confirmed exactly two prior denominator formulas,
+  identified stale user docs, and verified that dynamic effective slots are an
+  intentional backtest-only input to preserve.
 - Publication state, exact head, mergeability, CI, and current-head review
   verdicts: query live GitHub metadata. Do not encode those transient values in
   the same PR that contains this status file, because every correction would
@@ -54,24 +51,24 @@ Estimated completion:
 
 Next action:
 
-1. Poll PR #1174's exact head, mergeability, CI, and required reviews.
-2. Resolve any verified finding with focused regression coverage.
+1. Complete Rust/PyO3/Python, fake-live, real backtest, and optimizer validation.
+2. Publish a review-ready PR and resolve every verified finding with focused
+   regression coverage.
 3. Merge only after the exact-head gate is satisfied, then perform the declared
    VPS5 restart/smoke validation.
 
 ## Deployed Baseline
 
-- Remote `v8`: `f5395dda`, PR #1173
-- VPS5 repository: `f5395dda`, PR #1173
+- Remote `v8`: `61fbd0eb`, PR #1174
+- VPS5 repository: `61fbd0eb`, PR #1174
 - VPS5 expected bots: five; all are running after the controlled restart
-- Latest immediate and settled smoke: `ok=true`, `hard_failures=0`, all five
-  bots matched, zero failed remote/account-critical/fill-refresh calls, and
-  zero text-log hard/attention matches. Four HSL replays remained active but
-  were neither stale nor long-running. Five deployed
-  `forager.eligibility_changed` events were observed, one per bot, with bounded
-  source/list/operation/symbol payloads.
-- Known VPS5 tracked edit to preserve:
-  `passivbot-rust/src/equity_hard_stop_loss.rs`
+- Latest immediate, settled, and fresh smoke: `ok=true`, `hard_failures=0`, all
+  five bots matched, zero account-critical/fill-refresh failures, and zero
+  text-log hard/attention matches. One non-hard Hyperliquid candle rate-limit
+  event in the settled window cleared in the fresh window. Four HSL replays
+  remained active, non-stale, not long-running, and making progress.
+- The prior tracked Rust formatting edit was already fully present in PR #1174.
+  Its patch backup and autostash were retained on VPS5; tracked status is clean.
 - Preserve local/VPS configs, logs, monitor data, reports, and temporary files
 
 ## Review Gate
@@ -94,12 +91,11 @@ Next action:
 
 ## Next Slice
 
-The shared HSL episode-finalization transition is the first prerequisite for
-held-position protective readiness. After it merges and is deployed, reconcile
-the existing coin-mode live/backtest slot-budget denominator mismatch in its
-own behavior PR, then continue with immutable candidate replay and held-first
-protective sequencing. The design must preserve exact HSL reconstruction and
-keep observability events out of the decision authority. Remaining candidates:
+The coin-mode denominator parity correction is the active second prerequisite
+for held-position protective readiness. After it merges and is deployed,
+continue with immutable candidate replay and held-first protective sequencing.
+The design must preserve exact HSL reconstruction and keep observability events
+out of the decision authority. Remaining candidates:
 
 - realistic-scale replay fixtures and deeper internal-stage profiling
 - held-position protective-readiness source events and sequencing

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,21 +19,22 @@ Last updated: 2026-07-10.
 
 Current `origin/v8` head:
 
-- `f5395dda` after PR #1173, `Emit bounded forager eligibility events`.
+- `61fbd0eb` after PR #1174, `Centralize HSL episode finalization in Rust`.
 
 Current logging-overhaul head:
 
-- `f5395dda` after PR #1173, `Emit bounded forager eligibility events`
+- `61fbd0eb` after PR #1174, `Centralize HSL episode finalization in Rust`
   (latest merged logging-overhaul slice).
 
 Current work:
 
-- Branch `codex/v8-hsl-startup-transition-contract` centralizes post-RED
-  episode finalization in a pure Rust transition used by backtest and Python
-  live/history replay. It owns caller-supplied persistent no-restart peak/
-  drawdown evaluation, policy, disposition, and exact cooldown deadline;
-  coin live restart retains that peak like pside/backtest. Trigger math, history proof,
-  replay scheduling, exchange I/O, and order supervision are unchanged.
+- Branch `codex/v8-hsl-coin-denominator-parity` moves coin-HSL slot-budget and
+  raw-drawdown math into one Rust primitive used by backtest and Python
+  live/history replay. TWEL remains an activation/validation input but no
+  longer scales HSL sensitivity; dynamic effective slot count remains an
+  intentional backtest-only input. Rust `209/209`, default-feature test
+  compilation, focused Python `139/139`, fake-live `29/29`, a real Binance BTC
+  backtest, and a pymoo optimizer smoke pass.
 
 Current review gate:
 
@@ -64,6 +65,19 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1174 merged to `v8` as `61fbd0eb` after exact-head Hermes and Grok 4.5
+  green reviews plus green CI. VPS5 backed up the known Rust formatting patch,
+  pulled with autostash, and verified the patch was already fully represented
+  in merged `HEAD` before resolving the redundant conflict to a clean tracked
+  tree; both patch backup and autostash remain available. The release extension
+  was rebuilt and its loaded source stamp matched current Rust sources. All
+  five bots stopped after two exact-pane Ctrl-C grace windows, with no SIGTERM,
+  and restarted from `/root/bots_vps5.yaml`. Immediate, settled, and fresh
+  smoke reports returned `ok=true`, `hard_failures=0`, all five bots matched,
+  zero account-critical/fill-refresh failures, and zero text-log hard/attention
+  matches. One non-hard Hyperliquid candle rate-limit event in the settled
+  window cleared in the fresh window; four coin-HSL replays remained active,
+  non-stale, not long-running, and making progress.
 - PR #1173 merged to `v8` as `f5395dda` after exact-head Hermes and Grok 4.5
   approvals plus green CI. VPS5 pulled with autostash, preserving the known
   tracked Rust edit and local artifacts, then all five bots restarted from

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -28,7 +28,7 @@ Current logging-overhaul head:
 
 Current work:
 
-- Branch `codex/v8-hsl-coin-denominator-parity` moves coin-HSL slot-budget and
+- PR #1175 (`codex/v8-hsl-coin-denominator-parity`) moves coin-HSL slot-budget and
   raw-drawdown math into one Rust primitive used by backtest and Python
   live/history replay. TWEL remains an activation/validation input but no
   longer scales HSL sensitivity; dynamic effective slot count remains an

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -162,6 +162,10 @@ Related detailed plans:
      parity PR before using full-replay equivalence as the held-readiness gate.
      The current prerequisite branch separately centralizes post-episode
      no-restart/cooldown finalization in Rust without changing trigger math.
+   - 2026-07-10: PR #1174 merged and deployed the shared post-episode
+     transition. The dependent denominator-parity branch now moves coin slot
+     budget/raw drawdown into Rust, removes TWEL scaling from backtest, and
+     preserves TWEL activation plus intentional dynamic backtest slot counts.
 
 1. [x] Incident bundle generator.
    Status: initial implementation plus trace-report integration merged.

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -876,6 +876,10 @@ Each slice should update this checklist with its result.
      Independent preflight also found an existing coin-mode slot-budget
      denominator mismatch between live and backtest; reconcile that in a
      focused parity PR before relying on held-pair equivalence.
+   - Status: the dependent parity branch now centralizes coin slot-budget and
+     raw-drawdown math in Rust for live/replay and backtest. TWEL remains an
+     activation/validation input, while configured live slots and intentional
+     dynamic backtest slots remain caller-owned inputs.
 
 4. [ ] Full replay lower-complexity slice.
    - Replace avoidable nested scans and repeated fill/timeline work with exact

--- a/docs/risk_management.md
+++ b/docs/risk_management.md
@@ -280,10 +280,11 @@ This stateless contract has important operational consequences:
    realized-loss gating, and auto-unstuck allowance. Shortening it reduces
    historical memory; lengthening it can expose older drawdown or cooldown
    events.
-5. Changing HSL thresholds, signal mode, `n_positions`, TWEL, or lookback
-   settings can retroactively change reconstructed RED, cooldown, and
-   no-restart decisions. Review those changes as risk-policy changes, not just
-   parameter tuning.
+5. Changing HSL thresholds, signal mode, `n_positions`, TWEL activation
+   (zero/non-zero), or lookback settings can retroactively change reconstructed
+   RED, cooldown, and no-restart decisions. Positive TWEL magnitude does not
+   scale coin-HSL sensitivity. Review these changes as risk-policy changes, not
+   just parameter tuning.
 6. If HSL replay data is missing or incomplete, the bot should fail or defer
    visibly rather than substituting a safe-looking neutral drawdown.
 

--- a/passivbot-rust/src/backtest.rs
+++ b/passivbot-rust/src/backtest.rs
@@ -4783,26 +4783,25 @@ impl<'a> Backtest<'a> {
         }
         let (peak_realized, last_realized) = self.effective_coin_pnl_cumsum(k, idx, pside);
         let current_upnl = self.unrealized_pnl_coin_pside(idx, pside, k)?;
-        let drawdown_usd = (peak_realized - (last_realized + current_upnl)).max(0.0);
-        let slot_budget =
-            self.balance.usd_total_balance * total_wallet_exposure_limit / n_positions as f64;
-        if !slot_budget.is_finite() || slot_budget <= 0.0 {
-            return Err(format!(
-                "invalid coin HSL slot budget at k {} coin {} pside {}: balance={} twel={} n_positions={}",
-                k,
-                idx,
-                pside,
-                self.balance.usd_total_balance,
-                total_wallet_exposure_limit,
-                n_positions
-            ));
-        }
-        Ok((
-            drawdown_usd / slot_budget.max(f64::EPSILON),
+        let signal = ehsl::coin_drawdown_signal(
+            self.balance.usd_total_balance,
+            n_positions,
             peak_realized,
             last_realized,
             current_upnl,
-            slot_budget,
+        )
+        .map_err(|e| {
+            format!(
+                "invalid coin HSL drawdown signal at k {} coin {} pside {}: {}",
+                k, idx, pside, e
+            )
+        })?;
+        Ok((
+            signal.drawdown_raw,
+            peak_realized,
+            last_realized,
+            current_upnl,
+            signal.slot_budget,
         ))
     }
 
@@ -7547,8 +7546,9 @@ mod tests {
         };
         bt.balance.usd_total_balance = 100.0;
 
-        // slot budget = balance * TWEL / n_positions = 100 * 4 / 4 = 100;
-        // RED at drawdown >= 50.
+        // HSL slot budget = balance / configured n_positions = 100 / 4 = 25;
+        // TWEL is intentionally not part of HSL sensitivity. RED at drawdown
+        // >= 12.5.
         bt.record_coin_rolling_pnl(0, 0, LONG, 0.0);
         bt.equities.timestamps_ms.push(0);
         bt.equities.usd_total_equity.push(100.0);
@@ -7590,15 +7590,17 @@ mod tests {
     }
 
     #[test]
-    fn hard_stop_coin_signal_uses_static_configured_slot_budget() {
+    fn hard_stop_coin_signal_uses_configured_slot_budget() {
         let hlcvs = Array3::from_shape_vec((2, 2, 4), vec![100.0; 2 * 2 * 4]).unwrap();
         let btc_usd_prices = Array1::from_vec(vec![20_000.0, 20_000.0]);
 
         let make_bp = || {
             let mut bp_pair = BotParamsPair::default();
             bp_pair.long.n_positions = 4;
-            bp_pair.long.total_wallet_exposure_limit = 4.0;
-            bp_pair.long.wallet_exposure_limit = 1.0;
+            // A non-unit TWEL makes this a regression pin: HSL still uses
+            // balance / n_positions, not balance * TWEL / n_positions.
+            bp_pair.long.total_wallet_exposure_limit = 0.5;
+            bp_pair.long.wallet_exposure_limit = 0.125;
             bp_pair.long.ema_span_0 = 10.0;
             bp_pair.long.ema_span_1 = 20.0;
             bp_pair.long.hsl_enabled = true;
@@ -7671,7 +7673,17 @@ mod tests {
         assert_eq!(bt.hard_stop_coin[LONG][0].tier, ehsl::HardStopTier::Red);
         assert_eq!(bt.hard_stop_coin[LONG][1].tier, ehsl::HardStopTier::Green);
         assert_eq!(bt.hard_stop_drawdown_samples_pside[LONG].len(), 2);
-        assert!((bt.hard_stop_drawdown_samples_pside[LONG][1] - 0.8).abs() < 1e-12);
+        // Runtime projection floors synthetic equity at epsilon, so exported
+        // HSL drawdown_raw saturates at approximately 1.0.
+        assert!((bt.hard_stop_drawdown_samples_pside[LONG][1] - 1.0).abs() < 1e-12);
+
+        for twel in [1.0, 4.0] {
+            bt.bot_params_master.long.total_wallet_exposure_limit = twel;
+            let (drawdown_raw, _, _, _, slot_budget) =
+                bt.hard_stop_coin_drawdown_ratio(1, 0, LONG).unwrap();
+            assert!((slot_budget - 25.0).abs() < 1e-12);
+            assert!((drawdown_raw - 3.2).abs() < 1e-12);
+        }
 
         bt.hard_stop_coin[LONG][0].panic_close_event_start_equity_usd = Some(100.0);
         bt.hard_stop_coin[LONG][0].panic_close_event_loss_usd = 10.0;
@@ -7691,7 +7703,7 @@ mod tests {
     }
 
     #[test]
-    fn hard_stop_coin_signal_uses_dynamic_effective_slot_budget_when_enabled() {
+    fn hard_stop_coin_signal_uses_dynamic_slots_without_twel_scaling() {
         let hlcvs = Array3::from_shape_vec((2, 2, 4), vec![100.0; 2 * 2 * 4]).unwrap();
         let btc_usd_prices = Array1::from_vec(vec![20_000.0, 20_000.0]);
 
@@ -7770,9 +7782,12 @@ mod tests {
         bt.record_hard_stop_coin_drawdown_sample(LONG);
 
         assert_eq!(bt.effective_n_positions.long, 2);
-        assert_eq!(bt.hard_stop_coin[LONG][0].tier, ehsl::HardStopTier::Orange);
+        assert_eq!(bt.configured_n_positions.long, 4);
+        assert_eq!(bt.hard_stop_coin[LONG][0].tier, ehsl::HardStopTier::Red);
         assert_eq!(bt.hard_stop_drawdown_samples_pside[LONG].len(), 2);
-        assert!((bt.hard_stop_drawdown_samples_pside[LONG][1] - 0.4).abs() < 1e-12);
+        // Dynamic availability selects two slots, but TWEL=4.0 does not scale
+        // the HSL denominator: 80 / (100 / 2) = 1.6.
+        assert!((bt.hard_stop_drawdown_samples_pside[LONG][1] - 1.0).abs() < 1e-12);
     }
 
     #[test]
@@ -8186,7 +8201,7 @@ mod tests {
             vec![0, 60_000]
         );
         assert_eq!(bt.hard_stop_drawdown_samples_pside[LONG].len(), 2);
-        assert!((bt.hard_stop_drawdown_samples_pside[LONG][1] - 0.8).abs() < 1e-12);
+        assert!((bt.hard_stop_drawdown_samples_pside[LONG][1] - 1.0).abs() < 1e-12);
     }
 
     #[test]

--- a/passivbot-rust/src/equity_hard_stop_loss.rs
+++ b/passivbot-rust/src/equity_hard_stop_loss.rs
@@ -148,6 +148,55 @@ impl RollingPeakTracker {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CoinDrawdownSignal {
+    pub slot_budget: f64,
+    pub drawdown_usd: f64,
+    pub drawdown_raw: f64,
+}
+
+/// Derive the shared coin-HSL drawdown signal for live and backtest callers.
+///
+/// HSL is a drawdown stop, not an exposure scaler. The slot budget therefore
+/// uses account balance divided by the caller's applicable slot count; TWEL is
+/// intentionally not an input to this contract. Live supplies configured
+/// slots, while backtests may supply effective tradability-aware slots.
+pub fn coin_drawdown_signal(
+    balance: f64,
+    n_positions: usize,
+    peak_realized: f64,
+    last_realized: f64,
+    current_upnl: f64,
+) -> Result<CoinDrawdownSignal, String> {
+    if !balance.is_finite() || balance <= 0.0 {
+        return Err("balance must be finite and > 0".to_string());
+    }
+    if n_positions == 0 {
+        return Err("n_positions must be > 0".to_string());
+    }
+    if !peak_realized.is_finite() {
+        return Err("peak_realized must be finite".to_string());
+    }
+    if !last_realized.is_finite() {
+        return Err("last_realized must be finite".to_string());
+    }
+    if !current_upnl.is_finite() {
+        return Err("current_upnl must be finite".to_string());
+    }
+
+    let slot_budget = balance / n_positions as f64;
+    if !slot_budget.is_finite() || slot_budget <= 0.0 {
+        return Err("slot_budget must be finite and > 0".to_string());
+    }
+    let drawdown_usd = (peak_realized - (last_realized + current_upnl)).max(0.0);
+    let drawdown_raw = drawdown_usd / slot_budget;
+    Ok(CoinDrawdownSignal {
+        slot_budget,
+        drawdown_usd,
+        drawdown_raw,
+    })
+}
+
 /// Whether the permanent no-restart halt trips for a finalized RED stop.
 ///
 /// Contract (fable audit plan, clarified 2026-07-06): the no-restart trigger
@@ -514,6 +563,27 @@ mod tests {
         assert!(!s.red_active_now);
         assert!(state.red_seen_in_episode);
         assert_ne!(s.tier, HardStopTier::Red);
+    }
+
+    #[test]
+    fn coin_drawdown_signal_uses_caller_supplied_slot_count() {
+        let signal = coin_drawdown_signal(100.0, 4, 2.0, -1.0, -2.5).unwrap();
+        assert!((signal.slot_budget - 25.0).abs() < 1e-12);
+        assert!((signal.drawdown_usd - 5.5).abs() < 1e-12);
+        assert!((signal.drawdown_raw - 0.22).abs() < 1e-12);
+
+        let fewer_slots = coin_drawdown_signal(100.0, 2, 2.0, -1.0, -2.5).unwrap();
+        assert!((fewer_slots.slot_budget - 50.0).abs() < 1e-12);
+        assert!((fewer_slots.drawdown_raw - 0.11).abs() < 1e-12);
+    }
+
+    #[test]
+    fn coin_drawdown_signal_rejects_invalid_inputs() {
+        assert!(coin_drawdown_signal(0.0, 1, 0.0, 0.0, 0.0).is_err());
+        assert!(coin_drawdown_signal(100.0, 0, 0.0, 0.0, 0.0).is_err());
+        assert!(coin_drawdown_signal(100.0, 1, f64::NAN, 0.0, 0.0).is_err());
+        assert!(coin_drawdown_signal(100.0, 1, 0.0, f64::INFINITY, 0.0).is_err());
+        assert!(coin_drawdown_signal(100.0, 1, 0.0, 0.0, f64::NAN).is_err());
     }
 
     #[test]

--- a/passivbot-rust/src/lib.rs
+++ b/passivbot-rust/src/lib.rs
@@ -69,6 +69,7 @@ fn passivbot_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(calc_unstucking_close_py, m)?)?;
     m.add_function(wrap_pyfunction!(trailing_bundle_default_py, m)?)?;
     m.add_function(wrap_pyfunction!(hsl_no_restart_triggered, m)?)?;
+    m.add_function(wrap_pyfunction!(hsl_coin_drawdown_signal, m)?)?;
     m.add_function(wrap_pyfunction!(hsl_red_episode_finalization, m)?)?;
     m.add_function(wrap_pyfunction!(update_trailing_bundle_py, m)?)?;
     m.add_function(wrap_pyfunction!(equity_hard_stop_step_py, m)?)?;

--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -542,6 +542,31 @@ pub fn hsl_no_restart_triggered(
 }
 
 #[pyfunction]
+#[pyo3(signature = (*, balance, n_positions, peak_realized, last_realized, current_upnl))]
+pub fn hsl_coin_drawdown_signal(
+    py: Python<'_>,
+    balance: f64,
+    n_positions: usize,
+    peak_realized: f64,
+    last_realized: f64,
+    current_upnl: f64,
+) -> PyResult<Py<PyDict>> {
+    let result = ehsl::coin_drawdown_signal(
+        balance,
+        n_positions,
+        peak_realized,
+        last_realized,
+        current_upnl,
+    )
+    .map_err(PyValueError::new_err)?;
+    let out = PyDict::new_bound(py);
+    out.set_item("slot_budget", result.slot_budget)?;
+    out.set_item("drawdown_usd", result.drawdown_usd)?;
+    out.set_item("drawdown_raw", result.drawdown_raw)?;
+    Ok(out.unbind())
+}
+
+#[pyfunction]
 #[pyo3(signature = (
     *,
     restart_after_red_policy,

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -3446,17 +3446,21 @@ def _equity_hard_stop_apply_coin_metrics_sample(
         raise ValueError(
             f"coin HSL n_positions must round to > 0 for {symbol} {pside}, got {n_positions_raw}"
         )
-    # HSL is a drawdown stop, not an exposure scaler. Keep coin-mode live HSL
-    # sensitivity anchored to the configured slot count; TWEL/excess allowance
-    # must not make the RED threshold tolerate a larger percentage drawdown.
-    slot_budget = float(balance) / n_positions
-    if not math.isfinite(slot_budget) or slot_budget <= 0.0:
-        raise ValueError(
-            f"coin HSL slot_budget must be finite and > 0 for {symbol} {pside}, "
-            f"got balance={balance} n_positions={n_positions}"
+    signal = pbr.hsl_coin_drawdown_signal(
+        balance=float(balance),
+        n_positions=n_positions,
+        peak_realized=float(peak_realized),
+        last_realized=float(last_realized),
+        current_upnl=float(current_upnl),
+    )
+    if not isinstance(signal, dict):
+        raise TypeError(
+            "passivbot_rust.hsl_coin_drawdown_signal() must return a dict, "
+            f"got {type(signal).__name__}"
         )
-    drawdown_usd = max(0.0, float(peak_realized) - (float(last_realized) + float(current_upnl)))
-    drawdown_ratio = drawdown_usd / max(slot_budget, 1e-12)
+    slot_budget = float(signal["slot_budget"])
+    drawdown_usd = float(signal["drawdown_usd"])
+    drawdown_ratio = float(signal["drawdown_raw"])
     if last_metrics is not None and int(last_metrics["timestamp_ms"]) // 60_000 == current_minute:
         same_inputs = (
             str(last_metrics.get("signal_mode")) == "coin"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,35 @@ def _install_passivbot_rust_stub():
 
     stub.hsl_no_restart_triggered = _hsl_no_restart_triggered
 
+    def _hsl_coin_drawdown_signal(
+        *, balance, n_positions, peak_realized, last_realized, current_upnl
+    ):
+        balance = float(balance)
+        n_positions = int(n_positions)
+        peak_realized = float(peak_realized)
+        last_realized = float(last_realized)
+        current_upnl = float(current_upnl)
+        if not math.isfinite(balance) or balance <= 0.0:
+            raise ValueError("balance must be finite and > 0")
+        if n_positions <= 0:
+            raise ValueError("n_positions must be > 0")
+        for name, value in (
+            ("peak_realized", peak_realized),
+            ("last_realized", last_realized),
+            ("current_upnl", current_upnl),
+        ):
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+        slot_budget = balance / n_positions
+        drawdown_usd = max(0.0, peak_realized - (last_realized + current_upnl))
+        return {
+            "slot_budget": slot_budget,
+            "drawdown_usd": drawdown_usd,
+            "drawdown_raw": drawdown_usd / slot_budget,
+        }
+
+    stub.hsl_coin_drawdown_signal = _hsl_coin_drawdown_signal
+
     def _hsl_red_episode_finalization(
         *,
         restart_after_red_policy,

--- a/tests/test_equity_hard_stop_rolling_peak.py
+++ b/tests/test_equity_hard_stop_rolling_peak.py
@@ -12,6 +12,26 @@ pbr_is_stub = bool(getattr(pbr, "__is_stub__", False)) if pbr is not None else F
     pbr is None or pbr_is_stub,
     reason="passivbot_rust extension not available",
 )
+def test_coin_drawdown_signal_binding_uses_caller_supplied_slot_count():
+    out = pbr.hsl_coin_drawdown_signal(
+        balance=100.0,
+        n_positions=4,
+        peak_realized=2.0,
+        last_realized=-1.0,
+        current_upnl=-2.5,
+    )
+
+    assert out == {
+        "slot_budget": pytest.approx(25.0),
+        "drawdown_usd": pytest.approx(5.5),
+        "drawdown_raw": pytest.approx(0.22),
+    }
+
+
+@pytest.mark.skipif(
+    pbr is None or pbr_is_stub,
+    reason="passivbot_rust extension not available",
+)
 def test_red_episode_finalization_binding_returns_explicit_disposition():
     out = pbr.hsl_red_episode_finalization(
         restart_after_red_policy="threshold",


### PR DESCRIPTION
## Summary\n- centralize coin-HSL slot-budget and raw-drawdown math in one Rust primitive used by Python live/replay and Rust backtest\n- remove TWEL from the backtest denominator so positive TWEL magnitude cannot weaken the configured HSL threshold\n- preserve TWEL activation/validation and intentional dynamic effective slot counts in backtests\n- correct stale user documentation and record PR #1174 deployment evidence\n\n## Scope category\nTrading-path / Rust risk behavior parity.\n\n## Behavior impact\nLive coin-HSL semantics are unchanged: slot budget remains balance divided by configured n_positions. Backtests now match the no-TWEL-scaling contract. Historical backtest and optimizer results with coin HSL and TWEL other than 1.0 may change.\n\n## Ownership boundary\nRust owns shared slot-budget and raw-drawdown math. Python still owns live/history signal construction and configured slot lookup. Backtest still owns deterministic effective-slot selection when dynamic_wel_by_tradability is enabled.\n\n## Non-goals\n- no TWEL activation or validation change\n- no dynamic slot-count policy change\n- no RED tier, EMA, cooldown, or episode-finalization change\n- no replay ordering/concurrency change\n- no exchange behavior or new observability event\n\n## Validation\n- cargo test --no-default-features: 209 passed\n- cargo check --tests: passed\n- focused coin-HSL Rust tests: 7 passed\n- focused Python HSL/replay/binding suites: 139 passed\n- fake-live regression suite: 29 passed\n- release extension rebuilt; loaded source fingerprint matched branch sources\n- real Binance BTC backtest, 2026-06-01 through 2026-06-03: completion ratio 1.0\n- real pymoo optimizer smoke: completed and shut down cleanly\n- py_compile, cargo fmt --check, and git diff --check: passed\n\n## Reviewer focus\n- TWEL remains an activation/validation input but never reaches denominator math\n- live configured slots and backtest dynamic effective slots remain caller-owned\n- Rust/PyO3 validation and Python integration preserve exact metric behavior\n- expected metric and tier changes are limited to backtest coin HSL with non-unit TWEL\n\n## VPS after merge\nPull with autostash, rebuild and fingerprint-verify the Rust extension, restart the five declared bots using exact panes, then run immediate and settled bounded smoke checks.