### PR TITLE
Index coin-HSL replay fills once

### DIFF
--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -23,48 +23,48 @@ Estimated completion:
 ## Active Review Slice
 
 - PR and publication state: query live GitHub metadata;
-  `Count protective readiness from completion evidence`
-- Branch: `codex/v8-hsl-replay-scorecard-completion-fallback`
+  `Index coin-HSL replay fills once`
+- Branch: `codex/v8-hsl-fill-index`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
-- Base: `77e111f7277077b4d1c4c37a562a67dad8906665`
-- Scope: when a dedicated `held_protective_ready` event has rotated out of the
-  selected files, `live-performance-report` derives the bounded protective
-  elapsed aggregate from the retained completed replay record. It does not
-  synthesize a milestone record.
-- Triggering evidence: PR #1181's first no-restart VPS5 smoke correctly showed
-  all four compact full-replay completions, but reported
-  `protective_ready_bot_count=0` because the earlier milestone events had
-  rotated while every completion record still carried `protective_elapsed_s`.
-- Non-goals: no live event producer, replay ordering or arithmetic, HSL
-  threshold/episode/cooldown behavior, cache authority, exchange call, process
-  control, Rust, backtest, or smoke-verdict change.
-- Local validation: all `73` live-performance-report tests and `25`
-  incident-bundle integration tests pass. Python compilation and diff hygiene
-  pass; this follow-up does not touch imports.
-- Independent preflight: Terra's initial completion/startup fallback concern
-  was rejected at the pre-split compatibility boundary; after the strict
-  explicit-protective regression and code comment, Terra retracted the finding
-  and reported no blocker. Sol owns final adjudication.
+- Base: `e5b4d26d3235b910c7549675f18dce865431cbb1`
+- Scope: group cold coin-HSL fill history once by `(pside, symbol)` and reuse
+  the stable per-pair lists for cooldown/intervention contract inference and
+  position-size replay reconstruction. This removes repeated broad fill scans
+  before the separate sparse minute-replay slice.
+- Triggering evidence: post-PR #1180 VPS5 full replay remained between
+  `453.980s` and `1728.585s`. Source inspection confirmed both repeated
+  per-pair fill scans and the larger `pairs * timeline_rows` metric loop.
+- Non-goals: no minute-row skipping, replay ordering or arithmetic change, HSL
+  threshold/episode/cooldown behavior change, cache schema, exchange call,
+  process control, Rust, backtest, or smoke-verdict change.
+- Local validation: `144` coin-HSL replay, benchmark, and metric-regression
+  tests pass; Python compilation and diff hygiene pass. A deterministic
+  `30,000`-fill, `30`-pair comparison produced identical replay-event output
+  and reduced this preprocessing substep from `0.181s` to `0.027s` locally.
+- Independent preflight: Terra reported canonical cold-start history green and
+  identified one conflicting-alias edge. The index now fails loudly when
+  `pside` and `position_side` disagree, with a regression test. Sol owns final
+  adjudication.
 - Publication state, exact head, mergeability, CI, and current-head review
   verdicts: query live GitHub metadata. Do not encode those transient values in
   the same PR that contains this status file, because every correction would
   create a different head and immediately stale the embedded value.
 - Expected VPS action: after exact-head approval and merge, pull while
-  preserving local artifacts and run a bounded no-restart performance report
-  against the existing monitor history. Running bots need no restart because
-  this slice changes read-only report consumption only.
+  preserving local artifacts, restart the five supervised bots, and compare
+  replay timings plus the bounded smoke report. The initializer code is loaded
+  only at process start.
 
 Next action:
 
-1. Finish focused validation and independent preflight, publish the completion
-   fallback, resolve verified findings, and merge only after the exact-head
-   gate; then rerun the declared VPS5 no-restart report smoke.
+1. Finish validation and independent preflight, publish the fill-index slice,
+   resolve verified findings, and merge only after the exact-head gate; then
+   run the declared controlled VPS5 restart and smoke comparison.
 
 ## Deployed Baseline
 
-- Remote `v8`: `77e111f7`, PR #1181
-- VPS5 repository: `77e111f7`, PR #1181; tracked status clean
+- Remote `v8`: `e5b4d26d`, PR #1182
+- VPS5 repository: `e5b4d26d`, PR #1182; tracked status clean
 - VPS5 expected bots: five; all are running after the controlled restart
 - Immediate and fresh settled smoke reports were green: all five expected bots
   matched, hard failures were zero, and the fresh window recorded `614/614`
@@ -82,6 +82,10 @@ Next action:
   bounded current-segment scorecard reported four compact full-replay
   completions from `453.98s` to `1728.585s`, but exposed the active slice's
   missing completion fallback for the rotated protective milestones.
