### PR TITLE
Tolerate missing resource pressure latest values

### DIFF
--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -45,8 +45,11 @@ Estimated completion:
 - Local validation: the full performance-report suite, focused chronological
   and rotated regressions, Python compilation, diff hygiene, and added-line
   silent-handling scan pass. Terra implemented the isolated report/test patch;
-  Luna's focused delta review reported no findings and green-lit publication;
-  Sol adjudicated the contract.
+  Luna's focused delta review caught stale-latest and bounded-command gaps,
+  which were fixed before publication. A Codex PR review then found that an
+  unorderable trailing row could erase an established ordered snapshot; the
+  accumulator now preserves the ordered snapshot and has a regression. Sol
+  adjudicated the contract.
 - Publication state, exact head, mergeability, CI, and current-head review
   verdicts: query live GitHub metadata. Do not encode those transient values in
   the same PR that contains this status file, because every correction would

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,69 +22,64 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR and publication state: PR #1184; query live GitHub metadata for current
-  state; `Replay flat coin-HSL history at exact change points`
-- Branch: `codex/v8-hsl-sparse-replay`
+- PR and publication state: query live GitHub metadata;
+  `Tolerate missing resource-pressure latest values`
+- Branch: `codex/v8-resource-pressure-none`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
-- Base: `b29d5ca5fd3ffc2d75657459c0ab549e5484596d`
-- Scope: compact cold coin-HSL replay keeps currently held pair history dense,
-  but evaluates historical flat pairs only at exact account/pair run
-  boundaries, rolling-lookback expiries, fill/marker/cooldown/required/restart
-  boundaries, and the final row. Ambiguous fill replay falls back to the dense
-  path. Structured replay events and the performance report expose bounded
-  candidate/dense-equivalent row counts and strategy labels.
-- Triggering evidence: post-PR #1183 full replay completed in `601.246s` for
-  KuCoin, `914.691s` for Binance, `2009.120s` for GateIO, and `2279.519s` for
-  OKX. The indexed-fill load stage took only `0.103s` to `0.213s`, confirming
-  the per-pair minute loop is the dominant remaining local cost.
-- Non-goals: no held-pair sample skipping, HSL arithmetic or threshold change,
-  panic/cooldown/restart contract change, cache authority/schema, exchange
-  call, process control, Rust, backtest, or smoke-verdict change.
-- Local validation: the affected benchmark, coin-HSL, metric-regression, and
-  performance-report suites pass. A deterministic 43,201-minute, 30-pair
-  fixture with one held pair produced identical candidate/dense final-state
-  hashes while reducing replay samples from `825430` to `43652`; all `43201`
-  held-pair samples remained dense. The benchmark is offline and recorded zero
-  network, cache-read, and cache-write side effects.
-- Independent preflight: Terra identified three valid issues: held-pair density
-  was data-dependent, benchmark equivalence omitted restart/cooldown state, and
-  dense fallback telemetry was mislabeled. The implementation now forces held
-  pairs dense, hashes the behavior-relevant runtime state, reports mixed/dense
-  fallback counts, and has independent warning-clean regressions. Terra's final
-  delta review reported no findings and green-lit publication; Sol adjudicated
-  the fixes.
+- Base: `5526d5de21cf1b43cacc69f9b380a15bdf82e93b`
+- Scope: make the read-only resource-pressure accumulator tolerate a historical
+  `health.summary` field whose latest value is explicitly `null`, preserving
+  valid zeroes and omitting unavailable numeric statistics according to the
+  existing report contract. Add a focused regression and record PR #1184
+  deployment evidence.
+- Triggering evidence: after PR #1184 deployment,
+  `live-performance-report --include-rotated --event-tail-lines 5000
+  --max-event-files-per-bot 2 --section hsl_replay_profile` crashed in
+  `_ResourcePressureAccumulator._field_stats` when `clean(None)` called
+  `float(None)`. The lower-level event query with the same file/tail bounds
+  remained healthy and recovered all four replay completion records.
+- Non-goals: no live event producer, event parsing, monitor write, smoke verdict,
+  exchange call, process control, restart behavior, HSL/risk/order behavior,
+  Rust, backtest, or optimizer change.
+- Local validation: the full performance-report suite, focused chronological
+  and rotated regressions, Python compilation, diff hygiene, and added-line
+  silent-handling scan pass. Terra implemented the isolated report/test patch;
+  Luna's focused delta review reported no findings and green-lit publication;
+  Sol adjudicated the contract.
 - Publication state, exact head, mergeability, CI, and current-head review
   verdicts: query live GitHub metadata. Do not encode those transient values in
   the same PR that contains this status file, because every correction would
   create a different head and immediately stale the embedded value.
 - Expected VPS action: after exact-head approval and merge, pull while
