### PR TITLE
Polish position console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Position-change console and text lines now use a compact aligned transition
+  with old/new size and price plus WE, base-WEL, effective-WEL, TWEL, and uPnL.
+  The complete structured event remains unchanged for queries and incident
+  reconstruction.
+
 - Periodic structured health summaries now separate event-path manifest
   checkpoint and retention run counts and service totals/maxima within the
   existing inclusive monitor maintenance timing. Live smoke and performance

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -52,10 +52,11 @@ Estimated completion:
 
 Next action:
 
-1. Complete integrated validation and publish one review-worthy console PR.
-2. Hold its exact current head until Hermes, Grok 4.5, and CI are green;
-   resolve findings narrowly and require fresh exact-head verdicts after every
-   push.
+1. Hold the active console PR's exact current head until Hermes, Grok 4.5, and
+   CI are green;
+2. Resolve findings narrowly and require fresh exact-head verdicts after every
+   push, then merge and validate the exact five-bot VPS restart without creating
+   or altering a live position merely to exercise console formatting.
 3. In parallel, scope a separate retention optimization from PR #1206's fresh
    phase evidence without mixing persistence behavior into console formatting.
 
@@ -355,14 +356,15 @@ PR #1195's startup consumer correctness fixes, PR #1196's true fresh-entry
 eligibility producer, PR #1197's fresh-entry startup milestone, PR #1198's
 local connector-call boundary evidence, and PR #1199's startup fill-cache proof
 correlation, PR #1200's event-pipeline service timing, and PR #1203's fixed
-sink-class attribution are also merged and deployed. The active slice attributes
-the deployed monitor-sink long tail to fixed synchronous publisher phases.
+sink-class attribution, PR #1205's coalesced monitor manifest checkpoints, and
+PR #1206's monitor-maintenance phase attribution are also merged and deployed.
+The active slice polishes the human console projection of `position.changed`
+while preserving the structured event payload.
 
-After the phase-attribution slice is merged and validated, use production
-evidence to decide whether a monitor persistence optimization is warranted;
-otherwise select the next
-review-worthy bounded operator-tooling improvement sharing one code and
-validation surface.
+After the console slice is merged and validated, use PR #1206's production
+evidence to optimize the recurring retention path in a separate review-worthy
+slice. Keep persistence behavior and console presentation on separate code and
+validation surfaces.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,53 +22,67 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-monitor-maintenance-attribution`
-- Base: `435b20fb08d3221be6520f216ddc210612656d0d`, PR #1205
-- Triggering evidence: PR #1205 roughly halved per-write maintenance, but four
-  fresh settled health windows still attributed `77452.154ms` of
-  `83557.728ms` monitor service across 8,959 writes to inclusive maintenance.
-  Maintenance remained 92.69% of service, or `8.645ms` per write, and one
-  recurring event-path maintenance operation reached `7148.422ms` while queue
-  wait reached `7123.965ms`. Existing timing cannot distinguish the periodic
-  manifest checkpoint from retention's once-per-minute recursive scan.
-- Scope: preserve the inclusive maintenance metric and add fixed event-path
-  manifest-checkpoint and retention count/total/max timing. Propagate those
-  fields through the event pipeline timing window, `health.summary`,
-  `live-performance-report`, and `live-smoke-report` while keeping historical
-  rows that lack the fields valid.
-- Behavior boundary: attribution only. Preserve manifest cadence and retry,
-  retention cadence and policy, NDJSON append semantics, RLock ordering,
-  routing, queue/backpressure policy, error visibility, all event payloads,
-  all trading behavior, and existing configuration. Do not add file scans,
-  thresholds, alerts, verdicts, dynamic labels, threads, or queues.
-- Validation: due versus skipped and failed maintenance attempts; fixed timing
-  aggregation and consume/restore semantics; historical-row omission;
-  performance/smoke projection; publisher, event-bus, relay, monitor,
-  incident-bundle, and fake-live regressions; Python compilation; `git diff
+- Branch: `codex/v8-position-console-polish`
+- Base: `d61b3e18f6a6c0755d663e3e7fc72e8294fb7760`, PR #1206
+- Triggering evidence: live `position.changed` console lines expose the durable
+  event as a dense parser-oriented `key=value` sequence. They omit the already
+  persisted `wele_ratio`, even though operators need both base-WEL and
+  effective-WEL utilization and the legacy fallback previously aligned the
+  position transition for human scanning.
+- Scope: give only the event-derived position console/text projection one
+  compact aligned line containing action, coin, pside, old/new size and price,
+  WE, WEL, effective WEL, TWEL, and uPnL. Keep zeros visible, missing/non-finite
+  values explicit, long values untruncated, common coin aliases readable, and
+  labels free of ANSI/control characters.
+- Behavior boundary: console/text formatting only. Preserve the complete
+  structured `position.changed` event, event routing and volume, every other
+  event formatter, monitor persistence, smoke verdicts, configuration, and all
+  order/risk/trading behavior. Do not add multiline output or terminal colors
+  that could pollute text logs.
+- Validation: new/added/reduced/closed actions; signed shorts; zero, missing,
+  and non-finite metrics; fixed minimum columns; long values; common aliases;
+  control-character stripping; structured-event immutability; event-bus,
+  registry-doc, and fake-live regressions; Python compilation; `git diff
   --check`; added-line silent-handling audit; and independent preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
