### PR TITLE
Coalesce monitor manifest checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ All notable user-facing changes will be documented in this file.
 - Monitor event and history appends now coalesce the best-effort manifest
   checkpoint to the existing snapshot cadence while forcing it at lifecycle
   and rotation boundaries. Startup also recovers the event sequence from a
-  bounded tail scan when an unclean exit leaves the manifest stale, avoiding
-  ordinary sequence reuse without changing NDJSON append durability or trading
-  behavior.
+  fixed-memory current-segment scan when an unclean exit leaves the manifest
+  stale, preventing sequence reuse without changing NDJSON append durability or
+  trading behavior.
 
 - Periodic structured health summaries now split real monitor-sink service time
   into fixed event-conversion, publisher lock-wait, rotation, persistence, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ All notable user-facing changes will be documented in this file.
 - Monitor event and history appends now coalesce the best-effort manifest
   checkpoint to the existing snapshot cadence while forcing it at lifecycle
   and rotation boundaries. Startup also recovers the event sequence from a
-  fixed-memory current-segment scan when an unclean exit leaves the manifest
-  stale, preventing sequence reuse without changing NDJSON append durability or
-  trading behavior.
+  fixed-memory scan of checksummed current-segment recovery trailers when an
+  unclean exit leaves the manifest stale, preventing sequence reuse or payload
+  marker confusion without changing NDJSON append durability or trading
+  behavior.
 
 - Periodic structured health summaries now split real monitor-sink service time
   into fixed event-conversion, publisher lock-wait, rotation, persistence, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Monitor event and history appends now coalesce the best-effort manifest
+  checkpoint to the existing snapshot cadence while forcing it at lifecycle
+  and rotation boundaries. Startup also recovers the event sequence from a
+  bounded tail scan when an unclean exit leaves the manifest stale, avoiding
+  ordinary sequence reuse without changing NDJSON append durability or trading
+  behavior.
+
 - Periodic structured health summaries now split real monitor-sink service time
   into fixed event-conversion, publisher lock-wait, rotation, persistence, and
   maintenance totals/maxima. Live smoke and performance reports project the

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -34,9 +34,9 @@ Estimated completion:
   per existing snapshot interval during ordinary event/history appends. Force
   checkpoints during initialization, before and after rotation, after a
   successful snapshot, and at close. Recover startup sequence from the maximum
-  of the manifest and recoverable current-segment sequence markers using a
+  of the manifest and checksummed current-segment recovery trailers using a
   fixed-memory reverse chunk scan so unclean exits between checkpoints do not
-  reuse an event sequence.
+  reuse an event sequence or confuse payload fields with envelope metadata.
 - Behavior boundary: monitor persistence runtime only. Preserve NDJSON append
   and fsync semantics, RLock ordering, retention/compression, routing, queue and
   backpressure policy, error visibility, event payloads, all trading behavior,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -34,8 +34,9 @@ Estimated completion:
   per existing snapshot interval during ordinary event/history appends. Force
   checkpoints during initialization, before and after rotation, after a
   successful snapshot, and at close. Recover startup sequence from the maximum
-  of the manifest and the latest valid event row in a bounded reverse tail so
-  ordinary unclean exits between checkpoints do not reuse an event sequence.
+  of the manifest and recoverable current-segment sequence markers using a
+  fixed-memory reverse chunk scan so unclean exits between checkpoints do not
+  reuse an event sequence.
 - Behavior boundary: monitor persistence runtime only. Preserve NDJSON append
   and fsync semantics, RLock ordering, retention/compression, routing, queue and
   backpressure policy, error visibility, event payloads, all trading behavior,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -55,13 +55,12 @@ Estimated completion:
 
 Next action:
 
-1. Complete implementation and author validation, then publish one ready PR
-   with the runtime behavior and restart requirement explicit.
-2. Hold the exact current head until Hermes, Grok 4.5, and CI are green; resolve
-   findings narrowly and require fresh exact-head verdicts after every push.
-3. Merge only after that gate is green, then gracefully restart the five exact
+1. Hold PR #1205 at the exact current head until Hermes, Grok 4.5, and CI are
+   green; resolve findings narrowly and require fresh exact-head verdicts after
+   every push.
+2. Merge only after that gate is green, then gracefully restart the five exact
    VPS5 bot panes while preserving unrelated processes and local artifacts.
