### PR TITLE
Fix active HSL replay remaining estimates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ All notable user-facing changes will be documented in this file.
 - Coin-mode HSL replay progress now separates scanned candidate rows from
   applied state-update rows. Live performance and smoke reports use scan
   throughput for remaining-work estimates when available, retain explicit
-  legacy applied-row fallback labeling for older events, and do not change HSL
-  replay ordering, readiness, or trading behavior.
+  legacy applied-row fallback labeling for older events, use the dense upper
+  bound for the generic active replay estimate while keeping required-pair
+  estimates separate, and preserve exact terminal candidate-work estimates.
+  These report semantics do not change HSL replay ordering, readiness, or
+  trading behavior.
 
 - Isolated-only markets excluded from new entries by cross-margin preference
   now emit bounded per-side `config.market_compatibility` events while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ All notable user-facing changes will be documented in this file.
   throughput for remaining-work estimates when available, retain explicit
   legacy applied-row fallback labeling for older events, use the dense upper
   bound for the generic active replay estimate while keeping required-pair
-  estimates separate, and preserve exact terminal candidate-work estimates.
-  These report semantics do not change HSL replay ordering, readiness, or
-  trading behavior.
+  estimates separate, preserve exact terminal candidate-work estimates, and
+  keep legacy terminal events without candidate totals from reporting active
+  remaining work. These report semantics do not change HSL replay ordering,
+  readiness, or trading behavior.
 
 - Isolated-only markets excluded from new entries by cross-margin preference
   now emit bounded per-side `config.market_compatibility` events while

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,44 +22,58 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1190, `Expose HSL replay scan throughput`
-- Branch: `codex/v8-hsl-replay-scan-profile`
-- Base: `ff1b2c1f9ee9968a4e46f3ba598f3c7f091efe42`
-- Scope: expose per-pair and cumulative replay candidate rows scanned
-  separately from HSL state-update rows applied; make performance and smoke
-  ETA projections prefer scanned-row throughput; retain explicit legacy
-  applied-row fallback and exact terminal candidate-work estimates.
-- Behavior boundary: no replay candidate ordering, row application, yield
-  cadence, protective readiness, risk state, exchange call, Rust/order logic,
-  or trading behavior change. Each pair emits one bounded terminal progress
-  sample so halted and zero-apply scan work remains observable.
-- Validation: the focused HSL coin-mode, replay-benchmark, performance-report,
-  smoke-report, event-registry, incident-bundle, and restart-smoke suites pass.
-  Eight real fake-live HSL scenarios pass. Python compilation,
-  `git diff --check`, and the added-line silent-handling scan pass. Independent
-  preflight findings for halted-pair terminal progress and completed sparse
-  candidate-work estimates are resolved with regressions.
+- Branch: `codex/v8-hsl-required-zero-estimate`
+- Base: `6b2da757f2fbc590c12365870475176632269021`
+- Triggering evidence: the PR #1190 deployment reported active optional replay
+  with positive `estimated_dense_remaining_rows` but generic
+  `estimated_remaining_rows=0` because `required_pairs=0`. The same premature
+  zero can occur after required work completes while optional replay remains.
+- Scope: make generic active replay remaining rows/time use the full-replay
+  dense upper bound and label it `dense_rows_upper_bound`. Keep
+  `estimated_required_remaining_*` as the separate protective-work metric and
+  keep terminal `candidate_rows_terminal` estimates exact.
+- Behavior boundary: read-only performance/smoke report derivation and tests
+  only. No event producer, replay candidate/order/application, HSL state,
+  exchange call, process control, smoke verdict, Rust/order/risk logic, or
+  trading behavior change.
+- Validation: full performance-report, smoke-report, incident-bundle, and
+  restart-smoke-plan suites plus Python compilation, `git diff --check`, and
+  the added-line silent-handling scan.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
-  verdicts: query live GitHub metadata. Do not embed transient head or gate
-  values in this PR because doing so would immediately invalidate them.
-- Expected VPS action: after exact-head approval and merge, pull while
-  preserving local artifacts, restart the five exact supervised bot panes
-  because the HSL producer is shared live Python, preserve unrelated
-  `misc:0.0`, then query replay progress/completion scan fields and run
-  immediate plus settled smoke checks.
+  verdicts: query live GitHub metadata; do not embed self-invalidating values.
+- Expected VPS action: after merge, pull while preserving local artifacts and
+  run the bounded HSL replay profile plus smoke projections over the existing
+  PR #1190 replay records. Do not restart or signal bots because this slice
+  changes only on-demand report consumers.
 
 Next action:
 
