### PR TITLE
Deduplicate min effective cost console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Detailed min-effective-cost entry blocks now use their structured events as
+  the sole normal console/text lines when a live-event console sink is
+  available. Legacy detail lines remain the fallback, while the distinct
+  throttled aggregate summary and all gate behavior are unchanged.
+
 - Initial-entry distance-gate blocked and cleared transitions now use their
   structured events as the sole normal console/text lines when a live-event
   console sink is available. The throttled legacy summaries remain the

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,23 +22,24 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-entry-distance-console-migration`.
-- Base: `4bf7706d79f2e2404f785195973d13ea49c31efb`, merged PR #1218.
-- Slice: initial-entry distance-gate console ownership.
-- Triggering evidence: fresh post-PR #1218 Binance, GateIO, and OKX logs showed
-  the throttled legacy `[entry] initial entry staged but not placed` line
-  immediately followed by structured `entry.initial_distance_gate_blocked`
-  output for the same symbol and decision.
-- Scope: make the existing structured blocked/cleared events the sole normal
-  console/text owners when an enabled live-event pipeline has an actual console
-  sink. Preserve the legacy INFO summaries when the emitter, pipeline, or
-  console sink is unavailable. Enqueue or sink degradation must remain
-  single-owner and surface through pipeline health rather than trigger dynamic
-  dual writing.
-- Behavior boundary: preserve the one-hour blocked-event/INFO throttle,
-  repeated DEBUG diagnostics, gate state transitions, order filtering,
-  configuration validation, payloads, routes, exchange calls, and all trading
-  behavior.
+- Branch: `codex/v8-min-effective-cost-console-migration`.
+- Base: `23d9e72af180e8636de7f80cdff8178a60e61937`, merged PR #1219.
+- Slice: min-effective-cost entry-block console ownership.
+- Triggering evidence: fresh post-PR #1219 GateIO logs showed legacy `[entry]
+  initial entry blocked by min effective cost` immediately followed by the
+  structured `entry.min_effective_cost_blocked` line for the same SOL-long
+  decision.
+- Scope: make each existing structured min-effective-cost block event the sole
+  normal console/text owner when an enabled live-event pipeline has an actual
+  console sink. Preserve legacy detail when the emitter, pipeline, or console
+  sink is unavailable. Keep the distinct throttled aggregate summary for more
+  than three eligible blocks and every DEBUG detail/suppression line. Enqueue or
+  sink degradation must remain single-owner and surface through pipeline health
+  rather than trigger dynamic dual writing.
+- Behavior boundary: preserve Rust-owned diagnostics, side eligibility,
+  unchanged-set and per-symbol throttles, detail limit, aggregate cadence and
+  counts, payloads, routes, configuration, order filtering, exchange calls,
+  and all trading behavior.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: restart and observe only after this slice merges;
@@ -46,12 +47,27 @@ Estimated completion:
 
 ## Deployed Baseline
 
-- Remote `v8`: `4bf7706d79f2e2404f785195973d13ea49c31efb`, PR #1218
-- VPS5 repository: `4bf7706d79f2e2404f785195973d13ea49c31efb`, PR #1218; exact
+- Remote `v8`: `23d9e72af180e8636de7f80cdff8178a60e61937`, PR #1219
+- VPS5 repository: `23d9e72af180e8636de7f80cdff8178a60e61937`, PR #1219; exact
   tracked status clean and expected untracked artifacts preserved
-- VPS5 expected bots: five; running with PR #1218 restart PIDs
-  `908144/908203/908262/908320/908382`; pane PIDs unchanged; unrelated
+- VPS5 expected bots: five; running with PR #1219 restart PIDs
+  `912288/912290/912292/912293/912294`; pane PIDs unchanged; unrelated
   `misc:0.0` remains PID `434835`
+- PR #1219 merged and deployed at
+  `23d9e72af180e8636de7f80cdff8178a60e61937`. It made structured
+  initial-entry distance-gate blocked/cleared events own normal console/text
+  output while preserving throttles, state transitions, fallback, and trading
+  behavior. All five old bot processes exited naturally after one signal round;
+  KuCoin was last at 45 seconds, with no force action. Pane PIDs and unrelated
+  `misc:0.0` PID `434835` remained unchanged. Immediate and settled smoke
+  reports were `ok=true`. The final bounded report recorded `299/299` remote
+  calls, `32/32` account-critical calls, six successful fill refreshes, five
+  config-valid processes, zero hard/log/monitor/pipeline failures, and complete
+  required work for every active HSL replay. A transient `D` state cleared; the
+  final exact process sample showed all five bots `R` and a clean repository.
+  Natural blocked events on Binance, KuCoin, GateIO, and OKX appeared only as
+  the structured line, proving runtime single ownership without manufacturing
+  a transition.
 - PR #1218 merged and deployed at
   `4bf7706d79f2e2404f785195973d13ea49c31efb`. It made the structured
   ambiguous-cancel terminal warning the sole normal console/text owner and
@@ -486,11 +502,12 @@ retention wall-time tail is host descheduling/contention evidence and does not
 justify another retention optimization.
 
 PR #1215's fill console/text migration, PR #1216's periodic health console
-migration, PR #1217's execution-loop error-burst console migration, and PR
-#1218's ambiguous-cancel console migration are merged and deployed. PR #1216
-proved compact periodic-health ownership and sane RSS across four natural
-lines. Fresh Binance, GateIO, and OKX entry-distance-gate sequences exposed the
-next adjacent legacy/structured duplicate, tracked by the active slice above.
+migration, PR #1217's execution-loop error-burst console migration, PR #1218's
+ambiguous-cancel console migration, and PR #1219's entry-distance-gate console
+migration are merged and deployed. Natural post-PR #1219 blocked events on four
+bots proved structured single ownership. The same fresh GateIO log exposed the
+next adjacent legacy/structured duplicate for min-effective-cost entry blocks,
+tracked by the active slice above.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -69,6 +69,25 @@ Retuned goal boundary:
 
 VPS5 deployment status:
 
+- PR #1219 merged to `v8` as
+  `23d9e72af180e8636de7f80cdff8178a60e61937` after exact-head Hermes and
+  Grok 4.5 green reviews plus green CI. Structured initial-entry distance-gate
+  blocked/cleared events now own normal console/text output, with legacy
+  fallback retained and all throttle/state/order behavior unchanged. VPS5
+  gracefully restarted only the five exact bot panes; every old process exited
+  naturally after one signal round, KuCoin was last at 45 seconds, and no force
+  action was needed. Pane PIDs and unrelated `misc:0.0` PID `434835` were
+  unchanged; new bot PIDs were `912288/912290/912292/912293/912294`. Immediate
+  and settled smoke reports were green. The final bounded report recorded
+  `299/299` remote calls, `32/32` account-critical calls, six successful fill
+  refreshes, five config-valid processes, zero hard/log/monitor/pipeline
+  failures, and complete required work for every active HSL replay. A transient
+  `D` state cleared and the final exact sample showed all five bots `R` at a
+  clean repository. Natural blocked events on Binance, KuCoin, GateIO, and OKX
+  appeared only as structured lines, proving runtime single ownership. Fresh
+  GateIO output then exposed the next duplicate: legacy min-effective-cost
+  detail immediately followed by structured
+  `entry.min_effective_cost_blocked`.
 - PR #1218 merged to `v8` as
   `4bf7706d79f2e2404f785195973d13ea49c31efb` after exact-head Hermes and
   Grok 4.5 green reviews plus green CI. Structured ambiguous-cancel terminal

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -545,6 +545,18 @@ Related detailed plans:
     structured events already carry the bounded operator context and should own
     normal console/text output while retaining legacy fallback when structured
     console infrastructure is absent.
+    PR #1219 removed that entry-distance duplicate and deployed at
+    `23d9e72af180e8636de7f80cdff8178a60e61937`. Its final bounded smoke was
+    green with five config-valid bots, `299/299` remote and `32/32`
+    account-critical calls, six fill refreshes, complete required HSL replay
+    work, zero hard/log/monitor/pipeline failures, and a clean repository.
+    Natural post-deploy blocked events on Binance, KuCoin, GateIO, and OKX
+    proved structured single ownership. The same GateIO log exposed a separate
+    duplicate: legacy `initial entry blocked by min effective cost` immediately
+    followed by structured `entry.min_effective_cost_blocked`. The per-block
+    structured event should own normal detail output when its console sink is
+    available, while the distinct throttled aggregate summary for larger block
+    sets remains operator-visible.
 
     Work log:
     - 2026-06-30: Added value-safe `live-smoke-report` HSL status projections

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -10962,6 +10962,15 @@ class Passivbot:
         if not visible_blocks:
             return
         detail_limit = 3
+        emit_blocked_event = getattr(
+            self, "_emit_entry_min_effective_cost_blocked_event", None
+        )
+        pipeline = getattr(self, "_live_event_pipeline", None)
+        structured_console_available = bool(
+            callable(emit_blocked_event)
+            and Passivbot._live_event_console_available(self)
+            and getattr(pipeline, "console_sink", None) is not None
+        )
         for symbol, pside, block in visible_blocks[:detail_limit]:
             balance = float(block.get("balance", 0.0) or 0.0)
             effective_limit = float(block.get("effective_limit", 0.0) or 0.0)
@@ -10972,13 +10981,14 @@ class Passivbot:
                 block.get("projected_initial_cost", 0.0) or 0.0
             )
             effective_min_cost = float(block.get("effective_min_cost", 0.0) or 0.0)
-            logging.info(
-                "[entry] initial entry blocked by min effective cost | %s %s notional wanted/required=%.6f/%.6f action=skip_create docs=docs/configuration.md#filter_by_min_effective_cost",
-                Passivbot._log_symbol(symbol),
-                pside,
-                projected_initial_cost,
-                effective_min_cost,
-            )
+            if not structured_console_available:
+                logging.info(
+                    "[entry] initial entry blocked by min effective cost | %s %s notional wanted/required=%.6f/%.6f action=skip_create docs=docs/configuration.md#filter_by_min_effective_cost",
+                    Passivbot._log_symbol(symbol),
+                    pside,
+                    projected_initial_cost,
+                    effective_min_cost,
+                )
             logging.debug(
                 "[entry] initial entry min effective cost detail | symbol=%s pside=%s projected_initial_cost=%.6f required_effective_min_cost=%.6f balance=%.6f effective_limit=%.6f entry_initial_qty_pct=%.6f next_steps=increase_balance_or_reduce_bot.%s.n_positions_or_increase_per_slot_sizing override=live.filter_by_min_effective_cost=false caution=override_may_create_exchange-min-sized_entries",
                 Passivbot._log_symbol(symbol),
@@ -10990,15 +11000,16 @@ class Passivbot:
                 entry_initial_qty_pct,
                 pside,
             )
-            self._emit_entry_min_effective_cost_blocked_event(
-                symbol=symbol,
-                pside=pside,
-                projected_initial_cost=projected_initial_cost,
-                effective_min_cost=effective_min_cost,
-                balance=balance,
-                effective_limit=effective_limit,
-                entry_initial_qty_pct=entry_initial_qty_pct,
-            )
+            if callable(emit_blocked_event):
+                emit_blocked_event(
+                    symbol=symbol,
+                    pside=pside,
+                    projected_initial_cost=projected_initial_cost,
+                    effective_min_cost=effective_min_cost,
+                    balance=balance,
+                    effective_limit=effective_limit,
+                    entry_initial_qty_pct=entry_initial_qty_pct,
+                )
         if len(eligible_blocks) > detail_limit:
             examples = ",".join(
                 f"{Passivbot._log_symbol(symbol)}:{pside}"

--- a/tests/test_coin_filtering.py
+++ b/tests/test_coin_filtering.py
@@ -1,7 +1,54 @@
+import logging
+
 import pytest
 
 from passivbot import Passivbot
 from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
+
+
+class _FailingConsoleSink:
+    def write(self, _event):
+        raise OSError("console unavailable")
+
+
+def _make_min_effective_cost_event_bot(*, console_sink=None):
+    bot = Passivbot.__new__(Passivbot)
+    bot._min_effective_cost_last_log_ms = {}
+    bot._min_effective_cost_log_interval_ms = 900_000
+    bot._min_effective_cost_summary_last_log_ms = 0
+    bot._min_effective_cost_summary_log_interval_ms = 900_000
+    bot.is_pside_enabled = lambda pside: pside == "long"
+    bot.bot_id = "bot_min_cost"
+    bot.exchange = "binance"
+    bot.user = "binance_01"
+    bot.live_event_console_enabled = True
+    bot._live_event_current_cycle_id = "cy_min_cost"
+    sink = ListEventSink()
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink],
+        monitor_sinks=[],
+        console_sink=console_sink,
+    )
+    return bot, sink
+
+
+def _min_effective_cost_out(count=1):
+    return {
+        "diagnostics": {
+            "min_effective_cost_blocks": [
+                {
+                    "symbol_idx": idx,
+                    "pside": "long",
+                    "balance": 51.154957,
+                    "effective_limit": 1.5,
+                    "entry_initial_qty_pct": 0.0192,
+                    "projected_initial_cost": 1.4732627616,
+                    "effective_min_cost": 10.1,
+                }
+                for idx in range(count)
+            ]
+        }
+    }
 
 
 class CoinFilterHarness(Passivbot):
@@ -430,6 +477,151 @@ def test_log_min_effective_cost_blocks_emits_structured_event(monkeypatch):
     assert event.data["effective_limit"] == pytest.approx(1.5)
     assert event.data["entry_initial_qty_pct"] == pytest.approx(0.0192)
     assert event.data["action"] == "skip_create"
+
+
+@pytest.mark.parametrize("console_sink_fails", [False, True])
+def test_min_effective_cost_structured_console_owns_detail_line(
+    caplog, console_sink_fails
+):
+    console_sink = _FailingConsoleSink() if console_sink_fails else ListEventSink()
+    bot, sink = _make_min_effective_cost_event_bot(console_sink=console_sink)
+
+    try:
+        with caplog.at_level(logging.DEBUG):
+            bot._log_min_effective_cost_blocks(
+                _min_effective_cost_out(), {0: "BTC/USDC:USDC"}
+            )
+            bot._log_min_effective_cost_blocks(
+                _min_effective_cost_out(), {0: "BTC/USDC:USDC"}
+            )
+        assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    finally:
+        assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+    assert not [
+        record
+        for record in caplog.records
+        if record.levelno == logging.INFO
+        and "initial entry blocked by min effective cost |" in record.message
+    ]
+    assert sum(
+        "initial entry min effective cost detail" in record.message
+        for record in caplog.records
+    ) == 1
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED
+    ]
+    assert len(events) == 1
+    if console_sink_fails:
+        assert bot._live_event_pipeline.sink_error_counters["console"] >= 1
+    else:
+        assert console_sink.events == events
+
+
+def test_min_effective_cost_uses_legacy_detail_without_pipeline(caplog):
+    bot = Passivbot.__new__(Passivbot)
+    bot._min_effective_cost_last_log_ms = {}
+    bot._min_effective_cost_log_interval_ms = 900_000
+    bot._min_effective_cost_summary_last_log_ms = 0
+    bot._min_effective_cost_summary_log_interval_ms = 900_000
+    bot.is_pside_enabled = lambda pside: pside == "long"
+    bot.live_event_console_enabled = True
+    emitted = []
+    bot._emit_entry_min_effective_cost_blocked_event = lambda **kwargs: emitted.append(
+        kwargs
+    )
+
+    with caplog.at_level(logging.INFO):
+        bot._log_min_effective_cost_blocks(
+            _min_effective_cost_out(), {0: "BTC/USDC:USDC"}
+        )
+
+    assert sum(
+        "initial entry blocked by min effective cost | BTC long" in record.message
+        for record in caplog.records
+    ) == 1
+    assert len(emitted) == 1
+
+
+def test_min_effective_cost_uses_legacy_detail_without_console_sink(caplog):
+    bot, sink = _make_min_effective_cost_event_bot(console_sink=None)
+
+    try:
+        with caplog.at_level(logging.INFO):
+            bot._log_min_effective_cost_blocks(
+                _min_effective_cost_out(), {0: "BTC/USDC:USDC"}
+            )
+        assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    finally:
+        assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+    assert sum(
+        "initial entry blocked by min effective cost | BTC long" in record.message
+        for record in caplog.records
+    ) == 1
+    assert [
+        event.event_type
+        for event in sink.events
+        if event.event_type == EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED
+    ] == [EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED]
+
+
+def test_min_effective_cost_uses_legacy_detail_when_emitter_unavailable(caplog):
+    console_sink = ListEventSink()
+    bot, sink = _make_min_effective_cost_event_bot(console_sink=console_sink)
+    bot._emit_entry_min_effective_cost_blocked_event = None
+
+    try:
+        with caplog.at_level(logging.INFO):
+            bot._log_min_effective_cost_blocks(
+                _min_effective_cost_out(), {0: "BTC/USDC:USDC"}
+            )
+    finally:
+        assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+    assert sum(
+        "initial entry blocked by min effective cost | BTC long" in record.message
+        for record in caplog.records
+    ) == 1
+    assert sink.events == []
+    assert console_sink.events == []
+
+
+def test_min_effective_cost_structured_console_keeps_aggregate_summary(caplog):
+    console_sink = ListEventSink()
+    bot, sink = _make_min_effective_cost_event_bot(console_sink=console_sink)
+    idx_to_symbol = {idx: f"SYM{idx}/USDT:USDT" for idx in range(5)}
+
+    try:
+        with caplog.at_level(logging.INFO):
+            bot._log_min_effective_cost_blocks(
+                _min_effective_cost_out(count=5), idx_to_symbol
+            )
+        assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    finally:
+        assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+    info_messages = [
+        record.message for record in caplog.records if record.levelno == logging.INFO
+    ]
+    assert not [
+        message
+        for message in info_messages
+        if "initial entry blocked by min effective cost | SYM" in message
+    ]
+    assert sum(
+        "initial entries blocked by min effective cost summary" in message
+        for message in info_messages
+    ) == 1
+    events = [
+        event
+        for event in sink.events
+        if event.event_type == EventTypes.ENTRY_MIN_EFFECTIVE_COST_BLOCKED
+    ]
+    assert len(events) == 3
+    assert console_sink.events == events
 
 
 def test_log_min_effective_cost_blocks_is_throttled(monkeypatch):


### PR DESCRIPTION
## Summary

- make the existing structured min-effective-cost entry-block event the sole normal per-block console/text owner when an enabled live-event pipeline has an actual console sink
- retain the legacy detail fallback when the emitter, pipeline, or console sink is unavailable
- preserve DEBUG diagnostics, per-symbol and unchanged-set throttles, the three-detail limit, and the distinct aggregate summary for larger block sets
- record PR #1219 deployment evidence and the active follow-up in the logging-overhaul status documents

## Behavior boundary

This is an observability ownership change only. Rust-owned diagnostics, pside eligibility, order filtering, configuration, exchange calls, event payloads/routes, and all trading behavior are unchanged. A console enqueue or sink failure remains single-owner and is reported through pipeline health; it does not dynamically restore the legacy line.

## Validation

- focused min-effective-cost and event-bus suite: green
- full coin-filtering, event-bus, fake-live, and fake-exchange suite: 159 green before the final test-only delta
- balance-split suite excluding the known base hang: 218 green
- order orchestration and fresh-entry eligibility: 56 green
- final `tests/test_coin_filtering.py`: 20 green
- final focused min-effective-cost plus event-bus suite: green
- AI docs checker: 0 errors, one existing word-count warning
- event registry current; docs tests, Python compilation, and `git diff --check` green
- Ruff and Black are unavailable in the local environment

## Reviewer focus

- normal detail ownership versus legacy fallback
- no dynamic dual-write on console-sink failure
- repeated-call throttle preservation
- DEBUG detail and aggregate-summary retention
- no trading-path changes

## Deployment

After exact-head Hermes and Grok 4.5 green reviews plus green CI, merge to `v8`, gracefully restart only the five exact VPS5 bot panes, and run immediate and settled smoke checks. Do not manufacture min-effective-cost decisions.
