### PR TITLE
Improve structured fill console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live fill console/text output now projects structured `fill.ingested` events,
+  avoiding duplicate legacy lines when the structured console is available.
+  Large fill batches emit one `fills.ingested_summary` console/text event while
+  retaining every per-fill structured and monitor event; fill accounting,
+  history, and PnL semantics are unchanged.
+
 - Monitor retention now builds the same complete recursive inventory with one
   healthy-path `os.scandir` traversal and one explicit `DirEntry.stat` per
   visited entry, avoiding the duplicate directory scans performed by the prior

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -12,6 +12,20 @@ eligibility, replay order, or runtime decisions.
 
 The generated value reference is `../generated/live_event_registry.md`.
 
+## Fill Console Projection
+
+`fill.ingested` is the canonical normal-fill event. Every new fill remains present in structured
+and monitor sinks even when its human projection is suppressed. `operator_visible=false` affects
+only console and durable text sinks; it must not change fill accounting, fill history, health
+counters, PnL enrichment, or trading behavior.
+
+Batches of 20 fills or fewer project one bounded human line per fill. Larger batches suppress only
+those per-fill console/text lines and emit one `fills.ingested_summary` line with the batch count,
+the net realized PnL over fills whose PnL is known, the number of known-PnL fills, and the pending-PnL
+count. An all-pending batch must not present its known PnL as zero. The legacy direct logger is a
+fallback only when the structured live-event console is disabled or its pipeline is absent. Runtime
+sink degradation remains isolated by the event pipeline and must not activate dual writing.
+
 ## Fresh-Entry Eligibility
 
 Completed normal live plans emit `entry.initial_eligibility` to structured and monitor sinks. The

--- a/docs/ai/generated/live_event_registry.md
+++ b/docs/ai/generated/live_event_registry.md
@@ -51,6 +51,7 @@ The code-owned registries live in `src/live/event_bus.py`. Payload and emission 
 - `execution.create_skipped`
 - `execution.create_succeeded`
 - `fill.ingested`
+- `fills.ingested_summary`
 - `fills.refresh_summary`
 - `forager.eligibility_changed`
 - `forager.feature_unavailable`
@@ -199,6 +200,7 @@ The code-owned registries live in `src/live/event_bus.py`. Payload and emission 
 - `market_snapshot_diagnostic_skipped`
 - `min_effective_cost_blocked`
 - `new_fill`
+- `new_fill_batch`
 - `open_tail_projection`
 - `optional_ema_dropped`
 - `pending_exchange_config`

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -23,7 +23,8 @@ Estimated completion:
 ## Active Review Slice
 
 - Branch: `codex/v8-fill-console-migration`
-- Base: `91e40b911fd5378547b77ffbd7be1924846fa3e3`, PR #1214
+- PR: #1215
+- Base: `91e40b911fd5378547b77ffbd7be1924846fa3e3`, merged PR #1214
 - Triggering evidence: `fill.ingested` is routed to console/text while
   `_log_new_fill_events()` also writes the legacy per-fill or bulk line. Normal
   fills therefore appear twice, and batches over 20 defeat the legacy one-line
@@ -55,9 +56,9 @@ Estimated completion:
 
 Next action:
 