-- Expected VPS action: exact five-bot graceful restart, then bounded
-  `health.summary` evidence identifying manifest versus retention service time
-  plus immediate and settled smoke. Preserve unrelated processes and artifacts.
+- Expected VPS action: exact five-bot graceful restart, immediate and settled
+  smoke, and inspection of the next naturally emitted position change. Do not
+  create or alter a live position merely to exercise console formatting.
 
 Next action:
 
-1. Hold the active PR's exact current head until Hermes, Grok 4.5, and CI are
-   green; resolve findings narrowly and require fresh exact-head verdicts after
-   every push.
-2. Merge only after that gate is green, then restart the five exact VPS5 bot
-   panes while preserving unrelated processes and local artifacts.
-3. Use fresh phase metrics to choose the next retention/persistence action.
+1. Complete integrated validation and publish one review-worthy console PR.
+2. Hold its exact current head until Hermes, Grok 4.5, and CI are green;
+   resolve findings narrowly and require fresh exact-head verdicts after every
+   push.
+3. In parallel, scope a separate retention optimization from PR #1206's fresh
+   phase evidence without mixing persistence behavior into console formatting.
 
 ## Deployed Baseline
 
-- Remote `v8`: `435b20fb08d3221be6520f216ddc210612656d0d`, PR #1205
-- VPS5 repository: `435b20fb08d3221be6520f216ddc210612656d0d`, PR #1205; tracked
+- Remote `v8`: `d61b3e18f6a6c0755d663e3e7fc72e8294fb7760`, PR #1206
+- VPS5 repository: `d61b3e18f6a6c0755d663e3e7fc72e8294fb7760`, PR #1206; tracked
   status clean; expected untracked artifacts were preserved
