### PR TITLE
Fix startup readiness report lifecycle handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Startup readiness reporting now uses one canonical phase parser across
+  performance and smoke consumers, rejects conflicting `phase`/legacy `stage`
+  records, preserves current lifecycle state across event rotation, and keeps
+  prior restart samples available for smoke timing budgets.
+
 - `live-performance-report` now derives bounded current-lifecycle startup
   milestones for the first cycle, first Rust call, and first submitted
   exchange write from existing structured events. Missing observations remain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ All notable user-facing changes will be documented in this file.
 
 - Startup readiness reporting now uses one canonical phase parser across
   performance and smoke consumers, rejects conflicting `phase`/legacy `stage`
-  records, preserves current lifecycle state across event rotation, and keeps
-  prior restart samples available for smoke timing budgets.
+  records, rejects stale rotated lifecycle data after any incomplete current
+  tail, preserves bounded HSL replay context across sparse terminal events, and
+  keeps prior restart samples available for smoke timing budgets.
 
 - `live-performance-report` now derives bounded current-lifecycle startup
   milestones for the first cycle, first Rust call, and first submitted

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -32,11 +32,16 @@ Estimated completion:
   legacy `stage` differently.
 - Scope: use one canonical phase parser (`phase`, then legacy `stage`, reject
   conflicts), retain bounded current-lifecycle performance candidates across
-  rotation, and separate smoke's current lifecycle projection from its bounded
-  historical restart baseline.
+  rotation, reject stale rotated readiness/milestone candidates whenever any
+  retained current row proves the source is incomplete, preserve bounded HSL
+  replay context across sparse terminal events, and separate smoke's current
+  lifecycle projection from its bounded historical restart baseline.
 - Behavior boundary: read-only `live-performance-report` derivation and tests
   only. No event producer, startup/readiness decision, exchange call, process
   control, Rust/order/risk logic, smoke verdict, or trading behavior change.
+  Per-bot readiness/milestone records are current-lifecycle projections;
+  aggregate startup phase counts and timing summaries remain statistics over
+  all selected history.
 - Validation: focused and full performance-report tests, Python compilation,
   `git diff --check`, the added-line silent-handling scan, and independent
   preflight.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,6 +22,7 @@ Estimated completion:
 
 ## Active Review Slice
 
+- PR #1195, `Fix startup readiness report lifecycle handling`
 - Branch: `codex/v8-startup-readiness-correctness`
 - Base: `b15d349be5c544f9a8ac83618977b8a0cfd11ba5`
 - Triggering evidence: post-merge review reproduced three startup-report

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,47 +22,55 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1194, `Report startup action milestones`
-- Branch: `codex/v8-startup-action-milestones`
-- Base: `60f1f042dfbe7ece2f3f56faa0e3fdf9c4299d74`
-- Triggering evidence: existing `cycle.started`, `rust_orchestrator.called`, and
-  `execution.create_sent` / `execution.cancel_sent` events provide enough
-  bounded evidence to measure startup-to-first-action progress without a new
-  producer or live hot-path cost.
-- Scope: derive current-lifecycle `first_cycle_started`, `first_rust_called`,
-  and `first_exchange_write_submitted` observations in a new bounded
-  `startup_milestones` performance-report section. Missing selected evidence is
-  explicitly unknown, never zero. Use source order so capped
-  current-before-rotated scans retain the latest lifecycle.
+- Branch: `codex/v8-startup-readiness-correctness`
+- Base: `b15d349be5c544f9a8ac83618977b8a0cfd11ba5`
+- Triggering evidence: post-merge review reproduced three startup-report
+  correctness gaps: performance readiness lost current events when their start
+  marker was in a rotated segment; smoke discarded prior restart samples before
+  computing timing budgets; and performance/smoke interpreted `phase` and
+  legacy `stage` differently.
+- Scope: use one canonical phase parser (`phase`, then legacy `stage`, reject
+  conflicts), retain bounded current-lifecycle performance candidates across
+  rotation, and separate smoke's current lifecycle projection from its bounded
+  historical restart baseline.
 - Behavior boundary: read-only `live-performance-report` derivation and tests
-  only. A sent event proves submission intent before the connector call; it
-  does not prove connector/exchange success. Protective-only writes do not
-  prove fresh-entry eligibility. No event producer, startup/readiness decision,
-  exchange call, process control, Rust/order/risk logic, smoke verdict, or
-  trading behavior change.
+  only. No event producer, startup/readiness decision, exchange call, process
+  control, Rust/order/risk logic, smoke verdict, or trading behavior change.
 - Validation: focused and full performance-report tests, Python compilation,
   `git diff --check`, the added-line silent-handling scan, and independent
   preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: after merge, pull while preserving local artifacts and
-  run the exact bounded rotated startup-milestones report plus a settled smoke.
+  run bounded rotated startup-readiness/performance and settled smoke reports.
   Do not restart or signal bots because this slice changes only an on-demand
   report consumer.
 
 Next action:
 
-1. Complete the bounded startup-milestone derivation and regressions, publish
-   after clean independent preflight, and merge only after the exact-head
-   temporary Hermes + Grok 4.5 + green-CI gate is satisfied.
+1. Complete the three startup-consumer regressions, publish after clean
+   independent preflight, and merge only after the exact-head temporary Hermes
+   + Grok 4.5 + green-CI gate is satisfied.
 
 ## Deployed Baseline
 
-- Remote `v8`: `60f1f042dfbe7ece2f3f56faa0e3fdf9c4299d74`, PR #1193
-- VPS5 repository: `60f1f042dfbe7ece2f3f56faa0e3fdf9c4299d74`, PR #1193; tracked
+- Remote `v8`: `b15d349be5c544f9a8ac83618977b8a0cfd11ba5`, PR #1194
+- VPS5 repository: `b15d349be5c544f9a8ac83618977b8a0cfd11ba5`, PR #1194; tracked
   status clean; only expected untracked artifacts were preserved
 - VPS5 expected bots: five; all running with the PR #1192 restart PIDs;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1194 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded without process signals, preserving bot PIDs
