### PR TITLE
Fix fake-live HSL release smokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Restored the documented offline HSL restart smoke by pinning its fixture to
+  the intended per-side HSL contract and updating its post-flatten drawdown
+  assertion to the current panic-fill-anchored finalization semantics. Coin-mode
+  fake-live RED handling now exercises the production protective supervisor
+  instead of falling through normal planning while confirmations are pending.
+
 - Detailed min-effective-cost entry blocks now use their structured events as
   the sole normal console/text lines when a live-event console sink is
   available. Legacy detail lines remain the fallback, while the distinct

--- a/configs/fake_live_hsl_btc.hjson
+++ b/configs/fake_live_hsl_btc.hjson
@@ -106,6 +106,7 @@
     }
     execution_delay_seconds: 1.0
     hedge_mode: false
+    hsl_signal_mode: pside
     hsl_position_during_cooldown_policy: panic
     inactive_coin_candle_ttl_minutes: 10.0
     leverage: 5.0

--- a/scenarios/fake_live/hsl_long_red_restart.hjson
+++ b/scenarios/fake_live/hsl_long_red_restart.hjson
@@ -90,7 +90,7 @@
       long.halted: false
       long.no_restart_latched: false
       long.last_stop_event.auto_restart_eligible: true
-      long.last_stop_event.drawdown_raw: {min: 0.07, max: 0.08}
+      long.last_stop_event.drawdown_raw: {min: 0.001, max: 0.002}
     }
     summary_paths: {
       step_count: 4

--- a/src/tools/run_fake_live.py
+++ b/src/tools/run_fake_live.py
@@ -611,27 +611,39 @@ async def _run_fake_cycle(bot):
     if not await bot.update_pos_oos_pnls_ohlcvs():
         return {"updated": False}
     if bot._equity_hard_stop_enabled():
-        if any(
-            bot._equity_hard_stop_runtime_red_latched(pside) and not bot._hsl_state(pside)["halted"]
-            for pside in bot._hsl_psides()
-            if bot._equity_hard_stop_enabled(pside)
-        ):
-            if getattr(bot, "exchange", "").lower() == "fake":
-                return await _run_fake_red_supervisor_step(bot)
-            await bot._equity_hard_stop_run_red_supervisor()
-            return {"red_supervisor": True}
-        await bot._equity_hard_stop_check()
-        if any(
-            bot._equity_hard_stop_runtime_red_latched(pside) and not bot._hsl_state(pside)["halted"]
-            for pside in bot._hsl_psides()
-            if bot._equity_hard_stop_enabled(pside)
-        ):
-            if getattr(bot, "exchange", "").lower() == "fake":
-                return await _run_fake_red_supervisor_step(bot)
-            await bot._equity_hard_stop_run_red_supervisor()
-            return {"red_supervisor": True}
-        if _fake_all_hsl_psides_terminal_latched(bot):
-            return {"terminal_hsl": True}
+        if bot._equity_hard_stop_signal_mode() == "coin":
+            await bot._equity_hard_stop_check()
+            if bot._equity_hard_stop_coin_red_active():
+                # Exercise the production coin RED supervisor instead of the legacy
+                # pside stepping shim. The production path uses protective planning
+                # and its own authoritative refresh contract, which prevents normal
+                # staged planning from running while post-write confirmation is due.
+                await bot._equity_hard_stop_run_coin_red_supervisor()
+                return {"red_supervisor": True, "mode": "coin"}
+        else:
+            if any(
+                bot._equity_hard_stop_runtime_red_latched(pside)
+                and not bot._hsl_state(pside)["halted"]
+                for pside in bot._hsl_psides()
+                if bot._equity_hard_stop_enabled(pside)
+            ):
+                if getattr(bot, "exchange", "").lower() == "fake":
+                    return await _run_fake_red_supervisor_step(bot)
+                await bot._equity_hard_stop_run_red_supervisor()
+                return {"red_supervisor": True}
+            await bot._equity_hard_stop_check()
+            if any(
+                bot._equity_hard_stop_runtime_red_latched(pside)
+                and not bot._hsl_state(pside)["halted"]
+                for pside in bot._hsl_psides()
+                if bot._equity_hard_stop_enabled(pside)
+            ):
+                if getattr(bot, "exchange", "").lower() == "fake":
+                    return await _run_fake_red_supervisor_step(bot)
+                await bot._equity_hard_stop_run_red_supervisor()
+                return {"red_supervisor": True}
+            if _fake_all_hsl_psides_terminal_latched(bot):
+                return {"terminal_hsl": True}
     refresh_authoritative = getattr(bot, "refresh_authoritative_state", None)
     if callable(refresh_authoritative) and not await refresh_authoritative():
         return {"updated": False}

--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -842,8 +842,8 @@ async def test_hsl_replay_scenarios_run_end_to_end(
     _cleanup_fake_user_state(user)
     base_config_path = REPO_ROOT / "configs" / "fake_live_hsl_btc.hjson"
     cfg = load_config(str(base_config_path), verbose=False)
-    # These scenarios assert pside-level RED cooldown semantics. The live default is unified HSL
-    # signal mode, so pin the legacy scenario contract explicitly.
+    # These scenarios assert pside-level RED cooldown semantics. Keep that fixture contract
+    # explicit even though the shared fake-live config now pins the same mode.
     cfg["live"]["hsl_signal_mode"] = "pside"
     cfg["bot"]["long"]["hsl_red_threshold"] = 0.02
     cfg["bot"]["long"].setdefault("hsl", {})["red_threshold"] = 0.02
@@ -891,6 +891,91 @@ async def test_hsl_replay_scenarios_run_end_to_end(
         assert len(step_summaries) == expected_steps
         assert (run_dir / "hsl_trace.json").exists()
         assert expected_log_fragment in (run_dir / "fake_live.log").read_text(encoding="utf-8")
+    finally:
+        _cleanup_fake_user_state(user)
+
+
+@pytest.mark.asyncio
+@pytest.mark.fake_live
+async def test_documented_hsl_restart_scenario_runs_unmodified(tmp_path):
+    """Keep the checked-in offline smoke command and its assertions executable as written."""
+    import passivbot_rust as pbr
+
+    if getattr(pbr, "__is_stub__", False):
+        pytest.skip("requires real passivbot_rust extension")
+
+    user = f"fake_hsl_documented_{tmp_path.name}"
+    _cleanup_fake_user_state(user)
+    try:
+        args = argparse.Namespace(
+            config=str(REPO_ROOT / "configs" / "fake_live_hsl_btc.hjson"),
+            scenario=str(
+                REPO_ROOT / "scenarios" / "fake_live" / "hsl_long_red_restart.hjson"
+            ),
+            user=user,
+            max_steps=None,
+            output_dir=str(tmp_path),
+            log_level=1,
+            snapshot_each_step=False,
+        )
+        assert await _async_main(args) == 0
+    finally:
+        _cleanup_fake_user_state(user)
+
+
+@pytest.mark.asyncio
+@pytest.mark.fake_live
+async def test_coin_hsl_restart_scenario_uses_protective_supervisor(tmp_path):
+    """Coin-mode RED must not fall through normal planning with confirmations pending."""
+    import passivbot_rust as pbr
+
+    if getattr(pbr, "__is_stub__", False):
+        pytest.skip("requires real passivbot_rust extension")
+
+    user = f"fake_hsl_coin_supervisor_{tmp_path.name}"
+    _cleanup_fake_user_state(user)
+    cfg = load_config(
+        str(REPO_ROOT / "configs" / "fake_live_hsl_btc.hjson"), verbose=False
+    )
+    cfg["live"]["hsl_signal_mode"] = "coin"
+    config_path = tmp_path / "fake_live_hsl_btc_coin.json"
+    config_path.write_text(json.dumps(cfg), encoding="utf-8")
+    scenario = hjson.loads(
+        (REPO_ROOT / "scenarios" / "fake_live" / "hsl_long_red_restart.hjson").read_text(
+            encoding="utf-8"
+        )
+    )
+    scenario.pop("assertions", None)
+    scenario_path = tmp_path / "hsl_long_red_restart_coin.hjson"
+    scenario_path.write_text(hjson.dumps(scenario), encoding="utf-8")
+
+    try:
+        args = argparse.Namespace(
+            config=str(config_path),
+            scenario=str(scenario_path),
+            user=user,
+            max_steps=None,
+            output_dir=str(tmp_path),
+            log_level=1,
+            snapshot_each_step=False,
+        )
+        assert await _async_main(args) == 0
+
+        run_dirs = sorted(
+            path
+            for path in tmp_path.iterdir()
+            if path.is_dir() and (path / "remote_calls.json").exists()
+        )
+        assert len(run_dirs) == 1
+        artifacts = _load_run_artifacts(run_dirs[0])
+        assert artifacts["positions"] == []
+        assert any(
+            fill.get("symbol") == "BTC/USDT:USDT"
+            and fill.get("position_side") == "long"
+            and fill.get("side") == "sell"
+            and fill.get("reduceOnly") is True
+            for fill in artifacts["fills"]
+        )
     finally:
         _cleanup_fake_user_state(user)
 


### PR DESCRIPTION
Scope category: read-only tooling / offline runtime harness

## Scope
- route coin-mode fake-live RED handling through the production protective supervisor
- pin the documented restart fixture to its intended pside HSL contract
- update the checked-in post-flatten assertion to current panic-fill-anchored finalization semantics
- add exact-artifact and multi-step coin-mode regressions

Non-goals: no live-bot behavior changes, no exchange adapter changes, no Rust strategy/risk changes, no logging-overhaul changes.

## Behavior impact
The documented deterministic offline HSL smoke completes as written. Coin-mode fake-live no longer enters normal staged planning while post-write authoritative confirmations are pending.

Expected VPS action: none. This only changes the offline fake exchange harness and fixtures.

## Validation
- py_compile src/tools/run_fake_live.py tests/test_run_fake_live.py
- pytest -q tests/test_run_fake_live.py -m fake_live: 23 passed
- documented run_fake_live command with the checked-in config/scenario: passed
- focused documented pside and multi-step coin supervisor regressions: passed
- git diff --check: passed

## Reviewer focus
Please verify that calling the production coin RED supervisor from the deterministic harness preserves protective-only planning and that the checked-in pside fixture/assertion reflects the current HSL finalization contract.