-- VPS5 expected bots: five; running with PR #1205 restart PIDs
-  `871504/871509/871512/871516/871523`;
+- VPS5 expected bots: five; running with PR #1206 restart PIDs
+  `873338/873395/873458/873515/873576`;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1206 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
+  panes. All old bot processes exited naturally; pane PIDs
+  `856294/856332/856364/856398/856434` and unrelated `misc:0.0` PID `434835`
+  were preserved.
+- The settled two-minute smoke was hard-green with `575/575` remote and
+  `17/17` account-critical calls successful, all five expected processes
+  matched, states `R=3/S=2`, zero monitor or pipeline errors, and a clean
+  tracked repository. One HSL replay remained active but non-stale.
+- Four fresh health windows covered 2,328 monitor writes. Inclusive maintenance
+  was `23651.665ms`: 12 retention runs consumed `16210.383ms` with an
+  `8953.523ms` maximum, while 352 periodic manifest checkpoints consumed
+  `7377.475ms` with a `347.039ms` maximum. Retention therefore explains the
+  recurring long tail and is the next persistence optimization target. Drops,
+  sink errors, degraded counts, unhealthy pipelines, and final queue depth
+  were zero.
 - PR #1205 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
   panes. All old bot processes exited naturally; pane PIDs

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -69,6 +69,20 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1206 merged to `v8` as
+  `d61b3e18f6a6c0755d663e3e7fc72e8294fb7760` after exact-head Hermes and
+  Grok 4.5 approval plus green CI. It preserved inclusive maintenance timing
+  while adding fixed event-path manifest-checkpoint and retention
+  count/total/max attribution through health, performance, and smoke reports.
+  VPS5 fast-forwarded cleanly and gracefully restarted only the five configured
+  bot panes; all old bots exited naturally, pane PIDs remained unchanged, and
+  unrelated `misc:0.0` PID `434835` was preserved. The settled smoke was
+  hard-green with `575/575` remote and `17/17` account-critical calls
+  successful, all five processes matched, and zero monitor/pipeline errors.
+  Four fresh health windows attributed `16210.383ms` of `23651.665ms`
+  maintenance to 12 retention runs, including an `8953.523ms` maximum;
+  352 periodic manifest checkpoints consumed `7377.475ms` with a `347.039ms`
+  maximum. Retention is the next persistence optimization target.
 - PR #1205 merged to `v8` as
   `435b20fb08d3221be6520f216ddc210612656d0d` after exact-head Hermes and
   Grok 4.5 approval plus green CI. It coalesced ordinary best-effort manifest

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -508,6 +508,12 @@ Related detailed plans:
     summaries. EMA/candle/cache internals should stay structured DEBUG unless
     they directly explain a blocked trading action.
 
+    Active follow-up: render `position.changed` as an aligned human transition
+    with base/effective WEL utilization while preserving the complete
+    structured event. Remaining small readability gaps include zero-valued
+    fill/balance/entry-gate fields currently hidden by truthiness checks; handle
+    those as separate bounded formatter slices rather than broad console churn.
+
     Work log:
     - 2026-06-30: Added value-safe `live-smoke-report` HSL status projections
       for full, summary, and brief reports. The local full report keeps HSL

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -386,9 +386,12 @@ classification when enough source events exist.
     manifest checkpoints to the existing snapshot cadence and added bounded
     crash-safe event-sequence recovery without changing delivery. Fresh settled
     evidence reduced maintenance from `17.964ms` to `8.645ms` per write but
-    retained a recurring `7148.422ms` maintenance maximum. The active follow-up
-    separates periodic manifest-checkpoint and retention count/total/max timing
-    before changing persistence behavior.
+    retained a recurring `7148.422ms` maintenance maximum. PR #1206 separated
+    periodic manifest-checkpoint and retention count/total/max timing without
+    changing persistence behavior. Fresh VPS5 evidence attributed
+    `16210.383ms` and an `8953.523ms` maximum to 12 retention runs, versus
+    `7377.475ms` and a `347.039ms` maximum across 352 manifest checkpoints.
+    Retention is therefore the next persistence optimization target.
 - [ ] Exchange writes: create/cancel/close/panic write latency, exchange
   response latency, ambiguous write rate, confirmation latency.
   - Status: partial. The report now derives order-wave total duration,

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -5,6 +5,7 @@ from dataclasses import asdict, dataclass, field, replace
 import hashlib
 import json
 import logging
+import math
 import queue
 import re
 import threading
