### PR TITLE
Attribute monitor publisher service phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Periodic structured health summaries now split real monitor-sink service time
+  into fixed event-conversion, publisher lock-wait, rotation, persistence, and
+  maintenance totals/maxima. Live smoke and performance reports project the
+  same bounded fields without changing monitor persistence, event delivery,
+  verdicts, or trading behavior.
+
 - Periodic structured health summaries now attribute queued worker sink time to
   fixed structured and monitor sink classes with bounded per-window write
   counts and service totals/maxima. Live smoke and performance reports project

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,28 +22,32 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-event-pipeline-sink-attribution`
-- Base: `cbf1e5ed5bf8bfed4bd967a02d853c099105eabc`
-- Triggering evidence: PR #1200 measured live worker-service maxima above one
-  second while drops, sink errors, and degraded counts remained zero, but the
-  aggregate cannot identify whether the fixed structured or monitor sink class
-  accounted for the delay.
-- Scope: time each queued worker `sink.write()` attempt with a monotonic clock
-  and aggregate fixed structured/monitor write counts plus service total/max
-  over the existing health-summary timing window. Preserve aggregate worker
-  service timing. Rotate, confirm, and restore the new counters with the same
-  opaque timing token, including failed health-event enqueue and overlapping
-  snapshots. Project the fixed numeric fields through event-pipeline smoke
-  summaries and performance resource-pressure reports.
+- Branch: `codex/v8-monitor-publisher-phase-timing`
+- Base: `381f6a3f70f1da19abc85f75607541b5082cfb39`
+- Triggering evidence: deployed PR #1203 attributed essentially all queued
+  worker service to the monitor sink. Four fresh bots reported 2,525 monitor
+  writes, zero structured writes, monitor service total/max
+  `62842.105/5321.841ms`, and aggregate worker service total/max
+  `62937.772/5321.883ms`, with no drops, sink errors, degradation, or unhealthy
+  pipelines. The outer sink timing cannot identify which synchronous monitor
+  persistence phase caused the long tail.
+- Scope: attribute each real `MonitorEventSink` write to fixed monotonic phases:
+  live-event conversion, publisher lock wait, top-level rotation check/work,
+  envelope serialization plus NDJSON append, and post-append manifest/retention
+  maintenance. Aggregate total/max for each phase over the existing
+  health-summary timing window and rotate, confirm, or restore them with the
+  same opaque token. Project only those fixed numeric fields through smoke and
+  performance reports. Generic monitor sinks retain zero internal phase timing.
 - Behavior boundary: observability only. Do not make timing evidence a trading
-  gate, time synchronous console/text sinks, change queue capacity,
-  backpressure, routing, drop/error policy, add raw payloads or unbounded
-  labels, or alter order, risk, HSL, Rust, backtest, optimizer, or exchange
-  behavior.
-- Validation: event-bus route/timing and transactional restore tests, full
-  smoke/performance projection tests, health-payload passthrough tests, fake-live
-  event markers, Python compilation, `git diff --check`, added-line
-  silent-handling audit, and independent preflight.
+  gate; change publisher locking, fsync/durability, rotation, compression,
+  retention, queue capacity, backpressure, routing, or drop/error policy; add
+  raw payloads, dynamic labels, alerts, thresholds, or verdicts; or alter
+  order, risk, HSL, Rust, backtest, optimizer, or exchange behavior.
+- Validation: deterministic publisher/event-bus phase and failure timing,
+  transactional reset/restore/overlap tests, generic-sink zero tests, full
+  smoke/performance projections, health-payload passthrough, fake-live event
+  markers, Python compilation, `git diff --check`, added-line silent-handling
+  audit, and independent preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: exact five-bot graceful restart, then bounded
@@ -57,18 +61,34 @@ Next action:
    and require fresh exact-head verdicts after every push.
 2. Merge only after that gate is green, then gracefully restart the five exact
    VPS5 bot panes while preserving unrelated processes and local artifacts.
-3. Verify fresh fixed structured/monitor sink timing with bounded
+3. Verify fresh fixed monitor-publisher phase timing with bounded
    `health.summary`, smoke, and performance reports, including immediate and
    settled process and repository-state checks.
 
 ## Deployed Baseline
 
-- Remote `v8`: `cbf1e5ed5bf8bfed4bd967a02d853c099105eabc`, PR #1200
-- VPS5 repository: `cbf1e5ed5bf8bfed4bd967a02d853c099105eabc`, PR #1200; tracked
+- Remote `v8`: `381f6a3f70f1da19abc85f75607541b5082cfb39`, PR #1203
+- VPS5 repository: `381f6a3f70f1da19abc85f75607541b5082cfb39`, PR #1203; tracked
   status clean; only expected untracked artifacts were preserved
-- VPS5 expected bots: five; running with PR #1200 restart PIDs
-  `865892/865897/865901/865903/865905`;
+- VPS5 expected bots: five; running with PR #1203 restart PIDs
+  `867321/867324/867328/867331/867333`;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1203 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
+  panes. All old bot processes exited naturally; pane PIDs
+  `856294/856332/856364/856398/856434` and unrelated `misc:0.0` PID `434835`
+  were preserved.
+- Four fresh bots reported 2,525 processed events and monitor writes, zero
+  structured writes, monitor service total/max `62842.105/5321.841ms`, worker
+  service total/max `62937.772/5321.883ms`, and queue-wait total/max
+  `18035.11/2350.05ms`. Queue depth and unfinished work returned to zero; drops,
+  sink errors, degraded counts, and unhealthy pipelines remained zero. The
+  performance report independently projected the same fields and omitted them
+  from historical rows that predated the producer.
+- The final settled two-minute smoke was green with `360/360` remote and
+  `55/55` account-critical calls successful, all five expected processes
+  matched, exact states `R/R/R/R/S`, pane and unrelated process IDs preserved,
+  and a clean tracked repository.
 - PR #1200 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded cleanly and gracefully stopped only the five exact bot
   panes; all old Python PIDs exited naturally, including KuCoin after a bounded
@@ -286,10 +306,13 @@ latest-lifecycle report ordering, PR #1194's bounded startup action milestones,
 PR #1195's startup consumer correctness fixes, PR #1196's true fresh-entry
 eligibility producer, PR #1197's fresh-entry startup milestone, PR #1198's
 local connector-call boundary evidence, and PR #1199's startup fill-cache proof
-correlation are also merged and deployed. The active slice is selecting bounded
-event-pipeline service-time evidence.
+correlation, PR #1200's event-pipeline service timing, and PR #1203's fixed
+sink-class attribution are also merged and deployed. The active slice attributes
+the deployed monitor-sink long tail to fixed synchronous publisher phases.
 
-After the active service-time slice is merged and validated, select the next
+After the phase-attribution slice is merged and validated, use production
+evidence to decide whether a monitor persistence optimization is warranted;
+otherwise select the next
 review-worthy bounded operator-tooling improvement sharing one code and
 validation surface.
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7878,3 +7878,40 @@ VPS5 deployment status:
 - Expected VPS action: exact five-bot graceful restart, bounded per-sink timing
   evidence, and immediate plus settled smoke while preserving unrelated
   processes and local artifacts.
+
+### Deployed Slice: Event-Pipeline Sink Attribution
+
+- PR #1203 was approved by Hermes and Grok 4.5 on exact head `3239c6678`; CI
+  passed and it merged to `v8` as `381f6a3f7`.
+- VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
+  panes. Old bot processes exited naturally. Pane PIDs
+  `856294/856332/856364/856398/856434` and unrelated `misc:0.0` PID `434835`
+  were preserved; new bot PIDs were `867321/867324/867328/867331/867333`.
+- Four fresh bots reported 2,525 processed events and monitor writes, zero
+  structured writes, monitor service total/max `62842.105/5321.841ms`, worker
+  service total/max `62937.772/5321.883ms`, and queue-wait total/max
+  `18035.11/2350.05ms`. Drops, sink errors, degraded counts, and unhealthy
+  pipelines remained zero, so the runtime bottleneck was localized to the
+  monitor sink without changing delivery policy.
+- The final settled two-minute smoke was hard-green with `360/360` remote and
+  `55/55` account-critical calls successful, all five expected processes
+  matched, exact states `R/R/R/R/S`, and a clean tracked repository.
+
+### Active Slice: Monitor-Publisher Phase Attribution
+
+- Branch: `codex/v8-monitor-publisher-phase-timing` from deployed `381f6a3f7`.
+- Scope: attribute each real `MonitorEventSink` write to fixed monotonic
+  event-conversion, publisher lock-wait, top-level rotation, serialization plus
+  NDJSON append, and post-append manifest/retention maintenance phases. Retain
+  the existing monitor-sink total and rotate/confirm/restore all new totals and
+  maxima with the existing opaque health-window token.
+- Consumers: project only fixed numeric fields through smoke event-pipeline
+  summaries and performance resource-pressure statistics. Generic monitor sinks
+  report zero internal phases; historical records omit absent fields.
+- Non-goals: no publisher lock, fsync/durability, rotation, compression,
+  retention, routing, queue/backpressure, drop/error policy, payload, label,
+  threshold, alert, verdict, order, risk, HSL, Rust, backtest, optimizer,
+  exchange, or trading behavior change.
+- Expected VPS action: exact five-bot graceful restart, bounded phase timing
+  evidence, and immediate plus settled smoke while preserving unrelated
+  processes and local artifacts.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -356,9 +356,12 @@ Related detailed plans:
    first heartbeat, and optional psutil-backed system memory/swap pressure
    fields for host-level pressure scans. PR #1200 added per-health-window
    processed count, queue-wait total/max, and aggregate worker sink-service
-   total/max with non-consuming ordinary monitor snapshots. The active
-   follow-up attributes that worker time to fixed structured/monitor sink write
-   counts and service total/max.
+   total/max with non-consuming ordinary monitor snapshots. PR #1203 attributed
+   that worker time to fixed structured/monitor sink write counts and service
+   total/max. Deployed evidence found essentially all worker service in the
+   monitor sink, including a `5321.841ms` maximum. The active follow-up splits
+   real monitor writes into fixed conversion, publisher lock-wait, rotation,
+   persistence, and maintenance timing without changing delivery or verdicts.
 
    Remaining refinements: exchange-call counts, candle-fetch concurrency,
    lower-level event-loop lag if heartbeat lag proves too coarse, and

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -376,9 +376,12 @@ classification when enough source events exist.
     event IDs for direct event-stream correlation. Remaining work: source events
     for complete stage coverage where the live loop does not yet emit timings.
     PR #1200 added per-heartbeat queue-wait and worker sink-service
-    count/total/max source evidence without affecting delivery. The active
-    follow-up attributes worker service to fixed structured and monitor sink
-    classes with per-window write counts and service total/max.
+    count/total/max source evidence without affecting delivery. PR #1203
+    attributed worker service to fixed structured and monitor sink classes with
+    per-window write counts and service total/max. Deployed evidence localized
+    the long tail to the monitor sink; the active follow-up attributes real
+    monitor writes to fixed conversion, publisher lock-wait, rotation,
+    persistence, and maintenance phases.
 - [ ] Exchange writes: create/cancel/close/panic write latency, exchange
   response latency, ambiguous write rate, confirmation latency.
   - Status: partial. The report now derives order-wave total duration,

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -55,6 +55,17 @@ _LIVE_EVENT_DEBUG_PROFILE_ALIASES = {
     "remote-call": "remote_calls",
     "remote-calls": "remote_calls",
 }
+_MONITOR_PUBLISHER_PHASE_TIMING_KEYS = (
+    "lock_wait_ns",
+    "rotation_ns",
+    "persist_ns",
+    "maintenance_ns",
+)
+_MONITOR_PHASE_TIMING_KEYS = ("prepare_ns", *_MONITOR_PUBLISHER_PHASE_TIMING_KEYS)
+
+
+def _empty_monitor_phase_timing() -> dict[str, int]:
+    return {key: 0 for key in _MONITOR_PHASE_TIMING_KEYS}
 
 _STARTUP_PHASE_READINESS_CONTRACTS: Mapping[str, tuple[str, str]] = MappingProxyType(
     {
@@ -846,12 +857,55 @@ class LiveEventSink(Protocol):
         ...
 
 
+class _MonitorEventPrepareError(Exception):
+    def __init__(self, error: Exception, timing: dict[str, int]):
+        super().__init__(str(error))
+        self.error = error
+        self.timing = timing
+
+
 class MonitorEventSink:
-    def __init__(self, publisher: Any):
+    def __init__(self, publisher: Any, *, publisher_phase_timing: bool = False):
         self.publisher = publisher
+        self.publisher_phase_timing = bool(publisher_phase_timing)
 
     def write(self, event: LiveEvent) -> Any:
-        kind, tags, payload = event.to_monitor_event()
+        try:
+            result, _timing = self._write_with_timing(event)
+        except _MonitorEventPrepareError as exc:
+            raise exc.error from exc
+        if result is None:
+            raise RuntimeError(f"monitor publisher returned None for {event.event_type}")
+        return result
+
+    def _write_with_timing(self, event: LiveEvent) -> tuple[Any, dict[str, int]]:
+        timing = _empty_monitor_phase_timing()
+        prepare_started_ns = time.monotonic_ns()
+        try:
+            kind, tags, payload = event.to_monitor_event()
+        except Exception as exc:
+            raise _MonitorEventPrepareError(exc, timing) from exc
+        finally:
+            timing["prepare_ns"] = max(0, time.monotonic_ns() - prepare_started_ns)
+
+        if self.publisher_phase_timing:
+            record_event_timed = getattr(self.publisher, "_record_event_timed", None)
+            if not callable(record_event_timed):
+                raise TypeError(
+                    "monitor publisher phase timing requires _record_event_timed()"
+                )
+            result, publisher_timing = record_event_timed(
+                kind,
+                tags,
+                payload,
+                ts=event.ts_ms,
+                symbol=event.symbol,
+                pside=event.pside,
+            )
+            for key in _MONITOR_PUBLISHER_PHASE_TIMING_KEYS:
+                timing[key] = max(0, int(publisher_timing.get(key, 0)))
+            return result, timing
+
         result = self.publisher.record_event(
             kind,
             tags,
@@ -860,9 +914,7 @@ class MonitorEventSink:
             symbol=event.symbol,
             pside=event.pside,
         )
-        if result is None:
-            raise RuntimeError(f"monitor publisher returned None for {kind}")
-        return result
+        return result, timing
 
 
 class ListEventSink:
@@ -1801,6 +1853,16 @@ class _EventPipelineTimingWindow:
     monitor_sink_write_count: int
     monitor_sink_service_ns_total: int
     monitor_sink_service_ns_max: int
+    monitor_prepare_ns_total: int
+    monitor_prepare_ns_max: int
+    monitor_publisher_lock_wait_ns_total: int
+    monitor_publisher_lock_wait_ns_max: int
+    monitor_publisher_rotation_ns_total: int
+    monitor_publisher_rotation_ns_max: int
+    monitor_publisher_persist_ns_total: int
+    monitor_publisher_persist_ns_max: int
+    monitor_publisher_maintenance_ns_total: int
+    monitor_publisher_maintenance_ns_max: int
 
 
 @dataclass
@@ -1811,6 +1873,16 @@ class _EventPipelineSinkWriteTiming:
     monitor_sink_write_count: int = 0
     monitor_sink_service_ns_total: int = 0
     monitor_sink_service_ns_max: int = 0
+    monitor_prepare_ns_total: int = 0
+    monitor_prepare_ns_max: int = 0
+    monitor_publisher_lock_wait_ns_total: int = 0
+    monitor_publisher_lock_wait_ns_max: int = 0
+    monitor_publisher_rotation_ns_total: int = 0
+    monitor_publisher_rotation_ns_max: int = 0
+    monitor_publisher_persist_ns_total: int = 0
+    monitor_publisher_persist_ns_max: int = 0
+    monitor_publisher_maintenance_ns_total: int = 0
+    monitor_publisher_maintenance_ns_max: int = 0
 
     def record(self, sink_name: str, service_ns: int) -> None:
         service_ns = max(0, int(service_ns))
@@ -1826,6 +1898,20 @@ class _EventPipelineSinkWriteTiming:
             self.monitor_sink_service_ns_max = max(
                 self.monitor_sink_service_ns_max, service_ns
             )
+
+    def record_monitor_phase_timing(self, timing: Mapping[str, int]) -> None:
+        for source_key, field_prefix in (
+            ("prepare_ns", "monitor_prepare_ns"),
+            ("lock_wait_ns", "monitor_publisher_lock_wait_ns"),
+            ("rotation_ns", "monitor_publisher_rotation_ns"),
+            ("persist_ns", "monitor_publisher_persist_ns"),
+            ("maintenance_ns", "monitor_publisher_maintenance_ns"),
+        ):
+            value_ns = max(0, int(timing.get(source_key, 0)))
+            total_field = f"{field_prefix}_total"
+            max_field = f"{field_prefix}_max"
+            setattr(self, total_field, int(getattr(self, total_field)) + value_ns)
+            setattr(self, max_field, max(int(getattr(self, max_field)), value_ns))
 
 
 class LiveEventPipeline:
@@ -1873,6 +1959,16 @@ class LiveEventPipeline:
         self._timing_monitor_sink_write_count = 0
         self._timing_monitor_sink_service_ns_total = 0
         self._timing_monitor_sink_service_ns_max = 0
+        self._timing_monitor_prepare_ns_total = 0
+        self._timing_monitor_prepare_ns_max = 0
+        self._timing_monitor_publisher_lock_wait_ns_total = 0
+        self._timing_monitor_publisher_lock_wait_ns_max = 0
+        self._timing_monitor_publisher_rotation_ns_total = 0
+        self._timing_monitor_publisher_rotation_ns_max = 0
+        self._timing_monitor_publisher_persist_ns_total = 0
+        self._timing_monitor_publisher_persist_ns_max = 0
+        self._timing_monitor_publisher_maintenance_ns_total = 0
+        self._timing_monitor_publisher_maintenance_ns_max = 0
         self._pending_timing_windows: dict[int, _EventPipelineTimingWindow] = {}
         self._next_timing_snapshot_token = 1
         self._worker: threading.Thread | None = None
@@ -1954,6 +2050,32 @@ class LiveEventPipeline:
                 monitor_sink_service_ns_max=int(
                     self._timing_monitor_sink_service_ns_max
                 ),
+                monitor_prepare_ns_total=int(self._timing_monitor_prepare_ns_total),
+                monitor_prepare_ns_max=int(self._timing_monitor_prepare_ns_max),
+                monitor_publisher_lock_wait_ns_total=int(
+                    self._timing_monitor_publisher_lock_wait_ns_total
+                ),
+                monitor_publisher_lock_wait_ns_max=int(
+                    self._timing_monitor_publisher_lock_wait_ns_max
+                ),
+                monitor_publisher_rotation_ns_total=int(
+                    self._timing_monitor_publisher_rotation_ns_total
+                ),
+                monitor_publisher_rotation_ns_max=int(
+                    self._timing_monitor_publisher_rotation_ns_max
+                ),
+                monitor_publisher_persist_ns_total=int(
+                    self._timing_monitor_publisher_persist_ns_total
+                ),
+                monitor_publisher_persist_ns_max=int(
+                    self._timing_monitor_publisher_persist_ns_max
+                ),
+                monitor_publisher_maintenance_ns_total=int(
+                    self._timing_monitor_publisher_maintenance_ns_total
+                ),
+                monitor_publisher_maintenance_ns_max=int(
+                    self._timing_monitor_publisher_maintenance_ns_max
+                ),
             )
             timing_snapshot_token = None
             if consume_timing:
@@ -1972,6 +2094,16 @@ class LiveEventPipeline:
                 self._timing_monitor_sink_write_count = 0
                 self._timing_monitor_sink_service_ns_total = 0
                 self._timing_monitor_sink_service_ns_max = 0
+                self._timing_monitor_prepare_ns_total = 0
+                self._timing_monitor_prepare_ns_max = 0
+                self._timing_monitor_publisher_lock_wait_ns_total = 0
+                self._timing_monitor_publisher_lock_wait_ns_max = 0
+                self._timing_monitor_publisher_rotation_ns_total = 0
+                self._timing_monitor_publisher_rotation_ns_max = 0
+                self._timing_monitor_publisher_persist_ns_total = 0
+                self._timing_monitor_publisher_persist_ns_max = 0
+                self._timing_monitor_publisher_maintenance_ns_total = 0
+                self._timing_monitor_publisher_maintenance_ns_max = 0
         snapshot: dict[str, Any] = {
             "event_queue_depth": queue_depth,
             "event_queue_maxsize": queue_maxsize,
@@ -2012,6 +2144,36 @@ class LiveEventPipeline:
             ),
             "event_monitor_sink_service_ms_max": self._timing_ms(
                 timing_window.monitor_sink_service_ns_max
+            ),
+            "event_monitor_prepare_ms_total": self._timing_ms(
+                timing_window.monitor_prepare_ns_total
+            ),
+            "event_monitor_prepare_ms_max": self._timing_ms(
+                timing_window.monitor_prepare_ns_max
+            ),
+            "event_monitor_publisher_lock_wait_ms_total": self._timing_ms(
+                timing_window.monitor_publisher_lock_wait_ns_total
+            ),
+            "event_monitor_publisher_lock_wait_ms_max": self._timing_ms(
+                timing_window.monitor_publisher_lock_wait_ns_max
+            ),
+            "event_monitor_publisher_rotation_ms_total": self._timing_ms(
+                timing_window.monitor_publisher_rotation_ns_total
+            ),
+            "event_monitor_publisher_rotation_ms_max": self._timing_ms(
+                timing_window.monitor_publisher_rotation_ns_max
+            ),
+            "event_monitor_publisher_persist_ms_total": self._timing_ms(
+                timing_window.monitor_publisher_persist_ns_total
+            ),
+            "event_monitor_publisher_persist_ms_max": self._timing_ms(
+                timing_window.monitor_publisher_persist_ns_max
+            ),
+            "event_monitor_publisher_maintenance_ms_total": self._timing_ms(
+                timing_window.monitor_publisher_maintenance_ns_total
+            ),
+            "event_monitor_publisher_maintenance_ms_max": self._timing_ms(
+                timing_window.monitor_publisher_maintenance_ns_max
             ),
         }
         return (
@@ -2062,6 +2224,30 @@ class LiveEventPipeline:
             self._timing_monitor_sink_service_ns_max,
             int(pending.monitor_sink_service_ns_max),
         )
+        for field_name in (
+            "monitor_prepare_ns_total",
+            "monitor_publisher_lock_wait_ns_total",
+            "monitor_publisher_rotation_ns_total",
+            "monitor_publisher_persist_ns_total",
+            "monitor_publisher_maintenance_ns_total",
+        ):
+            setattr(
+                self,
+                f"_timing_{field_name}",
+                int(getattr(self, f"_timing_{field_name}")) + int(getattr(pending, field_name)),
+            )
+        for field_name in (
+            "monitor_prepare_ns_max",
+            "monitor_publisher_lock_wait_ns_max",
+            "monitor_publisher_rotation_ns_max",
+            "monitor_publisher_persist_ns_max",
+            "monitor_publisher_maintenance_ns_max",
+        ):
+            setattr(
+                self,
+                f"_timing_{field_name}",
+                max(int(getattr(self, f"_timing_{field_name}")), int(getattr(pending, field_name))),
+            )
 
     def emit(
         self,
@@ -2194,8 +2380,8 @@ class LiveEventPipeline:
                         )
                 if route.monitor:
                     for sink in self.monitor_sinks:
-                        self._write_sink_in_worker(
-                            "monitor", sink, live_event, sink_write_timing
+                        self._write_monitor_sink_in_worker(
+                            sink, live_event, sink_write_timing
                         )
             finally:
                 if item is not None:
@@ -2236,6 +2422,41 @@ class LiveEventPipeline:
                             self._timing_monitor_sink_service_ns_max,
                             sink_write_timing.monitor_sink_service_ns_max,
                         )
+                        self._timing_monitor_prepare_ns_total += (
+                            sink_write_timing.monitor_prepare_ns_total
+                        )
+                        self._timing_monitor_prepare_ns_max = max(
+                            self._timing_monitor_prepare_ns_max,
+                            sink_write_timing.monitor_prepare_ns_max,
+                        )
+                        self._timing_monitor_publisher_lock_wait_ns_total += (
+                            sink_write_timing.monitor_publisher_lock_wait_ns_total
+                        )
+                        self._timing_monitor_publisher_lock_wait_ns_max = max(
+                            self._timing_monitor_publisher_lock_wait_ns_max,
+                            sink_write_timing.monitor_publisher_lock_wait_ns_max,
+                        )
+                        self._timing_monitor_publisher_rotation_ns_total += (
+                            sink_write_timing.monitor_publisher_rotation_ns_total
+                        )
+                        self._timing_monitor_publisher_rotation_ns_max = max(
+                            self._timing_monitor_publisher_rotation_ns_max,
+                            sink_write_timing.monitor_publisher_rotation_ns_max,
+                        )
+                        self._timing_monitor_publisher_persist_ns_total += (
+                            sink_write_timing.monitor_publisher_persist_ns_total
+                        )
+                        self._timing_monitor_publisher_persist_ns_max = max(
+                            self._timing_monitor_publisher_persist_ns_max,
+                            sink_write_timing.monitor_publisher_persist_ns_max,
+                        )
+                        self._timing_monitor_publisher_maintenance_ns_total += (
+                            sink_write_timing.monitor_publisher_maintenance_ns_total
+                        )
+                        self._timing_monitor_publisher_maintenance_ns_max = max(
+                            self._timing_monitor_publisher_maintenance_ns_max,
+                            sink_write_timing.monitor_publisher_maintenance_ns_max,
+                        )
                 self._queue.task_done()
 
     def _write_sink(self, name: str, sink: LiveEventSink, event: LiveEvent) -> Any:
@@ -2263,6 +2484,34 @@ class LiveEventPipeline:
         except Exception as exc:
             self._handle_sink_failure(name, exc, sink_write_timing=sink_write_timing)
             return None
+
+    def _write_monitor_sink_in_worker(
+        self,
+        sink: LiveEventSink,
+        event: LiveEvent,
+        sink_write_timing: _EventPipelineSinkWriteTiming,
+    ) -> Any:
+        if not isinstance(sink, MonitorEventSink):
+            return self._write_sink_in_worker("monitor", sink, event, sink_write_timing)
+
+        sink_started_ns = time.monotonic_ns()
+        try:
+            result, phase_timing = sink._write_with_timing(event)
+            sink_write_timing.record_monitor_phase_timing(phase_timing)
+            if result is None:
+                raise RuntimeError(
+                    f"monitor publisher returned None for {event.event_type}"
+                )
+            return result
+        except _MonitorEventPrepareError as exc:
+            sink_write_timing.record_monitor_phase_timing(exc.timing)
+            self._handle_sink_failure("monitor", exc.error, sink_write_timing=sink_write_timing)
+            return None
+        except Exception as exc:
+            self._handle_sink_failure("monitor", exc, sink_write_timing=sink_write_timing)
+            return None
+        finally:
+            sink_write_timing.record("monitor", time.monotonic_ns() - sink_started_ns)
 
     def _handle_sink_failure(
         self,
@@ -2314,7 +2563,25 @@ class LiveEventPipeline:
                     time.monotonic_ns() if sink_write_timing is not None else 0
                 )
                 try:
-                    sink.write(degraded)
+                    if isinstance(sink, MonitorEventSink):
+                        result, phase_timing = sink._write_with_timing(degraded)
+                        if sink_write_timing is not None:
+                            sink_write_timing.record_monitor_phase_timing(phase_timing)
+                        if result is None:
+                            raise RuntimeError(
+                                f"monitor publisher returned None for {degraded.event_type}"
+                            )
+                    else:
+                        sink.write(degraded)
+                except _MonitorEventPrepareError as exc:
+                    if sink_write_timing is not None:
+                        sink_write_timing.record_monitor_phase_timing(exc.timing)
+                    with self._state_lock:
+                        self.sink_error_counters["monitor"] += 1
+                    logging.warning(
+                        "[event] failed to emit sink.degraded to monitor: %s",
+                        type(exc.error).__name__,
+                    )
                 except Exception as exc:
                     with self._state_lock:
                         self.sink_error_counters["monitor"] += 1

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -111,6 +111,16 @@ _RESOURCE_PRESSURE_FIELDS = (
     "event_monitor_sink_write_count",
     "event_monitor_sink_service_ms_total",
     "event_monitor_sink_service_ms_max",
+    "event_monitor_prepare_ms_total",
+    "event_monitor_prepare_ms_max",
+    "event_monitor_publisher_lock_wait_ms_total",
+    "event_monitor_publisher_lock_wait_ms_max",
+    "event_monitor_publisher_rotation_ms_total",
+    "event_monitor_publisher_rotation_ms_max",
+    "event_monitor_publisher_persist_ms_total",
+    "event_monitor_publisher_persist_ms_max",
+    "event_monitor_publisher_maintenance_ms_total",
+    "event_monitor_publisher_maintenance_ms_max",
 )
 _RESOURCE_PRESSURE_COUNTER_FIELDS = (
     "event_drop_counts",
@@ -4016,6 +4026,36 @@ class _ResourcePressureAccumulator:
             ),
             "latest_event_monitor_sink_service_ms_max": latest_field_max(
                 "event_monitor_sink_service_ms_max"
+            ),
+            "latest_event_monitor_prepare_ms_total_sum": latest_field_sum(
+                "event_monitor_prepare_ms_total"
+            ),
+            "latest_event_monitor_prepare_ms_max": latest_field_max(
+                "event_monitor_prepare_ms_max"
+            ),
+            "latest_event_monitor_publisher_lock_wait_ms_total_sum": latest_field_sum(
+                "event_monitor_publisher_lock_wait_ms_total"
+            ),
+            "latest_event_monitor_publisher_lock_wait_ms_max": latest_field_max(
+                "event_monitor_publisher_lock_wait_ms_max"
+            ),
+            "latest_event_monitor_publisher_rotation_ms_total_sum": latest_field_sum(
+                "event_monitor_publisher_rotation_ms_total"
+            ),
+            "latest_event_monitor_publisher_rotation_ms_max": latest_field_max(
+                "event_monitor_publisher_rotation_ms_max"
+            ),
+            "latest_event_monitor_publisher_persist_ms_total_sum": latest_field_sum(
+                "event_monitor_publisher_persist_ms_total"
+            ),
+            "latest_event_monitor_publisher_persist_ms_max": latest_field_max(
+                "event_monitor_publisher_persist_ms_max"
+            ),
+            "latest_event_monitor_publisher_maintenance_ms_total_sum": latest_field_sum(
+                "event_monitor_publisher_maintenance_ms_total"
+            ),
+            "latest_event_monitor_publisher_maintenance_ms_max": latest_field_max(
+                "event_monitor_publisher_maintenance_ms_max"
             ),
             "event_pipeline_unhealthy_bots": unhealthy_bots,
             "groups_truncated": len(groups) > limit,

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -2812,6 +2812,16 @@ def _event_pipeline_health_group(
         "event_monitor_sink_write_count",
         "event_monitor_sink_service_ms_total",
         "event_monitor_sink_service_ms_max",
+        "event_monitor_prepare_ms_total",
+        "event_monitor_prepare_ms_max",
+        "event_monitor_publisher_lock_wait_ms_total",
+        "event_monitor_publisher_lock_wait_ms_max",
+        "event_monitor_publisher_rotation_ms_total",
+        "event_monitor_publisher_rotation_ms_max",
+        "event_monitor_publisher_persist_ms_total",
+        "event_monitor_publisher_persist_ms_max",
+        "event_monitor_publisher_maintenance_ms_total",
+        "event_monitor_publisher_maintenance_ms_max",
     }
     if not any(key in payload for key in observed_keys):
         return None
@@ -2872,6 +2882,36 @@ def _event_pipeline_health_group(
         ),
         "latest_monitor_sink_service_ms_max": _non_negative_number(
             payload.get("event_monitor_sink_service_ms_max")
+        ),
+        "latest_monitor_prepare_ms_total": _non_negative_number(
+            payload.get("event_monitor_prepare_ms_total")
+        ),
+        "latest_monitor_prepare_ms_max": _non_negative_number(
+            payload.get("event_monitor_prepare_ms_max")
+        ),
+        "latest_monitor_publisher_lock_wait_ms_total": _non_negative_number(
+            payload.get("event_monitor_publisher_lock_wait_ms_total")
+        ),
+        "latest_monitor_publisher_lock_wait_ms_max": _non_negative_number(
+            payload.get("event_monitor_publisher_lock_wait_ms_max")
+        ),
+        "latest_monitor_publisher_rotation_ms_total": _non_negative_number(
+            payload.get("event_monitor_publisher_rotation_ms_total")
+        ),
+        "latest_monitor_publisher_rotation_ms_max": _non_negative_number(
+            payload.get("event_monitor_publisher_rotation_ms_max")
+        ),
+        "latest_monitor_publisher_persist_ms_total": _non_negative_number(
+            payload.get("event_monitor_publisher_persist_ms_total")
+        ),
+        "latest_monitor_publisher_persist_ms_max": _non_negative_number(
+            payload.get("event_monitor_publisher_persist_ms_max")
+        ),
+        "latest_monitor_publisher_maintenance_ms_total": _non_negative_number(
+            payload.get("event_monitor_publisher_maintenance_ms_total")
+        ),
+        "latest_monitor_publisher_maintenance_ms_max": _non_negative_number(
+            payload.get("event_monitor_publisher_maintenance_ms_max")
         ),
         "latest_pipeline_stopping": (
             bool(payload.get("event_pipeline_stopping"))
@@ -2939,6 +2979,16 @@ def _merge_event_pipeline_health_group(
             "latest_monitor_sink_write_count",
             "latest_monitor_sink_service_ms_total",
             "latest_monitor_sink_service_ms_max",
+            "latest_monitor_prepare_ms_total",
+            "latest_monitor_prepare_ms_max",
+            "latest_monitor_publisher_lock_wait_ms_total",
+            "latest_monitor_publisher_lock_wait_ms_max",
+            "latest_monitor_publisher_rotation_ms_total",
+            "latest_monitor_publisher_rotation_ms_max",
+            "latest_monitor_publisher_persist_ms_total",
+            "latest_monitor_publisher_persist_ms_max",
+            "latest_monitor_publisher_maintenance_ms_total",
+            "latest_monitor_publisher_maintenance_ms_max",
             "latest_pipeline_stopping",
             "latest_worker_alive",
             "latest_ids",
@@ -3042,6 +3092,44 @@ def _summarize_event_pipeline_health(
         ),
         "latest_monitor_sink_service_ms_max": _max_optional_numbers(
             group.get("latest_monitor_sink_service_ms_max")
+            for group in groups.values()
+        ),
+        "latest_monitor_prepare_ms_total_sum": _sum_optional_numbers(
+            group.get("latest_monitor_prepare_ms_total") for group in groups.values()
+        ),
+        "latest_monitor_prepare_ms_max": _max_optional_numbers(
+            group.get("latest_monitor_prepare_ms_max") for group in groups.values()
+        ),
+        "latest_monitor_publisher_lock_wait_ms_total_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_lock_wait_ms_total")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_lock_wait_ms_max": _max_optional_numbers(
+            group.get("latest_monitor_publisher_lock_wait_ms_max")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_rotation_ms_total_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_rotation_ms_total")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_rotation_ms_max": _max_optional_numbers(
+            group.get("latest_monitor_publisher_rotation_ms_max")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_persist_ms_total_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_persist_ms_total")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_persist_ms_max": _max_optional_numbers(
+            group.get("latest_monitor_publisher_persist_ms_max")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_maintenance_ms_total_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_maintenance_ms_total")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_maintenance_ms_max": _max_optional_numbers(
+            group.get("latest_monitor_publisher_maintenance_ms_max")
             for group in groups.values()
         ),
     }
@@ -7031,6 +7119,36 @@ def _summary_limited_groups(
             "latest_monitor_sink_service_ms_max": summary.get(
                 "latest_monitor_sink_service_ms_max"
             ),
+            "latest_monitor_prepare_ms_total_sum": summary.get(
+                "latest_monitor_prepare_ms_total_sum"
+            ),
+            "latest_monitor_prepare_ms_max": summary.get(
+                "latest_monitor_prepare_ms_max"
+            ),
+            "latest_monitor_publisher_lock_wait_ms_total_sum": summary.get(
+                "latest_monitor_publisher_lock_wait_ms_total_sum"
+            ),
+            "latest_monitor_publisher_lock_wait_ms_max": summary.get(
+                "latest_monitor_publisher_lock_wait_ms_max"
+            ),
+            "latest_monitor_publisher_rotation_ms_total_sum": summary.get(
+                "latest_monitor_publisher_rotation_ms_total_sum"
+            ),
+            "latest_monitor_publisher_rotation_ms_max": summary.get(
+                "latest_monitor_publisher_rotation_ms_max"
+            ),
+            "latest_monitor_publisher_persist_ms_total_sum": summary.get(
+                "latest_monitor_publisher_persist_ms_total_sum"
+            ),
+            "latest_monitor_publisher_persist_ms_max": summary.get(
+                "latest_monitor_publisher_persist_ms_max"
+            ),
+            "latest_monitor_publisher_maintenance_ms_total_sum": summary.get(
+                "latest_monitor_publisher_maintenance_ms_total_sum"
+            ),
+            "latest_monitor_publisher_maintenance_ms_max": summary.get(
+                "latest_monitor_publisher_maintenance_ms_max"
+            ),
             "latest_worker_not_alive_count": summary.get(
                 "latest_worker_not_alive_count"
             ),
@@ -8472,6 +8590,36 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
                 ),
                 "latest_monitor_sink_service_ms_max": event_pipeline_health.get(
                     "latest_monitor_sink_service_ms_max"
+                ),
+                "latest_monitor_prepare_ms_total_sum": event_pipeline_health.get(
+                    "latest_monitor_prepare_ms_total_sum"
+                ),
+                "latest_monitor_prepare_ms_max": event_pipeline_health.get(
+                    "latest_monitor_prepare_ms_max"
+                ),
+                "latest_monitor_publisher_lock_wait_ms_total_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_lock_wait_ms_total_sum"
+                ),
+                "latest_monitor_publisher_lock_wait_ms_max": event_pipeline_health.get(
+                    "latest_monitor_publisher_lock_wait_ms_max"
+                ),
+                "latest_monitor_publisher_rotation_ms_total_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_rotation_ms_total_sum"
+                ),
+                "latest_monitor_publisher_rotation_ms_max": event_pipeline_health.get(
+                    "latest_monitor_publisher_rotation_ms_max"
+                ),
+                "latest_monitor_publisher_persist_ms_total_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_persist_ms_total_sum"
+                ),
+                "latest_monitor_publisher_persist_ms_max": event_pipeline_health.get(
+                    "latest_monitor_publisher_persist_ms_max"
+                ),
+                "latest_monitor_publisher_maintenance_ms_total_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_maintenance_ms_total_sum"
+                ),
+                "latest_monitor_publisher_maintenance_ms_max": event_pipeline_health.get(
+                    "latest_monitor_publisher_maintenance_ms_max"
                 ),
                 "latest_worker_not_alive_count": _count_value(
                     event_pipeline_health.get("latest_worker_not_alive_count")

--- a/src/monitor_publisher.py
+++ b/src/monitor_publisher.py
@@ -13,6 +13,18 @@ from pathlib import Path
 from typing import Any, Iterable, Optional
 
 
+_MONITOR_EVENT_PHASE_TIMING_KEYS = (
+    "lock_wait_ns",
+    "rotation_ns",
+    "persist_ns",
+    "maintenance_ns",
+)
+
+
+def _empty_monitor_event_phase_timing() -> dict[str, int]:
+    return {key: 0 for key in _MONITOR_EVENT_PHASE_TIMING_KEYS}
+
+
 def _json_default(value: Any) -> Any:
     if isinstance(value, Path):
         return str(value)
@@ -575,38 +587,79 @@ class MonitorPublisher:
         symbol: Optional[str] = None,
         pside: Optional[str] = None,
     ) -> Optional[dict]:
+        result, _timing = self._record_event_timed(
+            kind,
+            tags,
+            payload,
+            ts=ts,
+            symbol=symbol,
+            pside=pside,
+        )
+        return result
+
+    def _record_event_timed(
+        self,
+        kind: str,
+        tags: Iterable[str],
+        payload: Optional[dict] = None,
+        *,
+        ts: Optional[int] = None,
+        symbol: Optional[str] = None,
+        pside: Optional[str] = None,
+    ) -> tuple[Optional[dict], dict[str, int]]:
+        timing = _empty_monitor_event_phase_timing()
+        lock_wait_started_ns = time.monotonic_ns()
         with self._lock:
+            timing["lock_wait_ns"] = max(0, time.monotonic_ns() - lock_wait_started_ns)
             now_ms = self._now_ms() if ts is None else int(ts)
             try:
-                self._rotate_events_if_needed(now_ms=now_ms)
-                self.seq += 1
-                envelope = {
-                    "ts": now_ms,
-                    "seq": self.seq,
-                    "kind": str(kind),
-                    "tags": [str(tag) for tag in tags],
-                    "exchange": self.exchange,
-                    "user": self.user,
-                    "payload": payload or {},
-                }
-                if symbol is not None:
-                    envelope["symbol"] = str(symbol)
-                if pside is not None:
-                    envelope["pside"] = str(pside)
-                line = json.dumps(
-                    envelope,
-                    separators=(",", ":"),
-                    sort_keys=True,
-                    default=_json_default,
-                )
-                with open(self.current_events_path, "a", encoding="utf-8") as f:
-                    f.write(line + "\n")
-                self._write_manifest(now_ms=now_ms)
-                self._prune_retention(now_ms=now_ms)
-                return envelope
+                rotation_started_ns = time.monotonic_ns()
+                try:
+                    self._rotate_events_if_needed(now_ms=now_ms)
+                finally:
+                    timing["rotation_ns"] = max(
+                        0, time.monotonic_ns() - rotation_started_ns
+                    )
+
+                persist_started_ns = time.monotonic_ns()
+                try:
+                    self.seq += 1
+                    envelope = {
+                        "ts": now_ms,
+                        "seq": self.seq,
+                        "kind": str(kind),
+                        "tags": [str(tag) for tag in tags],
+                        "exchange": self.exchange,
+                        "user": self.user,
+                        "payload": payload or {},
+                    }
+                    if symbol is not None:
+                        envelope["symbol"] = str(symbol)
+                    if pside is not None:
+                        envelope["pside"] = str(pside)
+                    line = json.dumps(
+                        envelope,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                        default=_json_default,
+                    )
+                    with open(self.current_events_path, "a", encoding="utf-8") as f:
+                        f.write(line + "\n")
+                finally:
+                    timing["persist_ns"] = max(0, time.monotonic_ns() - persist_started_ns)
+
+                maintenance_started_ns = time.monotonic_ns()
+                try:
+                    self._write_manifest(now_ms=now_ms)
+                    self._prune_retention(now_ms=now_ms)
+                finally:
+                    timing["maintenance_ns"] = max(
+                        0, time.monotonic_ns() - maintenance_started_ns
+                    )
+                return envelope, timing
             except Exception as exc:
                 self._log_write_failure(f"recording event {kind}", exc)
-                return None
+                return None, timing
 
     def record_error(
         self,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -6188,7 +6188,14 @@ class Passivbot:
                 user=getattr(self, "user", None),
                 bot_id=getattr(self, "bot_id", None),
             ),
-            monitor_sinks=[MonitorEventSink(publisher)] if publisher is not None else [],
+            monitor_sinks=[
+                MonitorEventSink(
+                    publisher,
+                    publisher_phase_timing=isinstance(publisher, MonitorPublisher),
+                )
+            ]
+            if publisher is not None
+            else [],
             console_sink=console_sink,
             debug_profiles=getattr(self, "live_event_debug_profiles", ()),
         )

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -581,6 +581,231 @@ def test_pipeline_health_snapshot_tracks_and_consumes_queue_timing(monkeypatch):
     assert pipeline.close(timeout=2.0) is True
 
 
+def test_pipeline_aggregates_and_resets_monitor_publisher_phase_timing(monkeypatch):
+    clock = {"ns": 1_000_000_000}
+    monkeypatch.setattr(
+        live_event_bus_module.time,
+        "monotonic_ns",
+        lambda: clock["ns"],
+    )
+    original_to_monitor_event = LiveEvent.to_monitor_event
+
+    def timed_to_monitor_event(event):
+        clock["ns"] += 1_000_000
+        return original_to_monitor_event(event)
+
+    class TimedPublisher:
+        def __init__(self):
+            self.timings = iter(
+                (
+                    {
+                        "lock_wait_ns": 2_000_000,
+                        "rotation_ns": 3_000_000,
+                        "persist_ns": 5_000_000,
+                        "maintenance_ns": 7_000_000,
+                    },
+                    {
+                        "lock_wait_ns": 11_000_000,
+                        "rotation_ns": 13_000_000,
+                        "persist_ns": 17_000_000,
+                        "maintenance_ns": 19_000_000,
+                    },
+                )
+            )
+
+        def _record_event_timed(self, kind, *_args, **_kwargs):
+            return {"kind": kind}, next(self.timings)
+
+    monkeypatch.setattr(LiveEvent, "to_monitor_event", timed_to_monitor_event)
+    pipeline = LiveEventPipeline(
+        start=False,
+        monitor_sinks=[
+            MonitorEventSink(TimedPublisher(), publisher_phase_timing=True)
+        ],
+        routes={EventTypes.SNAPSHOT_BUILT: EventRoute(structured=False, monitor=True)},
+    )
+
+    assert pipeline.emit(LiveEvent(EventTypes.SNAPSHOT_BUILT)) is not None
+    assert pipeline.emit(LiveEvent(EventTypes.SNAPSHOT_BUILT)) is not None
+    pipeline.start()
+    assert pipeline.flush(timeout=2.0) is True
+
+    expected = {
+        "event_monitor_prepare_ms_total": 2.0,
+        "event_monitor_prepare_ms_max": 1.0,
+        "event_monitor_publisher_lock_wait_ms_total": 13.0,
+        "event_monitor_publisher_lock_wait_ms_max": 11.0,
+        "event_monitor_publisher_rotation_ms_total": 16.0,
+        "event_monitor_publisher_rotation_ms_max": 13.0,
+        "event_monitor_publisher_persist_ms_total": 22.0,
+        "event_monitor_publisher_persist_ms_max": 17.0,
+        "event_monitor_publisher_maintenance_ms_total": 26.0,
+        "event_monitor_publisher_maintenance_ms_max": 19.0,
+    }
+    snapshot = pipeline.health_snapshot()
+    assert {key: snapshot[key] for key in expected} == expected
+    _consumed, token = pipeline.consume_timing_snapshot()
+    pipeline.confirm_timing_snapshot(token)
+    reset = pipeline.health_snapshot()
+    assert {key: reset[key] for key in expected} == {key: 0.0 for key in expected}
+    assert pipeline.close(timeout=2.0) is True
+
+
+def test_pipeline_monitor_phase_timing_restores_overlapping_window(monkeypatch):
+    clock = {"ns": 1_000_000_000}
+    monkeypatch.setattr(
+        live_event_bus_module.time,
+        "monotonic_ns",
+        lambda: clock["ns"],
+    )
+    pipeline = LiveEventPipeline(start=False)
+    pipeline._timing_monitor_prepare_ns_total = 2_000_000
+    pipeline._timing_monitor_prepare_ns_max = 2_000_000
+    pipeline._timing_monitor_publisher_persist_ns_total = 3_000_000
+    pipeline._timing_monitor_publisher_persist_ns_max = 3_000_000
+
+    first, first_token = pipeline.consume_timing_snapshot()
+    pipeline._timing_monitor_prepare_ns_total = 5_000_000
+    pipeline._timing_monitor_prepare_ns_max = 5_000_000
+    pipeline._timing_monitor_publisher_persist_ns_total = 7_000_000
+    pipeline._timing_monitor_publisher_persist_ns_max = 7_000_000
+    _second, second_token = pipeline.consume_timing_snapshot()
+    pipeline.confirm_timing_snapshot(first_token)
+    pipeline.restore_timing_snapshot(second_token)
+
+    assert first["event_monitor_prepare_ms_total"] == 2.0
+    assert first["event_monitor_publisher_persist_ms_total"] == 3.0
+    restored = pipeline.health_snapshot()
+    assert restored["event_monitor_prepare_ms_total"] == 5.0
+    assert restored["event_monitor_prepare_ms_max"] == 5.0
+    assert restored["event_monitor_publisher_persist_ms_total"] == 7.0
+    assert restored["event_monitor_publisher_persist_ms_max"] == 7.0
+
+
+def test_pipeline_custom_monitor_sink_reports_zero_internal_phase_timing():
+    class CustomMonitorSink:
+        def write(self, event):
+            return event
+
+    pipeline = LiveEventPipeline(
+        monitor_sinks=[CustomMonitorSink()],
+        routes={EventTypes.SNAPSHOT_BUILT: EventRoute(structured=False, monitor=True)},
+    )
+
+    assert pipeline.emit(LiveEvent(EventTypes.SNAPSHOT_BUILT)) is not None
+    assert pipeline.flush(timeout=2.0) is True
+    timing = pipeline.health_snapshot()
+    assert {
+        key: timing[key]
+        for key in timing
+        if key.startswith("event_monitor_prepare_ms")
+        or key.startswith("event_monitor_publisher_")
+    } == {
+        "event_monitor_prepare_ms_total": 0.0,
+        "event_monitor_prepare_ms_max": 0.0,
+        "event_monitor_publisher_lock_wait_ms_total": 0.0,
+        "event_monitor_publisher_lock_wait_ms_max": 0.0,
+        "event_monitor_publisher_rotation_ms_total": 0.0,
+        "event_monitor_publisher_rotation_ms_max": 0.0,
+        "event_monitor_publisher_persist_ms_total": 0.0,
+        "event_monitor_publisher_persist_ms_max": 0.0,
+        "event_monitor_publisher_maintenance_ms_total": 0.0,
+        "event_monitor_publisher_maintenance_ms_max": 0.0,
+    }
+    assert pipeline.close(timeout=2.0) is True
+
+
+def test_monitor_event_sink_custom_publisher_ignores_private_timing_name_collision():
+    class CustomPublisher:
+        def __init__(self):
+            self.recorded = []
+
+        def record_event(self, kind, *_args, **_kwargs):
+            self.recorded.append(kind)
+            return {"kind": kind}
+
+        def _record_event_timed(self, *_args, **_kwargs):
+            raise AssertionError("private timing hook must require explicit opt-in")
+
+    publisher = CustomPublisher()
+    event = LiveEvent(EventTypes.SNAPSHOT_BUILT)
+
+    result = MonitorEventSink(publisher).write(event)
+
+    assert result == {"kind": EventTypes.SNAPSHOT_BUILT}
+    assert publisher.recorded == [EventTypes.SNAPSHOT_BUILT]
+
+
+def test_pipeline_monitor_publisher_failure_retains_phase_timing(monkeypatch):
+    clock = {"ns": 1_000_000_000}
+    monkeypatch.setattr(
+        live_event_bus_module.time,
+        "monotonic_ns",
+        lambda: clock["ns"],
+    )
+
+    class FailingPublisher:
+        def _record_event_timed(self, *_args, **_kwargs):
+            return (
+                None,
+                {
+                    "lock_wait_ns": 2_000_000,
+                    "rotation_ns": 3_000_000,
+                    "persist_ns": 5_000_000,
+                    "maintenance_ns": 0,
+                },
+            )
+
+    pipeline = LiveEventPipeline(
+        monitor_sinks=[
+            MonitorEventSink(FailingPublisher(), publisher_phase_timing=True)
+        ],
+        routes={EventTypes.SNAPSHOT_BUILT: EventRoute(structured=False, monitor=True)},
+    )
+
+    assert pipeline.emit(LiveEvent(EventTypes.SNAPSHOT_BUILT)) is not None
+    assert pipeline.flush(timeout=2.0) is True
+    timing = pipeline.health_snapshot()
+    assert timing["event_monitor_publisher_lock_wait_ms_total"] == 2.0
+    assert timing["event_monitor_publisher_rotation_ms_total"] == 3.0
+    assert timing["event_monitor_publisher_persist_ms_total"] == 5.0
+    assert timing["event_monitor_publisher_maintenance_ms_total"] == 0.0
+    assert pipeline.sink_error_counters["monitor"] == 1
+    assert pipeline.close(timeout=2.0) is True
+
+
+def test_pipeline_retains_prepare_timing_when_monitor_conversion_fails(monkeypatch):
+    clock = {"ns": 1_000_000_000}
+    monkeypatch.setattr(
+        live_event_bus_module.time,
+        "monotonic_ns",
+        lambda: clock["ns"],
+    )
+
+    def fail_to_monitor_event(_event):
+        clock["ns"] += 4_000_000
+        raise ValueError("bad monitor event")
+
+    class Publisher:
+        def record_event(self, *_args, **_kwargs):
+            raise AssertionError("publisher must not receive a failed conversion")
+
+    monkeypatch.setattr(LiveEvent, "to_monitor_event", fail_to_monitor_event)
+    pipeline = LiveEventPipeline(
+        monitor_sinks=[MonitorEventSink(Publisher())],
+        routes={EventTypes.SNAPSHOT_BUILT: EventRoute(structured=False, monitor=True)},
+    )
+
+    assert pipeline.emit(LiveEvent(EventTypes.SNAPSHOT_BUILT)) is not None
+    assert pipeline.flush(timeout=2.0) is True
+    timing = pipeline.health_snapshot()
+    assert timing["event_monitor_prepare_ms_total"] == 4.0
+    assert timing["event_monitor_prepare_ms_max"] == 4.0
+    assert timing["event_monitor_publisher_lock_wait_ms_total"] == 0.0
+    assert pipeline.sink_error_counters["monitor"] == 1
+    assert pipeline.close(timeout=2.0) is True
+
+
 def test_pipeline_overlapping_timing_snapshots_resolve_by_token(monkeypatch):
     clock = {"ns": 1_000_000_000}
     monkeypatch.setattr(

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -4855,6 +4855,16 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
                     "event_monitor_sink_write_count": 5,
                     "event_monitor_sink_service_ms_total": 2.5,
                     "event_monitor_sink_service_ms_max": 1.2,
+                    "event_monitor_prepare_ms_total": 0.3,
+                    "event_monitor_prepare_ms_max": 0.2,
+                    "event_monitor_publisher_lock_wait_ms_total": 0.2,
+                    "event_monitor_publisher_lock_wait_ms_max": 0.1,
+                    "event_monitor_publisher_rotation_ms_total": 0.4,
+                    "event_monitor_publisher_rotation_ms_max": 0.25,
+                    "event_monitor_publisher_persist_ms_total": 1.0,
+                    "event_monitor_publisher_persist_ms_max": 0.6,
+                    "event_monitor_publisher_maintenance_ms_total": 0.5,
+                    "event_monitor_publisher_maintenance_ms_max": 0.3,
                 },
             ),
         ],
@@ -4881,6 +4891,16 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
                     "event_monitor_sink_write_count": 3,
                     "event_monitor_sink_service_ms_total": 1.5,
                     "event_monitor_sink_service_ms_max": 0.9,
+                    "event_monitor_prepare_ms_total": 0.2,
+                    "event_monitor_prepare_ms_max": 0.2,
+                    "event_monitor_publisher_lock_wait_ms_total": 0.1,
+                    "event_monitor_publisher_lock_wait_ms_max": 0.1,
+                    "event_monitor_publisher_rotation_ms_total": 0.2,
+                    "event_monitor_publisher_rotation_ms_max": 0.2,
+                    "event_monitor_publisher_persist_ms_total": 0.5,
+                    "event_monitor_publisher_persist_ms_max": 0.5,
+                    "event_monitor_publisher_maintenance_ms_total": 0.3,
+                    "event_monitor_publisher_maintenance_ms_max": 0.3,
                 },
             )
         ],
@@ -4910,6 +4930,15 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
     assert binance_fields["event_worker_service_ms_max"]["latest"] == 4
     assert binance_fields["event_structured_sink_service_ms_total"]["latest"] == 3.5
     assert binance_fields["event_monitor_sink_write_count"]["latest"] == 5
+    assert binance_fields["event_monitor_publisher_persist_ms_total"] == {
+        "latest": 1,
+        "count": 1,
+        "min": 1,
+        "max": 1,
+        "mean": 1,
+        "median": 1,
+        "p95": 1,
+    }
     assert {
         key: pressure[key]
         for key in (
@@ -4925,6 +4954,16 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
             "latest_event_monitor_sink_write_count_sum",
             "latest_event_monitor_sink_service_ms_total_sum",
             "latest_event_monitor_sink_service_ms_max",
+            "latest_event_monitor_prepare_ms_total_sum",
+            "latest_event_monitor_prepare_ms_max",
+            "latest_event_monitor_publisher_lock_wait_ms_total_sum",
+            "latest_event_monitor_publisher_lock_wait_ms_max",
+            "latest_event_monitor_publisher_rotation_ms_total_sum",
+            "latest_event_monitor_publisher_rotation_ms_max",
+            "latest_event_monitor_publisher_persist_ms_total_sum",
+            "latest_event_monitor_publisher_persist_ms_max",
+            "latest_event_monitor_publisher_maintenance_ms_total_sum",
+            "latest_event_monitor_publisher_maintenance_ms_max",
         )
     } == {
         "latest_event_pipeline_processed_total": 8,
@@ -4939,6 +4978,16 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
         "latest_event_monitor_sink_write_count_sum": 8,
         "latest_event_monitor_sink_service_ms_total_sum": 4,
         "latest_event_monitor_sink_service_ms_max": 1.2,
+        "latest_event_monitor_prepare_ms_total_sum": 0.5,
+        "latest_event_monitor_prepare_ms_max": 0.2,
+        "latest_event_monitor_publisher_lock_wait_ms_total_sum": 0.3,
+        "latest_event_monitor_publisher_lock_wait_ms_max": 0.1,
+        "latest_event_monitor_publisher_rotation_ms_total_sum": 0.6,
+        "latest_event_monitor_publisher_rotation_ms_max": 0.25,
+        "latest_event_monitor_publisher_persist_ms_total_sum": 1.5,
+        "latest_event_monitor_publisher_persist_ms_max": 0.6,
+        "latest_event_monitor_publisher_maintenance_ms_total_sum": 0.8,
+        "latest_event_monitor_publisher_maintenance_ms_max": 0.3,
     }
 
 

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2717,6 +2717,16 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
                     "event_monitor_sink_write_count": 8,
                     "event_monitor_sink_service_ms_total": 8.0,
                     "event_monitor_sink_service_ms_max": 4.0,
+                    "event_monitor_prepare_ms_total": 1.0,
+                    "event_monitor_prepare_ms_max": 0.4,
+                    "event_monitor_publisher_lock_wait_ms_total": 0.5,
+                    "event_monitor_publisher_lock_wait_ms_max": 0.3,
+                    "event_monitor_publisher_rotation_ms_total": 0.6,
+                    "event_monitor_publisher_rotation_ms_max": 0.4,
+                    "event_monitor_publisher_persist_ms_total": 4.0,
+                    "event_monitor_publisher_persist_ms_max": 2.0,
+                    "event_monitor_publisher_maintenance_ms_total": 2.5,
+                    "event_monitor_publisher_maintenance_ms_max": 1.5,
                 },
             )
         ],
@@ -2743,6 +2753,16 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
                     "event_monitor_sink_write_count": 3,
                     "event_monitor_sink_service_ms_total": 2.0,
                     "event_monitor_sink_service_ms_max": 2.0,
+                    "event_monitor_prepare_ms_total": 0.3,
+                    "event_monitor_prepare_ms_max": 0.3,
+                    "event_monitor_publisher_lock_wait_ms_total": 0.2,
+                    "event_monitor_publisher_lock_wait_ms_max": 0.2,
+                    "event_monitor_publisher_rotation_ms_total": 0.4,
+                    "event_monitor_publisher_rotation_ms_max": 0.4,
+                    "event_monitor_publisher_persist_ms_total": 0.7,
+                    "event_monitor_publisher_persist_ms_max": 0.7,
+                    "event_monitor_publisher_maintenance_ms_total": 0.4,
+                    "event_monitor_publisher_maintenance_ms_max": 0.4,
                 },
             )
         ],
@@ -2759,6 +2779,7 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
     assert groups["gateio/gateio_01"].get("latest_worker_service_ms_max") == 7.75
     assert groups["okx/okx_01"].get("latest_structured_sink_write_count") == 8
     assert groups["gateio/gateio_01"].get("latest_monitor_sink_service_ms_max") == 2
+    assert groups["okx/okx_01"].get("latest_monitor_publisher_persist_ms_max") == 2
     expected = {
         "latest_processed_total": 11,
         "latest_timing_window_ms_max": 1250,
@@ -2772,6 +2793,16 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
         "latest_monitor_sink_write_count_sum": 11,
         "latest_monitor_sink_service_ms_total_sum": 10,
         "latest_monitor_sink_service_ms_max": 4,
+        "latest_monitor_prepare_ms_total_sum": 1.3,
+        "latest_monitor_prepare_ms_max": 0.4,
+        "latest_monitor_publisher_lock_wait_ms_total_sum": 0.7,
+        "latest_monitor_publisher_lock_wait_ms_max": 0.3,
+        "latest_monitor_publisher_rotation_ms_total_sum": 1,
+        "latest_monitor_publisher_rotation_ms_max": 0.4,
+        "latest_monitor_publisher_persist_ms_total_sum": 4.7,
+        "latest_monitor_publisher_persist_ms_max": 2,
+        "latest_monitor_publisher_maintenance_ms_total_sum": 2.9,
+        "latest_monitor_publisher_maintenance_ms_max": 1.5,
     }
     assert {key: health[key] for key in expected} == expected
     assert {key: summary["event_pipeline_health"][key] for key in expected} == expected

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -215,3 +215,105 @@ def test_monitor_disk_full_errors_are_coalesced(tmp_path, monkeypatch, caplog):
     disk_messages = [msg for msg in messages if "disk full" in msg]
     assert len(disk_messages) == 1
     assert "suppressing repeat disk-full monitor errors for 60s" in disk_messages[0]
+
+
+def test_monitor_publisher_event_phase_timing_uses_fixed_boundaries(tmp_path, monkeypatch):
+    publisher = _make_publisher(tmp_path)
+    clock = {"ns": 1_000_000_000}
+    monkeypatch.setattr(
+        monitor_publisher_module.time,
+        "monotonic_ns",
+        lambda: clock["ns"],
+    )
+
+    class TimedLock:
+        def __enter__(self):
+            clock["ns"] += 1_000_000
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+    original_dumps = monitor_publisher_module.json.dumps
+    original_open = open
+
+    def timed_dumps(*args, **kwargs):
+        clock["ns"] += 3_000_000
+        return original_dumps(*args, **kwargs)
+
+    class TimedFile:
+        def __init__(self, file):
+            self.file = file
+
+        def __enter__(self):
+            self.file.__enter__()
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return self.file.__exit__(exc_type, exc_value, traceback)
+
+        def write(self, value):
+            clock["ns"] += 5_000_000
+            return self.file.write(value)
+
+    def timed_open(*args, **kwargs):
+        return TimedFile(original_open(*args, **kwargs))
+
+    publisher._lock = TimedLock()
+    monkeypatch.setattr(
+        publisher,
+        "_rotate_events_if_needed",
+        lambda **_kwargs: clock.__setitem__("ns", clock["ns"] + 2_000_000),
+    )
+    monkeypatch.setattr(
+        publisher,
+        "_write_manifest",
+        lambda **_kwargs: clock.__setitem__("ns", clock["ns"] + 7_000_000),
+    )
+    monkeypatch.setattr(
+        publisher,
+        "_prune_retention",
+        lambda **_kwargs: clock.__setitem__("ns", clock["ns"] + 11_000_000),
+    )
+    monkeypatch.setattr(monitor_publisher_module.json, "dumps", timed_dumps)
+    monkeypatch.setattr(monitor_publisher_module, "open", timed_open, raising=False)
+
+    event, timing = publisher._record_event_timed("test.event", ("test",), {"value": 1})
+
+    assert event is not None
+    assert timing == {
+        "lock_wait_ns": 1_000_000,
+        "rotation_ns": 2_000_000,
+        "persist_ns": 8_000_000,
+        "maintenance_ns": 18_000_000,
+    }
+
+
+def test_monitor_publisher_event_failure_retains_reached_phase_timing(tmp_path, monkeypatch):
+    publisher = _make_publisher(tmp_path)
+    clock = {"ns": 1_000_000_000}
+    monkeypatch.setattr(
+        monitor_publisher_module.time,
+        "monotonic_ns",
+        lambda: clock["ns"],
+    )
+
+    def fail_dumps(*_args, **_kwargs):
+        clock["ns"] += 3_000_000
+        raise TypeError("not serializable")
+
+    monkeypatch.setattr(
+        publisher,
+        "_rotate_events_if_needed",
+        lambda **_kwargs: clock.__setitem__("ns", clock["ns"] + 2_000_000),
+    )
+    monkeypatch.setattr(monitor_publisher_module.json, "dumps", fail_dumps)
+
+    event, timing = publisher._record_event_timed("test.event", ("test",), {"value": 1})
+
+    assert event is None
+    assert timing == {
+        "lock_wait_ns": 0,
+        "rotation_ns": 2_000_000,
+        "persist_ns": 3_000_000,
+        "maintenance_ns": 0,
+    }

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -1369,6 +1369,16 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
                 "event_monitor_sink_write_count": 120,
                 "event_monitor_sink_service_ms_total": 40.25,
                 "event_monitor_sink_service_ms_max": 6.75,
+                "event_monitor_prepare_ms_total": 4.5,
+                "event_monitor_prepare_ms_max": 0.75,
+                "event_monitor_publisher_lock_wait_ms_total": 1.5,
+                "event_monitor_publisher_lock_wait_ms_max": 0.5,
+                "event_monitor_publisher_rotation_ms_total": 2.5,
+                "event_monitor_publisher_rotation_ms_max": 1.25,
+                "event_monitor_publisher_persist_ms_total": 15.5,
+                "event_monitor_publisher_persist_ms_max": 3.25,
+                "event_monitor_publisher_maintenance_ms_total": 16.25,
+                "event_monitor_publisher_maintenance_ms_max": 4.5,
             }
 
     class FakeBot:
@@ -1472,6 +1482,32 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
     assert payload["event_monitor_sink_write_count"] == 120
     assert payload["event_monitor_sink_service_ms_total"] == 40.25
     assert payload["event_monitor_sink_service_ms_max"] == 6.75
+    assert {
+        key: payload[key]
+        for key in (
+            "event_monitor_prepare_ms_total",
+            "event_monitor_prepare_ms_max",
+            "event_monitor_publisher_lock_wait_ms_total",
+            "event_monitor_publisher_lock_wait_ms_max",
+            "event_monitor_publisher_rotation_ms_total",
+            "event_monitor_publisher_rotation_ms_max",
+            "event_monitor_publisher_persist_ms_total",
+            "event_monitor_publisher_persist_ms_max",
+            "event_monitor_publisher_maintenance_ms_total",
+            "event_monitor_publisher_maintenance_ms_max",
+        )
+    } == {
+        "event_monitor_prepare_ms_total": 4.5,
+        "event_monitor_prepare_ms_max": 0.75,
+        "event_monitor_publisher_lock_wait_ms_total": 1.5,
+        "event_monitor_publisher_lock_wait_ms_max": 0.5,
+        "event_monitor_publisher_rotation_ms_total": 2.5,
+        "event_monitor_publisher_rotation_ms_max": 1.25,
+        "event_monitor_publisher_persist_ms_total": 15.5,
+        "event_monitor_publisher_persist_ms_max": 3.25,
+        "event_monitor_publisher_maintenance_ms_total": 16.25,
+        "event_monitor_publisher_maintenance_ms_max": 4.5,
+    }
     assert bot._live_event_pipeline.consume_timing_calls == [False]
 
     consumed_payload, timing_token = bot._build_health_summary_payload(


### PR DESCRIPTION
## Scope

Category: observability producer and read-only report projection.

Deployed PR #1203 localized essentially all queued worker service to the monitor
sink, including a 5.322 second maximum. This PR keeps the existing outer timing
and attributes real `MonitorEventSink` writes to five fixed monotonic phases:

- live-event conversion
- publisher lock wait
- top-level event rotation check/work
- envelope serialization plus NDJSON append
- post-append manifest and retention maintenance

Each phase reports bounded per-health-window total/max fields through the same
opaque consume/confirm/restore token used by existing pipeline timing. Smoke and
performance reports project the fields without changing verdicts. Custom monitor
sinks and custom publishers retain their established write contract and report
zero internal phase timing unless explicitly opted in.

## Non-goals

- no publisher lock, fsync/durability, rotation, compression, or retention change
- no queue capacity, backpressure, routing, drop, sink-error, or degraded policy change
- no raw payloads, dynamic labels, alerts, thresholds, or verdict changes
- no order, risk, HSL, Rust, backtest, optimizer, exchange, or trading behavior change

## VPS action

After the exact-head review and CI gate, gracefully restart only the five exact
VPS5 bot panes. Verify bounded phase timing through fresh `health.summary`, smoke,
and performance reports, then run immediate and settled process/repository checks.
Preserve unrelated processes and all local artifacts.

## Validation

- 408 affected tests passed across publisher/event bus, smoke, performance,
  health emission, incident bundle, and fake-live surfaces
- targeted post-finding compatibility/install/phase/failure/health delta: 5 passed
- Python compilation passed for all changed runtime modules
- `git diff --check` passed
- added-line silent-handling audit found only explicit rethrow/observable existing
  monitor-write failure handling; no neutral fallback was added
- independent preflight found one P2 custom-publisher hook collision; fixed with
  explicit real-`MonitorPublisher` opt-in and a collision regression; delta
  re-review was clean

Known warnings are the pre-existing portalocker blocking-mode warning and
fake-live `utcfromtimestamp` deprecation warnings.

## Reviewer focus

- exact phase boundaries and failure timing
- concurrency and opaque timing-window reset/restore/overlap behavior
- custom publisher/sink compatibility and degraded monitor cascade
- sparse historical report projection and absence of verdict changes
- observability-only architecture boundary
