### PR TITLE
Keep live I/O responsive during background HSL replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable user-facing changes will be documented in this file.
   blocked per coin and position side until that pair is reconstructed, while
   cancellations and panic/reduce-only protection remain available. Replay
   events and smoke reports distinguish protective-ready time from full replay.
+  After protective readiness, replay now yields in smaller bounded chunks with
+  a short cooperative pause so live exchange I/O is not starved; held-position
+  reconstruction retains the faster startup cadence.
 
 - Coin-mode HSL drawdown normalization now uses one Rust-owned live/backtest
   contract: account balance divided by the applicable slot count. TWEL still

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,31 +22,33 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR: query live GitHub metadata; `Release coin-HSL startup after held protection`
-- Branch: `codex/v8-hsl-protective-readiness`
+- PR: query live GitHub metadata;
+  `Keep live I/O responsive during background coin-HSL replay`
+- Branch: `codex/v8-hsl-background-replay-cooperative`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
-- Base: `078a3fead1dc635877b9142cb394dd93e3747d54`
-- Scope: run the existing exact held-first coin replay in one task, release
-  startup after every held pair is protectively ready, and continue remaining
-  pairs in the background. Keep pending pairs blocked from initial-entry
-  creates at both planning and final submission while allowing cancellations
-  and panic/reduce-only creates. Expose protective/full timing and pair counts.
-- Non-goals: no HSL math/state contract change, replay algorithm rewrite,
-  checkpoint/cache schema change, exchange-call change, backtest behavior
-  change, or claim that cold history materialization itself is now fast.
-- Local validation: full coin-HSL, order-orchestration, exchange-config,
-  live-smoke-report, and live-event-bus suites; six focused realized-loss/HSL
-  tests; nine fake-live HSL/replay scenarios; Rust `209/209`, `cargo check
-  --tests`, and `cargo fmt --check`; and the deterministic 30-symbol,
-  1440-minute, two-iteration replay benchmark pass. The rebuilt extension stamp
-  matches this worktree; `py_compile`, reviewed added-line exception handling,
-  and `git diff --check` pass.
-- Independent preflight: one read-only test-surface audit identified the
-  existing replay, order, fake-live, smoke, and shutdown fixtures used by this
-  slice. Runtime design keeps one writer per pending pair and never rebuilds
-  shared HSL state after startup release. A separate current-diff concurrency
-  and safety review reported no P0-P2 findings.
+- Base: `abcc422bebb0ac19fcd50fcb8efa21d77b45d41f`
+- Scope: retain the existing fast 1,000-row cooperative cadence while startup
+  is blocked on held-position reconstruction. After protective readiness,
+  yield every 100 rows with a 10 ms pause so the same-process live event loop
+  can service exchange I/O while flat/cooldown pairs continue replaying.
+- Triggering evidence: after PR #1177 released startup, the four coin-HSL replay
+  bots were simultaneously in `blk_io_schedule`, VPS5 showed 40-44% I/O wait,
+  20-29 MB/s swap-in, 19-23 MB/s swap-out, and zero CPU idle, while fresh
+  account-critical remote failures occurred. The non-replay Hyperliquid bot
+  remained in normal `ep_poll` sleep.
+- Non-goals: no HSL math/state, pair ordering, readiness, entry gate,
+  checkpoint/cache schema, exchange-call, Rust, or backtest behavior change;
+  no replay vectorization or memory-layout rewrite.
+- Local validation: full coin-HSL suite; full order-orchestration and
+  exchange-config suites; 15 selected HSL/coin fake-live and integration tests;
+  benchmark-tool tests; syntax and diff checks. The deterministic 30-symbol,
+  1440-minute, two-iteration held-position benchmark retained its state hash
+  and zero side effects. A realistic flat-background probe reconstructed all
+  30 pairs in 6.37 seconds with no pending pairs.
+- Independent preflight: one read-only test audit confirmed the exact replay
+  task, held/cooldown/flat batch boundary, existing 1,000-row cadence, and
+  benchmark/test surfaces. No delegated edits were used.
 - Publication state, exact head, mergeability, CI, and current-head review
   verdicts: query live GitHub metadata. Do not encode those transient values in
   the same PR that contains this status file, because every correction would
@@ -57,21 +59,21 @@ Estimated completion:
 
 Next action:
 
-1. Resolve verified findings and merge only after the exact-head gate, then
-   perform the declared VPS5 restart/smoke validation.
+1. Publish the hotfix, resolve verified findings, and merge only after the
+   exact-head gate; then perform the declared VPS5 restart/smoke validation.
 
 ## Deployed Baseline
 
-- Remote `v8`: `078a3fea`, PR #1176
-- VPS5 repository: `078a3fea`, PR #1176
+- Remote `v8`: `abcc422b`, PR #1177
+- VPS5 repository: `abcc422b`, PR #1177; tracked status clean
 - VPS5 expected bots: five; all are running after the controlled restart
