### PR TITLE
Attribute monitor maintenance phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Periodic structured health summaries now separate event-path manifest
+  checkpoint and retention run counts and service totals/maxima within the
+  existing inclusive monitor maintenance timing. Live smoke and performance
+  reports project the fixed fields without changing persistence cadence,
+  retention policy, event delivery, verdicts, or trading behavior.
+
 - Monitor event and history appends now coalesce the best-effort manifest
   checkpoint to the existing snapshot cadence while forcing it at lifecycle
   and rotation boundaries. Startup also recovers the event sequence from a

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -54,13 +54,12 @@ Estimated completion:
 
 Next action:
 
-1. Complete local validation and independent preflight, then publish one
-   review-worthy attribution PR.
-2. Hold the exact current head until Hermes, Grok 4.5, and CI are green;
-   resolve findings narrowly and require fresh exact-head verdicts after every
-   push.
-3. Merge only after that gate is green, restart the five exact VPS5 bot panes,
-   and use fresh phase metrics to choose the next retention/persistence action.
+1. Hold the active PR's exact current head until Hermes, Grok 4.5, and CI are
+   green; resolve findings narrowly and require fresh exact-head verdicts after
+   every push.
+2. Merge only after that gate is green, then restart the five exact VPS5 bot
+   panes while preserving unrelated processes and local artifacts.
+3. Use fresh phase metrics to choose the next retention/persistence action.
 
 ## Deployed Baseline
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,56 +22,78 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-monitor-manifest-coalescing`
-- Base: `d1303f55b353e3a59d524afe12c7d72baeef6db6`
-- Triggering evidence: deployed PR #1204 attributed 47,478.85 of 53,903.942ms
-  monitor service time across 2,643 writes to post-append maintenance, or
-  88.08% cumulative and 17.964ms per write. Persistence totaled 3,619.444ms;
-  rotation 245.173ms; conversion 54.686ms. The worst single monitor write was
-  instead dominated by 1,661.187ms of publisher lock wait, so cumulative
-  maintenance and tail lock contention remain distinct concerns.
-- Scope: coalesce the best-effort monitor manifest checkpoint to at most once
-  per existing snapshot interval during ordinary event/history appends. Force
-  checkpoints during initialization, before and after rotation, after a
-  successful snapshot, and at close. Recover startup sequence from the maximum
-  of the manifest and checksummed current-segment recovery trailers using a
-  fixed-memory reverse chunk scan so unclean exits between checkpoints do not
-  reuse an event sequence or confuse payload fields with envelope metadata.
-- Behavior boundary: monitor persistence runtime only. Preserve NDJSON append
-  and fsync semantics, RLock ordering, retention/compression, routing, queue and
-  backpressure policy, error visibility, event payloads, all trading behavior,
-  and existing configuration. Do not add threads, queues, dynamic labels,
-  alerts, thresholds, verdicts, or lock-holder attribution in this slice.
-- Validation: deterministic checkpoint cadence and force-point tests; failed
-  checkpoint retry; bounded startup recovery from stale manifest, malformed or
-  invalid trailing rows, and a final row without newline; relay discoverability;
-  publisher/event-bus/passivbot monitor regressions; smoke, performance,
-  incident-bundle, and fake-live coverage; Python compilation; `git diff
+- Branch: `codex/v8-monitor-maintenance-attribution`
+- Base: `435b20fb08d3221be6520f216ddc210612656d0d`, PR #1205
+- Triggering evidence: PR #1205 roughly halved per-write maintenance, but four
+  fresh settled health windows still attributed `77452.154ms` of
+  `83557.728ms` monitor service across 8,959 writes to inclusive maintenance.
+  Maintenance remained 92.69% of service, or `8.645ms` per write, and one
+  recurring event-path maintenance operation reached `7148.422ms` while queue
+  wait reached `7123.965ms`. Existing timing cannot distinguish the periodic
+  manifest checkpoint from retention's once-per-minute recursive scan.
+- Scope: preserve the inclusive maintenance metric and add fixed event-path
+  manifest-checkpoint and retention count/total/max timing. Propagate those
+  fields through the event pipeline timing window, `health.summary`,
+  `live-performance-report`, and `live-smoke-report` while keeping historical
+  rows that lack the fields valid.
+- Behavior boundary: attribution only. Preserve manifest cadence and retry,
+  retention cadence and policy, NDJSON append semantics, RLock ordering,
+  routing, queue/backpressure policy, error visibility, all event payloads,
+  all trading behavior, and existing configuration. Do not add file scans,
+  thresholds, alerts, verdicts, dynamic labels, threads, or queues.
+- Validation: due versus skipped and failed maintenance attempts; fixed timing
+  aggregation and consume/restore semantics; historical-row omission;
+  performance/smoke projection; publisher, event-bus, relay, monitor,
+  incident-bundle, and fake-live regressions; Python compilation; `git diff
   --check`; added-line silent-handling audit; and independent preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: exact five-bot graceful restart, then bounded
-  `health.summary`/report evidence and immediate plus settled smoke. Preserve
-  unrelated processes and local artifacts.
+  `health.summary` evidence identifying manifest versus retention service time
+  plus immediate and settled smoke. Preserve unrelated processes and artifacts.
 
 Next action:
 
-1. Hold PR #1205 at the exact current head until Hermes, Grok 4.5, and CI are
-   green; resolve findings narrowly and require fresh exact-head verdicts after
-   every push.
-2. Merge only after that gate is green, then gracefully restart the five exact
-   VPS5 bot panes while preserving unrelated processes and local artifacts.
-3. Compare fresh monitor maintenance and lock-wait totals/maxima against the
-   PR #1204 baseline using immediate and settled smoke/performance evidence.
+1. Complete local validation and independent preflight, then publish one
+   review-worthy attribution PR.
+2. Hold the exact current head until Hermes, Grok 4.5, and CI are green;
+   resolve findings narrowly and require fresh exact-head verdicts after every
+   push.
+3. Merge only after that gate is green, restart the five exact VPS5 bot panes,
+   and use fresh phase metrics to choose the next retention/persistence action.
 
 ## Deployed Baseline
 