+- PR #1182 required no restart and recovered protective elapsed aggregates
+  from explicit completion evidence without synthesizing milestone records.
+  A fresh recovery smoke was green with `279/279` remote and `66/66`
+  account-critical calls successful; all five expected bots matched.
 - Preserve local/VPS configs, logs, monitor data, reports, and temporary files
 
 ## Review Gate
@@ -105,13 +109,13 @@ Next action:
 ## Next Slice
 
 The coin-HSL protective-readiness split, cooperative background cadence,
-current process-pressure query, and compact cold replay payload are merged and
-deployed. The active slice completes the bounded operator scorecard when early
-protective milestones rotate before the later full-replay completion.
+current process-pressure query, compact cold replay payload, and bounded replay
+scorecard are merged and deployed. The active slice removes repeated broad fill
+scans as the first behavior-neutral prerequisite for exact sparse full replay.
 Remaining candidates:
 
-- realistic-scale replay fixtures and deeper internal-stage profiling
-- lower-complexity full replay after the scorecard exposes its baseline
+- realistic sparse replay fixtures and dense-reference equivalence reporting
+- exact lower-complexity minute replay using indexed episode/change boundaries
 - unsupported configured-market and stock-perp compatibility events
 - bounded operator tooling improvements sharing one code and validation surface
 

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -601,6 +601,9 @@ Trading-impact labels:
 - [ ] Index fill events once by `(pside, symbol)`.
   - Reuse that index for replay contracts, panic detection, position-size
     replay, realized-PnL peak/current calculations, and cooldown discovery.
+  - Partial: the cold coin-HSL initializer now builds one stable pair index and
+    reuses it for replay-contract inference and position-size reconstruction.
+    Panic/cooldown indexing and sparse realized-PnL replay remain open.
 
 - [ ] Parallelize only where correctness boundaries are independent.
   - Coin-mode held-pair protective reconstruction may classify independent

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -3619,6 +3619,31 @@ def _equity_hard_stop_fill_replay_qty(fill: Any) -> Optional[float]:
     return None
 
 
+def _equity_hard_stop_index_coin_fill_events(
+    fill_events: list[Any],
+) -> dict[tuple[str, str], list[Any]]:
+    """Group fills by coin HSL scope without changing their source order."""
+    indexed: dict[tuple[str, str], list[Any]] = {}
+    for event in fill_events:
+        pside_alias = _equity_hard_stop_event_value(event, "pside")
+        position_side_alias = _equity_hard_stop_event_value(event, "position_side")
+        if (
+            pside_alias is not None
+            and position_side_alias is not None
+            and str(pside_alias).lower() != str(position_side_alias).lower()
+        ):
+            raise ValueError(
+                "coin HSL fill has conflicting pside aliases: "
+                f"pside={pside_alias!r} position_side={position_side_alias!r}"
+            )
+        pair = (
+            _equity_hard_stop_fill_pside(event),
+            _equity_hard_stop_fill_symbol(event),
+        )
+        indexed.setdefault(pair, []).append(event)
+    return indexed
+
+
 def _equity_hard_stop_coin_replay_events(
     fill_events: list[Any], pside: str, symbol: str, *, qty_step: float = 0.0
 ) -> tuple[list[tuple[int, str, float]], bool]:
@@ -4968,6 +4993,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             raise TypeError(
                 f"get_balance_equity_history()['fill_events'] must be a list, got {type(fill_events).__name__}"
             )
+        fill_events_by_pair = _equity_hard_stop_index_coin_fill_events(fill_events)
 
         compact_replay = history.get("hsl_coin_compact_replay")
         timeline = history.get("timeline")
@@ -5362,8 +5388,9 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         force=True,
                     )
                 state = self._hsl_coin_state(pside, symbol)
+                pair_fill_events = fill_events_by_pair.get((pside, symbol), [])
                 contract = self._equity_hard_stop_infer_coin_replay_contract(
-                    pside, symbol, fill_events, now_ms
+                    pside, symbol, pair_fill_events, now_ms
                 )
                 replay_start_boundary_ts = None
                 if contract["intervention_entry_ts"] is not None and contract["policy"] == "normal":
@@ -5388,7 +5415,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 seen_coin_timeline_fields = False
                 qty_step = _hsl_qty_step_for_symbol(self, symbol)
                 replay_events, replay_ambiguous = _equity_hard_stop_coin_replay_events(
-                    fill_events,
+                    pair_fill_events,
                     pside,
                     symbol,
                     qty_step=qty_step,

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -85,6 +85,107 @@ def test_hsl_coin_replay_candidate_batches_are_frozen_and_scope_prioritized():
     )
 
 
