### PR TITLE
Report startup action milestones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `live-performance-report` now derives bounded current-lifecycle startup
+  milestones for the first cycle, first Rust call, and first submitted
+  exchange write from existing structured events. Missing observations remain
+  explicitly unknown; submitted write events do not claim connector success
+  or fresh-entry eligibility.
+
 - Capped rotated `live-performance-report` scans now keep each bot's startup
   readiness snapshot on the latest observed lifecycle even though recent-file
   selection reads `current.ndjson` before older segments. Historical aggregate

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,18 +22,21 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1193, `Keep startup reports on latest lifecycle`
-- Branch: `codex/v8-performance-startup-lifecycle`
-- Base: `3b4b043eb66e8d0b42d792a5b94686b409901220`
-- Triggering evidence: capped rotated performance-report selection intentionally
-  processes `current.ndjson` before the selected older segment. The startup
-  accumulator reset per-bot state inline, so an older lifecycle encountered
-  later could overwrite the current startup snapshot.
-- Scope: make per-bot startup readiness state use event order rather than file
-  traversal order while preserving historical aggregate startup distributions.
-  Add a current-before-rotated regression with the production per-bot file cap.
+- Branch: `codex/v8-startup-action-milestones`
+- Base: `60f1f042dfbe7ece2f3f56faa0e3fdf9c4299d74`
+- Triggering evidence: existing `cycle.started`, `rust_orchestrator.called`, and
+  `execution.create_sent` / `execution.cancel_sent` events provide enough
+  bounded evidence to measure startup-to-first-action progress without a new
+  producer or live hot-path cost.
+- Scope: derive current-lifecycle `first_cycle_started`, `first_rust_called`,
+  and `first_exchange_write_submitted` observations in a new bounded
+  `startup_milestones` performance-report section. Missing selected evidence is
+  explicitly unknown, never zero. Use source order so capped
+  current-before-rotated scans retain the latest lifecycle.
 - Behavior boundary: read-only `live-performance-report` derivation and tests
-  only. No event producer, startup sequence/readiness decision, HSL state,
+  only. A sent event proves submission intent before the connector call; it
+  does not prove connector/exchange success. Protective-only writes do not
+  prove fresh-entry eligibility. No event producer, startup/readiness decision,
   exchange call, process control, Rust/order/risk logic, smoke verdict, or
   trading behavior change.
 - Validation: focused and full performance-report tests, Python compilation,
@@ -42,23 +45,34 @@ Estimated completion:
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: after merge, pull while preserving local artifacts and
-  run the exact bounded rotated startup-readiness report plus a settled smoke.
+  run the exact bounded rotated startup-milestones report plus a settled smoke.
   Do not restart or signal bots because this slice changes only an on-demand
   report consumer.
 
 Next action:
 
-1. Complete the narrow traversal-order fix and regression, publish after clean
-   independent preflight, and merge only after the exact-head temporary Hermes
-   + Grok 4.5 + green-CI gate is satisfied.
+1. Complete the bounded startup-milestone derivation and regressions, publish
+   after clean independent preflight, and merge only after the exact-head
+   temporary Hermes + Grok 4.5 + green-CI gate is satisfied.
 
 ## Deployed Baseline
 
-- Remote `v8`: `3b4b043eb66e8d0b42d792a5b94686b409901220`, PR #1192
-- VPS5 repository: `3b4b043eb66e8d0b42d792a5b94686b409901220`, PR #1192; tracked
+- Remote `v8`: `60f1f042dfbe7ece2f3f56faa0e3fdf9c4299d74`, PR #1193
+- VPS5 repository: `60f1f042dfbe7ece2f3f56faa0e3fdf9c4299d74`, PR #1193; tracked
   status clean; only expected untracked artifacts were preserved
-- VPS5 expected bots: five; all running after exact sequential pane restarts;
+- VPS5 expected bots: five; all running with the PR #1192 restart PIDs;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1193 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded without bot signals or restarts, preserving bot PIDs
+  `850148/850296/850370/850436/850495` and unrelated `misc:0.0` PID `434835`.
+  The exact capped current-plus-rotated report returned `ok=true`, scanned 12
+  files with zero errors/warnings, retained all five current per-bot lifecycle
+  snapshots, and preserved historical aggregates (`account` phase count six
+  versus five current bots). The settled smoke was hard-green with `322/322`
+  remote and `57/57` account-critical calls successful, all five bots matched,
+  no event-pipeline drops/sink errors, and a clean tracked repository. Report
+  I/O briefly produced three `D` samples; all five bots returned to `R` after
+  the quiet follow-up.
 - PR #1192 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 replaced bot PIDs `842617/842655/842687/842721/842757` with
   `850148/850296/850370/850436/850495`, preserving `misc:0.0` PID `434835`.