-1. Resolve any verified current-head findings. Merge only after the temporary
-   Hermes + Grok 4.5 + green-CI gate is satisfied on the same exact head, then
-   deploy and validate the expected replay fields and process boundaries on
-   VPS5.
+1. Complete exact-head review and CI for the narrow generic active-replay
+   estimate fix, merge only when the full gate is green, then validate the
+   corrected projection against existing VPS5 replay records without a bot
+   restart.
 
 ## Deployed Baseline
 
-- Remote `v8`: `ff1b2c1f9ee9968a4e46f3ba598f3c7f091efe42`, PR #1189
-- VPS5 repository: `ff1b2c1f9ee9968a4e46f3ba598f3c7f091efe42`, PR #1189; tracked status clean
+- Remote `v8`: `6b2da757f2fbc590c12365870475176632269021`, PR #1190
+- VPS5 repository: `6b2da757f2fbc590c12365870475176632269021`, PR #1190; tracked
+  status clean; only expected untracked artifacts were preserved
 - VPS5 expected bots: five; all running after the shared-code five-pane restart
+- PR #1190 merged as `6b2da757f2fbc590c12365870475176632269021` and was deployed
+  to VPS5. All five exact supervised panes were restarted, unrelated
+  `misc:0.0` PID `434835` was preserved, and immediate live evidence showed the
+  new scanned counters, scan rate, and candidate-row source. All four HSL
+  replays completed successfully in `108.782s` to `246.091s`, reaching
+  protective-ready in `9.920s` to `71.744s`; `total_scanned_rows` equaled
+  `candidate_rows`, `observed_candidate_work_pct=100`, and the source was
+  `candidate_rows_terminal`. The final fresh smoke was `ok=true` with `333/333`
+  remote and `45/45` account-critical calls successful, all five expected bots
+  matched, no hard/log/monitor failures, and a clean tracked repository. One
+  process was sampled in `D`, but no process hard failure occurred. A prior
+  monitor-row parse boundary was immediately revalidated clean.
+  A later direct process check showed `D` cleared: Binance, KuCoin, GateIO, and
+  Hyperliquid were `Ssl+/ep_poll`, OKX was `Rsl+`; `vmstat` showed `b=0` before
+  a transient `b=1` with low or zero sampled iowait.
 - PR #1188 was approved on exact head `363eca852` by Hermes and Grok 4.5;
   CI passed and it merged as `bd169747`. VPS5 fast-forwarded cleanly and
   gracefully restarted only `passivbot:4.0`; Hyperliquid bot PID `842779` was
@@ -140,13 +154,15 @@ current process-pressure query, compact cold replay payload, bounded replay
 scorecard, stable per-pair fill index, exact sparse flat-pair replay, and the
 rotated resource-pressure report fix, configured-market skip events, and fatal
 HIP-3 startup compatibility are merged and deployed. PR #1189's isolated-only
-initial-entry filter visibility is also merged and deployed. Active PR #1190
-implements HSL replay scanned-row throughput and corrected ETA projections; it
-is under exact-head review and is not yet merged or deployed.
+initial-entry filter visibility and PR #1190's HSL replay scanned-row
+throughput are also merged and deployed. The next active slice fixes the
+generic active replay remaining estimate when required work is empty or
+complete while optional replay remains, using the dense upper bound while
+keeping required and terminal candidate estimates separate.
 
