### PR TITLE
Record HIP-3 fatal startup compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Hyperliquid non-unified HIP-3 startup rejection now emits a bounded terminal
+  `config.market_compatibility` event before preserving the existing fatal
+  error. The event records only redacted account/capability counts and symbol
+  samples and does not change market, margin, or startup policy.
+
 - Unsupported configured markets now emit bounded
   `config.market_compatibility` structured and monitor events with list,
   position-side, count, redacted symbol sample, and stable reason context.

--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -173,6 +173,7 @@ full-replay terminal event.
 - `candle_disk_flush_completed`
 - `candle_disk_load_completed`
 - `config_market_unsupported`
+- `config_hip3_account_mode_unsupported`
 - `config_stock_perp_unavailable_market`
 - `config_stock_perp_wrong_exchange`
 - `ema_fallback_used`
@@ -269,6 +270,14 @@ durable publication. Stable reasons distinguish generic unsupported markets,
 stock perps configured on a non-Hyperliquid exchange, and unavailable
 Hyperliquid stock-perp markets. Emission is best-effort and must not change
 coin filtering, exchange calls, or trading behavior.
+
+Before the existing Hyperliquid non-unified HIP-3 startup guard raises,
+`config_hip3_account_mode_unsupported` records one hard failed compatibility
+event. Its account-level payload contains only a bounded, pre-redacted account
+abstraction, a stable action, and count/sample summaries for approved,
+position, open-order, isolated-only, and live-isolated symbols. The producer
+requires enqueue and waits at most 0.1 seconds for a best-effort terminal flush;
+emission or flush failure never suppresses or replaces the fatal startup error.
 
 Dynamic helpers are part of the same contract:
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -23,53 +23,66 @@ Estimated completion:
 ## Active Review Slice
 
 - PR and publication state: query live GitHub metadata;
-  `Emit configured-market compatibility events`
-- Branch: `codex/v8-market-compatibility-events`
+  `Record HIP-3 fatal startup compatibility`
+- Branch: `codex/v8-stock-perp-compatibility-events`
 - Head: query live GitHub metadata; this commit cannot embed its own final SHA
   without making that value stale
-- Base: `60357a0071eca8fac80c76fa64f60d328d5ed4a0`
-- Scope: emit one bounded, off-console/off-text
-  `config.market_compatibility` event when an approved or ignored configured
-  symbol is removed because it is absent from the exchange's eligible market
-  set. Preserve the existing once-per-change text logs and filtering behavior;
-  classify stock-perp-looking skipped symbols without changing compatibility
-  policy. Existing generic event-query, timeline, problem-event, smoke, and
-  incident-bundle surfaces consume the event without a bespoke aggregator.
-- Triggering evidence: current VPS5 text logs repeatedly report unsupported
-  approved coins for Binance (`CRO,MNT`) and OKX (`KAS,MNT,XMR`), including the
-  current July 11 log segments, but the condition is absent from structured
-  monitor history and cannot be reconstructed without scraping text logs.
-- Non-goals: no exchange call, eligible-market calculation, configured-coin
-  filtering, stock-perp margin/account policy, Hyperliquid fatal startup path,
-  isolated-only entry filtering, smoke verdict, process control, HSL/risk/order
-  behavior, Rust, backtest, or optimizer change.
-- Local validation: focused live-event, coin-list, smoke, query, incident,
-  registry-doc, compilation, diff, and added-line silent-handling checks pass.
-  Terra implemented the isolated producer/tests. Luna's independent preflight
-  found per-side query provenance, durable symbol bounds/redaction, retryable
-  enqueue dedupe, and changelog gaps; two delta rounds resolved all findings
-  and the final preflight is green. Sol owns event-contract adjudication and
-  publication.
+- Base: `b99d1b0520149299298252999864ac848c42ce42`
+- Scope: before Hyperliquid's existing non-unified HIP-3 startup gate raises
+  `FatalBotException`, emit and boundedly flush one off-console/off-text
+  `config.market_compatibility` event. The payload aggregates only safe,
+  bounded approved-position-open-order and margin-capability evidence; it does
+  not retain order IDs, sizes, prices, raw payloads, config paths, or free-form
+  exception text.
+- Triggering evidence: the fatal gate distinguishes approved HIP-3 symbols,
+  existing positions/open orders, isolated-only markets, and live isolated
+  margin state in one human exception, but structured history contains only a
+  generic startup error. A process can exit before queued semantic evidence is
+  durable, leaving incident tooling unable to classify the compatibility
+  failure without text-log parsing.
+- Non-goals: no account abstraction detection, market/margin policy,
+  fatal-decision or exception-message change; no generic isolated-only entry
+  filter event, exchange call, configured-coin filtering, smoke verdict,
+  process control, HSL/risk/order behavior, Rust, backtest, or optimizer change.
+- Local validation: the focused Hyperliquid fatal-state, event-bus, smoke,
+  enqueue/flush-failure, and registry-doc suite passes with 184 tests; Python
+  compilation and `git diff --check` pass. Added-line silent handling is limited
+  to the explicitly best-effort event enqueue/terminal flush. Independent Luna
+  preflight is green after confirming approved-only diagnostics make no new
+  margin-policy call and existing position/open-order paths preserve the prior
+  fatal contract. Terra implemented the isolated producer/tests; Sol owns the
+  terminal-event contract and publication.
 - Publication state, exact head, mergeability, CI, and current-head review
   verdicts: query live GitHub metadata. Do not encode those transient values in
   the same PR that contains this status file, because every correction would
   create a different head and immediately stale the embedded value.
 - Expected VPS action: after exact-head approval and merge, pull while