@@ -180,16 +194,20 @@ scorecard, stable per-pair fill index, exact sparse flat-pair replay, and the
 rotated resource-pressure report fix, configured-market skip events, and fatal
 HIP-3 startup compatibility are merged and deployed. PR #1189's isolated-only
 initial-entry filter visibility and PR #1190's HSL replay scanned-row
-throughput, PR #1191's corrected active/legacy-terminal replay estimates, and
-PR #1192's machine-readable startup readiness SLA semantics are also merged and
-deployed. The next active slice makes the performance report's per-bot startup
-snapshot independent of capped current-before-rotated traversal order.
+throughput, PR #1191's corrected active/legacy-terminal replay estimates,
+PR #1192's machine-readable startup readiness SLA semantics, and PR #1193's
+latest-lifecycle report ordering are also merged and deployed. The active
+slice derives bounded startup-to-first-cycle, first-Rust-call, and first
+exchange-write-submission observations from existing events.
 
 After this report-only follow-up is merged and validated, select the next
 review-worthy candidate from the remaining backlog, including:
 
-- bounded startup-to-first-action milestone evidence for true fresh-entry,
-  first-Rust-call, and first actual exchange-write observations
+- a separate producer contract for true fresh-entry eligibility, distinguishing
+  no candidate, blocked candidate, protective-only, already-satisfied, and
+  eligible outcomes
+- optional connector-boundary evidence if operators need actual exchange-write
+  invocation rather than the existing pre-call submitted event
 - bounded operator tooling improvements sharing one code and validation surface
 
 Do not create progress-only PRs or resume unrelated logging work from stale

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,6 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
+- PR #1194, `Report startup action milestones`
 - Branch: `codex/v8-startup-action-milestones`
 - Base: `60f1f042dfbe7ece2f3f56faa0e3fdf9c4299d74`
 - Triggering evidence: existing `cycle.started`, `rust_orchestrator.called`, and

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7597,3 +7597,38 @@ VPS5 deployment status:
   call, HSL/risk/order behavior, process control, smoke verdict, Rust,
   backtest, optimizer, or trading change. Expected VPS action is pull plus a
   bounded rotated report and settled smoke, with no bot restart.
+
+### Deployed Slice: Performance Startup Lifecycle Ordering
+
+- PR #1193 was approved by Hermes and Grok 4.5 on exact head `955fe215d`; CI
+  passed and it merged to `v8` as `60f1f042d`.
+- VPS5 fast-forwarded without bot signals or restarts. The five bot PIDs
+  `850148/850296/850370/850436/850495` and unrelated `misc:0.0` PID `434835`
+  remained unchanged.
+- The exact bounded current-plus-rotated startup-readiness report returned
+  `ok=true`, scanned 12 files with zero errors/warnings, retained all five
+  current lifecycle snapshots, and preserved historical aggregate timing
+  (`account` phase count six versus five current bots).
+- The settled smoke was hard-green with `322/322` remote and `57/57`
+  account-critical calls successful, all five bots matched, no event-pipeline
+  drops/sink errors, and a clean tracked repository. Three transient `D`
+  process samples during report I/O cleared; all five bots sampled `R` after a
+  quiet interval.
+
+### Active Slice: Startup Action Milestones
+
+- Branch: `codex/v8-startup-action-milestones` from deployed `60f1f042d`.
+- Scope: add a bounded read-only `startup_milestones` performance-report
+  section deriving the current lifecycle's first cycle, first Rust call, and
+  first exchange-write submission from existing structured events. Absence in
+  selected files remains explicitly unknown, and elapsed values require valid
+  lifecycle and event timestamps.
+- Contract boundary: `execution.create_sent` / `execution.cancel_sent` occur
+  before connector invocation, so the report says `submitted`, not actual or
+  successful exchange write. A protective-only write does not establish
+  fresh-entry eligibility. That eligibility needs a separate producer contract
+  after all reconciler/executor filters.
+- Non-goals: no event producer, exchange call, startup/readiness decision,
+  fresh-entry gate, process control, HSL/risk/order behavior, Rust, backtest,
+  optimizer, or smoke-verdict change. Expected VPS action is pull plus an exact
+  bounded rotated report and settled smoke, with no bot restart.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7617,6 +7617,7 @@ VPS5 deployment status:
 
 ### Active Slice: Startup Action Milestones
 