-  preserving local artifacts, restart the five supervised bots, and compare
-  candidate counts, full-replay timings, process pressure, and the bounded
-  smoke report. The initializer code is loaded only at process start.
+  preserving local artifacts and rerun the exact rotated report query. No bot
+  restart is expected because this slice changes only read-only report code.
 
 Next action:
 
-1. Resolve verified PR #1184 findings and merge only after the exact-head
-   reviewer and CI gate; then run the declared controlled VPS5 restart and
-   smoke comparison.
+1. Advance the read-only report fix through focused validation, independent
+   preflight, exact-head reviewers, and CI; resolve verified findings and merge
+   only when the full gate is green, then rerun the rotated VPS5 query.
 
 ## Deployed Baseline
 
-- Remote `v8`: `b29d5ca5`, PR #1183
-- VPS5 repository: `b29d5ca5`, PR #1183; tracked status clean
+- Remote `v8`: `5526d5de`, PR #1184
+- VPS5 repository: `5526d5de`, PR #1184; tracked status clean
 - VPS5 expected bots: five; all are running after the controlled restart
-- Immediate and fresh settled smoke reports were green: all five expected bots
-  matched, hard failures were zero, and the fresh recovery window recorded
-  `380/380` remote plus `42/42` account-critical calls succeeded. One Kucoin
-  `RequestTimeout` cycle failure in the wider restart window recovered before
-  the fresh smoke.
-- All four coin-HSL bots emitted `history_format=compact` and protective-ready
-  success in `13.337s` to `78.832s`. The first observed post-PR #1183 full
-  completions were KuCoin at `601.246s` and Binance at `914.691s`; OKX and
-  GateIO remained active without failures. The fill-index prerequisite reduced
-  history-loaded work to `0.103s` to `0.213s`, but did not remove the dominant
-  pair-minute loop.
+- PR #1184 was approved by Hermes and Grok 4.5 on exact head `9177dfed9`, CI
+  passed, and it merged as `5526d5de`. VPS5 fast-forwarded cleanly while
+  preserving untracked artifacts. The five old bots stopped after the second
+  exact-pane Ctrl-C; only the `passivbot` session was reloaded, and unrelated
+  `misc:0.0` remained PID `434835`.
+- Immediate and fresh settled smoke reports were hard-green with all five
+  expected bots matched and zero hard failures. The settled window recorded
+  `249/249` successful remote and `34/34` account-critical calls, process states
+  `R=4, S=1`, no uninterruptible sleep, and tracked repository status clean.
+- All four coin-HSL replays completed with strategy `mixed` and candidate
+  reduction from `86.865%` to `93.449%`: KuCoin `140.746s`, Binance `208.098s`,
+  GateIO `229.248s`, and OKX `269.711s`. The post-PR #1183 baseline was
+  `601.246s` to `2279.519s`, so the deployed replay is about `77%` to `89%`
+  faster while preserving dense held/ambiguous pairs.
 - PR #1181 required no restart; all five bot pane PIDs remained unchanged. Its
   bounded current-segment scorecard reported four compact full-replay
   completions from `453.98s` to `1728.585s`, but exposed the active slice's
@@ -117,12 +112,11 @@ Next action:
 
 The coin-HSL protective-readiness split, cooperative background cadence,
 current process-pressure query, compact cold replay payload, bounded replay