-  preserving local artifacts, restart only the five supervised bots because
-  this is a live event producer, verify bounded compatibility events for the
-  known Binance/OKX skips, and run immediate plus settled smoke checks.
+  preserving local artifacts, restart the exact supervised Hyperliquid pane to
+  load the Hyperliquid-only producer, and run immediate plus settled smoke
+  checks. The configured VPS5 account is unified, so no fatal event is expected
+  from healthy production startup; unit evidence owns the incompatible path.
 
 Next action:
 
-1. Complete the bounded configured-market event producer and regressions,
+1. Complete the bounded HIP-3 fatal compatibility producer and regressions,
    obtain independent preflight plus exact-head reviewers and CI, resolve
    verified findings, and merge only when the full gate is green.
 
 ## Deployed Baseline
 
-- Remote `v8`: `60357a00`; the post-#1186 delta is an unrelated example-config update
-- VPS5 repository: `b9748247`, PR #1186; tracked status clean
-- VPS5 expected bots: five; all remained running without restart
+- Remote `v8`: `b99d1b05`, PR #1187
+- VPS5 repository: `b99d1b05`, PR #1187; tracked status clean
+- VPS5 expected bots: five; all running after the controlled restart
+- PR #1187 was approved on exact head `74766c7cb` by Hermes, Grok 4.5, and the
+  independent Codex reviewer; CI passed and it merged as `b99d1b05`. VPS5
+  restarted only the five supervised bots, preserving `misc:0.0` PID `434835`.
+  A bounded event query found the exact four expected per-side
+  `config.market_compatibility` records: Binance `CRO,MNT` and OKX
+  `KAS,MNT,XMR`, all non-hard degraded approved-list evidence. An immediate
+  smoke caught a real KuCoin timeout; after it aged out, the settled smoke was
+  hard-green with `370/370` remote and `26/26` account-critical calls
+  successful, all five processes matched, states `R=4,S=1`, and no
+  uninterruptible sleep.
 - PR #1186 was approved on exact head `65d61702f` by Hermes, Grok 4.5, and the
   independent Codex reviewer that found both ordering regressions; CI passed
   and it merged as `b9748247`. VPS5 fast-forwarded without restarting bots.
@@ -127,12 +140,13 @@ Next action:
 The coin-HSL protective-readiness split, cooperative background cadence,
 current process-pressure query, compact cold replay payload, bounded replay
 scorecard, stable per-pair fill index, exact sparse flat-pair replay, and the
-rotated resource-pressure report fix are merged and deployed. The active slice
-makes configured-market compatibility skips available in structured history.
+rotated resource-pressure report fix plus configured-market skip events are
+merged and deployed. The active slice makes fatal HIP-3 startup compatibility
+available in durable structured history.
 Remaining candidates:
 
 - deeper internal-stage profiling if live residual cost remains material
