### PR TITLE
Add fresh entry eligibility evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Completed normal live order plans now emit one bounded structured/monitor
+  `entry.initial_eligibility` event. It distinguishes fresh initial entries
+  that were absent, already satisfied, blocked by an existing local gate,
+  accompanied only by protective actions, or selected for the final
+  connector-bound create batch immediately before invocation. The event
+  observes existing reconciliation
+  and execution decisions only; it does not add a gate, change order batches,
+  or claim exchange acknowledgement.
+
 - Startup readiness reporting now uses one canonical phase parser across
   performance and smoke consumers, rejects conflicting `phase`/legacy `stage`
   records, rejects stale rotated lifecycle data after any incomplete current

--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -50,6 +50,7 @@ across time.
 - `execution.create_succeeded`
 - `entry.initial_distance_gate_blocked`
 - `entry.initial_distance_gate_cleared`
+- `entry.initial_eligibility`
 - `entry.min_effective_cost_blocked`
 - `fill.ingested`
 - `fills.refresh_summary`
@@ -94,6 +95,62 @@ across time.
 - `unstuck.status`
 - `websocket.reconnect`
 
+## Fresh-Entry Eligibility Contract
+
+Completed normal live order plans emit one `entry.initial_eligibility` event
+to structured and monitor sinks only. The producer observes the existing Rust
+plan, Python reconciliation, and local pre-connector filters; it does not add
+or re-evaluate a trading gate.
+
+Each evaluated symbol/position-side record has one outcome, in this precedence:
+
+1. `eligible`: an initial-entry order survived the final batch cap and was
+   selected for the connector-bound `execute_orders` list immediately before
+   invocation.
+2. `blocked_candidate`: an initial candidate existed but no candidate reached
+   that boundary.
+3. `already_satisfied`: reconciliation removed the candidate because an open
+   order matched exactly or within the configured order-match tolerance.
+4. `protective_only`: the pair had protective/reduce-only/panic actions but no
+   initial candidate.
+5. `no_candidate`: the evaluated pair had no initial candidate; the stable
+   default reason is `rust_no_initial_candidate`.
+
+Stable per-record `reason_counts` values are:
+
+- `batch_capacity`
+- `conversion_zero_or_duplicate`
+- `debug_mode`
+- `exact_reconciliation_match`
+- `freshness_creation_guardrail`
+- `hsl_replay_pending`
+- `initial_entry_distance_gate`
+- `limit_order_create_market_distance`
+- `low_balance`
+- `malformed_actual_orders`
+- `mode_filter`
+- `order_match_tolerance`
+- `pending_exchange_config`
+- `pre_create_market_snapshot_unavailable`
+- `pre_create_planning_snapshot_invalid`
+- `protective_actions_only`
+- `recent_execution`
+- `rust_no_initial_candidate`
+- `state_change_detected`
+- `trailing_unavailable`
+- `unclassified_candidate` for an initial candidate not accounted for by a
+  known observation point
+- `reason_overflow` when a record exceeds its bounded reason-key limit
+
+`eligible` does not claim connector invocation completed, exchange acceptance,
+or order acknowledgement. Connector and exchange outcomes remain in the
+`execution.*` event family. The event retains full aggregate counts, samples at
+most 32 deterministic pair records, and contains no order price, quantity, raw
+payload, path, secret, or exception text. Planning failures, deferrals,
+shutdown interruption, and diagnostic tracing failures omit the event instead
+of emitting a misleading candidate-free result. Diagnostic and sink failures
+must not change order lists or execution results.
+
 ## HSL Replay Timing Fields
 
 For coin-mode `hsl.replay.completed`, `full_elapsed_s` measures total replay
@@ -133,6 +190,7 @@ full-replay terminal event.
 - `defer`
 - `degraded`
 - `ema`
+- `entry`
 - `execution`
 - `exchange`
 - `fallback`
@@ -189,6 +247,7 @@ full-replay terminal event.
 - `exchange_time_sync`
 - `exchange_time_sync_unavailable`
 - `execution_loop_error_burst`
+- `fresh_entry_eligibility`
 - `entry_cooldown_position_delta`
 - `fill_cache_doctor_report`
 - `fill_cache_quarantined`

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -1,6 +1,6 @@
 # Live Logging Overhaul Current Status
 
-Updated: 2026-07-11.
+Updated: 2026-07-12.
 
 This is the compact operational source for the active logging-overhaul loop.
 Read it before the historical progress ledger. Update it whenever the active
@@ -22,49 +22,55 @@ Estimated completion:
 
 ## Active Review Slice
 
-- PR #1195, `Fix startup readiness report lifecycle handling`
-- Branch: `codex/v8-startup-readiness-correctness`
-- Base: `b15d349be5c544f9a8ac83618977b8a0cfd11ba5`
-- Triggering evidence: post-merge review reproduced three startup-report
-  correctness gaps: performance readiness lost current events when their start
-  marker was in a rotated segment; smoke discarded prior restart samples before
-  computing timing budgets; and performance/smoke interpreted `phase` and
-  legacy `stage` differently.
-- Scope: use one canonical phase parser (`phase`, then legacy `stage`, reject
-  conflicts), retain bounded current-lifecycle performance candidates across
-  rotation, reject stale rotated readiness/milestone candidates whenever any
-  retained current row proves the source is incomplete, preserve bounded HSL
-  replay context across sparse terminal events, and separate smoke's current
-  lifecycle projection from its bounded historical restart baseline.
-- Behavior boundary: read-only `live-performance-report` derivation and tests
-  only. No event producer, startup/readiness decision, exchange call, process
-  control, Rust/order/risk logic, smoke verdict, or trading behavior change.
-  Per-bot readiness/milestone records are current-lifecycle projections;
-  aggregate startup phase counts and timing summaries remain statistics over
-  all selected history.
-- Validation: focused and full performance-report tests, Python compilation,
-  `git diff --check`, the added-line silent-handling scan, and independent
-  preflight.
+- Branch: `codex/v8-fresh-entry-eligibility`
+- Base: `739ebd49d7de40966145c5a1ca2c8aa3fe01a235`
+- Triggering evidence: existing planning, reconciliation, create-filter, and
+  pre-call submission events cannot answer why a fresh entry did or did not
+  become locally submit-ready in a completed cycle.
+- Scope: add one bounded, correlated fresh-entry eligibility producer contract
+  that distinguishes `no_candidate`, `blocked_candidate`,
+  `protective_only`, `already_satisfied`, and `eligible` after the
+  existing reconciler/executor gates.
+- Behavior boundary: observability must derive from existing order-path facts,
+  never add or duplicate a trading gate, mutate `to_create`, affect connector
+  calls, or treat event failure as an execution failure. Rust remains the order
+  authority; Python only reports the existing live reconciliation/I/O boundary.
+- Validation: 244 focused/adjacent tests and all 21 fake-live marker scenarios
+  pass, including outcome precedence, boundedness, reconciler/executor
+  mixed cases, exact pre-create gate attribution, schema validation, and event
+  failure isolation. Python compilation and `git diff --check` also pass;
+  independent exact-commit preflight remains before publication.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
-- Expected VPS action: after merge, pull while preserving local artifacts and
-  run bounded rotated startup-readiness/performance and settled smoke reports.
-  Do not restart or signal bots because this slice changes only an on-demand
-  report consumer.
+- Expected VPS action: after merge, pull while preserving local artifacts,
+  restart only the five exact supervised bot panes so the producer is loaded,
+  query the new event by cycle/pside, and run immediate plus settled smoke.
 
 Next action:
 
-1. Complete the three startup-consumer regressions, publish after clean
-   independent preflight, and merge only after the exact-head temporary Hermes
-   + Grok 4.5 + green-CI gate is satisfied.
+1. Freeze the validated implementation in one commit, run independent
+   exact-commit preflight, then publish for the temporary Hermes + Grok 4.5 +
+   green-CI current-head gate.
 
 ## Deployed Baseline
 
-- Remote `v8`: `b15d349be5c544f9a8ac83618977b8a0cfd11ba5`, PR #1194
-- VPS5 repository: `b15d349be5c544f9a8ac83618977b8a0cfd11ba5`, PR #1194; tracked
+- Remote `v8`: `739ebd49d7de40966145c5a1ca2c8aa3fe01a235`, PR #1195
+- VPS5 repository: `739ebd49d7de40966145c5a1ca2c8aa3fe01a235`, PR #1195; tracked
   status clean; only expected untracked artifacts were preserved
 - VPS5 expected bots: five; all running with the PR #1192 restart PIDs;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1195 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded without bot signals or restarts, preserving bot PIDs
+  `850148/850296/850370/850436/850495` and unrelated `misc:0.0` PID
+  `434835`. Bounded readiness and milestone reports scanned 12 files with
+  zero issues; incomplete sources no longer attached stale rotated lifecycle
+  data, while KuCoin retained its bounded sparse HSL context and first-cycle
+  milestone at `220.123s`. The first smoke caught a real KuCoin balance
+  timeout. After it aged out, the retry was green with `284/284` remote and
+  `57/57` account-critical calls successful, 5/5 bots matched, no hard/log/
+  monitor failures, no event-pipeline errors, and a clean tracked repository.
+  Two report-time `D` samples cleared; the quiet follow-up showed all five bots
+  `Rsl+`.
 - PR #1194 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded without process signals, preserving bot PIDs
   `850148/850296/850370/850436/850495` and unrelated `misc:0.0` PID `434835`.
@@ -212,15 +218,13 @@ initial-entry filter visibility and PR #1190's HSL replay scanned-row
 throughput, PR #1191's corrected active/legacy-terminal replay estimates,
 PR #1192's machine-readable startup readiness SLA semantics, PR #1193's
 latest-lifecycle report ordering, and PR #1194's bounded startup action
-milestones are also merged and deployed. The active slice corrects the
-remaining startup-readiness lifecycle, baseline, and phase-parity findings.
+milestones, plus PR #1195's startup consumer correctness fixes, are also merged
+and deployed. The active slice adds the missing true fresh-entry eligibility
+producer after all existing local pre-connector gates.
 
-After this report-only follow-up is merged and validated, select the next
-review-worthy candidate from the remaining backlog, including:
+After this producer is merged and validated, select the next review-worthy
+candidate from the remaining backlog, including:
 
