### PR TITLE
Replay flat coin HSL history at exact change points

### DIFF
--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,62 +22,69 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR and publication state: query live GitHub metadata;
-  `Index coin-HSL replay fills once`
-- Branch: `codex/v8-hsl-fill-index`
+- PR and publication state: unpublished; query live GitHub metadata after
+  publication; `Replay flat coin-HSL history at exact change points`
+- Branch: `codex/v8-hsl-sparse-replay`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
-- Base: `e5b4d26d3235b910c7549675f18dce865431cbb1`
-- Scope: group cold coin-HSL fill history once by `(pside, symbol)` and reuse
-  the stable per-pair lists for cooldown/intervention contract inference and
-  position-size replay reconstruction. This removes repeated broad fill scans
-  before the separate sparse minute-replay slice.
-- Triggering evidence: post-PR #1180 VPS5 full replay remained between
-  `453.980s` and `1728.585s`. Source inspection confirmed both repeated
-  per-pair fill scans and the larger `pairs * timeline_rows` metric loop.
-- Non-goals: no minute-row skipping, replay ordering or arithmetic change, HSL
-  threshold/episode/cooldown behavior change, cache schema, exchange call,
-  process control, Rust, backtest, or smoke-verdict change.
-- Local validation: `144` coin-HSL replay, benchmark, and metric-regression
-  tests pass; Python compilation and diff hygiene pass. A deterministic
-  `30,000`-fill, `30`-pair comparison produced identical replay-event output
-  and reduced this preprocessing substep from `0.181s` to `0.027s` locally.
-- Independent preflight: Terra reported canonical cold-start history green and
-  identified one conflicting-alias edge. The index now fails loudly when
-  `pside` and `position_side` disagree, with a regression test. Sol owns final
-  adjudication.
+- Base: `b29d5ca5fd3ffc2d75657459c0ab549e5484596d`
+- Scope: compact cold coin-HSL replay keeps currently held pair history dense,
+  but evaluates historical flat pairs only at exact account/pair run
+  boundaries, rolling-lookback expiries, fill/marker/cooldown/required/restart
+  boundaries, and the final row. Ambiguous fill replay falls back to the dense
+  path. Structured replay events and the performance report expose bounded
+  candidate/dense-equivalent row counts and strategy labels.
+- Triggering evidence: post-PR #1183 full replay completed in `601.246s` for
+  KuCoin and `914.691s` for Binance while OKX and GateIO remained active.
+  The indexed-fill load stage took only `0.103s` to `0.213s`, confirming the
+  per-pair minute loop is the dominant remaining local cost.
+- Non-goals: no held-pair sample skipping, HSL arithmetic or threshold change,
+  panic/cooldown/restart contract change, cache authority/schema, exchange
+  call, process control, Rust, backtest, or smoke-verdict change.
+- Local validation: the affected benchmark, coin-HSL, metric-regression, and
+  performance-report suites pass. A deterministic 43,201-minute, 30-pair
+  fixture with one held pair produced identical candidate/dense final-state
+  hashes while reducing replay samples from `825430` to `43652`; all `43201`
+  held-pair samples remained dense. The benchmark is offline and recorded zero
+  network, cache-read, and cache-write side effects.
+- Independent preflight: Terra identified three valid issues: held-pair density
+  was data-dependent, benchmark equivalence omitted restart/cooldown state, and
+  dense fallback telemetry was mislabeled. The implementation now forces held
+  pairs dense, hashes the behavior-relevant runtime state, reports mixed/dense
+  fallback counts, and has independent warning-clean regressions. Terra's final
+  delta review reported no findings and green-lit publication; Sol adjudicated
+  the fixes.
 - Publication state, exact head, mergeability, CI, and current-head review
   verdicts: query live GitHub metadata. Do not encode those transient values in
   the same PR that contains this status file, because every correction would
   create a different head and immediately stale the embedded value.
 - Expected VPS action: after exact-head approval and merge, pull while
   preserving local artifacts, restart the five supervised bots, and compare
-  replay timings plus the bounded smoke report. The initializer code is loaded
-  only at process start.
+  candidate counts, full-replay timings, process pressure, and the bounded
+  smoke report. The initializer code is loaded only at process start.
 
 Next action:
 
-1. Finish validation and independent preflight, publish the fill-index slice,
-   resolve verified findings, and merge only after the exact-head gate; then
-   run the declared controlled VPS5 restart and smoke comparison.
+1. Finish validation and independent preflight, publish the sparse-replay
+   slice, resolve verified findings, and merge only after the exact-head gate;
+   then run the declared controlled VPS5 restart and smoke comparison.
 
 ## Deployed Baseline
 
-- Remote `v8`: `e5b4d26d`, PR #1182
-- VPS5 repository: `e5b4d26d`, PR #1182; tracked status clean
+- Remote `v8`: `b29d5ca5`, PR #1183
+- VPS5 repository: `b29d5ca5`, PR #1183; tracked status clean
 - VPS5 expected bots: five; all are running after the controlled restart
 - Immediate and fresh settled smoke reports were green: all five expected bots
-  matched, hard failures were zero, and the fresh window recorded `614/614`
-  remote plus `90/90` account-critical calls succeeded. One Kucoin
+  matched, hard failures were zero, and the fresh recovery window recorded
+  `380/380` remote plus `42/42` account-critical calls succeeded. One Kucoin
   `RequestTimeout` cycle failure in the wider restart window recovered before
   the fresh smoke.
 - All four coin-HSL bots emitted `history_format=compact` and protective-ready
-  success. Kucoin completed full replay in `453.98s`; three background replays
-  remained active with no required pair work pending.
-- Compared with the pre-deploy sample, aggregate RSS fell from `694840 KB` to
-  `555296 KB`, all five processes moved from four `D` states to five `R`
-  states, and host swap use fell from `2926 MB` to `906 MB`. CPU remained high
-  while background replay continued.
+  success in `13.337s` to `78.832s`. The first observed post-PR #1183 full
+  completions were KuCoin at `601.246s` and Binance at `914.691s`; OKX and
+  GateIO remained active without failures. The fill-index prerequisite reduced
+  history-loaded work to `0.103s` to `0.213s`, but did not remove the dominant
+  pair-minute loop.
 - PR #1181 required no restart; all five bot pane PIDs remained unchanged. Its
   bounded current-segment scorecard reported four compact full-replay
   completions from `453.98s` to `1728.585s`, but exposed the active slice's
@@ -109,13 +116,14 @@ Next action:
 ## Next Slice
 
 The coin-HSL protective-readiness split, cooperative background cadence,
-current process-pressure query, compact cold replay payload, and bounded replay
-scorecard are merged and deployed. The active slice removes repeated broad fill
-scans as the first behavior-neutral prerequisite for exact sparse full replay.
+current process-pressure query, compact cold replay payload, bounded replay
+scorecard, and stable per-pair fill index are merged and deployed. The active
+slice uses exact sparse change points for historical flat-pair replay while
+keeping held-pair work dense.
 Remaining candidates:
 
-- realistic sparse replay fixtures and dense-reference equivalence reporting
-- exact lower-complexity minute replay using indexed episode/change boundaries
+- exact sparse replay deployment and VPS timing/process-pressure proof
+- deeper internal-stage profiling if live residual cost remains material
 - unsupported configured-market and stock-perp compatibility events
 - bounded operator tooling improvements sharing one code and validation surface
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,8 +22,8 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR and publication state: unpublished; query live GitHub metadata after
-  publication; `Replay flat coin-HSL history at exact change points`
+- PR and publication state: PR #1184; query live GitHub metadata for current
+  state; `Replay flat coin-HSL history at exact change points`
 - Branch: `codex/v8-hsl-sparse-replay`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
@@ -35,9 +35,9 @@ Estimated completion:
   path. Structured replay events and the performance report expose bounded
   candidate/dense-equivalent row counts and strategy labels.
 - Triggering evidence: post-PR #1183 full replay completed in `601.246s` for
-  KuCoin and `914.691s` for Binance while OKX and GateIO remained active.
-  The indexed-fill load stage took only `0.103s` to `0.213s`, confirming the
-  per-pair minute loop is the dominant remaining local cost.
+  KuCoin, `914.691s` for Binance, `2009.120s` for GateIO, and `2279.519s` for
+  OKX. The indexed-fill load stage took only `0.103s` to `0.213s`, confirming
+  the per-pair minute loop is the dominant remaining local cost.
 - Non-goals: no held-pair sample skipping, HSL arithmetic or threshold change,
   panic/cooldown/restart contract change, cache authority/schema, exchange
   call, process control, Rust, backtest, or smoke-verdict change.
@@ -65,9 +65,9 @@ Estimated completion:
 
 Next action:
 
-1. Finish validation and independent preflight, publish the sparse-replay
-   slice, resolve verified findings, and merge only after the exact-head gate;
-   then run the declared controlled VPS5 restart and smoke comparison.
+1. Resolve verified PR #1184 findings and merge only after the exact-head
+   reviewer and CI gate; then run the declared controlled VPS5 restart and
+   smoke comparison.
 
 ## Deployed Baseline
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7308,3 +7308,50 @@ VPS5 deployment status:
 - Validation in progress: coin-HSL and benchmark suites, compact/rich sample and
   final-state parity, balance-history regressions, syntax/diff checks, and a
   controlled post-merge VPS5 restart with process/RSS/swap/I/O comparison.