-- stock-perp account, isolated-only, and fatal-live-state compatibility events
+- generic isolated-only entry-filter compatibility events
 - bounded operator tooling improvements sharing one code and validation surface
 
 Do not create progress-only PRs or resume unrelated logging work from stale

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7435,3 +7435,41 @@ VPS5 deployment status:
   preflight found and then cleared per-side query provenance, durable symbol
   bounds/redaction, retryable enqueue dedupe, changelog, and equal-side query
   gaps across two delta rounds.
+
+### Deployed Slice: Configured-Market Compatibility Events
+
+- PR #1187 was approved by Hermes, Grok 4.5, and independent Codex on exact
+  head `74766c7cb`; CI passed and it merged to `v8` as `b99d1b05`.
+- VPS5 fast-forwarded cleanly and restarted only the five supervised bots.
+  The first graceful signal stopped OKX and Hyperliquid; a second exact-pane
+  Ctrl+C stopped Binance, KuCoin, and GateIO. The unrelated `misc:0.0` pane
+  remained PID `434835`.
+- A bounded current-segment query returned four exact
+  `config.market_compatibility` events: long and short records for Binance
+  `CRO,MNT` and OKX `KAS,MNT,XMR`, with bounded payloads, stable generic reason,
+  and non-hard degraded status.
+- The immediate smoke caught one real KuCoin authoritative-state timeout. The
+  settled two-minute smoke was hard-green with all five expected processes
+  matched, `370/370` remote calls and `26/26` account-critical calls
+  successful, `R=4,S=1`, no uninterruptible sleep, and tracked repository
+  status clean.
+
+### Active Slice: HIP-3 Fatal Startup Compatibility Event
+
+- Branch: `codex/v8-stock-perp-compatibility-events` from deployed
+  `b99d1b05`.
+- Scope: emit and boundedly flush one off-console/off-text
+  `config.market_compatibility` event before Hyperliquid's existing non-unified
+  HIP-3 startup gate raises. Retain only safe bounded counts/samples for
+  approved symbols, positions, open-order symbols, isolated-only capability,
+  live isolated margin state, and account abstraction.
+- Non-goals: no fatal decision/message, market/margin/account policy, exchange
+  call, generic isolated-only entry filtering, configured-coin filtering,
+  smoke verdict, HSL/risk/order behavior, Rust, backtest, or optimizer change.
+  Emission and flush remain best-effort and must never suppress or replace the
+  existing `FatalBotException`.
+- Focused validation passes 184 Hyperliquid fatal-state, event-bus, smoke,
+  enqueue/flush-failure, and registry-doc tests plus Python compilation and
+  `git diff --check`. Independent Luna preflight is green after verifying the
+  producer adds no metadata/policy/exchange call before the existing fatal
+  path; approved-only symbols do not recompute isolated-margin policy.

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -456,6 +456,10 @@ class HyperliquidBot(CCXTBot):
         if self.HIP3_ISOLATED_SUPPORTED or self._hl_supports_hip3_live_trading():
             return
         unsupported = []
+        position_symbols = set()
+        open_order_symbols = set()
+        isolated_only_symbols = set()
+        live_isolated_symbols = set()
         approved = set()
         for syms in getattr(self, "approved_coins_minus_ignored_coins", {}).values():
             approved.update(syms)
@@ -479,8 +483,16 @@ class HyperliquidBot(CCXTBot):
             has_orders = bool(getattr(self, "open_orders", {}).get(symbol))
             if not (has_pos or has_orders):
                 continue
+            if has_pos:
+                position_symbols.add(symbol)
+            if has_orders:
+                open_order_symbols.add(symbol)
             isolated_live_mode = getattr(self, "_hl_live_margin_modes", {}).get(symbol) == "isolated"
             isolated_only = self._requires_isolated_margin(symbol)
+            if isolated_only:
+                isolated_only_symbols.add(symbol)
+            if isolated_live_mode:
+                live_isolated_symbols.add(symbol)
             reasons = []
             if isolated_only:
                 reasons.append("isolated-only market")