@@ -68,6 +69,8 @@ _MONITOR_PUBLISHER_PHASE_TIMING_KEYS = (
     "retention_ns_max",
 )
 _MONITOR_PHASE_TIMING_KEYS = ("prepare_ns", *_MONITOR_PUBLISHER_PHASE_TIMING_KEYS)
+_ANSI_ESCAPE_RE = re.compile(r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+_CONTROL_CHARACTER_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
 
 def _empty_monitor_phase_timing() -> dict[str, int]:
@@ -1272,42 +1275,75 @@ def _console_fill_ingested_summary(event: LiveEvent) -> list[str]:
     return parts
 
 
-def _console_position_changed_summary(event: LiveEvent) -> list[str]:
+def _format_position_console_number(value: float | None) -> str:
+    if value is None or not math.isfinite(value):
+        return "-"
+    if value == 0.0:
+        return "0"
+    return f"{value:.10g}"
+
+
+def _format_position_console_percentage(value: float | None) -> str:
+    if value is None or not math.isfinite(value):
+        return "-"
+    percentage = value * 100.0
+    if not math.isfinite(percentage):
+        return "-"
+    if percentage == 0.0:
+        percentage = 0.0
+    return f"{percentage:.4f}%"
+
+
+def _format_position_console_label(value: object) -> str:
+    text = _ANSI_ESCAPE_RE.sub("", str(value or ""))
+    text = _CONTROL_CHARACTER_RE.sub(" ", text)
+    return " ".join(text.split()) or "-"
+
+
+def _format_position_console_coin(symbol: object) -> str:
+    coin = str(symbol or "").partition("/")[0]
+    if "1000" in coin:
+        start = coin.find("1000")
+        end = start + 1
+        while end < len(coin) and coin[end] == "0":
+            end += 1
+        coin = coin[:start] + coin[end:]
+    if coin.startswith("k") and coin[1:].isupper():
+        coin = coin[1:]
+    return _format_position_console_label(coin)
+
+
+def _format_console_position_changed(event: LiveEvent) -> str:
     data = event.data if isinstance(event.data, Mapping) else {}
-    parts: list[str] = []
-    action = _data_str(data, "action")
-    if action:
-        parts.append(f"action={action}")
-    old_size = _data_float(data, "old_size")
-    new_size = _data_float(data, "new_size")
-    if old_size is not None and new_size is not None:
-        parts.append(f"size={old_size}->{new_size}")
-    else:
-        if old_size is not None:
-            parts.append(f"old_size={old_size}")
-        if new_size is not None:
-            parts.append(f"new_size={new_size}")
-    size_delta = _data_float(data, "size_delta")
-    if size_delta:
-        parts.append(f"delta={size_delta}")
-    new_price = _data_float(data, "new_price")
-    if new_price:
-        parts.append(f"price={new_price}")
-    last_price = _data_float(data, "last_price")
-    if last_price:
-        parts.append(f"last={last_price}")
-    for label, key in (
-        ("we", "wallet_exposure"),
-        ("wel", "wel_ratio"),
-        ("twel", "twel_ratio"),
-    ):
-        value = _data_number(data, key)
-        if value is not None:
-            parts.append(f"{label}={value * 100.0:.4f}%")
-    upnl = _data_float(data, "upnl")
-    if upnl:
-        parts.append(f"upnl={upnl}")
-    return parts
+    action = _format_position_console_label(_data_str(data, "action"))
+    coin = _format_position_console_coin(event.symbol)
+    pside = _format_position_console_label(event.pside)
+    old_leg = (
+        f"{_format_position_console_number(_data_number(data, 'old_size'))} @ "
+        f"{_format_position_console_number(_data_number(data, 'old_price'))}"
+    )
+    new_leg = (
+        f"{_format_position_console_number(_data_number(data, 'new_size'))} @ "
+        f"{_format_position_console_number(_data_number(data, 'new_price'))}"
+    )
+    metrics = " ".join(
+        (
+            "WE="
+            f"{_format_position_console_percentage(_data_number(data, 'wallet_exposure'))}",
+            "WEL="
+            f"{_format_position_console_percentage(_data_number(data, 'wel_ratio'))}",
+            "eWEL="
+            f"{_format_position_console_percentage(_data_number(data, 'wele_ratio'))}",
+            "TWEL="
+            f"{_format_position_console_percentage(_data_number(data, 'twel_ratio'))}",
+            "uPnL="
+            f"{_format_position_console_number(_data_number(data, 'upnl'))}",
+        )
+    )
+    return (
+        f"[pos] {action:>7} {coin:<10} {pside:<5} {old_leg:<22} "
+        f"-> {new_leg:<22} | {metrics}"
+    )
 
 
 def _console_balance_changed_summary(event: LiveEvent) -> list[str]:
@@ -1756,8 +1792,6 @@ def _console_data_summary(event: LiveEvent) -> list[str]:
         return _console_health_summary(event)
     if event.event_type == EventTypes.FILL_INGESTED:
         return _console_fill_ingested_summary(event)
-    if event.event_type == EventTypes.POSITION_CHANGED:
-        return _console_position_changed_summary(event)
     if event.event_type == EventTypes.BALANCE_CHANGED:
         return _console_balance_changed_summary(event)
     if event.event_type == EventTypes.RISK_MODE_CHANGED:
@@ -1795,6 +1829,8 @@ def _operator_sink_event_visible(event: LiveEvent) -> bool:
 
 
 def format_console_event(event: LiveEvent) -> str:
+    if event.event_type == EventTypes.POSITION_CHANGED:
+        return _format_console_position_changed(event)
     base = f"[{_console_tag(event)}]"
     if event.status:
         base += f" {event.status}"

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -1859,34 +1859,217 @@ def test_console_format_summarizes_fill_ingested():
     )
 
 
