### PR TITLE
Emit configured market compatibility events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Unsupported configured markets now emit bounded
+  `config.market_compatibility` structured and monitor events with list,
+  position-side, count, redacted symbol sample, and stable reason context.
+  Existing coin filtering and text-log warnings are unchanged.
+
 - Added `passivbot tool pareto --scenario LABEL` for rebuilding and selecting from a
   scenario-specific nondominated sub-front of a suite optimization's saved aggregate Pareto
   members. Scenario metrics are used consistently for limits, objectives, and ranking, and output

--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -23,6 +23,7 @@ across time.
 - `cache.warmup_decision`
 - `candle.coverage_checked`
 - `candle.tail_projected`
+- `config.market_compatibility`
 - `cycle.completed`
 - `cycle.degraded`
 - `cycle.started`
@@ -171,6 +172,9 @@ full-replay terminal event.
 - `balance_changed`
 - `candle_disk_flush_completed`
 - `candle_disk_load_completed`
+- `config_market_unsupported`
+- `config_stock_perp_unavailable_market`
+- `config_stock_perp_wrong_exchange`
 - `ema_fallback_used`
 - `exchange_acknowledged`
 - `exchange_config_refresh`
@@ -247,6 +251,24 @@ sinks. Its data payload is limited to `source` (`config_sources` or
 Each change row contains its total `count` and at most 12 sorted `symbols`; no
 config path, raw source, or full list is retained. Emission is best-effort and
 must not affect eligibility refresh behavior.
+
+## Configured Market Compatibility Events
+
+`config.market_compatibility` records configured symbols removed by the
+existing eligible-market filter. It routes to structured and monitor sinks
+only and preserves the existing text-log warning. Unsupported approved symbols
+use status `degraded`, making them non-hard problem events; unsupported ignored
+symbols use status `skipped` because they do not weaken configured trading
+intent.
+
+The event envelope identifies one affected `pside`. The payload contains
+`list_kind`, total `skipped_count`, at most 12 sorted `skipped_symbols`, a
+truncation flag, bounded `reason_counts`, and bounded
+per-reason samples. Symbol samples are value-redacted and length-bounded before
+durable publication. Stable reasons distinguish generic unsupported markets,
+stock perps configured on a non-Hyperliquid exchange, and unavailable
+Hyperliquid stock-perp markets. Emission is best-effort and must not change
+coin filtering, exchange calls, or trading behavior.
 
 Dynamic helpers are part of the same contract:
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -23,52 +23,63 @@ Estimated completion:
 ## Active Review Slice
 
 - PR and publication state: query live GitHub metadata;
-  `Tolerate missing resource-pressure latest values`
-- Branch: `codex/v8-resource-pressure-none`
+  `Emit configured-market compatibility events`
+- Branch: `codex/v8-market-compatibility-events`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
-- Base: `5526d5de21cf1b43cacc69f9b380a15bdf82e93b`
-- Scope: make the read-only resource-pressure accumulator tolerate a historical
-  `health.summary` field whose latest value is explicitly `null`, preserving
-  valid zeroes and omitting unavailable numeric statistics according to the
-  existing report contract. Add a focused regression and record PR #1184
-  deployment evidence.
-- Triggering evidence: after PR #1184 deployment,
-  `live-performance-report --include-rotated --event-tail-lines 5000
-  --max-event-files-per-bot 2 --section hsl_replay_profile` crashed in
-  `_ResourcePressureAccumulator._field_stats` when `clean(None)` called
-  `float(None)`. The lower-level event query with the same file/tail bounds
-  remained healthy and recovered all four replay completion records.
-- Non-goals: no live event producer, event parsing, monitor write, smoke verdict,
-  exchange call, process control, restart behavior, HSL/risk/order behavior,
-  Rust, backtest, or optimizer change.
-- Local validation: the full performance-report suite, focused chronological
-  and rotated regressions, Python compilation, diff hygiene, and added-line
-  silent-handling scan pass. Terra implemented the isolated report/test patch;
-  Luna's focused delta review caught stale-latest and bounded-command gaps,
-  which were fixed before publication. A Codex PR review then found that an
-  unorderable trailing row could erase an established ordered snapshot; the
-  accumulator now preserves the ordered snapshot and has a regression. Sol
-  adjudicated the contract.
+- Base: `60357a0071eca8fac80c76fa64f60d328d5ed4a0`
+- Scope: emit one bounded, off-console/off-text
+  `config.market_compatibility` event when an approved or ignored configured
+  symbol is removed because it is absent from the exchange's eligible market
+  set. Preserve the existing once-per-change text logs and filtering behavior;
+  classify stock-perp-looking skipped symbols without changing compatibility
+  policy. Existing generic event-query, timeline, problem-event, smoke, and
+  incident-bundle surfaces consume the event without a bespoke aggregator.
+- Triggering evidence: current VPS5 text logs repeatedly report unsupported
+  approved coins for Binance (`CRO,MNT`) and OKX (`KAS,MNT,XMR`), including the
+  current July 11 log segments, but the condition is absent from structured
+  monitor history and cannot be reconstructed without scraping text logs.
+- Non-goals: no exchange call, eligible-market calculation, configured-coin
+  filtering, stock-perp margin/account policy, Hyperliquid fatal startup path,
+  isolated-only entry filtering, smoke verdict, process control, HSL/risk/order
+  behavior, Rust, backtest, or optimizer change.
+- Local validation: focused live-event, coin-list, smoke, query, incident,
+  registry-doc, compilation, diff, and added-line silent-handling checks pass.
+  Terra implemented the isolated producer/tests. Luna's independent preflight
+  found per-side query provenance, durable symbol bounds/redaction, retryable
+  enqueue dedupe, and changelog gaps; two delta rounds resolved all findings
+  and the final preflight is green. Sol owns event-contract adjudication and
+  publication.
 - Publication state, exact head, mergeability, CI, and current-head review
   verdicts: query live GitHub metadata. Do not encode those transient values in
   the same PR that contains this status file, because every correction would
   create a different head and immediately stale the embedded value.
 - Expected VPS action: after exact-head approval and merge, pull while
-  preserving local artifacts and rerun the exact rotated report query. No bot
-  restart is expected because this slice changes only read-only report code.
+  preserving local artifacts, restart only the five supervised bots because
+  this is a live event producer, verify bounded compatibility events for the
+  known Binance/OKX skips, and run immediate plus settled smoke checks.
 
 Next action:
 
-1. Advance the read-only report fix through focused validation, independent
-   preflight, exact-head reviewers, and CI; resolve verified findings and merge
-   only when the full gate is green, then rerun the rotated VPS5 query.
+1. Complete the bounded configured-market event producer and regressions,
+   obtain independent preflight plus exact-head reviewers and CI, resolve
+   verified findings, and merge only when the full gate is green.
 
 ## Deployed Baseline
 
-- Remote `v8`: `5526d5de`, PR #1184
-- VPS5 repository: `5526d5de`, PR #1184; tracked status clean
-- VPS5 expected bots: five; all are running after the controlled restart
+- Remote `v8`: `60357a00`; the post-#1186 delta is an unrelated example-config update
+- VPS5 repository: `b9748247`, PR #1186; tracked status clean
+- VPS5 expected bots: five; all remained running without restart
+- PR #1186 was approved on exact head `65d61702f` by Hermes, Grok 4.5, and the
+  independent Codex reviewer that found both ordering regressions; CI passed
+  and it merged as `b9748247`. VPS5 fast-forwarded without restarting bots.
+  The exact bounded rotated `hsl_replay_profile` report returned `ok=true`,
+  zero errors/warnings, and no resource-pressure crash. A settled two-minute
+  smoke was hard-green with `216/216` remote and `56/56` account-critical calls
+  successful, all five expected bots matched, and no text-log hard matches.
+  The original five bot PIDs remained unchanged and returned to `Rl+`; unrelated
+  `misc:0.0` remained PID `434835`. An earlier smoke window caught one real
+  KuCoin timeout cycle, which aged out before the settled green window.
 - PR #1184 was approved by Hermes and Grok 4.5 on exact head `9177dfed9`, CI
   passed, and it merged as `5526d5de`. VPS5 fast-forwarded cleanly while
   preserving untracked artifacts. The five old bots stopped after the second
@@ -115,13 +126,13 @@ Next action:
 
 The coin-HSL protective-readiness split, cooperative background cadence,
 current process-pressure query, compact cold replay payload, bounded replay
-scorecard, stable per-pair fill index, and exact sparse flat-pair replay are
-merged and deployed. The active slice fixes the rotated resource-pressure
-report crash exposed during post-deploy evidence collection.
+scorecard, stable per-pair fill index, exact sparse flat-pair replay, and the
+rotated resource-pressure report fix are merged and deployed. The active slice
+makes configured-market compatibility skips available in structured history.
 Remaining candidates:
 
 - deeper internal-stage profiling if live residual cost remains material
-- unsupported configured-market and stock-perp compatibility events
+- stock-perp account, isolated-only, and fatal-live-state compatibility events
 - bounded operator tooling improvements sharing one code and validation surface
 
 Do not create progress-only PRs or resume unrelated logging work from stale

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7393,3 +7393,45 @@ VPS5 deployment status:
   then found that an unorderable trailing row could erase an established
   ordered snapshot; the guard now preserves the ordered latest state and the
   full report suite passes with a focused regression.
+
+### Deployed Slice: Missing Resource-Pressure Latest Value
+
+- PR #1186 was approved on exact head `65d61702f` by Hermes, Grok 4.5, and the
+  independent Codex reviewer that raised the ordering findings. CI passed and
+  the PR merged to `v8` as `b9748247`.
+- VPS5 fast-forwarded while preserving untracked artifacts. Because the change
+  was a read-only report consumer, no bot restart occurred; all five original
+  bot PIDs and unrelated `misc:0.0` PID `434835` remained unchanged.
+- The exact bounded rotated command with `--event-tail-lines 5000`,
+  `--max-event-files-per-bot 2`, and `--section hsl_replay_profile` completed
+  with `ok=true`, zero errors/warnings, and no resource-pressure crash.
+- The first two-minute smoke exposed one real KuCoin authoritative-state
+  timeout cycle. After it aged out, the settled smoke was hard-green with all
+  five expected bots matched, `216/216` remote calls and `56/56`
+  account-critical calls successful, no text-log hard matches, and tracked
+  repository status clean. A direct process check showed all five unchanged
+  bot PIDs in `Rl+`.
+
+### Active Slice: Configured-Market Compatibility Events
+
+- Branch: `codex/v8-market-compatibility-events` from current remote `v8`
+  `60357a00`; VPS5 remains on deployed `b9748247` until this producer slice is
+  approved for restart.
+- Triggering evidence: current VPS5 text logs repeatedly report unsupported
+  approved coins for Binance (`CRO,MNT`) and OKX (`KAS,MNT,XMR`), but no
+  structured event records which configured markets were discarded or why.
+- Scope: emit one bounded off-console/off-text
+  `config.market_compatibility` event from the existing configured-coin skip
+  path, preserving text-log dedupe and all filtering behavior. Include safe
+  per-side list/count/sample context and classify stock-perp-looking skipped
+  symbols without changing stock-perp policy.
+- Non-goals: no exchange calls, eligible-market calculation, stock-perp
+  margin/account policy, Hyperliquid fatal startup enforcement, isolated-only
+  entry filtering, smoke verdict, HSL/risk/order behavior, Rust, backtest, or
+  optimizer change. Existing generic query/problem-event tooling consumes the
+  event; this slice does not add a bespoke report aggregator.
+- Focused live-event, coin-list, smoke, query, incident, registry-doc,
+  compilation, diff, and silent-handling checks pass. Luna's independent
+  preflight found and then cleared per-side query provenance, durable symbol
+  bounds/redaction, retryable enqueue dedupe, changelog, and equal-side query
+  gaps across two delta rounds.

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -76,6 +76,7 @@ class EventTypes:
     FORAGER_SELECTION = "forager.selection"
     FORAGER_FEATURE_UNAVAILABLE = "forager.feature_unavailable"
     FORAGER_ELIGIBILITY_CHANGED = "forager.eligibility_changed"
+    CONFIG_MARKET_COMPATIBILITY = "config.market_compatibility"
     EMA_BUNDLE_STARTED = "ema.bundle.started"
     EMA_BUNDLE_COMPLETED = "ema.bundle.completed"
     EMA_FALLBACK_USED = "ema.fallback_used"
@@ -232,6 +233,9 @@ class ReasonCodes:
     FORAGER_ELIGIBILITY_MEMBERSHIP_CHANGED = (
         "forager_eligibility_membership_changed"
     )
+    CONFIG_MARKET_UNSUPPORTED = "config_market_unsupported"
+    CONFIG_STOCK_PERP_WRONG_EXCHANGE = "config_stock_perp_wrong_exchange"
+    CONFIG_STOCK_PERP_UNAVAILABLE_MARKET = "config_stock_perp_unavailable_market"
     RECENT_EXECUTION = "recent_execution"
     REMOTE_FETCH = "remote_fetch"
     RISK_ENTRY_COOLDOWN_POSITION_DELTA = "entry_cooldown_position_delta"
@@ -385,6 +389,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.FORAGER_SELECTION,
     EventTypes.FORAGER_FEATURE_UNAVAILABLE,
     EventTypes.FORAGER_ELIGIBILITY_CHANGED,
+    EventTypes.CONFIG_MARKET_COMPATIBILITY,
     EventTypes.EMA_BUNDLE_STARTED,
     EventTypes.EMA_BUNDLE_COMPLETED,
     EventTypes.EMA_FALLBACK_USED,
@@ -693,6 +698,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     ),
     EventTypes.FORAGER_FEATURE_UNAVAILABLE: EventRoute(console=False, text=False),
     EventTypes.FORAGER_ELIGIBILITY_CHANGED: EventRoute(console=False, text=False),