+def test_coin_hsl_fill_index_preserves_pair_order_and_event_identity():
+    long_first = {
+        "timestamp": 30,
+        "symbol": "A",
+        "pside": "long",
+        "action": "increase",
+        "qty": 1.0,
+    }
+    short_fill = {
+        "timestamp": 20,
+        "symbol": "A",
+        "pside": "short",
+        "action": "increase",
+        "qty": 2.0,
+    }
+    long_second = {
+        "timestamp": 10,
+        "symbol": "A",
+        "pside": "long",
+        "action": "decrease",
+        "qty": 1.0,
+    }
+
+    indexed = hsl._equity_hard_stop_index_coin_fill_events(
+        [long_first, short_fill, long_second]
+    )
+
+    assert indexed == {
+        ("long", "A"): [long_first, long_second],
+        ("short", "A"): [short_fill],
+    }
+    assert indexed[("long", "A")][0] is long_first
+    assert indexed[("long", "A")][1] is long_second
+
+
+def test_coin_hsl_fill_index_rejects_conflicting_pside_aliases():
+    with pytest.raises(ValueError, match="conflicting pside aliases"):
+        hsl._equity_hard_stop_index_coin_fill_events(
+            [
+                {
+                    "timestamp": 1,
+                    "symbol": "A",
+                    "pside": "long",
+                    "position_side": "short",
+                    "action": "increase",
+                    "qty": 1.0,
+                }
+            ]
+        )
+
+
+def test_coin_hsl_fill_index_keeps_replay_and_contract_results_identical():
+    fills = [
+        {
+            "timestamp": 1,
+            "symbol": "A",
+            "pside": "long",
+            "action": "increase",
+            "qty": 1.0,
+        },
+        {
+            "timestamp": 2,
+            "symbol": "B",
+            "pside": "short",
+            "action": "increase",
+            "qty": 3.0,
+        },
+        {
+            "timestamp": 3,
+            "symbol": "A",
+            "pside": "long",
+            "action": "decrease",
+            "qty": 1.0,
+            "pb_order_type": "panic_close",
+        },
+        {
+            "timestamp": 4,
+            "symbol": "A",
+            "pside": "long",
+            "action": "increase",
+            "qty": 0.5,
+        },
+    ]
+    pair_fills = hsl._equity_hard_stop_index_coin_fill_events(fills)[("long", "A")]
+    bot = FakeHslBot(
+        hsl={"long": {"cooldown_minutes_after_red": 1.0}},
+        positions={"A": {"long": {"size": 0.5}}},
+    )
+    bot._equity_hard_stop_cooldown_position_policy = lambda: "normal"
+    bot._equity_hard_stop_has_open_position_symbol = lambda pside, symbol: True
+
+    assert hsl._equity_hard_stop_coin_replay_events(
+        pair_fills, "long", "A"
+    ) == hsl._equity_hard_stop_coin_replay_events(fills, "long", "A")
+    assert hsl._equity_hard_stop_infer_coin_replay_contract(
+        bot, "long", "A", pair_fills, 30_000
+    ) == hsl._equity_hard_stop_infer_coin_replay_contract(
+        bot, "long", "A", fills, 30_000
+    )
+
+
 def test_parse_hsl_config_warns_about_history_reinterpretation(caplog):
     bot = FakeHslBot(config={"live": {"hsl_signal_mode": "coin"}})
     values = {


### PR DESCRIPTION
## Summary
- build one stable `(pside, symbol)` fill index for cold coin-HSL startup
- reuse per-pair fills for cooldown/intervention contract inference and position-size replay reconstruction
- fail loudly on conflicting `pside`/`position_side` aliases and update the active status/performance plan

## Scope
This is the behavior-neutral prerequisite for later exact sparse minute replay. It does not skip replay rows or change HSL thresholds, episode/cooldown arithmetic, Rust behavior, cache schema, exchange calls, or order behavior.

## Validation
- `PYTHONPATH=src .../venv/bin/python -m pytest -q tests/test_hsl_coin_mode.py tests/test_hsl_replay_benchmark.py tests/test_hsl_metric_regression.py` -> 144 passed
- Python compilation and `git diff --check` pass
- deterministic 30,000-fill / 30-pair comparison: identical replay-event output; repeated-scan substep 0.181s vs indexed 0.027s locally (6.67x)
- independent Terra preflight and delta re-review: green

## VPS plan
After exact-head Hermes + Grok review and green CI, merge to `v8`, pull VPS5 preserving local artifacts, perform the controlled five-bot restart, and compare replay timings plus bounded smoke evidence. No VPS action before the merge gate.