### PR TITLE
Measure live event pipeline service time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Periodic structured health summaries now expose bounded event-pipeline queue
+  wait and worker sink-service timing windows. Live smoke and performance
+  reports project the processed counts, totals, and maxima without changing
+  event delivery, smoke verdicts, or trading behavior.
+
 - `live-performance-report` now correlates current-startup fill-cache loading
   with exact post-start fill-history coverage proof. Cache presence alone never
   claims proof, cache/proof ordering is explicit, and incomplete or absent

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -50,8 +50,14 @@ Estimated completion:
 
 Next action:
 
-1. Complete producer/consumer implementation and focused validation, then run
-   independent preflight and publish only when the branch is review-ready.
+1. Hold the published PR at the exact-current-head review gate until Hermes,
+   Grok 4.5, and CI are green; resolve any findings with narrow delta validation
+   and require fresh exact-head verdicts after every push.
+2. Merge only after that gate is green, then gracefully restart the five exact
+   VPS5 bot panes while preserving unrelated processes and local artifacts.
+3. Verify fresh event-pipeline timing fields with bounded `health.summary`,
+   smoke, and performance reports, including immediate and settled process and
+   repository-state checks.
 
 ## Deployed Baseline
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,48 +22,57 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-startup-fill-cache-proof`
-- Base: `e94da301bbaa52786e0cb218fa27f48263b80e6d`
-- Triggering evidence: startup lifecycle and fill-refresh evidence are reported
-  separately. Operators cannot yet correlate a current-startup cache load with
-  exact fill-history coverage proof or distinguish their observed ordering and
-  relation to relevant readiness phases.
-- Scope: add one bounded `startup_fill_cache_proof` performance-report section
-  that joins existing `bot.started`, startup timing, and
-  `fills.refresh_summary` evidence within the current lifecycle. Distinguish
-  cache presence from exact coverage proof, expose their observed ordering, and
-  preserve explicit unknown output when source completeness or proof evidence
-  is insufficient.
-- Behavior boundary: read-only report and tests only. Do not add or reinterpret
-  a startup/readiness/risk gate, infer proof from cache load, alter existing
-  startup/fill sections, or change live producer, order, HSL, Rust, backtest,
-  optimizer, exchange, or process behavior.
-- Validation: focused and full performance-report tests, Python compilation,
-  `git diff --check`, added-line silent-handling audit, and independent
-  preflight.
+- Branch: `codex/v8-event-pipeline-service-time`
+- Base: `7eca900379873e2124e1782601551e3b08c3e2ee`
+- Triggering evidence: event-pipeline health currently exposes queue depth,
+  unfinished work, drops, sink errors, and worker liveness but not bounded
+  worker service-time or queue-wait evidence.
+- Scope: timestamp private queue envelopes with a monotonic clock and aggregate
+  processed count, queue-wait total/max, and worker sink-service total/max over
+  each health-summary window. Periodic `health.summary` consumes/resets the
+  timing window transactionally: accepted enqueue commits it, while failed
+  enqueue merges it back into the active window. Ordinary monitor snapshots are
+  non-consuming. Project the fixed numeric fields through event-pipeline smoke
+  summaries and performance resource-pressure reports.
+- Behavior boundary: observability only. Do not make timing evidence a trading
+  gate, change queue capacity/backpressure/drop policy, add raw payloads or
+  unbounded labels, or alter order, risk, HSL, Rust, backtest, optimizer, or
+  exchange behavior.
+- Validation: event-bus concurrency/timing tests, health-payload reset tests,
+  full smoke/performance projection tests, fake-live event markers, Python
+  compilation, `git diff --check`, added-line silent-handling audit, and
+  independent preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
-- Expected VPS action: pull while preserving local artifacts, run a bounded
-  current-plus-rotated `startup_fill_cache_proof` report and settled smoke, and
-  verify bot plus unrelated-process PIDs remain unchanged. Do not restart bots
-  because this slice changes only a read-only consumer.
+- Expected VPS action: exact five-bot graceful restart, then bounded
+  `health.summary`/report evidence and immediate plus settled smoke. Preserve
+  unrelated processes and local artifacts.
 
 Next action:
 
-1. Complete local validation and independent preflight, publishing the branch
-   if it is not already a PR. Once published, wait for the temporary Hermes +
-   Grok 4.5 + green-CI gate on the exact current head. After merge, pull `v8`
-   on VPS5 without restarting bots, run the bounded proof report and settled
-   smoke, and verify all expected PIDs are unchanged.
+1. Complete producer/consumer implementation and focused validation, then run
+   independent preflight and publish only when the branch is review-ready.
 
 ## Deployed Baseline
 
-- Remote `v8`: `e94da301bbaa52786e0cb218fa27f48263b80e6d`, PR #1198
-- VPS5 repository: `e94da301bbaa52786e0cb218fa27f48263b80e6d`, PR #1198; tracked
+- Remote `v8`: `7eca900379873e2124e1782601551e3b08c3e2ee`, PR #1199
+- VPS5 repository: `7eca900379873e2124e1782601551e3b08c3e2ee`, PR #1199; tracked
   status clean; only expected untracked artifacts were preserved
 - VPS5 expected bots: five; running with PR #1198 restart PIDs
   `861950/861949/861953/861955/861957`;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1199 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded without bot signals or restarts. A bounded four-segment
+  per-bot proof report returned `ok=true` with zero issues and reported all five
+  current bots `proven`; cache loads preceded proof, and proof elapsed ranged
+  from `5.851s` to `38.306s`.
+- The first smoke retained a real KuCoin balance timeout; the next retained a
+  recovered KuCoin nonce error. After both aged out, the final two-minute smoke
+  was green with `283/283` remote and `39/39` account-critical calls successful,
+  zero hard/log/monitor/process failures, and a clean tracked repository. A
+  report-time `D` sample cleared; all five bots were `R/S` on the final exact
+  state check. Bot PIDs, pane PIDs, and unrelated `misc:0.0` PID `434835`
+  remained unchanged.
 - PR #1198 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded cleanly and gracefully stopped only the five exact bot
   panes; all old Python PIDs exited naturally. Existing pane PIDs and unrelated
@@ -254,16 +263,14 @@ throughput, PR #1191's corrected active/legacy-terminal replay estimates,
 PR #1192's machine-readable startup readiness SLA semantics, PR #1193's
 latest-lifecycle report ordering, PR #1194's bounded startup action milestones,
 PR #1195's startup consumer correctness fixes, PR #1196's true fresh-entry
-eligibility producer, PR #1197's fresh-entry startup milestone, and PR #1198's
-local connector-call boundary evidence are also merged and deployed. The active
-slice correlates existing startup fill-cache and exact history-proof evidence
-without changing either producer or any readiness decision.
+eligibility producer, PR #1197's fresh-entry startup milestone, PR #1198's
+local connector-call boundary evidence, and PR #1199's startup fill-cache proof
+correlation are also merged and deployed. The active slice is selecting bounded
+event-pipeline service-time evidence.
 
-After this report slice is merged and validated, select the next review-worthy
-candidate from the remaining backlog, including:
-
-- bounded event-pipeline service-time evidence
-- bounded operator tooling improvements sharing one code and validation surface
+After the active service-time slice is merged and validated, select the next
+review-worthy bounded operator-tooling improvement sharing one code and
+validation surface.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7799,3 +7799,43 @@ VPS5 deployment status:
   reinterpretation, process action, order/HSL/Rust/backtest/optimizer/exchange
   behavior, or smoke-verdict change. Expected VPS action is pull plus bounded
   report and settled smoke, with no bot restart.
+
+### Deployed Slice: Startup Fill-Cache Proof Correlation
+
+- PR #1199 was approved by Hermes and Grok 4.5 on exact head `3bd521424`; CI
+  passed and it merged to `v8` as `7eca90037`.
+- VPS5 fast-forwarded without bot signals or restarts. A bounded four-segment
+  per-bot `startup_fill_cache_proof` report returned `ok=true` with zero issues,
+  reported all five current bots `proven`, observed every cache load before
+  proof, and measured proof elapsed from `5.851s` to `38.306s`.
+- The first smoke retained a real KuCoin balance timeout; the next retained a
+  recovered KuCoin nonce error. After both aged out, the final two-minute smoke
+  was green with `283/283` remote and `39/39` account-critical calls successful,
+  zero hard/log/monitor/process failures, and a clean tracked repository.
+- One report-time `D` sample cleared. The final exact process check showed all
+  five bots in `R/S`; bot PIDs `861949/861950/861953/861955/861957`, pane PIDs
+  `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
+  remained unchanged.
+
+### Active Slice: Event-Pipeline Service-Time Evidence
+
+- Branch: `codex/v8-event-pipeline-service-time` from deployed `7eca90037`.
+- Triggering evidence: current event-pipeline health exposes queue depth,
+  unfinished work, drops, sink errors, and worker liveness but not bounded
+  queue-wait or worker service-time evidence.
+- Architecture selection is in progress. The slice must remain observability
+  only, bounded, low-cardinality, and isolated from trading decisions and event
+  delivery policy.
+- Selected design: private queue envelopes carry monotonic enqueue timestamps.
+  The worker aggregates processed count, queue-wait total/max, and sink-service
+  total/max over each health-summary window. Periodic structured health emission
+  rotates the timing window; accepted enqueue commits it, while failed enqueue
+  merges it back into the active window. Ordinary monitor snapshots do not
+  consume timing evidence.
+- Consumers: project only fixed numeric fields through smoke event-pipeline
+  summaries and performance resource-pressure statistics. Do not add timing
+  verdicts, alerts, thresholds, histograms, sampled slow events, labels, raw
+  payloads, queue/drop-policy changes, or trading/readiness gates.
+- Expected VPS action: exact five-bot graceful restart, bounded timing evidence,
+  and immediate plus settled smoke while preserving unrelated processes and
+  local artifacts.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -354,7 +354,9 @@ Related detailed plans:
    resource-pressure path also includes process CPU percent after psutil's
    non-blocking first-sample priming, health-summary scheduling lag after the
    first heartbeat, and optional psutil-backed system memory/swap pressure
