### PR TITLE
Trace connector order call boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live order writes now emit bounded structured/monitor evidence immediately
+  before concrete connector create and cancel calls. The events distinguish
+  local connector-call arrival from pre-call submission intent and exchange
+  acknowledgement without changing order payloads or execution behavior.
+
 - `live-performance-report` now derives the current lifecycle's first
   connector-bound initial-entry eligibility milestone from
   `entry.initial_eligibility`. Blocked, candidate-free, protective-only, and

--- a/docs/ai/live_event_registry.md
+++ b/docs/ai/live_event_registry.md
@@ -36,12 +36,14 @@ across time.
 - `exchange.time_sync`
 - `execution.ambiguous`
 - `execution.cancel_ambiguous_terminal`
+- `execution.cancel_connector_call_started`
 - `execution.cancel_failed`
 - `execution.cancel_sent`
 - `execution.cancel_succeeded`
 - `execution.confirmation_requested`
 - `execution.confirmation_satisfied`
 - `execution.confirmation_timeout`
+- `execution.create_connector_call_started`
 - `execution.create_deferred`
 - `execution.create_failed`
 - `execution.create_rejected`
@@ -151,6 +153,30 @@ shutdown interruption, and diagnostic tracing failures omit the event instead
 of emitting a misleading candidate-free result. Diagnostic and sink failures
 must not change order lists or execution results.
 
+## Connector Call Boundary Contract
+
+`execution.create_connector_call_started` and
+`execution.cancel_connector_call_started` are emitted to structured and monitor
+sinks only, immediately before Passivbot calls the concrete
+`cca.create_order` or `cca.cancel_order` coroutine. They mean only that local
+execution reached that connector call site. They do not claim that bytes were
+sent, that the exchange received or accepted the request, or that an order was
+acknowledged.
+
+The fixed payload fields are `action=create|cancel`,
+`connector_method=cca.create_order|cca.cancel_order`, and
+`connector_route=base|hyperliquid|okx`, plus bounded order shape fields and
+finite numeric values. Normal order-plan calls retain their cycle,
+`order_wave_id`, and `action_id` correlation. The events must not contain raw
+connector params, vault addresses, URLs, responses, exception text, paths, or
+arbitrary payloads. Diagnostic and sink failures must not prevent or alter the
+connector call.
+
+These events are distinct from the existing `execution.create_sent` and
+`execution.cancel_sent` pre-call submission-intent events and from terminal
+exchange outcome events. They do not define another startup performance
+milestone.
+
 ## HSL Replay Timing Fields
 
 For coin-mode `hsl.replay.completed`, `full_elapsed_s` measures total replay
@@ -239,6 +265,7 @@ full-replay terminal event.
 - `config_isolated_only_market_blocked`
 - `config_stock_perp_unavailable_market`
 - `config_stock_perp_wrong_exchange`
