### PR TITLE
Format balance changes as transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Balance-change console and text lines now show exact raw and snapped
+  before/after transitions with signed deltas, equity, and source in one compact
+  human-readable line. The complete structured event remains unchanged.
+
 - Monitor retention pruning now inventories retained files once per due run and
   reuses the same size/mtime snapshot for age and byte-cap deletion. Retention
   cadence, protected files, recursive byte accounting, direct-only deletion,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,48 +22,58 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-monitor-retention-inventory`
-- Base: `de6022432dae9f4513f7a56287535ba21120a39f`, PR #1207
-- Triggering evidence: PR #1206 attributed `16210.383ms` of fresh maintenance
-  time and an `8953.523ms` maximum to 12 retention runs. The current retention
-  path repeatedly scans candidate directories, recursively inventories bytes,
-  and rescans candidates when over cap.
-- Scope: build one bounded per-run recursive file inventory, stat each visited
-  path once, count every regular file toward the byte cap, classify only direct
-  non-current files in the three managed directories as deletion candidates,
-  and reuse their inventoried size/mtime for age and cap pruning.
-- Behavior boundary: preserve the 60-second due rule, callback and lock timing,
-  recursive byte accounting, direct-only deletion domain, protected current
-  files, strict age cutoff, oldest-first order, compression compatibility,
-  logging, and existing retry/error semantics. No cache, schema, configuration,
-  cadence, event, report, verdict, order, risk, or trading behavior change.
-- Validation: exact cutoff/order/protection, nested unknown files, candidate
-  exhaustion, byte-cap order, one traversal/stat per file, age/cap races,
-  file/directory symlinks, timing callbacks, concurrent publisher coverage,
-  monitor-publisher and integrated event/report regressions, Python compilation,
-  `git diff --check`, added-line silent-handling audit, and independent preflight.
+- Branch: `codex/v8-balance-console-transition`
+- Base: `2a13202f7aec07874ed318dcf6472e445187a98e`, PR #1208
+- Triggering evidence: fresh VPS5 logs show frequent dense balance lines that
+  repeat generic status/cycle/reason fields while omitting the exact previous
+  raw and snapped balances already present in the structured event.
+- Scope: render only `balance.changed` console/text output as one compact raw
+  and snapped before/after transition with signed deltas, equity, and source.
+  Keep zero and negative zero explicit, missing/non-finite values visible, long
+  finite values untruncated, and source labels free of ANSI/control characters.
+- Behavior boundary: console/text formatting only. Preserve the complete
+  structured event, producer payload, route and cadence, monitor persistence,
+  smoke verdicts, configuration, and every order/risk/trading behavior. Do not
+  add multiline output or terminal colors that could pollute text logs.
+- Validation: raw-only and snapped transitions; positive, negative, and zero
+  deltas; zero/negative-zero, missing, NaN, infinity, long values, source
+  sanitization, structured-event immutability, event-bus and integrated monitor
+  regressions, Python compilation, `git diff --check`, added-line
+  silent-handling audit, and independent preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: exact five-bot graceful restart, immediate and settled
-  smoke, and fresh maintenance/retention timing comparison.
+  smoke, and inspection of naturally emitted balance transitions.
 
 Next action:
 
-1. Hold the active retention PR's exact current head until Hermes, Grok 4.5,
-   and CI are green.
-2. Resolve findings narrowly and require fresh exact-head verdicts after every
-   push.
-3. Merge and validate the exact five-bot VPS restart, then compare fresh
-   retention totals/maxima against PR #1206's deployed evidence.
+1. Complete integrated validation and publish one review-worthy balance-console
+   PR.
+2. Hold its exact current head until Hermes, Grok 4.5, and CI are green; resolve
+   findings narrowly and require fresh exact-head verdicts after every push.
+3. Merge and validate the exact five-bot VPS restart using naturally emitted
+   balance changes only.
 
 ## Deployed Baseline
 
-- Remote `v8`: `de6022432dae9f4513f7a56287535ba21120a39f`, PR #1207
-- VPS5 repository: `de6022432dae9f4513f7a56287535ba21120a39f`, PR #1207; tracked
+- Remote `v8`: `2a13202f7aec07874ed318dcf6472e445187a98e`, PR #1208
+- VPS5 repository: `2a13202f7aec07874ed318dcf6472e445187a98e`, PR #1208; tracked
   status clean; expected untracked artifacts were preserved
-- VPS5 expected bots: five; running with PR #1207 restart PIDs
-  `874984/875044/875152/875026/875150`;
+- VPS5 expected bots: five; running with PR #1208 restart PIDs
+  `876970/876966/877074/876968/877076`;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1208 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
+  panes; every old bot exited naturally and pane PIDs remained unchanged.
+- The immediate smoke was hard-green. One settled window correctly retained a
+  real KuCoin timeout; after it aged out, the final two-minute smoke was
+  hard-green with `315/315` remote and `62/62` account-critical calls
+  successful, all five processes `R`, zero hard/log/monitor failures, and a
+  clean tracked repository.
+- Four fresh health windows covered 2,345 monitor writes. Twelve retention runs
+  consumed `5612.290ms` with a `690.434ms` maximum, down from PR #1206's matched
+  12-run `16210.383ms` total and `8953.523ms` maximum. Drops, sink errors,
+  degraded counts, unhealthy pipelines, and final queue depth were zero.
 - PR #1207 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
   panes; every old bot exited naturally and pane PIDs remained unchanged.
@@ -363,12 +373,14 @@ local connector-call boundary evidence, and PR #1199's startup fill-cache proof
 correlation, PR #1200's event-pipeline service timing, and PR #1203's fixed
 sink-class attribution, PR #1205's coalesced monitor manifest checkpoints, and
 PR #1206's monitor-maintenance phase attribution are also merged and deployed.
-PR #1207's human console projection of `position.changed` is also merged and
-deployed, with the structured event payload preserved.
+PR #1207's position console projection and PR #1208's one-pass monitor
+retention inventory are also merged and deployed with their behavior boundaries
+preserved.
 
-The active slice now uses PR #1206's production evidence to optimize the
-recurring retention path with one per-run inventory. Keep its persistence
-behavior and validation surface separate from further console readability work.
+The active slice now renders the frequent `balance.changed` console projection
+as an exact human transition. Keep fill formatting separate: its legacy and
+event-routed lines currently overlap and require an explicit migration contract
+for timestamps, pending PnL, and bulk summaries.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -47,10 +47,10 @@ Estimated completion:
 
 Next action:
 
-1. Complete integrated validation and publish one review-worthy balance-console
-   PR.
-2. Hold its exact current head until Hermes, Grok 4.5, and CI are green; resolve
-   findings narrowly and require fresh exact-head verdicts after every push.
+1. Hold the active balance-console PR's exact current head until Hermes,
+   Grok 4.5, and CI are green.
+2. Resolve findings narrowly and require fresh exact-head verdicts after every
+   push.
 3. Merge and validate the exact five-bot VPS restart using naturally emitted
    balance changes only.
 

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -69,6 +69,17 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1208 merged to `v8` as
+  `2a13202f7aec07874ed318dcf6472e445187a98e` after exact-head Hermes and
+  Grok 4.5 approval plus green CI. VPS5 fast-forwarded cleanly and gracefully
+  restarted only the five exact bot panes; all old bots exited naturally, pane
+  PIDs remained unchanged, and unrelated `misc:0.0` PID `434835` was preserved.
+  After one real KuCoin timeout aged out, the final two-minute smoke was
+  hard-green with `315/315` remote and `62/62` account-critical calls
+  successful, all five bots `R`, zero hard/log/monitor failures, and a clean
+  tracked repository. Four fresh health windows measured 12 retention runs at
+  `5612.290ms` total and `690.434ms` maximum, down from PR #1206's matched-run
+  `16210.383ms` total and `8953.523ms` maximum.
 - PR #1207 merged to `v8` as
   `de6022432dae9f4513f7a56287535ba21120a39f` after exact-head Hermes and
   Grok 4.5 approval plus green CI. VPS5 fast-forwarded cleanly and gracefully

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -510,10 +510,13 @@ Related detailed plans:
 
     PR #1207 deployed an aligned `position.changed` human transition with
     base/effective WEL utilization while preserving the complete structured
-    event; a natural live Hyperliquid change verified the projection. Remaining
-    small readability gaps include zero-valued
-    fill/balance/entry-gate fields currently hidden by truthiness checks; handle
-    those as separate bounded formatter slices rather than broad console churn.
+    event; a natural live Hyperliquid change verified the projection. Zero
+    values in fill, balance, and entry-gate summaries are already retained
+    because their numeric helper returns formatted strings; the prior
+    truthiness-gap note was incorrect. The active follow-up renders frequent
+    balance changes as exact raw/snapped transitions. Fill readability remains
+    separate because the legacy and event-routed lines overlap and the legacy
+    path still owns timestamp, pending-PnL, and bulk-summary semantics.
 
     Work log:
     - 2026-06-30: Added value-safe `live-smoke-report` HSL status projections

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -391,10 +391,10 @@ classification when enough source events exist.
     changing persistence behavior. Fresh VPS5 evidence attributed
     `16210.383ms` and an `8953.523ms` maximum to 12 retention runs, versus
     `7377.475ms` and a `347.039ms` maximum across 352 manifest checkpoints.
-    Retention is therefore the next persistence optimization target. The active
-    follow-up replaces repeated candidate/full-tree scans with one per-run
-    inventory while preserving cadence and deletion policy; fresh VPS timing
-    after review and merge must determine whether the long tail improves.
+    PR #1208 replaced repeated candidate/full-tree scans with one per-run
+    inventory while preserving cadence and deletion policy. Four fresh VPS5
+    windows measured the same 12 retention runs at `5612.290ms` total and
+    `690.434ms` maximum, materially reducing both cumulative cost and long tail.
 - [ ] Exchange writes: create/cancel/close/panic write latency, exchange
   response latency, ambiguous write rate, confirmation latency.
   - Status: partial. The report now derives order-wave total duration,

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -1290,6 +1290,22 @@ def _format_balance_console_delta(value: float | None) -> str:
     return rendered
 
 
+def _format_balance_console_transition(
+    previous: float | None, current: float | None, delta: float | None
+) -> str:
+    if (
+        previous is None
+        or current is None
+        or not math.isfinite(previous)
+        or not math.isfinite(current)
+    ):
+        return "unavailable"
+    return (
+        f"{_format_console_number(previous)} -> {_format_console_number(current)} "
+        f"({_format_balance_console_delta(delta)})"
+    )
+
+
 def _format_position_console_percentage(value: float | None) -> str:
     if value is None or not math.isfinite(value):
         return "-"
@@ -1355,21 +1371,21 @@ def _format_console_position_changed(event: LiveEvent) -> str:
 
 def _format_console_balance_changed(event: LiveEvent) -> str:
     data = event.data if isinstance(event.data, Mapping) else {}
-    previous_raw = _format_console_number(_data_number(data, "previous_balance_raw"))
-    raw = _format_console_number(_data_number(data, "balance_raw"))
-    raw_delta = _format_balance_console_delta(_data_number(data, "balance_raw_delta"))
-    previous_snapped = _format_console_number(
-        _data_number(data, "previous_balance_snapped")
+    raw_transition = _format_balance_console_transition(
+        _data_number(data, "previous_balance_raw"),
+        _data_number(data, "balance_raw"),
+        _data_number(data, "balance_raw_delta"),
     )
-    snapped = _format_console_number(_data_number(data, "balance_snapped"))
-    snapped_delta = _format_balance_console_delta(
-        _data_number(data, "balance_snapped_delta")
+    snapped_transition = _format_balance_console_transition(
+        _data_number(data, "previous_balance_snapped"),
+        _data_number(data, "balance_snapped"),
+        _data_number(data, "balance_snapped_delta"),
     )
     equity = _format_console_number(_data_number(data, "equity"))
     source = _format_console_label(_data_str(data, "source"))
     return (
-        f"[balance] {'raw':<5}{previous_raw} -> {raw} ({raw_delta}) | "
-        f"{'snap':<5}{previous_snapped} -> {snapped} ({snapped_delta}) | "
+        f"[balance] {'raw':<5}{raw_transition} | "
+        f"{'snap':<5}{snapped_transition} | "
         f"equity={equity} source={source}"
     )
 

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -1275,12 +1275,19 @@ def _console_fill_ingested_summary(event: LiveEvent) -> list[str]:
     return parts
 
 
-def _format_position_console_number(value: float | None) -> str:
+def _format_console_number(value: float | None) -> str:
     if value is None or not math.isfinite(value):
         return "-"
     if value == 0.0:
         return "0"
     return f"{value:.10g}"
+
+
+def _format_balance_console_delta(value: float | None) -> str:
+    rendered = _format_console_number(value)
+    if value is not None and math.isfinite(value) and value > 0.0:
+        return f"+{rendered}"
+    return rendered
 
 
 def _format_position_console_percentage(value: float | None) -> str:
@@ -1294,7 +1301,7 @@ def _format_position_console_percentage(value: float | None) -> str:
     return f"{percentage:.4f}%"
 
 
-def _format_position_console_label(value: object) -> str:
+def _format_console_label(value: object) -> str:
     text = _ANSI_ESCAPE_RE.sub("", str(value or ""))
     text = _CONTROL_CHARACTER_RE.sub(" ", text)
     return " ".join(text.split()) or "-"
@@ -1310,21 +1317,21 @@ def _format_position_console_coin(symbol: object) -> str:
         coin = coin[:start] + coin[end:]
     if coin.startswith("k") and coin[1:].isupper():
         coin = coin[1:]
-    return _format_position_console_label(coin)
+    return _format_console_label(coin)
 
 
 def _format_console_position_changed(event: LiveEvent) -> str:
     data = event.data if isinstance(event.data, Mapping) else {}
-    action = _format_position_console_label(_data_str(data, "action"))
+    action = _format_console_label(_data_str(data, "action"))
     coin = _format_position_console_coin(event.symbol)
-    pside = _format_position_console_label(event.pside)
+    pside = _format_console_label(event.pside)
     old_leg = (
-        f"{_format_position_console_number(_data_number(data, 'old_size'))} @ "
-        f"{_format_position_console_number(_data_number(data, 'old_price'))}"
+        f"{_format_console_number(_data_number(data, 'old_size'))} @ "
+        f"{_format_console_number(_data_number(data, 'old_price'))}"
     )
     new_leg = (
-        f"{_format_position_console_number(_data_number(data, 'new_size'))} @ "
-        f"{_format_position_console_number(_data_number(data, 'new_price'))}"
+        f"{_format_console_number(_data_number(data, 'new_size'))} @ "
+        f"{_format_console_number(_data_number(data, 'new_price'))}"
     )
     metrics = " ".join(
         (
@@ -1337,7 +1344,7 @@ def _format_console_position_changed(event: LiveEvent) -> str:
             "TWEL="
             f"{_format_position_console_percentage(_data_number(data, 'twel_ratio'))}",
             "uPnL="
-            f"{_format_position_console_number(_data_number(data, 'upnl'))}",
+            f"{_format_console_number(_data_number(data, 'upnl'))}",
         )
     )
     return (
@@ -1346,28 +1353,25 @@ def _format_console_position_changed(event: LiveEvent) -> str:
     )
 
 
-def _console_balance_changed_summary(event: LiveEvent) -> list[str]:
+def _format_console_balance_changed(event: LiveEvent) -> str:
     data = event.data if isinstance(event.data, Mapping) else {}
-    parts: list[str] = []
-    balance = _data_float(data, "balance_raw")
-    if balance:
-        parts.append(f"balance={balance}")
-    delta = _data_float(data, "balance_raw_delta")
-    if delta:
-        parts.append(f"delta={delta}")
-    snapped = _data_float(data, "balance_snapped")
-    if snapped:
-        parts.append(f"snapped={snapped}")
-    snapped_delta = _data_float(data, "balance_snapped_delta")
-    if snapped_delta:
-        parts.append(f"snapped_delta={snapped_delta}")
-    equity = _data_float(data, "equity")
-    if equity:
-        parts.append(f"equity={equity}")
-    source = _data_str(data, "source")
-    if source:
-        parts.append(f"source={source}")
-    return parts
+    previous_raw = _format_console_number(_data_number(data, "previous_balance_raw"))
+    raw = _format_console_number(_data_number(data, "balance_raw"))
+    raw_delta = _format_balance_console_delta(_data_number(data, "balance_raw_delta"))
+    previous_snapped = _format_console_number(
+        _data_number(data, "previous_balance_snapped")
+    )
+    snapped = _format_console_number(_data_number(data, "balance_snapped"))
+    snapped_delta = _format_balance_console_delta(
+        _data_number(data, "balance_snapped_delta")
+    )
+    equity = _format_console_number(_data_number(data, "equity"))
+    source = _format_console_label(_data_str(data, "source"))
+    return (
+        f"[balance] {'raw':<5}{previous_raw} -> {raw} ({raw_delta}) | "
+        f"{'snap':<5}{previous_snapped} -> {snapped} ({snapped_delta}) | "
+        f"equity={equity} source={source}"
+    )
 
 
 def _console_risk_mode_changed_summary(event: LiveEvent) -> list[str]:
@@ -1792,8 +1796,6 @@ def _console_data_summary(event: LiveEvent) -> list[str]:
         return _console_health_summary(event)
     if event.event_type == EventTypes.FILL_INGESTED:
         return _console_fill_ingested_summary(event)
-    if event.event_type == EventTypes.BALANCE_CHANGED:
-        return _console_balance_changed_summary(event)
     if event.event_type == EventTypes.RISK_MODE_CHANGED:
         return _console_risk_mode_changed_summary(event)
     if event.event_type == EventTypes.HSL_TRANSITION:
@@ -1831,6 +1833,8 @@ def _operator_sink_event_visible(event: LiveEvent) -> bool:
 def format_console_event(event: LiveEvent) -> str:
     if event.event_type == EventTypes.POSITION_CHANGED:
         return _format_console_position_changed(event)
+    if event.event_type == EventTypes.BALANCE_CHANGED:
+        return _format_console_balance_changed(event)
     base = f"[{_console_tag(event)}]"
     if event.status:
         base += f" {event.status}"

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -2175,7 +2175,65 @@ def test_console_format_balance_changed_handles_missing_and_nonfinite_values():
 
     rendered = format_console_event(event)
 
-    assert rendered == "[balance] raw  - -> - (-) | snap - -> - (-) | equity=- source=-"
+    assert rendered == (
+        "[balance] raw  unavailable | snap unavailable | equity=- source=-"
+    )
+    assert "nan" not in rendered.lower()
+    assert "inf" not in rendered.lower()
+
+
+@pytest.mark.parametrize(
+    ("previous_raw", "raw"),
+    [(None, 100.0), (100.0, None), (float("nan"), 100.0), (100.0, float("inf"))],
+)
+def test_console_format_balance_changed_does_not_infer_partial_raw_transition(
+    previous_raw, raw
+):
+    event = LiveEvent(
+        EventTypes.BALANCE_CHANGED,
+        data={
+            "previous_balance_raw": previous_raw,
+            "balance_raw": raw,
+            "balance_raw_delta": 5.0,
+            "previous_balance_snapped": 90.0,
+            "balance_snapped": 91.0,
+            "balance_snapped_delta": 1.0,
+            "equity": 100.0,
+            "source": "REST",
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[balance] raw  unavailable | snap 90 -> 91 (+1) | "
+        "equity=100 source=REST"
+    )
+
+
+@pytest.mark.parametrize(
+    "delta",
+    [None, float("nan"), float("inf"), float("-inf")],
+)
+def test_console_format_balance_changed_keeps_known_transition_when_delta_unavailable(delta):
+    event = LiveEvent(
+        EventTypes.BALANCE_CHANGED,
+        data={
+            "previous_balance_raw": 100.0,
+            "balance_raw": 105.0,
+            "balance_raw_delta": delta,
+            "previous_balance_snapped": 200.0,
+            "balance_snapped": 205.0,
+            "balance_snapped_delta": delta,
+            "equity": 105.0,
+            "source": "REST",
+        },
+    )
+
+    rendered = format_console_event(event)
+
+    assert rendered == (
+        "[balance] raw  100 -> 105 (-) | snap 200 -> 205 (-) | "
+        "equity=105 source=REST"
+    )
     assert "nan" not in rendered.lower()
     assert "inf" not in rendered.lower()
 

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -2072,27 +2072,157 @@ def test_console_format_position_changed_strips_ansi_and_control_characters():
     assert not any(ord(char) < 32 or 127 <= ord(char) <= 159 for char in rendered)
 
 
-def test_console_format_summarizes_balance_changed():
+def test_console_format_balance_changed_renders_exact_transition_and_preserves_projections():
     event = LiveEvent(
         EventTypes.BALANCE_CHANGED,
         status="succeeded",
         cycle_id="cy_balance",
         reason_code="balance_changed",
         data={
+            "previous_balance_raw": 1_000.0,
             "balance_raw": 1_005.25,
             "balance_raw_delta": 5.25,
+            "previous_balance_snapped": 1_000.0,
             "balance_snapped": 1_004.0,
             "balance_snapped_delta": 4.0,
             "equity": 1_010.75,
             "source": "REST",
         },
     )
+    before = event.to_dict()
+    monitor_before = event.to_monitor_event()
 
     assert format_console_event(event) == (
-        "[balance] succeeded cycle=cy_balance balance=1005.25 delta=5.25 "
-        "snapped=1004 snapped_delta=4 equity=1010.75 source=REST "
-        "reason=balance_changed"
+        "[balance] raw  1000 -> 1005.25 (+5.25) | snap 1000 -> 1004 (+4) | "
+        "equity=1010.75 source=REST"
     )
+    assert event.to_dict() == before
+    assert event.to_monitor_event() == monitor_before
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        (
+            {
+                "previous_balance_raw": 1_000.0,
+                "balance_raw": 995.0,
+                "balance_raw_delta": -5.0,
+                "previous_balance_snapped": 1_000.0,
+                "balance_snapped": 1_000.0,
+                "balance_snapped_delta": 0.0,
+                "equity": 995.0,
+                "source": "REST",
+            },
+            "[balance] raw  1000 -> 995 (-5) | snap 1000 -> 1000 (0) | "
+            "equity=995 source=REST",
+        ),
+        (
+            {
+                "previous_balance_raw": 1_000.0,
+                "balance_raw": 1_000.0,
+                "balance_raw_delta": -0.0,
+                "previous_balance_snapped": 1_000.0,
+                "balance_snapped": 999.0,
+                "balance_snapped_delta": -1.0,
+                "equity": 1_000.0,
+                "source": "REST",
+            },
+            "[balance] raw  1000 -> 1000 (0) | snap 1000 -> 999 (-1) | "
+            "equity=1000 source=REST",
+        ),
+    ],
+)
+def test_console_format_balance_changed_renders_raw_only_and_snapped_only_transitions(
+    data, expected
+):
+    assert format_console_event(LiveEvent(EventTypes.BALANCE_CHANGED, data=data)) == expected
+
+
+def test_console_format_balance_changed_renders_zero_and_negative_zero():
+    event = LiveEvent(
+        EventTypes.BALANCE_CHANGED,
+        data={
+            "previous_balance_raw": -0.0,
+            "balance_raw": 0.0,
+            "balance_raw_delta": -0.0,
+            "previous_balance_snapped": 0.0,
+            "balance_snapped": -0.0,
+            "balance_snapped_delta": 0.0,
+            "equity": -0.0,
+            "source": "REST",
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[balance] raw  0 -> 0 (0) | snap 0 -> 0 (0) | equity=0 source=REST"
+    )
+
+
+def test_console_format_balance_changed_handles_missing_and_nonfinite_values():
+    event = LiveEvent(
+        EventTypes.BALANCE_CHANGED,
+        data={
+            "previous_balance_raw": float("nan"),
+            "balance_raw": float("inf"),
+            "balance_raw_delta": float("-inf"),
+            "previous_balance_snapped": None,
+            "balance_snapped": float("nan"),
+            "balance_snapped_delta": float("inf"),
+            "equity": float("-inf"),
+        },
+    )
+
+    rendered = format_console_event(event)
+
+    assert rendered == "[balance] raw  - -> - (-) | snap - -> - (-) | equity=- source=-"
+    assert "nan" not in rendered.lower()
+    assert "inf" not in rendered.lower()
+
+
+def test_console_format_balance_changed_does_not_truncate_long_values():
+    event = LiveEvent(
+        EventTypes.BALANCE_CHANGED,
+        data={
+            "previous_balance_raw": 12_345_678_901.2345,
+            "balance_raw": 12_345_678_902.2345,
+            "balance_raw_delta": 1.0,
+            "previous_balance_snapped": 98_765_432_109.8765,
+            "balance_snapped": 98_765_432_110.8765,
+            "balance_snapped_delta": 1.0,
+            "equity": 123_456_789_012.3456,
+            "source": "VERY_LONG_FINITE_BALANCE_SOURCE",
+        },
+    )
+
+    rendered = format_console_event(event)
+
+    assert "1.23456789e+10 -> 1.23456789e+10 (+1)" in rendered
+    assert "9.876543211e+10 -> 9.876543211e+10 (+1)" in rendered
+    assert "equity=1.23456789e+11" in rendered
+    assert "VERY_LONG_FINITE_BALANCE_SOURCE" in rendered
+
+
+def test_console_format_balance_changed_sanitizes_source_to_one_colorless_line():
+    event = LiveEvent(
+        EventTypes.BALANCE_CHANGED,
+        data={
+            "previous_balance_raw": 1.0,
+            "balance_raw": 2.0,
+            "balance_raw_delta": 1.0,
+            "previous_balance_snapped": 1.0,
+            "balance_snapped": 2.0,
+            "balance_snapped_delta": 1.0,
+            "equity": 2.0,
+            "source": "\x1b[31mREST\x1b[0m\nprimary\tfeed\r",
+        },
+    )
+
+    rendered = format_console_event(event)
+
+    assert rendered.endswith("equity=2 source=REST primary feed")
+    assert "\x1b" not in rendered
+    assert not any(ord(char) < 32 or 127 <= ord(char) <= 159 for char in rendered)
 
 
 def test_console_format_summarizes_risk_mode_changed():


### PR DESCRIPTION
## Summary

- render `balance.changed` console/text output as exact raw and snapped before/after transitions with signed deltas
- keep equity and sanitized source visible while removing tautological `succeeded`, cycle, and reason fields from this human projection
- preserve the complete structured event, routes, cadence, persistence, and trading behavior
- record PR #1208's deployed retention improvement and correct the stale zero-value backlog note

Example:

```text
[balance] raw  1000 -> 1005.25 (+5.25) | snap 1000 -> 1004 (+4) | equity=1010.75 source=REST
```

## Evidence

Fresh VPS5 logs showed frequent dense lines such as:

```text
[balance] succeeded cycle=cy_1 balance=2969.402644 delta=2.78174011 snapped=2966.620903 snapped_delta=0 equity=2969.402644 source=REST reason=balance_changed
```

The producer already stores exact previous/current raw and snapped balances, both deltas, equity, and source. This PR changes only their console/text projection.

## Behavior boundary

- no producer payload, route, event volume/cadence, monitor data, smoke verdict, config, order, risk, HSL, or trading change
- zero and negative zero render `0`; positive deltas include `+`
- incomplete/non-finite before/after legs render `unavailable` instead of implying an unknown transition
- known endpoints with unavailable delta remain visible as `100 -> 105 (-)`
- long finite values are not string-truncated; source labels are one-line and ANSI/control sanitized
- fill formatting is intentionally excluded because legacy and event-routed fill lines overlap and the legacy path still owns timestamp, pending-PnL, and bulk-summary semantics

## Validation

- full `tests/test_live_event_bus.py`: 93 passed
- integrated event-bus, passivbot-monitor, monitor-relay, fake-live, and AI-doc suite: green
- focused balance/position formatter and balance-update integration: green
- Python compilation, `git diff --check`, and added-line silent-handling audit: green
- independent preflight found and verified fixes for unknown endpoint transitions and delta-only fallback coverage; final exact-head internal verdict green

## Deploy plan

After exact-head Hermes + Grok 4.5 + CI approval: gracefully restart only the five verified VPS5 bot panes, run immediate and settled smoke reports, and inspect naturally emitted balance transitions without creating any trading activity.
