### PR TITLE
Release coin HSL startup after held replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- Coin-mode HSL startup now freezes its replay candidate set and reconstructs
-  currently held pairs first, cooldown-affected pairs second, and remaining
-  historical pairs last. Full replay still completes before normal startup;
-  the first pair-progress event now makes the deterministic ordering visible.
+- Coin-mode HSL startup now reconstructs currently held pairs before declaring
+  protective readiness, then continues cooldown-affected and remaining flat
+  pairs in one shutdown-owned background replay. Initial entries remain
+  blocked per coin and position side until that pair is reconstructed, while
+  cancellations and panic/reduce-only protection remain available. Replay
+  events and smoke reports distinguish protective-ready time from full replay.
 
 - Coin-mode HSL drawdown normalization now uses one Rust-owned live/backtest
   contract: account balance divided by the applicable slot count. TWEL still

--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -95,8 +95,9 @@ across time.
 
 ## HSL Replay Timing Fields
 
-For `hsl.replay.completed`, `full_elapsed_s`, `startup_blocking_elapsed_s`, and
-`elapsed_s` measure total blocking startup time for the replay. Use
+For coin-mode `hsl.replay.completed`, `full_elapsed_s` measures total replay
+time, while `protective_elapsed_s` and `startup_blocking_elapsed_s` measure the
+time until all currently held pairs are protectively ready. Use
 `replay_loop_elapsed_s` for the replay-loop-only duration. Cache status events
 use `hsl.replay.cache` with `cache_status=hit|miss|rejected`; misses and
 rejections are non-authoritative performance-cache outcomes and should fall
@@ -106,6 +107,10 @@ Coin mode emits one `hsl.replay.progress` event with `stage=pair_replay` when
 the first frozen replay candidate starts, then keeps subsequent pair progress
 time-throttled. `is_held_pair`, `is_cooldown_pair`, and `pair_idx` expose the
 deterministic held/cooldown/remaining ordering without controlling it.
+After the held batch completes, `stage=held_protective_ready` exposes bounded
+`ready_pairs`, `pending_pairs`, and `protective_elapsed_s` fields. Remaining
+pairs continue in the same replay task; `hsl.replay.completed` remains the
+full-replay terminal event.
 
 ## Event Tags
 
@@ -183,6 +188,7 @@ deterministic held/cooldown/remaining ordering without controlling it.
 - `hsl_balance_override_account_level_replay_unsafe`
 - `hsl_history_empty`
 - `hsl_history_inputs_loaded`
+- `hsl_held_protective_ready`
 - `hsl_price_history_fetch_completed`
 - `hsl_price_history_fetch_started`
 - `hsl_price_history_symbol_fetch_completed`
@@ -194,6 +200,7 @@ deterministic held/cooldown/remaining ordering without controlling it.
 - `hsl_replay_cache_rejected`
 - `hsl_replay_cache_write_failed`
 - `hsl_replay_cache_written`
+- `hsl_replay_pending`
 - `hsl_timeline_replay_completed`
 - `hsl_timeline_replay_started`
 - `initial_entry_distance_gate`

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,7 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR: not yet opened; `Release coin-HSL startup after held protection`
+- PR: query live GitHub metadata; `Release coin-HSL startup after held protection`
 - Branch: `codex/v8-hsl-protective-readiness`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
@@ -57,9 +57,7 @@ Estimated completion:
 
 Next action:
 
-1. Finish author validation and publish the review-ready PR with the exact
-   non-goals above.
-2. Resolve verified findings and merge only after the exact-head gate, then
+1. Resolve verified findings and merge only after the exact-head gate, then
    perform the declared VPS5 restart/smoke validation.
 
 ## Deployed Baseline

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,27 +22,31 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR: not yet opened; `Prioritize protective coin-HSL replay candidates`
-- Branch: `codex/v8-hsl-held-first-replay`
+- PR: not yet opened; `Release coin-HSL startup after held protection`
+- Branch: `codex/v8-hsl-protective-readiness`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
-- Base: `493a61a9cb1659927a8d895fb25597b089988527`
-- Scope: freeze the existing coin-HSL replay candidates and order them held
-  pairs first, cooldown-affected pairs second, then all remaining pairs while
-  preserving deterministic relative order. Force one bounded first-pair
-  progress event so deployed ordering is directly observable.
-- Non-goals: no early startup release, background replay, protective-ready
-  claim, fresh-entry readiness change, HSL math/state change, cache contract,
-  exchange call, or backtest behavior change.
-- Local validation: full coin-HSL suite, focused HSL metric/startup/override
-  suites, fake-live marker suite (`21/21`), Rust `209/209`, and a deterministic
-  30-symbol/1440-minute/two-iteration replay benchmark pass. The loaded Rust
-  extension source stamp matches this worktree; `py_compile`, added-line
-  silent-handling audit, and `git diff --check` pass.
-- Independent preflight: confirmed pair-local HSL state and that a mere sort
-  cannot yet make protective orders executable because startup still awaits
-  full replay. The later readiness split needs explicit protective/full state,
-  fresh-entry blocking, shutdown coordination, and dedicated source events.
+- Base: `078a3fead1dc635877b9142cb394dd93e3747d54`
+- Scope: run the existing exact held-first coin replay in one task, release
+  startup after every held pair is protectively ready, and continue remaining
+  pairs in the background. Keep pending pairs blocked from initial-entry
+  creates at both planning and final submission while allowing cancellations
+  and panic/reduce-only creates. Expose protective/full timing and pair counts.
+- Non-goals: no HSL math/state contract change, replay algorithm rewrite,
+  checkpoint/cache schema change, exchange-call change, backtest behavior
+  change, or claim that cold history materialization itself is now fast.
+- Local validation: full coin-HSL, order-orchestration, exchange-config,
+  live-smoke-report, and live-event-bus suites; six focused realized-loss/HSL
+  tests; nine fake-live HSL/replay scenarios; Rust `209/209`, `cargo check
+  --tests`, and `cargo fmt --check`; and the deterministic 30-symbol,
+  1440-minute, two-iteration replay benchmark pass. The rebuilt extension stamp
+  matches this worktree; `py_compile`, reviewed added-line exception handling,
+  and `git diff --check` pass.
+- Independent preflight: one read-only test-surface audit identified the
+  existing replay, order, fake-live, smoke, and shutdown fixtures used by this
+  slice. Runtime design keeps one writer per pending pair and never rebuilds
+  shared HSL state after startup release. A separate current-diff concurrency
+  and safety review reported no P0-P2 findings.
 - Publication state, exact head, mergeability, CI, and current-head review
   verdicts: query live GitHub metadata. Do not encode those transient values in
   the same PR that contains this status file, because every correction would
@@ -53,20 +57,21 @@ Estimated completion:
 
 Next action:
 
-1. Publish the review-ready PR with the exact non-goals above.
+1. Finish author validation and publish the review-ready PR with the exact
+   non-goals above.
 2. Resolve verified findings and merge only after the exact-head gate, then
    perform the declared VPS5 restart/smoke validation.
 
 ## Deployed Baseline
 
-- Remote `v8`: `493a61a9`, PR #1175
-- VPS5 repository: `493a61a9`, PR #1175
+- Remote `v8`: `078a3fea`, PR #1176
+- VPS5 repository: `078a3fea`, PR #1176
 - VPS5 expected bots: five; all are running after the controlled restart
