### PR TITLE
Expose startup readiness SLA scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Existing `bot.startup_timing` events now include bounded machine-readable
+  readiness scope and trading-impact labels for account, HSL protective,
+  execution-loop, first-market-state, and background-candle milestones. The
+  best-effort active-candle phase remains timing-only. Live performance and
+  smoke reports expose per-bot and aggregate readiness SLA timing without
+  changing startup sequencing, readiness gates, exchange calls, or trading
+  behavior.
+
 - Coin-mode HSL replay progress now separates scanned candidate rows from
   applied state-update rows. Live performance and smoke reports use scan
   throughput for remaining-work estimates when available, retain explicit

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,46 +22,59 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1191, `Fix active HSL replay remaining estimates`
-- Branch: `codex/v8-hsl-required-zero-estimate`
-- Base: `6b2da757f2fbc590c12365870475176632269021`
-- Triggering evidence: the PR #1190 deployment reported active optional replay
-  with positive `estimated_dense_remaining_rows` but generic
-  `estimated_remaining_rows=0` because `required_pairs=0`. The same premature
-  zero can occur after required work completes while optional replay remains.
-- Scope: make generic active replay remaining rows/time use the full-replay
-  dense upper bound and label it `dense_rows_upper_bound`. Keep
-  `estimated_required_remaining_*` as the separate protective-work metric and
-  keep terminal `candidate_rows_terminal` estimates exact. Treat legacy
-  `full_replay` events without candidate totals as terminal rather than
-  reporting dense remaining work.
-- Behavior boundary: read-only performance/smoke report derivation and tests
-  only. No event producer, replay candidate/order/application, HSL state,
-  exchange call, process control, smoke verdict, Rust/order/risk logic, or
-  trading behavior change.
-- Validation: full performance-report, smoke-report, incident-bundle, and
-  restart-smoke-plan suites plus Python compilation, `git diff --check`, and
-  the added-line silent-handling scan.
+- Branch: `codex/v8-startup-readiness-sla`
+- Base: `359929007dce0b47c023a36fdef90a7106ae46da`
+- Triggering evidence: existing `bot.startup_timing` events carry elapsed phase
+  timing, but operators and reports cannot distinguish account-critical,
+  held-position protective, execution-loop, market-state, and background
+  readiness semantics without interpreting phase names.
+- Scope: centralize a bounded readiness contract for five existing startup
+  timing phases, emit `readiness_scope` and `trading_impact`, and project
+  per-bot plus aggregate readiness SLA timing in performance and smoke reports.
+  Consumers accept metadata only when it exactly matches the centralized phase
+  contract. The best-effort `active-candle` phase remains timing-only because
+  its warmup failure is tolerated and cannot prove readiness.
+- Behavior boundary: additive structured event metadata and read-only report
+  projection only. No startup ordering, readiness gate, HSL state/replay,
+  exchange call, process-control policy, Rust/order/risk logic, or trading
+  behavior change. This slice does not claim the still-missing true
+  fresh-entry, first-Rust-call, or first-exchange-write milestones.
+- Validation: event-contract/emitter, startup monitor, performance-report,
+  smoke-report, incident-bundle, and restart-smoke-plan suites plus Python
+  compilation, `git diff --check`, and the added-line silent-handling scan.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: after merge, pull while preserving local artifacts and
-  run the bounded HSL replay profile plus smoke projections over the existing
-  PR #1190 replay records. Do not restart or signal bots because this slice
-  changes only on-demand report consumers.
+  restart only the five exact supervised bot panes because the event producer
+  is loaded by running Python processes. Preserve unrelated `misc:0.0`, then
+  query the new startup fields and run immediate plus settled smoke checks.
 
 Next action:
 
-1. Complete exact-head review and CI for the narrow generic active-replay
-   estimate fix, merge only when the full gate is green, then validate the
-   corrected projection against existing VPS5 replay records without a bot
-   restart.
+1. Complete implementation and independent preflight, publish one review-worthy
+   PR, resolve verified findings, and merge only after the exact-head temporary
+   Hermes + Grok 4.5 + green-CI gate is satisfied.
 
 ## Deployed Baseline
 
-- Remote `v8`: `6b2da757f2fbc590c12365870475176632269021`, PR #1190
-- VPS5 repository: `6b2da757f2fbc590c12365870475176632269021`, PR #1190; tracked
+- Remote `v8`: `359929007dce0b47c023a36fdef90a7106ae46da`, PR #1191
+- VPS5 repository: `359929007dce0b47c023a36fdef90a7106ae46da`, PR #1191; tracked
   status clean; only expected untracked artifacts were preserved
