### PR TITLE
Improve periodic health console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Periodic health console/text output now projects the structured
+  `health.summary` event as one compact line when the live event console is
+  available, while retaining the same legacy fallback when it is disabled or
+  absent. Health payloads now include quote, error-budget, bounded slow-phase,
+  and correct RSS fields without changing trading behavior.
+
 - Live fill console/text output now projects structured `fill.ingested` events,
   avoiding duplicate legacy lines when the structured console is available.
   Large fill batches emit one `fills.ingested_summary` console/text event while

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -54,12 +54,11 @@ Estimated completion:
 
 Next action:
 
-1. Implement and validate the bounded periodic health console migration.
-2. Publish one review-worthy PR, then hold its exact current head for Hermes,
-   Grok 4.5, and CI.
-3. Resolve findings narrowly and require fresh exact-head verdicts after every
-   push. Merge only when the complete gate is green, then perform the exact
-   five-bot graceful VPS5 restart and immediate/settled smoke.
+1. Hold PR #1216 at its exact current head for Hermes, Grok 4.5, and CI.
+2. Resolve findings narrowly and require fresh exact-head verdicts after every
+   push.
+3. Merge only when the complete gate is green, then perform the exact five-bot
+   graceful VPS5 restart and immediate/settled smoke.
 
 ## Deployed Baseline
 
@@ -470,10 +469,11 @@ showed only `13.774%` thread CPU and `86.226%` direct non-CPU time. The long
 retention wall-time tail is host descheduling/contention evidence and does not
 justify another retention optimization.
 
-The active slice migrates normal fill console/text output to the structured
-event projection. Preserve durable per-fill events, historical timestamps,
-pending versus known PnL, bounded traceability, and one-line bulk summaries;
-keep the stdlib line only as fallback when the event console is unavailable.
+PR #1215's fill console/text migration is merged and deployed. The active slice
+is PR #1216's periodic health console migration: preserve durable health events,
+timing snapshot transactions, scheduler cadence, and error-burst formatting;
+render one compact normal health line and keep the stdlib line only as fallback
+when the structured console sink is unavailable.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -23,7 +23,7 @@ Estimated completion:
 ## Active Review Slice
 
 - Branch: `codex/v8-health-console-migration`
