### PR TITLE
Report fresh entry startup milestone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `live-performance-report` now derives the current lifecycle's first
+  connector-bound initial-entry eligibility milestone from
+  `entry.initial_eligibility`. Blocked, candidate-free, protective-only, and
+  malformed eligibility events do not claim fresh-entry readiness.
+
 - Completed normal live order plans now emit one bounded structured/monitor
   `entry.initial_eligibility` event. It distinguishes fresh initial entries
   that were absent, already satisfied, blocked by an existing local gate,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -46,9 +46,11 @@ Estimated completion:
 
 Next action:
 
-1. Complete the strict eligibility predicate and lifecycle regressions, run
-   independent preflight, then publish for the temporary Hermes + Grok 4.5 +
-   green-CI current-head gate.
+1. Wait for the temporary Hermes + Grok 4.5 + green-CI gate on the exact current
+   PR head. After merge, pull `v8` on VPS5 without restarting bots, run the
+   bounded current-plus-rotated `startup_milestones` report, and complete a
+   settled smoke while verifying the bot and unrelated-process PIDs are
+   unchanged.
 
 ## Deployed Baseline
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,44 +22,50 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-fresh-entry-eligibility`
-- Base: `739ebd49d7de40966145c5a1ca2c8aa3fe01a235`
-- Triggering evidence: existing planning, reconciliation, create-filter, and
-  pre-call submission events cannot answer why a fresh entry did or did not
-  become locally submit-ready in a completed cycle.
-- Scope: add one bounded, correlated fresh-entry eligibility producer contract
-  that distinguishes `no_candidate`, `blocked_candidate`,
-  `protective_only`, `already_satisfied`, and `eligible` after the
-  existing reconciler/executor gates.
-- Behavior boundary: observability must derive from existing order-path facts,
-  never add or duplicate a trading gate, mutate `to_create`, affect connector
-  calls, or treat event failure as an execution failure. Rust remains the order
-  authority; Python only reports the existing live reconciliation/I/O boundary.
-- Validation: 244 focused/adjacent tests and all 21 fake-live marker scenarios
-  pass, including outcome precedence, boundedness, reconciler/executor
-  mixed cases, exact pre-create gate attribution, schema validation, and event
-  failure isolation. Python compilation and `git diff --check` also pass. An
-  independent exact-commit preflight approved the executable delta with no
-  findings; its focused eligibility/event suite also passed.
+- Branch: `codex/v8-fresh-entry-startup-milestone`
+- Base: `2f6f61da6fdd6d61c8edbf204e2690d5ebf02e8d`
+- Triggering evidence: PR #1196 now emits true local fresh-entry eligibility,
+  but the startup milestone report cannot yet answer when the first initial
+  entry survived every local pre-connector gate.
+- Scope: derive one bounded current-lifecycle
+  `first_fresh_entry_eligible` startup milestone only when an
+  `entry.initial_eligibility` event reports a positive integer eligible count.
+  Classify it as `entry_blocker` and preserve explicit unknown output when the
+  qualifying event is absent from selected history.
+- Behavior boundary: read-only performance report and tests only. Do not add or
+  reinterpret a trading gate, treat blocked/candidate-free/protective-only
+  events as readiness, or claim connector invocation or exchange success.
+- Validation: focused and full performance-report tests, Python compilation,
+  `git diff --check`, added-line silent-handling audit, and independent
+  preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
-- Expected VPS action: after merge, pull while preserving local artifacts,
-  restart only the five exact supervised bot panes so the producer is loaded,
-  query the new event by cycle/pside, and run immediate plus settled smoke.
+- Expected VPS action: pull while preserving local artifacts, run an exact
+  bounded current-plus-rotated startup milestone report, and settled smoke.
+  Do not restart bots because this slice changes only a read-only consumer.
 
 Next action:
 
-1. Wait for the temporary Hermes + Grok 4.5 + green-CI current-head gate on PR
-   #1196, resolve any findings narrowly, then merge and run the declared exact
-   five-bot VPS5 restart plus immediate and settled smoke.
+1. Complete the strict eligibility predicate and lifecycle regressions, run
+   independent preflight, then publish for the temporary Hermes + Grok 4.5 +
+   green-CI current-head gate.
 
 ## Deployed Baseline
 
-- Remote `v8`: `739ebd49d7de40966145c5a1ca2c8aa3fe01a235`, PR #1195
-- VPS5 repository: `739ebd49d7de40966145c5a1ca2c8aa3fe01a235`, PR #1195; tracked
+- Remote `v8`: `2f6f61da6fdd6d61c8edbf204e2690d5ebf02e8d`, PR #1196
+- VPS5 repository: `2f6f61da6fdd6d61c8edbf204e2690d5ebf02e8d`, PR #1196; tracked
   status clean; only expected untracked artifacts were preserved
-- VPS5 expected bots: five; all running with the PR #1192 restart PIDs;
+- VPS5 expected bots: five; all running with the PR #1196 restart PIDs
+  `856325/856354/856386/856420/856456`;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1196 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded and restarted only the five supervised panes. A focused
+  query observed three bounded eligibility events with eligible,
+  distance-blocked, and no-candidate outcomes. The first smoke retained a real
+  KuCoin timeout; after recovery, the settled two-minute smoke was hard-green
+  with `348/348` remote and `43/43` account-critical calls successful. The
+  quiet one-minute smoke remained green at `175/175` and `34/34`; transient
+  report-time `D` samples cleared to exact `R/S` process states.
 - PR #1195 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded without bot signals or restarts, preserving bot PIDs
   `850148/850296/850370/850436/850495` and unrelated `misc:0.0` PID

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7700,3 +7700,38 @@ VPS5 deployment status:
   connector/exchange outcome claim, no Rust/order/risk/HSL behavior change, and
   no event-sink failure propagation into execution. Expected VPS action is an
   exact five-bot restart, bounded event query, and immediate plus settled smoke.
+
+### Deployed Slice: Fresh-Entry Eligibility Evidence
+
+- PR #1196 was approved by Hermes and Grok 4.5 on exact head `baf7d6794`; CI
+  passed and it merged to `v8` as `2f6f61da6`.
+- VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
+  panes. Python process PIDs became
+  `856325/856354/856386/856420/856456`; unrelated `misc:0.0` remained PID
+  `434835`.
+- A bounded current-segment query observed three
+  `entry.initial_eligibility` events. The payloads exposed eligible,
+  `initial_entry_distance_gate` blocked, and `rust_no_initial_candidate`
+  outcomes with full aggregates, 32-record sampling, cycle IDs, and order-wave
+  IDs without price/quantity/raw payload leakage.
+- The immediate smoke retained one real pre-restart KuCoin balance timeout;
+  KuCoin also had one post-restart authoritative-state timeout. After recovery,
+  a two-minute smoke was hard-green with `348/348` remote and `43/43`
+  account-critical calls successful, all five expected processes matched, no
+  hard/log/pipeline failures, and a clean tracked repository. The quiet
+  one-minute smoke remained green at `175/175` and `34/34`; transient sampled
+  `D` states cleared to exact `R/S` process states.
+
+### Active Slice: Fresh-Entry Startup Milestone
+
+- Branch: `codex/v8-fresh-entry-startup-milestone` from deployed
+  `2f6f61da6`.
+- Scope: derive bounded current-lifecycle
+  `first_fresh_entry_eligible` performance-report evidence only from an
+  `entry.initial_eligibility` event whose eligible outcome count is a positive
+  integer. Mark the milestone `entry_blocker` and keep absent evidence
+  explicitly unknown.
+- Non-goals: no producer, trading/readiness gate, connector/exchange outcome
+  claim, process action, Rust/order/risk/HSL behavior, backtest, optimizer, or
+  smoke verdict change. Expected VPS action is pull plus a bounded
+  current-plus-rotated report and settled smoke, with no bot restart.

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -315,8 +315,11 @@ classification when enough source events exist.
   protective, execution-loop, market-state, and background-candle readiness
   milestones. The best-effort active-position candle phase remains timing-only
   because its tolerated warmup failure cannot prove readiness.
-  Remaining work: true fresh-entry ready, first Rust call, and first
-  exchange-write readiness events.
+  PR #1194 derives the first cycle, first Rust call, and first locally submitted
+  exchange write from existing events. PR #1196 added true local fresh-entry
+  eligibility evidence; the active consumer projects its first qualifying
+  event as startup readiness. Remaining work is actual connector-invocation
+  evidence rather than another pre-call proxy.
 - [ ] Startup: process start to held-position protective HSL ready.
 - [ ] Startup: process start to fresh-entry ready.
 - [ ] Startup: process start to first planning cycle started/completed.
@@ -741,8 +744,10 @@ Trading-impact labels:
   aggregate scope timing for the readiness milestones already emitted. The
   active follow-up makes current per-bot lifecycle snapshots independent of
   capped current-before-rotated traversal order while preserving historical
-  aggregate distributions. True fresh-entry, first-Rust-call, and
-  first-exchange-write milestones remain missing.
+  aggregate distributions. PR #1194 added first-cycle, first-Rust-call, and
+  first locally submitted write milestones. PR #1196 added the source event
+  for true local fresh-entry eligibility, and the active consumer adds its
+  current-lifecycle milestone. Actual connector invocation remains distinct.
 
 - [ ] Add a full live-operation duration table.
   - Include startup, account refresh, fill refresh, cache proof, HSL replay,

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1642,10 +1642,41 @@ class _StartupReadinessAccumulator:
 _STARTUP_MILESTONE_EVENT_TYPES = {
     "cycle.started": "first_cycle_started",
     "rust_orchestrator.called": "first_rust_called",
+    "entry.initial_eligibility": "first_fresh_entry_eligible",
     "execution.create_sent": "first_exchange_write_submitted",
     "execution.cancel_sent": "first_exchange_write_submitted",
 }
 _STARTUP_MILESTONE_LABELS = tuple(dict.fromkeys(_STARTUP_MILESTONE_EVENT_TYPES.values()))
+_STARTUP_MILESTONE_TRADING_IMPACTS = {
+    "first_cycle_started": "cycle_delay",
+    "first_rust_called": "cycle_delay",
+    "first_fresh_entry_eligible": "entry_blocker",
+    "first_exchange_write_submitted": "cycle_delay",
+}
+
+
+def _startup_milestone_label(
+    event_type: str, live_event: dict[str, Any]
+) -> str | None:
+    label = _STARTUP_MILESTONE_EVENT_TYPES.get(event_type)
+    if label is None:
+        return None
+    if event_type != "entry.initial_eligibility":
+        return label
+    data = live_event.get("data")
+    if not isinstance(data, dict):
+        return None
+    outcome_counts = data.get("outcome_counts")
+    if not isinstance(outcome_counts, dict):
+        return None
+    eligible_count = outcome_counts.get("eligible")
+    if (
+        not isinstance(eligible_count, int)
+        or isinstance(eligible_count, bool)
+        or eligible_count <= 0
+    ):
+        return None
+    return label
 
 
 class _StartupMilestoneAccumulator:
@@ -1711,7 +1742,12 @@ class _StartupMilestoneAccumulator:
             source_complete=source_complete,
         )
         self._discard_superseded_state(bot)
-        if event_type != "bot.started" and event_type not in _STARTUP_MILESTONE_EVENT_TYPES:
+        label = (
+            None
+            if event_type == "bot.started"
+            else _startup_milestone_label(event_type, live_event)
+        )
+        if event_type != "bot.started" and label is None:
             return
         existing_state = self.bots.get(bot)
         previous_started_order = (
@@ -1754,13 +1790,14 @@ class _StartupMilestoneAccumulator:
         started_order = state.get("started_order")
         if started_order is not None and event_order <= started_order:
             return
-        label = _STARTUP_MILESTONE_EVENT_TYPES[event_type]
+        assert label is not None
         existing = state["milestones"].get(label)
         if existing is not None and event_order >= existing[0]:
             return
         milestone = self._observed_milestone(
             row=row,
             live_event=live_event,
+            label=label,
             started_ts=state.get("started_ts"),
         )
         state["milestones"][label] = (event_order, milestone, bool(source_complete))
@@ -1777,13 +1814,14 @@ class _StartupMilestoneAccumulator:
         *,
         row: dict[str, Any],
         live_event: dict[str, Any],
+        label: str,
         started_ts: int | None,
     ) -> dict[str, Any]:
         event_type = str(live_event.get("event_type") or row.get("kind") or "")
         item: dict[str, Any] = {
             "status": "observed",
             "event_type": event_type,
-            "trading_impact": "cycle_delay",
+            "trading_impact": _STARTUP_MILESTONE_TRADING_IMPACTS[label],
         }
         event_ts = _record_ts(row)
         if event_ts is not None:
@@ -1822,7 +1860,9 @@ class _StartupMilestoneAccumulator:
                             label: {
                                 "status": "unknown",
                                 "reason": "bot_started_not_observed_in_selected_events",
-                                "trading_impact": "cycle_delay",
+                                "trading_impact": _STARTUP_MILESTONE_TRADING_IMPACTS[
+                                    label
+                                ],
                             }
                             for label in _STARTUP_MILESTONE_LABELS
                         },
@@ -1834,7 +1874,7 @@ class _StartupMilestoneAccumulator:
                 label: {
                     "status": "unknown",
                     "reason": "not_observed_in_selected_events",
-                    "trading_impact": "cycle_delay",
+                    "trading_impact": _STARTUP_MILESTONE_TRADING_IMPACTS[label],
                 }
                 for label in _STARTUP_MILESTONE_LABELS
             }

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1759,6 +1759,7 @@ def test_live_performance_report_rejects_old_startup_data_after_unrelated_tail(
     assert report["startup_milestones"]["observed_counts"] == {
         "first_cycle_started": 0,
         "first_rust_called": 0,
+        "first_fresh_entry_eligible": 0,
         "first_exchange_write_submitted": 0,
     }
 
@@ -1844,6 +1845,7 @@ def test_live_performance_report_startup_milestones_current_lifecycle(tmp_path):
     assert startup["observed_counts"] == {
         "first_cycle_started": 1,
         "first_rust_called": 1,
+        "first_fresh_entry_eligible": 0,
         "first_exchange_write_submitted": 1,
     }
     assert startup["elapsed_ms"]["first_cycle_started"]["max"] == 100
@@ -1868,6 +1870,74 @@ def test_live_performance_report_startup_milestones_current_lifecycle(tmp_path):
     assert write["side"] == "buy"
     assert write["remote_call_id"] == "remote_1"
     assert "action_1" not in json.dumps(report["startup_milestones"], sort_keys=True)
+
+
+def test_live_performance_report_startup_milestone_requires_eligible_initial_entry(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="entry.initial_eligibility",
+                seq=2,
+                ts=1200,
+                ids={"cycle_id": "cy_1", "order_wave_id": "ow_1"},
+                data={"outcome_counts": {"blocked_candidate": 2, "eligible": 0}},
+            ),
+            _monitor_row(
+                event_type="entry.initial_eligibility",
+                seq=3,
+                ts=1300,
+                data={"outcome_counts": {"eligible": "1"}},
+            ),
+            _monitor_row(
+                event_type="entry.initial_eligibility",
+                seq=4,
+                ts=1400,
+                data={"outcome_counts": {"eligible": True}},
+            ),
+            _monitor_row(
+                event_type="entry.initial_eligibility",
+                seq=5,
+                ts=1500,
+                data={"outcome_counts": {"eligible": 1.0}},
+            ),
+            _monitor_row(
+                event_type="entry.initial_eligibility",
+                seq=6,
+                ts=1600,
+                ids={"cycle_id": "cy_2", "order_wave_id": "ow_2"},
+                data={"outcome_counts": {"eligible": 1, "no_candidate": 37}},
+            ),
+            _monitor_row(
+                event_type="entry.initial_eligibility",
+                seq=7,
+                ts=1700,
+                data={"outcome_counts": {"eligible": 2}},
+            ),
+        ],
+    )
+
+    startup = build_live_performance_report(tmp_path / "monitor")[
+        "startup_milestones"
+    ]
+
+    assert startup["observed_counts"]["first_fresh_entry_eligible"] == 1
+    assert startup["elapsed_ms"]["first_fresh_entry_eligible"]["max"] == 600
+    milestone = startup["bots"][0]["milestones"]["first_fresh_entry_eligible"]
+    assert milestone == {
+        "status": "observed",
+        "event_type": "entry.initial_eligibility",
+        "trading_impact": "entry_blocker",
+        "ts_ms": 1600,
+        "elapsed_ms": 600,
+        "event_id": "evt_6",
+        "cycle_id": "cy_2",
+        "order_wave_id": "ow_2",
+    }
 
 
 def test_startup_milestone_accumulator_retains_one_candidate_per_milestone():


### PR DESCRIPTION
## Scope

Category: **read-only tooling / performance report consumer**.

Adds a bounded current-lifecycle `first_fresh_entry_eligible` startup milestone derived from the `entry.initial_eligibility` producer merged in PR #1196.

A milestone is observed only when `data.outcome_counts.eligible` is a positive JSON integer. Blocked, candidate-free, protective-only, zero, boolean, float, string, missing, and malformed values do not establish readiness.

## Touched surfaces

- startup milestone accumulation in `src/live/performance_report.py`
- focused lifecycle/payload validation tests
- performance-readiness, compact status, historical deployment evidence, and changelog docs

## Behavior boundary / non-goals

- no event producer or live runtime change
- no trading/readiness gate or decision
- no connector/exchange call or outcome claim
- no Rust, order, risk, HSL, backtest, optimizer, process, or smoke-verdict change
- absent or incomplete selected history remains explicitly unknown
- `first_fresh_entry_eligible` is classified `entry_blocker`; it means a real initial entry survived all local pre-connector gates, not that connector invocation or exchange acknowledgement occurred

## Validation

- full `tests/test_live_performance_report.py` passed
- focused startup-milestone subset passed
- Python compilation passed
- `git diff --check` passed
- added-line silent-handling audit found no new broad catches/fallbacks
- independent exact-commit preflight before publication

## Reviewer focus

Please verify strict positive-integer eligibility validation, lifecycle/current-vs-rotated behavior, earliest-event retention, explicit unknown output, additive report compatibility, `entry_blocker` classification, and docs/deployment-evidence accuracy.

## VPS action

**No restart.** After merge, pull while preserving local artifacts; run a bounded current-plus-rotated `startup_milestones` report against the already-live PR #1196 events, then run settled smoke and verify bot/misc PIDs remain unchanged.