-- VPS5 expected bots: five; all running after the shared-code five-pane restart
+- VPS5 expected bots: five; all running with unchanged PIDs after the
+  report-only pull; unrelated `misc:0.0` remains PID `434835`
+- PR #1191 merged as `359929007dce0b47c023a36fdef90a7106ae46da` after
+  exact-head Hermes and Grok 4.5 approval plus green CI, then was pulled to
+  VPS5 without restarting bots. Real optional-replay progress with
+  `required_pairs=0` retained positive generic dense remaining work while
+  required remaining stayed zero; exact candidate terminal records stayed
+  zero. A retained legacy KuCoin terminal record without candidate totals
+  reported `legacy_terminal_no_candidate_rows`, generic remaining zero, and
+  retained its diagnostic dense remainder. The settled two-minute smoke was
+  green with `278/278` remote and `58/58` account-critical calls successful,
+  all five expected bots matched, no hard/log/monitor failures, and a clean
+  repository. Large rotated-history validation briefly produced host I/O waits;
+  after a quiet interval all five bot processes were `Rsl+` with their
+  original PIDs.
 - PR #1190 merged as `6b2da757f2fbc590c12365870475176632269021` and was deployed
   to VPS5. All five exact supervised panes were restarted, unrelated
   `misc:0.0` PID `434835` was preserved, and immediate live evidence showed the
@@ -158,12 +171,11 @@ scorecard, stable per-pair fill index, exact sparse flat-pair replay, and the
 rotated resource-pressure report fix, configured-market skip events, and fatal
 HIP-3 startup compatibility are merged and deployed. PR #1189's isolated-only
 initial-entry filter visibility and PR #1190's HSL replay scanned-row
-throughput are also merged and deployed. The next active slice fixes the
-generic active replay remaining estimate when required work is empty or
-complete while optional replay remains, using the dense upper bound while
-keeping required and terminal candidate estimates separate.
+throughput and PR #1191's corrected active/legacy-terminal replay estimates are
+also merged and deployed. The next active slice adds machine-readable readiness
+SLA semantics to existing startup timing events and reports.
 
-After this active slice is merged and its report-only VPS validation is
+After this active slice is merged and its producer/restart VPS validation is
 recorded, select the next review-worthy candidate from the remaining backlog,
 including:
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,6 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
+- PR #1192, `Expose startup readiness SLA scopes`
 - Branch: `codex/v8-startup-readiness-sla`
 - Base: `359929007dce0b47c023a36fdef90a7106ae46da`
 - Triggering evidence: existing `bot.startup_timing` events carry elapsed phase

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7546,6 +7546,7 @@ VPS5 deployment status:
 
 ### Active Slice: Startup Readiness SLA Semantics
 
+- PR #1192, `Expose startup readiness SLA scopes`.
 - Branch: `codex/v8-startup-readiness-sla` from deployed
   `359929007dce0b47c023a36fdef90a7106ae46da`.
 - Scope: add bounded `readiness_scope` and `trading_impact` fields to five

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -19,20 +19,22 @@ Last updated: 2026-07-11.
 
 Current `origin/v8` head:
 
