### PR TITLE
Expose HSL replay scan throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Coin-mode HSL replay progress now separates scanned candidate rows from
+  applied state-update rows. Live performance and smoke reports use scan
+  throughput for remaining-work estimates when available, retain explicit
+  legacy applied-row fallback labeling for older events, and do not change HSL
+  replay ordering, readiness, or trading behavior.
+
 - Isolated-only markets excluded from new entries by cross-margin preference
   now emit bounded per-side `config.market_compatibility` events while
   preserving the existing filter and warning behavior.

--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -105,9 +105,13 @@ rejections are non-authoritative performance-cache outcomes and should fall
 back to exchange-derived replay.
 
 Coin mode emits one `hsl.replay.progress` event with `stage=pair_replay` when
-the first frozen replay candidate starts, then keeps subsequent pair progress
-time-throttled. `is_held_pair`, `is_cooldown_pair`, and `pair_idx` expose the
-deterministic held/cooldown/remaining ordering without controlling it.
+the first frozen replay candidate starts, keeps in-pair progress time-throttled,
+and emits one terminal progress sample for each pair. `applied_rows` and
+`total_applied_rows` retain state-update counts; `scanned_rows`,
+`total_scanned_rows`, `scanned_rows_per_second`, and `pair_elapsed_s` expose
+candidate-row scan cost, including pairs which apply no rows. `is_held_pair`,
+`is_cooldown_pair`, and `pair_idx` expose the deterministic
+held/cooldown/remaining ordering without controlling it.
 After the held batch completes, `stage=held_protective_ready` exposes bounded
 `ready_pairs`, `pending_pairs`, and `protective_elapsed_s` fields. Remaining
 pairs continue in the same replay task; `hsl.replay.completed` remains the

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,53 +22,23 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR and publication state: query live GitHub metadata;
-  `Record isolated-only entry filtering`
-- Branch: `codex/v8-isolated-market-compatibility-events`
-- Head: query live GitHub metadata; this commit cannot embed its own final SHA
-  without making that value stale
-- Base: `bd16974743d5dc4bfd25491d052e62e90ecc3982`
-- Scope: when the existing generic CCXT margin-policy filter excludes an
-  isolated-only symbol from new entries under cross-margin preference, emit one
-  bounded, per-side, off-console/off-text `config.market_compatibility` event.
-  Keep warning and event dedupe independent so a failed enqueue retries without
-  duplicating the existing text warning.
-- Triggering evidence: `_filter_approved_symbols()` already emits a once-per-
-  process warning for the exact compatibility decision, but durable structured
-  history cannot answer which side/symbols were blocked or distinguish this
-  decision from an unavailable exchange market.
-- Non-goals: no margin capability/preference resolution, metadata or exchange
-  call, approved-symbol result, existing-position/order manageability, warning,
-  smoke verdict, process control, HSL/risk/order behavior, Rust, backtest, or
-  optimizer change.
-- Local validation: the focused margin-filter, CCXT contract-helper, event-bus,
-  smoke projection, and registry-doc suite passes with 213 tests; Python
-  compilation and `git diff --check` pass. Added-line silent handling is
-  limited to the explicitly best-effort event producer/caller guards. Luna's
-  first preflight found the manual `build_contract_bot()` initialization gap;
-  the explicit initializer and regression resolve it, and delta review found
-  no code regressions. Terra implemented the isolated producer/tests; Sol owns
-  the event contract, final preflight, and publication.
-- Publication state, exact head, mergeability, CI, and current-head review
-  verdicts: query live GitHub metadata. Do not encode those transient values in
-  the same PR that contains this status file, because every correction would
-  create a different head and immediately stale the embedded value.
-- Expected VPS action: after exact-head approval and merge, pull while
-  preserving local artifacts, restart the five exact supervised bot panes
-  because the producer is in shared CCXT filtering, query any emitted
-  compatibility records, and run immediate plus settled smoke checks.
+- PR #1189, `Record isolated-only entry filtering`, merged as
+  `ff1b2c1f9ee9968a4e46f3ba598f3c7f091efe42` and was deployed to VPS5.
+- Deployment smoke was green with all five supervised bots present and the
+  unrelated `misc` process preserved. The new isolated-only reason had zero
+  production matches because current configs do not exercise it.
 
 Next action:
 
-1. Complete the bounded isolated-only entry-filter producer and regressions,
-   obtain independent preflight plus exact-head reviewers and CI, resolve
-   verified findings, and merge only when the full gate is green.
+1. Review HSL replay scan-throughput observability: add scanned-row counters
+   and scan-rate reporting, and correct ETA estimators while preserving replay
+   behavior and existing applied-row metrics.
 
 ## Deployed Baseline
 
-- Remote `v8`: `bd169747`, PR #1188
-- VPS5 repository: `bd169747`, PR #1188; tracked status clean
-- VPS5 expected bots: five; all running after the Hyperliquid-only restart
+- Remote `v8`: `ff1b2c1f9ee9968a4e46f3ba598f3c7f091efe42`, PR #1189
+- VPS5 repository: `ff1b2c1f9ee9968a4e46f3ba598f3c7f091efe42`, PR #1189; tracked status clean
+- VPS5 expected bots: five; all running after the shared-code five-pane restart
 - PR #1188 was approved on exact head `363eca852` by Hermes and Grok 4.5;
   CI passed and it merged as `bd169747`. VPS5 fast-forwarded cleanly and
   gracefully restarted only `passivbot:4.0`; Hyperliquid bot PID `842779` was
@@ -149,11 +119,12 @@ current process-pressure query, compact cold replay payload, bounded replay
 scorecard, stable per-pair fill index, exact sparse flat-pair replay, and the
 rotated resource-pressure report fix, configured-market skip events, and fatal
 HIP-3 startup compatibility are merged and deployed. The active slice makes
-the remaining isolated-only initial-entry filter visible in durable structured
-history.
+the isolated-only initial-entry filter visible in durable structured history.
 Remaining candidates:
 
-- deeper internal-stage profiling if live residual cost remains material
+- HSL replay scan-throughput observability: scanned-row counters and rates plus
+  corrected ETA estimators, while preserving replay behavior and existing
+  applied-row metrics. This is selected for review; it is not yet complete.
 - bounded operator tooling improvements sharing one code and validation surface
 
 Do not create progress-only PRs or resume unrelated logging work from stale

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -139,13 +139,15 @@ The coin-HSL protective-readiness split, cooperative background cadence,
 current process-pressure query, compact cold replay payload, bounded replay
 scorecard, stable per-pair fill index, exact sparse flat-pair replay, and the
 rotated resource-pressure report fix, configured-market skip events, and fatal
-HIP-3 startup compatibility are merged and deployed. The active slice makes
-the isolated-only initial-entry filter visible in durable structured history.
-Remaining candidates:
+HIP-3 startup compatibility are merged and deployed. PR #1189's isolated-only
+initial-entry filter visibility is also merged and deployed. Active PR #1190
+implements HSL replay scanned-row throughput and corrected ETA projections; it
+is under exact-head review and is not yet merged or deployed.
 