-- Remote `v8`: `d1303f55b353e3a59d524afe12c7d72baeef6db6`, PR #1204
-- VPS5 repository: `d1303f55b353e3a59d524afe12c7d72baeef6db6`, PR #1204; tracked
-  status clean; only expected untracked artifacts were preserved
-- VPS5 expected bots: five; running with PR #1204 restart PIDs
-  `869404/869406/869556/869558/869564`;
+- Remote `v8`: `435b20fb08d3221be6520f216ddc210612656d0d`, PR #1205
+- VPS5 repository: `435b20fb08d3221be6520f216ddc210612656d0d`, PR #1205; tracked
+  status clean; expected untracked artifacts were preserved
+- VPS5 expected bots: five; running with PR #1205 restart PIDs
+  `871504/871509/871512/871516/871523`;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1205 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
+  panes. All old bot processes exited naturally; pane PIDs
+  `856294/856332/856364/856398/856434` and unrelated `misc:0.0` PID `434835`
+  were preserved.
+- The settled two-minute smoke was hard-green with `471/471` remote and
+  `61/61` account-critical calls successful, all five expected processes
+  matched, zero monitor parse/errors, and a clean tracked repository. One
+  report-time `D` sample caused no process hard failure.
+- Four initial fresh health windows covered 2,490 monitor writes. Monitor
+  service total/max was `20064.057/5543.611ms`; maintenance
+  `16914.708/5543.163ms`; persistence `1733.352/119.369ms`; lock wait
+  `544.284/487.369ms`; rotation `286.78/22.825ms`; and conversion
+  `48.654/0.325ms`. Drops, sink errors, degraded counts, unhealthy pipelines,
+  and final queue depth were zero.
+- Four later settled health windows covered 8,959 writes. Monitor service
+  total/max was `83557.728/7148.911ms`; maintenance
+  `77452.154/7148.422ms`; persistence `3084.764/111.555ms`; lock wait
+  `1507.36/508.744ms`; rotation `586.952/32.995ms`; and conversion
+  `206.946/32.574ms`. Maintenance fell from the PR #1204 baseline's
+  `17.964ms` to `8.645ms` per write, but remained the recurring long-tail
+  source. Drops, sink errors, degraded counts, unhealthy pipelines, and final
+  queue depth were zero. One unrelated hard exchange event remained in that
+  five-minute report window.
 - PR #1204 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
   panes. All old bot processes exited naturally; pane PIDs

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -69,6 +69,21 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1205 merged to `v8` as
+  `435b20fb08d3221be6520f216ddc210612656d0d` after exact-head Hermes and
+  Grok 4.5 approval plus green CI. It coalesced ordinary best-effort manifest
+  checkpoints while retaining forced durability points, and authenticated
+  current-segment sequence recovery with a fixed-memory reverse scan. VPS5
+  fast-forwarded cleanly and gracefully restarted only the five configured bot
+  panes; all old bots exited naturally, pane PIDs remained unchanged, and
+  unrelated `misc:0.0` PID `434835` was preserved. The settled two-minute smoke
+  was hard-green with `471/471` remote and `61/61` account-critical calls
+  successful, all five processes matched, zero monitor errors, and a clean
+  tracked repository. Four later settled health windows reduced maintenance
+  from the PR #1204 baseline's `17.964ms` to `8.645ms` per write, but still
+  recorded `77452.154ms` maintenance across 8,959 writes and a recurring
+  `7148.422ms` maximum. The next attribution slice separates periodic manifest
+  checkpoints from retention runs before changing persistence behavior.
 - PR #1191 merged to `v8` as
   `359929007dce0b47c023a36fdef90a7106ae46da` and was pulled to VPS5 without
   restarting bots. Existing optional progress, exact candidate terminal, and

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -382,9 +382,13 @@ classification when enough source events exist.
     monitor writes to fixed conversion, publisher lock-wait, rotation,
     persistence, and maintenance phases. Fresh VPS5 evidence found maintenance
     was 88.08% of cumulative monitor service while a separate 1,661.187ms lock
-    wait dominated the worst individual write. The active follow-up coalesces
-    best-effort manifest checkpoints to the existing snapshot cadence and adds
-    bounded crash-safe event-sequence recovery without changing delivery.
+    wait dominated the worst individual write. PR #1205 coalesced best-effort
+    manifest checkpoints to the existing snapshot cadence and added bounded
+    crash-safe event-sequence recovery without changing delivery. Fresh settled
+    evidence reduced maintenance from `17.964ms` to `8.645ms` per write but
+    retained a recurring `7148.422ms` maintenance maximum. The active follow-up
+    separates periodic manifest-checkpoint and retention count/total/max timing
+    before changing persistence behavior.
 - [ ] Exchange writes: create/cancel/close/panic write latency, exchange
   response latency, ambiguous write rate, confirmation latency.
   - Status: partial. The report now derives order-wave total duration,

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -60,6 +60,12 @@ _MONITOR_PUBLISHER_PHASE_TIMING_KEYS = (
     "rotation_ns",
     "persist_ns",
     "maintenance_ns",
+    "manifest_checkpoint_count",
+    "manifest_checkpoint_ns_total",
+    "manifest_checkpoint_ns_max",
+    "retention_run_count",
+    "retention_ns_total",
+    "retention_ns_max",
 )
 _MONITOR_PHASE_TIMING_KEYS = ("prepare_ns", *_MONITOR_PUBLISHER_PHASE_TIMING_KEYS)
 
@@ -1863,6 +1869,12 @@ class _EventPipelineTimingWindow:
     monitor_publisher_persist_ns_max: int
     monitor_publisher_maintenance_ns_total: int
     monitor_publisher_maintenance_ns_max: int
+    monitor_publisher_manifest_checkpoint_count: int
+    monitor_publisher_manifest_checkpoint_ns_total: int
+    monitor_publisher_manifest_checkpoint_ns_max: int
+    monitor_publisher_retention_run_count: int
+    monitor_publisher_retention_ns_total: int
+    monitor_publisher_retention_ns_max: int
 
 
 @dataclass
@@ -1883,6 +1895,12 @@ class _EventPipelineSinkWriteTiming:
     monitor_publisher_persist_ns_max: int = 0
     monitor_publisher_maintenance_ns_total: int = 0
     monitor_publisher_maintenance_ns_max: int = 0
+    monitor_publisher_manifest_checkpoint_count: int = 0
+    monitor_publisher_manifest_checkpoint_ns_total: int = 0
+    monitor_publisher_manifest_checkpoint_ns_max: int = 0
+    monitor_publisher_retention_run_count: int = 0
+    monitor_publisher_retention_ns_total: int = 0
+    monitor_publisher_retention_ns_max: int = 0
 
     def record(self, sink_name: str, service_ns: int) -> None:
         service_ns = max(0, int(service_ns))
@@ -1912,6 +1930,25 @@ class _EventPipelineSinkWriteTiming:
             max_field = f"{field_prefix}_max"
             setattr(self, total_field, int(getattr(self, total_field)) + value_ns)
             setattr(self, max_field, max(int(getattr(self, max_field)), value_ns))