+  `850148/850296/850370/850436/850495` and unrelated `misc:0.0` PID `434835`.
+  The exact bounded rotated `startup_milestones` report returned `ok=true`,
+  scanned 12 files / 46,748 records with zero errors/warnings, kept truncated
+  lifecycle evidence explicitly unknown, and observed KuCoin's first cycle at
+  `110.653s` without claiming unseen Rust/write milestones. The first smoke
+  caught one recovered Binance `InvalidNonce` and two transient `D` samples.
+  After settling, all `D` states cleared and the final two-minute smoke was
+  hard-green: `384/384` remote and `76/76` account-critical calls successful,
+  5/5 processes matched (`R=4,S=1`), no hard/log failures, no pipeline
+  drops/sink errors, and a clean tracked repository.
 - PR #1193 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded without bot signals or restarts, preserving bot PIDs
   `850148/850296/850370/850436/850495` and unrelated `misc:0.0` PID `434835`.
@@ -196,10 +204,10 @@ rotated resource-pressure report fix, configured-market skip events, and fatal
 HIP-3 startup compatibility are merged and deployed. PR #1189's isolated-only
 initial-entry filter visibility and PR #1190's HSL replay scanned-row
 throughput, PR #1191's corrected active/legacy-terminal replay estimates,
-PR #1192's machine-readable startup readiness SLA semantics, and PR #1193's
-latest-lifecycle report ordering are also merged and deployed. The active
-slice derives bounded startup-to-first-cycle, first-Rust-call, and first
-exchange-write-submission observations from existing events.
+PR #1192's machine-readable startup readiness SLA semantics, PR #1193's
+latest-lifecycle report ordering, and PR #1194's bounded startup action
+milestones are also merged and deployed. The active slice corrects the
+remaining startup-readiness lifecycle, baseline, and phase-parity findings.
 
 After this report-only follow-up is merged and validated, select the next
 review-worthy candidate from the remaining backlog, including:

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -13,9 +13,13 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Current Status
+## Historical Status Snapshot (PR #1191)
 
-Last updated: 2026-07-11.
+Snapshot captured: 2026-07-11.
+
+This block is retained as historical context and is not the operational current
+status. Use `docs/plans/live_logging_overhaul_current_status.md` for the active
+PR, deployed head, review gate, VPS state, and next action.
 
 Current `origin/v8` head:
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7653,6 +7653,7 @@ VPS5 deployment status:
 
 ### Active Slice: Startup Readiness Consumer Correctness
 
+- PR #1195, `Fix startup readiness report lifecycle handling`.
 - Branch: `codex/v8-startup-readiness-correctness` from deployed `b15d349be`.
 - Scope: resolve the three post-merge startup consumer findings together: keep
   performance readiness state when one lifecycle spans rotated/current files;

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7633,3 +7633,33 @@ VPS5 deployment status:
   fresh-entry gate, process control, HSL/risk/order behavior, Rust, backtest,
   optimizer, or smoke-verdict change. Expected VPS action is pull plus an exact
   bounded rotated report and settled smoke, with no bot restart.
+
+### Deployed Slice: Startup Action Milestones
+
+- PR #1194 was approved by Hermes and Grok 4.5 on exact head `a35e44eb2`; CI
+  passed and it merged to `v8` as `b15d349be`.
+- VPS5 fast-forwarded without bot signals or restarts. Bot PIDs
+  `850148/850296/850370/850436/850495` and unrelated `misc:0.0` PID `434835`
+  remained unchanged.
+- The exact bounded rotated `startup_milestones` report returned `ok=true`,
+  scanned 12 files / 46,748 records with zero errors/warnings, retained
+  truncated lifecycle evidence as explicit unknowns, and observed KuCoin's
+  first cycle at `110.653s` without claiming unseen Rust/write milestones.
+- The first smoke caught one recovered Binance `InvalidNonce` and two transient
+  `D` samples during report I/O. After settling, all `D` states cleared; the
+  final two-minute smoke was hard-green with `384/384` remote and `76/76`
+  account-critical calls successful, 5/5 processes matched (`R=4,S=1`), no
+  hard/log failures, no pipeline drops/sink errors, and a clean tracked repo.
+
+### Active Slice: Startup Readiness Consumer Correctness
+
+- Branch: `codex/v8-startup-readiness-correctness` from deployed `b15d349be`.
+- Scope: resolve the three post-merge startup consumer findings together: keep
+  performance readiness state when one lifecycle spans rotated/current files;
+  preserve prior restart timing samples for smoke p95 budgets while projecting
+  current readiness only; and make `phase` canonical with `stage` as fallback
+  only, rejecting conflicts in every performance/smoke timing consumer.
+- Non-goals: no event producer, readiness/startup decision, exchange call,
+  process control, HSL/risk/order behavior, Rust, backtest, optimizer, or smoke
+  verdict change. Expected VPS action is pull plus bounded reports and settled
+  smoke, with no bot restart.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7664,6 +7664,9 @@ VPS5 deployment status:
   preserve prior restart timing samples for smoke p95 budgets while projecting
   current readiness only; and make `phase` canonical with `stage` as fallback
   only, rejecting conflicts in every performance/smoke timing consumer.
+  Review follow-up also applies one bounded incomplete-source barrier to
+  readiness and milestones and preserves prior HSL replay context when a sparse
+  terminal event becomes the latest lifecycle candidate.
 - Non-goals: no event producer, readiness/startup decision, exchange call,
   process control, HSL/risk/order behavior, Rust, backtest, optimizer, or smoke
   verdict change. Expected VPS action is pull plus bounded reports and settled

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -65,6 +65,16 @@ _STARTUP_PHASE_READINESS_CONTRACTS: Mapping[str, tuple[str, str]] = MappingProxy
         "full-warmup": ("background_candles_complete", "entry_blocker"),
     }
 )
+_STARTUP_TIMING_PHASES = frozenset(
+    {
+        "account",
+        "active-candle",
+        "full-warmup",
+        "hsl",
+        "market",
+        "startup",
+    }
+)
 
 
 def startup_phase_readiness_contract(phase: object) -> dict[str, str] | None:
@@ -78,6 +88,20 @@ def startup_phase_readiness_contract(phase: object) -> dict[str, str] | None:
         "readiness_scope": values[0],
         "trading_impact": values[1],
     }
+
+
+def startup_timing_phase(data: object) -> str | None:
+    """Return canonical startup phase, with stage accepted only as legacy fallback."""
+    if not isinstance(data, Mapping):
+        return None
+    phase = str(data.get("phase") or "").strip()
+    stage = str(data.get("stage") or "").strip()
+    if phase and stage and phase != stage:
+        return None
+    value = phase or stage
+    if not value:
+        return None
+    return value if value in _STARTUP_TIMING_PHASES else "other"
 
 
 class EventTypes:

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1180,9 +1180,57 @@ def _startup_readiness_contract(
     return expected
 
 
-class _StartupReadinessAccumulator:
+class _StartupSourceCompletenessTracker:
+    """Track newer incomplete event sources without retaining their rows."""
+
     def __init__(self) -> None:
+        self.latest_incomplete_order: dict[
+            str, tuple[str, int, str, int, int, int]
+        ] = {}
+
+    def observe(
+        self,
+        *,
+        row: dict[str, Any],
+        live_event: dict[str, Any],
+        source_complete: bool,
+    ) -> None:
+        if source_complete:
+            return
+        bot = _bot_key(row, live_event)
+        event_order = _startup_event_order_key(row)
+        previous = self.latest_incomplete_order.get(bot)
+        if previous is None or event_order > previous:
+            self.latest_incomplete_order[bot] = event_order
+
+    def latest_for(
+        self,
+        bot: str,
+    ) -> tuple[str, int, str, int, int, int] | None:
+        return self.latest_incomplete_order.get(bot)
+
+    def supersedes(
+        self,
+        *,
+        bot: str,
+        event_order: tuple[str, int, str, int, int, int],
+    ) -> bool:
+        incomplete_order = self.latest_for(bot)
+        if incomplete_order is None or incomplete_order <= event_order:
+            return False
+        return incomplete_order[:3] != event_order[:3]
+
+
+class _StartupReadinessAccumulator:
+    def __init__(
+        self,
+        *,
+        source_completeness: _StartupSourceCompletenessTracker | None = None,
+    ) -> None:
         self.bots: dict[str, dict[str, Any]] = {}
+        self.source_completeness = (
+            source_completeness or _StartupSourceCompletenessTracker()
+        )
         self.startup_phase_counts: Counter[str] = Counter()
         self.startup_phase_elapsed_values: dict[str, list[int]] = {}
         self.startup_phase_since_previous_values: dict[str, list[int]] = {}
@@ -1218,6 +1266,47 @@ class _StartupReadinessAccumulator:
         ):
             state["latest_ts"] = int(ts)
         return state
+
+    def _discard_superseded_state(self, bot: str) -> None:
+        state = self.bots.get(bot)
+        if state is None:
+            return
+        started_order = state.get("_started_order")
+        started_superseded = (
+            started_order is not None
+            and self.source_completeness.supersedes(
+                bot=bot,
+                event_order=started_order,
+            )
+        )
+        retained = {
+            key: candidate
+            for key, candidate in state["_candidates"].items()
+            if not self.source_completeness.supersedes(
+                bot=bot,
+                event_order=candidate[0],
+            )
+        }
+        if not started_superseded and len(retained) == len(state["_candidates"]):
+            return
+        if not retained:
+            self.bots.pop(bot, None)
+            return
+        state.clear()
+        state.update(
+            {
+                "bot": bot,
+                "_candidates": retained,
+                "startup_phases_ms": {},
+                "latest_ts": None,
+            }
+        )
+        for _key, (_order, candidate, source_complete) in sorted(
+            retained.items(),
+            key=lambda item: item[1][0],
+        ):
+            if source_complete:
+                self._apply_candidate(state, candidate)
 
     @staticmethod
     def _apply_candidate(state: dict[str, Any], candidate: dict[str, Any]) -> None:
@@ -1266,6 +1355,12 @@ class _StartupReadinessAccumulator:
         ts = _record_ts(row)
         bot = _bot_key(row, live_event)
         event_order = _startup_event_order_key(row)
+        self.source_completeness.observe(
+            row=row,
+            live_event=live_event,
+            source_complete=source_complete,
+        )
+        self._discard_superseded_state(bot)
 
         stage: str | None = None
         elapsed_ms: int | None = None
@@ -1297,20 +1392,26 @@ class _StartupReadinessAccumulator:
                 )
 
         if event_type == "bot.started":
-            state = self._bot_state(row=row, live_event=live_event)
-            previous_started_order = state.get("_started_order")
+            existing_state = self.bots.get(bot)
+            previous_started_order = (
+                existing_state.get("_started_order")
+                if existing_state is not None
+                else None
+            )
             if (
                 previous_started_order is not None
                 and event_order <= previous_started_order
             ):
                 return
-            incomplete_order = state.get("_latest_incomplete_unanchored_order")
             if (
                 previous_started_order is None
-                and incomplete_order is not None
-                and incomplete_order > event_order
+                and self.source_completeness.supersedes(
+                    bot=bot,
+                    event_order=event_order,
+                )
             ):
                 return
+            state = self._bot_state(row=row, live_event=live_event)
             retained = {
                 key: candidate
                 for key, candidate in state["_candidates"].items()
@@ -1342,14 +1443,24 @@ class _StartupReadinessAccumulator:
             "bot.startup_timing",
         } and not event_type.startswith("hsl.replay."):
             return
+        existing_state = self.bots.get(bot)
+        started_order = (
+            existing_state.get("_started_order")
+            if existing_state is not None
+            else None
+        )
+        if (
+            started_order is None
+            and self.source_completeness.supersedes(
+                bot=bot,
+                event_order=event_order,
+            )
+        ):
+            return
         state = self._bot_state(row=row, live_event=live_event)
         started_order = state.get("_started_order")
         if started_order is not None and event_order <= started_order:
             return