-- Latest immediate, settled, and fresh smoke: `ok=true`, `hard_failures=0`, all
-  five bots matched, zero remote/account-critical/fill-refresh failures, and
-  zero text-log hard/attention matches. The fresh window contained one
-  non-hard Hyperliquid `ema.unavailable` debug event. Three HSL replays were
-  active, non-stale, not long-running, and making progress.
+- Latest immediate and settled smoke: `ok=true`, `hard_failures=0`, all five
+  bots matched, zero remote/account-critical/fill-refresh failures, and zero
+  text-log hard/attention matches. Four HSL replays were active and non-stale;
+  KuCoin completed, and the only extra settled-window signals were non-hard
+  Hyperliquid EMA/state-refresh events.
 - The prior tracked Rust formatting edit was already fully present in PR #1174.
   Its patch backup and autostash were retained on VPS5; tracked status is clean.
 - Preserve local/VPS configs, logs, monitor data, reports, and temporary files
@@ -91,12 +96,11 @@ Next action:
 
 ## Next Slice
 
-The denominator-parity prerequisite is merged and deployed. The active slice
-adds immutable held/cooldown-first candidate ordering without claiming early
-protective readiness. After that foundation merges, split held-position
-protective readiness from full replay while keeping fresh entries blocked until
-their cooldown eligibility is known. The design must preserve exact HSL
-reconstruction and keep observability events out of decision authority.
+The denominator-parity and immutable held/cooldown-first ordering prerequisites
+are merged and deployed. The active slice splits held-position protective
+readiness from full replay while keeping fresh entries blocked until their
+pair-specific cooldown eligibility is known. The design preserves exact HSL
+reconstruction and keeps observability events out of decision authority.
 Remaining candidates:
 
 - realistic-scale replay fixtures and deeper internal-stage profiling

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -68,14 +68,14 @@ slices.
 
 ### Goal 2: Remove HSL Broad Replay From The Protective Critical Path
 
-- [ ] A held `coin+pside` must not wait behind unrelated flat coins before its
+- [x] A held `coin+pside` must not wait behind unrelated flat coins before its
   exact HSL state is known.
-- [ ] HSL startup must expose separate states for account-critical ready,
+- [x] HSL startup must expose separate states for account-critical ready,
   held-position protective ready, fresh-entry/cooldown eligibility unknown,
   and full replay ready.
 - [ ] Current drawdown state takes precedence: a historical red crossing must
   not trigger a new panic if the exact current state is no longer red.
-- [ ] Full historical/cooldown reconstruction may continue after held positions
+- [x] Full historical/cooldown reconstruction may continue after held positions
   are protectively ready, but fresh entries remain blocked for symbols whose
   cooldown/trading eligibility is still unknown.
 - [ ] Acceptance: with 25-30 configured pairs and one held position,
@@ -864,7 +864,7 @@ Each slice should update this checklist with its result.
      equivalence checks; realistic-scale fixtures and deeper internal-stage
      profiling remain open.
 
-3. [ ] Held-position protective readiness slice.
+3. [x] Held-position protective readiness slice.
    - Classify currently held `coin+pside` pairs before unrelated flat pairs and
      emit explicit `hsl_protective_*` state events.
    - Acceptance: held-pair state matches existing full replay in tests, and a
@@ -880,11 +880,15 @@ Each slice should update this checklist with its result.
      raw-drawdown math in Rust for live/replay and backtest. TWEL remains an
      activation/validation input, while configured live slots and intentional
      dynamic backtest slots remain caller-owned inputs.
-   - Status: the next sequencing slice freezes the existing replay candidate
+   - Status: the sequencing slice freezes the existing replay candidate
      set and processes held pairs first, cooldown-affected pairs second, then
      remaining pairs with a bounded first-pair progress event. It deliberately
-     keeps full replay startup-blocking; protective/full readiness separation
-     and explicit protective-ready events remain the dependent behavior slice.
+     originally kept full replay startup-blocking. The dependent readiness
+     slice now releases startup after exact held-pair reconstruction, keeps
+     pending pair initial entries blocked at planning and final submission,
+     continues the same replay task under shutdown ownership, and emits bounded
+     protective/full timing plus ready/pending pair counts. Production elapsed
+     acceptance remains to be measured on VPS5 after merge.
 
 4. [ ] Full replay lower-complexity slice.
    - Replace avoidable nested scans and repeated fill/timeline work with exact

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -242,6 +242,7 @@ class ReasonCodes:
     )
     HSL_HISTORY_EMPTY = "hsl_history_empty"
     HSL_HISTORY_INPUTS_LOADED = "hsl_history_inputs_loaded"
