### PR TITLE
Prioritize protective coin-HSL replay candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Coin-mode HSL startup now freezes its replay candidate set and reconstructs
+  currently held pairs first, cooldown-affected pairs second, and remaining
+  historical pairs last. Full replay still completes before normal startup;
+  the first pair-progress event now makes the deterministic ordering visible.
+
 - Coin-mode HSL drawdown normalization now uses one Rust-owned live/backtest
   contract: account balance divided by the applicable slot count. TWEL still
   enables the side but no longer scales the HSL denominator, so increasing an

--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -102,6 +102,11 @@ use `hsl.replay.cache` with `cache_status=hit|miss|rejected`; misses and
 rejections are non-authoritative performance-cache outcomes and should fall
 back to exchange-derived replay.
 
+Coin mode emits one `hsl.replay.progress` event with `stage=pair_replay` when
+the first frozen replay candidate starts, then keeps subsequent pair progress
+time-throttled. `is_held_pair`, `is_cooldown_pair`, and `pair_idx` expose the
+deterministic held/cooldown/remaining ordering without controlling it.
+
 ## Event Tags
 
 - `account`

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,50 +22,51 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1175: `Align coin-HSL denominator across live and backtest`
-- Branch: `codex/v8-hsl-coin-denominator-parity`
+- PR: not yet opened; `Prioritize protective coin-HSL replay candidates`
+- Branch: `codex/v8-hsl-held-first-replay`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
-- Base: `61fbd0eb14efe8a3b77535b461eb1bf7c936fe41`
-- Scope: one Rust-owned coin-HSL drawdown primitive shared by Python live/replay
-  and Rust backtest. Slot budget is balance divided by the caller's applicable
-  slot count; TWEL remains an activation/validation input but cannot scale HSL
-  sensitivity.
-- Non-goals: no TWEL activation change, no dynamic-tradability slot-count
-  change, no RED tier/EMA/finalization change, no replay ordering change, no
-  exchange call, and no new observability event.
-- Local validation: Rust `209/209` plus default-feature test compilation pass;
-  focused Python HSL/replay/binding suites `139/139`; fake-live `29/29`; real
-  Binance BTC backtest and pymoo optimizer smoke pass; extension source stamp,
-  `py_compile`, `cargo fmt --check`, and `git diff --check` pass.
-- Independent preflight: confirmed exactly two prior denominator formulas,
-  identified stale user docs, and verified that dynamic effective slots are an
-  intentional backtest-only input to preserve.
+- Base: `493a61a9cb1659927a8d895fb25597b089988527`
+- Scope: freeze the existing coin-HSL replay candidates and order them held
+  pairs first, cooldown-affected pairs second, then all remaining pairs while
+  preserving deterministic relative order. Force one bounded first-pair
+  progress event so deployed ordering is directly observable.
+- Non-goals: no early startup release, background replay, protective-ready
+  claim, fresh-entry readiness change, HSL math/state change, cache contract,
+  exchange call, or backtest behavior change.
+- Local validation: full coin-HSL suite, focused HSL metric/startup/override
+  suites, fake-live marker suite (`21/21`), Rust `209/209`, and a deterministic
+  30-symbol/1440-minute/two-iteration replay benchmark pass. The loaded Rust
+  extension source stamp matches this worktree; `py_compile`, added-line
+  silent-handling audit, and `git diff --check` pass.
+- Independent preflight: confirmed pair-local HSL state and that a mere sort
+  cannot yet make protective orders executable because startup still awaits
+  full replay. The later readiness split needs explicit protective/full state,
+  fresh-entry blocking, shutdown coordination, and dedicated source events.
 - Publication state, exact head, mergeability, CI, and current-head review
   verdicts: query live GitHub metadata. Do not encode those transient values in
   the same PR that contains this status file, because every correction would
   create a different head and immediately stale the embedded value.
-- Expected VPS action: pull with autostash, rebuild and verify the Rust
-  extension, controlled five-bot restart, then immediate and settled bounded
-  smoke reports
+- Expected VPS action: pull while preserving local artifacts, controlled
+  five-bot restart for the live Python runtime change, then immediate and
+  settled bounded smoke reports. No Rust rebuild is required.
 
 Next action:
 
