### PR TITLE
Compact cold coin HSL replay memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Cold coin-mode HSL history reconstruction now uses a private compact
+  NumPy-backed replay payload instead of retaining the full nested per-minute,
+  per-symbol timeline. Public balance/equity history output, pside/unified HSL,
+  cache authority, episode/cooldown rules, and Rust risk math are unchanged.
+  The offline replay benchmark can now separate held and background work, opt
+  into a 30-day local-scale fixture, compare rich and compact history formats,
+  and report Python allocation peaks.
+
 - `passivbot tool live-smoke-report --processes` now includes bounded current
   live-process state counts, uninterruptible-sleep count, and CPU, memory, and
   RSS totals/maxima/reporting counts in full, summary, and brief output. These

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,53 +22,62 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR: query live GitHub metadata;
-  `Expose current live-process pressure in smoke reports`
-- Branch: `codex/v8-smoke-current-process-pressure`
+- PR: not yet published;
+  `Compact cold coin-HSL replay memory`
+- Branch: `codex/v8-hsl-direct-matrix-replay`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
-- Base: `d83797b700091100fd357bcb48f90be98d0b97e4`
-- Scope: aggregate already-parsed local `ps` fields under the existing
-  `processes` section: state counts, uninterruptible-sleep count, and bounded
-  CPU, memory, and RSS totals/maxima/reporting counts. Project the same fields
-  through full, summary, and brief smoke output.
-- Triggering evidence: after PR #1178, immediate and settled smokes were hard
-  green with live I/O succeeding, but event-derived `resource_pressure`
-  reported only Hyperliquid because replay-heavy bots could not emit timely
-  `health.summary` samples. Direct process probes simultaneously showed four
-  coin-HSL bots in `D` state with high RSS and swap/I/O pressure.
-- Non-goals: no event producer, monitor write, process signal, verdict/attention
-  threshold, exchange call, restart behavior, HSL/risk/order logic, Rust, or
-  backtest change.
-- Local validation: focused process parsing/projection tests plus full
-  smoke-report (77), restart-smoke-plan (24), and incident-bundle (25) suites
-  pass; syntax and diff checks pass. Missing RSS remains null with a zero
-  reporting count, and non-finite CPU or memory samples are excluded.
-- Independent preflight: one read-only audit confirmed the existing `ps`
-  parser, full process report, summary/brief whitelists, compatibility fallbacks,
-  and targeted test surfaces. No delegated edits were used.
+- Base: `c159d955f691085469858c57ed1d6ba7927d7905`
+- Scope: the internal cold coin-HSL history call requests aligned compact
+  timestamp, balance, account-realized, and per-pair realized/unrealized NumPy
+  arrays. `NaN` preserves unavailable pair values. Public history callers and
+  pside/unified replay retain the rich timeline contract. The offline benchmark
+  gains held/background counters, opt-in local-scale bounds, and tracemalloc
+  output.
+- Triggering evidence: after PR #1179, five live processes reported aggregate
+  RSS `648196 KB`; four coin-HSL processes were in uninterruptible sleep while
+  swap/page pressure remained high. A deterministic 43,201-minute, 30-symbol
+  local builder profile measured `686242590` rich-history peak allocation bytes
+  versus `73499666` compact-history bytes, an 89.3% reduction.
+- Non-goals: no HSL thresholds, episode/cooldown/no-restart semantics, cache
+  authority, pair priority, readiness gate, exchange write, process signal,
+  Rust, backtest, or pside/unified behavior change.
+- Local validation: full coin-HSL plus benchmark suites pass; the complete
+  balance-history suite passes with one unrelated known startup test excluded
+  after its asynchronous shutdown fixture stalled. Realized-loss tests pass.
+  Syntax and diff checks pass. Broader validation and exact counts will be
+  refreshed before publication.
+- Independent preflight: two read-only audits independently identified the
+  nested timeline as the dominant retained allocation and recommended a private
+  compact coin-only handoff. A Luna worker changed only the benchmark and its
+  tests; Sol owns the live-path implementation and review.
 - Publication state, exact head, mergeability, CI, and current-head review
   verdicts: query live GitHub metadata. Do not encode those transient values in
   the same PR that contains this status file, because every correction would
   create a different head and immediately stale the embedded value.
-- Expected VPS action: pull while preserving local artifacts and run a bounded
-  read-only process-section smoke. No bot restart or Rust rebuild is required.
+- Expected VPS action: after exact-head approval and merge, pull while
+  preserving local artifacts, restart the five configured bots with exact
+  tmux/process targeting, then compare protective/full replay time, process
+  states, RSS, swap, I/O wait, remote calls, and hard-failure smoke output.
 
 Next action:
 
-1. Publish the read-only tooling slice, resolve verified findings, and merge
-   only after the exact-head gate; then perform the declared VPS5 query smoke.
+1. Finish parity and broad local validation, publish the compact replay slice,
+   resolve verified findings, and merge only after the exact-head gate; then
+   perform the declared controlled VPS5 restart and comparative smoke.
 
 ## Deployed Baseline
 
-- Remote `v8`: `d83797b7`, PR #1178
-- VPS5 repository: `d83797b7`, PR #1178; tracked status clean
+- Remote `v8`: `c159d955`, PR #1179
+- VPS5 repository: `c159d955`, PR #1179; tracked status clean
 - VPS5 expected bots: five; all are running after the controlled restart
 - Immediate and settled smoke reports were green: all five expected bots
   matched, hard failures were zero, 396 remote calls and 43 account-critical
   calls succeeded across the two windows with zero failures, and no fill,
   process, event-pipeline, or text-log hard failure appeared.
-- Background replay remains memory/I/O intensive: settled direct probes showed
+- Background replay remains memory/I/O intensive: current process-section
+  output shows four of five bots in `D` state, aggregate RSS `648196 KB`, and
+  the earlier settled direct probes showed
   four coin-HSL processes in uninterruptible sleep/page wait, 29 MB/s sampled
   swap-in, 18 MB/s swap-out, 32% I/O wait, and zero idle. PR #1178 restored
   live-I/O responsiveness but intentionally did not reduce this footprint.
@@ -94,9 +103,10 @@ Next action:
 
 ## Next Slice
 
-The coin-HSL protective-readiness split and cooperative background cadence are
-merged and deployed. The active read-only slice makes current process pressure
-visible even when periodic event-derived health samples are absent or stale.
+The coin-HSL protective-readiness split, cooperative background cadence, and
+current process-pressure query are merged and deployed. The active slice
+removes the dominant nested Python allocation from cold coin replay while
+preserving the existing risk contract.
 Remaining candidates:
 
 - realistic-scale replay fixtures and deeper internal-stage profiling

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,7 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR: not yet published;
+- PR: [#1180](https://github.com/enarjord/passivbot/pull/1180),
   `Compact cold coin-HSL replay memory`
 - Branch: `codex/v8-hsl-direct-matrix-replay`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7275,3 +7275,24 @@ VPS5 deployment status:
 - Non-goals: no live event producer, monitor write, process signal, exchange
   call, restart policy, threshold, trading/risk/order behavior, Rust, or
   backtest change.
+
+### Draft Slice: Compact Cold Coin-HSL Replay Memory
+
+- Branch: `codex/v8-hsl-direct-matrix-replay` from deployed `c159d955`.
+- Triggering evidence: PR #1179 exposed four of five live processes in `D`
+  state with aggregate RSS `648196 KB`; prior direct probes showed sustained
+  swap and I/O wait during 30-day coin replay.
+- Scope: cold coin replay requests a private aligned NumPy payload for account
+  and per-pair history instead of retaining the public nested timeline. Missing
+  pair values remain explicit `NaN`, and currently held cache matrices remain
+  non-authoritative accelerators. Public history, cache reuse, pside/unified,
+  Rust HSL math, and backtest behavior are unchanged.
+- Measured local result: a deterministic 43,201-minute, 30-symbol builder with
+  one held and 29 historical-flat symbols reduced traced Python peak allocation
+  from `686242590` bytes to `73499666` bytes (89.3%).
+- Benchmark support now separates held/background pairs and samples, exposes
+  expected cooperative yields, allows an explicit 30-day local-scale run, and
+  optionally records tracemalloc current/peak bytes.
+- Validation in progress: coin-HSL and benchmark suites, compact/rich sample and
+  final-state parity, balance-history regressions, syntax/diff checks, and a
+  controlled post-merge VPS5 restart with process/RSS/swap/I/O comparison.

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -532,6 +532,12 @@ Trading-impact labels:
     states that have values on that row, or per-pair sparse series built once.
   - Avoid repeated nested dict scans and repeated full fill-list scans per
     symbol.
+  - Compact-memory slice implemented locally: cold coin replay now builds
+    aligned NumPy account/pair arrays instead of the rich nested timeline and
+    consumes those arrays directly. A 43,201-minute, 30-symbol builder profile
+    reduced Python peak allocations from `686242590` to `73499666` bytes
+    (89.3%). Pair iteration remains `rows * pairs`; fill indexing and a true
+    lower-complexity state update remain open.
   - Preserve current RED/green/current-drawdown semantics: a historical RED
     crossing must not cause a panic now if current replay state is no longer in
     the red zone.
@@ -545,6 +551,11 @@ Trading-impact labels:
     `coin+pside` pairs unnecessarily.
   - Confirm whether unrelated flat pairs can delay held-pair protective
     readiness.
+  - Answered for the observed VPS incident: retained nested Python history and
+    overlapping replay representations drove swap/page pressure. One-day
+    synthetic replay arithmetic completed 43,200 pair-minutes in about 0.3s,
+    while the 30-day rich builder retained about 686 MB of traced Python
+    allocations.
 
 - [ ] Prove whether coin-mode HSL needs cross-coin synchronization.
   - If one coin's HSL state depends only on that coin's fill/PnL and candle
@@ -581,6 +592,11 @@ Trading-impact labels:
     replay, optimized replay, and checkpoint resume.
   - Output metrics: elapsed, rows/s, per-stage timings, current HSL state by
     held pair, cooldown state by affected flat pair, and equivalence diff.
+  - Partial: the benchmark now distinguishes held/background pairs and samples,
+    reports expected cooperative yields, supports an explicit 43,201-minute
+    local-scale mode, compares timeline/compact final-state output, and can
+    report tracemalloc current/peak bytes. A realistic cooldown candidate and
+    detailed equivalence report remain open.
 
 - [ ] Index fill events once by `(pside, symbol)`.
   - Reuse that index for replay contracts, panic detection, position-size

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -11398,8 +11398,18 @@ class Passivbot:
         fill_events: Optional[List[dict]] = None,
         current_balance: Optional[float] = None,
         hsl_replay_signal_mode: Optional[str] = None,
+        hsl_coin_compact_replay: bool = False,
     ) -> Dict[str, Any]:
-        """Replay canonical fill events to produce historical balance/equity curves."""
+        """Replay canonical fills into public curves or private compact coin-HSL input.
+
+        `hsl_coin_compact_replay` is internal to cold coin-HSL startup. In that
+        mode the result omits the rich `timeline`, `balances`, and `equities`
+        projections and exposes `hsl_coin_compact_replay` instead.
+        """
+        if hsl_coin_compact_replay and str(hsl_replay_signal_mode or "").lower() != "coin":
+            raise ValueError(
+                "hsl_coin_compact_replay requires hsl_replay_signal_mode='coin'"
+            )
         history_started_s = time.monotonic()
         external_fill_events = fill_events is not None
         await self.init_pnls()
@@ -11546,6 +11556,30 @@ class Passivbot:
                 status="succeeded",
                 reason_code=ReasonCodes.HSL_HISTORY_EMPTY,
             )
+            if hsl_coin_compact_replay:
+                return {
+                    "hsl_coin_compact_replay": {
+                        "timestamps": np.asarray([int(ts_now)], dtype=np.int64),
+                        "balances": np.asarray([balance_now], dtype=np.float64),
+                        "realized_pnl": np.asarray([0.0], dtype=np.float64),
+                        "pair_values": {},
+                    },
+                    "panic_flatten_events": [],
+                    "fill_events": [],
+                    "metadata": {
+                        "lookback_days": parse_pnls_max_lookback_days(
+                            self.live_value("pnls_max_lookback_days"),
+                            field_name="live.pnls_max_lookback_days",
+                        ).display_value,
+                        "resolution_ms": ONE_MIN_MS,
+                        "events_used": 0,
+                        "symbols_covered": [],
+                        "missing_price_symbols": [],
+                        "history_format": "compact",
+                    },
+                    "hsl_replay_matrices": {},
+                    "hsl_replay_account_series": [],
+                }
             return {
                 "timeline": [point],
                 "panic_flatten_events": [],
@@ -11567,6 +11601,7 @@ class Passivbot:
                     "events_used": 0,
                     "symbols_covered": [],
                     "missing_price_symbols": [],
+                    "history_format": "timeline",
                 },
             }
 