-Do not begin a dependent next slice until PR #1190 is merged and its VPS5
-restart/query/smoke boundary is validated. After that evidence is recorded,
-select the next review-worthy candidate from the remaining backlog, including:
+After this active slice is merged and its report-only VPS validation is
+recorded, select the next review-worthy candidate from the remaining backlog,
+including:
 
 - bounded operator tooling improvements sharing one code and validation surface
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,6 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
+- PR #1191, `Fix active HSL replay remaining estimates`
 - Branch: `codex/v8-hsl-required-zero-estimate`
 - Base: `6b2da757f2fbc590c12365870475176632269021`
 - Triggering evidence: the PR #1190 deployment reported active optional replay
@@ -31,7 +32,9 @@ Estimated completion:
 - Scope: make generic active replay remaining rows/time use the full-replay
   dense upper bound and label it `dense_rows_upper_bound`. Keep
   `estimated_required_remaining_*` as the separate protective-work metric and
-  keep terminal `candidate_rows_terminal` estimates exact.
+  keep terminal `candidate_rows_terminal` estimates exact. Treat legacy
+  `full_replay` events without candidate totals as terminal rather than
+  reporting dense remaining work.
 - Behavior boundary: read-only performance/smoke report derivation and tests
   only. No event producer, replay candidate/order/application, HSL state,
   exchange call, process control, smoke verdict, Rust/order/risk logic, or

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,20 +19,20 @@ Last updated: 2026-07-11.
 
 Current `origin/v8` head:
 
