### PR TITLE
Deduplicate entry distance gate console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Initial-entry distance-gate blocked and cleared transitions now use their
+  structured events as the sole normal console/text lines when a live-event
+  console sink is available. The throttled legacy summaries remain the
+  fallback; gate state, eligibility, and order filtering are unchanged.
+
 - Ambiguous-cancel terminal states now use the structured execution warning as
   the sole normal console/text line when a live-event console sink is
   available, with an explicit full-account-confirmation cue in its compact

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,22 +22,23 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-ambiguous-cancel-console-migration`.
-- Base: `6599fba08cadffac99ce6a1ce2bfd3f58ca3fa15`, merged PR #1217.
-- Slice: ambiguous-cancel terminal-state console ownership.
-- Triggering evidence: retained OKX logs showed an
-  `execution.cancel_ambiguous_terminal` warning immediately followed by the
-  legacy `[order] ambiguous cancel terminal state; forcing full account
-  confirmation before next cycle` line for the same symbol.
-- Scope: make the existing structured warning the sole normal console/text
-  owner, ensure its compact projection communicates the required full
-  authoritative account confirmation, and preserve the legacy summary only
-  when structured console infrastructure is unavailable. Enqueue or sink
-  degradation must remain single-owner and surface through pipeline health,
-  not trigger dynamic dual writing.
-- Behavior boundary: preserve cancellation results, state-change detection,
-  authoritative confirmation surfaces and epochs, order-wave scheduling,
-  exchange calls, event emission, and all trading behavior.
+- Branch: `codex/v8-entry-distance-console-migration`.
+- Base: `4bf7706d79f2e2404f785195973d13ea49c31efb`, merged PR #1218.
+- Slice: initial-entry distance-gate console ownership.
+- Triggering evidence: fresh post-PR #1218 Binance, GateIO, and OKX logs showed
+  the throttled legacy `[entry] initial entry staged but not placed` line
+  immediately followed by structured `entry.initial_distance_gate_blocked`
+  output for the same symbol and decision.
+- Scope: make the existing structured blocked/cleared events the sole normal
+  console/text owners when an enabled live-event pipeline has an actual console
+  sink. Preserve the legacy INFO summaries when the emitter, pipeline, or
+  console sink is unavailable. Enqueue or sink degradation must remain
+  single-owner and surface through pipeline health rather than trigger dynamic
+  dual writing.
+- Behavior boundary: preserve the one-hour blocked-event/INFO throttle,
+  repeated DEBUG diagnostics, gate state transitions, order filtering,
+  configuration validation, payloads, routes, exchange calls, and all trading
+  behavior.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: restart and observe only after this slice merges;
@@ -45,12 +46,24 @@ Estimated completion:
 
 ## Deployed Baseline
 
-- Remote `v8`: `6599fba08cadffac99ce6a1ce2bfd3f58ca3fa15`, PR #1217
-- VPS5 repository: `6599fba08cadffac99ce6a1ce2bfd3f58ca3fa15`, PR #1217; exact
+- Remote `v8`: `4bf7706d79f2e2404f785195973d13ea49c31efb`, PR #1218
+- VPS5 repository: `4bf7706d79f2e2404f785195973d13ea49c31efb`, PR #1218; exact
   tracked status clean and expected untracked artifacts preserved
-- VPS5 expected bots: five; running with PR #1217 restart PIDs
-  `906664/906666/906668/906670/906672`; pane PIDs unchanged; unrelated
+- VPS5 expected bots: five; running with PR #1218 restart PIDs
+  `908144/908203/908262/908320/908382`; pane PIDs unchanged; unrelated
   `misc:0.0` remains PID `434835`
+- PR #1218 merged and deployed at
+  `4bf7706d79f2e2404f785195973d13ea49c31efb`. It made the structured
+  ambiguous-cancel terminal warning the sole normal console/text owner and
+  added the compact full-account-confirmation cue while preserving cancellation
+  and authoritative-confirmation behavior. All five old bot processes exited
+  naturally after one signal round; pane PIDs and unrelated `misc:0.0` PID
+  `434835` remained unchanged. The settled two-minute smoke returned `ok=true`,
+  `472/472` remote calls, `25/25` account-critical calls, `7/7` fill refreshes,
+  five matching processes/configs, zero hard/log/monitor/pipeline failures, four
+  complete active HSL replays, and an exact clean repository. A transient `D`
+  state cleared within 20 seconds. No natural ambiguous cancel occurred after
+  restart, so runtime format evidence remains absent rather than manufactured.
 - PR #1217 merged and deployed at
   `6599fba08cadffac99ce6a1ce2bfd3f58ca3fa15`. It made the structured
   execution-loop error-burst health event the sole normal console/text owner
@@ -473,10 +486,11 @@ retention wall-time tail is host descheduling/contention evidence and does not
 justify another retention optimization.
 
 PR #1215's fill console/text migration, PR #1216's periodic health console
-migration, and PR #1217's execution-loop error-burst console migration are
-merged and deployed. PR #1216 proved compact periodic-health ownership and sane
-RSS across four natural lines. The retained OKX ambiguous-cancel sequence is
-the next concrete duplicate and is tracked by the active follow-up above.
+migration, PR #1217's execution-loop error-burst console migration, and PR
+#1218's ambiguous-cancel console migration are merged and deployed. PR #1216
+proved compact periodic-health ownership and sane RSS across four natural
+lines. Fresh Binance, GateIO, and OKX entry-distance-gate sequences exposed the
+next adjacent legacy/structured duplicate, tracked by the active slice above.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -69,6 +69,22 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1218 merged to `v8` as
+  `4bf7706d79f2e2404f785195973d13ea49c31efb` after exact-head Hermes and
+  Grok 4.5 green reviews plus green CI. Structured ambiguous-cancel terminal
+  warnings now own normal console/text output and include the compact
+  full-account-confirmation cue; the legacy fallback remains for runtimes
+  without a usable structured console. VPS5 gracefully restarted only the five
+  exact bot panes; old processes exited naturally, pane PIDs and unrelated
+  `misc:0.0` PID `434835` were unchanged, and new bot PIDs were
+  `908144/908203/908262/908320/908382`. The settled two-minute smoke was green
+  with `472/472` remote calls, `25/25` account-critical calls, `7/7` fill
+  refreshes, all five processes/configs matched, zero hard/log/monitor/pipeline
+  failures, four complete active HSL replays, and an exact clean repository. A
+  transient `D` state cleared within 20 seconds. No natural ambiguous cancel
+  occurred after restart; fresh Binance, GateIO, and OKX logs instead exposed
+  the next adjacent duplicate between legacy and structured initial-entry
+  distance-gate blocked lines.
 - PR #1217 merged to `v8` as
   `6599fba08cadffac99ce6a1ce2bfd3f58ca3fa15` after exact-head Hermes and
   Grok 4.5 green reviews plus green CI. The structured execution-loop

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -532,6 +532,19 @@ Related detailed plans:
     exposed the next adjacent duplicate: structured
     `execution.cancel_ambiguous_terminal` followed by the legacy full-account
     confirmation summary for the same symbol.
+    PR #1218 removed that ambiguous-cancel duplicate and added the compact
+    full-account-confirmation cue without changing cancellation or confirmation
+    behavior. It merged and deployed at
+    `4bf7706d79f2e2404f785195973d13ea49c31efb`; the settled two-minute smoke was
+    green with five matching bots, `472/472` remote calls, `25/25`
+    account-critical calls, `7/7` fill refreshes, four complete active HSL
+    replays, zero hard/log/monitor/pipeline failures, and a clean repository.
+    Fresh Binance, GateIO, and OKX logs then exposed the next adjacent duplicate:
+    legacy `[entry] initial entry staged but not placed` immediately followed by
+    structured `entry.initial_distance_gate_blocked`. The blocked and cleared
+    structured events already carry the bounded operator context and should own
+    normal console/text output while retaining legacy fallback when structured
+    console infrastructure is absent.
 
     Work log:
     - 2026-06-30: Added value-safe `live-smoke-report` HSL status projections

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -16325,6 +16325,15 @@ class Passivbot:
             "price": float(order.get("price", 0.0) or 0.0),
         }
 
+    def _initial_entry_gate_structured_console_available(self) -> bool:
+        emit_gate_event = getattr(self, "_emit_initial_entry_distance_gate_event", None)
+        pipeline = getattr(self, "_live_event_pipeline", None)
+        return bool(
+            callable(emit_gate_event)
+            and Passivbot._live_event_console_available(self)
+            and getattr(pipeline, "console_sink", None) is not None
+        )
+
     def _log_initial_entry_distance_gate_block(
         self,
         order: dict,
@@ -16365,30 +16374,33 @@ class Passivbot:
                 self._resolve_pb_order_type(order),
             )
             return
-        logging.info(
-            "[entry] initial entry staged but not placed | symbol=%s pside=%s qty=%.10g price=%.10g market=%.10g dist=%.4f%% threshold=%.4f%% tolerance=%.4f%% type=%s reason=initial_entry_distance_gate",
-            Passivbot._log_symbol(probe["symbol"]),
-            probe["position_side"],
-            probe["qty"],
-            probe["price"],
-            market_price,
-            signed_dist * 100.0,
-            threshold * 100.0,
-            tolerance * 100.0,
-            self._resolve_pb_order_type(order),
-        )
+        if not self._initial_entry_gate_structured_console_available():
+            logging.info(
+                "[entry] initial entry staged but not placed | symbol=%s pside=%s qty=%.10g price=%.10g market=%.10g dist=%.4f%% threshold=%.4f%% tolerance=%.4f%% type=%s reason=initial_entry_distance_gate",
+                Passivbot._log_symbol(probe["symbol"]),
+                probe["position_side"],
+                probe["qty"],
+                probe["price"],
+                market_price,
+                signed_dist * 100.0,
+                threshold * 100.0,
+                tolerance * 100.0,
+                self._resolve_pb_order_type(order),
+            )
         event_order = dict(order)
         event_order["pb_order_type"] = self._resolve_pb_order_type(order)
-        self._emit_initial_entry_distance_gate_event(
-            event_type=EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
-            status="skipped",
-            action="skip_create",
-            order=event_order,
-            market_price=market_price,
-            signed_dist=signed_dist,
-            threshold=threshold,
-            tolerance=tolerance,
-        )
+        emit_gate_event = getattr(self, "_emit_initial_entry_distance_gate_event", None)
+        if callable(emit_gate_event):
+            emit_gate_event(
+                event_type=EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
+                status="skipped",
+                action="skip_create",
+                order=event_order,
+                market_price=market_price,
+                signed_dist=signed_dist,
+                threshold=threshold,
+                tolerance=tolerance,
+            )
 
     def _log_initial_entry_distance_gate_cleared(
         self,
@@ -16405,28 +16417,31 @@ class Passivbot:
         if key not in state:
             return
         state.pop(key, None)
-        logging.info(
-            "[entry] initial entry distance gate cleared | symbol=%s pside=%s qty=%.10g price=%.10g market=%.10g dist=%.4f%% threshold=%.4f%% type=%s",
-            Passivbot._log_symbol(order.get("symbol")),
-            str(order.get("position_side") or ""),
-            float(order.get("qty", 0.0) or 0.0),
-            float(order.get("price", 0.0) or 0.0),
-            market_price,
-            signed_dist * 100.0,
-            threshold * 100.0,
-            self._resolve_pb_order_type(order),
-        )
+        if not self._initial_entry_gate_structured_console_available():
+            logging.info(
+                "[entry] initial entry distance gate cleared | symbol=%s pside=%s qty=%.10g price=%.10g market=%.10g dist=%.4f%% threshold=%.4f%% type=%s",
+                Passivbot._log_symbol(order.get("symbol")),
+                str(order.get("position_side") or ""),
+                float(order.get("qty", 0.0) or 0.0),
+                float(order.get("price", 0.0) or 0.0),
+                market_price,
+                signed_dist * 100.0,
+                threshold * 100.0,
+                self._resolve_pb_order_type(order),
+            )
         event_order = dict(order)
         event_order["pb_order_type"] = self._resolve_pb_order_type(order)
-        self._emit_initial_entry_distance_gate_event(
-            event_type=EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
-            status="recovered",
-            action="allow_create",
-            order=event_order,
-            market_price=market_price,
-            signed_dist=signed_dist,
-            threshold=threshold,
-        )
+        emit_gate_event = getattr(self, "_emit_initial_entry_distance_gate_event", None)
+        if callable(emit_gate_event):
+            emit_gate_event(
+                event_type=EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
+                status="recovered",
+                action="allow_create",
+                order=event_order,
+                market_price=market_price,
+                signed_dist=signed_dist,
+                threshold=threshold,
+            )
 
     def _apply_mode_filters(
         self,

--- a/tests/test_initial_entry_distance_gate_events.py
+++ b/tests/test_initial_entry_distance_gate_events.py
@@ -1,14 +1,22 @@
+import logging
+
 import pytest
 
 from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
 from passivbot import Passivbot
 
 
-def _make_bot_with_event_sink():
+class _FailingConsoleSink:
+    def write(self, _event):
+        raise OSError("console unavailable")
+
+
+def _make_bot_with_event_sink(*, console_sink=None):
     bot = Passivbot.__new__(Passivbot)
     bot.bot_id = "bot_distance_gate"
     bot.exchange = "binance"
     bot.user = "binance_01"
+    bot.live_event_console_enabled = True
     bot._live_event_current_cycle_id = "cy_distance_gate"
     bot._initial_entry_distance_gate_log_state = {}
     bot.open_orders = {}
@@ -17,6 +25,7 @@ def _make_bot_with_event_sink():
     bot._live_event_pipeline = LiveEventPipeline(
         structured_sinks=[sink],
         monitor_sinks=[],
+        console_sink=console_sink,
     )
     return bot, sink
 
@@ -73,25 +82,25 @@ def test_initial_entry_distance_gate_block_emits_structured_event(monkeypatch):
     assert event.data["tolerance_pct"] == pytest.approx(0.05)
 
 
-def test_initial_entry_distance_gate_event_respects_info_throttle(monkeypatch):
+def test_initial_entry_distance_gate_event_respects_info_throttle(monkeypatch, caplog):
     bot, sink = _make_bot_with_event_sink()
     monkeypatch.setattr("passivbot.logging.info", lambda msg, *args: None)
-    monkeypatch.setattr("passivbot.logging.debug", lambda msg, *args: None)
 
     try:
         order = _initial_entry_order()
-        bot._log_initial_entry_distance_gate_block(
-            order,
-            market_price=100_000.0,
-            signed_dist=0.05,
-            threshold=0.01,
-        )
-        bot._log_initial_entry_distance_gate_block(
-            order,
-            market_price=100_000.0,
-            signed_dist=0.05,
-            threshold=0.01,
-        )
+        with caplog.at_level(logging.DEBUG):
+            bot._log_initial_entry_distance_gate_block(
+                order,
+                market_price=100_000.0,
+                signed_dist=0.05,
+                threshold=0.01,
+            )
+            bot._log_initial_entry_distance_gate_block(
+                order,
+                market_price=100_000.0,
+                signed_dist=0.05,
+                threshold=0.01,
+            )
         assert bot._live_event_pipeline.flush(timeout=2.0) is True
     finally:
         assert bot._live_event_pipeline.close(timeout=2.0) is True
@@ -101,6 +110,10 @@ def test_initial_entry_distance_gate_event_respects_info_throttle(monkeypatch):
         for event in sink.events
         if event.event_type == EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED
     ] == [EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED]
+    assert sum(
+        "initial entry creation still distance-gated" in record.message
+        for record in caplog.records
+    ) == 1
 
 
 def test_initial_entry_distance_gate_cleared_emits_structured_event(monkeypatch):
@@ -140,3 +153,126 @@ def test_initial_entry_distance_gate_cleared_emits_structured_event(monkeypatch)
     assert event.data["distance_pct"] == pytest.approx(0.5)
     assert event.data["threshold_pct"] == pytest.approx(1.0)
     assert "tolerance_pct" not in event.data
+
+
+@pytest.mark.parametrize("console_sink_fails", [False, True])
+def test_initial_entry_distance_gate_structured_console_owns_block_and_clear(
+    caplog, console_sink_fails
+):
+    console_sink = _FailingConsoleSink() if console_sink_fails else ListEventSink()
+    bot, sink = _make_bot_with_event_sink(console_sink=console_sink)
+    order = _initial_entry_order()
+
+    try:
+        with caplog.at_level(logging.INFO):
+            bot._log_initial_entry_distance_gate_block(
+                order,
+                market_price=100_000.0,
+                signed_dist=0.05,
+                threshold=0.01,
+            )
+            bot._log_initial_entry_distance_gate_cleared(
+                order,
+                market_price=96_000.0,
+                signed_dist=0.005,
+                threshold=0.01,
+            )
+        assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    finally:
+        assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+    assert not [
+        record
+        for record in caplog.records
+        if "initial entry staged but not placed" in record.message
+        or "initial entry distance gate cleared" in record.message
+    ]
+    gate_events = [
+        event
+        for event in sink.events
+        if event.event_type
+        in {
+            EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
+            EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
+        }
+    ]
+    assert [event.event_type for event in gate_events] == [
+        EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
+        EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
+    ]
+    assert bot._initial_entry_distance_gate_log_state == {}
+    if console_sink_fails:
+        assert bot._live_event_pipeline.sink_error_counters["console"] >= 1
+    else:
+        assert console_sink.events == gate_events
+
+
+def test_initial_entry_distance_gate_uses_legacy_fallback_without_console_sink(caplog):
+    bot, sink = _make_bot_with_event_sink(console_sink=None)
+    order = _initial_entry_order()
+
+    try:
+        with caplog.at_level(logging.INFO):
+            bot._log_initial_entry_distance_gate_block(
+                order,
+                market_price=100_000.0,
+                signed_dist=0.05,
+                threshold=0.01,
+            )
+            bot._log_initial_entry_distance_gate_cleared(
+                order,
+                market_price=96_000.0,
+                signed_dist=0.005,
+                threshold=0.01,
+            )
+        assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    finally:
+        assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+    legacy_messages = [record.message for record in caplog.records]
+    assert sum("initial entry staged but not placed" in msg for msg in legacy_messages) == 1
+    assert sum("initial entry distance gate cleared" in msg for msg in legacy_messages) == 1
+    assert [
+        event.event_type
+        for event in sink.events
+        if event.event_type
+        in {
+            EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
+            EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
+        }
+    ] == [
+        EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
+        EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
+    ]
+
+
+def test_initial_entry_distance_gate_uses_legacy_fallback_when_emitter_unavailable(
+    caplog,
+):
+    console_sink = ListEventSink()
+    bot, sink = _make_bot_with_event_sink(console_sink=console_sink)
+    bot._emit_initial_entry_distance_gate_event = None
+    order = _initial_entry_order()
+
+    try:
+        with caplog.at_level(logging.INFO):
+            bot._log_initial_entry_distance_gate_block(
+                order,
+                market_price=100_000.0,
+                signed_dist=0.05,
+                threshold=0.01,
+            )
+            bot._log_initial_entry_distance_gate_cleared(
+                order,
+                market_price=96_000.0,
+                signed_dist=0.005,
+                threshold=0.01,
+            )
+    finally:
+        assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+    legacy_messages = [record.message for record in caplog.records]
+    assert sum("initial entry staged but not placed" in msg for msg in legacy_messages) == 1
+    assert sum("initial entry distance gate cleared" in msg for msg in legacy_messages) == 1
+    assert sink.events == []
+    assert console_sink.events == []


### PR DESCRIPTION
## Scope

Category: observability producer / console projection ownership.

- Make the existing entry.initial_distance_gate_blocked and entry.initial_distance_gate_cleared events the sole normal console/text owners when an enabled live-event pipeline has an actual console sink.
- Keep the throttled legacy INFO summaries when the emitter, pipeline, or console sink is unavailable.
- Keep enqueue and sink degradation single-owner; event-pipeline health remains responsible for surfacing degradation.
- Update the active status, historical deployment evidence, backlog, and changelog.

Non-goals: no change to the one-hour throttle, repeated DEBUG diagnostic, gate state, order filtering, configuration validation, event payload/routes, exchange calls, eligibility, or trading behavior.

## Validation

- 107 focused initial-entry gate and live-event-bus tests: green.
- 325 broad executor/event-bus tests: green, excluding the known base-hanging test_start_bot_treats_hsl_value_error_as_terminal_startup_failure.
- 56 order-orchestration and fresh-entry eligibility tests: green.
- 40 fake-live and fake-exchange tests: green; existing datetime deprecation warnings only.
- AI documentation check: 0 errors, existing word-count warning only.
- Generated live-event registry check: current.
- AI-doc and registry-doc tests: green.
- Python compile and git diff --check: green.
- Ruff and Black are not installed in the repository venv used by this worktree.

A Luna read-only preflight found no findings; its only test-gap observation was resolved by directly asserting the repeated DEBUG diagnostic.

## Reviewer focus

Please verify actual-console-sink ownership detection, absent-emitter/pipeline/sink fallback, no dynamic dual writing on sink failure, and preservation of block/clear throttling and state transitions.

## VPS action

After exact-head reviews and CI are green: restart the five exact VPS5 bot panes and run immediate plus settled bounded smoke validation. Do not manufacture an entry-distance transition solely for format evidence.