@@ -12038,12 +12073,49 @@ class Passivbot:
                     )
 
         history_minutes = int(max(0, (end_minute - start_minute) // ONE_MIN_MS)) + 1
+        compact_coin_replay = bool(hsl_coin_compact_replay)
+        compact_record_minutes = (
+            int(max(0, (end_minute - record_start_minute) // ONE_MIN_MS)) + 1
+        )
+        compact_timestamps = (
+            np.empty(compact_record_minutes, dtype=np.int64)
+            if compact_coin_replay
+            else None
+        )
+        compact_balances = (
+            np.empty(compact_record_minutes, dtype=np.float64)
+            if compact_coin_replay
+            else None
+        )
+        compact_realized_pnl = (
+            np.empty(compact_record_minutes, dtype=np.float64)
+            if compact_coin_replay
+            else None
+        )
+        compact_pair_values: Dict[Tuple[str, str], Dict[str, np.ndarray]] = (
+            {
+                (pside, sym): {
+                    "realized_pnl": np.full(
+                        compact_record_minutes, np.nan, dtype=np.float64
+                    ),
+                    "unrealized_pnl": np.full(
+                        compact_record_minutes, np.nan, dtype=np.float64
+                    ),
+                }
+                for sym in sorted(symbols)
+                for pside in ("long", "short")
+            }
+            if compact_coin_replay
+            else {}
+        )
+        compact_row_idx = 0
         _emit_hsl_history_progress(
             "timeline_replay_started",
             {
                 "events": len(events),
                 "symbols": len(symbols),
                 "price_replay_symbols": len(price_replay_symbols),
+                "history_format": "compact" if compact_coin_replay else "timeline",
                 "history_minutes": history_minutes,
                 "record_start_ts": int(record_start_ts),
                 "start_ts": int(start_minute),
@@ -12211,64 +12283,98 @@ class Passivbot:
                         - record_start_realized_pnl_pside.get("short", 0.0)
                     ),
                 }
-                realized_pnl_coin_pside_window: Dict[str, Dict[str, float]] = {}
-                for sym in sorted(
-                    set(realized_pnl_coin_pside_running)
-                    | set(record_start_realized_pnl_coin_pside)
-                ):
-                    values = realized_pnl_coin_pside_running.get(
-                        sym, {"long": 0.0, "short": 0.0}
-                    )
-                    anchor = record_start_realized_pnl_coin_pside.get(
-                        sym, {"long": 0.0, "short": 0.0}
-                    )
-                    realized_pnl_coin_pside_window[sym] = {
-                        "long": float(values["long"] - anchor.get("long", 0.0)),
-                        "short": float(values["short"] - anchor.get("short", 0.0)),
-                    }
-                timeline_upnl_by_coin_pside = {
-                    sym: {
-                        "long": float(values["long"]),
-                        "short": float(values["short"]),
-                    }
-                    for sym, values in sorted(upnl_by_coin_pside.items())
-                }
-                for sym in sorted(realized_pnl_coin_pside_running):
-                    if sym not in active_symbols:
-                        timeline_upnl_by_coin_pside.setdefault(
+                if compact_coin_replay:
+                    if compact_row_idx >= compact_record_minutes:
+                        raise RuntimeError(
+                            "compact coin HSL replay row count exceeded allocated minute grid"
+                        )
+                    compact_timestamps[compact_row_idx] = int(minute)
+                    compact_balances[compact_row_idx] = float(balance)
+                    compact_realized_pnl[compact_row_idx] = float(realized_pnl_window)
+                    for sym, values in realized_pnl_coin_pside_running.items():
+                        anchor = record_start_realized_pnl_coin_pside.get(
                             sym, {"long": 0.0, "short": 0.0}
                         )
-                timeline.append(
-                    {
-                        "timestamp": minute,
-                        "balance": balance,
-                        "equity": balance + upnl,
-                        "unrealized_pnl": upnl,
-                        "realized_pnl": realized_pnl_window,
-                        "unrealized_pnl_long": upnl_by_pside["long"],
-                        "unrealized_pnl_short": upnl_by_pside["short"],
-                        "realized_pnl_long": realized_pnl_pside_window["long"],
-                        "realized_pnl_short": realized_pnl_pside_window["short"],
-                        "unrealized_pnl_by_coin_pside": timeline_upnl_by_coin_pside,
-                        "realized_pnl_by_coin_pside": realized_pnl_coin_pside_window,
-                        "is_flat": len(active_symbols) == 0,
-                        "is_flat_long": not any(
-                            not _is_flat_size(
-                                sym,
-                                positions.get(sym, {}).get("long", {}).get("size", 0.0),
+                        for pside in ("long", "short"):
+                            pair_values = compact_pair_values.get((pside, sym))
+                            if pair_values is None:
+                                continue
+                            pair_values["realized_pnl"][compact_row_idx] = float(
+                                values[pside] - anchor.get(pside, 0.0)
                             )
-                            for sym in positions
-                        ),
-                        "is_flat_short": not any(
-                            not _is_flat_size(
-                                sym,
-                                positions.get(sym, {}).get("short", {}).get("size", 0.0),
-                            )
-                            for sym in positions
-                        ),
-                        "panic_fill_count": int(panic_fill_count),
+                            if sym not in active_symbols:
+                                pair_values["unrealized_pnl"][compact_row_idx] = 0.0
+                    for sym, values in upnl_by_coin_pside.items():
+                        for pside, value in values.items():
+                            pair_values = compact_pair_values.get((pside, sym))
+                            if pair_values is not None:
+                                pair_values["unrealized_pnl"][compact_row_idx] = float(
+                                    value
+                                )
+                    compact_row_idx += 1
+                else:
+                    realized_pnl_coin_pside_window: Dict[str, Dict[str, float]] = {}
+                    for sym in sorted(
+                        set(realized_pnl_coin_pside_running)
+                        | set(record_start_realized_pnl_coin_pside)
+                    ):
+                        values = realized_pnl_coin_pside_running.get(
+                            sym, {"long": 0.0, "short": 0.0}
+                        )
+                        anchor = record_start_realized_pnl_coin_pside.get(
+                            sym, {"long": 0.0, "short": 0.0}
+                        )
+                        realized_pnl_coin_pside_window[sym] = {
+                            "long": float(values["long"] - anchor.get("long", 0.0)),
+                            "short": float(values["short"] - anchor.get("short", 0.0)),
+                        }
+                    timeline_upnl_by_coin_pside = {
+                        sym: {
+                            "long": float(values["long"]),
+                            "short": float(values["short"]),
+                        }
+                        for sym, values in sorted(upnl_by_coin_pside.items())
                     }
-                )
+                    for sym in sorted(realized_pnl_coin_pside_running):
+                        if sym not in active_symbols:
+                            timeline_upnl_by_coin_pside.setdefault(
+                                sym, {"long": 0.0, "short": 0.0}
+                            )
+                    timeline.append(
+                        {
+                            "timestamp": minute,
+                            "balance": balance,
+                            "equity": balance + upnl,
+                            "unrealized_pnl": upnl,
+                            "realized_pnl": realized_pnl_window,
+                            "unrealized_pnl_long": upnl_by_pside["long"],
+                            "unrealized_pnl_short": upnl_by_pside["short"],
+                            "realized_pnl_long": realized_pnl_pside_window["long"],
+                            "realized_pnl_short": realized_pnl_pside_window["short"],
+                            "unrealized_pnl_by_coin_pside": timeline_upnl_by_coin_pside,
+                            "realized_pnl_by_coin_pside": realized_pnl_coin_pside_window,
+                            "is_flat": len(active_symbols) == 0,
+                            "is_flat_long": not any(
+                                not _is_flat_size(
+                                    sym,
+                                    positions.get(sym, {})
+                                    .get("long", {})
+                                    .get("size", 0.0),
+                                )
+                                for sym in positions
+                            ),
+                            "is_flat_short": not any(
+                                not _is_flat_size(
+                                    sym,
+                                    positions.get(sym, {})
+                                    .get("short", {})
+                                    .get("size", 0.0),
+                                )
+                                for sym in positions
+                            ),
+                            "panic_fill_count": int(panic_fill_count),
+                        }
+                    )
             _collect_replay_matrix_rows(
                 int(minute), record=minute >= record_start_minute
             )
@@ -12277,7 +12383,12 @@ class Passivbot:
             )
             minute += ONE_MIN_MS
 
-        if not timeline:
+        if compact_coin_replay and compact_row_idx != compact_record_minutes:
+            raise RuntimeError(
+                "compact coin HSL replay row count does not match allocated minute grid: "
+                f"expected={compact_record_minutes} actual={compact_row_idx}"
+            )
+        if not compact_coin_replay and not timeline:
             point = {
                 "timestamp": ts_now,
                 "balance": balance_now,
@@ -12314,6 +12425,7 @@ class Passivbot:
             "symbols_covered": sorted(price_replay_symbols),
             "missing_price_symbols": sorted(missing_price_symbols),
             "approximate_price_sources": approximate_price_sources,
+            "history_format": "compact" if compact_coin_replay else "timeline",
         }
         _emit_hsl_history_progress(
             "timeline_replay_completed",
@@ -12321,7 +12433,10 @@ class Passivbot:
                 "events": len(events),
                 "symbols": len(symbols),
                 "price_replay_symbols": len(price_replay_symbols),
-                "timeline_rows": len(timeline),
+                "history_format": "compact" if compact_coin_replay else "timeline",
+                "timeline_rows": (
+                    compact_record_minutes if compact_coin_replay else len(timeline)
+                ),
                 "panic_events": len(panic_flatten_events),
                 "missing_price_symbols": len(missing_price_symbols),
                 "history_minutes": history_minutes,
@@ -12350,12 +12465,9 @@ class Passivbot:
                 end_ms=int(ts_now),
                 lookback=lookback,
             )
-        return {
-            "timeline": timeline,
+        result = {
             "panic_flatten_events": panic_flatten_events,
             "fill_events": events,
-            "balances": balances,
-            "equities": equities,
             "metadata": metadata,
             "hsl_replay_matrices": hsl_replay_matrices,
             "hsl_replay_account_series": (
@@ -12375,6 +12487,18 @@ class Passivbot:
                 "candle_covered_end_ms": int(end_minute),
             },
         }
+        if compact_coin_replay:
+            result["hsl_coin_compact_replay"] = {
+                "timestamps": compact_timestamps,
+                "balances": compact_balances,
+                "realized_pnl": compact_realized_pnl,
+                "pair_values": compact_pair_values,
+            }
+        else:
+            result["timeline"] = timeline
+            result["balances"] = balances
+            result["equities"] = equities
+        return result
 
     async def update_open_orders(self):
         """Refresh open orders from the exchange and reconcile the local cache."""

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -4948,6 +4948,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             history = await self.get_balance_equity_history(
                 current_balance=self.get_raw_balance(),
                 hsl_replay_signal_mode="coin",
+                hsl_coin_compact_replay=True,
             )
         history_loaded_s = time.monotonic()
         history_fetch_elapsed_s = max(0.0, history_loaded_s - history_fetch_started_s)
@@ -4968,13 +4969,105 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 f"get_balance_equity_history()['fill_events'] must be a list, got {type(fill_events).__name__}"
             )
 
-        if "timeline" not in history:
-            raise ValueError("get_balance_equity_history() missing required key: timeline")
-        timeline = history["timeline"]
-        if not isinstance(timeline, list):
-            raise TypeError(
-                f"get_balance_equity_history()['timeline'] must be a list, got {type(timeline).__name__}"
+        compact_replay = history.get("hsl_coin_compact_replay")
+        timeline = history.get("timeline")
+        if compact_replay is None:
+            if timeline is None:
+                raise ValueError(
+                    "get_balance_equity_history() missing required coin replay payload: "
+                    "timeline or hsl_coin_compact_replay"
+                )
+            if not isinstance(timeline, list):
+                raise TypeError(
+                    "get_balance_equity_history()['timeline'] must be a list, "
+                    f"got {type(timeline).__name__}"
+                )
+        else:
+            import numpy as np
+
+            if cache_reused:
+                raise ValueError("cache-reused coin HSL history must use the timeline contract")
+            if not isinstance(compact_replay, dict):
+                raise TypeError(
+                    "get_balance_equity_history()['hsl_coin_compact_replay'] must be a dict, "
+                    f"got {type(compact_replay).__name__}"
+                )
+            required_compact_fields = {
+                "timestamps",
+                "balances",
+                "realized_pnl",
+                "pair_values",
+            }
+            actual_compact_fields = set(compact_replay)
+            if actual_compact_fields != required_compact_fields:
+                raise ValueError(
+                    "compact coin HSL replay fields mismatch: "
+                    f"missing={sorted(required_compact_fields - actual_compact_fields)} "
+                    f"extra={sorted(actual_compact_fields - required_compact_fields)}"
+                )
+            compact_timestamps = np.asarray(compact_replay["timestamps"], dtype=np.int64)
+            compact_balances = np.asarray(compact_replay["balances"], dtype=np.float64)
+            compact_realized_pnl = np.asarray(
+                compact_replay["realized_pnl"], dtype=np.float64
             )
+            compact_pair_values = compact_replay["pair_values"]
+            if not isinstance(compact_pair_values, dict):
+                raise TypeError(
+                    "compact coin HSL replay pair_values must be a dict, "
+                    f"got {type(compact_pair_values).__name__}"
+                )
+            compact_len = len(compact_timestamps)
+            if compact_len == 0:
+                raise ValueError("compact coin HSL replay must contain at least one row")
+            if len(compact_balances) != compact_len or len(compact_realized_pnl) != compact_len:
+                raise ValueError("compact coin HSL replay account arrays must have equal lengths")
+            if compact_len > 1 and not bool(
+                np.all(np.diff(compact_timestamps) == _HSL_REPLAY_MATRIX_INTERVAL_MS)
+            ):
+                raise ValueError(
+                    "compact coin HSL replay timestamps must be contiguous 1m samples"
+                )
+            if not bool(np.all(np.isfinite(compact_balances))) or bool(
+                np.any(compact_balances <= 0.0)
+            ):
+                raise ValueError(
+                    "compact coin HSL replay balances must be finite and > 0"
+                )
+            if not bool(np.all(np.isfinite(compact_realized_pnl))):
+                raise ValueError("compact coin HSL replay realized_pnl must be finite")
+            normalized_pair_values: dict[tuple[str, str], dict[str, Any]] = {}
+            for pair, values in compact_pair_values.items():
+                if (
+                    not isinstance(pair, tuple)
+                    or len(pair) != 2
+                    or str(pair[0]) not in self._hsl_psides()
+                    or not str(pair[1])
+                ):
+                    raise ValueError(f"invalid compact coin HSL replay pair key: {pair!r}")
+                if not isinstance(values, dict) or set(values) != {
+                    "realized_pnl",
+                    "unrealized_pnl",
+                }:
+                    raise ValueError(
+                        f"invalid compact coin HSL replay values for {pair!r}"
+                    )
+                realized_values = np.asarray(values["realized_pnl"], dtype=np.float64)
+                unrealized_values = np.asarray(values["unrealized_pnl"], dtype=np.float64)
+                if len(realized_values) != compact_len or len(unrealized_values) != compact_len:
+                    raise ValueError(
+                        f"compact coin HSL replay pair arrays must match account length for {pair!r}"
+                    )
+                if bool(np.any(np.isinf(realized_values))) or bool(
+                    np.any(np.isinf(unrealized_values))
+                ):
+                    raise ValueError(
+                        f"compact coin HSL replay pair values must be finite or NaN for {pair!r}"
+                    )
+                normalized_pair_values[(str(pair[0]), str(pair[1]))] = {
+                    "realized_pnl": realized_values,
+                    "unrealized_pnl": unrealized_values,
+                }
+            compact_pair_values = normalized_pair_values
 
         now_ms = int(self.get_exchange_time())
         lookback_ms = self._equity_hard_stop_lookback_ms()
@@ -5017,25 +5110,37 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 if (pside, symbol) in current_position_pairs:
                     required_replay_pairs.add((pside, symbol))
                     remember_required_replay_start(pside, symbol, ts)
-        for row in timeline:
-            if not isinstance(row, dict):
-                continue
-            for key in ("realized_pnl_by_coin_pside", "unrealized_pnl_by_coin_pside"):
-                if key not in row or row[key] is None:
+        if compact_replay is not None:
+            for _pside, symbol in compact_pair_values:
+                if not self._equity_hard_stop_symbol_supported_for_coin_replay(symbol):
+                    skipped_unsupported_symbols.add(symbol)
                     continue
-                if not isinstance(row[key], dict):
-                    raise TypeError(
-                        f"get_balance_equity_history()['timeline'][]['{key}'] must be a dict, "
-                        f"got {type(row[key]).__name__}"
-                    )
-                for symbol in row[key].keys():
-                    symbol = str(symbol)
-                    if not symbol:
+                symbols.add(symbol)
+        else:
+            for row in timeline:
+                if not isinstance(row, dict):
+                    continue
+                for key in (
+                    "realized_pnl_by_coin_pside",
+                    "unrealized_pnl_by_coin_pside",
+                ):
+                    if key not in row or row[key] is None:
                         continue
-                    if not self._equity_hard_stop_symbol_supported_for_coin_replay(symbol):
-                        skipped_unsupported_symbols.add(symbol)
-                        continue
-                    symbols.add(symbol)
+                    if not isinstance(row[key], dict):
+                        raise TypeError(
+                            f"get_balance_equity_history()['timeline'][]['{key}'] must be a dict, "
+                            f"got {type(row[key]).__name__}"
+                        )
+                    for symbol in row[key].keys():
+                        symbol = str(symbol)
+                        if not symbol:
+                            continue
+                        if not self._equity_hard_stop_symbol_supported_for_coin_replay(
+                            symbol
+                        ):
+                            skipped_unsupported_symbols.add(symbol)
+                            continue
+                        symbols.add(symbol)
 
         latest_panic_by_coin_minute: dict[tuple[str, str, int], dict[str, Any]] = {}
         for item in panic_flatten_events:
@@ -5076,15 +5181,19 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             )
 
         timeline_rows: list[dict[str, Any]] = []
-        for row in timeline:
-            if not isinstance(row, dict):
-                continue
-            if "timestamp" not in row or "balance" not in row:
-                continue
-            ts = int(row["timestamp"])
-            if ts > now_ms:
-                break
-            timeline_rows.append(row)
+        if compact_replay is None:
+            for row in timeline:
+                if not isinstance(row, dict):
+                    continue
+                if "timestamp" not in row or "balance" not in row:
+                    continue
+                ts = int(row["timestamp"])
+                if ts > now_ms:
+                    break
+                timeline_rows.append(row)
+            replay_row_count = len(timeline_rows)
+        else:
+            replay_row_count = int(np.searchsorted(compact_timestamps, now_ms, side="right"))
 
         balance = float(self.get_raw_balance())
         rows = 0
@@ -5113,7 +5222,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             "[risk] HSL coin history reconstruction loaded | symbols=%d pairs=%d rows=%d fills=%d panic_events=%d",
             len(symbols),
             len(active_pairs),
-            len(timeline_rows),
+            replay_row_count,
             len(fill_events),
             len(panic_flatten_events),
         )
@@ -5123,12 +5232,15 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             {
                 "signal_mode": "coin",
                 "stage": "loaded",
+                "history_format": (
+                    "compact" if compact_replay is not None else "timeline"
+                ),
                 "symbols": len(symbols),
                 "pairs": len(active_pairs),
                 "held_pairs": len(active_held_pairs),
                 "cooldown_pairs": len(active_panic_pairs),
                 "required_pairs": len(active_required_pairs),
-                "timeline_rows": len(timeline_rows),
+                "timeline_rows": replay_row_count,
                 "fill_events": len(fill_events),
                 "panic_events": len(panic_flatten_events),
                 "skipped_unsupported_symbols": len(skipped_unsupported_symbols),
@@ -5176,7 +5288,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     "held_pairs": len(active_held_pairs),
                     "cooldown_pairs": len(active_panic_pairs),
                     "required_pairs": len(active_required_pairs),
-                    "timeline_rows": len(timeline_rows),
+                    "timeline_rows": replay_row_count,
                     "applied_rows": int(applied_rows),
                     "total_applied_rows": int(rows),
                     "rows_per_second": round(rows_per_second, 3)
@@ -5311,6 +5423,101 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         replay_event_idx += 1
                     return float(replay_size)
 
+                if compact_replay is not None:
+                    compact_values = compact_pair_values.get((pside, symbol))
+                    compact_realized_values = (
+                        None
+                        if compact_values is None
+                        else compact_values["realized_pnl"]
+                    )
+                    compact_unrealized_values = (
+                        None
+                        if compact_values is None
+                        else compact_values["unrealized_pnl"]
+                    )
+
+                    def iter_replay_rows():
+                        for compact_idx in range(replay_row_count):
+                            realized_value = (
+                                math.nan
+                                if compact_realized_values is None
+                                else float(compact_realized_values[compact_idx])
+                            )
+                            unrealized_value = (
+                                math.nan
+                                if compact_unrealized_values is None
+                                else float(compact_unrealized_values[compact_idx])
+                            )
+                            yield (
+                                compact_idx + 1,
+                                int(compact_timestamps[compact_idx]),
+                                float(compact_balances[compact_idx]),
+                                float(compact_realized_pnl[compact_idx]),
+                                not math.isnan(realized_value),
+                                realized_value,
+                                not math.isnan(unrealized_value),
+                                unrealized_value,
+                                None,
+                            )
+
+                else:
+
+                    def iter_replay_rows():
+                        for legacy_idx, row in enumerate(timeline_rows, start=1):
+                            has_realized_value = (
+                                _equity_hard_stop_history_coin_has_value(
+                                    row,
+                                    "realized_pnl_by_coin_pside",
+                                    symbol,
+                                    pside,
+                                )
+                            )
+                            has_unrealized_value = (
+                                _equity_hard_stop_history_coin_has_value(
+                                    row,
+                                    "unrealized_pnl_by_coin_pside",
+                                    symbol,
+                                    pside,
+                                )
+                            )
+                            yield (
+                                legacy_idx,
+                                int(row["timestamp"]),
+                                float(row["balance"]),
+                                (
+                                    float(row["realized_pnl"])
+                                    if "realized_pnl" in row
+                                    else None
+                                ),
+                                has_realized_value,
+                                (
+                                    _equity_hard_stop_history_coin_value(
+                                        row,
+                                        "realized_pnl_by_coin_pside",
+                                        symbol,
+                                        pside,
+                                        require_key=has_realized_value,
+                                        require_value=has_realized_value,
+                                    )
+                                    if has_realized_value
+                                    else 0.0
+                                ),
+                                has_unrealized_value,
+                                (
+                                    _equity_hard_stop_history_coin_value(
+                                        row,
+                                        "unrealized_pnl_by_coin_pside",
+                                        symbol,
+                                        pside,
+                                        require_key=has_unrealized_value,
+                                        require_value=has_unrealized_value,
+                                    )
+                                    if has_unrealized_value
+                                    else 0.0
+                                ),
+                                row,
+                            )
+
                 background_replay = bool(
                     self._equity_hard_stop_coin_protective_ready
                 )
@@ -5324,12 +5531,21 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     if background_replay
                     else 0.0
                 )
-                for row_idx, row in enumerate(timeline_rows, start=1):
+                for (
+                    row_idx,
+                    ts,
+                    row_balance,
+                    row_realized_pnl,
+                    has_realized,
+                    realized_value,
+                    has_unrealized,
+                    unrealized_value,
+                    source_row,
+                ) in iter_replay_rows():
                     if row_idx % yield_rows == 0:
                         await asyncio.sleep(yield_sleep_s)
                         check_shutdown("hsl_coin_history_replay_rows")
                         log_replay_progress(pair_idx, pside, symbol, applied_rows)
-                    ts = int(row["timestamp"])
                     if replay_start_boundary_ts is not None and ts < replay_start_boundary_ts:
                         continue
                     if state["halted"]:
@@ -5345,12 +5561,6 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                             reset_rolling_window()
                         else:
                             continue
-                    has_realized = _equity_hard_stop_history_coin_has_value(
-                        row, "realized_pnl_by_coin_pside", symbol, pside
-                    )
-                    has_unrealized = _equity_hard_stop_history_coin_has_value(
-                        row, "unrealized_pnl_by_coin_pside", symbol, pside
-                    )
                     row_has_coin_fields = has_realized or has_unrealized
                     require_coin_timeline_value = (
                         (
@@ -5364,14 +5574,22 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     if not require_coin_timeline_value:
                         continue
                     replay_position_size = replay_size_at(ts)
-                    abs_realized = _equity_hard_stop_history_coin_value(
-                        row,
-                        "realized_pnl_by_coin_pside",
-                        symbol,
-                        pside,
-                        require_key=require_coin_timeline_value,
-                        require_value=require_coin_timeline_value,
-                    )
+                    if not has_realized:
+                        if source_row is not None:
+                            _equity_hard_stop_history_coin_value(
+                                source_row,
+                                "realized_pnl_by_coin_pside",
+                                symbol,
+                                pside,
+                                require_key=True,
+                                require_value=True,
+                            )
+                        raise ValueError(
+                            "coin HSL replay missing required "
+                            "realized_pnl_by_coin_pside value for "
+                            f"{pside}:{symbol} at {ts}"
+                        )
+                    abs_realized = float(realized_value)
                     seen_coin_timeline_fields = True
                     last_realized = abs_realized - reset_baseline_realized
                     start_ms = None if lookback_ms is None else ts - int(lookback_ms)
@@ -5403,32 +5621,31 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         if replay_ambiguous or replay_position_size > flat_epsilon:
                             if not require_coin_timeline_fields:
                                 continue
-                            current_upnl = _equity_hard_stop_history_coin_value(
-                                row,
-                                "unrealized_pnl_by_coin_pside",
-                                symbol,
-                                pside,
-                                require_key=True,
-                                require_value=True,
+                            if source_row is not None:
+                                _equity_hard_stop_history_coin_value(
+                                    source_row,
+                                    "unrealized_pnl_by_coin_pside",
+                                    symbol,
+                                    pside,
+                                    require_key=True,
+                                    require_value=True,
+                                )
+                            raise ValueError(
+                                "coin HSL replay missing required "
+                                "unrealized_pnl_by_coin_pside value for "
+                                f"{pside}:{symbol} at {ts}"
                             )
                         else:
                             current_upnl = 0.0
                     else:
-                        current_upnl = _equity_hard_stop_history_coin_value(
-                            row,
-                            "unrealized_pnl_by_coin_pside",
-                            symbol,
-                            pside,
-                            require_key=require_coin_timeline_value,
-                            require_value=require_coin_timeline_value,
-                        )
+                        current_upnl = float(unrealized_value)
                     self._equity_hard_stop_prime_coin_runtime_for_replay(pside, symbol, ts)
                     marker = latest_panic_by_coin_minute.get((pside, symbol, ts))
                     metrics = self._equity_hard_stop_apply_coin_metrics_sample(
                         pside,
                         symbol,
                         ts,
-                        float(row["balance"]),
+                        row_balance,
                         peak_realized,
                         window_last_realized,
                         current_upnl,
@@ -5514,7 +5731,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         symbol=symbol,
                         stop_event_timestamp_ms=stop_ts,
                         balance=float(metrics["balance"]),
-                        realized_pnl_total=float(row["realized_pnl"]) if "realized_pnl" in row else None,
+                        realized_pnl_total=row_realized_pnl,
                         realized_pnl=float(metrics["realized_pnl"]),
                         unrealized_pnl=float(metrics["unrealized_pnl"]),
                         strategy_pnl=float(metrics["strategy_pnl"]),
@@ -5706,6 +5923,9 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             {
                 "signal_mode": "coin",
                 "stage": "full_replay",
+                "history_format": (
+                    "compact" if compact_replay is not None else "timeline"
+                ),
                 "rows": int(rows),
                 "applied_rows": int(rows),
                 "pairs": len(active_pairs),
@@ -5713,7 +5933,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 "cooldown_pairs": len(active_panic_pairs),
                 "required_pairs": len(active_required_pairs),
                 "skipped_pairs": int(skipped_pairs),
-                "timeline_rows": len(timeline_rows),
+                "timeline_rows": replay_row_count,
                 "fill_events": len(fill_events),
                 "panic_events": len(panic_flatten_events),
                 "rows_per_second": round(rows_per_second, 3)

--- a/src/tools/hsl_replay_benchmark.py
+++ b/src/tools/hsl_replay_benchmark.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import time
+import tracemalloc
 from collections import defaultdict
 from typing import Any
 
@@ -21,23 +22,52 @@ DEFAULT_ITERATIONS = 1
 MAX_MINUTES = 1_440
 MAX_SYMBOLS = 32
 MAX_ITERATIONS = 20
+LOCAL_SCALE_MAX_MINUTES = 43_201
+LOCAL_SCALE_MAX_SYMBOLS = 30
+BACKGROUND_YIELD_ROWS = 100
 
 
 def _fixture_symbol(index: int) -> str:
     return f"HSLBENCH{index:02d}/USDT:USDT"
 
 
-def build_coin_hsl_history_fixture(minutes: int, symbols: int) -> dict[str, Any]:
-    """Build a bounded, deterministic coin-HSL history with one active long per symbol."""
-    if not 1 <= int(minutes) <= MAX_MINUTES:
-        raise ValueError(f"minutes must be between 1 and {MAX_MINUTES}")
-    if not 1 <= int(symbols) <= MAX_SYMBOLS:
-        raise ValueError(f"symbols must be between 1 and {MAX_SYMBOLS}")
+def _validate_fixture_shape(
+    minutes: int,
+    symbols: int,
+    held_symbols: int | None,
+    *,
+    local_scale: bool,
+) -> tuple[int, int, int]:
+    max_minutes = LOCAL_SCALE_MAX_MINUTES if local_scale else MAX_MINUTES
+    max_symbols = LOCAL_SCALE_MAX_SYMBOLS if local_scale else MAX_SYMBOLS
+    minutes = int(minutes)
+    symbols = int(symbols)
+    held_symbols = symbols if held_symbols is None else int(held_symbols)
+    if not 1 <= minutes <= max_minutes:
+        raise ValueError(f"minutes must be between 1 and {max_minutes}")
+    if not 1 <= symbols <= max_symbols:
+        raise ValueError(f"symbols must be between 1 and {max_symbols}")
+    if not 0 <= held_symbols <= symbols:
+        raise ValueError(f"held_symbols must be between 0 and {symbols}")
+    return minutes, symbols, held_symbols
 
-    names = [_fixture_symbol(index) for index in range(int(symbols))]
+
+def build_coin_hsl_history_fixture(
+    minutes: int,
+    symbols: int,
+    held_symbols: int | None = None,
+    *,
+    local_scale: bool = False,
+) -> dict[str, Any]:
+    """Build deterministic coin-HSL history with optional flat background symbols."""
+    minutes, symbols, held_symbols = _validate_fixture_shape(
+        minutes, symbols, held_symbols, local_scale=local_scale
+    )
+
+    names = [_fixture_symbol(index) for index in range(symbols)]
     timeline: list[dict[str, Any]] = []
     fill_events: list[dict[str, Any]] = []
-    for symbol_index, symbol in enumerate(names):
+    for symbol_index, symbol in enumerate(names[:held_symbols]):
         fill_events.append(
             {
                 "timestamp": 1,
@@ -48,7 +78,7 @@ def build_coin_hsl_history_fixture(minutes: int, symbols: int) -> dict[str, Any]
                 "id": f"fixture-open-{symbol_index}",
             }
         )
-    for minute in range(1, int(minutes) + 1):
+    for minute in range(1, minutes + 1):
         realized_by_symbol: dict[str, dict[str, float]] = {}
         unrealized_by_symbol: dict[str, dict[str, float]] = {}
         total_realized = 0.0
@@ -74,16 +104,93 @@ def build_coin_hsl_history_fixture(minutes: int, symbols: int) -> dict[str, Any]
     }
 
 
+def build_coin_hsl_compact_fixture(
+    minutes: int,
+    symbols: int,
+    held_symbols: int | None = None,
+    *,
+    local_scale: bool = False,
+) -> dict[str, Any]:
+    """Build the same deterministic fixture directly in compact replay form."""
+    import numpy as np
+
+    minutes, symbols, held_symbols = _validate_fixture_shape(
+        minutes, symbols, held_symbols, local_scale=local_scale
+    )
+    names = [_fixture_symbol(index) for index in range(symbols)]
+    minute_numbers = np.arange(1, minutes + 1, dtype=np.int64)
+    timestamps = minute_numbers * 60_000
+    pair_values: dict[tuple[str, str], dict[str, Any]] = {}
+    realized_total = np.zeros(minutes, dtype=np.float64)
+    for symbol_index, symbol in enumerate(names):
+        realized = ((minute_numbers * (symbol_index + 3)) % 19).astype(
+            np.float64
+        ) / 100.0
+        unrealized = -(
+            (minute_numbers + symbol_index * 5) % 11
+        ).astype(np.float64) / 100.0
+        pair_values[("long", symbol)] = {
+            "realized_pnl": realized,
+            "unrealized_pnl": unrealized,
+        }
+        realized_total += realized
+    fill_events = [
+        {
+            "timestamp": 1,
+            "symbol": symbol,
+            "pside": "long",
+            "action": "increase",
+            "qty": 1.0,
+            "id": f"fixture-open-{symbol_index}",
+        }
+        for symbol_index, symbol in enumerate(names[:held_symbols])
+    ]
+    return {
+        "hsl_coin_compact_replay": {
+            "timestamps": timestamps,
+            "balances": np.full(minutes, 1_000.0, dtype=np.float64),
+            "realized_pnl": realized_total,
+            "pair_values": pair_values,
+        },
+        "fill_events": fill_events,
+        "panic_flatten_events": [],
+    }
+
+
 def _fixture_digest(history: dict[str, Any]) -> str:
+    compact = history.get("hsl_coin_compact_replay")
+    if compact is not None:
+        digest = hashlib.sha256()
+        for field in ("timestamps", "balances", "realized_pnl"):
+            digest.update(field.encode("utf-8"))
+            digest.update(compact[field].tobytes(order="C"))
+        for pair in sorted(compact["pair_values"]):
+            digest.update(f"{pair[0]}\0{pair[1]}".encode("utf-8"))
+            values = compact["pair_values"][pair]
+            digest.update(values["realized_pnl"].tobytes(order="C"))
+            digest.update(values["unrealized_pnl"].tobytes(order="C"))
+        digest.update(
+            json.dumps(
+                history["fill_events"], sort_keys=True, separators=(",", ":")
+            ).encode("utf-8")
+        )
+        return digest.hexdigest()
     encoded = json.dumps(history, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _make_offline_replay_bot(history: dict[str, Any], timings: dict[str, dict[str, int]]) -> Passivbot:
+def _make_offline_replay_bot(
+    history: dict[str, Any],
+    timings: dict[str, dict[str, int]],
+    held_symbols: set[str],
+    sample_counts: dict[str, int],
+) -> Passivbot:
     """Create an uninitialized bot that can only replay supplied in-memory history."""
     bot = Passivbot.__new__(Passivbot)
-    symbols = sorted(history["timeline"][0]["realized_pnl_by_coin_pside"])
-    now_ms = int(history["timeline"][-1]["timestamp"])
+    if "hsl_coin_compact_replay" in history:
+        now_ms = int(history["hsl_coin_compact_replay"]["timestamps"][-1])
+    else:
+        now_ms = int(history["timeline"][-1]["timestamp"])
     side_effects = {
         "network_calls": 0,
         "cache_reads": 0,
@@ -108,7 +215,7 @@ def _make_offline_replay_bot(history: dict[str, Any], timings: dict[str, dict[st
             "long": {"size": 1.0, "price": 100.0},
             "short": {"size": 0.0, "price": 0.0},
         }
-        for symbol in symbols
+        for symbol in held_symbols
     }
     bot.open_orders = {}
     bot.active_symbols = []
@@ -151,7 +258,7 @@ def _make_offline_replay_bot(history: dict[str, Any], timings: dict[str, dict[st
     bot.live_value = lambda key: bot.config["live"][key]
     bot._equity_hard_stop_realized_pnl_now = lambda pside=None: 0.0
     bot.bot_value = lambda pside, key: {
-        "n_positions": len(symbols),
+        "n_positions": len(held_symbols),
         "total_wallet_exposure_limit": 1.0,
     }[key]
 
@@ -195,6 +302,10 @@ def _make_offline_replay_bot(history: dict[str, Any], timings: dict[str, dict[st
         finally:
             timings["coin_metrics_sample"]["calls"] += 1
             timings["coin_metrics_sample"]["elapsed_ns"] += time.perf_counter_ns() - started_ns
+            symbol = args[1] if len(args) > 1 else kwargs["symbol"]
+            sample_counts[
+                "held_replay_samples" if symbol in held_symbols else "background_replay_samples"
+            ] += 1
 
     bot.get_balance_equity_history = history_provider
     bot._equity_hard_stop_try_reuse_replay_cache = no_cache_reuse
@@ -229,21 +340,50 @@ def _state_digest(bot: Passivbot) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-async def run_hsl_replay_benchmark(
-    *, minutes: int = DEFAULT_MINUTES, symbols: int = DEFAULT_SYMBOLS, iterations: int = DEFAULT_ITERATIONS
+async def _run_hsl_replay_benchmark(
+    *,
+    minutes: int = DEFAULT_MINUTES,
+    symbols: int = DEFAULT_SYMBOLS,
+    held_symbols: int | None = None,
+    iterations: int = DEFAULT_ITERATIONS,
+    local_scale: bool = False,
+    history_format: str = "timeline",
 ) -> dict[str, Any]:
     if getattr(pbr, "__is_stub__", False):
         raise RuntimeError("passivbot_rust extension is required for hsl-replay-benchmark")
     if not 1 <= int(iterations) <= MAX_ITERATIONS:
         raise ValueError(f"iterations must be between 1 and {MAX_ITERATIONS}")
 
-    history = build_coin_hsl_history_fixture(minutes=minutes, symbols=symbols)
+    minutes, symbols, held_symbols = _validate_fixture_shape(
+        minutes, symbols, held_symbols, local_scale=local_scale
+    )
+    if history_format == "timeline":
+        history = build_coin_hsl_history_fixture(
+            minutes=minutes,
+            symbols=symbols,
+            held_symbols=held_symbols,
+            local_scale=local_scale,
+        )
+    elif history_format == "compact":
+        history = build_coin_hsl_compact_fixture(
+            minutes=minutes,
+            symbols=symbols,
+            held_symbols=held_symbols,
+            local_scale=local_scale,
+        )
+    else:
+        raise ValueError(
+            "history_format must be one of timeline or compact, "
+            f"got {history_format!r}"
+        )
+    held_names = {_fixture_symbol(index) for index in range(held_symbols)}
     timing_totals: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    sample_counts: dict[str, int] = defaultdict(int)
     state_digests: list[str] = []
     side_effect_totals: dict[str, int] = defaultdict(int)
     full_replay_elapsed_ns = 0
     for _ in range(int(iterations)):
-        bot = _make_offline_replay_bot(history, timing_totals)
+        bot = _make_offline_replay_bot(history, timing_totals, held_names, sample_counts)
         started_ns = time.perf_counter_ns()
         previous_logging_disable = logging.root.manager.disable
         logging.disable(logging.CRITICAL)
@@ -258,11 +398,19 @@ async def run_hsl_replay_benchmark(
     if len(set(state_digests)) != 1:
         raise RuntimeError("offline coin-HSL replay produced non-deterministic final state")
 
-    expected_replay_samples = int(minutes) * int(symbols) * int(iterations)
-    expected_current_samples = int(symbols) * int(iterations)
+    expected_replay_samples = minutes * symbols * int(iterations)
+    expected_current_samples = symbols * int(iterations)
+    expected_held_samples = minutes * held_symbols * int(iterations)
+    background_symbols = symbols - held_symbols
+    expected_background_samples = minutes * background_symbols * int(iterations)
+    expected_background_yields = (
+        (minutes // BACKGROUND_YIELD_ROWS) * background_symbols * int(iterations)
+    )
+    held_current_samples = held_symbols * int(iterations)
+    background_current_samples = background_symbols * int(iterations)
     actual_sample_calls = int(timing_totals["coin_metrics_sample"]["calls"])
     elapsed_seconds = max(full_replay_elapsed_ns, 1) / 1_000_000_000.0
-    replay_rows = int(minutes) * int(iterations)
+    replay_rows = minutes * int(iterations)
     return {
         "schema_version": BENCHMARK_SCHEMA_VERSION,
         "kind": "hsl_replay_benchmark",
@@ -270,18 +418,35 @@ async def run_hsl_replay_benchmark(
         "fixture": {
             "minutes": int(minutes),
             "symbols": int(symbols),
-            "timeline_rows": len(history["timeline"]),
+            "held_symbols": held_symbols,
+            "background_symbols": background_symbols,
+            "history_format": history_format,
+            "timeline_rows": len(history.get("timeline") or []),
+            "compact_rows": (
+                len(history["hsl_coin_compact_replay"]["timestamps"])
+                if "hsl_coin_compact_replay" in history
+                else 0
+            ),
             "fill_events": len(history["fill_events"]),
             "panic_events": len(history["panic_flatten_events"]),
             "sha256": _fixture_digest(history),
         },
         "counters": {
             "iterations": int(iterations),
-            "active_pairs": int(symbols) * int(iterations),
+            "active_pairs": symbols * int(iterations),
+            "held_pairs": held_symbols * int(iterations),
+            "background_pairs": background_symbols * int(iterations),
             "expected_replay_samples": expected_replay_samples,
             "expected_current_samples": expected_current_samples,
+            "expected_held_samples": expected_held_samples,
+            "expected_background_samples": expected_background_samples,
+            "expected_background_yields": expected_background_yields,
             "coin_metrics_sample_calls": actual_sample_calls,
             "replay_samples_applied": actual_sample_calls - expected_current_samples,
+            "held_replay_samples": int(sample_counts["held_replay_samples"]) - held_current_samples,
+            "background_replay_samples": (
+                int(sample_counts["background_replay_samples"]) - background_current_samples
+            ),
         },
         "timings": {
             stage: {"calls": int(values["calls"]), "elapsed_ns": int(values["elapsed_ns"])}
@@ -302,6 +467,51 @@ async def run_hsl_replay_benchmark(
     }
 
 
+async def run_hsl_replay_benchmark(
+    *,
+    minutes: int = DEFAULT_MINUTES,
+    symbols: int = DEFAULT_SYMBOLS,
+    held_symbols: int | None = None,
+    iterations: int = DEFAULT_ITERATIONS,
+    local_scale: bool = False,
+    profile_memory: bool = False,
+    history_format: str = "timeline",
+) -> dict[str, Any]:
+    """Run the benchmark, optionally recording Python allocation peak usage."""
+    if getattr(pbr, "__is_stub__", False):
+        raise RuntimeError("passivbot_rust extension is required for hsl-replay-benchmark")
+    if not 1 <= int(iterations) <= MAX_ITERATIONS:
+        raise ValueError(f"iterations must be between 1 and {MAX_ITERATIONS}")
+    _validate_fixture_shape(minutes, symbols, held_symbols, local_scale=local_scale)
+
+    tracing_started_here = False
+    if profile_memory:
+        if not tracemalloc.is_tracing():
+            tracemalloc.start()
+            tracing_started_here = True
+        tracemalloc.reset_peak()
+    try:
+        report = await _run_hsl_replay_benchmark(
+            minutes=minutes,
+            symbols=symbols,
+            held_symbols=held_symbols,
+            iterations=iterations,
+            local_scale=local_scale,
+            history_format=history_format,
+        )
+        if profile_memory:
+            current_bytes, peak_bytes = tracemalloc.get_traced_memory()
+            report["memory"] = {
+                "tracemalloc": True,
+                "current_bytes": int(current_bytes),
+                "peak_bytes": int(peak_bytes),
+            }
+        return report
+    finally:
+        if tracing_started_here:
+            tracemalloc.stop()
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
@@ -312,7 +522,29 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--minutes", type=int, default=DEFAULT_MINUTES, help=f"Fixture minutes (1-{MAX_MINUTES}).")
     parser.add_argument("--symbols", type=int, default=DEFAULT_SYMBOLS, help=f"Fixture symbols (1-{MAX_SYMBOLS}).")
     parser.add_argument(
+        "--held-symbols",
+        type=int,
+        default=None,
+        help="Current-position symbols (default: all fixture symbols).",
+    )
+    parser.add_argument(
         "--iterations", type=int, default=DEFAULT_ITERATIONS, help=f"Replay iterations (1-{MAX_ITERATIONS})."
+    )
+    parser.add_argument(
+        "--local-scale",
+        action="store_true",
+        help=f"Allow local-scale limits ({LOCAL_SCALE_MAX_MINUTES} minutes, {LOCAL_SCALE_MAX_SYMBOLS} symbols).",
+    )
+    parser.add_argument(
+        "--profile-memory",
+        action="store_true",
+        help="Record Python allocation current and peak bytes with tracemalloc.",
+    )
+    parser.add_argument(
+        "--history-format",
+        choices=("timeline", "compact"),
+        default="timeline",
+        help="Replay payload representation (default: timeline).",
     )
     parser.add_argument("--compact", action="store_true", help="Emit compact single-line JSON.")
     return parser
@@ -325,7 +557,11 @@ def main(argv: list[str] | None = None) -> int:
             run_hsl_replay_benchmark(
                 minutes=int(args.minutes),
                 symbols=int(args.symbols),
+                held_symbols=args.held_symbols,
                 iterations=int(args.iterations),
+                local_scale=bool(args.local_scale),
+                profile_memory=bool(args.profile_memory),
+                history_format=str(args.history_format),
             )
         )
     except ValueError as exc:

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import math
 from types import MethodType, SimpleNamespace
 
 import pytest
@@ -2134,7 +2135,12 @@ async def test_data_maintainers_own_active_coin_hsl_replay_task():
     assert hourly_task.cancelled()
 
 
-async def _run_parity_history(monkeypatch):
+async def _run_parity_history(
+    monkeypatch,
+    *,
+    compact: bool = False,
+    fill_events_override: list[dict] | None = None,
+):
     """Run the real coin-mode collection over a small two-close scenario."""
     import numpy as np
     from unittest.mock import AsyncMock
@@ -2207,13 +2213,81 @@ async def _run_parity_history(monkeypatch):
             "pnl": 0.5,
         },
     ]
+    if fill_events_override is not None:
+        fill_events = fill_events_override
     history = await bot.get_balance_equity_history(
         fill_events=fill_events,
         current_balance=100.0,
         hsl_replay_signal_mode="coin",
+        hsl_coin_compact_replay=compact,
     )
     assert bot._live_event_pipeline.close(timeout=2.0) is True
     return history, symbol
+
+
+@pytest.mark.asyncio
+async def test_hsl_compact_coin_history_matches_authoritative_values(monkeypatch):
+    history, symbol = await _run_parity_history(monkeypatch)
+    compact_history, compact_symbol = await _run_parity_history(
+        monkeypatch, compact=True
+    )
+    assert compact_symbol == symbol
+    assert "timeline" not in compact_history
+    assert "balances" not in compact_history
+    assert "equities" not in compact_history
+    assert history["metadata"]["history_format"] == "timeline"
+    assert compact_history["metadata"]["history_format"] == "compact"
+    assert compact_history["hsl_replay_matrices"] == history["hsl_replay_matrices"]
+    assert (
+        compact_history["hsl_replay_account_series"]
+        == history["hsl_replay_account_series"]
+    )
+    compact = compact_history["hsl_coin_compact_replay"]
+    pair = compact["pair_values"][("long", symbol)]
+    assert compact["timestamps"].tolist() == [
+        int(row["timestamp"]) for row in history["timeline"]
+    ]
+    assert compact["balances"].tolist() == pytest.approx(
+        [float(row["balance"]) for row in history["timeline"]], abs=1e-9
+    )
+    assert compact["realized_pnl"].tolist() == pytest.approx(
+        [float(row["realized_pnl"]) for row in history["timeline"]], abs=1e-9
+    )
+    for idx, row in enumerate(history["timeline"]):
+        realized = row["realized_pnl_by_coin_pside"].get(symbol, {}).get("long")
+        unrealized = row["unrealized_pnl_by_coin_pside"].get(symbol, {}).get("long")
+        if realized is None:
+            assert math.isnan(pair["realized_pnl"][idx])
+        else:
+            assert pair["realized_pnl"][idx] == pytest.approx(realized, abs=1e-9)
+        if unrealized is None:
+            assert math.isnan(pair["unrealized_pnl"][idx])
+        else:
+            assert pair["unrealized_pnl"][idx] == pytest.approx(unrealized, abs=1e-9)
+
+
+@pytest.mark.asyncio
+async def test_hsl_compact_coin_history_zero_fill_shape(monkeypatch):
+    history, _symbol = await _run_parity_history(
+        monkeypatch,
+        compact=True,
+        fill_events_override=[],
+    )
+
+    assert set(history) == {
+        "hsl_coin_compact_replay",
+        "panic_flatten_events",
+        "fill_events",
+        "metadata",
+        "hsl_replay_matrices",
+        "hsl_replay_account_series",
+    }
+    compact = history["hsl_coin_compact_replay"]
+    assert compact["timestamps"].shape == (1,)
+    assert compact["balances"].tolist() == [100.0]
+    assert compact["realized_pnl"].tolist() == [0.0]
+    assert compact["pair_values"] == {}
+    assert history["metadata"]["history_format"] == "compact"
 
 
 @pytest.mark.asyncio
@@ -2273,6 +2347,10 @@ async def test_hsl_cache_synthesized_rows_match_authoritative_timeline(monkeypat
 @pytest.mark.asyncio
 async def test_hsl_cache_synthesized_replay_reaches_identical_coin_state(monkeypatch):
     history, symbol = await _run_parity_history(monkeypatch)
+    compact_history, compact_symbol = await _run_parity_history(
+        monkeypatch, compact=True
+    )
+    assert compact_symbol == symbol
     pair_arrays = hsl._hsl_replay_matrix_arrays(
         history["hsl_replay_matrices"]["long"][symbol]
     )
@@ -2286,7 +2364,7 @@ async def test_hsl_cache_synthesized_replay_reaches_identical_coin_state(monkeyp
     )
     end_ts = int(history["timeline"][-1]["timestamp"])
 
-    async def run_replay(timeline):
+    async def run_replay(payload):
         bot = make_coin_bot()
         bot.positions = {
             symbol: {
@@ -2298,11 +2376,7 @@ async def test_hsl_cache_synthesized_replay_reaches_identical_coin_state(monkeyp
         bot.get_exchange_time = lambda: end_ts
 
         async def fake_history(current_balance=None, **kwargs):
-            return {
-                "timeline": timeline,
-                "panic_flatten_events": [],
-                "fill_events": history["fill_events"],
-            }
+            return payload
 
         bot.get_balance_equity_history = fake_history
         samples = []
@@ -2326,8 +2400,21 @@ async def test_hsl_cache_synthesized_replay_reaches_identical_coin_state(monkeyp
         await bot._equity_hard_stop_initialize_coin_from_history()
         return bot, samples
 
-    bot_auth, samples_auth = await run_replay(history["timeline"])
-    bot_synth, samples_synth = await run_replay(synthesized)
+    def timeline_payload(timeline):
+        return {
+            "timeline": timeline,
+            "panic_flatten_events": [],
+            "fill_events": history["fill_events"],
+        }
+
+    compact_payload = {
+        "hsl_coin_compact_replay": compact_history["hsl_coin_compact_replay"],
+        "panic_flatten_events": [],
+        "fill_events": history["fill_events"],
+    }
+    bot_auth, samples_auth = await run_replay(timeline_payload(history["timeline"]))
+    bot_synth, samples_synth = await run_replay(timeline_payload(synthesized))
+    bot_compact, samples_compact = await run_replay(compact_payload)
 
     # The scenario dips through the orange tier mid-replay, so the sequences
     # prove parity across tier transitions rather than only green states.
@@ -2341,9 +2428,11 @@ async def test_hsl_cache_synthesized_replay_reaches_identical_coin_state(monkeyp
     assert [s for s in samples_synth if s[0] in auth_ts] == samples_auth
     extra = [s for s in samples_synth if s[0] not in auth_ts]
     assert all(tier == "green" and dd == 0.0 for _, tier, dd, *_ in extra)
+    assert samples_compact == samples_auth
 
     state_auth = bot_auth._hsl_coin_state("long", symbol)
     state_synth = bot_synth._hsl_coin_state("long", symbol)
+    state_compact = bot_compact._hsl_coin_state("long", symbol)
     metrics_auth = state_auth["last_metrics"]
     metrics_synth = state_synth["last_metrics"]
     assert metrics_auth is not None and metrics_synth is not None
@@ -2361,6 +2450,8 @@ async def test_hsl_cache_synthesized_replay_reaches_identical_coin_state(monkeyp
         assert metrics_synth[key] == pytest.approx(metrics_auth[key], abs=1e-9)
     assert state_synth["halted"] == state_auth["halted"]
     assert state_synth["cooldown_until_ms"] == state_auth["cooldown_until_ms"]
+    assert state_compact["halted"] == state_auth["halted"]
+    assert state_compact["cooldown_until_ms"] == state_auth["cooldown_until_ms"]
 
 
 async def _run_extension_history(monkeypatch):
@@ -3835,6 +3926,45 @@ def _red_episode_history(symbol, *, flatten_pnl, rows_upnl, flatten_ts=150_000):
     return {"timeline": timeline, "panic_flatten_events": [], "fill_events": fills}
 
 
+def _coin_history_as_compact(history, symbol):
+    import numpy as np
+
+    rows = history["timeline"]
+    return {
+        "hsl_coin_compact_replay": {
+            "timestamps": np.asarray(
+                [row["timestamp"] for row in rows], dtype=np.int64
+            ),
+            "balances": np.asarray(
+                [row["balance"] for row in rows], dtype=np.float64
+            ),
+            "realized_pnl": np.asarray(
+                [row["realized_pnl"] for row in rows], dtype=np.float64
+            ),
+            "pair_values": {
+                ("long", symbol): {
+                    "realized_pnl": np.asarray(
+                        [
+                            row["realized_pnl_by_coin_pside"][symbol]["long"]
+                            for row in rows
+                        ],
+                        dtype=np.float64,
+                    ),
+                    "unrealized_pnl": np.asarray(
+                        [
+                            row["unrealized_pnl_by_coin_pside"][symbol]["long"]
+                            for row in rows
+                        ],
+                        dtype=np.float64,
+                    ),
+                }
+            },
+        },
+        "panic_flatten_events": history["panic_flatten_events"],
+        "fill_events": history["fill_events"],
+    }
+
+
 def _flat_position_bot(symbol):
     bot = make_coin_bot()
     bot.positions = {
@@ -3844,7 +3974,10 @@ def _flat_position_bot(symbol):
 
 
 @pytest.mark.asyncio
-async def test_coin_hsl_replay_latches_cooldown_from_red_episode_ordinary_flatten():
+@pytest.mark.parametrize("compact", [False, True])
+async def test_coin_hsl_replay_latches_cooldown_from_red_episode_ordinary_flatten(
+    compact,
+):
     # Episode crosses RED (drawdown 0.6 >= 0.5) and is flattened at 150_000 by an
     # ordinary close with no panic marker: cooldown must anchor at the flatten fill.
     symbol = "A"
@@ -3852,7 +3985,10 @@ async def test_coin_hsl_replay_latches_cooldown_from_red_episode_ordinary_flatte
     bot.get_exchange_time = lambda: 180_000
 
     async def fake_history(current_balance=None, **kwargs):
-        return _red_episode_history(symbol, flatten_pnl=-30.0, rows_upnl=[0.0, 0.0])
+        history = _red_episode_history(
+            symbol, flatten_pnl=-30.0, rows_upnl=[0.0, 0.0]
+        )
+        return _coin_history_as_compact(history, symbol) if compact else history
 
     bot.get_balance_equity_history = fake_history
 
@@ -3868,7 +4004,10 @@ async def test_coin_hsl_replay_latches_cooldown_from_red_episode_ordinary_flatte
 
 
 @pytest.mark.asyncio
-async def test_coin_hsl_replay_latches_no_restart_from_red_episode_ordinary_flatten():
+@pytest.mark.parametrize("compact", [False, True])
+async def test_coin_hsl_replay_latches_no_restart_from_red_episode_ordinary_flatten(
+    compact,
+):
     # Same shape but the episode drawdown (1.6) breaches the no-restart threshold
     # (0.9) under policy=threshold: terminal halt, no cooldown.
     symbol = "A"
@@ -3876,7 +4015,10 @@ async def test_coin_hsl_replay_latches_no_restart_from_red_episode_ordinary_flat
     bot.get_exchange_time = lambda: 180_000
 
     async def fake_history(current_balance=None, **kwargs):
-        return _red_episode_history(symbol, flatten_pnl=-80.0, rows_upnl=[0.0, 0.0])
+        history = _red_episode_history(
+            symbol, flatten_pnl=-80.0, rows_upnl=[0.0, 0.0]
+        )
+        return _coin_history_as_compact(history, symbol) if compact else history
 
     bot.get_balance_equity_history = fake_history
 
@@ -4534,6 +4676,52 @@ async def test_coin_hsl_history_replay_requires_coin_timeline_fields():
     bot.get_balance_equity_history = fake_history
 
     with pytest.raises(ValueError, match="realized_pnl_by_coin_pside"):
+        await bot._equity_hard_stop_initialize_coin_from_history()
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_compact_replay_requires_nonflat_upnl():
+    import numpy as np
+
+    bot = make_coin_bot()
+    symbol = "A"
+    bot.positions = {
+        symbol: {
+            "long": {"size": 1.0, "price": 100.0},
+            "short": {"size": 0.0},
+        }
+    }
+
+    async def fake_history(current_balance=None, **kwargs):
+        return {
+            "hsl_coin_compact_replay": {
+                "timestamps": np.asarray([60_000], dtype=np.int64),
+                "balances": np.asarray([100.0], dtype=np.float64),
+                "realized_pnl": np.asarray([0.0], dtype=np.float64),
+                "pair_values": {
+                    ("long", symbol): {
+                        "realized_pnl": np.asarray([0.0], dtype=np.float64),
+                        "unrealized_pnl": np.asarray([np.nan], dtype=np.float64),
+                    }
+                },
+            },
+            "panic_flatten_events": [],
+            "fill_events": [
+                {
+                    "timestamp": 60_000,
+                    "symbol": symbol,
+                    "pside": "long",
+                    "action": "increase",
+                    "qty": 1.0,
+                    "price": 100.0,
+                    "pnl": 0.0,
+                }
+            ],
+        }
+
+    bot.get_balance_equity_history = fake_history
+
+    with pytest.raises(ValueError, match="unrealized_pnl_by_coin_pside"):
         await bot._equity_hard_stop_initialize_coin_from_history()
 
 

--- a/tests/test_hsl_replay_benchmark.py
+++ b/tests/test_hsl_replay_benchmark.py
@@ -42,10 +42,17 @@ def test_hsl_replay_benchmark_is_deterministic_and_has_no_side_effects():
     assert first["counters"] == {
         "iterations": 2,
         "active_pairs": 4,
+        "held_pairs": 4,
+        "background_pairs": 0,
         "expected_replay_samples": 16,
         "expected_current_samples": 4,
+        "expected_held_samples": 16,
+        "expected_background_samples": 0,
+        "expected_background_yields": 0,
         "coin_metrics_sample_calls": 20,
         "replay_samples_applied": 16,
+        "held_replay_samples": 16,
+        "background_replay_samples": 0,
     }
     assert first["timings"]["history_load"]["calls"] == 2
     assert first["timings"]["coin_metrics_sample"]["calls"] == 20
@@ -67,12 +74,131 @@ def test_hsl_replay_benchmark_is_deterministic_and_has_no_side_effects():
     assert _without_elapsed_ns(first) == _without_elapsed_ns(second)
 
 
+def test_hsl_replay_benchmark_separates_held_and_background_work():
+    report = asyncio.run(
+        hsl_replay_benchmark.run_hsl_replay_benchmark(
+            minutes=205, symbols=4, held_symbols=2, iterations=2
+        )
+    )
+
+    assert report["fixture"]["held_symbols"] == 2
+    assert report["fixture"]["background_symbols"] == 2
+    assert report["fixture"]["fill_events"] == 2
+    assert report["counters"] == {
+        "iterations": 2,
+        "active_pairs": 8,
+        "held_pairs": 4,
+        "background_pairs": 4,
+        "expected_replay_samples": 1_640,
+        "expected_current_samples": 8,
+        "expected_held_samples": 820,
+        "expected_background_samples": 820,
+        "expected_background_yields": 8,
+        "coin_metrics_sample_calls": 1_648,
+        "replay_samples_applied": 1_640,
+        "held_replay_samples": 820,
+        "background_replay_samples": 820,
+    }
+
+
+def test_hsl_replay_benchmark_memory_profile_is_opt_in():
+    report = asyncio.run(
+        hsl_replay_benchmark.run_hsl_replay_benchmark(
+            minutes=2,
+            symbols=2,
+            held_symbols=1,
+            profile_memory=True,
+            history_format="compact",
+        )
+    )
+
+    assert report["fixture"]["history_format"] == "compact"
+    assert report["fixture"]["timeline_rows"] == 0
+    assert report["fixture"]["compact_rows"] == 2
+    assert report["memory"]["tracemalloc"] is True
+    assert report["memory"]["current_bytes"] >= 0
+    assert report["memory"]["peak_bytes"] >= report["memory"]["current_bytes"]
+
+
+def test_hsl_replay_benchmark_local_scale_limits_are_opt_in():
+    with pytest.raises(ValueError, match="between 1 and 1440"):
+        hsl_replay_benchmark.build_coin_hsl_history_fixture(minutes=1_441, symbols=1)
+
+    history = hsl_replay_benchmark.build_coin_hsl_history_fixture(
+        minutes=1, symbols=30, held_symbols=1, local_scale=True
+    )
+    assert len(history["timeline"]) == 1
+    assert len(history["timeline"][0]["realized_pnl_by_coin_pside"]) == 30
+    assert len(history["fill_events"]) == 1
+    assert hsl_replay_benchmark._validate_fixture_shape(
+        43_201, 30, 1, local_scale=True
+    ) == (43_201, 30, 1)
+    with pytest.raises(ValueError, match="between 1 and 43201"):
+        hsl_replay_benchmark._validate_fixture_shape(
+            43_202, 30, 1, local_scale=True
+        )
+    with pytest.raises(ValueError, match="between 1 and 30"):
+        hsl_replay_benchmark._validate_fixture_shape(1, 31, 1, local_scale=True)
+
+
+def test_hsl_replay_benchmark_compact_and_timeline_reach_identical_state():
+    timeline = asyncio.run(
+        hsl_replay_benchmark.run_hsl_replay_benchmark(
+            minutes=8, symbols=3, held_symbols=2, history_format="timeline"
+        )
+    )
+    compact = asyncio.run(
+        hsl_replay_benchmark.run_hsl_replay_benchmark(
+            minutes=8, symbols=3, held_symbols=2, history_format="compact"
+        )
+    )
+
+    assert timeline["determinism"] == compact["determinism"]
+    assert timeline["counters"] == compact["counters"]
+    assert timeline["side_effects"] == compact["side_effects"]
+    assert timeline["fixture"]["timeline_rows"] == 8
+    assert compact["fixture"]["compact_rows"] == 8
+
+
 def test_hsl_replay_benchmark_main_emits_json(capsys):
     assert hsl_replay_benchmark.main(["--minutes", "2", "--symbols", "1", "--compact"]) == 0
 
     report = json.loads(capsys.readouterr().out)
     assert report["kind"] == "hsl_replay_benchmark"
     assert report["fixture"]["timeline_rows"] == 2
+
+    assert (
+        hsl_replay_benchmark.main(
+            [
+                "--minutes",
+                "2",
+                "--symbols",
+                "1",
+                "--history-format",
+                "compact",
+                "--compact",
+            ]
+        )
+        == 0
+    )
+    compact_report = json.loads(capsys.readouterr().out)
+    assert compact_report["fixture"]["history_format"] == "compact"
+
+    assert (
+        hsl_replay_benchmark.main(
+            [
+                "--local-scale",
+                "--minutes",
+                "1",
+                "--symbols",
+                "1",
+                "--compact",
+            ]
+        )
+        == 0
+    )
+    local_report = json.loads(capsys.readouterr().out)
+    assert local_report["fixture"]["minutes"] == 1
 
 
 def test_hsl_replay_benchmark_tool_dispatch_forwards_module_and_prog(monkeypatch):


### PR DESCRIPTION
## Summary

- make cold coin-mode HSL history construction return a private NumPy-backed compact replay payload instead of retaining the rich nested timeline
- preserve missing-value semantics with explicit NaN markers and fail loudly for required realized/non-flat unrealized inputs
- keep public history callers, pside/unified replay, cache authority, pair priority, episode/cooldown/no-restart rules, and Rust risk math unchanged
- extend `hsl-replay-benchmark` with timeline/compact formats, held/background counters, opt-in 30-day bounds, and tracemalloc output

## Evidence

A deterministic local builder profile used 43,201 minutes, 30 symbols, one held pair, and 29 historical-flat symbols:

- rich timeline peak: `686242590` traced Python bytes
- compact payload peak: `73499666` traced Python bytes
- reduction: 89.3%

The explicit 30-day benchmark completed `1296030` replay samples with deterministic state and zero side effects. Timeline and compact fixtures produce the same final-state digest and counters.

## Validation

- `123` coin-HSL tests passed, including compact/rich orange-tier parity, RED ordinary-flatten cooldown, terminal no-restart, zero-fill shape, missing-UPnL failure, and cache-artifact parity
- `7` replay benchmark tests passed
- `208` balance-history tests passed with the pre-existing stalled `test_start_bot_treats_hsl_value_error_as_terminal_startup_failure` fixture excluded
- `44` realized-loss tests passed
- `21` fake-live scenarios passed
- Rust HSL finalization/config focused checks passed
- `py_compile` and `git diff --check` passed
- two independent preflight reviews passed after delta fixes

## VPS plan after merge

Pull with local artifacts preserved, restart only the five configured `passivbot` tmux panes using exact pane/PID targeting, then compare compact `history_format` events, protective/full replay times, process states, RSS, swap, I/O wait, remote-call success, and bounded smoke hard failures against the `c159d955` baseline.