-- HSL replay scan-throughput observability: scanned-row counters and rates plus
-  corrected ETA estimators, while preserving replay behavior and existing
-  applied-row metrics. This is selected for review; it is not yet complete.
+Do not begin a dependent next slice until PR #1190 is merged and its VPS5
+restart/query/smoke boundary is validated. After that evidence is recorded,
+select the next review-worthy candidate from the remaining backlog, including:
+
 - bounded operator tooling improvements sharing one code and validation surface
 
 Do not create progress-only PRs or resume unrelated logging work from stale

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,17 +22,38 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1189, `Record isolated-only entry filtering`, merged as
-  `ff1b2c1f9ee9968a4e46f3ba598f3c7f091efe42` and was deployed to VPS5.
-- Deployment smoke was green with all five supervised bots present and the
-  unrelated `misc` process preserved. The new isolated-only reason had zero
-  production matches because current configs do not exercise it.
+- PR #1190, `Expose HSL replay scan throughput`
+- Branch: `codex/v8-hsl-replay-scan-profile`
+- Base: `ff1b2c1f9ee9968a4e46f3ba598f3c7f091efe42`
+- Scope: expose per-pair and cumulative replay candidate rows scanned
+  separately from HSL state-update rows applied; make performance and smoke
+  ETA projections prefer scanned-row throughput; retain explicit legacy
+  applied-row fallback and exact terminal candidate-work estimates.
+- Behavior boundary: no replay candidate ordering, row application, yield
+  cadence, protective readiness, risk state, exchange call, Rust/order logic,
+  or trading behavior change. Each pair emits one bounded terminal progress
+  sample so halted and zero-apply scan work remains observable.
+- Validation: the focused HSL coin-mode, replay-benchmark, performance-report,
+  smoke-report, event-registry, incident-bundle, and restart-smoke suites pass.
+  Eight real fake-live HSL scenarios pass. Python compilation,
+  `git diff --check`, and the added-line silent-handling scan pass. Independent
+  preflight findings for halted-pair terminal progress and completed sparse
+  candidate-work estimates are resolved with regressions.
+- Publication state, exact head, mergeability, CI, and current-head reviewer
+  verdicts: query live GitHub metadata. Do not embed transient head or gate
+  values in this PR because doing so would immediately invalidate them.
+- Expected VPS action: after exact-head approval and merge, pull while
+  preserving local artifacts, restart the five exact supervised bot panes
+  because the HSL producer is shared live Python, preserve unrelated
+  `misc:0.0`, then query replay progress/completion scan fields and run
+  immediate plus settled smoke checks.
 
 Next action:
 
-1. Review HSL replay scan-throughput observability: add scanned-row counters
-   and scan-rate reporting, and correct ETA estimators while preserving replay
-   behavior and existing applied-row metrics.
+1. Resolve any verified current-head findings. Merge only after the temporary
+   Hermes + Grok 4.5 + green-CI gate is satisfied on the same exact head, then
+   deploy and validate the expected replay fields and process boundaries on
+   VPS5.
 
 ## Deployed Baseline
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,19 +19,20 @@ Last updated: 2026-07-11.
 
 Current `origin/v8` head:
 