-def test_console_format_summarizes_position_changed():
+@pytest.mark.parametrize(
+    ("action", "old_size", "old_price", "new_size", "new_price"),
+    [
+        ("new", 0.0, 0.0, 0.07328, 67_352.9),
+        ("added", 0.07328, 67_352.9, 0.12, 67_000.0),
+        ("reduced", 0.12, 67_000.0, 0.07328, 67_352.9),
+        ("closed", 0.07328, 67_352.9, 0.0, 0.0),
+    ],
+)
+def test_console_format_position_changed_renders_all_actions(
+    action, old_size, old_price, new_size, new_price
+):
     event = LiveEvent(
         EventTypes.POSITION_CHANGED,
         status="succeeded",
         cycle_id="cy_pos",
-        symbol="ETH/USDT:USDT",
-        pside="short",
-        reason_code="short_increased",
+        symbol="BTC/USDT:USDT",
+        pside="long",
+        reason_code=action,
         data={
-            "action": "short_increased",
-            "old_size": -0.2,
-            "new_size": -0.35,
-            "size_delta": -0.15,
-            "new_price": 2_500.0,
-            "last_price": 2_480.0,
-            "wallet_exposure": 0.12,
-            "wel_ratio": 0.6,
-            "twel_ratio": 0.24,
-            "upnl": 7.5,
+            "action": action,
+            "old_size": old_size,
+            "old_price": old_price,
+            "new_size": new_size,
+            "new_price": new_price,
+            "wallet_exposure": 0.234841,
+            "wel_ratio": 1.095924,
+            "wele_ratio": 0.862929,
+            "twel_ratio": 0.178443,
+            "upnl": -265.815872,
         },
     )
 