-   fields for host-level pressure scans.
+   fields for host-level pressure scans. The active event-pipeline timing slice
+   adds per-health-window processed count, queue-wait total/max, and worker
+   sink-service total/max with non-consuming ordinary monitor snapshots.
 
    Remaining refinements: exchange-call counts, candle-fetch concurrency,
    lower-level event-loop lag if heartbeat lag proves too coarse, and

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -374,8 +374,9 @@ classification when enough source events exist.
     blocking scope. Timing groups, the normalized table, and ranked
     `slowest_blockers` also include the latest bounded report-safe canonical
     event IDs for direct event-stream correlation. Remaining work: source events
-    for event-pipeline overhead and complete stage coverage where the live loop
-    does not yet emit timings.
+    for complete stage coverage where the live loop does not yet emit timings.
+    The active event-pipeline slice adds per-heartbeat queue-wait and worker
+    sink-service count/total/max source evidence without affecting delivery.
 - [ ] Exchange writes: create/cancel/close/panic write latency, exchange
   response latency, ambiguous write rate, confirmation latency.
   - Status: partial. The report now derives order-wave total duration,
@@ -404,7 +405,10 @@ classification when enough source events exist.
     subtraction. Performance reports also expose aggregate latest event-pipeline
     queue/drop/sink/degraded counters and unhealthy-bot count, so operators can
     see whether observability itself is backed up or dropping data without
-    opening every per-bot group.
+    opening every per-bot group. The active slice adds fixed numeric
+    health-window processed counts, queue-wait total/max, and worker sink-service
+    total/max; reports retain per-field distributions and bounded latest
+    cross-bot aggregates.
     Remaining work: a lower-level event-loop lag probe can be added later if
     operators need sub-heartbeat scheduling latency, but the heartbeat lag now
     gives bounded non-misleading evidence for delayed health summaries.

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -1780,6 +1780,23 @@ def _logging_level(level: str) -> int:
     return logging.INFO
 
 