-- `77e111f7` after PR #1181, `Expose HSL replay readiness scorecard`.
+- `ff1b2c1f9ee9968a4e46f3ba598f3c7f091efe42` after PR #1189, `Record
+  isolated-only entry filtering`.
 
 Current logging-overhaul head:
 
-- `77e111f7` after PR #1181, `Expose HSL replay readiness scorecard`
-  (latest merged logging-overhaul slice).
+- `ff1b2c1f9ee9968a4e46f3ba598f3c7f091efe42` after PR #1189, `Record
+  isolated-only entry filtering` (latest merged logging-overhaul slice).
 
 Current work:
 
-- Branch `codex/v8-hsl-replay-scorecard-completion-fallback` makes the
-  protective elapsed aggregate use retained completion evidence when the
-  dedicated readiness milestone has rotated out of the selected event files.
-  It consumes existing events only and does not change HSL or live behavior.
+- Active review-worthy slice: HSL replay scan-throughput observability, adding
+  scanned-row counters and scan-rate reporting and correcting ETA estimators
+  while preserving replay behavior and existing applied-row metrics. This
+  slice is not yet merged or deployed.
 
 Current review gate:
 
@@ -61,6 +62,12 @@ Retuned goal boundary:
   with explicit no-SSH/no-merge boundaries.
 
 VPS5 deployment status:
+
+- PR #1189 merged to `v8` as
+  `ff1b2c1f9ee9968a4e46f3ba598f3c7f091efe42` and was deployed to VPS5. The
+  deployment smoke was green with all five supervised bots present and the
+  unrelated `misc` process preserved. The new isolated-only reason had zero
+  production matches because current configs do not exercise it.
 
 - PR #1181 merged to `v8` as `77e111f7` after exact-head Hermes and Grok 4.5
   green reviews plus green CI. VPS5 pulled cleanly without restarting bots; all

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1605,6 +1605,7 @@ def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
     out: dict[str, Any] = {}
     dense_work: int | None = None
     required_work: int | None = None
+    candidate_work: int | None = None
     if timeline_rows is not None and pairs is not None:
         dense_work = int(timeline_rows) * int(pairs)
         out["estimated_dense_pair_row_work"] = dense_work
@@ -1623,6 +1624,18 @@ def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
         out["estimated_held_pair_row_work"] = int(timeline_rows) * int(held_pairs)
     if timeline_rows is not None and cooldown_pairs is not None:
         out["estimated_cooldown_pair_row_work"] = int(timeline_rows) * int(cooldown_pairs)
+    if data.get("stage") == "full_replay":
+        candidate_value = _non_negative_number(data.get("candidate_rows"))
+        if candidate_value is not None:
+            candidate_work = int(candidate_value)
+            out["estimated_candidate_pair_row_work"] = candidate_work
+            if observed_rows is not None and candidate_work > 0:
+                out["observed_candidate_work_pct"] = _rounded_float(
+                    min(
+                        100.0,
+                        max(0.0, 100.0 * float(observed_rows) / float(candidate_work)),
+                    )
+                )
     if observed_applied_rows is not None:
         out["observed_applied_rows"] = int(observed_applied_rows)
     observed_scanned_rows = _non_negative_number(data.get("total_scanned_rows"))
@@ -1654,11 +1667,33 @@ def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
         )
         if required_remaining_ms is not None:
             out["estimated_required_remaining_ms"] = required_remaining_ms
-    primary_remaining_rows = (
-        required_remaining_rows
-        if required_remaining_rows is not None
-        else dense_remaining_rows
+    candidate_remaining_rows = _hsl_replay_remaining_rows(
+        estimated_work=candidate_work,
+        observed_rows=observed_rows,
     )
+    if candidate_remaining_rows is not None:
+        out["estimated_candidate_remaining_rows"] = candidate_remaining_rows
+        candidate_remaining_ms = _hsl_replay_eta_ms(
+            remaining_rows=candidate_remaining_rows,
+            rows_per_second=throughput_rate,
+        )
+        if candidate_remaining_ms is not None:
+            out["estimated_candidate_remaining_ms"] = candidate_remaining_ms
+    primary_remaining_rows = (
+        candidate_remaining_rows
+        if candidate_remaining_rows is not None
+        else (
+            required_remaining_rows
+            if required_remaining_rows is not None
+            else dense_remaining_rows
+        )
+    )
+    if candidate_remaining_rows is not None:
+        out["work_estimate_source"] = "candidate_rows_terminal"
+    elif required_remaining_rows is not None:
+        out["work_estimate_source"] = "required_dense_rows"
+    elif dense_remaining_rows is not None:
+        out["work_estimate_source"] = "dense_rows"
     if primary_remaining_rows is not None:
         out["estimated_remaining_rows"] = primary_remaining_rows
         primary_remaining_ms = _hsl_replay_eta_ms(

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -163,6 +163,7 @@ _HSL_REPLAY_NUMERIC_FIELDS = (
     "record_start_ts",
     "pair_idx",
     "applied_rows",
+    "scanned_rows",
     "candidate_rows",
     "dense_equivalent_rows",
     "candidate_reduction_pct",
@@ -170,9 +171,12 @@ _HSL_REPLAY_NUMERIC_FIELDS = (
     "dense_fallback_pairs",
     "sparse_replay_pairs",
     "total_applied_rows",
+    "total_scanned_rows",
     "rows",
     "skipped_pairs",
     "rows_per_second",
+    "scanned_rows_per_second",
+    "pair_elapsed_s",
     "elapsed_s",
     "history_build_elapsed_s",
     "price_history_fetch_elapsed_s",
@@ -1241,9 +1245,13 @@ class _StartupReadinessAccumulator:
                 "required_pairs",
                 "timeline_rows",
                 "applied_rows",
+                "scanned_rows",
                 "total_applied_rows",
+                "total_scanned_rows",
                 "skipped_pairs",
                 "rows_per_second",
+                "scanned_rows_per_second",
+                "pair_elapsed_s",
                 "elapsed_s",
                 "full_elapsed_s",
                 "startup_blocking_elapsed_s",
@@ -1539,12 +1547,26 @@ def _usage_pct(value: int | None, budget: int | None) -> int | None:
     return int(round(float(value) * 100.0 / float(budget)))
 
 
-def _hsl_replay_observed_rows(data: dict[str, Any]) -> int | None:
+def _hsl_replay_observed_applied_rows(data: dict[str, Any]) -> int | None:
     for key in ("total_applied_rows", "applied_rows", "rows"):
         value = _non_negative_number(data.get(key))
         if value is not None:
             return int(value)
     return None
+
+
+def _hsl_replay_work_observation(
+    data: dict[str, Any],
+) -> tuple[int | None, Any, str | None]:
+    scanned_rows = _non_negative_number(data.get("total_scanned_rows"))
+    if scanned_rows is not None:
+        return int(scanned_rows), data.get("scanned_rows_per_second"), "scanned_rows"
+    applied_rows = _hsl_replay_observed_applied_rows(data)
+    return (
+        applied_rows,
+        data.get("rows_per_second"),
+        "applied_rows_legacy" if applied_rows is not None else None,
+    )
 
 
 def _hsl_replay_remaining_rows(
@@ -1576,7 +1598,10 @@ def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
     required_pairs = _non_negative_number(data.get("required_pairs"))
     held_pairs = _non_negative_number(data.get("held_pairs"))
     cooldown_pairs = _non_negative_number(data.get("cooldown_pairs"))
-    observed_rows = _hsl_replay_observed_rows(data)
+    observed_applied_rows = _hsl_replay_observed_applied_rows(data)
+    observed_rows, throughput_rate, throughput_source = _hsl_replay_work_observation(
+        data
+    )
     out: dict[str, Any] = {}
     dense_work: int | None = None
     required_work: int | None = None
@@ -1598,8 +1623,13 @@ def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
         out["estimated_held_pair_row_work"] = int(timeline_rows) * int(held_pairs)
     if timeline_rows is not None and cooldown_pairs is not None:
         out["estimated_cooldown_pair_row_work"] = int(timeline_rows) * int(cooldown_pairs)
-    if observed_rows is not None:
-        out["observed_applied_rows"] = int(observed_rows)
+    if observed_applied_rows is not None:
+        out["observed_applied_rows"] = int(observed_applied_rows)
+    observed_scanned_rows = _non_negative_number(data.get("total_scanned_rows"))
+    if observed_scanned_rows is not None:
+        out["observed_scanned_rows"] = int(observed_scanned_rows)
+    if throughput_source is not None:
+        out["throughput_source"] = throughput_source
     dense_remaining_rows = _hsl_replay_remaining_rows(
         estimated_work=dense_work,
         observed_rows=observed_rows,
@@ -1608,7 +1638,7 @@ def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
         out["estimated_dense_remaining_rows"] = dense_remaining_rows
         dense_remaining_ms = _hsl_replay_eta_ms(
             remaining_rows=dense_remaining_rows,
-            rows_per_second=data.get("rows_per_second"),
+            rows_per_second=throughput_rate,
         )
         if dense_remaining_ms is not None:
             out["estimated_dense_remaining_ms"] = dense_remaining_ms
@@ -1620,7 +1650,7 @@ def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
         out["estimated_required_remaining_rows"] = required_remaining_rows
         required_remaining_ms = _hsl_replay_eta_ms(
             remaining_rows=required_remaining_rows,
-            rows_per_second=data.get("rows_per_second"),
+            rows_per_second=throughput_rate,
         )
         if required_remaining_ms is not None:
             out["estimated_required_remaining_ms"] = required_remaining_ms
@@ -1633,7 +1663,7 @@ def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
         out["estimated_remaining_rows"] = primary_remaining_rows
         primary_remaining_ms = _hsl_replay_eta_ms(
             remaining_rows=primary_remaining_rows,
-            rows_per_second=data.get("rows_per_second"),
+            rows_per_second=throughput_rate,
         )
         if primary_remaining_ms is not None:
             out["estimated_remaining_ms"] = primary_remaining_ms

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -4094,10 +4094,14 @@ def _compact_hsl_replay_data(live_event: dict[str, Any]) -> dict[str, Any]:
         "record_start_ts",
         "pair_idx",
         "applied_rows",
+        "scanned_rows",
         "total_applied_rows",
+        "total_scanned_rows",
         "rows",
         "skipped_pairs",
         "rows_per_second",
+        "scanned_rows_per_second",
+        "pair_elapsed_s",
         "elapsed_s",
         "history_build_elapsed_s",
         "price_history_fetch_elapsed_s",
@@ -4112,12 +4116,26 @@ def _compact_hsl_replay_data(live_event: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
-def _hsl_observed_rows(data: dict[str, Any]) -> int | None:
+def _hsl_observed_applied_rows(data: dict[str, Any]) -> int | None:
     for key in ("total_applied_rows", "rows", "applied_rows"):
         value = _non_negative_int(data.get(key))
         if value is not None:
             return value
     return None
+
+
+def _hsl_replay_work_observation(
+    data: dict[str, Any],
+) -> tuple[int | None, Any, str | None]:
+    scanned_rows = _non_negative_int(data.get("total_scanned_rows"))
+    if scanned_rows is not None:
+        return scanned_rows, data.get("scanned_rows_per_second"), "scanned_rows"
+    applied_rows = _hsl_observed_applied_rows(data)
+    return (
+        applied_rows,
+        data.get("rows_per_second"),
+        "applied_rows_legacy" if applied_rows is not None else None,
+    )
 
 
 def _hsl_replay_remaining_rows(
@@ -4152,7 +4170,10 @@ def _hsl_replay_derived(data: dict[str, Any]) -> dict[str, Any]:
     required_pairs = _non_negative_int(data.get("required_pairs"))
     held_pairs = _non_negative_int(data.get("held_pairs"))
     cooldown_pairs = _non_negative_int(data.get("cooldown_pairs"))
-    observed_rows = _hsl_observed_rows(data)
+    observed_applied_rows = _hsl_observed_applied_rows(data)
+    observed_rows, throughput_rate, throughput_source = _hsl_replay_work_observation(
+        data
+    )
     out: dict[str, Any] = {}
     dense_work: int | None = None
     required_work: int | None = None
@@ -4176,8 +4197,13 @@ def _hsl_replay_derived(data: dict[str, Any]) -> dict[str, Any]:
         out["estimated_held_pair_row_work"] = int(timeline_rows) * int(held_pairs)
     if timeline_rows is not None and cooldown_pairs is not None:
         out["estimated_cooldown_pair_row_work"] = int(timeline_rows) * int(cooldown_pairs)
-    if observed_rows is not None:
-        out["observed_applied_rows"] = int(observed_rows)
+    if observed_applied_rows is not None:
+        out["observed_applied_rows"] = int(observed_applied_rows)
+    observed_scanned_rows = _non_negative_int(data.get("total_scanned_rows"))
+    if observed_scanned_rows is not None:
+        out["observed_scanned_rows"] = observed_scanned_rows
+    if throughput_source is not None:
+        out["throughput_source"] = throughput_source
     dense_remaining_rows = _hsl_replay_remaining_rows(
         estimated_work=dense_work,
         observed_rows=observed_rows,
@@ -4186,7 +4212,7 @@ def _hsl_replay_derived(data: dict[str, Any]) -> dict[str, Any]:
         out["estimated_dense_remaining_rows"] = dense_remaining_rows
         dense_remaining_ms = _hsl_replay_eta_ms(
             remaining_rows=dense_remaining_rows,
-            rows_per_second=data.get("rows_per_second"),
+            rows_per_second=throughput_rate,
         )
         if dense_remaining_ms is not None:
             out["estimated_dense_remaining_ms"] = dense_remaining_ms
@@ -4198,7 +4224,7 @@ def _hsl_replay_derived(data: dict[str, Any]) -> dict[str, Any]:
         out["estimated_required_remaining_rows"] = required_remaining_rows
         required_remaining_ms = _hsl_replay_eta_ms(
             remaining_rows=required_remaining_rows,
-            rows_per_second=data.get("rows_per_second"),
+            rows_per_second=throughput_rate,
         )
         if required_remaining_ms is not None:
             out["estimated_required_remaining_ms"] = required_remaining_ms
@@ -4211,7 +4237,7 @@ def _hsl_replay_derived(data: dict[str, Any]) -> dict[str, Any]:
         out["estimated_remaining_rows"] = primary_remaining_rows
         primary_remaining_ms = _hsl_replay_eta_ms(
             remaining_rows=primary_remaining_rows,
-            rows_per_second=data.get("rows_per_second"),
+            rows_per_second=throughput_rate,
         )
         if primary_remaining_ms is not None:
             out["estimated_remaining_ms"] = primary_remaining_ms
@@ -7293,7 +7319,15 @@ def _brief_hsl_replay_active_groups(groups: Any) -> list[dict[str, Any]]:
             "held_pairs": _non_negative_int(data.get("held_pairs")),
             "cooldown_pairs": _non_negative_int(data.get("cooldown_pairs")),
             "total_applied_rows": _non_negative_int(data.get("total_applied_rows")),
+            "total_scanned_rows": _non_negative_int(data.get("total_scanned_rows")),
             "rows_per_second": _numeric_value(data.get("rows_per_second")),
+            "scanned_rows_per_second": _numeric_value(
+                data.get("scanned_rows_per_second")
+            ),
+            "throughput_source": derived.get("throughput_source"),
+            "observed_scanned_rows": _non_negative_int(
+                derived.get("observed_scanned_rows")
+            ),
             "observed_required_work_pct": derived.get("observed_required_work_pct"),
             "observed_work_pct": derived.get("observed_work_pct"),
             "estimated_dense_remaining_rows": _non_negative_int(

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -4095,6 +4095,7 @@ def _compact_hsl_replay_data(live_event: dict[str, Any]) -> dict[str, Any]:
         "pair_idx",
         "applied_rows",
         "scanned_rows",
+        "candidate_rows",
         "total_applied_rows",
         "total_scanned_rows",
         "rows",
@@ -4177,6 +4178,7 @@ def _hsl_replay_derived(data: dict[str, Any]) -> dict[str, Any]:
     out: dict[str, Any] = {}
     dense_work: int | None = None
     required_work: int | None = None
+    candidate_work: int | None = None
     if timeline_rows is not None and pairs is not None:
         dense_work = int(timeline_rows) * int(pairs)
         out["estimated_dense_pair_row_work"] = dense_work
@@ -4197,6 +4199,18 @@ def _hsl_replay_derived(data: dict[str, Any]) -> dict[str, Any]:
         out["estimated_held_pair_row_work"] = int(timeline_rows) * int(held_pairs)
     if timeline_rows is not None and cooldown_pairs is not None:
         out["estimated_cooldown_pair_row_work"] = int(timeline_rows) * int(cooldown_pairs)
+    if data.get("stage") == "full_replay":
+        candidate_work = _non_negative_int(data.get("candidate_rows"))
+        if candidate_work is not None:
+            out["estimated_candidate_pair_row_work"] = candidate_work
+            if observed_rows is not None and candidate_work > 0:
+                out["observed_candidate_work_pct"] = round(
+                    min(
+                        100.0,
+                        max(0.0, 100.0 * float(observed_rows) / float(candidate_work)),
+                    ),
+                    3,
+                )
     if observed_applied_rows is not None:
         out["observed_applied_rows"] = int(observed_applied_rows)
     observed_scanned_rows = _non_negative_int(data.get("total_scanned_rows"))
@@ -4228,11 +4242,33 @@ def _hsl_replay_derived(data: dict[str, Any]) -> dict[str, Any]:
         )
         if required_remaining_ms is not None:
             out["estimated_required_remaining_ms"] = required_remaining_ms
-    primary_remaining_rows = (
-        required_remaining_rows
-        if required_remaining_rows is not None
-        else dense_remaining_rows
+    candidate_remaining_rows = _hsl_replay_remaining_rows(
+        estimated_work=candidate_work,
+        observed_rows=observed_rows,
     )
+    if candidate_remaining_rows is not None:
+        out["estimated_candidate_remaining_rows"] = candidate_remaining_rows
+        candidate_remaining_ms = _hsl_replay_eta_ms(
+            remaining_rows=candidate_remaining_rows,
+            rows_per_second=throughput_rate,
+        )
+        if candidate_remaining_ms is not None:
+            out["estimated_candidate_remaining_ms"] = candidate_remaining_ms
+    primary_remaining_rows = (
+        candidate_remaining_rows
+        if candidate_remaining_rows is not None
+        else (
+            required_remaining_rows
+            if required_remaining_rows is not None
+            else dense_remaining_rows
+        )
+    )
+    if candidate_remaining_rows is not None:
+        out["work_estimate_source"] = "candidate_rows_terminal"
+    elif required_remaining_rows is not None:
+        out["work_estimate_source"] = "required_dense_rows"
+    elif dense_remaining_rows is not None:
+        out["work_estimate_source"] = "dense_rows"
     if primary_remaining_rows is not None:
         out["estimated_remaining_rows"] = primary_remaining_rows
         primary_remaining_ms = _hsl_replay_eta_ms(
@@ -7325,6 +7361,7 @@ def _brief_hsl_replay_active_groups(groups: Any) -> list[dict[str, Any]]:
                 data.get("scanned_rows_per_second")
             ),
             "throughput_source": derived.get("throughput_source"),
+            "work_estimate_source": derived.get("work_estimate_source"),
             "observed_scanned_rows": _non_negative_int(
                 derived.get("observed_scanned_rows")
             ),

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -5304,6 +5304,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
 
         balance = float(self.get_raw_balance())
         rows = 0
+        total_scanned_rows = 0
         replay_started_s = time.monotonic()
         pre_replay_elapsed_s = max(0.0, replay_started_s - history_loaded_s)
         last_progress_log_s = replay_started_s
@@ -5373,6 +5374,8 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             pside: str,
             symbol: str,
             applied_rows: int,
+            scanned_rows: int,
+            pair_started_s: float,
             *,
             force: bool = False,
         ) -> None:
@@ -5383,14 +5386,20 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             last_progress_log_s = now_s
             elapsed_s = max(0.0, now_s - replay_started_s)
             rows_per_second = float(rows) / elapsed_s if elapsed_s > 0.0 else None
+            scanned_rows_per_second = (
+                float(total_scanned_rows) / elapsed_s if elapsed_s > 0.0 else None
+            )
+            pair_elapsed_s = max(0.0, now_s - pair_started_s)
             logging.info(
-                "[risk] HSL coin history reconstruction progress | pair=%d/%d pside=%s symbol=%s applied_rows=%d total_rows=%d elapsed=%.1fs",
+                "[risk] HSL coin history reconstruction progress | pair=%d/%d pside=%s symbol=%s applied_rows=%d scanned_rows=%d total_rows=%d total_scanned_rows=%d elapsed=%.1fs",
                 pair_idx,
                 len(active_pairs),
                 pside,
                 symbol,
                 applied_rows,
+                scanned_rows,
                 rows,
+                total_scanned_rows,
                 now_s - replay_started_s,
             )
             _emit_hsl_replay_event(
@@ -5406,13 +5415,19 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     "required_pairs": len(active_required_pairs),
                     "timeline_rows": replay_row_count,
                     "applied_rows": int(applied_rows),
+                    "scanned_rows": int(scanned_rows),
                     "candidate_rows": pair_candidate_rows.get((pside, symbol)),
                     "total_applied_rows": int(rows),
+                    "total_scanned_rows": int(total_scanned_rows),
                     "rows_per_second": round(rows_per_second, 3)
                     if rows_per_second is not None
                     else None,
+                    "scanned_rows_per_second": round(scanned_rows_per_second, 3)
+                    if scanned_rows_per_second is not None
+                    else None,
                     "is_held_pair": (pside, symbol) in active_held_pairs,
                     "is_cooldown_pair": (pside, symbol) in active_panic_pairs,
+                    "pair_elapsed_s": round(pair_elapsed_s, 3),
                     "elapsed_s": round(elapsed_s, 3),
                 },
                 pside=pside,
@@ -5470,12 +5485,16 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             for pside, symbol in replay_candidates:
                 check_shutdown("hsl_coin_history_replay_pair")
                 pair_idx += 1
+                pair_started_s = time.monotonic()
+                scanned_rows = 0
                 if pair_idx == 1:
                     log_replay_progress(
                         pair_idx,
                         pside,
                         symbol,
                         0,
+                        scanned_rows,
+                        pair_started_s,
                         force=True,
                     )
                 state = self._hsl_coin_state(pside, symbol)
@@ -5730,10 +5749,19 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     unrealized_value,
                     source_row,
                 ) in enumerate(iter_replay_rows(), start=1):
+                    scanned_rows += 1
+                    total_scanned_rows += 1
                     if replay_iteration_idx % yield_rows == 0:
                         await asyncio.sleep(yield_sleep_s)
                         check_shutdown("hsl_coin_history_replay_rows")
-                        log_replay_progress(pair_idx, pside, symbol, applied_rows)
+                        log_replay_progress(
+                            pair_idx,
+                            pside,
+                            symbol,
+                            applied_rows,
+                            scanned_rows,
+                            pair_started_s,
+                        )
                     if replay_start_boundary_ts is not None and ts < replay_start_boundary_ts:
                         continue
                     if state["halted"]:
@@ -6091,13 +6119,24 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     )
                 pair_rows_applied[(pside, symbol)] = int(applied_rows)
                 mark_pair_ready(pside, symbol)
-                log_replay_progress(pair_idx, pside, symbol, applied_rows)
+                log_replay_progress(
+                    pair_idx,
+                    pside,
+                    symbol,
+                    applied_rows,
+                    scanned_rows,
+                    pair_started_s,
+                    force=True,
+                )
             if batch_idx == 0:
                 mark_protective_ready()
         self._equity_hard_stop_coin_initialized = True
         elapsed_s = max(0.0, time.monotonic() - replay_started_s)
         total_elapsed_s = max(0.0, time.monotonic() - initialization_started_s)
         rows_per_second = float(rows) / elapsed_s if elapsed_s > 0.0 else None
+        scanned_rows_per_second = (
+            float(total_scanned_rows) / elapsed_s if elapsed_s > 0.0 else None
+        )
         skipped_pairs = sum(1 for pair in active_pairs if pair_rows_applied.get(pair, 0) == 0)
         dense_equivalent_rows = int(replay_row_count * len(active_pairs))
         candidate_rows = int(sum(pair_candidate_rows.values()))
@@ -6137,6 +6176,8 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 "replay_strategy": replay_strategy,
                 "rows": int(rows),
                 "applied_rows": int(rows),
+                "total_applied_rows": int(rows),
+                "total_scanned_rows": int(total_scanned_rows),
                 "candidate_rows": candidate_rows,
                 "dense_equivalent_rows": dense_equivalent_rows,
                 "candidate_reduction_pct": round(candidate_reduction_pct, 3),
@@ -6153,6 +6194,9 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 "panic_events": len(panic_flatten_events),
                 "rows_per_second": round(rows_per_second, 3)
                 if rows_per_second is not None
+                else None,
+                "scanned_rows_per_second": round(scanned_rows_per_second, 3)
+                if scanned_rows_per_second is not None
                 else None,
                 "history_fetch_elapsed_s": round(history_fetch_elapsed_s, 3),
                 "pre_replay_elapsed_s": round(pre_replay_elapsed_s, 3),

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -6098,7 +6098,17 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                             reason,
                         )
                 if state["halted"]:
+                    pair_rows_applied[(pside, symbol)] = int(applied_rows)
                     mark_pair_ready(pside, symbol)
+                    log_replay_progress(
+                        pair_idx,
+                        pside,
+                        symbol,
+                        applied_rows,
+                        scanned_rows,
+                        pair_started_s,
+                        force=True,
+                    )
                     continue
                 if applied_rows == 0:
                     self._equity_hard_stop_prime_coin_runtime_for_replay(pside, symbol, now_ms)

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -1946,6 +1946,7 @@ async def test_coin_hsl_history_replay_emits_lifecycle_events():
         EventTypes.HSL_REPLAY_PROGRESS,
         EventTypes.HSL_REPLAY_PROGRESS,
         EventTypes.HSL_REPLAY_PROGRESS,
+        EventTypes.HSL_REPLAY_PROGRESS,
         EventTypes.HSL_REPLAY_COMPLETED,
     ]
     assert {event.cycle_id for event in events} == {"cy_hsl_replay"}
@@ -1965,17 +1966,35 @@ async def test_coin_hsl_history_replay_emits_lifecycle_events():
     assert events[2].reason_code == "pair_replay_progress"
     assert events[2].data["pair_idx"] == 1
     assert events[2].data["is_held_pair"] is True
-    assert events[3].status == "succeeded"
-    assert events[3].reason_code == ReasonCodes.HSL_HELD_PROTECTIVE_READY
-    assert events[3].data["stage"] == "held_protective_ready"
-    assert events[3].data["ready_pairs"] == 1
-    assert events[3].data["pending_pairs"] == 0
-    assert events[3].data["protective_elapsed_s"] is not None
-    completed = events[4]
+    assert events[2].data["applied_rows"] == 0
+    assert events[2].data["scanned_rows"] == 0
+    assert events[2].data["total_applied_rows"] == 0
+    assert events[2].data["total_scanned_rows"] == 0
+    assert events[2].data["rows_per_second"] is not None
+    assert events[2].data["scanned_rows_per_second"] is not None
+    assert events[2].data["pair_elapsed_s"] is not None
+    assert events[3].reason_code == "pair_replay_progress"
+    assert events[3].data["applied_rows"] == 2
+    assert events[3].data["scanned_rows"] == 2
+    assert events[3].data["total_applied_rows"] == 2
+    assert events[3].data["total_scanned_rows"] == 2
+    assert events[3].data["rows_per_second"] is not None
+    assert events[3].data["scanned_rows_per_second"] is not None
+    assert events[3].data["pair_elapsed_s"] is not None
+    assert events[4].status == "succeeded"
+    assert events[4].reason_code == ReasonCodes.HSL_HELD_PROTECTIVE_READY
+    assert events[4].data["stage"] == "held_protective_ready"
+    assert events[4].data["ready_pairs"] == 1
+    assert events[4].data["pending_pairs"] == 0
+    assert events[4].data["protective_elapsed_s"] is not None
+    completed = events[5]
     assert completed.status == "succeeded"
     assert completed.reason_code == "coin_history_replay_completed"
     assert completed.data["rows"] == 2
     assert completed.data["applied_rows"] == 2
+    assert completed.data["total_applied_rows"] == 2
+    assert completed.data["total_scanned_rows"] == 2
+    assert completed.data["total_scanned_rows"] == completed.data["candidate_rows"]
     assert completed.data["pairs"] == 1
     assert completed.data["held_pairs"] == 1
     assert completed.data["cooldown_pairs"] == 0
@@ -1985,6 +2004,7 @@ async def test_coin_hsl_history_replay_emits_lifecycle_events():
     assert completed.data["fill_events"] == 0
     assert completed.data["panic_events"] == 0
     assert completed.data["rows_per_second"] is not None
+    assert completed.data["scanned_rows_per_second"] is not None
     assert completed.data["history_fetch_elapsed_s"] is not None
     assert completed.data["pre_replay_elapsed_s"] is not None
     assert completed.data["replay_loop_elapsed_s"] is not None
@@ -1999,6 +2019,83 @@ async def test_coin_hsl_history_replay_emits_lifecycle_events():
         + completed.data["replay_loop_elapsed_s"]
     )
     assert phase_elapsed_s <= completed.data["startup_blocking_elapsed_s"] + 0.006
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_coin_hsl_history_replay_reports_scanned_optional_rows_without_apply():
+    from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+
+    bot = make_coin_bot()
+    symbol = "A"
+    bot._hsl_coin_state("long", symbol)
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+    )
+    bot._emit_live_event = MethodType(Passivbot._emit_live_event, bot)
+
+    async def fake_history(current_balance=None, **kwargs):
+        return {
+            "timeline": [
+                {
+                    "timestamp": 60_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {},
+                    "unrealized_pnl_by_coin_pside": {},
+                },
+                {
+                    "timestamp": 120_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {},
+                    "unrealized_pnl_by_coin_pside": {},
+                },
+            ],
+            "panic_flatten_events": [],
+            "fill_events": [
+                {
+                    "timestamp": 60_000,
+                    "symbol": symbol,
+                    "pside": "long",
+                    "action": "increase",
+                    "qty": 1.0,
+                }
+            ],
+        }
+
+    bot.get_balance_equity_history = fake_history
+
+    await bot._equity_hard_stop_initialize_coin_from_history()
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    pair_event = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.HSL_REPLAY_PROGRESS
+        and event.reason_code == "pair_replay_progress"
+    ][-1]
+    assert pair_event.data["applied_rows"] == 0
+    assert pair_event.data["scanned_rows"] == 2
+    assert pair_event.data["total_applied_rows"] == 0
+    assert pair_event.data["total_scanned_rows"] == 2
+    assert pair_event.data["rows_per_second"] is not None
+    assert pair_event.data["scanned_rows_per_second"] is not None
+    assert pair_event.data["pair_elapsed_s"] is not None
+
+    completed = next(
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.HSL_REPLAY_COMPLETED
+    )
+    assert completed.data["applied_rows"] == 0
+    assert completed.data["total_applied_rows"] == 0
+    assert completed.data["total_scanned_rows"] == 2
+    assert completed.data["total_scanned_rows"] == completed.data["candidate_rows"]
+    assert completed.data["rows_per_second"] is not None
+    assert completed.data["scanned_rows_per_second"] is not None
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
@@ -2052,13 +2149,16 @@ async def test_coin_hsl_history_replay_processes_held_late_symbol_first():
         if event.event_type == EventTypes.HSL_REPLAY_PROGRESS
         and event.reason_code == "pair_replay_progress"
     ]
-    assert len(pair_events) == 1
+    assert len(pair_events) == 3
     assert pair_events[0].symbol == "Z"
     assert pair_events[0].pside == "long"
     assert pair_events[0].data["pair_idx"] == 1
     assert pair_events[0].data["pairs"] == 2
     assert pair_events[0].data["held_pairs"] == 1
     assert pair_events[0].data["is_held_pair"] is True
+    assert pair_events[1].symbol == "Z"
+    assert pair_events[1].data["scanned_rows"] == 1
+    assert pair_events[2].symbol == "A"
     assert set(bot._equity_hard_stop_coin["long"]) == {"A", "Z"}
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -2067,6 +2067,23 @@ async def test_coin_hsl_history_replay_reports_scanned_optional_rows_without_app
         }
 
     bot.get_balance_equity_history = fake_history
+    now_ms = bot.get_exchange_time()
+
+    def active_cooldown_contract(self, pside, replay_symbol, fill_events, replay_now_ms):
+        del self, pside, replay_symbol, fill_events, replay_now_ms
+        return {
+            "policy": "normal",
+            "latest_panic_ts": 60_000,
+            "cooldown_until_ms": now_ms + 60_000,
+            "intervention_entry_ts": None,
+            "active_cooldown_now": True,
+            "intervention_active": False,
+            "unresolved_residue": False,
+        }
+
+    bot._equity_hard_stop_infer_coin_replay_contract = MethodType(
+        active_cooldown_contract, bot
+    )
 
     await bot._equity_hard_stop_initialize_coin_from_history()
 
@@ -2084,6 +2101,7 @@ async def test_coin_hsl_history_replay_reports_scanned_optional_rows_without_app
     assert pair_event.data["rows_per_second"] is not None
     assert pair_event.data["scanned_rows_per_second"] is not None
     assert pair_event.data["pair_elapsed_s"] is not None
+    assert bot._hsl_coin_state("long", symbol)["halted"] is True
 
     completed = next(
         event

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1662,6 +1662,50 @@ def test_live_performance_report_hsl_replay_profile(tmp_path):
     assert group["completed"]["derived"]["estimated_remaining_ms"] == 0
 
 
+def test_hsl_replay_profile_prefers_scanned_work_for_eta():
+    data = {
+        "timeline_rows": 100,
+        "pairs": 3,
+        "required_pairs": 1,
+        "total_applied_rows": 10,
+        "rows_per_second": 2.0,
+        "scanned_rows": 75,
+        "total_scanned_rows": 150,
+        "scanned_rows_per_second": 50.0,
+        "pair_elapsed_s": 1.5,
+        "secret": "must-not-render",
+    }
+    bounded = performance_report_module._bounded_hsl_replay_data(data)
+    derived = performance_report_module._derive_hsl_replay_profile(bounded)
+
+    assert bounded["scanned_rows"] == 75
+    assert bounded["pair_elapsed_s"] == 1.5
+    assert "secret" not in bounded
+    assert derived["throughput_source"] == "scanned_rows"
+    assert derived["observed_applied_rows"] == 10
+    assert derived["observed_scanned_rows"] == 150
+    assert derived["observed_work_pct"] == 50.0
+    assert derived["estimated_dense_remaining_rows"] == 150
+    assert derived["estimated_dense_remaining_ms"] == 3000
+
+
+def test_hsl_replay_profile_keeps_legacy_applied_work_fallback():
+    derived = performance_report_module._derive_hsl_replay_profile(
+        {
+            "timeline_rows": 100,
+            "pairs": 3,
+            "total_applied_rows": 10,
+            "rows_per_second": 2.0,
+        }
+    )
+
+    assert derived["throughput_source"] == "applied_rows_legacy"
+    assert derived["observed_applied_rows"] == 10
+    assert "observed_scanned_rows" not in derived
+    assert derived["estimated_dense_remaining_rows"] == 290
+    assert derived["estimated_dense_remaining_ms"] == 145000
+
+
 def test_live_performance_report_hsl_replay_profile_stage_summary(tmp_path):
     rows = [
         _monitor_row(
@@ -2061,6 +2105,7 @@ def test_live_performance_report_hsl_replay_profile_whitelists_values(tmp_path):
         "latest_elapsed_ms": 4500,
         "observed_applied_rows": 9,
         "price_history_fetch_elapsed_ms": 16500,
+        "throughput_source": "applied_rows_legacy",
         "timeline_replay_elapsed_ms": 3200,
     }
     assert "balance" not in rendered

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1670,6 +1670,7 @@ def test_hsl_replay_profile_prefers_scanned_work_for_eta():
         "total_applied_rows": 10,
         "rows_per_second": 2.0,
         "scanned_rows": 75,
+        "candidate_rows": 150,
         "total_scanned_rows": 150,
         "scanned_rows_per_second": 50.0,
         "pair_elapsed_s": 1.5,
@@ -1679,6 +1680,7 @@ def test_hsl_replay_profile_prefers_scanned_work_for_eta():
     derived = performance_report_module._derive_hsl_replay_profile(bounded)
 
     assert bounded["scanned_rows"] == 75
+    assert bounded["candidate_rows"] == 150
     assert bounded["pair_elapsed_s"] == 1.5
     assert "secret" not in bounded
     assert derived["throughput_source"] == "scanned_rows"
@@ -1687,6 +1689,14 @@ def test_hsl_replay_profile_prefers_scanned_work_for_eta():
     assert derived["observed_work_pct"] == 50.0
     assert derived["estimated_dense_remaining_rows"] == 150
     assert derived["estimated_dense_remaining_ms"] == 3000
+
+    terminal = performance_report_module._derive_hsl_replay_profile(
+        {**bounded, "stage": "full_replay"}
+    )
+    assert terminal["work_estimate_source"] == "candidate_rows_terminal"
+    assert terminal["estimated_candidate_pair_row_work"] == 150
+    assert terminal["estimated_candidate_remaining_rows"] == 0
+    assert terminal["estimated_remaining_rows"] == 0
 
 
 def test_hsl_replay_profile_keeps_legacy_applied_work_fallback():
@@ -1704,6 +1714,7 @@ def test_hsl_replay_profile_keeps_legacy_applied_work_fallback():
     assert "observed_scanned_rows" not in derived
     assert derived["estimated_dense_remaining_rows"] == 290
     assert derived["estimated_dense_remaining_ms"] == 145000
+    assert derived["work_estimate_source"] == "dense_rows"
 
 
 def test_live_performance_report_hsl_replay_profile_stage_summary(tmp_path):

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -4349,6 +4349,53 @@ def test_compact_hsl_replay_data_exposes_protective_readiness_counts():
     ] == 1250
 
 
+def test_hsl_replay_derived_prefers_scanned_work_for_eta():
+    compact = smoke_report_module._compact_hsl_replay_data(
+        {
+            "data": {
+                "timeline_rows": 100,
+                "pairs": 3,
+                "required_pairs": 1,
+                "total_applied_rows": 10,
+                "rows_per_second": 2.0,
+                "scanned_rows": 75,
+                "total_scanned_rows": 150,
+                "scanned_rows_per_second": 50.0,
+                "pair_elapsed_s": 1.5,
+                "secret": "must-not-render",
+            }
+        }
+    )
+    derived = smoke_report_module._hsl_replay_derived(compact)
+
+    assert compact["scanned_rows"] == 75
+    assert compact["pair_elapsed_s"] == 1.5
+    assert "secret" not in compact
+    assert derived["throughput_source"] == "scanned_rows"
+    assert derived["observed_applied_rows"] == 10
+    assert derived["observed_scanned_rows"] == 150
+    assert derived["observed_work_pct"] == 50.0
+    assert derived["estimated_dense_remaining_rows"] == 150
+    assert derived["estimated_dense_remaining_ms"] == 3000
+
+
+def test_hsl_replay_derived_keeps_legacy_applied_work_fallback():
+    derived = smoke_report_module._hsl_replay_derived(
+        {
+            "timeline_rows": 100,
+            "pairs": 3,
+            "total_applied_rows": 10,
+            "rows_per_second": 2.0,
+        }
+    )
+
+    assert derived["throughput_source"] == "applied_rows_legacy"
+    assert derived["observed_applied_rows"] == 10
+    assert "observed_scanned_rows" not in derived
+    assert derived["estimated_dense_remaining_rows"] == 290
+    assert derived["estimated_dense_remaining_ms"] == 145000
+
+
 def test_hsl_replay_health_retains_protective_ready_after_later_progress():
     groups = {}
     path = Path("events.ndjson")
@@ -4741,6 +4788,7 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
                 "cooldown_pairs": 1,
                 "total_applied_rows": 64000,
                 "rows_per_second": 318.415,
+                "throughput_source": "applied_rows_legacy",
                 "observed_required_work_pct": 7.407,
                 "observed_work_pct": 5.108,
                 "estimated_dense_remaining_rows": 43201 * 29 - 64000,

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -4359,6 +4359,7 @@ def test_hsl_replay_derived_prefers_scanned_work_for_eta():
                 "total_applied_rows": 10,
                 "rows_per_second": 2.0,
                 "scanned_rows": 75,
+                "candidate_rows": 150,
                 "total_scanned_rows": 150,
                 "scanned_rows_per_second": 50.0,
                 "pair_elapsed_s": 1.5,
@@ -4369,6 +4370,7 @@ def test_hsl_replay_derived_prefers_scanned_work_for_eta():
     derived = smoke_report_module._hsl_replay_derived(compact)
 
     assert compact["scanned_rows"] == 75
+    assert compact["candidate_rows"] == 150
     assert compact["pair_elapsed_s"] == 1.5
     assert "secret" not in compact
     assert derived["throughput_source"] == "scanned_rows"
@@ -4377,6 +4379,16 @@ def test_hsl_replay_derived_prefers_scanned_work_for_eta():
     assert derived["observed_work_pct"] == 50.0
     assert derived["estimated_dense_remaining_rows"] == 150
     assert derived["estimated_dense_remaining_ms"] == 3000
+
+    terminal_data = {
+        **compact,
+        "stage": "full_replay",
+    }
+    terminal = smoke_report_module._hsl_replay_derived(terminal_data)
+    assert terminal["work_estimate_source"] == "candidate_rows_terminal"
+    assert terminal["estimated_candidate_pair_row_work"] == 150
+    assert terminal["estimated_candidate_remaining_rows"] == 0
+    assert terminal["estimated_remaining_rows"] == 0
 
 
 def test_hsl_replay_derived_keeps_legacy_applied_work_fallback():
@@ -4394,6 +4406,7 @@ def test_hsl_replay_derived_keeps_legacy_applied_work_fallback():
     assert "observed_scanned_rows" not in derived
     assert derived["estimated_dense_remaining_rows"] == 290
     assert derived["estimated_dense_remaining_ms"] == 145000
+    assert derived["work_estimate_source"] == "dense_rows"
 
 
 def test_hsl_replay_health_retains_protective_ready_after_later_progress():
@@ -4789,6 +4802,7 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
                 "total_applied_rows": 64000,
                 "rows_per_second": 318.415,
                 "throughput_source": "applied_rows_legacy",
+                "work_estimate_source": "required_dense_rows",
                 "observed_required_work_pct": 7.407,
                 "observed_work_pct": 5.108,
                 "estimated_dense_remaining_rows": 43201 * 29 - 64000,


### PR DESCRIPTION
## Summary

- expose per-pair and cumulative HSL replay candidate rows scanned separately from state-update rows applied
- make live performance and smoke ETA estimates prefer scanned-row throughput while retaining explicit legacy applied-row fallback
- document the event-field contract and record the preceding deployed slice

## Behavioral boundary

- no change to replay candidate ordering, row processing, yields, readiness, risk state, or trading behavior
- existing `applied_rows`, `total_applied_rows`, and `rows_per_second` semantics remain unchanged
- one terminal pair-progress event is emitted per pair so zero-apply scan cost is observable

## Validation

- 365 focused HSL/report/registry/incident/restart-smoke tests passed
- 8 real fake-live HSL scenarios passed (7 pside replay scenarios plus coin-selective panic)
- Python compilation and `git diff --check` passed
- added-line silent-handling scan found no new matches