+
+### Deployed Slices: Compact Replay, Scorecard, And Fill Index
+
+- PR #1180 merged the compact cold replay payload after exact-head Hermes and
+  Grok approval plus green CI. VPS5 was restarted on the merge; all five bots
+  reached a settled hard-green smoke, and four coin-HSL bots emitted compact
+  protective-ready evidence. Full replay still took `453.980s` to `1728.585s`,
+  proving memory pressure improved without removing pair-minute complexity.
+- PRs #1181 and #1182 added bounded replay scorecard fields and recovered
+  protective elapsed aggregates from completion events. Both were read-only
+  report slices and required no bot restart.
+- PR #1183 grouped cold replay fills once by `(pside, symbol)` and reused the
+  stable index for replay-contract inference and position-size reconstruction.
+  Hermes and Grok approved exact head `73a0b935`, CI passed, and it merged as
+  `b29d5ca5`. VPS5 pulled the clean merge and restarted all five bots while
+  preserving local artifacts and the unrelated `misc` tmux session.
+- Immediate and fresh settled smoke windows were hard-green; the recovery
+  window recorded `380/380` successful remote and `42/42` account-critical
+  calls. The indexed history-loaded stage took only `0.103s` to `0.213s` for
+  `1406` to `5359` fills. KuCoin and Binance full replay later completed in
+  `601.246s` and `914.691s`; OKX and GateIO remained active without replay
+  failures. The remaining cost is the pair-minute metric loop.
+
+### Active Slice: Exact Sparse Flat-Pair HSL Replay
+
+- Branch: `codex/v8-hsl-sparse-replay` from deployed `b29d5ca5`.
+- Scope: keep currently held pair history dense, but replay historical flat
+  pairs only at exact account/pair value-run boundaries, rolling-lookback
+  expiry boundaries, fill/marker/cooldown/required/restart boundaries, and the
+  final row. Ambiguous fill replay falls back to dense iteration.
+- Structured replay events and `live-performance-report` expose bounded
+  strategy, candidate-row, dense-equivalent-row, and reduction fields.
+- Offline acceptance evidence: a 43,201-minute, 30-pair fixture with one held
+  pair, same-timestamp fills, account-balance changes, EMA smoothing, and
+  cooldown/panic transitions produced identical candidate/dense final-state
+  hashes. Candidate replay applied `43652` samples versus `825430` dense,
+  eliminating `781778` historical samples while preserving all `43201` held
+  samples. Network, cache-read, and cache-write side-effect counters stayed
+  zero.
+- Reproduce the full-scale proof offline with `passivbot tool
+  hsl-replay-benchmark --minutes 43201 --symbols 30 --held-symbols 1
+  --local-scale --compact`.
+- The affected benchmark, coin-HSL, HSL metric-regression, and performance
+  report suites pass. Terra's final delta preflight reported no findings after
+  held-density, equivalence-state, fallback-telemetry, and warning-clean test
+  fixes. Publication, exact-head reviews/CI, and post-merge VPS
+  timing/process-pressure validation remain pending.

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -98,9 +98,11 @@ slices.
   - Result: `passivbot tool hsl-replay-benchmark` replays a bounded in-memory
     coin-HSL fixture through the current initializer, with distinct profiled
     timeline-rows/s and pair-rows/s, per-stage timing, counter, fixture-hash,
-    final-state-hash, and side-effect-counter output. Realistic-scale
-    fill/row/pair fixtures and deeper internal-stage profiling remain part of
-    the open benchmark slice.
+    final-state-hash, and side-effect-counter output. The active sparse-replay
+    slice extends this to a 43,201-minute, 30-pair fixture with held and
+    historical-flat pairs, cooldown/panic transitions, same-timestamp fills,
+    account-balance changes, EMA smoothing, and exact dense-reference state and
+    sample-count comparison. Deeper internal-stage profiling remains open.
 - [ ] Acceptance: before optimizing, the report identifies the dominant cost
   category and provides a repeatable local benchmark.
 
@@ -536,8 +538,12 @@ Trading-impact labels:
     aligned NumPy account/pair arrays instead of the rich nested timeline and
     consumes those arrays directly. A 43,201-minute, 30-symbol builder profile
     reduced Python peak allocations from `686242590` to `73499666` bytes
-    (89.3%). Pair iteration remains `rows * pairs`; fill indexing and a true
-    lower-complexity state update remain open.
+    (89.3%). The fill-index prerequisite is deployed. The active sparse-replay
+    candidate keeps held-pair arrays dense and selects exact run, expiry, fill,
+    intervention, and terminal boundaries for historical flat pairs. Its
+    30-pair offline acceptance fixture reduced applied samples from `825430` to
+    `43652` with identical final-state hashes and all `43201` held samples
+    preserved.
   - Preserve current RED/green/current-drawdown semantics: a historical RED
     crossing must not cause a panic now if current replay state is no longer in
     the red zone.
@@ -592,11 +598,11 @@ Trading-impact labels:
     replay, optimized replay, and checkpoint resume.
   - Output metrics: elapsed, rows/s, per-stage timings, current HSL state by
     held pair, cooldown state by affected flat pair, and equivalence diff.