-4. Compare fresh monitor maintenance and lock-wait totals/maxima against the
+3. Compare fresh monitor maintenance and lock-wait totals/maxima against the
    PR #1204 baseline using immediate and settled smoke/performance evidence.
 
 ## Deployed Baseline

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,32 +22,31 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-monitor-publisher-phase-timing`
-- Base: `381f6a3f70f1da19abc85f75607541b5082cfb39`
-- Triggering evidence: deployed PR #1203 attributed essentially all queued
-  worker service to the monitor sink. Four fresh bots reported 2,525 monitor
-  writes, zero structured writes, monitor service total/max
-  `62842.105/5321.841ms`, and aggregate worker service total/max
-  `62937.772/5321.883ms`, with no drops, sink errors, degradation, or unhealthy
-  pipelines. The outer sink timing cannot identify which synchronous monitor
-  persistence phase caused the long tail.
-- Scope: attribute each real `MonitorEventSink` write to fixed monotonic phases:
-  live-event conversion, publisher lock wait, top-level rotation check/work,
-  envelope serialization plus NDJSON append, and post-append manifest/retention
-  maintenance. Aggregate total/max for each phase over the existing
-  health-summary timing window and rotate, confirm, or restore them with the
-  same opaque token. Project only those fixed numeric fields through smoke and
-  performance reports. Generic monitor sinks retain zero internal phase timing.
-- Behavior boundary: observability only. Do not make timing evidence a trading
-  gate; change publisher locking, fsync/durability, rotation, compression,
-  retention, queue capacity, backpressure, routing, or drop/error policy; add
-  raw payloads, dynamic labels, alerts, thresholds, or verdicts; or alter
-  order, risk, HSL, Rust, backtest, optimizer, or exchange behavior.
-- Validation: deterministic publisher/event-bus phase and failure timing,
-  transactional reset/restore/overlap tests, generic-sink zero tests, full
-  smoke/performance projections, health-payload passthrough, fake-live event
-  markers, Python compilation, `git diff --check`, added-line silent-handling
-  audit, and independent preflight.
+- Branch: `codex/v8-monitor-manifest-coalescing`
+- Base: `d1303f55b353e3a59d524afe12c7d72baeef6db6`
+- Triggering evidence: deployed PR #1204 attributed 47,478.85 of 53,903.942ms
+  monitor service time across 2,643 writes to post-append maintenance, or
+  88.08% cumulative and 17.964ms per write. Persistence totaled 3,619.444ms;
+  rotation 245.173ms; conversion 54.686ms. The worst single monitor write was
+  instead dominated by 1,661.187ms of publisher lock wait, so cumulative
+  maintenance and tail lock contention remain distinct concerns.
+- Scope: coalesce the best-effort monitor manifest checkpoint to at most once
+  per existing snapshot interval during ordinary event/history appends. Force
+  checkpoints during initialization, before and after rotation, after a
+  successful snapshot, and at close. Recover startup sequence from the maximum
+  of the manifest and the latest valid event row in a bounded reverse tail so
+  ordinary unclean exits between checkpoints do not reuse an event sequence.
+- Behavior boundary: monitor persistence runtime only. Preserve NDJSON append
+  and fsync semantics, RLock ordering, retention/compression, routing, queue and
+  backpressure policy, error visibility, event payloads, all trading behavior,
+  and existing configuration. Do not add threads, queues, dynamic labels,
+  alerts, thresholds, verdicts, or lock-holder attribution in this slice.
+- Validation: deterministic checkpoint cadence and force-point tests; failed
+  checkpoint retry; bounded startup recovery from stale manifest, malformed or
+  invalid trailing rows, and a final row without newline; relay discoverability;
+  publisher/event-bus/passivbot monitor regressions; smoke, performance,
+  incident-bundle, and fake-live coverage; Python compilation; `git diff
+  --check`; added-line silent-handling audit; and independent preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: exact five-bot graceful restart, then bounded
@@ -56,23 +55,37 @@ Estimated completion:
 
 Next action:
 
-1. Hold the published PR at the exact-current-head review gate until Hermes,
-   Grok 4.5, and CI are green; resolve any findings with narrow delta validation
-   and require fresh exact-head verdicts after every push.
-2. Merge only after that gate is green, then gracefully restart the five exact
+1. Complete implementation and author validation, then publish one ready PR
+   with the runtime behavior and restart requirement explicit.
+2. Hold the exact current head until Hermes, Grok 4.5, and CI are green; resolve
+   findings narrowly and require fresh exact-head verdicts after every push.
+3. Merge only after that gate is green, then gracefully restart the five exact
    VPS5 bot panes while preserving unrelated processes and local artifacts.
-3. Verify fresh fixed monitor-publisher phase timing with bounded
-   `health.summary`, smoke, and performance reports, including immediate and
-   settled process and repository-state checks.
+4. Compare fresh monitor maintenance and lock-wait totals/maxima against the
+   PR #1204 baseline using immediate and settled smoke/performance evidence.
 
 ## Deployed Baseline
 
-- Remote `v8`: `381f6a3f70f1da19abc85f75607541b5082cfb39`, PR #1203
-- VPS5 repository: `381f6a3f70f1da19abc85f75607541b5082cfb39`, PR #1203; tracked
+- Remote `v8`: `d1303f55b353e3a59d524afe12c7d72baeef6db6`, PR #1204
+- VPS5 repository: `d1303f55b353e3a59d524afe12c7d72baeef6db6`, PR #1204; tracked
   status clean; only expected untracked artifacts were preserved
-- VPS5 expected bots: five; running with PR #1203 restart PIDs
-  `867321/867324/867328/867331/867333`;
+- VPS5 expected bots: five; running with PR #1204 restart PIDs
+  `869404/869406/869556/869558/869564`;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1204 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
+  panes. All old bot processes exited naturally; pane PIDs
+  `856294/856332/856364/856398/856434` and unrelated `misc:0.0` PID `434835`
+  were preserved.
+- Four complete fresh health windows covered 2,643 monitor writes. Monitor
+  service total/max was `53903.942/1676.541ms`; maintenance
+  `47478.85/900.321ms`; persistence `3619.444/77.067ms`; lock wait
+  `2190.037/1661.187ms`; rotation `245.173/20.658ms`; and conversion
+  `54.686/1.139ms`. Drops, sink errors, degraded counts, unhealthy pipelines,
+  and final queue depth were zero.
+- The settled two-minute smoke was green with `346/346` remote and `51/51`
+  account-critical calls successful, all five expected processes matched,
+  exact states `R/R/R/R/S`, and a clean tracked repository.
 - PR #1203 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
   panes. All old bot processes exited naturally; pane PIDs

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7940,8 +7940,9 @@ VPS5 deployment status:
 - Branch: `codex/v8-monitor-manifest-coalescing` from deployed `d1303f55b`.
 - Scope: coalesce ordinary best-effort manifest checkpoints to the existing
   snapshot interval, force checkpoints at lifecycle and rotation boundaries,
-  and recover the maximum current-segment event sequence with a fixed-memory
-  reverse chunk scan when the manifest is stale after an unclean exit.
+  and recover the maximum checksummed current-segment event sequence with a
+  fixed-memory reverse chunk scan when the manifest is stale after an unclean
+  exit.
 - Non-goals: no change to NDJSON append/fsync semantics, lock ordering,
   retention/compression, event payloads, routing, queue/backpressure policy,
   monitor configuration, trading behavior, or lock-holder attribution.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7940,8 +7940,8 @@ VPS5 deployment status:
 - Branch: `codex/v8-monitor-manifest-coalescing` from deployed `d1303f55b`.
 - Scope: coalesce ordinary best-effort manifest checkpoints to the existing
   snapshot interval, force checkpoints at lifecycle and rotation boundaries,
-  and recover event sequence from a bounded reverse scan of the latest valid
-  current event row when the manifest is stale after an unclean exit.
+  and recover the maximum current-segment event sequence with a fixed-memory
+  reverse chunk scan when the manifest is stale after an unclean exit.
 - Non-goals: no change to NDJSON append/fsync semantics, lock ordering,
   retention/compression, event payloads, routing, queue/backpressure policy,
   monitor configuration, trading behavior, or lock-holder attribution.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -7915,3 +7915,35 @@ VPS5 deployment status:
 - Expected VPS action: exact five-bot graceful restart, bounded phase timing
   evidence, and immediate plus settled smoke while preserving unrelated
   processes and local artifacts.
+
+### Deployed Slice: Monitor-Publisher Phase Attribution
+
+- PR #1204 was approved by Hermes and Grok 4.5 on exact head `a538b27c2`; CI
+  passed and it merged to `v8` as `d1303f55b`.
+- VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
+  panes. All old bot processes exited naturally. Pane PIDs
+  `856294/856332/856364/856398/856434` and unrelated `misc:0.0` PID `434835`
+  were preserved; new bot PIDs were `869404/869406/869556/869558/869564`.
+- Four complete fresh health windows covered 2,643 monitor writes. Monitor
+  service total/max was `53903.942/1676.541ms`; maintenance
+  `47478.85/900.321ms`; persistence `3619.444/77.067ms`; lock wait
+  `2190.037/1661.187ms`; rotation `245.173/20.658ms`; and conversion
+  `54.686/1.139ms`. Maintenance represented 88.08% of cumulative monitor
+  service and averaged 17.964ms per write. The worst individual write was
+  instead almost entirely publisher lock wait.
+- The settled two-minute smoke was hard-green with `346/346` remote and
+  `51/51` account-critical calls successful, all five expected processes
+  matched, exact states `R/R/R/R/S`, and a clean tracked repository.
+
+### Active Slice: Monitor Manifest Checkpoint Coalescing
+
+- Branch: `codex/v8-monitor-manifest-coalescing` from deployed `d1303f55b`.
+- Scope: coalesce ordinary best-effort manifest checkpoints to the existing
+  snapshot interval, force checkpoints at lifecycle and rotation boundaries,
+  and recover event sequence from a bounded reverse scan of the latest valid
+  current event row when the manifest is stale after an unclean exit.
+- Non-goals: no change to NDJSON append/fsync semantics, lock ordering,
+  retention/compression, event payloads, routing, queue/backpressure policy,
+  monitor configuration, trading behavior, or lock-holder attribution.
+- Expected VPS action: exact five-bot graceful restart, immediate and settled
+  smoke, and before/after monitor maintenance plus lock-wait evidence.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -358,10 +358,13 @@ Related detailed plans:
    processed count, queue-wait total/max, and aggregate worker sink-service
    total/max with non-consuming ordinary monitor snapshots. PR #1203 attributed
    that worker time to fixed structured/monitor sink write counts and service
-   total/max. Deployed evidence found essentially all worker service in the
-   monitor sink, including a `5321.841ms` maximum. The active follow-up splits
-   real monitor writes into fixed conversion, publisher lock-wait, rotation,
-   persistence, and maintenance timing without changing delivery or verdicts.
+   total/max. PR #1204 then split real monitor writes into fixed conversion,
+   publisher lock-wait, rotation, persistence, and maintenance timing. Fresh
+   VPS5 evidence attributed 47,478.85 of 53,903.942ms cumulative monitor time
+   across 2,643 writes to maintenance, while a separate 1,661.187ms lock wait
+   dominated the worst single write. The active follow-up coalesces the
+   best-effort manifest checkpoint to the existing snapshot cadence, adds
+   bounded crash-safe sequence recovery, and preserves delivery and verdicts.
 
    Remaining refinements: exchange-call counts, candle-fetch concurrency,
    lower-level event-loop lag if heartbeat lag proves too coarse, and

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -378,10 +378,13 @@ classification when enough source events exist.
     PR #1200 added per-heartbeat queue-wait and worker sink-service
     count/total/max source evidence without affecting delivery. PR #1203
     attributed worker service to fixed structured and monitor sink classes with
-    per-window write counts and service total/max. Deployed evidence localized
-    the long tail to the monitor sink; the active follow-up attributes real
+    per-window write counts and service total/max. PR #1204 attributed real
     monitor writes to fixed conversion, publisher lock-wait, rotation,
-    persistence, and maintenance phases.
+    persistence, and maintenance phases. Fresh VPS5 evidence found maintenance
+    was 88.08% of cumulative monitor service while a separate 1,661.187ms lock
+    wait dominated the worst individual write. The active follow-up coalesces
+    best-effort manifest checkpoints to the existing snapshot cadence and adds
+    bounded crash-safe event-sequence recovery without changing delivery.
 - [ ] Exchange writes: create/cancel/close/panic write latency, exchange
   response latency, ambiguous write rate, confirmation latency.
   - Status: partial. The report now derives order-wave total duration,

--- a/src/monitor_publisher.py
+++ b/src/monitor_publisher.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gzip
+import hashlib
 import errno
 import json
 import logging
@@ -20,6 +21,10 @@ _MONITOR_EVENT_PHASE_TIMING_KEYS = (
     "maintenance_ns",
 )
 _CURRENT_EVENTS_REVERSE_READ_BYTES = 64 * 1024
+_EVENT_RECOVERY_CHECKSUM_BYTES = 16
+_EVENT_RECOVERY_MARKER = b',"_recovery":{"checksum":"'
+_EVENT_RECOVERY_SEQ_SEPARATOR = b'","seq":'
+_EVENT_RECOVERY_TRAILER_MAX_BYTES = 160
 
 
 def _empty_monitor_event_phase_timing() -> dict[str, int]:
@@ -217,8 +222,6 @@ class MonitorPublisher:
     def _max_recoverable_event_seq_in_current_segment(self) -> Optional[int]:
         """Return the maximum recoverable seq without buffering whole rows."""
 
-        seq_marker = b'"seq"'
-
         def iter_line_ranges_reverse(f, file_size: int):
             line_end = file_size
             scan_end = file_size
@@ -239,83 +242,49 @@ class MonitorPublisher:
                 scan_end = scan_start
             yield 0, line_end
 
-        def edge_byte(f, start: int, end: int, *, reverse: bool) -> Optional[int]:
-            if reverse:
-                cursor = end
-                while start < cursor:
-                    read_size = min(_CURRENT_EVENTS_REVERSE_READ_BYTES, cursor - start)
-                    cursor -= read_size
-                    f.seek(cursor)
-                    for value in reversed(f.read(read_size)):
-                        if value not in b" \t\r\n":
-                            return value
-            else:
-                cursor = start
-                while cursor < end:
-                    read_size = min(_CURRENT_EVENTS_REVERSE_READ_BYTES, end - cursor)
-                    f.seek(cursor)
-                    cursor += read_size
-                    for value in f.read(read_size):
-                        if value not in b" \t\r\n":
-                            return value
-            return None
-
-        def parse_seq_value(f, value_offset: int, line_end: int) -> Optional[int]:
-            f.seek(value_offset)
-            raw = f.read(min(64, line_end - value_offset))
-            cursor = 0
-            while cursor < len(raw) and raw[cursor] in b" \t\r\n":
-                cursor += 1
-            if cursor >= len(raw) or raw[cursor] != ord(":"):
-                return None
-            cursor += 1
-            while cursor < len(raw) and raw[cursor] in b" \t\r\n":
-                cursor += 1
-            digit_start = cursor
-            while cursor < len(raw) and 48 <= raw[cursor] <= 57:
-                cursor += 1
-            if digit_start == cursor:
-                return None
-            while cursor < len(raw) and raw[cursor] in b" \t\r\n":
-                cursor += 1
-            if cursor >= len(raw) or raw[cursor] not in b",}":
-                return None
-            return int(raw[digit_start:cursor].strip())
-
         def seq_from_line_range(f, line_start: int, line_end: int) -> Optional[int]:
-            if edge_byte(f, line_start, line_end, reverse=False) != ord("{"):
+            if line_end > line_start:
+                f.seek(line_end - 1)
+                if f.read(1) == b"\r":
+                    line_end -= 1
+            suffix_size = min(_EVENT_RECOVERY_TRAILER_MAX_BYTES, line_end - line_start)
+            if suffix_size <= 0:
                 return None
-            if edge_byte(f, line_start, line_end, reverse=True) != ord("}"):
+            f.seek(line_end - suffix_size)
+            suffix = f.read(suffix_size)
+            marker_idx = suffix.rfind(_EVENT_RECOVERY_MARKER)
+            if marker_idx < 0:
+                return None
+            marker_offset = line_end - suffix_size + marker_idx
+            trailer = suffix[marker_idx + len(_EVENT_RECOVERY_MARKER) :]
+            checksum, separator, seq_tail = trailer.partition(_EVENT_RECOVERY_SEQ_SEPARATOR)
+            if separator != _EVENT_RECOVERY_SEQ_SEPARATOR:
+                return None
+            if len(checksum) != _EVENT_RECOVERY_CHECKSUM_BYTES * 2:
+                return None
+            if not seq_tail.endswith(b"}}"):
+                return None
+            seq_raw = seq_tail[:-2]
+            if not seq_raw or len(seq_raw) > 32 or not seq_raw.isdigit():
                 return None
 
-            # record_event() serializes with sorted keys, so the envelope's
-            # top-level seq marker follows any matching marker in payload.
-            last_seq = None
-            overlap = b""
+            digest = hashlib.blake2b(digest_size=_EVENT_RECOVERY_CHECKSUM_BYTES)
             scan_offset = line_start
-            while scan_offset < line_end:
+            while scan_offset < marker_offset:
                 f.seek(scan_offset)
                 chunk = f.read(
-                    min(_CURRENT_EVENTS_REVERSE_READ_BYTES, line_end - scan_offset)
+                    min(_CURRENT_EVENTS_REVERSE_READ_BYTES, marker_offset - scan_offset)
                 )
-                data = overlap + chunk
-                data_offset = scan_offset - len(overlap)
-                search_offset = 0
-                while True:
-                    marker_idx = data.find(seq_marker, search_offset)
-                    if marker_idx < 0:
-                        break
-                    seq = parse_seq_value(
-                        f,
-                        data_offset + marker_idx + len(seq_marker),
-                        line_end,
-                    )
-                    if seq is not None:
-                        last_seq = seq
-                    search_offset = marker_idx + 1
-                overlap = data[-(len(seq_marker) - 1) :]
+                if not chunk:
+                    return None
+                digest.update(chunk)
                 scan_offset += len(chunk)
-            return last_seq
+            digest.update(b"}")
+            digest.update(b"\0seq:")
+            digest.update(seq_raw)
+            if digest.hexdigest().encode("ascii") != checksum:
+                return None
+            return int(seq_raw)
 
         try:
             with open(self.current_events_path, "rb") as f:
@@ -334,6 +303,28 @@ class MonitorPublisher:
                 exc,
             )
             return None
+
+    def _serialize_event_line(self, envelope: dict) -> str:
+        base_line = json.dumps(
+            envelope,
+            separators=(",", ":"),
+            sort_keys=True,
+            default=_json_default,
+        )
+        seq_text = str(int(envelope["seq"]))
+        digest = hashlib.blake2b(digest_size=_EVENT_RECOVERY_CHECKSUM_BYTES)
+        digest.update(base_line.encode("utf-8"))
+        digest.update(b"\0seq:")
+        digest.update(seq_text.encode("ascii"))
+        checksum = digest.hexdigest()
+        trailer = (
+            ',"_recovery":{"checksum":"'
+            + checksum
+            + '","seq":'
+            + seq_text
+            + "}}"
+        )
+        return base_line[:-1] + trailer
 
     def _build_manifest(self, now_ms: Optional[int] = None) -> dict:
         now_ms = self._now_ms() if now_ms is None else int(now_ms)
@@ -802,12 +793,7 @@ class MonitorPublisher:
                         envelope["symbol"] = str(symbol)
                     if pside is not None:
                         envelope["pside"] = str(pside)
-                    line = json.dumps(
-                        envelope,
-                        separators=(",", ":"),
-                        sort_keys=True,
-                        default=_json_default,
-                    )
+                    line = self._serialize_event_line(envelope)
                     with open(self.current_events_path, "a", encoding="utf-8") as f:
                         f.write(line + "\n")
                 finally:

--- a/src/monitor_publisher.py
+++ b/src/monitor_publisher.py
@@ -19,6 +19,7 @@ _MONITOR_EVENT_PHASE_TIMING_KEYS = (
     "persist_ns",
     "maintenance_ns",
 )
+_CURRENT_EVENTS_TAIL_BYTES = 64 * 1024
 
 
 def _empty_monitor_event_phase_timing() -> dict[str, int]:
@@ -133,8 +134,12 @@ class MonitorPublisher:
         self._disk_full_suppressed = 0
         self._lock = threading.RLock()
         self.seq = 0
+        self._manifest_dirty = False
+        self._manifest_retry_needed = False
+        self._last_manifest_write_monotonic_ms: Optional[int] = None
         self._ensure_layout()
         self._load_manifest_state()
+        self._recover_seq_from_current_events()
         self._write_manifest()
 
     @classmethod
@@ -160,6 +165,9 @@ class MonitorPublisher:
 
     def _now_ms(self) -> int:
         return int(time.time() * 1000)
+
+    def _monotonic_ms(self) -> int:
+        return int(time.monotonic() * 1000)
 
     def _ensure_layout(self) -> None:
         for path in (self.root, self.events_dir, self.history_dir, self.checkpoints_dir):
@@ -200,6 +208,46 @@ class MonitorPublisher:
                 }
         except Exception:
             self.history_segment_started_ms = {}
+
+    def _recover_seq_from_current_events(self) -> None:
+        latest_seq = self._latest_valid_event_seq_in_current_segment()
+        if latest_seq is not None:
+            self.seq = max(self.seq, latest_seq)
+
+    def _latest_valid_event_seq_in_current_segment(self) -> Optional[int]:
+        """Return the latest valid event seq from a fixed-size tail of the active segment."""
+        try:
+            with open(self.current_events_path, "rb") as f:
+                f.seek(0, os.SEEK_END)
+                end_offset = f.tell()
+                start_offset = max(0, end_offset - _CURRENT_EVENTS_TAIL_BYTES)
+                read_offset = max(0, start_offset - 1)
+                f.seek(read_offset)
+                tail = f.read(end_offset - read_offset)
+        except OSError as exc:
+            logging.warning(
+                "[monitor] unable to read current event segment %s: %s",
+                self.current_events_path,
+                exc,
+            )
+            return None
+
+        rows = tail.splitlines()
+        if start_offset and tail[:1] not in (b"\n", b"\r") and rows:
+            rows = rows[1:]
+        for raw_row in reversed(rows):
+            raw_row = raw_row.strip()
+            if not raw_row:
+                continue
+            try:
+                row = json.loads(raw_row.decode("utf-8"))
+                seq = row["seq"]
+            except (UnicodeDecodeError, json.JSONDecodeError, KeyError, TypeError):
+                continue
+            if isinstance(seq, bool) or not isinstance(seq, int) or seq < 0:
+                continue
+            return seq
+        return None
 
     def _build_manifest(self, now_ms: Optional[int] = None) -> dict:
         now_ms = self._now_ms() if now_ms is None else int(now_ms)
@@ -253,12 +301,37 @@ class MonitorPublisher:
             },
         }
 
-    def _write_manifest(self, now_ms: Optional[int] = None) -> None:
+    def _mark_manifest_dirty(self) -> None:
+        self._manifest_dirty = True
+
+    def _write_manifest(self, now_ms: Optional[int] = None) -> bool:
         with self._lock:
             try:
                 _atomic_write_json(self.manifest_path, self._build_manifest(now_ms=now_ms))
             except Exception as exc:
+                self._manifest_dirty = True
+                self._manifest_retry_needed = True
                 self._log_write_failure("writing manifest", exc)
+                return False
+            self._manifest_dirty = False
+            self._manifest_retry_needed = False
+            self._last_manifest_write_monotonic_ms = self._monotonic_ms()
+            return True
+
+    def _write_manifest_if_due(self, now_ms: Optional[int] = None) -> bool:
+        with self._lock:
+            if not self._manifest_dirty:
+                return False
+            cadence_now_ms = self._monotonic_ms()
+            if (
+                self._manifest_retry_needed
+                or self._last_manifest_write_monotonic_ms is None
+                or cadence_now_ms < self._last_manifest_write_monotonic_ms
+                or cadence_now_ms - self._last_manifest_write_monotonic_ms
+                >= self.snapshot_interval_ms
+            ):
+                return self._write_manifest(now_ms=now_ms)
+            return False
 
     def _log_write_failure(self, action: str, exc: BaseException) -> None:
         if not _is_disk_full_error(exc):
@@ -380,11 +453,15 @@ class MonitorPublisher:
                 rotated = self._rotated_path(
                     self.events_dir, self._segment_label(now_ms), ".ndjson"
                 )
+                # Preserve the current sequence before the active segment moves.
+                if not self._write_manifest(now_ms=now_ms):
+                    return
                 os.replace(self.current_events_path, rotated)
                 if self.compress_rotated_segments:
                     rotated = self._gzip_file(rotated)
                 self.current_events_path.touch()
                 self.current_segment_started_ms = now_ms
+                self._mark_manifest_dirty()
                 self._write_manifest(now_ms=now_ms)
                 self._prune_retention(now_ms=now_ms)
             except Exception as exc:
@@ -420,6 +497,7 @@ class MonitorPublisher:
                     rotated = self._gzip_file(rotated)
                 current_path.touch()
                 self.history_segment_started_ms[stream] = now_ms
+                self._mark_manifest_dirty()
                 self._write_manifest(now_ms=now_ms)
                 self._prune_retention(now_ms=now_ms)
             except Exception as exc:
@@ -466,7 +544,8 @@ class MonitorPublisher:
                 )
                 with open(current_path, "a", encoding="utf-8") as f:
                     f.write(line + "\n")
-                self._write_manifest(now_ms=now_ms)
+                self._mark_manifest_dirty()
+                self._write_manifest_if_due(now_ms=now_ms)
                 self._prune_retention(now_ms=now_ms)
                 return envelope
             except Exception as exc:
@@ -650,7 +729,8 @@ class MonitorPublisher:
 
                 maintenance_started_ns = time.monotonic_ns()
                 try:
-                    self._write_manifest(now_ms=now_ms)
+                    self._mark_manifest_dirty()
+                    self._write_manifest_if_due(now_ms=now_ms)
                     self._prune_retention(now_ms=now_ms)
                 finally:
                     timing["maintenance_ns"] = max(
@@ -704,6 +784,7 @@ class MonitorPublisher:
                 payload["meta"] = meta
                 _atomic_write_json(self.state_latest_path, payload)
                 self.last_snapshot_ms = now_ms
+                self._write_manifest(now_ms=now_ms)
                 if self.checkpoint_interval_ms > 0 and (
                     force or now_ms - self.last_checkpoint_ms >= self.checkpoint_interval_ms
                 ):
@@ -716,7 +797,6 @@ class MonitorPublisher:
                     if self.compress_rotated_segments:
                         self._gzip_file(checkpoint)
                     self.last_checkpoint_ms = now_ms
-                self._write_manifest(now_ms=now_ms)
                 self._prune_retention(now_ms=now_ms)
                 return True
             except Exception as exc:

--- a/src/monitor_publisher.py
+++ b/src/monitor_publisher.py
@@ -19,7 +19,7 @@ _MONITOR_EVENT_PHASE_TIMING_KEYS = (
     "persist_ns",
     "maintenance_ns",
 )
-_CURRENT_EVENTS_TAIL_BYTES = 64 * 1024
+_CURRENT_EVENTS_REVERSE_READ_BYTES = 64 * 1024
 
 
 def _empty_monitor_event_phase_timing() -> dict[str, int]:
@@ -210,20 +210,123 @@ class MonitorPublisher:
             self.history_segment_started_ms = {}
 
     def _recover_seq_from_current_events(self) -> None:
-        latest_seq = self._latest_valid_event_seq_in_current_segment()
-        if latest_seq is not None:
-            self.seq = max(self.seq, latest_seq)
+        recovered_seq = self._max_recoverable_event_seq_in_current_segment()
+        if recovered_seq is not None:
+            self.seq = max(self.seq, recovered_seq)
 
-    def _latest_valid_event_seq_in_current_segment(self) -> Optional[int]:
-        """Return the latest valid event seq from a fixed-size tail of the active segment."""
+    def _max_recoverable_event_seq_in_current_segment(self) -> Optional[int]:
+        """Return the maximum recoverable seq without buffering whole rows."""
+
+        seq_marker = b'"seq"'
+
+        def iter_line_ranges_reverse(f, file_size: int):
+            line_end = file_size
+            scan_end = file_size
+            while scan_end > 0:
+                read_size = min(_CURRENT_EVENTS_REVERSE_READ_BYTES, scan_end)
+                scan_start = scan_end - read_size
+                f.seek(scan_start)
+                chunk = f.read(read_size)
+                search_end = len(chunk)
+                while True:
+                    newline_idx = chunk.rfind(b"\n", 0, search_end)
+                    if newline_idx < 0:
+                        break
+                    line_start = scan_start + newline_idx + 1
+                    yield line_start, line_end
+                    line_end = scan_start + newline_idx
+                    search_end = newline_idx
+                scan_end = scan_start
+            yield 0, line_end
+
+        def edge_byte(f, start: int, end: int, *, reverse: bool) -> Optional[int]:
+            if reverse:
+                cursor = end
+                while start < cursor:
+                    read_size = min(_CURRENT_EVENTS_REVERSE_READ_BYTES, cursor - start)
+                    cursor -= read_size
+                    f.seek(cursor)
+                    for value in reversed(f.read(read_size)):
+                        if value not in b" \t\r\n":
+                            return value
+            else:
+                cursor = start
+                while cursor < end:
+                    read_size = min(_CURRENT_EVENTS_REVERSE_READ_BYTES, end - cursor)
+                    f.seek(cursor)
+                    cursor += read_size
+                    for value in f.read(read_size):
+                        if value not in b" \t\r\n":
+                            return value
+            return None
+
+        def parse_seq_value(f, value_offset: int, line_end: int) -> Optional[int]:
+            f.seek(value_offset)
+            raw = f.read(min(64, line_end - value_offset))
+            cursor = 0
+            while cursor < len(raw) and raw[cursor] in b" \t\r\n":
+                cursor += 1
+            if cursor >= len(raw) or raw[cursor] != ord(":"):
+                return None
+            cursor += 1
+            while cursor < len(raw) and raw[cursor] in b" \t\r\n":
+                cursor += 1
+            digit_start = cursor
+            while cursor < len(raw) and 48 <= raw[cursor] <= 57:
+                cursor += 1
+            if digit_start == cursor:
+                return None
+            while cursor < len(raw) and raw[cursor] in b" \t\r\n":
+                cursor += 1
+            if cursor >= len(raw) or raw[cursor] not in b",}":
+                return None
+            return int(raw[digit_start:cursor].strip())
+
+        def seq_from_line_range(f, line_start: int, line_end: int) -> Optional[int]:
+            if edge_byte(f, line_start, line_end, reverse=False) != ord("{"):
+                return None
+            if edge_byte(f, line_start, line_end, reverse=True) != ord("}"):
+                return None
+
+            # record_event() serializes with sorted keys, so the envelope's
+            # top-level seq marker follows any matching marker in payload.
+            last_seq = None
+            overlap = b""
+            scan_offset = line_start
+            while scan_offset < line_end:
+                f.seek(scan_offset)
+                chunk = f.read(
+                    min(_CURRENT_EVENTS_REVERSE_READ_BYTES, line_end - scan_offset)
+                )
+                data = overlap + chunk
+                data_offset = scan_offset - len(overlap)
+                search_offset = 0
+                while True:
+                    marker_idx = data.find(seq_marker, search_offset)
+                    if marker_idx < 0:
+                        break
+                    seq = parse_seq_value(
+                        f,
+                        data_offset + marker_idx + len(seq_marker),
+                        line_end,
+                    )
+                    if seq is not None:
+                        last_seq = seq
+                    search_offset = marker_idx + 1
+                overlap = data[-(len(seq_marker) - 1) :]
+                scan_offset += len(chunk)
+            return last_seq
+
         try:
             with open(self.current_events_path, "rb") as f:
                 f.seek(0, os.SEEK_END)
-                end_offset = f.tell()
-                start_offset = max(0, end_offset - _CURRENT_EVENTS_TAIL_BYTES)
-                read_offset = max(0, start_offset - 1)
-                f.seek(read_offset)
-                tail = f.read(end_offset - read_offset)
+                file_size = f.tell()
+                max_seq = None
+                for line_start, line_end in iter_line_ranges_reverse(f, file_size):
+                    seq = seq_from_line_range(f, line_start, line_end)
+                    if seq is not None and (max_seq is None or seq > max_seq):
+                        max_seq = seq
+                return max_seq
         except OSError as exc:
             logging.warning(
                 "[monitor] unable to read current event segment %s: %s",
@@ -231,23 +334,6 @@ class MonitorPublisher:
                 exc,
             )
             return None
-
-        rows = tail.splitlines()
-        if start_offset and tail[:1] not in (b"\n", b"\r") and rows:
-            rows = rows[1:]
-        for raw_row in reversed(rows):
-            raw_row = raw_row.strip()
-            if not raw_row:
-                continue
-            try:
-                row = json.loads(raw_row.decode("utf-8"))
-                seq = row["seq"]
-            except (UnicodeDecodeError, json.JSONDecodeError, KeyError, TypeError):
-                continue
-            if isinstance(seq, bool) or not isinstance(seq, int) or seq < 0:
-                continue
-            return seq
-        return None
 
     def _build_manifest(self, now_ms: Optional[int] = None) -> dict:
         now_ms = self._now_ms() if now_ms is None else int(now_ms)

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -350,12 +350,20 @@ def test_monitor_recovery_skips_blank_malformed_and_invalid_utf8_trailing_rows(t
     assert restarted.seq == 8
 
 
-def test_monitor_recovery_reads_only_bounded_current_segment_tail(tmp_path, monkeypatch):
+def test_monitor_recovery_reads_oversized_final_row_in_bounded_chunks(tmp_path, monkeypatch):
     publisher = _make_publisher(tmp_path)
-    publisher.current_events_path.write_bytes(
-        b"x" * (monitor_publisher_module._CURRENT_EVENTS_TAIL_BYTES * 2)
-        + b'\n{"seq":42,"kind":"persisted"}'
-    )
+    oversized_row = json.dumps(
+        {
+            "seq": 42,
+            "kind": "persisted",
+            "payload": {
+                "blob": "x"
+                * (monitor_publisher_module._CURRENT_EVENTS_REVERSE_READ_BYTES * 2)
+            },
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+    publisher.current_events_path.write_bytes(oversized_row)
     original_open = open
     read_sizes = []
 
@@ -385,8 +393,54 @@ def test_monitor_recovery_reads_only_bounded_current_segment_tail(tmp_path, monk
 
     monkeypatch.setattr(monitor_publisher_module, "open", tracking_open, raising=False)
 
-    assert publisher._latest_valid_event_seq_in_current_segment() == 42
-    assert read_sizes == [monitor_publisher_module._CURRENT_EVENTS_TAIL_BYTES + 1]
+    assert publisher._max_recoverable_event_seq_in_current_segment() == 42
+    assert len(read_sizes) >= 3
+    assert max(read_sizes) <= monitor_publisher_module._CURRENT_EVENTS_REVERSE_READ_BYTES
+
+
+def test_monitor_restart_does_not_reuse_seq_after_oversized_uncheckpointed_event(tmp_path):
+    publisher = _make_publisher(tmp_path, snapshot_interval_seconds=3600.0)
+    first = publisher.record_event(
+        "test.oversized",
+        ("test",),
+        {
+            "blob": "x"
+            * (monitor_publisher_module._CURRENT_EVENTS_REVERSE_READ_BYTES + 1024)
+        },
+        ts=1_000,
+    )
+    assert first["seq"] == 1
+    assert json.loads(publisher.manifest_path.read_text())["last_seq"] == 0
+
+    restarted = _make_publisher(tmp_path, snapshot_interval_seconds=3600.0)
+    second = restarted.record_event("test.after_restart", ("test",), {}, ts=2_000)
+
+    assert restarted.seq == 2
+    assert second["seq"] == 2
+    rows = [
+        json.loads(line) for line in restarted.current_events_path.read_text().splitlines()
+    ]
+    assert [row["seq"] for row in rows] == [1, 2]
+
+
+def test_monitor_recovery_ignores_lower_malformed_marker_after_newer_valid_rows(tmp_path):
+    publisher = _make_publisher(tmp_path, snapshot_interval_seconds=3600.0)
+    manifest = json.loads(publisher.manifest_path.read_text())
+    manifest["last_seq"] = 3
+    publisher.manifest_path.write_text(json.dumps(manifest) + "\n")
+    publisher.current_events_path.write_text(
+        "".join(
+            json.dumps({"seq": seq, "kind": "persisted"}) + "\n"
+            for seq in range(4, 9)
+        )
+        + '{"seq":3,garbage}\n'
+    )
+
+    restarted = _make_publisher(tmp_path, snapshot_interval_seconds=3600.0)
+    event = restarted.record_event("test.after_restart", ("test",), {}, ts=2_000)
+
+    assert restarted.seq == 9
+    assert event["seq"] == 9
 
 
 def test_monitor_event_rotation_forces_pre_and_post_manifest_checkpoints(tmp_path, monkeypatch):

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -329,7 +329,9 @@ def test_monitor_recovers_seq_from_stale_manifest_after_unclean_restart(tmp_path
     manifest = json.loads(publisher.manifest_path.read_text())
     manifest["last_seq"] = 3
     publisher.manifest_path.write_text(json.dumps(manifest) + "\n")
-    publisher.current_events_path.write_text(json.dumps({"seq": 8, "kind": "persisted"}) + "\n")
+    publisher.current_events_path.write_text(
+        publisher._serialize_event_line({"seq": 8, "kind": "persisted"}) + "\n"
+    )
 
     restarted = _make_publisher(tmp_path)
     assert restarted.seq == 8
@@ -343,7 +345,8 @@ def test_monitor_recovery_skips_blank_malformed_and_invalid_utf8_trailing_rows(t
     manifest["last_seq"] = 3
     publisher.manifest_path.write_text(json.dumps(manifest) + "\n")
     publisher.current_events_path.write_bytes(
-        b'{"seq":8,"kind":"persisted"}\n\n{not-json}\n\xff\xfe\n'
+        publisher._serialize_event_line({"seq": 8, "kind": "persisted"}).encode("utf-8")
+        + b"\n\n{not-json}\n\xff\xfe\n"
     )
 
     restarted = _make_publisher(tmp_path)
@@ -352,7 +355,7 @@ def test_monitor_recovery_skips_blank_malformed_and_invalid_utf8_trailing_rows(t
 
 def test_monitor_recovery_reads_oversized_final_row_in_bounded_chunks(tmp_path, monkeypatch):
     publisher = _make_publisher(tmp_path)
-    oversized_row = json.dumps(
+    oversized_row = publisher._serialize_event_line(
         {
             "seq": 42,
             "kind": "persisted",
@@ -361,7 +364,6 @@ def test_monitor_recovery_reads_oversized_final_row_in_bounded_chunks(tmp_path, 
                 * (monitor_publisher_module._CURRENT_EVENTS_REVERSE_READ_BYTES * 2)
             },
         },
-        separators=(",", ":"),
     ).encode("utf-8")
     publisher.current_events_path.write_bytes(oversized_row)
     original_open = open
@@ -398,6 +400,23 @@ def test_monitor_recovery_reads_oversized_final_row_in_bounded_chunks(tmp_path, 
     assert max(read_sizes) <= monitor_publisher_module._CURRENT_EVENTS_REVERSE_READ_BYTES
 
 
+def test_monitor_recovery_accepts_checksummed_crlf_row(tmp_path):
+    publisher = _make_publisher(tmp_path, snapshot_interval_seconds=3600.0)
+    manifest = json.loads(publisher.manifest_path.read_text())
+    manifest["last_seq"] = 3
+    publisher.manifest_path.write_text(json.dumps(manifest) + "\n")
+    publisher.current_events_path.write_bytes(
+        publisher._serialize_event_line({"seq": 8, "kind": "persisted"}).encode("utf-8")
+        + b"\r\n"
+    )
+
+    restarted = _make_publisher(tmp_path, snapshot_interval_seconds=3600.0)
+    event = restarted.record_event("test.after_restart", ("test",), {}, ts=2_000)
+
+    assert restarted.seq == 9
+    assert event["seq"] == 9
+
+
 def test_monitor_restart_does_not_reuse_seq_after_oversized_uncheckpointed_event(tmp_path):
     publisher = _make_publisher(tmp_path, snapshot_interval_seconds=3600.0)
     first = publisher.record_event(
@@ -428,12 +447,24 @@ def test_monitor_recovery_ignores_lower_malformed_marker_after_newer_valid_rows(
     manifest = json.loads(publisher.manifest_path.read_text())
     manifest["last_seq"] = 3
     publisher.manifest_path.write_text(json.dumps(manifest) + "\n")
+    corrupted_trailer = publisher._serialize_event_line(
+        {"seq": 999_999, "kind": "persisted"}
+    ).replace('"kind":"persisted"', '"kind":"tampered"')
+    tampered_trailer_seq = publisher._serialize_event_line(
+        {"seq": 42, "kind": "persisted"}
+    ).replace(',"seq":42}}', ',"seq":9007199254740993}}')
     publisher.current_events_path.write_text(
         "".join(
-            json.dumps({"seq": seq, "kind": "persisted"}) + "\n"
+            publisher._serialize_event_line({"seq": seq, "kind": "persisted"}) + "\n"
             for seq in range(4, 9)
         )
         + '{"seq":3,garbage}\n'
+        + '{"seq":9007199254740993,garbage}\n'
+        + '{"seq":3,"seq":9007199254740993}\n'
+        + corrupted_trailer
+        + "\n"
+        + tampered_trailer_seq
+        + "\n"
     )
 
     restarted = _make_publisher(tmp_path, snapshot_interval_seconds=3600.0)
@@ -441,6 +472,43 @@ def test_monitor_recovery_ignores_lower_malformed_marker_after_newer_valid_rows(
 
     assert restarted.seq == 9
     assert event["seq"] == 9
+
+
+def test_monitor_recovery_ignores_nested_seq_in_torn_event_payload(tmp_path):
+    publisher = _make_publisher(tmp_path, snapshot_interval_seconds=3600.0)
+    manifest = json.loads(publisher.manifest_path.read_text())
+    manifest["last_seq"] = 3
+    publisher.manifest_path.write_text(json.dumps(manifest) + "\n")
+    publisher.current_events_path.write_text(
+        "".join(
+            publisher._serialize_event_line({"seq": seq, "kind": "persisted"}) + "\n"
+            for seq in range(4, 9)
+        )
+        + '{"exchange":"x","kind":"test","payload":{"seq":9007199254740993}'
+    )
+
+    restarted = _make_publisher(tmp_path, snapshot_interval_seconds=3600.0)
+    event = restarted.record_event("test.after_restart", ("test",), {}, ts=2_000)
+
+    assert restarted.seq == 9
+    assert event["seq"] == 9
+
+
+def test_monitor_recovery_uses_envelope_seq_after_nested_payload_seq(tmp_path):
+    publisher = _make_publisher(tmp_path, snapshot_interval_seconds=3600.0)
+    event = publisher.record_event(
+        "test.nested_seq",
+        ("test",),
+        {"seq": 999_999},
+        ts=1_000,
+    )
+    assert event["seq"] == 1
+
+    restarted = _make_publisher(tmp_path, snapshot_interval_seconds=3600.0)
+    next_event = restarted.record_event("test.after_restart", ("test",), {}, ts=2_000)
+
+    assert restarted.seq == 2
+    assert next_event["seq"] == 2
 
 
 def test_monitor_event_rotation_forces_pre_and_post_manifest_checkpoints(tmp_path, monkeypatch):

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -36,6 +36,7 @@ def test_monitor_publisher_writes_manifest_events_and_snapshot(tmp_path):
     event = publisher.record_event("bot.start", ("bot", "lifecycle"), {"status": "starting"}, ts=1000)
     assert event["seq"] == 1
     publisher.record_error("error.bot", RuntimeError("boom"), payload={"source": "test"}, ts=1001)
+    publisher.close()
 
     root = tmp_path / "bybit" / "user01"
     manifest = json.loads((root / "manifest.json").read_text())
@@ -188,6 +189,7 @@ def test_monitor_publisher_concurrent_event_writes_keep_seq_and_manifest(tmp_pat
     seqs = sorted(event["seq"] for event in results)
     assert seqs == list(range(1, n_threads * n_per_thread + 1))
 
+    publisher.close()
     root = tmp_path / "bybit" / "user01"
     manifest = json.loads((root / "manifest.json").read_text())
     assert manifest["last_seq"] == n_threads * n_per_thread
@@ -215,6 +217,264 @@ def test_monitor_disk_full_errors_are_coalesced(tmp_path, monkeypatch, caplog):
     disk_messages = [msg for msg in messages if "disk full" in msg]
     assert len(disk_messages) == 1
     assert "suppressing repeat disk-full monitor errors for 60s" in disk_messages[0]
+
+
+def test_monitor_manifest_coalesces_event_and_history_writes_within_cadence(
+    tmp_path, monkeypatch
+):
+    publisher = _make_publisher(tmp_path, snapshot_interval_seconds=1.0)
+    original_atomic_write = monitor_publisher_module._atomic_write_json
+    manifest_writes = []
+
+    def count_manifest_writes(path, payload):
+        if path == publisher.manifest_path:
+            manifest_writes.append(payload)
+        return original_atomic_write(path, payload)
+
+    monkeypatch.setattr(monitor_publisher_module, "_atomic_write_json", count_manifest_writes)
+    monkeypatch.setattr(publisher, "_monotonic_ms", lambda: 1_001)
+    publisher._last_manifest_write_monotonic_ms = 1_000
+    for offset in range(1, 6):
+        assert publisher.record_event("test.event", ("test",), ts=1_000 + offset)
+        assert publisher.record_history_entry(
+            "fills", "fill", {"id": offset}, ts=1_000 + offset
+        )
+
+    assert manifest_writes == []
+    assert publisher._manifest_dirty is True
+    root = tmp_path / "bybit" / "user01"
+    assert len((root / "events" / "current.ndjson").read_text().splitlines()) == 5
+    assert len((root / "history" / "fills.current.ndjson").read_text().splitlines()) == 5
+
+
+def test_monitor_manifest_checkpoints_latest_seq_after_cadence_expires(tmp_path, monkeypatch):
+    publisher = _make_publisher(tmp_path, snapshot_interval_seconds=1.0)
+    original_atomic_write = monitor_publisher_module._atomic_write_json
+    manifest_writes = []
+
+    def count_manifest_writes(path, payload):
+        if path == publisher.manifest_path:
+            manifest_writes.append(payload)
+        return original_atomic_write(path, payload)
+
+    monkeypatch.setattr(monitor_publisher_module, "_atomic_write_json", count_manifest_writes)
+    monkeypatch.setattr(publisher, "_monotonic_ms", lambda: 2_000)
+    publisher._last_manifest_write_monotonic_ms = 1_000
+    event = publisher.record_event("test.event", ("test",), ts=2_000)
+
+    assert event["seq"] == 1
+    assert len(manifest_writes) == 1
+    assert manifest_writes[0]["last_seq"] == 1
+    assert publisher._manifest_dirty is False
+
+
+def test_monitor_manifest_cadence_ignores_old_and_decreasing_record_timestamps(
+    tmp_path, monkeypatch
+):
+    publisher = _make_publisher(tmp_path, snapshot_interval_seconds=1.0)
+    original_atomic_write = monitor_publisher_module._atomic_write_json
+    manifest_writes = []
+
+    def count_manifest_writes(path, payload):
+        if path == publisher.manifest_path:
+            manifest_writes.append(payload)
+        return original_atomic_write(path, payload)
+
+    monkeypatch.setattr(monitor_publisher_module, "_atomic_write_json", count_manifest_writes)
+    monkeypatch.setattr(publisher, "_monotonic_ms", lambda: 1_001)
+    publisher._last_manifest_write_monotonic_ms = 1_000
+
+    assert publisher.record_history_entry("fills", "fill", {"id": 1}, ts=10_000)
+    assert publisher.record_history_entry("fills", "fill", {"id": 2}, ts=5_000)
+    assert publisher.record_history_entry("fills", "fill", {"id": 3}, ts=1)
+
+    assert manifest_writes == []
+    assert publisher._manifest_dirty is True
+
+
+def test_monitor_failed_due_manifest_checkpoint_retries_on_next_write(tmp_path, monkeypatch):
+    publisher = _make_publisher(tmp_path, snapshot_interval_seconds=1.0)
+    original_atomic_write = monitor_publisher_module._atomic_write_json
+    manifest_attempts = []
+
+    def fail_first_manifest_write(path, payload):
+        if path == publisher.manifest_path:
+            manifest_attempts.append(payload)
+            if len(manifest_attempts) == 1:
+                raise OSError(errno.ENOSPC, "No space left on device")
+        return original_atomic_write(path, payload)
+
+    monkeypatch.setattr(
+        monitor_publisher_module, "_atomic_write_json", fail_first_manifest_write
+    )
+    monkeypatch.setattr(publisher, "_monotonic_ms", lambda: 2_000)
+    publisher._last_manifest_write_monotonic_ms = 1_000
+
+    first = publisher.record_event("test.event", ("test",), ts=2_000)
+    assert first["seq"] == 1
+    assert publisher._manifest_dirty is True
+    assert publisher._manifest_retry_needed is True
+
+    second = publisher.record_event("test.event", ("test",), ts=2_001)
+    assert second["seq"] == 2
+    assert len(manifest_attempts) == 2
+    assert publisher._manifest_dirty is False
+    assert publisher._manifest_retry_needed is False
+    manifest = json.loads(publisher.manifest_path.read_text())
+    assert manifest["last_seq"] == 2
+
+
+def test_monitor_recovers_seq_from_stale_manifest_after_unclean_restart(tmp_path):
+    publisher = _make_publisher(tmp_path)
+    manifest = json.loads(publisher.manifest_path.read_text())
+    manifest["last_seq"] = 3
+    publisher.manifest_path.write_text(json.dumps(manifest) + "\n")
+    publisher.current_events_path.write_text(json.dumps({"seq": 8, "kind": "persisted"}) + "\n")
+
+    restarted = _make_publisher(tmp_path)
+    assert restarted.seq == 8
+    event = restarted.record_event("test.event", ("test",), ts=1_000)
+    assert event["seq"] == 9
+
+
+def test_monitor_recovery_skips_blank_malformed_and_invalid_utf8_trailing_rows(tmp_path):
+    publisher = _make_publisher(tmp_path)
+    manifest = json.loads(publisher.manifest_path.read_text())
+    manifest["last_seq"] = 3
+    publisher.manifest_path.write_text(json.dumps(manifest) + "\n")
+    publisher.current_events_path.write_bytes(
+        b'{"seq":8,"kind":"persisted"}\n\n{not-json}\n\xff\xfe\n'
+    )
+
+    restarted = _make_publisher(tmp_path)
+    assert restarted.seq == 8
+
+
+def test_monitor_recovery_reads_only_bounded_current_segment_tail(tmp_path, monkeypatch):
+    publisher = _make_publisher(tmp_path)
+    publisher.current_events_path.write_bytes(
+        b"x" * (monitor_publisher_module._CURRENT_EVENTS_TAIL_BYTES * 2)
+        + b'\n{"seq":42,"kind":"persisted"}'
+    )
+    original_open = open
+    read_sizes = []
+
+    class TrackingFile:
+        def __init__(self, file):
+            self.file = file
+
+        def __enter__(self):
+            self.file.__enter__()
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return self.file.__exit__(exc_type, exc_value, traceback)
+
+        def __getattr__(self, name):
+            return getattr(self.file, name)
+
+        def read(self, size=-1):
+            read_sizes.append(size)
+            return self.file.read(size)
+
+    def tracking_open(path, *args, **kwargs):
+        file = original_open(path, *args, **kwargs)
+        if path == publisher.current_events_path and args and args[0] == "rb":
+            return TrackingFile(file)
+        return file
+
+    monkeypatch.setattr(monitor_publisher_module, "open", tracking_open, raising=False)
+
+    assert publisher._latest_valid_event_seq_in_current_segment() == 42
+    assert read_sizes == [monitor_publisher_module._CURRENT_EVENTS_TAIL_BYTES + 1]
+
+
+def test_monitor_event_rotation_forces_pre_and_post_manifest_checkpoints(tmp_path, monkeypatch):
+    publisher = _make_publisher(tmp_path, event_rotation_mb=0.00001)
+    publisher._last_manifest_write_monotonic_ms = publisher._monotonic_ms()
+    assert publisher.record_event("one", ("test",), ts=1_001)
+    original_write_manifest = publisher._write_manifest
+    checkpoints = []
+
+    def capture_checkpoint(**kwargs):
+        checkpoints.append((publisher.seq, publisher.current_segment_started_ms))
+        return original_write_manifest(**kwargs)
+
+    monkeypatch.setattr(publisher, "_write_manifest", capture_checkpoint)
+    assert publisher.record_event("two", ("test",), ts=1_002)
+
+    assert [seq for seq, _started_ms in checkpoints] == [1, 1]
+    assert checkpoints[0][1] != 1_002
+    assert checkpoints[1][1] == 1_002
+    manifest = json.loads(publisher.manifest_path.read_text())
+    assert manifest["last_seq"] == 1
+    assert manifest["current_segment_started_ms"] == 1_002
+
+
+def test_monitor_event_rotation_waits_for_successful_pre_rotation_checkpoint(
+    tmp_path, monkeypatch
+):
+    publisher = _make_publisher(tmp_path, event_rotation_mb=0.00001)
+    publisher._last_manifest_write_monotonic_ms = publisher._monotonic_ms()
+    assert publisher.record_event("one", ("test",), ts=1_001)
+    current_before = publisher.current_events_path.read_text()
+    original_write_manifest = publisher._write_manifest
+    attempts = []
+
+    def fail_first_checkpoint(**kwargs):
+        attempts.append(kwargs)
+        if len(attempts) == 1:
+            publisher._manifest_dirty = True
+            publisher._manifest_retry_needed = True
+            return False
+        return original_write_manifest(**kwargs)
+
+    monkeypatch.setattr(publisher, "_write_manifest", fail_first_checkpoint)
+
+    event = publisher.record_event("two", ("test",), ts=1_002)
+
+    assert event["seq"] == 2
+    assert current_before in publisher.current_events_path.read_text()
+    assert list(publisher.events_dir.glob("*.ndjson")) == [publisher.current_events_path]
+    assert publisher.current_segment_started_ms != 1_002
+    assert len(attempts) == 2
+    assert publisher._manifest_dirty is False
+    assert publisher._manifest_retry_needed is False
+    assert json.loads(publisher.manifest_path.read_text())["last_seq"] == 2
+
+    third = publisher.record_event("three", ("test",), ts=1_003)
+
+    assert third["seq"] == 3
+    rotated = [
+        path
+        for path in publisher.events_dir.glob("*.ndjson")
+        if path != publisher.current_events_path
+    ]
+    assert len(rotated) == 1
+    assert publisher.current_segment_started_ms == 1_003
+
+
+def test_monitor_history_rotation_snapshot_and_close_force_manifest_checkpoints(
+    tmp_path, monkeypatch
+):
+    publisher = _make_publisher(tmp_path, event_rotation_mb=0.00001)
+    publisher._last_manifest_write_monotonic_ms = publisher._monotonic_ms()
+    original_write_manifest = publisher._write_manifest
+    checkpoints = []
+
+    def capture_checkpoint(**kwargs):
+        checkpoints.append((publisher.seq, dict(publisher.history_segment_started_ms)))
+        return original_write_manifest(**kwargs)
+
+    monkeypatch.setattr(publisher, "_write_manifest", capture_checkpoint)
+    assert publisher.record_history_entry("fills", "fill", {"id": 1}, ts=1_001)
+    assert publisher.record_history_entry("fills", "fill", {"id": 2}, ts=1_002)
+    assert len(checkpoints) == 1
+    assert checkpoints[0][1]["fills"] == 1_002
+
+    assert publisher.write_snapshot({"account": {}}, ts=1_003, force=True)
+    publisher.close()
+    assert len(checkpoints) == 3
 
 
 def test_monitor_publisher_event_phase_timing_uses_fixed_boundaries(tmp_path, monkeypatch):
@@ -266,7 +526,7 @@ def test_monitor_publisher_event_phase_timing_uses_fixed_boundaries(tmp_path, mo
     )
     monkeypatch.setattr(
         publisher,
-        "_write_manifest",
+        "_write_manifest_if_due",
         lambda **_kwargs: clock.__setitem__("ns", clock["ns"] + 7_000_000),
     )
     monkeypatch.setattr(

--- a/tests/test_monitor_relay.py
+++ b/tests/test_monitor_relay.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import subprocess
 import sys
 
@@ -436,3 +437,21 @@ def test_monitor_relay_keeps_stale_bots_visible_before_pruning(tmp_path, monkeyp
     monkeypatch.setattr(monitor_relay.time, "time", lambda: 7.5)
 
     assert relay.visible_keys() == []
+
+
+def test_monitor_relay_uses_current_event_activity_when_manifest_is_stale(tmp_path, monkeypatch):
+    monitor_root = _make_monitor_root(tmp_path, snapshot_ts_ms=1000)
+    bot_root = monitor_root / "bybit" / "user01"
+    manifest_path = bot_root / "manifest.json"
+    snapshot_path = bot_root / "state.latest.json"
+    events_path = bot_root / "events" / "current.ndjson"
+
+    os.utime(manifest_path, (1.0, 1.0))
+    os.utime(snapshot_path, (1.0, 1.0))
+    os.utime(events_path, (199.0, 199.0))
+    monkeypatch.setattr(monitor_relay.time, "time", lambda: 200.0)
+
+    relay = monitor_relay.MonitorRelay(monitor_root=str(monitor_root), poll_interval_ms=10)
+
+    assert relay.active_keys() == [("bybit", "user01")]
+    assert relay.build_health_payload()["bots"][0]["status"] == "active"


### PR DESCRIPTION
## Scope

Category: runtime behavior (monitor persistence only).

- Coalesce ordinary best-effort monitor manifest checkpoints to the existing snapshot cadence.
- Force checkpoints at initialization, successful snapshots, close, and rotation boundaries.
- Defer event rotation when its pre-rotation checkpoint fails, then retry on the next write.
- Recover startup event sequence from the maximum of the manifest and checksummed current-segment recovery trailers using a fixed-memory reverse chunk scan.
- Keep checkpoint cadence monotonic so old or out-of-order event/history timestamps cannot trigger per-row manifest writes.
- Record the deployed PR #1204 phase evidence and this follow-up in the logging plans and changelog.

## Behavior impact

This reduces synchronous manifest atomic-write/fsync work on the event worker. It preserves NDJSON append durability semantics, RLock ordering, retention/compression, routing, queue/backpressure and error policy, event payloads, monitor configuration, and all trading behavior.

No Rust, order, risk, HSL, backtest, optimizer, exchange, or trading-path behavior changes.

Expected VPS action after merge: pull, gracefully restart the five exact supervised bot panes, then run immediate and settled smoke/performance checks. Compare monitor maintenance and lock-wait totals/maxima with the PR #1204 baseline.

## Triggering evidence

Fresh VPS5 phase timing after PR #1204 covered 2,643 monitor writes:

- monitor service total/max: `53903.942/1676.541ms`
- maintenance: `47478.85/900.321ms` (88.08% cumulative; 17.964ms/write)
- persistence: `3619.444/77.067ms`
- lock wait: `2190.037/1661.187ms`
- rotation: `245.173/20.658ms`
- conversion: `54.686/1.139ms`

This slice targets the cumulative maintenance cost. Lock-holder attribution remains a separate follow-up only if post-deploy evidence still warrants it.

## Validation

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_event_bus.py tests/test_monitor_publisher.py tests/test_monitor_relay.py tests/test_passivbot_monitor.py tests/test_live_smoke_report.py tests/test_live_performance_report.py tests/test_live_incident_bundle.py tests/test_run_fake_live.py`
  - 436 passed; existing portalocker and utcfromtimestamp warnings only.
- Python compilation for changed Python/test files.
- `git diff --check`.
- Added-line silent-handling audit: clean.
- Codex exact-head reviews reproduced both oversized-row sequence reuse and a torn nested-payload marker ambiguity. New event rows now carry a valid JSON `_recovery` trailer whose sequence is bound into a BLAKE2b-128 digest of the exact base envelope; startup accepts only authenticated trailers.
- Independent Terra probes are green for oversized rows, torn payload/trailer rows, nested payload sequences, malformed high/duplicate markers, base/checksum/trailer tampering, CRLF, Unicode/escaping, and chunk boundaries. Reads remain capped at 64 KiB; cached scans measured about 0.46s for 100,000 rows / 19.23 MiB and 0.19s for one 128 MiB row.

## Reviewer focus

Please focus on RLock/concurrency behavior, dirty/due/retry semantics, event-rotation crash ordering, authenticated recovery-trailer byte reconstruction, fixed-memory scanning, monotonic cadence under old history timestamps, and preservation of relay/activity and durability contracts.

Required merge gate: exact-current-head Hermes + Grok 4.5 + green CI. Claude is temporarily absent by maintainer authorization.