-scorecard, and stable per-pair fill index are merged and deployed. The active
-slice uses exact sparse change points for historical flat-pair replay while
-keeping held-pair work dense.
+scorecard, stable per-pair fill index, and exact sparse flat-pair replay are
+merged and deployed. The active slice fixes the rotated resource-pressure
+report crash exposed during post-deploy evidence collection.
 Remaining candidates:
 
-- exact sparse replay deployment and VPS timing/process-pressure proof
 - deeper internal-stage profiling if live residual cost remains material
 - unsupported configured-market and stock-perp compatibility events
 - bounded operator tooling improvements sharing one code and validation surface

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7353,5 +7353,40 @@ VPS5 deployment status:
 - The affected benchmark, coin-HSL, HSL metric-regression, and performance
   report suites pass. Terra's final delta preflight reported no findings after
   held-density, equivalence-state, fallback-telemetry, and warning-clean test
-  fixes. Publication, exact-head reviews/CI, and post-merge VPS
-  timing/process-pressure validation remain pending.
+  fixes.
+- PR #1184 was approved by Hermes and Grok 4.5 on exact head `9177dfed9`, CI
+  passed, and it merged to `v8` as `5526d5de`. VPS5 fast-forwarded cleanly and
+  restarted only the five supervised bots; unrelated `misc:0.0` remained PID
+  `434835`. Immediate and settled smokes were hard-green. The settled two-minute
+  window matched all five expected bots, recorded `249/249` successful remote
+  and `34/34` account-critical calls, process states `R=4, S=1`, no
+  uninterruptible sleep, and tracked repository status clean.
+- All four deployed replays completed with strategy `mixed`: KuCoin `140.746s`
+  at `89.975%` candidate reduction, Binance `208.098s` at `86.865%`, GateIO
+  `229.248s` at `93.449%`, and OKX `269.711s` at `93.235%`. Compared with the
+  post-PR #1183 baseline of `601.246s` to `2279.519s`, full replay improved by
+  about `77%` to `89%` while held and ambiguous pairs remained dense.
+
+### Active Slice: Missing Resource-Pressure Latest Value
+
+- Branch: `codex/v8-resource-pressure-none` from deployed `5526d5de`.
+- Triggering evidence: the post-deploy command `live-performance-report
+  --include-rotated --event-tail-lines 5000 --max-event-files-per-bot 2
+  --section hsl_replay_profile` crashed before projection because a historical
+  `health.summary` record had an explicit null resource-pressure field and
+  `_field_stats.clean()` called `float(None)`. `live-event-query` over the same
+  bounded rotated segments remained healthy and recovered all four new
+  completion records.
+- Scope: make the read-only resource-pressure accumulator tolerate unavailable
+  latest numeric values without fabricating a zero or dropping valid zeroes;
+  add a focused regression and preserve the existing output schema.
+- Non-goals: no producer, monitor/event parsing, smoke verdict, exchange call,
+  restart, process, HSL/risk/order, Rust, backtest, or optimizer change.
+- Expected validation: focused and full performance-report tests, Python
+  compilation, diff hygiene, silent-handling scan, independent Terra preflight,
+  and the exact bounded rotated VPS5 command after merge. No bot restart is
+  expected.
+- Local result: the full performance-report suite, focused chronological and
+  current-before-rotated regressions, Python compilation, diff hygiene, and
+  added-line silent-handling scan pass. Luna's focused delta review reported no
+  findings after stale-latest and bounded-command corrections.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7388,5 +7388,8 @@ VPS5 deployment status:
   expected.
 - Local result: the full performance-report suite, focused chronological and
   current-before-rotated regressions, Python compilation, diff hygiene, and
-  added-line silent-handling scan pass. Luna's focused delta review reported no
-  findings after stale-latest and bounded-command corrections.
+  added-line silent-handling scan pass. Luna's focused review found and cleared
+  stale-latest plus bounded-command gaps before publication. A Codex PR review
+  then found that an unorderable trailing row could erase an established
+  ordered snapshot; the guard now preserves the ordered latest state and the
+  full report suite passes with a focused regression.

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -108,17 +108,20 @@ slices.
 
 ### Goal 4: Optimize Exact HSL Replay
 