-- a separate producer contract for true fresh-entry eligibility, distinguishing
-  no candidate, blocked candidate, protective-only, already-satisfied, and
-  eligible outcomes
 - optional connector-boundary evidence if operators need actual exchange-write
   invocation rather than the existing pre-call submitted event
 - bounded operator tooling improvements sharing one code and validation surface

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -38,8 +38,9 @@ Estimated completion:
 - Validation: 244 focused/adjacent tests and all 21 fake-live marker scenarios
   pass, including outcome precedence, boundedness, reconciler/executor
   mixed cases, exact pre-create gate attribution, schema validation, and event
-  failure isolation. Python compilation and `git diff --check` also pass;
-  independent exact-commit preflight remains before publication.
+  failure isolation. Python compilation and `git diff --check` also pass. An
+  independent exact-commit preflight approved the executable delta with no
+  findings; its focused eligibility/event suite also passed.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: after merge, pull while preserving local artifacts,
@@ -48,9 +49,9 @@ Estimated completion:
 
 Next action:
 
-1. Freeze the validated implementation in one commit, run independent
-   exact-commit preflight, then publish for the temporary Hermes + Grok 4.5 +
-   green-CI current-head gate.
+1. Wait for the temporary Hermes + Grok 4.5 + green-CI current-head gate on PR
+   #1196, resolve any findings narrowly, then merge and run the declared exact
+   five-bot VPS5 restart plus immediate and settled smoke.
 
 ## Deployed Baseline
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7671,3 +7671,32 @@ VPS5 deployment status:
   process control, HSL/risk/order behavior, Rust, backtest, optimizer, or smoke
   verdict change. Expected VPS action is pull plus bounded reports and settled
   smoke, with no bot restart.
+
+### Deployed Slice: Startup Readiness Consumer Correctness
+
+- PR #1195 was approved by Hermes and Grok 4.5 on exact head `e9aab6b97`; CI
+  passed and it merged to `v8` as `739ebd49d`.
+- VPS5 fast-forwarded without signals or restarts. Bot PIDs
+  `850148/850296/850370/850436/850495` and unrelated `misc:0.0` PID
+  `434835` remained unchanged.
+- Bounded readiness and milestone reports scanned 12 files with zero issues.
+  Incomplete current sources no longer attached stale rotated lifecycle data;
+  KuCoin retained its bounded sparse HSL terminal context and exposed its first
+  cycle at `220.123s`.
+- The first smoke caught a real KuCoin balance timeout. After it aged out, the
+  retry was green with `284/284` remote and `57/57` account-critical calls
+  successful, all five bots matched, no hard/log/monitor failures, no event
+  pipeline errors, and a clean tracked repository. Two report-time `D`
+  samples cleared; all five bots were `Rsl+` on the quiet follow-up.
+
+### Active Slice: Fresh-Entry Eligibility Evidence
+
+- Branch: `codex/v8-fresh-entry-eligibility` from deployed `739ebd49d`.
+- Scope: emit one bounded, correlated observability contract that distinguishes
+  `no_candidate`, `blocked_candidate`, `protective_only`,
+  `already_satisfied`, and `eligible` after existing reconciliation and
+  local pre-connector filters.
+- Non-goals: no duplicate or changed entry gate, no `to_create` mutation, no
+  connector/exchange outcome claim, no Rust/order/risk/HSL behavior change, and
+  no event-sink failure propagation into execution. Expected VPS action is an
+  exact five-bot restart, bounded event query, and immediate plus settled smoke.

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -154,6 +154,7 @@ class EventTypes:
     EXECUTION_CREATE_REJECTED = "execution.create_rejected"
     EXECUTION_CREATE_DEFERRED = "execution.create_deferred"
     EXECUTION_CREATE_SKIPPED = "execution.create_skipped"
+    ENTRY_INITIAL_ELIGIBILITY = "entry.initial_eligibility"
     ENTRY_INITIAL_DISTANCE_GATE_BLOCKED = "entry.initial_distance_gate_blocked"
     ENTRY_INITIAL_DISTANCE_GATE_CLEARED = "entry.initial_distance_gate_cleared"
     ENTRY_MIN_EFFECTIVE_COST_BLOCKED = "entry.min_effective_cost_blocked"
@@ -205,6 +206,7 @@ class EventTags:
     DEFER = "defer"
     DEGRADED = "degraded"
     EMA = "ema"
+    ENTRY = "entry"
     EXECUTION = "execution"
     EXCHANGE = "exchange"
     FALLBACK = "fallback"
@@ -257,6 +259,7 @@ class ReasonCodes:
     EXCHANGE_TIME_SYNC_UNAVAILABLE = "exchange_time_sync_unavailable"
     WEBSOCKET_RECONNECT = "websocket_reconnect"
     EXECUTION_LOOP_ERROR_BURST = "execution_loop_error_burst"
+    FRESH_ENTRY_ELIGIBILITY = "fresh_entry_eligibility"
     FILL_CACHE_DOCTOR_REPORT = "fill_cache_doctor_report"
     FILL_CACHE_QUARANTINED = "fill_cache_quarantined"
     FILL_CACHE_READY = "fill_cache_ready"
@@ -467,6 +470,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.EXECUTION_CREATE_REJECTED,
     EventTypes.EXECUTION_CREATE_DEFERRED,
     EventTypes.EXECUTION_CREATE_SKIPPED,
+    EventTypes.ENTRY_INITIAL_ELIGIBILITY,
     EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
     EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
     EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED,
@@ -778,6 +782,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.EXECUTION_CREATE_REJECTED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CREATE_DEFERRED: EventRoute(console=False, text=False),
     EventTypes.EXECUTION_CREATE_SKIPPED: EventRoute(console=True, text=True),
+    EventTypes.ENTRY_INITIAL_ELIGIBILITY: EventRoute(console=False, text=False),
     EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED: EventRoute(
         console=True, text=True
     ),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -3419,6 +3419,39 @@ def emit_execution_create_filter_event(
         )
 
 