+@dataclass(frozen=True)
+class _QueuedLiveEvent:
+    event: LiveEvent
+    enqueued_ns: int
+
+
+@dataclass(frozen=True)
+class _EventPipelineTimingWindow:
+    started_ns: int
+    ended_ns: int
+    processed_count: int
+    queue_wait_ns_total: int
+    queue_wait_ns_max: int
+    worker_service_ns_total: int
+    worker_service_ns_max: int
+
+
 class LiveEventPipeline:
     def __init__(
         self,
@@ -1807,10 +1824,20 @@ class LiveEventPipeline:
         self.sink_error_counters: Counter[str] = Counter()
         self.degraded_events: deque[LiveEvent] = deque(maxlen=1_000)
         self._throttle_last_emit_ms: dict[tuple[str, str], int] = {}
-        self._queue: queue.Queue[LiveEvent | None] = queue.Queue(maxsize=queue_maxsize)
+        self._queue: queue.Queue[_QueuedLiveEvent | None] = queue.Queue(
+            maxsize=queue_maxsize
+        )
         self._stop = threading.Event()
         self._enqueue_lock = threading.RLock()
         self._state_lock = threading.RLock()
+        self._timing_window_started_ns = time.monotonic_ns()
+        self._timing_processed_count = 0
+        self._timing_queue_wait_ns_total = 0
+        self._timing_queue_wait_ns_max = 0
+        self._timing_worker_service_ns_total = 0
+        self._timing_worker_service_ns_max = 0
+        self._pending_timing_windows: dict[int, _EventPipelineTimingWindow] = {}
+        self._next_timing_snapshot_token = 1
         self._worker: threading.Thread | None = None
         if start:
             self.start()
@@ -1832,8 +1859,23 @@ class LiveEventPipeline:
         self.context = self.context.with_ids(**kwargs)
         return self.context
 
+    @staticmethod
+    def _timing_ms(value_ns: int) -> float:
+        return round(max(0, int(value_ns)) / 1_000_000.0, 3)
+
     def health_snapshot(self) -> dict[str, Any]:
         """Return best-effort operational counters for periodic health events."""
+        snapshot, _token = self._health_snapshot(consume_timing=False)
+        return snapshot
+
+    def consume_timing_snapshot(self) -> tuple[dict[str, Any], int]:
+        snapshot, token = self._health_snapshot(consume_timing=True)
+        assert token is not None
+        return snapshot, token
+
+    def _health_snapshot(
+        self, *, consume_timing: bool
+    ) -> tuple[dict[str, Any], int | None]:
         try:
             queue_depth = int(self._queue.qsize())
         except (AttributeError, NotImplementedError, TypeError, ValueError):
@@ -1850,6 +1892,27 @@ class LiveEventPipeline:
             drop_counts = dict(self.drop_counters)
             sink_error_counts = dict(self.sink_error_counters)
             degraded_count = len(self.degraded_events)
+            timing_now_ns = time.monotonic_ns()
+            timing_window = _EventPipelineTimingWindow(
+                started_ns=int(self._timing_window_started_ns),
+                ended_ns=int(timing_now_ns),
+                processed_count=int(self._timing_processed_count),
+                queue_wait_ns_total=int(self._timing_queue_wait_ns_total),
+                queue_wait_ns_max=int(self._timing_queue_wait_ns_max),
+                worker_service_ns_total=int(self._timing_worker_service_ns_total),
+                worker_service_ns_max=int(self._timing_worker_service_ns_max),
+            )
+            timing_snapshot_token = None
+            if consume_timing:
+                timing_snapshot_token = int(self._next_timing_snapshot_token)
+                self._next_timing_snapshot_token += 1
+                self._pending_timing_windows[timing_snapshot_token] = timing_window
+                self._timing_window_started_ns = int(timing_now_ns)
+                self._timing_processed_count = 0
+                self._timing_queue_wait_ns_total = 0
+                self._timing_queue_wait_ns_max = 0
+                self._timing_worker_service_ns_total = 0
+                self._timing_worker_service_ns_max = 0
         snapshot: dict[str, Any] = {
             "event_queue_depth": queue_depth,
             "event_queue_maxsize": queue_maxsize,
@@ -1863,8 +1926,51 @@ class LiveEventPipeline:
             "event_pipeline_worker_alive": bool(
                 self._worker is not None and self._worker.is_alive()
             ),
+            "event_pipeline_timing_window_ms": self._timing_ms(
+                max(0, timing_window.ended_ns - timing_window.started_ns)
+            ),
+            "event_pipeline_processed_count": timing_window.processed_count,
+            "event_queue_wait_ms_total": self._timing_ms(
+                timing_window.queue_wait_ns_total
+            ),
+            "event_queue_wait_ms_max": self._timing_ms(timing_window.queue_wait_ns_max),
+            "event_worker_service_ms_total": self._timing_ms(
+                timing_window.worker_service_ns_total
+            ),
+            "event_worker_service_ms_max": self._timing_ms(
+                timing_window.worker_service_ns_max
+            ),
         }
-        return {key: value for key, value in snapshot.items() if value is not None}
+        return (
+            {key: value for key, value in snapshot.items() if value is not None},
+            timing_snapshot_token,
+        )
+
+    def confirm_timing_snapshot(self, token: int) -> None:
+        with self._state_lock:
+            self._pending_timing_windows.pop(int(token), None)
+
+    def restore_timing_snapshot(self, token: int) -> None:
+        with self._state_lock:
+            pending = self._pending_timing_windows.pop(int(token), None)
+            if pending is not None:
+                self._restore_timing_window_locked(pending)
+
+    def _restore_timing_window_locked(
+        self, pending: _EventPipelineTimingWindow
+    ) -> None:
+        self._timing_window_started_ns = min(
+            int(pending.started_ns), int(self._timing_window_started_ns)
+        )
+        self._timing_processed_count += int(pending.processed_count)
+        self._timing_queue_wait_ns_total += int(pending.queue_wait_ns_total)
+        self._timing_queue_wait_ns_max = max(
+            self._timing_queue_wait_ns_max, int(pending.queue_wait_ns_max)
+        )
+        self._timing_worker_service_ns_total += int(pending.worker_service_ns_total)
+        self._timing_worker_service_ns_max = max(
+            self._timing_worker_service_ns_max, int(pending.worker_service_ns_max)
+        )
 
     def emit(
         self,
@@ -1909,7 +2015,12 @@ class LiveEventPipeline:
                     )
                 else:
                     try:
-                        self._queue.put_nowait(live_event)
+                        self._queue.put_nowait(
+                            _QueuedLiveEvent(
+                                event=live_event,
+                                enqueued_ns=time.monotonic_ns(),
+                            )
+                        )
                     except queue.Full:
                         enqueued = False
                         with self._state_lock:
@@ -1981,14 +2092,34 @@ class LiveEventPipeline:
             try:
                 if item is None:
                     return
-                route = self.route_for(item)
+                service_started_ns = time.monotonic_ns()
+                live_event = item.event
+                route = self.route_for(live_event)
                 if route.structured:
                     for sink in self.structured_sinks:
-                        self._write_sink("structured", sink, item)
+                        self._write_sink("structured", sink, live_event)
                 if route.monitor:
                     for sink in self.monitor_sinks:
-                        self._write_sink("monitor", sink, item)
+                        self._write_sink("monitor", sink, live_event)
             finally:
+                if item is not None:
+                    service_finished_ns = time.monotonic_ns()
+                    queue_wait_ns = max(
+                        0, int(service_started_ns) - int(item.enqueued_ns)
+                    )
+                    service_ns = max(
+                        0, int(service_finished_ns) - int(service_started_ns)
+                    )
+                    with self._state_lock:
+                        self._timing_processed_count += 1
+                        self._timing_queue_wait_ns_total += queue_wait_ns
+                        self._timing_queue_wait_ns_max = max(
+                            self._timing_queue_wait_ns_max, queue_wait_ns
+                        )
+                        self._timing_worker_service_ns_total += service_ns
+                        self._timing_worker_service_ns_max = max(
+                            self._timing_worker_service_ns_max, service_ns
+                        )
                 self._queue.task_done()
 
     def _write_sink(self, name: str, sink: LiveEventSink, event: LiveEvent) -> Any:

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1292,9 +1292,9 @@ def emit_startup_timing_event(bot: Any, *args: Any, **kwargs: Any) -> None:
 def _emit_health_summary_event_unchecked(
     bot: Any,
     payload: dict[str, Any],
-) -> None:
+) -> Any:
     data = dict(payload or {})