@@ -498,6 +510,15 @@ class HyperliquidBot(CCXTBot):
                 f"({'/'.join(state_bits)}; {', '.join(reasons)})"
             )
         if unsupported:
+            self._emit_hip3_account_mode_unsupported_event(
+                account_abstraction=getattr(self, "_hl_user_abstraction", "unknown"),
+                action="fatal_live_state_rejected",
+                approved_symbols=approved_hip3,
+                position_symbols=position_symbols,
+                open_order_symbols=open_order_symbols,
+                isolated_only_symbols=isolated_only_symbols,
+                live_isolated_symbols=live_isolated_symbols,
+            )
             raise FatalBotException(
                 "Hyperliquid HIP-3/non-standard perps require unifiedAccount or portfolioMargin "
                 "mode in Passivbot. "

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -236,6 +236,7 @@ class ReasonCodes:
     CONFIG_MARKET_UNSUPPORTED = "config_market_unsupported"
     CONFIG_STOCK_PERP_WRONG_EXCHANGE = "config_stock_perp_wrong_exchange"
     CONFIG_STOCK_PERP_UNAVAILABLE_MARKET = "config_stock_perp_unavailable_market"
+    CONFIG_HIP3_ACCOUNT_MODE_UNSUPPORTED = "config_hip3_account_mode_unsupported"
     RECENT_EXECUTION = "recent_execution"
     REMOTE_FETCH = "remote_fetch"
     RISK_ENTRY_COOLDOWN_POSITION_DELTA = "entry_cooldown_position_delta"

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -2170,6 +2170,95 @@ def emit_forager_eligibility_changed_event(
 _MARKET_COMPATIBILITY_SAMPLE_LIMIT = 12
 _MARKET_COMPATIBILITY_SYMBOL_MAX_LEN = 160
 _STOCK_PERP_PREFIXES = ("xyz:", "xyz-")
+_HIP3_ACCOUNT_MODE_FLUSH_TIMEOUT_S = 0.1
+
+
+def _bounded_market_symbol_summary(symbols: Any) -> dict[str, Any]:
+    raw_symbols = sorted({str(symbol) for symbol in (symbols or []) if symbol})
+    safe_symbols = [
+        _sanitize_remote_text(
+            symbol,
+            max_len=_MARKET_COMPATIBILITY_SYMBOL_MAX_LEN,
+        )
+        for symbol in raw_symbols[:_MARKET_COMPATIBILITY_SAMPLE_LIMIT]
+    ]
+    return {
+        "count": len(raw_symbols),
+        "sample": safe_symbols,
+        "truncated": len(raw_symbols) > _MARKET_COMPATIBILITY_SAMPLE_LIMIT,
+    }
+
+
+def _flush_live_event_pipeline_after_terminal_emit(bot: Any) -> None:
+    pipeline = getattr(bot, "_live_event_pipeline", None)
+    flush = getattr(pipeline, "flush", None)
+    if not callable(flush):
+        return
+    try:
+        flush(timeout=_HIP3_ACCOUNT_MODE_FLUSH_TIMEOUT_S)
+    except Exception as exc:
+        logging.debug(
+            "[event] terminal market compatibility flush failed: %s",
+            type(exc).__name__,
+        )
+
+
+def _emit_hip3_account_mode_unsupported_event_unchecked(
+    bot: Any,
+    *,
+    account_abstraction: Any,
+    action: str,
+    approved_symbols: Any,
+    position_symbols: Any,
+    open_order_symbols: Any,
+    isolated_only_symbols: Any,
+    live_isolated_symbols: Any,
+) -> bool:
+    emitted = _safe_emit(
+        bot,
+        EventTypes.CONFIG_MARKET_COMPATIBILITY,
+        level="error",
+        component="config.market_compatibility",
+        tags=(
+            EventTags.MARKET,
+            EventTags.ACCOUNT,
+            EventTags.MODE,
+            EventTags.AVAILABILITY,
+        ),
+        cycle_id=current_live_event_cycle_id(bot),
+        status="failed",
+        reason_code=ReasonCodes.CONFIG_HIP3_ACCOUNT_MODE_UNSUPPORTED,
+        data={
+            "account_abstraction": _sanitize_remote_text(
+                account_abstraction or "unknown",
+                max_len=96,
+            ),
+            "action": _sanitize_remote_text(action, max_len=96),
+            "approved_symbols": _bounded_market_symbol_summary(approved_symbols),
+            "position_symbols": _bounded_market_symbol_summary(position_symbols),
+            "open_order_symbols": _bounded_market_symbol_summary(open_order_symbols),
+            "isolated_only_symbols": _bounded_market_symbol_summary(isolated_only_symbols),
+            "live_isolated_symbols": _bounded_market_symbol_summary(live_isolated_symbols),
+        },
+        require_enqueue=True,
+    )
+    if emitted is not None:
+        _flush_live_event_pipeline_after_terminal_emit(bot)
+    return emitted is not None
+
+
+def emit_hip3_account_mode_unsupported_event(
+    bot: Any, *args: Any, **kwargs: Any
+) -> bool:
+    """Best-effort terminal visibility for unsupported Hyperliquid HIP-3 account state."""
+    try:
+        return _emit_hip3_account_mode_unsupported_event_unchecked(bot, *args, **kwargs)
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit HIP-3 account-mode compatibility event: %s",
+            type(exc).__name__,
+        )
+        return False
 
 
 def _market_compatibility_reason(symbol: str, exchange: str) -> str:

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -194,6 +194,13 @@ PROBLEM_EVENT_DATA_KEYS: dict[str, tuple[str, ...]] = {
         "skipped_count",
         "skipped_symbols",
         "reason_counts",
+        "account_abstraction",
+        "action",
+        "approved_symbols",
+        "position_symbols",
+        "open_order_symbols",
+        "isolated_only_symbols",
+        "live_isolated_symbols",
     ),
     EventTypes.CYCLE_DEGRADED: ("details", "authoritative_epoch"),
     EventTypes.EMA_UNAVAILABLE: (

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -668,6 +668,9 @@ class Passivbot:
     _emit_config_market_compatibility_event = (
         live_event_emitters.emit_config_market_compatibility_event
     )
+    _emit_hip3_account_mode_unsupported_event = (
+        live_event_emitters.emit_hip3_account_mode_unsupported_event
+    )
     _emit_forager_selection_event = live_event_emitters.emit_forager_selection_event
     _emit_ema_bundle_started_event = live_event_emitters.emit_ema_bundle_started_event
     _emit_ema_bundle_completed_event = live_event_emitters.emit_ema_bundle_completed_event

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -98,6 +98,10 @@ def test_live_event_reason_code_registry_values_are_unique_and_query_safe():
         ReasonCodes.CONFIG_STOCK_PERP_UNAVAILABLE_MARKET
         == "config_stock_perp_unavailable_market"
     )
+    assert (
+        ReasonCodes.CONFIG_HIP3_ACCOUNT_MODE_UNSUPPORTED
+        == "config_hip3_account_mode_unsupported"
+    )
     assert authoritative_reason_code("balance") == "authoritative_balance"
     assert sink_failed_reason_code("monitor") == "monitor_sink_failed"
     assert len(values) == len(set(values))
@@ -271,6 +275,8 @@ def test_route_table_keeps_data_events_off_console_by_default():
         assert DEFAULT_ROUTES[event_type].monitor is True
         assert DEFAULT_ROUTES[event_type].console is False
         assert DEFAULT_ROUTES[event_type].text is False
+    assert DEFAULT_ROUTES[EventTypes.CONFIG_MARKET_COMPATIBILITY].structured is True
+    assert DEFAULT_ROUTES[EventTypes.CONFIG_MARKET_COMPATIBILITY].monitor is True
     assert DEFAULT_ROUTES[EventTypes.ORDER_WAVE_COMPLETED].console is True
     assert DEFAULT_ROUTES[EventTypes.ORDER_WAVE_COMPLETED].text is True
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CREATE_DEFERRED].console is False

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1838,6 +1838,52 @@ def test_live_smoke_report_problem_events_include_market_compatibility_data(tmp_
     }
 
 