-- [ ] Replay currently held pairs first, cooldown-affected symbols second, and
+- [x] Replay currently held pairs first, cooldown-affected symbols second, and
   remaining flat symbols last or in background.
-- [ ] Replace avoidable `timeline_rows * pairs` work, repeated fill scans, and
+- [x] Replace avoidable `timeline_rows * pairs` work, repeated fill scans, and
   repeated data conversions with indexed, sparse, vectorized, or single-pass
   logic where exact equivalence is proven.
-- [ ] Keep panic/order-triggering decisions equivalent to the current HSL
+- [x] Keep panic/order-triggering decisions equivalent to the current HSL
   contract unless an explicit contract change is reviewed.
 - [ ] Add equivalence tests against the current full replay for
   `ema_span_minutes=1` and `ema_span_minutes>1`.
-- [ ] Acceptance: full HSL replay for 25-30 pairs over the configured lookback
+- [x] Acceptance: full HSL replay for 25-30 pairs over the configured lookback
   is no longer a 20-40 minute operation on VPS5-class hardware.
+  - Deployed PR #1184 completed four 30-day live replays in `140.746s` to
+    `269.711s`, with `86.865%` to `93.449%` candidate-row reduction and no
+    dense held/ambiguous-pair relaxation.
 
 ### Goal 5: Add Conservative HSL Checkpoints
 
@@ -524,7 +527,7 @@ Trading-impact labels:
 
 ### P0: HSL Replay Speed
 
-- [ ] Replace `timeline_rows * pairs` replay with an exact lower-complexity
+- [x] Replace `timeline_rows * pairs` replay with an exact lower-complexity
   path.
   - First optimization slice: finite-lookback replay now seeds pre-window state
     from fills, clamps dense candle/timeline construction to the configured
@@ -534,16 +537,17 @@ Trading-impact labels:
     states that have values on that row, or per-pair sparse series built once.
   - Avoid repeated nested dict scans and repeated full fill-list scans per
     symbol.
-  - Compact-memory slice implemented locally: cold coin replay now builds
+  - Compact-memory slice deployed: cold coin replay now builds
     aligned NumPy account/pair arrays instead of the rich nested timeline and
     consumes those arrays directly. A 43,201-minute, 30-symbol builder profile
     reduced Python peak allocations from `686242590` to `73499666` bytes
-    (89.3%). The fill-index prerequisite is deployed. The active sparse-replay
-    candidate keeps held-pair arrays dense and selects exact run, expiry, fill,
+    (89.3%). The fill-index prerequisite is deployed. Sparse replay keeps
+    held-pair arrays dense and selects exact run, expiry, fill,
     intervention, and terminal boundaries for historical flat pairs. Its
     30-pair offline acceptance fixture reduced applied samples from `825430` to
     `43652` with identical final-state hashes and all `43201` held samples
-    preserved.
+    preserved. VPS5 then completed the four live 30-day replays in `140.746s`
+    to `269.711s`, versus `601.246s` to `2279.519s` before sparse replay.
   - Preserve current RED/green/current-drawdown semantics: a historical RED
     crossing must not cause a panic now if current replay state is no longer in
     the red zone.

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -2045,7 +2045,7 @@ class _CacheWarmupAccumulator:
                 )
             state["latest_flush_completed"] = record
 
-        latest_changed = state.get("latest_ts") is None
+        latest_changed = ts is None or state.get("latest_ts") is None
         if ts is not None and state.get("latest_ts") is not None:
             latest_changed = int(ts) >= int(state["latest_ts"])
         if latest_changed:

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -2045,7 +2045,7 @@ class _CacheWarmupAccumulator:
                 )
             state["latest_flush_completed"] = record
 
-        latest_changed = ts is None or state.get("latest_ts") is None
+        latest_changed = state.get("latest_ts") is None
         if ts is not None and state.get("latest_ts") is not None:
             latest_changed = int(ts) >= int(state["latest_ts"])
         if latest_changed:
@@ -2751,7 +2751,7 @@ class _ResourcePressureAccumulator:
             self.bots[bot] = state
         state["count"] = int(state["count"]) + 1
         ts = _record_ts(row)