+- PR #1194, `Report startup action milestones`.
 - Branch: `codex/v8-startup-action-milestones` from deployed `60f1f042d`.
 - Scope: add a bounded read-only `startup_milestones` performance-report
   section deriving the current lifecycle's first cycle, first Rust call, and

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1455,7 +1455,13 @@ class _StartupMilestoneAccumulator:
     def __init__(self) -> None:
         self.bots: dict[str, dict[str, Any]] = {}
 
-    def add(self, *, row: dict[str, Any], live_event: dict[str, Any]) -> None:
+    def add(
+        self,
+        *,
+        row: dict[str, Any],
+        live_event: dict[str, Any],
+        source_complete: bool = True,
+    ) -> None:
         event_type = str(live_event.get("event_type") or row.get("kind") or "")
         if event_type != "bot.started" and event_type not in _STARTUP_MILESTONE_EVENT_TYPES:
             return
@@ -1473,15 +1479,23 @@ class _StartupMilestoneAccumulator:
             previous_started_order = state.get("started_order")
             if previous_started_order is not None and event_order <= previous_started_order:
                 return
+            incomplete_order = state.get("latest_incomplete_unanchored_order")
+            if (
+                previous_started_order is None
+                and incomplete_order is not None
+                and incomplete_order > event_order
+            ):
+                return
             state["started_order"] = event_order
             state["started_ts"] = _record_ts(row)
+            state.pop("latest_incomplete_unanchored_order", None)
             retained = {
                 label: candidate
                 for label, candidate in state["milestones"].items()
-                if candidate[0] > event_order
+                if candidate[0] > event_order and candidate[2]
             }
             state["milestones"] = retained
-            for _label, (_order, milestone) in retained.items():
+            for _label, (_order, milestone, _source_complete) in retained.items():
                 self._set_elapsed(milestone, started_ts=state["started_ts"])
             return
 
@@ -1489,6 +1503,10 @@ class _StartupMilestoneAccumulator:
         started_order = state.get("started_order")
         if started_order is not None and event_order <= started_order:
             return
+        if started_order is None and not source_complete:
+            incomplete_order = state.get("latest_incomplete_unanchored_order")
+            if incomplete_order is None or event_order > incomplete_order:
+                state["latest_incomplete_unanchored_order"] = event_order
         label = _STARTUP_MILESTONE_EVENT_TYPES[event_type]
         existing = state["milestones"].get(label)
         if existing is not None and event_order >= existing[0]:
@@ -1498,7 +1516,7 @@ class _StartupMilestoneAccumulator:
             live_event=live_event,
             started_ts=state.get("started_ts"),
         )
-        state["milestones"][label] = (event_order, milestone)
+        state["milestones"][label] = (event_order, milestone, bool(source_complete))
 
     @staticmethod
     def _set_elapsed(item: dict[str, Any], *, started_ts: int | None) -> None:
@@ -1573,7 +1591,7 @@ class _StartupMilestoneAccumulator:
                 }
                 for label in _STARTUP_MILESTONE_LABELS
             }
-            for label, (_order, observed) in state["milestones"].items():
+            for label, (_order, observed, _source_complete) in state["milestones"].items():
                 milestones[label] = observed
                 observed_counts[label] += 1
                 if observed.get("elapsed_ms") is not None:
@@ -4455,7 +4473,13 @@ def build_live_performance_report(
     bots: Counter[str] = Counter()
     event_tail_methods: Counter[str] = Counter()
 
-    def process_event_row(path: Path, line_no: int, raw_line: str) -> None:
+    def process_event_row(
+        path: Path,
+        line_no: int,
+        raw_line: str,
+        *,
+        source_complete: bool = True,
+    ) -> None:
         nonlocal records_total, live_events, legacy_events
         line = raw_line.strip()
         if not line:
@@ -4534,7 +4558,11 @@ def build_live_performance_report(
             cycle_scope=cycle_scope,
         )
         startup_readiness.add(row=row, live_event=live_event)
-        startup_milestones.add(row=row, live_event=live_event)
+        startup_milestones.add(
+            row=row,
+            live_event=live_event,
+            source_complete=source_complete,
+        )
         hsl_replay_profile.add(row=row, live_event=live_event)
         cache_warmup.add(row=row, live_event=live_event)
         fill_refresh.add(row=row, live_event=live_event)
@@ -4572,8 +4600,16 @@ def build_live_performance_report(
                             and row_window.line_numbers_exact
                         )
                         event_tail_methods[str(row_window.method)] += 1
+                    source_complete = (
+                        not row_window.limited or row_window.skipped_lines == 0
+                    )
                     for line_no, raw_line in row_iter:
-                        process_event_row(path, int(line_no), raw_line)
+                        process_event_row(
+                            path,
+                            int(line_no),
+                            raw_line,
+                            source_complete=source_complete,
+                        )
             else:
                 with _open_text(path) as stream:
                     for line_no, raw_line in enumerate(stream, start=1):

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1529,9 +1529,6 @@ class _StartupMilestoneAccumulator:
         if event_id is not None:
             item["event_id"] = event_id
         item.update(_bounded_event_ids(live_event))
-        action_id = _safe_label(_event_ids(live_event).get("action_id"), max_len=160)
-        if action_id is not None:
-            item["action_id"] = action_id
         for key in ("symbol", "pside", "side"):
             value = _safe_label(live_event.get(key) or row.get(key), max_len=120)
             if value is not None:

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1440,6 +1440,169 @@ class _StartupReadinessAccumulator:
         }
 
 
