### PR TITLE
Recover HSL protective timing from completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable user-facing changes will be documented in this file.
 - `passivbot tool live-performance-report` now retains each bot's explicit HSL
   protective-ready replay milestone and summarizes replay history formats,
   protective-ready elapsed time, and completed full-replay elapsed time from
-  existing structured events. This is read-only reporting and does not change
+  existing structured events. If the earlier milestone has rotated out of the
+  selected event files, its aggregate elapsed value is recovered from the
+  retained completion event. This is read-only reporting and does not change
   HSL startup or trading behavior.
 
 - Cold coin-mode HSL history reconstruction now uses a private compact

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -23,31 +23,29 @@ Estimated completion:
 ## Active Review Slice
 
 - PR and publication state: query live GitHub metadata;
-  `Expose HSL replay readiness scorecard`
-- Branch: `codex/v8-hsl-replay-scorecard`
+  `Count protective readiness from completion evidence`
+- Branch: `codex/v8-hsl-replay-scorecard-completion-fallback`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
-- Base: `6e72f374dca9f3e2d77924e84f9453bbd7561386`
-- Scope: `live-performance-report` retains each bot's explicit
-  `held_protective_ready` record, whitelists replay `history_format` and
-  `protective_elapsed_s`, derives stage elapsed milliseconds, and adds bounded
-  history-format, protective-ready, and completed-full-replay aggregates.
-- Triggering evidence: after PR #1180 deployed, all four coin-HSL bots used the
-  compact path and reached protective readiness in `11.237s` to `79.883s`, but
-  those values and the history format required manual event queries. Kucoin's
-  first full compact replay completed in `453.98s`; three broader background
-  replays remained active. The operator scorecard should expose these existing
-  events directly.
+- Base: `77e111f7277077b4d1c4c37a562a67dad8906665`
+- Scope: when a dedicated `held_protective_ready` event has rotated out of the
+  selected files, `live-performance-report` derives the bounded protective
+  elapsed aggregate from the retained completed replay record. It does not
+  synthesize a milestone record.
+- Triggering evidence: PR #1181's first no-restart VPS5 smoke correctly showed
+  all four compact full-replay completions, but reported
+  `protective_ready_bot_count=0` because the earlier milestone events had
+  rotated while every completion record still carried `protective_elapsed_s`.
 - Non-goals: no live event producer, replay ordering or arithmetic, HSL
   threshold/episode/cooldown behavior, cache authority, exchange call, process
   control, Rust, backtest, or smoke-verdict change.
-- Local validation: all `72` live-performance-report tests and `25`
+- Local validation: all `73` live-performance-report tests and `25`
   incident-bundle integration tests pass. Python compilation and diff hygiene
-  pass. Whole-file import sorting remains nonconforming at the unchanged
-  baseline; this slice does not touch imports.
-- Independent preflight: Terra found and Sol fixed scan-order-dependent retained
-  milestones by applying the existing full event-position ordering contract.
-  Delta re-review found no remaining blocker; Sol owns final adjudication.
+  pass; this follow-up does not touch imports.
+- Independent preflight: Terra's initial completion/startup fallback concern
+  was rejected at the pre-split compatibility boundary; after the strict
+  explicit-protective regression and code comment, Terra retracted the finding
+  and reported no blocker. Sol owns final adjudication.
 - Publication state, exact head, mergeability, CI, and current-head review
   verdicts: query live GitHub metadata. Do not encode those transient values in
   the same PR that contains this status file, because every correction would
@@ -59,14 +57,14 @@ Estimated completion:
 
 Next action:
 
-1. Finish focused validation and independent preflight, publish the scorecard
-   slice, resolve verified findings, and merge only after the exact-head gate;
-   then run the declared VPS5 no-restart report smoke.
+1. Finish focused validation and independent preflight, publish the completion
+   fallback, resolve verified findings, and merge only after the exact-head
+   gate; then rerun the declared VPS5 no-restart report smoke.
 
 ## Deployed Baseline
 
-- Remote `v8`: `6e72f374`, PR #1180
-- VPS5 repository: `6e72f374`, PR #1180; tracked status clean
+- Remote `v8`: `77e111f7`, PR #1181
+- VPS5 repository: `77e111f7`, PR #1181; tracked status clean
 - VPS5 expected bots: five; all are running after the controlled restart
 - Immediate and fresh settled smoke reports were green: all five expected bots
   matched, hard failures were zero, and the fresh window recorded `614/614`
@@ -80,6 +78,10 @@ Next action:
   `555296 KB`, all five processes moved from four `D` states to five `R`
   states, and host swap use fell from `2926 MB` to `906 MB`. CPU remained high
   while background replay continued.
+- PR #1181 required no restart; all five bot pane PIDs remained unchanged. Its
+  bounded current-segment scorecard reported four compact full-replay
+  completions from `453.98s` to `1728.585s`, but exposed the active slice's
+  missing completion fallback for the rotated protective milestones.
 - Preserve local/VPS configs, logs, monitor data, reports, and temporary files
 
 ## Review Gate