+def test_live_smoke_report_projects_safe_hip3_account_mode_compatibility_data(tmp_path):
+    events_dir = tmp_path / "monitor" / "hyperliquid" / "hl_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="config.market_compatibility",
+                seq=1,
+                ts=1000,
+                exchange="hyperliquid",
+                user="hl_01",
+                status="failed",
+                level="error",
+                reason_code="config_hip3_account_mode_unsupported",
+                data={
+                    "account_abstraction": "unknown",
+                    "action": "fatal_live_state_rejected",
+                    "approved_symbols": {"count": 1, "sample": ["xyz:TSLA"], "truncated": False},
+                    "position_symbols": {"count": 0, "sample": [], "truncated": False},
+                    "open_order_symbols": {"count": 1, "sample": ["xyz:SP500"], "truncated": False},
+                    "isolated_only_symbols": {"count": 2, "sample": ["xyz:SP500", "xyz:TSLA"], "truncated": False},
+                    "live_isolated_symbols": {"count": 1, "sample": ["xyz:SP500"], "truncated": False},
+                    "order_ids": ["must_not_surface"],
+                    "config_path": "/private/secret.json",
+                    "error": "free form exception text",
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    assert report["ok"] is False
+    event = report["problem_events"][0]
+    assert event["hard"] is True
+    assert event["latest_data"] == {
+        "account_abstraction": "unknown",
+        "action": "fatal_live_state_rejected",
+        "approved_symbols": {"count": 1, "sample": ["xyz:TSLA"], "truncated": False},
+        "position_symbols": {"count": 0, "truncated": False},
+        "open_order_symbols": {"count": 1, "sample": ["xyz:SP500"], "truncated": False},
+        "isolated_only_symbols": {"count": 2, "sample": ["xyz:SP500", "xyz:TSLA"], "truncated": False},
+        "live_isolated_symbols": {"count": 1, "sample": ["xyz:SP500"], "truncated": False},
+    }
+
+
 def test_live_smoke_report_summarizes_ema_readiness_health(tmp_path):
     events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
     _write_ndjson(

--- a/tests/test_stock_perps.py
+++ b/tests/test_stock_perps.py
@@ -530,12 +530,48 @@ class TestHyperliquidBotHIP3:
                 "marginModes": {"cross": False, "isolated": True},
             }
         }