+_STARTUP_MILESTONE_EVENT_TYPES = {
+    "cycle.started": "first_cycle_started",
+    "rust_orchestrator.called": "first_rust_called",
+    "execution.create_sent": "first_exchange_write_submitted",
+    "execution.cancel_sent": "first_exchange_write_submitted",
+}
+_STARTUP_MILESTONE_LABELS = tuple(dict.fromkeys(_STARTUP_MILESTONE_EVENT_TYPES.values()))
+
+
+class _StartupMilestoneAccumulator:
+    """Derive current-lifecycle startup milestones from selected monitor events."""
+
+    def __init__(self) -> None:
+        self.bots: dict[str, dict[str, Any]] = {}
+
+    def add(self, *, row: dict[str, Any], live_event: dict[str, Any]) -> None:
+        event_type = str(live_event.get("event_type") or row.get("kind") or "")
+        if event_type != "bot.started" and event_type not in _STARTUP_MILESTONE_EVENT_TYPES:
+            return
+        bot = _bot_key(row, live_event)
+        state = self.bots.setdefault(
+            bot,
+            {
+                "bot": bot,
+                "milestone_events_seen": 0,
+                "milestones": {},
+            },
+        )
+        event_order = _startup_event_order_key(row)
+        if event_type == "bot.started":
+            previous_started_order = state.get("started_order")
+            if previous_started_order is not None and event_order <= previous_started_order:
+                return
+            state["started_order"] = event_order
+            state["started_ts"] = _record_ts(row)
+            retained = {
+                label: candidate
+                for label, candidate in state["milestones"].items()
+                if candidate[0] > event_order
+            }
+            state["milestones"] = retained
+            for _label, (_order, milestone) in retained.items():
+                self._set_elapsed(milestone, started_ts=state["started_ts"])
+            return
+
+        state["milestone_events_seen"] += 1
+        started_order = state.get("started_order")
+        if started_order is not None and event_order <= started_order:
+            return
+        label = _STARTUP_MILESTONE_EVENT_TYPES[event_type]
+        existing = state["milestones"].get(label)
+        if existing is not None and event_order >= existing[0]:
+            return
+        milestone = self._observed_milestone(
+            row=row,
+            live_event=live_event,
+            started_ts=state.get("started_ts"),
+        )
+        state["milestones"][label] = (event_order, milestone)
+
+    @staticmethod
+    def _set_elapsed(item: dict[str, Any], *, started_ts: int | None) -> None:
+        item.pop("elapsed_ms", None)
+        event_ts = _non_negative_ms(item.get("ts_ms"))
+        if event_ts is not None and started_ts is not None and event_ts >= int(started_ts):
+            item["elapsed_ms"] = int(event_ts) - int(started_ts)
+
+    @staticmethod
+    def _observed_milestone(
+        *,
+        row: dict[str, Any],
+        live_event: dict[str, Any],
+        started_ts: int | None,
+    ) -> dict[str, Any]:
+        event_type = str(live_event.get("event_type") or row.get("kind") or "")
+        item: dict[str, Any] = {
+            "status": "observed",
+            "event_type": event_type,
+            "trading_impact": "cycle_delay",
+        }
+        event_ts = _record_ts(row)
+        if event_ts is not None:
+            item["ts_ms"] = int(event_ts)
+            if started_ts is not None and int(event_ts) >= int(started_ts):
+                item["elapsed_ms"] = int(event_ts) - int(started_ts)
+        event_id = _safe_label(live_event.get("event_id"), max_len=160)
+        if event_id is not None:
+            item["event_id"] = event_id
+        item.update(_bounded_event_ids(live_event))
+        action_id = _safe_label(_event_ids(live_event).get("action_id"), max_len=160)
+        if action_id is not None:
+            item["action_id"] = action_id
+        for key in ("symbol", "pside", "side"):
+            value = _safe_label(live_event.get(key) or row.get(key), max_len=120)
+            if value is not None:
+                item[key] = value
+        if event_type == "execution.create_sent":
+            item["action"] = "create"
+        elif event_type == "execution.cancel_sent":
+            item["action"] = "cancel"
+        return item
+
+    def to_dict(self, *, group_limit: int = GROUP_LIMIT) -> dict[str, Any]:
+        bot_items: list[dict[str, Any]] = []
+        observed_counts: Counter[str] = Counter()
+        elapsed_values: dict[str, list[int]] = {
+            label: [] for label in _STARTUP_MILESTONE_LABELS
+        }
+        events_without_start = 0
+
+        for bot, state in sorted(self.bots.items()):
+            if state.get("started_order") is None:
+                events_without_start += int(state["milestone_events_seen"])
+                bot_items.append(
+                    {
+                        "bot": bot,
+                        "milestones": {
+                            label: {
+                                "status": "unknown",
+                                "reason": "bot_started_not_observed_in_selected_events",
+                                "trading_impact": "cycle_delay",
+                            }
+                            for label in _STARTUP_MILESTONE_LABELS
+                        },
+                    }
+                )
+                continue
+            started_ts = state.get("started_ts")
+            milestones: dict[str, dict[str, Any]] = {
+                label: {
+                    "status": "unknown",
+                    "reason": "not_observed_in_selected_events",
+                    "trading_impact": "cycle_delay",
+                }
+                for label in _STARTUP_MILESTONE_LABELS
+            }
+            for label, (_order, observed) in state["milestones"].items():
+                milestones[label] = observed
+                observed_counts[label] += 1
+                if observed.get("elapsed_ms") is not None:
+                    elapsed_values[label].append(int(observed["elapsed_ms"]))
+            item: dict[str, Any] = {"bot": bot, "milestones": milestones}
+            if started_ts is not None:
+                item["bot_started_ts"] = int(started_ts)
+            bot_items.append(item)
+
+        limit = max(0, int(group_limit))
+        return {
+            "bot_count": len(bot_items),
+            "observed_counts": {
+                label: int(observed_counts[label]) for label in _STARTUP_MILESTONE_LABELS
+            },
+            "elapsed_ms": {
+                label: _number_summary(elapsed_values[label])
+                for label in _STARTUP_MILESTONE_LABELS
+                if elapsed_values[label]
+            },
+            "events_without_start": int(events_without_start),
+            "bots_truncated": len(bot_items) > limit,
+            "bots": bot_items[:limit],
+        }
+
+
 def _bounded_hsl_replay_data(data: Any) -> dict[str, Any]:
     if not isinstance(data, dict):
         return {}