-        if started_order is None and not source_complete:
-            incomplete_order = state.get("_latest_incomplete_unanchored_order")
-            if incomplete_order is None or event_order > incomplete_order:
-                state["_latest_incomplete_unanchored_order"] = event_order
 
         candidate_data: dict[str, Any] = {}
         debug_profiles = _known_debug_profiles(data.get("live_event_debug_profiles"))
@@ -1373,12 +1484,24 @@ class _StartupReadinessAccumulator:
             )
         if event_type.startswith("hsl.replay."):
             candidate_key = "hsl.replay"
+            existing = state["_candidates"].get(candidate_key)
             hsl_state: dict[str, Any] = {}
+            if existing is not None:
+                previous_hsl_state = existing[1].get("hsl_replay")
+                if isinstance(previous_hsl_state, dict):
+                    hsl_state.update(previous_hsl_state)
             if ts is not None:
                 hsl_state["latest_ts"] = int(ts)
-            hsl_state["event_type"] = event_type
-            hsl_state["status"] = live_event.get("status")
-            hsl_state["reason_code"] = live_event.get("reason_code")
+            hsl_state["event_type"] = _safe_label(event_type, max_len=120)
+            hsl_state["status"] = _safe_label(
+                live_event.get("status"),
+                max_len=120,
+            )
+            hsl_state["reason_code"] = _safe_label(
+                live_event.get("reason_code"),
+                max_len=120,
+            )
+            bounded_hsl_data = _bounded_hsl_replay_data(data)
             for key in (
                 "signal_mode",
                 "stage",
@@ -1399,8 +1522,8 @@ class _StartupReadinessAccumulator:
                 "full_elapsed_s",
                 "startup_blocking_elapsed_s",
             ):
-                if key in data:
-                    hsl_state[key] = data[key]
+                if key in bounded_hsl_data:
+                    hsl_state[key] = bounded_hsl_data[key]
             candidate["hsl_replay"] = hsl_state
 
         existing = state["_candidates"].get(candidate_key)