+        for source_key, field_name in (
+            ("manifest_checkpoint_count", "monitor_publisher_manifest_checkpoint_count"),
+            ("retention_run_count", "monitor_publisher_retention_run_count"),
+        ):
+            setattr(
+                self,
+                field_name,
+                int(getattr(self, field_name)) + max(0, int(timing.get(source_key, 0))),
+            )
+        for source_key, field_prefix in (
+            ("manifest_checkpoint_ns", "monitor_publisher_manifest_checkpoint_ns"),
+            ("retention_ns", "monitor_publisher_retention_ns"),
+        ):
+            total_field = f"{field_prefix}_total"
+            max_field = f"{field_prefix}_max"
+            value_total_ns = max(0, int(timing.get(f"{source_key}_total", 0)))
+            value_max_ns = max(0, int(timing.get(f"{source_key}_max", 0)))
+            setattr(self, total_field, int(getattr(self, total_field)) + value_total_ns)
+            setattr(self, max_field, max(int(getattr(self, max_field)), value_max_ns))
 
 
 class LiveEventPipeline:
@@ -1969,6 +2006,12 @@ class LiveEventPipeline:
         self._timing_monitor_publisher_persist_ns_max = 0
         self._timing_monitor_publisher_maintenance_ns_total = 0
         self._timing_monitor_publisher_maintenance_ns_max = 0
+        self._timing_monitor_publisher_manifest_checkpoint_count = 0
+        self._timing_monitor_publisher_manifest_checkpoint_ns_total = 0
+        self._timing_monitor_publisher_manifest_checkpoint_ns_max = 0
+        self._timing_monitor_publisher_retention_run_count = 0
+        self._timing_monitor_publisher_retention_ns_total = 0
+        self._timing_monitor_publisher_retention_ns_max = 0
         self._pending_timing_windows: dict[int, _EventPipelineTimingWindow] = {}
         self._next_timing_snapshot_token = 1
         self._worker: threading.Thread | None = None
@@ -2076,6 +2119,24 @@ class LiveEventPipeline:
                 monitor_publisher_maintenance_ns_max=int(
                     self._timing_monitor_publisher_maintenance_ns_max
                 ),
+                monitor_publisher_manifest_checkpoint_count=int(
+                    self._timing_monitor_publisher_manifest_checkpoint_count
+                ),
+                monitor_publisher_manifest_checkpoint_ns_total=int(
+                    self._timing_monitor_publisher_manifest_checkpoint_ns_total
+                ),
+                monitor_publisher_manifest_checkpoint_ns_max=int(
+                    self._timing_monitor_publisher_manifest_checkpoint_ns_max
+                ),
+                monitor_publisher_retention_run_count=int(
+                    self._timing_monitor_publisher_retention_run_count
+                ),
+                monitor_publisher_retention_ns_total=int(
+                    self._timing_monitor_publisher_retention_ns_total
+                ),
+                monitor_publisher_retention_ns_max=int(
+                    self._timing_monitor_publisher_retention_ns_max
+                ),
             )
             timing_snapshot_token = None
             if consume_timing:
@@ -2104,6 +2165,12 @@ class LiveEventPipeline:
                 self._timing_monitor_publisher_persist_ns_max = 0
                 self._timing_monitor_publisher_maintenance_ns_total = 0
                 self._timing_monitor_publisher_maintenance_ns_max = 0