-  - Partial: the benchmark now distinguishes held/background pairs and samples,
-    reports expected cooperative yields, supports an explicit 43,201-minute
-    local-scale mode, compares timeline/compact final-state output, and can
-    report tracemalloc current/peak bytes. A realistic cooldown candidate and
-    detailed equivalence report remain open.
+  - Active candidate: the benchmark distinguishes held/background pairs and
+    samples, reports expected cooperative yields, supports an explicit
+    43,201-minute local-scale mode, includes cooldown/panic and account-balance
+    transitions, and compares candidate and dense-reference final state plus
+    sample counts. It can also report tracemalloc current/peak bytes.
 
 - [ ] Index fill events once by `(pside, symbol)`.
   - Reuse that index for replay contracts, panic detection, position-size

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -128,6 +128,7 @@ _EXECUTION_CONFIRMATION_TERMINALS = {
 _HSL_REPLAY_STRING_FIELDS = (
     "error_type",
     "history_format",
+    "replay_strategy",
     "signal_mode",
     "stage",
     "timeframe",
@@ -162,6 +163,12 @@ _HSL_REPLAY_NUMERIC_FIELDS = (
     "record_start_ts",
     "pair_idx",
     "applied_rows",
+    "candidate_rows",
+    "dense_equivalent_rows",
+    "candidate_reduction_pct",
+    "dense_replay_pairs",
+    "dense_fallback_pairs",
+    "sparse_replay_pairs",
     "total_applied_rows",
     "rows",
     "skipped_pairs",
@@ -1793,6 +1800,9 @@ class _HslReplayProfileAccumulator:
         history_format = data.get("history_format")
         if history_format is not None and is_newer("history_format"):
             retain("history_format", str(history_format))
+        replay_strategy = data.get("replay_strategy")
+        if replay_strategy is not None and is_newer("replay_strategy"):
+            retain("replay_strategy", str(replay_strategy))
 
     def to_dict(
         self,
@@ -1807,6 +1817,7 @@ class _HslReplayProfileAccumulator:
         latest_stage_counts: Counter[str] = Counter()
         active_stage_counts: Counter[str] = Counter()
         history_format_counts: Counter[str] = Counter()
+        replay_strategy_counts: Counter[str] = Counter()
         protective_ready_elapsed_ms: list[int] = []
         full_replay_elapsed_ms: list[int] = []
         for bot, state in self.bots.items():
@@ -1825,6 +1836,7 @@ class _HslReplayProfileAccumulator:
                 "completed": state.get("completed"),
                 "failed": state.get("failed"),
                 "history_format": state.get("history_format"),
+                "replay_strategy": state.get("replay_strategy"),
             }
             group = {
                 key: value for key, value in group.items() if value not in (None, {}, [])
@@ -1846,6 +1858,9 @@ class _HslReplayProfileAccumulator:
             history_format = state.get("history_format")
             if history_format:
                 history_format_counts[str(history_format)] += 1
+            replay_strategy = state.get("replay_strategy")
+            if replay_strategy:
+                replay_strategy_counts[str(replay_strategy)] += 1
             protective_elapsed_ms = None
             protective_ready = state.get("protective_ready")
             if isinstance(protective_ready, dict):
@@ -1904,6 +1919,7 @@ class _HslReplayProfileAccumulator:
             "latest_stage_counts": dict(latest_stage_counts.most_common()),
             "active_stage_counts": dict(active_stage_counts.most_common()),
             "history_format_counts": dict(history_format_counts.most_common()),
+            "replay_strategy_counts": dict(replay_strategy_counts.most_common()),
             "active_bot_count": int(latest_status_counts.get("active", 0)),
             "completed_bot_count": int(latest_status_counts.get("completed", 0)),
             "failed_bot_count": int(latest_status_counts.get("failed", 0)),

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -3644,6 +3644,87 @@ def _equity_hard_stop_index_coin_fill_events(
     return indexed
 
 
+def _hsl_compact_sparse_replay_indices(
+    timestamps: Any,
+    balances: Any,
+    realized_values: Any,
+    unrealized_values: Any,
+    *,
+    lookback_ms: Optional[int],
+    boundary_timestamps: tuple[int, ...] = (),
+) -> Any:
+    """Select exact change-point rows for compact coin-HSL metric stepping.
+
+    Rust advances EMA state across elapsed constant-input minutes exactly. Run
+    endpoints preserve the dense rolling-window timestamp semantics; expiry
+    boundaries preserve changes caused only by the configured lookback.
+    """
+    import numpy as np
+
+    ts = np.asarray(timestamps, dtype=np.int64)
+    balance = np.asarray(balances, dtype=np.float64)
+    if ts.ndim != 1 or balance.ndim != 1 or len(ts) != len(balance):
+        raise ValueError("compact sparse replay timestamps/balances must be equal 1D arrays")
+    row_count = len(ts)
+    if row_count == 0:
+        return np.empty(0, dtype=np.int64)
+
+    selected = np.zeros(row_count, dtype=bool)
+
+    def mark_run_boundaries(values: Any) -> Any:
+        if values is None:
+            return np.empty(0, dtype=np.int64)
+        arr = np.asarray(values, dtype=np.float64)
+        if arr.ndim != 1 or len(arr) != row_count:
+            raise ValueError("compact sparse replay values must match timestamp length")
+        if row_count == 1:
+            starts = np.array([0], dtype=np.int64)
+        else:
+            finite = np.isfinite(arr)
+            same = (finite[1:] == finite[:-1]) & (
+                (~finite[1:]) | (arr[1:] == arr[:-1])
+            )
+            starts = np.concatenate(
+                (
+                    np.array([0], dtype=np.int64),
+                    np.flatnonzero(~same).astype(np.int64) + 1,
+                )
+            )
+        ends = np.concatenate((starts[1:] - 1, np.array([row_count - 1])))
+        selected[starts] = True
+        selected[ends] = True
+        return ends
+
+    mark_run_boundaries(balance)
+    realized_run_ends = mark_run_boundaries(realized_values)
+    mark_run_boundaries(unrealized_values)
+
+    if lookback_ms is not None:
+        lookback_ms = int(lookback_ms)
+        for run_end in realized_run_ends:
+            expiry_idx = int(
+                np.searchsorted(
+                    ts,
+                    int(ts[int(run_end)]) + lookback_ms,
+                    side="right",
+                )
+            )
+            if expiry_idx < row_count:
+                selected[expiry_idx] = True
+                if expiry_idx > 0:
+                    selected[expiry_idx - 1] = True
+
+    for boundary_ts in boundary_timestamps:
+        boundary_idx = int(np.searchsorted(ts, int(boundary_ts), side="left"))
+        if boundary_idx < row_count:
+            selected[boundary_idx] = True
+        if boundary_idx > 0:
+            selected[boundary_idx - 1] = True
+
+    selected[-1] = True
+    return np.flatnonzero(selected).astype(np.int64)
+
+
 def _equity_hard_stop_coin_replay_events(
     fill_events: list[Any], pside: str, symbol: str, *, qty_step: float = 0.0
 ) -> tuple[list[tuple[int, str, float]], bool]:
@@ -5244,6 +5325,10 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
         )
         self._equity_hard_stop_coin_replay_pending_pairs = set(active_pairs)
         pair_rows_applied: dict[tuple[str, str], int] = {}
+        pair_candidate_rows: dict[tuple[str, str], int] = {}
+        dense_replay_pairs = 0
+        dense_fallback_pairs = 0
+        sparse_replay_pairs = 0
         logging.info(
             "[risk] HSL coin history reconstruction loaded | symbols=%d pairs=%d rows=%d fills=%d panic_events=%d",
             len(symbols),
@@ -5260,6 +5345,11 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 "stage": "loaded",
                 "history_format": (
                     "compact" if compact_replay is not None else "timeline"
+                ),
+                "replay_strategy": (
+                    "compact_pending_classification"
+                    if compact_replay is not None
+                    else "dense_timeline"
                 ),
                 "symbols": len(symbols),
                 "pairs": len(active_pairs),
@@ -5316,6 +5406,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     "required_pairs": len(active_required_pairs),
                     "timeline_rows": replay_row_count,
                     "applied_rows": int(applied_rows),
+                    "candidate_rows": pair_candidate_rows.get((pside, symbol)),
                     "total_applied_rows": int(rows),
                     "rows_per_second": round(rows_per_second, 3)
                     if rows_per_second is not None
@@ -5388,6 +5479,14 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         force=True,
                     )
                 state = self._hsl_coin_state(pside, symbol)
+                cooldown_minutes = float(
+                    self.hsl[pside]["cooldown_minutes_after_red"]
+                )
+                cooldown_ms = (
+                    int(round(cooldown_minutes * 60_000.0))
+                    if cooldown_minutes > 0.0
+                    else 0
+                )
                 pair_fill_events = fill_events_by_pair.get((pside, symbol), [])
                 contract = self._equity_hard_stop_infer_coin_replay_contract(
                     pside, symbol, pair_fill_events, now_ms
@@ -5420,6 +5519,43 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     symbol,
                     qty_step=qty_step,
                 )
+                pair_uses_dense_replay = (
+                    compact_replay is None
+                    or replay_ambiguous
+                    or (pside, symbol) in active_held_pairs
+                )
+                if pair_uses_dense_replay:
+                    dense_replay_pairs += 1
+                    if compact_replay is not None and replay_ambiguous:
+                        dense_fallback_pairs += 1
+                else:
+                    sparse_replay_pairs += 1
+                sparse_boundary_timestamps = []
+                if required_start_ts is not None:
+                    sparse_boundary_timestamps.append(int(required_start_ts))
+                if replay_start_boundary_ts is not None:
+                    sparse_boundary_timestamps.append(int(replay_start_boundary_ts))
+                if contract["cooldown_until_ms"] is not None:
+                    sparse_boundary_timestamps.append(int(contract["cooldown_until_ms"]))
+                for event_ts, _action, _qty in replay_events:
+                    sparse_boundary_timestamps.append(
+                        int(event_ts) // _HSL_REPLAY_MATRIX_INTERVAL_MS
+                        * _HSL_REPLAY_MATRIX_INTERVAL_MS
+                    )
+                    if cooldown_ms > 0:
+                        sparse_boundary_timestamps.append(int(event_ts) + cooldown_ms)
+                for (
+                    marker_pside,
+                    marker_symbol,
+                    marker_minute_ts,
+                ), marker_payload in latest_panic_by_coin_minute.items():
+                    if marker_pside != pside or marker_symbol != symbol:
+                        continue
+                    sparse_boundary_timestamps.append(int(marker_minute_ts))
+                    if cooldown_ms > 0:
+                        sparse_boundary_timestamps.append(
+                            int(marker_payload["timestamp"]) + cooldown_ms
+                        )
 
                 def reset_rolling_window() -> None:
                     nonlocal window_base_realized
@@ -5462,9 +5598,33 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         if compact_values is None
                         else compact_values["unrealized_pnl"]
                     )
+                    compact_replay_indices = (
+                        np.arange(replay_row_count, dtype=np.int64)
+                        if pair_uses_dense_replay
+                        else _hsl_compact_sparse_replay_indices(
+                            compact_timestamps[:replay_row_count],
+                            compact_balances[:replay_row_count],
+                            (
+                                None
+                                if compact_realized_values is None
+                                else compact_realized_values[:replay_row_count]
+                            ),
+                            (
+                                None
+                                if compact_unrealized_values is None
+                                else compact_unrealized_values[:replay_row_count]
+                            ),
+                            lookback_ms=lookback_ms,
+                            boundary_timestamps=tuple(sparse_boundary_timestamps),
+                        )
+                    )
+                    pair_candidate_rows[(pside, symbol)] = int(
+                        len(compact_replay_indices)
+                    )
 
                     def iter_replay_rows():
-                        for compact_idx in range(replay_row_count):
+                        for compact_idx in compact_replay_indices:
+                            compact_idx = int(compact_idx)
                             realized_value = (
                                 math.nan
                                 if compact_realized_values is None
@@ -5488,6 +5648,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                             )
 
                 else:
+                    pair_candidate_rows[(pside, symbol)] = int(replay_row_count)
 
                     def iter_replay_rows():
                         for legacy_idx, row in enumerate(timeline_rows, start=1):
@@ -5558,7 +5719,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     if background_replay
                     else 0.0
                 )
-                for (
+                for replay_iteration_idx, (
                     row_idx,
                     ts,
                     row_balance,
@@ -5568,8 +5729,8 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     has_unrealized,
                     unrealized_value,
                     source_row,
-                ) in iter_replay_rows():
-                    if row_idx % yield_rows == 0:
+                ) in enumerate(iter_replay_rows(), start=1):
+                    if replay_iteration_idx % yield_rows == 0:
                         await asyncio.sleep(yield_sleep_s)
                         check_shutdown("hsl_coin_history_replay_rows")
                         log_replay_progress(pair_idx, pside, symbol, applied_rows)
@@ -5938,6 +6099,26 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
         total_elapsed_s = max(0.0, time.monotonic() - initialization_started_s)
         rows_per_second = float(rows) / elapsed_s if elapsed_s > 0.0 else None
         skipped_pairs = sum(1 for pair in active_pairs if pair_rows_applied.get(pair, 0) == 0)
+        dense_equivalent_rows = int(replay_row_count * len(active_pairs))
+        candidate_rows = int(sum(pair_candidate_rows.values()))
+        candidate_reduction_pct = (
+            0.0
+            if dense_equivalent_rows <= 0
+            else max(
+                0.0,
+                (dense_equivalent_rows - candidate_rows)
+                / dense_equivalent_rows
+                * 100.0,
+            )
+        )
+        replay_strategy = "dense_timeline"
+        if compact_replay is not None:
+            if sparse_replay_pairs > 0 and dense_replay_pairs > 0:
+                replay_strategy = "mixed"
+            elif sparse_replay_pairs > 0:
+                replay_strategy = "sparse_change_points"
+            else:
+                replay_strategy = "dense_compact"
         logging.info(
             "[risk] HSL coin history reconstruction completed | rows=%d pairs=%d elapsed=%.1fs",
             rows,
@@ -5953,8 +6134,15 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 "history_format": (
                     "compact" if compact_replay is not None else "timeline"
                 ),
+                "replay_strategy": replay_strategy,
                 "rows": int(rows),
                 "applied_rows": int(rows),
+                "candidate_rows": candidate_rows,
+                "dense_equivalent_rows": dense_equivalent_rows,
+                "candidate_reduction_pct": round(candidate_reduction_pct, 3),
+                "dense_replay_pairs": int(dense_replay_pairs),
+                "dense_fallback_pairs": int(dense_fallback_pairs),
+                "sparse_replay_pairs": int(sparse_replay_pairs),
                 "pairs": len(active_pairs),
                 "held_pairs": len(active_held_pairs),
                 "cooldown_pairs": len(active_panic_pairs),

--- a/src/tools/hsl_replay_benchmark.py
+++ b/src/tools/hsl_replay_benchmark.py
@@ -5,6 +5,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import math
 import time
 import tracemalloc
 from collections import defaultdict
@@ -15,7 +16,7 @@ import passivbot_rust as pbr
 from passivbot import Passivbot
 
 
-BENCHMARK_SCHEMA_VERSION = 1
+BENCHMARK_SCHEMA_VERSION = 2
 DEFAULT_MINUTES = 240
 DEFAULT_SYMBOLS = 8
 DEFAULT_ITERATIONS = 1
@@ -25,6 +26,18 @@ MAX_ITERATIONS = 20
 LOCAL_SCALE_MAX_MINUTES = 43_201
 LOCAL_SCALE_MAX_SYMBOLS = 30
 BACKGROUND_YIELD_ROWS = 100
+FIXTURE_EMA_SPAN_MINUTES = 7.0
+FIXTURE_RED_THRESHOLD = 0.12
+FIXTURE_BALANCE = 1_000.0
+FIXTURE_ACCOUNT_DRIVER_INDEX = 2
+DENSE_REFERENCE_HISTORY_FORMAT = "timeline"
+DEFAULT_HISTORY_FORMAT = "compact"
+REFERENCE_SAMPLE_COUNT_KEYS = (
+    "coin_metrics_sample_calls",
+    "replay_samples_applied",
+    "held_replay_samples",
+    "background_replay_samples",
+)
 
 
 def _fixture_symbol(index: int) -> str:
@@ -42,7 +55,7 @@ def _validate_fixture_shape(
     max_symbols = LOCAL_SCALE_MAX_SYMBOLS if local_scale else MAX_SYMBOLS
     minutes = int(minutes)
     symbols = int(symbols)
-    held_symbols = symbols if held_symbols is None else int(held_symbols)
+    held_symbols = 1 if held_symbols is None else int(held_symbols)
     if not 1 <= minutes <= max_minutes:
         raise ValueError(f"minutes must be between 1 and {max_minutes}")
     if not 1 <= symbols <= max_symbols:
@@ -52,20 +65,52 @@ def _validate_fixture_shape(
     return minutes, symbols, held_symbols
 
 
-def build_coin_hsl_history_fixture(
-    minutes: int,
-    symbols: int,
-    held_symbols: int | None = None,
-    *,
-    local_scale: bool = False,
-) -> dict[str, Any]:
-    """Build deterministic coin-HSL history with optional flat background symbols."""
-    minutes, symbols, held_symbols = _validate_fixture_shape(
-        minutes, symbols, held_symbols, local_scale=local_scale
+def _fixture_episodes(minutes: int, symbols: int) -> list[dict[str, Any]]:
+    """Return fixed historical episodes that fit within the requested horizon."""
+    templates = (
+        (1, 601, 613, "historical_a", False),
+        (1, 12_001, 12_013, "historical_b", False),
+        (1, 30_001, 30_014, "historical_c", False),
+        (FIXTURE_ACCOUNT_DRIVER_INDEX, 18_001, 18_006, "balance_driver", False),
+        (3, 36_001, 36_015, "panic_flatten", True),
     )
+    episodes = [
+        {
+            "symbol_index": symbol_index,
+            "start_minute": start_minute,
+            "end_minute": end_minute,
+            "name": name,
+            "panic_flatten": panic_flatten,
+        }
+        for symbol_index, start_minute, end_minute, name, panic_flatten in templates
+        if symbol_index < symbols and end_minute <= minutes
+    ]
+    for symbol_index in range(4, symbols):
+        start_minute = 1_001 + (symbol_index - 4) * 1_200
+        end_minute = start_minute + 8
+        if end_minute > minutes:
+            break
+        episodes.append(
+            {
+                "symbol_index": symbol_index,
+                "start_minute": start_minute,
+                "end_minute": end_minute,
+                "name": f"background_{symbol_index:02d}",
+                "panic_flatten": False,
+            }
+        )
+    return episodes
 
+
+def _build_fixture_contract(minutes: int, symbols: int, held_symbols: int) -> dict[str, Any]:
+    """Build the scenario contract shared by dense fixture encodings.
+
+    Pair 0 remains held at the end of the replay. Pair 1 has short historical
+    episodes separated by multi-thousand-minute flat gaps. Pair 2 is an account
+    balance driver, and pair 3 ends in a historical panic flatten when present.
+    """
     names = [_fixture_symbol(index) for index in range(symbols)]
-    timeline: list[dict[str, Any]] = []
+    episodes = _fixture_episodes(minutes, symbols)
     fill_events: list[dict[str, Any]] = []
     for symbol_index, symbol in enumerate(names[:held_symbols]):
         fill_events.append(
@@ -75,32 +120,186 @@ def build_coin_hsl_history_fixture(
                 "pside": "long",
                 "action": "increase",
                 "qty": 1.0,
-                "id": f"fixture-open-{symbol_index}",
+                "id": f"fixture-current-open-{symbol_index}",
             }
         )
-    for minute in range(1, minutes + 1):
-        realized_by_symbol: dict[str, dict[str, float]] = {}
-        unrealized_by_symbol: dict[str, dict[str, float]] = {}
-        total_realized = 0.0
-        for symbol_index, symbol in enumerate(names):
-            realized = float((minute * (symbol_index + 3)) % 19) / 100.0
-            unrealized = -float((minute + symbol_index * 5) % 11) / 100.0
-            realized_by_symbol[symbol] = {"long": realized}
-            unrealized_by_symbol[symbol] = {"long": unrealized}
-            total_realized += realized
+    panic_flatten_events: list[dict[str, Any]] = []
+    for episode in episodes:
+        symbol = names[episode["symbol_index"]]
+        start_ts = int(episode["start_minute"]) * 60_000 + 100
+        end_ts = int(episode["end_minute"]) * 60_000 + 200
+        if episode["name"] == "historical_a":
+            # Deliberately preserve source order at one exchange timestamp.
+            fill_events.extend(
+                (
+                    {
+                        "timestamp": start_ts,
+                        "symbol": symbol,
+                        "pside": "long",
+                        "action": "increase",
+                        "qty": 0.4,
+                        "id": "fixture-historical-a-open-first",
+                    },
+                    {
+                        "timestamp": start_ts,
+                        "symbol": symbol,
+                        "pside": "long",
+                        "action": "increase",
+                        "qty": 0.6,
+                        "id": "fixture-historical-a-open-second",
+                    },
+                )
+            )
+        else:
+            fill_events.append(
+                {
+                    "timestamp": start_ts,
+                    "symbol": symbol,
+                    "pside": "long",
+                    "action": "increase",
+                    "qty": 1.0,
+                    "id": f"fixture-{episode['name']}-open",
+                }
+            )
+        fill_events.append(
+            {
+                "timestamp": end_ts,
+                "symbol": symbol,
+                "pside": "long",
+                "action": "decrease",
+                "qty": 1.0,
+                "id": f"fixture-{episode['name']}-close",
+            }
+        )
+        if episode["panic_flatten"]:
+            panic_flatten_events.append(
+                {
+                    "timestamp": end_ts,
+                    "minute_timestamp": int(episode["end_minute"]) * 60_000,
+                    "pside": "long",
+                    "symbol": symbol,
+                }
+            )
+    return {
+        "kind": "coin_hsl_dense_reference_fixture",
+        "minutes": minutes,
+        "symbols": names,
+        "held_symbols": names[:held_symbols],
+        "ema_span_minutes": FIXTURE_EMA_SPAN_MINUTES,
+        "red_threshold": FIXTURE_RED_THRESHOLD,
+        "account_balance_driver_symbol": (
+            names[FIXTURE_ACCOUNT_DRIVER_INDEX]
+            if FIXTURE_ACCOUNT_DRIVER_INDEX < symbols
+            else None
+        ),
+        "episodes": episodes,
+        "same_timestamp_fill_order": [
+            "fixture-historical-a-open-first",
+            "fixture-historical-a-open-second",
+        ]
+        if any(episode["name"] == "historical_a" for episode in episodes)
+        else [],
+        "fill_events": fill_events,
+        "panic_flatten_events": panic_flatten_events,
+        "pair_values_are_dense": True,
+    }
+
+
+def _build_dense_series(
+    minutes: int, symbols: int, contract: dict[str, Any]
+) -> tuple[Any, Any, Any, dict[tuple[str, str], dict[str, Any]]]:
+    """Create dense account and per-pair arrays from the scenario contract."""
+    import numpy as np
+
+    minute_numbers = np.arange(1, minutes + 1, dtype=np.int64)
+    timestamps = minute_numbers * 60_000
+    balances = np.full(minutes, FIXTURE_BALANCE, dtype=np.float64)
+    pair_values: dict[tuple[str, str], dict[str, Any]] = {}
+    episodes_by_symbol: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for episode in contract["episodes"]:
+        episodes_by_symbol[int(episode["symbol_index"])].append(episode)
+    for symbol_index, symbol in enumerate(contract["symbols"]):
+        symbol_episodes = episodes_by_symbol[symbol_index]
+        if symbol in contract["held_symbols"]:
+            realized = np.zeros(minutes, dtype=np.float64)
+            unrealized = -(
+                ((minute_numbers + symbol_index) % 17).astype(np.float64) + 1.0
+            ) / 100.0
+        elif symbol_episodes:
+            first_start_minute = min(
+                int(episode["start_minute"]) for episode in symbol_episodes
+            )
+            realized = np.full(minutes, np.nan, dtype=np.float64)
+            unrealized = np.full(minutes, np.nan, dtype=np.float64)
+            covered = minute_numbers >= first_start_minute
+            realized[covered] = 0.0
+            unrealized[covered] = 0.0
+        else:
+            realized = np.full(minutes, np.nan, dtype=np.float64)
+            unrealized = np.full(minutes, np.nan, dtype=np.float64)
+        for episode_index, episode in enumerate(symbol_episodes, start=1):
+            start_minute = int(episode["start_minute"])
+            end_minute = int(episode["end_minute"])
+            active = (minute_numbers >= start_minute) & (minute_numbers <= end_minute)
+            progress = (minute_numbers[active] - start_minute + 1) / (
+                end_minute - start_minute + 1
+            )
+            loss = 0.02 if episode["name"] == "balance_driver" else 0.24
+            unrealized[active] = -loss * FIXTURE_BALANCE * progress
+            realized[minute_numbers >= end_minute] += (
+                24.0 if episode["name"] == "balance_driver" else 3.0 * episode_index
+            )
+            if episode["name"] == "balance_driver":
+                balances[minute_numbers >= end_minute] += 24.0
+        pair_values[("long", symbol)] = {
+            "realized_pnl": realized,
+            "unrealized_pnl": unrealized,
+        }
+    realized_total = np.zeros(minutes, dtype=np.float64)
+    for values in pair_values.values():
+        realized_total += np.nan_to_num(values["realized_pnl"], nan=0.0)
+    return timestamps, balances, realized_total, pair_values
+
+
+def build_coin_hsl_history_fixture(
+    minutes: int,
+    symbols: int,
+    held_symbols: int | None = None,
+    *,
+    local_scale: bool = False,
+) -> dict[str, Any]:
+    """Build the dense-reference timeline fixture for coin-HSL replay."""
+    minutes, symbols, held_symbols = _validate_fixture_shape(
+        minutes, symbols, held_symbols, local_scale=local_scale
+    )
+    contract = _build_fixture_contract(minutes, symbols, held_symbols)
+    timestamps, balances, realized_total, pair_values = _build_dense_series(
+        minutes, symbols, contract
+    )
+    timeline: list[dict[str, Any]] = []
+    for index, timestamp in enumerate(timestamps):
         timeline.append(
             {
-                "timestamp": minute * 60_000,
-                "balance": 1_000.0,
-                "realized_pnl": total_realized,
-                "realized_pnl_by_coin_pside": realized_by_symbol,
-                "unrealized_pnl_by_coin_pside": unrealized_by_symbol,
+                "timestamp": int(timestamp),
+                "balance": float(balances[index]),
+                "realized_pnl": float(realized_total[index]),
+                "realized_pnl_by_coin_pside": {
+                    symbol: {"long": float(values["realized_pnl"][index])}
+                    for (_pside, symbol), values in pair_values.items()
+                    if math.isfinite(float(values["realized_pnl"][index]))
+                },
+                "unrealized_pnl_by_coin_pside": {
+                    symbol: {"long": float(values["unrealized_pnl"][index])}
+                    for (_pside, symbol), values in pair_values.items()
+                    if math.isfinite(float(values["unrealized_pnl"][index]))
+                },
             }
         )
     return {
         "timeline": timeline,
-        "fill_events": fill_events,
-        "panic_flatten_events": [],
+        "fill_events": contract["fill_events"],
+        "panic_flatten_events": contract["panic_flatten_events"],
+        "fixture_contract": contract,
     }
 
 
@@ -111,56 +310,43 @@ def build_coin_hsl_compact_fixture(
     *,
     local_scale: bool = False,
 ) -> dict[str, Any]:
-    """Build the same deterministic fixture directly in compact replay form."""
+    """Build the dense-reference fixture in compact replay form."""
     import numpy as np
 
     minutes, symbols, held_symbols = _validate_fixture_shape(
         minutes, symbols, held_symbols, local_scale=local_scale
     )
-    names = [_fixture_symbol(index) for index in range(symbols)]
-    minute_numbers = np.arange(1, minutes + 1, dtype=np.int64)
-    timestamps = minute_numbers * 60_000
-    pair_values: dict[tuple[str, str], dict[str, Any]] = {}
-    realized_total = np.zeros(minutes, dtype=np.float64)
-    for symbol_index, symbol in enumerate(names):
-        realized = ((minute_numbers * (symbol_index + 3)) % 19).astype(
-            np.float64
-        ) / 100.0
-        unrealized = -(
-            (minute_numbers + symbol_index * 5) % 11
-        ).astype(np.float64) / 100.0
-        pair_values[("long", symbol)] = {
-            "realized_pnl": realized,
-            "unrealized_pnl": unrealized,
-        }
-        realized_total += realized
-    fill_events = [
-        {
-            "timestamp": 1,
-            "symbol": symbol,
-            "pside": "long",
-            "action": "increase",
-            "qty": 1.0,
-            "id": f"fixture-open-{symbol_index}",
-        }
-        for symbol_index, symbol in enumerate(names[:held_symbols])
-    ]
+    contract = _build_fixture_contract(minutes, symbols, held_symbols)
+    timestamps, balances, realized_total, pair_values = _build_dense_series(
+        minutes, symbols, contract
+    )
+    pair_values = {
+        pair: values
+        for pair, values in pair_values.items()
+        if bool(np.any(np.isfinite(values["realized_pnl"])))
+        or bool(np.any(np.isfinite(values["unrealized_pnl"])))
+    }
     return {
         "hsl_coin_compact_replay": {
             "timestamps": timestamps,
-            "balances": np.full(minutes, 1_000.0, dtype=np.float64),
+            "balances": balances,
             "realized_pnl": realized_total,
             "pair_values": pair_values,
         },
-        "fill_events": fill_events,
-        "panic_flatten_events": [],
+        "fill_events": contract["fill_events"],
+        "panic_flatten_events": contract["panic_flatten_events"],
+        "fixture_contract": contract,
     }
 
 
 def _fixture_digest(history: dict[str, Any]) -> str:
+    digest = hashlib.sha256()
+    contract = history["fixture_contract"]
+    digest.update(
+        json.dumps(contract, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
     compact = history.get("hsl_coin_compact_replay")
     if compact is not None:
-        digest = hashlib.sha256()
         for field in ("timestamps", "balances", "realized_pnl"):
             digest.update(field.encode("utf-8"))
             digest.update(compact[field].tobytes(order="C"))
@@ -169,13 +355,16 @@ def _fixture_digest(history: dict[str, Any]) -> str:
             values = compact["pair_values"][pair]
             digest.update(values["realized_pnl"].tobytes(order="C"))
             digest.update(values["unrealized_pnl"].tobytes(order="C"))
-        digest.update(
-            json.dumps(
-                history["fill_events"], sort_keys=True, separators=(",", ":")
-            ).encode("utf-8")
-        )
         return digest.hexdigest()
-    encoded = json.dumps(history, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    for row in history["timeline"]:
+        digest.update(json.dumps(row, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _fixture_contract_digest(history: dict[str, Any]) -> str:
+    encoded = json.dumps(
+        history["fixture_contract"], sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
 
 
@@ -232,9 +421,9 @@ def _make_offline_replay_bot(
     bot.hsl = {
         "long": {
             "enabled": True,
-            "red_threshold": 0.95,
+            "red_threshold": FIXTURE_RED_THRESHOLD,
             "tier_ratios": {"yellow": 0.5, "orange": 0.75},
-            "ema_span_minutes": 15.0,
+            "ema_span_minutes": FIXTURE_EMA_SPAN_MINUTES,
             "cooldown_minutes_after_red": 5.0,
             "no_restart_drawdown_threshold": 1.0,
             "restart_after_red_policy": "threshold",
@@ -243,9 +432,9 @@ def _make_offline_replay_bot(
         },
         "short": {
             "enabled": False,
-            "red_threshold": 0.95,
+            "red_threshold": FIXTURE_RED_THRESHOLD,
             "tier_ratios": {"yellow": 0.5, "orange": 0.75},
-            "ema_span_minutes": 15.0,
+            "ema_span_minutes": FIXTURE_EMA_SPAN_MINUTES,
             "cooldown_minutes_after_red": 5.0,
             "no_restart_drawdown_threshold": 1.0,
             "restart_after_red_policy": "threshold",
@@ -318,11 +507,17 @@ def _make_offline_replay_bot(
     return bot
 
 
-def _state_digest(bot: Passivbot) -> str:
+def _state_projection(bot: Passivbot) -> list[dict[str, Any]]:
+    def stop_event_projection(value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+        return {key: item for key, item in value.items() if key != "triggered_at"}
+
     state_projection = []
     for pside, symbols in sorted(bot._equity_hard_stop_coin.items()):
         for symbol, state in sorted(symbols.items()):
             metrics = state.get("last_metrics") or {}
+            runtime = state["runtime"]
             state_projection.append(
                 {
                     "pside": pside,
@@ -330,14 +525,114 @@ def _state_digest(bot: Passivbot) -> str:
                     "halted": bool(state["halted"]),
                     "no_restart_latched": bool(state["no_restart_latched"]),
                     "cooldown_until_ms": state["cooldown_until_ms"],
-                    "tier": metrics.get("tier"),
-                    "drawdown_raw": metrics.get("drawdown_raw"),
-                    "drawdown_ema": metrics.get("drawdown_ema"),
-                    "drawdown_score": metrics.get("drawdown_score"),
+                    "pnl_reset_timestamp_ms": state["pnl_reset_timestamp_ms"],
+                    "cooldown_intervention_active": bool(
+                        state["cooldown_intervention_active"]
+                    ),
+                    "cooldown_repanic_reset_pending": bool(
+                        state["cooldown_repanic_reset_pending"]
+                    ),
+                    "cooldown_unresolved_residue": bool(
+                        state["cooldown_unresolved_residue"]
+                    ),
+                    "pending_red_since_ms": state["pending_red_since_ms"],
+                    "red_flat_confirmations": int(state["red_flat_confirmations"]),
+                    "red_trigger_event_emitted": bool(
+                        state["red_trigger_event_emitted"]
+                    ),
+                    "no_restart_peak_strategy_equity": float(
+                        state["no_restart_peak_strategy_equity"]
+                    ),
+                    "pending_stop_event": stop_event_projection(
+                        state["pending_stop_event"]
+                    ),
+                    "last_stop_event": stop_event_projection(state["last_stop_event"]),
+                    "runtime": {
+                        "initialized": bool(runtime.initialized()),
+                        "red_latched": bool(runtime.red_latched()),
+                        "red_seen_in_episode": bool(runtime.red_seen_in_episode()),
+                        "tier": str(runtime.tier()),
+                        "drawdown_ema": float(runtime.drawdown_ema()),
+                        "peak_strategy_equity": float(runtime.peak_strategy_equity()),
+                        "rolling_peak_strategy_equity": float(
+                            runtime.rolling_peak_strategy_equity()
+                        ),
+                    },
+                    "last_metrics": {
+                        key: metrics.get(key)
+                        for key in (
+                            "timestamp_ms",
+                            "tier",
+                            "red_active_now",
+                            "red_seen_in_episode",
+                            "balance",
+                            "slot_budget",
+                            "peak_realized_pnl",
+                            "realized_pnl",
+                            "unrealized_pnl",
+                            "drawdown_raw",
+                            "drawdown_ema",
+                            "drawdown_score",
+                        )
+                    },
                 }
             )
+    return state_projection
+
+
+def _state_digest_from_projection(state_projection: list[dict[str, Any]]) -> str:
     encoded = json.dumps(state_projection, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _state_digest(bot: Passivbot) -> str:
+    return _state_digest_from_projection(_state_projection(bot))
+
+
+def _sample_count_projection(report: dict[str, Any]) -> dict[str, int]:
+    return {key: int(report["counters"][key]) for key in REFERENCE_SAMPLE_COUNT_KEYS}
+
+
+def compare_dense_reference_output(
+    dense_reference: dict[str, Any], candidate: dict[str, Any]
+) -> dict[str, Any]:
+    """Compare a replay candidate with the dense fixture reference output.
+
+    A future sparse per-pair consumer can call this with its own report. Timing is
+    deliberately excluded: fixture identity, non-increasing sample counts, and
+    final reconstructed per-pair state define equivalence.
+    """
+    reference_samples = _sample_count_projection(dense_reference)
+    candidate_samples = _sample_count_projection(candidate)
+    reference_state = dense_reference["output_state"]
+    candidate_state = candidate["output_state"]
+    fixture_matches = (
+        dense_reference["fixture"]["scenario_sha256"]
+        == candidate["fixture"]["scenario_sha256"]
+    )
+    sample_reduction = {
+        key: reference_samples[key] - candidate_samples[key]
+        for key in REFERENCE_SAMPLE_COUNT_KEYS
+    }
+    samples_match = all(reduction >= 0 for reduction in sample_reduction.values())
+    state_matches = reference_state == candidate_state
+    return {
+        "fixture_scenario_matches": fixture_matches,
+        "sample_counts": {
+            "matches": samples_match,
+            "dense_reference": reference_samples,
+            "candidate": candidate_samples,
+            "reduction": sample_reduction,
+        },
+        "output_state": {
+            "matches": state_matches,
+            "dense_reference_sha256": reference_state["sha256"],
+            "candidate_sha256": candidate_state["sha256"],
+            "dense_reference": reference_state["pairs"],
+            "candidate": candidate_state["pairs"],
+        },
+        "matches": fixture_matches and samples_match and state_matches,
+    }
 
 
 async def _run_hsl_replay_benchmark(
@@ -347,7 +642,7 @@ async def _run_hsl_replay_benchmark(
     held_symbols: int | None = None,
     iterations: int = DEFAULT_ITERATIONS,
     local_scale: bool = False,
-    history_format: str = "timeline",
+    history_format: str = DEFAULT_HISTORY_FORMAT,
 ) -> dict[str, Any]:
     if getattr(pbr, "__is_stub__", False):
         raise RuntimeError("passivbot_rust extension is required for hsl-replay-benchmark")
@@ -377,9 +672,17 @@ async def _run_hsl_replay_benchmark(
             f"got {history_format!r}"
         )
     held_names = {_fixture_symbol(index) for index in range(held_symbols)}
+    active_names = set(held_names)
+    active_names.update(
+        str(event["symbol"])
+        for event in history["fill_events"]
+        if event.get("symbol")
+    )
+    active_symbols = len(active_names)
     timing_totals: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
     sample_counts: dict[str, int] = defaultdict(int)
     state_digests: list[str] = []
+    state_projections: list[list[dict[str, Any]]] = []
     side_effect_totals: dict[str, int] = defaultdict(int)
     full_replay_elapsed_ns = 0
     for _ in range(int(iterations)):
@@ -392,16 +695,23 @@ async def _run_hsl_replay_benchmark(
         finally:
             logging.disable(previous_logging_disable)
         full_replay_elapsed_ns += time.perf_counter_ns() - started_ns
-        state_digests.append(_state_digest(bot))
+        state_projection = _state_projection(bot)
+        state_projections.append(state_projection)
+        state_digests.append(_state_digest_from_projection(state_projection))
         for key, value in bot._offline_hsl_benchmark_side_effects.items():
             side_effect_totals[key] += int(value)
-    if len(set(state_digests)) != 1:
+    if len(set(state_digests)) != 1 or len(
+        {
+            json.dumps(projection, sort_keys=True, separators=(",", ":"))
+            for projection in state_projections
+        }
+    ) != 1:
         raise RuntimeError("offline coin-HSL replay produced non-deterministic final state")
 
-    expected_replay_samples = minutes * symbols * int(iterations)
-    expected_current_samples = symbols * int(iterations)
+    expected_replay_samples = minutes * active_symbols * int(iterations)
+    expected_current_samples = active_symbols * int(iterations)
     expected_held_samples = minutes * held_symbols * int(iterations)
-    background_symbols = symbols - held_symbols
+    background_symbols = active_symbols - held_symbols
     expected_background_samples = minutes * background_symbols * int(iterations)
     expected_background_yields = (
         (minutes // BACKGROUND_YIELD_ROWS) * background_symbols * int(iterations)
@@ -429,11 +739,24 @@ async def _run_hsl_replay_benchmark(
             ),
             "fill_events": len(history["fill_events"]),
             "panic_events": len(history["panic_flatten_events"]),
+            "scenario_sha256": _fixture_contract_digest(history),
             "sha256": _fixture_digest(history),
+            "contract": {
+                "ema_span_minutes": history["fixture_contract"]["ema_span_minutes"],
+                "red_threshold": history["fixture_contract"]["red_threshold"],
+                "account_balance_driver_symbol": history["fixture_contract"][
+                    "account_balance_driver_symbol"
+                ],
+                "historical_episodes": len(history["fixture_contract"]["episodes"]),
+                "same_timestamp_fill_order": history["fixture_contract"][
+                    "same_timestamp_fill_order"
+                ],
+                "pair_values_are_dense": history["fixture_contract"]["pair_values_are_dense"],
+            },
         },
         "counters": {
             "iterations": int(iterations),
-            "active_pairs": symbols * int(iterations),
+            "active_pairs": active_symbols * int(iterations),
             "held_pairs": held_symbols * int(iterations),
             "background_pairs": background_symbols * int(iterations),
             "expected_replay_samples": expected_replay_samples,
@@ -461,8 +784,13 @@ async def _run_hsl_replay_benchmark(
         "throughput": {
             "timeline_rows_per_second": replay_rows / elapsed_seconds,
             "pair_rows_per_second": expected_replay_samples / elapsed_seconds,
+            "applied_pair_samples_per_second": actual_sample_calls / elapsed_seconds,
         },
         "determinism": {"final_state_sha256": state_digests[0]},
+        "output_state": {
+            "sha256": state_digests[0],
+            "pairs": state_projections[0],
+        },
         "side_effects": dict(sorted(side_effect_totals.items())),
     }
 
@@ -475,7 +803,7 @@ async def run_hsl_replay_benchmark(
     iterations: int = DEFAULT_ITERATIONS,
     local_scale: bool = False,
     profile_memory: bool = False,
-    history_format: str = "timeline",
+    history_format: str = DEFAULT_HISTORY_FORMAT,
 ) -> dict[str, Any]:
     """Run the benchmark, optionally recording Python allocation peak usage."""
     if getattr(pbr, "__is_stub__", False):
@@ -499,6 +827,23 @@ async def run_hsl_replay_benchmark(
             local_scale=local_scale,
             history_format=history_format,
         )
+        reference_report = report
+        if history_format != DENSE_REFERENCE_HISTORY_FORMAT:
+            reference_report = await _run_hsl_replay_benchmark(
+                minutes=minutes,
+                symbols=symbols,
+                held_symbols=held_symbols,
+                iterations=iterations,
+                local_scale=local_scale,
+                history_format=DENSE_REFERENCE_HISTORY_FORMAT,
+            )
+        report["dense_reference"] = {
+            "history_format": DENSE_REFERENCE_HISTORY_FORMAT,
+            "fixture_scenario_sha256": reference_report["fixture"]["scenario_sha256"],
+            "sample_counts": _sample_count_projection(reference_report),
+            "output_state": reference_report["output_state"],
+        }
+        report["equivalence"] = compare_dense_reference_output(reference_report, report)
         if profile_memory:
             current_bytes, peak_bytes = tracemalloc.get_traced_memory()
             report["memory"] = {
@@ -525,7 +870,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--held-symbols",
         type=int,
         default=None,
-        help="Current-position symbols (default: all fixture symbols).",
+        help="Current-position symbols (default: one fixture symbol).",
     )
     parser.add_argument(
         "--iterations", type=int, default=DEFAULT_ITERATIONS, help=f"Replay iterations (1-{MAX_ITERATIONS})."
@@ -543,8 +888,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--history-format",
         choices=("timeline", "compact"),
-        default="timeline",
-        help="Replay payload representation (default: timeline).",
+        default=DEFAULT_HISTORY_FORMAT,
+        help="Replay payload representation (default: compact dense reference).",
     )
     parser.add_argument("--compact", action="store_true", help="Emit compact single-line JSON.")
     return parser

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -186,6 +186,41 @@ def test_coin_hsl_fill_index_keeps_replay_and_contract_results_identical():
     )
 
 
+def test_compact_sparse_replay_indices_keep_run_and_explicit_boundaries():
+    import numpy as np
+
+    timestamps = np.arange(20, dtype=np.int64) * 60_000
+    constant = np.zeros(20, dtype=np.float64)
+
+    indices = hsl._hsl_compact_sparse_replay_indices(
+        timestamps,
+        np.full(20, 100.0, dtype=np.float64),
+        constant,
+        constant,
+        lookback_ms=30 * 24 * 60 * 60 * 1_000,
+        boundary_timestamps=(10 * 60_000,),
+    )
+
+    assert indices.tolist() == [0, 9, 10, 19]
+
+
+def test_compact_sparse_replay_indices_keep_rolling_window_expiry_boundary():
+    import numpy as np
+
+    timestamps = np.arange(10, dtype=np.int64) * 60_000
+    realized = np.asarray([0.0, 0.0, 0.0] + [1.0] * 7, dtype=np.float64)
+
+    indices = hsl._hsl_compact_sparse_replay_indices(
+        timestamps,
+        np.full(10, 100.0, dtype=np.float64),
+        realized,
+        np.zeros(10, dtype=np.float64),
+        lookback_ms=2 * 60_000,
+    )
+
+    assert indices.tolist() == [0, 2, 3, 4, 5, 9]
+
+
 def test_parse_hsl_config_warns_about_history_reinterpretation(caplog):
     bot = FakeHslBot(config={"live": {"hsl_signal_mode": "coin"}})
     values = {
@@ -4072,6 +4107,219 @@ def _flat_position_bot(symbol):
         symbol: {"long": {"size": 0.0, "price": 0.0}, "short": {"size": 0.0, "price": 0.0}}
     }
     return bot
+
+
+@pytest.mark.asyncio
+async def test_compact_sparse_replay_matches_dense_state_across_flat_gaps():
+    symbol = "A"
+    rows = []
+    for minute in range(1, 21):
+        balance = 100.0 if minute < 10 else 90.0
+        realized = 0.0 if minute < 3 else -1.0
+        upnl = -1.0 if minute == 2 else 0.0
+        rows.append(
+            {
+                "timestamp": minute * 60_000,
+                "balance": balance,
+                "realized_pnl": realized,
+                "realized_pnl_by_coin_pside": {
+                    symbol: {"long": realized, "short": 0.0}
+                },
+                "unrealized_pnl_by_coin_pside": {
+                    symbol: {"long": upnl, "short": 0.0}
+                },
+            }
+        )
+    history = {
+        "timeline": rows,
+        "panic_flatten_events": [],
+        "fill_events": [
+            {
+                "timestamp": 120_001,
+                "symbol": symbol,
+                "pside": "long",
+                "action": "increase",
+                "qty": 1.0,
+            },
+            {
+                "timestamp": 180_001,
+                "symbol": symbol,
+                "pside": "long",
+                "action": "decrease",
+                "qty": 1.0,
+                "pnl": -1.0,
+            },
+        ],
+    }
+
+    async def run(payload):
+        bot = _flat_position_bot(symbol)
+        bot.hsl["long"]["ema_span_minutes"] = 5.0
+        bot.get_exchange_time = lambda: rows[-1]["timestamp"]
+
+        async def fake_history(current_balance=None, **kwargs):
+            return payload
+
+        bot.get_balance_equity_history = fake_history
+        calls = 0
+        original_apply = bot._equity_hard_stop_apply_coin_metrics_sample
+
+        def count_apply(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return original_apply(*args, **kwargs)
+
+        bot._equity_hard_stop_apply_coin_metrics_sample = count_apply
+        await bot._equity_hard_stop_initialize_coin_from_history()
+        state = bot._hsl_coin_state("long", symbol)
+        return state, calls
+
+    dense_state, dense_calls = await run(history)
+    sparse_state, sparse_calls = await run(_coin_history_as_compact(history, symbol))
+
+    assert sparse_calls < dense_calls
+    assert sparse_state["halted"] == dense_state["halted"]
+    assert sparse_state["no_restart_latched"] == dense_state["no_restart_latched"]
+    assert sparse_state["cooldown_until_ms"] == dense_state["cooldown_until_ms"]
+    assert sparse_state["pnl_reset_timestamp_ms"] == dense_state["pnl_reset_timestamp_ms"]
+    assert sparse_state["runtime"].red_seen_in_episode() == (
+        dense_state["runtime"].red_seen_in_episode()
+    )
+    for key in (
+        "timestamp_ms",
+        "tier",
+        "red_active_now",
+        "red_seen_in_episode",
+        "balance",
+        "slot_budget",
+        "peak_realized_pnl",
+        "realized_pnl",
+        "unrealized_pnl",
+        "drawdown_raw",
+        "drawdown_ema",
+        "drawdown_score",
+    ):
+        if isinstance(dense_state["last_metrics"][key], float):
+            assert sparse_state["last_metrics"][key] == pytest.approx(
+                dense_state["last_metrics"][key], abs=1e-12
+            )
+        else:
+            assert sparse_state["last_metrics"][key] == dense_state["last_metrics"][key]
+
+
+@pytest.mark.asyncio
+async def test_compact_replay_keeps_held_and_ambiguous_pairs_dense():
+    import numpy as np
+
+    symbol = "A"
+    row_count = 20
+
+    async def run(position_size, fill_events):
+        bot = _flat_position_bot(symbol)
+        bot.positions[symbol]["long"] = {"size": position_size, "price": 100.0}
+        captured = []
+
+        def record_event(event_type, tags, data, **kwargs):
+            captured.append((event_type, data))
+
+        bot._monitor_record_event = record_event
+        payload = {
+            "hsl_coin_compact_replay": {
+                "timestamps": np.arange(1, row_count + 1, dtype=np.int64) * 60_000,
+                "balances": np.full(row_count, 100.0, dtype=np.float64),
+                "realized_pnl": np.zeros(row_count, dtype=np.float64),
+                "pair_values": {
+                    ("long", symbol): {
+                        "realized_pnl": np.zeros(row_count, dtype=np.float64),
+                        "unrealized_pnl": np.zeros(row_count, dtype=np.float64),
+                    }
+                },
+            },
+            "panic_flatten_events": [],
+            "fill_events": fill_events,
+        }
+
+        async def fake_history(current_balance=None, **kwargs):
+            return payload
+
+        bot.get_balance_equity_history = fake_history
+        bot.get_exchange_time = lambda: row_count * 60_000
+        await bot._equity_hard_stop_initialize_coin_from_history()
+        return next(data for event_type, data in captured if event_type == "hsl.replay.completed")
+
+    held = await run(1.0, [])
+    assert held["candidate_rows"] == row_count
+    assert held["dense_replay_pairs"] == 1
+    assert held["dense_fallback_pairs"] == 0
+    assert held["sparse_replay_pairs"] == 0
+
+    ambiguous = await run(
+        0.0,
+        [
+            {
+                "timestamp": 60_001,
+                "symbol": symbol,
+                "pside": "long",
+                "action": "unknown",
+                "qty": 1.0,
+            }
+        ],
+    )
+    assert ambiguous["replay_strategy"] == "dense_compact"
+    assert ambiguous["candidate_rows"] == row_count
+    assert ambiguous["dense_equivalent_rows"] == row_count
+    assert ambiguous["dense_replay_pairs"] == 1
+    assert ambiguous["dense_fallback_pairs"] == 1
+    assert ambiguous["sparse_replay_pairs"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("compact", [False, True])
+async def test_sparse_and_dense_replay_reject_nan_after_pair_coverage(compact):
+    symbol = "A"
+    history = {
+        "timeline": [
+            {
+                "timestamp": minute * 60_000,
+                "balance": 100.0,
+                "realized_pnl": 0.0,
+                "realized_pnl_by_coin_pside": {
+                    symbol: {"long": value, "short": 0.0}
+                },
+                "unrealized_pnl_by_coin_pside": {
+                    symbol: {"long": value, "short": 0.0}
+                },
+            }
+            for minute, value in ((1, 0.0), (2, 0.0), (3, float("nan")))
+        ],
+        "panic_flatten_events": [],
+        "fill_events": [
+            {
+                "timestamp": 60_001,
+                "symbol": symbol,
+                "pside": "long",
+                "action": "increase",
+                "qty": 1.0,
+            },
+            {
+                "timestamp": 120_001,
+                "symbol": symbol,
+                "pside": "long",
+                "action": "decrease",
+                "qty": 1.0,
+            },
+        ],
+    }
+    bot = _flat_position_bot(symbol)
+
+    async def fake_history(current_balance=None, **kwargs):
+        return _coin_history_as_compact(history, symbol) if compact else history
+
+    bot.get_balance_equity_history = fake_history
+    bot.get_exchange_time = lambda: 180_000
+
+    with pytest.raises(ValueError, match="realized_pnl_by_coin_pside"):
+        await bot._equity_hard_stop_initialize_coin_from_history()
 
 
 @pytest.mark.asyncio

--- a/tests/test_hsl_replay_benchmark.py
+++ b/tests/test_hsl_replay_benchmark.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import os
 import sys
@@ -37,32 +38,33 @@ def test_hsl_replay_benchmark_is_deterministic_and_has_no_side_effects():
     )
 
     assert first["offline"] is True
-    assert first["fixture"]["timeline_rows"] == 4
-    assert first["fixture"]["fill_events"] == 2
+    assert first["fixture"]["compact_rows"] == 4
+    assert first["fixture"]["fill_events"] == 1
     assert first["counters"] == {
         "iterations": 2,
-        "active_pairs": 4,
-        "held_pairs": 4,
+        "active_pairs": 2,
+        "held_pairs": 2,
         "background_pairs": 0,
-        "expected_replay_samples": 16,
-        "expected_current_samples": 4,
-        "expected_held_samples": 16,
+        "expected_replay_samples": 8,
+        "expected_current_samples": 2,
+        "expected_held_samples": 8,
         "expected_background_samples": 0,
         "expected_background_yields": 0,
-        "coin_metrics_sample_calls": 20,
-        "replay_samples_applied": 16,
-        "held_replay_samples": 16,
+        "coin_metrics_sample_calls": 10,
+        "replay_samples_applied": 8,
+        "held_replay_samples": 8,
         "background_replay_samples": 0,
     }
     assert first["timings"]["history_load"]["calls"] == 2
-    assert first["timings"]["coin_metrics_sample"]["calls"] == 20
-    assert first["timings"]["current_upnl"]["calls"] == 4
+    assert first["timings"]["coin_metrics_sample"]["calls"] == 10
+    assert first["timings"]["current_upnl"]["calls"] == 2
     assert first["timings"]["cache_reuse_skipped"]["calls"] == 2
     assert first["timings"]["cache_persist_skipped"]["calls"] == 2
     assert first["throughput"]["timeline_rows_per_second"] > 0.0
     assert first["throughput"]["pair_rows_per_second"] == pytest.approx(
-        first["throughput"]["timeline_rows_per_second"] * 2
+        first["throughput"]["timeline_rows_per_second"]
     )
+    assert first["throughput"]["applied_pair_samples_per_second"] > 0.0
     assert first["side_effects"] == {
         "cache_reads": 0,
         "cache_writes": 0,
@@ -71,33 +73,36 @@ def test_hsl_replay_benchmark_is_deterministic_and_has_no_side_effects():
         "monitor_events": 0,
         "network_calls": 0,
     }
+    assert first["equivalence"]["matches"] is True
+    assert first["equivalence"]["sample_counts"]["matches"] is True
+    assert first["equivalence"]["output_state"]["matches"] is True
     assert _without_elapsed_ns(first) == _without_elapsed_ns(second)
 
 
 def test_hsl_replay_benchmark_separates_held_and_background_work():
     report = asyncio.run(
         hsl_replay_benchmark.run_hsl_replay_benchmark(
-            minutes=205, symbols=4, held_symbols=2, iterations=2
+            minutes=700, symbols=4, held_symbols=1, iterations=2
         )
     )
 
-    assert report["fixture"]["held_symbols"] == 2
-    assert report["fixture"]["background_symbols"] == 2
-    assert report["fixture"]["fill_events"] == 2
+    assert report["fixture"]["held_symbols"] == 1
+    assert report["fixture"]["background_symbols"] == 1
+    assert report["fixture"]["fill_events"] == 4
     assert report["counters"] == {
         "iterations": 2,
-        "active_pairs": 8,
-        "held_pairs": 4,
-        "background_pairs": 4,
-        "expected_replay_samples": 1_640,
-        "expected_current_samples": 8,
-        "expected_held_samples": 820,
-        "expected_background_samples": 820,
-        "expected_background_yields": 8,
-        "coin_metrics_sample_calls": 1_648,
-        "replay_samples_applied": 1_640,
-        "held_replay_samples": 820,
-        "background_replay_samples": 820,
+        "active_pairs": 4,
+        "held_pairs": 2,
+        "background_pairs": 2,
+        "expected_replay_samples": 2_800,
+        "expected_current_samples": 4,
+        "expected_held_samples": 1_400,
+        "expected_background_samples": 1_400,
+        "expected_background_yields": 14,
+        "coin_metrics_sample_calls": 1_438,
+        "replay_samples_applied": 1_434,
+        "held_replay_samples": 1_400,
+        "background_replay_samples": 34,
     }
 
 
@@ -128,7 +133,7 @@ def test_hsl_replay_benchmark_local_scale_limits_are_opt_in():
         minutes=1, symbols=30, held_symbols=1, local_scale=True
     )
     assert len(history["timeline"]) == 1
-    assert len(history["timeline"][0]["realized_pnl_by_coin_pside"]) == 30
+    assert len(history["timeline"][0]["realized_pnl_by_coin_pside"]) == 1
     assert len(history["fill_events"]) == 1
     assert hsl_replay_benchmark._validate_fixture_shape(
         43_201, 30, 1, local_scale=True
@@ -139,25 +144,135 @@ def test_hsl_replay_benchmark_local_scale_limits_are_opt_in():
         )
     with pytest.raises(ValueError, match="between 1 and 30"):
         hsl_replay_benchmark._validate_fixture_shape(1, 31, 1, local_scale=True)
+    assert hsl_replay_benchmark._validate_fixture_shape(
+        1, 1, 0, local_scale=True
+    ) == (1, 1, 0)
+
+
+def test_hsl_replay_benchmark_full_scale_fixture_has_sparse_replay_cases():
+    fixture = hsl_replay_benchmark.build_coin_hsl_compact_fixture(
+        minutes=43_201, symbols=4, held_symbols=1, local_scale=True
+    )
+    contract = fixture["fixture_contract"]
+    compact = fixture["hsl_coin_compact_replay"]
+
+    assert len(compact["timestamps"]) == 43_201
+    assert contract["held_symbols"] == ["HSLBENCH00/USDT:USDT"]
+    assert contract["ema_span_minutes"] > 1.0
+    assert contract["pair_values_are_dense"] is True
+    assert contract["account_balance_driver_symbol"] == "HSLBENCH02/USDT:USDT"
+    assert [episode["name"] for episode in contract["episodes"]] == [
+        "historical_a",
+        "historical_b",
+        "historical_c",
+        "balance_driver",
+        "panic_flatten",
+    ]
+    historical_episodes = [
+        episode for episode in contract["episodes"] if episode["symbol_index"] == 1
+    ]
+    assert len(historical_episodes) == 3
+    assert historical_episodes[1]["start_minute"] - historical_episodes[0]["end_minute"] > 1_000
+    assert historical_episodes[2]["start_minute"] - historical_episodes[1]["end_minute"] > 1_000
+    fill_ids = [event["id"] for event in fixture["fill_events"]]
+    assert [fill_ids.index(event_id) for event_id in contract["same_timestamp_fill_order"]] == sorted(
+        fill_ids.index(event_id) for event_id in contract["same_timestamp_fill_order"]
+    )
+    ordered_fills = [
+        event
+        for event in fixture["fill_events"]
+        if event["id"] in contract["same_timestamp_fill_order"]
+    ]
+    assert len({event["timestamp"] for event in ordered_fills}) == 1
+    assert compact["balances"][18_004] == pytest.approx(1_000.0)
+    assert compact["balances"][18_005] == pytest.approx(1_024.0)
+    assert fixture["panic_flatten_events"] == [
+        {
+            "timestamp": 2_160_900_200,
+            "minute_timestamp": 2_160_900_000,
+            "pside": "long",
+            "symbol": "HSLBENCH03/USDT:USDT",
+        }
+    ]
 
 
 def test_hsl_replay_benchmark_compact_and_timeline_reach_identical_state():
     timeline = asyncio.run(
         hsl_replay_benchmark.run_hsl_replay_benchmark(
-            minutes=8, symbols=3, held_symbols=2, history_format="timeline"
+            minutes=700, symbols=2, held_symbols=1, history_format="timeline"
         )
     )
     compact = asyncio.run(
         hsl_replay_benchmark.run_hsl_replay_benchmark(
-            minutes=8, symbols=3, held_symbols=2, history_format="compact"
+            minutes=700, symbols=2, held_symbols=1, history_format="compact"
         )
     )
 
     assert timeline["determinism"] == compact["determinism"]
-    assert timeline["counters"] == compact["counters"]
     assert timeline["side_effects"] == compact["side_effects"]
-    assert timeline["fixture"]["timeline_rows"] == 8
-    assert compact["fixture"]["compact_rows"] == 8
+    assert timeline["fixture"]["scenario_sha256"] == compact["fixture"]["scenario_sha256"]
+    assert compact["dense_reference"]["history_format"] == "timeline"
+    assert compact["equivalence"]["matches"] is True
+    assert compact["equivalence"]["output_state"]["matches"] is True
+    assert compact["equivalence"]["sample_counts"]["matches"] is True
+    assert compact["equivalence"]["sample_counts"]["reduction"]["replay_samples_applied"] > 0
+    assert timeline["fixture"]["timeline_rows"] == 700
+    assert compact["fixture"]["compact_rows"] == 700
+
+
+def test_hsl_replay_benchmark_dense_reference_comparison_detects_mismatch():
+    reference = asyncio.run(
+        hsl_replay_benchmark.run_hsl_replay_benchmark(minutes=8, symbols=3, held_symbols=1)
+    )
+    candidate = copy.deepcopy(reference)
+    candidate["counters"]["replay_samples_applied"] = (
+        reference["dense_reference"]["sample_counts"]["replay_samples_applied"] + 1
+    )
+
+    comparison = hsl_replay_benchmark.compare_dense_reference_output(reference, candidate)
+
+    assert comparison["fixture_scenario_matches"] is True
+    assert comparison["sample_counts"]["matches"] is False
+    assert comparison["output_state"]["matches"] is True
+    assert comparison["matches"] is False
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        ("pnl_reset_timestamp_ms",),
+        ("cooldown_intervention_active",),
+        ("cooldown_repanic_reset_pending",),
+        ("cooldown_unresolved_residue",),
+        ("runtime", "red_seen_in_episode"),
+        ("last_metrics", "red_seen_in_episode"),
+    ],
+)
+def test_hsl_replay_benchmark_equivalence_detects_runtime_contract_state(path):
+    reference = asyncio.run(
+        hsl_replay_benchmark.run_hsl_replay_benchmark(
+            minutes=8, symbols=3, held_symbols=1
+        )
+    )
+    candidate = copy.deepcopy(reference)
+    value = candidate["output_state"]["pairs"][0]
+    for key in path[:-1]:
+        value = value[key]
+    current = value[path[-1]]
+    value[path[-1]] = not current if isinstance(current, bool) else 123_456
+    candidate["output_state"]["sha256"] = (
+        hsl_replay_benchmark._state_digest_from_projection(
+            candidate["output_state"]["pairs"]
+        )
+    )
+
+    comparison = hsl_replay_benchmark.compare_dense_reference_output(
+        reference, candidate
+    )
+
+    assert comparison["sample_counts"]["matches"] is True
+    assert comparison["output_state"]["matches"] is False
+    assert comparison["matches"] is False
 
 
 def test_hsl_replay_benchmark_main_emits_json(capsys):
@@ -165,7 +280,7 @@ def test_hsl_replay_benchmark_main_emits_json(capsys):
 
     report = json.loads(capsys.readouterr().out)
     assert report["kind"] == "hsl_replay_benchmark"
-    assert report["fixture"]["timeline_rows"] == 2
+    assert report["fixture"]["compact_rows"] == 2
 
     assert (
         hsl_replay_benchmark.main(

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1793,6 +1793,13 @@ def test_live_performance_report_hsl_replay_profile_exposes_protective_scorecard
                     "signal_mode": "coin",
                     "stage": "full_replay",
                     "history_format": "compact",
+                    "replay_strategy": "sparse_change_points",
+                    "candidate_rows": 120,
+                    "dense_equivalent_rows": 1200,
+                    "candidate_reduction_pct": 90.0,
+                    "dense_replay_pairs": 1,
+                    "dense_fallback_pairs": 0,
+                    "sparse_replay_pairs": 9,
                     "full_elapsed_s": 30.0,
                 },
             ),
@@ -1843,6 +1850,7 @@ def test_live_performance_report_hsl_replay_profile_exposes_protective_scorecard
                     "signal_mode": "coin",
                     "stage": "loaded",
                     "history_format": "timeline",
+                    "replay_strategy": "dense_timeline",
                 },
             ),
             _monitor_row(
@@ -1875,6 +1883,10 @@ def test_live_performance_report_hsl_replay_profile_exposes_protective_scorecard
                     "signal_mode": "coin",
                     "stage": "full_replay",
                     "history_format": "compact",
+                    "replay_strategy": "sparse_change_points",
+                    "candidate_rows": 100,
+                    "dense_equivalent_rows": 1000,
+                    "candidate_reduction_pct": 90.0,
                     "protective_elapsed_s": 5.0,
                     "startup_blocking_elapsed_s": 5.0,
                     "full_elapsed_s": 25.0,
@@ -1894,6 +1906,10 @@ def test_live_performance_report_hsl_replay_profile_exposes_protective_scorecard
     groups = {group["bot"]: group for group in profile["groups"]}
 
     assert profile["history_format_counts"] == {"compact": 2, "timeline": 1}
+    assert profile["replay_strategy_counts"] == {
+        "sparse_change_points": 2,
+        "dense_timeline": 1,
+    }
     assert profile["protective_ready_bot_count"] == 3
     assert profile["protective_ready_elapsed_ms"]["count"] == 3
     assert profile["protective_ready_elapsed_ms"]["min"] == 5000
@@ -1901,9 +1917,32 @@ def test_live_performance_report_hsl_replay_profile_exposes_protective_scorecard
     assert profile["full_replay_elapsed_ms"]["count"] == 2
     assert profile["full_replay_elapsed_ms"]["max"] == 30000
     assert summary_profile["history_format_counts"] == {"compact": 2, "timeline": 1}
+    assert summary_profile["replay_strategy_counts"] == {
+        "sparse_change_points": 2,
+        "dense_timeline": 1,
+    }
     assert summary_profile["protective_ready_elapsed_ms"]["max"] == 20000
     assert summary_profile["full_replay_elapsed_ms"]["max"] == 30000
     assert groups["binance/binance_01"]["history_format"] == "compact"
+    assert groups["binance/binance_01"]["replay_strategy"] == "sparse_change_points"
+    assert groups["binance/binance_01"]["completed"]["data"]["candidate_rows"] == 120
+    assert (
+        groups["binance/binance_01"]["completed"]["data"]["dense_equivalent_rows"]
+        == 1200
+    )
+    assert (
+        groups["binance/binance_01"]["completed"]["data"]["candidate_reduction_pct"]
+        == 90.0
+    )
+    assert groups["binance/binance_01"]["completed"]["data"][
+        "dense_replay_pairs"
+    ] == 1
+    assert groups["binance/binance_01"]["completed"]["data"][
+        "dense_fallback_pairs"
+    ] == 0
+    assert groups["binance/binance_01"]["completed"]["data"][
+        "sparse_replay_pairs"
+    ] == 9
     assert groups["binance/binance_01"]["protective_ready"]["derived"] == {
         "latest_elapsed_ms": 12300,
         "protective_elapsed_ms": 12300,
@@ -1911,6 +1950,7 @@ def test_live_performance_report_hsl_replay_profile_exposes_protective_scorecard
         "startup_blocking_elapsed_ms": 12300,
     }
     assert groups["gateio/gateio_01"]["history_format"] == "timeline"
+    assert groups["gateio/gateio_01"]["replay_strategy"] == "dense_timeline"
     assert groups["gateio/gateio_01"]["protective_ready"]["derived"] == {
         "latest_elapsed_ms": 20000,
         "startup_blocking": True,


### PR DESCRIPTION
## Summary

- keep currently held coin-HSL pairs on the exact dense replay path
- replay historical flat pairs at exact account/pair run, lookback-expiry, fill/intervention, and terminal boundaries
- fall back to dense replay when fill reconstruction is ambiguous
- expose bounded replay strategy, candidate/dense-equivalent rows, reduction, and dense-fallback pair counts
- extend the offline benchmark with realistic held/background episodes and dense-reference state equivalence

## Safety Boundary

- no HSL arithmetic, threshold, panic, cooldown, restart, or entry-gate contract change
- no held-pair sample skipping
- no cache-authority/schema, exchange-call, Rust, backtest, process-control, or smoke-verdict change
- ambiguous fill replay fails over to dense iteration

## Validation

- affected benchmark, coin-HSL, metric-regression, and performance-report suites: green
- Python compilation, `git diff --check`, and added-line silent-handling scan: green
- final Terra preflight: no findings after two delta rounds
- 43,201-minute, 30-pair offline dense-reference benchmark:
  - exact expanded behavior-state hash parity
  - candidate samples: 43,652
  - dense samples: 825,430
  - reduction: 781,778
  - held samples: 43,201 on both paths
  - network/cache read/cache write side effects: zero

Reproduce with:

```bash
passivbot tool hsl-replay-benchmark --minutes 43201 --symbols 30 --held-symbols 1 --local-scale --compact
```

Repository-wide pytest collection was attempted but stopped before tests because the shared venv's loaded Rust extension did not match current Rust sources. This branch changes no Rust code; the complete affected suites above passed with the existing extension.

## Deploy Plan

After exact-head reviewer approval and green CI, merge to `v8`, fast-forward VPS5 while preserving local artifacts, restart only the five supervised `passivbot` panes, and compare candidate counts, full replay timing, process pressure, and bounded smoke health. Do not touch the unrelated `misc` tmux session.