+    HSL_HELD_PROTECTIVE_READY = "hsl_held_protective_ready"
     HSL_PRICE_HISTORY_FETCH_COMPLETED = "hsl_price_history_fetch_completed"
     HSL_PRICE_HISTORY_FETCH_STARTED = "hsl_price_history_fetch_started"
     HSL_PRICE_HISTORY_SYMBOL_FETCH_COMPLETED = (
@@ -253,6 +254,7 @@ class ReasonCodes:
     HSL_REPLAY_CACHE_REJECTED = "hsl_replay_cache_rejected"
     HSL_REPLAY_CACHE_WRITTEN = "hsl_replay_cache_written"
     HSL_REPLAY_CACHE_WRITE_FAILED = "hsl_replay_cache_write_failed"
+    HSL_REPLAY_PENDING = "hsl_replay_pending"
     HSL_RAW_RED_PENDING_EMA_CONFIRMATION = "hsl_raw_red_pending_ema_confirmation"
     HSL_RED_FINALIZED_WITHOUT_EXCHANGE_ORDER = (
         "hsl_red_finalized_without_exchange_order"

--- a/src/live/executor.py
+++ b/src/live/executor.py
@@ -77,6 +77,43 @@ def _order_is_protective_create(order: dict) -> bool:
     return _order_is_reduce_only(order) or _order_is_panic(order)
 
 
+def _filter_hsl_replay_pending_creates(
+    bot, passivbot_cls, orders: list[dict], order_wave
+) -> list[dict]:
+    pending_pairs = set(
+        getattr(bot, "_equity_hard_stop_coin_replay_pending_pairs", set()) or set()
+    )
+    if not pending_pairs:
+        return orders
+    blocked = [
+        order
+        for order in orders
+        if not _order_is_protective_create(order)
+        and (
+            str(order.get("position_side") or order.get("positionSide") or "").lower(),
+            str(order.get("symbol") or ""),
+        )
+        in pending_pairs
+    ]
+    if not blocked:
+        return orders
+    blocked_ids = {id(order) for order in blocked}
+    if order_wave is not None:
+        order_wave["skipped_create"] += len(blocked)
+    passivbot_cls._emit_execution_create_filter_event(
+        bot,
+        event_type=EventTypes.EXECUTION_CREATE_SKIPPED,
+        status="skipped",
+        reason_code=ReasonCodes.HSL_REPLAY_PENDING,
+        order_count=len(blocked),
+        symbols=_symbols_from_orders(blocked),
+        wave=order_wave,
+        message="initial-entry creates skipped until coin HSL replay is ready",
+        data={"pending_pairs_count": len(pending_pairs)},
+    )
+    return [order for order in orders if id(order) not in blocked_ids]
+
+
 def _symbols_from_orders(orders: list[dict]) -> list[str]:
     return sorted(str(order["symbol"]) for order in orders if order.get("symbol"))
 
@@ -222,6 +259,9 @@ async def execute_order_plan(
                     len(to_cancel),
                     len(to_create),
                 )
+    to_create = _filter_hsl_replay_pending_creates(
+        bot, passivbot_cls, to_create, order_wave
+    )
     if bot.debug_mode:
         if to_cancel:
             logging.info(

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -4040,6 +4040,8 @@ def _compact_hsl_replay_data(live_event: dict[str, Any]) -> dict[str, Any]:
         "symbols",
         "pairs",
         "held_pairs",
+        "ready_pairs",
+        "pending_pairs",
         "cooldown_pairs",
         "required_pairs",
         "timeline_rows",
@@ -4070,6 +4072,7 @@ def _compact_hsl_replay_data(live_event: dict[str, Any]) -> dict[str, Any]:
         "price_history_fetch_elapsed_s",
         "timeline_replay_elapsed_s",
         "full_elapsed_s",
+        "protective_elapsed_s",
         "startup_blocking_elapsed_s",
     ):
         value = _numeric_value(data.get(key))
@@ -4187,6 +4190,7 @@ def _hsl_replay_derived(data: dict[str, Any]) -> dict[str, Any]:
         ("price_history_fetch_elapsed_s", "price_history_fetch_elapsed_ms"),
         ("timeline_replay_elapsed_s", "timeline_replay_elapsed_ms"),
         ("full_elapsed_s", "full_elapsed_ms"),
+        ("protective_elapsed_s", "protective_elapsed_ms"),
         ("startup_blocking_elapsed_s", "startup_blocking_elapsed_ms"),
     ):
         value = data.get(source_key)
@@ -4261,6 +4265,7 @@ def _merge_hsl_replay_group(
             "latest": None,
             "started": None,
             "loaded": None,
+            "protective_ready": None,
             "progress": None,
             "completed": None,
         }
@@ -4296,6 +4301,12 @@ def _merge_hsl_replay_group(
         and is_newer(record, group.get("loaded"))
     ):
         group["loaded"] = record
+    elif (
+        event_type == EventTypes.HSL_REPLAY_PROGRESS
+        and data.get("stage") == "held_protective_ready"
+        and is_newer(record, group.get("protective_ready"))
+    ):
+        group["protective_ready"] = record
     elif event_type == EventTypes.HSL_REPLAY_PROGRESS and is_newer(
         record, group.get("progress")
     ):
@@ -4351,6 +4362,7 @@ def _hsl_replay_record_elapsed_ms(record: Any) -> int | None:
             "latest_elapsed_ms",
             "startup_blocking_elapsed_ms",
             "full_elapsed_ms",
+            "protective_elapsed_ms",
             "history_build_elapsed_ms",
             "price_history_fetch_elapsed_ms",
             "timeline_replay_elapsed_ms",
@@ -4453,6 +4465,9 @@ def _summarize_hsl_replay_health(
             "latest": latest,
             "started": _public_hsl_replay_record(group.get("started")),
             "loaded": _public_hsl_replay_record(group.get("loaded")),
+            "protective_ready": _public_hsl_replay_record(
+                group.get("protective_ready")
+            ),
             "progress": _public_hsl_replay_record(group.get("progress")),
             "completed": completed,
             "failed": failed,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1280,6 +1280,12 @@ class Passivbot:
         }
         self._equity_hard_stop_coin = {"long": {}, "short": {}}
         self._equity_hard_stop_coin_initialized = False
+        self._equity_hard_stop_coin_protective_ready = False
+        self._equity_hard_stop_coin_replay_ready_pairs = set()
+        self._equity_hard_stop_coin_replay_pending_pairs = set()
+        self._equity_hard_stop_coin_replay_failure = None
+        self._equity_hard_stop_coin_replay_ready_event = None
+        self._equity_hard_stop_coin_replay_task = None
 
     _monitor_record_event = pb_monitor._monitor_record_event
     _monitor_record_error = pb_monitor._monitor_record_error
@@ -1935,6 +1941,9 @@ class Passivbot:
     )
     _equity_hard_stop_initialize_coin_from_history = (
         pb_hsl._equity_hard_stop_initialize_coin_from_history
+    )
+    _equity_hard_stop_start_coin_history_replay = (
+        pb_hsl._equity_hard_stop_start_coin_history_replay
     )
     _equity_hard_stop_log_status = pb_hsl._equity_hard_stop_log_status
     _equity_hard_stop_check = pb_hsl._equity_hard_stop_check
@@ -2996,7 +3005,7 @@ class Passivbot:
                 hsl_mode = self._equity_hard_stop_signal_mode()
                 if hsl_mode == "coin":
                     boot_stage = "equity_hard_stop_initialize_coin_from_history"
-                    await self._equity_hard_stop_initialize_coin_from_history()
+                    await self._equity_hard_stop_start_coin_history_replay()
                 else:
                     await self._equity_hard_stop_initialize_from_history()
                 Passivbot._startup_timing_mark(self, "hsl", details=f"mode={hsl_mode}")
@@ -5331,7 +5340,10 @@ class Passivbot:
         max_n_fails = 10
         if self._equity_hard_stop_enabled():
             if self._equity_hard_stop_signal_mode() == "coin":
-                if not getattr(self, "_equity_hard_stop_coin_initialized", False):
+                if not (
+                    getattr(self, "_equity_hard_stop_coin_initialized", False)
+                    or getattr(self, "_equity_hard_stop_coin_protective_ready", False)
+                ):
                     await self._equity_hard_stop_initialize_coin_from_history()
             elif not all(
                 self._equity_hard_stop_runtime_initialized(pside)
@@ -8345,6 +8357,22 @@ class Passivbot:
                     return "graceful_stop"
                 return self._equity_hard_stop_halted_mode(pside, symbol)
         if symbol is not None:
+            if (
+                self._equity_hard_stop_enabled(pside)
+                and self._equity_hard_stop_signal_mode() == "coin"
+                and (pside, symbol)
+                in getattr(
+                    self, "_equity_hard_stop_coin_replay_pending_pairs", set()
+                )
+            ):
+                configured_mode = self.config_get(
+                    ["live", f"forced_mode_{pside}"], symbol
+                )
+                if configured_mode:
+                    expanded_mode = expand_PB_mode(configured_mode)
+                    if expanded_mode != "normal":
+                        return expanded_mode
+                return "graceful_stop"
             runtime_forced = (
                 getattr(self, "_runtime_forced_modes", {}).get(pside, {}).get(symbol)
             )
@@ -13571,6 +13599,27 @@ class Passivbot:
                 if orange_mode == "tp_only_with_active_entry_cancellation":
                     return "tp_only_with_active_entry_cancellation"
 
+        if (
+            self._equity_hard_stop_enabled(pside)
+            and self._equity_hard_stop_signal_mode() == "coin"
+        ):
+            replay_pending = getattr(
+                self, "_equity_hard_stop_coin_replay_pending_pairs", set()
+            )
+            if (pside, symbol) in replay_pending:
+                configured_mode = self.config_get(
+                    ["live", f"forced_mode_{pside}"], symbol
+                )
+                if configured_mode:
+                    expanded_mode = expand_PB_mode(configured_mode)
+                    if expanded_mode != "normal":
+                        return self._apply_ignored_coin_mode(
+                            pside, symbol, expanded_mode
+                        )
+                return self._apply_ignored_coin_mode(
+                    pside, symbol, "graceful_stop"
+                )
+
         runtime_forced = (
             getattr(self, "_runtime_forced_modes", {}).get(pside, {}).get(symbol)
         )
@@ -17167,7 +17216,10 @@ class Passivbot:
 
     async def start_data_maintainers(self):
         """Spawn background tasks responsible for market metadata and order watching."""
+        hsl_replay_task = getattr(self, "_equity_hard_stop_coin_replay_task", None)
         if hasattr(self, "maintainers"):
+            if self.maintainers.get("hsl_coin_replay") is hsl_replay_task:
+                self.maintainers.pop("hsl_coin_replay")
             self.stop_data_maintainers()
         maintainer_names = ["maintain_hourly_cycle"]
         if self.ws_enabled:
@@ -17180,6 +17232,8 @@ class Passivbot:
             name: asyncio.create_task(getattr(self, name)())
             for name in maintainer_names
         }