+                self._timing_monitor_publisher_manifest_checkpoint_count = 0
+                self._timing_monitor_publisher_manifest_checkpoint_ns_total = 0
+                self._timing_monitor_publisher_manifest_checkpoint_ns_max = 0
+                self._timing_monitor_publisher_retention_run_count = 0
+                self._timing_monitor_publisher_retention_ns_total = 0
+                self._timing_monitor_publisher_retention_ns_max = 0
         snapshot: dict[str, Any] = {
             "event_queue_depth": queue_depth,
             "event_queue_maxsize": queue_maxsize,
@@ -2175,6 +2242,24 @@ class LiveEventPipeline:
             "event_monitor_publisher_maintenance_ms_max": self._timing_ms(
                 timing_window.monitor_publisher_maintenance_ns_max
             ),
+            "event_monitor_publisher_manifest_checkpoint_count": (
+                timing_window.monitor_publisher_manifest_checkpoint_count
+            ),
+            "event_monitor_publisher_manifest_checkpoint_ms_total": self._timing_ms(
+                timing_window.monitor_publisher_manifest_checkpoint_ns_total
+            ),
+            "event_monitor_publisher_manifest_checkpoint_ms_max": self._timing_ms(
+                timing_window.monitor_publisher_manifest_checkpoint_ns_max
+            ),
+            "event_monitor_publisher_retention_run_count": (
+                timing_window.monitor_publisher_retention_run_count
+            ),
+            "event_monitor_publisher_retention_ms_total": self._timing_ms(
+                timing_window.monitor_publisher_retention_ns_total
+            ),
+            "event_monitor_publisher_retention_ms_max": self._timing_ms(
+                timing_window.monitor_publisher_retention_ns_max
+            ),
         }
         return (
             {key: value for key, value in snapshot.items() if value is not None},
@@ -2230,6 +2315,10 @@ class LiveEventPipeline:
             "monitor_publisher_rotation_ns_total",
             "monitor_publisher_persist_ns_total",
             "monitor_publisher_maintenance_ns_total",
+            "monitor_publisher_manifest_checkpoint_count",
+            "monitor_publisher_manifest_checkpoint_ns_total",
+            "monitor_publisher_retention_run_count",
+            "monitor_publisher_retention_ns_total",
         ):
             setattr(
                 self,
@@ -2242,6 +2331,8 @@ class LiveEventPipeline:
             "monitor_publisher_rotation_ns_max",
             "monitor_publisher_persist_ns_max",
             "monitor_publisher_maintenance_ns_max",
+            "monitor_publisher_manifest_checkpoint_ns_max",
+            "monitor_publisher_retention_ns_max",
         ):
             setattr(
                 self,
@@ -2456,6 +2547,26 @@ class LiveEventPipeline:
                         self._timing_monitor_publisher_maintenance_ns_max = max(
                             self._timing_monitor_publisher_maintenance_ns_max,
                             sink_write_timing.monitor_publisher_maintenance_ns_max,
+                        )
+                        self._timing_monitor_publisher_manifest_checkpoint_count += (
+                            sink_write_timing.monitor_publisher_manifest_checkpoint_count
+                        )
+                        self._timing_monitor_publisher_manifest_checkpoint_ns_total += (
+                            sink_write_timing.monitor_publisher_manifest_checkpoint_ns_total
+                        )
+                        self._timing_monitor_publisher_manifest_checkpoint_ns_max = max(
+                            self._timing_monitor_publisher_manifest_checkpoint_ns_max,
+                            sink_write_timing.monitor_publisher_manifest_checkpoint_ns_max,
+                        )
+                        self._timing_monitor_publisher_retention_run_count += (
+                            sink_write_timing.monitor_publisher_retention_run_count
+                        )
+                        self._timing_monitor_publisher_retention_ns_total += (
+                            sink_write_timing.monitor_publisher_retention_ns_total
+                        )
+                        self._timing_monitor_publisher_retention_ns_max = max(
+                            self._timing_monitor_publisher_retention_ns_max,
+                            sink_write_timing.monitor_publisher_retention_ns_max,
                         )
                 self._queue.task_done()
 

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -121,6 +121,12 @@ _RESOURCE_PRESSURE_FIELDS = (
     "event_monitor_publisher_persist_ms_max",
     "event_monitor_publisher_maintenance_ms_total",
     "event_monitor_publisher_maintenance_ms_max",
+    "event_monitor_publisher_manifest_checkpoint_count",
+    "event_monitor_publisher_manifest_checkpoint_ms_total",
+    "event_monitor_publisher_manifest_checkpoint_ms_max",
+    "event_monitor_publisher_retention_run_count",
+    "event_monitor_publisher_retention_ms_total",
+    "event_monitor_publisher_retention_ms_max",
 )
 _RESOURCE_PRESSURE_COUNTER_FIELDS = (
     "event_drop_counts",
@@ -4056,6 +4062,24 @@ class _ResourcePressureAccumulator:
             ),
             "latest_event_monitor_publisher_maintenance_ms_max": latest_field_max(
                 "event_monitor_publisher_maintenance_ms_max"
+            ),
+            "latest_event_monitor_publisher_manifest_checkpoint_count_sum": latest_field_sum(
+                "event_monitor_publisher_manifest_checkpoint_count"
+            ),
+            "latest_event_monitor_publisher_manifest_checkpoint_ms_total_sum": latest_field_sum(
+                "event_monitor_publisher_manifest_checkpoint_ms_total"
+            ),
+            "latest_event_monitor_publisher_manifest_checkpoint_ms_max": latest_field_max(
+                "event_monitor_publisher_manifest_checkpoint_ms_max"
+            ),
+            "latest_event_monitor_publisher_retention_run_count_sum": latest_field_sum(
+                "event_monitor_publisher_retention_run_count"
+            ),
+            "latest_event_monitor_publisher_retention_ms_total_sum": latest_field_sum(
+                "event_monitor_publisher_retention_ms_total"
+            ),
+            "latest_event_monitor_publisher_retention_ms_max": latest_field_max(
+                "event_monitor_publisher_retention_ms_max"
             ),
             "event_pipeline_unhealthy_bots": unhealthy_bots,
             "groups_truncated": len(groups) > limit,

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -2822,6 +2822,12 @@ def _event_pipeline_health_group(
         "event_monitor_publisher_persist_ms_max",
         "event_monitor_publisher_maintenance_ms_total",
         "event_monitor_publisher_maintenance_ms_max",
+        "event_monitor_publisher_manifest_checkpoint_count",
+        "event_monitor_publisher_manifest_checkpoint_ms_total",
+        "event_monitor_publisher_manifest_checkpoint_ms_max",
+        "event_monitor_publisher_retention_run_count",
+        "event_monitor_publisher_retention_ms_total",
+        "event_monitor_publisher_retention_ms_max",
     }
     if not any(key in payload for key in observed_keys):
         return None
@@ -2913,6 +2919,24 @@ def _event_pipeline_health_group(
         "latest_monitor_publisher_maintenance_ms_max": _non_negative_number(
             payload.get("event_monitor_publisher_maintenance_ms_max")
         ),
+        "latest_monitor_publisher_manifest_checkpoint_count": _non_negative_int(
+            payload.get("event_monitor_publisher_manifest_checkpoint_count")
+        ),
+        "latest_monitor_publisher_manifest_checkpoint_ms_total": _non_negative_number(
+            payload.get("event_monitor_publisher_manifest_checkpoint_ms_total")
+        ),
+        "latest_monitor_publisher_manifest_checkpoint_ms_max": _non_negative_number(
+            payload.get("event_monitor_publisher_manifest_checkpoint_ms_max")
+        ),
+        "latest_monitor_publisher_retention_run_count": _non_negative_int(
+            payload.get("event_monitor_publisher_retention_run_count")
+        ),
+        "latest_monitor_publisher_retention_ms_total": _non_negative_number(
+            payload.get("event_monitor_publisher_retention_ms_total")
+        ),
+        "latest_monitor_publisher_retention_ms_max": _non_negative_number(
+            payload.get("event_monitor_publisher_retention_ms_max")
+        ),
         "latest_pipeline_stopping": (
             bool(payload.get("event_pipeline_stopping"))
             if "event_pipeline_stopping" in payload
@@ -2989,6 +3013,12 @@ def _merge_event_pipeline_health_group(
             "latest_monitor_publisher_persist_ms_max",
             "latest_monitor_publisher_maintenance_ms_total",
             "latest_monitor_publisher_maintenance_ms_max",
+            "latest_monitor_publisher_manifest_checkpoint_count",
+            "latest_monitor_publisher_manifest_checkpoint_ms_total",
+            "latest_monitor_publisher_manifest_checkpoint_ms_max",
+            "latest_monitor_publisher_retention_run_count",
+            "latest_monitor_publisher_retention_ms_total",
+            "latest_monitor_publisher_retention_ms_max",
             "latest_pipeline_stopping",
             "latest_worker_alive",
             "latest_ids",
@@ -3130,6 +3160,30 @@ def _summarize_event_pipeline_health(
         ),
         "latest_monitor_publisher_maintenance_ms_max": _max_optional_numbers(
             group.get("latest_monitor_publisher_maintenance_ms_max")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_manifest_checkpoint_count_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_manifest_checkpoint_count")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_manifest_checkpoint_ms_total_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_manifest_checkpoint_ms_total")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_manifest_checkpoint_ms_max": _max_optional_numbers(
+            group.get("latest_monitor_publisher_manifest_checkpoint_ms_max")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_run_count_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_retention_run_count")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_ms_total_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_retention_ms_total")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_ms_max": _max_optional_numbers(
+            group.get("latest_monitor_publisher_retention_ms_max")
             for group in groups.values()
         ),
     }
@@ -7149,6 +7203,24 @@ def _summary_limited_groups(
             "latest_monitor_publisher_maintenance_ms_max": summary.get(
                 "latest_monitor_publisher_maintenance_ms_max"
             ),
+            "latest_monitor_publisher_manifest_checkpoint_count_sum": summary.get(
+                "latest_monitor_publisher_manifest_checkpoint_count_sum"
+            ),
+            "latest_monitor_publisher_manifest_checkpoint_ms_total_sum": summary.get(
+                "latest_monitor_publisher_manifest_checkpoint_ms_total_sum"
+            ),
+            "latest_monitor_publisher_manifest_checkpoint_ms_max": summary.get(
+                "latest_monitor_publisher_manifest_checkpoint_ms_max"
+            ),
+            "latest_monitor_publisher_retention_run_count_sum": summary.get(
+                "latest_monitor_publisher_retention_run_count_sum"
+            ),
+            "latest_monitor_publisher_retention_ms_total_sum": summary.get(
+                "latest_monitor_publisher_retention_ms_total_sum"
+            ),
+            "latest_monitor_publisher_retention_ms_max": summary.get(
+                "latest_monitor_publisher_retention_ms_max"
+            ),
             "latest_worker_not_alive_count": summary.get(
                 "latest_worker_not_alive_count"
             ),
@@ -8620,6 +8692,24 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
                 ),
                 "latest_monitor_publisher_maintenance_ms_max": event_pipeline_health.get(
                     "latest_monitor_publisher_maintenance_ms_max"
+                ),
+                "latest_monitor_publisher_manifest_checkpoint_count_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_manifest_checkpoint_count_sum"
+                ),
+                "latest_monitor_publisher_manifest_checkpoint_ms_total_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_manifest_checkpoint_ms_total_sum"
+                ),
+                "latest_monitor_publisher_manifest_checkpoint_ms_max": event_pipeline_health.get(
+                    "latest_monitor_publisher_manifest_checkpoint_ms_max"
+                ),
+                "latest_monitor_publisher_retention_run_count_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_run_count_sum"
+                ),
+                "latest_monitor_publisher_retention_ms_total_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_ms_total_sum"
+                ),
+                "latest_monitor_publisher_retention_ms_max": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_ms_max"
                 ),
                 "latest_worker_not_alive_count": _count_value(
                     event_pipeline_health.get("latest_worker_not_alive_count")

--- a/src/monitor_publisher.py
+++ b/src/monitor_publisher.py
@@ -11,7 +11,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Callable, Iterable, Optional
 
 
 _MONITOR_EVENT_PHASE_TIMING_KEYS = (
@@ -19,6 +19,12 @@ _MONITOR_EVENT_PHASE_TIMING_KEYS = (
     "rotation_ns",
     "persist_ns",
     "maintenance_ns",
+    "manifest_checkpoint_count",
+    "manifest_checkpoint_ns_total",
+    "manifest_checkpoint_ns_max",
+    "retention_run_count",
+    "retention_ns_total",
+    "retention_ns_max",
 )
 _CURRENT_EVENTS_REVERSE_READ_BYTES = 64 * 1024
 _EVENT_RECOVERY_CHECKSUM_BYTES = 16
@@ -395,20 +401,30 @@ class MonitorPublisher:
             self._last_manifest_write_monotonic_ms = self._monotonic_ms()
             return True
 
-    def _write_manifest_if_due(self, now_ms: Optional[int] = None) -> bool:
-        with self._lock:
-            if not self._manifest_dirty:
-                return False
-            cadence_now_ms = self._monotonic_ms()
-            if (
-                self._manifest_retry_needed
-                or self._last_manifest_write_monotonic_ms is None
-                or cadence_now_ms < self._last_manifest_write_monotonic_ms
-                or cadence_now_ms - self._last_manifest_write_monotonic_ms
-                >= self.snapshot_interval_ms
-            ):
-                return self._write_manifest(now_ms=now_ms)
+    def _manifest_checkpoint_due(self) -> bool:
+        if not self._manifest_dirty:
             return False
+        cadence_now_ms = self._monotonic_ms()
+        return (
+            self._manifest_retry_needed
+            or self._last_manifest_write_monotonic_ms is None
+            or cadence_now_ms < self._last_manifest_write_monotonic_ms
+            or cadence_now_ms - self._last_manifest_write_monotonic_ms
+            >= self.snapshot_interval_ms
+        )
+
+    def _write_manifest_if_due(
+        self,
+        now_ms: Optional[int] = None,
+        *,
+        on_attempt: Optional[Callable[[], None]] = None,
+    ) -> bool:
+        with self._lock:
+            if not self._manifest_checkpoint_due():
+                return False
+            if on_attempt is not None:
+                on_attempt()
+            return self._write_manifest(now_ms=now_ms)
 
     def _log_write_failure(self, action: str, exc: BaseException) -> None:
         if not _is_disk_full_error(exc):
@@ -456,12 +472,24 @@ class MonitorPublisher:
                 files.append(path)
         return sorted(files, key=lambda path: path.stat().st_mtime)
 
-    def _prune_retention(self, now_ms: Optional[int] = None) -> None:
+    def _retention_due(self, now_ms: int) -> bool:
+        return not (
+            self.last_retention_ms and now_ms - self.last_retention_ms < 60_000
+        )
+
+    def _prune_retention(
+        self,
+        now_ms: Optional[int] = None,
+        *,
+        on_run: Optional[Callable[[], None]] = None,
+    ) -> None:
         with self._lock:
             now_ms = self._now_ms() if now_ms is None else int(now_ms)
-            if self.last_retention_ms and now_ms - self.last_retention_ms < 60_000:
+            if not self._retention_due(now_ms):
                 return
             self.last_retention_ms = now_ms
+            if on_run is not None:
+                on_run()
             try:
                 cutoff_ms = now_ms - int(self.retain_days * 24.0 * 60.0 * 60.0 * 1000.0)
                 if self.retain_days >= 0.0:
@@ -802,8 +830,42 @@ class MonitorPublisher:
                 maintenance_started_ns = time.monotonic_ns()
                 try:
                     self._mark_manifest_dirty()
-                    self._write_manifest_if_due(now_ms=now_ms)
-                    self._prune_retention(now_ms=now_ms)
+                    manifest_checkpoint_started_ns: int | None = None
+
+                    def on_manifest_checkpoint_attempt() -> None:
+                        nonlocal manifest_checkpoint_started_ns
+                        manifest_checkpoint_started_ns = time.monotonic_ns()
+                        timing["manifest_checkpoint_count"] += 1
+
+                    try:
+                        self._write_manifest_if_due(
+                            now_ms=now_ms, on_attempt=on_manifest_checkpoint_attempt
+                        )
+                    finally:
+                        if manifest_checkpoint_started_ns is not None:
+                            manifest_checkpoint_ns = max(
+                                0, time.monotonic_ns() - manifest_checkpoint_started_ns
+                            )
+                            timing["manifest_checkpoint_ns_total"] += manifest_checkpoint_ns
+                            timing["manifest_checkpoint_ns_max"] = max(
+                                timing["manifest_checkpoint_ns_max"], manifest_checkpoint_ns
+                            )
+                    retention_started_ns: int | None = None
+
+                    def on_retention_run() -> None:
+                        nonlocal retention_started_ns
+                        retention_started_ns = time.monotonic_ns()
+                        timing["retention_run_count"] += 1
+
+                    try:
+                        self._prune_retention(now_ms=now_ms, on_run=on_retention_run)
+                    finally:
+                        if retention_started_ns is not None:
+                            retention_ns = max(0, time.monotonic_ns() - retention_started_ns)
+                            timing["retention_ns_total"] += retention_ns
+                            timing["retention_ns_max"] = max(
+                                timing["retention_ns_max"], retention_ns
+                            )
                 finally:
                     timing["maintenance_ns"] = max(
                         0, time.monotonic_ns() - maintenance_started_ns

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -603,12 +603,24 @@ def test_pipeline_aggregates_and_resets_monitor_publisher_phase_timing(monkeypat
                         "rotation_ns": 3_000_000,
                         "persist_ns": 5_000_000,
                         "maintenance_ns": 7_000_000,
+                        "manifest_checkpoint_count": 1,
+                        "manifest_checkpoint_ns_total": 2_000_000,
+                        "manifest_checkpoint_ns_max": 2_000_000,
+                        "retention_run_count": 1,
+                        "retention_ns_total": 4_000_000,
+                        "retention_ns_max": 4_000_000,
                     },
                     {
                         "lock_wait_ns": 11_000_000,
                         "rotation_ns": 13_000_000,
                         "persist_ns": 17_000_000,
                         "maintenance_ns": 19_000_000,
+                        "manifest_checkpoint_count": 0,
+                        "manifest_checkpoint_ns_total": 0,
+                        "manifest_checkpoint_ns_max": 0,
+                        "retention_run_count": 0,
+                        "retention_ns_total": 0,
+                        "retention_ns_max": 0,
                     },
                 )
             )
@@ -641,6 +653,12 @@ def test_pipeline_aggregates_and_resets_monitor_publisher_phase_timing(monkeypat
         "event_monitor_publisher_persist_ms_max": 17.0,
         "event_monitor_publisher_maintenance_ms_total": 26.0,
         "event_monitor_publisher_maintenance_ms_max": 19.0,
+        "event_monitor_publisher_manifest_checkpoint_count": 1,
+        "event_monitor_publisher_manifest_checkpoint_ms_total": 2.0,
+        "event_monitor_publisher_manifest_checkpoint_ms_max": 2.0,
+        "event_monitor_publisher_retention_run_count": 1,
+        "event_monitor_publisher_retention_ms_total": 4.0,
+        "event_monitor_publisher_retention_ms_max": 4.0,
     }
     snapshot = pipeline.health_snapshot()
     assert {key: snapshot[key] for key in expected} == expected
@@ -663,23 +681,43 @@ def test_pipeline_monitor_phase_timing_restores_overlapping_window(monkeypatch):
     pipeline._timing_monitor_prepare_ns_max = 2_000_000
     pipeline._timing_monitor_publisher_persist_ns_total = 3_000_000
     pipeline._timing_monitor_publisher_persist_ns_max = 3_000_000
+    pipeline._timing_monitor_publisher_manifest_checkpoint_count = 2
+    pipeline._timing_monitor_publisher_manifest_checkpoint_ns_total = 13_000_000
+    pipeline._timing_monitor_publisher_manifest_checkpoint_ns_max = 8_000_000
+    pipeline._timing_monitor_publisher_retention_run_count = 3
+    pipeline._timing_monitor_publisher_retention_ns_total = 17_000_000
+    pipeline._timing_monitor_publisher_retention_ns_max = 9_000_000
 
     first, first_token = pipeline.consume_timing_snapshot()
     pipeline._timing_monitor_prepare_ns_total = 5_000_000
     pipeline._timing_monitor_prepare_ns_max = 5_000_000
     pipeline._timing_monitor_publisher_persist_ns_total = 7_000_000
     pipeline._timing_monitor_publisher_persist_ns_max = 7_000_000
+    pipeline._timing_monitor_publisher_manifest_checkpoint_count = 5
+    pipeline._timing_monitor_publisher_manifest_checkpoint_ns_total = 19_000_000
+    pipeline._timing_monitor_publisher_manifest_checkpoint_ns_max = 12_000_000
+    pipeline._timing_monitor_publisher_retention_run_count = 7
+    pipeline._timing_monitor_publisher_retention_ns_total = 23_000_000
+    pipeline._timing_monitor_publisher_retention_ns_max = 14_000_000
     _second, second_token = pipeline.consume_timing_snapshot()
     pipeline.confirm_timing_snapshot(first_token)
     pipeline.restore_timing_snapshot(second_token)
 
     assert first["event_monitor_prepare_ms_total"] == 2.0
     assert first["event_monitor_publisher_persist_ms_total"] == 3.0
+    assert first["event_monitor_publisher_manifest_checkpoint_count"] == 2
+    assert first["event_monitor_publisher_retention_run_count"] == 3
     restored = pipeline.health_snapshot()
     assert restored["event_monitor_prepare_ms_total"] == 5.0
     assert restored["event_monitor_prepare_ms_max"] == 5.0
     assert restored["event_monitor_publisher_persist_ms_total"] == 7.0
     assert restored["event_monitor_publisher_persist_ms_max"] == 7.0
+    assert restored["event_monitor_publisher_manifest_checkpoint_count"] == 5
+    assert restored["event_monitor_publisher_manifest_checkpoint_ms_total"] == 19.0
+    assert restored["event_monitor_publisher_manifest_checkpoint_ms_max"] == 12.0
+    assert restored["event_monitor_publisher_retention_run_count"] == 7
+    assert restored["event_monitor_publisher_retention_ms_total"] == 23.0
+    assert restored["event_monitor_publisher_retention_ms_max"] == 14.0
 
 
 def test_pipeline_custom_monitor_sink_reports_zero_internal_phase_timing():
@@ -711,6 +749,12 @@ def test_pipeline_custom_monitor_sink_reports_zero_internal_phase_timing():
         "event_monitor_publisher_persist_ms_max": 0.0,
         "event_monitor_publisher_maintenance_ms_total": 0.0,
         "event_monitor_publisher_maintenance_ms_max": 0.0,
+        "event_monitor_publisher_manifest_checkpoint_count": 0,
+        "event_monitor_publisher_manifest_checkpoint_ms_total": 0.0,
+        "event_monitor_publisher_manifest_checkpoint_ms_max": 0.0,
+        "event_monitor_publisher_retention_run_count": 0,
+        "event_monitor_publisher_retention_ms_total": 0.0,
+        "event_monitor_publisher_retention_ms_max": 0.0,
     }
     assert pipeline.close(timeout=2.0) is True
 

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -4865,6 +4865,12 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
                     "event_monitor_publisher_persist_ms_max": 0.6,
                     "event_monitor_publisher_maintenance_ms_total": 0.5,
                     "event_monitor_publisher_maintenance_ms_max": 0.3,