+- `connector_call_started`
 - `ema_fallback_used`
 - `exchange_acknowledged`
 - `exchange_config_refresh`

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,44 +22,58 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-fresh-entry-startup-milestone`
-- Base: `2f6f61da6fdd6d61c8edbf204e2690d5ebf02e8d`
-- Triggering evidence: PR #1196 now emits true local fresh-entry eligibility,
-  but the startup milestone report cannot yet answer when the first initial
-  entry survived every local pre-connector gate.
-- Scope: derive one bounded current-lifecycle
-  `first_fresh_entry_eligible` startup milestone only when an
-  `entry.initial_eligibility` event reports a positive integer eligible count.
-  Classify it as `entry_blocker` and preserve explicit unknown output when the
-  qualifying event is absent from selected history.
-- Behavior boundary: read-only performance report and tests only. Do not add or
-  reinterpret a trading gate, treat blocked/candidate-free/protective-only
-  events as readiness, or claim connector invocation or exchange success.
-- Validation: focused and full performance-report tests, Python compilation,
-  `git diff --check`, added-line silent-handling audit, and independent
-  preflight.
+- Branch: `codex/v8-connector-invocation-events`
+- Base: `fda0e1323135a3db1bc69ff154d066d103ac6c9e`
+- Triggering evidence: existing `execution.create_sent` and
+  `execution.cancel_sent` events are emitted before the batch executor reaches
+  a concrete connector call. They prove submission intent but not local
+  arrival at `cca.create_order` or `cca.cancel_order`.
+- Scope: emit bounded structured/monitor-only
+  `execution.create_connector_call_started` and
+  `execution.cancel_connector_call_started` events immediately before the
+  concrete base, Hyperliquid, and OKX connector call sites. Preserve normal
+  cycle, order-wave, and action correlation without adding fields to connector
+  payloads.
+- Behavior boundary: observability only. The events claim local call-site
+  arrival, not bytes sent, exchange receipt, acceptance, or acknowledgement.
+  Event failures must not prevent or alter connector calls. Do not add another
+  startup milestone or change order, risk, HSL, Rust, backtest, or optimizer
+  behavior.
+- Validation: focused and adjacent event/executor/connector/report tests, full
+  fake-live marker suite, Python compilation, `git diff --check`, added-line
+  silent-handling audit, and independent preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
-- Expected VPS action: pull while preserving local artifacts, run an exact
-  bounded current-plus-rotated startup milestone report, and settled smoke.
-  Do not restart bots because this slice changes only a read-only consumer.
+- Expected VPS action: pull while preserving local artifacts, gracefully
+  restart only the five exact supervised bot panes because this is a producer
+  change, query the call-boundary chain only when legitimate order activity
+  occurs, and run immediate plus settled smoke. Do not create synthetic live
+  orders for validation.
 
 Next action:
 
-1. Wait for the temporary Hermes + Grok 4.5 + green-CI gate on the exact current
-   PR head. After merge, pull `v8` on VPS5 without restarting bots, run the
-   bounded current-plus-rotated `startup_milestones` report, and complete a
-   settled smoke while verifying the bot and unrelated-process PIDs are
-   unchanged.
+1. Complete the connector-boundary regressions and fake-live suite, run
+   independent preflight, then publish for the temporary Hermes + Grok 4.5 +
+   green-CI current-head gate.
 
 ## Deployed Baseline
 
-- Remote `v8`: `2f6f61da6fdd6d61c8edbf204e2690d5ebf02e8d`, PR #1196
-- VPS5 repository: `2f6f61da6fdd6d61c8edbf204e2690d5ebf02e8d`, PR #1196; tracked
+- Remote `v8`: `fda0e1323135a3db1bc69ff154d066d103ac6c9e`, PR #1197
+- VPS5 repository: `fda0e1323135a3db1bc69ff154d066d103ac6c9e`, PR #1197; tracked
   status clean; only expected untracked artifacts were preserved
-- VPS5 expected bots: five; all running with the PR #1196 restart PIDs
+- VPS5 expected bots: five; all still running with the PR #1196 restart PIDs
   `856325/856354/856386/856420/856456`;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1197 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded without bot signals or restarts. A bounded eight-segment
+  Binance lifecycle report returned `ok=true` with zero issues and observed
+  `first_fresh_entry_eligible` at `240.110s`, alongside first cycle, Rust call,
+  and submitted write evidence. The settled two-minute smoke was hard-green
+  with `208/208` remote and `53/53` account-critical calls successful, all five
+  expected processes matched, no hard/log/monitor failures, and a clean tracked
+  repository. One report-time `D` sample cleared; all five bots were `R` on the
+  final exact-state check. Bot, pane, and unrelated `misc:0.0` PIDs remained
+  unchanged.
 - PR #1196 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded and restarted only the five supervised panes. A focused
   query observed three bounded eligibility events with eligible,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -52,9 +52,11 @@ Estimated completion:
 
 Next action:
 
-1. Complete the connector-boundary regressions and fake-live suite, run
-   independent preflight, then publish for the temporary Hermes + Grok 4.5 +
-   green-CI current-head gate.
+1. Wait for the temporary Hermes + Grok 4.5 + green-CI gate on the exact current
+   PR head. After merge, pull `v8` on VPS5, gracefully restart only the five
+   exact supervised bot panes, query the call-boundary chain from legitimate
+   order activity, and complete immediate plus settled smoke while preserving
+   unrelated processes and local artifacts.
 
 ## Deployed Baseline
 
@@ -240,16 +242,17 @@ HIP-3 startup compatibility are merged and deployed. PR #1189's isolated-only
 initial-entry filter visibility and PR #1190's HSL replay scanned-row
 throughput, PR #1191's corrected active/legacy-terminal replay estimates,
 PR #1192's machine-readable startup readiness SLA semantics, PR #1193's
-latest-lifecycle report ordering, and PR #1194's bounded startup action
-milestones, plus PR #1195's startup consumer correctness fixes, are also merged
-and deployed. The active slice adds the missing true fresh-entry eligibility
-producer after all existing local pre-connector gates.
+latest-lifecycle report ordering, PR #1194's bounded startup action milestones,
+PR #1195's startup consumer correctness fixes, PR #1196's true fresh-entry
+eligibility producer, and PR #1197's fresh-entry startup milestone are also
+merged and deployed. The active PR #1198 slice adds the missing local
+connector-call boundary evidence without claiming exchange receipt or outcome.
 
-After this producer is merged and validated, select the next review-worthy
+After PR #1198 is merged and validated, select the next review-worthy
 candidate from the remaining backlog, including:
 
-- optional connector-boundary evidence if operators need actual exchange-write
-  invocation rather than the existing pre-call submitted event
+- bounded startup fill-cache proof correlation/reporting
+- bounded event-pipeline service-time evidence
 - bounded operator tooling improvements sharing one code and validation surface
 
 Do not create progress-only PRs or resume unrelated logging work from stale

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7735,3 +7735,35 @@ VPS5 deployment status:
   claim, process action, Rust/order/risk/HSL behavior, backtest, optimizer, or
   smoke verdict change. Expected VPS action is pull plus a bounded
   current-plus-rotated report and settled smoke, with no bot restart.
+
+### Deployed Slice: Fresh-Entry Startup Milestone
+
+- PR #1197 was approved by Hermes and Grok 4.5 on exact head `cb76fd5b9`; CI
+  passed and it merged to `v8` as `fda0e1323`.
+- VPS5 fast-forwarded without bot signals or restarts. Bot PIDs
+  `856325/856354/856386/856420/856456`, their exact pane PIDs, and unrelated
+  `misc:0.0` PID `434835` remained unchanged; the tracked repository was clean.
+- A bounded eight-segment Binance lifecycle report returned `ok=true` with no
+  issues and observed first cycle at `84.484s`, first Rust call at `239.008s`,
+  first submitted write at `240.106s`, and
+  `first_fresh_entry_eligible` at `240.110s`.
+- The settled two-minute smoke was hard-green with `208/208` remote and `53/53`
+  account-critical calls successful, all five expected processes matched, no
+  hard/log/monitor failures, and a clean tracked repository. One sampled `D`
+  state cleared; all five bots were `R` on the final exact-state check.
+
+### Active Slice: Connector Call Boundary Evidence
+
+- Branch: `codex/v8-connector-invocation-events` from deployed `fda0e1323`.
+- Scope: emit one bounded structured/monitor event immediately before each
+  concrete `cca.create_order` or `cca.cancel_order` call through the base,
+  Hyperliquid, and OKX routes. Preserve normal cycle/order-wave/action
+  correlation without adding fields to connector payloads.
+- Contract: the events prove only local connector call-site arrival. They do
+  not claim bytes sent, exchange receipt, acceptance, or acknowledgement, and
+  they do not create another startup milestone. Diagnostic failures remain
+  isolated from connector execution.
+- Non-goals: no order, risk, HSL, Rust, backtest, optimizer, connector payload,
+  or exchange-error behavior change. Expected VPS action is an exact five-bot
+  graceful restart, legitimate-activity event query, and immediate plus settled
+  smoke; validation must not create synthetic live orders.

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -1161,6 +1161,11 @@ class HyperliquidBot(CCXTBot):
             return False
 
         try:
+            self._emit_execution_connector_call_started_event(
+                order=order,
+                action="cancel",
+                connector_route="hyperliquid",
+            )
             res = await self.cca.cancel_order(order["id"], symbol=order["symbol"], params=params)
             # Sometimes hyperliquid returns an "ok" wrapper with an embedded error; treat as non-fatal.
             if _is_already_gone(res):

--- a/src/exchanges/okx.py
+++ b/src/exchanges/okx.py
@@ -188,6 +188,11 @@ class OKXBot(CCXTBot):
     async def execute_cancellation(self, order: dict) -> dict:
         """OKX: Cancel order with special handling for 51400 (already cancelled/filled)."""
         try:
+            self._emit_execution_connector_call_started_event(
+                order=order,
+                action="cancel",
+                connector_route="okx",
+            )
             return await self.cca.cancel_order(order["id"], symbol=order["symbol"])
         except Exception as e:
             # 51400 = order already cancelled or filled - not an error

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -149,6 +149,9 @@ class EventTypes:
     ORDER_WAVE_STARTED = "order_wave.started"
     ORDER_WAVE_COMPLETED = "order_wave.completed"
     EXECUTION_CREATE_SENT = "execution.create_sent"
+    EXECUTION_CREATE_CONNECTOR_CALL_STARTED = (
+        "execution.create_connector_call_started"
+    )
     EXECUTION_CREATE_SUCCEEDED = "execution.create_succeeded"
     EXECUTION_CREATE_FAILED = "execution.create_failed"
     EXECUTION_CREATE_REJECTED = "execution.create_rejected"
@@ -159,6 +162,9 @@ class EventTypes:
     ENTRY_INITIAL_DISTANCE_GATE_CLEARED = "entry.initial_distance_gate_cleared"
     ENTRY_MIN_EFFECTIVE_COST_BLOCKED = "entry.min_effective_cost_blocked"
     EXECUTION_CANCEL_SENT = "execution.cancel_sent"
+    EXECUTION_CANCEL_CONNECTOR_CALL_STARTED = (
+        "execution.cancel_connector_call_started"
+    )
     EXECUTION_CANCEL_SUCCEEDED = "execution.cancel_succeeded"
     EXECUTION_CANCEL_FAILED = "execution.cancel_failed"
     EXECUTION_CANCEL_AMBIGUOUS_TERMINAL = "execution.cancel_ambiguous_terminal"
@@ -250,6 +256,7 @@ class ReasonCodes:
     BALANCE_CHANGED = "balance_changed"
     CANDLE_DISK_FLUSH_COMPLETED = "candle_disk_flush_completed"
     CANDLE_DISK_LOAD_COMPLETED = "candle_disk_load_completed"
+    CONNECTOR_CALL_STARTED = "connector_call_started"
     EMA_FALLBACK_USED = "ema_fallback_used"
     EXCHANGE_ACKNOWLEDGED = "exchange_acknowledged"
     EXCHANGE_CONFIG_REFRESH = "exchange_config_refresh"
@@ -465,6 +472,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.ORDER_WAVE_STARTED,
     EventTypes.ORDER_WAVE_COMPLETED,
     EventTypes.EXECUTION_CREATE_SENT,
+    EventTypes.EXECUTION_CREATE_CONNECTOR_CALL_STARTED,
     EventTypes.EXECUTION_CREATE_SUCCEEDED,
     EventTypes.EXECUTION_CREATE_FAILED,
     EventTypes.EXECUTION_CREATE_REJECTED,
@@ -475,6 +483,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
     EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED,
     EventTypes.EXECUTION_CANCEL_SENT,
+    EventTypes.EXECUTION_CANCEL_CONNECTOR_CALL_STARTED,
     EventTypes.EXECUTION_CANCEL_SUCCEEDED,
     EventTypes.EXECUTION_CANCEL_FAILED,
     EventTypes.EXECUTION_CANCEL_AMBIGUOUS_TERMINAL,
@@ -777,6 +786,9 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.ORDER_WAVE_STARTED: EventRoute(console=False),
     EventTypes.ORDER_WAVE_COMPLETED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CREATE_SENT: EventRoute(console=False),
+    EventTypes.EXECUTION_CREATE_CONNECTOR_CALL_STARTED: EventRoute(
+        console=False, text=False
+    ),
     EventTypes.EXECUTION_CREATE_SUCCEEDED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CREATE_FAILED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CREATE_REJECTED: EventRoute(console=True, text=True),
@@ -791,6 +803,9 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     ),
     EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CANCEL_SENT: EventRoute(console=False),
+    EventTypes.EXECUTION_CANCEL_CONNECTOR_CALL_STARTED: EventRoute(
+        console=False, text=False
+    ),
     EventTypes.EXECUTION_CANCEL_SUCCEEDED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CANCEL_FAILED: EventRoute(console=True, text=True),
     EventTypes.EXECUTION_CANCEL_AMBIGUOUS_TERMINAL: EventRoute(console=True, text=True),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import hashlib
+import math
 import re
 from collections import Counter
 from urllib.parse import urlsplit, urlunsplit
@@ -1071,6 +1072,11 @@ def _safe_float(value: Any) -> float | None:
     except (TypeError, ValueError):
         return None
     return number if number == number else None
+
+
+def _safe_finite_float(value: Any) -> float | None:
+    number = _safe_float(value)
+    return number if number is not None and math.isfinite(number) else None
 
 
 def _safe_int(value: Any) -> int | None:
@@ -3356,6 +3362,135 @@ def _execution_event_ids(
         if index is not None:
             action_id = f"{order_wave_id}:{action}:{int(index)}"
     return order_wave_id, action_id
+
+
+def _execution_connector_call_context(
+    bot: Any,
+    order: dict | None,
+    *,
+    action: str,
+) -> tuple[dict | None, int | None]:
+    wave = getattr(bot, "_order_wave_in_progress", None)
+    index = None
+    context = getattr(bot, "_execution_connector_call_context", None)
+    if isinstance(context, dict) and context.get("action") == action:
+        if isinstance(context.get("wave"), dict):
+            wave = context["wave"]
+        for candidate_index, candidate in enumerate(context.get("orders") or []):
+            if candidate is order:
+                index = candidate_index
+                break
+    return wave, index
+
+
+def emit_execution_connector_call_started_event(
+    bot: Any,
+    *,
+    order: dict | None,
+    action: str,
+    connector_route: str,
+) -> None:
+    """Emit bounded evidence immediately before a concrete connector call."""
+    try:
+        event_types = {
+            "create": EventTypes.EXECUTION_CREATE_CONNECTOR_CALL_STARTED,
+            "cancel": EventTypes.EXECUTION_CANCEL_CONNECTOR_CALL_STARTED,
+        }
+        connector_methods = {
+            "create": "cca.create_order",
+            "cancel": "cca.cancel_order",
+        }
+        allowed_routes = {"base", "hyperliquid", "okx"}
+        if action not in event_types:
+            raise ValueError(f"unsupported connector action: {action}")
+        if connector_route not in allowed_routes:
+            raise ValueError(f"unsupported connector route: {connector_route}")
+
+        wave, index = _execution_connector_call_context(
+            bot,
+            order,
+            action=action,
+        )
+        order_wave_id, action_id = _execution_event_ids(
+            wave,
+            action=action,
+            index=index,
+        )
+        order_data = _order_event_data(order, index=index)
+        data: dict[str, Any] = {
+            "action": action,
+            "connector_method": connector_methods[action],
+            "connector_route": connector_route,
+        }
+        if index is not None:
+            data["index"] = int(index)
+        for key in ("pb_order_type", "order_type"):
+            if order_data.get(key) is not None:
+                data[key] = str(order_data[key])[:64]
+        if "reduce_only" in order_data:
+            data["reduce_only"] = bool(order_data["reduce_only"])
+        for key in ("client_order_id_short", "order_id_short"):
+            if order_data.get(key) is not None:
+                data[key] = str(order_data[key])[:64]
+        for key in ("price", "qty"):
+            if (safe_value := _safe_finite_float(order_data.get(key))) is not None:
+                data[key] = safe_value
+        delta = order_data.get("delta")
+        if isinstance(delta, dict):
+            safe_delta = {
+                key: safe_value
+                for key in ("price_pct_diff", "qty_pct_diff")
+                if (safe_value := _safe_finite_float(delta.get(key))) is not None
+            }
+            if safe_delta:
+                data["delta"] = safe_delta
+        _safe_emit(
+            bot,
+            event_types[action],
+            level="debug",
+            component="execution.connector_call",
+            tags=(EventTags.EXECUTION, EventTags.ORDER, action),
+            cycle_id=current_live_event_cycle_id(bot),
+            order_wave_id=order_wave_id,
+            action_id=action_id,
+            symbol=(
+                str(order.get("symbol"))
+                if isinstance(order, dict) and order.get("symbol")
+                else None
+            ),
+            pside=(
+                str(order.get("position_side"))
+                if isinstance(order, dict) and order.get("position_side")
+                else None
+            ),
+            side=(
+                str(order.get("side"))
+                if isinstance(order, dict) and order.get("side")
+                else None
+            ),
+            order_id=(
+                str(order.get("id") or order.get("order_id"))
+                if isinstance(order, dict)
+                and (order.get("id") or order.get("order_id"))
+                else None
+            ),
+            client_order_id=(
+                str(order.get("custom_id") or order.get("clientOrderId"))
+                if isinstance(order, dict)
+                and (order.get("custom_id") or order.get("clientOrderId"))
+                else None
+            ),
+            status="started",
+            reason_code=ReasonCodes.CONNECTOR_CALL_STARTED,
+            data=data,
+        )
+    except Exception as exc:
+        logging.debug(
+            "[event] failed to emit connector call event action=%s route=%s error_type=%s",
+            action,
+            connector_route,
+            type(exc).__name__,
+        )
 
 
 def emit_execution_create_filter_event(

--- a/src/live/executor.py
+++ b/src/live/executor.py
@@ -603,6 +603,12 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
         )
     _record_fresh_entry_orders(bot, "record_eligible_orders", orders)
     _emit_fresh_entry_eligibility(bot, passivbot_cls, wave)
+    connector_call_context = {
+        "action": "create",
+        "orders": orders,
+        "wave": wave,
+    }
+    bot._execution_connector_call_context = connector_call_context
     try:
         res = await bot.execute_orders(orders)
     except RestartBotException:
@@ -631,6 +637,12 @@ async def execute_orders_parent(bot, orders: list[dict]) -> list[dict]:
                 error=exc,
             )
         raise
+    finally:
+        if (
+            getattr(bot, "_execution_connector_call_context", None)
+            is connector_call_context
+        ):
+            bot._execution_connector_call_context = None
     if not res:
         for idx, order in enumerate(orders):
             passivbot_cls._emit_execution_order_event(
@@ -824,6 +836,12 @@ async def execute_cancellations_parent(bot, orders: list[dict]) -> list[dict]:
             index=idx,
             wave=wave,
         )
+    connector_call_context = {
+        "action": "cancel",
+        "orders": orders,
+        "wave": wave,
+    }
+    bot._execution_connector_call_context = connector_call_context
     try:
         res = await bot.execute_cancellations(orders)
     except RestartBotException:
@@ -843,6 +861,12 @@ async def execute_cancellations_parent(bot, orders: list[dict]) -> list[dict]:
                 error=exc,
             )
         raise
+    finally:
+        if (
+            getattr(bot, "_execution_connector_call_context", None)
+            is connector_call_context
+        ):
+            bot._execution_connector_call_context = None
     to_return = []
     if len(orders) != len(res):
         bot.execution_scheduled = True

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -699,6 +699,9 @@ class Passivbot:
     )
     _emit_order_wave_started_event = live_event_emitters.emit_order_wave_started_event
     _emit_order_wave_completed_event = live_event_emitters.emit_order_wave_completed_event
+    _emit_execution_connector_call_started_event = (
+        live_event_emitters.emit_execution_connector_call_started_event
+    )
     _emit_planning_defer_summary_event = (
         live_event_emitters.emit_planning_defer_summary_event
     )
@@ -17948,6 +17951,11 @@ class Passivbot:
             "price": order["price"],
             "params": self._build_order_params(order),
         }
+        self._emit_execution_connector_call_started_event(
+            order=order,
+            action="create",
+            connector_route="base",
+        )
         executed = await self.cca.create_order(**params)
         return executed
 
@@ -17959,6 +17967,11 @@ class Passivbot:
         """Cancel a single order via the exchange client."""
         executed = None
         try:
+            self._emit_execution_connector_call_started_event(
+                order=order,
+                action="cancel",
+                connector_route="base",
+            )
             executed = await self.cca.cancel_order(order["id"], symbol=order["symbol"])
             return executed
         except Exception as e:

--- a/tests/exchanges/test_ccxt_bot.py
+++ b/tests/exchanges/test_ccxt_bot.py
@@ -626,6 +626,86 @@ class TestCCXTBotBatchOrderDiagnostics:
         ) in caplog.text
 
 
+class TestCCXTBotConnectorCallEvents:
+    @pytest.mark.asyncio
+    async def test_execute_order_emits_before_connector_with_batch_ids(self):
+        from exchanges.ccxt_bot import CCXTBot
+        from live.event_bus import EventTypes, ReasonCodes
+
+        markers = []
+        order = {
+            "symbol": "BTC/USDT:USDT",
+            "type": "limit",
+            "side": "buy",
+            "position_side": "long",
+            "qty": 0.01,
+            "price": 100000.0,
+            "reduce_only": False,
+            "custom_id": "cid-1",
+        }
+
+        class CCA:
+            async def create_order(self, **params):
+                markers.append(("connector", params))
+                return {"id": "oid-1", "status": "open"}
+
+        bot = CCXTBot.__new__(CCXTBot)
+        bot.exchange = "binance"
+        bot.user = "binance_01"
+        bot.bot_id = "bot-1"
+        bot.cca = CCA()
+        bot._build_order_params = lambda _order: {"postOnly": True}
+        bot._live_event_current_cycle_id = "cy_3"
+        bot._execution_connector_call_context = {
+            "action": "create",
+            "orders": [order],
+            "wave": {"event_id": "ow_3"},
+        }
+
+        def capture(event_type, **kwargs):
+            markers.append(("event", event_type, kwargs))
+
+        bot._emit_live_event = capture
+
+        result = await bot.execute_order(order)
+
+        assert result == {"id": "oid-1", "status": "open"}
+        assert [marker[0] for marker in markers] == ["event", "connector"]
+        _, event_type, event = markers[0]
+        assert event_type == EventTypes.EXECUTION_CREATE_CONNECTOR_CALL_STARTED
+        assert event["reason_code"] == ReasonCodes.CONNECTOR_CALL_STARTED
+        assert event["order_wave_id"] == "ow_3"
+        assert event["action_id"] == "ow_3:create:0"
+        assert event["data"]["connector_route"] == "base"
+        assert event["data"]["connector_method"] == "cca.create_order"
+
+    @pytest.mark.asyncio
+    async def test_cancel_connector_call_survives_event_failure(self):
+        from exchanges.ccxt_bot import CCXTBot
+
+        connector_calls = []
+
+        class CCA:
+            async def cancel_order(self, order_id, symbol=None):
+                connector_calls.append((order_id, symbol))
+                return {"id": order_id, "status": "canceled"}
+
+        bot = CCXTBot.__new__(CCXTBot)
+        bot.exchange = "binance"
+        bot.cca = CCA()
+
+        def fail_emit(*_args, **_kwargs):
+            raise RuntimeError("diagnostic sink unavailable")
+
+        bot._emit_live_event = fail_emit
+        result = await bot.execute_cancellation(
+            {"id": "oid-2", "symbol": "ETH/USDT:USDT"}
+        )
+
+        assert result == {"id": "oid-2", "status": "canceled"}
+        assert connector_calls == [("oid-2", "ETH/USDT:USDT")]
+
+
 class TestCCXTBotExecuteCancellation:
     """Tests for execute_cancellation."""
 

--- a/tests/test_exchange_config_updates.py
+++ b/tests/test_exchange_config_updates.py
@@ -579,13 +579,16 @@ async def test_okx_update_config_verified_net_mode_fails_loudly():
 async def test_okx_already_gone_cancel_does_not_log_raw_exception(caplog, capsys):
     from exchanges.okx import OKXBot
 
+    markers = []
+
+    async def cancel_order(*_args, **_kwargs):
+        markers.append("connector")
+        raise Exception('{"sCode":"51400","apiKey":"RAW_OKX_CANCEL_SECRET"}')
+
     bot = OKXBot.__new__(OKXBot)
-    bot.cca = SimpleNamespace(
-        cancel_order=AsyncMock(
-            side_effect=Exception(
-                '{"sCode":"51400","apiKey":"RAW_OKX_CANCEL_SECRET"}'
-            )
-        )
+    bot.cca = SimpleNamespace(cancel_order=cancel_order)
+    bot._emit_execution_connector_call_started_event = lambda **kwargs: markers.append(
+        ("event", kwargs)
     )
     order = {
         "id": "order-1",
@@ -605,6 +608,10 @@ async def test_okx_already_gone_cancel_does_not_log_raw_exception(caplog, capsys
     assert "sCode" not in rendered
     assert "cancel skipped: BTC" in caplog.text
     assert "error_type=Exception" in caplog.text
+    assert markers[0][0] == "event"
+    assert markers[0][1]["action"] == "cancel"
+    assert markers[0][1]["connector_route"] == "okx"
+    assert markers[1] == "connector"
 
 
 @pytest.mark.asyncio

--- a/tests/test_hyperliquid_balance_cache.py
+++ b/tests/test_hyperliquid_balance_cache.py
@@ -87,9 +87,11 @@ class DummyCCA:
 @pytest.mark.asyncio
 async def test_hyperliquid_already_gone_cancel_requests_full_confirmation(stubbed_modules):
     HyperliquidBot = importlib.import_module("exchanges.hyperliquid").HyperliquidBot
+    markers = []
 
     class _AlreadyGoneCancelCCA:
         async def cancel_order(self, order_id, symbol=None, params=None):
+            markers.append(("connector", order_id, symbol, params))
             assert order_id == "abc123"
             assert symbol == "BTC/USDC:USDC"
             assert params == {}
@@ -98,12 +100,18 @@ async def test_hyperliquid_already_gone_cancel_requests_full_confirmation(stubbe
     bot = HyperliquidBot.__new__(HyperliquidBot)
     bot.user_info = {"is_vault": False}
     bot.cca = _AlreadyGoneCancelCCA()
+    bot._emit_execution_connector_call_started_event = lambda **kwargs: markers.append(
+        ("event", kwargs)
+    )
 
     res = await bot.execute_cancellation({"id": "abc123", "symbol": "BTC/USDC:USDC"})
 
     assert res["status"] == "success"
     assert res["_passivbot_cancel_requires_full_authoritative_confirmation"] is True
     assert bot.did_cancel_order(res) is True
+    assert [marker[0] for marker in markers] == ["event", "connector"]
+    assert markers[0][1]["action"] == "cancel"
+    assert markers[0][1]["connector_route"] == "hyperliquid"
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -308,6 +308,8 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.FORAGER_FEATURE_UNAVAILABLE,
         EventTypes.FORAGER_ELIGIBILITY_CHANGED,
         EventTypes.ENTRY_INITIAL_ELIGIBILITY,
+        EventTypes.EXECUTION_CREATE_CONNECTOR_CALL_STARTED,
+        EventTypes.EXECUTION_CANCEL_CONNECTOR_CALL_STARTED,
         EventTypes.CONFIG_MARKET_COMPATIBILITY,
         EventTypes.ACTION_PLANNED,
         EventTypes.EMA_BUNDLE_STARTED,

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1822,8 +1822,26 @@ def test_live_performance_report_startup_milestones_current_lifecycle(tmp_path):
                 ids={"cycle_id": "cy_1", "snapshot_id": "snap_1"},
             ),
             _monitor_row(
-                event_type="execution.create_sent",
+                event_type="execution.create_connector_call_started",
                 seq=4,
+                ts=1500,
+                symbol="BTCUSDT",
+                pside="long",
+                side="buy",
+                ids={
+                    "cycle_id": "cy_1",
+                    "order_wave_id": "ow_1",
+                    "action_id": "ow_1:create:0",
+                },
+                data={
+                    "action": "create",
+                    "connector_method": "cca.create_order",
+                    "connector_route": "base",
+                },
+            ),
+            _monitor_row(
+                event_type="execution.create_sent",
+                seq=5,
                 ts=1600,
                 symbol="BTCUSDT",
                 pside="long",

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -3869,6 +3869,10 @@ async def test_execute_orders_parent_records_order_opened_event():
             return None
 
         async def execute_orders(self, orders):
+            context = self._execution_connector_call_context
+            assert context["action"] == "create"
+            assert context["orders"][0] is orders[0]
+            assert context["wave"] is self._order_wave_in_progress
             return [{"id": "abc123", **orders[0]}]
 
         def did_create_order(self, executed):
@@ -3894,6 +3898,7 @@ async def test_execute_orders_parent_records_order_opened_event():
     res = await pb_mod.Passivbot.execute_orders_parent(bot, [order])
 
     assert len(res) == 1
+    assert bot._execution_connector_call_context is None
     assert bot._health_orders_placed == 1
     assert bot.monitor_publisher.events[-1]["kind"] == "order.opened"
     assert bot.monitor_publisher.events[-1]["symbol"] == "BTC/USDT:USDT"
@@ -3998,6 +4003,79 @@ def test_execution_debug_profile_adds_bounded_order_write_shape():
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_connector_call_event_is_bounded_and_correlated_to_batch_action():
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _emit_execution_connector_call_started_event = (
+            pb_mod.Passivbot._emit_execution_connector_call_started_event
+        )
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "binance"
+            self.user = "binance_01"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_21"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+
+    bot = FakeBot()
+    order = {
+        "symbol": "BTC/USDT:USDT",
+        "side": "buy",
+        "position_side": "long",
+        "type": "limit" * 20,
+        "pb_order_type": "entry_grid_normal_long" * 8,
+        "qty": 0.01,
+        "price": 100000.0,
+        "reduce_only": False,
+        "custom_id": "cid-connector-1234567890",
+        "id": "oid-connector-1234567890",
+        "raw_payload": "RAW_CONNECTOR_SECRET",
+        "_context": "/private/operator/path",
+        "_reason": "RAW_CONNECTOR_REASON_SECRET",
+        "_delta": {"price_pct_diff": float("inf"), "qty_pct_diff": 0.002},
+    }
+    bot._execution_connector_call_context = {
+        "action": "create",
+        "orders": [order],
+        "wave": {"id": 4, "event_id": "ow_4"},
+    }
+
+    bot._emit_execution_connector_call_started_event(
+        order=order,
+        action="create",
+        connector_route="base",
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[-1]
+    assert event.event_type == EventTypes.EXECUTION_CREATE_CONNECTOR_CALL_STARTED
+    assert event.component == "execution.connector_call"
+    assert event.status == "started"
+    assert event.reason_code == ReasonCodes.CONNECTOR_CALL_STARTED
+    assert event.cycle_id == "cy_21"
+    assert event.order_wave_id == "ow_4"
+    assert event.action_id == "ow_4:create:0"
+    assert event.order_id == "oid-connector-1234567890"
+    assert event.client_order_id == "cid-connector-1234567890"
+    assert event.data["connector_method"] == "cca.create_order"
+    assert event.data["connector_route"] == "base"
+    assert len(event.data["order_type"]) == 64
+    assert len(event.data["pb_order_type"]) == 64
+    assert event.data["delta"] == {"qty_pct_diff": 0.002}
+    rendered = json.dumps(event.to_dict(), sort_keys=True)
+    assert "RAW_CONNECTOR_SECRET" not in rendered
+    assert "RAW_CONNECTOR_REASON_SECRET" not in rendered
+    assert "/private/operator/path" not in rendered
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 @pytest.mark.asyncio
 async def test_execute_cancellations_parent_emits_ambiguous_confirmation_events():
     import passivbot as pb_mod
@@ -4048,6 +4126,10 @@ async def test_execute_cancellations_parent_emits_ambiguous_confirmation_events(
             return None
 
         async def execute_cancellations(self, orders):
+            context = self._execution_connector_call_context
+            assert context["action"] == "cancel"
+            assert context["orders"][0] is orders[0]
+            assert context["wave"] is self._order_wave_in_progress
             return [
                 {
                     "status": "success",
@@ -4083,6 +4165,7 @@ async def test_execute_cancellations_parent_emits_ambiguous_confirmation_events(
     res = await pb_mod.Passivbot.execute_cancellations_parent(bot, [order])
 
     assert len(res) == 1
+    assert bot._execution_connector_call_context is None
     assert bot._authoritative_pending_confirmations == {
         "balance": 5,
         "positions": 5,

--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -177,22 +177,45 @@ def test_apply_assertions_supports_remote_call_paths():
 @pytest.mark.asyncio
 @pytest.mark.fake_live
 async def test_fake_client_request_log_counts_order_writes():
+    from exchanges.ccxt_bot import CCXTBot
+
     client = FakeCCXTClient(_scenario(), quote="USDT")
-    order = await client.create_order(
-        "BTC/USDT:USDT",
-        "limit",
-        "buy",
-        0.01,
-        90.0,
-        {"positionSide": "LONG", "clientOrderId": "pb-test"},
+    emitted = []
+    bot = CCXTBot.__new__(CCXTBot)
+    bot.exchange = "fake"
+    bot.user = "fake_01"
+    bot.bot_id = "fake_bot"
+    bot.cca = client
+    bot._build_order_params = lambda _order: {
+        "positionSide": "LONG",
+        "clientOrderId": "pb-test",
+    }
+    bot._emit_live_event = lambda event_type, **kwargs: emitted.append(
+        (event_type, kwargs)
     )
-    await client.cancel_order(order["id"], "BTC/USDT:USDT")
+    requested = {
+        "symbol": "BTC/USDT:USDT",
+        "type": "limit",
+        "side": "buy",
+        "position_side": "long",
+        "qty": 0.01,
+        "price": 90.0,
+        "reduce_only": False,
+        "custom_id": "pb-test",
+    }
+
+    order = await bot.execute_order(requested)
+    await bot.execute_cancellation(order)
 
     summary = _summarize_remote_calls(client.export_request_log())
 
     assert summary["by_method"]["create_order"] == 1
     assert summary["by_method"]["cancel_order"] == 1
     assert summary["by_category"]["order_write"] == 2
+    assert [event_type for event_type, _kwargs in emitted] == [
+        "execution.create_connector_call_started",
+        "execution.cancel_connector_call_started",
+    ]
 
 
 @pytest.mark.fake_live


### PR DESCRIPTION
## Summary

- add structured/monitor-only `execution.create_connector_call_started` and `execution.cancel_connector_call_started` evidence immediately before concrete connector calls
- cover the generic create/cancel routes plus Hyperliquid and OKX cancellation overrides
- preserve normal cycle, order-wave, and action correlation through a short-lived batch context that never enters connector payloads
- keep the payload fixed, finite, bounded, and free of raw connector params, vault addresses, URLs, responses, exception text, and arbitrary paths
- record PR #1197's no-restart VPS5 deployment evidence and make this connector-boundary slice the active logging-overhaul work

## Contract

These events mean only that Passivbot reached the local `cca.create_order` or `cca.cancel_order` call site. They do not claim bytes were sent, exchange receipt, acceptance, or acknowledgement. Existing `execution.create_sent` / `execution.cancel_sent` remain pre-call submission-intent events, terminal events remain authoritative outcomes, and startup performance milestones are unchanged.

Event and sink failures are best-effort and cannot prevent or alter the connector call. No order list, connector params, exchange error handling, risk/HSL logic, Rust, backtest, or optimizer behavior changes.

## Validation

- 239 monitor, event-bus, registry, and performance-report tests passed
- 168 connector, exchange override, executor integration, and CCXT contract tests passed
- all 21 fake-live marked tests passed
- focused event ordering, failure isolation, payload bounds, Hyperliquid, OKX, fake-client request-log, and milestone non-double-count regressions passed
- Python compilation passed
- `git diff --check` passed
- exhaustive live call-site search found exactly four concrete connector writes and all are covered
- added-line silent-handling audit found only the intentional fail-open emitter catch
- independent Terra preflight approved with no findings and reran focused tests, compilation, call-site inventory, and diff checks

Real backtest/optimizer smokes are not applicable because this changes only live Python connector observability. Fake-live coverage exercises real Passivbot create/cancel methods against the deterministic fake connector.

## Reviewer focus

- event ordering is immediately before each concrete connector coroutine call
- no duplicate event for inherited Hyperliquid creates or other base routes
- batch context correlation is identity-based and cleared in `finally` on success and exceptions
- payload and error isolation cannot affect trading behavior or leak connector inputs
- new events do not alter startup milestones or existing execution-health semantics

## Post-merge VPS5 validation

This producer change requires a graceful restart of only the five exact supervised bot panes after pulling `v8`. Preserve unrelated processes and local artifacts. Query the sent -> connector-call-started -> terminal chain only from legitimate live order activity; do not create synthetic live orders. Run immediate and settled smoke and verify event-pipeline health.