+    EventTypes.CONFIG_MARKET_COMPATIBILITY: EventRoute(console=False, text=False),
     EventTypes.EMA_BUNDLE_STARTED: EventRoute(console=False, text=False),
     EventTypes.EMA_BUNDLE_COMPLETED: EventRoute(console=False, text=False),
     EventTypes.EMA_FALLBACK_USED: EventRoute(console=False, text=False),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -2167,6 +2167,113 @@ def emit_forager_eligibility_changed_event(
         )
 
 
+_MARKET_COMPATIBILITY_SAMPLE_LIMIT = 12
+_MARKET_COMPATIBILITY_SYMBOL_MAX_LEN = 160
+_STOCK_PERP_PREFIXES = ("xyz:", "xyz-")
+
+
+def _market_compatibility_reason(symbol: str, exchange: str) -> str:
+    base = symbol.split("/", 1)[0].casefold()
+    if not base.startswith(_STOCK_PERP_PREFIXES):
+        return ReasonCodes.CONFIG_MARKET_UNSUPPORTED
+    if exchange.casefold() != "hyperliquid":
+        return ReasonCodes.CONFIG_STOCK_PERP_WRONG_EXCHANGE
+    return ReasonCodes.CONFIG_STOCK_PERP_UNAVAILABLE_MARKET
+
+
+def _emit_config_market_compatibility_event_unchecked(
+    bot: Any,
+    *,
+    list_kind: str,
+    pside: str,
+    skipped_symbols: set[str],
+) -> bool:
+    if list_kind not in {"approved_coins", "ignored_coins"}:
+        raise ValueError(f"unsupported configured market list kind {list_kind!r}")
+    if pside not in {"long", "short"}:
+        raise ValueError(f"unsupported configured market pside {pside!r}")
+    symbols = sorted({str(symbol) for symbol in skipped_symbols if symbol})
+    if not symbols:
+        return False
+    safe_symbols = {
+        symbol: _sanitize_remote_text(
+            symbol,
+            max_len=_MARKET_COMPATIBILITY_SYMBOL_MAX_LEN,
+        )
+        for symbol in symbols
+    }
+    exchange = str(getattr(bot, "exchange", "") or "")
+    by_reason: dict[str, list[str]] = {}
+    for symbol in symbols:
+        reason_code = _market_compatibility_reason(symbol, exchange)
+        by_reason.setdefault(reason_code, []).append(symbol)
+    reason_samples = [
+        {
+            "reason_code": reason_code,
+            "count": len(reason_symbols),
+            "symbols": [
+                safe_symbols[symbol]
+                for symbol in reason_symbols[:_MARKET_COMPATIBILITY_SAMPLE_LIMIT]
+            ],
+            "symbols_truncated": (
+                len(reason_symbols) > _MARKET_COMPATIBILITY_SAMPLE_LIMIT
+            ),
+        }
+        for reason_code, reason_symbols in sorted(by_reason.items())
+    ]
+    event_reason = (
+        next(iter(by_reason))
+        if len(by_reason) == 1
+        else ReasonCodes.CONFIG_MARKET_UNSUPPORTED
+    )
+    return (
+        _safe_emit(
+            bot,
+            EventTypes.CONFIG_MARKET_COMPATIBILITY,
+            level="info",
+            component="config.market_compatibility",
+            tags=(EventTags.MARKET, EventTags.AVAILABILITY),
+            cycle_id=current_live_event_cycle_id(bot),
+            pside=pside,
+            status="degraded" if list_kind == "approved_coins" else "skipped",
+            reason_code=event_reason,
+            data={
+                "list_kind": list_kind,
+                "skipped_count": len(symbols),
+                "skipped_symbols": [
+                    safe_symbols[symbol]
+                    for symbol in symbols[:_MARKET_COMPATIBILITY_SAMPLE_LIMIT]
+                ],
+                "skipped_symbols_truncated": (
+                    len(symbols) > _MARKET_COMPATIBILITY_SAMPLE_LIMIT
+                ),
+                "reason_counts": {
+                    reason_code: len(reason_symbols)
+                    for reason_code, reason_symbols in sorted(by_reason.items())
+                },
+                "reason_samples": reason_samples,
+            },
+            require_enqueue=True,
+        )
+        is not None
+    )
+
+
+def emit_config_market_compatibility_event(
+    bot: Any, *args: Any, **kwargs: Any
+) -> bool:
+    """Best-effort visibility for configured symbols skipped before eligibility."""
+    try:
+        return _emit_config_market_compatibility_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.CONFIG_MARKET_COMPATIBILITY,
+            exc,
+        )
+        return False
+
+
 def _emit_forager_selection_event_unchecked(
     bot: Any,
     *,

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -189,6 +189,12 @@ EXECUTION_HEALTH_EVENT_TYPES = {
     EventTypes.EXECUTION_CONFIRMATION_TIMEOUT,
 }
 PROBLEM_EVENT_DATA_KEYS: dict[str, tuple[str, ...]] = {
+    EventTypes.CONFIG_MARKET_COMPATIBILITY: (
+        "list_kind",
+        "skipped_count",
+        "skipped_symbols",
+        "reason_counts",
+    ),
     EventTypes.CYCLE_DEGRADED: ("details", "authoritative_epoch"),
     EventTypes.EMA_UNAVAILABLE: (
         "optional_drop_count",

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -665,6 +665,9 @@ class Passivbot:
     _emit_forager_eligibility_changed_event = (
         live_event_emitters.emit_forager_eligibility_changed_event
     )
+    _emit_config_market_compatibility_event = (
+        live_event_emitters.emit_config_market_compatibility_event
+    )
     _emit_forager_selection_event = live_event_emitters.emit_forager_selection_event
     _emit_ema_bundle_started_event = live_event_emitters.emit_ema_bundle_started_event
     _emit_ema_bundle_completed_event = live_event_emitters.emit_ema_bundle_completed_event
@@ -17712,6 +17715,31 @@ class Passivbot:
                                     symbol_list,
                                 )
                                 warned.add(warn_key)
+                            event_keys = getattr(
+                                self,
+                                "_market_compatibility_event_keys",
+                                None,
+                            )
+                            if event_keys is None:
+                                event_keys = set()
+                                setattr(
+                                    self,
+                                    "_market_compatibility_event_keys",
+                                    event_keys,
+                                )
+                            affected_psides = (
+                                ("long", "short") if psides_equal else (pside,)
+                            )
+                            for affected_pside in affected_psides:
+                                event_key = (*warn_key, affected_pside)
+                                if event_key not in event_keys:
+                                    emitted = self._emit_config_market_compatibility_event(
+                                        list_kind=k_coins,
+                                        pside=affected_pside,
+                                        skipped_symbols=set(skipped),
+                                    )
+                                    if emitted:
+                                        event_keys.add(event_key)
                             symbols = symbols - set(skipped)
             symbols_already = getattr(self, k_coins)[pside]
             if symbols_already != symbols:

--- a/tests/test_live_coin_lists.py
+++ b/tests/test_live_coin_lists.py
@@ -75,16 +75,85 @@ def test_ignored_coin_overrides_forced_normal_to_graceful_stop():
 def test_add_to_coins_lists_skips_symbols_not_in_eligible_markets(caplog):
     bot = Passivbot.__new__(Passivbot)
     bot.exchange = "bitget"
-    bot.markets_dict = {"AAA/USDT:USDT": {"swap": True}}
+    eligible_symbol = "AAA/USDT:USDT"
+    skipped_symbols = {f"ZZ{index:02d}/USDT:USDT" for index in range(14)}
+    bot.markets_dict = {eligible_symbol: {"swap": True}}
+    bot.eligible_symbols = {eligible_symbol}
+    bot.approved_coins = {"long": set(), "short": set()}
+    bot.ignored_coins = {"long": set(), "short": set()}
+    structured = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(structured_sinks=[structured])
+
+    def fake_coin_to_symbol(self, coin, verbose=True):
+        return eligible_symbol if coin == "AAA" else f"{coin}/USDT:USDT"
+
+    bot.coin_to_symbol = fake_coin_to_symbol.__get__(bot, Passivbot)
+
+    with caplog.at_level(logging.INFO):
+        bot.add_to_coins_lists(
+            {
+                "long": ["AAA", *[f"ZZ{index:02d}" for index in range(14)]],
+                "short": [],
+            },
+            "approved_coins",
+            log_psides={"long"},
+        )
+        bot.add_to_coins_lists(
+            {
+                "long": ["AAA", *[f"ZZ{index:02d}" for index in range(14)]],
+                "short": [],
+            },
+            "approved_coins",
+            log_psides={"long"},
+        )
+
+    assert bot.approved_coins["long"] == {eligible_symbol}
+    assert bot.approved_coins["short"] == set()
+    warnings = [
+        rec.message for rec in caplog.records if "skipping unsupported markets" in rec.message.lower()
+    ]
+    assert len(warnings) == 1
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in structured.events
+        if event.event_type == EventTypes.CONFIG_MARKET_COMPATIBILITY
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.reason_code == ReasonCodes.CONFIG_MARKET_UNSUPPORTED
+    assert event.status == "degraded"
+    assert event.pside == "long"
+    assert event.data == {
+        "list_kind": "approved_coins",
+        "skipped_count": 14,
+        "skipped_symbols": sorted(skipped_symbols)[:12],
+        "skipped_symbols_truncated": True,
+        "reason_counts": {ReasonCodes.CONFIG_MARKET_UNSUPPORTED: 14},
+        "reason_samples": [
+            {
+                "reason_code": ReasonCodes.CONFIG_MARKET_UNSUPPORTED,
+                "count": 14,
+                "symbols": sorted(skipped_symbols)[:12],
+                "symbols_truncated": True,
+            }
+        ],
+    }
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_add_to_coins_lists_ignores_market_compatibility_emission_failure(caplog):
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "bitget"
     bot.eligible_symbols = {"AAA/USDT:USDT"}
     bot.approved_coins = {"long": set(), "short": set()}
     bot.ignored_coins = {"long": set(), "short": set()}
+    bot.coin_to_symbol = lambda coin, verbose=True: f"{coin}/USDT:USDT"
 
-    def fake_coin_to_symbol(self, coin, verbose=True):
-        mapping = {"AAA": "AAA/USDT:USDT", "BBB": "BBB/USDT:USDT"}
-        return mapping.get(coin, f"{coin}/USDT:USDT")
+    def fail_emit(*_args, **_kwargs):
+        raise RuntimeError("event sink unavailable")
 
-    bot.coin_to_symbol = fake_coin_to_symbol.__get__(bot, Passivbot)
+    bot._emit_live_event = fail_emit
 
     with caplog.at_level(logging.INFO):
         bot.add_to_coins_lists(
@@ -92,18 +161,210 @@ def test_add_to_coins_lists_skips_symbols_not_in_eligible_markets(caplog):
             "approved_coins",
             log_psides={"long"},
         )
-        bot.add_to_coins_lists(
-            {"long": ["AAA", "BBB"], "short": []},
-            "approved_coins",
-            log_psides={"long"},
-        )
 
     assert bot.approved_coins["long"] == {"AAA/USDT:USDT"}
-    assert bot.approved_coins["short"] == set()
-    warnings = [
-        rec.message for rec in caplog.records if "skipping unsupported markets" in rec.message.lower()
+    assert any(
+        "skipping unsupported markets" in record.message.lower()
+        for record in caplog.records
+    )
+
+    structured = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(structured_sinks=[structured])
+    bot._emit_live_event = Passivbot._emit_live_event.__get__(bot, Passivbot)
+    bot.add_to_coins_lists(
+        {"long": ["AAA", "BBB"], "short": []},
+        "approved_coins",
+        log_psides={"long"},
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in structured.events
+        if event.event_type == EventTypes.CONFIG_MARKET_COMPATIBILITY
     ]
-    assert len(warnings) == 1
+    assert len(events) == 1
+    assert len(
+        [
+            record
+            for record in caplog.records
+            if "skipping unsupported markets" in record.message.lower()
+        ]
+    ) == 1
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_add_to_coins_lists_market_compatibility_preserves_pside_provenance():
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "bitget"
+    bot.eligible_symbols = {"AAA/USDT:USDT"}
+    bot.approved_coins = {"long": set(), "short": set()}
+    bot.ignored_coins = {"long": set(), "short": set()}
+    structured = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(structured_sinks=[structured])
+    bot.coin_to_symbol = lambda coin, verbose=True: f"{coin}/USDT:USDT"
+
+    bot.add_to_coins_lists(
+        {"long": ["BBB"], "short": ["CCC"]},
+        "approved_coins",
+        log_psides={"long", "short"},
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in structured.events
+        if event.event_type == EventTypes.CONFIG_MARKET_COMPATIBILITY
+    ]
+    assert len(events) == 2
+    assert {event.pside for event in events} == {"long", "short"}
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_add_to_coins_lists_equal_sides_emit_queryable_per_side_events(caplog):
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "bitget"
+    bot.eligible_symbols = {"AAA/USDT:USDT"}
+    bot.approved_coins = {"long": set(), "short": set()}
+    bot.ignored_coins = {"long": set(), "short": set()}
+    structured = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(structured_sinks=[structured])
+    bot.coin_to_symbol = lambda coin, verbose=True: f"{coin}/USDT:USDT"
+
+    with caplog.at_level(logging.INFO):
+        bot.add_to_coins_lists(
+            {"long": ["BBB"], "short": ["BBB"]},
+            "approved_coins",
+            log_psides={"long", "short"},
+        )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in structured.events
+        if event.event_type == EventTypes.CONFIG_MARKET_COMPATIBILITY
+    ]
+    assert len(events) == 2
+    assert {event.pside for event in events} == {"long", "short"}
+    assert len(
+        [
+            record
+            for record in caplog.records
+            if "skipping unsupported markets" in record.message.lower()
+        ]
+    ) == 1
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_add_to_coins_lists_market_compatibility_sanitizes_durable_symbols():
+    long_coin = "X" * 10_000
+    secret_coin = "api_key=secret"
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "bitget"
+    bot.eligible_symbols = {"AAA/USDT:USDT"}
+    bot.approved_coins = {"long": set(), "short": set()}
+    bot.ignored_coins = {"long": set(), "short": set()}
+    structured = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(structured_sinks=[structured])
+    bot.coin_to_symbol = lambda coin, verbose=True: f"{coin}/USDT:USDT"
+
+    bot.add_to_coins_lists(
+        {"long": [long_coin, secret_coin], "short": []},
+        "approved_coins",
+        log_psides={"long"},
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = next(
+        event
+        for event in structured.events
+        if event.event_type == EventTypes.CONFIG_MARKET_COMPATIBILITY
+    )
+    rendered = str(event.data)
+    assert "secret" not in rendered
+    assert "[redacted]" in rendered
+    assert all(len(symbol) <= 175 for symbol in event.data["skipped_symbols"])
+    assert all(
+        len(symbol) <= 175
+        for sample in event.data["reason_samples"]
+        for symbol in sample["symbols"]
+    )
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_add_to_coins_lists_unsupported_ignored_market_is_not_degraded():
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = "bitget"
+    bot.eligible_symbols = {"AAA/USDT:USDT"}
+    bot.approved_coins = {"long": set(), "short": set()}
+    bot.ignored_coins = {"long": set(), "short": set()}
+    structured = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(structured_sinks=[structured])
+    bot.coin_to_symbol = lambda coin, verbose=True: f"{coin}/USDT:USDT"
+
+    bot.add_to_coins_lists(
+        {"long": ["BBB"], "short": []},
+        "ignored_coins",
+        log_psides={"long"},
+    )
+
+    assert bot.ignored_coins["long"] == set()
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in structured.events
+        if event.event_type == EventTypes.CONFIG_MARKET_COMPATIBILITY
+    ]
+    assert len(events) == 1
+    assert events[0].status == "skipped"
+    assert events[0].pside == "long"
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.parametrize(
+    ("exchange", "expected_reason"),
+    [
+        ("bitget", ReasonCodes.CONFIG_STOCK_PERP_WRONG_EXCHANGE),
+        ("hyperliquid", ReasonCodes.CONFIG_STOCK_PERP_UNAVAILABLE_MARKET),
+    ],
+)
+def test_add_to_coins_lists_classifies_skipped_stock_perps(exchange, expected_reason):
+    stock_symbol = "xyz:TSLA/USDC:USDC"
+    bot = Passivbot.__new__(Passivbot)
+    bot.exchange = exchange
+    bot.eligible_symbols = {"BTC/USDT:USDT"}
+    bot.approved_coins = {"long": set(), "short": set()}
+    bot.ignored_coins = {"long": set(), "short": set()}
+    structured = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(structured_sinks=[structured])
+    bot.coin_to_symbol = lambda coin, verbose=True: stock_symbol
+
+    bot.add_to_coins_lists(
+        {"long": ["xyz:TSLA"], "short": []},
+        "approved_coins",
+        log_psides={"long"},
+    )
+
+    assert bot.approved_coins["long"] == set()
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in structured.events
+        if event.event_type == EventTypes.CONFIG_MARKET_COMPATIBILITY
+    ]
+    assert len(events) == 1
+    event = events[0]
+    assert event.reason_code == expected_reason
+    assert event.data["reason_counts"] == {expected_reason: 1}
+    assert event.data["reason_samples"] == [
+        {
+            "reason_code": expected_reason,
+            "count": 1,
+            "symbols": [stock_symbol],
+            "symbols_truncated": False,
+        }
+    ]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
 def test_refresh_approved_ignored_coin_lists_supports_explicit_all_per_side():

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -77,6 +77,10 @@ def test_live_event_tag_registry_values_are_unique_and_query_safe():
     assert all(re.fullmatch(r"[a-z][a-z0-9_]*", value) for value in values)
 
 
+def test_market_compatibility_event_type_is_stable():
+    assert EventTypes.CONFIG_MARKET_COMPATIBILITY == "config.market_compatibility"
+
+
 def test_live_event_reason_code_registry_values_are_unique_and_query_safe():
     values = _registry_values(ReasonCodes)
 
@@ -85,6 +89,15 @@ def test_live_event_reason_code_registry_values_are_unique_and_query_safe():
     assert ReasonCodes.EXCHANGE_CONFIG_REFRESH == "exchange_config_refresh"
     assert ReasonCodes.EXECUTION_LOOP_ERROR_BURST == "execution_loop_error_burst"
     assert ReasonCodes.WARMUP_CACHE_DECISION == "warmup_cache_decision"
+    assert ReasonCodes.CONFIG_MARKET_UNSUPPORTED == "config_market_unsupported"
+    assert (
+        ReasonCodes.CONFIG_STOCK_PERP_WRONG_EXCHANGE
+        == "config_stock_perp_wrong_exchange"
+    )
+    assert (
+        ReasonCodes.CONFIG_STOCK_PERP_UNAVAILABLE_MARKET
+        == "config_stock_perp_unavailable_market"
+    )
     assert authoritative_reason_code("balance") == "authoritative_balance"
     assert sink_failed_reason_code("monitor") == "monitor_sink_failed"
     assert len(values) == len(set(values))
@@ -232,6 +245,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
     for event_type in (
         EventTypes.FORAGER_FEATURE_UNAVAILABLE,
         EventTypes.FORAGER_ELIGIBILITY_CHANGED,
+        EventTypes.CONFIG_MARKET_COMPATIBILITY,
         EventTypes.ACTION_PLANNED,
         EventTypes.EMA_BUNDLE_STARTED,
         EventTypes.EMA_BUNDLE_COMPLETED,

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1798,6 +1798,46 @@ def test_live_smoke_report_problem_events_include_allowlisted_ema_data(tmp_path)
     assert "ignored_extra" not in latest_data
 
 
+def test_live_smoke_report_problem_events_include_market_compatibility_data(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="config.market_compatibility",
+                seq=1,
+                ts=1000,
+                status="degraded",
+                level="info",
+                reason_code="config_market_unsupported",
+                pside="long",
+                data={
+                    "list_kind": "approved_coins",
+                    "skipped_count": 2,
+                    "skipped_symbols": ["CRO/USDT:USDT", "MNT/USDT:USDT"],
+                    "skipped_symbols_truncated": False,
+                    "reason_counts": {"config_market_unsupported": 2},
+                    "reason_samples": [{"do_not_surface": "extra detail"}],
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    assert report["ok"] is True
+    event = report["problem_events"][0]
+    assert event["event_type"] == "config.market_compatibility"
+    assert event["hard"] is False
+    assert event["pside"] == "long"
+    assert event["latest_data"] == {
+        "list_kind": "approved_coins",
+        "skipped_count": 2,
+        "skipped_symbols": ["CRO/USDT:USDT", "MNT/USDT:USDT"],
+        "reason_counts": {"config_market_unsupported": 2},
+    }
+
+
 def test_live_smoke_report_summarizes_ema_readiness_health(tmp_path):
     events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Scope

`observability-only` live event producer plus generic problem-event projection.

## Touched surfaces

- add bounded `config.market_compatibility` event and stable reason codes
- emit one queryable event per affected position side from the existing configured-market skip path
- keep approved skips as non-hard degraded evidence and ignored-list skips as non-problem skipped evidence
- redact and length-bound symbol samples before durable enqueue
- preserve existing configured-coin filtering and single-shot text warning behavior
- expose safe list/count/symbol/reason fields through the existing generic smoke/problem-event projection
- update registry, changelog, and logging-overhaul ledgers

## Expected VPS action

Restart required after merge because this adds a live event producer. Pull while preserving local artifacts, restart only the five supervised VPS5 bots, verify bounded Binance/OKX compatibility events, then run immediate and settled smoke checks. Do not touch the unrelated `misc` tmux session.

## Validation

- focused coin-list, event-bus, smoke, registry-doc, event-query, and incident-bundle suite: green
- Python compilation: green
- `git diff --check origin/v8...HEAD`: green
- added-line silent-handling scan: only the intentional debug-logged best-effort emitter boundary
- independent Luna preflight: green after resolving per-side query provenance, durable symbol bounds/redaction, enqueue retry, changelog, and equal-side query findings

No backtest, optimizer, fake-live, or exchange smoke was run because this does not touch trading logic, exchange I/O, backtest/optimizer behavior, or order/risk paths.

## Reviewer focus

- event remains observational and cannot affect filtering or trading behavior
- per-side events preserve `live-event-query --pside` and problem-group semantics
- enqueue-gated dedupe retries after failed publication without duplicating legacy warnings
- durable payload bounds/redaction and safe generic problem-event fields
- approved versus ignored skip severity

## Non-goals

- no eligible-market calculation or configured-coin filtering change
- no Hyperliquid fatal startup, account compatibility, or isolated-only entry event yet
- no stock-perp margin policy change
- no exchange call, process control, smoke verdict, HSL/risk/order, Rust, backtest, or optimizer change
