### PR TITLE
Add scenario-specific Pareto selection for suite fronts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool pareto --scenario LABEL` for rebuilding and selecting from a
+  scenario-specific nondominated sub-front of a suite optimization's saved aggregate Pareto
+  members. Scenario metrics are used consistently for limits, objectives, and ranking, and output
+  explicitly notes that candidates discarded from the original aggregate front are not recoverable.
+
 - `passivbot tool live-performance-report` now retains each bot's explicit HSL
   protective-ready replay milestone and summarizes replay history formats,
   protective-ready elapsed time, and completed full-replay elapsed time from

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -40,6 +40,7 @@ passivbot tool pareto optimize_results/... -m utility \
   --weight adg_strategy_eq=4 \
   --weight drawdown_worst_strategy_eq=2 \
   --show-top 5
+passivbot tool pareto optimize_results/... --scenario opt_2025_to_present
 passivbot tool pareto --json
 ```
 
@@ -56,6 +57,14 @@ The explorer applies limits first, then ranks the retained candidates. It is int
 promoting one config out of a large Pareto front without opening the dashboard. Its selection
 methods are practical decision heuristics for high-dimensional Passivbot fronts, not full formal
 multi-criteria decision-analysis implementations.
+
+For suite optimization results, `--scenario LABEL` projects every saved Pareto member onto that
+scenario's stored metric values, applies CLI limits in that scenario context, rebuilds a
+nondominated sub-front using the original `optimize.scoring` goals, and then runs the selected
+decision method. Suite artifacts store one mean value per scenario and metric, so explicit
+non-`mean` limit statistics are unavailable in this mode. The rebuilt front covers only members of
+the saved aggregate-suite Pareto front: candidates already discarded by the optimizer cannot be
+recovered, so it is not the complete scenario Pareto front across all evaluated candidates.
 
 `passivbot tool pareto-explorer` is a CLI alias for the same tool.
 

