### PR TITLE
Keep startup reports on latest lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Capped rotated `live-performance-report` scans now keep each bot's startup
+  readiness snapshot on the latest observed lifecycle even though recent-file
+  selection reads `current.ndjson` before older segments. Historical aggregate
+  startup distributions remain unchanged.
+
 - Existing `bot.startup_timing` events now include bounded machine-readable
   readiness scope and trading-impact labels for account, HSL protective,
   execution-loop, first-market-state, and background-candle milestones. The

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,6 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
+- PR #1193, `Keep startup reports on latest lifecycle`
 - Branch: `codex/v8-performance-startup-lifecycle`
 - Base: `3b4b043eb66e8d0b42d792a5b94686b409901220`
 - Triggering evidence: capped rotated performance-report selection intentionally

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,47 +22,54 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1192, `Expose startup readiness SLA scopes`
-- Branch: `codex/v8-startup-readiness-sla`
-- Base: `359929007dce0b47c023a36fdef90a7106ae46da`
-- Triggering evidence: existing `bot.startup_timing` events carry elapsed phase
-  timing, but operators and reports cannot distinguish account-critical,
-  held-position protective, execution-loop, market-state, and background
-  readiness semantics without interpreting phase names.
-- Scope: centralize a bounded readiness contract for five existing startup
-  timing phases, emit `readiness_scope` and `trading_impact`, and project
-  per-bot plus aggregate readiness SLA timing in performance and smoke reports.
-  Consumers accept metadata only when it exactly matches the centralized phase
-  contract. The best-effort `active-candle` phase remains timing-only because
-  its warmup failure is tolerated and cannot prove readiness.
-- Behavior boundary: additive structured event metadata and read-only report
-  projection only. No startup ordering, readiness gate, HSL state/replay,
-  exchange call, process-control policy, Rust/order/risk logic, or trading
-  behavior change. This slice does not claim the still-missing true
-  fresh-entry, first-Rust-call, or first-exchange-write milestones.
-- Validation: event-contract/emitter, startup monitor, performance-report,
-  smoke-report, incident-bundle, and restart-smoke-plan suites plus Python
-  compilation, `git diff --check`, and the added-line silent-handling scan.
+- Branch: `codex/v8-performance-startup-lifecycle`
+- Base: `3b4b043eb66e8d0b42d792a5b94686b409901220`
+- Triggering evidence: capped rotated performance-report selection intentionally
+  processes `current.ndjson` before the selected older segment. The startup
+  accumulator reset per-bot state inline, so an older lifecycle encountered
+  later could overwrite the current startup snapshot.
+- Scope: make per-bot startup readiness state use event order rather than file
+  traversal order while preserving historical aggregate startup distributions.
+  Add a current-before-rotated regression with the production per-bot file cap.
+- Behavior boundary: read-only `live-performance-report` derivation and tests
+  only. No event producer, startup sequence/readiness decision, HSL state,
+  exchange call, process control, Rust/order/risk logic, smoke verdict, or
+  trading behavior change.
+- Validation: focused and full performance-report tests, Python compilation,
+  `git diff --check`, the added-line silent-handling scan, and independent
+  preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: after merge, pull while preserving local artifacts and
-  restart only the five exact supervised bot panes because the event producer
-  is loaded by running Python processes. Preserve unrelated `misc:0.0`, then
-  query the new startup fields and run immediate plus settled smoke checks.
+  run the exact bounded rotated startup-readiness report plus a settled smoke.
+  Do not restart or signal bots because this slice changes only an on-demand
+  report consumer.
 
 Next action:
 
-1. Complete implementation and independent preflight, publish one review-worthy
-   PR, resolve verified findings, and merge only after the exact-head temporary
-   Hermes + Grok 4.5 + green-CI gate is satisfied.
+1. Complete the narrow traversal-order fix and regression, publish after clean
+   independent preflight, and merge only after the exact-head temporary Hermes
+   + Grok 4.5 + green-CI gate is satisfied.
 
 ## Deployed Baseline
 
-- Remote `v8`: `359929007dce0b47c023a36fdef90a7106ae46da`, PR #1191
-- VPS5 repository: `359929007dce0b47c023a36fdef90a7106ae46da`, PR #1191; tracked
+- Remote `v8`: `3b4b043eb66e8d0b42d792a5b94686b409901220`, PR #1192
+- VPS5 repository: `3b4b043eb66e8d0b42d792a5b94686b409901220`, PR #1192; tracked
   status clean; only expected untracked artifacts were preserved