+                    "event_monitor_publisher_manifest_checkpoint_count": 2,
+                    "event_monitor_publisher_manifest_checkpoint_ms_total": 0.1,
+                    "event_monitor_publisher_manifest_checkpoint_ms_max": 0.08,
+                    "event_monitor_publisher_retention_run_count": 3,
+                    "event_monitor_publisher_retention_ms_total": 0.2,
+                    "event_monitor_publisher_retention_ms_max": 0.15,
                 },
             ),
         ],
@@ -4901,6 +4907,12 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
                     "event_monitor_publisher_persist_ms_max": 0.5,
                     "event_monitor_publisher_maintenance_ms_total": 0.3,
                     "event_monitor_publisher_maintenance_ms_max": 0.3,
+                    "event_monitor_publisher_manifest_checkpoint_count": 1,
+                    "event_monitor_publisher_manifest_checkpoint_ms_total": 0.1,
+                    "event_monitor_publisher_manifest_checkpoint_ms_max": 0.1,
+                    "event_monitor_publisher_retention_run_count": 1,
+                    "event_monitor_publisher_retention_ms_total": 0.1,
+                    "event_monitor_publisher_retention_ms_max": 0.1,
                 },
             )
         ],
@@ -4939,6 +4951,15 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
         "median": 1,
         "p95": 1,
     }