@@ -104,8 +106,8 @@ Next action:
 
 The coin-HSL protective-readiness split, cooperative background cadence,
 current process-pressure query, and compact cold replay payload are merged and
-deployed. The active slice turns the resulting readiness and full-replay timing
-events into a bounded operator scorecard without changing live behavior.
+deployed. The active slice completes the bounded operator scorecard when early
+protective milestones rotate before the later full-replay completion.
 Remaining candidates:
 
 - realistic-scale replay fixtures and deeper internal-stage profiling

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,19 @@ Last updated: 2026-07-11.
 
 Current `origin/v8` head:
 
-- `6e72f374` after PR #1180, `Compact cold coin-HSL replay memory`.
+- `77e111f7` after PR #1181, `Expose HSL replay readiness scorecard`.
 
 Current logging-overhaul head:
 
-- `6e72f374` after PR #1180, `Compact cold coin-HSL replay memory`
+- `77e111f7` after PR #1181, `Expose HSL replay readiness scorecard`
   (latest merged logging-overhaul slice).
 
 Current work:
 
-- Branch `codex/v8-hsl-replay-scorecard` makes the read-only performance report
-  retain each bot's protective-ready record and summarize replay history format,
-  protective elapsed time, and completed full-replay elapsed time. It consumes
-  existing events only and does not change HSL or live behavior.
+- Branch `codex/v8-hsl-replay-scorecard-completion-fallback` makes the
+  protective elapsed aggregate use retained completion evidence when the
+  dedicated readiness milestone has rotated out of the selected event files.
+  It consumes existing events only and does not change HSL or live behavior.
 
 Current review gate:
 
@@ -62,6 +62,13 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1181 merged to `v8` as `77e111f7` after exact-head Hermes and Grok 4.5
+  green reviews plus green CI. VPS5 pulled cleanly without restarting bots; all
+  five pane PIDs remained unchanged. A bounded current-segment scorecard
+  reported four compact full-replay completions from `453.98s` to `1728.585s`
+  but `protective_ready_bot_count=0`, because the dedicated milestones had
+  rotated while each completion record retained `protective_elapsed_s`. The
+  active follow-up closes that report-only aggregation gap.
 - PR #1180 merged to `v8` as `6e72f374` after exact-head Hermes and Grok 4.5
   green reviews plus green CI. VPS5 pulled cleanly and restarted only the five
   configured bot panes; one stopped after the first exact-pane Ctrl-C and four

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -871,7 +871,11 @@ Each slice should update this checklist with its result.
      distinguishes historical failures from each bot's latest observed status.
      The active HSL scorecard slice adds per-bot retained protective-ready
      records plus bounded replay history-format, protective elapsed, and
-     completed full-replay elapsed aggregates from existing events.
+     completed full-replay elapsed aggregates from existing events. Its VPS5
+     smoke exposed that early protective milestones may rotate before a
+     current-segment report; the active follow-up uses the completion record's
+     retained protective elapsed value for that aggregate without synthesizing
+     a missing milestone.
 
 2. [ ] HSL replay benchmark/profiling slice.
    - Add an offline deterministic benchmark or fixture path for coin-mode HSL

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1846,20 +1846,28 @@ class _HslReplayProfileAccumulator:
             history_format = state.get("history_format")
             if history_format:
                 history_format_counts[str(history_format)] += 1
+            protective_elapsed_ms = None
             protective_ready = state.get("protective_ready")
             if isinstance(protective_ready, dict):
                 derived = protective_ready.get("derived")
                 if isinstance(derived, dict):
-                    elapsed_ms = derived.get("protective_elapsed_ms")
-                    if elapsed_ms is None:
-                        elapsed_ms = derived.get("startup_blocking_elapsed_ms")
-                    if elapsed_ms is not None:
-                        protective_ready_elapsed_ms.append(int(elapsed_ms))
+                    protective_elapsed_ms = derived.get("protective_elapsed_ms")
+                    if protective_elapsed_ms is None:
+                        protective_elapsed_ms = derived.get(
+                            "startup_blocking_elapsed_ms"
+                        )
             completed = state.get("completed")
             if isinstance(completed, dict):
                 derived = completed.get("derived")
-                if isinstance(derived, dict) and derived.get("full_elapsed_ms") is not None:
-                    full_replay_elapsed_ms.append(int(derived["full_elapsed_ms"]))
+                if isinstance(derived, dict):
+                    if protective_elapsed_ms is None:
+                        # Pre-split completions may have startup blocking time
+                        # without an equivalent protective-ready milestone.
+                        protective_elapsed_ms = derived.get("protective_elapsed_ms")
+                    if derived.get("full_elapsed_ms") is not None:
+                        full_replay_elapsed_ms.append(int(derived["full_elapsed_ms"]))
+            if protective_elapsed_ms is not None:
+                protective_ready_elapsed_ms.append(int(protective_elapsed_ms))
             groups.append(
                 _with_hsl_replay_active_age(group, report_ts_ms=int(report_ts_ms))
             )

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1861,6 +1861,26 @@ def test_live_performance_report_hsl_replay_profile_exposes_protective_scorecard
                 },
             ),
         ],