+        bot._requires_isolated_margin = MagicMock(
+            side_effect=AssertionError("approved-only diagnostics must not recompute policy")
+        )
+        emitted = []
+        pipeline = MagicMock()
+        pipeline.emit.side_effect = lambda event, *, require_enqueue: (
+            emitted.append((event, require_enqueue)) or event
+        )
+        bot._live_event_pipeline = pipeline
 
         with pytest.raises(
             FatalBotException,
             match="require unifiedAccount or portfolioMargin mode",
-        ):
+        ) as exc_info:
             bot._assert_supported_live_state()
+
+        assert str(exc_info.value) == (
+            "Hyperliquid HIP-3/non-standard perps require unifiedAccount or portfolioMargin "
+            "mode in Passivbot. Current abstraction=unknown. Unsupported HIP-3 state detected: "
+            "approved_coins=xyz:TSLA. Upgrade the Hyperliquid account to unifiedAccount/"
+            "portfolioMargin or remove all HIP-3 symbols, positions, and open orders before "
+            "running the bot."
+        )
+
+        assert len(emitted) == 1
+        event, require_enqueue = emitted[0]
+        assert require_enqueue is True
+        assert event.event_type == "config.market_compatibility"
+        assert event.level == "error"
+        assert event.status == "failed"
+        assert event.reason_code == "config_hip3_account_mode_unsupported"
+        assert event.data == {
+            "account_abstraction": "unknown",
+            "action": "fatal_live_state_rejected",
+            "approved_symbols": {"count": 1, "sample": ["xyz:TSLA/USDC:USDC"], "truncated": False},
+            "position_symbols": {"count": 0, "sample": [], "truncated": False},
+            "open_order_symbols": {"count": 0, "sample": [], "truncated": False},
+            "isolated_only_symbols": {"count": 0, "sample": [], "truncated": False},
+            "live_isolated_symbols": {"count": 0, "sample": [], "truncated": False},
+        }
+        pipeline.flush.assert_called_once_with(timeout=0.1)
+        bot._requires_isolated_margin.assert_not_called()
 
     def test_isolated_only_hip3_open_orders_hard_fail(self, bot_class):
         bot = object.__new__(bot_class)