+    assert binance_fields["event_monitor_publisher_manifest_checkpoint_count"] == {
+        "latest": 2,
+        "count": 1,
+        "min": 2,
+        "max": 2,
+        "mean": 2,
+        "median": 2,
+        "p95": 2,
+    }
     assert {
         key: pressure[key]
         for key in (
@@ -4964,6 +4985,12 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
             "latest_event_monitor_publisher_persist_ms_max",
             "latest_event_monitor_publisher_maintenance_ms_total_sum",
             "latest_event_monitor_publisher_maintenance_ms_max",
+            "latest_event_monitor_publisher_manifest_checkpoint_count_sum",
+            "latest_event_monitor_publisher_manifest_checkpoint_ms_total_sum",
+            "latest_event_monitor_publisher_manifest_checkpoint_ms_max",
+            "latest_event_monitor_publisher_retention_run_count_sum",
+            "latest_event_monitor_publisher_retention_ms_total_sum",
+            "latest_event_monitor_publisher_retention_ms_max",
         )
     } == {
         "latest_event_pipeline_processed_total": 8,
@@ -4988,6 +5015,12 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
         "latest_event_monitor_publisher_persist_ms_max": 0.6,
         "latest_event_monitor_publisher_maintenance_ms_total_sum": 0.8,
         "latest_event_monitor_publisher_maintenance_ms_max": 0.3,
+        "latest_event_monitor_publisher_manifest_checkpoint_count_sum": 3,
+        "latest_event_monitor_publisher_manifest_checkpoint_ms_total_sum": 0.2,
+        "latest_event_monitor_publisher_manifest_checkpoint_ms_max": 0.1,
+        "latest_event_monitor_publisher_retention_run_count_sum": 4,
+        "latest_event_monitor_publisher_retention_ms_total_sum": 0.3,
+        "latest_event_monitor_publisher_retention_ms_max": 0.15,
     }
 
 
