### PR TITLE
Refresh v8 canon long defaults

### DIFF
--- a/configs/examples/default_trailing_martingale_long.json
+++ b/configs/examples/default_trailing_martingale_long.json
@@ -160,30 +160,30 @@
     "bot": {
         "long": {
             "forager": {
-                "score_weights": {"ema_readiness": 0.2, "volatility": 0.34, "volume": 0.46},
-                "volatility_ema_span_1m": 187.0,
-                "volume_drop_pct": 0.02,
-                "volume_ema_span_1m": 1280.0
+                "score_weights": {"ema_readiness": 0.18, "volatility": 0.36, "volume": 0.46},
+                "volatility_ema_span_1m": 360.0,
+                "volume_drop_pct": 0.06,
+                "volume_ema_span_1m": 1400.0
             },
             "hsl": {
-                "cooldown_minutes_after_red": 4041.0,
-                "ema_span_minutes": 639.0,
+                "cooldown_minutes_after_red": 2160.0,
+                "ema_span_minutes": 720.0,
                 "enabled": false,
                 "no_restart_drawdown_threshold": 1,
                 "orange_tier_mode": "tp_only_with_active_entry_cancellation",
                 "panic_close_order_type": "limit",
-                "red_threshold": 0.117,
+                "red_threshold": 0.15,
                 "restart_after_red_policy": "threshold",
                 "tier_ratios": {"orange": 0.75, "yellow": 0.5}
             },
             "risk": {
-                "entry_cooldown_minutes": 7.3,
+                "entry_cooldown_minutes": 7.4,
                 "n_positions": 5.0,
                 "position_exposure_enforcer_enabled": false,
                 "position_exposure_enforcer_threshold": 1.0,
                 "total_exposure_enforcer_enabled": true,
                 "total_exposure_enforcer_policy": "reduce_overweight",
-                "total_exposure_enforcer_threshold": 1.002,
+                "total_exposure_enforcer_threshold": 1.0,
                 "total_exposure_entry_gate_enabled": true,
                 "total_wallet_exposure_limit": 1.5,
                 "we_excess_allowance_mode": "bounded",
@@ -192,42 +192,42 @@
             "strategy": {
                 "trailing_martingale": {
                     "close": {
-                        "qty_pct": 0.22,
-                        "retracement_base_pct": 0.0001,
-                        "retracement_volatility_1h_weight": 5.8,
-                        "retracement_volatility_1m_weight": 39.03,
-                        "threshold_base_pct": -0.0179,
-                        "threshold_volatility_1h_weight": 0.13,
+                        "qty_pct": 0.55,
+                        "retracement_base_pct": 0.0002,
+                        "retracement_volatility_1h_weight": 17.79,
+                        "retracement_volatility_1m_weight": 36.11,
+                        "threshold_base_pct": -0.014,
+                        "threshold_volatility_1h_weight": 0.37,
                         "threshold_volatility_1m_weight": 7.94,
-                        "threshold_we_weight": 0.0148
+                        "threshold_we_weight": -0.0282
                     },
-                    "ema_span_0": 130.0,
-                    "ema_span_1": 130.0,
+                    "ema_span_0": 120.0,
+                    "ema_span_1": 120.0,
                     "entry": {
-                        "double_down_factor": 0.68,
+                        "double_down_factor": 0.67,
                         "ema_gate_mode": "all",
-                        "initial_ema_dist": 0.0184,
-                        "initial_qty_pct": 0.0673,
+                        "initial_ema_dist": 0.019,
+                        "initial_qty_pct": 0.0727,
                         "retracement_base_pct": 0.0011,
-                        "retracement_volatility_1h_weight": 13.35,
-                        "retracement_volatility_1m_weight": 18.54,
-                        "retracement_we_weight": 4.575,
+                        "retracement_volatility_1h_weight": 22.09,
+                        "retracement_volatility_1m_weight": 23.1,
+                        "retracement_we_weight": 0.998,
                         "threshold_base_pct": 0.0248,
-                        "threshold_volatility_1h_weight": 1.64,
-                        "threshold_volatility_1m_weight": 35.21,
-                        "threshold_we_weight": 4.107
+                        "threshold_volatility_1h_weight": 1.67,
+                        "threshold_volatility_1m_weight": 25.76,
+                        "threshold_we_weight": 4.066
                     },
-                    "volatility_ema_span_1h": 1537.0,
-                    "volatility_ema_span_1m": 1425.0
+                    "volatility_ema_span_1h": 784.0,
+                    "volatility_ema_span_1m": 1131.0
                 }
             },
             "unstuck": {
-                "close_pct": 0.024,
-                "ema_dist": -0.1238,
+                "close_pct": 0.105,
+                "ema_dist": -0.0809,
                 "ema_gating_enabled": true,
                 "enabled": true,
-                "loss_allowance_pct": 0.0063,
-                "threshold": 0.432
+                "loss_allowance_pct": 0.0071,
+                "threshold": 0.425
             }
         },
         "short": {

--- a/passivbot-rust/src/strategies/spec.rs
+++ b/passivbot-rust/src/strategies/spec.rs
@@ -52,7 +52,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "ema_span_0",
         path: &["ema_span_0"],
-        long_default: 130.0,
+        long_default: 120.0,
         short_default: 60.0,
         long_bounds: &[100.0, 2880.0, 10.0],
         short_bounds: &[100.0, 2880.0, 10.0],
@@ -60,7 +60,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "ema_span_1",
         path: &["ema_span_1"],
-        long_default: 130.0,
+        long_default: 120.0,
         short_default: 60.0,
         long_bounds: &[100.0, 2880.0, 10.0],
         short_bounds: &[100.0, 2880.0, 10.0],
@@ -68,7 +68,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "volatility_ema_span_1h",
         path: &["volatility_ema_span_1h"],
-        long_default: 1537.0,
+        long_default: 784.0,
         short_default: 672.0,
         long_bounds: &[168.0, 2016.0, 1.0],
         short_bounds: &[168.0, 2016.0, 1.0],
@@ -76,7 +76,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "volatility_ema_span_1m",
         path: &["volatility_ema_span_1m"],
-        long_default: 1425.0,
+        long_default: 1131.0,
         short_default: 5.0,
         long_bounds: &[5.0, 1440.0, 1.0],
         short_bounds: &[5.0, 1440.0, 1.0],
@@ -84,7 +84,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_double_down_factor",
         path: &["entry", "double_down_factor"],
-        long_default: 0.68,
+        long_default: 0.67,
         short_default: 0.2,
         long_bounds: &[0.2, 1.0, 0.01],
         short_bounds: &[0.2, 1.0, 0.01],
@@ -92,7 +92,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_initial_qty_pct",
         path: &["entry", "initial_qty_pct"],
-        long_default: 0.0673,
+        long_default: 0.0727,
         short_default: 0.005,
         long_bounds: &[0.005, 0.1, 0.0001],
         short_bounds: &[0.005, 0.1, 0.0001],
@@ -100,7 +100,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_initial_ema_dist",
         path: &["entry", "initial_ema_dist"],
-        long_default: 0.0184,
+        long_default: 0.019,
         short_default: -0.1,
         long_bounds: &[-0.1, 0.02, 0.0001],
         short_bounds: &[-0.1, 0.02, 0.0001],
@@ -116,7 +116,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_threshold_we_weight",
         path: &["entry", "threshold_we_weight"],
-        long_default: 4.107,
+        long_default: 4.066,
         short_default: 0.0,
         long_bounds: &[0.0, 5.0, 0.001],
         short_bounds: &[0.0, 5.0, 0.001],
@@ -124,7 +124,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_threshold_volatility_1h_weight",
         path: &["entry", "threshold_volatility_1h_weight"],
-        long_default: 1.64,
+        long_default: 1.67,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -132,7 +132,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_threshold_volatility_1m_weight",
         path: &["entry", "threshold_volatility_1m_weight"],
-        long_default: 35.21,
+        long_default: 25.76,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -148,7 +148,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_retracement_we_weight",
         path: &["entry", "retracement_we_weight"],
-        long_default: 4.575,
+        long_default: 0.998,
         short_default: 0.0,
         long_bounds: &[0.0, 5.0, 0.001],
         short_bounds: &[0.0, 5.0, 0.001],
@@ -156,7 +156,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_retracement_volatility_1h_weight",
         path: &["entry", "retracement_volatility_1h_weight"],
-        long_default: 13.35,
+        long_default: 22.09,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -164,7 +164,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "entry_retracement_volatility_1m_weight",
         path: &["entry", "retracement_volatility_1m_weight"],
-        long_default: 18.54,
+        long_default: 23.1,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -172,7 +172,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_qty_pct",
         path: &["close", "qty_pct"],
-        long_default: 0.22,
+        long_default: 0.55,
         short_default: 0.05,
         long_bounds: &[0.05, 1.0, 0.01],
         short_bounds: &[0.05, 1.0, 0.01],
@@ -180,7 +180,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_threshold_base_pct",
         path: &["close", "threshold_base_pct"],
-        long_default: -0.0179,
+        long_default: -0.014,
         short_default: -0.02,
         long_bounds: &[-0.02, 0.02, 0.0001],
         short_bounds: &[-0.02, 0.02, 0.0001],
@@ -188,7 +188,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_threshold_we_weight",
         path: &["close", "threshold_we_weight"],
-        long_default: 0.0148,
+        long_default: -0.0282,
         short_default: -0.1,
         long_bounds: &[-0.1, 0.1, 0.0001],
         short_bounds: &[-0.1, 0.1, 0.0001],
@@ -196,7 +196,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_threshold_volatility_1h_weight",
         path: &["close", "threshold_volatility_1h_weight"],
-        long_default: 0.13,
+        long_default: 0.37,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -212,7 +212,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_retracement_base_pct",
         path: &["close", "retracement_base_pct"],
-        long_default: 0.0001,
+        long_default: 0.0002,
         short_default: 0.0,
         long_bounds: &[0.0001, 0.01, 0.0001],
         short_bounds: &[0.0001, 0.01, 0.0001],
@@ -220,7 +220,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_retracement_volatility_1h_weight",
         path: &["close", "retracement_volatility_1h_weight"],
-        long_default: 5.8,
+        long_default: 17.79,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],
@@ -228,7 +228,7 @@ const TRAILING_MARTINGALE_PARAM_SEEDS: &[NestedParamSeed] = &[
     NestedParamSeed {
         name: "close_retracement_volatility_1m_weight",
         path: &["close", "retracement_volatility_1m_weight"],
-        long_default: 39.03,
+        long_default: 36.11,
         short_default: 0.01,
         long_bounds: &[0.01, 40.0, 0.01],
         short_bounds: &[0.01, 40.0, 0.01],

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -13,22 +13,22 @@ def _get_shared_bot_defaults():
         "long": {
             "forager": {
                 "score_weights": {
-                    "ema_readiness": 0.2,
-                    "volatility": 0.34,
+                    "ema_readiness": 0.18,
+                    "volatility": 0.36,
                     "volume": 0.46
                 },
-                "volatility_ema_span_1m": 187.0,
-                "volume_drop_pct": 0.02,
-                "volume_ema_span_1m": 1280.0
+                "volatility_ema_span_1m": 360.0,
+                "volume_drop_pct": 0.06,
+                "volume_ema_span_1m": 1400.0
             },
             "hsl": {
-                "cooldown_minutes_after_red": 4041.0,
-                "ema_span_minutes": 639.0,
+                "cooldown_minutes_after_red": 2160.0,
+                "ema_span_minutes": 720.0,
                 "enabled": False,
                 "no_restart_drawdown_threshold": 1,
                 "orange_tier_mode": "tp_only_with_active_entry_cancellation",
                 "panic_close_order_type": "limit",
-                "red_threshold": 0.117,
+                "red_threshold": 0.15,
                 "restart_after_red_policy": "threshold",
                 "tier_ratios": {
                     "orange": 0.75,
@@ -36,25 +36,25 @@ def _get_shared_bot_defaults():
                 }
             },
             "risk": {
-                "entry_cooldown_minutes": 7.3,
+                "entry_cooldown_minutes": 7.4,
                 "n_positions": 5.0,
                 "position_exposure_enforcer_enabled": False,
                 "position_exposure_enforcer_threshold": 1.0,
                 "total_exposure_enforcer_enabled": True,
                 "total_exposure_enforcer_policy": "reduce_overweight",
-                "total_exposure_enforcer_threshold": 1.002,
+                "total_exposure_enforcer_threshold": 1.0,
                 "total_exposure_entry_gate_enabled": True,
                 "total_wallet_exposure_limit": 1.5,
                 "we_excess_allowance_mode": "bounded",
                 "we_excess_allowance_pct": 0.5
             },
             "unstuck": {
-                "close_pct": 0.024,
-                "ema_dist": -0.1238,
+                "close_pct": 0.105,
+                "ema_dist": -0.0809,
                 "ema_gating_enabled": True,
                 "enabled": True,
-                "loss_allowance_pct": 0.0063,
-                "threshold": 0.432
+                "loss_allowance_pct": 0.0071,
+                "threshold": 0.425
             }
         },
         "short": {

--- a/tests/test_config_utils_helpers.py
+++ b/tests/test_config_utils_helpers.py
@@ -13,6 +13,7 @@ from config import load_input_config, prepare_config
 from config.coerce import normalize_hsl_restart_after_red_policy, normalize_hsl_signal_mode
 from config.project import project_config
 from config.runtime_compile import compile_runtime_config
+from config.strategy_spec import get_strategy_defaults
 from config.validate import validate_config
 from config_transform import ConfigTransformTracker, record_transform
 from utils import normalize_coins_source
@@ -117,6 +118,18 @@ def test_default_example_config_loads_with_grouped_shape_and_live_execution_sett
     assert "market_orders_allowed" in loaded["live"]
     assert "market_order_near_touch_threshold" in loaded["live"]
     assert "pnls_max_lookback_days" in loaded["live"]
+
+
+def test_default_trailing_martingale_long_example_matches_template_and_rust_defaults():
+    raw = json.loads(Path("configs/examples/default_trailing_martingale_long.json").read_text())
+    template_long = get_template_config()["bot"]["long"]
+
+    for section in ("forager", "hsl", "risk", "unstuck"):
+        assert raw["bot"]["long"][section] == template_long[section]
+
+    assert raw["bot"]["long"]["strategy"]["trailing_martingale"] == get_strategy_defaults(
+        "trailing_martingale"
+    )["long"]
 
 
 def test_shipped_example_configs_load_with_grouped_canonical_shape():


### PR DESCRIPTION
Summary
- refresh default long-side schema values from tmp/canon_candidate.json
- refresh trailing_martingale long defaults in Rust strategy metadata
- regenerate configs/examples/default_trailing_martingale_long.json
- leave bot.short unchanged because the default short total_wallet_exposure_limit is 0.0

Validation
- fetched fresh origin/v8 before branching
- rebuilt/restamped passivbot_rust from the isolated worktree
- confirmed template/example projected bot.long matches tmp/canon_candidate.json
- PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-4/venv/bin/python -m pytest tests/test_config_pipeline.py tests/test_config_utils_helpers.py tests/test_format_config.py tests/test_streamlined_json.py
- cargo fmt --check
- git diff --check
- silent-handling audit: existing matches only; no new code paths added