+        if hsl_replay_task is not None and not hsl_replay_task.done():
+            self.maintainers["hsl_coin_replay"] = hsl_replay_task
 
     # Legacy websocket 1m ohlcv watchers removed; CandlestickManager is authoritative
 

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -4870,6 +4870,16 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
     prev_stage = getattr(self, "_log_silence_watchdog_stage", "idle")
     raise_if_shutdown = getattr(self, "_raise_if_shutdown_requested", None)
     initialization_started_s = time.monotonic()
+    watchdog_context_restored = False
+    protective_ready_elapsed_s: Optional[float] = None
+    ready_event = getattr(self, "_equity_hard_stop_coin_replay_ready_event", None)
+    if ready_event is None:
+        ready_event = asyncio.Event()
+        self._equity_hard_stop_coin_replay_ready_event = ready_event
+    self._equity_hard_stop_coin_protective_ready = False
+    self._equity_hard_stop_coin_replay_ready_pairs = set()
+    self._equity_hard_stop_coin_replay_pending_pairs = set()
+    self._equity_hard_stop_coin_replay_failure = None
 
     def check_shutdown(stage: str) -> None:
         if callable(raise_if_shutdown):
@@ -5094,6 +5104,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             active_held_pairs,
             active_panic_pairs,
         )
+        self._equity_hard_stop_coin_replay_pending_pairs = set(active_pairs)
         pair_rows_applied: dict[tuple[str, str], int] = {}
         logging.info(
             "[risk] HSL coin history reconstruction loaded | symbols=%d pairs=%d rows=%d fills=%d panic_events=%d",
@@ -5178,8 +5189,52 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 reason_code="pair_replay_progress",
             )
 
+        def mark_pair_ready(pside: str, symbol: str) -> None:
+            pair = (pside, symbol)
+            self._equity_hard_stop_coin_replay_pending_pairs.discard(pair)
+            self._equity_hard_stop_coin_replay_ready_pairs.add(pair)
+
+        def mark_protective_ready() -> None:
+            nonlocal protective_ready_elapsed_s, watchdog_context_restored
+            if self._equity_hard_stop_coin_protective_ready:
+                return
+            self._equity_hard_stop_coin_protective_ready = True
+            startup_blocking_elapsed_s = max(
+                0.0, time.monotonic() - initialization_started_s
+            )
+            protective_ready_elapsed_s = startup_blocking_elapsed_s
+            _emit_hsl_replay_event(
+                self,
+                EventTypes.HSL_REPLAY_PROGRESS,
+                {
+                    "signal_mode": "coin",
+                    "stage": "held_protective_ready",
+                    "held_pairs": len(active_held_pairs),
+                    "ready_pairs": len(
+                        self._equity_hard_stop_coin_replay_ready_pairs
+                    ),
+                    "pending_pairs": len(
+                        self._equity_hard_stop_coin_replay_pending_pairs
+                    ),
+                    "pairs": len(active_pairs),
+                    "startup_blocking_elapsed_s": round(
+                        startup_blocking_elapsed_s, 3
+                    ),
+                    "protective_elapsed_s": round(startup_blocking_elapsed_s, 3),
+                    "elapsed_s": round(startup_blocking_elapsed_s, 3),
+                },
+                status="succeeded",
+                reason_code=ReasonCodes.HSL_HELD_PROTECTIVE_READY,
+            )
+            if hasattr(self, "_set_log_silence_watchdog_context"):
+                self._set_log_silence_watchdog_context(
+                    phase=prev_phase, stage=prev_stage
+                )
+                watchdog_context_restored = True
+            ready_event.set()
+
         pair_idx = 0
-        for replay_candidates in replay_candidate_batches:
+        for batch_idx, replay_candidates in enumerate(replay_candidate_batches):
             for pside, symbol in replay_candidates:
                 check_shutdown("hsl_coin_history_replay_pair")
                 pair_idx += 1
@@ -5594,6 +5649,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                             reason,
                         )
                 if state["halted"]:
+                    mark_pair_ready(pside, symbol)
                     continue
                 if applied_rows == 0:
                     self._equity_hard_stop_prime_coin_runtime_for_replay(pside, symbol, now_ms)
@@ -5613,7 +5669,10 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         realized_pnl_total=float(self._equity_hard_stop_realized_pnl_now()),
                     )
                 pair_rows_applied[(pside, symbol)] = int(applied_rows)
+                mark_pair_ready(pside, symbol)
                 log_replay_progress(pair_idx, pside, symbol, applied_rows)
+            if batch_idx == 0:
+                mark_protective_ready()
         self._equity_hard_stop_coin_initialized = True
         elapsed_s = max(0.0, time.monotonic() - replay_started_s)
         total_elapsed_s = max(0.0, time.monotonic() - initialization_started_s)
@@ -5648,7 +5707,18 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 "pre_replay_elapsed_s": round(pre_replay_elapsed_s, 3),
                 "replay_loop_elapsed_s": round(elapsed_s, 3),
                 "full_elapsed_s": round(total_elapsed_s, 3),
-                "startup_blocking_elapsed_s": round(total_elapsed_s, 3),
+                "startup_blocking_elapsed_s": round(
+                    protective_ready_elapsed_s
+                    if protective_ready_elapsed_s is not None
+                    else total_elapsed_s,
+                    3,
+                ),
+                "protective_elapsed_s": round(
+                    protective_ready_elapsed_s
+                    if protective_ready_elapsed_s is not None
+                    else total_elapsed_s,
+                    3,
+                ),
                 "elapsed_s": round(total_elapsed_s, 3),
                 "cache_reused": bool(cache_reused),
             },
@@ -5668,6 +5738,8 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 exc,
             )
     except asyncio.CancelledError:
+        self._equity_hard_stop_coin_replay_failure = "shutdown_cancelled"
+        ready_event.set()
         _emit_hsl_replay_event(
             self,
             EventTypes.HSL_REPLAY_FAILED,
@@ -5689,6 +5761,10 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
         )
         raise
     except Exception as exc:
+        self._equity_hard_stop_coin_replay_failure = (
+            f"{type(exc).__name__}: {exc}"
+        )
+        ready_event.set()
         _emit_hsl_replay_event(
             self,
             EventTypes.HSL_REPLAY_FAILED,
@@ -5712,8 +5788,51 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
         )
         raise
     finally:
-        if hasattr(self, "_set_log_silence_watchdog_context"):
+        if (
+            not watchdog_context_restored
+            and hasattr(self, "_set_log_silence_watchdog_context")
+        ):
             self._set_log_silence_watchdog_context(phase=prev_phase, stage=prev_stage)
+
+
+async def _equity_hard_stop_start_coin_history_replay(self) -> None:
+    if getattr(self, "_equity_hard_stop_coin_initialized", False):
+        return
+    if getattr(self, "_equity_hard_stop_coin_protective_ready", False):
+        return
+    task = getattr(self, "_equity_hard_stop_coin_replay_task", None)
+    if task is None or task.done():
+        ready_event = asyncio.Event()
+        self._equity_hard_stop_coin_replay_ready_event = ready_event
+
+        async def run_replay() -> None:
+            try:
+                await self._equity_hard_stop_initialize_coin_from_history()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # The initializer already emitted/stored the failure. After
+                # protective readiness, keep held-pair management alive while
+                # unreplayed flat pairs remain explicitly entry-blocked.
+                if not getattr(
+                    self, "_equity_hard_stop_coin_protective_ready", False
+                ):
+                    raise
+
+        task = asyncio.create_task(run_replay(), name="hsl_coin_replay")
+        self._equity_hard_stop_coin_replay_task = task
+        if not isinstance(getattr(self, "maintainers", None), dict):
+            self.maintainers = {}
+        self.maintainers["hsl_coin_replay"] = task
+    ready_event = self._equity_hard_stop_coin_replay_ready_event
+    await ready_event.wait()
+    if not getattr(self, "_equity_hard_stop_coin_protective_ready", False):
+        await task
+        failure = getattr(self, "_equity_hard_stop_coin_replay_failure", None)
+        raise RuntimeError(
+            "coin HSL replay failed before held-position protective readiness"
+            + (f": {failure}" if failure else "")
+        )
 
 
 def _equity_hard_stop_log_status(self, pside: str, metrics: dict) -> None:
@@ -5779,7 +5898,10 @@ async def _equity_hard_stop_check(self) -> Optional[dict]:
     if not self._equity_hard_stop_enabled():
         return None
     if self._equity_hard_stop_signal_mode() == "coin":
-        if not getattr(self, "_equity_hard_stop_coin_initialized", False):
+        if not (
+            getattr(self, "_equity_hard_stop_coin_initialized", False)
+            or getattr(self, "_equity_hard_stop_coin_protective_ready", False)
+        ):
             await self._equity_hard_stop_initialize_coin_from_history()
         return await self._equity_hard_stop_check_coin()
     if not all(
@@ -6033,10 +6155,34 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
     ts_ms = int(self.get_exchange_time())
     out = {}
     symbols = sorted(self._equity_hard_stop_coin_symbols())
+    partial_replay = (
+        getattr(self, "_equity_hard_stop_coin_protective_ready", False)
+        and not getattr(self, "_equity_hard_stop_coin_initialized", False)
+    )
+    ready_pairs = set(
+        getattr(self, "_equity_hard_stop_coin_replay_ready_pairs", set()) or set()
+    )
+    pending_pairs = set(
+        getattr(self, "_equity_hard_stop_coin_replay_pending_pairs", set()) or set()
+    )
+    if partial_replay:
+        newly_held_pending = sorted(
+            pair
+            for pair in pending_pairs
+            if self._equity_hard_stop_has_open_position_symbol(*pair)
+        )
+        if newly_held_pending:
+            rendered = ",".join(f"{pside}:{symbol}" for pside, symbol in newly_held_pending)
+            raise RestartBotException(
+                "coin HSL replay still pending for newly held pair(s); "
+                f"restart required for held-first reconstruction: {rendered}"
+            )
     for pside in self._hsl_psides():
         if not self._equity_hard_stop_coin_active_pside(pside):
             continue
         for symbol in symbols:
+            if partial_replay and (pside, symbol) not in ready_pairs:
+                continue
             state = self._hsl_coin_state(pside, symbol)
             if state["halted"]:
                 if await self._equity_hard_stop_handle_coin_position_during_cooldown(

--- a/tests/test_exchange_config_updates.py
+++ b/tests/test_exchange_config_updates.py
@@ -1403,6 +1403,135 @@ async def test_execute_order_plan_posts_replacement_matching_cancel_same_cycle()
 
 
 @pytest.mark.asyncio
+async def test_execute_order_plan_blocks_pending_hsl_entry_but_allows_cancel_and_close():
+    import passivbot as pb_mod
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_execution_create_filter_event = (
+            pb_mod.Passivbot._emit_execution_create_filter_event
+        )
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _shutdown_requested = pb_mod.Passivbot._shutdown_requested
+        _ensure_freshness_ledger = pb_mod.Passivbot._ensure_freshness_ledger
+
+        debug_mode = False
+        balance_threshold = 0.0
+        quote = "USDT"
+        stop_signal_received = False
+        state_change_detected_by_symbol = set()
+        config = {"live": {}, "_raw_effective": {"live": {}}}
+
+        def __init__(self):
+            self._live_event_current_cycle_id = "cy_hsl_replay_pending"
+            self._live_event_sink = ListEventSink()
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[self._live_event_sink], monitor_sinks=[]
+            )
+            self._equity_hard_stop_coin_replay_pending_pairs = {
+                ("long", "BTC/USDT:USDT")
+            }
+            self.cancelled_orders = None
+            self.config_symbols = None
+            self.created_orders = None
+            self.execution_scheduled = False
+            self._current_planning_snapshot = FreshPlanningSnapshot()
+            self.market_snapshot_provider = FreshMarketSnapshotProvider()
+
+        def get_raw_balance(self):
+            return 100.0
+
+        async def execute_cancellations_parent(self, orders):
+            self.cancelled_orders = list(orders)
+            return list(orders)
+
+        async def update_exchange_configs(self, symbols=None):
+            self.config_symbols = list(symbols or [])
+            return set(symbols or [])
+
+        def order_was_recently_updated(self, order):
+            return 0
+
+        async def execute_orders_parent(self, orders):
+            self.created_orders = list(orders)
+            return list(orders)
+
+        def _current_planning_snapshot_invalid_for_creations(self, symbols):
+            return []
+
+        async def _get_live_market_snapshots(
+            self,
+            symbols,
+            *,
+            max_age_ms=10_000,
+            context="live",
+            allow_completed_candle_fallback=False,
+        ):
+            return await self.market_snapshot_provider.get_snapshots(
+                symbols, max_age_ms=max_age_ms
+            )
+
+        def _live_market_snapshot_max_age_ms(self):
+            return 10_000
+
+        def _record_market_snapshot_surface(self, symbols, snapshots):
+            return None
+
+        def _market_snapshot_signature_invalid(self, symbols):
+            return []
+
+    symbol = "BTC/USDT:USDT"
+    to_cancel = [
+        {
+            "symbol": symbol,
+            "side": "buy",
+            "position_side": "long",
+            "price": 0.9,
+            "qty": 1.0,
+            "reduce_only": False,
+        }
+    ]
+    entry = {
+        "symbol": symbol,
+        "side": "buy",
+        "position_side": "long",
+        "price": 0.9,
+        "qty": 1.0,
+        "reduce_only": False,
+        "pb_order_type": "entry_grid_long",
+    }
+    close = {
+        "symbol": symbol,
+        "side": "sell",
+        "position_side": "long",
+        "price": 1.1,
+        "qty": 1.0,
+        "reduce_only": True,
+        "pb_order_type": "close_grid_long",
+    }
+
+    bot = FakeBot()
+    await pb_mod.Passivbot.execute_order_plan_to_exchange(
+        bot, to_cancel, [entry, close]
+    )
+
+    assert bot.cancelled_orders == to_cancel
+    assert bot.config_symbols == [symbol]
+    assert bot.created_orders == [close]
+    assert bot.execution_scheduled is True
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    skipped = [
+        event
+        for event in bot._live_event_sink.events
+        if event.reason_code == ReasonCodes.HSL_REPLAY_PENDING
+    ]
+    assert len(skipped) == 1
+    assert skipped[0].data["order_count"] == 1
+    assert skipped[0].data["pending_pairs_count"] == 1
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
 async def test_execute_to_exchange_skips_creations_pending_exchange_config():
     import passivbot as pb_mod
 

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -5,6 +5,8 @@ from types import MethodType, SimpleNamespace
 import pytest
 
 from passivbot import Passivbot
+from passivbot_exceptions import RestartBotException
+from live.event_bus import ReasonCodes
 
 pbr = pytest.importorskip("passivbot_rust", reason="passivbot_rust extension not available")
 hsl = pytest.importorskip("passivbot_hsl", reason="live HSL dependencies not available")
@@ -401,7 +403,7 @@ def test_hsl_replay_matrix_cache_try_load_emits_hit_event(tmp_path):
 
 
 def test_hsl_replay_matrix_cache_try_load_emits_miss_event(tmp_path):
-    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
 
     metadata = _hsl_cache_metadata()
     bot = FakeHslBot()
@@ -1528,6 +1530,7 @@ def bind_hsl_methods(bot):
         "_equity_hard_stop_count_blocking_open_orders_symbol",
         "_equity_hard_stop_history_coin_value",
         "_equity_hard_stop_initialize_coin_from_history",
+        "_equity_hard_stop_start_coin_history_replay",
         "_equity_hard_stop_initialize_from_history",
         "_equity_hard_stop_infer_replay_contract",
         "_equity_hard_stop_apply_sample",
@@ -1687,7 +1690,7 @@ def test_coin_hsl_restart_reset_preserves_persistent_no_restart_peak():
 
 @pytest.mark.asyncio
 async def test_coin_hsl_replay_cancels_when_shutdown_requested_after_history_load():
-    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
 
     bot = make_coin_bot()
     bot.stop_signal_received = False
@@ -1745,7 +1748,7 @@ async def test_coin_hsl_replay_cancels_when_shutdown_requested_after_history_loa
 
 @pytest.mark.asyncio
 async def test_coin_hsl_history_replay_emits_lifecycle_events():
-    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline, ReasonCodes
 
     bot = make_coin_bot()
     symbol = "A"
@@ -1805,6 +1808,7 @@ async def test_coin_hsl_history_replay_emits_lifecycle_events():
         EventTypes.HSL_REPLAY_STARTED,
         EventTypes.HSL_REPLAY_PROGRESS,
         EventTypes.HSL_REPLAY_PROGRESS,
+        EventTypes.HSL_REPLAY_PROGRESS,
         EventTypes.HSL_REPLAY_COMPLETED,
     ]
     assert {event.cycle_id for event in events} == {"cy_hsl_replay"}