-- Latest immediate and settled smoke: `ok=true`, `hard_failures=0`, all five
-  bots matched, zero remote/account-critical/fill-refresh failures, and zero
-  text-log hard/attention matches. Four HSL replays were active and non-stale;
-  KuCoin completed, and the only extra settled-window signals were non-hard
-  Hyperliquid EMA/state-refresh events.
-- The prior tracked Rust formatting edit was already fully present in PR #1174.
-  Its patch backup and autostash were retained on VPS5; tracked status is clean.
+- Immediate post-restart smoke was green: `ok=true`, `hard_failures=0`, all five
+  bots matched, and zero remote/account-critical/fill/log failures.
+- Protective-ready events proved startup release for GateIO, KuCoin, and OKX
+  with no held positions, while exact background replay remained active.
+  Settled probes then exposed the resource-pressure incident summarized in the
+  active-slice evidence above. Five bots remain alive; do not restart them
+  reflexively while the dependent hotfix is under review.
 - Preserve local/VPS configs, logs, monitor data, reports, and temporary files
 
 ## Review Gate
@@ -94,11 +96,10 @@ Next action:
 
 ## Next Slice
 
-The denominator-parity and immutable held/cooldown-first ordering prerequisites
-are merged and deployed. The active slice splits held-position protective
-readiness from full replay while keeping fresh entries blocked until their
-pair-specific cooldown eligibility is known. The design preserves exact HSL
-reconstruction and keeps observability events out of decision authority.
+The denominator-parity, immutable held/cooldown-first ordering, and
+held-position protective-readiness split are merged and deployed. The active
+hotfix bounds event-loop monopolization during the resulting background replay
+without changing replay results or pair readiness.
 Remaining candidates:
 
 - realistic-scale replay fixtures and deeper internal-stage profiling

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7228,3 +7228,24 @@ VPS5 deployment status:
 - Expected validation: focused resource-pressure performance-report tests, full
   `tests/test_live_performance_report.py`, `py_compile`, `git diff --check`,
   and the standard added-line silent-handling scan.
+
+### Deployed Slice: Coin-HSL Protective Readiness And Cooperative Follow-Up
+
+- PR #1177 was approved by Hermes and Grok 4.5 on exact head `3bc2991f8`,
+  passed CI, and merged to `v8` as `abcc422b`. VPS5 pulled that merge with
+  tracked status clean and preserved local artifacts, then all five configured
+  bots were restarted through the exact `passivbot` tmux session.
+- The immediate two-minute smoke was green with all five bots matched and no
+  remote, account-critical, fill, process, event-pipeline, or text-log hard
+  failures. GateIO, KuCoin, and OKX subsequently emitted protective-ready
+  events before full replay completed, proving the intended startup split.
+- Settled evidence exposed a dependent live-runtime issue: all four coin-HSL
+  replay processes were in `blk_io_schedule` while VPS5 reported 40-44% I/O
+  wait, 20-29 MB/s swap-in, 19-23 MB/s swap-out, zero CPU idle, and fresh
+  account-critical remote failures. The non-replay Hyperliquid bot remained in
+  `ep_poll` with much lower RSS.
+- Follow-up branch `codex/v8-hsl-background-replay-cooperative` keeps the fast
+  held-position cadence but yields every 100 rows with a 10 ms pause after
+  protective readiness. The change is limited to Python live replay scheduling
+  plus one responsiveness regression and docs; HSL state/math, Rust/backtest,
+  exchange calls, pair ordering, readiness, and entry gates are unchanged.

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -57,6 +57,9 @@ _HSL_REPLAY_CACHE_REQUIRED_METADATA = (
     "candle_covered_end_ms",
 )
 _HSL_REPLAY_CACHE_FILL_HISTORY_SCOPES = ("unknown", "window", "all")
+_HSL_COIN_REPLAY_STARTUP_YIELD_ROWS = 1_000
+_HSL_COIN_REPLAY_BACKGROUND_YIELD_ROWS = 100
+_HSL_COIN_REPLAY_BACKGROUND_YIELD_SLEEP_S = 0.01
 
 
 def _hsl_flat_epsilon(qty_step: Any = 0.0) -> float:
@@ -5308,9 +5311,22 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         replay_event_idx += 1
                     return float(replay_size)
 
+                background_replay = bool(
+                    self._equity_hard_stop_coin_protective_ready
+                )
+                yield_rows = (
+                    _HSL_COIN_REPLAY_BACKGROUND_YIELD_ROWS
+                    if background_replay
+                    else _HSL_COIN_REPLAY_STARTUP_YIELD_ROWS
+                )
+                yield_sleep_s = (
+                    _HSL_COIN_REPLAY_BACKGROUND_YIELD_SLEEP_S
+                    if background_replay
+                    else 0.0
+                )
                 for row_idx, row in enumerate(timeline_rows, start=1):