-1. Poll PR #1175's exact head, mergeability, CI, and required reviews.
-2. Resolve every verified finding with focused regression coverage.
-3. Merge only after the exact-head gate is satisfied, then perform the declared
-   VPS5 restart/smoke validation.
+1. Publish the review-ready PR with the exact non-goals above.
+2. Resolve verified findings and merge only after the exact-head gate, then
+   perform the declared VPS5 restart/smoke validation.
 
 ## Deployed Baseline
 
-- Remote `v8`: `61fbd0eb`, PR #1174
-- VPS5 repository: `61fbd0eb`, PR #1174
+- Remote `v8`: `493a61a9`, PR #1175
+- VPS5 repository: `493a61a9`, PR #1175
 - VPS5 expected bots: five; all are running after the controlled restart
 - Latest immediate, settled, and fresh smoke: `ok=true`, `hard_failures=0`, all
-  five bots matched, zero account-critical/fill-refresh failures, and zero
-  text-log hard/attention matches. One non-hard Hyperliquid candle rate-limit
-  event in the settled window cleared in the fresh window. Four HSL replays
-  remained active, non-stale, not long-running, and making progress.
+  five bots matched, zero remote/account-critical/fill-refresh failures, and
+  zero text-log hard/attention matches. The fresh window contained one
+  non-hard Hyperliquid `ema.unavailable` debug event. Three HSL replays were
+  active, non-stale, not long-running, and making progress.
 - The prior tracked Rust formatting edit was already fully present in PR #1174.
   Its patch backup and autostash were retained on VPS5; tracked status is clean.
 - Preserve local/VPS configs, logs, monitor data, reports, and temporary files
@@ -90,11 +91,13 @@ Next action:
 
 ## Next Slice
 
-The coin-mode denominator parity correction is the active second prerequisite
-for held-position protective readiness. After it merges and is deployed,
-continue with immutable candidate replay and held-first protective sequencing.
-The design must preserve exact HSL reconstruction and keep observability events
-out of the decision authority. Remaining candidates:
+The denominator-parity prerequisite is merged and deployed. The active slice
+adds immutable held/cooldown-first candidate ordering without claiming early
+protective readiness. After that foundation merges, split held-position
+protective readiness from full replay while keeping fresh entries blocked until
+their cooldown eligibility is known. The design must preserve exact HSL
+reconstruction and keep observability events out of decision authority.
+Remaining candidates:
 
 - realistic-scale replay fixtures and deeper internal-stage profiling
 - held-position protective-readiness source events and sequencing

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,22 +19,23 @@ Last updated: 2026-07-10.
 
 Current `origin/v8` head:
 