-1. Complete the bounded fill-console migration and independent preflight.
-2. Publish one review-worthy PR and require Hermes, Grok 4.5, and CI green on
-   its exact current head; resolve findings narrowly and re-review every push.
+1. Hold PR #1215 at its exact current head for Hermes, Grok 4.5, and CI.
+2. Resolve findings narrowly and require fresh exact-head verdicts after every
+   push.
 3. Merge only when the complete gate is green, then perform the exact five-bot
    graceful VPS5 restart and immediate/settled smoke without fabricating a fill.
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,58 +22,68 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-monitor-retention-cpu-attribution`
-- Base: `157fe0db6e2ec1348d47ff62155ae7a6f2d2b4df`, PR #1213
-- Triggering evidence: four post-PR #1213 health windows contained 54 natural
-  retention runs. Retention total/max was `60803.819/11066.952ms`; inventory
-  total/max was `59485.603/11039.628ms`; and age-filter total/max was only
-  `528.574/44.451ms`. The preceding six-run sample instead contained one
-  `8460ms` age-filter outlier with only `0.107ms` age-unlink work. The long tail
-  therefore moves between phases while VPS5 is CPU-saturated rather than
-  identifying a stable phase algorithm to optimize. The 54-run sample visited
-  90,972 entries, found 90,404 candidates, deleted 10 files by age and none by
-  cap, and retained zero drops, sink errors, degraded counts, final queue depth,
-  or unfinished work.
-- Scope: add paired whole-retention thread-CPU and directly computed non-CPU
-  total/max timing. Each due run captures wall and thread CPU clocks at the same
-  boundaries and computes `max(0, wall - thread_cpu)` for that run before
-  aggregation. Project both fields through transactional event-pipeline health
-  windows, smoke reports, and performance reports. Do not infer non-CPU time by
-  subtracting independently aggregated maxima.
-- Behavior boundary: additive diagnostics only. Preserve retention cadence,
-  `last_retention_ms`, lock scope, traversal, accounting, candidate order and
-  deletion domain, age/cap policy, error handling, configuration, and every
-  order/risk/trading behavior. Do not add caching, staggering, workers,
-  thresholds, verdicts, or phase optimizations.
-- Validation: paired deterministic clock behavior, due/not-due boundaries,
-  failure/finally retention, event-pipeline aggregation/reset/restore,
-  historical absence behavior, smoke/performance projections, integrated
-  monitor regressions, Python compilation, `git diff --check`, silent-handling
-  audit, and independent preflight.
+- Branch: `codex/v8-fill-console-migration`
+- Base: `91e40b911fd5378547b77ffbd7be1924846fa3e3`, PR #1214
+- Triggering evidence: `fill.ingested` is routed to console/text while
+  `_log_new_fill_events()` also writes the legacy per-fill or bulk line. Normal
+  fills therefore appear twice, and batches over 20 defeat the legacy one-line
+  summary by projecting every durable per-fill event. The event formatter also
+  lacks the legacy line's fill timestamp, pending-PnL state, and bounded fill
+  trace identifier.
+- Scope: make structured fill events own the normal human projection. Add the
+  non-sensitive fields required for timestamp, pending/known PnL, and bounded
+  hashed trace parity; add one distinct structured bulk-summary event; suppress
+  only per-fill console/text projection for batches over 20; and retain the
+  stdlib fill line only when the structured event console is disabled or its
+  pipeline is absent.
+- Behavior boundary: observability migration only. Preserve fill ingestion,
+  ordering, deduplication, cache/history writes, monitor fill records, health
+  counters, realized-PnL accounting, structured per-fill durability, and every
+  order/risk/trading behavior. Do not change enrichment, fee resolution,
+  exchange fetches, or fill/PnL readiness policy.
+- Validation: formatter parity for historical timestamps, signed quantity,
+  pending and known-zero close PnL, bounded identifiers, and bulk summaries;
+  console/text visibility versus durable structured/monitor delivery; stdlib
+  fallback behavior; integrated fill ingestion tests; offline fake-live fill
+  evidence; generated registry/docs checks; Python compilation;
+  `git diff --check`; silent-handling audit; and independent preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
-- Expected VPS action: exact five-bot graceful restart, immediate and settled
-  smoke, then at least 30 naturally emitted due runs comparing paired retention
-  wall, thread-CPU, and directly computed non-CPU evidence. Select no retention
-  phase optimization unless the paired evidence supports it.
+- Expected VPS action: exact five-bot graceful restart plus immediate and
+  settled smoke. Validate a naturally occurring fill if one appears; do not
+  create, cancel, or alter an order merely to produce console evidence.
 
 Next action:
 
-1. Hold PR #1214's exact current head until Hermes, Grok 4.5, and CI are green.
-2. Resolve findings narrowly and require fresh exact-head verdicts after every
-   push.
+1. Complete the bounded fill-console migration and independent preflight.
+2. Publish one review-worthy PR and require Hermes, Grok 4.5, and CI green on
+   its exact current head; resolve findings narrowly and re-review every push.
 3. Merge only when the complete gate is green, then perform the exact five-bot
-   graceful VPS5 restart, immediate and settled smoke, and at least 30 natural
-   due runs comparing paired wall, thread-CPU, and non-CPU evidence.
+   graceful VPS5 restart and immediate/settled smoke without fabricating a fill.
 
 ## Deployed Baseline
 
-- Remote `v8`: `157fe0db6e2ec1348d47ff62155ae7a6f2d2b4df`, PR #1213
-- VPS5 repository: `157fe0db6e2ec1348d47ff62155ae7a6f2d2b4df`, PR #1213; tracked
+- Remote `v8`: `91e40b911fd5378547b77ffbd7be1924846fa3e3`, PR #1214
+- VPS5 repository: `91e40b911fd5378547b77ffbd7be1924846fa3e3`, PR #1214; tracked
   status clean; expected untracked artifacts were preserved
-- VPS5 expected bots: five; running with PR #1213 restart PIDs
-  `899640/899643/899647/899648/899650`;
+- VPS5 expected bots: five; running with PR #1214 restart PIDs
+  `901310/901313/901316/901319/901321`;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1214 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
+  panes; every old bot exited naturally without force kill. Pane PIDs and
+  unrelated `misc:0.0` PID `434835` were preserved. A real KuCoin timeout made
+  the first settled window red and remained visible; after it aged out, the
+  final two-minute smoke was hard-green with `251/251` remote and `38/38`
+  account-critical calls, all five expected processes, zero hard/log/monitor
+  failures, no active HSL replay, and a clean tracked repository.
+- Seven distinct post-deploy health windows contained 52 natural retention
+  runs. Paired wall/thread-CPU/non-CPU totals were
+  `54076.226/7448.346/46627.879ms`: thread CPU was `13.774%` and direct non-CPU
+  time was `86.226%`, with the accounting identity matching within `0.001ms`.
+  Drops, sink errors, degraded counts, final queue depth, and unfinished work
+  remained zero. The residual wall-time tail is host descheduling/contention
+  evidence and does not justify another retention CPU or phase optimization.
 - PR #1213 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
   panes; every old bot exited naturally, including KuCoin after about 132
@@ -442,15 +452,16 @@ retention inventory are also merged and deployed with their behavior boundaries
 preserved. PR #1210's balance console transition is merged, deployed, and
 validated from natural balance changes on all five bots. PR #1211's retention
 phase attribution, PR #1212's direct `os.scandir` inventory, and PR #1213's
-whole-loop age/cap attribution are merged and deployed. The long retention
-wall-time tail moves between phases under VPS5 contention and does not justify
-another phase optimization.
+whole-loop age/cap attribution are merged and deployed. PR #1214's paired
+thread-CPU/non-CPU attribution is also merged and deployed; 52 natural runs
+showed only `13.774%` thread CPU and `86.226%` direct non-CPU time. The long
+retention wall-time tail is host descheduling/contention evidence and does not
+justify another retention optimization.
 
-The active slice adds paired whole-retention thread-CPU and directly computed
-non-CPU timing for every due run while preserving all retention behavior. Keep
-fill formatting separate: its legacy and event-routed lines currently overlap
-and require an explicit migration contract for timestamps, pending PnL, and
-bulk summaries.
+The active slice migrates normal fill console/text output to the structured
+event projection. Preserve durable per-fill events, historical timestamps,
+pending versus known PnL, bounded traceability, and one-line bulk summaries;
+keep the stdlib line only as fallback when the event console is unavailable.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -69,6 +69,46 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1214 merged to `v8` as
+  `91e40b911fd5378547b77ffbd7be1924846fa3e3` after exact-head Hermes and
+  Grok 4.5 approval plus green CI. It added paired whole-retention thread-CPU
+  and directly computed non-CPU timing without changing retention behavior.
+  VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
+  panes; every old bot exited naturally without force kill, and pane PIDs plus
+  unrelated `misc:0.0` PID `434835` were preserved. After one real KuCoin
+  timeout aged out, the final two-minute smoke was hard-green with `251/251`
+  remote and `38/38` account-critical calls successful, all five processes
+  present, zero hard/log/monitor failures, and a clean tracked repository.
+  Seven distinct health windows contained 52 natural retention runs:
+  wall/thread-CPU/non-CPU totals were `54076.226/7448.346/46627.879ms`, or
+  `13.774%` CPU and `86.226%` direct non-CPU time, with zero pipeline drops,
+  sink errors, degraded counts, or final queue residue. This closes retention
+  CPU/phase optimization as the next action; the residual tail is host
+  descheduling/contention evidence.
+- PR #1213 merged to `v8` as
+  `157fe0db6e2ec1348d47ff62155ae7a6f2d2b4df` after exact-head Hermes and
+  Grok 4.5 approval plus green CI. It timed the whole age-filter and cap-prune
+  loops while preserving their exact selection, ordering, deletion, and failure
+  behavior. VPS5 restarted only the five exact bot panes and preserved pane
+  PIDs plus unrelated `misc:0.0` PID `434835`. After one real KuCoin timeout
+  aged out, the final smoke was hard-green with `403/403` remote and `67/67`
+  account-critical calls successful. Four health windows contained 54 natural
+  runs: retention total/max was `60803.819/11066.952ms`, inventory was
+  `59485.603/11039.628ms`, and age filtering was `528.574/44.451ms`; combined
+  with an earlier isolated age-filter outlier, the long tail moved between
+  phases rather than identifying stable algorithmic work to optimize.
+- PR #1212 merged to `v8` as
+  `f68f10c4a3754c5603cfd7d97e5bc3e5a861f8cc` after exact-head Hermes and
+  Grok 4.5 approval plus green CI. It replaced the retention inventory's
+  duplicate `Path.rglob` traversal/stat work with one recursive `os.scandir`
+  pass and bounded scan-error isolation while preserving retention policy.
+  VPS5 restarted only the five exact bot panes and preserved pane PIDs plus
+  unrelated `misc:0.0` PID `434835`. The final smoke was hard-green with
+  `396/396` remote and `72/72` account-critical calls successful. Across 59
+  natural runs, inventory maximum improved about 78% while drops, sink errors,
+  degraded counts, and final queue depth remained zero; the residual wall-time
+  tail remained diagnostic evidence rather than support for another behavior
+  optimization.
 - PR #1211 merged to `v8` as
   `3a17fdb9768de80212d2dcd3c097350508d69caa` after exact-head Hermes and
   Grok 4.5 approval plus green CI. It added fixed inventory, age-unlink, and

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -513,10 +513,10 @@ Related detailed plans:
     event; a natural live Hyperliquid change verified the projection. Zero
     values in fill, balance, and entry-gate summaries are already retained
     because their numeric helper returns formatted strings; the prior
-    truthiness-gap note was incorrect. The active follow-up renders frequent
-    balance changes as exact raw/snapped transitions. Fill readability remains
-    separate because the legacy and event-routed lines overlap and the legacy
-    path still owns timestamp, pending-PnL, and bulk-summary semantics.
+    truthiness-gap note was incorrect. PR #1210 renders frequent balance changes
+    as exact raw/snapped transitions. The active fill follow-up removes the
+    legacy/event duplicate only after the structured projection owns timestamp,
+    pending-PnL, bounded traceability, and bulk-summary semantics.
 
     Work log:
     - 2026-06-30: Added value-safe `live-smoke-report` HSL status projections

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import Counter, deque
 from dataclasses import asdict, dataclass, field, replace
+from datetime import datetime, timezone
 import hashlib
 import json
 import logging
@@ -212,6 +213,7 @@ class EventTypes:
     EXECUTION_CONFIRMATION_TIMEOUT = "execution.confirmation_timeout"
     FILLS_REFRESH_SUMMARY = "fills.refresh_summary"
     FILL_INGESTED = "fill.ingested"
+    FILLS_INGESTED_SUMMARY = "fills.ingested_summary"
     POSITION_CHANGED = "position.changed"
     BALANCE_CHANGED = "balance.changed"
     RISK_MODE_CHANGED = "risk.mode_changed"
@@ -316,6 +318,7 @@ class ReasonCodes:
     MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED = "market_snapshot_diagnostic_skipped"
     MIN_EFFECTIVE_COST_BLOCKED = "min_effective_cost_blocked"
     NEW_FILL = "new_fill"
+    NEW_FILL_BATCH = "new_fill_batch"
     OPEN_TAIL_PROJECTION = "open_tail_projection"
     OPTIONAL_EMA_DROPPED = "optional_ema_dropped"
     PENDING_EXCHANGE_CONFIG = "pending_exchange_config"
@@ -531,6 +534,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.EXECUTION_CONFIRMATION_TIMEOUT,
     EventTypes.FILLS_REFRESH_SUMMARY,
     EventTypes.FILL_INGESTED,
+    EventTypes.FILLS_INGESTED_SUMMARY,
     EventTypes.POSITION_CHANGED,
     EventTypes.BALANCE_CHANGED,
     EventTypes.RISK_MODE_CHANGED,
@@ -853,6 +857,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.EXECUTION_CONFIRMATION_TIMEOUT: EventRoute(console=True, text=True),
     EventTypes.FILLS_REFRESH_SUMMARY: EventRoute(console=False, text=False),
     EventTypes.FILL_INGESTED: EventRoute(console=True, text=True),
+    EventTypes.FILLS_INGESTED_SUMMARY: EventRoute(console=True, text=True),
     EventTypes.POSITION_CHANGED: EventRoute(console=True, text=True),
     EventTypes.BALANCE_CHANGED: EventRoute(console=True, text=True),
     EventTypes.RISK_MODE_CHANGED: EventRoute(console=True, text=True),
@@ -983,6 +988,7 @@ _CONSOLE_EVENT_TAGS = {
     EventTypes.EXECUTION_CONFIRMATION_SATISFIED: "execute",
     EventTypes.EXECUTION_CONFIRMATION_TIMEOUT: "execute",
     EventTypes.FILL_INGESTED: "fill",
+    EventTypes.FILLS_INGESTED_SUMMARY: "fill",
     EventTypes.POSITION_CHANGED: "pos",
     EventTypes.BALANCE_CHANGED: "balance",
     EventTypes.RISK_MODE_CHANGED: "risk",
@@ -1267,30 +1273,85 @@ def _console_rust_summary(event: LiveEvent) -> list[str]:
     return parts
 
 
-def _console_fill_ingested_summary(event: LiveEvent) -> list[str]:
+def _format_fill_console_timestamp(value: object) -> str | None:
+    try:
+        timestamp = int(value)
+    except (TypeError, ValueError):
+        return None
+    if timestamp <= 0:
+        return None
+    try:
+        return datetime.fromtimestamp(timestamp / 1000.0, tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _format_console_fill_ingested(event: LiveEvent) -> str:
     data = event.data if isinstance(event.data, Mapping) else {}
-    parts: list[str] = []
-    if event.side:
-        parts.append(f"side={event.side}")
-    order_type = _data_str(data, "pb_order_type")
-    if order_type:
-        parts.append(f"type={order_type}")
-    qty = _data_float(data, "qty")
-    price = _data_float(data, "price")
-    if qty:
-        parts.append(f"qty={qty}")
-    if price:
-        parts.append(f"price={price}")
-    pnl = _data_float(data, "pnl")
-    if pnl:
-        parts.append(f"pnl={pnl}")
-    fee = _data_float(data, "fee")
-    if fee:
-        parts.append(f"fee={fee}")
-    client_id = _data_str(data, "client_order_id_short")
-    if client_id:
-        parts.append(f"client_id={client_id}")
-    return parts
+    parts = ["[fill]"]
+    timestamp = _format_fill_console_timestamp(data.get("timestamp"))
+    if timestamp:
+        parts.append(timestamp)
+    parts.append(_format_position_console_coin(event.symbol))
+    parts.append(_format_console_label(event.pside))
+    order_type = _format_console_label(_data_str(data, "pb_order_type"))
+    parts.append(order_type)
+
+    qty = _data_number(data, "qty")
+    signed_qty = qty
+    if qty is not None and str(event.side or "").lower() == "sell":
+        signed_qty = -abs(qty)
+    elif qty is not None and str(event.side or "").lower() == "buy":
+        signed_qty = abs(qty)
+    qty_rendered = _format_console_number(signed_qty)
+    if signed_qty is not None and str(event.side or "").lower() == "buy":
+        qty_rendered = f"+{qty_rendered}"
+    parts.append(qty_rendered)
+    parts.extend(("@", _format_console_number(_data_number(data, "price"))))
+
+    is_close = "close" in str(_data_str(data, "pb_order_type") or "").lower()
+    pnl = _data_number(data, "pnl")
+    pnl_status = str(_data_str(data, "pnl_status") or "complete").lower()
+    if is_close or (pnl is not None and pnl != 0.0):
+        if pnl_status == "pending":
+            parts.append(", pnl=pending")
+        elif pnl is not None:
+            pnl_rendered = _format_console_number(pnl)
+            pnl_sign = "+" if pnl >= 0.0 else ""
+            parts.append(f", pnl={pnl_sign}{pnl_rendered} USDT")
+    fee = _data_number(data, "fee")
+    if fee is not None and fee != 0.0:
+        parts.append(f", fee={_format_console_number(fee)} USDT")
+    if order_type == "unknown":
+        client_id = _data_str(data, "client_order_id_short")
+        if client_id:
+            parts.append(f"(coid={_format_console_label(client_id)})")
+    fill_id_hash = _data_str(data, "fill_id_hash")
+    if fill_id_hash:
+        parts.append(f"id={fill_id_hash[:12]}")
+    return " ".join(parts).replace(" ,", ",")
+
+
+def _format_console_fills_ingested_summary(event: LiveEvent) -> str:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    count = _data_int(data, "count")
+    total_pnl = _data_number(data, "known_net_realized_pnl")
+    known_pnl_count = _data_int(data, "known_pnl_count")
+    pending_pnl_count = _data_int(data, "pending_pnl_count")
+    count_label = "-" if count is None else str(count)
+    if known_pnl_count == 0:
+        message = f"[fill] {count_label} fills, pnl=-"
+    else:
+        pnl_label = "-" if total_pnl is None else _format_console_number(total_pnl)
+        pnl_sign = "+" if total_pnl is not None and total_pnl >= 0.0 else ""
+        message = f"[fill] {count_label} fills, pnl={pnl_sign}{pnl_label} USDT"
+    if known_pnl_count is not None:
+        message += f", pnl_known={known_pnl_count}"
+    if pending_pnl_count:
+        message += f", pnl_pending={pending_pnl_count}"
+    return message
 
 
 def _format_console_number(value: float | None) -> str:
@@ -1828,8 +1889,6 @@ def _console_data_summary(event: LiveEvent) -> list[str]:
         return _console_forager_selection_summary(event)
     if event.event_type == EventTypes.HEALTH_SUMMARY:
         return _console_health_summary(event)
-    if event.event_type == EventTypes.FILL_INGESTED:
-        return _console_fill_ingested_summary(event)
     if event.event_type == EventTypes.RISK_MODE_CHANGED:
         return _console_risk_mode_changed_summary(event)
     if event.event_type == EventTypes.HSL_TRANSITION:
@@ -1859,12 +1918,19 @@ def _hsl_status_operator_visible(event: LiveEvent) -> bool:
 
 
 def _operator_sink_event_visible(event: LiveEvent) -> bool:
+    if event.event_type == EventTypes.FILL_INGESTED:
+        data = event.data if isinstance(event.data, Mapping) else {}
+        return data.get("operator_visible") is not False
     if event.event_type == EventTypes.HSL_STATUS:
         return _hsl_status_operator_visible(event)
     return True
 
 
 def format_console_event(event: LiveEvent) -> str:
+    if event.event_type == EventTypes.FILL_INGESTED:
+        return _format_console_fill_ingested(event)
+    if event.event_type == EventTypes.FILLS_INGESTED_SUMMARY:
+        return _format_console_fills_ingested_summary(event)
     if event.event_type == EventTypes.POSITION_CHANGED:
         return _format_console_position_changed(event)
     if event.event_type == EventTypes.BALANCE_CHANGED:

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -4513,7 +4513,13 @@ def emit_fills_refresh_summary_event(bot: Any, *args: Any, **kwargs: Any) -> Non
         logging.debug("[event] failed to emit fills refresh summary event: %s", exc)
 
 
-def emit_fill_ingested_event(bot: Any, event: Any, *, payload: dict | None = None) -> None:
+def emit_fill_ingested_event(
+    bot: Any,
+    event: Any,
+    *,
+    payload: dict | None = None,
+    operator_visible: bool = True,
+) -> None:
     try:
         fill_payload = dict(payload or {})
         fill_id = getattr(event, "id", None)
@@ -4528,6 +4534,10 @@ def emit_fill_ingested_event(bot: Any, event: Any, *, payload: dict | None = Non
             "pnl": _safe_float(getattr(event, "pnl", None)),
             "fee": _safe_float(getattr(event, "fee", None)),
             "pb_order_type": str(getattr(event, "pb_order_type", "") or "").lower(),
+            "pnl_status": str(
+                getattr(event, "pnl_status", "complete") or "complete"
+            ).lower()[:80],
+            "operator_visible": bool(operator_visible),
             "source_ids_count": len(source_ids),
         }
         for key in ("qty", "price", "pnl", "fee", "pb_order_type", "timestamp"):
@@ -4554,6 +4564,34 @@ def emit_fill_ingested_event(bot: Any, event: Any, *, payload: dict | None = Non
         )
     except Exception as exc:
         logging.debug("[event] failed to emit fill ingested event: %s", exc)
+
+
+def emit_fills_ingested_summary_event(
+    bot: Any,
+    *,
+    count: int,
+    known_net_realized_pnl: float,
+    known_pnl_count: int,
+    pending_pnl_count: int,
+) -> None:
+    try:
+        bot._emit_live_event(
+            EventTypes.FILLS_INGESTED_SUMMARY,
+            level="info",
+            component="fills.ingest",
+            tags=(EventTags.FILLS, EventTags.FILL, EventTags.SUMMARY),
+            cycle_id=bot._current_live_event_cycle_id(),
+            status="succeeded",
+            reason_code=ReasonCodes.NEW_FILL_BATCH,
+            data={
+                "count": max(0, int(count)),
+                "known_net_realized_pnl": _safe_finite_float(known_net_realized_pnl),
+                "known_pnl_count": max(0, int(known_pnl_count)),
+                "pending_pnl_count": max(0, int(pending_pnl_count)),
+            },
+        )
+    except Exception as exc:
+        logging.debug("[event] failed to emit fills ingested summary event: %s", exc)
 
 
 def emit_position_changed_event(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -649,6 +649,9 @@ class Passivbot:
         live_event_emitters.emit_fills_refresh_summary_event
     )
     _emit_fill_ingested_event = live_event_emitters.emit_fill_ingested_event
+    _emit_fills_ingested_summary_event = (
+        live_event_emitters.emit_fills_ingested_summary_event
+    )
     _emit_risk_mode_changed_event = live_event_emitters.emit_risk_mode_changed_event
     _emit_realized_loss_gate_blocked_event = (
         live_event_emitters.emit_realized_loss_gate_blocked_event
@@ -10542,25 +10545,37 @@ class Passivbot:
             fill_event_net_pnl(ev) for ev in new_events if not fill_event_pnl_pending(ev)
         )
 
-        if len(new_events) > 20:
+        batch_summary = len(new_events) > 20
+        pending_count = 0
+        known_pnl_count = 0
+        total_pnl = 0.0
+        if batch_summary:
             # Truncate to summary
             pending_count = sum(1 for ev in new_events if fill_event_pnl_pending(ev))
+            known_pnl_count = len(new_events) - pending_count
             total_pnl = sum(
                 fill_event_net_pnl(ev) for ev in new_events if not fill_event_pnl_pending(ev)
             )
-            pnl_sign = "+" if total_pnl >= 0 else ""
-            pending_suffix = f", pnl_pending={pending_count}" if pending_count else ""
-            logging.info(
-                "[fill] %d fills, pnl=%s%s USDT%s",
-                len(new_events),
-                pnl_sign,
-                round_dynamic(total_pnl, 3),
-                pending_suffix,
-            )
-        else:
-            # Log each event
-            for event in sorted(new_events, key=lambda e: e.timestamp):
-                logging.info(self._log_fill_event(event))
+        if not self._live_event_console_available():
+            if batch_summary:
+                if known_pnl_count:
+                    pnl_sign = "+" if total_pnl >= 0 else ""
+                    pnl_label = f"{pnl_sign}{round_dynamic(total_pnl, 3)} USDT"
+                else:
+                    pnl_label = "-"
+                pending_suffix = f", pnl_pending={pending_count}" if pending_count else ""
+                logging.info(
+                    "[fill] %d fills, pnl=%s, pnl_known=%d%s",
+                    len(new_events),
+                    pnl_label,
+                    known_pnl_count,
+                    pending_suffix,
+                )
+            else:
+                # Log each event
+                for event in sorted(new_events, key=lambda e: e.timestamp):
+                    logging.info(self._log_fill_event(event))
+
         for event in sorted(new_events, key=lambda e: e.timestamp):
             self._monitor_record_fill_history(event)
             fill_payload = self._monitor_fill_payload(event)
@@ -10574,7 +10589,20 @@ class Passivbot:
             )
             emit_fill_ingested = getattr(self, "_emit_fill_ingested_event", None)
             if callable(emit_fill_ingested):
-                emit_fill_ingested(event, payload=fill_payload)
+                emit_fill_ingested(
+                    event,
+                    payload=fill_payload,
+                    operator_visible=not batch_summary,
+                )
+        if batch_summary:
+            emit_summary = getattr(self, "_emit_fills_ingested_summary_event", None)
+            if callable(emit_summary):
+                emit_summary(
+                    count=len(new_events),
+                    known_net_realized_pnl=total_pnl,
+                    known_pnl_count=known_pnl_count,
+                    pending_pnl_count=pending_count,
+                )
 
     def _log_enriched_fill_events(self, events: list) -> None:
         """Log realized-PnL enrichment for already seen close fills."""

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -356,6 +356,8 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED].text is True
     assert DEFAULT_ROUTES[EventTypes.FILL_INGESTED].console is True
     assert DEFAULT_ROUTES[EventTypes.FILL_INGESTED].text is True
+    assert DEFAULT_ROUTES[EventTypes.FILLS_INGESTED_SUMMARY].console is True
+    assert DEFAULT_ROUTES[EventTypes.FILLS_INGESTED_SUMMARY].text is True
     assert DEFAULT_ROUTES[EventTypes.POSITION_CHANGED].console is True
     assert DEFAULT_ROUTES[EventTypes.POSITION_CHANGED].text is True
     assert DEFAULT_ROUTES[EventTypes.BALANCE_CHANGED].console is True
@@ -1961,28 +1963,139 @@ def test_console_format_summarizes_health_error_burst_without_raw_error():
 def test_console_format_summarizes_fill_ingested():
     event = LiveEvent(
         EventTypes.FILL_INGESTED,
-        status="succeeded",
-        cycle_id="cy_fill",
         symbol="BTC/USDT:USDT",
         pside="long",
         side="buy",
-        reason_code="new_fill",
         data={
+            "timestamp": 1_782_271_234_000,
             "pb_order_type": "entry_grid_normal_long",
             "qty": 0.001,
             "price": 101_234.5,
             "pnl": -1.25,
             "fee": -0.04,
-            "client_order_id_short": "abc123",
             "fill_id_hash": "9f54f33d005de125ca93371eeda0374f039e520574633e8335066351e275c6a2",
         },
     )
 
     assert format_console_event(event) == (
-        "[fill] succeeded cycle=cy_fill side=buy type=entry_grid_normal_long "
-        "qty=0.001 price=101234.5 pnl=-1.25 fee=-0.04 client_id=abc123 "
-        "symbol=BTC/USDT:USDT pside=long reason=new_fill"
+        "[fill] 2026-06-24T03:20:34Z BTC long entry_grid_normal_long +0.001 @ 101234.5, "
+        "pnl=-1.25 USDT, fee=-0.04 USDT id=9f54f33d005d"
     )
+
+
+def test_console_format_fill_ingested_preserves_pending_and_known_zero_close_pnl():
+    pending = LiveEvent(
+        EventTypes.FILL_INGESTED,
+        symbol="ETH/USDT:USDT",
+        pside="short",
+        side="sell",
+        data={
+            "timestamp": 1_704_067_200_000,
+            "pb_order_type": "close_grid_normal_short",
+            "qty": 0.5,
+            "price": 2_500.0,
+            "pnl": 0.0,
+            "pnl_status": "pending",
+        },
+    )
+    known_zero = LiveEvent(
+        EventTypes.FILL_INGESTED,
+        symbol="ETH/USDT:USDT",
+        pside="short",
+        side="sell",
+        data={
+            "timestamp": 1_704_067_200_000,
+            "pb_order_type": "close_grid_normal_short",
+            "qty": 0.5,
+            "price": 2_500.0,
+            "pnl": 0.0,
+            "pnl_status": "complete",
+        },
+    )
+
+    assert format_console_event(pending).endswith("-0.5 @ 2500, pnl=pending")
+    assert format_console_event(known_zero).endswith("-0.5 @ 2500, pnl=+0 USDT")
+
+
+def test_console_format_fill_ingested_uses_hash_prefix_and_bounded_unknown_client_id():
+    raw_fill_id = "exchange-fill-id-should-never-be-rendered"
+    event = LiveEvent(
+        EventTypes.FILL_INGESTED,
+        symbol="SOL/USDT:USDT",
+        pside="long",
+        side="buy",
+        data={
+            "pb_order_type": "unknown",
+            "qty": 2.0,
+            "price": 100.0,
+            "client_order_id_short": "pbot_unknown...7b51e9d2",
+            "fill_id_hash": "a1b2c3d4e5f67890aabbccddeeff00112233445566778899aabbccddeeff0011",
+        },
+    )
+
+    rendered = format_console_event(event)
+
+    assert "(coid=pbot_unknown...7b51e9d2)" in rendered
+    assert "id=a1b2c3d4e5f6" in rendered
+    assert raw_fill_id not in rendered
+
+
+def test_console_format_fills_ingested_summary():
+    event = LiveEvent(
+        EventTypes.FILLS_INGESTED_SUMMARY,
+        data={
+            "count": 21,
+            "known_net_realized_pnl": 4.25,
+            "known_pnl_count": 19,
+            "pending_pnl_count": 2,
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[fill] 21 fills, pnl=+4.25 USDT, pnl_known=19, pnl_pending=2"
+    )
+
+
+def test_console_format_fills_ingested_summary_does_not_claim_zero_for_all_pending():
+    event = LiveEvent(
+        EventTypes.FILLS_INGESTED_SUMMARY,
+        data={
+            "count": 21,
+            "known_net_realized_pnl": 0.0,
+            "known_pnl_count": 0,
+            "pending_pnl_count": 21,
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[fill] 21 fills, pnl=-, pnl_known=0, pnl_pending=21"
+    )
+
+
+def test_operator_visibility_suppresses_fill_console_and_text_only():
+    structured = ListEventSink()
+    monitor = ListEventSink()
+    console = ListEventSink()
+    text = ListEventSink()
+    pipeline = LiveEventPipeline(
+        structured_sinks=[structured],
+        monitor_sinks=[monitor],
+        console_sink=console,
+        text_sink=text,
+    )
+    event = LiveEvent(
+        EventTypes.FILL_INGESTED,
+        data={"operator_visible": False, "qty": 1.0, "price": 100.0},
+    )
+
+    pipeline.emit(event)
+
+    assert pipeline.flush(timeout=2.0) is True
+    assert structured.events == [event]
+    assert monitor.events == [event]
+    assert console.events == []
+    assert text.events == []
+    assert pipeline.close(timeout=2.0) is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -3671,7 +3671,11 @@ def test_log_new_fill_events_emits_fill_ingested_event():
     class FakeBot:
         _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
         _emit_fill_ingested_event = pb_mod.Passivbot._emit_fill_ingested_event
+        _emit_fills_ingested_summary_event = (
+            pb_mod.Passivbot._emit_fills_ingested_summary_event
+        )
         _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _live_event_console_available = pb_mod.Passivbot._live_event_console_available
         _log_fill_event = pb_mod.Passivbot._log_fill_event
         _log_new_fill_events = pb_mod.Passivbot._log_new_fill_events
         _monitor_fill_payload = pb_mod.Passivbot._monitor_fill_payload
@@ -3687,6 +3691,7 @@ def test_log_new_fill_events_emits_fill_ingested_event():
                 structured_sinks=[sink],
                 monitor_sinks=[],
             )
+            self.live_event_console_enabled = False
             self.monitor_publisher = RecorderPublisher()
             self._health_fills = 0
             self._health_pnl = 0.0
@@ -3725,6 +3730,8 @@ def test_log_new_fill_events_emits_fill_ingested_event():
     assert live_event.side == "sell"
     assert live_event.data["qty"] == pytest.approx(0.5)
     assert live_event.data["pnl"] == pytest.approx(12.0)
+    assert live_event.data["pnl_status"] == "complete"
+    assert live_event.data["operator_visible"] is True
     assert live_event.data["fill_id_hash"] == hashlib.sha256(
         source_derived_fill_id.encode("utf-8")
     ).hexdigest()
@@ -3733,6 +3740,292 @@ def test_log_new_fill_events_emits_fill_ingested_event():
     assert "source_ids" not in live_event.data
     assert "trade-a" not in str(live_event.data)
     assert "trade-b" not in str(live_event.data)
+    assert "trade-a" not in live_event.to_json()
+    assert "trade-b" not in live_event.to_json()
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_log_new_fill_events_uses_structured_console_without_legacy_duplicate(caplog):
+    import passivbot as pb_mod
+
+    structured = ListEventSink()
+    console = ListEventSink()
+    text = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_fill_ingested_event = pb_mod.Passivbot._emit_fill_ingested_event
+        _emit_fills_ingested_summary_event = (
+            pb_mod.Passivbot._emit_fills_ingested_summary_event
+        )
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _live_event_console_available = pb_mod.Passivbot._live_event_console_available
+        _log_fill_event = pb_mod.Passivbot._log_fill_event
+        _log_new_fill_events = pb_mod.Passivbot._log_new_fill_events
+        _monitor_fill_payload = pb_mod.Passivbot._monitor_fill_payload
+        _monitor_record_event = pb_mod.Passivbot._monitor_record_event
+        _monitor_record_fill_history = pb_mod.Passivbot._monitor_record_fill_history
+
+        def __init__(self):
+            self.exchange = "bybit"
+            self.user = "bybit_01"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_console"
+            self.live_event_console_enabled = True
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[structured],
+                monitor_sinks=[],
+                console_sink=console,
+                text_sink=text,
+            )
+            self.monitor_publisher = RecorderPublisher()
+            self._health_fills = 0
+            self._health_pnl = 0.0
+
+    event = SimpleNamespace(
+        id="fill-1",
+        timestamp=1_704_067_200_000,
+        symbol="BTC/USDT:USDT",
+        side="buy",
+        position_side="long",
+        qty=0.1,
+        price=40_000.0,
+        pnl=0.0,
+        fee=-0.1,
+        fee_paid=-0.1,
+        pb_order_type="entry_grid_normal_long",
+        client_order_id="pbot-1",
+        source_ids=["source-1"],
+        pnl_status="complete",
+    )
+    bot = FakeBot()
+
+    with caplog.at_level(logging.INFO):
+        bot._log_new_fill_events([event])
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert [event.event_type for event in structured.events] == [EventTypes.FILL_INGESTED]
+    assert [event.event_type for event in console.events] == [EventTypes.FILL_INGESTED]
+    assert [event.event_type for event in text.events] == [EventTypes.FILL_INGESTED]
+    assert not any(record.message.startswith("[fill]") for record in caplog.records)
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.parametrize("console_enabled,pipeline_available", [(False, True), (True, False)])
+def test_log_new_fill_events_uses_legacy_fallback_when_console_is_disabled_or_unavailable(
+    caplog, console_enabled, pipeline_available
+):
+    import passivbot as pb_mod
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_fill_ingested_event = pb_mod.Passivbot._emit_fill_ingested_event
+        _emit_fills_ingested_summary_event = (
+            pb_mod.Passivbot._emit_fills_ingested_summary_event
+        )
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _live_event_console_available = pb_mod.Passivbot._live_event_console_available
+        _log_fill_event = pb_mod.Passivbot._log_fill_event
+        _log_new_fill_events = pb_mod.Passivbot._log_new_fill_events
+        _monitor_fill_payload = pb_mod.Passivbot._monitor_fill_payload
+        _monitor_record_event = pb_mod.Passivbot._monitor_record_event
+        _monitor_record_fill_history = pb_mod.Passivbot._monitor_record_fill_history
+
+        def __init__(self):
+            self.exchange = "bybit"
+            self.user = "bybit_01"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_fallback"
+            self.live_event_console_enabled = console_enabled
+            self._live_event_pipeline = (
+                LiveEventPipeline(structured_sinks=[], monitor_sinks=[])
+                if pipeline_available
+                else None
+            )
+            self.monitor_publisher = RecorderPublisher()
+            self._health_fills = 0
+            self._health_pnl = 0.0
+
+    event = SimpleNamespace(
+        id="fill-2",
+        timestamp=1_704_067_200_000,
+        symbol="BTC/USDT:USDT",
+        side="buy",
+        position_side="long",
+        qty=0.1,
+        price=40_000.0,
+        pnl=0.0,
+        fee=0.0,
+        fee_paid=0.0,
+        pb_order_type="entry_grid_normal_long",
+        client_order_id="pbot-2",
+        source_ids=["source-2"],
+        pnl_status="complete",
+    )
+    bot = FakeBot()
+
+    with caplog.at_level(logging.INFO):
+        bot._log_new_fill_events([event])
+
+    assert any(record.message.startswith("[fill]") for record in caplog.records)
+    if bot._live_event_pipeline is not None:
+        assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_log_new_fill_events_legacy_batch_fallback_does_not_claim_all_pending_zero_pnl(
+    caplog,
+):
+    import passivbot as pb_mod
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_fill_ingested_event = pb_mod.Passivbot._emit_fill_ingested_event
+        _emit_fills_ingested_summary_event = (
+            pb_mod.Passivbot._emit_fills_ingested_summary_event
+        )
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _live_event_console_available = pb_mod.Passivbot._live_event_console_available
+        _log_fill_event = pb_mod.Passivbot._log_fill_event
+        _log_new_fill_events = pb_mod.Passivbot._log_new_fill_events
+        _monitor_fill_payload = pb_mod.Passivbot._monitor_fill_payload
+        _monitor_record_event = pb_mod.Passivbot._monitor_record_event
+        _monitor_record_fill_history = pb_mod.Passivbot._monitor_record_fill_history
+
+        def __init__(self):
+            self.exchange = "bybit"
+            self.user = "bybit_01"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_pending_fallback"
+            self.live_event_console_enabled = False
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[], monitor_sinks=[]
+            )
+            self.monitor_publisher = RecorderPublisher()
+            self._health_fills = 0
+            self._health_pnl = 0.0
+
+    events = [
+        SimpleNamespace(
+            id=f"pending-{idx}",
+            timestamp=1_704_067_200_000 + idx,
+            symbol="ETH/USDT:USDT",
+            side="sell",
+            position_side="long",
+            qty=0.1,
+            price=2_500.0,
+            pnl=0.0,
+            fee=0.0,
+            fee_paid=0.0,
+            pb_order_type="close_grid_normal_long",
+            client_order_id=f"pbot-{idx}",
+            source_ids=[f"source-{idx}"],
+            pnl_status="pending",
+        )
+        for idx in range(21)
+    ]
+    bot = FakeBot()
+
+    with caplog.at_level(logging.INFO):
+        bot._log_new_fill_events(events)
+
+    fill_lines = [
+        record.message for record in caplog.records if record.message.startswith("[fill]")
+    ]
+    assert fill_lines == [
+        "[fill] 21 fills, pnl=-, pnl_known=0, pnl_pending=21"
+    ]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_log_new_fill_events_emits_batch_summary_without_per_fill_console_text(caplog):
+    import passivbot as pb_mod
+
+    structured = ListEventSink()
+    monitor = ListEventSink()
+    console = ListEventSink()
+    text = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_fill_ingested_event = pb_mod.Passivbot._emit_fill_ingested_event
+        _emit_fills_ingested_summary_event = (
+            pb_mod.Passivbot._emit_fills_ingested_summary_event
+        )
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _live_event_console_available = pb_mod.Passivbot._live_event_console_available
+        _log_fill_event = pb_mod.Passivbot._log_fill_event
+        _log_new_fill_events = pb_mod.Passivbot._log_new_fill_events
+        _monitor_fill_payload = pb_mod.Passivbot._monitor_fill_payload
+        _monitor_record_event = pb_mod.Passivbot._monitor_record_event
+        _monitor_record_fill_history = pb_mod.Passivbot._monitor_record_fill_history
+
+        def __init__(self):
+            self.exchange = "bybit"
+            self.user = "bybit_01"
+            self.bot_id = "bot_1"
+            self._live_event_current_cycle_id = "cy_batch"
+            self.live_event_console_enabled = True
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[structured],
+                monitor_sinks=[monitor],
+                console_sink=console,
+                text_sink=text,
+            )
+            self.monitor_publisher = RecorderPublisher()
+            self._health_fills = 0
+            self._health_pnl = 0.0
+
+    events = [
+        SimpleNamespace(
+            id=f"fill-{idx}",
+            timestamp=1_704_067_200_000 + idx,
+            symbol="ETH/USDT:USDT",
+            side="sell",
+            position_side="long",
+            qty=0.1,
+            price=2_500.0,
+            pnl=1.0,
+            fee=-0.1,
+            fee_paid=-0.1,
+            pb_order_type="close_grid_normal_long",
+            client_order_id=f"pbot-{idx}",
+            source_ids=[f"source-{idx}"],
+            pnl_status="pending" if idx in {3, 17} else "complete",
+        )
+        for idx in range(21)
+    ]
+    bot = FakeBot()
+
+    with caplog.at_level(logging.INFO):
+        bot._log_new_fill_events(events)
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert [event.event_type for event in structured.events] == [
+        *([EventTypes.FILL_INGESTED] * 21),
+        EventTypes.FILLS_INGESTED_SUMMARY,
+    ]
+    assert [event.event_type for event in monitor.events] == [
+        *([EventTypes.FILL_INGESTED] * 21),
+        EventTypes.FILLS_INGESTED_SUMMARY,
+    ]
+    assert [event.event_type for event in console.events] == [
+        EventTypes.FILLS_INGESTED_SUMMARY
+    ]
+    assert [event.event_type for event in text.events] == [
+        EventTypes.FILLS_INGESTED_SUMMARY
+    ]
+    assert all(event.data["operator_visible"] is False for event in structured.events[:-1])
+    assert structured.events[-1].data == {
+        "count": 21,
+        "known_net_realized_pnl": pytest.approx(17.1),
+        "known_pnl_count": 19,
+        "pending_pnl_count": 2,
+    }
+    assert len(bot.monitor_publisher.fills) == 21
+    assert len(bot.monitor_publisher.events) == 21
+    assert bot._health_fills == 21
+    assert bot._health_pnl == pytest.approx(17.1)
+    assert not any(record.message.startswith("[fill]") for record in caplog.records)
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
@@ -4582,6 +4875,7 @@ def test_log_new_fill_events_records_fill_history():
 
     class FakeBot:
         _log_new_fill_events = pb_mod.Passivbot._log_new_fill_events
+        _live_event_console_available = pb_mod.Passivbot._live_event_console_available
         _monitor_record_event = pb_mod.Passivbot._monitor_record_event
         _monitor_fill_payload = pb_mod.Passivbot._monitor_fill_payload
         _monitor_record_fill_history = pb_mod.Passivbot._monitor_record_fill_history

--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import hjson
 import json
 import shutil
@@ -1157,7 +1158,15 @@ async def test_fake_live_all_lookback_backfills_narrow_fill_cache_once(tmp_path,
         log_text = (run_dir / "fake_live.log").read_text(encoding="utf-8")
         assert "[fills] refresh: events=3 (+1)" in log_text
         assert "initial_entry_boot" in log_text
-        assert sum("[fill]" in line and " id=10" in line for line in log_text.splitlines()) == 1
+        fill_ref = hashlib.sha256(b"10").hexdigest()[:12]
+        assert (
+            sum(
+                "[fill]" in line and f" id={fill_ref}" in line
+                for line in log_text.splitlines()
+            )
+            == 1
+        )
+        assert not any("[fill]" in line and " id=10" in line for line in log_text.splitlines())
 
         cache = FillEventCache(cache_dir)
         cached_ids = [str(event.id) for event in cache.load()]


### PR DESCRIPTION
## Scope

- make structured `fill.ingested` events own normal console/text fill output
- preserve one durable structured and monitor event per fill while suppressing only human per-fill lines for batches over 20
- add `fills.ingested_summary` with known and pending PnL counts
- retain the legacy direct fill logger only when the structured console is disabled or its pipeline is absent
- preserve fill accounting, history, enrichment, health counters, and trading behavior

## Human output

- compact UTC timestamp, coin, position side, order type, signed quantity, price, PnL/fee, and bounded hashed fill reference
- all-pending batches render `pnl=-`, not a fabricated zero
- large batches render one summary while all per-fill durable events remain available

## Non-goals

- no exchange fetching, fill deduplication, fee/PnL readiness, order, risk, or trading changes
- no runtime dual writing after a structured sink failure
- no VPS or exchange action performed for validation

## Validation

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_passivbot_monitor.py tests/test_run_fake_live.py -q`
- full `tests/test_run_fake_live.py` passed
- `tests/test_ai_docs.py tests/test_live_event_registry_docs.py` passed
- generated event registry `--check`
- changed Python modules and tests compile
- `git diff --check`
- changed-diff silent-handling audit: only the observability-only summary emitter catch is new
- independent Terra preflight and delta re-review: no blocking findings

## VPS validation after merge

Gracefully restart only the five exact bot panes, then run immediate and settled smoke checks. Observe a natural fill if one occurs; do not create, cancel, or alter orders to manufacture console evidence.
