### PR TITLE
Attribute monitor retention CPU time

### DIFF
--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -59,12 +59,12 @@ Estimated completion:
 
 Next action:
 
-1. Complete the paired thread-CPU/non-CPU implementation and targeted tests.
-2. Pass independent preflight, publish a review-worthy PR, and hold its exact
-   current head until Hermes, Grok 4.5, and CI are green.
-3. Resolve findings narrowly and require fresh exact-head verdicts after every
-   push. Merge only when the complete gate is green, then repeat the exact
-   five-bot VPS restart and bounded runtime-evidence sequence.
+1. Hold PR #1214's exact current head until Hermes, Grok 4.5, and CI are green.
+2. Resolve findings narrowly and require fresh exact-head verdicts after every
+   push.
+3. Merge only when the complete gate is green, then perform the exact five-bot
+   graceful VPS5 restart, immediate and settled smoke, and at least 30 natural
+   due runs comparing paired wall, thread-CPU, and non-CPU evidence.
 
 ## Deployed Baseline
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -1,6 +1,6 @@
 # Live Logging Overhaul Current Status
 
-Updated: 2026-07-12.
+Updated: 2026-07-13.
 
 This is the compact operational source for the active logging-overhaul loop.
 Read it before the historical progress ledger. Update it whenever the active