-- VPS5 expected bots: five; all running with unchanged PIDs after the
-  report-only pull; unrelated `misc:0.0` remains PID `434835`
+- VPS5 expected bots: five; all running after exact sequential pane restarts;
+  unrelated `misc:0.0` remains PID `434835`
+- PR #1192 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 replaced bot PIDs `842617/842655/842687/842721/842757` with
+  `850148/850296/850370/850436/850495`, preserving `misc:0.0` PID `434835`.
+  Live reports accepted five account and execution-loop scopes, four
+  held-position protective scopes, three first-market-state scopes, and a
+  completed background-candle scope using canonical impact labels;
+  `active-candle` remained timing-only. The immediate smoke caught three real
+  KuCoin balance timeouts, then the settled two-minute smoke was hard-green
+  with `380/380` remote and `16/16` account-critical calls successful, all five
+  configured bots matched, no pipeline drops/sink errors, and a clean tracked
+  repository. Two transient `D` states during cache/replay work cleared to
+  `R/S` on the quiet follow-up sample.
 - PR #1191 merged as `359929007dce0b47c023a36fdef90a7106ae46da` after
   exact-head Hermes and Grok 4.5 approval plus green CI, then was pulled to
   VPS5 without restarting bots. Real optional-replay progress with
@@ -172,14 +179,16 @@ scorecard, stable per-pair fill index, exact sparse flat-pair replay, and the
 rotated resource-pressure report fix, configured-market skip events, and fatal
 HIP-3 startup compatibility are merged and deployed. PR #1189's isolated-only
 initial-entry filter visibility and PR #1190's HSL replay scanned-row
-throughput and PR #1191's corrected active/legacy-terminal replay estimates are
-also merged and deployed. The next active slice adds machine-readable readiness
-SLA semantics to existing startup timing events and reports.
+throughput, PR #1191's corrected active/legacy-terminal replay estimates, and
+PR #1192's machine-readable startup readiness SLA semantics are also merged and
+deployed. The next active slice makes the performance report's per-bot startup
+snapshot independent of capped current-before-rotated traversal order.
 
-After this active slice is merged and its producer/restart VPS validation is
-recorded, select the next review-worthy candidate from the remaining backlog,
-including:
+After this report-only follow-up is merged and validated, select the next
+review-worthy candidate from the remaining backlog, including:
 
+- bounded startup-to-first-action milestone evidence for true fresh-entry,
+  first-Rust-call, and first actual exchange-write observations
 - bounded operator tooling improvements sharing one code and validation surface
 
 Do not create progress-only PRs or resume unrelated logging work from stale

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7583,6 +7583,7 @@ VPS5 deployment status:
 
 ### Active Slice: Performance Startup Lifecycle Ordering
 
+- PR #1193, `Keep startup reports on latest lifecycle`.
 - Branch: `codex/v8-performance-startup-lifecycle` from deployed
   `3b4b043eb66e8d0b42d792a5b94686b409901220`.
 - Triggering evidence: the bounded per-bot file selector reads current first,

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7562,3 +7562,37 @@ VPS5 deployment status:
 - Expected VPS action: restart only the five exact supervised bot panes after
   exact-head approval and merge, preserve unrelated `misc:0.0`, query the new
   startup event/report fields, and run immediate plus settled smoke checks.
+
+### Deployed Slice: Startup Readiness SLA Semantics
+
+- PR #1192 was approved by Hermes and Grok 4.5 on exact head `9eb8e4a96`; CI
+  passed and it merged to `v8` as `3b4b043eb`.
+- VPS5 fast-forwarded cleanly and sequentially restarted only the five exact
+  supervised panes. Bot PIDs `842617/842655/842687/842721/842757` became
+  `850148/850296/850370/850436/850495`; unrelated `misc:0.0` stayed PID
+  `434835`.
+- Live performance evidence accepted all five account and execution-loop
+  scopes, four held-position protective scopes, three first-market-state
+  scopes, and a later completed background-candle scope with canonical impact
+  labels. The best-effort `active-candle` phase remained timing-only.
+- The immediate smoke caught three real KuCoin balance timeouts. After they
+  aged out, the settled two-minute smoke was hard-green with `380/380` remote
+  and `16/16` account-critical calls successful, all five expected bots
+  matched, no event-pipeline drops or sink errors, and a clean tracked repo.
+  Two cache/replay-time `D` samples cleared to `R/S` on the quiet follow-up.
+
+### Active Slice: Performance Startup Lifecycle Ordering
+
+- Branch: `codex/v8-performance-startup-lifecycle` from deployed
+  `3b4b043eb66e8d0b42d792a5b94686b409901220`.
+- Triggering evidence: the bounded per-bot file selector reads current first,
+  then the selected rotated segment. The performance startup accumulator reset
+  inline, allowing older lifecycle records encountered later to overwrite the
+  current per-bot snapshot.
+- Scope: use event ordering for current per-bot startup state while preserving
+  historical aggregate phase/readiness distributions; cover the production
+  `include_rotated` plus `max_event_files_per_bot=2` path.
+- Non-goals: no producer, event schema, startup/readiness decision, exchange
+  call, HSL/risk/order behavior, process control, smoke verdict, Rust,
+  backtest, optimizer, or trading change. Expected VPS action is pull plus a
+  bounded rotated report and settled smoke, with no bot restart.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -339,6 +339,11 @@ Related detailed plans:
      timing events plus per-bot/aggregate performance and smoke projections.
      It remains additive and does not claim fresh-entry, first-Rust-call, or
      first-exchange-write readiness.