@@ -1528,8 +1651,49 @@ _STARTUP_MILESTONE_LABELS = tuple(dict.fromkeys(_STARTUP_MILESTONE_EVENT_TYPES.v
 class _StartupMilestoneAccumulator:
     """Derive current-lifecycle startup milestones from selected monitor events."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        source_completeness: _StartupSourceCompletenessTracker | None = None,
+    ) -> None:
         self.bots: dict[str, dict[str, Any]] = {}
+        self.source_completeness = (
+            source_completeness or _StartupSourceCompletenessTracker()
+        )
+
+    def _discard_superseded_state(self, bot: str) -> None:
+        state = self.bots.get(bot)
+        if state is None:
+            return
+        started_order = state.get("started_order")
+        started_superseded = (
+            started_order is not None
+            and self.source_completeness.supersedes(
+                bot=bot,
+                event_order=started_order,
+            )
+        )
+        retained = {
+            label: candidate
+            for label, candidate in state["milestones"].items()
+            if not self.source_completeness.supersedes(
+                bot=bot,
+                event_order=candidate[0],
+            )
+        }
+        if not started_superseded and len(retained) == len(state["milestones"]):
+            return
+        if not retained:
+            self.bots.pop(bot, None)
+            return
+        state.clear()
+        state.update(
+            {
+                "bot": bot,
+                "milestone_events_seen": len(retained),
+                "milestones": retained,
+            }
+        )
 
     def add(
         self,
@@ -1539,9 +1703,30 @@ class _StartupMilestoneAccumulator:
         source_complete: bool = True,
     ) -> None:
         event_type = str(live_event.get("event_type") or row.get("kind") or "")
+        bot = _bot_key(row, live_event)
+        event_order = _startup_event_order_key(row)
+        self.source_completeness.observe(
+            row=row,
+            live_event=live_event,
+            source_complete=source_complete,
+        )
+        self._discard_superseded_state(bot)
         if event_type != "bot.started" and event_type not in _STARTUP_MILESTONE_EVENT_TYPES:
             return
-        bot = _bot_key(row, live_event)
+        existing_state = self.bots.get(bot)
+        previous_started_order = (
+            existing_state.get("started_order")
+            if existing_state is not None
+            else None
+        )
+        if (
+            previous_started_order is None
+            and self.source_completeness.supersedes(
+                bot=bot,
+                event_order=event_order,
+            )
+        ):
+            return
         state = self.bots.setdefault(
             bot,
             {
@@ -1550,21 +1735,11 @@ class _StartupMilestoneAccumulator:
                 "milestones": {},
             },
         )
-        event_order = _startup_event_order_key(row)
         if event_type == "bot.started":
-            previous_started_order = state.get("started_order")
             if previous_started_order is not None and event_order <= previous_started_order:
-                return
-            incomplete_order = state.get("latest_incomplete_unanchored_order")
-            if (
-                previous_started_order is None
-                and incomplete_order is not None
-                and incomplete_order > event_order
-            ):
                 return
             state["started_order"] = event_order
             state["started_ts"] = _record_ts(row)
-            state.pop("latest_incomplete_unanchored_order", None)
             retained = {
                 label: candidate
                 for label, candidate in state["milestones"].items()
@@ -1579,10 +1754,6 @@ class _StartupMilestoneAccumulator:
         started_order = state.get("started_order")
         if started_order is not None and event_order <= started_order:
             return
-        if started_order is None and not source_complete:
-            incomplete_order = state.get("latest_incomplete_unanchored_order")
-            if incomplete_order is None or event_order > incomplete_order:
-                state["latest_incomplete_unanchored_order"] = event_order
         label = _STARTUP_MILESTONE_EVENT_TYPES[event_type]
         existing = state["milestones"].get(label)
         if existing is not None and event_order >= existing[0]:
@@ -1699,9 +1870,9 @@ def _bounded_hsl_replay_data(data: Any) -> dict[str, Any]:
         return {}
     out: dict[str, Any] = {}
     for key in _HSL_REPLAY_STRING_FIELDS:
-        value = data.get(key)
+        value = _safe_label(data.get(key), max_len=120)
         if value is not None:
-            out[key] = str(value)
+            out[key] = value
     for key in _HSL_REPLAY_BOOL_FIELDS:
         if key in data:
             out[key] = bool(data.get(key))
@@ -4531,8 +4702,13 @@ def build_live_performance_report(
     accumulator = _PerformanceAccumulator()
     decision_boundary = _DecisionBoundaryAccumulator()
     input_staleness = _InputStalenessAccumulator()
-    startup_readiness = _StartupReadinessAccumulator()
-    startup_milestones = _StartupMilestoneAccumulator()
+    startup_source_completeness = _StartupSourceCompletenessTracker()
+    startup_readiness = _StartupReadinessAccumulator(
+        source_completeness=startup_source_completeness
+    )
+    startup_milestones = _StartupMilestoneAccumulator(
+        source_completeness=startup_source_completeness
+    )
     report_ts_ms = utc_ms()
     hsl_replay_profile = _HslReplayProfileAccumulator()
     cache_warmup = _CacheWarmupAccumulator()

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -13,6 +13,7 @@ from live.event_bus import (
     LIVE_EVENT_ID_KEYS,
     LIVE_EVENT_MONITOR_PAYLOAD_KEY,
     startup_phase_readiness_contract,
+    startup_timing_phase,
     utc_ms,
 )
 from live.event_file_rows import event_file_rows
@@ -1188,9 +1189,6 @@ class _StartupReadinessAccumulator:
         self.readiness_scope_counts: Counter[str] = Counter()
         self.readiness_scope_elapsed_values: dict[str, list[int]] = {}
         self.readiness_trading_impact_counts: Counter[str] = Counter()
-        self.lifecycle_started_order: dict[
-            str, tuple[str, int, str, int, int, int]
-        ] = {}
 
     @staticmethod
     def _update_debug_profiles(state: dict[str, Any], data: dict[str, Any]) -> None:
@@ -1209,6 +1207,7 @@ class _StartupReadinessAccumulator:
         if state is None:
             state = {
                 "bot": bot,
+                "_candidates": {},
                 "startup_phases_ms": {},
                 "latest_ts": None,
             }
@@ -1220,7 +1219,48 @@ class _StartupReadinessAccumulator:
             state["latest_ts"] = int(ts)
         return state
 
-    def add(self, *, row: dict[str, Any], live_event: dict[str, Any]) -> None:
+    @staticmethod
+    def _apply_candidate(state: dict[str, Any], candidate: dict[str, Any]) -> None:
+        ts = candidate.get("ts")
+        if ts is not None and (
+            state.get("latest_ts") is None or int(ts) > int(state["latest_ts"])
+        ):
+            state["latest_ts"] = int(ts)
+        event_type = candidate["event_type"]
+        if event_type == "bot.ready":
+            if ts is not None:
+                state["bot_ready_ts"] = int(ts)
+            state["lifecycle_status"] = "ready"
+            _StartupReadinessAccumulator._update_debug_profiles(
+                state,
+                candidate["data"],
+            )
+            return
+        if event_type == "bot.startup_timing":
+            stage = candidate["stage"]
+            elapsed_ms = candidate.get("elapsed_ms")
+            if elapsed_ms is None:
+                return
+            state["startup_phases_ms"][stage] = int(elapsed_ms)
+            contract = candidate.get("contract")
+            if contract is not None:
+                readiness_sla = state.setdefault("readiness_sla", {})
+                readiness_sla[contract["readiness_scope"]] = {
+                    "phase": stage,
+                    "elapsed_ms": int(elapsed_ms),
+                    "trading_impact": contract["trading_impact"],
+                }
+            return
+        if event_type.startswith("hsl.replay."):
+            state["hsl_replay"] = candidate["hsl_replay"]
+
+    def add(
+        self,
+        *,
+        row: dict[str, Any],
+        live_event: dict[str, Any],
+        source_complete: bool = True,
+    ) -> None:
         event_type = str(live_event.get("event_type") or row.get("kind") or "")
         data = live_event.get("data") if isinstance(live_event.get("data"), dict) else {}
         ts = _record_ts(row)
@@ -1231,7 +1271,10 @@ class _StartupReadinessAccumulator:
         elapsed_ms: int | None = None
         contract: dict[str, str] | None = None
         if event_type == "bot.startup_timing":
-            stage = _startup_phase_label(data.get("stage") or data.get("phase"))
+            raw_phase = startup_timing_phase(data)
+            if raw_phase is None:
+                return
+            stage = _startup_phase_label(raw_phase)
             elapsed_ms = _startup_elapsed_ms(data)
             if elapsed_ms is not None:
                 self.startup_phase_counts[stage] += 1
@@ -1254,19 +1297,32 @@ class _StartupReadinessAccumulator:
                 )
 
         if event_type == "bot.started":
-            previous_started_order = self.lifecycle_started_order.get(bot)
+            state = self._bot_state(row=row, live_event=live_event)
+            previous_started_order = state.get("_started_order")
             if (
                 previous_started_order is not None
                 and event_order <= previous_started_order
             ):
                 return
-            self.lifecycle_started_order[bot] = event_order
-            state = self._bot_state(row=row, live_event=live_event)
-            bot = str(state["bot"])
+            incomplete_order = state.get("_latest_incomplete_unanchored_order")
+            if (
+                previous_started_order is None
+                and incomplete_order is not None
+                and incomplete_order > event_order
+            ):
+                return
+            retained = {
+                key: candidate
+                for key, candidate in state["_candidates"].items()
+                if candidate[0] > event_order and candidate[2]
+            }
+            bot_name = str(state["bot"])
             state.clear()
             state.update(
                 {
-                    "bot": bot,
+                    "bot": bot_name,
+                    "_candidates": retained,
+                    "_started_order": event_order,
                     "startup_phases_ms": {},
                     "latest_ts": int(ts) if ts is not None else None,
                 }
@@ -1275,41 +1331,49 @@ class _StartupReadinessAccumulator:
                 state["bot_started_ts"] = int(ts)
             state["lifecycle_status"] = "started"
             self._update_debug_profiles(state, data)
+            for _key, (_order, candidate, _complete) in sorted(
+                retained.items(),
+                key=lambda item: item[1][0],
+            ):
+                self._apply_candidate(state, candidate)
             return
-        started_order = self.lifecycle_started_order.get(bot)
+        if event_type not in {
+            "bot.ready",
+            "bot.startup_timing",
+        } and not event_type.startswith("hsl.replay."):
+            return
+        state = self._bot_state(row=row, live_event=live_event)
+        started_order = state.get("_started_order")
         if started_order is not None and event_order <= started_order:
             return
-        if event_type == "bot.ready":
-            state = self._bot_state(row=row, live_event=live_event)
-            if ts is not None:
-                state["bot_ready_ts"] = int(ts)
-            state["lifecycle_status"] = "ready"
-            self._update_debug_profiles(state, data)
-            return
+        if started_order is None and not source_complete:
+            incomplete_order = state.get("_latest_incomplete_unanchored_order")
+            if incomplete_order is None or event_order > incomplete_order:
+                state["_latest_incomplete_unanchored_order"] = event_order
+
+        candidate_data: dict[str, Any] = {}
+        debug_profiles = _known_debug_profiles(data.get("live_event_debug_profiles"))
+        if debug_profiles:
+            candidate_data["live_event_debug_profiles"] = debug_profiles
+        candidate: dict[str, Any] = {
+            "event_type": event_type,
+            "ts": int(ts) if ts is not None else None,
+            "data": candidate_data,
+        }
+        candidate_key = event_type
         if event_type == "bot.startup_timing":
-            state = self._bot_state(row=row, live_event=live_event)
             assert stage is not None
-            if elapsed_ms is not None:
-                state["startup_phases_ms"][stage] = int(elapsed_ms)
-                if contract is not None:
-                    scope = contract["readiness_scope"]
-                    impact = contract["trading_impact"]
-                    readiness_sla = state.get("readiness_sla")
-                    if not isinstance(readiness_sla, dict):
-                        readiness_sla = {}
-                        state["readiness_sla"] = readiness_sla
-                    readiness_sla[scope] = {
-                        "phase": stage,
-                        "elapsed_ms": int(elapsed_ms),
-                        "trading_impact": impact,
-                    }
-            return
+            candidate_key = f"startup:{stage}"
+            candidate.update(
+                {
+                    "stage": stage,
+                    "elapsed_ms": elapsed_ms,
+                    "contract": contract,
+                }
+            )
         if event_type.startswith("hsl.replay."):
-            state = self._bot_state(row=row, live_event=live_event)
-            hsl_state = state.get("hsl_replay")
-            if not isinstance(hsl_state, dict):
-                hsl_state = {}
-                state["hsl_replay"] = hsl_state
+            candidate_key = "hsl.replay"
+            hsl_state: dict[str, Any] = {}
             if ts is not None:
                 hsl_state["latest_ts"] = int(ts)
             hsl_state["event_type"] = event_type
@@ -1337,6 +1401,18 @@ class _StartupReadinessAccumulator:
             ):
                 if key in data:
                     hsl_state[key] = data[key]
+            candidate["hsl_replay"] = hsl_state
+
+        existing = state["_candidates"].get(candidate_key)
+        if existing is not None and event_order <= existing[0]:
+            return
+        state["_candidates"][candidate_key] = (
+            event_order,
+            candidate,
+            bool(source_complete),
+        )
+        if started_order is not None or source_complete:
+            self._apply_candidate(state, candidate)
 
     def to_dict(
         self,
@@ -4278,7 +4354,10 @@ def _add_event_timings(
         return
 
     if event_type == "bot.startup_timing":
-        stage = _startup_phase_label(data.get("stage") or data.get("phase"))
+        raw_phase = startup_timing_phase(data)
+        if raw_phase is None:
+            return
+        stage = _startup_phase_label(raw_phase)
         operation = f"startup.{stage}"
         value_ms = _non_negative_ms(data.get("elapsed_ms"))
         if value_ms is None:
@@ -4557,7 +4636,11 @@ def build_live_performance_report(
             live_event=live_event,
             cycle_scope=cycle_scope,
         )
-        startup_readiness.add(row=row, live_event=live_event)
+        startup_readiness.add(
+            row=row,
+            live_event=live_event,
+            source_complete=source_complete,
+        )
         startup_milestones.add(
             row=row,
             live_event=live_event,

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -15,6 +15,7 @@ from live.event_bus import (
     LIVE_EVENT_MONITOR_PAYLOAD_KEY,
     EventTypes,
     startup_phase_readiness_contract,
+    startup_timing_phase,
     utc_ms,
 )
 from live.event_file_rows import event_file_rows
@@ -5431,8 +5432,8 @@ def _startup_timing_record(
     data = live_event.get("data")
     if not isinstance(data, dict):
         return None
-    phase = str(data.get("phase") or "").strip()
-    if not phase:
+    phase = startup_timing_phase(data)
+    if phase is None:
         return None
     elapsed_ms = _non_negative_int(data.get("elapsed_ms"))
     since_previous_ms = _non_negative_int(data.get("since_previous_ms"))
@@ -5489,6 +5490,8 @@ def _startup_records_after_latest_started(
 
 def _summarize_startup_timings(
     records_by_bot: dict[str, list[dict[str, Any]]],
+    *,
+    baseline_records_by_bot: dict[str, list[dict[str, Any]]] | None = None,
 ) -> list[dict[str, Any]]:
     summaries: list[dict[str, Any]] = []
     for bot_key, records in sorted(records_by_bot.items()):
@@ -5497,8 +5500,24 @@ def _summarize_startup_timings(
             phases[str(record["phase"])].append(record)
         phase_summaries: dict[str, dict[str, Any]] = {}
         for phase, phase_records in sorted(phases.items()):
-            window = phase_records[-STARTUP_TIMING_BASELINE_WINDOW:]
-            latest = window[-1]
+            latest = phase_records[-1]
+            baseline_records = (
+                baseline_records_by_bot[bot_key]
+                if baseline_records_by_bot is not None
+                and bot_key in baseline_records_by_bot
+                else records
+            )
+            latest_key = _sort_startup_record_key(latest)
+            historical_phase_records = [
+                record
+                for record in sorted(
+                    baseline_records,
+                    key=_sort_startup_record_key,
+                )
+                if record.get("phase") == phase
+                and _sort_startup_record_key(record) <= latest_key
+            ]
+            window = historical_phase_records[-STARTUP_TIMING_BASELINE_WINDOW:]
             elapsed_values = [
                 int(record["elapsed_ms"])
                 for record in window
@@ -6268,7 +6287,8 @@ def _scan_events(
             _startup_records_after_latest_started(
                 startup_timing_records,
                 startup_latest_started,
-            )
+            ),
+            baseline_records_by_bot=startup_timing_records,
         ),
         "remote_call_failures": _summarize_remote_call_failures(
             remote_call_failure_groups

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -32,6 +32,7 @@ from live.event_bus import (
     resolve_live_event_console_enabled,
     sink_failed_reason_code,
     startup_phase_readiness_contract,
+    startup_timing_phase,
 )
 from live.events import DiagnosticEvent
 from monitor_publisher import MonitorPublisher
@@ -120,6 +121,18 @@ def test_startup_phase_readiness_contract_is_bounded_and_defensive():
     assert startup_phase_readiness_contract("active-candle") is None
     assert startup_phase_readiness_contract("unknown") is None
     assert startup_phase_readiness_contract(["account"]) is None
+
+
+def test_startup_timing_phase_is_canonical_and_rejects_conflicts():
+    assert startup_timing_phase({"phase": "account"}) == "account"
+    assert startup_timing_phase({"stage": "hsl"}) == "hsl"
+    assert startup_timing_phase({"phase": "startup", "stage": "startup"}) == (
+        "startup"
+    )
+    assert startup_timing_phase({"phase": "account", "stage": "hsl"}) is None
+    assert startup_timing_phase({"phase": "custom-phase"}) == "other"
+    assert startup_timing_phase({}) is None
+    assert startup_timing_phase(None) is None
 
 
 def test_live_event_reason_code_registry_values_are_unique_and_query_safe():

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1456,6 +1456,54 @@ def test_live_performance_report_startup_readiness_completed_hsl_not_active(tmp_
     assert startup["bots"][0]["hsl_replay"]["skipped_pairs"] == 1
 
 
+def test_live_performance_report_startup_readiness_keeps_sparse_hsl_context(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="hsl.replay.progress",
+                seq=2,
+                ts=2000,
+                status="progress",
+                data={
+                    "signal_mode": "coin",
+                    "stage": "pair_replay",
+                    "pairs": 26,
+                    "held_pairs": 1,
+                    "rows_per_second": 300,
+                },
+            ),
+            _monitor_row(
+                event_type="hsl.replay.failed",
+                seq=3,
+                ts=3000,
+                status="failed",
+                reason_code="replay_failed",
+                data={"signal_mode": "coin", "elapsed_s": 5},
+            ),
+        ],
+    )
+
+    hsl_replay = build_live_performance_report(tmp_path / "monitor")[
+        "startup_readiness"
+    ]["bots"][0]["hsl_replay"]
+
+    assert hsl_replay == {
+        "latest_ts": 3000,
+        "event_type": "hsl.replay.failed",
+        "status": "failed",
+        "reason_code": "replay_failed",
+        "signal_mode": "coin",
+        "stage": "pair_replay",
+        "pairs": 26,
+        "held_pairs": 1,
+        "rows_per_second": 300,
+        "elapsed_s": 5,
+    }
+
+
 def test_live_performance_report_startup_readiness_resets_on_restart(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(
@@ -1667,6 +1715,52 @@ def test_live_performance_report_startup_readiness_rejects_old_tail_anchor(tmp_p
     assert "bot_started_ts" not in bot
     assert "bot_ready_ts" not in bot
     assert "lifecycle_status" not in bot
+
+
+@pytest.mark.parametrize("max_event_files_per_bot", [0, 2])
+def test_live_performance_report_rejects_old_startup_data_after_unrelated_tail(
+    tmp_path,
+    max_event_files_per_bot,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "2026-07-10T00-00-00.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=2,
+                ts=1500,
+                data={"phase": "account", "elapsed_ms": 500},
+            ),
+            _monitor_row(event_type="execution.create_sent", seq=3, ts=2000),
+        ],
+    )
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=4, ts=4000),
+            _monitor_row(event_type="health.summary", seq=5, ts=5000),
+            _monitor_row(event_type="health.summary", seq=6, ts=6000),
+            _monitor_row(event_type="health.summary", seq=7, ts=7000),
+        ],
+    )
+
+    report = build_live_performance_report(
+        tmp_path / "monitor",
+        include_rotated=True,
+        max_event_files_per_bot=max_event_files_per_bot,
+        event_tail_lines=3,
+    )
+
+    assert report["event_window"]["event_tail_limited_files"] == 2
+    assert report["startup_readiness"]["bots"] == []
+    assert report["startup_milestones"]["bots"] == []
+    assert report["startup_milestones"]["observed_counts"] == {
+        "first_cycle_started": 0,
+        "first_rust_called": 0,
+        "first_exchange_write_submitted": 0,
+    }
 
 
 def test_live_performance_report_startup_readiness_is_bounded(tmp_path):
@@ -2719,6 +2813,20 @@ def test_live_performance_report_hsl_replay_profile_whitelists_values(tmp_path):
     assert "api_key" not in rendered
     assert "secret" not in rendered
     assert "drawdown_raw" not in rendered
+
+
+def test_bounded_hsl_replay_data_bounds_string_values():
+    bounded = performance_report_module._bounded_hsl_replay_data(
+        {
+            "stage": "x" * 100_000,
+            "signal_mode": "coin",
+        }
+    )
+
+    assert bounded == {
+        "signal_mode": "coin",
+        "stage": "x" * 120,
+    }
 
 
 def test_live_performance_report_hsl_history_elapsed_is_latest_when_replay_not_started(

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1375,6 +1375,47 @@ def test_live_performance_report_rejects_mismatched_startup_readiness_contract(
     )
 
 
+def test_live_performance_report_startup_phase_uses_stage_only_as_legacy_fallback(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=1,
+                ts=1000,
+                data={"stage": "hsl", "elapsed_ms": 1000},
+            ),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=2,
+                ts=2000,
+                data={
+                    "phase": "account",
+                    "stage": "hsl",
+                    "elapsed_ms": 2000,
+                },
+            ),
+        ],
+    )
+
+    startup = build_live_performance_report(tmp_path / "monitor")["startup_readiness"]
+
+    assert startup["startup_phase_counts"] == {"hsl": 1}
+    assert startup["bots"][0]["startup_phases_ms"] == {"hsl": 1000}
+    startup_groups = {
+        group["operation"]: group
+        for group in build_live_performance_report(tmp_path / "monitor")[
+            "operation_durations"
+        ]["groups"]
+        if group["operation"].startswith("startup.")
+    }
+    assert set(startup_groups) == {"startup.hsl"}
+    assert startup_groups["startup.hsl"]["count"] == 1
+
+
 def test_live_performance_report_startup_readiness_completed_hsl_not_active(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(
@@ -1543,6 +1584,89 @@ def test_live_performance_report_startup_readiness_uses_event_order_with_file_ca
         "account_critical": 1,
         "held_position_protective": 1,
     }
+
+
+def test_live_performance_report_startup_readiness_joins_complete_rotated_lifecycle(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "2026-07-10T00-00-00.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=2,
+                ts=1100,
+                data={
+                    "phase": "account",
+                    "elapsed_ms": 100,
+                    "readiness_scope": "account_critical",
+                    "trading_impact": "protective_blocker",
+                },
+            ),
+        ],
+    )
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=3,
+                ts=2000,
+                data={
+                    "phase": "hsl",
+                    "elapsed_ms": 1000,
+                    "readiness_scope": "held_position_protective",
+                    "trading_impact": "protective_blocker",
+                },
+            ),
+            _monitor_row(event_type="bot.ready", seq=4, ts=2100),
+        ],
+    )
+
+    startup = build_live_performance_report(
+        tmp_path / "monitor",
+        include_rotated=True,
+        max_event_files_per_bot=2,
+    )["startup_readiness"]
+    bot = startup["bots"][0]
+
+    assert bot["bot_started_ts"] == 1000
+    assert bot["bot_ready_ts"] == 2100
+    assert bot["lifecycle_status"] == "ready"
+    assert bot["startup_phases_ms"] == {"account": 100, "hsl": 1000}
+    assert set(bot["readiness_sla"]) == {
+        "account_critical",
+        "held_position_protective",
+    }
+
+
+def test_live_performance_report_startup_readiness_rejects_old_tail_anchor(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "2026-07-10T00-00-00.ndjson",
+        [_monitor_row(event_type="bot.started", seq=1, ts=1000)],
+    )
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=2, ts=4000),
+            _monitor_row(event_type="bot.ready", seq=3, ts=5000),
+        ],
+    )
+
+    startup = build_live_performance_report(
+        tmp_path / "monitor",
+        include_rotated=True,
+        max_event_files_per_bot=2,
+        event_tail_lines=1,
+    )["startup_readiness"]
+    bot = startup["bots"][0]
+
+    assert "bot_started_ts" not in bot
+    assert "bot_ready_ts" not in bot
+    assert "lifecycle_status" not in bot
 
 
 def test_live_performance_report_startup_readiness_is_bounded(tmp_path):

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -3455,6 +3455,96 @@ def test_live_smoke_report_startup_readiness_resets_on_bot_started(tmp_path):
     }
 
 
+def test_live_smoke_report_startup_budget_keeps_prior_restart_samples(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "2026-07-10T00-00-00.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=2,
+                ts=2000,
+                data={
+                    "phase": "account",
+                    "elapsed_ms": 1000,
+                    "since_previous_ms": 1000,
+                },
+            ),
+        ],
+    )
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=3, ts=3000),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=4,
+                ts=4000,
+                data={
+                    "phase": "account",
+                    "elapsed_ms": 2000,
+                    "since_previous_ms": 2000,
+                },
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        include_rotated=True,
+        max_event_files_per_bot=2,
+    )
+    phase = report["startup_timings"][0]["phases"]["account"]
+
+    assert phase["latest_elapsed_ms"] == 2000
+    assert phase["samples"] == 2
+    assert phase["elapsed_budget"] == {
+        "status": "over_budget",
+        "latest_ms": 2000,
+        "budget_ms": 1000,
+        "baseline_samples": 1,
+        "usage_pct": 200,
+        "over_budget_by_ms": 1000,
+        "source": "prior_p95_ms",
+    }
+
+
+def test_live_smoke_report_startup_phase_uses_stage_only_as_legacy_fallback(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=1,
+                ts=1000,
+                data={
+                    "stage": "hsl",
+                    "elapsed_ms": 1000,
+                    "since_previous_ms": 1000,
+                },
+            ),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=2,
+                ts=2000,
+                data={
+                    "phase": "account",
+                    "stage": "hsl",
+                    "elapsed_ms": 2000,
+                    "since_previous_ms": 1000,
+                },
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+
+    assert set(report["startup_timings"][0]["phases"]) == {"hsl"}
+
+
 def test_live_smoke_report_summarizes_shutdown_events(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- preserve bounded current-lifecycle startup readiness across current/rotated event segments in either traversal order
- keep prior restart samples available for smoke timing budgets while projecting only the latest lifecycle
- canonicalize startup timing phase parsing across performance and smoke consumers
- preserve bounded HSL replay context across sparse terminal events

## Contract
- phase is canonical; stage is accepted only as a legacy fallback
- conflicting phase/stage records are rejected
- any incomplete newer source blocks or retroactively invalidates stale rotated readiness and milestone lifecycle candidates
- HSL replay context is field-whitelisted and string/status/reason values are bounded
- per-bot records are current-lifecycle projections; aggregate startup timings cover selected history
- report-only change: no producer, trading, process-control, or smoke-verdict behavior changes

## Validation
- affected five-file pytest matrix: green (291 tests)
- Python compilation: green
- git diff --check: green
- added-line silent-handling scan: clean
- independent integrated preflight: green, including capped/no-cap traversal, same-source retained starts, sparse HSL terminal, and restart reset