-        latest_changed = ts is None or state.get("latest_ts") is None
+        latest_changed = state.get("latest_ts") is None
         if ts is not None and state.get("latest_ts") is not None:
             latest_changed = int(ts) >= int(state["latest_ts"])
         if ts is not None and latest_changed:

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -2726,14 +2726,19 @@ class _ResourcePressureAccumulator:
             if counters:
                 observed_counters[key] = counters
         observed_bools = {
-            key: bool(data.get(key))
+            key: data[key]
             for key in _RESOURCE_PRESSURE_BOOL_FIELDS
-            if key in data
+            if isinstance(data.get(key), bool)
         }
-        if not observed_values and not observed_counters and not observed_bools:
-            return
         bot = _bot_key(row, live_event)
         state = self.bots.get(bot)
+        if (
+            state is None
+            and not observed_values
+            and not observed_counters
+            and not observed_bools
+        ):
+            return
         if state is None:
             state = {
                 "bot": bot,
@@ -2753,15 +2758,16 @@ class _ResourcePressureAccumulator:
             state["latest_ts"] = int(ts)
         for key, value in observed_values.items():
             state["values"][key].append(value)
-            if latest_changed:
-                state["latest"][key] = value
         if latest_changed:
-            state["latest"].update(observed_bools)
+            state["latest"] = {**observed_values, **observed_bools}
             state["latest_counters"] = observed_counters
         self.event_types[event_type] += 1
 
     @staticmethod
     def _field_stats(values: list[float | int], latest: Any) -> dict[str, Any]:
+        latest_value = _non_negative_number(latest)
+        if latest_value is None:
+            return {}
         numeric = sorted(float(value) for value in values)
         if not numeric:
             return {}
@@ -2786,7 +2792,7 @@ class _ResourcePressureAccumulator:
             return rounded
 
         out: dict[str, Any] = {
-            "latest": clean(latest),
+            "latest": clean(latest_value),
             "count": len(numeric),
             "min": clean(numeric[0]),
             "max": clean(numeric[-1]),

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -3543,6 +3543,37 @@ def test_live_performance_report_resource_pressure_latest_snapshot_clears_invali
     assert "latest_event_pipeline_worker_alive" not in group
 
 
+def test_live_performance_report_resource_pressure_unordered_row_keeps_ordered_latest(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="health.summary",
+                seq=1,
+                ts=1000,
+                component="monitor.health",
+                data={"rss_bytes": 1000},
+            ),
+            _monitor_row(
+                event_type="health.summary",
+                seq=2,
+                ts="invalid",
+                component="monitor.health",
+                data={"rss_bytes": None},
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    group = report["resource_pressure"]["groups"][0]
+
+    assert group["count"] == 2
+    assert group["latest_ts"] == 1000
+    assert group["fields"]["rss_bytes"]["latest"] == 1000
+    assert group["fields"]["rss_bytes"]["count"] == 1
+
+
 def test_live_performance_report_resource_pressure_summary_is_bounded(tmp_path, monkeypatch):
     monkeypatch.setattr(performance_report_module, "utc_ms", lambda: 5000)
     events_dir = tmp_path / "monitor" / "mixed" / "events"

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -3438,6 +3438,111 @@ def test_live_performance_report_resource_pressure_whitelists_health_fields(tmp_
     assert "raw-payload" not in rendered
 
 
+def test_live_performance_report_resource_pressure_omits_missing_latest_rotated_field(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    stale_rotated = events_dir / "2026-06-24T00-00-00.ndjson"
+    rotated = events_dir / "2026-06-25T00-00-00.ndjson"
+    current = events_dir / "current.ndjson"
+    _write_ndjson(
+        stale_rotated,
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=500,
+                data={"elapsed_ms": 1000},
+            )
+        ],
+    )
+    _write_ndjson(
+        rotated,
+        [
+            _monitor_row(
+                event_type="health.summary",
+                seq=2,
+                ts=1000,
+                component="monitor.health",
+                data={"rss_bytes": 1000},
+            )
+        ],
+    )
+    _write_ndjson(
+        current,
+        [
+            _monitor_row(
+                event_type="health.summary",
+                seq=3,
+                ts=2000,
+                component="monitor.health",
+                data={"rss_bytes": None, "event_queue_depth": 0},
+            )
+        ],
+    )
+    os.utime(stale_rotated, (1000, 1000))
+    os.utime(rotated, (1500, 1500))
+    os.utime(current, (2000, 2000))
+
+    report = build_live_performance_report(
+        tmp_path / "monitor",
+        include_rotated=True,
+        max_event_files=2,
+    )
+    group = report["resource_pressure"]["groups"][0]
+
+    assert report["files_scanned"] == 2
+    assert group["count"] == 2
+    assert "rss_bytes" not in group["fields"]
+    assert group["fields"]["event_queue_depth"]["latest"] == 0
+
+
+def test_live_performance_report_resource_pressure_latest_snapshot_clears_invalid_fields(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="health.summary",
+                seq=1,
+                ts=1000,
+                component="monitor.health",
+                data={
+                    "rss_bytes": 1000,
+                    "memory_percent": 6.5,
+                    "cpu_percent": 12.0,
+                    "event_queue_depth": 5,
+                    "event_pipeline_worker_alive": True,
+                },
+            ),
+            _monitor_row(
+                event_type="health.summary",
+                seq=2,
+                ts=2000,
+                component="monitor.health",
+                data={
+                    "rss_bytes": None,
+                    "memory_percent": float("nan"),
+                    "cpu_percent": -1,
+                    "event_queue_depth": 0,
+                    "event_pipeline_worker_alive": None,
+                },
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    group = report["resource_pressure"]["groups"][0]
+
+    assert group["count"] == 2
+    assert "rss_bytes" not in group["fields"]
+    assert "memory_percent" not in group["fields"]
+    assert "cpu_percent" not in group["fields"]
+    assert group["fields"]["event_queue_depth"]["latest"] == 0
+    assert group["fields"]["event_queue_depth"]["count"] == 2
+    assert group["fields"]["event_queue_depth"]["min"] == 0
+    assert group["fields"]["event_queue_depth"]["max"] == 5
+    assert "latest_event_pipeline_worker_alive" not in group
+
+
 def test_live_performance_report_resource_pressure_summary_is_bounded(tmp_path, monkeypatch):
     monkeypatch.setattr(performance_report_module, "utc_ms", lambda: 5000)
     events_dir = tmp_path / "monitor" / "mixed" / "events"


### PR DESCRIPTION
## Summary

- treat each newer `health.summary` as the complete latest resource-pressure snapshot
- clear stale latest fields when the newer value is omitted, `null`, NaN, negative, or otherwise invalid
- preserve valid historical samples and valid zero latest values
- add chronological and current-before-rotated regressions
- record PR #1184 merge/deploy and sparse replay performance evidence

## Trigger

After PR #1184 deployment, this bounded read-only command crashed before projecting the requested HSL section:

```bash
passivbot tool live-performance-report monitor \
  --recent-minutes 15 \
  --include-rotated \
  --event-tail-lines 5000 \
  --max-event-files-per-bot 2 \
  --section hsl_replay_profile \
  --compact
```

`_ResourcePressureAccumulator._field_stats` attempted `float(None)` because current segments are scanned before rotated segments and the newest snapshot had no valid latest value for an older observed field.

## Contract

- no numeric zero is fabricated for unavailable data
- a valid zero remains a valid latest sample
- invalid or omitted latest fields do not retain stale prior values
- historical valid samples remain recorded internally
- no event producer, parser, monitor write, smoke verdict, exchange call, process/restart, trading, HSL/risk/order, Rust, backtest, or optimizer change

## Validation

- full `tests/test_live_performance_report.py`: green
- focused chronological and current-before-rotated regressions: green
- Python compilation: green
- `git diff --check`: green
- added-line silent-handling scan: clean
- Luna focused delta preflight: no findings

## Deploy Plan

After exact-head Hermes/Grok approval and green CI, fast-forward VPS5 while preserving local artifacts and rerun the exact bounded command above. No bot restart is expected because this changes only read-only report code.
