### PR TITLE
Speed up monitor retention inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Monitor retention now builds the same complete recursive inventory with one
+  healthy-path `os.scandir` traversal and one explicit `DirEntry.stat` per
+  visited entry, avoiding the duplicate directory scans performed by the prior
+  `Path.rglob` path. A failed directory scan gets one bounded immediate retry;
+  persistent errors still isolate that subtree. Cadence, symlink handling,
+  protected paths, accounting, and deletion policy are unchanged.
+
 - Periodic structured health summaries now split monitor retention work into
   fixed inventory, age-unlink, and byte-cap-unlink timings plus bounded work
   counts. Live smoke and performance reports project the same fields without

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,54 +22,70 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-monitor-retention-phase-timing`
-- Base: `e604ac7ea7d3e2cdea05d37f3cbd0fce5aee99b1`, PR #1209
-- Triggering evidence: after PR #1208 reduced matched 12-run retention timing
-  from `16210.383ms` total / `8953.523ms` max to `5612.290ms` / `690.434ms`,
-  a later 10-run VPS5 window still recorded `14255.296ms` total and an
-  `8654.591ms` maximum. Whole-run timing cannot distinguish inventory/stat
-  latency from age or byte-cap unlink work.
-- Scope: add fixed inventory, age-unlink, and cap-unlink timing totals/maxima,
-  plus inventory visited/candidate and successful deletion counts, to the
-  existing event-path monitor timing window and its smoke/performance report
-  projections.
-- Behavior boundary: additive low-cardinality telemetry only. Preserve
-  retention cadence, `last_retention_ms`, lock scope, traversal and candidate
-  order, age and cap policy, failure handling, monitor delivery, report
-  verdicts, configuration, and every order/risk/trading behavior. Do not emit
-  paths, samples, labels, or additional events.
-- Validation: due/skip, disappearing files, age and cap deletion, unlink
-  failure, timing aggregation/reset/restore, generic monitor-sink zeroes,
-  per-bot and aggregate report projection, historical omission, unchanged
-  verdicts, integrated monitor regressions, Python compilation,
-  `git diff --check`, silent-handling audit, and independent preflight.
+- Branch: `codex/v8-monitor-retention-scandir`
+- Base: `3a17fdb9768de80212d2dcd3c097350508d69caa`, PR #1211
+- Triggering evidence: the first four post-PR #1211 health windows attributed
+  `15369.148ms` of `15591.553ms` retention time to inventory. The
+  `10253.648ms` retention maximum contained a `10241.787ms` inventory maximum;
+  20,158 entries yielded 20,032 candidates with zero age or cap deletions.
+  A read-only two-order VPS5 benchmark preserved entry/file counts while direct
+  `os.scandir` took `43-112ms` per active root versus `94-587ms` for the
+  current `Path.rglob` plus `Path.stat` path.
+- Scope: replace only the full retention inventory walker with one direct
+  healthy-path `os.scandir` traversal and one explicit `DirEntry.stat` per
+  visited entry. Preserve full recursive accounting and direct-candidate
+  collection; retry one transient directory-scan failure before isolating a
+  persistently unavailable subtree.
+- Behavior boundary: performance implementation only. Preserve the 60-second
+  cadence, `last_retention_ms`, lock scope, directory-symlink non-traversal,
+  file-symlink accounting, protected paths, candidate ordering, age and cap
+  policy, persistent scan-error isolation, timing schema, configuration, and every
+  order/risk/trading behavior. Do not add caching, staggering, workers, paths,
+  labels, samples, or events.
+- Validation: static inventory parity, one healthy traversal and explicit stat
+  per entry, transient/persistent scan errors, directory and entry disappearance,
+  file and directory symlinks, nested unknown files,
+  protected paths, age and cap ordering, timing counters, integrated monitor
+  regressions, Python compilation, `git diff --check`, silent-handling audit,
+  and independent preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: exact five-bot graceful restart, immediate and settled
-  smoke, then collection of naturally emitted phase-attributed retention
-  windows.
+  smoke, then at least 30 naturally emitted due runs comparing normalized
+  inventory p50/p95/max and process I/O-wait evidence.
 
 Next action:
 
-1. Hold the active retention-phase attribution PR's exact current head until
-   Hermes, Grok 4.5, and CI are green.
+1. Hold the active benchmark-supported `scandir` inventory PR's exact current
+   head until Hermes, Grok 4.5, and CI are green.
 2. Resolve findings narrowly and require fresh exact-head verdicts after every
    push.
 3. Merge, perform the exact five-bot graceful VPS restart, run immediate and
-   settled smoke, then collect fresh phase-attributed retention windows before
-   selecting any further persistence optimization.
+   settled smoke, then collect enough due runs to test the production p95/max
+   claim before selecting any further persistence change.
 
 ## Deployed Baseline
 
-- Remote `v8`: `e604ac7ea7d3e2cdea05d37f3cbd0fce5aee99b1`, PR #1209
-- VPS5 repository: `d509dde70caff9eea6a9d445f3571b6ac70d5184`, PR #1210; tracked
+- Remote `v8`: `3a17fdb9768de80212d2dcd3c097350508d69caa`, PR #1211
+- VPS5 repository: `3a17fdb9768de80212d2dcd3c097350508d69caa`, PR #1211; tracked
   status clean; expected untracked artifacts were preserved
-- VPS5 expected bots: five; running with PR #1210 restart PIDs
-  `883768/883922/883918/883930/883980`;
+- VPS5 expected bots: five; running with PR #1211 restart PIDs
+  `892535/892537/892539/892541/892543`;
   unrelated `misc:0.0` remains PID `434835`
-- PR #1209 advanced remote `v8` with documentation-only review and monitor
-  persistence contracts. No VPS5 pull or restart is claimed for that docs-only
-  merge; the last verified deployed code remains PR #1210.
+- PR #1211 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded cleanly through PR #1209 and #1211 and gracefully
+  restarted only the five exact bot panes; all old bots exited naturally, pane
+  PIDs and unrelated `misc:0.0` PID `434835` were preserved. Immediate smoke
+  was hard-green with `130/130` remote and `42/42` account-critical calls.
+  Settled smoke was hard-green with `385/385` remote and `45/45`
+  account-critical calls, no active HSL replay, zero hard/log/monitor failures,
+  all five expected processes, and a clean tracked repository. Three processes
+  were sampled briefly in `D` during inventory I/O and all returned to `R`.
+- Four fresh health windows covered 2,238 monitor writes. Twelve retention runs
+  consumed `15591.553ms` total with a `10253.648ms` maximum; inventory explained
+  `15369.148ms` total and a `10241.787ms` maximum. The runs visited 20,158
+  entries and found 20,032 direct candidates, with zero age/cap deletions,
+  proving inventory traversal/stat is the active long-tail source.
 - PR #1210 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
   panes; every old bot exited naturally and pane PIDs remained unchanged.
@@ -396,13 +412,14 @@ PR #1206's monitor-maintenance phase attribution are also merged and deployed.
 PR #1207's position console projection and PR #1208's one-pass monitor
 retention inventory are also merged and deployed with their behavior boundaries
 preserved. PR #1210's balance console transition is merged, deployed, and
-validated from natural balance changes on all five bots.
+validated from natural balance changes on all five bots. PR #1211's retention
+phase attribution is merged and deployed; fresh evidence isolates inventory as
+98.574% of retention service time in the first four health windows.
 
-The active slice attributes the recurring retention long tail to inventory,
-age-unlink, or byte-cap-unlink work before another persistence optimization is
-selected. Keep fill formatting separate: its legacy and event-routed lines
-currently overlap and require an explicit migration contract for timestamps,
-pending PnL, and bulk summaries.
+The active slice replaces only the full inventory walker with benchmarked
+direct `os.scandir` traversal. Keep fill formatting separate: its legacy and
+event-routed lines currently overlap and require an explicit migration contract
+for timestamps, pending PnL, and bulk summaries.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -69,6 +69,23 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1211 merged to `v8` as
+  `3a17fdb9768de80212d2dcd3c097350508d69caa` after exact-head Hermes and
+  Grok 4.5 approval plus green CI. It added fixed inventory, age-unlink, and
+  cap-unlink timings and bounded work counts without changing retention
+  behavior. VPS5 fast-forwarded cleanly through PR #1209 and #1211 and
+  gracefully restarted only the five exact bot panes; pane PIDs and unrelated
+  `misc:0.0` PID `434835` were preserved. Immediate and settled smoke were
+  hard-green; settled evidence had `385/385` remote and `45/45`
+  account-critical calls successful, no active HSL replay, zero hard/log/monitor
+  failures, all five processes present, and a clean tracked repository. Three
+  processes briefly sampled `D` during inventory I/O and all returned to `R`.
+  Four health windows covered 2,238 monitor writes and 12 retention runs:
+  inventory consumed `15369.148ms` of `15591.553ms` total and explained
+  `10241.787ms` of the `10253.648ms` maximum. The runs visited 20,158 entries,
+  found 20,032 candidates, and performed zero age/cap deletions. A subsequent
+  read-only two-order VPS5 benchmark preserved topology while direct
+  `os.scandir` took `43-112ms` versus `94-587ms` for the current walker.
 - PR #1210 merged to `v8` as
   `d509dde70caff9eea6a9d445f3571b6ac70d5184` after exact-head Hermes and
   Grok 4.5 approval plus green CI. It changed only the console/text projection

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -396,9 +396,14 @@ classification when enough source events exist.
     windows measured the same 12 retention runs at `5612.290ms` total and
     `690.434ms` maximum. A later 10-run window recorded `14255.296ms` total and
     an `8654.591ms` maximum, so the ordinary cost improved but the long tail
-    remained. The active attribution slice separates inventory, age-unlink,
-    and cap-unlink timing plus bounded work counts before another persistence
-    optimization is selected.
+    remained. PR #1211 then separated inventory, age-unlink, and cap-unlink
+    timing plus bounded work counts. Its first
+    four deployed health windows assigned `15369.148ms` of `15591.553ms`
+    retention time to inventory, including `10241.787ms` of the
+    `10253.648ms` maximum, across 20,158 visited entries and 20,032 candidates
+    with no deletions. A read-only production-filesystem benchmark then showed
+    direct `os.scandir` preserving topology in `43-112ms` versus `94-587ms`
+    for the current walker; that narrow substitution is the active slice.
 - [ ] Exchange writes: create/cancel/close/panic write latency, exchange
   response latency, ambiguous write rate, confirmation latency.
   - Status: partial. The report now derives order-wave total duration,

--- a/src/monitor_publisher.py
+++ b/src/monitor_publisher.py
@@ -10,6 +10,7 @@ import stat
 import threading
 import time
 import uuid
+from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional
@@ -487,20 +488,41 @@ class MonitorPublisher:
         candidate_dirs = {self.events_dir, self.history_dir, self.checkpoints_dir}
         total_bytes = 0
         candidates: list[tuple[Path, int, float]] = []
-        for path in self.root.rglob("*"):
-            if on_entry is not None:
-                on_entry()
-            try:
-                file_stat = path.stat()
-            except FileNotFoundError:
+        pending_dirs = deque([self.root])
+        while pending_dirs:
+            directory = pending_dirs.popleft()
+            entries = None
+            for _attempt in range(2):
+                try:
+                    entries = os.scandir(directory)
+                    break
+                except OSError:
+                    continue
+            if entries is None:
                 continue
-            if not stat.S_ISREG(file_stat.st_mode):
-                continue
-            total_bytes += file_stat.st_size
-            if path.parent in candidate_dirs and path not in protected:
-                candidates.append((path, file_stat.st_size, file_stat.st_mtime))
-                if on_candidate is not None:
-                    on_candidate()
+            child_dirs: list[Path] = []
+            with entries:
+                for entry in entries:
+                    path = Path(entry.path)
+                    if on_entry is not None:
+                        on_entry()
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            child_dirs.append(path)
+                    except OSError:
+                        pass
+                    try:
+                        file_stat = entry.stat()
+                    except FileNotFoundError:
+                        continue
+                    if not stat.S_ISREG(file_stat.st_mode):
+                        continue
+                    total_bytes += file_stat.st_size
+                    if path.parent in candidate_dirs and path not in protected:
+                        candidates.append((path, file_stat.st_size, file_stat.st_mtime))
+                        if on_candidate is not None:
+                            on_candidate()
+            pending_dirs.extend(child_dirs)
         return total_bytes, sorted(candidates, key=lambda candidate: candidate[2])
 
     def _retention_due(self, now_ms: int) -> bool:

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -2,6 +2,7 @@ import errno
 import json
 import logging
 import os
+import stat
 import threading
 from pathlib import Path
 
@@ -807,13 +808,14 @@ def test_monitor_publisher_event_timing_records_retention_phases_for_due_run(
     _write_retention_file(cap_candidate, size=10, mtime_ms=100_000)
     expected_entries_visited = len(list(publisher.root.rglob("*")))
     clock = {"ns": 0}
-    original_rglob = Path.rglob
+    original_scandir = monitor_publisher_module.os.scandir
     original_unlink = Path.unlink
+    inventory_scans = []
 
-    def timed_rglob(path, pattern):
-        for entry in original_rglob(path, pattern):
-            yield entry
-            clock["ns"] += 1_000
+    def timed_scandir(path):
+        inventory_scans.append(Path(path))
+        clock["ns"] += 1_000
+        return original_scandir(path)
 
     def timed_unlink(path, *args, **kwargs):
         if path == old_candidate:
@@ -823,7 +825,7 @@ def test_monitor_publisher_event_timing_records_retention_phases_for_due_run(
         return original_unlink(path, *args, **kwargs)
 
     monkeypatch.setattr(monitor_publisher_module.time, "monotonic_ns", lambda: clock["ns"])
-    monkeypatch.setattr(Path, "rglob", timed_rglob)
+    monkeypatch.setattr(monitor_publisher_module.os, "scandir", timed_scandir)
     monkeypatch.setattr(Path, "unlink", timed_unlink)
 
     event, timing = publisher._record_event_timed(
@@ -832,8 +834,9 @@ def test_monitor_publisher_event_timing_records_retention_phases_for_due_run(
 
     assert event is not None
     assert timing["retention_run_count"] == 1
-    assert timing["retention_inventory_ns_total"] == expected_entries_visited * 1_000
-    assert timing["retention_inventory_ns_max"] == expected_entries_visited * 1_000
+    expected_inventory_ns = len(inventory_scans) * 1_000
+    assert timing["retention_inventory_ns_total"] == expected_inventory_ns
+    assert timing["retention_inventory_ns_max"] == expected_inventory_ns
     assert timing["retention_age_unlink_ns_total"] == 2_000
     assert timing["retention_age_unlink_ns_max"] == 2_000
     assert timing["retention_cap_unlink_ns_total"] == 3_000
@@ -903,12 +906,11 @@ def test_monitor_publisher_event_timing_keeps_completed_phases_after_cap_unlink_
     candidate = publisher.events_dir / "candidate.ndjson"
     _write_retention_file(candidate, size=10, mtime_ms=1)
     clock = {"ns": 0}
-    original_rglob = Path.rglob
+    original_scandir = monitor_publisher_module.os.scandir
 
-    def timed_rglob(path, pattern):
-        for entry in original_rglob(path, pattern):
-            yield entry
-            clock["ns"] += 1_000
+    def timed_scandir(path):
+        clock["ns"] += 1_000
+        return original_scandir(path)
 
     def fail_candidate_unlink(path, *args, **_kwargs):
         if path == candidate:
@@ -917,7 +919,7 @@ def test_monitor_publisher_event_timing_keeps_completed_phases_after_cap_unlink_
         raise AssertionError(f"unexpected unlink: {path}")
 
     monkeypatch.setattr(monitor_publisher_module.time, "monotonic_ns", lambda: clock["ns"])
-    monkeypatch.setattr(Path, "rglob", timed_rglob)
+    monkeypatch.setattr(monitor_publisher_module.os, "scandir", timed_scandir)
     monkeypatch.setattr(Path, "unlink", fail_candidate_unlink)
 
     event, timing = publisher._record_event_timed(
@@ -987,6 +989,113 @@ def test_monitor_retention_counts_nested_unknown_files_but_never_deletes_them(tm
 
     assert not direct_candidate.exists()
     assert nested_unknown.exists()
+
+
+def test_monitor_retention_inventory_tolerates_entry_disappearing_before_stat(
+    tmp_path, monkeypatch
+):
+    publisher = _make_publisher(tmp_path, retain_days=-1.0)
+    disappeared = publisher.events_dir / "disappeared.ndjson"
+    _write_retention_file(disappeared, size=10, mtime_ms=1)
+    original_scandir = monitor_publisher_module.os.scandir
+    original_unlink = Path.unlink
+    entries_visited = []
+
+    class DisappearedEntry:
+        def __init__(self, entry):
+            self._entry = entry
+
+        def __getattr__(self, name):
+            return getattr(self._entry, name)
+
+        def stat(self, *_args, **_kwargs):
+            original_unlink(disappeared)
+            raise FileNotFoundError(disappeared)
+
+    class WrappedScandir:
+        def __init__(self, iterator):
+            self._iterator = iterator
+
+        def __enter__(self):
+            self._iterator.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self._iterator.__exit__(*args)
+
+        def __iter__(self):
+            for entry in self._iterator:
+                if Path(entry.path) == disappeared:
+                    yield DisappearedEntry(entry)
+                else:
+                    yield entry
+
+    def wrapped_scandir(path):
+        return WrappedScandir(original_scandir(path))
+
+    monkeypatch.setattr(monitor_publisher_module.os, "scandir", wrapped_scandir)
+    total_bytes, candidates = publisher._retention_inventory(
+        on_entry=lambda: entries_visited.append(None)
+    )
+
+    assert not disappeared.exists()
+    assert total_bytes >= 0
+    assert all(path != disappeared for path, _size, _mtime in candidates)
+    assert len(entries_visited) > 0
+
+
+def test_monitor_retention_inventory_tolerates_directory_disappearing_before_scan(
+    tmp_path, monkeypatch
+):
+    publisher = _make_publisher(tmp_path, retain_days=-1.0)
+    vanished_dir = publisher.root / "unknown" / "vanished"
+    nested = vanished_dir / "nested.bin"
+    _write_retention_file(nested, size=10, mtime_ms=1)
+    original_scandir = monitor_publisher_module.os.scandir
+    vanished_scan_attempts = []
+
+    def disappearing_scandir(path):
+        if Path(path) == vanished_dir:
+            vanished_scan_attempts.append(None)
+            if nested.exists():
+                nested.unlink()
+                vanished_dir.rmdir()
+            raise FileNotFoundError(vanished_dir)
+        return original_scandir(path)
+
+    monkeypatch.setattr(monitor_publisher_module.os, "scandir", disappearing_scandir)
+    total_bytes, candidates = publisher._retention_inventory()
+
+    assert not vanished_dir.exists()
+    assert len(vanished_scan_attempts) == 2
+    assert total_bytes >= 0
+    assert all(path != nested for path, _size, _mtime in candidates)
+
+
+def test_monitor_retention_inventory_retries_one_transient_directory_scan_error(
+    tmp_path, monkeypatch
+):
+    publisher = _make_publisher(tmp_path, retain_days=-1.0)
+    candidate = publisher.events_dir / "candidate.ndjson"
+    nested_unknown = publisher.root / "unknown" / "nested" / "keep.bin"
+    _write_retention_file(candidate, size=11, mtime_ms=1)
+    _write_retention_file(nested_unknown, size=13, mtime_ms=2)
+    original_scandir = monitor_publisher_module.os.scandir
+    root_scan_attempts = []
+
+    def transient_scandir(path):
+        if Path(path) == publisher.root:
+            root_scan_attempts.append(None)
+            if len(root_scan_attempts) == 1:
+                raise OSError("transient scan failure")
+        return original_scandir(path)
+
+    monkeypatch.setattr(monitor_publisher_module.os, "scandir", transient_scandir)
+    total_bytes, candidates = publisher._retention_inventory()
+
+    assert len(root_scan_attempts) == 2
+    assert total_bytes >= candidate.stat().st_size + nested_unknown.stat().st_size
+    assert [path for path, _size, _mtime in candidates] == [candidate]
 
 
 def test_monitor_retention_age_disappearance_updates_total_before_cap(tmp_path, monkeypatch):
@@ -1069,6 +1178,53 @@ def test_monitor_retention_counts_and_unlinks_direct_file_symlink_only(tmp_path)
     assert (outside_dir / "nested.bin").exists()
 
 
+def test_monitor_retention_scandir_inventory_matches_pathlib_semantics(tmp_path):
+    publisher = _make_publisher(tmp_path, retain_days=-1.0)
+    direct_events = publisher.events_dir / "events.ndjson"
+    direct_history = publisher.history_dir / "history.ndjson"
+    nested_unknown = publisher.root / "unknown" / "nested" / "keep.bin"
+    _write_retention_file(direct_events, size=11, mtime_ms=10)
+    _write_retention_file(direct_history, size=13, mtime_ms=10)
+    _write_retention_file(nested_unknown, size=17, mtime_ms=10)
+    outside_file = tmp_path / "outside.bin"
+    outside_file.write_bytes(b"outside")
+    file_link = publisher.checkpoints_dir / "linked.bin"
+    file_link.symlink_to(outside_file)
+    outside_dir = tmp_path / "outside-dir"
+    outside_dir.mkdir()
+    (outside_dir / "not-managed.bin").write_bytes(b"outside-dir")
+    (publisher.root / "linked-dir").symlink_to(outside_dir, target_is_directory=True)
+    protected = {
+        publisher.manifest_path,
+        publisher.state_latest_path,
+        publisher.current_events_path,
+        *publisher._current_history_paths.values(),
+    }
+    candidate_dirs = {
+        publisher.events_dir,
+        publisher.history_dir,
+        publisher.checkpoints_dir,
+    }
+    expected_total = 0
+    expected_candidates = []
+    for path in publisher.root.rglob("*"):
+        try:
+            file_stat = path.stat()
+        except FileNotFoundError:
+            continue
+        if not stat.S_ISREG(file_stat.st_mode):
+            continue
+        expected_total += file_stat.st_size
+        if path.parent in candidate_dirs and path not in protected:
+            expected_candidates.append((path, file_stat.st_size, file_stat.st_mtime))
+    expected_candidates.sort(key=lambda candidate: candidate[2])
+
+    total_bytes, candidates = publisher._retention_inventory()
+
+    assert total_bytes == expected_total
+    assert candidates == expected_candidates
+
+
 def test_monitor_retention_byte_cap_deletes_surviving_candidates_oldest_first(tmp_path, monkeypatch):
     publisher = _make_publisher(tmp_path, retain_days=-1.0)
     oldest = publisher.history_dir / "oldest.ndjson"
@@ -1098,35 +1254,53 @@ def test_monitor_retention_uses_one_recursive_traversal_when_over_byte_cap(tmp_p
     _write_retention_file(candidate, size=10, mtime_ms=1)
     total_bytes = sum(path.stat().st_size for path in publisher.root.rglob("*") if path.is_file())
     publisher.max_total_bytes = total_bytes - candidate.stat().st_size
-    original_rglob = Path.rglob
-    original_iterdir = Path.iterdir
-    original_stat = Path.stat
-    traversals = []
-    candidate_directory_listings = []
-    regular_files = {path for path in publisher.root.rglob("*") if path.is_file()}
-    regular_file_stats = {path: 0 for path in regular_files}
+    visited_paths = set(publisher.root.rglob("*"))
+    expected_directories = {
+        publisher.root,
+        *(path for path in visited_paths if path.is_dir() and not path.is_symlink()),
+    }
+    original_scandir = monitor_publisher_module.os.scandir
+    scanned_directories = []
+    entry_stat_counts = {path: 0 for path in visited_paths}
 
-    def count_root_rglob(path, pattern):
-        if path == publisher.root and pattern == "*":
-            traversals.append(path)
-        return original_rglob(path, pattern)
+    class CountingEntry:
+        def __init__(self, entry):
+            self._entry = entry
 
-    def count_candidate_directory_listing(path):
-        if path in {publisher.events_dir, publisher.history_dir, publisher.checkpoints_dir}:
-            candidate_directory_listings.append(path)
-        return original_iterdir(path)
+        def __getattr__(self, name):
+            return getattr(self._entry, name)
 
-    def count_regular_file_stat(path, *args, **kwargs):
-        if path in regular_file_stats:
-            regular_file_stats[path] += 1
-        return original_stat(path, *args, **kwargs)
+        def stat(self, *args, **kwargs):
+            entry_stat_counts[Path(self._entry.path)] += 1
+            return self._entry.stat(*args, **kwargs)
 
-    monkeypatch.setattr(Path, "rglob", count_root_rglob)
-    monkeypatch.setattr(Path, "iterdir", count_candidate_directory_listing)
-    monkeypatch.setattr(Path, "stat", count_regular_file_stat)
+    class CountingScandir:
+        def __init__(self, iterator):
+            self._iterator = iterator
+
+        def __enter__(self):
+            self._iterator.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self._iterator.__exit__(*args)
+
+        def __iter__(self):
+            return (CountingEntry(entry) for entry in self._iterator)
+
+    def count_scandir(path):
+        scanned_directories.append(Path(path))
+        return CountingScandir(original_scandir(path))
+
+    def fail_legacy_traversal(*_args, **_kwargs):
+        raise AssertionError("legacy Path traversal used")
+
+    monkeypatch.setattr(monitor_publisher_module.os, "scandir", count_scandir)
+    monkeypatch.setattr(Path, "rglob", fail_legacy_traversal)
+    monkeypatch.setattr(Path, "iterdir", fail_legacy_traversal)
     publisher._prune_retention(now_ms=100_000)
 
-    assert traversals == [publisher.root]
-    assert candidate_directory_listings == []
-    assert set(regular_file_stats.values()) == {1}
+    assert set(scanned_directories) == expected_directories
+    assert len(scanned_directories) == len(expected_directories)
+    assert set(entry_stat_counts.values()) == {1}
     assert not candidate.exists()


### PR DESCRIPTION
## Summary
- replace the healthy-path `Path.rglob` inventory with one direct `os.scandir` traversal
- keep one explicit `DirEntry.stat` per visited entry and one bounded retry for transient directory-open errors
- preserve retention cadence, complete accounting, symlink behavior, candidate ordering, protection, and deletion policy

## Evidence
PR #1211 attributed 15369.148ms of 15591.553ms retention time to inventory; its 10241.787ms inventory maximum explained nearly all of the 10253.648ms retention maximum. A read-only two-order VPS5 benchmark preserved entry/file counts while the candidate traversal took 43-112ms per active root versus 94-587ms for the current path.

## Validation
- 40 monitor publisher tests, including static old/new parity, equal-mtime ordering, one traversal/stat per entry, symlinks, nested unknown files, transient retry, persistent disappearance, and age/cap semantics
- integrated event-bus, health, smoke/performance, relay, fake-live, and AI-doc suites
- Python compilation, silent-handling audit, and git diff check
- independent preflight finding fixed and delta re-review green

## Boundary
No caching, staggering, cadence/config change, background worker, telemetry schema change, or trading behavior change.