### PR TITLE
Correlate startup fill cache proof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `live-performance-report` now correlates current-startup fill-cache loading
+  with exact post-start fill-history coverage proof. Cache presence alone never
+  claims proof, cache/proof ordering is explicit, and incomplete or absent
+  lifecycle evidence remains unknown.
+
 - Live order writes now emit bounded structured/monitor evidence immediately
   before concrete connector create and cancel calls. The events distinguish
   local connector-call arrival from pre-call submission intent and exchange

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,50 +22,60 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-connector-invocation-events`
-- Base: `fda0e1323135a3db1bc69ff154d066d103ac6c9e`
-- Triggering evidence: existing `execution.create_sent` and
-  `execution.cancel_sent` events are emitted before the batch executor reaches
-  a concrete connector call. They prove submission intent but not local
-  arrival at `cca.create_order` or `cca.cancel_order`.
-- Scope: emit bounded structured/monitor-only
-  `execution.create_connector_call_started` and
-  `execution.cancel_connector_call_started` events immediately before the
-  concrete base, Hyperliquid, and OKX connector call sites. Preserve normal
-  cycle, order-wave, and action correlation without adding fields to connector
-  payloads.
-- Behavior boundary: observability only. The events claim local call-site
-  arrival, not bytes sent, exchange receipt, acceptance, or acknowledgement.
-  Event failures must not prevent or alter connector calls. Do not add another
-  startup milestone or change order, risk, HSL, Rust, backtest, or optimizer
-  behavior.
-- Validation: focused and adjacent event/executor/connector/report tests, full
-  fake-live marker suite, Python compilation, `git diff --check`, added-line
-  silent-handling audit, and independent preflight.
+- Branch: `codex/v8-startup-fill-cache-proof`
+- Base: `e94da301bbaa52786e0cb218fa27f48263b80e6d`
+- Triggering evidence: startup lifecycle and fill-refresh evidence are reported
+  separately. Operators cannot yet correlate a current-startup cache load with
+  exact fill-history coverage proof or distinguish their observed ordering and
+  relation to relevant readiness phases.
+- Scope: add one bounded `startup_fill_cache_proof` performance-report section
+  that joins existing `bot.started`, startup timing, and
+  `fills.refresh_summary` evidence within the current lifecycle. Distinguish
+  cache presence from exact coverage proof, expose their observed ordering, and
+  preserve explicit unknown output when source completeness or proof evidence
+  is insufficient.
+- Behavior boundary: read-only report and tests only. Do not add or reinterpret
+  a startup/readiness/risk gate, infer proof from cache load, alter existing
+  startup/fill sections, or change live producer, order, HSL, Rust, backtest,
+  optimizer, exchange, or process behavior.
+- Validation: focused and full performance-report tests, Python compilation,
+  `git diff --check`, added-line silent-handling audit, and independent
+  preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
-- Expected VPS action: pull while preserving local artifacts, gracefully
-  restart only the five exact supervised bot panes because this is a producer
-  change, query the call-boundary chain only when legitimate order activity
-  occurs, and run immediate plus settled smoke. Do not create synthetic live
-  orders for validation.
+- Expected VPS action: pull while preserving local artifacts, run a bounded
+  current-plus-rotated `startup_fill_cache_proof` report and settled smoke, and
+  verify bot plus unrelated-process PIDs remain unchanged. Do not restart bots
+  because this slice changes only a read-only consumer.
 
 Next action:
 
-1. Wait for the temporary Hermes + Grok 4.5 + green-CI gate on the exact current
-   PR head. After merge, pull `v8` on VPS5, gracefully restart only the five
-   exact supervised bot panes, query the call-boundary chain from legitimate
-   order activity, and complete immediate plus settled smoke while preserving
-   unrelated processes and local artifacts.
+1. Complete local validation and independent preflight, publishing the branch
+   if it is not already a PR. Once published, wait for the temporary Hermes +
+   Grok 4.5 + green-CI gate on the exact current head. After merge, pull `v8`
+   on VPS5 without restarting bots, run the bounded proof report and settled
+   smoke, and verify all expected PIDs are unchanged.
 
 ## Deployed Baseline
 
-- Remote `v8`: `fda0e1323135a3db1bc69ff154d066d103ac6c9e`, PR #1197
-- VPS5 repository: `fda0e1323135a3db1bc69ff154d066d103ac6c9e`, PR #1197; tracked
+- Remote `v8`: `e94da301bbaa52786e0cb218fa27f48263b80e6d`, PR #1198
+- VPS5 repository: `e94da301bbaa52786e0cb218fa27f48263b80e6d`, PR #1198; tracked
   status clean; only expected untracked artifacts were preserved
-- VPS5 expected bots: five; all still running with the PR #1196 restart PIDs
-  `856325/856354/856386/856420/856456`;
+- VPS5 expected bots: five; running with PR #1198 restart PIDs
+  `861950/861949/861953/861955/861957`;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1198 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded cleanly and gracefully stopped only the five exact bot
+  panes; all old Python PIDs exited naturally. Existing pane PIDs and unrelated
+  `misc:0.0` PID `434835` were preserved, then the exact supervisor commands
+  started the five new bots.
+- The immediate smoke retained a real KuCoin authoritative-state timeout:
+  `264/267` remote and `15/18` account-critical calls succeeded. After recovery,
+  the settled two-minute smoke was hard-green with `325/325` remote and `53/53`
+  account-critical calls successful, all five expected processes matched, no
+  hard/log/monitor/pipeline failures, no `D` states, and a clean tracked repo.
+  Current post-restart segments contained neither `execution.*_sent` nor
+  connector-call events, so no live order was fabricated for validation.
 - PR #1197 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded without bot signals or restarts. A bounded eight-segment
   Binance lifecycle report returned `ok=true` with zero issues and observed
@@ -244,14 +254,14 @@ throughput, PR #1191's corrected active/legacy-terminal replay estimates,
 PR #1192's machine-readable startup readiness SLA semantics, PR #1193's
 latest-lifecycle report ordering, PR #1194's bounded startup action milestones,
 PR #1195's startup consumer correctness fixes, PR #1196's true fresh-entry
-eligibility producer, and PR #1197's fresh-entry startup milestone are also
-merged and deployed. The active PR #1198 slice adds the missing local
-connector-call boundary evidence without claiming exchange receipt or outcome.
+eligibility producer, PR #1197's fresh-entry startup milestone, and PR #1198's
+local connector-call boundary evidence are also merged and deployed. The active
+slice correlates existing startup fill-cache and exact history-proof evidence
+without changing either producer or any readiness decision.
 
-After PR #1198 is merged and validated, select the next review-worthy
+After this report slice is merged and validated, select the next review-worthy
 candidate from the remaining backlog, including:
 
-- bounded startup fill-cache proof correlation/reporting
 - bounded event-pipeline service-time evidence
 - bounded operator tooling improvements sharing one code and validation surface
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7767,3 +7767,35 @@ VPS5 deployment status:
   or exchange-error behavior change. Expected VPS action is an exact five-bot
   graceful restart, legitimate-activity event query, and immediate plus settled
   smoke; validation must not create synthetic live orders.
+
+### Deployed Slice: Connector Call Boundary Evidence
+
+- PR #1198 was approved by Hermes and Grok 4.5 on exact head `c13d27143`; CI
+  passed and it merged to `v8` as `e94da301b`.
+- VPS5 fast-forwarded cleanly and gracefully stopped only the five exact bot
+  panes. All old Python processes exited naturally. Existing pane PIDs and
+  unrelated `misc:0.0` PID `434835` remained preserved; the exact supervisor
+  commands then started bot PIDs `861950/861949/861953/861955/861957`.
+- The immediate smoke retained one real KuCoin authoritative-state timeout:
+  `264/267` remote and `15/18` account-critical calls succeeded. After recovery,
+  the settled two-minute smoke was hard-green with `325/325` remote and `53/53`
+  account-critical calls successful, all five expected processes matched, no
+  hard/log/monitor/pipeline failures, no `D` states, and a clean tracked repo.
+- Current post-restart segments contained neither `execution.*_sent` nor
+  connector-call events. Validation therefore retained explicit no-observation
+  evidence and did not manufacture a live order.
+
+### Active Slice: Startup Fill-Cache Proof Correlation
+
+- Branch: `codex/v8-startup-fill-cache-proof` from deployed `e94da301b`.
+- Scope: add one bounded performance-report section that joins the current
+  `bot.started` lifecycle with existing startup cache-load and exact fill-history
+  proof evidence. Cache presence alone must never claim coverage proof.
+- Contract: report `proven`, `unproven`, or explicit `unknown` from valid
+  post-start proof evidence only, preserve incomplete-source barriers and
+  lifecycle resets, expose cache/proof ordering, and retain only bounded
+  allowlisted proof values plus valid elapsed/phase relation evidence.
+- Non-goals: no event producer, startup/readiness/risk gate, existing report
+  reinterpretation, process action, order/HSL/Rust/backtest/optimizer/exchange
+  behavior, or smoke-verdict change. Expected VPS action is pull plus bounded
+  report and settled smoke, with no bot restart.

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -317,9 +317,9 @@ classification when enough source events exist.
   because its tolerated warmup failure cannot prove readiness.
   PR #1194 derives the first cycle, first Rust call, and first locally submitted
   exchange write from existing events. PR #1196 added true local fresh-entry
-  eligibility evidence; the active consumer projects its first qualifying
-  event as startup readiness. Remaining work is actual connector-invocation
-  evidence rather than another pre-call proxy.
+  eligibility evidence, and PR #1197 projects its first qualifying event as
+  startup readiness. PR #1198 adds distinct local connector-call boundary
+  evidence without claiming exchange receipt or acknowledgement.
 - [ ] Startup: process start to held-position protective HSL ready.
 - [ ] Startup: process start to fresh-entry ready.
 - [ ] Startup: process start to first planning cycle started/completed.
@@ -341,8 +341,9 @@ classification when enough source events exist.
     summarized by `live-performance-report` as `cache_warmup`, including
     bounded warm-cache reuse/cold-path decisions, candle load/flush row counts,
     source/reason counters, and elapsed timing where present. Remaining work:
-    fill-cache coverage proof, HSL/checkpoint compatibility decisions, repair
-    scope, and repair elapsed time.
+    the active report slice correlates existing fill-cache load and exact
+    coverage-proof evidence to the current startup lifecycle. HSL/checkpoint
+    compatibility decisions, repair scope, and repair elapsed time remain.
 - [ ] Account state: balance, positions, open orders, fills, state-refresh wall
   time, surface max/sum time, retry/degraded counts.
 - [ ] Market data: ticker/market price age, candle close age, EMA bundle age,

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1905,6 +1905,401 @@ class _StartupMilestoneAccumulator:
         }
 
 
+class _StartupFillCacheProofAccumulator:
+    """Derive bounded fill-history coverage evidence for each current lifecycle."""
+
+    _CACHE_STATUSES = frozenset({"deferred", "failed", "succeeded"})
+    _CACHE_REASONS = frozenset({"fill_cache_ready"})
+    _COVERAGE_REASONS = frozenset(
+        {
+            "full_history",
+            "full_history_scope_not_proven",
+            "known_gap_overlaps_lookback",
+            "missing_cache",
+            "missing_pnl_manager",
+            "window_coverage_not_proven",
+            "window_covered",
+        }
+    )
+    _HISTORY_SCOPES = frozenset({"all", "unknown", "window"})
+    _GAP_REASONS = frozenset(
+        {
+            "auto_detected",
+            "confirmed_legitimate",
+            "fetch_failed",
+            "manual",
+            "unknown",
+        }
+    )
+
+    def __init__(
+        self,
+        *,
+        source_completeness: _StartupSourceCompletenessTracker | None = None,
+    ) -> None:
+        self.bots: dict[str, dict[str, Any]] = {}
+        self.source_completeness = (
+            source_completeness or _StartupSourceCompletenessTracker()
+        )
+
+    @staticmethod
+    def _event_ts(row: dict[str, Any]) -> int | None:
+        value = row.get("ts")
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            return None
+        return int(value)
+
+    @staticmethod
+    def _bounded_enum(value: Any, allowed: frozenset[str]) -> str | None:
+        label = _safe_label(value, max_len=120)
+        if label is None:
+            return None
+        return label if label in allowed else "other"
+
+    @staticmethod
+    def _cache_load_summary(live_event: dict[str, Any]) -> dict[str, Any] | None:
+        data = live_event.get("data")
+        if not isinstance(data, dict):
+            return None
+        if data.get("source") != "startup" or data.get("refresh_mode") != "cache_load":
+            return None
+        summary: dict[str, Any] = {}
+        status = _StartupFillCacheProofAccumulator._bounded_enum(
+            live_event.get("status"),
+            _StartupFillCacheProofAccumulator._CACHE_STATUSES,
+        )
+        if status is not None:
+            summary["status"] = status
+        reason = _StartupFillCacheProofAccumulator._bounded_enum(
+            live_event.get("reason_code"),
+            _StartupFillCacheProofAccumulator._CACHE_REASONS,
+        )
+        if reason is not None:
+            summary["reason"] = reason
+        history_scope = _StartupFillCacheProofAccumulator._bounded_enum(
+            data.get("history_scope"),
+            _StartupFillCacheProofAccumulator._HISTORY_SCOPES,
+        )
+        if history_scope is not None:
+            summary["history_scope"] = history_scope
+        return summary
+
+    @staticmethod
+    def _proof_summary(live_event: dict[str, Any]) -> dict[str, Any] | None:
+        data = live_event.get("data")
+        if not isinstance(data, dict):
+            return None
+        coverage_after = data.get("coverage_after")
+        if not isinstance(coverage_after, dict):
+            return None
+        ready = coverage_after.get("ready")
+        if not isinstance(ready, bool):
+            return None
+        summary: dict[str, Any] = {"ready": ready}
+        enum_fields = {
+            "reason": _StartupFillCacheProofAccumulator._COVERAGE_REASONS,
+            "history_scope": _StartupFillCacheProofAccumulator._HISTORY_SCOPES,
+            "gap_reason": _StartupFillCacheProofAccumulator._GAP_REASONS,
+        }
+        for key, allowed in enum_fields.items():
+            value = _StartupFillCacheProofAccumulator._bounded_enum(
+                coverage_after.get(key), allowed
+            )
+            if value is not None:
+                summary[key] = value
+        for key in ("covered_start_ms", "oldest_event_ts", "gap_start_ts", "gap_end_ts"):
+            value = coverage_after.get(key)
+            if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                summary[key] = int(value)
+        return summary
+
+    def _discard_superseded_state(self, bot: str) -> None:
+        state = self.bots.get(bot)
+        if state is None:
+            return
+        retained: dict[str, Any] = {}
+        for key, candidate in state.items():
+            if key == "bot" or candidate is None:
+                continue
+            if not self.source_completeness.supersedes(
+                bot=bot,
+                event_order=candidate[0],
+            ):
+                retained[key] = candidate
+        if not retained:
+            self.bots.pop(bot, None)
+            return
+        state.clear()
+        state.update({"bot": bot, **retained})
+
+    @staticmethod
+    def _candidate_is_after(
+        candidate: tuple[Any, ...], started_order: tuple[str, int, str, int, int, int]
+    ) -> bool:
+        return candidate[0] > started_order and bool(candidate[-1])
+
+    @staticmethod
+    def _replace_earliest(
+        state: dict[str, Any], key: str, candidate: tuple[Any, ...]
+    ) -> None:
+        existing = state.get(key)
+        if existing is None or candidate[0] < existing[0]:
+            state[key] = candidate
+
+    @staticmethod
+    def _replace_latest(
+        state: dict[str, Any], key: str, candidate: tuple[Any, ...]
+    ) -> None:
+        existing = state.get(key)
+        if existing is None or candidate[0] > existing[0]:
+            state[key] = candidate
+
+    def add(
+        self,
+        *,
+        row: dict[str, Any],
+        live_event: dict[str, Any],
+        source_complete: bool = True,
+    ) -> None:
+        event_type = str(live_event.get("event_type") or row.get("kind") or "")
+        bot = _bot_key(row, live_event)
+        event_order = _startup_event_order_key(row)
+        self.source_completeness.observe(
+            row=row,
+            live_event=live_event,
+            source_complete=source_complete,
+        )
+        self._discard_superseded_state(bot)
+
+        if event_type == "bot.started":
+            existing_state = self.bots.get(bot)
+            previous_started = (
+                existing_state.get("started") if existing_state is not None else None
+            )
+            if previous_started is not None and event_order <= previous_started[0]:
+                return
+            if (
+                previous_started is None
+                and self.source_completeness.supersedes(
+                    bot=bot,
+                    event_order=event_order,
+                )
+            ):
+                return
+            retained: dict[str, Any] = {}
+            if existing_state is not None:
+                for key, candidate in existing_state.items():
+                    if key == "bot" or candidate is None:
+                        continue
+                    if self._candidate_is_after(candidate, event_order):
+                        retained[key] = candidate
+            state = self.bots.setdefault(bot, {"bot": bot})
+            state.clear()
+            state.update(
+                {
+                    "bot": bot,
+                    "started": (
+                        event_order,
+                        self._event_ts(row),
+                        bool(source_complete),
+                    ),
+                    **retained,
+                }
+            )
+            return
+
+        cache_load = (
+            self._cache_load_summary(live_event)
+            if event_type == "fills.refresh_summary"
+            else None
+        )
+        proof = (
+            self._proof_summary(live_event)
+            if event_type == "fills.refresh_summary"
+            else None
+        )
+        phase = None
+        if event_type == "bot.startup_timing":
+            phase = startup_timing_phase(live_event.get("data"))
+            if phase not in {"hsl", "startup"}:
+                phase = None
+        if cache_load is None and proof is None and phase is None:
+            return
+
+        existing_state = self.bots.get(bot)
+        if (
+            existing_state is None
+            and self.source_completeness.supersedes(
+                bot=bot,
+                event_order=event_order,
+            )
+        ):
+            return
+        state = self.bots.setdefault(bot, {"bot": bot})
+        started = state.get("started")
+        if started is not None and event_order <= started[0]:
+            return
+        # Retain the newer incomplete-source boundary while older rotated rows
+        # are processed so they cannot repopulate stale lifecycle evidence.
+        self._replace_latest(
+            state,
+            "source_observation",
+            (event_order, bool(source_complete)),
+        )
+
+        if cache_load is not None:
+            cache_candidate = (
+                event_order,
+                cache_load,
+                self._event_ts(row),
+                bool(source_complete),
+            )
+            self._replace_earliest(
+                state,
+                "cache_load" if cache_candidate[2] is not None else "invalid_cache_load",
+                cache_candidate,
+            )
+        if proof is not None:
+            candidate = (
+                event_order,
+                proof,
+                self._event_ts(row),
+                bool(source_complete),
+            )
+            if candidate[2] is None:
+                self._replace_latest(state, "invalid_proof", candidate)
+            elif proof["ready"]:
+                self._replace_earliest(state, "first_ready_proof", candidate)
+            else:
+                self._replace_latest(state, "latest_unproven_proof", candidate)
+        if phase is not None:
+            phase_candidate = (
+                event_order,
+                self._event_ts(row),
+                bool(source_complete),
+            )
+            if phase_candidate[1] is not None and phase_candidate[2]:
+                self._replace_earliest(state, f"first_{phase}_phase", phase_candidate)
+                self._replace_latest(state, f"last_{phase}_phase", phase_candidate)
+
+    @staticmethod
+    def _phase_relation(
+        state: dict[str, Any],
+        proof: tuple[Any, ...] | None,
+        *,
+        lifecycle_source_complete: bool,
+    ) -> str:
+        if not lifecycle_source_complete or proof is None or proof[2] is None:
+            return "unknown"
+        proof_order = proof[0]
+        proof_ts = int(proof[2])
+        first_startup = state.get("first_startup_phase")
+        if (
+            first_startup is not None
+            and first_startup[0] < proof_order
+            and int(first_startup[1]) <= proof_ts
+        ):
+            return "after_startup"
+        last_hsl = state.get("last_hsl_phase")
+        if (
+            last_hsl is not None
+            and last_hsl[0] > proof_order
+            and int(last_hsl[1]) >= proof_ts
+        ):
+            return "before_hsl"
+        first_hsl = state.get("first_hsl_phase")
+        if (
+            first_hsl is not None
+            and first_hsl[0] < proof_order
+            and int(first_hsl[1]) <= proof_ts
+        ):
+            return "after_hsl"
+        return "unknown"
+
+    def to_dict(self, *, group_limit: int = GROUP_LIMIT) -> dict[str, Any]:
+        bot_items: list[dict[str, Any]] = []
+        for bot, state in sorted(self.bots.items()):
+            started = state.get("started")
+            proof = (
+                state.get("first_ready_proof")
+                or state.get("latest_unproven_proof")
+                or state.get("invalid_proof")
+            )
+            lifecycle_source_complete = bool(
+                started is not None
+                and started[2]
+                and (proof is None or proof[3])
+            )
+            item: dict[str, Any] = {
+                "bot": bot,
+                "lifecycle_source_complete": lifecycle_source_complete,
+                "status": "unknown",
+                "cache_load_relation": "not_observed",
+                "startup_phase_relation": "unknown",
+            }
+            started_ts = started[1] if started is not None else None
+            if started_ts is not None:
+                item["bot_started_ts"] = int(started_ts)
+            if started is None:
+                bot_items.append(item)
+                continue
+
+            cache_load = state.get("cache_load") or state.get("invalid_cache_load")
+            if cache_load is not None and cache_load[1]:
+                cache_load_summary = dict(cache_load[1])
+                cache_load_ts = cache_load[2]
+                if cache_load_ts is not None:
+                    cache_load_summary["ts_ms"] = int(cache_load_ts)
+                    if started_ts is not None and int(cache_load_ts) >= int(started_ts):
+                        cache_load_summary["elapsed_ms_from_start"] = int(
+                            cache_load_ts
+                        ) - int(started_ts)
+                item["cache_load"] = cache_load_summary
+
+            if cache_load is not None and proof is not None:
+                if cache_load[0] < proof[0]:
+                    item["cache_load_relation"] = "before_proof"
+                elif cache_load[0] > proof[0]:
+                    item["cache_load_relation"] = "after_proof"
+                else:
+                    item["cache_load_relation"] = "same_event"
+
+            proof_ts = proof[2] if proof is not None else None
+            if proof is not None and proof_ts is not None:
+                item["proof"] = dict(proof[1])
+            if (
+                proof is not None
+                and lifecycle_source_complete
+                and started_ts is not None
+                and proof_ts is not None
+                and int(proof_ts) >= int(started_ts)
+            ):
+                item["status"] = "proven" if proof[1]["ready"] else "unproven"
+                item["proof_elapsed_ms_from_start"] = int(proof_ts) - int(started_ts)
+                item["startup_phase_relation"] = self._phase_relation(
+                    state,
+                    proof,
+                    lifecycle_source_complete=lifecycle_source_complete,
+                )
+            bot_items.append(item)
+
+        limit = max(0, int(group_limit))
+        status_counts = Counter(str(item.get("status") or "unknown") for item in bot_items)
+        proof_elapsed_values = [
+            int(item["proof_elapsed_ms_from_start"])
+            for item in bot_items
+            if isinstance(item.get("proof_elapsed_ms_from_start"), int)
+            and not isinstance(item.get("proof_elapsed_ms_from_start"), bool)
+        ]
+        return {
+            "bot_count": len(bot_items),
+            "status_counts": dict(sorted(status_counts.items())),
+            "proof_elapsed_ms": _number_summary(proof_elapsed_values),
+            "bots_truncated": len(bot_items) > limit,
+            "bots": bot_items[:limit],
+        }
+
+
 def _bounded_hsl_replay_data(data: Any) -> dict[str, Any]:
     if not isinstance(data, dict):
         return {}
@@ -4749,6 +5144,9 @@ def build_live_performance_report(
     startup_milestones = _StartupMilestoneAccumulator(
         source_completeness=startup_source_completeness
     )
+    startup_fill_cache_proof = _StartupFillCacheProofAccumulator(
+        source_completeness=startup_source_completeness
+    )
     report_ts_ms = utc_ms()
     hsl_replay_profile = _HslReplayProfileAccumulator()
     cache_warmup = _CacheWarmupAccumulator()
@@ -4862,6 +5260,11 @@ def build_live_performance_report(
             live_event=live_event,
             source_complete=source_complete,
         )
+        startup_fill_cache_proof.add(
+            row=row,
+            live_event=live_event,
+            source_complete=source_complete,
+        )
         hsl_replay_profile.add(row=row, live_event=live_event)
         cache_warmup.add(row=row, live_event=live_event)
         fill_refresh.add(row=row, live_event=live_event)
@@ -4959,6 +5362,9 @@ def build_live_performance_report(
             report_ts_ms=report_ts_ms,
         ),
         "startup_milestones": startup_milestones.to_dict(group_limit=group_limit),
+        "startup_fill_cache_proof": startup_fill_cache_proof.to_dict(
+            group_limit=group_limit
+        ),
         "hsl_replay_profile": hsl_replay_profile.to_dict(
             group_limit=group_limit,
             report_ts_ms=report_ts_ms,
@@ -5102,6 +5508,17 @@ def summarize_live_performance_report(
         if len(milestone_bots) > max(0, int(group_limit)):
             startup_milestones["bots_truncated"] = True
         summary["startup_milestones"] = startup_milestones
+    if isinstance(report.get("startup_fill_cache_proof"), dict):
+        startup_fill_cache_proof = dict(report["startup_fill_cache_proof"])
+        proof_bots = (
+            startup_fill_cache_proof.get("bots")
+            if isinstance(startup_fill_cache_proof.get("bots"), list)
+            else []
+        )
+        startup_fill_cache_proof["bots"] = proof_bots[: max(0, int(group_limit))]
+        if len(proof_bots) > max(0, int(group_limit)):
+            startup_fill_cache_proof["bots_truncated"] = True
+        summary["startup_fill_cache_proof"] = startup_fill_cache_proof
     if isinstance(report.get("hsl_replay_profile"), dict):
         hsl_replay_profile = dict(report["hsl_replay_profile"])
         hsl_groups = (

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -2179,6 +2179,577 @@ def test_live_performance_report_startup_milestones_are_bounded_and_projectable(
     assert "startup_readiness" not in projected
 
 
+def test_live_performance_report_startup_fill_cache_proof_uses_exact_post_start_proof(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=2,
+                ts=1100,
+                status="succeeded",
+                reason_code="fill_cache_ready",
+                data={
+                    "source": "startup",
+                    "refresh_mode": "cache_load",
+                    "history_scope": "window",
+                    "event_count_after": 99,
+                },
+            ),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=3,
+                ts=1200,
+                status="deferred",
+                reason_code="fill_history_coverage_unavailable",
+                data={
+                    "coverage_after": {
+                        "ready": False,
+                        "reason": "window_coverage_not_proven",
+                        "history_scope": "window",
+                        "covered_start_ms": 0,
+                        "oldest_event_ts": 500,
+                    }
+                },
+            ),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=4,
+                ts=1300,
+                data={"phase": "hsl", "elapsed_ms": 300},
+            ),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=5,
+                ts=1400,
+                status="succeeded",
+                reason_code="fills_refresh_succeeded",
+                data={
+                    "coverage_after": {
+                        "ready": True,
+                        "reason": "window_covered",
+                        "history_scope": "window",
+                        "covered_start_ms": 400,
+                        "oldest_event_ts": 300,
+                    }
+                },
+            ),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=6,
+                ts=1500,
+                data={
+                    "coverage_after": {
+                        "ready": True,
+                        "reason": "full_history",
+                        "history_scope": "all",
+                    }
+                },
+            ),
+        ],
+    )
+
+    section = build_live_performance_report(tmp_path / "monitor")[
+        "startup_fill_cache_proof"
+    ]
+    proof = section["bots"][0]
+
+    assert proof == {
+        "bot": "binance/binance_01",
+        "bot_started_ts": 1000,
+        "lifecycle_source_complete": True,
+        "status": "proven",
+        "cache_load_relation": "before_proof",
+        "cache_load": {
+            "status": "succeeded",
+            "reason": "fill_cache_ready",
+            "history_scope": "window",
+            "ts_ms": 1100,
+            "elapsed_ms_from_start": 100,
+        },
+        "proof": {
+            "ready": True,
+            "reason": "window_covered",
+            "history_scope": "window",
+            "covered_start_ms": 400,
+            "oldest_event_ts": 300,
+        },
+        "proof_elapsed_ms_from_start": 400,
+        "startup_phase_relation": "after_hsl",
+    }
+    assert section["status_counts"] == {"proven": 1}
+    assert section["proof_elapsed_ms"] == {
+        "count": 1,
+        "min": 400,
+        "max": 400,
+        "mean": 400,
+        "median": 400,
+        "p95": 400,
+    }
+
+
+def test_live_performance_report_startup_fill_cache_proof_keeps_cache_without_proof_unknown(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=2,
+                ts=1100,
+                status="succeeded",
+                reason_code="fill_cache_ready",
+                data={
+                    "source": "startup",
+                    "refresh_mode": "cache_load",
+                    "history_scope": "all",
+                    "coverage_ready_after": True,
+                },
+            ),
+        ],
+    )
+
+    proof = build_live_performance_report(tmp_path / "monitor")[
+        "startup_fill_cache_proof"
+    ]["bots"][0]
+
+    assert proof == {
+        "bot": "binance/binance_01",
+        "bot_started_ts": 1000,
+        "lifecycle_source_complete": True,
+        "status": "unknown",
+        "cache_load_relation": "not_observed",
+        "cache_load": {
+            "status": "succeeded",
+            "reason": "fill_cache_ready",
+            "history_scope": "all",
+            "ts_ms": 1100,
+            "elapsed_ms_from_start": 100,
+        },
+        "startup_phase_relation": "unknown",
+    }
+
+
+def test_live_performance_report_startup_fill_cache_proof_reports_reverse_cache_order(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=2,
+                ts=1200,
+                data={"coverage_after": {"ready": True, "reason": "full_history"}},
+            ),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=3,
+                ts=1300,
+                status="succeeded",
+                reason_code="fill_cache_ready",
+                data={"source": "startup", "refresh_mode": "cache_load"},
+            ),
+        ],
+    )
+
+    proof = build_live_performance_report(tmp_path / "monitor")[
+        "startup_fill_cache_proof"
+    ]["bots"][0]
+
+    assert proof["status"] == "proven"
+    assert proof["cache_load_relation"] == "after_proof"
+
+
+def test_live_performance_report_startup_fill_cache_proof_uses_latest_unproven_reason(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=2,
+                ts=1200,
+                data={
+                    "coverage_after": {
+                        "ready": False,
+                        "reason": "window_coverage_not_proven",
+                        "history_scope": "window",
+                        "covered_start_ms": 100,
+                    }
+                },
+            ),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=3,
+                ts=1300,
+                data={
+                    "coverage_after": {
+                        "ready": False,
+                        "reason": "known_gap_overlaps_lookback",
+                        "history_scope": "window",
+                        "covered_start_ms": 100,
+                        "oldest_event_ts": 90,
+                        "gap_reason": "fetch_failed",
+                        "gap_start_ts": 120,
+                        "gap_end_ts": 180,
+                    }
+                },
+            ),
+        ],
+    )
+
+    proof = build_live_performance_report(tmp_path / "monitor")[
+        "startup_fill_cache_proof"
+    ]["bots"][0]
+
+    assert proof["status"] == "unproven"
+    assert proof["cache_load_relation"] == "not_observed"
+    assert proof["proof"] == {
+        "ready": False,
+        "reason": "known_gap_overlaps_lookback",
+        "history_scope": "window",
+        "covered_start_ms": 100,
+        "oldest_event_ts": 90,
+        "gap_reason": "fetch_failed",
+        "gap_start_ts": 120,
+        "gap_end_ts": 180,
+    }
+    assert proof["proof_elapsed_ms_from_start"] == 300
+
+
+@pytest.mark.parametrize(
+    "phase, phase_ts, proof_ts, expected_relation",
+    [
+        ("hsl", 1300, 1200, "before_hsl"),
+        ("startup", 1100, 1200, "after_startup"),
+    ],
+)
+def test_live_performance_report_startup_fill_cache_proof_uses_only_exact_phase_anchors(
+    tmp_path, phase, phase_ts, proof_ts, expected_relation
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    rows = [_monitor_row(event_type="bot.started", seq=1, ts=1000)]
+    if phase_ts < proof_ts:
+        rows.append(
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=2,
+                ts=phase_ts,
+                data={"phase": phase, "elapsed_ms": phase_ts - 1000},
+            )
+        )
+    rows.append(
+        _monitor_row(
+            event_type="fills.refresh_summary",
+            seq=3,
+            ts=proof_ts,
+            data={"coverage_after": {"ready": True, "reason": "full_history"}},
+        )
+    )
+    if phase_ts > proof_ts:
+        rows.append(
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=4,
+                ts=phase_ts,
+                data={"phase": phase, "elapsed_ms": phase_ts - 1000},
+            )
+        )
+    _write_ndjson(events_dir / "current.ndjson", rows)
+
+    proof = build_live_performance_report(tmp_path / "monitor")[
+        "startup_fill_cache_proof"
+    ]["bots"][0]
+
+    assert proof["status"] == "proven"
+    assert proof["startup_phase_relation"] == expected_relation
+
+
+def test_live_performance_report_startup_fill_cache_proof_prefers_after_startup_relation(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=2,
+                ts=1100,
+                data={"phase": "hsl", "elapsed_ms": 100},
+            ),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=3,
+                ts=1200,
+                data={"phase": "startup", "elapsed_ms": 200},
+            ),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=4,
+                ts=1300,
+                data={"coverage_after": {"ready": True, "reason": "full_history"}},
+            ),
+        ],
+    )
+
+    proof = build_live_performance_report(tmp_path / "monitor")[
+        "startup_fill_cache_proof"
+    ]["bots"][0]
+
+    assert proof["startup_phase_relation"] == "after_startup"
+
+
+def test_live_performance_report_startup_fill_cache_proof_resets_and_rejects_incomplete_sources(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "2026-07-10T00-00-00.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=2,
+                ts=1200,
+                data={"coverage_after": {"ready": True, "reason": "full_history"}},
+            ),
+        ],
+    )
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=3, ts=2000),
+            _monitor_row(event_type="health.summary", seq=4, ts=2100),
+        ],
+    )
+
+    reset = build_live_performance_report(
+        tmp_path / "monitor",
+        include_rotated=True,
+        max_event_files_per_bot=2,
+    )["startup_fill_cache_proof"]["bots"][0]
+
+    assert reset == {
+        "bot": "binance/binance_01",
+        "bot_started_ts": 2000,
+        "lifecycle_source_complete": True,
+        "status": "unknown",
+        "cache_load_relation": "not_observed",
+        "startup_phase_relation": "unknown",
+    }
+
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="health.summary", seq=4, ts=2100),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=5,
+                ts=2200,
+                data={"phase": "hsl", "elapsed_ms": 200},
+            ),
+        ],
+    )
+    stale = build_live_performance_report(
+        tmp_path / "monitor",
+        include_rotated=True,
+        max_event_files_per_bot=2,
+        event_tail_lines=1,
+    )["startup_fill_cache_proof"]["bots"][0]
+
+    assert stale == {
+        "bot": "binance/binance_01",
+        "lifecycle_source_complete": False,
+        "status": "unknown",
+        "cache_load_relation": "not_observed",
+        "startup_phase_relation": "unknown",
+    }
+
+
+@pytest.mark.parametrize("started_ts, proof_ts", [(None, 1200), (1000, None), (1000, -1)])
+def test_live_performance_report_startup_fill_cache_proof_rejects_invalid_timestamps(
+    tmp_path, started_ts, proof_ts
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=started_ts),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=2,
+                ts=proof_ts,
+                data={"coverage_after": {"ready": True, "reason": "full_history"}},
+            ),
+        ],
+    )
+
+    proof = build_live_performance_report(tmp_path / "monitor")[
+        "startup_fill_cache_proof"
+    ]["bots"][0]
+
+    assert proof["status"] == "unknown"
+    assert "proof_elapsed_ms_from_start" not in proof
+    assert proof["startup_phase_relation"] == "unknown"
+
+
+def test_live_performance_report_startup_fill_cache_proof_uses_later_valid_evidence(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=2,
+                ts=None,
+                status="succeeded",
+                reason_code="malformed_cache_ts",
+                data={"source": "startup", "refresh_mode": "cache_load"},
+            ),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=3,
+                ts=1100,
+                status="succeeded",
+                reason_code="fill_cache_ready",
+                data={"source": "startup", "refresh_mode": "cache_load"},
+            ),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=4,
+                ts=None,
+                data={"coverage_after": {"ready": True, "reason": "malformed_ts"}},
+            ),
+            _monitor_row(
+                event_type="fills.refresh_summary",
+                seq=5,
+                ts=1200,
+                data={"coverage_after": {"ready": True, "reason": "full_history"}},
+            ),
+        ],
+    )
+
+    proof = build_live_performance_report(tmp_path / "monitor")[
+        "startup_fill_cache_proof"
+    ]["bots"][0]
+
+    assert proof["status"] == "proven"
+    assert proof["cache_load_relation"] == "before_proof"
+    assert proof["cache_load"] == {
+        "status": "succeeded",
+        "reason": "fill_cache_ready",
+        "ts_ms": 1100,
+        "elapsed_ms_from_start": 100,
+    }
+    assert proof["proof"] == {"ready": True, "reason": "full_history"}
+    assert proof["proof_elapsed_ms_from_start"] == 200
+
+
+def test_live_performance_report_startup_fill_cache_proof_is_bounded_whitelisted_and_projectable(
+    tmp_path,
+):
+    for index in range(3):
+        events_dir = tmp_path / "monitor" / "binance" / f"user_{index}" / "events"
+        _write_ndjson(
+            events_dir / "current.ndjson",
+            [
+                _monitor_row(
+                    event_type="bot.started",
+                    seq=1,
+                    ts=1000 + index,
+                    user=f"user_{index}",
+                ),
+                _monitor_row(
+                    event_type="fills.refresh_summary",
+                    seq=2,
+                    ts=1100 + index,
+                    user=f"user_{index}",
+                    data={
+                        "coverage_after": {
+                            "ready": False,
+                            "reason": (
+                                "private_secret"
+                                if index == 0
+                                else "known_gap_overlaps_lookback"
+                            ),
+                            "history_scope": "private/secret" if index == 0 else "window",
+                            "gap_reason": (
+                                "/private/secret/api_key_abc"
+                                if index == 0
+                                else "fetch_failed"
+                            ),
+                            "gap_start_ts": 100,
+                            "gap_end_ts": 200,
+                            "raw_payload": "leak_marker",
+                            "path": "/root/passivbot/private",
+                        },
+                        "error": "api_key=secret",
+                        "debug": {"raw_payload": "leak_marker"},
+                    },
+                ),
+            ],
+        )
+
+    report = build_live_performance_report(tmp_path / "monitor", group_limit=2)
+    summary = summarize_live_performance_report(report, group_limit=1)
+    projected = project_live_performance_report_sections(
+        report, ["startup_fill_cache_proof"]
+    )
+    section = report["startup_fill_cache_proof"]
+    rendered = json.dumps(section, sort_keys=True)
+
+    assert section["bot_count"] == 3
+    assert section["status_counts"] == {"unproven": 3}
+    assert section["proof_elapsed_ms"]["count"] == 3
+    assert section["bots_truncated"] is True
+    assert len(section["bots"]) == 2
+    assert set(section["bots"][0]) == {
+        "bot",
+        "bot_started_ts",
+        "lifecycle_source_complete",
+        "status",
+        "cache_load_relation",
+        "proof",
+        "proof_elapsed_ms_from_start",
+        "startup_phase_relation",
+    }
+    assert set(section["bots"][0]["proof"]) == {
+        "ready",
+        "reason",
+        "history_scope",
+        "gap_reason",
+        "gap_start_ts",
+        "gap_end_ts",
+    }
+    assert section["bots"][0]["proof"]["reason"] == "other"
+    assert section["bots"][0]["proof"]["history_scope"] == "other"
+    assert section["bots"][0]["proof"]["gap_reason"] == "other"
+    assert "leak_marker" not in rendered
+    assert "/root/passivbot" not in rendered
+    assert "api_key" not in rendered
+    assert len(summary["startup_fill_cache_proof"]["bots"]) == 1
+    assert "startup_fill_cache_proof" in projected
+    assert "startup_milestones" not in projected
+
+
 def test_live_performance_report_startup_readiness_hsl_whitelist(tmp_path, monkeypatch):
     monkeypatch.setattr(performance_report_module, "utc_ms", lambda: 122000)
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"


### PR DESCRIPTION
## Scope

Category: read-only tooling.

Adds a bounded `startup_fill_cache_proof` section to `live-performance-report`.
It correlates the current `bot.started` lifecycle with existing startup
cache-load, exact nested `coverage_after.ready` proof, and HSL/startup phase
evidence.

## Contract

- Cache presence never claims fill-history coverage.
- Only canonical nested `coverage_after.ready` booleans produce `proven` or
  `unproven`.
- Cache/proof ordering is explicit: `before_proof`, `after_proof`, `same_event`,
  or `not_observed`.
- Restart boundaries and incomplete selected sources prevent stale rotated
  evidence from becoming current proof.
- Malformed timestamps remain unknown unless later valid exact evidence exists.
- Text fields use fixed value allowlists; unknown values render as `other`.
- Output and summaries remain bounded by the existing group limit.

No event producer, startup/readiness/risk gate, existing report semantics,
process behavior, order/HSL/Rust/backtest/optimizer, or exchange behavior
changes.

## Validation

- `tests/test_live_performance_report.py`: 111 passed
- `tests/test_live_incident_bundle.py`: 25 passed
- `tests/test_live_restart_smoke_plan.py` + `tests/test_live_smoke_report.py`: 110
  passed
- Python compilation passed
- `git diff --check` passed
- added-line silent-handling audit passed
- independent preflight and finding delta re-review: green, no remaining
  findings

Backtest, optimizer, and fake-live smokes are not applicable because this
changes only a read-only report consumer.

## VPS action

After merge: pull `v8` without restarting bots, run a bounded
current-plus-rotated `startup_fill_cache_proof` report and settled smoke, and
verify bot, pane, and unrelated process PIDs remain unchanged.

## Reviewer focus

Please verify lifecycle/source-completeness boundaries, exact proof semantics,
cache/proof ordering, strict value-level privacy bounds, and summary/projection
boundedness.