+        ("okx", "okx_01"): [
+            _monitor_row(
+                event_type="hsl.replay.completed",
+                seq=1,
+                ts=3500,
+                exchange="okx",
+                user="okx_01",
+                component="risk.hsl",
+                status="succeeded",
+                reason_code="coin_history_replay_completed",
+                data={
+                    "signal_mode": "coin",
+                    "stage": "full_replay",
+                    "history_format": "compact",
+                    "protective_elapsed_s": 5.0,
+                    "startup_blocking_elapsed_s": 5.0,
+                    "full_elapsed_s": 25.0,
+                },
+            ),
+        ],
     }
     for (exchange, user), rows in fixtures.items():
         _write_ndjson(
@@ -1873,14 +1893,14 @@ def test_live_performance_report_hsl_replay_profile_exposes_protective_scorecard
     summary_profile = summarize_live_performance_report(report)["hsl_replay_profile"]
     groups = {group["bot"]: group for group in profile["groups"]}
 
-    assert profile["history_format_counts"] == {"compact": 1, "timeline": 1}
-    assert profile["protective_ready_bot_count"] == 2
-    assert profile["protective_ready_elapsed_ms"]["count"] == 2
-    assert profile["protective_ready_elapsed_ms"]["min"] == 12300
+    assert profile["history_format_counts"] == {"compact": 2, "timeline": 1}
+    assert profile["protective_ready_bot_count"] == 3
+    assert profile["protective_ready_elapsed_ms"]["count"] == 3
+    assert profile["protective_ready_elapsed_ms"]["min"] == 5000
     assert profile["protective_ready_elapsed_ms"]["max"] == 20000
-    assert profile["full_replay_elapsed_ms"]["count"] == 1
+    assert profile["full_replay_elapsed_ms"]["count"] == 2
     assert profile["full_replay_elapsed_ms"]["max"] == 30000
-    assert summary_profile["history_format_counts"] == {"compact": 1, "timeline": 1}
+    assert summary_profile["history_format_counts"] == {"compact": 2, "timeline": 1}
     assert summary_profile["protective_ready_elapsed_ms"]["max"] == 20000
     assert summary_profile["full_replay_elapsed_ms"]["max"] == 30000
     assert groups["binance/binance_01"]["history_format"] == "compact"
@@ -1896,6 +1916,44 @@ def test_live_performance_report_hsl_replay_profile_exposes_protective_scorecard
         "startup_blocking": True,
         "startup_blocking_elapsed_ms": 20000,
     }
+    assert groups["okx/okx_01"]["history_format"] == "compact"
+    assert "protective_ready" not in groups["okx/okx_01"]
+    assert groups["okx/okx_01"]["completed"]["derived"][
+        "protective_elapsed_ms"
+    ] == 5000
+
+
+def test_live_performance_report_completion_requires_explicit_protective_elapsed(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="hsl.replay.completed",
+                seq=1,
+                ts=1000,
+                component="risk.hsl",
+                status="succeeded",
+                reason_code="coin_history_replay_completed",
+                data={
+                    "signal_mode": "coin",
+                    "stage": "full_replay",
+                    "startup_blocking_elapsed_s": 9.0,
+                    "full_elapsed_s": 10.0,
+                },
+            )
+        ],
+    )
+
+    profile = build_live_performance_report(tmp_path / "monitor")[
+        "hsl_replay_profile"
+    ]
+
+    assert profile["protective_ready_bot_count"] == 0
+    assert profile["protective_ready_elapsed_ms"] == {}
+    assert profile["full_replay_elapsed_ms"]["max"] == 10000
 
 
 def test_live_performance_report_hsl_replay_profile_whitelists_values(tmp_path):


### PR DESCRIPTION
## Summary

- recover the bounded protective-ready elapsed aggregate from an HSL replay completion when the earlier dedicated milestone has rotated out of the selected event files
- require explicit completion `protective_elapsed_s`; do not reinterpret older completion-only `startup_blocking_elapsed_s` or synthesize a `protective_ready` record
- add regressions for completion-only current history and the pre-split non-fabrication boundary
- record PR #1181's no-restart VPS5 evidence and the runtime-discovered report gap

This is a read-only performance-report correction. It does not change HSL producers, replay behavior, exchange calls, smoke verdicts, Rust, backtest, or running bot state.

## Triggering evidence

PR #1181's bounded current-segment VPS5 scorecard found all four compact full-replay completions (453.980s to 1728.585s), but reported `protective_ready_bot_count=0`. The dedicated early milestones had rotated out, while every retained current completion record still carried explicit `protective_elapsed_s` values (11.237s to 79.883s).

## Validation

- `98 passed`: `tests/test_live_performance_report.py` + `tests/test_live_incident_bundle.py`
- Python compilation passes
- `git diff --check` passes
- independent Terra preflight is green after the strict pre-split compatibility boundary was reviewed; no blocker remains

## VPS plan

After exact-head reviewer approvals and green CI, pull without restarting bots and rerun the same bounded current-segment `hsl_replay_profile` summary. Expected evidence: four compact completions, four protective-ready aggregate values recovered from explicit completion data, unchanged pane PIDs, and no process signal.