### PR TITLE
Deduplicate ambiguous cancel console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Ambiguous-cancel terminal states now use the structured execution warning as
+  the sole normal console/text line when a live-event console sink is
+  available, with an explicit full-account-confirmation cue in its compact
+  projection. The legacy summary remains the fallback; cancellation and
+  authoritative-confirmation behavior are unchanged.
+
 - Execution-loop error bursts now use the structured `health.summary` console
   projection as the sole normal console/text line when a live-event console sink
   is available. The legacy warning remains the fallback when that projection or

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,33 +22,47 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-error-burst-console-migration`.
-- Base: `13e6e484cf20b1265f2b4874b14ff7ab32d10bfd`, merged PR #1216.
-- Slice: execution-loop error-burst console ownership.
-- Triggering evidence: after PR #1216, a natural KuCoin error burst wrote two
-  adjacent console lines: structured `health.summary`
-  `reason=execution_loop_error_burst` and legacy `[health] execution loop error
-  burst`.
-- Scope: make the existing structured degraded health event the sole normal
-  console/text owner when its enabled pipeline has a console sink. Preserve the
-  legacy warning only when the pipeline, console sink, or callable emitter seam
-  is unavailable. Do not turn pipeline enqueue, flush, or sink degradation into
-  dual writing.
-- Behavior boundary: preserve burst thresholds, event payload/redaction,
-  individual error logs, restart/backoff, and trading behavior.
+- Branch: `codex/v8-ambiguous-cancel-console-migration`.
+- Base: `6599fba08cadffac99ce6a1ce2bfd3f58ca3fa15`, merged PR #1217.
+- Slice: ambiguous-cancel terminal-state console ownership.
+- Triggering evidence: retained OKX logs showed an
+  `execution.cancel_ambiguous_terminal` warning immediately followed by the
+  legacy `[order] ambiguous cancel terminal state; forcing full account
+  confirmation before next cycle` line for the same symbol.
+- Scope: make the existing structured warning the sole normal console/text
+  owner, ensure its compact projection communicates the required full
+  authoritative account confirmation, and preserve the legacy summary only
+  when structured console infrastructure is unavailable. Enqueue or sink
+  degradation must remain single-owner and surface through pipeline health,
+  not trigger dynamic dual writing.
+- Behavior boundary: preserve cancellation results, state-change detection,
+  authoritative confirmation surfaces and epochs, order-wave scheduling,
+  exchange calls, event emission, and all trading behavior.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
-- Expected VPS action: restart and observe only after this follow-up merges;
+- Expected VPS action: restart and observe only after this slice merges;
   this isolated implementation work does not contact VPS5 or exchanges.
 
 ## Deployed Baseline
 
-- Remote `v8`: `13e6e484cf20b1265f2b4874b14ff7ab32d10bfd`, PR #1216
-- VPS5 repository: `13e6e484cf20b1265f2b4874b14ff7ab32d10bfd`, PR #1216; exact
+- Remote `v8`: `6599fba08cadffac99ce6a1ce2bfd3f58ca3fa15`, PR #1217
+- VPS5 repository: `6599fba08cadffac99ce6a1ce2bfd3f58ca3fa15`, PR #1217; exact
   tracked status clean and expected untracked artifacts preserved
-- VPS5 expected bots: five; running with PR #1216 restart PIDs
-  `905310/905312/905314/905315/905316`; pane PIDs unchanged; unrelated
+- VPS5 expected bots: five; running with PR #1217 restart PIDs
+  `906664/906666/906668/906670/906672`; pane PIDs unchanged; unrelated
   `misc:0.0` remains PID `434835`
+- PR #1217 merged and deployed at
+  `6599fba08cadffac99ce6a1ce2bfd3f58ca3fa15`. It made the structured
+  execution-loop error-burst health event the sole normal console/text owner
+  while preserving legacy fallback and every threshold, payload, restart, and
+  trading boundary. All five old bot processes exited naturally after one
+  signal round; exact pane PIDs and unrelated `misc:0.0` PID `434835` remained
+  unchanged. A real KuCoin timeout made the first settled window red. After
+  recovery, the final two-minute smoke returned `ok=true`, `284/284` remote
+  calls, `62/62` account-critical calls, five running processes, `8/8` fill
+  refreshes, zero pipeline failures, no active HSL replay, and an exact clean
+  repository. No natural post-restart error burst occurred, so runtime format
+  evidence remains absent rather than manufactured.
 - PR #1216 merged and deployed at
   `13e6e484cf20b1265f2b4874b14ff7ab32d10bfd`. The settled smoke returned
   `ok=true`, `414/414` remote calls, `70/70` account-critical calls, five
@@ -458,11 +472,11 @@ showed only `13.774%` thread CPU and `86.226%` direct non-CPU time. The long
 retention wall-time tail is host descheduling/contention evidence and does not
 justify another retention optimization.
 
-PR #1215's fill console/text migration and PR #1216's periodic health console
-migration are merged and deployed. PR #1216 proved compact single ownership and
-sane RSS across four natural periodic health lines; the only newly exposed
-duplicate is the separate execution-loop error-burst warning, tracked by the
-active follow-up above.
+PR #1215's fill console/text migration, PR #1216's periodic health console
+migration, and PR #1217's execution-loop error-burst console migration are
+merged and deployed. PR #1216 proved compact periodic-health ownership and sane
+RSS across four natural lines. The retained OKX ambiguous-cancel sequence is
+the next concrete duplicate and is tracked by the active follow-up above.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -69,6 +69,22 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1217 merged to `v8` as
+  `6599fba08cadffac99ce6a1ce2bfd3f58ca3fa15` after exact-head Hermes and
+  Grok 4.5 green reviews plus green CI. The structured execution-loop
+  error-burst event now owns normal console/text output while configurations
+  without a usable structured console retain the legacy warning. VPS5
+  gracefully restarted only the five exact bot panes; old processes exited
+  naturally, pane PIDs and unrelated `misc:0.0` PID `434835` were unchanged,
+  and new bot PIDs were `906664/906666/906668/906670/906672`. A real KuCoin
+  timeout made the first settled window red. After recovery, the final
+  two-minute smoke returned `ok=true`, `284/284` remote calls, `62/62`
+  account-critical calls, five running bots, `8/8` fill refreshes, zero event
+  pipeline failures, no active HSL replay, and an exact clean repository. No
+  natural error burst occurred after restart, so runtime format evidence
+  remains absent rather than manufactured. Retained OKX logs instead exposed
+  the next adjacent structured/legacy duplicate for ambiguous cancel terminal
+  states.
 - PR #1216 merged to `v8` as
   `13e6e484cf20b1265f2b4874b14ff7ab32d10bfd` and was deployed after the exact
   review gate. The five new bot PIDs were

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -522,8 +522,16 @@ Related detailed plans:
     `ok=true` settled smoke (`414/414` remote, `70/70` account-critical,
     five process/config checks, `12/12` fill refreshes, and zero tracked
     repository changes).
-    The natural KuCoin error burst exposed the remaining separate
-    structured/legacy duplicate, now the next focused console-ownership slice.
+    PR #1217 then removed the natural KuCoin execution-loop error-burst
+    structured/legacy duplicate while preserving the legacy fallback when no
+    structured console sink exists. It merged and deployed at
+    `6599fba08cadffac99ce6a1ce2bfd3f58ca3fa15`; after a real transient KuCoin
+    timeout aged out, the final two-minute smoke was green with `284/284`
+    remote and `62/62` account-critical calls, all five bots running, zero
+    pipeline failures, and a clean tracked repository. Retained OKX logs then
+    exposed the next adjacent duplicate: structured
+    `execution.cancel_ambiguous_terminal` followed by the legacy full-account
+    confirmation summary for the same symbol.
 
     Work log:
     - 2026-06-30: Added value-safe `live-smoke-report` HSL status projections

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -1097,6 +1097,8 @@ def _console_order_wave_summary(event: LiveEvent) -> list[str]:
 def _console_order_summary(event: LiveEvent) -> list[str]:
     data = event.data if isinstance(event.data, Mapping) else {}
     parts: list[str] = []
+    if event.event_type == EventTypes.EXECUTION_CANCEL_AMBIGUOUS_TERMINAL:
+        parts.append("confirmation=full_account_required")
     if event.order_wave_id:
         parts.append(f"wave={event.order_wave_id}")
     if event.side:

--- a/src/live/executor.py
+++ b/src/live/executor.py
@@ -982,11 +982,16 @@ async def execute_cancellations_parent(bot, orders: list[dict]) -> list[dict]:
         )
         if ambiguous_symbols:
             confirmation_surfaces = bot._authoritative_full_confirmation_surfaces()
-            logging.info(
-                "[order] ambiguous cancel terminal state; forcing full account confirmation "
-                "before next cycle | symbols=%s",
-                passivbot_cls._log_symbols(ambiguous_symbols, limit=12),
-            )
+            if not (
+                _live_event_console_available(bot, passivbot_cls)
+                and getattr(getattr(bot, "_live_event_pipeline", None), "console_sink", None)
+                is not None
+            ):
+                logging.info(
+                    "[order] ambiguous cancel terminal state; forcing full account confirmation "
+                    "before next cycle | symbols=%s",
+                    passivbot_cls._log_symbols(ambiguous_symbols, limit=12),
+                )
         if hasattr(bot, "_request_authoritative_confirmation"):
             bot._request_authoritative_confirmation(confirmation_surfaces)
         else:

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -1530,6 +1530,26 @@ def test_console_format_summarizes_order_write_without_raw_payload():
     )
 
 
+def test_console_format_marks_ambiguous_cancel_as_requiring_full_account_confirmation():
+    event = LiveEvent(
+        EventTypes.EXECUTION_CANCEL_AMBIGUOUS_TERMINAL,
+        status="degraded",
+        cycle_id="cy_3",
+        order_wave_id="ow_2",
+        symbol="AAVE/USDT:USDT",
+        pside="long",
+        side="buy",
+        reason_code="requires_full_authoritative_confirmation",
+        data={"order_type": "limit"},
+    )
+
+    assert format_console_event(event) == (
+        "[order] degraded cycle=cy_3 confirmation=full_account_required "
+        "wave=ow_2 side=buy type=limit symbol=AAVE/USDT:USDT pside=long "
+        "reason=requires_full_authoritative_confirmation"
+    )
+
+
 def test_console_format_summarizes_create_filter_payload():
     event = LiveEvent(
         EventTypes.EXECUTION_CREATE_SKIPPED,

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -8713,6 +8713,155 @@ async def test_ambiguous_cancel_forces_full_authoritative_confirmation():
     assert bot.state_change_detected_by_symbol == {"BTC/USDT:USDT"}
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("console_sink_fails", [False, True])
+async def test_ambiguous_cancel_structured_console_owns_confirmation_message(
+    caplog, console_sink_fails
+):
+    class FailingConsoleSink:
+        def write(self, _event):
+            raise OSError("console unavailable")
+
+    bot = Passivbot.__new__(Passivbot)
+    bot.debug_mode = False
+    bot.execution_scheduled = False
+    bot.state_change_detected_by_symbol = set()
+    bot._health_orders_cancelled = 0
+    bot.live_event_console_enabled = True
+    bot._live_event_current_cycle_id = "cy_ambiguous_cancel"
+    structured_sink = ListEventSink()
+    console_sink = FailingConsoleSink() if console_sink_fails else ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[structured_sink],
+        monitor_sinks=[],
+        console_sink=console_sink,
+    )
+    confirmations = []
+    order = {
+        "id": "abc123",
+        "symbol": "BTC/USDT:USDT",
+        "side": "buy",
+        "position_side": "long",
+        "qty": 0.001,
+        "price": 100_000.0,
+        "reduce_only": False,
+    }
+
+    async def fake_execute_cancellations(orders):
+        assert orders == [order]
+        return [
+            {
+                "status": "success",
+                "_passivbot_cancel_requires_full_authoritative_confirmation": True,
+            }
+        ]
+
+    bot.live_value = lambda key: 10 if key == "max_n_cancellations_per_batch" else None
+    bot.add_to_recent_order_cancellations = lambda _order: None
+    bot.log_order_action = lambda *args, **kwargs: None
+    bot._log_order_action_summary = lambda *args, **kwargs: None
+    bot.execute_cancellations = fake_execute_cancellations
+    bot.did_cancel_order = lambda executed, _order: executed.get("status") == "success"
+    bot.remove_order = lambda *args, **kwargs: None
+    bot._monitor_order_payload = lambda *args, **kwargs: {}
+    bot._monitor_record_event = lambda *args, **kwargs: None
+    bot._request_authoritative_confirmation = lambda surfaces: confirmations.append(
+        set(surfaces)
+    )
+
+    with caplog.at_level(logging.INFO):
+        res = await Passivbot.execute_cancellations_parent(bot, [order])
+
+    assert len(res) == 1
+    assert confirmations == [{"balance", "positions", "open_orders", "fills"}]
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    terminal_events = [
+        event
+        for event in structured_sink.events
+        if event.event_type == EventTypes.EXECUTION_CANCEL_AMBIGUOUS_TERMINAL
+    ]
+    assert len(terminal_events) == 1
+    assert not [
+        record
+        for record in caplog.records
+        if "ambiguous cancel terminal state; forcing full account confirmation" in record.message
+    ]
+    if console_sink_fails:
+        assert bot._live_event_pipeline.sink_error_counters["console"] >= 1
+    else:
+        assert console_sink.events == terminal_events
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_cancel_uses_legacy_confirmation_message_without_structured_console(
+    caplog,
+):
+    bot = Passivbot.__new__(Passivbot)
+    bot.debug_mode = False
+    bot.execution_scheduled = False
+    bot.state_change_detected_by_symbol = set()
+    bot._health_orders_cancelled = 0
+    bot.live_event_console_enabled = True
+    bot._live_event_current_cycle_id = "cy_ambiguous_cancel"
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+        console_sink=None,
+    )
+    order = {
+        "id": "abc123",
+        "symbol": "BTC/USDT:USDT",
+        "side": "buy",
+        "position_side": "long",
+        "qty": 0.001,
+        "price": 100_000.0,
+        "reduce_only": False,
+    }
+
+    async def fake_execute_cancellations(orders):
+        assert orders == [order]
+        return [
+            {
+                "status": "success",
+                "_passivbot_cancel_requires_full_authoritative_confirmation": True,
+            }
+        ]
+
+    bot.live_value = lambda key: 10 if key == "max_n_cancellations_per_batch" else None
+    bot.add_to_recent_order_cancellations = lambda _order: None
+    bot.log_order_action = lambda *args, **kwargs: None
+    bot._log_order_action_summary = lambda *args, **kwargs: None
+    bot.execute_cancellations = fake_execute_cancellations
+    bot.did_cancel_order = lambda executed, _order: executed.get("status") == "success"
+    bot.remove_order = lambda *args, **kwargs: None
+    bot._monitor_order_payload = lambda *args, **kwargs: {}
+    bot._monitor_record_event = lambda *args, **kwargs: None
+    bot._request_authoritative_confirmation = lambda _surfaces: None
+
+    with caplog.at_level(logging.INFO):
+        res = await Passivbot.execute_cancellations_parent(bot, [order])
+
+    assert len(res) == 1
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert [
+        event.event_type
+        for event in sink.events
+        if event.event_type == EventTypes.EXECUTION_CANCEL_AMBIGUOUS_TERMINAL
+    ] == [EventTypes.EXECUTION_CANCEL_AMBIGUOUS_TERMINAL]
+    legacy_messages = [
+        record.message
+        for record in caplog.records
+        if "ambiguous cancel terminal state; forcing full account confirmation" in record.message
+    ]
+    assert legacy_messages == [
+        "[order] ambiguous cancel terminal state; forcing full account confirmation "
+        "before next cycle | symbols=BTC"
+    ]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_positions_signature_ignores_margin_used_and_margin_mode_noise():
     bot = Passivbot.__new__(Passivbot)
     positions_a = [


### PR DESCRIPTION
## Scope

- Category: observability producer and console projection.
- Make `execution.cancel_ambiguous_terminal` the sole normal console/text owner when an enabled live-event pipeline has an actual console sink.
- Add `confirmation=full_account_required` to the compact structured projection.
- Retain the existing legacy aggregate line when structured console infrastructure is unavailable.
- Keep runtime enqueue or sink degradation single-owner; pipeline health reports the failure instead of dynamically dual-writing.
- Record PR #1217 deployment evidence and the retained OKX duplicate that motivated this slice.

## Behavior boundary

No cancellation result, state-change detection, confirmation surface or epoch, order-wave scheduling, exchange call, event schema, monitor route, restart, risk, HSL, Rust, backtest, optimizer, or trading behavior changes.

## VPS action

After exact-head reviews and CI are green: merge to `v8`, restart only the five exact supervised VPS5 bot panes, then run immediate and settled smoke checks. Observe a natural ambiguous cancel if one occurs; do not manufacture exchange failures.

## Validation

- `5 passed, 314 deselected`: focused ambiguous-cancel and formatter regressions, including present-but-failing console sink behavior.
- `318 passed`: `test_live_event_bus.py` plus `test_passivbot_balance_split.py`, excluding the independently base-hanging HSL startup test.
- `89 passed`: monitor plus AI-doc and event-registry doc tests.
- `21 passed`: local fake-live suite; 692 existing datetime deprecation warnings.
- Compileall clean on touched runtime modules.
- AI docs: 0 errors, existing word-count warning only.
- Generated live-event registry current.
- `git diff --check` clean; added-line silent-handling scan clean.

## Reviewer focus

- Confirm actual-console-sink fallback semantics and single normal console ownership, including sink degradation.
- Confirm the compact confirmation cue is accurate and bounded.
- Confirm execution and authoritative-confirmation behavior is unchanged.

Residual runtime evidence: retained OKX logs prove the prior duplicate, but a post-deploy natural ambiguous cancel may not occur during the bounded smoke window.