### PR TITLE
Expose HSL replay readiness scorecard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-performance-report` now retains each bot's explicit HSL
+  protective-ready replay milestone and summarizes replay history formats,
+  protective-ready elapsed time, and completed full-replay elapsed time from
+  existing structured events. This is read-only reporting and does not change
+  HSL startup or trading behavior.
+
 - Cold coin-mode HSL history reconstruction now uses a private compact
   NumPy-backed replay payload instead of retaining the full nested per-minute,
   per-symbol timeline. Public balance/equity history output, pside/unified HSL,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -1,6 +1,6 @@
 # Live Logging Overhaul Current Status
 
-Updated: 2026-07-10.
+Updated: 2026-07-11.
 
 This is the compact operational source for the active logging-overhaul loop.
 Read it before the historical progress ledger. Update it whenever the active
@@ -22,65 +22,64 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR: [#1180](https://github.com/enarjord/passivbot/pull/1180),
-  `Compact cold coin-HSL replay memory`
-- Branch: `codex/v8-hsl-direct-matrix-replay`
+- PR and publication state: query live GitHub metadata;
+  `Expose HSL replay readiness scorecard`
+- Branch: `codex/v8-hsl-replay-scorecard`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
-- Base: `c159d955f691085469858c57ed1d6ba7927d7905`
-- Scope: the internal cold coin-HSL history call requests aligned compact
-  timestamp, balance, account-realized, and per-pair realized/unrealized NumPy
-  arrays. `NaN` preserves unavailable pair values. Public history callers and
-  pside/unified replay retain the rich timeline contract. The offline benchmark
-  gains held/background counters, opt-in local-scale bounds, and tracemalloc
-  output.
-- Triggering evidence: after PR #1179, five live processes reported aggregate
-  RSS `648196 KB`; four coin-HSL processes were in uninterruptible sleep while
-  swap/page pressure remained high. A deterministic 43,201-minute, 30-symbol
-  local builder profile measured `686242590` rich-history peak allocation bytes
-  versus `73499666` compact-history bytes, an 89.3% reduction.
-- Non-goals: no HSL thresholds, episode/cooldown/no-restart semantics, cache
-  authority, pair priority, readiness gate, exchange write, process signal,
-  Rust, backtest, or pside/unified behavior change.
-- Local validation: full coin-HSL plus benchmark suites pass; the complete
-  balance-history suite passes with one unrelated known startup test excluded
-  after its asynchronous shutdown fixture stalled. Realized-loss tests pass.
-  Syntax and diff checks pass. Broader validation and exact counts will be
-  refreshed before publication.
-- Independent preflight: two read-only audits independently identified the
-  nested timeline as the dominant retained allocation and recommended a private
-  compact coin-only handoff. A Luna worker changed only the benchmark and its
-  tests; Sol owns the live-path implementation and review.
+- Base: `6e72f374dca9f3e2d77924e84f9453bbd7561386`
+- Scope: `live-performance-report` retains each bot's explicit
+  `held_protective_ready` record, whitelists replay `history_format` and
+  `protective_elapsed_s`, derives stage elapsed milliseconds, and adds bounded
+  history-format, protective-ready, and completed-full-replay aggregates.
+- Triggering evidence: after PR #1180 deployed, all four coin-HSL bots used the
+  compact path and reached protective readiness in `11.237s` to `79.883s`, but
+  those values and the history format required manual event queries. Kucoin's
+  first full compact replay completed in `453.98s`; three broader background
+  replays remained active. The operator scorecard should expose these existing
+  events directly.
+- Non-goals: no live event producer, replay ordering or arithmetic, HSL
+  threshold/episode/cooldown behavior, cache authority, exchange call, process
+  control, Rust, backtest, or smoke-verdict change.
+- Local validation: all `72` live-performance-report tests and `25`
+  incident-bundle integration tests pass. Python compilation and diff hygiene
+  pass. Whole-file import sorting remains nonconforming at the unchanged
+  baseline; this slice does not touch imports.
+- Independent preflight: Terra found and Sol fixed scan-order-dependent retained
+  milestones by applying the existing full event-position ordering contract.
+  Delta re-review found no remaining blocker; Sol owns final adjudication.
 - Publication state, exact head, mergeability, CI, and current-head review
   verdicts: query live GitHub metadata. Do not encode those transient values in
   the same PR that contains this status file, because every correction would
   create a different head and immediately stale the embedded value.
 - Expected VPS action: after exact-head approval and merge, pull while
-  preserving local artifacts, restart the five configured bots with exact
-  tmux/process targeting, then compare protective/full replay time, process
-  states, RSS, swap, I/O wait, remote calls, and hard-failure smoke output.
+  preserving local artifacts and run a bounded no-restart performance report
+  against the existing monitor history. Running bots need no restart because
+  this slice changes read-only report consumption only.
 
 Next action:
 
-1. Finish parity and broad local validation, publish the compact replay slice,
-   resolve verified findings, and merge only after the exact-head gate; then
-   perform the declared controlled VPS5 restart and comparative smoke.
+1. Finish focused validation and independent preflight, publish the scorecard
+   slice, resolve verified findings, and merge only after the exact-head gate;
+   then run the declared VPS5 no-restart report smoke.
 
 ## Deployed Baseline
 
-- Remote `v8`: `c159d955`, PR #1179
-- VPS5 repository: `c159d955`, PR #1179; tracked status clean
+- Remote `v8`: `6e72f374`, PR #1180
+- VPS5 repository: `6e72f374`, PR #1180; tracked status clean
 - VPS5 expected bots: five; all are running after the controlled restart
-- Immediate and settled smoke reports were green: all five expected bots
-  matched, hard failures were zero, 396 remote calls and 43 account-critical
-  calls succeeded across the two windows with zero failures, and no fill,
-  process, event-pipeline, or text-log hard failure appeared.
-- Background replay remains memory/I/O intensive: current process-section
-  output shows four of five bots in `D` state, aggregate RSS `648196 KB`, and
-  the earlier settled direct probes showed
-  four coin-HSL processes in uninterruptible sleep/page wait, 29 MB/s sampled
-  swap-in, 18 MB/s swap-out, 32% I/O wait, and zero idle. PR #1178 restored
-  live-I/O responsiveness but intentionally did not reduce this footprint.
+- Immediate and fresh settled smoke reports were green: all five expected bots
+  matched, hard failures were zero, and the fresh window recorded `614/614`
+  remote plus `90/90` account-critical calls succeeded. One Kucoin
+  `RequestTimeout` cycle failure in the wider restart window recovered before
+  the fresh smoke.
+- All four coin-HSL bots emitted `history_format=compact` and protective-ready
+  success. Kucoin completed full replay in `453.98s`; three background replays
+  remained active with no required pair work pending.
+- Compared with the pre-deploy sample, aggregate RSS fell from `694840 KB` to
+  `555296 KB`, all five processes moved from four `D` states to five `R`
+  states, and host swap use fell from `2926 MB` to `906 MB`. CPU remained high
+  while background replay continued.
 - Preserve local/VPS configs, logs, monitor data, reports, and temporary files
 
 ## Review Gate
@@ -103,14 +102,14 @@ Next action:
 
 ## Next Slice
 
-The coin-HSL protective-readiness split, cooperative background cadence, and
-current process-pressure query are merged and deployed. The active slice
-removes the dominant nested Python allocation from cold coin replay while
-preserving the existing risk contract.
+The coin-HSL protective-readiness split, cooperative background cadence,
+current process-pressure query, and compact cold replay payload are merged and
+deployed. The active slice turns the resulting readiness and full-replay timing
+events into a bounded operator scorecard without changing live behavior.
 Remaining candidates:
 
 - realistic-scale replay fixtures and deeper internal-stage profiling
-- held-position protective-readiness source events and sequencing
+- lower-complexity full replay after the scorecard exposes its baseline
 - unsupported configured-market and stock-perp compatibility events
 - bounded operator tooling improvements sharing one code and validation surface
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,27 +15,23 @@ merge, live smoke evidence changes, or new gaps are discovered.
 
 ## Current Status
 
-Last updated: 2026-07-10.
+Last updated: 2026-07-11.
 
 Current `origin/v8` head:
 
-- `493a61a9` after PR #1175, `Align coin-HSL denominator across live and
-  backtest`.
+- `6e72f374` after PR #1180, `Compact cold coin-HSL replay memory`.
 
 Current logging-overhaul head:
 
-- `493a61a9` after PR #1175, `Align coin-HSL denominator across live and
-  backtest`
+- `6e72f374` after PR #1180, `Compact cold coin-HSL replay memory`
   (latest merged logging-overhaul slice).
 
 Current work:
 
-- Branch `codex/v8-hsl-held-first-replay` freezes coin-HSL replay candidates
-  and orders held pairs first, cooldown pairs second, then remaining pairs.
-  This is the deterministic sequencing foundation only; full replay remains
-  startup-blocking until the later protective/full-readiness split. Full
-  coin-HSL, focused HSL metric/startup/override, fake-live `21/21`, Rust
-  `209/209`, and realistic bounded replay-benchmark validation pass.
+- Branch `codex/v8-hsl-replay-scorecard` makes the read-only performance report
+  retain each bot's protective-ready record and summarize replay history format,
+  protective elapsed time, and completed full-replay elapsed time. It consumes
+  existing events only and does not change HSL or live behavior.
 
 Current review gate:
 
@@ -66,6 +62,15 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1180 merged to `v8` as `6e72f374` after exact-head Hermes and Grok 4.5
+  green reviews plus green CI. VPS5 pulled cleanly and restarted only the five
+  configured bot panes; one stopped after the first exact-pane Ctrl-C and four
+  after the second, with no SIGTERM. Immediate and fresh settled smokes were
+  green. All four coin-HSL bots used compact history and reached protective
+  readiness in `11.237s` to `79.883s`; Kucoin completed full replay in
+  `453.98s`. Fresh RSS was `555296 KB`, all five processes were `R`, and host
+  swap use was `906 MB`, compared with `694840 KB`, four `D` processes, and
+  `2926 MB` swap before deployment. Three background replays remained active.
 - PR #1175 merged to `v8` as `493a61a9` after exact-head Hermes and Grok 4.5
   green reviews plus green CI. VPS5 pulled cleanly, rebuilt the Rust extension,
   and verified its loaded source stamp. All five bots stopped after two

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -621,8 +621,10 @@ Trading-impact labels:
     `held_pairs`, `cooldown_pairs`, `required_pairs`, `applied_rows`,
     `total_applied_rows`, `skipped_pairs` on completion, `rows_per_second`,
     `full_elapsed_s`, and `startup_blocking_elapsed_s`.
-  - Remaining: add true `protective_elapsed_s` once protective readiness is
-    split from full replay.
+  - Done: the protective-readiness split emits true `protective_elapsed_s`,
+    and the active scorecard slice retains that milestone separately from
+    later pair progress while summarizing protective and full-replay elapsed
+    milliseconds.
 
 - [ ] Set concrete performance acceptance targets after the first optimized
   implementation.
@@ -865,8 +867,11 @@ Each slice should update this checklist with its result.
    - Status: resource-pressure groups now expose process, sample-age, queue,
      drop, sink-error, degraded, and unhealthy-bot aggregates. PR #1162 added
      bounded exchange-config refresh success/failure groups and elapsed timings
-     from existing `exchange.config_refresh` events. The current recovery slice
+     from existing `exchange.config_refresh` events. The recovery slice
      distinguishes historical failures from each bot's latest observed status.
+     The active HSL scorecard slice adds per-bot retained protective-ready
+     records plus bounded replay history-format, protective elapsed, and
+     completed full-replay elapsed aggregates from existing events.
 
 2. [ ] HSL replay benchmark/profiling slice.
    - Add an offline deterministic benchmark or fixture path for coin-mode HSL

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -127,6 +127,7 @@ _EXECUTION_CONFIRMATION_TERMINALS = {
 }
 _HSL_REPLAY_STRING_FIELDS = (
     "error_type",
+    "history_format",
     "signal_mode",
     "stage",
     "timeframe",
@@ -170,6 +171,7 @@ _HSL_REPLAY_NUMERIC_FIELDS = (
     "price_history_fetch_elapsed_s",
     "timeline_replay_elapsed_s",
     "full_elapsed_s",
+    "protective_elapsed_s",
     "startup_blocking_elapsed_s",
 )
 _CACHE_EVENT_TYPES = {
@@ -1634,6 +1636,7 @@ def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
         ("price_history_fetch_elapsed_s", "price_history_fetch_elapsed_ms"),
         ("timeline_replay_elapsed_s", "timeline_replay_elapsed_ms"),
         ("full_elapsed_s", "full_elapsed_ms"),
+        ("protective_elapsed_s", "protective_elapsed_ms"),
         ("startup_blocking_elapsed_s", "startup_blocking_elapsed_ms"),
     ):
         value_ms = _elapsed_s_to_ms(data.get(source_key))
@@ -1641,6 +1644,15 @@ def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
             out[target_key] = value_ms
             if source_key == "history_build_elapsed_s" and "latest_elapsed_ms" not in out:
                 out["latest_elapsed_ms"] = value_ms
+    if "latest_elapsed_ms" not in out:
+        for key in (
+            "full_elapsed_ms",
+            "protective_elapsed_ms",
+            "startup_blocking_elapsed_ms",
+        ):
+            if key in out:
+                out["latest_elapsed_ms"] = int(out[key])
+                break
     if data.get("startup_blocking_elapsed_s") is not None:
         out["startup_blocking"] = True
     return out
@@ -1731,9 +1743,19 @@ class _HslReplayProfileAccumulator:
         state["total_events"] = int(state["total_events"]) + 1
         state["event_types"][event_type] += 1
         ts = _record_ts(row)
-        latest_changed = ts is None or state.get("latest_ts") is None
-        if ts is not None and state.get("latest_ts") is not None:
-            latest_changed = int(ts) >= int(state["latest_ts"])
+        position = _metric_event_position(row)
+
+        def is_newer(field: str) -> bool:
+            existing = state.get(f"_{field}_position")
+            if position is None:
+                return existing is None and state.get(field) is None
+            return existing is None or position >= existing
+
+        def retain(field: str, value: Any) -> None:
+            state[field] = value
+            if position is not None:
+                state[f"_{field}_position"] = position
+
         record = {
             key: value
             for key, value in {
@@ -1749,19 +1771,28 @@ class _HslReplayProfileAccumulator:
             if value not in (None, {}, [])
         }
         if event_type == "hsl.replay.progress" and stage == "loaded":
-            state["loaded"] = record
-        elif event_type == "hsl.replay.completed":
-            state["completed"] = record
-        elif event_type == "hsl.replay.failed":
-            state["failed"] = record
-        elif event_type == "hsl.replay.progress":
-            state["progress"] = record
-        elif event_type == "hsl.replay.started":
-            state["started"] = record
-        if latest_changed:
+            if is_newer("loaded"):
+                retain("loaded", record)
+        elif event_type == "hsl.replay.progress" and stage == "held_protective_ready":
+            if is_newer("protective_ready"):
+                retain("protective_ready", record)
+            if is_newer("progress"):
+                retain("progress", record)
+        elif event_type == "hsl.replay.completed" and is_newer("completed"):
+            retain("completed", record)
+        elif event_type == "hsl.replay.failed" and is_newer("failed"):
+            retain("failed", record)
+        elif event_type == "hsl.replay.progress" and is_newer("progress"):
+            retain("progress", record)
+        elif event_type == "hsl.replay.started" and is_newer("started"):
+            retain("started", record)
+        if is_newer("latest"):
             if ts is not None:
                 state["latest_ts"] = int(ts)
-            state["latest"] = record
+            retain("latest", record)
+        history_format = data.get("history_format")
+        if history_format is not None and is_newer("history_format"):
+            retain("history_format", str(history_format))
 
     def to_dict(
         self,
@@ -1775,6 +1806,9 @@ class _HslReplayProfileAccumulator:
         latest_status_counts: Counter[str] = Counter()
         latest_stage_counts: Counter[str] = Counter()
         active_stage_counts: Counter[str] = Counter()
+        history_format_counts: Counter[str] = Counter()
+        protective_ready_elapsed_ms: list[int] = []
+        full_replay_elapsed_ms: list[int] = []
         for bot, state in self.bots.items():
             group = {
                 "bot": bot,
@@ -1786,9 +1820,11 @@ class _HslReplayProfileAccumulator:
                 "latest": state.get("latest"),
                 "started": state.get("started"),
                 "loaded": state.get("loaded"),
+                "protective_ready": state.get("protective_ready"),
                 "progress": state.get("progress"),
                 "completed": state.get("completed"),
                 "failed": state.get("failed"),
+                "history_format": state.get("history_format"),
             }
             group = {
                 key: value for key, value in group.items() if value not in (None, {}, [])
@@ -1807,6 +1843,23 @@ class _HslReplayProfileAccumulator:
                     latest_stage_counts[latest_stage] += 1
                     if latest_status == "active":
                         active_stage_counts[latest_stage] += 1
+            history_format = state.get("history_format")
+            if history_format:
+                history_format_counts[str(history_format)] += 1
+            protective_ready = state.get("protective_ready")
+            if isinstance(protective_ready, dict):
+                derived = protective_ready.get("derived")
+                if isinstance(derived, dict):
+                    elapsed_ms = derived.get("protective_elapsed_ms")
+                    if elapsed_ms is None:
+                        elapsed_ms = derived.get("startup_blocking_elapsed_ms")
+                    if elapsed_ms is not None:
+                        protective_ready_elapsed_ms.append(int(elapsed_ms))
+            completed = state.get("completed")
+            if isinstance(completed, dict):
+                derived = completed.get("derived")
+                if isinstance(derived, dict) and derived.get("full_elapsed_ms") is not None:
+                    full_replay_elapsed_ms.append(int(derived["full_elapsed_ms"]))
             groups.append(
                 _with_hsl_replay_active_age(group, report_ts_ms=int(report_ts_ms))
             )
@@ -1842,9 +1895,15 @@ class _HslReplayProfileAccumulator:
             "latest_status_counts": dict(latest_status_counts.most_common()),
             "latest_stage_counts": dict(latest_stage_counts.most_common()),
             "active_stage_counts": dict(active_stage_counts.most_common()),
+            "history_format_counts": dict(history_format_counts.most_common()),
             "active_bot_count": int(latest_status_counts.get("active", 0)),
             "completed_bot_count": int(latest_status_counts.get("completed", 0)),
             "failed_bot_count": int(latest_status_counts.get("failed", 0)),
+            "protective_ready_bot_count": len(protective_ready_elapsed_ms),
+            "protective_ready_elapsed_ms": _number_summary(
+                protective_ready_elapsed_ms
+            ),
+            "full_replay_elapsed_ms": _number_summary(full_replay_elapsed_ms),
             "groups_truncated": len(groups) > limit,
             "groups": groups[:limit],
         }

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1744,6 +1744,160 @@ def test_live_performance_report_hsl_replay_profile_stage_summary(tmp_path):
     assert profile["failed_bot_count"] == 1
 
 
+def test_live_performance_report_hsl_replay_profile_exposes_protective_scorecard(
+    tmp_path,
+):
+    fixtures = {
+        ("binance", "binance_01"): [
+            _monitor_row(
+                event_type="hsl.replay.progress",
+                seq=1,
+                ts=1000,
+                exchange="binance",
+                user="binance_01",
+                component="risk.hsl",
+                status="started",
+                reason_code="history_loaded",
+                data={
+                    "signal_mode": "coin",
+                    "stage": "loaded",
+                    "history_format": "compact",
+                },
+            ),
+            _monitor_row(
+                event_type="hsl.replay.progress",
+                seq=2,
+                ts=2000,
+                exchange="binance",
+                user="binance_01",
+                component="risk.hsl",
+                status="succeeded",
+                reason_code="hsl_held_protective_ready",
+                data={
+                    "signal_mode": "coin",
+                    "stage": "held_protective_ready",
+                    "protective_elapsed_s": 12.3,
+                    "startup_blocking_elapsed_s": 12.3,
+                },
+            ),
+            _monitor_row(
+                event_type="hsl.replay.completed",
+                seq=3,
+                ts=3000,
+                exchange="binance",
+                user="binance_01",
+                component="risk.hsl",
+                status="succeeded",
+                reason_code="coin_history_replay_completed",
+                data={
+                    "signal_mode": "coin",
+                    "stage": "full_replay",
+                    "history_format": "compact",
+                    "full_elapsed_s": 30.0,
+                },
+            ),
+            _monitor_row(
+                event_type="hsl.replay.progress",
+                seq=4,
+                ts=1500,
+                exchange="binance",
+                user="binance_01",
+                component="risk.hsl",
+                status="succeeded",
+                reason_code="hsl_held_protective_ready",
+                data={
+                    "signal_mode": "coin",
+                    "stage": "held_protective_ready",
+                    "protective_elapsed_s": 99.0,
+                    "startup_blocking_elapsed_s": 99.0,
+                },
+            ),
+            _monitor_row(
+                event_type="hsl.replay.completed",
+                seq=5,
+                ts=2500,
+                exchange="binance",
+                user="binance_01",
+                component="risk.hsl",
+                status="succeeded",
+                reason_code="coin_history_replay_completed",
+                data={
+                    "signal_mode": "coin",
+                    "stage": "full_replay",
+                    "history_format": "timeline",
+                    "full_elapsed_s": 99.0,
+                },
+            ),
+        ],
+        ("gateio", "gateio_01"): [
+            _monitor_row(
+                event_type="hsl.replay.progress",
+                seq=1,
+                ts=1500,
+                exchange="gateio",
+                user="gateio_01",
+                component="risk.hsl",
+                status="started",
+                reason_code="history_loaded",
+                data={
+                    "signal_mode": "coin",
+                    "stage": "loaded",
+                    "history_format": "timeline",
+                },
+            ),
+            _monitor_row(
+                event_type="hsl.replay.progress",
+                seq=2,
+                ts=2500,
+                exchange="gateio",
+                user="gateio_01",
+                component="risk.hsl",
+                status="succeeded",
+                reason_code="hsl_held_protective_ready",
+                data={
+                    "signal_mode": "coin",
+                    "stage": "held_protective_ready",
+                    "startup_blocking_elapsed_s": 20.0,
+                },
+            ),
+        ],
+    }
+    for (exchange, user), rows in fixtures.items():
+        _write_ndjson(
+            tmp_path / "monitor" / exchange / user / "events" / "current.ndjson",
+            rows,
+        )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    profile = report["hsl_replay_profile"]
+    summary_profile = summarize_live_performance_report(report)["hsl_replay_profile"]
+    groups = {group["bot"]: group for group in profile["groups"]}
+
+    assert profile["history_format_counts"] == {"compact": 1, "timeline": 1}
+    assert profile["protective_ready_bot_count"] == 2
+    assert profile["protective_ready_elapsed_ms"]["count"] == 2
+    assert profile["protective_ready_elapsed_ms"]["min"] == 12300
+    assert profile["protective_ready_elapsed_ms"]["max"] == 20000
+    assert profile["full_replay_elapsed_ms"]["count"] == 1
+    assert profile["full_replay_elapsed_ms"]["max"] == 30000
+    assert summary_profile["history_format_counts"] == {"compact": 1, "timeline": 1}
+    assert summary_profile["protective_ready_elapsed_ms"]["max"] == 20000
+    assert summary_profile["full_replay_elapsed_ms"]["max"] == 30000
+    assert groups["binance/binance_01"]["history_format"] == "compact"
+    assert groups["binance/binance_01"]["protective_ready"]["derived"] == {
+        "latest_elapsed_ms": 12300,
+        "protective_elapsed_ms": 12300,
+        "startup_blocking": True,
+        "startup_blocking_elapsed_ms": 12300,
+    }
+    assert groups["gateio/gateio_01"]["history_format"] == "timeline"
+    assert groups["gateio/gateio_01"]["protective_ready"]["derived"] == {
+        "latest_elapsed_ms": 20000,
+        "startup_blocking": True,
+        "startup_blocking_elapsed_ms": 20000,
+    }
+
+
 def test_live_performance_report_hsl_replay_profile_whitelists_values(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary

- retain each bot's newest `held_protective_ready` HSL replay milestone in `live-performance-report`
- whitelist and report existing `history_format` and `protective_elapsed_s` fields
- add bounded history-format counts plus protective-ready and completed-full-replay elapsed summaries
- use the existing timestamp/sequence/path/line event-position contract for all retained replay records, so rotated or out-of-order input cannot overwrite newer milestones
- update the logging-overhaul status and performance checklist with PR #1180's verified VPS5 baseline

This is a read-only report consumer change. It does not alter live producers, replay arithmetic or ordering, HSL behavior, exchange calls, process control, Rust, backtest, or smoke verdicts.

## Triggering evidence

After PR #1180 deployed, all four coin-HSL bots used compact history and reached protective readiness in 11.237s to 79.883s. Kucoin completed full replay in 453.98s. Those fields required manual event queries because the performance scorecard did not retain the protective milestone or expose the format/protective elapsed values.

## Validation

- `97 passed`: `tests/test_live_performance_report.py` + `tests/test_live_incident_bundle.py`
- focused HSL replay profile suite: `5 passed`
- Python compilation passes
- `git diff --check` passes
- real local no-data CLI smoke preserves explicit bounded scorecard fields
- independent Terra preflight found one scan-order issue; the fix uses full event-position ordering and an out-of-order regression, and delta re-review is green
- whole-file `isort --check-only` remains nonconforming at the unchanged baseline; this diff does not touch imports

## VPS plan

After exact-head reviewer approvals and green CI, pull the read-only report change while preserving local artifacts and run a bounded `live-performance-report --section hsl_replay_profile --summary` against existing VPS5 monitor history. No bot restart is required.