-    _safe_emit(
+    return _safe_emit(
         bot,
         EventTypes.HEALTH_SUMMARY,
         level="info",
@@ -1304,14 +1304,16 @@ def _emit_health_summary_event_unchecked(
         status="succeeded",
         reason_code=ReasonCodes.PERIODIC_HEALTH_SUMMARY,
         data=data,
+        require_enqueue=True,
     )
 
 
-def emit_health_summary_event(bot: Any, *args: Any, **kwargs: Any) -> None:
+def emit_health_summary_event(bot: Any, *args: Any, **kwargs: Any) -> Any:
     try:
-        _emit_health_summary_event_unchecked(bot, *args, **kwargs)
+        return _emit_health_summary_event_unchecked(bot, *args, **kwargs)
     except Exception as exc:
         logging.debug("[event] failed to emit health summary event: %s", exc)
+        return None
 
 
 def _emit_market_snapshot_diagnostic_skipped_event_unchecked(

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -99,6 +99,12 @@ _RESOURCE_PRESSURE_FIELDS = (
     "event_dropped_total",
     "event_sink_error_total",
     "event_degraded_count",
+    "event_pipeline_timing_window_ms",
+    "event_pipeline_processed_count",
+    "event_queue_wait_ms_total",
+    "event_queue_wait_ms_max",
+    "event_worker_service_ms_total",
+    "event_worker_service_ms_max",
 )
 _RESOURCE_PRESSURE_COUNTER_FIELDS = (
     "event_drop_counts",
@@ -3889,7 +3895,9 @@ class _ResourcePressureAccumulator:
             for group in groups
             if group.get("latest_event_age_ms") is not None
         ]
-        def latest_field_int(group: dict[str, Any], field: str) -> int | None:
+        def latest_field_number(
+            group: dict[str, Any], field: str
+        ) -> float | int | None:
             fields = group.get("fields")
             if not isinstance(fields, dict):
                 return None
@@ -3897,9 +3905,32 @@ class _ResourcePressureAccumulator:
             if not isinstance(stats, dict):
                 return None
             value = stats.get("latest")
-            if value is None:
+            return _non_negative_number(value)
+
+        def latest_field_int(group: dict[str, Any], field: str) -> int | None:
+            value = latest_field_number(group, field)
+            return None if value is None else int(value)
+
+        def latest_field_max(field: str) -> float | int | None:
+            values = [
+                value
+                for group in groups
+                for value in [latest_field_number(group, field)]
+                if value is not None
+            ]
+            return max(values) if values else None
+
+        def latest_field_sum(field: str) -> float | int | None:
+            values = [
+                value
+                for group in groups
+                for value in [latest_field_number(group, field)]
+                if value is not None
+            ]
+            if not values:
                 return None
-            return int(value)
+            total = sum(float(value) for value in values)
+            return int(total) if total.is_integer() else round(total, 3)
 
         latest_queue_depths = [
             value
@@ -3944,6 +3975,24 @@ class _ResourcePressureAccumulator:
             "latest_event_dropped_total_sum": dropped_total_latest_sum,
             "latest_event_sink_error_total_sum": sink_error_total_latest_sum,
             "latest_event_degraded_count_sum": degraded_count_latest_sum,
+            "latest_event_pipeline_processed_total": latest_field_sum(
+                "event_pipeline_processed_count"
+            ),
+            "latest_event_pipeline_timing_window_ms_max": latest_field_max(
+                "event_pipeline_timing_window_ms"
+            ),
+            "latest_event_queue_wait_ms_total_sum": latest_field_sum(
+                "event_queue_wait_ms_total"
+            ),
+            "latest_event_queue_wait_ms_max": latest_field_max(
+                "event_queue_wait_ms_max"
+            ),
+            "latest_event_worker_service_ms_total_sum": latest_field_sum(
+                "event_worker_service_ms_total"
+            ),
+            "latest_event_worker_service_ms_max": latest_field_max(
+                "event_worker_service_ms_max"
+            ),
             "event_pipeline_unhealthy_bots": unhealthy_bots,
             "groups_truncated": len(groups) > limit,
             "groups": groups[:limit],

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -2800,6 +2800,12 @@ def _event_pipeline_health_group(
         "event_degraded_count",
         "event_pipeline_stopping",
         "event_pipeline_worker_alive",
+        "event_pipeline_timing_window_ms",
+        "event_pipeline_processed_count",
+        "event_queue_wait_ms_total",
+        "event_queue_wait_ms_max",
+        "event_worker_service_ms_total",
+        "event_worker_service_ms_max",
     }
     if not any(key in payload for key in observed_keys):
         return None
@@ -2825,6 +2831,24 @@ def _event_pipeline_health_group(
             payload.get("event_sink_error_counts")
         ),
         "latest_degraded_count": _non_negative_int(payload.get("event_degraded_count")),
+        "latest_timing_window_ms": _non_negative_number(
+            payload.get("event_pipeline_timing_window_ms")
+        ),
+        "latest_processed_count": _non_negative_int(
+            payload.get("event_pipeline_processed_count")
+        ),
+        "latest_queue_wait_ms_total": _non_negative_number(
+            payload.get("event_queue_wait_ms_total")
+        ),
+        "latest_queue_wait_ms_max": _non_negative_number(
+            payload.get("event_queue_wait_ms_max")
+        ),
+        "latest_worker_service_ms_total": _non_negative_number(
+            payload.get("event_worker_service_ms_total")
+        ),
+        "latest_worker_service_ms_max": _non_negative_number(
+            payload.get("event_worker_service_ms_max")
+        ),
         "latest_pipeline_stopping": (
             bool(payload.get("event_pipeline_stopping"))
             if "event_pipeline_stopping" in payload
@@ -2879,6 +2903,12 @@ def _merge_event_pipeline_health_group(
             "latest_sink_error_total",
             "latest_sink_error_counts",
             "latest_degraded_count",
+            "latest_timing_window_ms",
+            "latest_processed_count",
+            "latest_queue_wait_ms_total",
+            "latest_queue_wait_ms_max",
+            "latest_worker_service_ms_total",
+            "latest_worker_service_ms_max",
             "latest_pipeline_stopping",
             "latest_worker_alive",
             "latest_ids",
@@ -2910,7 +2940,7 @@ def _summarize_event_pipeline_health(
         }
         for group in ordered[:EVENT_PIPELINE_HEALTH_GROUP_LIMIT]
     ]
-    return {
+    out = {
         "total": sum(int(group.get("count", 0)) for group in groups.values()),
         "groups_truncated": len(ordered) > EVENT_PIPELINE_HEALTH_GROUP_LIMIT,
         "event_types": dict(event_type_counts.most_common()),
@@ -2940,6 +2970,33 @@ def _summarize_event_pipeline_health(
         ),
         "groups": compact_groups,
     }
+    processed_counts = [
+        int(value)
+        for group in groups.values()
+        if (value := _non_negative_int(group.get("latest_processed_count")))
+        is not None
+    ]
+    timing_fields = {
+        "latest_timing_window_ms_max": _max_optional_numbers(
+            group.get("latest_timing_window_ms") for group in groups.values()
+        ),
+        "latest_queue_wait_ms_total_sum": _sum_optional_numbers(
+            group.get("latest_queue_wait_ms_total") for group in groups.values()
+        ),
+        "latest_queue_wait_ms_max": _max_optional_numbers(
+            group.get("latest_queue_wait_ms_max") for group in groups.values()
+        ),
+        "latest_worker_service_ms_total_sum": _sum_optional_numbers(
+            group.get("latest_worker_service_ms_total") for group in groups.values()
+        ),
+        "latest_worker_service_ms_max": _max_optional_numbers(
+            group.get("latest_worker_service_ms_max") for group in groups.values()
+        ),
+    }
+    if processed_counts:
+        out["latest_processed_total"] = sum(processed_counts)
+    out.update({key: value for key, value in timing_fields.items() if value is not None})
+    return out
 
 
 def _resource_pressure_group(
@@ -4057,6 +4114,37 @@ def _numeric_value(value: Any) -> int | float | None:
     if parsed.is_integer():
         return int(parsed)
     return round(parsed, 6)
+
+
+def _non_negative_number(value: Any) -> int | float | None:
+    parsed = _numeric_value(value)
+    if parsed is None or float(parsed) < 0.0:
+        return None
+    return parsed
+
+
+def _sum_optional_numbers(values: Iterable[Any]) -> int | float | None:
+    parsed = [
+        value
+        for item in values
+        if (value := _non_negative_number(item)) is not None
+    ]
+    if not parsed:
+        return None
+    total = sum(float(value) for value in parsed)
+    return int(total) if total.is_integer() else round(total, 6)
+
+
+def _max_optional_numbers(values: Iterable[Any]) -> int | float | None:
+    parsed = [
+        value
+        for item in values
+        if (value := _non_negative_number(item)) is not None
+    ]
+    if not parsed:
+        return None
+    maximum = max(float(value) for value in parsed)
+    return int(maximum) if maximum.is_integer() else round(maximum, 6)
 
 
 def _compact_hsl_replay_data(live_event: dict[str, Any]) -> dict[str, Any]:
@@ -6859,6 +6947,20 @@ def _summary_limited_groups(
             "latest_dropped_total": summary.get("latest_dropped_total"),
             "latest_sink_error_total": summary.get("latest_sink_error_total"),
             "latest_degraded_total": summary.get("latest_degraded_total"),
+            "latest_processed_total": summary.get("latest_processed_total"),
+            "latest_timing_window_ms_max": summary.get(
+                "latest_timing_window_ms_max"
+            ),
+            "latest_queue_wait_ms_total_sum": summary.get(
+                "latest_queue_wait_ms_total_sum"
+            ),
+            "latest_queue_wait_ms_max": summary.get("latest_queue_wait_ms_max"),
+            "latest_worker_service_ms_total_sum": summary.get(
+                "latest_worker_service_ms_total_sum"
+            ),
+            "latest_worker_service_ms_max": summary.get(
+                "latest_worker_service_ms_max"
+            ),
             "latest_worker_not_alive_count": summary.get(
                 "latest_worker_not_alive_count"
             ),
@@ -8246,30 +8348,52 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         },
         "staged_readiness": staged_readiness_brief,
         "event_pipeline": {
-            "total": _count_value(event_pipeline_health.get("total")),
-            "bots": _count_value(event_pipeline_health.get("bots")),
-            "latest_queue_depth_total": _count_value(
-                event_pipeline_health.get("latest_queue_depth_total")
-            ),
-            "latest_queue_unfinished_total": _count_value(
-                event_pipeline_health.get("latest_queue_unfinished_total")
-            ),
-            "latest_dropped_total": _count_value(
-                event_pipeline_health.get("latest_dropped_total")
-            ),
-            "latest_sink_error_total": _count_value(
-                event_pipeline_health.get("latest_sink_error_total")
-            ),
-            "latest_degraded_total": _count_value(
-                event_pipeline_health.get("latest_degraded_total")
-            ),
-            "latest_worker_not_alive_count": _count_value(
-                event_pipeline_health.get("latest_worker_not_alive_count")
-            ),
-            "latest_stopping_count": _count_value(
-                event_pipeline_health.get("latest_stopping_count")
-            ),
-            "event_types": event_pipeline_health.get("event_types") or {},
+            key: value
+            for key, value in {
+                "total": _count_value(event_pipeline_health.get("total")),
+                "bots": _count_value(event_pipeline_health.get("bots")),
+                "latest_queue_depth_total": _count_value(
+                    event_pipeline_health.get("latest_queue_depth_total")
+                ),
+                "latest_queue_unfinished_total": _count_value(
+                    event_pipeline_health.get("latest_queue_unfinished_total")
+                ),
+                "latest_dropped_total": _count_value(
+                    event_pipeline_health.get("latest_dropped_total")
+                ),
+                "latest_sink_error_total": _count_value(
+                    event_pipeline_health.get("latest_sink_error_total")
+                ),
+                "latest_degraded_total": _count_value(
+                    event_pipeline_health.get("latest_degraded_total")
+                ),
+                "latest_processed_total": event_pipeline_health.get(
+                    "latest_processed_total"
+                ),
+                "latest_timing_window_ms_max": event_pipeline_health.get(
+                    "latest_timing_window_ms_max"
+                ),
+                "latest_queue_wait_ms_total_sum": event_pipeline_health.get(
+                    "latest_queue_wait_ms_total_sum"
+                ),
+                "latest_queue_wait_ms_max": event_pipeline_health.get(
+                    "latest_queue_wait_ms_max"
+                ),
+                "latest_worker_service_ms_total_sum": event_pipeline_health.get(
+                    "latest_worker_service_ms_total_sum"
+                ),
+                "latest_worker_service_ms_max": event_pipeline_health.get(
+                    "latest_worker_service_ms_max"
+                ),
+                "latest_worker_not_alive_count": _count_value(
+                    event_pipeline_health.get("latest_worker_not_alive_count")
+                ),
+                "latest_stopping_count": _count_value(
+                    event_pipeline_health.get("latest_stopping_count")
+                ),
+                "event_types": event_pipeline_health.get("event_types") or {},
+            }.items()
+            if value is not None
         },
         "resource_pressure": {
             "total": _count_value(resource_pressure.get("total")),

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -2374,9 +2374,32 @@ class Passivbot:
         )
         emit_health_summary = getattr(self, "_emit_health_summary_event", None)
         if callable(emit_health_summary):
+            pipeline = getattr(self, "_live_event_pipeline", None)
+            confirm_timing = getattr(pipeline, "confirm_timing_snapshot", None)
+            restore_timing = getattr(pipeline, "restore_timing_snapshot", None)
+            timing_snapshot_token = None
             try:
-                emit_health_summary(self._build_health_summary_payload(now_ms=now_ms))
+                payload_result = self._build_health_summary_payload(
+                    now_ms=now_ms,
+                    reset_event_pipeline_timing=True,
+                )
+                if isinstance(payload_result, tuple):
+                    health_payload, timing_snapshot_token = payload_result
+                else:
+                    health_payload = payload_result
+                    timing_snapshot_token = None
+                emitted = emit_health_summary(health_payload)
+                if emitted is None:
+                    if callable(restore_timing) and timing_snapshot_token is not None:
+                        restore_timing(timing_snapshot_token)
+                elif callable(confirm_timing) and timing_snapshot_token is not None:
+                    confirm_timing(timing_snapshot_token)
             except Exception as exc:
+                if (
+                    callable(restore_timing)
+                    and timing_snapshot_token is not None
+                ):
+                    restore_timing(timing_snapshot_token)
                 logging.debug("[event] failed preparing health summary event: %s", exc)
         self._maybe_log_candle_health_summary()
 

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -444,7 +444,12 @@ def _monitor_handle_candlestick_persist(
     publisher.record_completed_candles(symbol, timeframe, candles)
 
 
-def _build_health_summary_payload(self, *, now_ms: Optional[int] = None) -> dict:
+def _build_health_summary_payload(
+    self,
+    *,
+    now_ms: Optional[int] = None,
+    reset_event_pipeline_timing: bool = False,
+) -> dict | tuple[dict, int | None]:
     now_ms = utc_ms() if now_ms is None else int(now_ms)
     n_long = 0
     n_short = 0
@@ -492,14 +497,28 @@ def _build_health_summary_payload(self, *, now_ms: Optional[int] = None) -> dict
     payload.update(_get_system_memory_payload())
     pipeline = getattr(self, "_live_event_pipeline", None)
     health_snapshot = getattr(pipeline, "health_snapshot", None)
+    timing_snapshot_token = None
     if callable(health_snapshot):
         try:
-            pipeline_payload = health_snapshot()
+            if reset_event_pipeline_timing:
+                consume_timing_snapshot = getattr(
+                    pipeline, "consume_timing_snapshot", None
+                )
+                if callable(consume_timing_snapshot):
+                    pipeline_payload, timing_snapshot_token = (
+                        consume_timing_snapshot()
+                    )
+                else:
+                    pipeline_payload = health_snapshot()
+            else:
+                pipeline_payload = health_snapshot()
         except Exception as exc:
             logging.debug("[monitor] event pipeline health snapshot unavailable: %s", exc)
             pipeline_payload = {}
         if isinstance(pipeline_payload, dict):
             payload.update(pipeline_payload)
+    if reset_event_pipeline_timing:
+        return payload, timing_snapshot_token
     return payload
 
 

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -7,6 +7,7 @@ import time
 
 import pytest
 
+import live.event_bus as live_event_bus_module
 from live.event_bus import (
     DEFAULT_ROUTES,
     EventRoute,
@@ -486,6 +487,117 @@ def test_pipeline_health_snapshot_reports_queue_and_degraded_counters():
     pipeline._queue.task_done()
 
 
+def test_pipeline_health_snapshot_tracks_and_consumes_queue_timing(monkeypatch):
+    clock = {"ns": 1_000_000_000}
+    monkeypatch.setattr(
+        live_event_bus_module.time,
+        "monotonic_ns",
+        lambda: clock["ns"],
+    )
+
+    class ControlledSink:
+        def write(self, event):
+            clock["ns"] += 3_000_000
+            return event
+
+    pipeline = LiveEventPipeline(
+        start=False,
+        structured_sinks=[ControlledSink()],
+        routes={
+            EventTypes.DATA_PACKET_UPDATED: EventRoute(
+                structured=True, monitor=False, console=False
+            )
+        },
+    )
+
+    assert pipeline.emit(LiveEvent(EventTypes.DATA_PACKET_UPDATED)) is not None
+    clock["ns"] += 7_000_000
+    pipeline.start()
+    assert pipeline.flush(timeout=2.0) is True
+
+    expected_timing = {
+        "event_pipeline_timing_window_ms": 10.0,
+        "event_pipeline_processed_count": 1,
+        "event_queue_wait_ms_total": 7.0,
+        "event_queue_wait_ms_max": 7.0,
+        "event_worker_service_ms_total": 3.0,
+        "event_worker_service_ms_max": 3.0,
+    }
+    non_consuming_snapshot = pipeline.health_snapshot()
+    assert {key: non_consuming_snapshot[key] for key in expected_timing} == expected_timing
+    repeated_snapshot = pipeline.health_snapshot()
+    assert {key: repeated_snapshot[key] for key in expected_timing} == expected_timing
+    consumed_snapshot, consumed_token = pipeline.consume_timing_snapshot()
+    assert {key: consumed_snapshot[key] for key in expected_timing} == expected_timing
+    pipeline.restore_timing_snapshot(consumed_token)
+    restored_snapshot = pipeline.health_snapshot()
+    assert {key: restored_snapshot[key] for key in expected_timing} == expected_timing
+    _confirmed_snapshot, confirmed_token = pipeline.consume_timing_snapshot()
+    pipeline.confirm_timing_snapshot(confirmed_token)
+    reset_snapshot = pipeline.health_snapshot()
+    assert {key: reset_snapshot[key] for key in expected_timing} == {
+        "event_pipeline_timing_window_ms": 0.0,
+        "event_pipeline_processed_count": 0,
+        "event_queue_wait_ms_total": 0.0,
+        "event_queue_wait_ms_max": 0.0,
+        "event_worker_service_ms_total": 0.0,
+        "event_worker_service_ms_max": 0.0,
+    }
+    assert pipeline.close(timeout=2.0) is True
+
+
+def test_pipeline_overlapping_timing_snapshots_resolve_by_token(monkeypatch):
+    clock = {"ns": 1_000_000_000}
+    monkeypatch.setattr(
+        live_event_bus_module.time,
+        "monotonic_ns",
+        lambda: clock["ns"],
+    )
+    pipeline = LiveEventPipeline(start=False)
+    pipeline._timing_processed_count = 7
+
+    first, first_token = pipeline.consume_timing_snapshot()
+    pipeline._timing_processed_count = 3
+    clock["ns"] += 1_000_000
+    second, second_token = pipeline.consume_timing_snapshot()
+    pipeline.confirm_timing_snapshot(first_token)
+    pipeline.restore_timing_snapshot(second_token)
+
+    assert first["event_pipeline_processed_count"] == 7
+    assert second["event_pipeline_processed_count"] == 3
+    assert pipeline.health_snapshot()["event_pipeline_processed_count"] == 3
+
+
+def test_pipeline_restore_merges_newly_processed_timing(monkeypatch):
+    clock = {"ns": 1_000_000_000}
+    monkeypatch.setattr(
+        live_event_bus_module.time,
+        "monotonic_ns",
+        lambda: clock["ns"],
+    )
+    pipeline = LiveEventPipeline(start=False)
+    pipeline._timing_processed_count = 5
+    pipeline._timing_queue_wait_ns_total = 8_000_000
+    pipeline._timing_queue_wait_ns_max = 3_000_000
+    pipeline._timing_worker_service_ns_total = 12_000_000
+    pipeline._timing_worker_service_ns_max = 5_000_000
+    _snapshot, token = pipeline.consume_timing_snapshot()
+
+    pipeline._timing_processed_count = 2
+    pipeline._timing_queue_wait_ns_total = 7_000_000
+    pipeline._timing_queue_wait_ns_max = 6_000_000
+    pipeline._timing_worker_service_ns_total = 4_000_000
+    pipeline._timing_worker_service_ns_max = 3_000_000
+    pipeline.restore_timing_snapshot(token)
+
+    restored = pipeline.health_snapshot()
+    assert restored["event_pipeline_processed_count"] == 7
+    assert restored["event_queue_wait_ms_total"] == 15
+    assert restored["event_queue_wait_ms_max"] == 6
+    assert restored["event_worker_service_ms_total"] == 16
+    assert restored["event_worker_service_ms_max"] == 5
+
+
 def test_pipeline_queue_overflow_is_logged_and_monitor_visible(caplog):
     monitor = ListEventSink()
     pipeline = LiveEventPipeline(
@@ -614,7 +726,7 @@ def test_pipeline_close_waits_for_in_flight_enqueue_before_sentinel():
             self.release_put_nowait = threading.Event()
 
         def put_nowait(self, item):
-            if isinstance(item, LiveEvent):
+            if isinstance(getattr(item, "event", item), LiveEvent):
                 self.entered_put_nowait.set()
                 assert self.release_put_nowait.wait(timeout=2.0)
             return super().put_nowait(item)

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -4811,6 +4811,105 @@ def test_live_performance_report_resource_pressure_from_health_summary(tmp_path,
     assert group["latest_event_pipeline_worker_alive"] is True
 
 
+def test_live_performance_report_resource_pressure_projects_event_pipeline_timing(
+    tmp_path,
+):
+    binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    okx_events = tmp_path / "monitor" / "okx" / "okx_01" / "events"
+    _write_ndjson(
+        binance_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="health.summary",
+                seq=1,
+                ts=1000,
+                data={
+                    "event_pipeline_timing_window_ms": 60,
+                    "event_pipeline_processed_count": 2,
+                    "event_queue_wait_ms_total": 1.5,
+                    "event_queue_wait_ms_max": 1.0,
+                    "event_worker_service_ms_total": 2.0,
+                    "event_worker_service_ms_max": 2.0,
+                },
+            ),
+            _monitor_row(
+                event_type="health.summary",
+                seq=2,
+                ts=2000,
+                data={
+                    "event_pipeline_timing_window_ms": 120,
+                    "event_pipeline_processed_count": 5,
+                    "event_queue_wait_ms_total": 4.5,
+                    "event_queue_wait_ms_max": 3.0,
+                    "event_worker_service_ms_total": 7.5,
+                    "event_worker_service_ms_max": 4.0,
+                },
+            ),
+        ],
+    )
+    _write_ndjson(
+        okx_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="health.summary",
+                exchange="okx",
+                user="okx_01",
+                seq=3,
+                ts=1500,
+                data={
+                    "event_pipeline_timing_window_ms": 90,
+                    "event_pipeline_processed_count": 3,
+                    "event_queue_wait_ms_total": 2.25,
+                    "event_queue_wait_ms_max": 2.25,
+                    "event_worker_service_ms_total": 3.5,
+                    "event_worker_service_ms_max": 3.5,
+                },
+            )
+        ],
+    )
+
+    pressure = build_live_performance_report(tmp_path / "monitor")["resource_pressure"]
+    groups = {group["bot"]: group for group in pressure["groups"]}
+    binance_fields = groups["binance/binance_01"]["fields"]
+    assert binance_fields["event_pipeline_processed_count"] == {
+        "latest": 5,
+        "count": 2,
+        "min": 2,
+        "max": 5,
+        "mean": 4,
+        "median": 4,
+        "p95": 5,
+    }
+    assert binance_fields["event_queue_wait_ms_total"] == {
+        "latest": 4.5,
+        "count": 2,
+        "min": 1.5,
+        "max": 4.5,
+        "mean": 3,
+        "median": 3,
+        "p95": 4.35,
+    }
+    assert binance_fields["event_worker_service_ms_max"]["latest"] == 4
+    assert {
+        key: pressure[key]
+        for key in (
+            "latest_event_pipeline_processed_total",
+            "latest_event_pipeline_timing_window_ms_max",
+            "latest_event_queue_wait_ms_total_sum",
+            "latest_event_queue_wait_ms_max",
+            "latest_event_worker_service_ms_total_sum",
+            "latest_event_worker_service_ms_max",
+        )
+    } == {
+        "latest_event_pipeline_processed_total": 8,
+        "latest_event_pipeline_timing_window_ms_max": 120,
+        "latest_event_queue_wait_ms_total_sum": 6.75,
+        "latest_event_queue_wait_ms_max": 3,
+        "latest_event_worker_service_ms_total_sum": 11,
+        "latest_event_worker_service_ms_max": 4,
+    }
+
+
 def test_live_performance_report_resource_pressure_whitelists_health_fields(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2692,6 +2692,74 @@ def test_live_smoke_report_event_pipeline_health_aggregates_multi_bot_queue_over
     }
 
 
+def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
+    okx_events = tmp_path / "monitor" / "okx" / "okx_01" / "events"
+    gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        okx_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="health.summary",
+                exchange="okx",
+                user="okx_01",
+                seq=1,
+                ts=2000,
+                data={
+                    "event_pipeline_timing_window_ms": 1250.0,
+                    "event_pipeline_processed_count": 8,
+                    "event_queue_wait_ms_total": 12.5,
+                    "event_queue_wait_ms_max": 8.5,
+                    "event_worker_service_ms_total": 20.25,
+                    "event_worker_service_ms_max": 15.5,
+                },
+            )
+        ],
+    )
+    _write_ndjson(
+        gateio_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="health.summary",
+                exchange="gateio",
+                user="gateio_01",
+                seq=2,
+                ts=1500,
+                data={
+                    "event_pipeline_timing_window_ms": 900.0,
+                    "event_pipeline_processed_count": 3,
+                    "event_queue_wait_ms_total": 6.5,
+                    "event_queue_wait_ms_max": 6.5,
+                    "event_worker_service_ms_total": 7.75,
+                    "event_worker_service_ms_max": 7.75,
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    summary = summarize_live_smoke_report(report)
+    brief = summarize_live_smoke_report_brief(report)
+    health = report["event_pipeline_health"]
+
+    groups = {group["bot"]: group for group in health["groups"]}
+    assert groups["okx/okx_01"].get("latest_processed_count") == 8
+    assert groups["okx/okx_01"].get("latest_queue_wait_ms_max") == 8.5
+    assert groups["gateio/gateio_01"].get("latest_worker_service_ms_max") == 7.75
+    expected = {
+        "latest_processed_total": 11,
+        "latest_timing_window_ms_max": 1250,
+        "latest_queue_wait_ms_total_sum": 19,
+        "latest_queue_wait_ms_max": 8.5,
+        "latest_worker_service_ms_total_sum": 28,
+        "latest_worker_service_ms_max": 15.5,
+    }
+    assert {key: health[key] for key in expected} == expected
+    assert {key: summary["event_pipeline_health"][key] for key in expected} == expected
+    assert {key: brief["event_pipeline"][key] for key in expected} == expected
+    assert report["ok"] is True
+    assert report["attention"] is False
+
+
 def test_live_smoke_report_problem_events_include_cycle_degraded_details(tmp_path):
     events_dir = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
     _write_ndjson(

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1335,7 +1335,19 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
     import passivbot as pb_mod
 
     class FakePipeline:
+        def __init__(self):
+            self.consume_timing_calls = []
+
         def health_snapshot(self):
+            self.consume_timing_calls.append(False)
+            return self._snapshot()
+
+        def consume_timing_snapshot(self):
+            self.consume_timing_calls.append(True)
+            return self._snapshot(), 41
+
+        @staticmethod
+        def _snapshot():
             return {
                 "event_queue_depth": 3,
                 "event_queue_maxsize": 100,
@@ -1345,6 +1357,12 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
                 "event_sink_error_counts": {"monitor": 1},
                 "event_degraded_count": 4,
                 "event_pipeline_worker_alive": True,
+                "event_pipeline_timing_window_ms": 60_000.5,
+                "event_pipeline_processed_count": 120,
+                "event_queue_wait_ms_total": 45.25,
+                "event_queue_wait_ms_max": 7.5,
+                "event_worker_service_ms_total": 98.75,
+                "event_worker_service_ms_max": 12.25,
             }
 
     class FakeBot:
@@ -1407,7 +1425,8 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
         },
     )
 
-    payload = FakeBot()._build_health_summary_payload(now_ms=160_000)
+    bot = FakeBot()
+    payload = bot._build_health_summary_payload(now_ms=160_000)
 
     assert payload["uptime_ms"] == 60_000
     assert payload["health_summary_lag_ms"] == 2345
@@ -1435,6 +1454,21 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
     assert payload["event_sink_error_counts"] == {"monitor": 1}
     assert payload["event_degraded_count"] == 4
     assert payload["event_pipeline_worker_alive"] is True
+    assert payload["event_pipeline_timing_window_ms"] == 60_000.5
+    assert payload["event_pipeline_processed_count"] == 120
+    assert payload["event_queue_wait_ms_total"] == 45.25
+    assert payload["event_queue_wait_ms_max"] == 7.5
+    assert payload["event_worker_service_ms_total"] == 98.75
+    assert payload["event_worker_service_ms_max"] == 12.25
+    assert bot._live_event_pipeline.consume_timing_calls == [False]
+
+    consumed_payload, timing_token = bot._build_health_summary_payload(
+        now_ms=160_000,
+        reset_event_pipeline_timing=True,
+    )
+    assert consumed_payload["event_pipeline_processed_count"] == 120
+    assert timing_token == 41
+    assert bot._live_event_pipeline.consume_timing_calls == [False, True]
 
 
 def test_process_cpu_percent_reuses_psutil_process(monkeypatch):
@@ -1512,6 +1546,7 @@ def test_log_health_summary_emits_structured_event(caplog, monkeypatch):
             self.error_counts = [190000]
             self.candle_health_called = False
             self.payload_now_ms = None
+            self.payload_reset_event_pipeline_timing = None
             self._live_event_current_cycle_id = "cy_health"
             self._live_event_pipeline = LiveEventPipeline(
                 structured_sinks=[sink],
@@ -1524,9 +1559,15 @@ def test_log_health_summary_emits_structured_event(caplog, monkeypatch):
         def get_hysteresis_snapped_balance(self):
             return 999.5
 
-        def _build_health_summary_payload(self, *, now_ms=None):
+        def _build_health_summary_payload(
+            self,
+            *,
+            now_ms=None,
+            reset_event_pipeline_timing=False,
+        ):
             self.payload_now_ms = now_ms
-            return {
+            self.payload_reset_event_pipeline_timing = reset_event_pipeline_timing
+            payload = {
                 "uptime_ms": 60000,
                 "last_loop_duration_ms": 2500,
                 "positions_long": 1,
@@ -1542,12 +1583,27 @@ def test_log_health_summary_emits_structured_event(caplog, monkeypatch):
                 "rate_limits": 5,
                 "rss_bytes": 987654,
             }
+            return (payload, 17) if reset_event_pipeline_timing else payload
 
         def _maybe_log_candle_health_summary(self):
             self.candle_health_called = True
 
     monkeypatch.setattr(pb_mod, "utc_ms", lambda: 200000)
     bot = FakeBot()
+    confirmed = []
+    restored = []
+    original_confirm = bot._live_event_pipeline.confirm_timing_snapshot
+    original_restore = bot._live_event_pipeline.restore_timing_snapshot
+    def confirm_timing(token):
+        confirmed.append(token)
+        original_confirm(token)
+
+    def restore_timing(token):
+        restored.append(token)
+        original_restore(token)
+
+    bot._live_event_pipeline.confirm_timing_snapshot = confirm_timing
+    bot._live_event_pipeline.restore_timing_snapshot = restore_timing
 
     with caplog.at_level(logging.INFO):
         bot._log_health_summary()
@@ -1557,13 +1613,41 @@ def test_log_health_summary_emits_structured_event(caplog, monkeypatch):
     assert "orders=+2/-1" in caplog.text
     assert bot.candle_health_called is True
     assert bot.payload_now_ms == 200000
+    assert bot.payload_reset_event_pipeline_timing is True
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     event = sink.events[0]
     assert event.event_type == EventTypes.HEALTH_SUMMARY
     assert event.cycle_id == "cy_health"
     assert event.data["rss_bytes"] == 987654
     assert event.data["errors_last_hour"] == 1
+    assert confirmed == [17]
+    assert restored == []
+
+    bot._emit_health_summary_event = lambda _payload: None
+    bot._log_health_summary()
+    assert confirmed == [17]
+    assert restored == [17]
     assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_health_summary_event_requires_successful_enqueue():
+    class FakeBot:
+        exchange = "okx"
+        user = "okx_01"
+        bot_id = "bot_1"
+        _live_event_current_cycle_id = "cy_health"
+
+        def __init__(self):
+            self.kwargs = None
+
+        def _emit_live_event(self, _event_type, **kwargs):
+            self.kwargs = kwargs
+            return None
+
+    bot = FakeBot()
+
+    assert live_event_emitters.emit_health_summary_event(bot, {"uptime_ms": 1}) is None
+    assert bot.kwargs["require_enqueue"] is True
 
 
 def test_maybe_log_health_summary_tracks_scheduler_lag(monkeypatch):


### PR DESCRIPTION
## Scope

Category: observability producer and read-only report consumers.

Adds bounded per-health-window event-pipeline timing evidence:

- processed event count
- queue-wait total and maximum
- worker sink-service total and maximum
- timing-window duration

Private queue envelopes use a monotonic timestamp. No timing metadata is added
to `LiveEvent` payloads.

## Transaction contract

- Ordinary monitor snapshots are non-consuming.
- Periodic `health.summary` atomically rotates a timing window and receives an
  opaque private token.
- Successful required enqueue confirms that token.
- Failed enqueue restores and merges the exact window with any events processed
  after rotation.
- Overlapping windows resolve independently by token, including out-of-order
  confirm/restore.
- Tokens never enter structured events or reports.

Smoke event-pipeline summaries and performance resource-pressure reports expose
only fixed numeric fields and bounded latest/distribution aggregates.

## Non-goals

No queue capacity, backpressure, drop policy, routing, sink persistence,
readiness, risk, HSL, order, Rust, backtest, optimizer, exchange, smoke-verdict,
alert, threshold, histogram, sampled slow-event, or trading behavior change.

## Validation

- Event bus + monitor + smoke + performance suites: 340 passed
- Fake-live suite: 29 passed
- Incident bundle + restart smoke plan: 49 passed
- Total unique tests: 418 passed
- Python compilation passed for all changed runtime modules
- `git diff --check` passed
- added-line silent-handling audit passed
- independent architecture preflight found and re-reviewed two timing-window
  transaction races; final exact-diff preflight: green, no findings

Backtest and optimizer smokes are not applicable because no trading or strategy
behavior changes.

## VPS action

After merge: gracefully restart only the five exact supervised bot panes,
preserve unrelated processes and local artifacts, query fresh bounded
`health.summary`/smoke/performance timing evidence, and require immediate plus
settled smoke acceptance.

## Reviewer focus

Please verify monotonic timing boundaries, queue-envelope and close/flush
semantics, tokenized overlap/failure restoration, lock ordering, required health
enqueue acknowledgement, sink-failure accounting, historical missing-field
semantics, bounded report aggregation, and trading/delivery/verdict isolation.