@@ -1825,31 +1829,39 @@ async def test_coin_hsl_history_replay_emits_lifecycle_events():
     assert events[2].data["pair_idx"] == 1
     assert events[2].data["is_held_pair"] is True
     assert events[3].status == "succeeded"
-    assert events[3].reason_code == "coin_history_replay_completed"
-    assert events[3].data["rows"] == 2
-    assert events[3].data["applied_rows"] == 2
-    assert events[3].data["pairs"] == 1
-    assert events[3].data["held_pairs"] == 1
-    assert events[3].data["cooldown_pairs"] == 0
-    assert events[3].data["required_pairs"] == 1
-    assert events[3].data["skipped_pairs"] == 0
-    assert events[3].data["timeline_rows"] == 2
-    assert events[3].data["fill_events"] == 0
-    assert events[3].data["panic_events"] == 0
-    assert events[3].data["rows_per_second"] is not None
-    assert events[3].data["history_fetch_elapsed_s"] is not None
-    assert events[3].data["pre_replay_elapsed_s"] is not None
-    assert events[3].data["replay_loop_elapsed_s"] is not None
-    assert events[3].data["full_elapsed_s"] is not None
-    assert events[3].data["startup_blocking_elapsed_s"] is not None
-    assert events[3].data["elapsed_s"] is not None
-    assert events[3].data["history_fetch_elapsed_s"] > 0.0
+    assert events[3].reason_code == ReasonCodes.HSL_HELD_PROTECTIVE_READY
+    assert events[3].data["stage"] == "held_protective_ready"
+    assert events[3].data["ready_pairs"] == 1
+    assert events[3].data["pending_pairs"] == 0
+    assert events[3].data["protective_elapsed_s"] is not None
+    completed = events[4]
+    assert completed.status == "succeeded"
+    assert completed.reason_code == "coin_history_replay_completed"
+    assert completed.data["rows"] == 2
+    assert completed.data["applied_rows"] == 2
+    assert completed.data["pairs"] == 1
+    assert completed.data["held_pairs"] == 1
+    assert completed.data["cooldown_pairs"] == 0
+    assert completed.data["required_pairs"] == 1
+    assert completed.data["skipped_pairs"] == 0
+    assert completed.data["timeline_rows"] == 2
+    assert completed.data["fill_events"] == 0
+    assert completed.data["panic_events"] == 0
+    assert completed.data["rows_per_second"] is not None
+    assert completed.data["history_fetch_elapsed_s"] is not None
+    assert completed.data["pre_replay_elapsed_s"] is not None
+    assert completed.data["replay_loop_elapsed_s"] is not None
+    assert completed.data["full_elapsed_s"] is not None
+    assert completed.data["protective_elapsed_s"] is not None
+    assert completed.data["startup_blocking_elapsed_s"] is not None
+    assert completed.data["elapsed_s"] is not None
+    assert completed.data["history_fetch_elapsed_s"] > 0.0
     phase_elapsed_s = (
-        events[3].data["history_fetch_elapsed_s"]
-        + events[3].data["pre_replay_elapsed_s"]
-        + events[3].data["replay_loop_elapsed_s"]
+        completed.data["history_fetch_elapsed_s"]
+        + completed.data["pre_replay_elapsed_s"]
+        + completed.data["replay_loop_elapsed_s"]
     )
