### PR TITLE
Attribute live event sink service time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Periodic structured health summaries now attribute queued worker sink time to
+  fixed structured and monitor sink classes with bounded per-window write
+  counts and service totals/maxima. Live smoke and performance reports project
+  the same fields without changing routing, delivery, verdicts, or trading
+  behavior.
+
 - Periodic structured health summaries now expose bounded event-pipeline queue
   wait and worker sink-service timing windows. Live smoke and performance
   reports project the processed counts, totals, and maxima without changing

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -52,10 +52,14 @@ Estimated completion:
 
 Next action:
 
-1. Complete the fixed sink-class producer and report projections with focused
-   transactional, privacy, and missing-history tests.
-2. Run full affected validation and independent preflight, then publish only
-   when the branch is review-ready.
+1. Hold the published PR at the exact-current-head review gate until Hermes,
+   Grok 4.5, and CI are green; resolve any findings with narrow delta validation
+   and require fresh exact-head verdicts after every push.
+2. Merge only after that gate is green, then gracefully restart the five exact
+   VPS5 bot panes while preserving unrelated processes and local artifacts.
+3. Verify fresh fixed structured/monitor sink timing with bounded
+   `health.summary`, smoke, and performance reports, including immediate and
+   settled process and repository-state checks.
 
 ## Deployed Baseline
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,26 +22,28 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-event-pipeline-service-time`
-- Base: `7eca900379873e2124e1782601551e3b08c3e2ee`
-- Triggering evidence: event-pipeline health currently exposes queue depth,
-  unfinished work, drops, sink errors, and worker liveness but not bounded
-  worker service-time or queue-wait evidence.
-- Scope: timestamp private queue envelopes with a monotonic clock and aggregate
-  processed count, queue-wait total/max, and worker sink-service total/max over
-  each health-summary window. Periodic `health.summary` consumes/resets the
-  timing window transactionally: accepted enqueue commits it, while failed
-  enqueue merges it back into the active window. Ordinary monitor snapshots are
-  non-consuming. Project the fixed numeric fields through event-pipeline smoke
+- Branch: `codex/v8-event-pipeline-sink-attribution`
+- Base: `cbf1e5ed5bf8bfed4bd967a02d853c099105eabc`
+- Triggering evidence: PR #1200 measured live worker-service maxima above one
+  second while drops, sink errors, and degraded counts remained zero, but the
+  aggregate cannot identify whether the fixed structured or monitor sink class
+  accounted for the delay.
+- Scope: time each queued worker `sink.write()` attempt with a monotonic clock
+  and aggregate fixed structured/monitor write counts plus service total/max
+  over the existing health-summary timing window. Preserve aggregate worker
+  service timing. Rotate, confirm, and restore the new counters with the same
+  opaque timing token, including failed health-event enqueue and overlapping
+  snapshots. Project the fixed numeric fields through event-pipeline smoke
   summaries and performance resource-pressure reports.
 - Behavior boundary: observability only. Do not make timing evidence a trading
-  gate, change queue capacity/backpressure/drop policy, add raw payloads or
-  unbounded labels, or alter order, risk, HSL, Rust, backtest, optimizer, or
-  exchange behavior.
-- Validation: event-bus concurrency/timing tests, health-payload reset tests,
-  full smoke/performance projection tests, fake-live event markers, Python
-  compilation, `git diff --check`, added-line silent-handling audit, and
-  independent preflight.
+  gate, time synchronous console/text sinks, change queue capacity,
+  backpressure, routing, drop/error policy, add raw payloads or unbounded
+  labels, or alter order, risk, HSL, Rust, backtest, optimizer, or exchange
+  behavior.
+- Validation: event-bus route/timing and transactional restore tests, full
+  smoke/performance projection tests, health-payload passthrough tests, fake-live
+  event markers, Python compilation, `git diff --check`, added-line
+  silent-handling audit, and independent preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: exact five-bot graceful restart, then bounded
@@ -50,23 +52,32 @@ Estimated completion:
 
 Next action:
 
-1. Hold the published PR at the exact-current-head review gate until Hermes,
-   Grok 4.5, and CI are green; resolve any findings with narrow delta validation
-   and require fresh exact-head verdicts after every push.
-2. Merge only after that gate is green, then gracefully restart the five exact
-   VPS5 bot panes while preserving unrelated processes and local artifacts.
-3. Verify fresh event-pipeline timing fields with bounded `health.summary`,
-   smoke, and performance reports, including immediate and settled process and
-   repository-state checks.
+1. Complete the fixed sink-class producer and report projections with focused
+   transactional, privacy, and missing-history tests.
+2. Run full affected validation and independent preflight, then publish only
+   when the branch is review-ready.
 
 ## Deployed Baseline
 
-- Remote `v8`: `7eca900379873e2124e1782601551e3b08c3e2ee`, PR #1199
-- VPS5 repository: `7eca900379873e2124e1782601551e3b08c3e2ee`, PR #1199; tracked
+- Remote `v8`: `cbf1e5ed5bf8bfed4bd967a02d853c099105eabc`, PR #1200
+- VPS5 repository: `cbf1e5ed5bf8bfed4bd967a02d853c099105eabc`, PR #1200; tracked
   status clean; only expected untracked artifacts were preserved
-- VPS5 expected bots: five; running with PR #1198 restart PIDs
-  `861950/861949/861953/861955/861957`;
+- VPS5 expected bots: five; running with PR #1200 restart PIDs
+  `865892/865897/865901/865903/865905`;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1200 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded cleanly and gracefully stopped only the five exact bot
+  panes; all old Python PIDs exited naturally, including KuCoin after a bounded
+  uninterruptible wait. Pane PIDs and unrelated `misc:0.0` PID `434835` were
+  preserved before the exact supervisor commands started the five new bots.
+- Fresh smoke and performance reports projected three health windows with
+  `1517` processed events, queue-wait total/max `29858.257/1077.844ms`, and
+  worker-service total/max `63316.18/1033.432ms`; drops, sink errors, degraded
+  counts, and unhealthy pipelines were zero. A real GateIO authoritative
+  balance timeout made one intermediate smoke red. After recovery, the final
+  two-minute smoke was green with `432/432` remote and `59/59`
+  account-critical calls successful, all five expected processes matched,
+  exact states `R/R/R/R/S`, and a clean tracked repository.
 - PR #1199 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded without bot signals or restarts. A bounded four-segment
   per-bot proof report returned `ok=true` with zero issues and reported all five

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7839,3 +7839,42 @@ VPS5 deployment status:
 - Expected VPS action: exact five-bot graceful restart, bounded timing evidence,
   and immediate plus settled smoke while preserving unrelated processes and
   local artifacts.
+
+### Deployed Slice: Event-Pipeline Service-Time Evidence
+
+- PR #1200 was approved by Hermes and Grok 4.5 on exact head `9b7baf0b6`; CI
+  passed and it merged to `v8` as `cbf1e5ed5`.
+- VPS5 fast-forwarded cleanly and gracefully stopped only the five exact bot
+  panes. All old Python processes exited naturally, including KuCoin after a
+  bounded uninterruptible wait. Existing pane PIDs and unrelated `misc:0.0` PID
+  `434835` remained preserved; the exact supervisor commands then started bot
+  PIDs `865892/865897/865901/865903/865905`.
+- Fresh smoke and performance reports projected three health windows with
+  `1517` processed events, queue-wait total/max `29858.257/1077.844ms`, and
+  worker-service total/max `63316.18/1033.432ms`; drops, sink errors, degraded
+  counts, and unhealthy pipelines were zero.
+- A real GateIO authoritative-balance timeout made one intermediate smoke red.
+  After recovery, the final two-minute smoke was hard-green with `432/432`
+  remote and `59/59` account-critical calls successful, all five expected
+  processes matched, exact states `R/R/R/R/S`, and a clean tracked repository.
+
+### Active Slice: Event-Pipeline Sink Attribution
+
+- Branch: `codex/v8-event-pipeline-sink-attribution` from deployed
+  `cbf1e5ed5`.
+- Triggering evidence: live worker-service maxima exceeded one second while
+  drops, sink errors, and degraded counts remained zero, but the aggregate
+  timing cannot distinguish structured from monitor sink cost.
+- Scope: add fixed per-health-window structured/monitor sink write counts and
+  per-write service total/max. Use the existing monotonic worker clock and
+  transactional timing-window token; preserve aggregate worker timing and all
+  queue/routing/delivery behavior.
+- Consumers: project only fixed numeric fields through smoke event-pipeline
+  summaries and performance resource-pressure statistics. Historical events
+  without these fields remain absent rather than synthetic zero.
+- Non-goals: no console/text timing, labels, samples, thresholds, verdict
+  changes, queue policy, routing, event payload, order, risk, HSL, Rust,
+  backtest, optimizer, exchange, or trading behavior changes.
+- Expected VPS action: exact five-bot graceful restart, bounded per-sink timing
+  evidence, and immediate plus settled smoke while preserving unrelated
+  processes and local artifacts.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -354,9 +354,11 @@ Related detailed plans:
    resource-pressure path also includes process CPU percent after psutil's
    non-blocking first-sample priming, health-summary scheduling lag after the
    first heartbeat, and optional psutil-backed system memory/swap pressure
-   fields for host-level pressure scans. The active event-pipeline timing slice
-   adds per-health-window processed count, queue-wait total/max, and worker
-   sink-service total/max with non-consuming ordinary monitor snapshots.
+   fields for host-level pressure scans. PR #1200 added per-health-window
+   processed count, queue-wait total/max, and aggregate worker sink-service
+   total/max with non-consuming ordinary monitor snapshots. The active
+   follow-up attributes that worker time to fixed structured/monitor sink write
+   counts and service total/max.
 
    Remaining refinements: exchange-call counts, candle-fetch concurrency,
    lower-level event-loop lag if heartbeat lag proves too coarse, and

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -375,8 +375,10 @@ classification when enough source events exist.
     `slowest_blockers` also include the latest bounded report-safe canonical
     event IDs for direct event-stream correlation. Remaining work: source events
     for complete stage coverage where the live loop does not yet emit timings.
-    The active event-pipeline slice adds per-heartbeat queue-wait and worker
-    sink-service count/total/max source evidence without affecting delivery.
+    PR #1200 added per-heartbeat queue-wait and worker sink-service
+    count/total/max source evidence without affecting delivery. The active
+    follow-up attributes worker service to fixed structured and monitor sink
+    classes with per-window write counts and service total/max.
 - [ ] Exchange writes: create/cancel/close/panic write latency, exchange
   response latency, ambiguous write rate, confirmation latency.
   - Status: partial. The report now derives order-wave total duration,
@@ -405,10 +407,12 @@ classification when enough source events exist.
     subtraction. Performance reports also expose aggregate latest event-pipeline
     queue/drop/sink/degraded counters and unhealthy-bot count, so operators can
     see whether observability itself is backed up or dropping data without
-    opening every per-bot group. The active slice adds fixed numeric
-    health-window processed counts, queue-wait total/max, and worker sink-service
+    opening every per-bot group. PR #1200 added fixed numeric health-window
+    processed counts, queue-wait total/max, and aggregate worker sink-service
     total/max; reports retain per-field distributions and bounded latest
-    cross-bot aggregates.
+    cross-bot aggregates. The active follow-up adds fixed structured/monitor
+    sink write counts and service total/max so aggregate worker delay can be
+    attributed without labels or sampled payloads.
     Remaining work: a lower-level event-loop lag probe can be added later if
     operators need sub-heartbeat scheduling latency, but the heartbeat lag now
     gives bounded non-misleading evidence for delayed health summaries.

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -1795,6 +1795,37 @@ class _EventPipelineTimingWindow:
     queue_wait_ns_max: int
     worker_service_ns_total: int
     worker_service_ns_max: int
+    structured_sink_write_count: int
+    structured_sink_service_ns_total: int
+    structured_sink_service_ns_max: int
+    monitor_sink_write_count: int
+    monitor_sink_service_ns_total: int
+    monitor_sink_service_ns_max: int
+
+
+@dataclass
+class _EventPipelineSinkWriteTiming:
+    structured_sink_write_count: int = 0
+    structured_sink_service_ns_total: int = 0
+    structured_sink_service_ns_max: int = 0
+    monitor_sink_write_count: int = 0
+    monitor_sink_service_ns_total: int = 0
+    monitor_sink_service_ns_max: int = 0
+
+    def record(self, sink_name: str, service_ns: int) -> None:
+        service_ns = max(0, int(service_ns))
+        if sink_name == "structured":
+            self.structured_sink_write_count += 1
+            self.structured_sink_service_ns_total += service_ns
+            self.structured_sink_service_ns_max = max(
+                self.structured_sink_service_ns_max, service_ns
+            )
+        elif sink_name == "monitor":
+            self.monitor_sink_write_count += 1
+            self.monitor_sink_service_ns_total += service_ns
+            self.monitor_sink_service_ns_max = max(
+                self.monitor_sink_service_ns_max, service_ns
+            )
 
 
 class LiveEventPipeline:
@@ -1836,6 +1867,12 @@ class LiveEventPipeline:
         self._timing_queue_wait_ns_max = 0
         self._timing_worker_service_ns_total = 0
         self._timing_worker_service_ns_max = 0
+        self._timing_structured_sink_write_count = 0
+        self._timing_structured_sink_service_ns_total = 0
+        self._timing_structured_sink_service_ns_max = 0
+        self._timing_monitor_sink_write_count = 0
+        self._timing_monitor_sink_service_ns_total = 0
+        self._timing_monitor_sink_service_ns_max = 0
         self._pending_timing_windows: dict[int, _EventPipelineTimingWindow] = {}
         self._next_timing_snapshot_token = 1
         self._worker: threading.Thread | None = None
@@ -1901,6 +1938,22 @@ class LiveEventPipeline:
                 queue_wait_ns_max=int(self._timing_queue_wait_ns_max),
                 worker_service_ns_total=int(self._timing_worker_service_ns_total),
                 worker_service_ns_max=int(self._timing_worker_service_ns_max),
+                structured_sink_write_count=int(
+                    self._timing_structured_sink_write_count
+                ),
+                structured_sink_service_ns_total=int(
+                    self._timing_structured_sink_service_ns_total
+                ),
+                structured_sink_service_ns_max=int(
+                    self._timing_structured_sink_service_ns_max
+                ),
+                monitor_sink_write_count=int(self._timing_monitor_sink_write_count),
+                monitor_sink_service_ns_total=int(
+                    self._timing_monitor_sink_service_ns_total
+                ),
+                monitor_sink_service_ns_max=int(
+                    self._timing_monitor_sink_service_ns_max
+                ),
             )
             timing_snapshot_token = None
             if consume_timing:
@@ -1913,6 +1966,12 @@ class LiveEventPipeline:
                 self._timing_queue_wait_ns_max = 0
                 self._timing_worker_service_ns_total = 0
                 self._timing_worker_service_ns_max = 0
+                self._timing_structured_sink_write_count = 0
+                self._timing_structured_sink_service_ns_total = 0
+                self._timing_structured_sink_service_ns_max = 0
+                self._timing_monitor_sink_write_count = 0
+                self._timing_monitor_sink_service_ns_total = 0
+                self._timing_monitor_sink_service_ns_max = 0
         snapshot: dict[str, Any] = {
             "event_queue_depth": queue_depth,
             "event_queue_maxsize": queue_maxsize,
@@ -1939,6 +1998,20 @@ class LiveEventPipeline:
             ),
             "event_worker_service_ms_max": self._timing_ms(
                 timing_window.worker_service_ns_max
+            ),
+            "event_structured_sink_write_count": timing_window.structured_sink_write_count,
+            "event_structured_sink_service_ms_total": self._timing_ms(
+                timing_window.structured_sink_service_ns_total
+            ),
+            "event_structured_sink_service_ms_max": self._timing_ms(
+                timing_window.structured_sink_service_ns_max
+            ),
+            "event_monitor_sink_write_count": timing_window.monitor_sink_write_count,
+            "event_monitor_sink_service_ms_total": self._timing_ms(
+                timing_window.monitor_sink_service_ns_total
+            ),
+            "event_monitor_sink_service_ms_max": self._timing_ms(
+                timing_window.monitor_sink_service_ns_max
             ),
         }
         return (
@@ -1970,6 +2043,24 @@ class LiveEventPipeline:
         self._timing_worker_service_ns_total += int(pending.worker_service_ns_total)
         self._timing_worker_service_ns_max = max(
             self._timing_worker_service_ns_max, int(pending.worker_service_ns_max)
+        )
+        self._timing_structured_sink_write_count += int(
+            pending.structured_sink_write_count
+        )
+        self._timing_structured_sink_service_ns_total += int(
+            pending.structured_sink_service_ns_total
+        )
+        self._timing_structured_sink_service_ns_max = max(
+            self._timing_structured_sink_service_ns_max,
+            int(pending.structured_sink_service_ns_max),
+        )
+        self._timing_monitor_sink_write_count += int(pending.monitor_sink_write_count)
+        self._timing_monitor_sink_service_ns_total += int(
+            pending.monitor_sink_service_ns_total
+        )
+        self._timing_monitor_sink_service_ns_max = max(
+            self._timing_monitor_sink_service_ns_max,
+            int(pending.monitor_sink_service_ns_max),
         )
 
     def emit(
@@ -2093,14 +2184,19 @@ class LiveEventPipeline:
                 if item is None:
                     return
                 service_started_ns = time.monotonic_ns()
+                sink_write_timing = _EventPipelineSinkWriteTiming()
                 live_event = item.event
                 route = self.route_for(live_event)
                 if route.structured:
                     for sink in self.structured_sinks:
-                        self._write_sink("structured", sink, live_event)
+                        self._write_sink_in_worker(
+                            "structured", sink, live_event, sink_write_timing
+                        )
                 if route.monitor:
                     for sink in self.monitor_sinks:
-                        self._write_sink("monitor", sink, live_event)
+                        self._write_sink_in_worker(
+                            "monitor", sink, live_event, sink_write_timing
+                        )
             finally:
                 if item is not None:
                     service_finished_ns = time.monotonic_ns()
@@ -2120,20 +2216,69 @@ class LiveEventPipeline:
                         self._timing_worker_service_ns_max = max(
                             self._timing_worker_service_ns_max, service_ns
                         )
+                        self._timing_structured_sink_write_count += (
+                            sink_write_timing.structured_sink_write_count
+                        )
+                        self._timing_structured_sink_service_ns_total += (
+                            sink_write_timing.structured_sink_service_ns_total
+                        )
+                        self._timing_structured_sink_service_ns_max = max(
+                            self._timing_structured_sink_service_ns_max,
+                            sink_write_timing.structured_sink_service_ns_max,
+                        )
+                        self._timing_monitor_sink_write_count += (
+                            sink_write_timing.monitor_sink_write_count
+                        )
+                        self._timing_monitor_sink_service_ns_total += (
+                            sink_write_timing.monitor_sink_service_ns_total
+                        )
+                        self._timing_monitor_sink_service_ns_max = max(
+                            self._timing_monitor_sink_service_ns_max,
+                            sink_write_timing.monitor_sink_service_ns_max,
+                        )
                 self._queue.task_done()
 
     def _write_sink(self, name: str, sink: LiveEventSink, event: LiveEvent) -> Any:
         try:
             return sink.write(event)
         except Exception as exc:
-            with self._state_lock:
-                self.sink_error_counters[name] += 1
-            self._record_degraded(
-                reason_code=sink_failed_reason_code(name),
-                message=f"{name} sink failed: {type(exc).__name__}",
-                data={"sink": name, "error_type": type(exc).__name__, "error": str(exc)},
-            )
+            self._handle_sink_failure(name, exc)
             return None
+
+    def _write_sink_in_worker(
+        self,
+        name: str,
+        sink: LiveEventSink,
+        event: LiveEvent,
+        sink_write_timing: _EventPipelineSinkWriteTiming,
+    ) -> Any:
+        sink_started_ns = time.monotonic_ns()
+        try:
+            try:
+                return sink.write(event)
+            finally:
+                sink_write_timing.record(
+                    name, time.monotonic_ns() - sink_started_ns
+                )
+        except Exception as exc:
+            self._handle_sink_failure(name, exc, sink_write_timing=sink_write_timing)
+            return None
+
+    def _handle_sink_failure(
+        self,
+        name: str,
+        exc: Exception,
+        *,
+        sink_write_timing: _EventPipelineSinkWriteTiming | None = None,
+    ) -> None:
+        with self._state_lock:
+            self.sink_error_counters[name] += 1
+        self._record_degraded(
+            reason_code=sink_failed_reason_code(name),
+            message=f"{name} sink failed: {type(exc).__name__}",
+            data={"sink": name, "error_type": type(exc).__name__, "error": str(exc)},
+            sink_write_timing=sink_write_timing,
+        )
 
     def _record_degraded(
         self,
@@ -2141,6 +2286,7 @@ class LiveEventPipeline:
         reason_code: str,
         message: str,
         data: Mapping[str, Any] | None = None,
+        sink_write_timing: _EventPipelineSinkWriteTiming | None = None,
     ) -> None:
         degraded = LiveEvent(
             EventTypes.SINK_DEGRADED,
@@ -2164,6 +2310,9 @@ class LiveEventPipeline:
                     self.sink_error_counters["console"] += 1
         if reason_code != "monitor_sink_failed":
             for sink in self.monitor_sinks:
+                sink_started_ns = (
+                    time.monotonic_ns() if sink_write_timing is not None else 0
+                )
                 try:
                     sink.write(degraded)
                 except Exception as exc:
@@ -2173,6 +2322,11 @@ class LiveEventPipeline:
                         "[event] failed to emit sink.degraded to monitor: %s",
                         type(exc).__name__,
                     )
+                finally:
+                    if sink_write_timing is not None:
+                        sink_write_timing.record(
+                            "monitor", time.monotonic_ns() - sink_started_ns
+                        )
 
 
 def emit_event(

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -105,6 +105,12 @@ _RESOURCE_PRESSURE_FIELDS = (
     "event_queue_wait_ms_max",
     "event_worker_service_ms_total",
     "event_worker_service_ms_max",
+    "event_structured_sink_write_count",
+    "event_structured_sink_service_ms_total",
+    "event_structured_sink_service_ms_max",
+    "event_monitor_sink_write_count",
+    "event_monitor_sink_service_ms_total",
+    "event_monitor_sink_service_ms_max",
 )
 _RESOURCE_PRESSURE_COUNTER_FIELDS = (
     "event_drop_counts",
@@ -3992,6 +3998,24 @@ class _ResourcePressureAccumulator:
             ),
             "latest_event_worker_service_ms_max": latest_field_max(
                 "event_worker_service_ms_max"
+            ),
+            "latest_event_structured_sink_write_count_sum": latest_field_sum(
+                "event_structured_sink_write_count"
+            ),
+            "latest_event_structured_sink_service_ms_total_sum": latest_field_sum(
+                "event_structured_sink_service_ms_total"
+            ),
+            "latest_event_structured_sink_service_ms_max": latest_field_max(
+                "event_structured_sink_service_ms_max"
+            ),
+            "latest_event_monitor_sink_write_count_sum": latest_field_sum(
+                "event_monitor_sink_write_count"
+            ),
+            "latest_event_monitor_sink_service_ms_total_sum": latest_field_sum(
+                "event_monitor_sink_service_ms_total"
+            ),
+            "latest_event_monitor_sink_service_ms_max": latest_field_max(
+                "event_monitor_sink_service_ms_max"
             ),
             "event_pipeline_unhealthy_bots": unhealthy_bots,
             "groups_truncated": len(groups) > limit,

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -2806,6 +2806,12 @@ def _event_pipeline_health_group(
         "event_queue_wait_ms_max",
         "event_worker_service_ms_total",
         "event_worker_service_ms_max",
+        "event_structured_sink_write_count",
+        "event_structured_sink_service_ms_total",
+        "event_structured_sink_service_ms_max",
+        "event_monitor_sink_write_count",
+        "event_monitor_sink_service_ms_total",
+        "event_monitor_sink_service_ms_max",
     }
     if not any(key in payload for key in observed_keys):
         return None
@@ -2848,6 +2854,24 @@ def _event_pipeline_health_group(
         ),
         "latest_worker_service_ms_max": _non_negative_number(
             payload.get("event_worker_service_ms_max")
+        ),
+        "latest_structured_sink_write_count": _non_negative_int(
+            payload.get("event_structured_sink_write_count")
+        ),
+        "latest_structured_sink_service_ms_total": _non_negative_number(
+            payload.get("event_structured_sink_service_ms_total")
+        ),
+        "latest_structured_sink_service_ms_max": _non_negative_number(
+            payload.get("event_structured_sink_service_ms_max")
+        ),
+        "latest_monitor_sink_write_count": _non_negative_int(
+            payload.get("event_monitor_sink_write_count")
+        ),
+        "latest_monitor_sink_service_ms_total": _non_negative_number(
+            payload.get("event_monitor_sink_service_ms_total")
+        ),
+        "latest_monitor_sink_service_ms_max": _non_negative_number(
+            payload.get("event_monitor_sink_service_ms_max")
         ),
         "latest_pipeline_stopping": (
             bool(payload.get("event_pipeline_stopping"))
@@ -2909,6 +2933,12 @@ def _merge_event_pipeline_health_group(
             "latest_queue_wait_ms_max",
             "latest_worker_service_ms_total",
             "latest_worker_service_ms_max",
+            "latest_structured_sink_write_count",
+            "latest_structured_sink_service_ms_total",
+            "latest_structured_sink_service_ms_max",
+            "latest_monitor_sink_write_count",
+            "latest_monitor_sink_service_ms_total",
+            "latest_monitor_sink_service_ms_max",
             "latest_pipeline_stopping",
             "latest_worker_alive",
             "latest_ids",
@@ -2991,6 +3021,28 @@ def _summarize_event_pipeline_health(
         ),
         "latest_worker_service_ms_max": _max_optional_numbers(
             group.get("latest_worker_service_ms_max") for group in groups.values()
+        ),
+        "latest_structured_sink_write_count_sum": _sum_optional_numbers(
+            group.get("latest_structured_sink_write_count") for group in groups.values()
+        ),
+        "latest_structured_sink_service_ms_total_sum": _sum_optional_numbers(
+            group.get("latest_structured_sink_service_ms_total")
+            for group in groups.values()
+        ),
+        "latest_structured_sink_service_ms_max": _max_optional_numbers(
+            group.get("latest_structured_sink_service_ms_max")
+            for group in groups.values()
+        ),
+        "latest_monitor_sink_write_count_sum": _sum_optional_numbers(
+            group.get("latest_monitor_sink_write_count") for group in groups.values()
+        ),
+        "latest_monitor_sink_service_ms_total_sum": _sum_optional_numbers(
+            group.get("latest_monitor_sink_service_ms_total")
+            for group in groups.values()
+        ),
+        "latest_monitor_sink_service_ms_max": _max_optional_numbers(
+            group.get("latest_monitor_sink_service_ms_max")
+            for group in groups.values()
         ),
     }
     if processed_counts:
@@ -6961,6 +7013,24 @@ def _summary_limited_groups(
             "latest_worker_service_ms_max": summary.get(
                 "latest_worker_service_ms_max"
             ),
+            "latest_structured_sink_write_count_sum": summary.get(
+                "latest_structured_sink_write_count_sum"
+            ),
+            "latest_structured_sink_service_ms_total_sum": summary.get(
+                "latest_structured_sink_service_ms_total_sum"
+            ),
+            "latest_structured_sink_service_ms_max": summary.get(
+                "latest_structured_sink_service_ms_max"
+            ),
+            "latest_monitor_sink_write_count_sum": summary.get(
+                "latest_monitor_sink_write_count_sum"
+            ),
+            "latest_monitor_sink_service_ms_total_sum": summary.get(
+                "latest_monitor_sink_service_ms_total_sum"
+            ),
+            "latest_monitor_sink_service_ms_max": summary.get(
+                "latest_monitor_sink_service_ms_max"
+            ),
             "latest_worker_not_alive_count": summary.get(
                 "latest_worker_not_alive_count"
             ),
@@ -8384,6 +8454,24 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
                 ),
                 "latest_worker_service_ms_max": event_pipeline_health.get(
                     "latest_worker_service_ms_max"
+                ),
+                "latest_structured_sink_write_count_sum": event_pipeline_health.get(
+                    "latest_structured_sink_write_count_sum"
+                ),
+                "latest_structured_sink_service_ms_total_sum": event_pipeline_health.get(
+                    "latest_structured_sink_service_ms_total_sum"
+                ),
+                "latest_structured_sink_service_ms_max": event_pipeline_health.get(
+                    "latest_structured_sink_service_ms_max"
+                ),
+                "latest_monitor_sink_write_count_sum": event_pipeline_health.get(
+                    "latest_monitor_sink_write_count_sum"
+                ),
+                "latest_monitor_sink_service_ms_total_sum": event_pipeline_health.get(
+                    "latest_monitor_sink_service_ms_total_sum"
+                ),
+                "latest_monitor_sink_service_ms_max": event_pipeline_health.get(
+                    "latest_monitor_sink_service_ms_max"
                 ),
                 "latest_worker_not_alive_count": _count_value(
                     event_pipeline_health.get("latest_worker_not_alive_count")

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -496,32 +496,59 @@ def test_pipeline_health_snapshot_tracks_and_consumes_queue_timing(monkeypatch):
     )
 
     class ControlledSink:
+        def __init__(self, service_ns):
+            self.service_ns = service_ns
+            self.events = []
+
         def write(self, event):
-            clock["ns"] += 3_000_000
+            self.events.append(event)
+            clock["ns"] += self.service_ns
             return event
 
+    structured = ControlledSink(3_000_000)
+    structured_secondary = ControlledSink(2_000_000)
+    monitor = ControlledSink(5_000_000)
+    console = ControlledSink(11_000_000)
+    text = ControlledSink(13_000_000)
     pipeline = LiveEventPipeline(
         start=False,
-        structured_sinks=[ControlledSink()],
+        structured_sinks=[structured, structured_secondary],
+        monitor_sinks=[monitor],
+        console_sink=console,
+        text_sink=text,
         routes={
             EventTypes.DATA_PACKET_UPDATED: EventRoute(
                 structured=True, monitor=False, console=False
-            )
+            ),
+            EventTypes.SNAPSHOT_BUILT: EventRoute(
+                structured=False, monitor=True, console=False
+            ),
+            EventTypes.CYCLE_STARTED: EventRoute(
+                structured=True, monitor=True, console=True, text=True
+            ),
         },
     )
 
     assert pipeline.emit(LiveEvent(EventTypes.DATA_PACKET_UPDATED)) is not None
+    assert pipeline.emit(LiveEvent(EventTypes.SNAPSHOT_BUILT)) is not None
+    assert pipeline.emit(LiveEvent(EventTypes.CYCLE_STARTED)) is not None
     clock["ns"] += 7_000_000
     pipeline.start()
     assert pipeline.flush(timeout=2.0) is True
 
     expected_timing = {
-        "event_pipeline_timing_window_ms": 10.0,
-        "event_pipeline_processed_count": 1,
-        "event_queue_wait_ms_total": 7.0,
-        "event_queue_wait_ms_max": 7.0,
-        "event_worker_service_ms_total": 3.0,
-        "event_worker_service_ms_max": 3.0,
+        "event_pipeline_timing_window_ms": 51.0,
+        "event_pipeline_processed_count": 3,
+        "event_queue_wait_ms_total": 84.0,
+        "event_queue_wait_ms_max": 36.0,
+        "event_worker_service_ms_total": 20.0,
+        "event_worker_service_ms_max": 10.0,
+        "event_structured_sink_write_count": 4,
+        "event_structured_sink_service_ms_total": 10.0,
+        "event_structured_sink_service_ms_max": 3.0,
+        "event_monitor_sink_write_count": 2,
+        "event_monitor_sink_service_ms_total": 10.0,
+        "event_monitor_sink_service_ms_max": 5.0,
     }
     non_consuming_snapshot = pipeline.health_snapshot()
     assert {key: non_consuming_snapshot[key] for key in expected_timing} == expected_timing
@@ -542,7 +569,15 @@ def test_pipeline_health_snapshot_tracks_and_consumes_queue_timing(monkeypatch):
         "event_queue_wait_ms_max": 0.0,
         "event_worker_service_ms_total": 0.0,
         "event_worker_service_ms_max": 0.0,
+        "event_structured_sink_write_count": 0,
+        "event_structured_sink_service_ms_total": 0.0,
+        "event_structured_sink_service_ms_max": 0.0,
+        "event_monitor_sink_write_count": 0,
+        "event_monitor_sink_service_ms_total": 0.0,
+        "event_monitor_sink_service_ms_max": 0.0,
     }
+    assert len(console.events) == 1
+    assert len(text.events) == 1
     assert pipeline.close(timeout=2.0) is True
 
 
@@ -555,17 +590,40 @@ def test_pipeline_overlapping_timing_snapshots_resolve_by_token(monkeypatch):
     )
     pipeline = LiveEventPipeline(start=False)
     pipeline._timing_processed_count = 7
+    pipeline._timing_structured_sink_write_count = 2
+    pipeline._timing_structured_sink_service_ns_total = 3_000_000
+    pipeline._timing_structured_sink_service_ns_max = 2_000_000
+    pipeline._timing_monitor_sink_write_count = 3
+    pipeline._timing_monitor_sink_service_ns_total = 8_000_000
+    pipeline._timing_monitor_sink_service_ns_max = 4_000_000
 
     first, first_token = pipeline.consume_timing_snapshot()
     pipeline._timing_processed_count = 3
+    pipeline._timing_structured_sink_write_count = 5
+    pipeline._timing_structured_sink_service_ns_total = 11_000_000
+    pipeline._timing_structured_sink_service_ns_max = 7_000_000
+    pipeline._timing_monitor_sink_write_count = 1
+    pipeline._timing_monitor_sink_service_ns_total = 6_000_000
+    pipeline._timing_monitor_sink_service_ns_max = 6_000_000
     clock["ns"] += 1_000_000
     second, second_token = pipeline.consume_timing_snapshot()
     pipeline.confirm_timing_snapshot(first_token)
     pipeline.restore_timing_snapshot(second_token)
 
     assert first["event_pipeline_processed_count"] == 7
+    assert first["event_structured_sink_write_count"] == 2
+    assert first["event_monitor_sink_write_count"] == 3
     assert second["event_pipeline_processed_count"] == 3
-    assert pipeline.health_snapshot()["event_pipeline_processed_count"] == 3
+    assert second["event_structured_sink_write_count"] == 5
+    assert second["event_structured_sink_service_ms_total"] == 11
+    assert second["event_structured_sink_service_ms_max"] == 7
+    assert second["event_monitor_sink_write_count"] == 1
+    assert second["event_monitor_sink_service_ms_total"] == 6
+    assert second["event_monitor_sink_service_ms_max"] == 6
+    restored = pipeline.health_snapshot()
+    assert restored["event_pipeline_processed_count"] == 3
+    assert restored["event_structured_sink_write_count"] == 5
+    assert restored["event_monitor_sink_write_count"] == 1
 
 
 def test_pipeline_restore_merges_newly_processed_timing(monkeypatch):
@@ -581,6 +639,12 @@ def test_pipeline_restore_merges_newly_processed_timing(monkeypatch):
     pipeline._timing_queue_wait_ns_max = 3_000_000
     pipeline._timing_worker_service_ns_total = 12_000_000
     pipeline._timing_worker_service_ns_max = 5_000_000
+    pipeline._timing_structured_sink_write_count = 3
+    pipeline._timing_structured_sink_service_ns_total = 21_000_000
+    pipeline._timing_structured_sink_service_ns_max = 9_000_000
+    pipeline._timing_monitor_sink_write_count = 4
+    pipeline._timing_monitor_sink_service_ns_total = 30_000_000
+    pipeline._timing_monitor_sink_service_ns_max = 11_000_000
     _snapshot, token = pipeline.consume_timing_snapshot()
 
     pipeline._timing_processed_count = 2
@@ -588,6 +652,12 @@ def test_pipeline_restore_merges_newly_processed_timing(monkeypatch):
     pipeline._timing_queue_wait_ns_max = 6_000_000
     pipeline._timing_worker_service_ns_total = 4_000_000
     pipeline._timing_worker_service_ns_max = 3_000_000
+    pipeline._timing_structured_sink_write_count = 2
+    pipeline._timing_structured_sink_service_ns_total = 8_000_000
+    pipeline._timing_structured_sink_service_ns_max = 6_000_000
+    pipeline._timing_monitor_sink_write_count = 1
+    pipeline._timing_monitor_sink_service_ns_total = 12_000_000
+    pipeline._timing_monitor_sink_service_ns_max = 12_000_000
     pipeline.restore_timing_snapshot(token)
 
     restored = pipeline.health_snapshot()
@@ -596,6 +666,12 @@ def test_pipeline_restore_merges_newly_processed_timing(monkeypatch):
     assert restored["event_queue_wait_ms_max"] == 6
     assert restored["event_worker_service_ms_total"] == 16
     assert restored["event_worker_service_ms_max"] == 5
+    assert restored["event_structured_sink_write_count"] == 5
+    assert restored["event_structured_sink_service_ms_total"] == 29
+    assert restored["event_structured_sink_service_ms_max"] == 9
+    assert restored["event_monitor_sink_write_count"] == 5
+    assert restored["event_monitor_sink_service_ms_total"] == 42
+    assert restored["event_monitor_sink_service_ms_max"] == 12
 
 
 def test_pipeline_queue_overflow_is_logged_and_monitor_visible(caplog):
@@ -627,12 +703,25 @@ def test_pipeline_queue_overflow_is_logged_and_monitor_visible(caplog):
     assert any("live event queue full" in record.message for record in caplog.records)
 
 
-def test_sink_failure_degrades_observability_without_raising():
+def test_sink_failure_degrades_observability_without_raising(monkeypatch):
+    clock = {"ns": 1_000_000_000}
+    monkeypatch.setattr(
+        live_event_bus_module.time,
+        "monotonic_ns",
+        lambda: clock["ns"],
+    )
+
     class FailingSink:
         def write(self, event):
+            clock["ns"] += 3_000_000
             raise OSError("disk full")
 
-    monitor = ListEventSink()
+    class ControlledMonitorSink(ListEventSink):
+        def write(self, event):
+            clock["ns"] += 5_000_000
+            return super().write(event)
+
+    monitor = ControlledMonitorSink()
     pipeline = LiveEventPipeline(
         structured_sinks=[FailingSink()],
         monitor_sinks=[monitor],
@@ -644,6 +733,13 @@ def test_sink_failure_degrades_observability_without_raising():
     assert event.event_type == EventTypes.SNAPSHOT_BUILT
     assert pipeline.flush(timeout=2.0) is True
     assert pipeline.sink_error_counters["structured"] == 1
+    timing = pipeline.health_snapshot()
+    assert timing["event_structured_sink_write_count"] == 1
+    assert timing["event_structured_sink_service_ms_total"] == 3
+    assert timing["event_structured_sink_service_ms_max"] == 3
+    assert timing["event_monitor_sink_write_count"] == 1
+    assert timing["event_monitor_sink_service_ms_total"] == 5
+    assert timing["event_monitor_sink_service_ms_max"] == 5
     assert pipeline.degraded_events[-1].reason_code == "structured_sink_failed"
     assert monitor.events[-1].event_type == EventTypes.SINK_DEGRADED
     assert monitor.events[-1].reason_code == "structured_sink_failed"
@@ -665,6 +761,7 @@ def test_monitor_sink_none_ack_records_monitor_sink_failure():
     assert event.event_type == EventTypes.SNAPSHOT_BUILT
     assert pipeline.flush(timeout=2.0) is True
     assert pipeline.sink_error_counters["monitor"] == 1
+    assert pipeline.health_snapshot()["event_monitor_sink_write_count"] == 1
     assert pipeline.degraded_events[-1].reason_code == "monitor_sink_failed"
     assert pipeline.close(timeout=2.0) is True
 

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -4830,6 +4830,12 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
                     "event_queue_wait_ms_max": 1.0,
                     "event_worker_service_ms_total": 2.0,
                     "event_worker_service_ms_max": 2.0,
+                    "event_structured_sink_write_count": 2,
+                    "event_structured_sink_service_ms_total": 1.2,
+                    "event_structured_sink_service_ms_max": 0.8,
+                    "event_monitor_sink_write_count": 2,
+                    "event_monitor_sink_service_ms_total": 0.8,
+                    "event_monitor_sink_service_ms_max": 0.5,
                 },
             ),
             _monitor_row(
@@ -4843,6 +4849,12 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
                     "event_queue_wait_ms_max": 3.0,
                     "event_worker_service_ms_total": 7.5,
                     "event_worker_service_ms_max": 4.0,
+                    "event_structured_sink_write_count": 5,
+                    "event_structured_sink_service_ms_total": 3.5,
+                    "event_structured_sink_service_ms_max": 1.5,
+                    "event_monitor_sink_write_count": 5,
+                    "event_monitor_sink_service_ms_total": 2.5,
+                    "event_monitor_sink_service_ms_max": 1.2,
                 },
             ),
         ],
@@ -4863,6 +4875,12 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
                     "event_queue_wait_ms_max": 2.25,
                     "event_worker_service_ms_total": 3.5,
                     "event_worker_service_ms_max": 3.5,
+                    "event_structured_sink_write_count": 3,
+                    "event_structured_sink_service_ms_total": 2.0,
+                    "event_structured_sink_service_ms_max": 1.0,
+                    "event_monitor_sink_write_count": 3,
+                    "event_monitor_sink_service_ms_total": 1.5,
+                    "event_monitor_sink_service_ms_max": 0.9,
                 },
             )
         ],
@@ -4890,6 +4908,8 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
         "p95": 4.35,
     }
     assert binance_fields["event_worker_service_ms_max"]["latest"] == 4
+    assert binance_fields["event_structured_sink_service_ms_total"]["latest"] == 3.5
+    assert binance_fields["event_monitor_sink_write_count"]["latest"] == 5
     assert {
         key: pressure[key]
         for key in (
@@ -4899,6 +4919,12 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
             "latest_event_queue_wait_ms_max",
             "latest_event_worker_service_ms_total_sum",
             "latest_event_worker_service_ms_max",
+            "latest_event_structured_sink_write_count_sum",
+            "latest_event_structured_sink_service_ms_total_sum",
+            "latest_event_structured_sink_service_ms_max",
+            "latest_event_monitor_sink_write_count_sum",
+            "latest_event_monitor_sink_service_ms_total_sum",
+            "latest_event_monitor_sink_service_ms_max",
         )
     } == {
         "latest_event_pipeline_processed_total": 8,
@@ -4907,6 +4933,12 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
         "latest_event_queue_wait_ms_max": 3,
         "latest_event_worker_service_ms_total_sum": 11,
         "latest_event_worker_service_ms_max": 4,
+        "latest_event_structured_sink_write_count_sum": 8,
+        "latest_event_structured_sink_service_ms_total_sum": 5.5,
+        "latest_event_structured_sink_service_ms_max": 1.5,
+        "latest_event_monitor_sink_write_count_sum": 8,
+        "latest_event_monitor_sink_service_ms_total_sum": 4,
+        "latest_event_monitor_sink_service_ms_max": 1.2,
     }
 
 

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2711,6 +2711,12 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
                     "event_queue_wait_ms_max": 8.5,
                     "event_worker_service_ms_total": 20.25,
                     "event_worker_service_ms_max": 15.5,
+                    "event_structured_sink_write_count": 8,
+                    "event_structured_sink_service_ms_total": 12.0,
+                    "event_structured_sink_service_ms_max": 7.0,
+                    "event_monitor_sink_write_count": 8,
+                    "event_monitor_sink_service_ms_total": 8.0,
+                    "event_monitor_sink_service_ms_max": 4.0,
                 },
             )
         ],
@@ -2731,6 +2737,12 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
                     "event_queue_wait_ms_max": 6.5,
                     "event_worker_service_ms_total": 7.75,
                     "event_worker_service_ms_max": 7.75,
+                    "event_structured_sink_write_count": 3,
+                    "event_structured_sink_service_ms_total": 4.0,
+                    "event_structured_sink_service_ms_max": 3.0,
+                    "event_monitor_sink_write_count": 3,
+                    "event_monitor_sink_service_ms_total": 2.0,
+                    "event_monitor_sink_service_ms_max": 2.0,
                 },
             )
         ],
@@ -2745,6 +2757,8 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
     assert groups["okx/okx_01"].get("latest_processed_count") == 8
     assert groups["okx/okx_01"].get("latest_queue_wait_ms_max") == 8.5
     assert groups["gateio/gateio_01"].get("latest_worker_service_ms_max") == 7.75
+    assert groups["okx/okx_01"].get("latest_structured_sink_write_count") == 8
+    assert groups["gateio/gateio_01"].get("latest_monitor_sink_service_ms_max") == 2
     expected = {
         "latest_processed_total": 11,
         "latest_timing_window_ms_max": 1250,
@@ -2752,6 +2766,12 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
         "latest_queue_wait_ms_max": 8.5,
         "latest_worker_service_ms_total_sum": 28,
         "latest_worker_service_ms_max": 15.5,
+        "latest_structured_sink_write_count_sum": 11,
+        "latest_structured_sink_service_ms_total_sum": 16,
+        "latest_structured_sink_service_ms_max": 7,
+        "latest_monitor_sink_write_count_sum": 11,
+        "latest_monitor_sink_service_ms_total_sum": 10,
+        "latest_monitor_sink_service_ms_max": 4,
     }
     assert {key: health[key] for key in expected} == expected
     assert {key: summary["event_pipeline_health"][key] for key in expected} == expected

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1363,6 +1363,12 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
                 "event_queue_wait_ms_max": 7.5,
                 "event_worker_service_ms_total": 98.75,
                 "event_worker_service_ms_max": 12.25,
+                "event_structured_sink_write_count": 120,
+                "event_structured_sink_service_ms_total": 55.5,
+                "event_structured_sink_service_ms_max": 8.25,
+                "event_monitor_sink_write_count": 120,
+                "event_monitor_sink_service_ms_total": 40.25,
+                "event_monitor_sink_service_ms_max": 6.75,
             }
 
     class FakeBot:
@@ -1460,6 +1466,12 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
     assert payload["event_queue_wait_ms_max"] == 7.5
     assert payload["event_worker_service_ms_total"] == 98.75
     assert payload["event_worker_service_ms_max"] == 12.25
+    assert payload["event_structured_sink_write_count"] == 120
+    assert payload["event_structured_sink_service_ms_total"] == 55.5
+    assert payload["event_structured_sink_service_ms_max"] == 8.25
+    assert payload["event_monitor_sink_write_count"] == 120
+    assert payload["event_monitor_sink_service_ms_total"] == 40.25
+    assert payload["event_monitor_sink_service_ms_max"] == 6.75
     assert bot._live_event_pipeline.consume_timing_calls == [False]
 
     consumed_payload, timing_token = bot._build_health_summary_payload(


### PR DESCRIPTION
## Summary

- attribute queued-worker sink service time to fixed `structured` and `monitor` sink classes
- expose per-health-window write counts and service total/max through health, smoke, and performance reports
- carry the new counters through the existing transactional consume/confirm/restore timing window
- record PR #1200 deployment evidence and advance the active logging-overhaul handoff

## Contract

Each actual queued-worker `sink.write()` attempt is counted and timed with `monotonic_ns`, including failed attempts and the direct monitor write of a structured failure's `sink.degraded` event. Aggregate worker service timing remains end-to-end. Synchronous console/text writes are excluded. Fields are fixed numeric values only; no sink implementation names, paths, event types, payload samples, labels, or tokens are emitted. Historical health events without the fields omit them rather than synthesizing zero.

This does not change routing, queue capacity, backpressure, drop/error policy, delivery semantics, smoke verdicts, console behavior, trading decisions, order/risk/HSL/Rust/backtest/optimizer/exchange behavior, or event payloads.

## Validation

- 418 affected tests passed: event bus, monitor, smoke, performance, incident bundle, restart plan, and fake-live
- all 62 event-bus tests passed after the final failure-cascade regression
- changed Python modules and tests compile
- `git diff --check` clean
- added-line silent-handling audit contains only the explicit existing sink-failure handler moved into a helper; it still increments counters and emits bounded degraded evidence
- independent architecture review and final preflight green after one P2 test-coverage fix

Expected post-merge action: gracefully restart the five exact VPS5 bot panes, then verify fresh per-sink timing in bounded health/smoke/performance reports plus immediate and settled smoke. Preserve unrelated processes and local artifacts.

## Reviewer focus

Please check per-write exactly-once timing (including failures), transactional restore/overlapping tokens, console/text exclusion, fixed-cardinality/privacy, historical missing-field behavior, report aggregate naming, and isolation from delivery/trading behavior.