-    assert format_console_event(event) == (
-        "[pos] succeeded cycle=cy_pos action=short_increased size=-0.2->-0.35 "
-        "delta=-0.15 price=2500 last=2480 we=12.0000% wel=60.0000% "
-        "twel=24.0000% upnl=7.5 symbol=ETH/USDT:USDT pside=short "
-        "reason=short_increased"
+    rendered = format_console_event(event)
+
+    assert rendered.startswith(f"[pos] {action:>7} BTC        long  ")
+    assert "succeeded" not in rendered
+    assert "cycle=" not in rendered
+    assert "symbol=" not in rendered
+    assert "pside=" not in rendered
+    assert "reason=" not in rendered
+    assert "WE=23.4841% WEL=109.5924% eWEL=86.2929% TWEL=17.8443%" in rendered
+    assert "uPnL=-265.815872" in rendered
+
+
+def test_console_format_position_changed_aligns_columns_and_preserves_event_data():
+    event = LiveEvent(
+        EventTypes.POSITION_CHANGED,
+        status="succeeded",
+        cycle_id="cy_pos",
+        symbol="BTC/USDT:USDT",
+        pside="long",
+        reason_code="new",
+        data={
+            "action": "new",
+            "old_size": 0.0,
+            "old_price": 0.0,
+            "new_size": 0.07328,
+            "new_price": 67_352.9,
+            "wallet_exposure": 0.234841,
+            "wel_ratio": 1.095924,
+            "wele_ratio": 0.862929,
+            "twel_ratio": 0.178443,
+            "upnl": -265.815872,
+        },
     )
+    before = event.to_dict()
+
+    rendered = format_console_event(event)
+
+    assert rendered == (
+        "[pos]     new BTC        long  0 @ 0                  "
+        "-> 0.07328 @ 67352.9      | WE=23.4841% WEL=109.5924% "
+        "eWEL=86.2929% TWEL=17.8443% uPnL=-265.815872"
+    )
+    assert event.to_dict() == before
+
+
+def test_console_format_position_changed_renders_zero_and_missing_metrics():
+    event = LiveEvent(
+        EventTypes.POSITION_CHANGED,
+        symbol="ETH/USDT:USDT",
+        pside="short",
+        data={
+            "action": "closed",
+            "old_size": 0.0,
+            "old_price": 0.0,
+            "new_size": 0.0,
+            "new_price": 0.0,
+            "wallet_exposure": 0.0,
+            "wel_ratio": 0.0,
+            "upnl": 0.0,
+        },
+    )
+
+    rendered = format_console_event(event)
+
+    assert "0 @ 0" in rendered
+    assert "WE=0.0000% WEL=0.0000% eWEL=- TWEL=- uPnL=0" in rendered
+
+
+def test_console_format_position_changed_does_not_truncate_long_values():
+    event = LiveEvent(
+        EventTypes.POSITION_CHANGED,
+        symbol="VERYLONGCOINNAME/USDT:USDT",
+        pside="very_long_position_side",
+        data={
+            "action": "very_long_action_name",
+            "old_size": 12345678901.2345,
+            "old_price": 98765432109.8765,
+            "new_size": 12345678902.2345,
+            "new_price": 98765432110.8765,
+        },
+    )
+
+    rendered = format_console_event(event)
+
+    assert "VERYLONGCOINNAME" in rendered
+    assert "very_long_action_name" in rendered
+    assert "very_long_position_side" in rendered
+    assert "1.23456789e+10 @ 9.876543211e+10" in rendered
+    assert "WE=- WEL=- eWEL=- TWEL=- uPnL=-" in rendered
+
+
+def test_console_format_position_changed_preserves_signed_short_values():
+    event = LiveEvent(
+        EventTypes.POSITION_CHANGED,
+        symbol="BTC/USDT:USDT",
+        pside="short",
+        data={
+            "action": "added",
+            "old_size": -0.2,
+            "old_price": 67_000.0,
+            "new_size": -0.35,
+            "new_price": 66_500.0,
+            "wallet_exposure": 0.12,
+            "wel_ratio": 0.6,
+            "wele_ratio": 0.5,
+            "twel_ratio": 0.24,
+            "upnl": -7.5,
+        },
+    )
+
+    rendered = format_console_event(event)
+
+    assert "short -0.2 @ 67000" in rendered
+    assert "-> -0.35 @ 66500" in rendered
+    assert "eWEL=50.0000%" in rendered
+    assert "uPnL=-7.5" in rendered
+
+
+def test_console_format_position_changed_handles_nonfinite_and_missing_values():
+    event = LiveEvent(
+        EventTypes.POSITION_CHANGED,
+        data={
+            "old_size": float("nan"),
+            "old_price": float("inf"),
+            "new_size": float("-inf"),
+            "new_price": None,
+            "wallet_exposure": float("nan"),
+            "wel_ratio": float("inf"),
+            "wele_ratio": float("-inf"),
+            "twel_ratio": None,
+            "upnl": float("nan"),
+        },
+    )
+
+    rendered = format_console_event(event)
+
+    assert rendered.startswith("[pos]       - -          -     - @ -")
+    assert "-> - @ -" in rendered
+    assert "WE=- WEL=- eWEL=- TWEL=- uPnL=-" in rendered
+    assert "nan" not in rendered.lower()
+    assert "inf" not in rendered.lower()
+
+
+@pytest.mark.parametrize(
+    ("symbol", "expected_coin"),
+    [
+        ("1000PEPE/USDT:USDT", "PEPE"),
+        ("kSHIB/USDC:USDC", "SHIB"),
+    ],
+)
+def test_console_format_position_changed_normalizes_common_coin_aliases(
+    symbol, expected_coin
+):
+    event = LiveEvent(
+        EventTypes.POSITION_CHANGED,
+        symbol=symbol,
+        pside="long",
+        data={"action": "new"},
+    )
+
+    rendered = format_console_event(event)
+
+    assert rendered.startswith(f"[pos]     new {expected_coin:<10} long  ")
+
+
+def test_console_format_position_changed_strips_ansi_and_control_characters():
+    event = LiveEvent(
+        EventTypes.POSITION_CHANGED,
+        symbol="BTC\n/USDT:USDT",
+        pside="long\r",
+        data={"action": "\x1b[31mnew\x1b[0m\t"},
+    )
+
+    rendered = format_console_event(event)
+
+    assert rendered.startswith("[pos]     new BTC        long  ")
+    assert "\x1b" not in rendered
+    assert not any(ord(char) < 32 or 127 <= ord(char) <= 159 for char in rendered)
 
 
 def test_console_format_summarizes_balance_changed():


### PR DESCRIPTION
## Summary\n- render position.changed console/text output as one compact aligned old-to-new position transition\n- show WE, base-WEL utilization, effective-WEL utilization, TWEL utilization, and uPnL, including zero and missing values\n- keep labels single-line and ANSI-free, normalize common 1000TOKEN/kTOKEN display aliases, and never truncate long values\n- preserve the complete structured position.changed event and every other formatter\n\n## Motivation\nThe structured event already persists wele_ratio, but the human console projection dropped it and exposed a dense parser-oriented key=value line. Operators need both base-WEL and effective-WEL utilization at a glance.\n\n## Behavior boundary\nConsole/text formatting only. No event producer/envelope changes, event volume/routing changes, persistence changes, config changes, smoke-verdict changes, or order/risk/trading behavior changes. No ANSI colors because the same projection may be written to text logs.\n\n## Validation\n- 452 integrated tests: event bus, registry docs, monitor publisher, performance/smoke reports, relay, monitor, incident bundle, fake live, and AI docs\n- Python compilation\n- git diff --check\n- added-line silent-handling audit\n- independent preflight and delta re-review: green\n\n## Deployment note\nAfter merge, restart only the five exact VPS5 bot panes and run immediate/settled smoke. Inspect the next naturally emitted position change; do not create or alter a live position merely to exercise formatting.\n\n## Review gate\nTemporary maintainer-authorized gate while Claude is rate-limited: exact current-head Hermes + Grok 4.5 green reviews and green CI. Any additional reviewer finding must still be resolved.