@@ -4275,6 +4438,7 @@ def build_live_performance_report(
     decision_boundary = _DecisionBoundaryAccumulator()
     input_staleness = _InputStalenessAccumulator()
     startup_readiness = _StartupReadinessAccumulator()
+    startup_milestones = _StartupMilestoneAccumulator()
     report_ts_ms = utc_ms()
     hsl_replay_profile = _HslReplayProfileAccumulator()
     cache_warmup = _CacheWarmupAccumulator()
@@ -4373,6 +4537,7 @@ def build_live_performance_report(
             cycle_scope=cycle_scope,
         )
         startup_readiness.add(row=row, live_event=live_event)
+        startup_milestones.add(row=row, live_event=live_event)
         hsl_replay_profile.add(row=row, live_event=live_event)
         cache_warmup.add(row=row, live_event=live_event)
         fill_refresh.add(row=row, live_event=live_event)
@@ -4461,6 +4626,7 @@ def build_live_performance_report(
             group_limit=group_limit,
             report_ts_ms=report_ts_ms,
         ),
+        "startup_milestones": startup_milestones.to_dict(group_limit=group_limit),
         "hsl_replay_profile": hsl_replay_profile.to_dict(
             group_limit=group_limit,
             report_ts_ms=report_ts_ms,
@@ -4593,6 +4759,17 @@ def summarize_live_performance_report(
         if len(startup_bots) > max(0, int(group_limit)):
             startup_readiness["bots_truncated"] = True
         summary["startup_readiness"] = startup_readiness
+    if isinstance(report.get("startup_milestones"), dict):
+        startup_milestones = dict(report["startup_milestones"])
+        milestone_bots = (
+            startup_milestones.get("bots")
+            if isinstance(startup_milestones.get("bots"), list)
+            else []
+        )
+        startup_milestones["bots"] = milestone_bots[: max(0, int(group_limit))]
+        if len(milestone_bots) > max(0, int(group_limit)):
+            startup_milestones["bots_truncated"] = True
+        summary["startup_milestones"] = startup_milestones
     if isinstance(report.get("hsl_replay_profile"), dict):
         hsl_replay_profile = dict(report["hsl_replay_profile"])
         hsl_groups = (

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1584,6 +1584,233 @@ def test_live_performance_report_startup_readiness_is_bounded(tmp_path):
     assert list(startup["bots"][0]["startup_phases_ms"]) == ["account"]
 
 
+def test_live_performance_report_startup_milestones_current_lifecycle(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="cycle.started",
+                seq=2,
+                ts=1100,
+                ids={"cycle_id": "cy_1"},
+            ),
+            _monitor_row(
+                event_type="rust_orchestrator.called",
+                seq=3,
+                ts=1300,
+                ids={"cycle_id": "cy_1", "snapshot_id": "snap_1"},
+            ),
+            _monitor_row(
+                event_type="execution.create_sent",
+                seq=4,
+                ts=1600,
+                symbol="BTCUSDT",
+                pside="long",
+                side="buy",
+                ids={
+                    "cycle_id": "cy_1",
+                    "action_id": "action_1",
+                    "remote_call_id": "remote_1",
+                },
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    startup = report["startup_milestones"]
+
+    assert startup["bot_count"] == 1
+    assert startup["events_without_start"] == 0
+    assert startup["observed_counts"] == {
+        "first_cycle_started": 1,
+        "first_rust_called": 1,
+        "first_exchange_write_submitted": 1,
+    }
+    assert startup["elapsed_ms"]["first_cycle_started"]["max"] == 100
+    assert startup["elapsed_ms"]["first_rust_called"]["max"] == 300
+    assert startup["elapsed_ms"]["first_exchange_write_submitted"]["max"] == 600
+    bot = startup["bots"][0]
+    assert bot["bot_started_ts"] == 1000
+    assert bot["milestones"]["first_cycle_started"] == {
+        "status": "observed",
+        "event_type": "cycle.started",
+        "trading_impact": "cycle_delay",
+        "ts_ms": 1100,
+        "elapsed_ms": 100,
+        "event_id": "evt_2",
+        "cycle_id": "cy_1",
+    }
+    write = bot["milestones"]["first_exchange_write_submitted"]
+    assert write["event_type"] == "execution.create_sent"
+    assert write["action"] == "create"
+    assert write["symbol"] == "BTCUSDT"
+    assert write["pside"] == "long"
+    assert write["side"] == "buy"
+    assert write["action_id"] == "action_1"
+    assert write["remote_call_id"] == "remote_1"
+
+
+def test_startup_milestone_accumulator_retains_one_candidate_per_milestone():
+    accumulator = performance_report_module._StartupMilestoneAccumulator()
+    started = _monitor_row(event_type="bot.started", seq=1, ts=1000)
+    accumulator.add(row=started, live_event=started["payload"]["_live_event"])
+
+    event_types = (
+        "cycle.started",
+        "rust_orchestrator.called",
+        "execution.create_sent",
+    )
+    for index in range(1000):
+        for offset, event_type in enumerate(event_types):
+            row = _monitor_row(
+                event_type=event_type,
+                seq=2 + index * len(event_types) + offset,
+                ts=1100 + index * len(event_types) + offset,
+            )
+            accumulator.add(row=row, live_event=row["payload"]["_live_event"])
+
+    state = accumulator.bots["binance/binance_01"]
+    assert state["milestone_events_seen"] == 3000
+    assert len(state["milestones"]) == 3
+    assert accumulator.to_dict()["bots"][0]["milestones"]["first_cycle_started"][
+        "event_id"
+    ] == "evt_2"
+
+
+def test_live_performance_report_startup_milestones_cancel_only_and_unknown(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(event_type="execution.create_skipped", seq=2, ts=1100),
+            _monitor_row(event_type="execution.create_deferred", seq=3, ts=1200),
+            _monitor_row(
+                event_type="execution.cancel_sent",
+                seq=4,
+                ts=1300,
+                ids={"remote_call_id": "cancel_1"},
+            ),
+        ],
+    )
+
+    startup = build_live_performance_report(tmp_path / "monitor")[
+        "startup_milestones"
+    ]
+    milestones = startup["bots"][0]["milestones"]
+
+    assert milestones["first_cycle_started"] == {
+        "status": "unknown",
+        "reason": "not_observed_in_selected_events",
+        "trading_impact": "cycle_delay",
+    }
+    assert milestones["first_rust_called"]["status"] == "unknown"
+    assert milestones["first_exchange_write_submitted"]["action"] == "cancel"
+    assert milestones["first_exchange_write_submitted"]["event_type"] == (
+        "execution.cancel_sent"
+    )
+
+
+@pytest.mark.parametrize("current_started_ts", [None, 1000])
+def test_live_performance_report_startup_milestones_use_latest_ordered_lifecycle(
+    tmp_path, current_started_ts
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "2026-07-10T00-00-00.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(event_type="cycle.started", seq=2, ts=1100),
+            _monitor_row(event_type="rust_orchestrator.called", seq=3, ts=1200),
+            _monitor_row(event_type="execution.create_sent", seq=4, ts=1300),
+        ],
+    )
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=current_started_ts),
+            _monitor_row(event_type="cycle.started", seq=2, ts=2100),
+        ],
+    )
+
+    startup = build_live_performance_report(
+        tmp_path / "monitor",
+        include_rotated=True,
+        max_event_files_per_bot=2,
+    )["startup_milestones"]
+    bot = startup["bots"][0]
+
+    if current_started_ts is None:
+        assert "bot_started_ts" not in bot
+        assert "elapsed_ms" not in bot["milestones"]["first_cycle_started"]
+    else:
+        assert bot["bot_started_ts"] == current_started_ts
+        assert bot["milestones"]["first_cycle_started"]["elapsed_ms"] == 1100
+    assert bot["milestones"]["first_cycle_started"]["ts_ms"] == 2100
+    assert bot["milestones"]["first_rust_called"]["status"] == "unknown"
+    assert bot["milestones"]["first_exchange_write_submitted"]["status"] == (
+        "unknown"
+    )
+    assert startup["observed_counts"]["first_rust_called"] == 0
+    assert startup["observed_counts"]["first_exchange_write_submitted"] == 0
+
+
+def test_live_performance_report_startup_milestones_are_bounded_and_projectable(
+    tmp_path,
+):
+    for index in range(3):
+        events_dir = tmp_path / "monitor" / "binance" / f"user_{index}" / "events"
+        _write_ndjson(
+            events_dir / "current.ndjson",
+            [
+                _monitor_row(
+                    event_type="bot.started",
+                    seq=1,
+                    ts=1000,
+                    user=f"user_{index}",
+                ),
+                _monitor_row(
+                    event_type="cycle.started",
+                    seq=2,
+                    ts=1100,
+                    user=f"user_{index}",
+                ),
+            ],
+        )
+    orphan_dir = tmp_path / "monitor" / "okx" / "orphan" / "events"
+    _write_ndjson(
+        orphan_dir / "current.ndjson",
+        [_monitor_row(event_type="cycle.started", seq=1, ts=1000, user="orphan")],
+    )
+
+    full_report = build_live_performance_report(tmp_path / "monitor", group_limit=10)
+    report = build_live_performance_report(tmp_path / "monitor", group_limit=2)
+    startup = report["startup_milestones"]
+    summary = summarize_live_performance_report(report, group_limit=1)
+    projected = project_live_performance_report_sections(
+        report, ["startup_milestones"]
+    )
+
+    assert startup["bot_count"] == 4
+    assert startup["bots_truncated"] is True
+    assert len(startup["bots"]) == 2
+    assert startup["events_without_start"] == 1
+    orphan = next(
+        item
+        for item in full_report["startup_milestones"]["bots"]
+        if item["bot"] == "binance/orphan"
+    )
+    assert orphan["milestones"]["first_cycle_started"]["reason"] == (
+        "bot_started_not_observed_in_selected_events"
+    )
+    assert summary["startup_milestones"]["bot_count"] == 4
+    assert len(summary["startup_milestones"]["bots"]) == 1
+    assert "startup_milestones" in projected
+    assert "startup_readiness" not in projected
+
+
 def test_live_performance_report_startup_readiness_hsl_whitelist(tmp_path, monkeypatch):
     monkeypatch.setattr(performance_report_module, "utc_ms", lambda: 122000)
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1757,6 +1757,68 @@ def test_live_performance_report_startup_milestones_use_latest_ordered_lifecycle
     assert startup["observed_counts"]["first_exchange_write_submitted"] == 0
 
 