-- `ff1b2c1f9ee9968a4e46f3ba598f3c7f091efe42` after PR #1189, `Record
-  isolated-only entry filtering`.
+- `6b2da757f2fbc590c12365870475176632269021` after PR #1190, `Expose HSL
+  replay scan throughput`.
 
 Current logging-overhaul head:
 
-- `ff1b2c1f9ee9968a4e46f3ba598f3c7f091efe42` after PR #1189, `Record
-  isolated-only entry filtering` (latest merged logging-overhaul slice).
+- `6b2da757f2fbc590c12365870475176632269021` after PR #1190, `Expose HSL
+  replay scan throughput` (latest merged logging-overhaul slice).
 
 Current work:
 
-- Active review-worthy slice: HSL replay scan-throughput observability, adding
-  scanned-row counters and scan-rate reporting and correcting ETA estimators
-  while preserving replay behavior and existing applied-row metrics. This
-  slice is not yet merged or deployed.
+- Active narrow slice: fix the generic active replay remaining estimate when
+  `required_pairs=0` or required work has completed while optional replay
+  remains. Use the dense upper bound for the generic active estimate, keep the
+  required metric separate, and retain exact terminal candidate estimates.
 
 Current review gate:
 
@@ -63,6 +63,23 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1190 merged to `v8` as
+  `6b2da757f2fbc590c12365870475176632269021` and was deployed to VPS5. The
+  tracked repository was clean and only expected untracked artifacts were
+  preserved. All five exact supervised panes restarted, while unrelated
+  `misc:0.0` PID `434835` remained preserved. Immediate live evidence showed
+  the new scanned counters, scan rate, and candidate-row source. All four HSL
+  replays completed successfully in `108.782s` to `246.091s`, with
+  protective-ready in `9.920s` to `71.744s`; `total_scanned_rows` equaled
+  `candidate_rows`, `observed_candidate_work_pct=100`, and the source was
+  `candidate_rows_terminal`. Final fresh smoke was `ok=true`, with `333/333`
+  remote and `45/45` account-critical calls successful, all five expected bots
+  matched, no hard/log/monitor failures, and a clean tracked repository. One
+  process was sampled in `D`, but no process hard failure occurred. A prior
+  monitor-row parse boundary immediately revalidated clean.
+  A later direct process check showed `D` cleared: Binance, KuCoin, GateIO, and
+  Hyperliquid were `Ssl+/ep_poll`, OKX was `Rsl+`; `vmstat` showed `b=0` before
+  a transient `b=1` with low or zero sampled iowait.
 - PR #1189 merged to `v8` as
   `ff1b2c1f9ee9968a4e46f3ba598f3c7f091efe42` and was deployed to VPS5. The
   deployment smoke was green with all five supervised bots present and the

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1679,13 +1679,16 @@ def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
         )
         if candidate_remaining_ms is not None:
             out["estimated_candidate_remaining_ms"] = candidate_remaining_ms
+    is_terminal = data.get("stage") == "full_replay"
     primary_remaining_rows = (
         candidate_remaining_rows
         if candidate_remaining_rows is not None
-        else dense_remaining_rows
+        else (0 if is_terminal else dense_remaining_rows)
     )
     if candidate_remaining_rows is not None:
         out["work_estimate_source"] = "candidate_rows_terminal"
+    elif is_terminal:
+        out["work_estimate_source"] = "legacy_terminal_no_candidate_rows"
     elif dense_remaining_rows is not None:
         out["work_estimate_source"] = "dense_rows_upper_bound"
     if primary_remaining_rows is not None:

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1682,18 +1682,12 @@ def _derive_hsl_replay_profile(data: dict[str, Any]) -> dict[str, Any]:
     primary_remaining_rows = (
         candidate_remaining_rows
         if candidate_remaining_rows is not None
-        else (
-            required_remaining_rows
-            if required_remaining_rows is not None
-            else dense_remaining_rows
-        )
+        else dense_remaining_rows
     )
     if candidate_remaining_rows is not None:
         out["work_estimate_source"] = "candidate_rows_terminal"
-    elif required_remaining_rows is not None:
-        out["work_estimate_source"] = "required_dense_rows"
     elif dense_remaining_rows is not None:
-        out["work_estimate_source"] = "dense_rows"
+        out["work_estimate_source"] = "dense_rows_upper_bound"
     if primary_remaining_rows is not None:
         out["estimated_remaining_rows"] = primary_remaining_rows
         primary_remaining_ms = _hsl_replay_eta_ms(

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -4257,18 +4257,12 @@ def _hsl_replay_derived(data: dict[str, Any]) -> dict[str, Any]:
     primary_remaining_rows = (
         candidate_remaining_rows
         if candidate_remaining_rows is not None
-        else (
-            required_remaining_rows
-            if required_remaining_rows is not None
-            else dense_remaining_rows
-        )
+        else dense_remaining_rows
     )
     if candidate_remaining_rows is not None:
         out["work_estimate_source"] = "candidate_rows_terminal"
-    elif required_remaining_rows is not None:
-        out["work_estimate_source"] = "required_dense_rows"
     elif dense_remaining_rows is not None:
-        out["work_estimate_source"] = "dense_rows"
+        out["work_estimate_source"] = "dense_rows_upper_bound"
     if primary_remaining_rows is not None:
         out["estimated_remaining_rows"] = primary_remaining_rows
         primary_remaining_ms = _hsl_replay_eta_ms(

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -4254,13 +4254,16 @@ def _hsl_replay_derived(data: dict[str, Any]) -> dict[str, Any]:
         )
         if candidate_remaining_ms is not None:
             out["estimated_candidate_remaining_ms"] = candidate_remaining_ms
+    is_terminal = data.get("stage") == "full_replay"
     primary_remaining_rows = (
         candidate_remaining_rows
         if candidate_remaining_rows is not None
-        else dense_remaining_rows
+        else (0 if is_terminal else dense_remaining_rows)
     )
     if candidate_remaining_rows is not None:
         out["work_estimate_source"] = "candidate_rows_terminal"
+    elif is_terminal:
+        out["work_estimate_source"] = "legacy_terminal_no_candidate_rows"
     elif dense_remaining_rows is not None:
         out["work_estimate_source"] = "dense_rows_upper_bound"
     if primary_remaining_rows is not None:

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1584,6 +1584,7 @@ def test_live_performance_report_hsl_replay_profile(tmp_path):
                     "cooldown_pairs": 1,
                     "required_pairs": 3,
                     "timeline_rows": 10,
+                    "candidate_rows": 30,
                     "rows": 30,
                     "applied_rows": 30,
                     "skipped_pairs": 1,
@@ -1644,10 +1645,10 @@ def test_live_performance_report_hsl_replay_profile(tmp_path):
     assert group["progress"]["derived"]["estimated_required_pair_row_work"] == 30
     assert group["progress"]["derived"]["estimated_dense_remaining_rows"] == 28
     assert group["progress"]["derived"]["estimated_required_remaining_rows"] == 18
-    assert group["progress"]["derived"]["estimated_remaining_rows"] == 18
+    assert group["progress"]["derived"]["estimated_remaining_rows"] == 28
     assert group["progress"]["derived"]["estimated_dense_remaining_ms"] == 227
     assert group["progress"]["derived"]["estimated_required_remaining_ms"] == 146
-    assert group["progress"]["derived"]["estimated_remaining_ms"] == 146
+    assert group["progress"]["derived"]["estimated_remaining_ms"] == 227
     assert group["progress"]["derived"]["latest_elapsed_ms"] == 2500
     assert group["completed"]["derived"]["startup_blocking_elapsed_ms"] == 7500
     assert group["completed"]["derived"]["startup_blocking"] is True
@@ -1658,15 +1659,20 @@ def test_live_performance_report_hsl_replay_profile(tmp_path):
     assert group["completed"]["derived"]["observed_work_pct"] == 75
     assert group["completed"]["derived"]["estimated_dense_remaining_rows"] == 10
     assert group["completed"]["derived"]["estimated_dense_remaining_ms"] == 250
+    assert group["completed"]["derived"]["work_estimate_source"] == (
+        "candidate_rows_terminal"
+    )
     assert group["completed"]["derived"]["estimated_remaining_rows"] == 0
     assert group["completed"]["derived"]["estimated_remaining_ms"] == 0
 
 
-def test_hsl_replay_profile_prefers_scanned_work_for_eta():
+@pytest.mark.parametrize("required_pairs", (0, 1))
+def test_hsl_replay_profile_prefers_scanned_work_for_eta(required_pairs):
     data = {
+        "stage": "pair_replay",
         "timeline_rows": 100,
         "pairs": 3,
-        "required_pairs": 1,
+        "required_pairs": required_pairs,
         "total_applied_rows": 10,
         "rows_per_second": 2.0,
         "scanned_rows": 75,
@@ -1689,6 +1695,11 @@ def test_hsl_replay_profile_prefers_scanned_work_for_eta():
     assert derived["observed_work_pct"] == 50.0
     assert derived["estimated_dense_remaining_rows"] == 150
     assert derived["estimated_dense_remaining_ms"] == 3000
+    assert derived["estimated_required_remaining_rows"] == 0
+    assert derived["estimated_required_remaining_ms"] == 0
+    assert derived["work_estimate_source"] == "dense_rows_upper_bound"
+    assert derived["estimated_remaining_rows"] == 150
+    assert derived["estimated_remaining_ms"] == 3000
 
     terminal = performance_report_module._derive_hsl_replay_profile(
         {**bounded, "stage": "full_replay"}
@@ -1714,7 +1725,7 @@ def test_hsl_replay_profile_keeps_legacy_applied_work_fallback():
     assert "observed_scanned_rows" not in derived
     assert derived["estimated_dense_remaining_rows"] == 290
     assert derived["estimated_dense_remaining_ms"] == 145000
-    assert derived["work_estimate_source"] == "dense_rows"
+    assert derived["work_estimate_source"] == "dense_rows_upper_bound"
 
 
 def test_live_performance_report_hsl_replay_profile_stage_summary(tmp_path):

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1711,14 +1711,13 @@ def test_hsl_replay_profile_prefers_scanned_work_for_eta(required_pairs):
 
 
 def test_hsl_replay_profile_keeps_legacy_applied_work_fallback():
-    derived = performance_report_module._derive_hsl_replay_profile(
-        {
-            "timeline_rows": 100,
-            "pairs": 3,
-            "total_applied_rows": 10,
-            "rows_per_second": 2.0,
-        }
-    )
+    data = {
+        "timeline_rows": 100,
+        "pairs": 3,
+        "total_applied_rows": 10,
+        "rows_per_second": 2.0,
+    }
+    derived = performance_report_module._derive_hsl_replay_profile(data)
 
     assert derived["throughput_source"] == "applied_rows_legacy"
     assert derived["observed_applied_rows"] == 10
@@ -1726,6 +1725,14 @@ def test_hsl_replay_profile_keeps_legacy_applied_work_fallback():
     assert derived["estimated_dense_remaining_rows"] == 290
     assert derived["estimated_dense_remaining_ms"] == 145000
     assert derived["work_estimate_source"] == "dense_rows_upper_bound"
+
+    terminal = performance_report_module._derive_hsl_replay_profile(
+        {**data, "stage": "full_replay"}
+    )
+    assert terminal["estimated_dense_remaining_rows"] == 290
+    assert terminal["work_estimate_source"] == "legacy_terminal_no_candidate_rows"
+    assert terminal["estimated_remaining_rows"] == 0
+    assert terminal["estimated_remaining_ms"] == 0
 
 
 def test_live_performance_report_hsl_replay_profile_stage_summary(tmp_path):

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -4349,13 +4349,15 @@ def test_compact_hsl_replay_data_exposes_protective_readiness_counts():
     ] == 1250
 
 
-def test_hsl_replay_derived_prefers_scanned_work_for_eta():
+@pytest.mark.parametrize("required_pairs", (0, 1))
+def test_hsl_replay_derived_prefers_scanned_work_for_eta(required_pairs):
     compact = smoke_report_module._compact_hsl_replay_data(
         {
             "data": {
+                "stage": "pair_replay",
                 "timeline_rows": 100,
                 "pairs": 3,
-                "required_pairs": 1,
+                "required_pairs": required_pairs,
                 "total_applied_rows": 10,
                 "rows_per_second": 2.0,
                 "scanned_rows": 75,
@@ -4379,6 +4381,11 @@ def test_hsl_replay_derived_prefers_scanned_work_for_eta():
     assert derived["observed_work_pct"] == 50.0
     assert derived["estimated_dense_remaining_rows"] == 150
     assert derived["estimated_dense_remaining_ms"] == 3000
+    assert derived["estimated_required_remaining_rows"] == 0
+    assert derived["estimated_required_remaining_ms"] == 0
+    assert derived["work_estimate_source"] == "dense_rows_upper_bound"
+    assert derived["estimated_remaining_rows"] == 150
+    assert derived["estimated_remaining_ms"] == 3000
 
     terminal_data = {
         **compact,
@@ -4406,7 +4413,7 @@ def test_hsl_replay_derived_keeps_legacy_applied_work_fallback():
     assert "observed_scanned_rows" not in derived
     assert derived["estimated_dense_remaining_rows"] == 290
     assert derived["estimated_dense_remaining_ms"] == 145000
-    assert derived["work_estimate_source"] == "dense_rows"
+    assert derived["work_estimate_source"] == "dense_rows_upper_bound"
 
 
 def test_hsl_replay_health_retains_protective_ready_after_later_progress():
@@ -4723,11 +4730,11 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
         43201 * 20 - 64000
     )
     assert active_group["latest"]["derived"]["estimated_remaining_rows"] == (
-        43201 * 20 - 64000
+        43201 * 29 - 64000
     )
     assert active_group["latest"]["derived"]["estimated_dense_remaining_ms"] == 3733584
     assert active_group["latest"]["derived"]["estimated_required_remaining_ms"] == 2512507
-    assert active_group["latest"]["derived"]["estimated_remaining_ms"] == 2512507
+    assert active_group["latest"]["derived"]["estimated_remaining_ms"] == 3733584
     assert active_group["latest"]["derived"]["observed_work_pct"] == pytest.approx(
         5.108
     )
@@ -4775,8 +4782,8 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
         "failed_attention_bots": 1,
         "max_active_latest_elapsed_ms": 755750,
         "max_active_latest_event_age_ms": 360000,
-        "max_active_estimated_remaining_rows": 800020,
-        "max_active_estimated_remaining_ms": 2512507,
+        "max_active_estimated_remaining_rows": 43201 * 29 - 64000,
+        "max_active_estimated_remaining_ms": 3733584,
         "max_active_estimated_dense_remaining_rows": 43201 * 29 - 64000,
         "max_active_estimated_dense_remaining_ms": 3733584,
         "max_active_estimated_required_remaining_rows": 43201 * 20 - 64000,
@@ -4802,15 +4809,15 @@ def test_live_smoke_report_summarizes_hsl_replay_health(tmp_path, monkeypatch):
                 "total_applied_rows": 64000,
                 "rows_per_second": 318.415,
                 "throughput_source": "applied_rows_legacy",
-                "work_estimate_source": "required_dense_rows",
+                "work_estimate_source": "dense_rows_upper_bound",
                 "observed_required_work_pct": 7.407,
                 "observed_work_pct": 5.108,
                 "estimated_dense_remaining_rows": 43201 * 29 - 64000,
                 "estimated_dense_remaining_ms": 3733584,
                 "estimated_required_remaining_rows": 43201 * 20 - 64000,
                 "estimated_required_remaining_ms": 2512507,
-                "estimated_remaining_rows": 800020,
-                "estimated_remaining_ms": 2512507,
+                "estimated_remaining_rows": 43201 * 29 - 64000,
+                "estimated_remaining_ms": 3733584,
             }
         ],
         "event_types": {

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -4399,14 +4399,13 @@ def test_hsl_replay_derived_prefers_scanned_work_for_eta(required_pairs):
 
 
 def test_hsl_replay_derived_keeps_legacy_applied_work_fallback():
-    derived = smoke_report_module._hsl_replay_derived(
-        {
-            "timeline_rows": 100,
-            "pairs": 3,
-            "total_applied_rows": 10,
-            "rows_per_second": 2.0,
-        }
-    )
+    data = {
+        "timeline_rows": 100,
+        "pairs": 3,
+        "total_applied_rows": 10,
+        "rows_per_second": 2.0,
+    }
+    derived = smoke_report_module._hsl_replay_derived(data)
 
     assert derived["throughput_source"] == "applied_rows_legacy"
     assert derived["observed_applied_rows"] == 10
@@ -4414,6 +4413,14 @@ def test_hsl_replay_derived_keeps_legacy_applied_work_fallback():
     assert derived["estimated_dense_remaining_rows"] == 290
     assert derived["estimated_dense_remaining_ms"] == 145000
     assert derived["work_estimate_source"] == "dense_rows_upper_bound"
+
+    terminal = smoke_report_module._hsl_replay_derived(
+        {**data, "stage": "full_replay"}
+    )
+    assert terminal["estimated_dense_remaining_rows"] == 290
+    assert terminal["work_estimate_source"] == "legacy_terminal_no_candidate_rows"
+    assert terminal["estimated_remaining_rows"] == 0
+    assert terminal["estimated_remaining_ms"] == 0
 
 
 def test_hsl_replay_health_retains_protective_ready_after_later_progress():


### PR DESCRIPTION
## Summary
- make generic active HSL replay remaining work use the full-replay dense upper bound
- keep required-pair estimates separate and preserve exact terminal candidate-row estimates
- record PR #1190 deployment evidence and the report-only validation boundary

## Live evidence
PR #1190 exposed an active optional replay with positive estimated_dense_remaining_rows but estimated_remaining_rows=0 because required_pairs=0. The same premature zero can occur once required work finishes while optional replay continues.

## Behavior boundary
Report derivation, tests, and planning documentation only. No HSL producer/state, replay order/application, exchange calls, process control, smoke verdict, Rust/order/risk logic, or trading behavior changes. VPS validation requires a pull and bounded report queries over existing records; no bot restart or signals.

## Validation
- 180 tests: performance report, smoke report, incident bundle, restart smoke plan
- focused performance-report suite
- independent parity matrix across performance/smoke derivation
- Python compilation
- git diff --check
- added-line silent-handling scan
- independent static preflight: no findings