### PR TITLE
Migrate execution error burst console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Execution-loop error bursts now use the structured `health.summary` console
+  projection as the sole normal console/text line when a live-event console sink
+  is available. The legacy warning remains the fallback when that projection or
+  its emitter is unavailable; error thresholds, redaction, restart/backoff, and
+  trading behavior are unchanged.
+
 - Periodic health console/text output now projects the structured
   `health.summary` event as one compact line when the live event console is
   available, while retaining the same legacy fallback when it is disabled or

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,52 +22,41 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-health-console-migration`
-- PR: #1216
-- Base: `6af983c539d00acd802aabad66044868afd45aa4`, merged PR #1215
-- Triggering evidence: every periodic health interval writes both a legacy
-  `[health]` line and a structured `health.summary` console projection. The
-  duplicate is frequent on every bot, the structured projection is needlessly
-  machine-like, and the legacy Linux `ru_maxrss` conversion visibly reports
-  `rss=0MB` while the structured event carries the correct byte count.
-- Scope: make the periodic structured `health.summary` event own the normal
-  human projection. Render one compact line with human uptime, loop time,
-  positions, raw/snapped balance and quote currency, orders, fills/PnL, error
-  budget, correct RSS, and only nonzero health/pipeline anomalies. Retain the
-  stdlib health line only when the structured event console is disabled or its
-  pipeline is absent. Preserve the separate error-burst health projection.
-- Behavior boundary: observability migration only. Preserve health counters,
-  scheduler cadence, event-pipeline timing snapshot transactions, candle-health
-  logging, and every order/risk/trading behavior. Do not change exchange calls,
-  health thresholds, restart policy, or smoke verdict policy.
-- Validation: compact periodic formatter coverage including zero values,
-  raw/snapped balance, quote currency, fills/PnL, errors, RSS, and anomaly-only
-  fields; single-line structured ownership versus stdlib fallback; timing
-  snapshot confirm/restore behavior; preserved error-burst formatting;
-  integrated monitor tests; generated registry/docs checks; Python compilation;
-  `git diff --check`; silent-handling audit; and independent preflight.
+- Branch: `codex/v8-error-burst-console-migration`.
+- Base: `13e6e484cf20b1265f2b4874b14ff7ab32d10bfd`, merged PR #1216.
+- Slice: execution-loop error-burst console ownership.
+- Triggering evidence: after PR #1216, a natural KuCoin error burst wrote two
+  adjacent console lines: structured `health.summary`
+  `reason=execution_loop_error_burst` and legacy `[health] execution loop error
+  burst`.
+- Scope: make the existing structured degraded health event the sole normal
+  console/text owner when its enabled pipeline has a console sink. Preserve the
+  legacy warning only when the pipeline, console sink, or callable emitter seam
+  is unavailable. Do not turn pipeline enqueue, flush, or sink degradation into
+  dual writing.
+- Behavior boundary: preserve burst thresholds, event payload/redaction,
+  individual error logs, restart/backoff, and trading behavior.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
-- Expected VPS action: exact five-bot graceful restart plus immediate and
-  settled smoke. Periodic health output occurs naturally, so validate exactly
-  one compact line per interval without creating or altering trading state.
-
-Next action:
-
-1. Hold PR #1216 at its exact current head for Hermes, Grok 4.5, and CI.
-2. Resolve findings narrowly and require fresh exact-head verdicts after every
-   push.
-3. Merge only when the complete gate is green, then perform the exact five-bot
-   graceful VPS5 restart and immediate/settled smoke.
+- Expected VPS action: restart and observe only after this follow-up merges;
+  this isolated implementation work does not contact VPS5 or exchanges.
 
 ## Deployed Baseline
 
-- Remote `v8`: `6af983c539d00acd802aabad66044868afd45aa4`, PR #1215
-- VPS5 repository: `6af983c539d00acd802aabad66044868afd45aa4`, PR #1215; tracked
-  status clean; expected untracked artifacts were preserved
-- VPS5 expected bots: five; running with PR #1215 restart PIDs
-  `903757/903759/903761/903763/903765`;
-  unrelated `misc:0.0` remains PID `434835`
+- Remote `v8`: `13e6e484cf20b1265f2b4874b14ff7ab32d10bfd`, PR #1216
+- VPS5 repository: `13e6e484cf20b1265f2b4874b14ff7ab32d10bfd`, PR #1216; exact
+  tracked status clean and expected untracked artifacts preserved
+- VPS5 expected bots: five; running with PR #1216 restart PIDs
+  `905310/905312/905314/905315/905316`; pane PIDs unchanged; unrelated
+  `misc:0.0` remains PID `434835`
+- PR #1216 merged and deployed at
+  `13e6e484cf20b1265f2b4874b14ff7ab32d10bfd`. The settled smoke returned
+  `ok=true`, `414/414` remote calls, `70/70` account-critical calls, five
+  green process/config checks, `12/12` fill refreshes, and exact repository
+  head with zero tracked changes. Four natural periodic health lines proved
+  compact single ownership and sane RSS. A natural KuCoin error burst
+  separately exposed the remaining adjacent legacy/structured error-burst
+  duplicate, which is the active follow-up above.
 - PR #1215 merged after exact-head Hermes and Grok 4.5 approval plus green CI.
   It made structured fill events own normal console/text output, added one
   bounded bulk summary while preserving every durable per-fill event, and kept
@@ -469,11 +458,11 @@ showed only `13.774%` thread CPU and `86.226%` direct non-CPU time. The long
 retention wall-time tail is host descheduling/contention evidence and does not
 justify another retention optimization.
 
-PR #1215's fill console/text migration is merged and deployed. The active slice
-is PR #1216's periodic health console migration: preserve durable health events,
-timing snapshot transactions, scheduler cadence, and error-burst formatting;
-render one compact normal health line and keep the stdlib line only as fallback
-when the structured console sink is unavailable.
+PR #1215's fill console/text migration and PR #1216's periodic health console
+migration are merged and deployed. PR #1216 proved compact single ownership and
+sane RSS across four natural periodic health lines; the only newly exposed
+duplicate is the separate execution-loop error-burst warning, tracked by the
+active follow-up above.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -69,6 +69,17 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1216 merged to `v8` as
+  `13e6e484cf20b1265f2b4874b14ff7ab32d10bfd` and was deployed after the exact
+  review gate. The five new bot PIDs were
+  `905310/905312/905314/905315/905316`; pane PIDs and unrelated `misc:0.0` PID
+  `434835` were unchanged. Settled smoke returned `ok=true`, `414/414` remote
+  calls, `70/70` account-critical calls, five green process/config checks,
+  `12/12` fill refreshes, and the exact repository head with zero tracked
+  changes. Four natural
+  periodic health lines proved compact single ownership and sane RSS. A natural
+  KuCoin error burst exposed a separate structured/legacy duplicate, retained
+  as the next focused console-ownership slice.
 - PR #1215 merged to `v8` as
   `6af983c539d00acd802aabad66044868afd45aa4` after exact-head Hermes and
   Grok 4.5 approval plus green CI. Structured `fill.ingested` events now own

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -516,9 +516,14 @@ Related detailed plans:
     truthiness-gap note was incorrect. PR #1210 renders frequent balance changes
     as exact raw/snapped transitions. PR #1215 removed the fill legacy/event
     duplicate after the structured projection gained timestamp, pending-PnL,
-    bounded traceability, and bulk-summary semantics. The active follow-up
-    removes the frequent periodic-health duplicate and replaces its incorrect
-    legacy Linux RSS rendering with the structured payload's byte count.
+    bounded traceability, and bulk-summary semantics. PR #1216 merged and
+    deployed at `13e6e484cf20b1265f2b4874b14ff7ab32d10bfd`: four natural
+    periodic health lines proved compact single ownership and sane RSS, with
+    `ok=true` settled smoke (`414/414` remote, `70/70` account-critical,
+    five process/config checks, `12/12` fill refreshes, and zero tracked
+    repository changes).
+    The natural KuCoin error burst exposed the remaining separate
+    structured/legacy duplicate, now the next focused console-ownership slice.
 
     Work log:
     - 2026-06-30: Added value-safe `live-smoke-report` HSL status projections

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -5233,12 +5233,22 @@ class Passivbot:
         state["last_log_ms"] = now
         top = ",".join(f"{name}:{n}" for name, n in endpoints.most_common(5))
         window_s = max(1, int((now - int(state["first_ms"])) / 1000))
-        self._emit_execution_loop_error_burst_event(
-            count=count,
-            window_s=window_s,
-            endpoints=endpoints,
-            latest_fields=fields,
+        emit_error_burst = getattr(self, "_emit_execution_loop_error_burst_event", None)
+        pipeline = getattr(self, "_live_event_pipeline", None)
+        structured_console_available = bool(
+            callable(emit_error_burst)
+            and Passivbot._live_event_console_available(self)
+            and getattr(pipeline, "console_sink", None) is not None
         )
+        if callable(emit_error_burst):
+            emit_error_burst(
+                count=count,
+                window_s=window_s,
+                endpoints=endpoints,
+                latest_fields=fields,
+            )
+        if structured_console_available:
+            return
         logging.warning(
             "[health] execution loop error burst | count=%d window=%ds top=%s latest_type=%s status=%s code=%s action=restart_backoff_continues",
             count,

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -19,6 +19,7 @@ from live.event_bus import (
     EventTags,
     EventTypes,
     ListEventSink,
+    LiveEvent,
     LiveEventPipeline,
     ReasonCodes,
 )
@@ -9520,16 +9521,19 @@ def test_execution_loop_error_burst_summarizes_repeated_endpoints(caplog, monkey
     assert "action=restart_backoff_continues" in messages[0]
 
 
-def test_execution_loop_error_burst_emits_structured_health_event(caplog, monkeypatch):
+def test_execution_loop_error_burst_structured_console_owns_warning(caplog, monkeypatch):
     sink = ListEventSink()
+    console_sink = ListEventSink()
     bot = Passivbot.__new__(Passivbot)
     bot.exchange = "kucoin"
     bot.user = "kucoin_01"
     bot.bot_id = "bot_1"
+    bot.live_event_console_enabled = True
     bot._live_event_current_cycle_id = "cy_error"
     bot._live_event_pipeline = LiveEventPipeline(
         structured_sinks=[sink],
         monitor_sinks=[],
+        console_sink=console_sink,
     )
     now = {"value": 1_000_000}
     monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now["value"])
@@ -9550,6 +9554,11 @@ def test_execution_loop_error_burst_emits_structured_health_event(caplog, monkey
         bot._log_execution_loop_error_burst(fields)
 
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert not [
+        record
+        for record in caplog.records
+        if "[health] execution loop error burst" in record.message
+    ]
     events = sink.events
     assert len(events) == 1
     event = events[0]
@@ -9573,7 +9582,130 @@ def test_execution_loop_error_burst_emits_structured_health_event(caplog, monkey
     assert "SECRET" not in event.data["latest_error"]
     assert "SIG" not in event.data["latest_error"]
     assert "[redacted]" in event.data["latest_error"]
+    assert console_sink.events == [event]
     assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.parametrize(
+    ("console_enabled", "has_pipeline"),
+    [
+        (True, False),
+        (False, True),
+        (True, True),
+    ],
+)
+def test_execution_loop_error_burst_uses_legacy_fallback_without_structured_console(
+    caplog, monkeypatch, console_enabled, has_pipeline
+):
+    bot = Passivbot.__new__(Passivbot)
+    bot.live_event_console_enabled = console_enabled
+    structured_sink = ListEventSink()
+    if has_pipeline:
+        bot._live_event_pipeline = LiveEventPipeline(
+            structured_sinks=[structured_sink],
+            monitor_sinks=[],
+            console_sink=None,
+        )
+    now = {"value": 1_000_000}
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now["value"])
+    fields = {
+        "error_type": "RequestTimeout",
+        "status": "-",
+        "code": "-",
+        "error": "kucoinfutures GET https://api-futures.kucoin.com/api/v1/account-overview",
+    }
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(3):
+            bot._log_execution_loop_error_burst(fields)
+
+    messages = [record.message for record in caplog.records]
+    assert len(messages) == 1
+    assert "[health] execution loop error burst" in messages[0]
+    if has_pipeline:
+        assert bot._live_event_pipeline.flush(timeout=2.0) is True
+        assert [event.reason_code for event in structured_sink.events] == [
+            ReasonCodes.EXECUTION_LOOP_ERROR_BURST
+        ]
+        assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.parametrize("emitter_state", ["missing", "noncallable"])
+def test_execution_loop_error_burst_uses_legacy_fallback_when_emitter_unavailable(
+    caplog, monkeypatch, emitter_state
+):
+    bot = Passivbot.__new__(Passivbot)
+    bot.live_event_console_enabled = True
+    if emitter_state == "missing":
+        monkeypatch.delattr(Passivbot, "_emit_execution_loop_error_burst_event")
+    else:
+        bot._emit_execution_loop_error_burst_event = object()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[],
+        monitor_sinks=[],
+        console_sink=ListEventSink(),
+    )
+    now = {"value": 1_000_000}
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now["value"])
+    fields = {
+        "error_type": "RequestTimeout",
+        "status": "-",
+        "code": "-",
+        "error": "kucoinfutures GET https://api-futures.kucoin.com/api/v1/account-overview",
+    }
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(3):
+            bot._log_execution_loop_error_burst(fields)
+
+    messages = [record.message for record in caplog.records]
+    assert len(messages) == 1
+    assert "[health] execution loop error burst" in messages[0]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_execution_loop_error_burst_keeps_structured_console_owner_when_queue_is_full(
+    caplog, monkeypatch
+):
+    console_sink = ListEventSink()
+    pipeline = LiveEventPipeline(
+        structured_sinks=[ListEventSink()],
+        monitor_sinks=[],
+        console_sink=console_sink,
+        queue_maxsize=1,
+        start=False,
+    )
+    pipeline.emit(LiveEvent(EventTypes.CYCLE_STARTED))
+    bot = Passivbot.__new__(Passivbot)
+    bot.live_event_console_enabled = True
+    bot._live_event_pipeline = pipeline
+    now = {"value": 1_000_000}
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now["value"])
+    fields = {
+        "error_type": "RequestTimeout",
+        "status": "-",
+        "code": "-",
+        "error": "kucoinfutures GET https://api-futures.kucoin.com/api/v1/account-overview",
+    }
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(3):
+            bot._log_execution_loop_error_burst(fields)
+
+    assert not [
+        record
+        for record in caplog.records
+        if "[health] execution loop error burst" in record.message
+    ]
+    assert [
+        event.reason_code
+        for event in console_sink.events
+        if event.reason_code == ReasonCodes.EXECUTION_LOOP_ERROR_BURST
+    ] == [ReasonCodes.EXECUTION_LOOP_ERROR_BURST]
+    assert pipeline.health_snapshot()["event_dropped_total"] == 1
+    pipeline._queue.get_nowait()
+    pipeline._queue.task_done()
+    assert pipeline.close(timeout=2.0) is True
 
 
 def test_staged_refresh_timing_summary_aggregates_routine_fast_refreshes(


### PR DESCRIPTION
## Summary
- make structured `health.summary` with `reason=execution_loop_error_burst` the sole normal console/text projection when the enabled live-event pipeline has a console sink
- preserve the legacy warning when the pipeline, console sink, or callable emitter is unavailable
- keep structured/monitor emission without a console sink and avoid dynamic dual-writing when the event queue or a sink degrades
- record PR #1216 deployment evidence and the natural KuCoin duplicate that triggered this slice

## Behavior boundary
Observability only. Burst thresholds, payload/redaction, individual error logs, restart/backoff, exchange calls, and trading behavior are unchanged.

Base: `13e6e484cf20b1265f2b4874b14ff7ab32d10bfd`
Head: `af121f7086`

## Validation
- `8 passed`: focused execution-loop error-burst ownership/fallback tests
- `215 passed, 1 deselected`: full `test_passivbot_balance_split.py` except one unrelated target-branch startup-HSL hang
- `91 passed`: `tests/test_live_event_bus.py`
- `87 passed`: `tests/test_passivbot_monitor.py`
- `2 passed`: AI docs and live-event registry docs
- `check_ai_docs.py`: 0 errors, existing word-count warning only
- generated live-event registry check
- Python compilation
- `git diff --check`
- touched-diff silent-handling audit
- independent read-only preflight: green

The deselected `test_start_bot_treats_hsl_value_error_as_terminal_startup_failure` times out after 90 seconds on pristine `origin/v8` at the same base and is not changed by this PR.

## VPS plan
After exact-head reviewer and CI gates are green, fast-forward VPS5, gracefully restart only the five exact bot panes, preserve pane ownership and the unrelated misc pane, then run immediate and settled smoke. Natural error-burst output will be observed only if it occurs; no exchange failure will be manufactured.