-- PR: not yet published
+- PR: #1216
 - Base: `6af983c539d00acd802aabad66044868afd45aa4`, merged PR #1215
 - Triggering evidence: every periodic health interval writes both a legacy
   `[health]` line and a structured `health.summary` console projection. The

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,54 +22,65 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-fill-console-migration`
-- PR: #1215
-- Base: `91e40b911fd5378547b77ffbd7be1924846fa3e3`, merged PR #1214
-- Triggering evidence: `fill.ingested` is routed to console/text while
-  `_log_new_fill_events()` also writes the legacy per-fill or bulk line. Normal
-  fills therefore appear twice, and batches over 20 defeat the legacy one-line
-  summary by projecting every durable per-fill event. The event formatter also
-  lacks the legacy line's fill timestamp, pending-PnL state, and bounded fill
-  trace identifier.
-- Scope: make structured fill events own the normal human projection. Add the
-  non-sensitive fields required for timestamp, pending/known PnL, and bounded
-  hashed trace parity; add one distinct structured bulk-summary event; suppress
-  only per-fill console/text projection for batches over 20; and retain the
-  stdlib fill line only when the structured event console is disabled or its
-  pipeline is absent.
-- Behavior boundary: observability migration only. Preserve fill ingestion,
-  ordering, deduplication, cache/history writes, monitor fill records, health
-  counters, realized-PnL accounting, structured per-fill durability, and every
-  order/risk/trading behavior. Do not change enrichment, fee resolution,
-  exchange fetches, or fill/PnL readiness policy.
-- Validation: formatter parity for historical timestamps, signed quantity,
-  pending and known-zero close PnL, bounded identifiers, and bulk summaries;
-  console/text visibility versus durable structured/monitor delivery; stdlib
-  fallback behavior; integrated fill ingestion tests; offline fake-live fill
-  evidence; generated registry/docs checks; Python compilation;
+- Branch: `codex/v8-health-console-migration`
+- PR: not yet published
+- Base: `6af983c539d00acd802aabad66044868afd45aa4`, merged PR #1215
+- Triggering evidence: every periodic health interval writes both a legacy
+  `[health]` line and a structured `health.summary` console projection. The
+  duplicate is frequent on every bot, the structured projection is needlessly
+  machine-like, and the legacy Linux `ru_maxrss` conversion visibly reports
+  `rss=0MB` while the structured event carries the correct byte count.
+- Scope: make the periodic structured `health.summary` event own the normal
+  human projection. Render one compact line with human uptime, loop time,
+  positions, raw/snapped balance and quote currency, orders, fills/PnL, error
+  budget, correct RSS, and only nonzero health/pipeline anomalies. Retain the
+  stdlib health line only when the structured event console is disabled or its
+  pipeline is absent. Preserve the separate error-burst health projection.
+- Behavior boundary: observability migration only. Preserve health counters,
+  scheduler cadence, event-pipeline timing snapshot transactions, candle-health
+  logging, and every order/risk/trading behavior. Do not change exchange calls,
+  health thresholds, restart policy, or smoke verdict policy.
+- Validation: compact periodic formatter coverage including zero values,
+  raw/snapped balance, quote currency, fills/PnL, errors, RSS, and anomaly-only
+  fields; single-line structured ownership versus stdlib fallback; timing
+  snapshot confirm/restore behavior; preserved error-burst formatting;
+  integrated monitor tests; generated registry/docs checks; Python compilation;
   `git diff --check`; silent-handling audit; and independent preflight.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: exact five-bot graceful restart plus immediate and
-  settled smoke. Validate a naturally occurring fill if one appears; do not
-  create, cancel, or alter an order merely to produce console evidence.
+  settled smoke. Periodic health output occurs naturally, so validate exactly
+  one compact line per interval without creating or altering trading state.
 
 Next action:
 
-1. Hold PR #1215 at its exact current head for Hermes, Grok 4.5, and CI.
-2. Resolve findings narrowly and require fresh exact-head verdicts after every
-   push.
-3. Merge only when the complete gate is green, then perform the exact five-bot
-   graceful VPS5 restart and immediate/settled smoke without fabricating a fill.
+1. Implement and validate the bounded periodic health console migration.
+2. Publish one review-worthy PR, then hold its exact current head for Hermes,
+   Grok 4.5, and CI.
+3. Resolve findings narrowly and require fresh exact-head verdicts after every
+   push. Merge only when the complete gate is green, then perform the exact
+   five-bot graceful VPS5 restart and immediate/settled smoke.
 
 ## Deployed Baseline
 
-- Remote `v8`: `91e40b911fd5378547b77ffbd7be1924846fa3e3`, PR #1214
-- VPS5 repository: `91e40b911fd5378547b77ffbd7be1924846fa3e3`, PR #1214; tracked
+- Remote `v8`: `6af983c539d00acd802aabad66044868afd45aa4`, PR #1215
+- VPS5 repository: `6af983c539d00acd802aabad66044868afd45aa4`, PR #1215; tracked
   status clean; expected untracked artifacts were preserved
-- VPS5 expected bots: five; running with PR #1214 restart PIDs
-  `901310/901313/901316/901319/901321`;
+- VPS5 expected bots: five; running with PR #1215 restart PIDs
+  `903757/903759/903761/903763/903765`;
   unrelated `misc:0.0` remains PID `434835`
+- PR #1215 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
+  It made structured fill events own normal console/text output, added one
+  bounded bulk summary while preserving every durable per-fill event, and kept
+  the stdlib fallback for configurations without a structured console. VPS5
+  fast-forwarded cleanly and gracefully restarted only the five exact bot
+  panes; every old bot exited naturally without force kill. Pane PIDs and the
+  unrelated `misc:0.0` PID `434835` were preserved. Initial windows honestly
+  reported real KuCoin timeouts; after recovery, the final two-minute smoke was
+  hard-green with `384/384` remote and `71/71` account-critical calls, all five
+  expected processes, zero hard/log/monitor failures, no active HSL replay, and
+  a clean tracked repository. No natural post-restart fill occurred, so runtime
+  fill-format evidence remains absent rather than manufactured.
 - PR #1214 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   VPS5 fast-forwarded cleanly and gracefully restarted only the five exact bot
   panes; every old bot exited naturally without force kill. Pane PIDs and

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -69,6 +69,21 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1215 merged to `v8` as
+  `6af983c539d00acd802aabad66044868afd45aa4` after exact-head Hermes and
+  Grok 4.5 approval plus green CI. Structured `fill.ingested` events now own
+  normal console/text output, batches over 20 use one bounded summary while
+  preserving every durable per-fill event, and configurations without the
+  structured console retain the stdlib fallback. VPS5 gracefully restarted
+  only the five exact bot panes and preserved pane PIDs plus unrelated
+  `misc:0.0` PID `434835`. Initial windows retained real KuCoin timeouts; the
+  final two-minute smoke was hard-green with `384/384` remote and `71/71`
+  account-critical calls successful, all five processes present, zero
+  hard/log/monitor failures, and a clean tracked repository. No natural fill
+  occurred after restart, so no runtime fill-format claim is made. Real logs
+  instead exposed duplicate periodic health lines and an incorrect legacy
+  `rss=0MB`; the next slice migrates that periodic projection to one compact
+  structured-event-owned human line.
 - PR #1214 merged to `v8` as
   `91e40b911fd5378547b77ffbd7be1924846fa3e3` after exact-head Hermes and
   Grok 4.5 approval plus green CI. It added paired whole-retention thread-CPU

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -514,9 +514,11 @@ Related detailed plans:
     values in fill, balance, and entry-gate summaries are already retained
     because their numeric helper returns formatted strings; the prior
     truthiness-gap note was incorrect. PR #1210 renders frequent balance changes
-    as exact raw/snapped transitions. The active fill follow-up removes the
-    legacy/event duplicate only after the structured projection owns timestamp,
-    pending-PnL, bounded traceability, and bulk-summary semantics.
+    as exact raw/snapped transitions. PR #1215 removed the fill legacy/event
+    duplicate after the structured projection gained timestamp, pending-PnL,
+    bounded traceability, and bulk-summary semantics. The active follow-up
+    removes the frequent periodic-health duplicate and replaces its incorrect
+    legacy Linux RSS rendering with the structured payload's byte count.
 
     Work log:
     - 2026-06-30: Added value-safe `live-smoke-report` HSL status projections

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -1675,6 +1675,105 @@ def _console_health_summary(event: LiveEvent) -> list[str]:
     return parts
 
 
+def _format_console_duration_ms(duration_ms: int) -> str:
+    total_seconds = max(0, duration_ms // 1000)
+    days, remainder = divmod(total_seconds, 86_400)
+    hours, remainder = divmod(remainder, 3_600)
+    minutes, seconds = divmod(remainder, 60)
+    if days:
+        return f"{days}d{hours}h{minutes}m"
+    if hours:
+        return f"{hours}h{minutes}m{seconds}s"
+    if minutes:
+        return f"{minutes}m{seconds}s"
+    return f"{seconds}s"
+
+
+def format_periodic_health_summary(data: Mapping[str, Any]) -> str:
+    """Render the bounded operator projection for a periodic health summary."""
+    uptime_ms = _data_int(data, "uptime_ms")
+    loop_ms = _data_int(data, "last_loop_duration_ms")
+    long_count = _data_int(data, "positions_long")
+    short_count = _data_int(data, "positions_short")
+    parts = [
+        f"uptime={_format_console_duration_ms(uptime_ms or 0)}",
+        f"loop={loop_ms / 1000.0:.1f}s" if loop_ms and loop_ms > 0 else "loop=n/a",
+        f"positions={long_count or 0}L/{short_count or 0}S",
+    ]
+
+    balance = _data_number(data, "balance_raw")
+    quote = _data_str(data, "quote")
+    if balance is not None:
+        suffix = f" {quote}" if quote else ""
+        balance_part = f"balance={balance:.2f}{suffix}"
+        snapped = _data_number(data, "balance_snapped")
+        if snapped is not None and abs(balance - snapped) > 1e-9:
+            balance_part += f" (snap {snapped:.2f})"
+        parts.append(balance_part)
+
+    placed = _data_int(data, "orders_placed")
+    cancelled = _data_int(data, "orders_cancelled")
+    parts.append(f"orders=+{placed or 0}/-{cancelled or 0}")
+
+    fills = _data_int(data, "fills")
+    fills = fills if fills is not None else 0
+    fills_part = f"fills={fills}"
+    if fills > 0:
+        pnl = _data_number(data, "pnl")
+        if pnl is not None:
+            pnl_suffix = f" {quote}" if quote else ""
+            fills_part += f" (pnl={pnl:+.2f}{pnl_suffix})"
+    parts.append(fills_part)
+
+    errors = _data_int(data, "errors_last_hour")
+    error_budget_max = _data_int(data, "error_budget_max")
+    parts.append(f"errors={errors or 0}/{error_budget_max or 10}")
+
+    ws = _data_int(data, "ws_reconnects")
+    if ws:
+        parts.append(f"ws={ws}")
+    rate_limits = _data_int(data, "rate_limits")
+    if rate_limits:
+        parts.append(f"rate_limits={rate_limits}")
+    rss_bytes = _data_int(data, "rss_bytes")
+    if rss_bytes is not None:
+        parts.append(f"rss={rss_bytes / 1024.0 / 1024.0:.1f}MiB")
+    summary_lag_ms = _data_int(data, "health_summary_lag_ms")
+    if summary_lag_ms:
+        parts.append(f"health_lag={summary_lag_ms / 1000.0:.1f}s")
+
+    slow_phases = data.get("slow_phases")
+    if isinstance(slow_phases, list):
+        shown = []
+        for item in slow_phases[:3]:
+            if not isinstance(item, Mapping):
+                continue
+            phase = _data_str(item, "phase")
+            duration_ms = _data_int(item, "duration_ms")
+            if phase and duration_ms and duration_ms > 0:
+                shown.append(f"{phase}:{duration_ms / 1000.0:.1f}s")
+        if shown:
+            parts.append("slow=" + ",".join(shown))
+
+    queue_depth = _data_int(data, "event_queue_depth")
+    if queue_depth:
+        queue_max = _data_int(data, "event_queue_maxsize")
+        parts.append(
+            f"event_q={queue_depth}/{queue_max}"
+            if queue_max
+            else f"event_q={queue_depth}"
+        )
+    dropped = _data_int(data, "event_dropped_total")
+    if dropped:
+        parts.append(f"event_dropped={dropped}")
+    sink_errors = _data_int(data, "event_sink_error_total")
+    if sink_errors:
+        parts.append(f"sink_errors={sink_errors}")
+    if data.get("event_pipeline_worker_alive") is False:
+        parts.append("event_worker=dead")
+    return "[health] " + " | ".join(parts)
+
+
 def _format_console_ratio(value: Any) -> str | None:
     if value is None:
         return None
@@ -1927,6 +2026,11 @@ def _operator_sink_event_visible(event: LiveEvent) -> bool:
 
 
 def format_console_event(event: LiveEvent) -> str:
+    if (
+        event.event_type == EventTypes.HEALTH_SUMMARY
+        and event.reason_code == ReasonCodes.PERIODIC_HEALTH_SUMMARY
+    ):
+        return format_periodic_health_summary(event.data)
     if event.event_type == EventTypes.FILL_INGESTED:
         return _format_console_fill_ingested(event)
     if event.event_type == EventTypes.FILLS_INGESTED_SUMMARY:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -61,6 +61,7 @@ from live.events import DiagnosticEvent, emit_diagnostic_event, run_diagnostic_s
 from live.event_bus import (
     ConsoleSummarySink,
     EventTypes,
+    format_periodic_health_summary,
     LIVE_EVENT_CONSOLE_ENV,
     LIVE_EVENT_DEBUG_PROFILE_ENV,
     LiveEventContext,
@@ -2293,117 +2294,40 @@ class Passivbot:
     def _log_health_summary(self) -> None:
         """Log a health summary with uptime and counters."""
         now_ms = utc_ms()
-        uptime_ms = now_ms - self._health_start_ms
-        uptime_str = self._format_duration(uptime_ms)
-
-        # Count current positions
-        n_long = 0
-        n_short = 0
-        for symbol, pos_data in self.positions.items():
-            if pos_data.get("long", {}).get("size", 0.0) != 0.0:
-                n_long += 1
-            if pos_data.get("short", {}).get("size", 0.0) != 0.0:
-                n_short += 1
-
-        balance_raw = self.get_raw_balance()
-        balance_snapped = self.get_hysteresis_snapped_balance()
-        balance_str = f"{balance_raw:.2f} {self.quote}"
-        if abs(balance_raw - balance_snapped) > 1e-9:
-            balance_str += f" (snap {balance_snapped:.2f})"
-
-        # Build fills string with PnL if fills > 0
-        if self._health_fills > 0:
-            pnl_sign = "+" if self._health_pnl >= 0 else ""
-            fills_str = (
-                f"fills={self._health_fills} (pnl={pnl_sign}{self._health_pnl:.2f})"
-            )
-        else:
-            fills_str = "fills=0"
-
-        # Loop timing
-        loop_ms = getattr(self, "_last_loop_duration_ms", 0)
-        loop_str = f"{loop_ms / 1000:.1f}s" if loop_ms > 0 else "n/a"
-        slow_phase_str = ""
-        try:
-            loop_timing = getattr(self, "_last_loop_timing_ms", {}) or {}
-            if loop_ms >= 60_000 and isinstance(loop_timing, dict) and loop_timing:
-                ranked = sorted(
-                    (
-                        (str(phase), int(duration_ms))
-                        for phase, duration_ms in loop_timing.items()
-                    ),
-                    key=lambda item: item[1],
-                    reverse=True,
-                )
-                slow_phase_str = " | slow_phases=" + ",".join(
-                    f"{phase}:{duration_ms / 1000:.1f}s"
-                    for phase, duration_ms in ranked[:3]
-                    if duration_ms > 0
-                )
-        except Exception:
-            slow_phase_str = ""
-
-        # Error budget: count of errors in last hour vs max
-        error_counts = getattr(self, "error_counts", [])
-        now = utc_ms()
-        recent_errors = len([x for x in error_counts if x > now - 1000 * 60 * 60])
-        max_errors = 10
-        error_budget_str = f"{recent_errors}/{max_errors}"
-
-        # Memory usage
-        try:
-            import resource
-
-            rss_mb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024 / 1024
-            mem_str = f"rss={rss_mb:.0f}MB"
-        except Exception:
-            mem_str = ""
-
-        logging.info(
-            "[health] uptime=%s | loop=%s | positions=%d long, %d short | balance=%s | "
-            "orders=+%d/-%d | %s | errors=%s | ws_reconnects=%d | rate_limits=%d%s",
-            uptime_str,
-            loop_str,
-            n_long,
-            n_short,
-            balance_str,
-            self._health_orders_placed,
-            self._health_orders_cancelled,
-            fills_str,
-            error_budget_str,
-            self._health_ws_reconnects,
-            self._health_rate_limits,
-            f"{slow_phase_str}{f' | {mem_str}' if mem_str else ''}",
-        )
         emit_health_summary = getattr(self, "_emit_health_summary_event", None)
-        if callable(emit_health_summary):
-            pipeline = getattr(self, "_live_event_pipeline", None)
-            confirm_timing = getattr(pipeline, "confirm_timing_snapshot", None)
-            restore_timing = getattr(pipeline, "restore_timing_snapshot", None)
-            timing_snapshot_token = None
-            try:
-                payload_result = self._build_health_summary_payload(
-                    now_ms=now_ms,
-                    reset_event_pipeline_timing=True,
-                )
-                if isinstance(payload_result, tuple):
-                    health_payload, timing_snapshot_token = payload_result
-                else:
-                    health_payload = payload_result
-                    timing_snapshot_token = None
+        can_emit = callable(emit_health_summary)
+        pipeline = getattr(self, "_live_event_pipeline", None)
+        confirm_timing = getattr(pipeline, "confirm_timing_snapshot", None)
+        restore_timing = getattr(pipeline, "restore_timing_snapshot", None)
+        timing_snapshot_token = None
+        try:
+            payload_result = self._build_health_summary_payload(
+                now_ms=now_ms,
+                reset_event_pipeline_timing=can_emit,
+            )
+            if isinstance(payload_result, tuple):
+                health_payload, timing_snapshot_token = payload_result
+            else:
+                health_payload = payload_result
+                timing_snapshot_token = None
+            health_console_available = bool(
+                can_emit
+                and Passivbot._live_event_console_available(self)
+                and getattr(pipeline, "console_sink", None) is not None
+            )
+            if not health_console_available:
+                logging.info(format_periodic_health_summary(health_payload))
+            if can_emit:
                 emitted = emit_health_summary(health_payload)
                 if emitted is None:
                     if callable(restore_timing) and timing_snapshot_token is not None:
                         restore_timing(timing_snapshot_token)
                 elif callable(confirm_timing) and timing_snapshot_token is not None:
                     confirm_timing(timing_snapshot_token)
-            except Exception as exc:
-                if (
-                    callable(restore_timing)
-                    and timing_snapshot_token is not None
-                ):
-                    restore_timing(timing_snapshot_token)
-                logging.debug("[event] failed preparing health summary event: %s", exc)
+        except Exception as exc:
+            if callable(restore_timing) and timing_snapshot_token is not None:
+                restore_timing(timing_snapshot_token)
+            logging.debug("[event] failed preparing health summary event: %s", exc)
         self._maybe_log_candle_health_summary()
 
     def _unstuck_loss_allowance_pct_overrides_for_logging(self, pside: str) -> dict[str, float]:

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -469,15 +469,34 @@ def _build_health_summary_payload(
         "positions_short": n_short,
         "balance_raw": balance_raw,
         "balance_snapped": balance_snapped,
+        "quote": str(getattr(self, "quote", "") or ""),
         "equity": float(getattr(self, "_monitor_last_equity", balance_raw) or balance_raw),
         "orders_placed": int(self._health_orders_placed),
         "orders_cancelled": int(self._health_orders_cancelled),
         "fills": int(self._health_fills),
         "pnl": float(self._health_pnl),
         "errors_last_hour": recent_errors,
+        "error_budget_max": 10,
         "ws_reconnects": int(self._health_ws_reconnects),
         "rate_limits": int(self._health_rate_limits),
     }
+    loop_ms = payload["last_loop_duration_ms"]
+    loop_timings = getattr(self, "_last_loop_timing_ms", {}) or {}
+    if loop_ms >= 60_000 and isinstance(loop_timings, dict):
+        slow_phases = []
+        for phase, duration_ms in loop_timings.items():
+            try:
+                duration_ms = int(duration_ms)
+            except (TypeError, ValueError):
+                continue
+            if duration_ms > 0:
+                slow_phases.append((str(phase)[:64], duration_ms))
+        slow_phases.sort(key=lambda item: item[1], reverse=True)
+        if slow_phases:
+            payload["slow_phases"] = [
+                {"phase": phase, "duration_ms": duration_ms}
+                for phase, duration_ms in slow_phases[:3]
+            ]
     summary_lag_ms = getattr(self, "_health_summary_lag_ms", None)
     if summary_lag_ms is not None:
         payload["health_summary_lag_ms"] = max(0, int(summary_lag_ms))

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -1903,12 +1903,14 @@ def test_console_format_summarizes_periodic_health():
             "positions_long": 2,
             "positions_short": 1,
             "balance_raw": 1_005.25,
-            "equity": 1_010.75,
+            "balance_snapped": 1_004.75,
+            "quote": "USDT",
             "orders_placed": 3,
             "orders_cancelled": 1,
             "fills": 2,
             "pnl": -1.5,
             "errors_last_hour": 1,
+            "error_budget_max": 10,
             "ws_reconnects": 2,
             "rate_limits": 3,
             "rss_bytes": 157_286_400,
@@ -1921,11 +1923,46 @@ def test_console_format_summarizes_periodic_health():
     )
 
     assert format_console_event(event) == (
-        "[health] succeeded cycle=cy_health uptime=123s loop=1.2s "
-        "positions=2L/1S balance=1005.25 equity=1010.75 orders=+3/-1 "
-        "fills=2:pnl=-1.5 errors=1/h ws=2 rate_limits=3 rss=150.0MiB "
-        "event_q=4/1000 event_dropped=2 sink_errors=1 "
-        "reason=periodic_health_summary"
+        "[health] uptime=2m3s | loop=1.2s | positions=2L/1S | "
+        "balance=1005.25 USDT (snap 1004.75) | orders=+3/-1 | "
+        "fills=2 (pnl=-1.50 USDT) | errors=1/10 | ws=2 | rate_limits=3 | "
+        "rss=150.0MiB | event_q=4/1000 | event_dropped=2 | sink_errors=1"
+    )
+
+
+def test_console_format_periodic_health_keeps_zero_balance_and_known_zero_pnl():
+    event = LiveEvent(
+        EventTypes.HEALTH_SUMMARY,
+        reason_code=ReasonCodes.PERIODIC_HEALTH_SUMMARY,
+        data={
+            "uptime_ms": 1_173_000,
+            "last_loop_duration_ms": 39_500,
+            "positions_long": 0,
+            "positions_short": 0,
+            "balance_raw": 0.0,
+            "balance_snapped": 0.0,
+            "quote": "USDT",
+            "orders_placed": 0,
+            "orders_cancelled": 0,
+            "fills": 1,
+            "pnl": 0.0,
+            "errors_last_hour": 0,
+            "error_budget_max": 10,
+            "rss_bytes": 87_658_496,
+            "ws_reconnects": 0,
+            "rate_limits": 0,
+            "health_summary_lag_ms": 0,
+            "event_queue_depth": 0,
+            "event_dropped_total": 0,
+            "event_sink_error_total": 0,
+            "event_pipeline_worker_alive": True,
+        },
+    )
+
+    assert format_console_event(event) == (
+        "[health] uptime=19m33s | loop=39.5s | positions=0L/0S | "
+        "balance=0.00 USDT | orders=+0/-0 | fills=1 (pnl=+0.00 USDT) | "
+        "errors=0/10 | rss=83.6MiB"
     )
 
 

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -11,6 +11,7 @@ import pytest
 
 import live.event_emitters as live_event_emitters
 from live.event_bus import (
+    ConsoleSummarySink,
     EventTypes,
     ListEventSink,
     LiveEvent,
@@ -1397,6 +1398,7 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
             }
             self._health_start_ms = 100_000
             self._last_loop_duration_ms = 1234
+            self._last_loop_timing_ms = {}
             self._health_summary_lag_ms = 2345
             self._monitor_last_equity = 1001.0
             self._health_orders_placed = 5
@@ -1405,6 +1407,7 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
             self._health_pnl = 8.5
             self._health_ws_reconnects = 1
             self._health_rate_limits = 2
+            self.quote = "USDT"
             self.error_counts = [159_000, 10_000]
             self._live_event_pipeline = FakePipeline()
 
@@ -1448,6 +1451,9 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
     assert payload["health_summary_lag_ms"] == 2345
     assert payload["positions_long"] == 1
     assert payload["positions_short"] == 1
+    assert payload["quote"] == "USDT"
+    assert payload["error_budget_max"] == 10
+    assert "slow_phases" not in payload
     assert payload["rss_bytes"] == 123456
     assert payload["memory_percent"] == 12.5
     assert payload["cpu_percent"] == 34.25
@@ -1518,6 +1524,20 @@ def test_build_health_summary_payload_includes_resource_pressure(monkeypatch):
     assert timing_token == 41
     assert bot._live_event_pipeline.consume_timing_calls == [False, True]
 
+    bot._last_loop_duration_ms = 60_000
+    bot._last_loop_timing_ms = {
+        "market": 1_000,
+        "maintenance": 5_000,
+        "account": 3_000,
+        "ignored": 500,
+    }
+    slow_payload = bot._build_health_summary_payload(now_ms=160_000)
+    assert slow_payload["slow_phases"] == [
+        {"phase": "maintenance", "duration_ms": 5_000},
+        {"phase": "account", "duration_ms": 3_000},
+        {"phase": "market", "duration_ms": 1_000},
+    ]
+
 
 def test_process_cpu_percent_reuses_psutil_process(monkeypatch):
     import passivbot as pb_mod
@@ -1559,7 +1579,7 @@ def test_process_cpu_percent_reuses_psutil_process(monkeypatch):
     ]
 
 
-def test_log_health_summary_emits_structured_event(caplog, monkeypatch):
+def test_log_health_summary_structured_console_owns_periodic_line(caplog, monkeypatch):
     import passivbot as pb_mod
 
     sink = ListEventSink()
@@ -1591,6 +1611,7 @@ def test_log_health_summary_emits_structured_event(caplog, monkeypatch):
             self._health_pnl = 1.25
             self._health_ws_reconnects = 4
             self._health_rate_limits = 5
+            self.live_event_console_enabled = True
             self.error_counts = [190000]
             self.candle_health_called = False
             self.payload_now_ms = None
@@ -1599,6 +1620,9 @@ def test_log_health_summary_emits_structured_event(caplog, monkeypatch):
             self._live_event_pipeline = LiveEventPipeline(
                 structured_sinks=[sink],
                 monitor_sinks=[],
+                console_sink=ConsoleSummarySink(
+                    logging.getLogger("passivbot.live_event_console")
+                ),
             )
 
         def get_raw_balance(self):
@@ -1622,11 +1646,13 @@ def test_log_health_summary_emits_structured_event(caplog, monkeypatch):
                 "positions_short": 0,
                 "balance_raw": 1000.0,
                 "balance_snapped": 999.5,
+                "quote": "USDT",
                 "orders_placed": 2,
                 "orders_cancelled": 1,
                 "fills": 3,
                 "pnl": 1.25,
                 "errors_last_hour": 1,
+                "error_budget_max": 10,
                 "ws_reconnects": 4,
                 "rate_limits": 5,
                 "rss_bytes": 987654,
@@ -1655,14 +1681,19 @@ def test_log_health_summary_emits_structured_event(caplog, monkeypatch):
 
     with caplog.at_level(logging.INFO):
         bot._log_health_summary()
+        assert bot._live_event_pipeline.flush(timeout=2.0) is True
 
-    assert "[health] uptime=1m0s" in caplog.text
-    assert "positions=1 long, 0 short" in caplog.text
-    assert "orders=+2/-1" in caplog.text
+    health_records = [record for record in caplog.records if "[health]" in record.message]
+    assert [record.name for record in health_records] == ["passivbot.live_event_console"]
+    assert health_records[0].message == (
+        "[health] uptime=1m0s | loop=2.5s | positions=1L/0S | "
+        "balance=1000.00 USDT (snap 999.50) | orders=+2/-1 | "
+        "fills=3 (pnl=+1.25 USDT) | errors=1/10 | ws=4 | rate_limits=5 | "
+        "rss=0.9MiB"
+    )
     assert bot.candle_health_called is True
     assert bot.payload_now_ms == 200000
     assert bot.payload_reset_event_pipeline_timing is True
-    assert bot._live_event_pipeline.flush(timeout=2.0) is True
     event = sink.events[0]
     assert event.event_type == EventTypes.HEALTH_SUMMARY
     assert event.cycle_id == "cy_health"
@@ -1675,6 +1706,128 @@ def test_log_health_summary_emits_structured_event(caplog, monkeypatch):
     bot._log_health_summary()
     assert confirmed == [17]
     assert restored == [17]
+    assert [record for record in caplog.records if "[health]" in record.message] == health_records
+
+    def raise_on_emit(_payload):
+        raise RuntimeError("synthetic enqueue failure")
+
+    bot._emit_health_summary_event = raise_on_emit
+    bot._log_health_summary()
+    assert confirmed == [17]
+    assert restored == [17, 17]
+    assert [record for record in caplog.records if "[health]" in record.message] == health_records
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.parametrize("console_enabled", [False, True])
+def test_log_health_summary_uses_legacy_fallback_without_console_sink(
+    caplog, monkeypatch, console_enabled
+):
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _emit_health_summary_event = pb_mod.Passivbot._emit_health_summary_event
+        _log_health_summary = pb_mod.Passivbot._log_health_summary
+
+        def __init__(self):
+            self.exchange = "okx"
+            self.user = "okx_01"
+            self.bot_id = "bot_1"
+            self.live_event_console_enabled = console_enabled
+            self._live_event_current_cycle_id = "cy_health"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink], monitor_sinks=[]
+            )
+
+        def _build_health_summary_payload(self, **_kwargs):
+            return {
+                "uptime_ms": 1_173_000,
+                "last_loop_duration_ms": 39_500,
+                "positions_long": 0,
+                "positions_short": 0,
+                "balance_raw": 2946.66,
+                "balance_snapped": 2951.82,
+                "quote": "USDT",
+                "orders_placed": 0,
+                "orders_cancelled": 0,
+                "fills": 0,
+                "pnl": 0.0,
+                "errors_last_hour": 0,
+                "error_budget_max": 10,
+                "rss_bytes": 87_658_496,
+            }
+
+        def _maybe_log_candle_health_summary(self):
+            return None
+
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: 200_000)
+    bot = FakeBot()
+
+    with caplog.at_level(logging.INFO):
+        bot._log_health_summary()
+        assert bot._live_event_pipeline.flush(timeout=2.0) is True
+
+    health_records = [record for record in caplog.records if "[health]" in record.message]
+    assert len(health_records) == 1
+    assert health_records[0].message == (
+        "[health] uptime=19m33s | loop=39.5s | positions=0L/0S | "
+        "balance=2946.66 USDT (snap 2951.82) | orders=+0/-0 | fills=0 | "
+        "errors=0/10 | rss=83.6MiB"
+    )
+    assert sink.events[0].event_type == EventTypes.HEALTH_SUMMARY
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_log_health_summary_uses_fallback_when_emitter_missing(caplog, monkeypatch):
+    import passivbot as pb_mod
+
+    class FakeBot:
+        _emit_health_summary_event = None
+        _log_health_summary = pb_mod.Passivbot._log_health_summary
+
+        def __init__(self):
+            self.live_event_console_enabled = True
+            self._live_event_pipeline = LiveEventPipeline(
+                console_sink=ConsoleSummarySink(
+                    logging.getLogger("passivbot.live_event_console")
+                )
+            )
+            self.payload_reset_event_pipeline_timing = None
+
+        def _build_health_summary_payload(
+            self, *, now_ms=None, reset_event_pipeline_timing=False
+        ):
+            self.payload_reset_event_pipeline_timing = reset_event_pipeline_timing
+            return {
+                "uptime_ms": 1_000,
+                "last_loop_duration_ms": 0,
+                "positions_long": 0,
+                "positions_short": 0,
+                "orders_placed": 0,
+                "orders_cancelled": 0,
+                "fills": 0,
+                "errors_last_hour": 0,
+                "error_budget_max": 10,
+            }
+
+        def _maybe_log_candle_health_summary(self):
+            return None
+
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: 200_000)
+    bot = FakeBot()
+
+    with caplog.at_level(logging.INFO):
+        bot._log_health_summary()
+
+    assert bot.payload_reset_event_pipeline_timing is False
+    assert [record.message for record in caplog.records if "[health]" in record.message] == [
+        "[health] uptime=1s | loop=n/a | positions=0L/0S | orders=+0/-0 | "
+        "fills=0 | errors=0/10"
+    ]
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 


### PR DESCRIPTION
## Summary
- make periodic structured health events own console/text output when the console sink is actually available
- render one compact human health line with raw/snapped balance, error budget, correct RSS, bounded slow phases, and anomaly-only fields
- preserve legacy fallback, timing snapshot transactions, error-burst formatting, scheduler cadence, and trading behavior

## Validation
- rebuilt and stamped the exact Rust extension; runtime fingerprint verified
- 364 relevant event-bus, monitor, logging, docs, query, smoke-report, and incident-bundle tests passed
- generated live-event registry check passed
- Python compilation and git diff --check passed
- independent read-only preflight and delta re-review green

## VPS plan
After exact-head Hermes + Grok 4.5 + CI approval, merge to v8, gracefully restart only the five exact VPS5 bot panes, then validate one natural compact periodic health line per interval plus immediate and settled smoke. No trading state will be created or altered for validation.