@@ -22,54 +22,74 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-monitor-retention-loop-timing`
-- Base: `f68f10c4a3754c5603cfd7d97e5bc3e5a861f8cc`, PR #1212
-- Triggering evidence: 59 post-PR #1212 due runs visited 99,393 entries.
-  Inventory normalized per-window per-run p50/p95/max was
-  `766.188/1763.343/2254.624ms`, and inventory maximum fell about 78% from the
-  PR #1211 baseline's `10241.787ms`. The overall retention maximum nevertheless
-  remained `9772.147ms`; its window exposed only `1309.122ms` inventory maximum
-  and millisecond-scale unlink maxima. Existing independently aggregated maxima
-  cannot identify which unmeasured loop contained that run's remaining wall time.
-- Scope: add fixed whole-loop `age_filter` and `cap_prune` total/max timing.
-  `age_filter` contains classification, survivor construction, and nested age
-  unlinks. `cap_prune` contains the cap decision, survivor traversal, and nested
-  cap unlinks, including the under-cap return. Preserve the existing nested
-  unlink timings and project all fields through transactional event-pipeline
-  health windows, smoke reports, and performance reports.
+- Branch: `codex/v8-monitor-retention-cpu-attribution`
+- Base: `157fe0db6e2ec1348d47ff62155ae7a6f2d2b4df`, PR #1213
+- Triggering evidence: four post-PR #1213 health windows contained 54 natural
+  retention runs. Retention total/max was `60803.819/11066.952ms`; inventory
+  total/max was `59485.603/11039.628ms`; and age-filter total/max was only
+  `528.574/44.451ms`. The preceding six-run sample instead contained one
+  `8460ms` age-filter outlier with only `0.107ms` age-unlink work. The long tail
+  therefore moves between phases while VPS5 is CPU-saturated rather than
+  identifying a stable phase algorithm to optimize. The 54-run sample visited
+  90,972 entries, found 90,404 candidates, deleted 10 files by age and none by
+  cap, and retained zero drops, sink errors, degraded counts, final queue depth,
+  or unfinished work.
+- Scope: add paired whole-retention thread-CPU and directly computed non-CPU
+  total/max timing. Each due run captures wall and thread CPU clocks at the same
+  boundaries and computes `max(0, wall - thread_cpu)` for that run before
+  aggregation. Project both fields through transactional event-pipeline health
+  windows, smoke reports, and performance reports. Do not infer non-CPU time by
+  subtracting independently aggregated maxima.
 - Behavior boundary: additive diagnostics only. Preserve retention cadence,
   `last_retention_ms`, lock scope, traversal, accounting, candidate order and
   deletion domain, age/cap policy, error handling, configuration, and every
   order/risk/trading behavior. Do not add caching, staggering, workers,
-  thresholds, verdicts, or derived maximum arithmetic.
-- Validation: due/not-due and under-cap phase boundaries, nested unlink
-  containment, failure/finally retention, event-pipeline aggregation/reset/
-  restore, historical absence behavior, smoke/performance projections,
-  integrated monitor regressions, Python compilation, `git diff --check`,
-  silent-handling audit, and independent preflight.
+  thresholds, verdicts, or phase optimizations.
+- Validation: paired deterministic clock behavior, due/not-due boundaries,
+  failure/finally retention, event-pipeline aggregation/reset/restore,
+  historical absence behavior, smoke/performance projections, integrated
+  monitor regressions, Python compilation, `git diff --check`, silent-handling
+  audit, and independent preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: exact five-bot graceful restart, immediate and settled
-  smoke, then at least 30 naturally emitted due runs comparing whole-loop
-  age/cap attribution with retention and process I/O-wait evidence.
+  smoke, then at least 30 naturally emitted due runs comparing paired retention
+  wall, thread-CPU, and directly computed non-CPU evidence. Select no retention
+  phase optimization unless the paired evidence supports it.
 
 Next action:
 
-1. Hold PR #1213's exact current head until Hermes, Grok 4.5, and CI are green.
-2. Resolve findings narrowly and require fresh exact-head verdicts after every
-   push.
-3. Merge, perform the exact five-bot graceful VPS restart, run immediate and
-   settled smoke, then collect at least 30 natural due runs. Select no further
-   persistence change unless correlated phase and process evidence justifies it.
+1. Complete the paired thread-CPU/non-CPU implementation and targeted tests.
+2. Pass independent preflight, publish a review-worthy PR, and hold its exact
+   current head until Hermes, Grok 4.5, and CI are green.
+3. Resolve findings narrowly and require fresh exact-head verdicts after every
+   push. Merge only when the complete gate is green, then repeat the exact
+   five-bot VPS restart and bounded runtime-evidence sequence.
 
 ## Deployed Baseline
 
-- Remote `v8`: `f68f10c4a3754c5603cfd7d97e5bc3e5a861f8cc`, PR #1212
-- VPS5 repository: `f68f10c4a3754c5603cfd7d97e5bc3e5a861f8cc`, PR #1212; tracked
+- Remote `v8`: `157fe0db6e2ec1348d47ff62155ae7a6f2d2b4df`, PR #1213
+- VPS5 repository: `157fe0db6e2ec1348d47ff62155ae7a6f2d2b4df`, PR #1213; tracked
   status clean; expected untracked artifacts were preserved
-- VPS5 expected bots: five; running with PR #1212 restart PIDs
-  `894485/894487/894489/894491/894493`;
+- VPS5 expected bots: five; running with PR #1213 restart PIDs
+  `899640/899643/899647/899648/899650`;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1213 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
+  panes; every old bot exited naturally, including KuCoin after about 132
+  seconds, with no force kill. Pane PIDs and unrelated `misc:0.0` PID `434835`
+  were preserved. A real KuCoin timeout correctly made one settled smoke red;
+  after it aged out, the final two-minute smoke was hard-green with `403/403`
+  remote and `67/67` account-critical calls, all five expected processes, zero
+  hard/log/monitor failures, no active HSL replay, and a clean tracked
+  repository. A later quiet check found all five bots `R` at the deployed head.
+- Four fresh health windows contained 54 natural retention runs with
+  `60803.819ms` total and an `11066.952ms` maximum. Inventory accounted for
+  `59485.603ms` total and an `11039.628ms` maximum, while age-filter total/max
+  was `528.574/44.451ms`. Combined with the earlier isolated age-filter outlier,
+  this proves the wall-time tail moves between phases under VPS5 contention;
+  it does not justify another phase optimization. Drops, sink errors, degraded
+  counts, final queue depth, and unfinished work remained zero.
 - PR #1212 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
   panes; every old bot exited naturally, and pane PIDs plus unrelated
@@ -421,14 +441,16 @@ PR #1207's position console projection and PR #1208's one-pass monitor
 retention inventory are also merged and deployed with their behavior boundaries
 preserved. PR #1210's balance console transition is merged, deployed, and
 validated from natural balance changes on all five bots. PR #1211's retention
-phase attribution and PR #1212's direct `os.scandir` inventory are merged and
-deployed. PR #1212 reduced inventory maximum about 78%, while a remaining
-overall retention maximum lacked whole-loop age/cap attribution.
+phase attribution, PR #1212's direct `os.scandir` inventory, and PR #1213's
+whole-loop age/cap attribution are merged and deployed. The long retention
+wall-time tail moves between phases under VPS5 contention and does not justify
+another phase optimization.
 
-The active slice adds only whole-loop `age_filter` and `cap_prune` timing while
-preserving nested unlink timing and all retention behavior. Keep fill formatting
-separate: its legacy and event-routed lines currently overlap and require an
-explicit migration contract for timestamps, pending PnL, and bulk summaries.
+The active slice adds paired whole-retention thread-CPU and directly computed
+non-CPU timing for every due run while preserving all retention behavior. Keep
+fill formatting separate: its legacy and event-routed lines currently overlap
+and require an explicit migration contract for timestamps, pending PnL, and
+bulk summaries.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -67,6 +67,10 @@ _MONITOR_PUBLISHER_PHASE_TIMING_KEYS = (
     "retention_run_count",
     "retention_ns_total",
     "retention_ns_max",
+    "retention_thread_cpu_ns_total",
+    "retention_thread_cpu_ns_max",
+    "retention_non_cpu_ns_total",
+    "retention_non_cpu_ns_max",
     "retention_inventory_ns_total",
     "retention_inventory_ns_max",
     "retention_age_filter_ns_total",
@@ -1945,6 +1949,10 @@ class _EventPipelineTimingWindow:
     monitor_publisher_retention_run_count: int
     monitor_publisher_retention_ns_total: int
     monitor_publisher_retention_ns_max: int
+    monitor_publisher_retention_thread_cpu_ns_total: int
+    monitor_publisher_retention_thread_cpu_ns_max: int
+    monitor_publisher_retention_non_cpu_ns_total: int
+    monitor_publisher_retention_non_cpu_ns_max: int
     monitor_publisher_retention_inventory_ns_total: int
     monitor_publisher_retention_inventory_ns_max: int
     monitor_publisher_retention_age_filter_ns_total: int
@@ -1985,6 +1993,10 @@ class _EventPipelineSinkWriteTiming:
     monitor_publisher_retention_run_count: int = 0
     monitor_publisher_retention_ns_total: int = 0
     monitor_publisher_retention_ns_max: int = 0
+    monitor_publisher_retention_thread_cpu_ns_total: int = 0
+    monitor_publisher_retention_thread_cpu_ns_max: int = 0
+    monitor_publisher_retention_non_cpu_ns_total: int = 0
+    monitor_publisher_retention_non_cpu_ns_max: int = 0
     monitor_publisher_retention_inventory_ns_total: int = 0
     monitor_publisher_retention_inventory_ns_max: int = 0
     monitor_publisher_retention_age_filter_ns_total: int = 0
@@ -2051,6 +2063,14 @@ class _EventPipelineSinkWriteTiming:
         for source_key, field_prefix in (
             ("manifest_checkpoint_ns", "monitor_publisher_manifest_checkpoint_ns"),
             ("retention_ns", "monitor_publisher_retention_ns"),
+            (
+                "retention_thread_cpu_ns",
+                "monitor_publisher_retention_thread_cpu_ns",
+            ),
+            (
+                "retention_non_cpu_ns",
+                "monitor_publisher_retention_non_cpu_ns",
+            ),
             ("retention_inventory_ns", "monitor_publisher_retention_inventory_ns"),
             ("retention_age_filter_ns", "monitor_publisher_retention_age_filter_ns"),
             ("retention_cap_prune_ns", "monitor_publisher_retention_cap_prune_ns"),
@@ -2126,6 +2146,10 @@ class LiveEventPipeline:
         self._timing_monitor_publisher_retention_run_count = 0
         self._timing_monitor_publisher_retention_ns_total = 0
         self._timing_monitor_publisher_retention_ns_max = 0
+        self._timing_monitor_publisher_retention_thread_cpu_ns_total = 0
+        self._timing_monitor_publisher_retention_thread_cpu_ns_max = 0
+        self._timing_monitor_publisher_retention_non_cpu_ns_total = 0
+        self._timing_monitor_publisher_retention_non_cpu_ns_max = 0
         self._timing_monitor_publisher_retention_inventory_ns_total = 0
         self._timing_monitor_publisher_retention_inventory_ns_max = 0
         self._timing_monitor_publisher_retention_age_filter_ns_total = 0
@@ -2265,6 +2289,18 @@ class LiveEventPipeline:
                 monitor_publisher_retention_ns_max=int(
                     self._timing_monitor_publisher_retention_ns_max
                 ),
+                monitor_publisher_retention_thread_cpu_ns_total=int(
+                    self._timing_monitor_publisher_retention_thread_cpu_ns_total
+                ),
+                monitor_publisher_retention_thread_cpu_ns_max=int(
+                    self._timing_monitor_publisher_retention_thread_cpu_ns_max
+                ),
+                monitor_publisher_retention_non_cpu_ns_total=int(
+                    self._timing_monitor_publisher_retention_non_cpu_ns_total
+                ),
+                monitor_publisher_retention_non_cpu_ns_max=int(
+                    self._timing_monitor_publisher_retention_non_cpu_ns_max
+                ),
                 monitor_publisher_retention_inventory_ns_total=int(
                     self._timing_monitor_publisher_retention_inventory_ns_total
                 ),
@@ -2341,6 +2377,10 @@ class LiveEventPipeline:
                 self._timing_monitor_publisher_retention_run_count = 0
                 self._timing_monitor_publisher_retention_ns_total = 0
                 self._timing_monitor_publisher_retention_ns_max = 0
+                self._timing_monitor_publisher_retention_thread_cpu_ns_total = 0
+                self._timing_monitor_publisher_retention_thread_cpu_ns_max = 0
+                self._timing_monitor_publisher_retention_non_cpu_ns_total = 0
+                self._timing_monitor_publisher_retention_non_cpu_ns_max = 0
                 self._timing_monitor_publisher_retention_inventory_ns_total = 0
                 self._timing_monitor_publisher_retention_inventory_ns_max = 0
                 self._timing_monitor_publisher_retention_age_filter_ns_total = 0
@@ -2444,6 +2484,18 @@ class LiveEventPipeline:
             "event_monitor_publisher_retention_ms_max": self._timing_ms(
                 timing_window.monitor_publisher_retention_ns_max
             ),
+            "event_monitor_publisher_retention_thread_cpu_ms_total": self._timing_ms(
+                timing_window.monitor_publisher_retention_thread_cpu_ns_total
+            ),
+            "event_monitor_publisher_retention_thread_cpu_ms_max": self._timing_ms(
+                timing_window.monitor_publisher_retention_thread_cpu_ns_max
+            ),
+            "event_monitor_publisher_retention_non_cpu_ms_total": self._timing_ms(
+                timing_window.monitor_publisher_retention_non_cpu_ns_total
+            ),
+            "event_monitor_publisher_retention_non_cpu_ms_max": self._timing_ms(
+                timing_window.monitor_publisher_retention_non_cpu_ns_max
+            ),
             "event_monitor_publisher_retention_inventory_ms_total": self._timing_ms(
                 timing_window.monitor_publisher_retention_inventory_ns_total
             ),
@@ -2545,6 +2597,8 @@ class LiveEventPipeline:
             "monitor_publisher_manifest_checkpoint_ns_total",
             "monitor_publisher_retention_run_count",
             "monitor_publisher_retention_ns_total",
+            "monitor_publisher_retention_thread_cpu_ns_total",
+            "monitor_publisher_retention_non_cpu_ns_total",
             "monitor_publisher_retention_inventory_ns_total",
             "monitor_publisher_retention_age_filter_ns_total",
             "monitor_publisher_retention_cap_prune_ns_total",
@@ -2569,6 +2623,8 @@ class LiveEventPipeline:
             "monitor_publisher_maintenance_ns_max",
             "monitor_publisher_manifest_checkpoint_ns_max",
             "monitor_publisher_retention_ns_max",
+            "monitor_publisher_retention_thread_cpu_ns_max",
+            "monitor_publisher_retention_non_cpu_ns_max",
             "monitor_publisher_retention_inventory_ns_max",
             "monitor_publisher_retention_age_filter_ns_max",
             "monitor_publisher_retention_cap_prune_ns_max",
@@ -2813,6 +2869,8 @@ class LiveEventPipeline:
                             sink_write_timing.monitor_publisher_retention_ns_max,
                         )
                         for field_name in (
+                            "monitor_publisher_retention_thread_cpu_ns_total",
+                            "monitor_publisher_retention_non_cpu_ns_total",
                             "monitor_publisher_retention_inventory_ns_total",
                             "monitor_publisher_retention_age_filter_ns_total",
                             "monitor_publisher_retention_cap_prune_ns_total",
@@ -2831,6 +2889,8 @@ class LiveEventPipeline:
                                 + int(getattr(sink_write_timing, field_name)),
                             )
                         for field_name in (
+                            "monitor_publisher_retention_thread_cpu_ns_max",
+                            "monitor_publisher_retention_non_cpu_ns_max",
                             "monitor_publisher_retention_inventory_ns_max",
                             "monitor_publisher_retention_age_filter_ns_max",
                             "monitor_publisher_retention_cap_prune_ns_max",

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -127,6 +127,10 @@ _RESOURCE_PRESSURE_FIELDS = (
     "event_monitor_publisher_retention_run_count",
     "event_monitor_publisher_retention_ms_total",
     "event_monitor_publisher_retention_ms_max",
+    "event_monitor_publisher_retention_thread_cpu_ms_total",
+    "event_monitor_publisher_retention_thread_cpu_ms_max",
+    "event_monitor_publisher_retention_non_cpu_ms_total",
+    "event_monitor_publisher_retention_non_cpu_ms_max",
     "event_monitor_publisher_retention_inventory_ms_total",
     "event_monitor_publisher_retention_inventory_ms_max",
     "event_monitor_publisher_retention_age_filter_ms_total",
@@ -4094,6 +4098,18 @@ class _ResourcePressureAccumulator:
             ),
             "latest_event_monitor_publisher_retention_ms_max": latest_field_max(
                 "event_monitor_publisher_retention_ms_max"
+            ),
+            "latest_event_monitor_publisher_retention_thread_cpu_ms_total_sum": latest_field_sum(
+                "event_monitor_publisher_retention_thread_cpu_ms_total"
+            ),
+            "latest_event_monitor_publisher_retention_thread_cpu_ms_max": latest_field_max(
+                "event_monitor_publisher_retention_thread_cpu_ms_max"
+            ),
+            "latest_event_monitor_publisher_retention_non_cpu_ms_total_sum": latest_field_sum(
+                "event_monitor_publisher_retention_non_cpu_ms_total"
+            ),
+            "latest_event_monitor_publisher_retention_non_cpu_ms_max": latest_field_max(
+                "event_monitor_publisher_retention_non_cpu_ms_max"
             ),
             "latest_event_monitor_publisher_retention_inventory_ms_total_sum": latest_field_sum(
                 "event_monitor_publisher_retention_inventory_ms_total"

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -2828,6 +2828,10 @@ def _event_pipeline_health_group(
         "event_monitor_publisher_retention_run_count",
         "event_monitor_publisher_retention_ms_total",
         "event_monitor_publisher_retention_ms_max",
+        "event_monitor_publisher_retention_thread_cpu_ms_total",
+        "event_monitor_publisher_retention_thread_cpu_ms_max",
+        "event_monitor_publisher_retention_non_cpu_ms_total",
+        "event_monitor_publisher_retention_non_cpu_ms_max",
         "event_monitor_publisher_retention_inventory_ms_total",
         "event_monitor_publisher_retention_inventory_ms_max",
         "event_monitor_publisher_retention_age_filter_ms_total",
@@ -2950,6 +2954,18 @@ def _event_pipeline_health_group(
         ),
         "latest_monitor_publisher_retention_ms_max": _non_negative_number(
             payload.get("event_monitor_publisher_retention_ms_max")
+        ),
+        "latest_monitor_publisher_retention_thread_cpu_ms_total": _non_negative_number(
+            payload.get("event_monitor_publisher_retention_thread_cpu_ms_total")
+        ),
+        "latest_monitor_publisher_retention_thread_cpu_ms_max": _non_negative_number(
+            payload.get("event_monitor_publisher_retention_thread_cpu_ms_max")
+        ),
+        "latest_monitor_publisher_retention_non_cpu_ms_total": _non_negative_number(
+            payload.get("event_monitor_publisher_retention_non_cpu_ms_total")
+        ),
+        "latest_monitor_publisher_retention_non_cpu_ms_max": _non_negative_number(
+            payload.get("event_monitor_publisher_retention_non_cpu_ms_max")
         ),
         "latest_monitor_publisher_retention_inventory_ms_total": _non_negative_number(
             payload.get("event_monitor_publisher_retention_inventory_ms_total")
@@ -3075,6 +3091,10 @@ def _merge_event_pipeline_health_group(
             "latest_monitor_publisher_retention_run_count",
             "latest_monitor_publisher_retention_ms_total",
             "latest_monitor_publisher_retention_ms_max",
+            "latest_monitor_publisher_retention_thread_cpu_ms_total",
+            "latest_monitor_publisher_retention_thread_cpu_ms_max",
+            "latest_monitor_publisher_retention_non_cpu_ms_total",
+            "latest_monitor_publisher_retention_non_cpu_ms_max",
             "latest_monitor_publisher_retention_inventory_ms_total",
             "latest_monitor_publisher_retention_inventory_ms_max",
             "latest_monitor_publisher_retention_age_filter_ms_total",
@@ -3254,6 +3274,22 @@ def _summarize_event_pipeline_health(
         ),
         "latest_monitor_publisher_retention_ms_max": _max_optional_numbers(
             group.get("latest_monitor_publisher_retention_ms_max")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_thread_cpu_ms_total_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_retention_thread_cpu_ms_total")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_thread_cpu_ms_max": _max_optional_numbers(
+            group.get("latest_monitor_publisher_retention_thread_cpu_ms_max")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_non_cpu_ms_total_sum": _sum_optional_numbers(
+            group.get("latest_monitor_publisher_retention_non_cpu_ms_total")
+            for group in groups.values()
+        ),
+        "latest_monitor_publisher_retention_non_cpu_ms_max": _max_optional_numbers(
+            group.get("latest_monitor_publisher_retention_non_cpu_ms_max")
             for group in groups.values()
         ),
         "latest_monitor_publisher_retention_inventory_ms_total_sum": _sum_optional_numbers(
@@ -7347,6 +7383,18 @@ def _summary_limited_groups(
             "latest_monitor_publisher_retention_ms_max": summary.get(
                 "latest_monitor_publisher_retention_ms_max"
             ),
+            "latest_monitor_publisher_retention_thread_cpu_ms_total_sum": summary.get(
+                "latest_monitor_publisher_retention_thread_cpu_ms_total_sum"
+            ),
+            "latest_monitor_publisher_retention_thread_cpu_ms_max": summary.get(
+                "latest_monitor_publisher_retention_thread_cpu_ms_max"
+            ),
+            "latest_monitor_publisher_retention_non_cpu_ms_total_sum": summary.get(
+                "latest_monitor_publisher_retention_non_cpu_ms_total_sum"
+            ),
+            "latest_monitor_publisher_retention_non_cpu_ms_max": summary.get(
+                "latest_monitor_publisher_retention_non_cpu_ms_max"
+            ),
             "latest_monitor_publisher_retention_inventory_ms_total_sum": summary.get(
                 "latest_monitor_publisher_retention_inventory_ms_total_sum"
             ),
@@ -8878,6 +8926,18 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
                 ),
                 "latest_monitor_publisher_retention_ms_max": event_pipeline_health.get(
                     "latest_monitor_publisher_retention_ms_max"
+                ),
+                "latest_monitor_publisher_retention_thread_cpu_ms_total_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_thread_cpu_ms_total_sum"
+                ),
+                "latest_monitor_publisher_retention_thread_cpu_ms_max": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_thread_cpu_ms_max"
+                ),
+                "latest_monitor_publisher_retention_non_cpu_ms_total_sum": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_non_cpu_ms_total_sum"
+                ),
+                "latest_monitor_publisher_retention_non_cpu_ms_max": event_pipeline_health.get(
+                    "latest_monitor_publisher_retention_non_cpu_ms_max"
                 ),
                 "latest_monitor_publisher_retention_inventory_ms_total_sum": event_pipeline_health.get(
                     "latest_monitor_publisher_retention_inventory_ms_total_sum"

--- a/src/monitor_publisher.py
+++ b/src/monitor_publisher.py
@@ -27,6 +27,10 @@ _MONITOR_EVENT_PHASE_TIMING_KEYS = (
     "retention_run_count",
     "retention_ns_total",
     "retention_ns_max",
+    "retention_thread_cpu_ns_total",
+    "retention_thread_cpu_ns_max",
+    "retention_non_cpu_ns_total",
+    "retention_non_cpu_ns_max",
     "retention_inventory_ns_total",
     "retention_inventory_ns_max",
     "retention_age_filter_ns_total",
@@ -42,6 +46,9 @@ _MONITOR_EVENT_PHASE_TIMING_KEYS = (
     "retention_age_deleted",
     "retention_cap_deleted",
 )
+_RETENTION_TIMING_KEYS = tuple(
+    key for key in _MONITOR_EVENT_PHASE_TIMING_KEYS if key.startswith("retention_")
+)
 _CURRENT_EVENTS_REVERSE_READ_BYTES = 64 * 1024
 _EVENT_RECOVERY_CHECKSUM_BYTES = 16
 _EVENT_RECOVERY_MARKER = b',"_recovery":{"checksum":"'
@@ -51,6 +58,15 @@ _EVENT_RECOVERY_TRAILER_MAX_BYTES = 160
 
 def _empty_monitor_event_phase_timing() -> dict[str, int]:
     return {key: 0 for key in _MONITOR_EVENT_PHASE_TIMING_KEYS}
+
+
+def _merge_retention_timing(target: dict[str, int], source: dict[str, int]) -> None:
+    for key in _RETENTION_TIMING_KEYS:
+        value = max(0, int(source.get(key, 0)))
+        if key.endswith("_max"):
+            target[key] = max(int(target.get(key, 0)), value)
+        else:
+            target[key] = int(target.get(key, 0)) + value
 
 
 def _json_default(value: Any) -> Any:
@@ -160,6 +176,10 @@ class MonitorPublisher:
         self._disk_full_last_log_ms = 0
         self._disk_full_suppressed = 0
         self._lock = threading.RLock()
+        self._pending_retention_timing = {
+            key: 0 for key in _RETENTION_TIMING_KEYS
+        }
+        self._thread_cpu_clock_warning_logged = False
         self.seq = 0
         self._manifest_dirty = False
         self._manifest_retry_needed = False
@@ -534,6 +554,94 @@ class MonitorPublisher:
             self.last_retention_ms and now_ms - self.last_retention_ms < 60_000
         )
 
+    def _thread_cpu_time_ns(self) -> int | None:
+        try:
+            return time.thread_time_ns()
+        except Exception as exc:
+            # CPU attribution is diagnostic-only and must not block persistence.
+            if not self._thread_cpu_clock_warning_logged:
+                logging.warning(
+                    "[monitor] thread CPU clock unavailable; retention CPU attribution disabled: %s",
+                    exc,
+                )
+                self._thread_cpu_clock_warning_logged = True
+            return None
+
+    def _record_pending_retention_timing(self, now_ms: Optional[int]) -> None:
+        timing = {key: 0 for key in _RETENTION_TIMING_KEYS}
+        retention_started_ns: int | None = None
+        retention_thread_cpu_started_ns: int | None = None
+
+        def on_run() -> None:
+            nonlocal retention_started_ns, retention_thread_cpu_started_ns
+            retention_started_ns = time.monotonic_ns()
+            retention_thread_cpu_started_ns = self._thread_cpu_time_ns()
+            timing["retention_run_count"] += 1
+
+        def on_phase(phase: str, duration_ns: int) -> None:
+            total_key = f"retention_{phase}_ns_total"
+            max_key = f"retention_{phase}_ns_max"
+            duration_ns = max(0, int(duration_ns))
+            timing[total_key] += duration_ns
+            timing[max_key] = max(timing[max_key], duration_ns)
+
+        def on_counter(counter: str) -> None:
+            timing[f"retention_{counter}"] += 1
+
+        try:
+            self._prune_retention(
+                now_ms=now_ms,
+                on_run=on_run,
+                on_phase=on_phase,
+                on_counter=on_counter,
+            )
+        finally:
+            if retention_started_ns is not None:
+                retention_thread_cpu_finished_ns = (
+                    self._thread_cpu_time_ns()
+                    if retention_thread_cpu_started_ns is not None
+                    else None
+                )
+                retention_ns = max(
+                    0, time.monotonic_ns() - retention_started_ns
+                )
+                timing["retention_ns_total"] += retention_ns
+                timing["retention_ns_max"] = max(
+                    timing["retention_ns_max"], retention_ns
+                )
+                if retention_thread_cpu_finished_ns is not None:
+                    retention_thread_cpu_ns = max(
+                        0,
+                        retention_thread_cpu_finished_ns
+                        - int(retention_thread_cpu_started_ns),
+                    )
+                    retention_non_cpu_ns = max(
+                        0, retention_ns - retention_thread_cpu_ns
+                    )
+                    timing["retention_thread_cpu_ns_total"] += (
+                        retention_thread_cpu_ns
+                    )
+                    timing["retention_thread_cpu_ns_max"] = max(
+                        timing["retention_thread_cpu_ns_max"],
+                        retention_thread_cpu_ns,
+                    )
+                    timing["retention_non_cpu_ns_total"] += retention_non_cpu_ns
+                    timing["retention_non_cpu_ns_max"] = max(
+                        timing["retention_non_cpu_ns_max"],
+                        retention_non_cpu_ns,
+                    )
+                with self._lock:
+                    _merge_retention_timing(self._pending_retention_timing, timing)
+
+    def _consume_pending_retention_timing(
+        self, timing: dict[str, int]
+    ) -> None:
+        with self._lock:
+            _merge_retention_timing(timing, self._pending_retention_timing)
+            self._pending_retention_timing = {
+                key: 0 for key in _RETENTION_TIMING_KEYS
+            }
+
     def _prune_retention(
         self,
         now_ms: Optional[int] = None,
@@ -542,6 +650,9 @@ class MonitorPublisher:
         on_phase: Optional[Callable[[str, int], None]] = None,
         on_counter: Optional[Callable[[str], None]] = None,
     ) -> None:
+        if on_run is None and on_phase is None and on_counter is None:
+            self._record_pending_retention_timing(now_ms)
+            return
         with self._lock:
             now_ms = self._now_ms() if now_ms is None else int(now_ms)
             if not self._retention_due(now_ms):
@@ -888,6 +999,7 @@ class MonitorPublisher:
             ts=ts,
             symbol=symbol,
             pside=pside,
+            consume_pending_retention_timing=False,
         )
         return result
 
@@ -900,6 +1012,7 @@ class MonitorPublisher:
         ts: Optional[int] = None,
         symbol: Optional[str] = None,
         pside: Optional[str] = None,
+        consume_pending_retention_timing: bool = True,
     ) -> tuple[Optional[dict], dict[str, int]]:
         timing = _empty_monitor_event_phase_timing()
         lock_wait_started_ns = time.monotonic_ns()
@@ -961,10 +1074,12 @@ class MonitorPublisher:
                                 timing["manifest_checkpoint_ns_max"], manifest_checkpoint_ns
                             )
                     retention_started_ns: int | None = None
+                    retention_thread_cpu_started_ns: int | None = None
 
                     def on_retention_run() -> None:
-                        nonlocal retention_started_ns
+                        nonlocal retention_started_ns, retention_thread_cpu_started_ns
                         retention_started_ns = time.monotonic_ns()
+                        retention_thread_cpu_started_ns = self._thread_cpu_time_ns()
                         timing["retention_run_count"] += 1
 
                     def on_retention_phase(phase: str, duration_ns: int) -> None:
@@ -977,20 +1092,52 @@ class MonitorPublisher:
                     def on_retention_counter(counter: str) -> None:
                         timing[f"retention_{counter}"] += 1
 
-                    try:
+                    if consume_pending_retention_timing:
                         self._prune_retention(
                             now_ms=now_ms,
                             on_run=on_retention_run,
                             on_phase=on_retention_phase,
                             on_counter=on_retention_counter,
                         )
-                    finally:
+                    else:
+                        self._prune_retention(now_ms=now_ms)
+                    if consume_pending_retention_timing:
                         if retention_started_ns is not None:
-                            retention_ns = max(0, time.monotonic_ns() - retention_started_ns)
+                            retention_thread_cpu_finished_ns = (
+                                self._thread_cpu_time_ns()
+                                if retention_thread_cpu_started_ns is not None
+                                else None
+                            )
+                            retention_ns = max(
+                                0, time.monotonic_ns() - retention_started_ns
+                            )
                             timing["retention_ns_total"] += retention_ns
                             timing["retention_ns_max"] = max(
                                 timing["retention_ns_max"], retention_ns
                             )
+                            if retention_thread_cpu_finished_ns is not None:
+                                retention_thread_cpu_ns = max(
+                                    0,
+                                    retention_thread_cpu_finished_ns
+                                    - int(retention_thread_cpu_started_ns),
+                                )
+                                retention_non_cpu_ns = max(
+                                    0, retention_ns - retention_thread_cpu_ns
+                                )
+                                timing["retention_thread_cpu_ns_total"] += (
+                                    retention_thread_cpu_ns
+                                )
+                                timing["retention_thread_cpu_ns_max"] = max(
+                                    timing["retention_thread_cpu_ns_max"],
+                                    retention_thread_cpu_ns,
+                                )
+                                timing["retention_non_cpu_ns_total"] += (
+                                    retention_non_cpu_ns
+                                )
+                                timing["retention_non_cpu_ns_max"] = max(
+                                    timing["retention_non_cpu_ns_max"],
+                                    retention_non_cpu_ns,
+                                )
                 finally:
                     timing["maintenance_ns"] = max(
                         0, time.monotonic_ns() - maintenance_started_ns
@@ -999,6 +1146,9 @@ class MonitorPublisher:
             except Exception as exc:
                 self._log_write_failure(f"recording event {kind}", exc)
                 return None, timing
+            finally:
+                if consume_pending_retention_timing:
+                    self._consume_pending_retention_timing(timing)
 
     def record_error(
         self,

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -609,6 +609,10 @@ def test_pipeline_aggregates_and_resets_monitor_publisher_phase_timing(monkeypat
                         "retention_run_count": 1,
                         "retention_ns_total": 4_000_000,
                         "retention_ns_max": 4_000_000,
+                        "retention_thread_cpu_ns_total": 1_500_000,
+                        "retention_thread_cpu_ns_max": 1_500_000,
+                        "retention_non_cpu_ns_total": 2_500_000,
+                        "retention_non_cpu_ns_max": 2_500_000,
                         "retention_inventory_ns_total": 3_000_000,
                         "retention_inventory_ns_max": 3_000_000,
                         "retention_age_filter_ns_total": 1_800_000,
@@ -635,6 +639,10 @@ def test_pipeline_aggregates_and_resets_monitor_publisher_phase_timing(monkeypat
                         "retention_run_count": 0,
                         "retention_ns_total": 0,
                         "retention_ns_max": 0,
+                        "retention_thread_cpu_ns_total": 0,
+                        "retention_thread_cpu_ns_max": 0,
+                        "retention_non_cpu_ns_total": 0,
+                        "retention_non_cpu_ns_max": 0,
                         "retention_inventory_ns_total": 0,
                         "retention_inventory_ns_max": 0,
                         "retention_age_filter_ns_total": 0,
@@ -687,6 +695,10 @@ def test_pipeline_aggregates_and_resets_monitor_publisher_phase_timing(monkeypat
         "event_monitor_publisher_retention_run_count": 1,
         "event_monitor_publisher_retention_ms_total": 4.0,
         "event_monitor_publisher_retention_ms_max": 4.0,
+        "event_monitor_publisher_retention_thread_cpu_ms_total": 1.5,
+        "event_monitor_publisher_retention_thread_cpu_ms_max": 1.5,
+        "event_monitor_publisher_retention_non_cpu_ms_total": 2.5,
+        "event_monitor_publisher_retention_non_cpu_ms_max": 2.5,
         "event_monitor_publisher_retention_inventory_ms_total": 3.0,
         "event_monitor_publisher_retention_inventory_ms_max": 3.0,
         "event_monitor_publisher_retention_age_filter_ms_total": 1.8,
@@ -729,6 +741,10 @@ def test_pipeline_monitor_phase_timing_restores_overlapping_window(monkeypatch):
     pipeline._timing_monitor_publisher_retention_run_count = 3
     pipeline._timing_monitor_publisher_retention_ns_total = 17_000_000
     pipeline._timing_monitor_publisher_retention_ns_max = 9_000_000
+    pipeline._timing_monitor_publisher_retention_thread_cpu_ns_total = 7_000_000
+    pipeline._timing_monitor_publisher_retention_thread_cpu_ns_max = 4_000_000
+    pipeline._timing_monitor_publisher_retention_non_cpu_ns_total = 10_000_000
+    pipeline._timing_monitor_publisher_retention_non_cpu_ns_max = 5_000_000
     pipeline._timing_monitor_publisher_retention_inventory_ns_total = 11_000_000
     pipeline._timing_monitor_publisher_retention_inventory_ns_max = 6_000_000
     pipeline._timing_monitor_publisher_retention_age_filter_ns_total = 8_000_000
@@ -755,6 +771,10 @@ def test_pipeline_monitor_phase_timing_restores_overlapping_window(monkeypatch):
     pipeline._timing_monitor_publisher_retention_run_count = 7
     pipeline._timing_monitor_publisher_retention_ns_total = 23_000_000
     pipeline._timing_monitor_publisher_retention_ns_max = 14_000_000
+    pipeline._timing_monitor_publisher_retention_thread_cpu_ns_total = 8_000_000
+    pipeline._timing_monitor_publisher_retention_thread_cpu_ns_max = 5_000_000
+    pipeline._timing_monitor_publisher_retention_non_cpu_ns_total = 15_000_000
+    pipeline._timing_monitor_publisher_retention_non_cpu_ns_max = 9_000_000
     pipeline._timing_monitor_publisher_retention_inventory_ns_total = 17_000_000
     pipeline._timing_monitor_publisher_retention_inventory_ns_max = 10_000_000
     pipeline._timing_monitor_publisher_retention_age_filter_ns_total = 13_000_000
@@ -788,6 +808,10 @@ def test_pipeline_monitor_phase_timing_restores_overlapping_window(monkeypatch):
     assert restored["event_monitor_publisher_retention_run_count"] == 7
     assert restored["event_monitor_publisher_retention_ms_total"] == 23.0
     assert restored["event_monitor_publisher_retention_ms_max"] == 14.0
+    assert restored["event_monitor_publisher_retention_thread_cpu_ms_total"] == 8.0
+    assert restored["event_monitor_publisher_retention_thread_cpu_ms_max"] == 5.0
+    assert restored["event_monitor_publisher_retention_non_cpu_ms_total"] == 15.0
+    assert restored["event_monitor_publisher_retention_non_cpu_ms_max"] == 9.0
     assert restored["event_monitor_publisher_retention_inventory_ms_total"] == 17.0
     assert restored["event_monitor_publisher_retention_inventory_ms_max"] == 10.0
     assert restored["event_monitor_publisher_retention_age_filter_ms_total"] == 13.0
@@ -839,6 +863,10 @@ def test_pipeline_custom_monitor_sink_reports_zero_internal_phase_timing():
         "event_monitor_publisher_retention_run_count": 0,
         "event_monitor_publisher_retention_ms_total": 0.0,
         "event_monitor_publisher_retention_ms_max": 0.0,
+        "event_monitor_publisher_retention_thread_cpu_ms_total": 0.0,
+        "event_monitor_publisher_retention_thread_cpu_ms_max": 0.0,
+        "event_monitor_publisher_retention_non_cpu_ms_total": 0.0,
+        "event_monitor_publisher_retention_non_cpu_ms_max": 0.0,
         "event_monitor_publisher_retention_inventory_ms_total": 0.0,
         "event_monitor_publisher_retention_inventory_ms_max": 0.0,
         "event_monitor_publisher_retention_age_filter_ms_total": 0.0,

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -4838,6 +4838,10 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
                     "event_monitor_sink_service_ms_max": 0.5,
                     "event_monitor_publisher_retention_inventory_ms_total": 99.0,
                     "event_monitor_publisher_retention_inventory_ms_max": 98.0,
+                    "event_monitor_publisher_retention_thread_cpu_ms_total": 97.0,
+                    "event_monitor_publisher_retention_thread_cpu_ms_max": 96.0,
+                    "event_monitor_publisher_retention_non_cpu_ms_total": 95.0,
+                    "event_monitor_publisher_retention_non_cpu_ms_max": 94.0,
                     "event_monitor_publisher_retention_age_unlink_ms_total": 97.0,
                     "event_monitor_publisher_retention_age_unlink_ms_max": 96.0,
                     "event_monitor_publisher_retention_cap_unlink_ms_total": 95.0,
@@ -4881,6 +4885,10 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
                     "event_monitor_publisher_retention_run_count": 3,
                     "event_monitor_publisher_retention_ms_total": 0.2,
                     "event_monitor_publisher_retention_ms_max": 0.15,
+                    "event_monitor_publisher_retention_thread_cpu_ms_total": 0.05,
+                    "event_monitor_publisher_retention_thread_cpu_ms_max": 0.03,
+                    "event_monitor_publisher_retention_non_cpu_ms_total": 0.15,
+                    "event_monitor_publisher_retention_non_cpu_ms_max": 0.12,
                     "event_monitor_publisher_retention_inventory_ms_total": 0.35,
                     "event_monitor_publisher_retention_inventory_ms_max": 0.22,
                     "event_monitor_publisher_retention_age_filter_ms_total": 0.28,
@@ -4937,6 +4945,10 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
                     "event_monitor_publisher_retention_run_count": 1,
                     "event_monitor_publisher_retention_ms_total": 0.1,
                     "event_monitor_publisher_retention_ms_max": 0.1,
+                    "event_monitor_publisher_retention_thread_cpu_ms_total": 0.04,
+                    "event_monitor_publisher_retention_thread_cpu_ms_max": 0.03,
+                    "event_monitor_publisher_retention_non_cpu_ms_total": 0.06,
+                    "event_monitor_publisher_retention_non_cpu_ms_max": 0.05,
                     "event_monitor_publisher_retention_inventory_ms_total": 0.2,
                     "event_monitor_publisher_retention_inventory_ms_max": 0.14,
                     "event_monitor_publisher_retention_age_filter_ms_total": 0.17,
@@ -5014,6 +5026,10 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
         "count"
     ] == 1
     retention_fields = (
+        "event_monitor_publisher_retention_thread_cpu_ms_total",
+        "event_monitor_publisher_retention_thread_cpu_ms_max",
+        "event_monitor_publisher_retention_non_cpu_ms_total",
+        "event_monitor_publisher_retention_non_cpu_ms_max",
         "event_monitor_publisher_retention_inventory_ms_total",
         "event_monitor_publisher_retention_inventory_ms_max",
         "event_monitor_publisher_retention_age_filter_ms_total",
@@ -5032,6 +5048,10 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
     assert {
         key: binance_fields[key]["latest"] for key in retention_fields
     } == {
+        "event_monitor_publisher_retention_thread_cpu_ms_total": 0.05,
+        "event_monitor_publisher_retention_thread_cpu_ms_max": 0.03,
+        "event_monitor_publisher_retention_non_cpu_ms_total": 0.15,
+        "event_monitor_publisher_retention_non_cpu_ms_max": 0.12,
         "event_monitor_publisher_retention_inventory_ms_total": 0.35,
         "event_monitor_publisher_retention_inventory_ms_max": 0.22,
         "event_monitor_publisher_retention_age_filter_ms_total": 0.28,
@@ -5050,6 +5070,10 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
     assert {
         key: okx_fields[key]["latest"] for key in retention_fields
     } == {
+        "event_monitor_publisher_retention_thread_cpu_ms_total": 0.04,
+        "event_monitor_publisher_retention_thread_cpu_ms_max": 0.03,
+        "event_monitor_publisher_retention_non_cpu_ms_total": 0.06,
+        "event_monitor_publisher_retention_non_cpu_ms_max": 0.05,
         "event_monitor_publisher_retention_inventory_ms_total": 0.2,
         "event_monitor_publisher_retention_inventory_ms_max": 0.14,
         "event_monitor_publisher_retention_age_filter_ms_total": 0.17,
@@ -5096,6 +5120,10 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
             "latest_event_monitor_publisher_retention_run_count_sum",
             "latest_event_monitor_publisher_retention_ms_total_sum",
             "latest_event_monitor_publisher_retention_ms_max",
+            "latest_event_monitor_publisher_retention_thread_cpu_ms_total_sum",
+            "latest_event_monitor_publisher_retention_thread_cpu_ms_max",
+            "latest_event_monitor_publisher_retention_non_cpu_ms_total_sum",
+            "latest_event_monitor_publisher_retention_non_cpu_ms_max",
             "latest_event_monitor_publisher_retention_inventory_ms_total_sum",
             "latest_event_monitor_publisher_retention_inventory_ms_max",
             "latest_event_monitor_publisher_retention_age_filter_ms_total_sum",
@@ -5140,6 +5168,10 @@ def test_live_performance_report_resource_pressure_projects_event_pipeline_timin
         "latest_event_monitor_publisher_retention_run_count_sum": 4,
         "latest_event_monitor_publisher_retention_ms_total_sum": 0.3,
         "latest_event_monitor_publisher_retention_ms_max": 0.15,
+        "latest_event_monitor_publisher_retention_thread_cpu_ms_total_sum": 0.09,
+        "latest_event_monitor_publisher_retention_thread_cpu_ms_max": 0.03,
+        "latest_event_monitor_publisher_retention_non_cpu_ms_total_sum": 0.21,
+        "latest_event_monitor_publisher_retention_non_cpu_ms_max": 0.12,
         "latest_event_monitor_publisher_retention_inventory_ms_total_sum": 0.55,
         "latest_event_monitor_publisher_retention_inventory_ms_max": 0.22,
         "latest_event_monitor_publisher_retention_age_filter_ms_total_sum": 0.45,

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2707,6 +2707,10 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
                 data={
                     "event_monitor_publisher_retention_inventory_ms_total": 99.0,
                     "event_monitor_publisher_retention_inventory_ms_max": 98.0,
+                    "event_monitor_publisher_retention_thread_cpu_ms_total": 97.0,
+                    "event_monitor_publisher_retention_thread_cpu_ms_max": 96.0,
+                    "event_monitor_publisher_retention_non_cpu_ms_total": 95.0,
+                    "event_monitor_publisher_retention_non_cpu_ms_max": 94.0,
                     "event_monitor_publisher_retention_age_filter_ms_total": 97.5,
                     "event_monitor_publisher_retention_age_filter_ms_max": 96.5,
                     "event_monitor_publisher_retention_cap_prune_ms_total": 95.5,
@@ -2756,6 +2760,10 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
                     "event_monitor_publisher_retention_run_count": 3,
                     "event_monitor_publisher_retention_ms_total": 1.0,
                     "event_monitor_publisher_retention_ms_max": 0.6,
+                    "event_monitor_publisher_retention_thread_cpu_ms_total": 0.4,
+                    "event_monitor_publisher_retention_thread_cpu_ms_max": 0.25,
+                    "event_monitor_publisher_retention_non_cpu_ms_total": 0.6,
+                    "event_monitor_publisher_retention_non_cpu_ms_max": 0.35,
                     "event_monitor_publisher_retention_inventory_ms_total": 1.7,
                     "event_monitor_publisher_retention_inventory_ms_max": 1.1,
                     "event_monitor_publisher_retention_age_filter_ms_total": 1.2,
@@ -2812,6 +2820,10 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
                     "event_monitor_publisher_retention_run_count": 1,
                     "event_monitor_publisher_retention_ms_total": 0.2,
                     "event_monitor_publisher_retention_ms_max": 0.2,
+                    "event_monitor_publisher_retention_thread_cpu_ms_total": 0.05,
+                    "event_monitor_publisher_retention_thread_cpu_ms_max": 0.04,
+                    "event_monitor_publisher_retention_non_cpu_ms_total": 0.15,
+                    "event_monitor_publisher_retention_non_cpu_ms_max": 0.16,
                     "event_monitor_publisher_retention_inventory_ms_total": 0.4,
                     "event_monitor_publisher_retention_inventory_ms_max": 0.25,
                     "event_monitor_publisher_retention_age_filter_ms_total": 0.35,
@@ -2846,6 +2858,10 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
     assert groups["okx/okx_01"].get("latest_monitor_publisher_manifest_checkpoint_count") == 2
     assert groups["gateio/gateio_01"].get("latest_monitor_publisher_retention_run_count") == 1
     retention_group_fields = (
+        "latest_monitor_publisher_retention_thread_cpu_ms_total",
+        "latest_monitor_publisher_retention_thread_cpu_ms_max",
+        "latest_monitor_publisher_retention_non_cpu_ms_total",
+        "latest_monitor_publisher_retention_non_cpu_ms_max",
         "latest_monitor_publisher_retention_inventory_ms_total",
         "latest_monitor_publisher_retention_inventory_ms_max",
         "latest_monitor_publisher_retention_age_filter_ms_total",
@@ -2864,6 +2880,10 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
     assert {
         key: groups["okx/okx_01"][key] for key in retention_group_fields
     } == {
+        "latest_monitor_publisher_retention_thread_cpu_ms_total": 0.4,
+        "latest_monitor_publisher_retention_thread_cpu_ms_max": 0.25,
+        "latest_monitor_publisher_retention_non_cpu_ms_total": 0.6,
+        "latest_monitor_publisher_retention_non_cpu_ms_max": 0.35,
         "latest_monitor_publisher_retention_inventory_ms_total": 1.7,
         "latest_monitor_publisher_retention_inventory_ms_max": 1.1,
         "latest_monitor_publisher_retention_age_filter_ms_total": 1.2,
@@ -2882,6 +2902,10 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
     assert {
         key: groups["gateio/gateio_01"][key] for key in retention_group_fields
     } == {
+        "latest_monitor_publisher_retention_thread_cpu_ms_total": 0.05,
+        "latest_monitor_publisher_retention_thread_cpu_ms_max": 0.04,
+        "latest_monitor_publisher_retention_non_cpu_ms_total": 0.15,
+        "latest_monitor_publisher_retention_non_cpu_ms_max": 0.16,
         "latest_monitor_publisher_retention_inventory_ms_total": 0.4,
         "latest_monitor_publisher_retention_inventory_ms_max": 0.25,
         "latest_monitor_publisher_retention_age_filter_ms_total": 0.35,
@@ -2926,6 +2950,10 @@ def test_live_smoke_report_projects_multi_bot_event_pipeline_timing(tmp_path):
         "latest_monitor_publisher_retention_run_count_sum": 4,
         "latest_monitor_publisher_retention_ms_total_sum": 1.2,
         "latest_monitor_publisher_retention_ms_max": 0.6,
+        "latest_monitor_publisher_retention_thread_cpu_ms_total_sum": 0.45,
+        "latest_monitor_publisher_retention_thread_cpu_ms_max": 0.25,
+        "latest_monitor_publisher_retention_non_cpu_ms_total_sum": 0.75,
+        "latest_monitor_publisher_retention_non_cpu_ms_max": 0.35,
         "latest_monitor_publisher_retention_inventory_ms_total_sum": 2.1,
         "latest_monitor_publisher_retention_inventory_ms_max": 1.1,
         "latest_monitor_publisher_retention_age_filter_ms_total_sum": 1.55,

--- a/tests/test_monitor_publisher.py
+++ b/tests/test_monitor_publisher.py
@@ -605,10 +605,16 @@ def test_monitor_history_rotation_snapshot_and_close_force_manifest_checkpoints(
 def test_monitor_publisher_event_phase_timing_uses_fixed_boundaries(tmp_path, monkeypatch):
     publisher = _make_publisher(tmp_path)
     clock = {"ns": 1_000_000_000}
+    thread_cpu_clock = {"ns": 500_000_000}
     monkeypatch.setattr(
         monitor_publisher_module.time,
         "monotonic_ns",
         lambda: clock["ns"],
+    )
+    monkeypatch.setattr(
+        monitor_publisher_module.time,
+        "thread_time_ns",
+        lambda: thread_cpu_clock["ns"],
     )
 
     class TimedLock:
@@ -662,6 +668,7 @@ def test_monitor_publisher_event_phase_timing_uses_fixed_boundaries(tmp_path, mo
         "_prune_retention",
         lambda **kwargs: (
             kwargs["on_run"](),
+            thread_cpu_clock.__setitem__("ns", thread_cpu_clock["ns"] + 4_000_000),
             clock.__setitem__("ns", clock["ns"] + 11_000_000),
         ),
     )
@@ -683,6 +690,10 @@ def test_monitor_publisher_event_phase_timing_uses_fixed_boundaries(tmp_path, mo
         "retention_run_count": 1,
         "retention_ns_total": 11_000_000,
         "retention_ns_max": 11_000_000,
+        "retention_thread_cpu_ns_total": 4_000_000,
+        "retention_thread_cpu_ns_max": 4_000_000,
+        "retention_non_cpu_ns_total": 7_000_000,
+        "retention_non_cpu_ns_max": 7_000_000,
         "retention_inventory_ns_total": 0,
         "retention_inventory_ns_max": 0,
         "retention_age_filter_ns_total": 0,
@@ -734,6 +745,10 @@ def test_monitor_publisher_event_failure_retains_reached_phase_timing(tmp_path, 
         "retention_run_count": 0,
         "retention_ns_total": 0,
         "retention_ns_max": 0,
+        "retention_thread_cpu_ns_total": 0,
+        "retention_thread_cpu_ns_max": 0,
+        "retention_non_cpu_ns_total": 0,
+        "retention_non_cpu_ns_max": 0,
         "retention_inventory_ns_total": 0,
         "retention_inventory_ns_max": 0,
         "retention_age_filter_ns_total": 0,
@@ -870,6 +885,10 @@ def test_monitor_publisher_event_timing_zeroes_retention_phases_when_not_due(tmp
     assert event is not None
     assert timing["retention_run_count"] == 0
     for key in (
+        "retention_thread_cpu_ns_total",
+        "retention_thread_cpu_ns_max",
+        "retention_non_cpu_ns_total",
+        "retention_non_cpu_ns_max",
         "retention_inventory_ns_total",
         "retention_inventory_ns_max",
         "retention_age_filter_ns_total",
@@ -886,6 +905,209 @@ def test_monitor_publisher_event_timing_zeroes_retention_phases_when_not_due(tmp
         "retention_cap_deleted",
     ):
         assert timing[key] == 0
+
+
+def test_monitor_publisher_event_timing_records_retention_cpu_attribution_for_due_run(
+    tmp_path, monkeypatch
+):
+    publisher = _make_publisher(tmp_path)
+    clocks = {"wall_ns": 10_000, "thread_cpu_ns": 1_000}
+
+    monkeypatch.setattr(
+        monitor_publisher_module.time, "monotonic_ns", lambda: clocks["wall_ns"]
+    )
+    monkeypatch.setattr(
+        monitor_publisher_module.time,
+        "thread_time_ns",
+        lambda: clocks["thread_cpu_ns"],
+    )
+
+    def run_retention(**kwargs):
+        kwargs["on_run"]()
+        clocks["wall_ns"] += 80
+        clocks["thread_cpu_ns"] += 100
+
+    monkeypatch.setattr(publisher, "_prune_retention", run_retention)
+
+    event, timing = publisher._record_event_timed(
+        "test.event", ("test",), {"value": 1}, ts=100_000
+    )
+
+    assert event is not None
+    assert timing["retention_run_count"] == 1
+    assert timing["retention_ns_total"] == 80
+    assert timing["retention_thread_cpu_ns_total"] == 100
+    assert timing["retention_thread_cpu_ns_max"] == 100
+    assert timing["retention_non_cpu_ns_total"] == 0
+    assert timing["retention_non_cpu_ns_max"] == 0
+
+
+def test_monitor_publisher_event_timing_omits_cpu_clock_when_retention_not_due(
+    tmp_path, monkeypatch
+):
+    publisher = _make_publisher(tmp_path)
+    publisher.last_retention_ms = 100_000
+    thread_cpu_calls = []
+
+    monkeypatch.setattr(monitor_publisher_module.time, "monotonic_ns", lambda: 10_000)
+    monkeypatch.setattr(
+        monitor_publisher_module.time,
+        "thread_time_ns",
+        lambda: thread_cpu_calls.append(None),
+    )
+
+    event, timing = publisher._record_event_timed(
+        "test.event", ("test",), {"value": 1}, ts=100_001
+    )
+
+    assert event is not None
+    assert thread_cpu_calls == []
+    assert timing["retention_run_count"] == 0
+    assert timing["retention_thread_cpu_ns_total"] == 0
+    assert timing["retention_thread_cpu_ns_max"] == 0
+    assert timing["retention_non_cpu_ns_total"] == 0
+    assert timing["retention_non_cpu_ns_max"] == 0
+
+
+def test_monitor_publisher_event_timing_retains_cpu_attribution_after_retention_error(
+    tmp_path, monkeypatch, caplog
+):
+    publisher = _make_publisher(tmp_path)
+    clocks = {"wall_ns": 10_000, "thread_cpu_ns": 1_000}
+
+    monkeypatch.setattr(
+        monitor_publisher_module.time, "monotonic_ns", lambda: clocks["wall_ns"]
+    )
+    monkeypatch.setattr(
+        monitor_publisher_module.time,
+        "thread_time_ns",
+        lambda: clocks["thread_cpu_ns"],
+    )
+
+    def fail_retention_inventory(**_kwargs):
+        clocks["wall_ns"] += 80
+        clocks["thread_cpu_ns"] += 30
+        raise OSError("retention unavailable")
+
+    monkeypatch.setattr(publisher, "_retention_inventory", fail_retention_inventory)
+
+    event, timing = publisher._record_event_timed(
+        "test.event", ("test",), {"value": 1}, ts=100_000
+    )
+
+    assert event is not None
+    assert "retention pruning failed: retention unavailable" in caplog.text
+    assert timing["retention_run_count"] == 1
+    assert timing["retention_ns_total"] == 80
+    assert timing["retention_thread_cpu_ns_total"] == 30
+    assert timing["retention_thread_cpu_ns_max"] == 30
+    assert timing["retention_non_cpu_ns_total"] == 50
+    assert timing["retention_non_cpu_ns_max"] == 50
+
+
+def test_monitor_publisher_event_timing_includes_due_rotation_retention(
+    tmp_path, monkeypatch
+):
+    publisher = _make_publisher(tmp_path, event_rotation_mb=0.000001)
+    publisher.current_events_path.write_text("rotated event\n")
+    clocks = {"wall_ns": 10_000, "thread_cpu_ns": 1_000}
+
+    monkeypatch.setattr(
+        monitor_publisher_module.time, "monotonic_ns", lambda: clocks["wall_ns"]
+    )
+    monkeypatch.setattr(
+        monitor_publisher_module.time,
+        "thread_time_ns",
+        lambda: clocks["thread_cpu_ns"],
+    )
+
+    def timed_inventory(**_kwargs):
+        clocks["wall_ns"] += 80
+        clocks["thread_cpu_ns"] += 30
+        return 0, []
+
+    monkeypatch.setattr(publisher, "_retention_inventory", timed_inventory)
+
+    event, timing = publisher._record_event_timed(
+        "test.event", ("test",), {"value": 1}, ts=100_000
+    )
+
+    assert event is not None
+    assert timing["retention_run_count"] == 1
+    assert timing["retention_ns_total"] == 80
+    assert timing["retention_thread_cpu_ns_total"] == 30
+    assert timing["retention_non_cpu_ns_total"] == 50
+
+
+def test_monitor_publisher_event_timing_drains_external_retention(
+    tmp_path, monkeypatch
+):
+    publisher = _make_publisher(tmp_path)
+    clocks = {"wall_ns": 10_000, "thread_cpu_ns": 1_000}
+
+    monkeypatch.setattr(
+        monitor_publisher_module.time, "monotonic_ns", lambda: clocks["wall_ns"]
+    )
+    monkeypatch.setattr(
+        monitor_publisher_module.time,
+        "thread_time_ns",
+        lambda: clocks["thread_cpu_ns"],
+    )
+
+    def timed_inventory(**_kwargs):
+        clocks["wall_ns"] += 70
+        clocks["thread_cpu_ns"] += 20
+        return 0, []
+
+    monkeypatch.setattr(publisher, "_retention_inventory", timed_inventory)
+
+    assert publisher.write_snapshot({"account": {}}, ts=100_000, force=True)
+    event, timing = publisher._record_event_timed(
+        "test.event", ("test",), {"value": 1}, ts=100_001
+    )
+
+    assert event is not None
+    assert timing["retention_run_count"] == 1
+    assert timing["retention_ns_total"] == 70
+    assert timing["retention_thread_cpu_ns_total"] == 20
+    assert timing["retention_non_cpu_ns_total"] == 50
+
+
+def test_monitor_publisher_thread_cpu_clock_failure_does_not_block_retention(
+    tmp_path, monkeypatch, caplog
+):
+    publisher = _make_publisher(tmp_path)
+    clock = {"wall_ns": 10_000}
+    inventory_attempts = []
+
+    monkeypatch.setattr(
+        monitor_publisher_module.time, "monotonic_ns", lambda: clock["wall_ns"]
+    )
+
+    def fail_thread_cpu_clock():
+        raise RuntimeError("thread clock unavailable")
+
+    def timed_inventory(**_kwargs):
+        inventory_attempts.append(None)
+        clock["wall_ns"] += 80
+        return 0, []
+
+    monkeypatch.setattr(
+        monitor_publisher_module.time, "thread_time_ns", fail_thread_cpu_clock
+    )
+    monkeypatch.setattr(publisher, "_retention_inventory", timed_inventory)
+
+    event, timing = publisher._record_event_timed(
+        "test.event", ("test",), {"value": 1}, ts=100_000
+    )
+
+    assert event is not None
+    assert inventory_attempts == [None]
+    assert timing["retention_run_count"] == 1
+    assert timing["retention_ns_total"] == 80
+    assert timing["retention_thread_cpu_ns_total"] == 0
+    assert timing["retention_non_cpu_ns_total"] == 0
+    assert caplog.text.count("thread CPU clock unavailable") == 1
 
 
 def test_monitor_publisher_event_timing_excludes_tolerated_age_disappearance(
@@ -1221,9 +1443,9 @@ def test_monitor_retention_logs_cap_unlink_failure_and_keeps_due_interval(
     original_inventory = publisher._retention_inventory
     original_unlink = Path.unlink
 
-    def count_inventory():
+    def count_inventory(**kwargs):
         inventory_attempts.append(None)
-        return original_inventory()
+        return original_inventory(**kwargs)
 
     def fail_candidate_unlink(path, *args, **kwargs):
         if path == candidate:


### PR DESCRIPTION
## Summary
- measure paired whole-retention wall and current-thread CPU intervals for every due retention run
- compute non-CPU time directly per run before total/max aggregation
- carry retention timing from rotation, history, snapshot, and direct publisher paths into the next transactional event-pipeline health window
- project CPU/non-CPU fields through smoke and performance reports

## Behavior boundary
Observability only. No retention cadence, lock scope, traversal, deletion policy, accounting, configuration, trading, order, or risk behavior changes. A failed thread-CPU clock logs once and does not block retention or event persistence.

## Evidence
Post-PR #1213, 54 natural runs recorded retention total/max 60803.819/11066.952ms, inventory 59485.603/11039.628ms, and age-filter 528.574/44.451ms. An earlier isolated age-filter outlier showed that wall-time tails move between phases under VPS5 contention. This PR distinguishes CPU work from non-CPU delay without another phase optimization.

## Validation
- 341 targeted monitor publisher, event bus, smoke report, and performance report tests passed
- Python compilation passed for all touched source modules
- AI documentation check: 0 errors, 0 warnings
- git diff --check passed
- independent preflight and delta re-review: no findings

## Merge gate
Hold the exact current head until Hermes, Grok 4.5, and CI are green. After merge, deploy with the exact five-pane graceful VPS5 restart and collect at least 30 natural due runs.