@@ -5024,6 +5057,11 @@ def test_live_performance_report_resource_pressure_whitelists_health_fields(tmp_
             "latest"
         ]
         == 70
+    )
+    assert not any(
+        key.startswith("event_monitor_publisher_manifest_checkpoint")
+        or key.startswith("event_monitor_publisher_retention")
+        for key in report["resource_pressure"]["groups"][0]["fields"]
     )
     assert "balance_raw" not in rendered
     assert "balance_snapped" not in rendered

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2727,6 +2727,12 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
                     "event_monitor_publisher_persist_ms_max": 2.0,
                     "event_monitor_publisher_maintenance_ms_total": 2.5,
                     "event_monitor_publisher_maintenance_ms_max": 1.5,
+                    "event_monitor_publisher_manifest_checkpoint_count": 2,
+                    "event_monitor_publisher_manifest_checkpoint_ms_total": 0.5,
+                    "event_monitor_publisher_manifest_checkpoint_ms_max": 0.3,
+                    "event_monitor_publisher_retention_run_count": 3,
+                    "event_monitor_publisher_retention_ms_total": 1.0,
+                    "event_monitor_publisher_retention_ms_max": 0.6,
                 },
             )
         ],
@@ -2763,6 +2769,12 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
                     "event_monitor_publisher_persist_ms_max": 0.7,
                     "event_monitor_publisher_maintenance_ms_total": 0.4,
                     "event_monitor_publisher_maintenance_ms_max": 0.4,
+                    "event_monitor_publisher_manifest_checkpoint_count": 1,
+                    "event_monitor_publisher_manifest_checkpoint_ms_total": 0.1,
+                    "event_monitor_publisher_manifest_checkpoint_ms_max": 0.1,
+                    "event_monitor_publisher_retention_run_count": 1,
+                    "event_monitor_publisher_retention_ms_total": 0.2,
+                    "event_monitor_publisher_retention_ms_max": 0.2,
                 },
             )
         ],
@@ -2780,6 +2792,8 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
     assert groups["okx/okx_01"].get("latest_structured_sink_write_count") == 8
     assert groups["gateio/gateio_01"].get("latest_monitor_sink_service_ms_max") == 2
     assert groups["okx/okx_01"].get("latest_monitor_publisher_persist_ms_max") == 2
+    assert groups["okx/okx_01"].get("latest_monitor_publisher_manifest_checkpoint_count") == 2
+    assert groups["gateio/gateio_01"].get("latest_monitor_publisher_retention_run_count") == 1
     expected = {
         "latest_processed_total": 11,
         "latest_timing_window_ms_max": 1250,
@@ -2803,12 +2817,56 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
         "latest_monitor_publisher_persist_ms_max": 2,
         "latest_monitor_publisher_maintenance_ms_total_sum": 2.9,
         "latest_monitor_publisher_maintenance_ms_max": 1.5,
+        "latest_monitor_publisher_manifest_checkpoint_count_sum": 3,
+        "latest_monitor_publisher_manifest_checkpoint_ms_total_sum": 0.6,
+        "latest_monitor_publisher_manifest_checkpoint_ms_max": 0.3,
+        "latest_monitor_publisher_retention_run_count_sum": 4,
+        "latest_monitor_publisher_retention_ms_total_sum": 1.2,
+        "latest_monitor_publisher_retention_ms_max": 0.6,
     }
     assert {key: health[key] for key in expected} == expected
     assert {key: summary["event_pipeline_health"][key] for key in expected} == expected
     assert {key: brief["event_pipeline"][key] for key in expected} == expected
     assert report["ok"] is True
     assert report["attention"] is False
