### PR TITLE
Attribute monitor retention phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Periodic structured health summaries now split monitor retention work into
+  fixed inventory, age-unlink, and byte-cap-unlink timings plus bounded work
+  counts. Live smoke and performance reports project the same fields without
+  changing retention cadence, policy, failure handling, report verdicts, or
+  trading behavior.
+
 - Balance-change console and text lines now show exact raw and snapped
   before/after transitions with signed deltas, equity, and source in one compact
   human-readable line. The complete structured event remains unchanged.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,46 +22,66 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-balance-console-transition`
-- Base: `2a13202f7aec07874ed318dcf6472e445187a98e`, PR #1208
-- Triggering evidence: fresh VPS5 logs show frequent dense balance lines that
-  repeat generic status/cycle/reason fields while omitting the exact previous
-  raw and snapped balances already present in the structured event.
-- Scope: render only `balance.changed` console/text output as one compact raw
-  and snapped before/after transition with signed deltas, equity, and source.
-  Keep zero and negative zero explicit, missing/non-finite values visible, long
-  finite values untruncated, and source labels free of ANSI/control characters.
-- Behavior boundary: console/text formatting only. Preserve the complete
-  structured event, producer payload, route and cadence, monitor persistence,
-  smoke verdicts, configuration, and every order/risk/trading behavior. Do not
-  add multiline output or terminal colors that could pollute text logs.
-- Validation: raw-only and snapped transitions; positive, negative, and zero
-  deltas; zero/negative-zero, missing, NaN, infinity, long values, source
-  sanitization, structured-event immutability, event-bus and integrated monitor
-  regressions, Python compilation, `git diff --check`, added-line
-  silent-handling audit, and independent preflight.
+- Branch: `codex/v8-monitor-retention-phase-timing`
+- Base: `e604ac7ea7d3e2cdea05d37f3cbd0fce5aee99b1`, PR #1209
+- Triggering evidence: after PR #1208 reduced matched 12-run retention timing
+  from `16210.383ms` total / `8953.523ms` max to `5612.290ms` / `690.434ms`,
+  a later 10-run VPS5 window still recorded `14255.296ms` total and an
+  `8654.591ms` maximum. Whole-run timing cannot distinguish inventory/stat
+  latency from age or byte-cap unlink work.
+- Scope: add fixed inventory, age-unlink, and cap-unlink timing totals/maxima,
+  plus inventory visited/candidate and successful deletion counts, to the
+  existing event-path monitor timing window and its smoke/performance report
+  projections.
+- Behavior boundary: additive low-cardinality telemetry only. Preserve
+  retention cadence, `last_retention_ms`, lock scope, traversal and candidate
+  order, age and cap policy, failure handling, monitor delivery, report
+  verdicts, configuration, and every order/risk/trading behavior. Do not emit
+  paths, samples, labels, or additional events.
+- Validation: due/skip, disappearing files, age and cap deletion, unlink
+  failure, timing aggregation/reset/restore, generic monitor-sink zeroes,
+  per-bot and aggregate report projection, historical omission, unchanged
+  verdicts, integrated monitor regressions, Python compilation,
+  `git diff --check`, silent-handling audit, and independent preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: exact five-bot graceful restart, immediate and settled
-  smoke, and inspection of naturally emitted balance transitions.
+  smoke, then collection of naturally emitted phase-attributed retention
+  windows.
 
 Next action:
 
-1. Hold the active balance-console PR's exact current head until Hermes,
-   Grok 4.5, and CI are green.
+1. Hold the active retention-phase attribution PR's exact current head until
+   Hermes, Grok 4.5, and CI are green.
 2. Resolve findings narrowly and require fresh exact-head verdicts after every
    push.
-3. Merge and validate the exact five-bot VPS restart using naturally emitted
-   balance changes only.
+3. Merge, perform the exact five-bot graceful VPS restart, run immediate and
+   settled smoke, then collect fresh phase-attributed retention windows before
+   selecting any further persistence optimization.
 
 ## Deployed Baseline
 
-- Remote `v8`: `2a13202f7aec07874ed318dcf6472e445187a98e`, PR #1208
-- VPS5 repository: `2a13202f7aec07874ed318dcf6472e445187a98e`, PR #1208; tracked
+- Remote `v8`: `e604ac7ea7d3e2cdea05d37f3cbd0fce5aee99b1`, PR #1209
+- VPS5 repository: `d509dde70caff9eea6a9d445f3571b6ac70d5184`, PR #1210; tracked
   status clean; expected untracked artifacts were preserved
-- VPS5 expected bots: five; running with PR #1208 restart PIDs
-  `876970/876966/877074/876968/877076`;
+- VPS5 expected bots: five; running with PR #1210 restart PIDs
+  `883768/883922/883918/883930/883980`;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1209 advanced remote `v8` with documentation-only review and monitor
+  persistence contracts. No VPS5 pull or restart is claimed for that docs-only
+  merge; the last verified deployed code remains PR #1210.
+- PR #1210 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
+  panes; every old bot exited naturally and pane PIDs remained unchanged.
+  The final settled smoke was hard-green with `428/428` remote and `76/76`
+  account-critical calls successful, all five processes present, zero hard,
+  log, or monitor failures, and a clean tracked repository. Natural balance
+  changes on all five bots showed the compact raw/snap transition contract;
+  no trading state was created or altered for validation.
+- A later 10-run window recorded `14255.296ms` retention total and an
+  `8654.591ms` maximum. PR #1208 improved ordinary and cumulative work but did
+  not eliminate the retention long tail; phase attribution is required before
+  another behavior change.
 - PR #1208 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
   panes; every old bot exited naturally and pane PIDs remained unchanged.
@@ -375,12 +395,14 @@ sink-class attribution, PR #1205's coalesced monitor manifest checkpoints, and
 PR #1206's monitor-maintenance phase attribution are also merged and deployed.
 PR #1207's position console projection and PR #1208's one-pass monitor
 retention inventory are also merged and deployed with their behavior boundaries
-preserved.
+preserved. PR #1210's balance console transition is merged, deployed, and
+validated from natural balance changes on all five bots.
 
-The active slice now renders the frequent `balance.changed` console projection
-as an exact human transition. Keep fill formatting separate: its legacy and
-event-routed lines currently overlap and require an explicit migration contract
-for timestamps, pending PnL, and bulk summaries.
+The active slice attributes the recurring retention long tail to inventory,
+age-unlink, or byte-cap-unlink work before another persistence optimization is
+selected. Keep fill formatting separate: its legacy and event-routed lines
+currently overlap and require an explicit migration contract for timestamps,
+pending PnL, and bulk summaries.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -69,6 +69,17 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1210 merged to `v8` as
+  `d509dde70caff9eea6a9d445f3571b6ac70d5184` after exact-head Hermes and
+  Grok 4.5 approval plus green CI. It changed only the console/text projection
+  of `balance.changed` to show exact raw and snapped before/after transitions,
+  signed deltas, equity, and source. VPS5 fast-forwarded cleanly and gracefully
+  restarted only the five exact bot panes; pane PIDs and unrelated `misc:0.0`
+  PID `434835` were preserved. Natural balance changes on all five bots matched
+  the new contract. After two real KuCoin timeout windows aged out, the final
+  settled smoke was hard-green with `428/428` remote and `76/76`
+  account-critical calls successful, all five processes present, zero hard,
+  log, or monitor failures, and a clean tracked repository.
 - PR #1208 merged to `v8` as
   `2a13202f7aec07874ed318dcf6472e445187a98e` after exact-head Hermes and
   Grok 4.5 approval plus green CI. VPS5 fast-forwarded cleanly and gracefully
@@ -79,7 +90,11 @@ VPS5 deployment status:
   successful, all five bots `R`, zero hard/log/monitor failures, and a clean
   tracked repository. Four fresh health windows measured 12 retention runs at
   `5612.290ms` total and `690.434ms` maximum, down from PR #1206's matched-run
-  `16210.383ms` total and `8953.523ms` maximum.
+  `16210.383ms` total and `8953.523ms` maximum. A later 10-run window after the
+  PR #1210 restart recorded `14255.296ms` total and an `8654.591ms` maximum,
+  proving that the one-pass inventory improved ordinary/cumulative work but did
+  not eliminate the long tail. The active follow-up adds inventory, age-unlink,
+  and cap-unlink attribution before selecting another persistence change.
 - PR #1207 merged to `v8` as
   `de6022432dae9f4513f7a56287535ba21120a39f` after exact-head Hermes and
   Grok 4.5 approval plus green CI. VPS5 fast-forwarded cleanly and gracefully

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -394,7 +394,11 @@ classification when enough source events exist.
     PR #1208 replaced repeated candidate/full-tree scans with one per-run
     inventory while preserving cadence and deletion policy. Four fresh VPS5
     windows measured the same 12 retention runs at `5612.290ms` total and
-    `690.434ms` maximum, materially reducing both cumulative cost and long tail.
+    `690.434ms` maximum. A later 10-run window recorded `14255.296ms` total and
+    an `8654.591ms` maximum, so the ordinary cost improved but the long tail
+    remained. The active attribution slice separates inventory, age-unlink,
+    and cap-unlink timing plus bounded work counts before another persistence
+    optimization is selected.
 - [ ] Exchange writes: create/cancel/close/panic write latency, exchange
   response latency, ambiguous write rate, confirmation latency.
   - Status: partial. The report now derives order-wave total duration,

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -388,6 +388,10 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   duration, without copying shutdown error text. The `execution_timing` section derives
   aggregate exchange-action latency groups from existing order-wave, order create/cancel,
   and confirmation events with missing/unpaired counters, without exposing raw order payloads.
+  Event-pipeline health also attributes due monitor-retention work to fixed inventory,
+  age-unlink, and byte-cap-unlink totals/maxima with visited, candidate, and successful
+  deletion counts. These fields are diagnostic only and do not change retention policy or
+  report verdicts.
   The `hsl_replay_profile` section derives bounded HSL replay work/progress summaries from
   existing `hsl.replay.*` events, including pair counts, timeline rows, rows/s, estimated
   dense pair-row work, observed progress percentage, and startup-blocking elapsed time where

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -67,6 +67,16 @@ _MONITOR_PUBLISHER_PHASE_TIMING_KEYS = (
     "retention_run_count",
     "retention_ns_total",
     "retention_ns_max",
+    "retention_inventory_ns_total",
+    "retention_inventory_ns_max",
+    "retention_age_unlink_ns_total",
+    "retention_age_unlink_ns_max",
+    "retention_cap_unlink_ns_total",
+    "retention_cap_unlink_ns_max",
+    "retention_inventory_entries_visited",
+    "retention_inventory_candidates",
+    "retention_age_deleted",
+    "retention_cap_deleted",
 )
 _MONITOR_PHASE_TIMING_KEYS = ("prepare_ns", *_MONITOR_PUBLISHER_PHASE_TIMING_KEYS)
 _ANSI_ESCAPE_RE = re.compile(r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
@@ -1931,6 +1941,16 @@ class _EventPipelineTimingWindow:
     monitor_publisher_retention_run_count: int
     monitor_publisher_retention_ns_total: int
     monitor_publisher_retention_ns_max: int
+    monitor_publisher_retention_inventory_ns_total: int
+    monitor_publisher_retention_inventory_ns_max: int
+    monitor_publisher_retention_age_unlink_ns_total: int
+    monitor_publisher_retention_age_unlink_ns_max: int
+    monitor_publisher_retention_cap_unlink_ns_total: int
+    monitor_publisher_retention_cap_unlink_ns_max: int
+    monitor_publisher_retention_inventory_entries_visited: int
+    monitor_publisher_retention_inventory_candidates: int
+    monitor_publisher_retention_age_deleted: int
+    monitor_publisher_retention_cap_deleted: int
 
 
 @dataclass
@@ -1957,6 +1977,16 @@ class _EventPipelineSinkWriteTiming:
     monitor_publisher_retention_run_count: int = 0
     monitor_publisher_retention_ns_total: int = 0
     monitor_publisher_retention_ns_max: int = 0
+    monitor_publisher_retention_inventory_ns_total: int = 0
+    monitor_publisher_retention_inventory_ns_max: int = 0
+    monitor_publisher_retention_age_unlink_ns_total: int = 0
+    monitor_publisher_retention_age_unlink_ns_max: int = 0
+    monitor_publisher_retention_cap_unlink_ns_total: int = 0
+    monitor_publisher_retention_cap_unlink_ns_max: int = 0
+    monitor_publisher_retention_inventory_entries_visited: int = 0
+    monitor_publisher_retention_inventory_candidates: int = 0
+    monitor_publisher_retention_age_deleted: int = 0
+    monitor_publisher_retention_cap_deleted: int = 0
 
     def record(self, sink_name: str, service_ns: int) -> None:
         service_ns = max(0, int(service_ns))
@@ -1989,15 +2019,29 @@ class _EventPipelineSinkWriteTiming:
         for source_key, field_name in (
             ("manifest_checkpoint_count", "monitor_publisher_manifest_checkpoint_count"),
             ("retention_run_count", "monitor_publisher_retention_run_count"),
+            (
+                "retention_inventory_entries_visited",
+                "monitor_publisher_retention_inventory_entries_visited",
+            ),
+            (
+                "retention_inventory_candidates",
+                "monitor_publisher_retention_inventory_candidates",
+            ),
+            ("retention_age_deleted", "monitor_publisher_retention_age_deleted"),
+            ("retention_cap_deleted", "monitor_publisher_retention_cap_deleted"),
         ):
             setattr(
                 self,
                 field_name,
-                int(getattr(self, field_name)) + max(0, int(timing.get(source_key, 0))),
+                int(getattr(self, field_name))
+                + max(0, int(timing.get(source_key, 0))),
             )
         for source_key, field_prefix in (
             ("manifest_checkpoint_ns", "monitor_publisher_manifest_checkpoint_ns"),
             ("retention_ns", "monitor_publisher_retention_ns"),
+            ("retention_inventory_ns", "monitor_publisher_retention_inventory_ns"),
+            ("retention_age_unlink_ns", "monitor_publisher_retention_age_unlink_ns"),
+            ("retention_cap_unlink_ns", "monitor_publisher_retention_cap_unlink_ns"),
         ):
             total_field = f"{field_prefix}_total"
             max_field = f"{field_prefix}_max"
@@ -2068,6 +2112,16 @@ class LiveEventPipeline:
         self._timing_monitor_publisher_retention_run_count = 0
         self._timing_monitor_publisher_retention_ns_total = 0
         self._timing_monitor_publisher_retention_ns_max = 0
+        self._timing_monitor_publisher_retention_inventory_ns_total = 0
+        self._timing_monitor_publisher_retention_inventory_ns_max = 0
+        self._timing_monitor_publisher_retention_age_unlink_ns_total = 0
+        self._timing_monitor_publisher_retention_age_unlink_ns_max = 0
+        self._timing_monitor_publisher_retention_cap_unlink_ns_total = 0
+        self._timing_monitor_publisher_retention_cap_unlink_ns_max = 0
+        self._timing_monitor_publisher_retention_inventory_entries_visited = 0
+        self._timing_monitor_publisher_retention_inventory_candidates = 0
+        self._timing_monitor_publisher_retention_age_deleted = 0
+        self._timing_monitor_publisher_retention_cap_deleted = 0
         self._pending_timing_windows: dict[int, _EventPipelineTimingWindow] = {}
         self._next_timing_snapshot_token = 1
         self._worker: threading.Thread | None = None
@@ -2193,6 +2247,36 @@ class LiveEventPipeline:
                 monitor_publisher_retention_ns_max=int(
                     self._timing_monitor_publisher_retention_ns_max
                 ),
+                monitor_publisher_retention_inventory_ns_total=int(
+                    self._timing_monitor_publisher_retention_inventory_ns_total
+                ),
+                monitor_publisher_retention_inventory_ns_max=int(
+                    self._timing_monitor_publisher_retention_inventory_ns_max
+                ),
+                monitor_publisher_retention_age_unlink_ns_total=int(
+                    self._timing_monitor_publisher_retention_age_unlink_ns_total
+                ),
+                monitor_publisher_retention_age_unlink_ns_max=int(
+                    self._timing_monitor_publisher_retention_age_unlink_ns_max
+                ),
+                monitor_publisher_retention_cap_unlink_ns_total=int(
+                    self._timing_monitor_publisher_retention_cap_unlink_ns_total
+                ),
+                monitor_publisher_retention_cap_unlink_ns_max=int(
+                    self._timing_monitor_publisher_retention_cap_unlink_ns_max
+                ),
+                monitor_publisher_retention_inventory_entries_visited=int(
+                    self._timing_monitor_publisher_retention_inventory_entries_visited
+                ),
+                monitor_publisher_retention_inventory_candidates=int(
+                    self._timing_monitor_publisher_retention_inventory_candidates
+                ),
+                monitor_publisher_retention_age_deleted=int(
+                    self._timing_monitor_publisher_retention_age_deleted
+                ),
+                monitor_publisher_retention_cap_deleted=int(
+                    self._timing_monitor_publisher_retention_cap_deleted
+                ),
             )
             timing_snapshot_token = None
             if consume_timing:
@@ -2227,6 +2311,16 @@ class LiveEventPipeline:
                 self._timing_monitor_publisher_retention_run_count = 0
                 self._timing_monitor_publisher_retention_ns_total = 0
                 self._timing_monitor_publisher_retention_ns_max = 0
+                self._timing_monitor_publisher_retention_inventory_ns_total = 0
+                self._timing_monitor_publisher_retention_inventory_ns_max = 0
+                self._timing_monitor_publisher_retention_age_unlink_ns_total = 0
+                self._timing_monitor_publisher_retention_age_unlink_ns_max = 0
+                self._timing_monitor_publisher_retention_cap_unlink_ns_total = 0
+                self._timing_monitor_publisher_retention_cap_unlink_ns_max = 0
+                self._timing_monitor_publisher_retention_inventory_entries_visited = 0
+                self._timing_monitor_publisher_retention_inventory_candidates = 0
+                self._timing_monitor_publisher_retention_age_deleted = 0
+                self._timing_monitor_publisher_retention_cap_deleted = 0
         snapshot: dict[str, Any] = {
             "event_queue_depth": queue_depth,
             "event_queue_maxsize": queue_maxsize,
@@ -2316,6 +2410,36 @@ class LiveEventPipeline:
             "event_monitor_publisher_retention_ms_max": self._timing_ms(
                 timing_window.monitor_publisher_retention_ns_max
             ),
+            "event_monitor_publisher_retention_inventory_ms_total": self._timing_ms(
+                timing_window.monitor_publisher_retention_inventory_ns_total
+            ),
+            "event_monitor_publisher_retention_inventory_ms_max": self._timing_ms(
+                timing_window.monitor_publisher_retention_inventory_ns_max
+            ),
+            "event_monitor_publisher_retention_age_unlink_ms_total": self._timing_ms(
+                timing_window.monitor_publisher_retention_age_unlink_ns_total
+            ),
+            "event_monitor_publisher_retention_age_unlink_ms_max": self._timing_ms(
+                timing_window.monitor_publisher_retention_age_unlink_ns_max
+            ),
+            "event_monitor_publisher_retention_cap_unlink_ms_total": self._timing_ms(
+                timing_window.monitor_publisher_retention_cap_unlink_ns_total
+            ),
+            "event_monitor_publisher_retention_cap_unlink_ms_max": self._timing_ms(
+                timing_window.monitor_publisher_retention_cap_unlink_ns_max
+            ),
+            "event_monitor_publisher_retention_inventory_entries_visited": (
+                timing_window.monitor_publisher_retention_inventory_entries_visited
+            ),
+            "event_monitor_publisher_retention_inventory_candidates": (
+                timing_window.monitor_publisher_retention_inventory_candidates
+            ),
+            "event_monitor_publisher_retention_age_deleted": (
+                timing_window.monitor_publisher_retention_age_deleted
+            ),
+            "event_monitor_publisher_retention_cap_deleted": (
+                timing_window.monitor_publisher_retention_cap_deleted
+            ),
         }
         return (
             {key: value for key, value in snapshot.items() if value is not None},
@@ -2375,11 +2499,19 @@ class LiveEventPipeline:
             "monitor_publisher_manifest_checkpoint_ns_total",
             "monitor_publisher_retention_run_count",
             "monitor_publisher_retention_ns_total",
+            "monitor_publisher_retention_inventory_ns_total",
+            "monitor_publisher_retention_age_unlink_ns_total",
+            "monitor_publisher_retention_cap_unlink_ns_total",
+            "monitor_publisher_retention_inventory_entries_visited",
+            "monitor_publisher_retention_inventory_candidates",
+            "monitor_publisher_retention_age_deleted",
+            "monitor_publisher_retention_cap_deleted",
         ):
             setattr(
                 self,
                 f"_timing_{field_name}",
-                int(getattr(self, f"_timing_{field_name}")) + int(getattr(pending, field_name)),
+                int(getattr(self, f"_timing_{field_name}"))
+                + int(getattr(pending, field_name)),
             )
         for field_name in (
             "monitor_prepare_ns_max",
@@ -2389,11 +2521,17 @@ class LiveEventPipeline:
             "monitor_publisher_maintenance_ns_max",
             "monitor_publisher_manifest_checkpoint_ns_max",
             "monitor_publisher_retention_ns_max",
+            "monitor_publisher_retention_inventory_ns_max",
+            "monitor_publisher_retention_age_unlink_ns_max",
+            "monitor_publisher_retention_cap_unlink_ns_max",
         ):
             setattr(
                 self,
                 f"_timing_{field_name}",
-                max(int(getattr(self, f"_timing_{field_name}")), int(getattr(pending, field_name))),
+                max(
+                    int(getattr(self, f"_timing_{field_name}")),
+                    int(getattr(pending, field_name)),
+                ),
             )
 
     def emit(
@@ -2624,6 +2762,36 @@ class LiveEventPipeline:
                             self._timing_monitor_publisher_retention_ns_max,
                             sink_write_timing.monitor_publisher_retention_ns_max,
                         )
+                        for field_name in (
+                            "monitor_publisher_retention_inventory_ns_total",
+                            "monitor_publisher_retention_age_unlink_ns_total",
+                            "monitor_publisher_retention_cap_unlink_ns_total",
+                            "monitor_publisher_retention_inventory_entries_visited",
+                            "monitor_publisher_retention_inventory_candidates",
+                            "monitor_publisher_retention_age_deleted",
+                            "monitor_publisher_retention_cap_deleted",
+                        ):
+                            timing_field = f"_timing_{field_name}"
+                            setattr(
+                                self,
+                                timing_field,
+                                int(getattr(self, timing_field))
+                                + int(getattr(sink_write_timing, field_name)),
+                            )
+                        for field_name in (
+                            "monitor_publisher_retention_inventory_ns_max",
+                            "monitor_publisher_retention_age_unlink_ns_max",
+                            "monitor_publisher_retention_cap_unlink_ns_max",
+                        ):
+                            timing_field = f"_timing_{field_name}"
+                            setattr(
+                                self,
+                                timing_field,
+                                max(
+                                    int(getattr(self, timing_field)),
+                                    int(getattr(sink_write_timing, field_name)),
+                                ),
+                            )
                 self._queue.task_done()
 
     def _write_sink(self, name: str, sink: LiveEventSink, event: LiveEvent) -> Any:

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -127,6 +127,16 @@ _RESOURCE_PRESSURE_FIELDS = (
     "event_monitor_publisher_retention_run_count",
     "event_monitor_publisher_retention_ms_total",
     "event_monitor_publisher_retention_ms_max",
+    "event_monitor_publisher_retention_inventory_ms_total",
+    "event_monitor_publisher_retention_inventory_ms_max",
+    "event_monitor_publisher_retention_age_unlink_ms_total",
+    "event_monitor_publisher_retention_age_unlink_ms_max",
+    "event_monitor_publisher_retention_cap_unlink_ms_total",
+    "event_monitor_publisher_retention_cap_unlink_ms_max",
+    "event_monitor_publisher_retention_inventory_entries_visited",
+    "event_monitor_publisher_retention_inventory_candidates",
+    "event_monitor_publisher_retention_age_deleted",
+    "event_monitor_publisher_retention_cap_deleted",
 )
 _RESOURCE_PRESSURE_COUNTER_FIELDS = (
     "event_drop_counts",
@@ -4080,6 +4090,36 @@ class _ResourcePressureAccumulator:
             ),
             "latest_event_monitor_publisher_retention_ms_max": latest_field_max(
                 "event_monitor_publisher_retention_ms_max"
+            ),
+            "latest_event_monitor_publisher_retention_inventory_ms_total_sum": latest_field_sum(
+                "event_monitor_publisher_retention_inventory_ms_total"
+            ),
+            "latest_event_monitor_publisher_retention_inventory_ms_max": latest_field_max(
+                "event_monitor_publisher_retention_inventory_ms_max"
+            ),
+            "latest_event_monitor_publisher_retention_age_unlink_ms_total_sum": latest_field_sum(
+                "event_monitor_publisher_retention_age_unlink_ms_total"
+            ),
+            "latest_event_monitor_publisher_retention_age_unlink_ms_max": latest_field_max(
+                "event_monitor_publisher_retention_age_unlink_ms_max"
+            ),
+            "latest_event_monitor_publisher_retention_cap_unlink_ms_total_sum": latest_field_sum(
+                "event_monitor_publisher_retention_cap_unlink_ms_total"
+            ),
+            "latest_event_monitor_publisher_retention_cap_unlink_ms_max": latest_field_max(
+                "event_monitor_publisher_retention_cap_unlink_ms_max"
+            ),
+            "latest_event_monitor_publisher_retention_inventory_entries_visited_sum": latest_field_sum(
+                "event_monitor_publisher_retention_inventory_entries_visited"
+            ),
+            "latest_event_monitor_publisher_retention_inventory_candidates_sum": latest_field_sum(
+                "event_monitor_publisher_retention_inventory_candidates"
+            ),
+            "latest_event_monitor_publisher_retention_age_deleted_sum": latest_field_sum(
+                "event_monitor_publisher_retention_age_deleted"
+            ),
+            "latest_event_monitor_publisher_retention_cap_deleted_sum": latest_field_sum(
+                "event_monitor_publisher_retention_cap_deleted"
             ),
             "event_pipeline_unhealthy_bots": unhealthy_bots,
             "groups_truncated": len(groups) > limit,

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -2828,6 +2828,16 @@ def _event_pipeline_health_group(
         "event_monitor_publisher_retention_run_count",
         "event_monitor_publisher_retention_ms_total",
         "event_monitor_publisher_retention_ms_max",
+        "event_monitor_publisher_retention_inventory_ms_total",
+        "event_monitor_publisher_retention_inventory_ms_max",
+        "event_monitor_publisher_retention_age_unlink_ms_total",
+        "event_monitor_publisher_retention_age_unlink_ms_max",
+        "event_monitor_publisher_retention_cap_unlink_ms_total",
+        "event_monitor_publisher_retention_cap_unlink_ms_max",
+        "event_monitor_publisher_retention_inventory_entries_visited",
+        "event_monitor_publisher_retention_inventory_candidates",
+        "event_monitor_publisher_retention_age_deleted",
+        "event_monitor_publisher_retention_cap_deleted",
     }
     if not any(key in payload for key in observed_keys):
         return None
@@ -2937,6 +2947,36 @@ def _event_pipeline_health_group(
         "latest_monitor_publisher_retention_ms_max": _non_negative_number(
             payload.get("event_monitor_publisher_retention_ms_max")
         ),
+        "latest_monitor_publisher_retention_inventory_ms_total": _non_negative_number(
+            payload.get("event_monitor_publisher_retention_inventory_ms_total")
+        ),
+        "latest_monitor_publisher_retention_inventory_ms_max": _non_negative_number(
+            payload.get("event_monitor_publisher_retention_inventory_ms_max")
+        ),
+        "latest_monitor_publisher_retention_age_unlink_ms_total": _non_negative_number(
+            payload.get("event_monitor_publisher_retention_age_unlink_ms_total")
+        ),
+        "latest_monitor_publisher_retention_age_unlink_ms_max": _non_negative_number(
+            payload.get("event_monitor_publisher_retention_age_unlink_ms_max")
+        ),
+        "latest_monitor_publisher_retention_cap_unlink_ms_total": _non_negative_number(
+            payload.get("event_monitor_publisher_retention_cap_unlink_ms_total")
+        ),
+        "latest_monitor_publisher_retention_cap_unlink_ms_max": _non_negative_number(
+            payload.get("event_monitor_publisher_retention_cap_unlink_ms_max")
+        ),
+        "latest_monitor_publisher_retention_inventory_entries_visited": _non_negative_int(
+            payload.get("event_monitor_publisher_retention_inventory_entries_visited")
+        ),
+        "latest_monitor_publisher_retention_inventory_candidates": _non_negative_int(
+            payload.get("event_monitor_publisher_retention_inventory_candidates")
+        ),
+        "latest_monitor_publisher_retention_age_deleted": _non_negative_int(
+            payload.get("event_monitor_publisher_retention_age_deleted")
+        ),
+        "latest_monitor_publisher_retention_cap_deleted": _non_negative_int(
+            payload.get("event_monitor_publisher_retention_cap_deleted")
+        ),
         "latest_pipeline_stopping": (
             bool(payload.get("event_pipeline_stopping"))
             if "event_pipeline_stopping" in payload
@@ -3019,6 +3059,16 @@ def _merge_event_pipeline_health_group(
             "latest_monitor_publisher_retention_run_count",
             "latest_monitor_publisher_retention_ms_total",
             "latest_monitor_publisher_retention_ms_max",
+            "latest_monitor_publisher_retention_inventory_ms_total",
+            "latest_monitor_publisher_retention_inventory_ms_max",
+            "latest_monitor_publisher_retention_age_unlink_ms_total",
+            "latest_monitor_publisher_retention_age_unlink_ms_max",
+            "latest_monitor_publisher_retention_cap_unlink_ms_total",
+            "latest_monitor_publisher_retention_cap_unlink_ms_max",
+            "latest_monitor_publisher_retention_inventory_entries_visited",
+            "latest_monitor_publisher_retention_inventory_candidates",
+            "latest_monitor_publisher_retention_age_deleted",
+            "latest_monitor_publisher_retention_cap_deleted",
             "latest_pipeline_stopping",
             "latest_worker_alive",
             "latest_ids",
@@ -3184,6 +3234,46 @@ def _summarize_event_pipeline_health(
         ),
         "latest_monitor_publisher_retention_ms_max": _max_optional_numbers(
             group.get("latest_monitor_publisher_retention_ms_max")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_inventory_ms_total_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_retention_inventory_ms_total")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_inventory_ms_max": _max_optional_numbers(
+            group.get("latest_monitor_publisher_retention_inventory_ms_max")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_age_unlink_ms_total_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_retention_age_unlink_ms_total")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_age_unlink_ms_max": _max_optional_numbers(
+            group.get("latest_monitor_publisher_retention_age_unlink_ms_max")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_cap_unlink_ms_total_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_retention_cap_unlink_ms_total")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_cap_unlink_ms_max": _max_optional_numbers(
+            group.get("latest_monitor_publisher_retention_cap_unlink_ms_max")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_inventory_entries_visited_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_retention_inventory_entries_visited")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_inventory_candidates_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_retention_inventory_candidates")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_age_deleted_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_retention_age_deleted")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_cap_deleted_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_retention_cap_deleted")
             for group in groups.values()
         ),
     }
@@ -7221,6 +7311,36 @@ def _summary_limited_groups(
             "latest_monitor_publisher_retention_ms_max": summary.get(
                 "latest_monitor_publisher_retention_ms_max"
             ),
+            "latest_monitor_publisher_retention_inventory_ms_total_sum": summary.get(
+                "latest_monitor_publisher_retention_inventory_ms_total_sum"
+            ),
+            "latest_monitor_publisher_retention_inventory_ms_max": summary.get(
+                "latest_monitor_publisher_retention_inventory_ms_max"
+            ),
+            "latest_monitor_publisher_retention_age_unlink_ms_total_sum": summary.get(
+                "latest_monitor_publisher_retention_age_unlink_ms_total_sum"
+            ),
+            "latest_monitor_publisher_retention_age_unlink_ms_max": summary.get(
+                "latest_monitor_publisher_retention_age_unlink_ms_max"
+            ),
+            "latest_monitor_publisher_retention_cap_unlink_ms_total_sum": summary.get(
+                "latest_monitor_publisher_retention_cap_unlink_ms_total_sum"
+            ),
+            "latest_monitor_publisher_retention_cap_unlink_ms_max": summary.get(
+                "latest_monitor_publisher_retention_cap_unlink_ms_max"
+            ),
+            "latest_monitor_publisher_retention_inventory_entries_visited_sum": summary.get(
+                "latest_monitor_publisher_retention_inventory_entries_visited_sum"
+            ),
+            "latest_monitor_publisher_retention_inventory_candidates_sum": summary.get(
+                "latest_monitor_publisher_retention_inventory_candidates_sum"
+            ),
+            "latest_monitor_publisher_retention_age_deleted_sum": summary.get(
+                "latest_monitor_publisher_retention_age_deleted_sum"
+            ),
+            "latest_monitor_publisher_retention_cap_deleted_sum": summary.get(
+                "latest_monitor_publisher_retention_cap_deleted_sum"
+            ),
             "latest_worker_not_alive_count": summary.get(
                 "latest_worker_not_alive_count"
             ),
@@ -8710,6 +8830,36 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
                 ),
                 "latest_monitor_publisher_retention_ms_max": event_pipeline_health.get(
                     "latest_monitor_publisher_retention_ms_max"
+                ),
+                "latest_monitor_publisher_retention_inventory_ms_total_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_inventory_ms_total_sum"
+                ),
+                "latest_monitor_publisher_retention_inventory_ms_max": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_inventory_ms_max"
+                ),
+                "latest_monitor_publisher_retention_age_unlink_ms_total_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_age_unlink_ms_total_sum"
+                ),
+                "latest_monitor_publisher_retention_age_unlink_ms_max": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_age_unlink_ms_max"
+                ),
+                "latest_monitor_publisher_retention_cap_unlink_ms_total_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_cap_unlink_ms_total_sum"
+                ),
+                "latest_monitor_publisher_retention_cap_unlink_ms_max": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_cap_unlink_ms_max"
+                ),
+                "latest_monitor_publisher_retention_inventory_entries_visited_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_inventory_entries_visited_sum"
+                ),
+                "latest_monitor_publisher_retention_inventory_candidates_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_inventory_candidates_sum"
+                ),
+                "latest_monitor_publisher_retention_age_deleted_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_age_deleted_sum"
+                ),
+                "latest_monitor_publisher_retention_cap_deleted_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_cap_deleted_sum"
                 ),
                 "latest_worker_not_alive_count": _count_value(
                     event_pipeline_health.get("latest_worker_not_alive_count")

--- a/src/monitor_publisher.py
+++ b/src/monitor_publisher.py
@@ -26,6 +26,16 @@ _MONITOR_EVENT_PHASE_TIMING_KEYS = (
     "retention_run_count",
     "retention_ns_total",
     "retention_ns_max",
+    "retention_inventory_ns_total",
+    "retention_inventory_ns_max",
+    "retention_age_unlink_ns_total",
+    "retention_age_unlink_ns_max",
+    "retention_cap_unlink_ns_total",
+    "retention_cap_unlink_ns_max",
+    "retention_inventory_entries_visited",
+    "retention_inventory_candidates",
+    "retention_age_deleted",
+    "retention_cap_deleted",
 )
 _CURRENT_EVENTS_REVERSE_READ_BYTES = 64 * 1024
 _EVENT_RECOVERY_CHECKSUM_BYTES = 16
@@ -460,7 +470,12 @@ class MonitorPublisher:
         path.unlink()
         return gz_path
 
-    def _retention_inventory(self) -> tuple[int, list[tuple[Path, int, float]]]:
+    def _retention_inventory(
+        self,
+        *,
+        on_entry: Optional[Callable[[], None]] = None,
+        on_candidate: Optional[Callable[[], None]] = None,
+    ) -> tuple[int, list[tuple[Path, int, float]]]:
         """Return total retained bytes and direct rotated-file deletion candidates."""
 
         protected = {
@@ -473,6 +488,8 @@ class MonitorPublisher:
         total_bytes = 0
         candidates: list[tuple[Path, int, float]] = []
         for path in self.root.rglob("*"):
+            if on_entry is not None:
+                on_entry()
             try:
                 file_stat = path.stat()
             except FileNotFoundError:
@@ -482,6 +499,8 @@ class MonitorPublisher:
             total_bytes += file_stat.st_size
             if path.parent in candidate_dirs and path not in protected:
                 candidates.append((path, file_stat.st_size, file_stat.st_mtime))
+                if on_candidate is not None:
+                    on_candidate()
         return total_bytes, sorted(candidates, key=lambda candidate: candidate[2])
 
     def _retention_due(self, now_ms: int) -> bool:
@@ -494,6 +513,8 @@ class MonitorPublisher:
         now_ms: Optional[int] = None,
         *,
         on_run: Optional[Callable[[], None]] = None,
+        on_phase: Optional[Callable[[str, int], None]] = None,
+        on_counter: Optional[Callable[[str], None]] = None,
     ) -> None:
         with self._lock:
             now_ms = self._now_ms() if now_ms is None else int(now_ms)
@@ -503,18 +524,47 @@ class MonitorPublisher:
             if on_run is not None:
                 on_run()
             try:
-                cutoff_ms = now_ms - int(self.retain_days * 24.0 * 60.0 * 60.0 * 1000.0)
-                total_bytes, candidates = self._retention_inventory()
+                cutoff_ms = now_ms - int(
+                    self.retain_days * 24.0 * 60.0 * 60.0 * 1000.0
+                )
+                inventory_started_ns = (
+                    time.monotonic_ns() if on_phase is not None else None
+                )
+                try:
+                    if on_counter is None:
+                        total_bytes, candidates = self._retention_inventory()
+                    else:
+                        total_bytes, candidates = self._retention_inventory(
+                            on_entry=lambda: on_counter("inventory_entries_visited"),
+                            on_candidate=lambda: on_counter("inventory_candidates"),
+                        )
+                finally:
+                    if inventory_started_ns is not None:
+                        on_phase(
+                            "inventory",
+                            max(0, time.monotonic_ns() - inventory_started_ns),
+                        )
                 if self.retain_days >= 0.0:
                     survivors = []
                     for path, size, mtime in candidates:
                         if int(mtime * 1000.0) < cutoff_ms:
+                            age_unlink_started_ns = (
+                                time.monotonic_ns() if on_phase is not None else None
+                            )
                             try:
                                 path.unlink()
                             except FileNotFoundError:
                                 total_bytes -= size
                                 continue
+                            finally:
+                                if age_unlink_started_ns is not None:
+                                    on_phase(
+                                        "age_unlink",
+                                        max(0, time.monotonic_ns() - age_unlink_started_ns),
+                                    )
                             total_bytes -= size
+                            if on_counter is not None:
+                                on_counter("age_deleted")
                         else:
                             survivors.append((path, size, mtime))
                 else:
@@ -525,8 +575,20 @@ class MonitorPublisher:
                 for path, size, _mtime in survivors:
                     if total_bytes <= self.max_total_bytes:
                         break
-                    path.unlink()
+                    cap_unlink_started_ns = (
+                        time.monotonic_ns() if on_phase is not None else None
+                    )
+                    try:
+                        path.unlink()
+                    finally:
+                        if cap_unlink_started_ns is not None:
+                            on_phase(
+                                "cap_unlink",
+                                max(0, time.monotonic_ns() - cap_unlink_started_ns),
+                            )
                     total_bytes -= size
+                    if on_counter is not None:
+                        on_counter("cap_deleted")
             except Exception as exc:
                 logging.error("[monitor] retention pruning failed: %s", exc)
 
@@ -858,8 +920,23 @@ class MonitorPublisher:
                         retention_started_ns = time.monotonic_ns()
                         timing["retention_run_count"] += 1
 
+                    def on_retention_phase(phase: str, duration_ns: int) -> None:
+                        total_key = f"retention_{phase}_ns_total"
+                        max_key = f"retention_{phase}_ns_max"
+                        duration_ns = max(0, int(duration_ns))
+                        timing[total_key] += duration_ns
+                        timing[max_key] = max(timing[max_key], duration_ns)
+
+                    def on_retention_counter(counter: str) -> None:
+                        timing[f"retention_{counter}"] += 1
+
                     try:
-                        self._prune_retention(now_ms=now_ms, on_run=on_retention_run)
+                        self._prune_retention(
+                            now_ms=now_ms,
+                            on_run=on_retention_run,
+                            on_phase=on_retention_phase,
+                            on_counter=on_retention_counter,
+                        )
                     finally:
                         if retention_started_ns is not None:
                             retention_ns = max(0, time.monotonic_ns() - retention_started_ns)

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -609,6 +609,16 @@ def test_pipeline_aggregates_and_resets_monitor_publisher_phase_timing(monkeypat
                         "retention_run_count": 1,
                         "retention_ns_total": 4_000_000,
                         "retention_ns_max": 4_000_000,
+                        "retention_inventory_ns_total": 3_000_000,
+                        "retention_inventory_ns_max": 3_000_000,
+                        "retention_age_unlink_ns_total": 700_000,
+                        "retention_age_unlink_ns_max": 700_000,
+                        "retention_cap_unlink_ns_total": 300_000,
+                        "retention_cap_unlink_ns_max": 300_000,
+                        "retention_inventory_entries_visited": 11,
+                        "retention_inventory_candidates": 7,
+                        "retention_age_deleted": 2,
+                        "retention_cap_deleted": 1,
                     },
                     {
                         "lock_wait_ns": 11_000_000,
@@ -621,6 +631,16 @@ def test_pipeline_aggregates_and_resets_monitor_publisher_phase_timing(monkeypat
                         "retention_run_count": 0,
                         "retention_ns_total": 0,
                         "retention_ns_max": 0,
+                        "retention_inventory_ns_total": 0,
+                        "retention_inventory_ns_max": 0,
+                        "retention_age_unlink_ns_total": 0,
+                        "retention_age_unlink_ns_max": 0,
+                        "retention_cap_unlink_ns_total": 0,
+                        "retention_cap_unlink_ns_max": 0,
+                        "retention_inventory_entries_visited": 0,
+                        "retention_inventory_candidates": 0,
+                        "retention_age_deleted": 0,
+                        "retention_cap_deleted": 0,
                     },
                 )
             )
@@ -659,6 +679,16 @@ def test_pipeline_aggregates_and_resets_monitor_publisher_phase_timing(monkeypat
         "event_monitor_publisher_retention_run_count": 1,
         "event_monitor_publisher_retention_ms_total": 4.0,
         "event_monitor_publisher_retention_ms_max": 4.0,
+        "event_monitor_publisher_retention_inventory_ms_total": 3.0,
+        "event_monitor_publisher_retention_inventory_ms_max": 3.0,
+        "event_monitor_publisher_retention_age_unlink_ms_total": 0.7,
+        "event_monitor_publisher_retention_age_unlink_ms_max": 0.7,
+        "event_monitor_publisher_retention_cap_unlink_ms_total": 0.3,
+        "event_monitor_publisher_retention_cap_unlink_ms_max": 0.3,
+        "event_monitor_publisher_retention_inventory_entries_visited": 11,
+        "event_monitor_publisher_retention_inventory_candidates": 7,
+        "event_monitor_publisher_retention_age_deleted": 2,
+        "event_monitor_publisher_retention_cap_deleted": 1,
     }
     snapshot = pipeline.health_snapshot()
     assert {key: snapshot[key] for key in expected} == expected
@@ -687,6 +717,16 @@ def test_pipeline_monitor_phase_timing_restores_overlapping_window(monkeypatch):
     pipeline._timing_monitor_publisher_retention_run_count = 3
     pipeline._timing_monitor_publisher_retention_ns_total = 17_000_000
     pipeline._timing_monitor_publisher_retention_ns_max = 9_000_000
+    pipeline._timing_monitor_publisher_retention_inventory_ns_total = 11_000_000
+    pipeline._timing_monitor_publisher_retention_inventory_ns_max = 6_000_000
+    pipeline._timing_monitor_publisher_retention_age_unlink_ns_total = 4_000_000
+    pipeline._timing_monitor_publisher_retention_age_unlink_ns_max = 3_000_000
+    pipeline._timing_monitor_publisher_retention_cap_unlink_ns_total = 2_000_000
+    pipeline._timing_monitor_publisher_retention_cap_unlink_ns_max = 1_000_000
+    pipeline._timing_monitor_publisher_retention_inventory_entries_visited = 31
+    pipeline._timing_monitor_publisher_retention_inventory_candidates = 13
+    pipeline._timing_monitor_publisher_retention_age_deleted = 4
+    pipeline._timing_monitor_publisher_retention_cap_deleted = 2
 
     first, first_token = pipeline.consume_timing_snapshot()
     pipeline._timing_monitor_prepare_ns_total = 5_000_000
@@ -699,6 +739,16 @@ def test_pipeline_monitor_phase_timing_restores_overlapping_window(monkeypatch):
     pipeline._timing_monitor_publisher_retention_run_count = 7
     pipeline._timing_monitor_publisher_retention_ns_total = 23_000_000
     pipeline._timing_monitor_publisher_retention_ns_max = 14_000_000
+    pipeline._timing_monitor_publisher_retention_inventory_ns_total = 17_000_000
+    pipeline._timing_monitor_publisher_retention_inventory_ns_max = 10_000_000
+    pipeline._timing_monitor_publisher_retention_age_unlink_ns_total = 5_000_000
+    pipeline._timing_monitor_publisher_retention_age_unlink_ns_max = 4_000_000
+    pipeline._timing_monitor_publisher_retention_cap_unlink_ns_total = 3_000_000
+    pipeline._timing_monitor_publisher_retention_cap_unlink_ns_max = 2_000_000
+    pipeline._timing_monitor_publisher_retention_inventory_entries_visited = 47
+    pipeline._timing_monitor_publisher_retention_inventory_candidates = 19
+    pipeline._timing_monitor_publisher_retention_age_deleted = 6
+    pipeline._timing_monitor_publisher_retention_cap_deleted = 3
     _second, second_token = pipeline.consume_timing_snapshot()
     pipeline.confirm_timing_snapshot(first_token)
     pipeline.restore_timing_snapshot(second_token)
@@ -718,6 +768,16 @@ def test_pipeline_monitor_phase_timing_restores_overlapping_window(monkeypatch):
     assert restored["event_monitor_publisher_retention_run_count"] == 7
     assert restored["event_monitor_publisher_retention_ms_total"] == 23.0
     assert restored["event_monitor_publisher_retention_ms_max"] == 14.0
+    assert restored["event_monitor_publisher_retention_inventory_ms_total"] == 17.0
+    assert restored["event_monitor_publisher_retention_inventory_ms_max"] == 10.0
+    assert restored["event_monitor_publisher_retention_age_unlink_ms_total"] == 5.0
+    assert restored["event_monitor_publisher_retention_age_unlink_ms_max"] == 4.0
+    assert restored["event_monitor_publisher_retention_cap_unlink_ms_total"] == 3.0
+    assert restored["event_monitor_publisher_retention_cap_unlink_ms_max"] == 2.0
+    assert restored["event_monitor_publisher_retention_inventory_entries_visited"] == 47
+    assert restored["event_monitor_publisher_retention_inventory_candidates"] == 19
+    assert restored["event_monitor_publisher_retention_age_deleted"] == 6
+    assert restored["event_monitor_publisher_retention_cap_deleted"] == 3
 
 
 def test_pipeline_custom_monitor_sink_reports_zero_internal_phase_timing():
@@ -755,6 +815,16 @@ def test_pipeline_custom_monitor_sink_reports_zero_internal_phase_timing():
         "event_monitor_publisher_retention_run_count": 0,
         "event_monitor_publisher_retention_ms_total": 0.0,
         "event_monitor_publisher_retention_ms_max": 0.0,
+        "event_monitor_publisher_retention_inventory_ms_total": 0.0,
+        "event_monitor_publisher_retention_inventory_ms_max": 0.0,
+        "event_monitor_publisher_retention_age_unlink_ms_total": 0.0,
+        "event_monitor_publisher_retention_age_unlink_ms_max": 0.0,
+        "event_monitor_publisher_retention_cap_unlink_ms_total": 0.0,
+        "event_monitor_publisher_retention_cap_unlink_ms_max": 0.0,
+        "event_monitor_publisher_retention_inventory_entries_visited": 0,
+        "event_monitor_publisher_retention_inventory_candidates": 0,
+        "event_monitor_publisher_retention_age_deleted": 0,
+        "event_monitor_publisher_retention_cap_deleted": 0,
     }
     assert pipeline.close(timeout=2.0) is True
 

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -4836,6 +4836,16 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
                     "event_monitor_sink_write_count": 2,
                     "event_monitor_sink_service_ms_total": 0.8,
                     "event_monitor_sink_service_ms_max": 0.5,
+                    "event_monitor_publisher_retention_inventory_ms_total": 99.0,
+                    "event_monitor_publisher_retention_inventory_ms_max": 98.0,
+                    "event_monitor_publisher_retention_age_unlink_ms_total": 97.0,
+                    "event_monitor_publisher_retention_age_unlink_ms_max": 96.0,
+                    "event_monitor_publisher_retention_cap_unlink_ms_total": 95.0,
+                    "event_monitor_publisher_retention_cap_unlink_ms_max": 94.0,
+                    "event_monitor_publisher_retention_inventory_entries_visited": 93,
+                    "event_monitor_publisher_retention_inventory_candidates": 92,
+                    "event_monitor_publisher_retention_age_deleted": 91,
+                    "event_monitor_publisher_retention_cap_deleted": 90,
                 },
             ),
             _monitor_row(
@@ -4871,6 +4881,16 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
                     "event_monitor_publisher_retention_run_count": 3,
                     "event_monitor_publisher_retention_ms_total": 0.2,
                     "event_monitor_publisher_retention_ms_max": 0.15,
+                    "event_monitor_publisher_retention_inventory_ms_total": 0.35,
+                    "event_monitor_publisher_retention_inventory_ms_max": 0.22,
+                    "event_monitor_publisher_retention_age_unlink_ms_total": 0.18,
+                    "event_monitor_publisher_retention_age_unlink_ms_max": 0.11,
+                    "event_monitor_publisher_retention_cap_unlink_ms_total": 0.27,
+                    "event_monitor_publisher_retention_cap_unlink_ms_max": 0.16,
+                    "event_monitor_publisher_retention_inventory_entries_visited": 14,
+                    "event_monitor_publisher_retention_inventory_candidates": 5,
+                    "event_monitor_publisher_retention_age_deleted": 2,
+                    "event_monitor_publisher_retention_cap_deleted": 1,
                 },
             ),
         ],
@@ -4913,14 +4933,27 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
                     "event_monitor_publisher_retention_run_count": 1,
                     "event_monitor_publisher_retention_ms_total": 0.1,
                     "event_monitor_publisher_retention_ms_max": 0.1,
+                    "event_monitor_publisher_retention_inventory_ms_total": 0.2,
+                    "event_monitor_publisher_retention_inventory_ms_max": 0.14,
+                    "event_monitor_publisher_retention_age_unlink_ms_total": 0.15,
+                    "event_monitor_publisher_retention_age_unlink_ms_max": 0.1,
+                    "event_monitor_publisher_retention_cap_unlink_ms_total": 0.11,
+                    "event_monitor_publisher_retention_cap_unlink_ms_max": 0.08,
+                    "event_monitor_publisher_retention_inventory_entries_visited": 7,
+                    "event_monitor_publisher_retention_inventory_candidates": 3,
+                    "event_monitor_publisher_retention_age_deleted": 1,
+                    "event_monitor_publisher_retention_cap_deleted": 0,
                 },
             )
         ],
     )
 
-    pressure = build_live_performance_report(tmp_path / "monitor")["resource_pressure"]
+    report = build_live_performance_report(tmp_path / "monitor")
+    assert report["ok"] is True
+    pressure = report["resource_pressure"]
     groups = {group["bot"]: group for group in pressure["groups"]}
     binance_fields = groups["binance/binance_01"]["fields"]
+    okx_fields = groups["okx/okx_01"]["fields"]
     assert binance_fields["event_pipeline_processed_count"] == {
         "latest": 5,
         "count": 2,
@@ -4960,6 +4993,46 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
         "median": 2,
         "p95": 2,
     }
+    retention_fields = (
+        "event_monitor_publisher_retention_inventory_ms_total",
+        "event_monitor_publisher_retention_inventory_ms_max",
+        "event_monitor_publisher_retention_age_unlink_ms_total",
+        "event_monitor_publisher_retention_age_unlink_ms_max",
+        "event_monitor_publisher_retention_cap_unlink_ms_total",
+        "event_monitor_publisher_retention_cap_unlink_ms_max",
+        "event_monitor_publisher_retention_inventory_entries_visited",
+        "event_monitor_publisher_retention_inventory_candidates",
+        "event_monitor_publisher_retention_age_deleted",
+        "event_monitor_publisher_retention_cap_deleted",
+    )
+    assert {
+        key: binance_fields[key]["latest"] for key in retention_fields
+    } == {
+        "event_monitor_publisher_retention_inventory_ms_total": 0.35,
+        "event_monitor_publisher_retention_inventory_ms_max": 0.22,
+        "event_monitor_publisher_retention_age_unlink_ms_total": 0.18,
+        "event_monitor_publisher_retention_age_unlink_ms_max": 0.11,
+        "event_monitor_publisher_retention_cap_unlink_ms_total": 0.27,
+        "event_monitor_publisher_retention_cap_unlink_ms_max": 0.16,
+        "event_monitor_publisher_retention_inventory_entries_visited": 14,
+        "event_monitor_publisher_retention_inventory_candidates": 5,
+        "event_monitor_publisher_retention_age_deleted": 2,
+        "event_monitor_publisher_retention_cap_deleted": 1,
+    }
+    assert {
+        key: okx_fields[key]["latest"] for key in retention_fields
+    } == {
+        "event_monitor_publisher_retention_inventory_ms_total": 0.2,
+        "event_monitor_publisher_retention_inventory_ms_max": 0.14,
+        "event_monitor_publisher_retention_age_unlink_ms_total": 0.15,
+        "event_monitor_publisher_retention_age_unlink_ms_max": 0.1,
+        "event_monitor_publisher_retention_cap_unlink_ms_total": 0.11,
+        "event_monitor_publisher_retention_cap_unlink_ms_max": 0.08,
+        "event_monitor_publisher_retention_inventory_entries_visited": 7,
+        "event_monitor_publisher_retention_inventory_candidates": 3,
+        "event_monitor_publisher_retention_age_deleted": 1,
+        "event_monitor_publisher_retention_cap_deleted": 0,
+    }
     assert {
         key: pressure[key]
         for key in (
@@ -4991,6 +5064,16 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
             "latest_event_monitor_publisher_retention_run_count_sum",
             "latest_event_monitor_publisher_retention_ms_total_sum",
             "latest_event_monitor_publisher_retention_ms_max",
+            "latest_event_monitor_publisher_retention_inventory_ms_total_sum",
+            "latest_event_monitor_publisher_retention_inventory_ms_max",
+            "latest_event_monitor_publisher_retention_age_unlink_ms_total_sum",
+            "latest_event_monitor_publisher_retention_age_unlink_ms_max",
+            "latest_event_monitor_publisher_retention_cap_unlink_ms_total_sum",
+            "latest_event_monitor_publisher_retention_cap_unlink_ms_max",
+            "latest_event_monitor_publisher_retention_inventory_entries_visited_sum",
+            "latest_event_monitor_publisher_retention_inventory_candidates_sum",
+            "latest_event_monitor_publisher_retention_age_deleted_sum",
+            "latest_event_monitor_publisher_retention_cap_deleted_sum",
         )
     } == {
         "latest_event_pipeline_processed_total": 8,
@@ -5021,6 +5104,16 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
         "latest_event_monitor_publisher_retention_run_count_sum": 4,
         "latest_event_monitor_publisher_retention_ms_total_sum": 0.3,
         "latest_event_monitor_publisher_retention_ms_max": 0.15,
+        "latest_event_monitor_publisher_retention_inventory_ms_total_sum": 0.55,
+        "latest_event_monitor_publisher_retention_inventory_ms_max": 0.22,
+        "latest_event_monitor_publisher_retention_age_unlink_ms_total_sum": 0.33,
+        "latest_event_monitor_publisher_retention_age_unlink_ms_max": 0.11,
+        "latest_event_monitor_publisher_retention_cap_unlink_ms_total_sum": 0.38,
+        "latest_event_monitor_publisher_retention_cap_unlink_ms_max": 0.16,
+        "latest_event_monitor_publisher_retention_inventory_entries_visited_sum": 21,
+        "latest_event_monitor_publisher_retention_inventory_candidates_sum": 8,
+        "latest_event_monitor_publisher_retention_age_deleted_sum": 3,
+        "latest_event_monitor_publisher_retention_cap_deleted_sum": 1,
     }
 
 
@@ -5031,12 +5124,30 @@ def test_live_performance_report_resource_pressure_whitelists_health_fields(tmp_
         [
             _monitor_row(
                 event_type="health.summary",
-                seq=1,
+                seq=0,
                 ts=1000,
                 component="monitor.health",
                 data={
-                    "rss_bytes": 1000,
-                    "system_memory_percent": 70.0,
+                    "event_monitor_publisher_retention_inventory_ms_total": 9.0,
+                    "event_monitor_publisher_retention_inventory_ms_max": 8.0,
+                    "event_monitor_publisher_retention_age_unlink_ms_total": 7.0,
+                    "event_monitor_publisher_retention_age_unlink_ms_max": 6.0,
+                    "event_monitor_publisher_retention_cap_unlink_ms_total": 5.0,
+                    "event_monitor_publisher_retention_cap_unlink_ms_max": 4.0,
+                    "event_monitor_publisher_retention_inventory_entries_visited": 3,
+                    "event_monitor_publisher_retention_inventory_candidates": 2,
+                    "event_monitor_publisher_retention_age_deleted": 1,
+                    "event_monitor_publisher_retention_cap_deleted": 1,
+                },
+            ),
+            _monitor_row(
+                event_type="health.summary",
+                seq=1,
+                ts=2000,
+                component="monitor.health",
+                data={
+                    "rss_bytes": 1200,
+                    "system_memory_percent": 60.0,
                     "balance_raw": {"leak_marker": "raw-balance"},
                     "balance_snapped": {"leak_marker": "snapped-balance"},
                     "equity": "leak-equity",
@@ -5051,12 +5162,13 @@ def test_live_performance_report_resource_pressure_whitelists_health_fields(tmp_
     report = build_live_performance_report(tmp_path / "monitor")
     rendered = json.dumps(report["resource_pressure"], sort_keys=True)
 
-    assert report["resource_pressure"]["groups"][0]["fields"]["rss_bytes"]["latest"] == 1000
+    assert report["ok"] is True
+    assert report["resource_pressure"]["groups"][0]["fields"]["rss_bytes"]["latest"] == 1200
     assert (
         report["resource_pressure"]["groups"][0]["fields"]["system_memory_percent"][
             "latest"
         ]
-        == 70
+        == 60
     )
     assert not any(
         key.startswith("event_monitor_publisher_manifest_checkpoint")

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2702,6 +2702,25 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
                 event_type="health.summary",
                 exchange="okx",
                 user="okx_01",
+                seq=0,
+                ts=1000,
+                data={
+                    "event_monitor_publisher_retention_inventory_ms_total": 99.0,
+                    "event_monitor_publisher_retention_inventory_ms_max": 98.0,
+                    "event_monitor_publisher_retention_age_unlink_ms_total": 97.0,
+                    "event_monitor_publisher_retention_age_unlink_ms_max": 96.0,
+                    "event_monitor_publisher_retention_cap_unlink_ms_total": 95.0,
+                    "event_monitor_publisher_retention_cap_unlink_ms_max": 94.0,
+                    "event_monitor_publisher_retention_inventory_entries_visited": 93,
+                    "event_monitor_publisher_retention_inventory_candidates": 92,
+                    "event_monitor_publisher_retention_age_deleted": 91,
+                    "event_monitor_publisher_retention_cap_deleted": 90,
+                },
+            ),
+            _monitor_row(
+                event_type="health.summary",
+                exchange="okx",
+                user="okx_01",
                 seq=1,
                 ts=2000,
                 data={
@@ -2733,6 +2752,16 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
                     "event_monitor_publisher_retention_run_count": 3,
                     "event_monitor_publisher_retention_ms_total": 1.0,
                     "event_monitor_publisher_retention_ms_max": 0.6,
+                    "event_monitor_publisher_retention_inventory_ms_total": 1.7,
+                    "event_monitor_publisher_retention_inventory_ms_max": 1.1,
+                    "event_monitor_publisher_retention_age_unlink_ms_total": 0.8,
+                    "event_monitor_publisher_retention_age_unlink_ms_max": 0.5,
+                    "event_monitor_publisher_retention_cap_unlink_ms_total": 0.9,
+                    "event_monitor_publisher_retention_cap_unlink_ms_max": 0.6,
+                    "event_monitor_publisher_retention_inventory_entries_visited": 21,
+                    "event_monitor_publisher_retention_inventory_candidates": 8,
+                    "event_monitor_publisher_retention_age_deleted": 3,
+                    "event_monitor_publisher_retention_cap_deleted": 2,
                 },
             )
         ],
@@ -2775,6 +2804,16 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
                     "event_monitor_publisher_retention_run_count": 1,
                     "event_monitor_publisher_retention_ms_total": 0.2,
                     "event_monitor_publisher_retention_ms_max": 0.2,
+                    "event_monitor_publisher_retention_inventory_ms_total": 0.4,
+                    "event_monitor_publisher_retention_inventory_ms_max": 0.25,
+                    "event_monitor_publisher_retention_age_unlink_ms_total": 0.3,
+                    "event_monitor_publisher_retention_age_unlink_ms_max": 0.2,
+                    "event_monitor_publisher_retention_cap_unlink_ms_total": 0.5,
+                    "event_monitor_publisher_retention_cap_unlink_ms_max": 0.35,
+                    "event_monitor_publisher_retention_inventory_entries_visited": 9,
+                    "event_monitor_publisher_retention_inventory_candidates": 4,
+                    "event_monitor_publisher_retention_age_deleted": 1,
+                    "event_monitor_publisher_retention_cap_deleted": 0,
                 },
             )
         ],
@@ -2794,6 +2833,46 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
     assert groups["okx/okx_01"].get("latest_monitor_publisher_persist_ms_max") == 2
     assert groups["okx/okx_01"].get("latest_monitor_publisher_manifest_checkpoint_count") == 2
     assert groups["gateio/gateio_01"].get("latest_monitor_publisher_retention_run_count") == 1
+    retention_group_fields = (
+        "latest_monitor_publisher_retention_inventory_ms_total",
+        "latest_monitor_publisher_retention_inventory_ms_max",
+        "latest_monitor_publisher_retention_age_unlink_ms_total",
+        "latest_monitor_publisher_retention_age_unlink_ms_max",
+        "latest_monitor_publisher_retention_cap_unlink_ms_total",
+        "latest_monitor_publisher_retention_cap_unlink_ms_max",
+        "latest_monitor_publisher_retention_inventory_entries_visited",
+        "latest_monitor_publisher_retention_inventory_candidates",
+        "latest_monitor_publisher_retention_age_deleted",
+        "latest_monitor_publisher_retention_cap_deleted",
+    )
+    assert {
+        key: groups["okx/okx_01"][key] for key in retention_group_fields
+    } == {
+        "latest_monitor_publisher_retention_inventory_ms_total": 1.7,
+        "latest_monitor_publisher_retention_inventory_ms_max": 1.1,
+        "latest_monitor_publisher_retention_age_unlink_ms_total": 0.8,
+        "latest_monitor_publisher_retention_age_unlink_ms_max": 0.5,
+        "latest_monitor_publisher_retention_cap_unlink_ms_total": 0.9,
+        "latest_monitor_publisher_retention_cap_unlink_ms_max": 0.6,
+        "latest_monitor_publisher_retention_inventory_entries_visited": 21,
+        "latest_monitor_publisher_retention_inventory_candidates": 8,
+        "latest_monitor_publisher_retention_age_deleted": 3,
+        "latest_monitor_publisher_retention_cap_deleted": 2,
+    }
+    assert {
+        key: groups["gateio/gateio_01"][key] for key in retention_group_fields
+    } == {
+        "latest_monitor_publisher_retention_inventory_ms_total": 0.4,
+        "latest_monitor_publisher_retention_inventory_ms_max": 0.25,
+        "latest_monitor_publisher_retention_age_unlink_ms_total": 0.3,
+        "latest_monitor_publisher_retention_age_unlink_ms_max": 0.2,
+        "latest_monitor_publisher_retention_cap_unlink_ms_total": 0.5,
+        "latest_monitor_publisher_retention_cap_unlink_ms_max": 0.35,
+        "latest_monitor_publisher_retention_inventory_entries_visited": 9,
+        "latest_monitor_publisher_retention_inventory_candidates": 4,
+        "latest_monitor_publisher_retention_age_deleted": 1,
+        "latest_monitor_publisher_retention_cap_deleted": 0,
+    }
     expected = {
         "latest_processed_total": 11,
         "latest_timing_window_ms_max": 1250,
@@ -2823,6 +2902,16 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
         "latest_monitor_publisher_retention_run_count_sum": 4,
         "latest_monitor_publisher_retention_ms_total_sum": 1.2,
         "latest_monitor_publisher_retention_ms_max": 0.6,
+        "latest_monitor_publisher_retention_inventory_ms_total_sum": 2.1,
+        "latest_monitor_publisher_retention_inventory_ms_max": 1.1,
+        "latest_monitor_publisher_retention_age_unlink_ms_total_sum": 1.1,
+        "latest_monitor_publisher_retention_age_unlink_ms_max": 0.5,
+        "latest_monitor_publisher_retention_cap_unlink_ms_total_sum": 1.4,
+        "latest_monitor_publisher_retention_cap_unlink_ms_max": 0.6,
+        "latest_monitor_publisher_retention_inventory_entries_visited_sum": 30,
+        "latest_monitor_publisher_retention_inventory_candidates_sum": 12,
+        "latest_monitor_publisher_retention_age_deleted_sum": 4,
+        "latest_monitor_publisher_retention_cap_deleted_sum": 2,
     }
     assert {key: health[key] for key in expected} == expected
     assert {key: summary["event_pipeline_health"][key] for key in expected} == expected
@@ -2836,6 +2925,25 @@ def test_live_smoke_report_omits_missing_monitor_maintenance_attribution(tmp_pat
     _write_ndjson(
         events_dir / "current.ndjson",
         [
+            _monitor_row(
+                event_type="health.summary",
+                exchange="okx",
+                user="okx_01",
+                seq=0,
+                ts=1000,
+                data={
+                    "event_monitor_publisher_retention_inventory_ms_total": 9.0,
+                    "event_monitor_publisher_retention_inventory_ms_max": 8.0,
+                    "event_monitor_publisher_retention_age_unlink_ms_total": 7.0,
+                    "event_monitor_publisher_retention_age_unlink_ms_max": 6.0,
+                    "event_monitor_publisher_retention_cap_unlink_ms_total": 5.0,
+                    "event_monitor_publisher_retention_cap_unlink_ms_max": 4.0,
+                    "event_monitor_publisher_retention_inventory_entries_visited": 3,
+                    "event_monitor_publisher_retention_inventory_candidates": 2,
+                    "event_monitor_publisher_retention_age_deleted": 1,
+                    "event_monitor_publisher_retention_cap_deleted": 1,
+                },
+            ),
             _monitor_row(
                 event_type="health.summary",
                 exchange="okx",

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -682,6 +682,16 @@ def test_monitor_publisher_event_phase_timing_uses_fixed_boundaries(tmp_path, mo
         "retention_run_count": 1,
         "retention_ns_total": 11_000_000,
         "retention_ns_max": 11_000_000,
+        "retention_inventory_ns_total": 0,
+        "retention_inventory_ns_max": 0,
+        "retention_age_unlink_ns_total": 0,
+        "retention_age_unlink_ns_max": 0,
+        "retention_cap_unlink_ns_total": 0,
+        "retention_cap_unlink_ns_max": 0,
+        "retention_inventory_entries_visited": 0,
+        "retention_inventory_candidates": 0,
+        "retention_age_deleted": 0,
+        "retention_cap_deleted": 0,
     }
 
 
@@ -719,6 +729,16 @@ def test_monitor_publisher_event_failure_retains_reached_phase_timing(tmp_path, 
         "retention_run_count": 0,
         "retention_ns_total": 0,
         "retention_ns_max": 0,
+        "retention_inventory_ns_total": 0,
+        "retention_inventory_ns_max": 0,
+        "retention_age_unlink_ns_total": 0,
+        "retention_age_unlink_ns_max": 0,
+        "retention_cap_unlink_ns_total": 0,
+        "retention_cap_unlink_ns_max": 0,
+        "retention_inventory_entries_visited": 0,
+        "retention_inventory_candidates": 0,
+        "retention_age_deleted": 0,
+        "retention_cap_deleted": 0,
     }
 
 
@@ -751,7 +771,7 @@ def test_monitor_publisher_event_timing_counts_failed_due_attempts(tmp_path, mon
     def fail_atomic_write(*_args, **_kwargs):
         raise OSError("manifest unavailable")
 
-    def fail_retention_inventory():
+    def fail_retention_inventory(**_kwargs):
         inventory_attempts.append(None)
         raise OSError("retention unavailable")
 
@@ -775,6 +795,144 @@ def test_monitor_publisher_event_timing_counts_failed_due_attempts(tmp_path, mon
     assert len(inventory_attempts) == 1
     publisher._prune_retention(now_ms=160_000)
     assert len(inventory_attempts) == 2
+
+
+def test_monitor_publisher_event_timing_records_retention_phases_for_due_run(
+    tmp_path, monkeypatch
+):
+    publisher = _make_publisher(tmp_path, retain_days=0.0, max_total_bytes=0)
+    old_candidate = publisher.events_dir / "old.ndjson"
+    cap_candidate = publisher.history_dir / "current.ndjson"
+    _write_retention_file(old_candidate, size=10, mtime_ms=1)
+    _write_retention_file(cap_candidate, size=10, mtime_ms=100_000)
+    expected_entries_visited = len(list(publisher.root.rglob("*")))
+    clock = {"ns": 0}
+    original_rglob = Path.rglob
+    original_unlink = Path.unlink
+
+    def timed_rglob(path, pattern):
+        for entry in original_rglob(path, pattern):
+            yield entry
+            clock["ns"] += 1_000
+
+    def timed_unlink(path, *args, **kwargs):
+        if path == old_candidate:
+            clock["ns"] += 2_000
+        elif path == cap_candidate:
+            clock["ns"] += 3_000
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(monitor_publisher_module.time, "monotonic_ns", lambda: clock["ns"])
+    monkeypatch.setattr(Path, "rglob", timed_rglob)
+    monkeypatch.setattr(Path, "unlink", timed_unlink)
+
+    event, timing = publisher._record_event_timed(
+        "test.event", ("test",), {"value": 1}, ts=100_000
+    )
+
+    assert event is not None
+    assert timing["retention_run_count"] == 1
+    assert timing["retention_inventory_ns_total"] == expected_entries_visited * 1_000
+    assert timing["retention_inventory_ns_max"] == expected_entries_visited * 1_000
+    assert timing["retention_age_unlink_ns_total"] == 2_000
+    assert timing["retention_age_unlink_ns_max"] == 2_000
+    assert timing["retention_cap_unlink_ns_total"] == 3_000
+    assert timing["retention_cap_unlink_ns_max"] == 3_000
+    assert timing["retention_inventory_entries_visited"] == expected_entries_visited
+    assert timing["retention_inventory_candidates"] == 2
+    assert timing["retention_age_deleted"] == 1
+    assert timing["retention_cap_deleted"] == 1
+
+
+def test_monitor_publisher_event_timing_zeroes_retention_phases_when_not_due(tmp_path):
+    publisher = _make_publisher(tmp_path)
+    publisher.last_retention_ms = 100_000
+
+    event, timing = publisher._record_event_timed(
+        "test.event", ("test",), {"value": 1}, ts=100_001
+    )
+
+    assert event is not None
+    assert timing["retention_run_count"] == 0
+    for key in (
+        "retention_inventory_ns_total",
+        "retention_inventory_ns_max",
+        "retention_age_unlink_ns_total",
+        "retention_age_unlink_ns_max",
+        "retention_cap_unlink_ns_total",
+        "retention_cap_unlink_ns_max",
+        "retention_inventory_entries_visited",
+        "retention_inventory_candidates",
+        "retention_age_deleted",
+        "retention_cap_deleted",
+    ):
+        assert timing[key] == 0
+
+
+def test_monitor_publisher_event_timing_excludes_tolerated_age_disappearance(
+    tmp_path, monkeypatch
+):
+    publisher = _make_publisher(tmp_path, retain_days=0.0)
+    disappeared = publisher.events_dir / "disappeared.ndjson"
+    _write_retention_file(disappeared, size=10, mtime_ms=1)
+    original_unlink = Path.unlink
+
+    def disappear_then_unlink(path, *args, **kwargs):
+        if path == disappeared:
+            original_unlink(path, *args, **kwargs)
+            raise FileNotFoundError(path)
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", disappear_then_unlink)
+    event, timing = publisher._record_event_timed(
+        "test.event", ("test",), {"value": 1}, ts=100_000
+    )
+
+    assert event is not None
+    assert not disappeared.exists()
+    assert timing["retention_inventory_candidates"] == 1
+    assert timing["retention_age_deleted"] == 0
+    assert timing["retention_cap_deleted"] == 0
+    assert timing["retention_age_unlink_ns_total"] >= 0
+
+
+def test_monitor_publisher_event_timing_keeps_completed_phases_after_cap_unlink_error(
+    tmp_path, monkeypatch, caplog
+):
+    publisher = _make_publisher(tmp_path, retain_days=-1.0, max_total_bytes=0)
+    candidate = publisher.events_dir / "candidate.ndjson"
+    _write_retention_file(candidate, size=10, mtime_ms=1)
+    clock = {"ns": 0}
+    original_rglob = Path.rglob
+
+    def timed_rglob(path, pattern):
+        for entry in original_rglob(path, pattern):
+            yield entry
+            clock["ns"] += 1_000
+
+    def fail_candidate_unlink(path, *args, **_kwargs):
+        if path == candidate:
+            clock["ns"] += 4_000
+            raise OSError("candidate unavailable")
+        raise AssertionError(f"unexpected unlink: {path}")
+
+    monkeypatch.setattr(monitor_publisher_module.time, "monotonic_ns", lambda: clock["ns"])
+    monkeypatch.setattr(Path, "rglob", timed_rglob)
+    monkeypatch.setattr(Path, "unlink", fail_candidate_unlink)
+
+    event, timing = publisher._record_event_timed(
+        "test.event", ("test",), {"value": 1}, ts=100_000
+    )
+
+    assert event is not None
+    assert candidate.exists()
+    assert "retention pruning failed: candidate unavailable" in caplog.text
+    assert timing["retention_inventory_entries_visited"] > 0
+    assert timing["retention_inventory_candidates"] == 1
+    assert timing["retention_inventory_ns_total"] > 0
+    assert timing["retention_cap_unlink_ns_total"] == 4_000
+    assert timing["retention_cap_unlink_ns_max"] == 4_000
+    assert timing["retention_cap_deleted"] == 0
 
 
 def _write_retention_file(path, *, size, mtime_ms):


### PR DESCRIPTION
## Summary
- attribute due event-path monitor retention work to inventory, age unlink, and byte-cap unlink timings
- expose bounded visited, candidate, and successful-deletion counts through the existing transactional health window
- project the fixed fields in smoke/performance reports and correct the operational long-tail evidence

## Contract
- additive observability only; no retention cadence, lock, traversal, ordering, deletion policy, error handling, verdict, config, or trading change
- no paths, labels, samples, or extra events
- current files remain protected; recursive regular-file accounting and direct-only oldest-first deletion are unchanged

## Validation
- focused publisher, event-bus, health transaction, smoke, and performance report suites
- monitor relay, incident bundle, fake-live harness, AI docs, and event registry regressions
- Python compilation and git diff check
- independent preflight: no actionable findings

## Live evidence motivating this slice
PR #1208 improved a matched 12-run window from 16210.383ms total / 8953.523ms max to 5612.290ms / 690.434ms, but a later 10-run window recorded 14255.296ms total and an 8654.591ms maximum. This PR adds attribution before another persistence behavior change.