-- `6b2da757f2fbc590c12365870475176632269021` after PR #1190, `Expose HSL
-  replay scan throughput`.
+- `359929007dce0b47c023a36fdef90a7106ae46da` after PR #1191, `Fix active
+  HSL replay remaining estimates`.
 
 Current logging-overhaul head:
 
-- `6b2da757f2fbc590c12365870475176632269021` after PR #1190, `Expose HSL
-  replay scan throughput` (latest merged logging-overhaul slice).
+- `359929007dce0b47c023a36fdef90a7106ae46da` after PR #1191, `Fix active
+  HSL replay remaining estimates` (latest merged logging-overhaul slice).
 
 Current work:
 
-- Active narrow slice: fix the generic active replay remaining estimate when
-  `required_pairs=0` or required work has completed while optional replay
-  remains. Use the dense upper bound for the generic active estimate, keep the
-  required metric separate, and retain exact terminal candidate estimates.
+- Active slice: add centralized readiness scope and trading-impact metadata to
+  five existing `bot.startup_timing` phases, then expose per-bot and
+  aggregate readiness SLA timing in performance and smoke reports without
+  changing startup or trading behavior. Keep the best-effort `active-candle`
+  phase timing-only because it cannot prove readiness after a tolerated warmup
+  failure.
 
 Current review gate:
 
@@ -63,6 +65,15 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1191 merged to `v8` as
+  `359929007dce0b47c023a36fdef90a7106ae46da` and was pulled to VPS5 without
+  restarting bots. Existing optional progress, exact candidate terminal, and
+  retained legacy terminal records all produced the corrected report
+  semantics. The settled smoke was green with `278/278` remote and `58/58`
+  account-critical calls successful, all five expected processes matched, no
+  hard/log/monitor failures, and a clean tracked repository. All bot PIDs and
+  unrelated `misc:0.0` PID `434835` remained unchanged; after the bounded
+  rotated-history scans settled, all five bots were `Rsl+`.
 - PR #1190 merged to `v8` as
   `6b2da757f2fbc590c12365870475176632269021` and was deployed to VPS5. The
   tracked repository was clean and only expected untracked artifacts were
@@ -7532,3 +7543,21 @@ VPS5 deployment status:
   lacked the new diagnostics dedupe set; an explicit initializer and direct
   filter regression resolve the finding, and delta review found no code
   regression.
+
+### Active Slice: Startup Readiness SLA Semantics
+
+- Branch: `codex/v8-startup-readiness-sla` from deployed
+  `359929007dce0b47c023a36fdef90a7106ae46da`.
+- Scope: add bounded `readiness_scope` and `trading_impact` fields to five
+  existing `bot.startup_timing` phases through one centralized contract. Keep
+  the best-effort `active-candle` phase timing-only because its tolerated
+  failure path cannot prove readiness.
+  Performance and smoke reports accept only exact contract matches and expose
+  per-bot plus aggregate readiness SLA timing.
+- Non-goals: no new readiness decision, startup ordering, HSL/replay state,
+  exchange call, process policy, Rust/order/risk logic, backtest, optimizer, or
+  trading behavior. True fresh-entry, first-Rust-call, and
+  first-exchange-write milestones remain future source-event work.
+- Expected VPS action: restart only the five exact supervised bot panes after
+  exact-head approval and merge, preserve unrelated `misc:0.0`, query the new
+  startup event/report fields, and run immediate plus settled smoke checks.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -334,6 +334,11 @@ Related detailed plans:
      `live-smoke-report` phase summaries, comparing latest elapsed/phase
      timings against prior local p95 baselines without changing startup
      behavior or adding new runtime events.
+   - 2026-07-11: Active branch `codex/v8-startup-readiness-sla` adds
+     centralized readiness scope and trading-impact labels to existing startup
+     timing events plus per-bot/aggregate performance and smoke projections.
+     It remains additive and does not claim fresh-entry, first-Rust-call, or
+     first-exchange-write readiness.
 
 5. [x] Resource pressure telemetry.
    Status: initial implementation merged. `health.summary` events now include

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -309,10 +309,14 @@ classification when enough source events exist.
 - [ ] Startup: process start to account-critical ready.
 - Status: partial. Existing `bot.startup_timing` events are summarized by
   `live-performance-report` as `startup_readiness`, including per-bot startup
-  phases and aggregate bounded phase elapsed/since-previous timing. Remaining
-  work: explicit account-critical ready, held-position protective HSL ready,
-  fresh-entry ready, first cycle/Rust call, and first exchange-write readiness
-  events.
+  phases and aggregate bounded phase elapsed/since-previous timing. The active
+  readiness-SLA slice adds centralized machine-readable scope and
+  trading-impact metadata for existing account-critical, held-position
+  protective, execution-loop, market-state, and background-candle readiness
+  milestones. The best-effort active-position candle phase remains timing-only
+  because its tolerated warmup failure cannot prove readiness.
+  Remaining work: true fresh-entry ready, first Rust call, and first
+  exchange-write readiness events.
 - [ ] Startup: process start to held-position protective HSL ready.
 - [ ] Startup: process start to fresh-entry ready.
 - [ ] Startup: process start to first planning cycle started/completed.
@@ -732,9 +736,11 @@ Trading-impact labels:
     exchange write eligibility, and full background replay complete.
   - Group by exchange/user/bot so VPS-class regressions are visible before a
     panic incident.
-  - Status: partial. Startup phase timing aggregation is available from
-    existing phase events, but true order-class readiness SLA events are still
-    missing.
+- Status: partial. Startup phase timing aggregation is available from
+  existing phase events. The active readiness-SLA slice adds per-bot and
+  aggregate scope timing for the readiness milestones already emitted, while
+  true fresh-entry, first-Rust-call, and first-exchange-write milestones remain
+  missing.
 
 - [ ] Add a full live-operation duration table.
   - Include startup, account refresh, fill refresh, cache proof, HSL replay,

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -9,6 +9,7 @@ import queue
 import re
 import threading
 import time
+from types import MappingProxyType
 import uuid
 from typing import Any, Iterable, Mapping, Protocol
 
@@ -54,6 +55,29 @@ _LIVE_EVENT_DEBUG_PROFILE_ALIASES = {
     "remote-call": "remote_calls",
     "remote-calls": "remote_calls",
 }
+
+_STARTUP_PHASE_READINESS_CONTRACTS: Mapping[str, tuple[str, str]] = MappingProxyType(
+    {
+        "account": ("account_critical", "protective_blocker"),
+        "hsl": ("held_position_protective", "protective_blocker"),
+        "startup": ("execution_loop", "protective_blocker"),
+        "market": ("first_market_state", "cycle_delay"),
+        "full-warmup": ("background_candles_complete", "entry_blocker"),
+    }
+)
+
+
+def startup_phase_readiness_contract(phase: object) -> dict[str, str] | None:
+    """Return bounded readiness metadata for a known startup phase."""
+    if not isinstance(phase, str):
+        return None
+    values = _STARTUP_PHASE_READINESS_CONTRACTS.get(phase)
+    if values is None:
+        return None
+    return {
+        "readiness_scope": values[0],
+        "trading_impact": values[1],
+    }
 
 
 class EventTypes:

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -15,6 +15,7 @@ from live.event_bus import (
     authoritative_reason_code,
     emit_event,
     live_event_debug_profile_enabled,
+    startup_phase_readiness_contract,
     utc_ms,
 )
 
@@ -1242,13 +1243,17 @@ def _emit_startup_timing_event_unchecked(
 ) -> None:
     elapsed = _safe_int(elapsed_ms)
     since_previous = _safe_int(since_previous_ms)
+    phase_text = str(phase)
     data: dict[str, Any] = {
-        "phase": str(phase),
+        "phase": phase_text,
         "elapsed_ms": max(0, int(elapsed)) if elapsed is not None else 0,
         "since_previous_ms": (
             max(0, int(since_previous)) if since_previous is not None else 0
         ),
     }
+    readiness_contract = startup_phase_readiness_contract(phase_text)
+    if readiness_contract is not None:
+        data.update(readiness_contract)
     if details:
         data["details"] = str(details)
     if live_event_debug_profile_enabled(bot, "startup"):

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -12,6 +12,7 @@ from live.event_bus import (
     LIVE_EVENT_DEBUG_PROFILES,
     LIVE_EVENT_ID_KEYS,
     LIVE_EVENT_MONITOR_PAYLOAD_KEY,
+    startup_phase_readiness_contract,
     utc_ms,
 )
 from live.event_file_rows import event_file_rows
@@ -1147,12 +1148,28 @@ def _startup_phase_label(value: Any) -> str:
     return "other"
 
 
+def _startup_readiness_contract(
+    data: dict[str, Any], phase: str
+) -> dict[str, str] | None:
+    expected = startup_phase_readiness_contract(phase)
+    if expected is None:
+        return None
+    if data.get("readiness_scope") != expected["readiness_scope"]:
+        return None
+    if data.get("trading_impact") != expected["trading_impact"]:
+        return None
+    return expected
+
+
 class _StartupReadinessAccumulator:
     def __init__(self) -> None:
         self.bots: dict[str, dict[str, Any]] = {}
         self.startup_phase_counts: Counter[str] = Counter()
         self.startup_phase_elapsed_values: dict[str, list[int]] = {}
         self.startup_phase_since_previous_values: dict[str, list[int]] = {}
+        self.readiness_scope_counts: Counter[str] = Counter()
+        self.readiness_scope_elapsed_values: dict[str, list[int]] = {}
+        self.readiness_trading_impact_counts: Counter[str] = Counter()
 
     @staticmethod
     def _update_debug_profiles(state: dict[str, Any], data: dict[str, Any]) -> None:
@@ -1219,6 +1236,24 @@ class _StartupReadinessAccumulator:
                 self.startup_phase_elapsed_values.setdefault(stage, []).append(
                     int(elapsed_ms)
                 )
+                contract = _startup_readiness_contract(data, stage)
+                if contract is not None:
+                    scope = contract["readiness_scope"]
+                    impact = contract["trading_impact"]
+                    readiness_sla = state.get("readiness_sla")
+                    if not isinstance(readiness_sla, dict):
+                        readiness_sla = {}
+                        state["readiness_sla"] = readiness_sla
+                    readiness_sla[scope] = {
+                        "phase": stage,
+                        "elapsed_ms": int(elapsed_ms),
+                        "trading_impact": impact,
+                    }
+                    self.readiness_scope_counts[scope] += 1
+                    self.readiness_scope_elapsed_values.setdefault(scope, []).append(
+                        int(elapsed_ms)
+                    )
+                    self.readiness_trading_impact_counts[impact] += 1
             since_previous_ms = _non_negative_ms(data.get("since_previous_ms"))
             if since_previous_ms is not None:
                 self.startup_phase_since_previous_values.setdefault(stage, []).append(
@@ -1278,6 +1313,12 @@ class _StartupReadinessAccumulator:
                 SUMMARY_GROUP_LIMIT
             )
         ]
+        readiness_scopes = [
+            scope
+            for scope, _count in self.readiness_scope_counts.most_common(
+                SUMMARY_GROUP_LIMIT
+            )
+        ]
         for bot, state in sorted(self.bots.items()):
             phases = dict(sorted(state.get("startup_phases_ms", {}).items()))
             item = {
@@ -1288,6 +1329,11 @@ class _StartupReadinessAccumulator:
             }
             if len(phases) > limit:
                 item["startup_phases_truncated"] = True
+            readiness_sla = dict(sorted((state.get("readiness_sla") or {}).items()))
+            if readiness_sla:
+                item["readiness_sla"] = dict(list(readiness_sla.items())[:limit])
+                if len(readiness_sla) > limit:
+                    item["readiness_sla_truncated"] = True
             if state.get("bot_started_ts") is not None:
                 item["bot_started_ts"] = int(state["bot_started_ts"])
             if state.get("bot_ready_ts") is not None:
@@ -1332,6 +1378,19 @@ class _StartupReadinessAccumulator:
                 for phase in phase_labels
                 if self.startup_phase_since_previous_values.get(phase)
             },
+            "readiness_scope_counts": {
+                scope: int(self.readiness_scope_counts[scope])
+                for scope in readiness_scopes
+            },
+            "readiness_scope_elapsed_ms": {
+                scope: _number_summary(
+                    self.readiness_scope_elapsed_values.get(scope, [])
+                )
+                for scope in readiness_scopes
+            },
+            "readiness_trading_impact_counts": dict(
+                sorted(self.readiness_trading_impact_counts.items())
+            ),
             "bots_truncated": len(bot_items) > limit,
             "bots": bot_items[:limit],
         }
@@ -4002,12 +4061,17 @@ def _add_event_timings(
         value_ms = _non_negative_ms(data.get("elapsed_ms"))
         if value_ms is None:
             value_ms = _elapsed_s_to_ms(data.get("elapsed_s"))
+        contract = _startup_readiness_contract(data, stage)
         accumulator.add(
             row=row,
             live_event=live_event,
             operation=operation,
             value_ms=value_ms,
-            trading_impact=_trading_impact_for_event(event_type, operation),
+            trading_impact=(
+                contract["trading_impact"]
+                if contract is not None
+                else _trading_impact_for_event(event_type, operation)
+            ),
         )
         return
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -11,7 +11,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Iterable
 
-from live.event_bus import LIVE_EVENT_MONITOR_PAYLOAD_KEY, EventTypes, utc_ms
+from live.event_bus import (
+    LIVE_EVENT_MONITOR_PAYLOAD_KEY,
+    EventTypes,
+    startup_phase_readiness_contract,
+    utc_ms,
+)
 from live.event_file_rows import event_file_rows
 from live.event_query import (
     _limit_recent_event_files_per_bot,
@@ -5433,7 +5438,7 @@ def _startup_timing_record(
     since_previous_ms = _non_negative_int(data.get("since_previous_ms"))
     if elapsed_ms is None and since_previous_ms is None:
         return None
-    return {
+    record = {
         "phase": phase,
         "elapsed_ms": elapsed_ms,
         "since_previous_ms": since_previous_ms,
@@ -5443,6 +5448,14 @@ def _startup_timing_record(
         "path": str(path),
         "line": int(line_no),
     }
+    contract = startup_phase_readiness_contract(phase)
+    if (
+        contract is not None
+        and data.get("readiness_scope") == contract["readiness_scope"]
+        and data.get("trading_impact") == contract["trading_impact"]
+    ):
+        record.update(contract)
+    return record
 
 
 def _sort_startup_record_key(record: dict[str, Any]) -> tuple[int, int, str, int]:
@@ -5454,6 +5467,24 @@ def _sort_startup_record_key(record: dict[str, Any]) -> tuple[int, int, str, int
         str(record.get("path") or ""),
         int(record.get("line") or 0),
     )
+
+
+def _startup_records_after_latest_started(
+    records_by_bot: dict[str, list[dict[str, Any]]],
+    latest_started_by_bot: dict[str, dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    current: dict[str, list[dict[str, Any]]] = {}
+    for bot_key, records in records_by_bot.items():
+        marker = latest_started_by_bot.get(bot_key)
+        marker_key = _sort_startup_record_key(marker) if marker is not None else None
+        selected = [
+            record
+            for record in records
+            if marker_key is None or _sort_startup_record_key(record) > marker_key
+        ]
+        if selected:
+            current[bot_key] = selected
+    return current
 
 
 def _summarize_startup_timings(
@@ -5510,6 +5541,9 @@ def _summarize_startup_timings(
                     latest_phase, phase_summary["p95_ms"]
                 ),
             }
+            for key in ("readiness_scope", "trading_impact"):
+                if latest.get(key) is not None:
+                    phase_summaries[phase][key] = latest[key]
             details = latest.get("details")
             if details not in (None, ""):
                 phase_summaries[phase]["latest_details"] = _redact_log_text(
@@ -5782,6 +5816,7 @@ def _scan_events(
     event_files_skipped_by_limit = 0
     event_file_limit_groups = 0
     startup_timing_records: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    startup_latest_started: dict[str, dict[str, Any]] = {}
     remote_call_failure_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     remote_call_health_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     remote_call_timing_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -6127,6 +6162,18 @@ def _scan_events(
                                 "base_hard": is_hard_problem_event(live_event),
                             }
                         )
+                    if event_type == EventTypes.BOT_STARTED:
+                        marker = {
+                            "ts": row.get("ts"),
+                            "seq": row.get("seq"),
+                            "path": str(path),
+                            "line": int(line_no),
+                        }
+                        previous_marker = startup_latest_started.get(bot_key)
+                        if previous_marker is None or _sort_startup_record_key(
+                            marker
+                        ) > _sort_startup_record_key(previous_marker):
+                            startup_latest_started[bot_key] = marker
                     startup_timing = _startup_timing_record(
                         row=row,
                         live_event=live_event,
@@ -6217,7 +6264,12 @@ def _scan_events(
         "hard_problem_event_count": sum(
             int(value["hard_problem_events"]) for value in bots.values()
         ),
-        "startup_timings": _summarize_startup_timings(startup_timing_records),
+        "startup_timings": _summarize_startup_timings(
+            _startup_records_after_latest_started(
+                startup_timing_records,
+                startup_latest_started,
+            )
+        ),
         "remote_call_failures": _summarize_remote_call_failures(
             remote_call_failure_groups
         ),
@@ -6884,6 +6936,8 @@ def _brief_startup_timings(startup_timings: Any) -> dict[str, Any]:
     max_latest_phase_ms: int | None = None
     max_startup_elapsed_ms: int | None = None
     startup_phase_bots = 0
+    readiness_scope_counts: Counter[str] = Counter()
+    readiness_scope_elapsed_ms_max: dict[str, int] = {}
     for row in rows:
         if not isinstance(row, dict):
             continue
@@ -6908,6 +6962,14 @@ def _brief_startup_timings(startup_timings: Any) -> dict[str, Any]:
                         max_startup_elapsed_ms
                         if max_startup_elapsed_ms is not None
                         else 0,
+                    )
+                readiness_scope = phase_data.get("readiness_scope")
+                if readiness_scope is not None:
+                    scope = str(readiness_scope)
+                    readiness_scope_counts[scope] += 1
+                    readiness_scope_elapsed_ms_max[scope] = max(
+                        latest_elapsed,
+                        readiness_scope_elapsed_ms_max.get(scope, 0),
                     )
             if latest_phase is not None:
                 max_latest_phase_ms = max(
@@ -6934,8 +6996,12 @@ def _brief_startup_timings(startup_timings: Any) -> dict[str, Any]:
             "max_latest_elapsed_ms": max_latest_elapsed_ms,
             "max_latest_phase_ms": max_latest_phase_ms,
             "max_startup_elapsed_ms": max_startup_elapsed_ms,
+            "readiness_scope_counts": dict(sorted(readiness_scope_counts.items())),
+            "readiness_scope_elapsed_ms_max": dict(
+                sorted(readiness_scope_elapsed_ms_max.items())
+            ),
         }.items()
-        if value is not None
+        if value not in (None, {})
     }
 
 

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -31,6 +31,7 @@ from live.event_bus import (
     redact_payload,
     resolve_live_event_console_enabled,
     sink_failed_reason_code,
+    startup_phase_readiness_contract,
 )
 from live.events import DiagnosticEvent
 from monitor_publisher import MonitorPublisher
@@ -79,6 +80,46 @@ def test_live_event_tag_registry_values_are_unique_and_query_safe():
 
 def test_market_compatibility_event_type_is_stable():
     assert EventTypes.CONFIG_MARKET_COMPATIBILITY == "config.market_compatibility"
+
+
+def test_startup_phase_readiness_contract_is_bounded_and_defensive():
+    expected = {
+        "account": {
+            "readiness_scope": "account_critical",
+            "trading_impact": "protective_blocker",
+        },
+        "hsl": {
+            "readiness_scope": "held_position_protective",
+            "trading_impact": "protective_blocker",
+        },
+        "startup": {
+            "readiness_scope": "execution_loop",
+            "trading_impact": "protective_blocker",
+        },
+        "market": {
+            "readiness_scope": "first_market_state",
+            "trading_impact": "cycle_delay",
+        },
+        "full-warmup": {
+            "readiness_scope": "background_candles_complete",
+            "trading_impact": "entry_blocker",
+        },
+    }
+
+    for phase, contract in expected.items():
+        assert startup_phase_readiness_contract(phase) == contract
+        assert set(contract) == {"readiness_scope", "trading_impact"}
+
+    first = startup_phase_readiness_contract("account")
+    second = startup_phase_readiness_contract("account")
+    assert first is not None
+    assert second is not None
+    assert first is not second
+    first["readiness_scope"] = "modified"
+    assert second["readiness_scope"] == "account_critical"
+    assert startup_phase_readiness_contract("active-candle") is None
+    assert startup_phase_readiness_contract("unknown") is None
+    assert startup_phase_readiness_contract(["account"]) is None
 
 
 def test_live_event_reason_code_registry_values_are_unique_and_query_safe():

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1237,14 +1237,26 @@ def test_live_performance_report_startup_readiness_summary(tmp_path, monkeypatch
                 seq=2,
                 ts=2000,
                 component="bot.startup",
-                data={"stage": "account", "elapsed_ms": 900, "since_previous_ms": 900},
+                data={
+                    "stage": "account",
+                    "elapsed_ms": 900,
+                    "since_previous_ms": 900,
+                    "readiness_scope": "account_critical",
+                    "trading_impact": "protective_blocker",
+                },
             ),
             _monitor_row(
                 event_type="bot.startup_timing",
                 seq=3,
                 ts=3000,
                 component="bot.startup",
-                data={"stage": "hsl", "elapsed_s": 2.5, "since_previous_ms": 1600},
+                data={
+                    "stage": "hsl",
+                    "elapsed_s": 2.5,
+                    "since_previous_ms": 1600,
+                    "readiness_scope": "held_position_protective",
+                    "trading_impact": "protective_blocker",
+                },
             ),
             _monitor_row(
                 event_type="hsl.replay.progress",
@@ -1285,6 +1297,30 @@ def test_live_performance_report_startup_readiness_summary(tmp_path, monkeypatch
     assert startup["debug_profile_counts"] == {"ema": 1, "rust": 1}
     assert "api_key=should_not_render" not in json.dumps(startup, sort_keys=True)
     assert bot["startup_phases_ms"] == {"account": 900, "hsl": 2500}
+    assert bot["readiness_sla"] == {
+        "account_critical": {
+            "phase": "account",
+            "elapsed_ms": 900,
+            "trading_impact": "protective_blocker",
+        },
+        "held_position_protective": {
+            "phase": "hsl",
+            "elapsed_ms": 2500,
+            "trading_impact": "protective_blocker",
+        },
+    }
+    assert startup["readiness_scope_counts"] == {
+        "account_critical": 1,
+        "held_position_protective": 1,
+    }
+    assert startup["readiness_scope_elapsed_ms"]["account_critical"]["max"] == 900
+    assert (
+        startup["readiness_scope_elapsed_ms"]["held_position_protective"]["max"]
+        == 2500
+    )
+    assert startup["readiness_trading_impact_counts"] == {
+        "protective_blocker": 2,
+    }
     assert startup["startup_phase_counts"] == {"account": 1, "hsl": 1}
     assert startup["startup_phase_elapsed_ms"]["account"] == {
         "count": 1,
@@ -1302,6 +1338,41 @@ def test_live_performance_report_startup_readiness_summary(tmp_path, monkeypatch
     assert bot["hsl_replay"]["held_pairs"] == 1
     assert bot["hsl_replay"]["rows_per_second"] == 289.4
     assert bot["hsl_replay"]["latest_event_age_ms"] == 60000
+
+
+def test_live_performance_report_rejects_mismatched_startup_readiness_contract(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=1,
+                ts=1000,
+                data={
+                    "phase": "account",
+                    "elapsed_ms": 900,
+                    "readiness_scope": "held_position_protective",
+                    "trading_impact": "diagnostics_only",
+                },
+            )
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    startup = report["startup_readiness"]
+
+    assert startup["bots"][0]["startup_phases_ms"] == {"account": 900}
+    assert "readiness_sla" not in startup["bots"][0]
+    assert startup["readiness_scope_counts"] == {}
+    startup_groups = {
+        group["operation"]: group for group in report["operation_durations"]["groups"]
+    }
+    assert startup_groups["startup.account"]["trading_impact"] == (
+        "blocks_startup_readiness"
+    )
 
 
 def test_live_performance_report_startup_readiness_completed_hsl_not_active(tmp_path):

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -3195,6 +3195,8 @@ def test_live_smoke_report_summarizes_startup_phase_baselines(tmp_path):
                     "phase": "account",
                     "elapsed_ms": 3000,
                     "since_previous_ms": 3000,
+                    "readiness_scope": "account_critical",
+                    "trading_impact": "protective_blocker",
                 },
             ),
             _monitor_row(
@@ -3207,6 +3209,8 @@ def test_live_smoke_report_summarizes_startup_phase_baselines(tmp_path):
                     "phase": "startup",
                     "elapsed_ms": 10000,
                     "since_previous_ms": 7000,
+                    "readiness_scope": "execution_loop",
+                    "trading_impact": "protective_blocker",
                     "details": "ready api_key=AKIA123 Authorization: Bearer TOKEN123",
                 },
             ),
@@ -3259,6 +3263,8 @@ def test_live_smoke_report_summarizes_startup_phase_baselines(tmp_path):
                     },
                     "latest_elapsed_vs_p95_pct": 100,
                     "latest_phase_vs_p95_pct": 100,
+                    "readiness_scope": "account_critical",
+                    "trading_impact": "protective_blocker",
                 },
                 "startup": {
                     "samples": 2,
@@ -3297,6 +3303,8 @@ def test_live_smoke_report_summarizes_startup_phase_baselines(tmp_path):
                     },
                     "latest_elapsed_vs_p95_pct": 100,
                     "latest_phase_vs_p95_pct": 100,
+                    "readiness_scope": "execution_loop",
+                    "trading_impact": "protective_blocker",
                     "latest_details": (
                         "ready api_key=[redacted] Authorization: [redacted]"
                     ),
@@ -3321,6 +3329,14 @@ def test_live_smoke_report_summarizes_startup_phase_baselines(tmp_path):
         "max_latest_elapsed_ms": 10000,
         "max_latest_phase_ms": 7000,
         "max_startup_elapsed_ms": 10000,
+        "readiness_scope_counts": {
+            "account_critical": 1,
+            "execution_loop": 1,
+        },
+        "readiness_scope_elapsed_ms_max": {
+            "account_critical": 3000,
+            "execution_loop": 10000,
+        },
     }
 
 
@@ -3339,6 +3355,8 @@ def test_live_smoke_report_startup_budget_no_baseline(tmp_path):
                     "phase": "account",
                     "elapsed_ms": 2000,
                     "since_previous_ms": 2000,
+                    "readiness_scope": "held_position_protective",
+                    "trading_impact": "diagnostics_only",
                 },
             )
         ],
@@ -3357,6 +3375,84 @@ def test_live_smoke_report_startup_budget_no_baseline(tmp_path):
         "source": "prior_p95_ms",
     }
     assert phase["phase_budget"]["status"] == "no_baseline"
+    assert "readiness_scope" not in phase
+    assert "trading_impact" not in phase
+    brief = summarize_live_smoke_report_brief(report)
+    assert "readiness_scope_counts" not in brief["startup_timings"]
+
+
+def test_live_smoke_report_startup_readiness_resets_on_bot_started(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "2026-07-10T00-00-00.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=1,
+                ts=1000,
+                data={
+                    "phase": "hsl",
+                    "elapsed_ms": 9000,
+                    "since_previous_ms": 6000,
+                    "readiness_scope": "held_position_protective",
+                    "trading_impact": "protective_blocker",
+                },
+            ),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=2,
+                ts=2000,
+                data={
+                    "phase": "full-warmup",
+                    "elapsed_ms": 15000,
+                    "since_previous_ms": 6000,
+                    "readiness_scope": "background_candles_complete",
+                    "trading_impact": "entry_blocker",
+                },
+            ),
+        ],
+    )
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=3, ts=3000),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=4,
+                ts=4000,
+                data={
+                    "phase": "account",
+                    "elapsed_ms": 1000,
+                    "since_previous_ms": 1000,
+                    "readiness_scope": "account_critical",
+                    "trading_impact": "protective_blocker",
+                },
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        include_rotated=True,
+        max_event_files_per_bot=2,
+    )
+    startup = report["startup_timings"]
+
+    assert len(startup) == 1
+    assert set(startup[0]["phases"]) == {"account"}
+    summary = summarize_live_smoke_report(report)
+    assert set(summary["startup_timings"]["groups"][0]["phases"]) == {"account"}
+    assert summarize_live_smoke_report_brief(report)["startup_timings"] == {
+        "bots": 1,
+        "phases": 1,
+        "over_budget_phases": 0,
+        "startup_phase_bots": 0,
+        "max_latest_elapsed_ms": 1000,
+        "max_latest_phase_ms": 1000,
+        "readiness_scope_counts": {"account_critical": 1},
+        "readiness_scope_elapsed_ms_max": {"account_critical": 1000},
+    }
 
 
 def test_live_smoke_report_summarizes_shutdown_events(tmp_path):

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -200,11 +200,15 @@ def test_startup_timing_mark_emits_structured_event(monkeypatch, caplog):
         "phase": "account",
         "elapsed_ms": 2500,
         "since_previous_ms": 2500,
+        "readiness_scope": "account_critical",
+        "trading_impact": "protective_blocker",
     }
     assert events[1].data == {
         "phase": "hsl",
         "elapsed_ms": 7000,
         "since_previous_ms": 4500,
+        "readiness_scope": "held_position_protective",
+        "trading_impact": "protective_blocker",
         "details": "mode=coin",
     }
     assert events[1].level == "info"
@@ -250,7 +254,9 @@ def test_startup_timing_debug_profile_adds_bounded_phase_shape(
             "details",
             "elapsed_ms",
             "phase",
+            "readiness_scope",
             "since_previous_ms",
+            "trading_impact",
         ],
         "phase": "account",
         "elapsed_ms": 2500,
@@ -306,8 +312,48 @@ def test_startup_timing_mark_suppresses_legacy_log_when_event_console_active(
         "phase": "account",
         "elapsed_ms": 2500,
         "since_previous_ms": 2500,
+        "readiness_scope": "account_critical",
+        "trading_impact": "protective_blocker",
     }
     assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_startup_timing_best_effort_active_candle_omits_readiness_contract_fields():
+    class FakeBot:
+        live_event_debug_profiles = ()
+
+        def __init__(self):
+            self.events = []
+
+        def _emit_live_event(self, event_type, **kwargs):
+            self.events.append((event_type, kwargs))
+
+    bot = FakeBot()
+    live_event_emitters.emit_startup_timing_event(
+        bot,
+        phase="active-candle",
+        elapsed_ms=2500,
+        since_previous_ms=500,
+    )
+
+    assert bot.events == [
+        (
+            EventTypes.BOT_STARTUP_TIMING,
+            {
+                "level": "info",
+                "component": "bot.startup",
+                "tags": ("bot", "startup", "timing"),
+                "cycle_id": None,
+                "status": "succeeded",
+                "reason_code": ReasonCodes.STARTUP_PHASE_READY,
+                "data": {
+                    "phase": "active-candle",
+                    "elapsed_ms": 2500,
+                    "since_previous_ms": 500,
+                },
+            },
+        )
+    ]
 
 
 def test_routine_planning_defer_summary_emits_live_event(monkeypatch):


### PR DESCRIPTION
## Scope

Category: observability producer and read-only reporting.

- Add one centralized contract for five existing `bot.startup_timing` phases.
- Emit bounded `readiness_scope` and canonical `trading_impact` metadata.
- Project exact-contract matches into per-bot and aggregate performance and smoke readiness SLA views.
- Keep smoke startup readiness on the latest observed bot lifecycle independent of rotated-file scan order.

## Behavior

This is additive observability only. It does not change startup sequencing, readiness decisions, HSL replay/state, exchange calls, process-control policy, Rust/order/risk logic, or trading behavior.

The best-effort `active-candle` phase intentionally remains timing-only because its tolerated warmup failure cannot prove readiness. This PR does not claim true fresh-entry, first-Rust-call, or first-exchange-write readiness.

Expected VPS action: pull after merge, restart only the five exact supervised bot panes because the producer is loaded by running Python processes, preserve unrelated `misc:0.0`, then query new startup fields and run immediate plus settled smoke checks.

## Validation

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_event_bus.py tests/test_passivbot_monitor.py tests/test_live_performance_report.py tests/test_live_smoke_report.py tests/test_live_incident_bundle.py tests/test_live_restart_smoke_plan.py`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py src/live/event_emitters.py src/live/performance_report.py src/live/smoke_report.py`
- `git diff --check`
- added-line silent-handling scan: only bounded internal accumulator defaults
- independent full preflight and exact delta re-review: no findings after fixes

## Reviewer Focus

Please verify phase-to-readiness semantics, canonical impact classification, exact-contract rejection behavior, lifecycle filtering across capped rotated scans, payload boundedness, report compatibility, and documentation claims.

Residual risk: current readiness semantics are limited to milestones the producer already emits; missing true entry/Rust/write milestones remain explicit future work.