+def emit_initial_entry_eligibility_event(
+    bot: Any,
+    *,
+    data: dict[str, Any],
+    wave: dict | None = None,
+) -> None:
+    """Emit bounded cycle-local fresh-entry eligibility evidence."""
+    try:
+        order_wave_id, _action_id = _execution_event_ids(
+            wave,
+            action="create",
+            index=None,
+        )
+        _safe_emit(
+            bot,
+            EventTypes.ENTRY_INITIAL_ELIGIBILITY,
+            level="debug",
+            component="entry.initial_eligibility",
+            tags=(EventTags.ENTRY, EventTags.AVAILABILITY, EventTags.EXECUTION),
+            cycle_id=current_live_event_cycle_id(bot),
+            order_wave_id=order_wave_id,
+            status="succeeded",
+            reason_code=ReasonCodes.FRESH_ENTRY_ELIGIBILITY,
+            data=dict(data),
+        )
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit %s: %s",
+            EventTypes.ENTRY_INITIAL_ELIGIBILITY,
+            exc,
+        )
+
+
 def emit_execution_order_event(
     bot: Any,
     *,

--- a/src/live/executor.py
+++ b/src/live/executor.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import logging
 import math
 import sys
-from collections import defaultdict
+from collections import Counter, defaultdict
 
 from passivbot_exceptions import RestartBotException
 from live.event_bus import EventTypes, ReasonCodes
+from live.fresh_entry_eligibility import FreshEntryEligibilityTrace
 from pure_funcs import shorten_custom_id
 from utils import utc_ms as _utils_utc_ms
 
@@ -118,6 +119,69 @@ def _symbols_from_orders(orders: list[dict]) -> list[str]:
     return sorted(str(order["symbol"]) for order in orders if order.get("symbol"))
 
 
+def _orders_removed_by_identity(before: list[dict], after: list[dict]) -> list[dict]:
+    remaining = Counter(id(order) for order in after)
+    removed = []
+    for order in before:
+        order_id = id(order)
+        if remaining[order_id] > 0:
+            remaining[order_id] -= 1
+        else:
+            removed.append(order)
+    return removed
+
+
+def _fresh_entry_trace(bot) -> FreshEntryEligibilityTrace | None:
+    trace = getattr(bot, "_fresh_entry_eligibility_trace", None)
+    return trace if isinstance(trace, FreshEntryEligibilityTrace) else None
+
+
+def _record_fresh_entry_orders(
+    bot, method: str, orders: list[dict], reason: str | None = None
+) -> None:
+    """Record one existing executor decision without allowing diagnostics to affect it."""
+    trace = _fresh_entry_trace(bot)
+    if trace is None:
+        return
+    try:
+        recorder = getattr(trace, method)
+        if reason is None:
+            recorder(orders)
+        else:
+            recorder(orders, reason)
+    except Exception as exc:
+        bot._fresh_entry_eligibility_trace = None
+        logging.debug(
+            "[entry] fresh-entry eligibility trace disabled during execution | "
+            "method=%s error_type=%s",
+            method,
+            type(exc).__name__,
+        )
+
+
+def _emit_fresh_entry_eligibility(bot, passivbot_cls, wave) -> None:
+    """Consume and emit the cycle trace exactly once on a completed local plan."""
+    trace = _fresh_entry_trace(bot)
+    bot._fresh_entry_eligibility_trace = None
+    if trace is None:
+        return
+    try:
+        data = trace.to_event_data()
+    except Exception as exc:
+        logging.debug(
+            "[entry] fresh-entry eligibility payload build failed | error_type=%s",
+            type(exc).__name__,
+        )
+        return
+    try:
+        passivbot_cls._emit_initial_entry_eligibility_event(bot, data=data, wave=wave)
+    except Exception as exc:
+        logging.debug(
+            "[entry] fresh-entry eligibility event emission failed | error_type=%s",
+            type(exc).__name__,
+        )
+
+
 def _create_rejection_reason(result) -> str:
     if isinstance(result, BaseException):
         return "result_exception"
@@ -175,10 +239,14 @@ def _remember_ambiguous_create(
 
 async def execute_to_exchange(bot, *, prepare_cycle: bool = True):
     """Run one execution cycle including config sync and order placement/cancellation."""
-    if prepare_cycle:
-        await bot.execution_cycle()
-    to_cancel, to_create = await bot.calc_orders_to_cancel_and_create()
-    return await execute_order_plan(bot, to_cancel, to_create)
+    bot._fresh_entry_eligibility_trace = None
+    try:
+        if prepare_cycle:
+            await bot.execution_cycle()
+        to_cancel, to_create = await bot.calc_orders_to_cancel_and_create()
+        return await execute_order_plan(bot, to_cancel, to_create)
+    finally:
+        bot._fresh_entry_eligibility_trace = None
 
 
 async def execute_order_plan(
@@ -232,6 +300,9 @@ async def execute_order_plan(
             if order_wave is not None:
                 order_wave["skipped_create"] += len(blocked_creates)
             if blocked_creates:
+                _record_fresh_entry_orders(
+                    bot, "record_blocked_orders", blocked_creates, "low_balance"
+                )
                 passivbot_cls._emit_execution_create_filter_event(
                     bot,
                     event_type=EventTypes.EXECUTION_CREATE_SKIPPED,
@@ -259,8 +330,15 @@ async def execute_order_plan(
                     len(to_cancel),
                     len(to_create),
                 )
+    before_hsl_filter = list(to_create)
     to_create = _filter_hsl_replay_pending_creates(
         bot, passivbot_cls, to_create, order_wave
+    )
+    _record_fresh_entry_orders(
+        bot,
+        "record_blocked_orders",
+        _orders_removed_by_identity(before_hsl_filter, to_create),
+        "hsl_replay_pending",
     )
     if bot.debug_mode:
         if to_cancel:
@@ -279,6 +357,9 @@ async def execute_order_plan(
             order_wave["cancel_posted"] = len(res or [])
     if bot.debug_mode:
         if to_create:
+            _record_fresh_entry_orders(
+                bot, "record_blocked_orders", to_create, "debug_mode"
+            )
             logging.info(
                 "[order] debug mode would create orders | count=%d", len(to_create)
             )
@@ -300,6 +381,12 @@ async def execute_order_plan(
             else:
                 to_create_mod.append(order)
         if recent_execution_deferred:
+            _record_fresh_entry_orders(
+                bot,
+                "record_blocked_orders",
+                [order for order, _delay in recent_execution_deferred],
+                "recent_execution",
+            )
             passivbot_cls._emit_execution_create_filter_event(
                 bot,
                 event_type=EventTypes.EXECUTION_CREATE_DEFERRED,
@@ -336,6 +423,12 @@ async def execute_order_plan(
                 ),
             )
             if state_filtered_orders:
+                _record_fresh_entry_orders(
+                    bot,
+                    "record_blocked_orders",
+                    state_filtered_orders,
+                    "state_change_detected",
+                )
                 passivbot_cls._emit_execution_create_filter_event(
                     bot,
                     event_type=EventTypes.EXECUTION_CREATE_SKIPPED,
@@ -366,6 +459,7 @@ async def execute_order_plan(
             configured_symbols = await bot.update_exchange_configs(creation_symbols)
             if bot._shutdown_requested():
                 bot._order_wave_in_progress = None
+                bot._fresh_entry_eligibility_trace = None
                 return None
             pending_config = sorted(
                 set(creation_symbols) - set(configured_symbols or set())
@@ -379,6 +473,12 @@ async def execute_order_plan(
                     passivbot_cls._log_symbols(pending_config, limit=12),
                 )
                 if pending_config_orders:
+                    _record_fresh_entry_orders(
+                        bot,
+                        "record_blocked_orders",
+                        pending_config_orders,
+                        "pending_exchange_config",
+                    )
                     passivbot_cls._emit_execution_create_filter_event(
                         bot,
                         event_type=EventTypes.EXECUTION_CREATE_SKIPPED,
@@ -442,6 +542,7 @@ async def execute_order_plan(
                         type(exc).__name__,
                     )
                 await bot.restart_bot_on_too_many_errors()
+    _emit_fresh_entry_eligibility(bot, passivbot_cls, order_wave)
     if to_cancel or to_create:
         bot.execution_scheduled = True
     if not passivbot_cls._shutdown_requested(bot):
@@ -459,7 +560,14 @@ async def execute_order_plan(
 async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
     """Submit a batch of orders after throttling and bookkeeping."""
     passivbot_cls = _pb_attr("Passivbot")
-    orders = orders[: int(bot.live_value("max_n_creations_per_batch"))]
+    requested_orders = list(orders)
+    orders = requested_orders[: int(bot.live_value("max_n_creations_per_batch"))]
+    _record_fresh_entry_orders(
+        bot,
+        "record_blocked_orders",
+        _orders_removed_by_identity(requested_orders, orders),
+        "batch_capacity",
+    )
     grouped_orders: dict[str, list[dict]] = defaultdict(list)
     emitted_ts = (
         int(bot.get_exchange_time()) if hasattr(bot, "get_exchange_time") else _utc_ms()
@@ -493,6 +601,8 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
             index=idx,
             wave=wave,
         )
+    _record_fresh_entry_orders(bot, "record_eligible_orders", orders)
+    _emit_fresh_entry_eligibility(bot, passivbot_cls, wave)
     try:
         res = await bot.execute_orders(orders)
     except RestartBotException:

--- a/src/live/fresh_entry_eligibility.py
+++ b/src/live/fresh_entry_eligibility.py
@@ -1,0 +1,329 @@
+"""Dependency-light diagnostics for why fresh initial entries were not created."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+
+
+_PSIDES = frozenset(("long", "short"))
+_FACT_ALIASES = {
+    "evaluated": "evaluated",
+    "evaluated_count": "evaluated",
+    "ideal": "ideal",
+    "ideal_count": "ideal",
+    "satisfied": "satisfied",
+    "satisfied_count": "satisfied",
+    "blocked": "blocked",
+    "blocked_count": "blocked",
+    "protective": "protective",
+    "protective_count": "protective",
+    "eligible": "eligible",
+    "eligible_count": "eligible",
+}
+_OUTCOMES = (
+    "eligible",
+    "blocked_candidate",
+    "already_satisfied",
+    "protective_only",
+    "no_candidate",
+)
+_SYMBOL_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:/-]*\Z")
+_REASON_RE = re.compile(r"[a-z][a-z0-9_]*\Z")
+_NORMALIZE_RE = re.compile(r"[^a-z0-9]+")
+
+
+@dataclass
+class _TraceRecord:
+    facts: dict[str, int] = field(
+        default_factory=lambda: {fact: 0 for fact in set(_FACT_ALIASES.values())}
+    )
+    reason_counts: dict[str, int] = field(default_factory=dict)
+
+
+class FreshEntryEligibilityTrace:
+    """Collect bounded, per-position-side eligibility facts without affecting orders.
+
+    This object intentionally does not decode Passivbot client IDs. Callers that already
+    decoded an order can use :meth:`record_count` to report the corresponding fact.
+    """
+
+    MAX_LABEL_LENGTH = 120
+    MAX_REASON_KEYS_PER_RECORD = 16
+    _REASON_OVERFLOW = "reason_overflow"
+    _UNCLASSIFIED_CANDIDATE = "unclassified_candidate"
+    _RUST_NO_INITIAL_CANDIDATE = "rust_no_initial_candidate"
+    _PROTECTIVE_ACTIONS_ONLY = "protective_actions_only"
+
+    def __init__(self) -> None:
+        self._records: dict[tuple[str, str], _TraceRecord] = {}
+
+    def record_evaluated(self, symbol: str, pside: str) -> None:
+        """Record that a symbol/position side was considered for a fresh entry."""
+        self.record_count(symbol, pside, "evaluated")
+
+    def record_ideal_orders(self, orders: Iterable[Mapping[str, object]] | object) -> None:
+        """Record readable, non-protective initial-entry candidates from ``orders``."""
+        self._record_initial_orders(orders, "ideal")
+
+    def record_satisfied_orders(
+        self, orders: Iterable[Mapping[str, object]] | object, reason: str
+    ) -> None:
+        """Record readable initial entries already accounted for by an existing order."""
+        self._record_initial_orders(orders, "satisfied", reason=reason)
+
+    def record_blocked_orders(
+        self, orders: Iterable[Mapping[str, object]] | object, reason: str
+    ) -> None:
+        """Record readable initial entries blocked before creation."""
+        self._record_initial_orders(orders, "blocked", reason=reason)
+
+    def record_protective_orders(
+        self, orders: Iterable[Mapping[str, object]] | object
+    ) -> None:
+        """Record reduce-only or panic orders separately from fresh-entry candidates."""
+        for order in self._iter_orders(orders):
+            if not self._is_protective(order):
+                continue
+            pair = self._order_pair(order)
+            if pair is not None:
+                self.record_count(*pair, "protective")
+
+    def record_eligible_orders(
+        self, orders: Iterable[Mapping[str, object]] | object
+    ) -> None:
+        """Record readable initial entries that remain eligible for creation."""
+        self._record_initial_orders(orders, "eligible")
+
+    def record_count(
+        self,
+        symbol: str,
+        pside: str,
+        fact: str,
+        count: int = 1,
+        reason: str | None = None,
+    ) -> None:
+        """Record already-classified facts supplied by an integration point.
+
+        Labels and counts are validated here because this direct API is the boundary
+        between arbitrary integration data and the queryable diagnostic payload.
+        """
+        key = self._validate_pair(symbol, pside)
+        normalized_fact = self._validate_fact(fact)
+        normalized_count = self._validate_count(count)
+        normalized_reason = self._validate_reason(reason) if reason is not None else None
+        if normalized_count == 0:
+            return
+        record = self._records.setdefault(key, _TraceRecord())
+        record.facts[normalized_fact] += normalized_count
+        if normalized_reason is not None:
+            self._add_bounded_reason(
+                record.reason_counts,
+                normalized_reason,
+                normalized_count,
+                self.MAX_REASON_KEYS_PER_RECORD,
+            )
+
+    def to_event_data(self, max_records: int = 32) -> dict[str, object]:
+        """Return a deterministic, bounded event-safe view of the collected facts."""
+        if isinstance(max_records, bool) or not isinstance(max_records, int) or max_records < 0:
+            raise ValueError("max_records must be a nonnegative integer")
+        record_limit = max_records
+        records: list[dict[str, object]] = []
+        records_total = 0
+        outcome_counts = {outcome: 0 for outcome in _OUTCOMES}
+        event_reason_counts: dict[str, int] = {}
+        evaluated_count = 0
+
+        for (symbol, pside), record in sorted(self._records.items()):
+            records_total += 1
+            outcome, reason_counts = self._record_outcome(record)
+            outcome_counts[outcome] += 1
+            evaluated_count += record.facts["evaluated"]
+            for reason, count in reason_counts.items():
+                event_reason_counts[reason] = event_reason_counts.get(reason, 0) + count
+            if len(records) < record_limit:
+                records.append(
+                    {
+                        "symbol": symbol,
+                        "pside": pside,
+                        "outcome": outcome,
+                        "evaluated_count": record.facts["evaluated"],
+                        "ideal_count": record.facts["ideal"],
+                        "satisfied_count": record.facts["satisfied"],
+                        "blocked_count": record.facts["blocked"],
+                        "protective_count": record.facts["protective"],
+                        "eligible_count": record.facts["eligible"],
+                        "reason_counts": dict(sorted(reason_counts.items())),
+                    }
+                )
+
+        return {
+            "evaluated_count": evaluated_count,
+            "outcome_counts": outcome_counts,
+            "reason_counts": dict(sorted(event_reason_counts.items())),
+            "records_total": records_total,
+            "records": records,
+            "records_truncated": records_total > record_limit,
+        }
+
+    def _record_initial_orders(
+        self, orders: Iterable[Mapping[str, object]] | object, fact: str, reason: str | None = None
+    ) -> None:
+        if reason is not None:
+            # Validate once, before any partial batch changes are recorded.
+            self._validate_reason(reason)
+        for order in self._iter_orders(orders):
+            if not self._is_initial_entry(order) or self._is_protective(order):
+                continue
+            pair = self._order_pair(order)
+            if pair is not None:
+                self.record_count(*pair, fact, reason=reason)
+
+    @staticmethod
+    def _iter_orders(
+        orders: Iterable[Mapping[str, object]] | object,
+    ) -> Iterable[Mapping[str, object]]:
+        if isinstance(orders, (str, bytes, Mapping)):
+            return ()
+        try:
+            iterator = iter(orders)  # type: ignore[arg-type]
+        except TypeError:
+            return ()
+        return (order for order in iterator if isinstance(order, Mapping))
+
+    def _order_pair(self, order: Mapping[str, object]) -> tuple[str, str] | None:
+        symbol = order.get("symbol")
+        pside = (
+            order.get("position_side")
+            or order.get("positionSide")
+            or order.get("pside")
+        )
+        try:
+            return self._validate_pair(symbol, pside)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _normalized_text(value: object) -> str:
+        if not isinstance(value, str):
+            return ""
+        return _NORMALIZE_RE.sub("_", value.lower()).strip("_")
+
+    def _is_initial_entry(self, order: Mapping[str, object]) -> bool:
+        pb_type = self._normalized_text(order.get("pb_order_type"))
+        custom_id = self._normalized_text(order.get("custom_id"))
+        return pb_type.startswith("entry_initial_") or custom_id.startswith("entry_initial_")
+
+    def _is_protective(self, order: Mapping[str, object]) -> bool:
+        reduce_only = order.get("reduce_only", order.get("reduceOnly", False))
+        if isinstance(reduce_only, str):
+            if reduce_only.lower() in {"true", "1", "yes"}:
+                return True
+        elif bool(reduce_only):
+            return True
+        return "panic" in self._normalized_text(order.get("pb_order_type"))
+
+    def _record_outcome(self, record: _TraceRecord) -> tuple[str, dict[str, int]]:
+        facts = record.facts
+        unaccounted = max(
+            0,
+            facts["ideal"] - facts["eligible"] - facts["blocked"] - facts["satisfied"],
+        )
+        if facts["eligible"] > 0:
+            outcome = "eligible"
+        elif facts["blocked"] > 0 or unaccounted > 0:
+            outcome = "blocked_candidate"
+        elif facts["satisfied"] > 0:
+            outcome = "already_satisfied"
+        elif facts["ideal"] == 0 and facts["protective"] > 0:
+            outcome = "protective_only"
+        else:
+            outcome = "no_candidate"
+
+        reason_counts = dict(record.reason_counts)
+        if unaccounted:
+            self._add_bounded_reason(
+                reason_counts,
+                self._UNCLASSIFIED_CANDIDATE,
+                unaccounted,
+                self.MAX_REASON_KEYS_PER_RECORD,
+            )
+        elif outcome == "protective_only" and not reason_counts:
+            self._add_bounded_reason(
+                reason_counts,
+                self._PROTECTIVE_ACTIONS_ONLY,
+                max(1, facts["protective"]),
+                self.MAX_REASON_KEYS_PER_RECORD,
+            )
+        elif outcome == "no_candidate" and not reason_counts:
+            self._add_bounded_reason(
+                reason_counts,
+                self._RUST_NO_INITIAL_CANDIDATE,
+                1,
+                self.MAX_REASON_KEYS_PER_RECORD,
+            )
+        return outcome, reason_counts
+
+    @classmethod
+    def _add_bounded_reason(
+        cls, reason_counts: dict[str, int], reason: str, count: int, limit: int
+    ) -> None:
+        if reason in reason_counts:
+            reason_counts[reason] += count
+            return
+        if len(reason_counts) < limit:
+            reason_counts[reason] = count
+            return
+        if cls._REASON_OVERFLOW in reason_counts:
+            reason_counts[cls._REASON_OVERFLOW] += count
+            return
+        # Reserve one bounded bucket for any reasons beyond this point.
+        last_reason = sorted(reason_counts)[-1]
+        overflow_count = reason_counts.pop(last_reason)
+        reason_counts[cls._REASON_OVERFLOW] = overflow_count + count
+
+    @classmethod
+    def _validate_pair(cls, symbol: object, pside: object) -> tuple[str, str]:
+        return cls._validate_symbol(symbol), cls._validate_pside(pside)
+
+    @classmethod
+    def _validate_symbol(cls, symbol: object) -> str:
+        if (
+            not isinstance(symbol, str)
+            or len(symbol) > cls.MAX_LABEL_LENGTH
+            or not _SYMBOL_RE.fullmatch(symbol)
+        ):
+            raise ValueError("symbol must be a safe query label no longer than 120 characters")
+        return symbol
+
+    @staticmethod
+    def _validate_pside(pside: object) -> str:
+        if not isinstance(pside, str) or pside.lower() not in _PSIDES:
+            raise ValueError("pside must be 'long' or 'short'")
+        return pside.lower()
+
+    @staticmethod
+    def _validate_fact(fact: object) -> str:
+        if not isinstance(fact, str) or fact not in _FACT_ALIASES:
+            raise ValueError(
+                "fact must be one of evaluated, ideal, satisfied, blocked, protective, eligible"
+            )
+        return _FACT_ALIASES[fact]
+
+    @classmethod
+    def _validate_reason(cls, reason: object) -> str:
+        if (
+            not isinstance(reason, str)
+            or len(reason) > cls.MAX_LABEL_LENGTH
+            or not _REASON_RE.fullmatch(reason)
+        ):
+            raise ValueError("reason must be a safe query label no longer than 120 characters")
+        return reason
+
+    @staticmethod
+    def _validate_count(count: object) -> int:
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            raise ValueError("count must be a nonnegative integer")
+        return count

--- a/src/live/market_data.py
+++ b/src/live/market_data.py
@@ -84,6 +84,24 @@ def _emit_pre_create_skip_event(
     )
 
 
+def _record_fresh_entry_blocks(bot, orders: list[dict], reason: str) -> None:
+    """Observe an existing pre-create filter without affecting its decision."""
+    trace = getattr(bot, "_fresh_entry_eligibility_trace", None)
+    recorder = getattr(trace, "record_blocked_orders", None)
+    if not callable(recorder):
+        return
+    try:
+        recorder(orders, reason)
+    except Exception as exc:
+        bot._fresh_entry_eligibility_trace = None
+        logging.debug(
+            "[entry] fresh-entry eligibility trace disabled during market filter | "
+            "reason=%s error_type=%s",
+            reason,
+            type(exc).__name__,
+        )
+
+
 def market_snapshot_ticker_strategy(bot) -> str:
     """Choose the cheapest safe ticker endpoint shape for market snapshots."""
     explicit = get_optional_live_value(
@@ -145,6 +163,9 @@ async def filter_fresh_market_snapshot_creations(
                 message="create orders skipped because planning snapshot is invalid before create",
                 details=planning_snapshot_invalid,
             )
+            _record_fresh_entry_blocks(
+                bot, orders, "pre_create_planning_snapshot_invalid"
+            )
             return []
         logging.info(
             "[market] refreshing stale planning market snapshot before create | symbols=%s stale=%s",
@@ -176,6 +197,9 @@ async def filter_fresh_market_snapshot_creations(
             message="create orders skipped because pre-create market snapshot refresh failed",
             error_type=type(exc).__name__,
         )
+        _record_fresh_entry_blocks(
+            bot, orders, "pre_create_market_snapshot_unavailable"
+        )
         return []
     if invalid:
         logging.warning(
@@ -191,6 +215,9 @@ async def filter_fresh_market_snapshot_creations(
             stage="market_snapshot_validation",
             message="create orders skipped because pre-create market snapshots are stale",
             details=invalid,
+        )
+        _record_fresh_entry_blocks(
+            bot, orders, "pre_create_market_snapshot_unavailable"
         )
         return []
     orders = _filter_limit_order_creations_by_market_distance(bot, orders, snapshots)
@@ -252,6 +279,11 @@ def _filter_limit_order_creations_by_market_distance(
             continue
         kept.append(order)
     if skipped:
+        _record_fresh_entry_blocks(
+            bot,
+            [item["order"] for item in skipped],
+            "limit_order_create_market_distance",
+        )
         _log_limit_order_distance_skips(
             bot,
             skipped,

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -4,8 +4,10 @@ import json
 import logging
 import math
 import sys
+from collections import Counter
 from typing import Iterable, Optional
 
+from live.fresh_entry_eligibility import FreshEntryEligibilityTrace
 from live.freshness import ACCOUNT_SURFACES
 from pure_funcs import determine_side_from_order_tuple, filter_orders, shorten_custom_id
 from utils import symbol_to_coin, ts_to_date, utc_ms as _utils_utc_ms
@@ -31,6 +33,107 @@ def _utc_ms() -> int:
     if module is not None and hasattr(module, "utc_ms"):
         return int(module.utc_ms())
     return int(_utils_utc_ms())
+
+
+def _orders_removed_by_identity(before: list[dict], after: list[dict]) -> list[dict]:
+    """Return objects removed by an existing filter without comparing mutable payloads."""
+    remaining = Counter(id(order) for order in after)
+    removed = []
+    for order in before:
+        order_id = id(order)
+        if remaining[order_id] > 0:
+            remaining[order_id] -= 1
+        else:
+            removed.append(order)
+    return removed
+
+
+def _trace_record(
+    trace: FreshEntryEligibilityTrace | None,
+    method: str,
+    *args,
+    **kwargs,
+) -> FreshEntryEligibilityTrace | None:
+    """Best-effort diagnostic recording which can never affect order reconciliation."""
+    if trace is None:
+        return None
+    try:
+        getattr(trace, method)(*args, **kwargs)
+        return trace
+    except Exception as exc:
+        logging.debug(
+            "[entry] fresh-entry eligibility trace disabled during reconciliation | "
+            "method=%s error_type=%s",
+            method,
+            type(exc).__name__,
+        )
+        return None
+
+
+def _initialize_fresh_entry_trace(
+    bot,
+    ideal_orders: dict,
+    actual_orders: dict[str, list[dict]],
+) -> FreshEntryEligibilityTrace | None:
+    """Build cycle-local diagnostic scope from already evaluated live symbols and orders."""
+    trace: FreshEntryEligibilityTrace | None = FreshEntryEligibilityTrace()
+    try:
+        flat_ideal = [
+            order
+            for orders in ideal_orders.values()
+            if isinstance(orders, list)
+            for order in orders
+            if isinstance(order, dict)
+        ]
+        flat_actual = [
+            order
+            for orders in actual_orders.values()
+            if isinstance(orders, list)
+            for order in orders
+            if isinstance(order, dict)
+        ]
+        observed_pairs = {
+            (str(order.get("symbol") or ""), str(order.get("position_side") or ""))
+            for order in flat_ideal + flat_actual
+            if order.get("symbol") and order.get("position_side") in {"long", "short"}
+        }
+        active_symbols = set(getattr(bot, "active_symbols", ()) or ())
+        planning_snapshot = getattr(bot, "_current_planning_snapshot", None)
+        active_symbols.update(getattr(planning_snapshot, "symbols", ()) or ())
+        enabled = getattr(bot, "is_pside_enabled", None)
+        if callable(enabled):
+            for pside in ("long", "short"):
+                try:
+                    pside_enabled = bool(enabled(pside))
+                except Exception:
+                    pside_enabled = False
+                if pside_enabled:
+                    observed_pairs.update(
+                        (str(symbol), pside) for symbol in active_symbols if symbol
+                    )
+        for symbol, pside in sorted(observed_pairs):
+            trace.record_evaluated(symbol, pside)
+        trace.record_ideal_orders(flat_ideal)
+        trace.record_protective_orders(flat_ideal)
+        for pair, count in dict(
+            getattr(bot, "_fresh_entry_conversion_blocked_counts", {}) or {}
+        ).items():
+            if not isinstance(pair, tuple) or len(pair) != 2:
+                continue
+            trace.record_count(
+                pair[0],
+                pair[1],
+                "blocked",
+                count=int(count),
+                reason="conversion_zero_or_duplicate",
+            )
+        return trace
+    except Exception as exc:
+        logging.debug(
+            "[entry] fresh-entry eligibility trace initialization failed | error_type=%s",
+            type(exc).__name__,
+        )
+        return None
 
 
 def add_to_recent_order_cancellations(bot, order):
@@ -781,6 +884,7 @@ def mark_account_critical_state_dirty(
 
 async def calc_orders_to_cancel_and_create(bot):
     """Determine which existing orders to cancel and which new ones to place."""
+    bot._fresh_entry_eligibility_trace = None
     ideal_orders = await bot.calc_ideal_orders()
     return await calc_orders_to_cancel_and_create_from_ideal(bot, ideal_orders)
 
@@ -794,13 +898,20 @@ async def calc_orders_to_cancel_and_create_from_ideal(
     apply_initial_entry_gate: bool = True,
     apply_creation_guardrails: bool = True,
     apply_mode_filters: bool = True,
+    collect_fresh_entry_eligibility: bool = True,
 ):
     """Reconcile exchange orders against a supplied ideal order map."""
+    bot._fresh_entry_eligibility_trace = None
     if not hasattr(bot, "_last_plan_detail"):
         bot._last_plan_detail = {}
 
     actual_orders = bot._snapshot_actual_orders(
         actual_symbols, psides_by_symbol=actual_psides_by_symbol
+    )
+    trace = (
+        _initialize_fresh_entry_trace(bot, ideal_orders, actual_orders)
+        if collect_fresh_entry_eligibility and isinstance(ideal_orders, dict)
+        else None
     )
     malformed_actual_symbols = set(
         getattr(bot, "_malformed_actual_order_symbols", set()) or set()
@@ -819,6 +930,12 @@ async def calc_orders_to_cancel_and_create_from_ideal(
             ideal_orders.get(symbol, []) if isinstance(ideal_orders, dict) else []
         )
         if symbol in malformed_actual_symbols:
+            trace = _trace_record(
+                trace,
+                "record_blocked_orders",
+                ideal_list,
+                "malformed_actual_orders",
+            )
             blocked_actual = len(symbol_orders) + int(
                 malformed_actual_counts.get(symbol, 0) or 0
             )
@@ -833,21 +950,50 @@ async def calc_orders_to_cancel_and_create_from_ideal(
                 )
             )
             continue
-        cancel_, create_ = bot._reconcile_symbol_orders(
-            symbol,
-            symbol_orders,
-            ideal_list,
-            keys,
-            apply_mode_filters=apply_mode_filters,
-        )
+        if trace is not None:
+            cancel_, create_, raw_create = bot._reconcile_symbol_orders(
+                symbol,
+                symbol_orders,
+                ideal_list,
+                keys,
+                apply_mode_filters=apply_mode_filters,
+                return_unfiltered_create=True,
+            )
+            trace = _trace_record(
+                trace,
+                "record_satisfied_orders",
+                _orders_removed_by_identity(ideal_list, raw_create),
+                "exact_reconciliation_match",
+            )
+            trace = _trace_record(
+                trace,
+                "record_blocked_orders",
+                _orders_removed_by_identity(raw_create, create_),
+                "mode_filter",
+            )
+        else:
+            cancel_, create_ = bot._reconcile_symbol_orders(
+                symbol,
+                symbol_orders,
+                ideal_list,
+                keys,
+                apply_mode_filters=apply_mode_filters,
+            )
         pre_cancel = len(cancel_)
         pre_create = len(create_)
         trailing_skipped = 0
         if symbol in trailing_unavailable_symbols:
+            before_trailing_create = list(create_)
             cancel_, create_, trailing_skipped, fully_blocked = (
                 filter_trailing_unavailable_reconciliation(
                     bot, symbol, cancel_, create_, ideal_list
                 )
+            )
+            trace = _trace_record(
+                trace,
+                "record_blocked_orders",
+                _orders_removed_by_identity(before_trailing_create, create_),
+                "trailing_unavailable",
             )
             if fully_blocked:
                 blocked_total = len(symbol_orders) + len(ideal_list)
@@ -863,7 +1009,14 @@ async def calc_orders_to_cancel_and_create_from_ideal(
                 )
                 continue
         cancel_, create_ = bot._annotate_order_deltas(cancel_, create_)
+        before_tolerance_create = list(create_)
         cancel_, create_, skipped = bot._apply_order_match_tolerance(cancel_, create_)
+        trace = _trace_record(
+            trace,
+            "record_satisfied_orders",
+            _orders_removed_by_identity(before_tolerance_create, create_),
+            "order_match_tolerance",
+        )
         skipped += trailing_skipped
         plan_summaries.append(
             (symbol, pre_cancel, len(cancel_), pre_create, len(create_), skipped)
@@ -872,15 +1025,29 @@ async def calc_orders_to_cancel_and_create_from_ideal(
         to_create += create_
 
     if apply_initial_entry_gate:
+        before_initial_entry_gate = list(to_create)
         to_create, initial_entry_gate_skipped = (
             await bot._apply_initial_entry_distance_gate(to_create)
+        )
+        trace = _trace_record(
+            trace,
+            "record_blocked_orders",
+            _orders_removed_by_identity(before_initial_entry_gate, to_create),
+            "initial_entry_distance_gate",
         )
     else:
         initial_entry_gate_skipped = 0
     to_cancel = await bot._sort_orders_by_market_diff(to_cancel, "to_cancel")
     to_create = await bot._sort_orders_by_market_diff(to_create, "to_create")
     if apply_creation_guardrails:
+        before_creation_guardrails = list(to_create)
         to_create, freshness_skipped = bot._apply_freshness_creation_guardrails(to_create)
+        trace = _trace_record(
+            trace,
+            "record_blocked_orders",
+            _orders_removed_by_identity(before_creation_guardrails, to_create),
+            "freshness_creation_guardrail",
+        )
     else:
         freshness_skipped = 0
     if plan_summaries:
@@ -904,7 +1071,8 @@ async def calc_orders_to_cancel_and_create_from_ideal(
             if c or cr or skipped:
                 if prev != current:
                     detail_parts.append(
-                        f"{passivbot_cls._log_symbol(symbol)}:c{pre_c}->{c} cr{pre_cr}->{cr} skip{skipped}"
+                        f"{passivbot_cls._log_symbol(symbol)}:c{pre_c}->{c} "
+                        f"cr{pre_cr}->{cr} skip{skipped}"
                     )
         detail = " | ".join(detail_parts[:6])
         summary_key = (
@@ -947,6 +1115,8 @@ async def calc_orders_to_cancel_and_create_from_ideal(
                     f" | {' '.join(extra)}" if extra else "",
                     f" | details: {detail}" if detail else "",
                 )
+    if collect_fresh_entry_eligibility:
+        bot._fresh_entry_eligibility_trace = trace
     return to_cancel, to_create
 
 
@@ -1069,11 +1239,15 @@ def reconcile_symbol_orders(
     keys: tuple[str, ...],
     *,
     apply_mode_filters: bool = True,
-) -> tuple[list[dict], list[dict]]:
+    return_unfiltered_create: bool = False,
+) -> tuple[list[dict], list[dict]] | tuple[list[dict], list[dict], list[dict]]:
     """Return cancel/create lists for a single symbol after mode filtering."""
     to_cancel, to_create = filter_orders(actual_orders, ideal_orders, keys)
+    raw_create = list(to_create)
     if apply_mode_filters:
         to_cancel, to_create = bot._apply_mode_filters(symbol, to_cancel, to_create)
+    if return_unfiltered_create:
+        return to_cancel, to_create, raw_create
     return to_cancel, to_create
 
 
@@ -1388,8 +1562,10 @@ def to_executable_orders(
     bot, ideal_orders: dict, last_prices: dict[str, float]
 ) -> tuple[dict[str, list], set[str]]:
     """Convert raw order tuples into api-ready dicts and find WEL-restricted symbols."""
+    bot._fresh_entry_conversion_blocked_counts = {}
     ideal_orders_f: dict[str, list] = {}
     wel_blocked_symbols: set[str] = set()
+    conversion_blocked_counts: Counter = Counter()
     order_market_diff = _pb_attr("order_market_diff")
     snake_of = _pb_attr("snake_of")
 
@@ -1413,10 +1589,14 @@ def to_executable_orders(
         ):
             position_side = "long" if "long" in order[2] else "short"
             if order[0] == 0.0:
+                if str(order[2]).startswith("entry_initial_"):
+                    conversion_blocked_counts[(symbol, position_side)] += 1
                 continue
             seen_key = str(abs(order[0])) + str(order[1]) + order[2]
             if seen_key in seen:
                 logging.debug("duplicate ideal order for %s skipped: %s", symbol, order)
+                if str(order[2]).startswith("entry_initial_"):
+                    conversion_blocked_counts[(symbol, position_side)] += 1
                 continue
             pb_order_type = snake_of(order[3])
             # The Rust orchestrator is the single source of execution-type
@@ -1448,6 +1628,7 @@ def to_executable_orders(
                 }
             )
             seen.add(seen_key)
+    bot._fresh_entry_conversion_blocked_counts = dict(conversion_blocked_counts)
     return (
         bot._finalize_reduce_only_orders(ideal_orders_f, last_prices),
         wel_blocked_symbols,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -631,6 +631,9 @@ class Passivbot:
     _emit_execution_create_filter_event = (
         live_event_emitters.emit_execution_create_filter_event
     )
+    _emit_initial_entry_eligibility_event = (
+        live_event_emitters.emit_initial_entry_eligibility_event
+    )
     _emit_initial_entry_distance_gate_event = (
         live_event_emitters.emit_initial_entry_distance_gate_event
     )
@@ -16186,6 +16189,7 @@ class Passivbot:
             apply_initial_entry_gate=False,
             apply_creation_guardrails=False,
             apply_mode_filters=False,
+            collect_fresh_entry_eligibility=False,
         )
 
     def _snapshot_actual_orders(
@@ -16207,7 +16211,8 @@ class Passivbot:
         keys: tuple[str, ...],
         *,
         apply_mode_filters: bool = True,
-    ) -> tuple[list[dict], list[dict]]:
+        return_unfiltered_create: bool = False,
+    ) -> tuple[list[dict], list[dict]] | tuple[list[dict], list[dict], list[dict]]:
         """Return cancel/create lists for a single symbol after mode filtering."""
         return reconciler.reconcile_symbol_orders(
             self,
@@ -16216,6 +16221,7 @@ class Passivbot:
             ideal_orders,
             keys,
             apply_mode_filters=apply_mode_filters,
+            return_unfiltered_create=return_unfiltered_create,
         )
 
     def _annotate_order_deltas(

--- a/tests/test_fresh_entry_eligibility.py
+++ b/tests/test_fresh_entry_eligibility.py
@@ -1,0 +1,223 @@
+from copy import deepcopy
+
+import pytest
+
+from live.fresh_entry_eligibility import FreshEntryEligibilityTrace
+
+
+def _initial(symbol="BTC/USDT:USDT", pside="long", **overrides):
+    order = {
+        "symbol": symbol,
+        "position_side": pside,
+        "pb_order_type": f"entry_initial_normal_{pside}",
+    }
+    order.update(overrides)
+    return order
+
+
+@pytest.mark.parametrize(
+    ("configure", "expected"),
+    [
+        (lambda trace, order: trace.record_eligible_orders([order]), "eligible"),
+        (
+            lambda trace, order: trace.record_blocked_orders([order], "distance_gate"),
+            "blocked_candidate",
+        ),
+        (
+            lambda trace, order: trace.record_satisfied_orders([order], "open_order"),
+            "already_satisfied",
+        ),
+        (
+            lambda trace, order: trace.record_protective_orders([order]),
+            "protective_only",
+        ),
+        (lambda trace, order: None, "no_candidate"),
+    ],
+)
+def test_all_outcomes(configure, expected):
+    trace = FreshEntryEligibilityTrace()
+    order = _initial()
+    if expected == "protective_only":
+        order["reduce_only"] = True
+        order["pb_order_type"] = "close_grid_long"
+    trace.record_evaluated(order["symbol"], order["position_side"])
+    configure(trace, order)
+
+    event = trace.to_event_data()
+
+    assert event["records"][0]["outcome"] == expected
+    assert event["outcome_counts"][expected] == 1
+    assert set(event["records"][0]) == {
+        "symbol",
+        "pside",
+        "outcome",
+        "evaluated_count",
+        "ideal_count",
+        "satisfied_count",
+        "blocked_count",
+        "protective_count",
+        "eligible_count",
+        "reason_counts",
+    }
+
+
+def test_outcome_precedence_prefers_eligible_then_blocked():
+    trace = FreshEntryEligibilityTrace()
+    eligible = _initial("ADA/USDT:USDT", "long")
+    blocked = _initial("BTC/USDT:USDT", "short")
+
+    trace.record_ideal_orders([eligible, blocked])
+    trace.record_eligible_orders([eligible])
+    trace.record_blocked_orders([eligible, blocked], "risk_gate")
+    trace.record_satisfied_orders([blocked], "open_order")
+
+    records = {(item["symbol"], item["pside"]): item for item in trace.to_event_data()["records"]}
+    assert records[("ADA/USDT:USDT", "long")]["outcome"] == "eligible"
+    assert records[("BTC/USDT:USDT", "short")]["outcome"] == "blocked_candidate"
+
+
+def test_unaccounted_ideal_candidate_is_blocked_with_synthetic_reason():
+    trace = FreshEntryEligibilityTrace()
+    trace.record_ideal_orders([_initial()])
+
+    event = trace.to_event_data()
+    record = event["records"][0]
+    assert record["outcome"] == "blocked_candidate"
+    assert record["reason_counts"] == {"unclassified_candidate": 1}
+    assert event["reason_counts"] == {"unclassified_candidate": 1}
+
+
+def test_candidate_free_outcomes_have_stable_default_reasons():
+    trace = FreshEntryEligibilityTrace()
+    trace.record_evaluated("BTC/USDT:USDT", "long")
+    trace.record_evaluated("ETH/USDT:USDT", "short")
+    trace.record_protective_orders(
+        [
+            {
+                "symbol": "ETH/USDT:USDT",
+                "position_side": "short",
+                "pb_order_type": "close_panic_short",
+                "reduce_only": True,
+            }
+        ]
+    )
+
+    records = {
+        (item["symbol"], item["pside"]): item
+        for item in trace.to_event_data()["records"]
+    }
+
+    assert records[("BTC/USDT:USDT", "long")]["reason_counts"] == {
+        "rust_no_initial_candidate": 1
+    }
+    assert records[("ETH/USDT:USDT", "short")]["reason_counts"] == {
+        "protective_actions_only": 1
+    }
+
+
+def test_normalized_type_and_custom_id_classification_and_protective_filtering():
+    trace = FreshEntryEligibilityTrace()
+    from_type = _initial("ADA/USDT:USDT", pb_order_type=" ENTRY-INITIAL-NORMAL-LONG ")
+    from_custom_id = _initial(
+        "BTC/USDT:USDT", pb_order_type="unknown", custom_id="entry initial normal long"
+    )
+    panic = _initial("ETH/USDT:USDT", pb_order_type="close_panic_long")
+    reduce_only_initial = _initial("SOL/USDT:USDT", reduceOnly=True)
+
+    trace.record_ideal_orders([from_type, from_custom_id, panic, reduce_only_initial])
+    trace.record_protective_orders([from_type, from_custom_id, panic, reduce_only_initial])
+    records = {(item["symbol"], item["pside"]): item for item in trace.to_event_data()["records"]}
+
+    assert records[("ADA/USDT:USDT", "long")]["ideal_count"] == 1
+    assert records[("BTC/USDT:USDT", "long")]["ideal_count"] == 1
+    assert records[("ETH/USDT:USDT", "long")]["protective_count"] == 1
+    assert records[("SOL/USDT:USDT", "long")]["protective_count"] == 1
+    assert ("ETH/USDT:USDT", "long") not in {
+        key for key, value in records.items() if value["ideal_count"]
+    }
+
+
+def test_records_sort_deterministically_by_symbol_then_pside():
+    trace = FreshEntryEligibilityTrace()
+    trace.record_evaluated("BTC/USDT:USDT", "short")
+    trace.record_evaluated("ADA/USDT:USDT", "short")
+    trace.record_evaluated("BTC/USDT:USDT", "long")
+
+    assert [(item["symbol"], item["pside"]) for item in trace.to_event_data()["records"]] == [
+        ("ADA/USDT:USDT", "short"),
+        ("BTC/USDT:USDT", "long"),
+        ("BTC/USDT:USDT", "short"),
+    ]
+
+
+def test_default_32_record_truncation_preserves_full_aggregate_counts():
+    trace = FreshEntryEligibilityTrace()
+    for index in range(33):
+        symbol = f"S{index:03d}/USDT:USDT"
+        trace.record_evaluated(symbol, "long")
+        trace.record_count(symbol, "long", "blocked", reason="distance_gate")
+
+    event = trace.to_event_data()
+
+    assert event["records_total"] == 33
+    assert len(event["records"]) == 32
+    assert event["records_truncated"] is True
+    assert event["evaluated_count"] == 33
+    assert event["outcome_counts"]["blocked_candidate"] == 33
+    assert event["reason_counts"] == {"distance_gate": 33}
+
+
+def test_unsafe_labels_and_invalid_pside_are_rejected_without_leaking_them():
+    trace = FreshEntryEligibilityTrace()
+    with pytest.raises(ValueError, match="safe query label"):
+        trace.record_evaluated("BTC/USDT unsafe", "long")
+    with pytest.raises(ValueError, match="safe query label"):
+        trace.record_count("BTC/USDT:USDT", "long", "blocked", reason="secret=value")
+    with pytest.raises(ValueError, match="safe query label"):
+        trace.record_count("BTC/USDT:USDT", "long", "blocked", reason="r" * 121)
+    with pytest.raises(ValueError, match="safe query label"):
+        trace.record_evaluated("B" * 121, "long")
+    with pytest.raises(ValueError, match="pside"):
+        trace.record_evaluated("BTC/USDT:USDT", "both")
+
+    assert trace.to_event_data()["records_total"] == 0
+
+
+def test_malformed_orders_are_ignored_and_input_orders_are_not_mutated():
+    trace = FreshEntryEligibilityTrace()
+    valid = _initial()
+    malformed = [
+        None,
+        "entry_initial_normal_long",
+        {},
+        _initial(symbol="bad symbol"),
+        _initial(pside="both"),
+    ]
+    orders = [valid, *malformed]
+    before = deepcopy(orders)
+
+    trace.record_ideal_orders(orders)
+    trace.record_satisfied_orders(orders, "open_order")
+    trace.record_blocked_orders(orders, "distance_gate")
+    trace.record_eligible_orders(orders)
+    trace.record_protective_orders([_initial(reduce_only=True), *orders])
+
+    assert orders == before
+    event = trace.to_event_data()
+    assert event["records_total"] == 1
+    record = event["records"][0]
+    assert record["ideal_count"] == record["satisfied_count"] == record["blocked_count"] == 1
+    assert record["eligible_count"] == 1
+    assert record["outcome"] == "eligible"
+
+
+@pytest.mark.parametrize("count", [-1, 1.0, "1", True])
+def test_record_count_requires_nonnegative_integer_count(count):
+    trace = FreshEntryEligibilityTrace()
+    with pytest.raises(ValueError, match="nonnegative integer"):
+        trace.record_count("BTC/USDT:USDT", "long", "ideal", count=count)
+    with pytest.raises(ValueError, match="fact"):
+        trace.record_count("BTC/USDT:USDT", "long", "unknown")
+
+    trace.record_count("BTC/USDT:USDT", "long", "ideal", count=0)
+    assert trace.to_event_data()["records_total"] == 0

--- a/tests/test_fresh_entry_eligibility_integration.py
+++ b/tests/test_fresh_entry_eligibility_integration.py
@@ -1,0 +1,395 @@
+import types
+
+import pytest
+
+from live import event_emitters, executor, market_data, reconciler
+from live.event_bus import EventTypes, ListEventSink, LiveEvent, LiveEventPipeline
+from live.fresh_entry_eligibility import FreshEntryEligibilityTrace
+from live.market_snapshot import MarketSnapshot
+from passivbot import Passivbot
+
+
+def _initial(symbol: str, pside: str = "long", *, price: float = 100.0) -> dict:
+    return {
+        "symbol": symbol,
+        "side": "buy" if pside == "long" else "sell",
+        "position_side": pside,
+        "qty": 1.0,
+        "price": price,
+        "reduce_only": False,
+        "custom_id": f"entry-initial-{pside}",
+        "pb_order_type": f"entry_initial_normal_{pside}",
+        "type": "limit",
+    }
+
+
+def _protective(symbol: str, pside: str = "long") -> dict:
+    return {
+        "symbol": symbol,
+        "side": "sell" if pside == "long" else "buy",
+        "position_side": pside,
+        "qty": 1.0,
+        "price": 101.0,
+        "reduce_only": True,
+        "custom_id": f"close-panic-{pside}",
+        "pb_order_type": f"close_panic_{pside}",
+        "type": "limit",
+    }
+
+
+def test_eligibility_emitter_builds_schema_valid_correlated_event():
+    sink = ListEventSink()
+
+    class EventBot:
+        _live_event_current_cycle_id = "cy_1"
+
+        def __init__(self):
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink], monitor_sinks=[]
+            )
+
+        def _emit_live_event(self, event_type, **kwargs):
+            return self._live_event_pipeline.emit(LiveEvent(event_type, **kwargs))
+
+    bot = EventBot()
+    event_emitters.emit_initial_entry_eligibility_event(
+        bot,
+        data={"records_total": 0, "records": []},
+        wave={"event_id": "ow_1"},
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert len(sink.events) == 1
+    event = sink.events[0]
+    assert event.event_type == EventTypes.ENTRY_INITIAL_ELIGIBILITY
+    assert event.status == "succeeded"
+    assert event.cycle_id == "cy_1"
+    assert event.order_wave_id == "ow_1"
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def _reconciliation_bot(symbol: str, actual_orders: list[dict]) -> Passivbot:
+    bot = Passivbot.__new__(Passivbot)
+    bot.active_symbols = [symbol]
+    bot.PB_modes = {"long": {symbol: "normal"}, "short": {symbol: "normal"}}
+    bot._last_plan_detail = {}
+    bot._malformed_actual_order_symbols = set()
+    bot._orchestrator_trailing_unavailable_symbols = set()
+    bot._malformed_actual_order_counts = {}
+    bot._fresh_entry_conversion_blocked_counts = {}
+    bot._snapshot_actual_orders = lambda *args, **kwargs: {symbol: list(actual_orders)}
+    bot.is_pside_enabled = lambda pside: pside == "long"
+    bot._annotate_order_deltas = lambda cancel, create: (cancel, create)
+    bot._apply_order_match_tolerance = lambda cancel, create: (cancel, create, 0)
+    bot._apply_freshness_creation_guardrails = lambda create: (create, 0)
+    bot._order_plan_summary_is_interesting = lambda **kwargs: False
+
+    async def keep_initials(self, orders):
+        return orders, 0
+
+    async def keep_sort(self, orders, _label):
+        return orders
+
+    bot._apply_initial_entry_distance_gate = types.MethodType(keep_initials, bot)
+    bot._sort_orders_by_market_diff = types.MethodType(keep_sort, bot)
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_trace_distinguishes_satisfied_and_no_candidate():
+    symbol = "BTC/USDT:USDT"
+    matching = _initial(symbol)
+    bot = _reconciliation_bot(symbol, [matching])
+
+    to_cancel, to_create = await reconciler.calc_orders_to_cancel_and_create_from_ideal(
+        bot, {symbol: [_initial(symbol)]}
+    )
+
+    assert to_cancel == []
+    assert to_create == []
+    data = bot._fresh_entry_eligibility_trace.to_event_data()
+    assert data["records"][0]["outcome"] == "already_satisfied"
+    assert data["records"][0]["reason_counts"] == {
+        "exact_reconciliation_match": 1
+    }
+
+    empty_bot = _reconciliation_bot(symbol, [])
+    await reconciler.calc_orders_to_cancel_and_create_from_ideal(
+        empty_bot, {symbol: []}
+    )
+    empty_data = empty_bot._fresh_entry_eligibility_trace.to_event_data()
+    assert empty_data["records"][0]["outcome"] == "no_candidate"
+    assert empty_data["records"][0]["reason_counts"] == {
+        "rust_no_initial_candidate": 1
+    }
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_trace_observes_distance_block_and_protective_only():
+    symbol = "BTC/USDT:USDT"
+    bot = _reconciliation_bot(symbol, [])
+
+    async def block_initials(self, orders):
+        return [], len(orders)
+
+    bot._apply_initial_entry_distance_gate = types.MethodType(block_initials, bot)
+    await reconciler.calc_orders_to_cancel_and_create_from_ideal(
+        bot, {symbol: [_initial(symbol)]}
+    )
+    data = bot._fresh_entry_eligibility_trace.to_event_data()
+    assert data["records"][0]["outcome"] == "blocked_candidate"
+    assert data["records"][0]["reason_counts"] == {
+        "initial_entry_distance_gate": 1
+    }
+
+    protective_bot = _reconciliation_bot(symbol, [])
+    await reconciler.calc_orders_to_cancel_and_create_from_ideal(
+        protective_bot, {symbol: [_protective(symbol)]}
+    )
+    protective_data = protective_bot._fresh_entry_eligibility_trace.to_event_data()
+    assert protective_data["records"][0]["outcome"] == "protective_only"
+    assert protective_data["records"][0]["reason_counts"] == {
+        "protective_actions_only": 1
+    }
+
+
+class _CreateBot:
+    def __init__(self, trace: FreshEntryEligibilityTrace):
+        self._fresh_entry_eligibility_trace = trace
+        self._order_wave_in_progress = {"event_id": "ow_1"}
+        self._health_orders_placed = 0
+        self.debug_mode = False
+        self.submitted: list[dict] = []
+
+    def live_value(self, key):
+        assert key == "max_n_creations_per_batch"
+        return 1
+
+    def get_exchange_time(self):
+        return 123456
+
+    def log_order_action(self, *args, **kwargs):
+        return None
+
+    def _log_order_action_summary(self, *args, **kwargs):
+        return None
+
+    def _is_market_execution_order(self, _order):
+        return False
+
+    async def execute_orders(self, orders):
+        self.submitted = list(orders)
+        return [{"id": "created", **order} for order in orders]
+
+    def did_create_order(self, _result):
+        return True
+
+    def add_to_recent_order_executions(self, _order):
+        return None
+
+    def add_new_order(self, _order, source="POST"):
+        return None
+
+    def _monitor_record_event(self, *args, **kwargs):
+        return None
+
+    def _monitor_order_payload(self, order, source="POST"):
+        return {"source": source, "symbol": order["symbol"]}
+
+
+@pytest.mark.asyncio
+async def test_final_batch_cap_classifies_eligible_and_blocked_without_changing_submission(
+    monkeypatch,
+):
+    first = _initial("ADA/USDT:USDT")
+    second = _initial("BTC/USDT:USDT")
+    trace = FreshEntryEligibilityTrace()
+    trace.record_ideal_orders([first, second])
+    trace.record_evaluated(first["symbol"], "long")
+    trace.record_evaluated(second["symbol"], "long")
+    bot = _CreateBot(trace)
+    emitted = []
+
+    monkeypatch.setattr(Passivbot, "_record_emitted_order_custom_id", lambda *args, **kwargs: None)
+    monkeypatch.setattr(Passivbot, "_emit_execution_order_event", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        Passivbot,
+        "_emit_initial_entry_eligibility_event",
+        lambda _bot, *, data, wave=None: emitted.append((data, wave)),
+    )
+
+    result = await executor.execute_orders_parent(bot, [first, second])
+
+    assert bot.submitted == [first]
+    assert len(result) == 1
+    assert len(emitted) == 1
+    records = {
+        item["symbol"]: item for item in emitted[0][0]["records"]
+    }
+    assert records[first["symbol"]]["outcome"] == "eligible"
+    assert records[second["symbol"]]["outcome"] == "blocked_candidate"
+    assert records[second["symbol"]]["reason_counts"] == {"batch_capacity": 1}
+    assert bot._fresh_entry_eligibility_trace is None
+
+
+@pytest.mark.asyncio
+async def test_completed_plan_emits_low_balance_block_from_existing_filter(monkeypatch):
+    order = _initial("BTC/USDT:USDT")
+    trace = FreshEntryEligibilityTrace()
+    trace.record_ideal_orders([order])
+    trace.record_evaluated(order["symbol"], "long")
+    emitted = []
+
+    class PlanBot:
+        debug_mode = False
+        balance_threshold = 1.0
+        quote = "USDT"
+        state_change_detected_by_symbol = set()
+        _equity_hard_stop_coin_replay_pending_pairs = set()
+
+        def __init__(self):
+            self._fresh_entry_eligibility_trace = trace
+            self.execution_scheduled = False
+
+        def get_raw_balance(self):
+            return 0.0
+
+        async def execute_cancellations_parent(self, _orders):
+            return []
+
+    bot = PlanBot()
+    wave = {
+        "skipped_create": 0,
+        "deferred_create": 0,
+    }
+    monkeypatch.setattr(Passivbot, "_begin_order_wave", lambda *args, **kwargs: wave)
+    monkeypatch.setattr(
+        Passivbot, "_emit_execution_create_filter_event", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        Passivbot,
+        "_emit_initial_entry_eligibility_event",
+        lambda _bot, *, data, wave=None: emitted.append(data),
+    )
+    monkeypatch.setattr(Passivbot, "_live_event_console_available", lambda *args: False)
+    monkeypatch.setattr(Passivbot, "_shutdown_requested", lambda *args: True)
+    monkeypatch.setattr(Passivbot, "_track_order_wave_confirmation", lambda *args: None)
+    monkeypatch.setattr(Passivbot, "_log_order_wave_summary", lambda *args: None)
+
+    await executor.execute_order_plan(bot, [], [order])
+
+    assert len(emitted) == 1
+    assert emitted[0]["records"][0]["outcome"] == "blocked_candidate"
+    assert emitted[0]["records"][0]["reason_counts"] == {"low_balance": 1}
+    assert bot._fresh_entry_eligibility_trace is None
+
+
+@pytest.mark.asyncio
+async def test_pre_create_market_filter_records_exact_existing_gate_reasons():
+    order = _initial("BTC/USDT:USDT", price=1.0)
+
+    class MarketBot:
+        config = {"live": {"limit_order_create_max_market_dist_pct": 0.1}}
+
+        def __init__(self, invalid=None, snapshot_error=None):
+            self._fresh_entry_eligibility_trace = FreshEntryEligibilityTrace()
+            self._fresh_entry_eligibility_trace.record_ideal_orders([order])
+            self._invalid = invalid or []
+            self._snapshot_error = snapshot_error
+
+        def _current_planning_snapshot_invalid_for_creations(self, _symbols):
+            return self._invalid
+
+        async def _get_live_market_snapshots(self, symbols, **kwargs):
+            if self._snapshot_error is not None:
+                raise self._snapshot_error
+            return {
+                symbol: MarketSnapshot(
+                    symbol=symbol,
+                    bid=99.0,
+                    ask=101.0,
+                    last=100.0,
+                    fetched_ms=1,
+                    source="test",
+                )
+                for symbol in symbols
+            }
+
+        def _live_market_snapshot_max_age_ms(self):
+            return 10_000
+
+        def _record_market_snapshot_surface(self, _symbols, _snapshots):
+            return None
+
+        def _market_snapshot_signature_invalid(self, _symbols):
+            return []
+
+        def _emit_execution_create_filter_event(self, **kwargs):
+            return None
+
+        def _log_symbols(self, symbols, limit=12):
+            return ",".join(symbols[:limit])
+
+        def _log_compact_symbol_payload(self, _details):
+            return "details"
+
+        def _log_symbol(self, symbol):
+            return str(symbol)
+
+    planning_bot = MarketBot(
+        invalid=[{"surface": "positions", "reason": "epoch_too_old"}]
+    )
+    assert await market_data.filter_fresh_market_snapshot_creations(
+        planning_bot, [order]
+    ) == []
+    planning_record = planning_bot._fresh_entry_eligibility_trace.to_event_data()[
+        "records"
+    ][0]
+    assert planning_record["reason_counts"] == {
+        "pre_create_planning_snapshot_invalid": 1
+    }
+
+    unavailable_bot = MarketBot(snapshot_error=RuntimeError("unavailable"))
+    assert await market_data.filter_fresh_market_snapshot_creations(
+        unavailable_bot, [order]
+    ) == []
+    unavailable_record = unavailable_bot._fresh_entry_eligibility_trace.to_event_data()[
+        "records"
+    ][0]
+    assert unavailable_record["reason_counts"] == {
+        "pre_create_market_snapshot_unavailable": 1
+    }
+
+    distance_bot = MarketBot()
+    assert await market_data.filter_fresh_market_snapshot_creations(
+        distance_bot, [order]
+    ) == []
+    distance_record = distance_bot._fresh_entry_eligibility_trace.to_event_data()[
+        "records"
+    ][0]
+    assert distance_record["reason_counts"] == {
+        "limit_order_create_market_distance": 1
+    }
+
+
+@pytest.mark.asyncio
+async def test_eligibility_emitter_failure_cannot_change_connector_batch(monkeypatch):
+    order = _initial("BTC/USDT:USDT")
+    trace = FreshEntryEligibilityTrace()
+    trace.record_ideal_orders([order])
+    trace.record_evaluated(order["symbol"], "long")
+    bot = _CreateBot(trace)
+
+    monkeypatch.setattr(Passivbot, "_record_emitted_order_custom_id", lambda *args, **kwargs: None)
+    monkeypatch.setattr(Passivbot, "_emit_execution_order_event", lambda *args, **kwargs: None)
+
+    def fail_emission(*args, **kwargs):
+        raise RuntimeError("diagnostic sink failed")
+
+    monkeypatch.setattr(Passivbot, "_emit_initial_entry_eligibility_event", fail_emission)
+
+    result = await executor.execute_orders_parent(bot, [order])
+
+    assert bot.submitted == [order]
+    assert len(result) == 1
+    assert bot._fresh_entry_eligibility_trace is None

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -307,6 +307,7 @@ def test_route_table_keeps_data_events_off_console_by_default():
     for event_type in (
         EventTypes.FORAGER_FEATURE_UNAVAILABLE,
         EventTypes.FORAGER_ELIGIBILITY_CHANGED,
+        EventTypes.ENTRY_INITIAL_ELIGIBILITY,
         EventTypes.CONFIG_MARKET_COMPATIBILITY,
         EventTypes.ACTION_PLANNED,
         EventTypes.EMA_BUNDLE_STARTED,


### PR DESCRIPTION
## Scope

Category: **live observability producer**.

Adds one bounded `entry.initial_eligibility` event per completed normal local order plan so operators can distinguish:

- `eligible`
- `blocked_candidate`
- `already_satisfied`
- `protective_only`
- `no_candidate`

The producer observes existing Rust planning, Python reconciliation, existing pre-create filters, and the final connector-bound batch immediately before invocation.

## Touched surfaces

- cycle-local fresh-entry trace and deterministic bounded projection
- reconciler and executor observation points
- exact pre-create market/planning filter attribution
- structured/monitor event registry and emitter
- focused unit/integration/fake-live coverage
- logging-overhaul status/progress docs and changelog

## Behavior boundary / non-goals

- no new or duplicated trading gate
- no mutation of order lists or connector batches
- no Rust, risk, HSL, unstuck, exchange, backtest, or optimizer behavior change
- no claim of connector completion or exchange acknowledgement
- trace/event/sink failure cannot become an execution failure
- no price, quantity, raw payload, path, secret, or exception text in the eligibility payload

Rust remains the order authority. Python reports facts at its existing live reconciliation and I/O boundaries.

## Validation

- `244 passed`: focused eligibility, event bus, orchestration, exchange-config, ownership, and monitor suites
- `21 passed`: full `tests/test_run_fake_live.py -m fake_live`
- real assertion-free protective RED fake-live smoke: panic close posted/filled and one bounded `protective_only / protective_actions_only` event emitted
- Python compilation
- `git diff --check`
- added-line silent-handling audit; new broad catches are diagnostic-only failure isolation
- independent exact-commit preflight before publication

## Reviewer focus

Please verify behavior neutrality, exact outcome/reason attribution, trace lifecycle and one-event semantics, final-batch meaning of `eligible`, boundedness/redaction/hot-path cost, failure isolation, and docs/test alignment.

## VPS action

**Restart required after merge.** Pull while preserving local artifacts; restart only the five exact supervised bot panes so the new producer loads; query `entry.initial_eligibility` by cycle/position side; run immediate and settled smoke; preserve and verify the unrelated `misc:0.0` process.