### PR TITLE
Reuse monitor retention inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Monitor retention pruning now inventories retained files once per due run and
+  reuses the same size/mtime snapshot for age and byte-cap deletion. Retention
+  cadence, protected files, recursive byte accounting, direct-only deletion,
+  and oldest-first policy are unchanged.
+
 - Position-change console and text lines now use a compact aligned transition
   with old/new size and price plus WE, base-WEL, effective-WEL, TWEL, and uPnL.
   The complete structured event remains unchanged for queries and incident

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,52 +22,57 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-position-console-polish`
-- Base: `d61b3e18f6a6c0755d663e3e7fc72e8294fb7760`, PR #1206
-- Triggering evidence: live `position.changed` console lines expose the durable
-  event as a dense parser-oriented `key=value` sequence. They omit the already
-  persisted `wele_ratio`, even though operators need both base-WEL and
-  effective-WEL utilization and the legacy fallback previously aligned the
-  position transition for human scanning.
-- Scope: give only the event-derived position console/text projection one
-  compact aligned line containing action, coin, pside, old/new size and price,
-  WE, WEL, effective WEL, TWEL, and uPnL. Keep zeros visible, missing/non-finite
-  values explicit, long values untruncated, common coin aliases readable, and
-  labels free of ANSI/control characters.
-- Behavior boundary: console/text formatting only. Preserve the complete
-  structured `position.changed` event, event routing and volume, every other
-  event formatter, monitor persistence, smoke verdicts, configuration, and all
-  order/risk/trading behavior. Do not add multiline output or terminal colors
-  that could pollute text logs.
-- Validation: new/added/reduced/closed actions; signed shorts; zero, missing,
-  and non-finite metrics; fixed minimum columns; long values; common aliases;
-  control-character stripping; structured-event immutability; event-bus,
-  registry-doc, and fake-live regressions; Python compilation; `git diff
-  --check`; added-line silent-handling audit; and independent preflight.
+- Branch: `codex/v8-monitor-retention-inventory`
+- Base: `de6022432dae9f4513f7a56287535ba21120a39f`, PR #1207
+- Triggering evidence: PR #1206 attributed `16210.383ms` of fresh maintenance
+  time and an `8953.523ms` maximum to 12 retention runs. The current retention
+  path repeatedly scans candidate directories, recursively inventories bytes,
+  and rescans candidates when over cap.
+- Scope: build one bounded per-run recursive file inventory, stat each visited
+  path once, count every regular file toward the byte cap, classify only direct
+  non-current files in the three managed directories as deletion candidates,
+  and reuse their inventoried size/mtime for age and cap pruning.
+- Behavior boundary: preserve the 60-second due rule, callback and lock timing,
+  recursive byte accounting, direct-only deletion domain, protected current
+  files, strict age cutoff, oldest-first order, compression compatibility,
+  logging, and existing retry/error semantics. No cache, schema, configuration,
+  cadence, event, report, verdict, order, risk, or trading behavior change.
+- Validation: exact cutoff/order/protection, nested unknown files, candidate
+  exhaustion, byte-cap order, one traversal/stat per file, age/cap races,
+  file/directory symlinks, timing callbacks, concurrent publisher coverage,
+  monitor-publisher and integrated event/report regressions, Python compilation,
+  `git diff --check`, added-line silent-handling audit, and independent preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: exact five-bot graceful restart, immediate and settled
-  smoke, and inspection of the next naturally emitted position change. Do not
-  create or alter a live position merely to exercise console formatting.
+  smoke, and fresh maintenance/retention timing comparison.
 
 Next action:
 
-1. Hold the active console PR's exact current head until Hermes, Grok 4.5, and
-   CI are green;
+1. Hold the active retention PR's exact current head until Hermes, Grok 4.5,
+   and CI are green.
 2. Resolve findings narrowly and require fresh exact-head verdicts after every
-   push, then merge and validate the exact five-bot VPS restart without creating
-   or altering a live position merely to exercise console formatting.
-3. In parallel, scope a separate retention optimization from PR #1206's fresh
-   phase evidence without mixing persistence behavior into console formatting.
+   push.
+3. Merge and validate the exact five-bot VPS restart, then compare fresh
+   retention totals/maxima against PR #1206's deployed evidence.
 
 ## Deployed Baseline
 
-- Remote `v8`: `d61b3e18f6a6c0755d663e3e7fc72e8294fb7760`, PR #1206
-- VPS5 repository: `d61b3e18f6a6c0755d663e3e7fc72e8294fb7760`, PR #1206; tracked
+- Remote `v8`: `de6022432dae9f4513f7a56287535ba21120a39f`, PR #1207
+- VPS5 repository: `de6022432dae9f4513f7a56287535ba21120a39f`, PR #1207; tracked
   status clean; expected untracked artifacts were preserved
-- VPS5 expected bots: five; running with PR #1206 restart PIDs
-  `873338/873395/873458/873515/873576`;
+- VPS5 expected bots: five; running with PR #1207 restart PIDs
+  `874984/875044/875152/875026/875150`;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1207 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
+  panes; every old bot exited naturally and pane PIDs remained unchanged.
+- Immediate and settled two-minute smokes were hard-green. The settled window
+  reported `359/359` remote and `51/51` account-critical calls successful,
+  all five expected processes matched, states `R=4/S=1`, zero hard/log/monitor
+  failures, and a clean tracked repository. Hyperliquid naturally emitted the
+  aligned position line with `WE`, `WEL`, `eWEL`, `TWEL`, and `uPnL`; no live
+  position was created or altered for validation.
 - PR #1206 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
   panes. All old bot processes exited naturally; pane PIDs
@@ -358,13 +363,12 @@ local connector-call boundary evidence, and PR #1199's startup fill-cache proof
 correlation, PR #1200's event-pipeline service timing, and PR #1203's fixed
 sink-class attribution, PR #1205's coalesced monitor manifest checkpoints, and
 PR #1206's monitor-maintenance phase attribution are also merged and deployed.
-The active slice polishes the human console projection of `position.changed`
-while preserving the structured event payload.
+PR #1207's human console projection of `position.changed` is also merged and
+deployed, with the structured event payload preserved.
 
-After the console slice is merged and validated, use PR #1206's production
-evidence to optimize the recurring retention path in a separate review-worthy
-slice. Keep persistence behavior and console presentation on separate code and
-validation surfaces.
+The active slice now uses PR #1206's production evidence to optimize the
+recurring retention path with one per-run inventory. Keep its persistence
+behavior and validation surface separate from further console readability work.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -69,6 +69,16 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1207 merged to `v8` as
+  `de6022432dae9f4513f7a56287535ba21120a39f` after exact-head Hermes and
+  Grok 4.5 approval plus green CI. VPS5 fast-forwarded cleanly and gracefully
+  restarted only the five exact bot panes; all old bots exited naturally, pane
+  PIDs remained unchanged, and unrelated `misc:0.0` PID `434835` was preserved.
+  The settled two-minute smoke was hard-green with `359/359` remote and `51/51`
+  account-critical calls successful, all five processes matched, states
+  `R=4/S=1`, zero hard/log/monitor failures, and a clean tracked repository.
+  A natural Hyperliquid position change proved the aligned console projection
+  and effective-WEL field without synthetic trading activity.
 - PR #1206 merged to `v8` as
   `d61b3e18f6a6c0755d663e3e7fc72e8294fb7760` after exact-head Hermes and
   Grok 4.5 approval plus green CI. It preserved inclusive maintenance timing

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -508,9 +508,10 @@ Related detailed plans:
     summaries. EMA/candle/cache internals should stay structured DEBUG unless
     they directly explain a blocked trading action.
 
-    Active follow-up: render `position.changed` as an aligned human transition
-    with base/effective WEL utilization while preserving the complete
-    structured event. Remaining small readability gaps include zero-valued
+    PR #1207 deployed an aligned `position.changed` human transition with
+    base/effective WEL utilization while preserving the complete structured
+    event; a natural live Hyperliquid change verified the projection. Remaining
+    small readability gaps include zero-valued
     fill/balance/entry-gate fields currently hidden by truthiness checks; handle
     those as separate bounded formatter slices rather than broad console churn.
 

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -391,7 +391,10 @@ classification when enough source events exist.
     changing persistence behavior. Fresh VPS5 evidence attributed
     `16210.383ms` and an `8953.523ms` maximum to 12 retention runs, versus
     `7377.475ms` and a `347.039ms` maximum across 352 manifest checkpoints.
-    Retention is therefore the next persistence optimization target.
+    Retention is therefore the next persistence optimization target. The active
+    follow-up replaces repeated candidate/full-tree scans with one per-run
+    inventory while preserving cadence and deletion policy; fresh VPS timing
+    after review and merge must determine whether the long tail improves.
 - [ ] Exchange writes: create/cancel/close/panic write latency, exchange
   response latency, ambiguous write rate, confirmation latency.
   - Status: partial. The report now derives order-wave total duration,

--- a/src/monitor_publisher.py
+++ b/src/monitor_publisher.py
@@ -6,6 +6,7 @@ import errno
 import json
 import logging
 import os
+import stat
 import threading
 import time
 import uuid
@@ -459,18 +460,29 @@ class MonitorPublisher:
         path.unlink()
         return gz_path
 
-    def _rotatable_files(self) -> list[Path]:
-        files: list[Path] = []
-        for directory in (self.events_dir, self.history_dir, self.checkpoints_dir):
-            if not directory.exists():
+    def _retention_inventory(self) -> tuple[int, list[tuple[Path, int, float]]]:
+        """Return total retained bytes and direct rotated-file deletion candidates."""
+
+        protected = {
+            self.manifest_path,
+            self.state_latest_path,
+            self.current_events_path,
+            *self._current_history_paths.values(),
+        }
+        candidate_dirs = {self.events_dir, self.history_dir, self.checkpoints_dir}
+        total_bytes = 0
+        candidates: list[tuple[Path, int, float]] = []
+        for path in self.root.rglob("*"):
+            try:
+                file_stat = path.stat()
+            except FileNotFoundError:
                 continue
-            for path in directory.iterdir():
-                if not path.is_file():
-                    continue
-                if path == self.current_events_path or path in self._current_history_paths.values():
-                    continue
-                files.append(path)
-        return sorted(files, key=lambda path: path.stat().st_mtime)
+            if not stat.S_ISREG(file_stat.st_mode):
+                continue
+            total_bytes += file_stat.st_size
+            if path.parent in candidate_dirs and path not in protected:
+                candidates.append((path, file_stat.st_size, file_stat.st_mtime))
+        return total_bytes, sorted(candidates, key=lambda candidate: candidate[2])
 
     def _retention_due(self, now_ms: int) -> bool:
         return not (
@@ -492,38 +504,27 @@ class MonitorPublisher:
                 on_run()
             try:
                 cutoff_ms = now_ms - int(self.retain_days * 24.0 * 60.0 * 60.0 * 1000.0)
+                total_bytes, candidates = self._retention_inventory()
                 if self.retain_days >= 0.0:
-                    for path in list(self._rotatable_files()):
-                        try:
-                            if int(path.stat().st_mtime * 1000.0) < cutoff_ms:
+                    survivors = []
+                    for path, size, mtime in candidates:
+                        if int(mtime * 1000.0) < cutoff_ms:
+                            try:
                                 path.unlink()
-                        except FileNotFoundError:
-                            continue
-
-                total_bytes = 0
-                all_files: list[Path] = []
-                for path in self.root.rglob("*"):
-                    if not path.is_file():
-                        continue
-                    total_bytes += path.stat().st_size
-                    all_files.append(path)
+                            except FileNotFoundError:
+                                total_bytes -= size
+                                continue
+                            total_bytes -= size
+                        else:
+                            survivors.append((path, size, mtime))
+                else:
+                    survivors = candidates
                 if total_bytes <= self.max_total_bytes:
                     return
 
-                protected = {
-                    self.manifest_path,
-                    self.state_latest_path,
-                    self.current_events_path,
-                    *self._current_history_paths.values(),
-                }
-                candidates = [path for path in self._rotatable_files() if path not in protected]
-                for path in candidates:
+                for path, size, _mtime in survivors:
                     if total_bytes <= self.max_total_bytes:
                         break
-                    try:
-                        size = path.stat().st_size
-                    except FileNotFoundError:
-                        continue
                     path.unlink()
                     total_bytes -= size
             except Exception as exc:

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -1,7 +1,9 @@
 import errno
 import json
 import logging
+import os
 import threading
+from pathlib import Path
 
 from monitor_publisher import MonitorPublisher
 import monitor_publisher as monitor_publisher_module
@@ -744,15 +746,17 @@ def test_monitor_publisher_event_timing_counts_due_maintenance_only(tmp_path):
 def test_monitor_publisher_event_timing_counts_failed_due_attempts(tmp_path, monkeypatch, caplog):
     publisher = _make_publisher(tmp_path)
     publisher._last_manifest_write_monotonic_ms = None
+    inventory_attempts = []
 
     def fail_atomic_write(*_args, **_kwargs):
         raise OSError("manifest unavailable")
 
-    def fail_rotatable_files():
+    def fail_retention_inventory():
+        inventory_attempts.append(None)
         raise OSError("retention unavailable")
 
     monkeypatch.setattr(monitor_publisher_module, "_atomic_write_json", fail_atomic_write)
-    monkeypatch.setattr(publisher, "_rotatable_files", fail_rotatable_files)
+    monkeypatch.setattr(publisher, "_retention_inventory", fail_retention_inventory)
 
     event, timing = publisher._record_event_timed(
         "test.event", ("test",), {"value": 1}, ts=100_000
@@ -765,3 +769,206 @@ def test_monitor_publisher_event_timing_counts_failed_due_attempts(tmp_path, mon
     assert timing["retention_ns_total"] >= timing["retention_ns_max"]
     assert "writing manifest" in caplog.text
     assert "retention pruning failed" in caplog.text
+    assert len(inventory_attempts) == 1
+
+    publisher._prune_retention(now_ms=100_001)
+    assert len(inventory_attempts) == 1
+    publisher._prune_retention(now_ms=160_000)
+    assert len(inventory_attempts) == 2
+
+
+def _write_retention_file(path, *, size, mtime_ms):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x" * size)
+    os.utime(path, ns=(mtime_ms * 1_000_000, mtime_ms * 1_000_000))
+
+
+def test_monitor_retention_age_cutoff_orders_direct_candidates_and_protects_current_paths(
+    tmp_path, monkeypatch
+):
+    publisher = _make_publisher(tmp_path, retain_days=1.0)
+    now_ms = 200_000_000
+    cutoff_ms = now_ms - 86_400_000
+    oldest = publisher.events_dir / "oldest.ndjson"
+    newer = publisher.checkpoints_dir / "newer.json"
+    at_cutoff = publisher.history_dir / "at-cutoff.ndjson"
+    protected_history = publisher._history_current_path("fills")
+    _write_retention_file(oldest, size=1, mtime_ms=cutoff_ms - 2)
+    _write_retention_file(newer, size=1, mtime_ms=cutoff_ms - 1)
+    _write_retention_file(at_cutoff, size=1, mtime_ms=cutoff_ms)
+    _write_retention_file(publisher.current_events_path, size=1, mtime_ms=cutoff_ms - 3)
+    _write_retention_file(protected_history, size=1, mtime_ms=cutoff_ms - 3)
+    unlinked = []
+    original_unlink = Path.unlink
+
+    def record_unlink(path, *args, **kwargs):
+        unlinked.append(path)
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", record_unlink)
+    publisher._prune_retention(now_ms=now_ms)
+
+    assert unlinked == [oldest, newer]
+    assert not oldest.exists()
+    assert not newer.exists()
+    assert at_cutoff.exists()
+    assert publisher.current_events_path.exists()
+    assert protected_history.exists()
+
+
+def test_monitor_retention_counts_nested_unknown_files_but_never_deletes_them(tmp_path):
+    publisher = _make_publisher(tmp_path, retain_days=-1.0)
+    direct_candidate = publisher.events_dir / "rotated.ndjson"
+    nested_unknown = publisher.root / "unknown" / "nested" / "keep.bin"
+    _write_retention_file(direct_candidate, size=10, mtime_ms=1)
+    _write_retention_file(nested_unknown, size=40, mtime_ms=2)
+    total_bytes = sum(path.stat().st_size for path in publisher.root.rglob("*") if path.is_file())
+    publisher.max_total_bytes = 0
+
+    publisher._prune_retention(now_ms=100_000)
+
+    assert not direct_candidate.exists()
+    assert nested_unknown.exists()
+
+
+def test_monitor_retention_age_disappearance_updates_total_before_cap(tmp_path, monkeypatch):
+    publisher = _make_publisher(tmp_path, retain_days=0.0)
+    disappeared = publisher.events_dir / "disappeared.ndjson"
+    at_cutoff = publisher.history_dir / "at-cutoff.ndjson"
+    _write_retention_file(disappeared, size=10, mtime_ms=1)
+    _write_retention_file(at_cutoff, size=10, mtime_ms=100_000)
+    total_bytes = sum(path.stat().st_size for path in publisher.root.rglob("*") if path.is_file())
+    publisher.max_total_bytes = total_bytes - disappeared.stat().st_size
+    original_unlink = Path.unlink
+
+    def disappear_then_unlink(path, *args, **kwargs):
+        if path == disappeared:
+            original_unlink(path, *args, **kwargs)
+            raise FileNotFoundError(path)
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", disappear_then_unlink)
+    publisher._prune_retention(now_ms=100_000)
+
+    assert not disappeared.exists()
+    assert at_cutoff.exists()
+
+
+def test_monitor_retention_logs_cap_unlink_failure_and_keeps_due_interval(
+    tmp_path, monkeypatch, caplog
+):
+    publisher = _make_publisher(tmp_path, retain_days=-1.0)
+    candidate = publisher.events_dir / "rotated.ndjson"
+    _write_retention_file(candidate, size=10, mtime_ms=1)
+    publisher.max_total_bytes = 0
+    inventory_attempts = []
+    original_inventory = publisher._retention_inventory
+    original_unlink = Path.unlink
+
+    def count_inventory():
+        inventory_attempts.append(None)
+        return original_inventory()
+
+    def fail_candidate_unlink(path, *args, **kwargs):
+        if path == candidate:
+            raise OSError("candidate unavailable")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(publisher, "_retention_inventory", count_inventory)
+    monkeypatch.setattr(Path, "unlink", fail_candidate_unlink)
+    publisher._prune_retention(now_ms=100_000)
+
+    assert candidate.exists()
+    assert inventory_attempts == [None]
+    assert "retention pruning failed: candidate unavailable" in caplog.text
+
+    publisher._prune_retention(now_ms=100_001)
+    assert inventory_attempts == [None]
+
+
+def test_monitor_retention_counts_and_unlinks_direct_file_symlink_only(tmp_path):
+    publisher = _make_publisher(tmp_path, retain_days=-1.0)
+    outside_file = tmp_path / "outside.bin"
+    outside_file.write_bytes(b"outside")
+    file_link = publisher.events_dir / "linked.bin"
+    file_link.symlink_to(outside_file)
+    outside_dir = tmp_path / "outside-dir"
+    outside_dir.mkdir()
+    (outside_dir / "nested.bin").write_bytes(b"nested")
+    directory_link = publisher.root / "linked-dir"
+    directory_link.symlink_to(outside_dir, target_is_directory=True)
+
+    total_bytes, candidates = publisher._retention_inventory()
+    candidate_sizes = {path: size for path, size, _mtime in candidates}
+    assert candidate_sizes[file_link] == outside_file.stat().st_size
+    publisher.max_total_bytes = total_bytes - candidate_sizes[file_link]
+
+    publisher._prune_retention(now_ms=100_000)
+
+    assert not file_link.is_symlink()
+    assert outside_file.exists()
+    assert directory_link.exists()
+    assert (outside_dir / "nested.bin").exists()
+
+
+def test_monitor_retention_byte_cap_deletes_surviving_candidates_oldest_first(tmp_path, monkeypatch):
+    publisher = _make_publisher(tmp_path, retain_days=-1.0)
+    oldest = publisher.history_dir / "oldest.ndjson"
+    newer = publisher.events_dir / "newer.ndjson"
+    _write_retention_file(oldest, size=10, mtime_ms=1)
+    _write_retention_file(newer, size=10, mtime_ms=2)
+    total_bytes = sum(path.stat().st_size for path in publisher.root.rglob("*") if path.is_file())
+    publisher.max_total_bytes = total_bytes - oldest.stat().st_size - newer.stat().st_size
+    unlinked = []
+    original_unlink = Path.unlink
+
+    def record_unlink(path, *args, **kwargs):
+        unlinked.append(path)
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", record_unlink)
+    publisher._prune_retention(now_ms=100_000)
+
+    assert unlinked == [oldest, newer]
+    assert not oldest.exists()
+    assert not newer.exists()
+
+
+def test_monitor_retention_uses_one_recursive_traversal_when_over_byte_cap(tmp_path, monkeypatch):
+    publisher = _make_publisher(tmp_path, retain_days=-1.0)
+    candidate = publisher.events_dir / "rotated.ndjson"
+    _write_retention_file(candidate, size=10, mtime_ms=1)
+    total_bytes = sum(path.stat().st_size for path in publisher.root.rglob("*") if path.is_file())
+    publisher.max_total_bytes = total_bytes - candidate.stat().st_size
+    original_rglob = Path.rglob
+    original_iterdir = Path.iterdir
+    original_stat = Path.stat
+    traversals = []
+    candidate_directory_listings = []
+    regular_files = {path for path in publisher.root.rglob("*") if path.is_file()}
+    regular_file_stats = {path: 0 for path in regular_files}
+
+    def count_root_rglob(path, pattern):
+        if path == publisher.root and pattern == "*":
+            traversals.append(path)
+        return original_rglob(path, pattern)
+
+    def count_candidate_directory_listing(path):
+        if path in {publisher.events_dir, publisher.history_dir, publisher.checkpoints_dir}:
+            candidate_directory_listings.append(path)
+        return original_iterdir(path)
+
+    def count_regular_file_stat(path, *args, **kwargs):
+        if path in regular_file_stats:
+            regular_file_stats[path] += 1
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "rglob", count_root_rglob)
+    monkeypatch.setattr(Path, "iterdir", count_candidate_directory_listing)
+    monkeypatch.setattr(Path, "stat", count_regular_file_stat)
+    publisher._prune_retention(now_ms=100_000)
+
+    assert traversals == [publisher.root]
+    assert candidate_directory_listings == []
+    assert set(regular_file_stats.values()) == {1}
+    assert not candidate.exists()


### PR DESCRIPTION
## Summary

- inventory monitor retention files once per due run instead of rescanning candidate directories and the full tree
- reuse inventoried size and mtime for strict age pruning and oldest-first byte-cap pruning
- preserve retention cadence, recursive byte accounting, direct-only deletion, protected current files, compression compatibility, and existing error/retry behavior
- add focused policy, race, traversal/stat, and symlink regressions; update the logging-overhaul handoff and deployment evidence

## Evidence

PR #1206 attributed `16210.383ms` of `23651.665ms` fresh monitor maintenance to 12 retention runs, with an `8953.523ms` maximum. The settled PR #1207 baseline also observed three retention runs totaling `2445.548ms`, maximum `1061.071ms`, before this optimization.

The old path could perform a direct candidate scan, a recursive byte scan, and another direct candidate scan when over cap, with repeated metadata probes. The new path performs one recursive inventory and one explicit stat per visited path, then reuses the bounded candidate snapshot.

## Behavior boundary

- no cadence, schema, config, event, report, verdict, order, risk, HSL, or trading behavior change
- nested and unknown regular files still count toward the byte cap but are never deletion candidates
- only direct non-current files under `events/`, `history/`, and `checkpoints/` remain candidates
- strict age cutoff and oldest-first cap order are unchanged
- an age candidate that disappears after inventory now removes its inventoried size from the cached total, preventing an unnecessary extra cap deletion

## Validation

- integrated monitor publisher, event bus, performance report, smoke report, monitor relay, passivbot monitor, incident bundle, fake-live, and AI-doc suite: green
- focused `tests/test_monitor_publisher.py`: 32 passed
- Python compilation and `git diff --check`: green
- added-line silent-handling audit: no new fallback in the touched retention path
- independent implementation review found and verified the age-disappearance cap-boundary fix
- independent full-branch preflight: green, no findings

## Deploy plan

After exact-head Hermes + Grok 4.5 + CI approval: gracefully restart only the five verified VPS5 bot panes, run immediate and settled smoke reports, and compare fresh retention totals/maxima with the pre-optimization evidence above.