@@ -555,13 +591,149 @@ class TestHyperliquidBotHIP3:
             }
         }
         bot.open_orders = {"xyz:SP500/USDC:USDC": [{"id": "1"}]}
-        bot._hl_live_margin_modes = {}
+        bot._hl_live_margin_modes = {"xyz:SP500/USDC:USDC": "isolated"}
         bot._hl_unified_enabled = False
         bot._hl_user_abstraction = "unknown"
         bot.approved_coins_minus_ignored_coins = {"long": set(), "short": set()}
+        emitted = []
+        pipeline = MagicMock()
+        pipeline.emit.side_effect = lambda event, *, require_enqueue: (
+            emitted.append((event, require_enqueue)) or event
+        )
+        bot._live_event_pipeline = pipeline
 
         with pytest.raises(FatalBotException, match="Unsupported HIP-3 state detected"):
             bot._assert_supported_live_state()
+
+        event, require_enqueue = emitted[0]
+        assert require_enqueue is True
+        assert event.data["approved_symbols"]["count"] == 0
+        assert event.data["position_symbols"] == {
+            "count": 0,
+            "sample": [],
+            "truncated": False,
+        }
+        assert event.data["open_order_symbols"] == {
+            "count": 1,
+            "sample": ["xyz:SP500/USDC:USDC"],
+            "truncated": False,
+        }
+        assert event.data["isolated_only_symbols"]["count"] == 1
+        assert event.data["live_isolated_symbols"] == {
+            "count": 1,
+            "sample": ["xyz:SP500/USDC:USDC"],
+            "truncated": False,
+        }
+        pipeline.flush.assert_called_once_with(timeout=0.1)
+
+    def test_hip3_account_mode_event_payload_is_bounded_and_pre_redacted(self):
+        from live import event_emitters
+
+        bot = types.SimpleNamespace()
+        emitted = []
+        pipeline = MagicMock()
+        pipeline.emit.side_effect = lambda event, *, require_enqueue: (
+            emitted.append((event, require_enqueue)) or event
+        )
+        bot._live_event_pipeline = pipeline
+        bot._emit_live_event = lambda event_type, **kwargs: event_emitters.emit_live_event(
+            bot, event_type, **kwargs
+        )
+
+        assert event_emitters.emit_hip3_account_mode_unsupported_event(
+            bot,
+            account_abstraction="api_key=account-secret",
+            action="fatal_live_state_rejected",
+            approved_symbols=[f"xyz:SYM{i}" for i in range(14)],
+            position_symbols=["xyz:api_key=position-secret"],
+            open_order_symbols=["xyz:SP500"],
+            isolated_only_symbols=["xyz:SP500"],
+            live_isolated_symbols=[],
+        )
+
+        event, require_enqueue = emitted[0]
+        assert require_enqueue is True
+        assert event.data["account_abstraction"] == "api_key=[redacted]"
+        assert event.data["approved_symbols"]["count"] == 14
+        assert len(event.data["approved_symbols"]["sample"]) == 12
+        assert event.data["approved_symbols"]["truncated"] is True
+        assert event.data["position_symbols"]["sample"] == ["xyz:api_key=[redacted]"]
+        assert not {"order_ids", "sizes", "prices", "raw_payload", "config_path"} & set(
+            event.data
+        )
+        pipeline.flush.assert_called_once_with(timeout=0.1)
+
+    def test_hip3_account_mode_event_flushes_real_pipeline_before_fatal_raise(self, bot_class):
+        from live.event_bus import ListEventSink, LiveEventPipeline
+
+        bot = object.__new__(bot_class)
+        bot.HIP3_PREFIX = bot_class.HIP3_PREFIX
+        bot.HIP3_ALT_PREFIXES = bot_class.HIP3_ALT_PREFIXES
+        bot._hl_unified_enabled = False
+        bot._hl_user_abstraction = "unknown"
+        bot.approved_coins_minus_ignored_coins = {
+            "long": {"xyz:TSLA/USDC:USDC"},
+            "short": set(),
+        }
+        bot.positions = {}
+        bot.open_orders = {}
+        bot.markets_dict = {
+            "xyz:TSLA/USDC:USDC": {
+                "baseName": "xyz:TSLA",
+                "info": {"onlyIsolated": True},
+                "marginModes": {"cross": False, "isolated": True},
+            }
+        }
+        structured = ListEventSink()
+        bot._live_event_pipeline = LiveEventPipeline(structured_sinks=[structured])
+
+        with pytest.raises(FatalBotException):
+            bot._assert_supported_live_state()
+
+        assert len(structured.events) == 1
+        assert structured.events[0].reason_code == (
+            "config_hip3_account_mode_unsupported"
+        )
+        assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+    @pytest.mark.parametrize("failure_stage", ["enqueue", "flush"])
+    def test_hip3_account_mode_event_failures_do_not_replace_fatal_raise(
+        self, bot_class, failure_stage
+    ):
+        bot = object.__new__(bot_class)
+        bot.HIP3_PREFIX = bot_class.HIP3_PREFIX
+        bot.HIP3_ALT_PREFIXES = bot_class.HIP3_ALT_PREFIXES
+        bot._hl_unified_enabled = False
+        bot._hl_user_abstraction = "unknown"
+        bot.approved_coins_minus_ignored_coins = {"long": {"xyz:TSLA/USDC:USDC"}, "short": set()}
+        bot.positions = {}
+        bot.open_orders = {}
+        bot.markets_dict = {
+            "xyz:TSLA/USDC:USDC": {
+                "baseName": "xyz:TSLA",
+                "info": {"onlyIsolated": True},
+                "marginModes": {"cross": False, "isolated": True},
+            }
+        }
+        pipeline = MagicMock()
+        if failure_stage == "enqueue":
+            pipeline.emit.side_effect = RuntimeError("enqueue failure")
+        else:
+            pipeline.emit.side_effect = lambda event, *, require_enqueue: event
+            pipeline.flush.side_effect = RuntimeError("flush failure")
+        bot._live_event_pipeline = pipeline
+
+        with pytest.raises(
+            FatalBotException,
+            match="require unifiedAccount or portfolioMargin mode",
+        ):
+            bot._assert_supported_live_state()
+
+        pipeline.emit.assert_called_once()
+        if failure_stage == "enqueue":
+            pipeline.flush.assert_not_called()
+        else:
+            pipeline.flush.assert_called_once_with(timeout=0.1)
 
     @pytest.mark.asyncio
     async def test_fetch_open_orders_queries_explicit_hip3_symbol_with_symbol_scope(self, bot_class):