+def test_live_performance_report_startup_milestones_reject_old_tail_anchor(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "2026-07-10T00-00-00.ndjson",
+        [_monitor_row(event_type="bot.started", seq=1, ts=1000)],
+    )
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=4000),
+            _monitor_row(event_type="execution.create_sent", seq=2, ts=5000),
+        ],
+    )
+
+    report = build_live_performance_report(
+        tmp_path / "monitor",
+        include_rotated=True,
+        max_event_files_per_bot=2,
+        event_tail_lines=1,
+    )
+    startup = report["startup_milestones"]
+    bot = startup["bots"][0]
+
+    assert report["event_window"]["event_tail_skipped_lines"] == 1
+    assert "bot_started_ts" not in bot
+    assert bot["milestones"]["first_exchange_write_submitted"] == {
+        "status": "unknown",
+        "reason": "bot_started_not_observed_in_selected_events",
+        "trading_impact": "cycle_delay",
+    }
+    assert startup["events_without_start"] == 1
+
+
+def test_live_performance_report_startup_milestones_join_complete_rotated_lifecycle(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "2026-07-10T00-00-00.ndjson",
+        [_monitor_row(event_type="bot.started", seq=1, ts=1000)],
+    )
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="rust_orchestrator.called", seq=2, ts=2000),
+            _monitor_row(event_type="execution.create_sent", seq=3, ts=3000),
+        ],
+    )
+
+    startup = build_live_performance_report(
+        tmp_path / "monitor",
+        include_rotated=True,
+        max_event_files_per_bot=2,
+        event_tail_lines=10,
+    )["startup_milestones"]
+    bot = startup["bots"][0]
+
+    assert bot["bot_started_ts"] == 1000
+    assert bot["milestones"]["first_rust_called"]["elapsed_ms"] == 1000
+    assert bot["milestones"]["first_exchange_write_submitted"]["elapsed_ms"] == 2000
+
+
 def test_live_performance_report_startup_milestones_are_bounded_and_projectable(
     tmp_path,
 ):

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1648,8 +1648,8 @@ def test_live_performance_report_startup_milestones_current_lifecycle(tmp_path):
     assert write["symbol"] == "BTCUSDT"
     assert write["pside"] == "long"
     assert write["side"] == "buy"