-                    if row_idx % 1000 == 0:
-                        await asyncio.sleep(0)
+                    if row_idx % yield_rows == 0:
+                        await asyncio.sleep(yield_sleep_s)
                         check_shutdown("hsl_coin_history_replay_rows")
                         log_replay_progress(pair_idx, pside, symbol, applied_rows)
                     ts = int(row["timestamp"])

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -1993,6 +1993,46 @@ async def test_coin_hsl_start_releases_after_held_pair_and_owns_one_continuation
 
 
 @pytest.mark.asyncio
+async def test_coin_hsl_background_replay_yields_before_one_thousand_rows():
+    bot = make_coin_bot()
+    bot.positions = {}
+    bot.get_exchange_time = lambda: 10_000_000
+
+    async def fake_history(current_balance=None, **kwargs):
+        return {
+            "timeline": [
+                {
+                    "timestamp": minute * 60_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {
+                        "A": {"long": 0.0, "short": 0.0}
+                    },
+                    "unrealized_pnl_by_coin_pside": {
+                        "A": {"long": 0.0, "short": 0.0}
+                    },
+                }
+                for minute in range(1, 151)
+            ],
+            "panic_flatten_events": [],
+            "fill_events": [],
+        }
+
+    bot.get_balance_equity_history = fake_history
+
+    await bot._equity_hard_stop_start_coin_history_replay()
+
+    replay_task = bot._equity_hard_stop_coin_replay_task
+    assert bot._equity_hard_stop_coin_protective_ready is True
+    assert replay_task.done() is False
+    assert bot._equity_hard_stop_coin_replay_pending_pairs == {("long", "A")}
+
+    await asyncio.wait_for(replay_task, timeout=1.0)
+    assert bot._equity_hard_stop_coin_initialized is True
+    assert bot._equity_hard_stop_coin_replay_pending_pairs == set()
+
+
+@pytest.mark.asyncio
 async def test_coin_hsl_partial_replay_restarts_if_pending_pair_becomes_held():
     bot = make_coin_bot()
     bot._equity_hard_stop_coin_protective_ready = True


### PR DESCRIPTION
## Scope

Category: runtime behavior / restart-deploy behavior.

- Keep the existing fast 1,000-row cooperative cadence while startup is blocked on held-position coin-HSL reconstruction.
- After protective readiness, yield every 100 rows with a 10 ms pause while cooldown and flat pairs continue in the same shutdown-owned task.
- Record the deployed PR #1177 evidence and this dependent hotfix in the compact status and progress ledger.

## Triggering evidence

After PR #1177 released startup, the four coin-HSL replay bots were simultaneously in `blk_io_schedule`. VPS5 showed 40-44% I/O wait, 20-29 MB/s swap-in, 19-23 MB/s swap-out, and zero CPU idle while fresh account-critical remote failures occurred. The non-replay Hyperliquid bot remained in normal `ep_poll` sleep with much lower RSS.

## Non-goals

- No HSL math/state, pair ordering, readiness, pending-entry gate, checkpoint/cache schema, or exchange-call change.
- No Rust or backtest behavior change.
- No replay vectorization, memory-layout rewrite, or claim that cold history materialization is fast.

## Safety behavior

Held-position replay retains the previous startup cadence and remains exact before protective readiness. Only later background pairs use the tighter cooperative cadence. Pair readiness, failure isolation, shutdown ownership, and initial-entry blocking remain unchanged.

## Validation

- Full `tests/test_hsl_coin_mode.py`: pass.
- Full `tests/test_order_orchestration.py` + `tests/test_exchange_config_updates.py`: 66 pass.
- HSL/coin selection across order/config/fake-live tests: 15 pass.
- `tests/test_hsl_replay_benchmark.py`: 3 pass.
- Deterministic benchmark: 30 symbols, 1,440 minutes, 2 iterations; same final state hash, 86,400 replay samples, zero network/cache/latch/monitor side effects.
- Flat-background runtime probe: 30 symbols, 1,440 minutes; completed all pairs in 6.37 s with zero pending pairs.
- `py_compile`, `git diff --check`, and added-line silent-fallback scan: pass.
- Independent read-only test/path audit: exact task/batch boundary and benchmark surfaces confirmed.

## Reviewer focus

Please verify the readiness boundary used to select the cadence, event-loop liveness, unchanged held-first behavior, shutdown responsiveness, and whether the 100-row/10 ms background budget is a safe production tradeoff given the VPS evidence.

## VPS action

After Hermes + Grok 4.5 + CI are green on the exact head: pull while preserving local artifacts, controlled restart of the five configured bots, then immediate and settled bounded smoke/resource probes. No Rust rebuild is required.

## Residual risk

This hotfix bounds same-process event-loop monopolization but does not reduce the replay history memory footprint. Production smoke must confirm whether remote-call failures and swap/I/O pressure improve; deeper replay vectorization or memory work remains a separate slice.