### PR DESCRIPTION
## Scope

Category: observability producer.

Before the existing Hyperliquid non-unified HIP-3 startup guard raises `FatalBotException`, emit one bounded `config.market_compatibility` event with reason `config_hip3_account_mode_unsupported` and wait at most 0.1 seconds for the required-enqueue event to flush.

The payload contains only redacted/bounded account abstraction, stable action, and count/sample summaries for approved, position, open-order, isolated-only, and live-isolated symbols. It remains off console/text routes and is projected through the existing generic smoke problem-event surface.

## Non-goals

- No fatal decision or exception-message change
- No account abstraction detection, market/margin policy, or exchange call
- No configured-coin or generic isolated-only entry filtering change
- No process control, HSL/risk/order behavior, Rust, backtest, or optimizer change

## Validation

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_stock_perps.py tests/test_live_smoke_report.py tests/test_live_event_bus.py tests/test_live_event_registry_docs.py` (184 passed)
- Python compilation for changed runtime/tests passed
- `git diff --check` passed
- Independent Luna integrated preflight: green

Regression coverage proves the fatal text/decision is preserved, approved-only diagnostics do not recompute isolated-margin policy, enqueue/flush failures cannot replace the fatal error, and a real event pipeline makes the terminal event visible before the raise.

## Reviewer focus

Please verify on exact head `363eca8526f4d2be1cbb7b153cf88e120feec5e6` that observability adds no metadata/policy/exchange call before the existing fatal path, payloads are safely bounded/redacted, and the best-effort terminal flush cannot weaken the fatal contract.

## VPS action

After merge: pull while preserving artifacts, restart only the exact supervised Hyperliquid pane, then run immediate and settled bounded smoke checks. The production account is unified, so healthy startup should not emit this fatal compatibility event.