-    assert phase_elapsed_s <= events[3].data["startup_blocking_elapsed_s"] + 0.006
+    assert phase_elapsed_s <= completed.data["startup_blocking_elapsed_s"] + 0.006
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
@@ -1912,6 +1924,174 @@ async def test_coin_hsl_history_replay_processes_held_late_symbol_first():
     assert pair_events[0].data["is_held_pair"] is True
     assert set(bot._equity_hard_stop_coin["long"]) == {"A", "Z"}
     assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_start_releases_after_held_pair_and_owns_one_continuation():
+    bot = make_coin_bot()
+    bot.positions = {
+        "Z": {
+            "long": {"size": 1.0, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    flat_pair_started = asyncio.Event()
+    release_flat_pair = asyncio.Event()
+
+    async def fake_history(current_balance=None, **kwargs):
+        return {
+            "timeline": [
+                {
+                    "timestamp": 60_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {
+                        "A": {"long": 0.0, "short": 0.0},
+                        "Z": {"long": 0.0, "short": 0.0},
+                    },
+                    "unrealized_pnl_by_coin_pside": {
+                        "A": {"long": 0.0, "short": 0.0},
+                        "Z": {"long": -1.0, "short": 0.0},
+                    },
+                }
+            ],
+            "panic_flatten_events": [],
+            "fill_events": [],
+        }
+
+    async def gated_upnl(pside=None, symbol=None):
+        if symbol == "A":
+            flat_pair_started.set()
+            await release_flat_pair.wait()
+        return 0.0
+
+    bot.get_balance_equity_history = fake_history
+    bot._calc_upnl_sum_strict = gated_upnl
+
+    await bot._equity_hard_stop_start_coin_history_replay()
+
+    assert bot._equity_hard_stop_coin_protective_ready is True
+    assert getattr(bot, "_equity_hard_stop_coin_initialized", False) is False
+    assert bot._equity_hard_stop_coin_replay_ready_pairs == {("long", "Z")}
+    assert bot._equity_hard_stop_coin_replay_pending_pairs == {("long", "A")}
+    assert bot._equity_hard_stop_coin_replay_task.done() is False
+    assert bot.maintainers["hsl_coin_replay"] is bot._equity_hard_stop_coin_replay_task
+    await asyncio.wait_for(flat_pair_started.wait(), timeout=1.0)
+
+    same_task = bot._equity_hard_stop_coin_replay_task
+    await bot._equity_hard_stop_start_coin_history_replay()
+    assert bot._equity_hard_stop_coin_replay_task is same_task
+
+    release_flat_pair.set()
+    await asyncio.wait_for(same_task, timeout=1.0)
+    assert bot._equity_hard_stop_coin_initialized is True
+    assert bot._equity_hard_stop_coin_replay_pending_pairs == set()
+    assert bot._equity_hard_stop_coin_replay_ready_pairs == {
+        ("long", "A"),
+        ("long", "Z"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_partial_replay_restarts_if_pending_pair_becomes_held():
+    bot = make_coin_bot()
+    bot._equity_hard_stop_coin_protective_ready = True
+    bot._equity_hard_stop_coin_initialized = False
+    bot._equity_hard_stop_coin_replay_ready_pairs = set()
+    bot._equity_hard_stop_coin_replay_pending_pairs = {("long", "A")}
+    bot.positions = {
+        "A": {
+            "long": {"size": 1.0, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+
+    with pytest.raises(
+        RestartBotException,
+        match="restart required for held-first reconstruction: long:A",
+    ):
+        await bot._equity_hard_stop_check_coin()
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_background_failure_keeps_pending_pair_blocked_without_retry():
+    bot = make_coin_bot()
+    bot.positions = {
+        "Z": {
+            "long": {"size": 1.0, "price": 100.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+
+    async def fake_history(current_balance=None, **kwargs):
+        return {
+            "timeline": [
+                {
+                    "timestamp": 60_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {
+                        "A": {"long": 0.0, "short": 0.0},
+                        "Z": {"long": 0.0, "short": 0.0},
+                    },
+                    "unrealized_pnl_by_coin_pside": {
+                        "A": {"long": 0.0, "short": 0.0},
+                        "Z": {"long": -1.0, "short": 0.0},
+                    },
+                }
+            ],
+            "panic_flatten_events": [],
+            "fill_events": [],
+        }
+
+    async def failing_upnl(pside=None, symbol=None):
+        if symbol == "A":
+            raise RuntimeError("flat replay failed")
+        return 0.0
+
+    bot.get_balance_equity_history = fake_history
+    bot._calc_upnl_sum_strict = failing_upnl
+
+    await bot._equity_hard_stop_start_coin_history_replay()
+    replay_task = bot._equity_hard_stop_coin_replay_task
+    await asyncio.wait_for(replay_task, timeout=1.0)
+
+    assert getattr(bot, "_equity_hard_stop_coin_initialized", False) is False
+    assert bot._equity_hard_stop_coin_replay_ready_pairs == {("long", "Z")}
+    assert bot._equity_hard_stop_coin_replay_pending_pairs == {("long", "A")}
+    assert "flat replay failed" in bot._equity_hard_stop_coin_replay_failure
+    await bot._equity_hard_stop_start_coin_history_replay()
+    assert bot._equity_hard_stop_coin_replay_task is replay_task
+
+    metrics = await bot._equity_hard_stop_check_coin()
+    assert "long:Z" in metrics
+    assert "long:A" not in metrics
+
+
+@pytest.mark.asyncio
+async def test_data_maintainers_own_active_coin_hsl_replay_task():
+    bot = Passivbot.__new__(Passivbot)
+    bot.ws_enabled = False
+    blocker = asyncio.Event()
+
+    async def maintain_hourly_cycle():
+        await blocker.wait()
+
+    async def continue_replay():
+        await blocker.wait()
+
+    bot.maintain_hourly_cycle = maintain_hourly_cycle
+    replay_task = asyncio.create_task(continue_replay())
+    bot._equity_hard_stop_coin_replay_task = replay_task
+
+    await bot.start_data_maintainers()
+
+    assert bot.maintainers["hsl_coin_replay"] is replay_task
+    hourly_task = bot.maintainers["maintain_hourly_cycle"]
+    bot.stop_data_maintainers(verbose=False)
+    await asyncio.gather(replay_task, hourly_task, return_exceptions=True)
+    assert replay_task.cancelled()
+    assert hourly_task.cancelled()
 
 
 async def _run_parity_history(monkeypatch):

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import os
+from collections import Counter
+from pathlib import Path
 
 import pytest
 
@@ -4187,6 +4189,94 @@ def test_live_smoke_report_summarizes_cache_health(tmp_path):
     rendered = json.dumps(report["cache_health"], sort_keys=True)
     assert "private-cache" not in rendered
     assert "raw-cache-row" not in rendered
+
+
+def test_compact_hsl_replay_data_exposes_protective_readiness_counts():
+    compact = smoke_report_module._compact_hsl_replay_data(
+        {
+            "data": {
+                "signal_mode": "coin",
+                "stage": "held_protective_ready",
+                "pairs": 12,
+                "held_pairs": 2,
+                "ready_pairs": 2,
+                "pending_pairs": 10,
+                "protective_elapsed_s": 1.25,
+                "secret": "must-not-render",
+            }
+        }
+    )
+
+    assert compact == {
+        "signal_mode": "coin",
+        "stage": "held_protective_ready",
+        "pairs": 12,
+        "held_pairs": 2,
+        "ready_pairs": 2,
+        "pending_pairs": 10,
+        "protective_elapsed_s": 1.25,
+    }
+    assert smoke_report_module._hsl_replay_derived(compact)[
+        "protective_elapsed_ms"
+    ] == 1250
+
+
+def test_hsl_replay_health_retains_protective_ready_after_later_progress():
+    groups = {}
+    path = Path("events.ndjson")
+    ready = _monitor_row(
+        event_type="hsl.replay.progress",
+        seq=1,
+        ts=1000,
+        reason_code="hsl_held_protective_ready",
+        status="succeeded",
+        data={
+            "signal_mode": "coin",
+            "stage": "held_protective_ready",
+            "pairs": 10,
+            "ready_pairs": 1,
+            "pending_pairs": 9,
+            "protective_elapsed_s": 2.0,
+        },
+    )
+    later = _monitor_row(
+        event_type="hsl.replay.progress",
+        seq=2,
+        ts=2000,
+        reason_code="pair_replay_progress",
+        status="started",
+        data={
+            "signal_mode": "coin",
+            "stage": "pair_replay",
+            "pairs": 10,
+            "pair_idx": 2,
+        },
+    )
+    for line_no, row in enumerate((ready, later), start=1):
+        smoke_report_module._merge_hsl_replay_group(
+            groups,
+            bot_key="binance/test",
+            row=row,
+            live_event=row["payload"]["_live_event"],
+            path=path,
+            line_no=line_no,
+        )
+
+    summary = smoke_report_module._summarize_hsl_replay_health(
+        groups,
+        Counter({"hsl.replay.progress": 2}),
+        report_ts_ms=2500,
+    )
+    group = summary["groups"][0]
+    assert group["latest"]["data"]["stage"] == "pair_replay"
+    assert group["protective_ready"]["data"] == {
+        "signal_mode": "coin",
+        "stage": "held_protective_ready",
+        "pairs": 10,
+        "ready_pairs": 1,
+        "pending_pairs": 9,
+        "protective_elapsed_s": 2,
+    }
 
 
 def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):

--- a/tests/test_order_orchestration.py
+++ b/tests/test_order_orchestration.py
@@ -85,6 +85,48 @@ def _make_order(
     }
 
 
+def test_coin_hsl_pending_replay_mode_override_is_pair_scoped():
+    bot = Passivbot.__new__(Passivbot)
+    bot.hsl = {
+        "long": {"orange_tier_mode": "graceful_stop"},
+        "short": {"orange_tier_mode": "graceful_stop"},
+    }
+    bot._runtime_forced_modes = {
+        "long": {"BTC/USDT:USDT": "panic", "ETH/USDT:USDT": "panic"},
+        "short": {},
+    }
+    bot._equity_hard_stop_coin_replay_pending_pairs = {
+        ("long", "BTC/USDT:USDT"),
+        ("long", "MANUAL/USDT:USDT"),
+    }
+    bot._equity_hard_stop_enabled = lambda pside=None: True
+    bot._equity_hard_stop_signal_mode = lambda: "coin"
+    bot._hsl_state = lambda pside: {"halted": False}
+    bot._equity_hard_stop_runtime_red_latched = lambda pside: False
+    bot._equity_hard_stop_runtime_tier = lambda pside: "green"
+    bot.config_get = lambda path, symbol=None: (
+        "manual" if symbol == "MANUAL/USDT:USDT" else None
+    )
+    bot.markets_dict = {
+        "BTC/USDT:USDT": {"active": True},
+        "ETH/USDT:USDT": {"active": True},
+        "MANUAL/USDT:USDT": {"active": True},
+    }
+    bot.ineligible_symbols = {}
+    bot._apply_ignored_coin_mode = lambda pside, symbol, mode=None: mode
+
+    assert (
+        bot._orchestrator_mode_override("long", "BTC/USDT:USDT")
+        == "graceful_stop"
+    )
+    assert bot.get_forced_PB_mode("long", "BTC/USDT:USDT") == "graceful_stop"
+    assert bot._orchestrator_mode_override("short", "BTC/USDT:USDT") is None
+    assert bot._orchestrator_mode_override("long", "ETH/USDT:USDT") == "panic"
+    assert bot.get_forced_PB_mode("long", "ETH/USDT:USDT") == "panic"
+    assert bot._orchestrator_mode_override("long", "MANUAL/USDT:USDT") == "manual"
+    assert bot.get_forced_PB_mode("long", "MANUAL/USDT:USDT") == "manual"
+
+
 @pytest.mark.parametrize(
     ("order_type", "qty", "position_side", "position_size"),
     [


### PR DESCRIPTION
## Scope

Category: runtime behavior / restart-deploy behavior.

- Release coin-mode HSL startup after the existing exact held-pair replay batch is complete.
- Continue cooldown-affected and remaining flat pairs in the same shutdown-owned replay task.
- Block pending pair initial-entry creates at both planning and final exchange submission.
- Preserve cancellations, panic creates, reduce-only creates, explicit non-normal forced modes, and completed-pair HSL modes.
- Emit bounded protective-ready timing and ready/pending pair counts; retain protective readiness in smoke reports while full replay remains active.

## Non-goals

- No HSL math, thresholds, episode, cooldown, or restart-policy changes.
- No replay algorithm or cache/checkpoint schema rewrite.
- No exchange-call or backtest behavior changes.
- No claim that cold history materialization itself is now fast.

## Safety behavior

A pair is published ready only after its historical replay and exact current sample complete. Background replay cannot expose partial forced modes because pending readiness masks them. A newly held pending pair forces restart so it is reconstructed held-first. A post-readiness continuation failure leaves unreplayed flat pairs entry-blocked while ready held pairs remain managed.

## Validation

- `tests/test_hsl_coin_mode.py` full: pass
- `tests/test_order_orchestration.py` full: pass
- `tests/test_exchange_config_updates.py` full: pass
- `tests/test_live_smoke_report.py` full: pass
- `tests/test_live_event_bus.py` full: pass
- focused realized-loss/HSL tests: 6 pass
- fake-live coin-HSL/replay/lookback scenarios: 9 pass
- Rust: 209/209; `cargo check --tests`; `cargo fmt --check`
- deterministic replay benchmark: 30 symbols, 1440 minutes, 2 iterations; pass with zero network/cache/latch side effects
- rebuilt/restamped Rust extension fingerprint matches worktree
- `py_compile`, `git diff --check`, and reviewed added-line exception audit: pass
- independent current-diff concurrency/safety review: no P0-P2 findings

## Reviewer focus

Please verify task ownership across startup/shutdown, partial-state isolation, pair-scoped entry blocking, panic/reduce-only/cancel preservation, and failure behavior.

## VPS action

After exact-head reviewer and CI gates are green: pull on VPS5, controlled restart of the five configured bots, then immediate and settled bounded smoke reports. No Rust rebuild is required because Rust sources are unchanged.

## Residual risk

Cold history collection still precedes held-pair replay and may remain material. Production protective-ready elapsed time must be measured on VPS5 after merge.