+   - 2026-07-11: Follow-up branch
+     `codex/v8-performance-startup-lifecycle` makes capped rotated performance
+     reports retain the latest lifecycle's per-bot startup snapshot independent
+     of current-before-rotated file traversal while preserving historical
+     aggregate distributions.
 
 5. [x] Resource pressure telemetry.
    Status: initial implementation merged. `health.summary` events now include

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -309,8 +309,8 @@ classification when enough source events exist.
 - [ ] Startup: process start to account-critical ready.
 - Status: partial. Existing `bot.startup_timing` events are summarized by
   `live-performance-report` as `startup_readiness`, including per-bot startup
-  phases and aggregate bounded phase elapsed/since-previous timing. The active
-  readiness-SLA slice adds centralized machine-readable scope and
+  phases and aggregate bounded phase elapsed/since-previous timing. PR #1192
+  added centralized machine-readable scope and
   trading-impact metadata for existing account-critical, held-position
   protective, execution-loop, market-state, and background-candle readiness
   milestones. The best-effort active-position candle phase remains timing-only
@@ -737,10 +737,12 @@ Trading-impact labels:
   - Group by exchange/user/bot so VPS-class regressions are visible before a
     panic incident.
 - Status: partial. Startup phase timing aggregation is available from
-  existing phase events. The active readiness-SLA slice adds per-bot and
-  aggregate scope timing for the readiness milestones already emitted, while
-  true fresh-entry, first-Rust-call, and first-exchange-write milestones remain
-  missing.
+  existing phase events. PR #1192 added per-bot and
+  aggregate scope timing for the readiness milestones already emitted. The
+  active follow-up makes current per-bot lifecycle snapshots independent of
+  capped current-before-rotated traversal order while preserving historical
+  aggregate distributions. True fresh-entry, first-Rust-call, and
+  first-exchange-write milestones remain missing.
 
 - [ ] Add a full live-operation duration table.
   - Include startup, account refresh, fill refresh, cache proof, HSL replay,

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1113,6 +1113,24 @@ def _startup_elapsed_ms(data: dict[str, Any]) -> int | None:
     return _elapsed_s_to_ms(data.get("elapsed_s"))
 
 