-    assert write["action_id"] == "action_1"
     assert write["remote_call_id"] == "remote_1"
+    assert "action_1" not in json.dumps(report["startup_milestones"], sort_keys=True)
 
 
 def test_startup_milestone_accumulator_retains_one_candidate_per_milestone():


### PR DESCRIPTION
## Summary

- derive current-lifecycle first-cycle, first-Rust-call, and first exchange-write-submission milestones from existing structured events
- report missing or unanchored selected evidence as explicit unknown states
- keep per-bot retention constant at one sanitized candidate per milestone and preserve capped current-before-rotated ordering
- record PR #1193 deployment evidence and the fresh-entry/connector-success non-goals

## Contract

`execution.create_sent` and `execution.cancel_sent` prove pre-connector submission only. They do not prove connector/exchange success or fresh-entry eligibility. This PR is a read-only report consumer and changes no live producer, exchange call, readiness gate, order/risk logic, or process behavior.

## Validation

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_performance_report.py tests/test_live_incident_bundle.py tests/test_live_restart_smoke_plan.py` (137 passed)
- Python compilation
- `git diff --check`
- added-line silent-handling scan
- bounded real CLI section smoke
- independent Terra preflight and delta re-review: green after resolving unbounded event retention

## VPS

After exact-head reviewer and CI approval: pull only, no restart; run bounded rotated `startup_milestones` report and settled smoke.