+
+
+def test_live_smoke_report_omits_missing_monitor_maintenance_attribution(tmp_path):
+    events_dir = tmp_path / "monitor" / "okx" / "okx_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="health.summary",
+                exchange="okx",
+                user="okx_01",
+                seq=1,
+                ts=2000,
+                data={
+                    "event_pipeline_processed_count": 3,
+                    "event_monitor_publisher_maintenance_ms_total": 2.5,
+                    "event_monitor_publisher_maintenance_ms_max": 1.5,
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    summary = summarize_live_smoke_report(report)
+    brief = summarize_live_smoke_report_brief(report)
+    health = report["event_pipeline_health"]
+    group = health["groups"][0]
+    new_prefixes = (
+        "latest_monitor_publisher_manifest_checkpoint",
+        "latest_monitor_publisher_retention",
+    )
+
+    assert not any(key.startswith(new_prefixes) for key in group)
+    assert not any(key.startswith(new_prefixes) for key in health)
+    assert not any(
+        key.startswith(new_prefixes) for key in summary["event_pipeline_health"]
+    )
+    assert not any(key.startswith(new_prefixes) for key in brief["event_pipeline"])
 
 
 def test_live_smoke_report_problem_events_include_cycle_degraded_details(tmp_path):

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -649,15 +649,22 @@ def test_monitor_publisher_event_phase_timing_uses_fixed_boundaries(tmp_path, mo
     monkeypatch.setattr(
         publisher,
         "_write_manifest_if_due",
-        lambda **_kwargs: clock.__setitem__("ns", clock["ns"] + 7_000_000),
+        lambda **kwargs: (
+            kwargs["on_attempt"](),
+            clock.__setitem__("ns", clock["ns"] + 7_000_000),
+        ),
     )
     monkeypatch.setattr(
         publisher,
         "_prune_retention",
-        lambda **_kwargs: clock.__setitem__("ns", clock["ns"] + 11_000_000),
+        lambda **kwargs: (
+            kwargs["on_run"](),
+            clock.__setitem__("ns", clock["ns"] + 11_000_000),
+        ),
     )
     monkeypatch.setattr(monitor_publisher_module.json, "dumps", timed_dumps)
     monkeypatch.setattr(monitor_publisher_module, "open", timed_open, raising=False)
+    publisher._last_manifest_write_monotonic_ms = None
 
     event, timing = publisher._record_event_timed("test.event", ("test",), {"value": 1})
 
@@ -667,6 +674,12 @@ def test_monitor_publisher_event_phase_timing_uses_fixed_boundaries(tmp_path, mo
         "rotation_ns": 2_000_000,
         "persist_ns": 8_000_000,
         "maintenance_ns": 18_000_000,
+        "manifest_checkpoint_count": 1,
+        "manifest_checkpoint_ns_total": 7_000_000,
+        "manifest_checkpoint_ns_max": 7_000_000,
+        "retention_run_count": 1,
+        "retention_ns_total": 11_000_000,
+        "retention_ns_max": 11_000_000,
     }
 
 
@@ -698,4 +711,57 @@ def test_monitor_publisher_event_failure_retains_reached_phase_timing(tmp_path, 
         "rotation_ns": 2_000_000,
         "persist_ns": 3_000_000,
         "maintenance_ns": 0,
+        "manifest_checkpoint_count": 0,
+        "manifest_checkpoint_ns_total": 0,
+        "manifest_checkpoint_ns_max": 0,
+        "retention_run_count": 0,
+        "retention_ns_total": 0,
+        "retention_ns_max": 0,
     }
+
+
+def test_monitor_publisher_event_timing_counts_due_maintenance_only(tmp_path):
+    publisher = _make_publisher(tmp_path)
+    publisher._last_manifest_write_monotonic_ms = None
+
+    _first_event, first_timing = publisher._record_event_timed(
+        "test.event", ("test",), {"value": 1}, ts=100_000
+    )
+    _second_event, second_timing = publisher._record_event_timed(
+        "test.event", ("test",), {"value": 2}, ts=100_001
+    )
+
+    assert first_timing["manifest_checkpoint_count"] == 1
+    assert first_timing["retention_run_count"] == 1
+    assert first_timing["manifest_checkpoint_ns_total"] >= 0
+    assert first_timing["retention_ns_total"] >= 0
+    assert second_timing["manifest_checkpoint_count"] == 0
+    assert second_timing["retention_run_count"] == 0
+    assert second_timing["manifest_checkpoint_ns_total"] == 0
+    assert second_timing["retention_ns_total"] == 0
+
+
+def test_monitor_publisher_event_timing_counts_failed_due_attempts(tmp_path, monkeypatch, caplog):
+    publisher = _make_publisher(tmp_path)
+    publisher._last_manifest_write_monotonic_ms = None
+
+    def fail_atomic_write(*_args, **_kwargs):
+        raise OSError("manifest unavailable")
+
+    def fail_rotatable_files():
+        raise OSError("retention unavailable")
+
+    monkeypatch.setattr(monitor_publisher_module, "_atomic_write_json", fail_atomic_write)
+    monkeypatch.setattr(publisher, "_rotatable_files", fail_rotatable_files)
+
+    event, timing = publisher._record_event_timed(
+        "test.event", ("test",), {"value": 1}, ts=100_000
+    )
+
+    assert event is not None
+    assert timing["manifest_checkpoint_count"] == 1
+    assert timing["retention_run_count"] == 1
+    assert timing["manifest_checkpoint_ns_total"] >= timing["manifest_checkpoint_ns_max"]
+    assert timing["retention_ns_total"] >= timing["retention_ns_max"]
+    assert "writing manifest" in caplog.text
+    assert "retention pruning failed" in caplog.text


### PR DESCRIPTION
## Summary\n- preserve the inclusive monitor maintenance timing while splitting event-path manifest checkpoint and retention run count/total/max metrics\n- propagate fixed fields through timing snapshot consume/restore, health summaries, performance reports, and smoke reports\n- keep historical health rows omission-safe and document PR #1205 deployment evidence plus the active attribution boundary\n\n## Production evidence\nAfter PR #1205, four settled VPS5 health windows covered 8,959 monitor writes. Maintenance consumed 77,452.154ms of 83,557.728ms monitor service (92.69%, 8.645ms/write) and reached 7,148.422ms while queue wait reached 7,123.965ms. Existing timing cannot distinguish the periodic manifest checkpoint from retention's once-per-minute scan.\n\n## Behavior boundary\nAttribution only. This does not change manifest cadence/retry, retention cadence/policy, NDJSON persistence, locking, routing, queue/backpressure behavior, error visibility, smoke verdicts, configuration, or trading behavior.\n\n## Validation\n- 294 tests: publisher, event bus, performance report, smoke report, AI docs\n- 146 adjacent tests: monitor relay, passivbot monitor, incident bundle, fake live\n- Python compilation\n- git diff --check\n- added-line silent-handling audit\n- independent preflight and delta re-review: green\n\n## Review gate\nTemporary maintainer-authorized gate while Claude is rate-limited: exact current-head Hermes + Grok 4.5 green reviews and green CI. Any additional reviewer finding must still be resolved.