+def _startup_event_order_key(
+    row: dict[str, Any],
+) -> tuple[str, int, str, int, int, int]:
+    timestamp_ms = _record_ts(row)
+    sequence = _non_negative_ms(row.get("seq"))
+    source_path_text = str(row.get(_PERFORMANCE_REPORT_SOURCE_PATH_KEY) or "")
+    source_path = Path(source_path_text)
+    source_line = _non_negative_ms(row.get(_PERFORMANCE_REPORT_SOURCE_LINE_KEY))
+    return (
+        str(source_path.parent) if source_path_text else "",
+        1 if source_path.name == "current.ndjson" else 0,
+        source_path.name,
+        -1 if source_line is None else int(source_line),
+        -1 if timestamp_ms is None else int(timestamp_ms),
+        -1 if sequence is None else int(sequence),
+    )
+
+
 _LIVE_EVENT_DEBUG_PROFILE_SET = set(LIVE_EVENT_DEBUG_PROFILES)
 _STARTUP_PHASE_LABELS = {
     "account",
@@ -1170,6 +1188,9 @@ class _StartupReadinessAccumulator:
         self.readiness_scope_counts: Counter[str] = Counter()
         self.readiness_scope_elapsed_values: dict[str, list[int]] = {}
         self.readiness_trading_impact_counts: Counter[str] = Counter()
+        self.lifecycle_started_order: dict[
+            str, tuple[str, int, str, int, int, int]
+        ] = {}
 
     @staticmethod
     def _update_debug_profiles(state: dict[str, Any], data: dict[str, Any]) -> None:
@@ -1203,7 +1224,43 @@ class _StartupReadinessAccumulator:
         event_type = str(live_event.get("event_type") or row.get("kind") or "")
         data = live_event.get("data") if isinstance(live_event.get("data"), dict) else {}
         ts = _record_ts(row)
+        bot = _bot_key(row, live_event)
+        event_order = _startup_event_order_key(row)
+
+        stage: str | None = None
+        elapsed_ms: int | None = None
+        contract: dict[str, str] | None = None
+        if event_type == "bot.startup_timing":
+            stage = _startup_phase_label(data.get("stage") or data.get("phase"))
+            elapsed_ms = _startup_elapsed_ms(data)
+            if elapsed_ms is not None:
+                self.startup_phase_counts[stage] += 1
+                self.startup_phase_elapsed_values.setdefault(stage, []).append(
+                    int(elapsed_ms)
+                )
+                contract = _startup_readiness_contract(data, stage)
+                if contract is not None:
+                    scope = contract["readiness_scope"]
+                    impact = contract["trading_impact"]
+                    self.readiness_scope_counts[scope] += 1
+                    self.readiness_scope_elapsed_values.setdefault(scope, []).append(
+                        int(elapsed_ms)
+                    )
+                    self.readiness_trading_impact_counts[impact] += 1
+            since_previous_ms = _non_negative_ms(data.get("since_previous_ms"))
+            if since_previous_ms is not None:
+                self.startup_phase_since_previous_values.setdefault(stage, []).append(
+                    int(since_previous_ms)
+                )
+
         if event_type == "bot.started":
+            previous_started_order = self.lifecycle_started_order.get(bot)
+            if (
+                previous_started_order is not None
+                and event_order <= previous_started_order
+            ):
+                return
+            self.lifecycle_started_order[bot] = event_order
             state = self._bot_state(row=row, live_event=live_event)
             bot = str(state["bot"])
             state.clear()
@@ -1219,6 +1276,9 @@ class _StartupReadinessAccumulator:
             state["lifecycle_status"] = "started"
             self._update_debug_profiles(state, data)
             return
+        started_order = self.lifecycle_started_order.get(bot)
+        if started_order is not None and event_order <= started_order:
+            return
         if event_type == "bot.ready":
             state = self._bot_state(row=row, live_event=live_event)
             if ts is not None:
@@ -1228,15 +1288,9 @@ class _StartupReadinessAccumulator:
             return
         if event_type == "bot.startup_timing":
             state = self._bot_state(row=row, live_event=live_event)
-            stage = _startup_phase_label(data.get("stage") or data.get("phase"))
-            elapsed_ms = _startup_elapsed_ms(data)
+            assert stage is not None
             if elapsed_ms is not None:
                 state["startup_phases_ms"][stage] = int(elapsed_ms)
-                self.startup_phase_counts[stage] += 1
-                self.startup_phase_elapsed_values.setdefault(stage, []).append(
-                    int(elapsed_ms)
-                )
-                contract = _startup_readiness_contract(data, stage)
                 if contract is not None:
                     scope = contract["readiness_scope"]
                     impact = contract["trading_impact"]
@@ -1249,16 +1303,6 @@ class _StartupReadinessAccumulator:
                         "elapsed_ms": int(elapsed_ms),
                         "trading_impact": impact,
                     }