-- `61fbd0eb` after PR #1174, `Centralize HSL episode finalization in Rust`.
+- `493a61a9` after PR #1175, `Align coin-HSL denominator across live and
+  backtest`.
 
 Current logging-overhaul head:
 
-- `61fbd0eb` after PR #1174, `Centralize HSL episode finalization in Rust`
+- `493a61a9` after PR #1175, `Align coin-HSL denominator across live and
+  backtest`
   (latest merged logging-overhaul slice).
 
 Current work:
 
-- PR #1175 (`codex/v8-hsl-coin-denominator-parity`) moves coin-HSL slot-budget and
-  raw-drawdown math into one Rust primitive used by backtest and Python
-  live/history replay. TWEL remains an activation/validation input but no
-  longer scales HSL sensitivity; dynamic effective slot count remains an
-  intentional backtest-only input. Rust `209/209`, default-feature test
-  compilation, focused Python `139/139`, fake-live `29/29`, a real Binance BTC
-  backtest, and a pymoo optimizer smoke pass.
+- Branch `codex/v8-hsl-held-first-replay` freezes coin-HSL replay candidates
+  and orders held pairs first, cooldown pairs second, then remaining pairs.
+  This is the deterministic sequencing foundation only; full replay remains
+  startup-blocking until the later protective/full-readiness split. Full
+  coin-HSL, focused HSL metric/startup/override, fake-live `21/21`, Rust
+  `209/209`, and realistic bounded replay-benchmark validation pass.
 
 Current review gate:
 
@@ -65,6 +66,15 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1175 merged to `v8` as `493a61a9` after exact-head Hermes and Grok 4.5
+  green reviews plus green CI. VPS5 pulled cleanly, rebuilt the Rust extension,
+  and verified its loaded source stamp. All five bots stopped after two
+  exact-pane Ctrl-C grace windows, with no SIGTERM, and restarted from
+  `/root/bots_vps5.yaml`. Immediate, settled, and fresh smoke reports returned
+  `ok=true`, `hard_failures=0`, all five bots matched, zero failed
+  remote/account-critical/fill-refresh calls, and zero text-log hard/attention
+  matches. The fresh window had one non-hard Hyperliquid `ema.unavailable`
+  debug event; three HSL replays remained active and non-stale.
 - PR #1174 merged to `v8` as `61fbd0eb` after exact-head Hermes and Grok 4.5
   green reviews plus green CI. VPS5 backed up the known Rust formatting patch,
   pulled with autostash, and verified the patch was already fully represented

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -880,6 +880,11 @@ Each slice should update this checklist with its result.
      raw-drawdown math in Rust for live/replay and backtest. TWEL remains an
      activation/validation input, while configured live slots and intentional
      dynamic backtest slots remain caller-owned inputs.
+   - Status: the next sequencing slice freezes the existing replay candidate
+     set and processes held pairs first, cooldown-affected pairs second, then
+     remaining pairs with a bounded first-pair progress event. It deliberately
+     keeps full replay startup-blocking; protective/full readiness separation
+     and explicit protective-ready events remain the dependent behavior slice.
 
 4. [ ] Full replay lower-complexity slice.
    - Replace avoidable nested scans and repeated fill/timeline work with exact

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -11,7 +11,7 @@ import time
 import traceback
 from collections import deque
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 import passivbot_rust as pbr
 
@@ -4437,6 +4437,22 @@ def _equity_hard_stop_refresh_halted_runtime_forced_modes(self) -> None:
             )
 
 
+def _hsl_coin_replay_candidate_batches(
+    active_pairs: Iterable[tuple[str, str]],
+    held_pairs: Iterable[tuple[str, str]],
+    cooldown_pairs: Iterable[tuple[str, str]],
+) -> tuple[tuple[tuple[str, str], ...], ...]:
+    """Freeze coin replay candidates into protective-priority batches."""
+    frozen = tuple(active_pairs)
+    held = set(held_pairs)
+    cooldown = set(cooldown_pairs) - held
+    return (
+        tuple(pair for pair in frozen if pair in held),
+        tuple(pair for pair in frozen if pair in cooldown),
+        tuple(pair for pair in frozen if pair not in held and pair not in cooldown),
+    )
+
+
 async def _equity_hard_stop_initialize_from_history(self) -> None:
     if not self._equity_hard_stop_enabled():
         return
@@ -5063,16 +5079,21 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
         pre_replay_elapsed_s = max(0.0, replay_started_s - history_loaded_s)
         last_progress_log_s = replay_started_s
         replay_symbols = set(symbols)
-        active_pairs = [
+        active_pairs = tuple(
             (pside, symbol)
             for pside in self._hsl_psides()
             if self._equity_hard_stop_coin_active_pside(pside)
             for symbol in sorted(replay_symbols)
-        ]
+        )
         active_pair_set = set(active_pairs)
         active_held_pairs = active_pair_set.intersection(current_position_pairs)
         active_panic_pairs = active_pair_set.intersection(panic_replay_pairs)
         active_required_pairs = active_pair_set.intersection(required_replay_pairs)
+        replay_candidate_batches = _hsl_coin_replay_candidate_batches(
+            active_pairs,
+            active_held_pairs,
+            active_panic_pairs,
+        )
         pair_rows_applied: dict[tuple[str, str], int] = {}
         logging.info(
             "[risk] HSL coin history reconstruction loaded | symbols=%d pairs=%d rows=%d fills=%d panic_events=%d",
@@ -5158,13 +5179,18 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             )
 
         pair_idx = 0
-        for pside in self._hsl_psides():
-            check_shutdown("hsl_coin_history_replay_pside")
-            if not self._equity_hard_stop_coin_active_pside(pside):
-                continue
-            for symbol in sorted(replay_symbols):
+        for replay_candidates in replay_candidate_batches:
+            for pside, symbol in replay_candidates:
                 check_shutdown("hsl_coin_history_replay_pair")
                 pair_idx += 1
+                if pair_idx == 1:
+                    log_replay_progress(
+                        pair_idx,
+                        pside,
+                        symbol,
+                        0,
+                        force=True,
+                    )
                 state = self._hsl_coin_state(pside, symbol)
                 contract = self._equity_hard_stop_infer_coin_replay_contract(
                     pside, symbol, fill_events, now_ms

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -60,6 +60,28 @@ def test_hsl_signal_mode_requires_normalized_live_config():
         hsl._equity_hard_stop_signal_mode(bot)
 
 
+def test_hsl_coin_replay_candidate_batches_are_frozen_and_scope_prioritized():
+    active = [
+        ("long", "A"),
+        ("long", "Z"),
+        ("short", "B"),
+        ("long", "C"),
+    ]
+    held = {("long", "Z"), ("short", "B")}
+    cooldown = {("long", "Z"), ("long", "C")}
+
+    batches = hsl._hsl_coin_replay_candidate_batches(active, held, cooldown)
+
+    active.append(("short", "NEW"))
+    held.clear()
+    cooldown.clear()
+    assert batches == (
+        (("long", "Z"), ("short", "B")),
+        (("long", "C"),),
+        (("long", "A"),),
+    )
+
+
 def test_parse_hsl_config_warns_about_history_reinterpretation(caplog):
     bot = FakeHslBot(config={"live": {"hsl_signal_mode": "coin"}})
     values = {
@@ -1782,6 +1804,7 @@ async def test_coin_hsl_history_replay_emits_lifecycle_events():
     assert [event.event_type for event in events] == [
         EventTypes.HSL_REPLAY_STARTED,
         EventTypes.HSL_REPLAY_PROGRESS,
+        EventTypes.HSL_REPLAY_PROGRESS,
         EventTypes.HSL_REPLAY_COMPLETED,
     ]
     assert {event.cycle_id for event in events} == {"cy_hsl_replay"}
@@ -1797,32 +1820,97 @@ async def test_coin_hsl_history_replay_emits_lifecycle_events():
     assert events[1].data["history_fetch_elapsed_s"] is not None
     assert events[1].data["pre_replay_elapsed_s"] is not None
     assert events[1].data["elapsed_s"] is not None
-    assert events[2].status == "succeeded"
-    assert events[2].reason_code == "coin_history_replay_completed"
-    assert events[2].data["rows"] == 2
-    assert events[2].data["applied_rows"] == 2
-    assert events[2].data["pairs"] == 1
-    assert events[2].data["held_pairs"] == 1
-    assert events[2].data["cooldown_pairs"] == 0
-    assert events[2].data["required_pairs"] == 1
-    assert events[2].data["skipped_pairs"] == 0
-    assert events[2].data["timeline_rows"] == 2
-    assert events[2].data["fill_events"] == 0
-    assert events[2].data["panic_events"] == 0
-    assert events[2].data["rows_per_second"] is not None
-    assert events[2].data["history_fetch_elapsed_s"] is not None
-    assert events[2].data["pre_replay_elapsed_s"] is not None
-    assert events[2].data["replay_loop_elapsed_s"] is not None
-    assert events[2].data["full_elapsed_s"] is not None
-    assert events[2].data["startup_blocking_elapsed_s"] is not None
-    assert events[2].data["elapsed_s"] is not None
-    assert events[2].data["history_fetch_elapsed_s"] > 0.0
+    assert events[2].status == "started"
+    assert events[2].reason_code == "pair_replay_progress"
+    assert events[2].data["pair_idx"] == 1
+    assert events[2].data["is_held_pair"] is True
+    assert events[3].status == "succeeded"
+    assert events[3].reason_code == "coin_history_replay_completed"
+    assert events[3].data["rows"] == 2
+    assert events[3].data["applied_rows"] == 2
+    assert events[3].data["pairs"] == 1
+    assert events[3].data["held_pairs"] == 1
+    assert events[3].data["cooldown_pairs"] == 0
+    assert events[3].data["required_pairs"] == 1
+    assert events[3].data["skipped_pairs"] == 0
+    assert events[3].data["timeline_rows"] == 2
+    assert events[3].data["fill_events"] == 0
+    assert events[3].data["panic_events"] == 0
+    assert events[3].data["rows_per_second"] is not None
+    assert events[3].data["history_fetch_elapsed_s"] is not None
+    assert events[3].data["pre_replay_elapsed_s"] is not None
+    assert events[3].data["replay_loop_elapsed_s"] is not None
+    assert events[3].data["full_elapsed_s"] is not None
+    assert events[3].data["startup_blocking_elapsed_s"] is not None
+    assert events[3].data["elapsed_s"] is not None
+    assert events[3].data["history_fetch_elapsed_s"] > 0.0
     phase_elapsed_s = (
-        events[2].data["history_fetch_elapsed_s"]
-        + events[2].data["pre_replay_elapsed_s"]
-        + events[2].data["replay_loop_elapsed_s"]
+        events[3].data["history_fetch_elapsed_s"]
+        + events[3].data["pre_replay_elapsed_s"]
+        + events[3].data["replay_loop_elapsed_s"]
     )
-    assert phase_elapsed_s <= events[2].data["startup_blocking_elapsed_s"] + 0.006
+    assert phase_elapsed_s <= events[3].data["startup_blocking_elapsed_s"] + 0.006
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_history_replay_processes_held_late_symbol_first():
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+
+    bot = make_coin_bot()
+    bot.positions = {
+        "Z": {
+            "long": {"size": 1.0, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+
+    async def fake_history(current_balance=None, **kwargs):
+        return {
+            "timeline": [
+                {
+                    "timestamp": 60_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {
+                        "A": {"long": 0.0, "short": 0.0},
+                        "Z": {"long": 0.0, "short": 0.0},
+                    },
+                    "unrealized_pnl_by_coin_pside": {
+                        "A": {"long": 0.0, "short": 0.0},
+                        "Z": {"long": -1.0, "short": 0.0},
+                    },
+                }
+            ],
+            "panic_flatten_events": [],
+            "fill_events": [],
+        }
+
+    bot.get_balance_equity_history = fake_history
+
+    await bot._equity_hard_stop_initialize_coin_from_history()
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    pair_events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.HSL_REPLAY_PROGRESS
+        and event.reason_code == "pair_replay_progress"
+    ]
+    assert len(pair_events) == 1
+    assert pair_events[0].symbol == "Z"
+    assert pair_events[0].pside == "long"
+    assert pair_events[0].data["pair_idx"] == 1
+    assert pair_events[0].data["pairs"] == 2
+    assert pair_events[0].data["held_pairs"] == 1
+    assert pair_events[0].data["is_held_pair"] is True
+    assert set(bot._equity_hard_stop_coin["long"]) == {"A", "Z"}
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
## Scope

Category: runtime behavior plus bounded HSL observability.

- Freeze the existing coin-HSL replay candidate set.
- Replay held pairs first, panic/cooldown-affected pairs second, then remaining pairs while preserving deterministic relative order.
- Force one bounded first-pair `hsl.replay.progress` event so deployed ordering is directly observable.
- Update the active logging/performance status and user-facing changelog.

## Explicit non-goals

This does **not** release startup before full replay, run replay in the background, claim protective readiness, change fresh-entry readiness, alter HSL math/state/cache contracts, contact exchanges, or change backtest behavior. The later protective/full-readiness split remains a separate dependent PR.

## Expected behavior impact

A late-sorting held pair no longer waits behind unrelated flat pairs for its HSL state reconstruction. Final full-replay state and startup blocking remain unchanged. Event order changes intentionally to expose the first frozen candidate.

## Validation

- `PYTHONPATH=src .../python -m pytest -q tests/test_hsl_coin_mode.py`
- focused HSL metric/startup/override suites: 23 passed
- `PYTHONPATH=src .../python -m pytest -q -m fake_live`: 21 passed
- `cargo test --no-default-features`: 209 passed
- `cargo check --tests`
- loaded Rust extension fingerprint verified against this worktree
- `passivbot tool hsl-replay-benchmark --minutes 1440 --symbols 30 --iterations 2 --compact`
- `py_compile`, added-line silent-handling audit, `cargo fmt --check`, and `git diff --check`

## Reviewer focus

Please verify immutable candidate snapshot semantics, held/cooldown/remaining priority without final-state drift, and that the forced first-pair event cannot affect decision authority.

## VPS action

After exact-head reviews and green CI: pull while preserving local artifacts, controlled five-bot restart for the live Python runtime change, then immediate and settled bounded smoke reports. No Rust rebuild is required.