--- a/src/pareto_explorer.py
+++ b/src/pareto_explorer.py
@@ -21,6 +21,7 @@ from config.metrics import resolve_metric_value
 from config.scoring import (
     ObjectiveSpec,
     default_objective_goal,
+    dominates_objectives,
     extract_objective_specs,
     from_engine_value,
     objective_spec_by_metric,
@@ -66,6 +67,7 @@ class ParetoCandidate:
     objectives: Dict[str, float]
     stats_flat: Dict[str, float]
     aggregated_values: Dict[str, float]
+    scenario: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -347,6 +349,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Selection method. Default: ideal.",
     )
     parser.add_argument(
+        "--scenario",
+        type=str,
+        default=None,
+        metavar="LABEL",
+        help=(
+            "Rebuild a scenario-specific sub-front from the saved suite Pareto members, "
+            "then select from it using the named scenario's metric values."
+        ),
+    )
+    parser.add_argument(
         "-l",
         "--limit",
         action="append",
@@ -456,6 +468,118 @@ def _extract_suite_metrics(
                 if isinstance(value, (int, float)) and math.isfinite(float(value)):
                     aggregated_values[str(metric)] = float(value)
     return stats_flat, aggregated_values
+
+
+def _scenario_metric_values(
+    entry: Mapping[str, Any], scenario: str, *, source: Path
+) -> Dict[str, float]:
+    suite_metrics = entry.get("suite_metrics")
+    if not isinstance(suite_metrics, Mapping):
+        raise ValueError(
+            f"Scenario {scenario!r} requires suite Pareto artifacts, but {source.name} "
+            "has no suite_metrics payload."
+        )
+    metrics = suite_metrics.get("metrics")
+    if not isinstance(metrics, Mapping):
+        raise ValueError(
+            f"Scenario {scenario!r} requires the current suite_metrics.metrics payload, "
+            f"but {source.name} does not contain it."
+        )
+
+    values: Dict[str, float] = {}
+    available_labels: set[str] = set()
+    for metric, payload in metrics.items():
+        if not isinstance(payload, Mapping):
+            continue
+        scenarios = payload.get("scenarios")
+        if not isinstance(scenarios, Mapping):
+            continue
+        available_labels.update(str(label) for label in scenarios)
+        if scenario not in scenarios:
+            continue
+        value = scenarios[scenario]
+        if not isinstance(value, (int, float)) or not math.isfinite(float(value)):
+            raise ValueError(
+                f"Scenario metric {metric!r} for {scenario!r} in {source.name} "
+                f"is not a finite number: {value!r}"
+            )
+        values[str(metric)] = float(value)
+
+    if not values:
+        available = ", ".join(sorted(available_labels)) if available_labels else "<none>"
+        raise ValueError(
+            f"Unknown or unavailable scenario {scenario!r} in {source.name}. "
+            f"Available scenarios: {available}"
+        )
+    return values
+
+
+def project_candidates_to_scenario(
+    candidates: Sequence[ParetoCandidate],
+    scoring_specs: Sequence[ObjectiveSpec],
+    scenario: str,
+) -> List[ParetoCandidate]:
+    label = str(scenario).strip()
+    if not label:
+        raise ValueError("--scenario requires a non-empty scenario label.")
+
+    projected: List[ParetoCandidate] = []
+    required_metrics = [spec.metric for spec in scoring_specs]
+    for candidate in candidates:
+        values = _scenario_metric_values(candidate.entry, label, source=candidate.path)
+        objectives: Dict[str, float] = {}
+        missing: List[str] = []
+        for metric in required_metrics:
+            value = resolve_metric_value(values, metric)
+            if value is None:
+                missing.append(metric)
+            else:
+                objectives[metric] = float(value)
+        if missing:
+            raise ValueError(
+                f"Scenario {label!r} is missing scoring metric(s) {missing} "
+                f"in {candidate.path.name}."
+            )
+        projected.append(
+            ParetoCandidate(
+                path=candidate.path,
+                entry=candidate.entry,
+                objectives=objectives,
+                stats_flat={f"{metric}_mean": value for metric, value in values.items()},
+                aggregated_values=values,
+                scenario=label,
+            )
+        )
+    return projected
+
+
+def build_scenario_front(
+    candidates: Sequence[ParetoCandidate],
+    scoring_specs: Sequence[ObjectiveSpec],
+) -> List[ParetoCandidate]:
+    metrics = [spec.metric for spec in scoring_specs]
+    front: List[ParetoCandidate] = []
+    front_vectors: List[tuple[float, ...]] = []
+    for candidate in candidates:
+        vector = tuple(float(candidate.objectives[metric]) for metric in metrics)
+        if vector in front_vectors:
+            continue
+        if any(
+            dominates_objectives(existing, vector, scoring_specs)
+            for existing in front_vectors
+        ):
+            continue
+        dominated_indices = [
+            idx
+            for idx, existing in enumerate(front_vectors)
+            if dominates_objectives(vector, existing, scoring_specs)
+        ]
+        for idx in reversed(dominated_indices):
+            front.pop(idx)
+            front_vectors.pop(idx)
+        front.append(candidate)
+        front_vectors.append(vector)
+    return front
 
 
 def _extract_objectives(entry: Mapping[str, Any]) -> Dict[str, float]:
@@ -733,6 +857,13 @@ def _resolve_limit_value(
     metric = str(entry.get("metric", "")).strip()
     if not metric:
         return None
+    if candidate.scenario is not None and "stat" in entry:
+        requested_stat = str(entry.get("stat", "")).strip().lower()
+        if requested_stat != "mean":
+            raise ValueError(
+                f"Scenario {candidate.scenario!r} stores one mean value per metric; "
+                f"limit stat={requested_stat!r} is unavailable for {candidate.path.name}."
+            )
     stat = resolve_limit_stat(
         dict(entry),
         aggregate_cfg=dict(aggregate_cfg) if aggregate_cfg else None,
@@ -1100,6 +1231,8 @@ def format_selection_result(
     candidates: Sequence[ParetoCandidate],
     loaded_count: int,
     retained_count: int,
+    scenario: Optional[str] = None,
+    scenario_front_count: Optional[int] = None,
     active_limits: Sequence[Dict[str, Any]],
     result: SelectionResult,
     show_top: int = 1,
@@ -1109,20 +1242,34 @@ def format_selection_result(
     selected_display_path = _display_path(result.candidate.path)
     backtest_command = f"passivbot backtest {selected_display_path}"
     lines: List[str] = []
-    lines.extend(
-        _render_key_value_box(
+    summary_rows = [
+        ("Pareto directory", _display_path(pareto_dir)),
+        ("Loaded candidates", str(loaded_count)),
+        ("Retained after limits", str(retained_count)),
+    ]
+    if scenario is not None:
+        summary_rows.extend(
             [
-                ("Pareto directory", _display_path(pareto_dir)),
-                ("Loaded candidates", str(loaded_count)),
-                ("Retained after limits", str(retained_count)),
-                ("Applied limits", str(len(active_limits))),
-                ("Method", result.method),
-                (score_label, score_value),
-                ("Selected file", selected_filename),
-                ("Selected path", selected_display_path),
+                ("Scenario", scenario),
+                ("Scenario front", str(scenario_front_count or 0)),
+                ("Front scope", "saved aggregate Pareto members"),
             ]
         )
+    summary_rows.extend(
+        [
+            ("Applied limits", str(len(active_limits))),
+            ("Method", result.method),
+            (score_label, score_value),
+            ("Selected file", selected_filename),
+            ("Selected path", selected_display_path),
+        ]
     )
+    lines.extend(_render_key_value_box(summary_rows))
+    if scenario is not None:
+        lines.append(
+            "Scenario-front note: rebuilt only from saved aggregate Pareto members; "
+            "candidates discarded by the suite optimizer are not recoverable here."
+        )
     lines.append(f"Backtest command: {backtest_command}")
     lines.append(f"Method summary: {_method_explanation(result.method)}")
     active_metrics = result.details.get("active_metrics")
@@ -1247,15 +1394,29 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
             )
         raw_path = str(latest)
     pareto_dir, candidates, scoring_specs = load_candidates(raw_path)
+    raw_scenario = getattr(args, "scenario", None)
+    scenario = str(raw_scenario).strip() if raw_scenario is not None else None
+    selection_candidates = (
+        project_candidates_to_scenario(candidates, scoring_specs, scenario)
+        if scenario is not None
+        else candidates
+    )
     filtered_candidates, active_limits = filter_candidates(
-        candidates,
+        selection_candidates,
         limits_payload=getattr(args, "limits_payload", None),
         limit_entries=list(getattr(args, "limit_entries", []) or []),
     )
     if not filtered_candidates:
         raise ValueError("No Pareto candidates remained after applying limits.")
+    scenario_front = (
+        build_scenario_front(filtered_candidates, scoring_specs)
+        if scenario is not None
+        else filtered_candidates
+    )
+    if not scenario_front:
+        raise ValueError("No Pareto candidates remained after rebuilding the scenario front.")
     result = select_candidate(
-        filtered_candidates,
+        scenario_front,
         scoring_specs,
         method=method,
         objectives_arg=getattr(args, "objectives", None),
@@ -1265,8 +1426,8 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
     )
     show_top = max(1, int(getattr(args, "show_top", 1) or 1))
     if getattr(args, "json_output", False):
-        ranking_order = result.details.get("ranking_order") or [filtered_candidates.index(result.candidate)]
-        score_vector = result.details.get("score_vector") or [result.score] * len(filtered_candidates)
+        ranking_order = result.details.get("ranking_order") or [scenario_front.index(result.candidate)]
+        score_vector = result.details.get("score_vector") or [result.score] * len(scenario_front)
         active_metrics = result.details.get("active_metrics") or list(result.objective_values)
         payload = {
             "pareto_dir": str(pareto_dir),
@@ -1285,7 +1446,7 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
             },
             "top_candidates": _json_ready(
                 _ranked_rows(
-                    filtered_candidates,
+                    scenario_front,
                     active_metrics,
                     ranking_order,
                     score_vector,
@@ -1293,14 +1454,25 @@ def run_from_args(args: argparse.Namespace) -> SelectionResult:
                 )
             ),
         }
+        if scenario is not None:
+            payload.update(
+                {
+                    "scenario": scenario,
+                    "front_scope": "saved_aggregate_pareto_members",
+                    "scenario_front_count": len(scenario_front),
+                    "scenario_front_complete": False,
+                }
+            )
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
         print(
             format_selection_result(
                 pareto_dir,
-                candidates=filtered_candidates,
+                candidates=scenario_front,
                 loaded_count=len(candidates),
                 retained_count=len(filtered_candidates),
+                scenario=scenario,
+                scenario_front_count=len(scenario_front) if scenario is not None else None,
                 active_limits=active_limits,
                 result=result,
                 show_top=show_top,

--- a/tests/test_pareto_explorer.py
+++ b/tests/test_pareto_explorer.py
@@ -8,9 +8,11 @@ from pathlib import Path
 import pytest
 
 from pareto_explorer import (
+    build_scenario_front,
     build_parser,
     filter_candidates,
     load_candidates,
+    project_candidates_to_scenario,
     run_from_args,
     select_candidate,
 )
@@ -151,6 +153,83 @@ def _write_fill_suite_candidate(
     }
     with open(path / f"{name}.json", "w") as f:
         json.dump(payload, f, indent=2)
+
+
+def _write_scenario_candidate(
+    path: Path,
+    name: str,
+    *,
+    aggregate: dict[str, float],
+    scenarios: dict[str, dict[str, float]],
+) -> None:
+    scoring = [
+        {"metric": "metric_a", "goal": "max"},
+        {"metric": "metric_b", "goal": "min"},
+    ]
+    metric_names = set(aggregate)
+    for values in scenarios.values():
+        metric_names.update(values)
+    suite_metrics = {}
+    for metric in sorted(metric_names):
+        scenario_values = {
+            label: values[metric]
+            for label, values in scenarios.items()
+            if metric in values
+        }
+        suite_metrics[metric] = {
+            "stats": _metric_stats(aggregate[metric]),
+            "aggregated": aggregate[metric],
+            "scenarios": scenario_values,
+        }
+    payload = {
+        "optimize": {"scoring": scoring},
+        "metrics": {"objectives": aggregate},
+        "suite_metrics": {
+            "metrics": suite_metrics,
+            "scenario_labels": list(scenarios),
+        },
+    }
+    with open(path / f"{name}.json", "w") as f:
+        json.dump(payload, f, indent=2)
+
+
+@pytest.fixture()
+def scenario_pareto_dir(tmp_path: Path) -> Path:
+    pareto_dir = tmp_path / "suite_run" / "pareto"
+    pareto_dir.mkdir(parents=True)
+    values = {
+        "a": {
+            "bull": {"metric_a": 0.9, "metric_b": 0.4, "sharpe_ratio_strategy_eq": 1.2},
+            "bear": {"metric_a": 0.2, "metric_b": 0.8, "sharpe_ratio_strategy_eq": 0.2},
+        },
+        "b": {
+            "bull": {"metric_a": 0.8, "metric_b": 0.3, "sharpe_ratio_strategy_eq": 1.0},
+            "bear": {"metric_a": 0.8, "metric_b": 0.5, "sharpe_ratio_strategy_eq": 1.5},
+        },
+        "c_dominated": {
+            "bull": {"metric_a": 0.7, "metric_b": 0.5, "sharpe_ratio_strategy_eq": 0.8},
+            "bear": {"metric_a": 0.6, "metric_b": 0.7, "sharpe_ratio_strategy_eq": 0.7},
+        },
+        "d": {
+            "bull": {"metric_a": 0.5, "metric_b": 0.1, "sharpe_ratio_strategy_eq": 0.5},
+            "bear": {"metric_a": 0.9, "metric_b": 0.9, "sharpe_ratio_strategy_eq": 1.1},
+        },
+    }
+    for name, scenario_values in values.items():
+        _write_scenario_candidate(
+            pareto_dir,
+            name,
+            aggregate={
+                "metric_a": 0.5,
+                "metric_b": 0.5,
+                "sharpe_ratio_strategy_eq": 0.5,
+            },
+            scenarios={
+                "bull": scenario_values["bull"],
+                "bear": scenario_values["bear"],
+            },
+        )
+    return pareto_dir
 
 
 @pytest.fixture()
@@ -354,6 +433,125 @@ def test_build_parser_defaults_to_ideal_method():
     parser = build_parser()
     args = parser.parse_args([])
     assert args.method == "ideal"
+
+
+def test_build_parser_accepts_scenario():
+    args = build_parser().parse_args(["--scenario", "bull"])
+    assert args.scenario == "bull"
+
+
+def test_project_and_rebuild_scenario_front(scenario_pareto_dir: Path):
+    _pareto_dir, candidates, specs = load_candidates(scenario_pareto_dir)
+
+    bull = project_candidates_to_scenario(candidates, specs, "bull")
+    bull_front = build_scenario_front(bull, specs)
+    bear = project_candidates_to_scenario(candidates, specs, "bear")
+    bear_front = build_scenario_front(bear, specs)
+
+    assert [candidate.path.stem for candidate in bull_front] == ["a", "b", "d"]
+    assert [candidate.path.stem for candidate in bear_front] == ["b", "d"]
+    assert bull_front[0].objectives == {"metric_a": 0.9, "metric_b": 0.4}
+
+
+def test_scenario_front_keeps_first_exact_objective_vector(scenario_pareto_dir: Path):
+    duplicate = json.loads((scenario_pareto_dir / "a.json").read_text())
+    (scenario_pareto_dir / "z_duplicate.json").write_text(json.dumps(duplicate))
+    _pareto_dir, candidates, specs = load_candidates(scenario_pareto_dir)
+
+    front = build_scenario_front(
+        project_candidates_to_scenario(candidates, specs, "bull"),
+        specs,
+    )
+
+    assert "a" in [candidate.path.stem for candidate in front]
+    assert "z_duplicate" not in [candidate.path.stem for candidate in front]
+
+
+def test_scenario_projection_fails_for_non_suite_candidate(sample_pareto_dir: Path):
+    _pareto_dir, candidates, specs = load_candidates(sample_pareto_dir)
+    with pytest.raises(ValueError, match="requires suite Pareto artifacts"):
+        project_candidates_to_scenario(candidates, specs, "bull")
+
+
+def test_scenario_projection_lists_available_labels(scenario_pareto_dir: Path):
+    _pareto_dir, candidates, specs = load_candidates(scenario_pareto_dir)
+    with pytest.raises(ValueError, match="Available scenarios: bear, bull"):
+        project_candidates_to_scenario(candidates, specs, "sideways")
+
+
+def test_scenario_projection_fails_when_scoring_metric_is_missing(
+    scenario_pareto_dir: Path,
+):
+    candidate_path = scenario_pareto_dir / "a.json"
+    payload = json.loads(candidate_path.read_text())
+    del payload["suite_metrics"]["metrics"]["metric_b"]["scenarios"]["bull"]
+    candidate_path.write_text(json.dumps(payload))
+    _pareto_dir, candidates, specs = load_candidates(scenario_pareto_dir)
+
+    with pytest.raises(ValueError, match="missing scoring metric.*metric_b"):
+        project_candidates_to_scenario(candidates, specs, "bull")
+
+
+def test_scenario_limit_uses_scalar_and_rejects_non_mean_stat(
+    scenario_pareto_dir: Path,
+):
+    _pareto_dir, candidates, specs = load_candidates(scenario_pareto_dir)
+    projected = project_candidates_to_scenario(candidates, specs, "bull")
+
+    filtered, _limits = filter_candidates(
+        projected,
+        limits_payload=None,
+        limit_entries=["metric_a>0.75"],
+    )
+    assert [candidate.path.stem for candidate in filtered] == ["a", "b"]
+
+    with pytest.raises(ValueError, match="stores one mean value.*stat='max'.*unavailable"):
+        filter_candidates(
+            projected,
+            limits_payload=None,
+            limit_entries=["metric_a>0.75 stat=max"],
+        )
+
+
+def test_run_from_args_scenario_json_reports_scope_and_uses_scenario_metrics(
+    scenario_pareto_dir: Path,
+    capsys,
+):
+    args = build_parser().parse_args(
+        [
+            str(scenario_pareto_dir),
+            "--scenario",
+            "bear",
+            "--objectives",
+            "sharpe_ratio_strategy_eq",
+            "--json",
+        ]
+    )
+    result = run_from_args(args)
+    payload = json.loads(capsys.readouterr().out)
+
+    assert result.candidate.path.stem == "b"
+    assert payload["scenario"] == "bear"
+    assert payload["front_scope"] == "saved_aggregate_pareto_members"
+    assert payload["scenario_front_complete"] is False
+    assert payload["loaded_count"] == 4
+    assert payload["retained_count"] == 4
+    assert payload["scenario_front_count"] == 2
+    assert payload["selected"]["objectives"]["sharpe_ratio_strategy_eq"] == pytest.approx(1.5)
+
+
+def test_run_from_args_scenario_text_documents_incomplete_front(
+    scenario_pareto_dir: Path,
+    capsys,
+):
+    args = build_parser().parse_args([str(scenario_pareto_dir), "--scenario", "bull"])
+    run_from_args(args)
+    output = capsys.readouterr().out
+
+    assert "| Scenario              | bull" in output
+    assert "| Scenario front        | 3" in output
+    assert "saved aggregate Pareto members" in output
+    assert "candidates discarded by the suite optimizer are not recoverable" in output
 
 
 def test_run_from_args_prints_summary(sample_pareto_dir: Path, capsys):


### PR DESCRIPTION
## Summary
- add passivbot tool pareto --scenario LABEL
- project saved suite Pareto members onto per-scenario metric values
- apply scenario-aware limits, rebuild the nondominated sub-front, then use existing selectors
- report and document that the result only covers saved aggregate Pareto members

## Validation
- 97 focused Pareto, metric-schema, aggregate, analyzer, compress, and merge tests passed
- real two-scenario suite optimize smoke completed with BTC-only and ETH-only scenarios
- real tool smoke loaded 7 saved members; BTC-only retained 7 and ETH-only retained 6 after scenario dominance
- git diff --check passed