-                    self.readiness_scope_counts[scope] += 1
-                    self.readiness_scope_elapsed_values.setdefault(scope, []).append(
-                        int(elapsed_ms)
-                    )
-                    self.readiness_trading_impact_counts[impact] += 1
-            since_previous_ms = _non_negative_ms(data.get("since_previous_ms"))
-            if since_previous_ms is not None:
-                self.startup_phase_since_previous_values.setdefault(stage, []).append(
-                    int(since_previous_ms)
-                )
             return
         if event_type.startswith("hsl.replay."):
             state = self._bot_state(row=row, live_event=live_event)

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1380,7 +1380,12 @@ def test_live_performance_report_startup_readiness_completed_hsl_not_active(tmp_
     _write_ndjson(
         events_dir / "current.ndjson",
         [
-            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="bot.started",
+                seq=1,
+                ts=1000,
+                data={"live_event_debug_profiles": ["rust"]},
+            ),
             _monitor_row(
                 event_type="hsl.replay.completed",
                 seq=2,
@@ -1452,6 +1457,92 @@ def test_live_performance_report_startup_readiness_resets_on_restart(tmp_path):
     assert "bot_ready_ts" not in bot
     assert "startup_phases_ms" not in bot
     assert "hsl_replay" not in bot
+
+
+@pytest.mark.parametrize("current_started_ts", [None, 1000])
+def test_live_performance_report_startup_readiness_uses_event_order_with_file_cap(
+    tmp_path, current_started_ts
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "2026-07-10T00-00-00.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=2,
+                ts=1100,
+                data={
+                    "stage": "hsl",
+                    "elapsed_ms": 9000,
+                    "readiness_scope": "held_position_protective",
+                    "trading_impact": "protective_blocker",
+                },
+            ),
+            _monitor_row(
+                event_type="hsl.replay.completed",
+                seq=3,
+                ts=1200,
+                status="succeeded",
+                data={"stage": "full_replay", "pairs": 2},
+            ),
+            _monitor_row(event_type="bot.ready", seq=4, ts=1300),
+        ],
+    )
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.started",
+                seq=1,
+                ts=current_started_ts,
+                data={"live_event_debug_profiles": ["state"]},
+            ),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=2,
+                ts=2100,
+                data={
+                    "stage": "account",
+                    "elapsed_ms": 300,
+                    "readiness_scope": "account_critical",
+                    "trading_impact": "protective_blocker",
+                },
+            ),
+            _monitor_row(event_type="bot.ready", seq=3, ts=2200),
+        ],
+    )
+
+    report = build_live_performance_report(
+        tmp_path / "monitor",
+        include_rotated=True,
+        max_event_files_per_bot=2,
+    )
+    startup = report["startup_readiness"]
+    bot = startup["bots"][0]
+
+    assert bot["lifecycle_status"] == "ready"
+    if current_started_ts is None:
+        assert "bot_started_ts" not in bot
+    else:
+        assert bot["bot_started_ts"] == current_started_ts
+    assert bot["bot_ready_ts"] == 2200
+    assert bot["debug_profiles"] == ["state"]
+    assert bot["startup_phases_ms"] == {"account": 300}
+    assert bot["readiness_sla"] == {
+        "account_critical": {
+            "phase": "account",
+            "elapsed_ms": 300,
+            "trading_impact": "protective_blocker",
+        }
+    }
+    assert "hsl_replay" not in bot
+    assert startup["startup_phase_counts"] == {"account": 1, "hsl": 1}
+    assert startup["startup_phase_elapsed_ms"]["hsl"]["max"] == 9000
+    assert startup["readiness_scope_counts"] == {
+        "account_critical": 1,
+        "held_position_protective": 1,
+    }
 
 
 def test_live_performance_report_startup_readiness_is_bounded(tmp_path):


### PR DESCRIPTION
## Scope

Category: read-only tooling.

- Keep each `live-performance-report` per-bot startup snapshot on the latest observed `bot.started` lifecycle, independent of capped current-before-rotated file traversal.
- Use deterministic segment/current position and line ordering when timestamps or sequences are absent or equal.
- Preserve historical aggregate startup phase and readiness distributions across every selected timing event.
- Record PR #1192 merge/deploy evidence and the active follow-up in compact planning docs.

## Behavior

This changes only on-demand report derivation. It does not change event production, startup sequencing/readiness decisions, HSL state, exchange calls, process control, smoke verdicts, Rust/order/risk logic, or trading behavior.

Expected VPS action: pull after merge and run the exact bounded rotated startup-readiness report plus a settled smoke. No bot restart or process signal.

## Validation

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_performance_report.py tests/test_live_incident_bundle.py tests/test_live_restart_smoke_plan.py`
- focused production-cap regression for `include_rotated=True` and `max_event_files_per_bot=2`, parameterized for missing and equal lifecycle timestamp metadata
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/performance_report.py`
- `git diff --check`
- added-line silent-handling scan: clean
- independent preflight found two ordering edge cases; exact delta re-review confirms both cleared with no new findings

## Reviewer Focus

Please verify current-versus-rotated segment ordering, missing/equal timestamp behavior, stale ready/HSL/debug/readiness exclusion, unchanged historical aggregate semantics, memory cost, and report-only scope.

Residual risk: rotated segment chronology relies on the existing timestamped segment naming contract; `current.ndjson` is explicitly ordered last.