### PR TITLE
Repair stale HSL test contracts

### DIFF
--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -2553,7 +2553,7 @@ async def test_start_bot_treats_hsl_value_error_as_terminal_startup_failure(monk
     bot.warmup_trading_ready_candles = AsyncMock()
     bot._equity_hard_stop_enabled = lambda *args, **kwargs: True
     bot._equity_hard_stop_signal_mode = lambda *args, **kwargs: "coin"
-    bot._equity_hard_stop_initialize_coin_from_history = AsyncMock(
+    bot._equity_hard_stop_start_coin_history_replay = AsyncMock(
         side_effect=ValueError("missing unrealized_pnl_by_coin_pside")
     )
 

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import math
 import sys
 import types
 
@@ -38,6 +39,73 @@ def _make_mock_pbr():
         )
 
     module.hsl_no_restart_triggered = _hsl_no_restart_triggered
+
+    def _hsl_red_episode_finalization(
+        *,
+        restart_after_red_policy,
+        stop_timestamp_ms,
+        stop_equity,
+        stop_peak_strategy_equity,
+        previous_no_restart_peak_strategy_equity,
+        drawdown_ema,
+        red_threshold,
+        no_restart_drawdown_threshold,
+        cooldown_minutes_after_red,
+    ):
+        values = (
+            float(stop_equity),
+            float(stop_peak_strategy_equity),
+            float(previous_no_restart_peak_strategy_equity),
+            float(drawdown_ema),
+            float(red_threshold),
+            float(no_restart_drawdown_threshold),
+            float(cooldown_minutes_after_red),
+        )
+        if not all(math.isfinite(value) for value in values):
+            raise ValueError("HSL red episode finalization inputs must be finite")
+        if stop_equity <= 0.0:
+            raise ValueError("stop_equity must be > 0")
+        if stop_peak_strategy_equity < stop_equity:
+            raise ValueError("stop_peak_strategy_equity must be >= stop_equity")
+        if previous_no_restart_peak_strategy_equity < 0.0:
+            raise ValueError("previous no-restart peak must be >= 0")
+        if not (0.0 < red_threshold <= no_restart_drawdown_threshold <= 1.0):
+            raise ValueError(
+                "no_restart_drawdown_threshold must satisfy red_threshold <= threshold <= 1"
+            )
+        if cooldown_minutes_after_red < 0.0:
+            raise ValueError("cooldown_minutes_after_red must be >= 0")
+        peak = max(
+            previous_no_restart_peak_strategy_equity,
+            stop_peak_strategy_equity,
+            stop_equity,
+        )
+        raw = max(0.0, 1.0 - stop_equity / peak)
+        no_restart = _hsl_no_restart_triggered(
+            restart_after_red_policy,
+            raw,
+            drawdown_ema,
+            no_restart_drawdown_threshold,
+        )
+        cooldown_until_ms = None
+        if not no_restart and cooldown_minutes_after_red > 0.0:
+            cooldown_ms = max(1, round(cooldown_minutes_after_red * 60_000.0))
+            cooldown_until_ms = int(stop_timestamp_ms) + int(cooldown_ms)
+        return {
+            "no_restart_peak_strategy_equity": peak,
+            "no_restart_drawdown_raw": raw,
+            "no_restart_latched": no_restart,
+            "cooldown_until_ms": cooldown_until_ms,
+            "disposition": (
+                "no_restart"
+                if no_restart
+                else "cooldown"
+                if cooldown_until_ms is not None
+                else "halted_no_cooldown"
+            ),
+        }
+
+    module.hsl_red_episode_finalization = _hsl_red_episode_finalization
 
     class _EquityHardStopRollingPeak:
         def __init__(self):
@@ -2863,6 +2931,7 @@ async def test_hard_stop_finalize_red_stop_terminal_latches_and_stops(monkeypatc
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     _hsl_cfg(bot)["cooldown_minutes_after_red"] = 5.0
+    _hsl_cfg(bot)["red_threshold"] = 0.05
     _hsl_cfg(bot)["no_restart_drawdown_threshold"] = 0.1
 
     async def fake_compute(pside, _ts):
@@ -2903,6 +2972,7 @@ async def test_hard_stop_finalize_red_stop_equal_threshold_latches_terminal(
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     _hsl_cfg(bot)["cooldown_minutes_after_red"] = 5.0
+    _hsl_cfg(bot)["red_threshold"] = 0.05
     _hsl_cfg(bot)["no_restart_drawdown_threshold"] = 0.1
 
     async def fake_compute(pside, _ts):
@@ -2943,6 +3013,7 @@ async def test_hard_stop_finalize_red_stop_autorestarts_after_cooldown(monkeypat
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     _hsl_cfg(bot)["cooldown_minutes_after_red"] = 1.0
+    _hsl_cfg(bot)["red_threshold"] = 0.05
     _hsl_cfg(bot)["no_restart_drawdown_threshold"] = 0.2
     _hsl_state(bot)["runtime"]._initialized = True
     _hsl_state(bot)["runtime"]._red_latched = True
@@ -3056,6 +3127,7 @@ async def test_hard_stop_finalize_red_stop_uses_persistent_no_restart_peak(monke
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     _hsl_cfg(bot)["cooldown_minutes_after_red"] = 1.0
+    _hsl_cfg(bot)["red_threshold"] = 0.05
     _hsl_cfg(bot)["no_restart_drawdown_threshold"] = 0.2
     sink = ListEventSink()
     bot._live_event_current_cycle_id = "cy_hsl_repeat_red"

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -94,9 +94,10 @@ def _make_mock_pbr():
         )
         cooldown_until_ms = None
         if not no_restart and cooldown_minutes_after_red > 0.0:
-            cooldown_ms_f64 = math.floor(cooldown_minutes_after_red * 60_000.0 + 0.5)
+            cooldown_ms_f64 = cooldown_minutes_after_red * 60_000.0
             if not math.isfinite(cooldown_ms_f64) or cooldown_ms_f64 > float(u64_max):
                 raise ValueError("cooldown_minutes_after_red is too large")
+            cooldown_ms_f64 = math.floor(cooldown_ms_f64 + 0.5)
             # Rust's positive float-to-u64 cast saturates, as does the timestamp add.
             cooldown_ms = max(1, min(u64_max, int(cooldown_ms_f64)))
             cooldown_until_ms = min(u64_max, stop_timestamp_ms + cooldown_ms)
@@ -541,11 +542,12 @@ def test_mock_hsl_red_episode_finalization_rejects_negative_drawdown_ema():
         fn(**_red_episode_finalization_kwargs(drawdown_ema=-0.01))
 
 
-def test_mock_hsl_red_episode_finalization_rejects_oversized_cooldown():
+@pytest.mark.parametrize("cooldown_minutes", [1.0e20, 1.0e308])
+def test_mock_hsl_red_episode_finalization_rejects_oversized_cooldown(cooldown_minutes):
     fn = _make_mock_pbr().hsl_red_episode_finalization
 
     with pytest.raises(ValueError, match="cooldown_minutes_after_red is too large"):
-        fn(**_red_episode_finalization_kwargs(cooldown_minutes_after_red=1.0e20))
+        fn(**_red_episode_finalization_kwargs(cooldown_minutes_after_red=cooldown_minutes))
 
 
 def test_mock_hsl_red_episode_finalization_saturates_cooldown_deadline():

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -52,6 +52,9 @@ def _make_mock_pbr():
         no_restart_drawdown_threshold,
         cooldown_minutes_after_red,
     ):
+        u64_max = (1 << 64) - 1
+        if not isinstance(stop_timestamp_ms, int) or not 0 <= stop_timestamp_ms <= u64_max:
+            raise OverflowError("stop_timestamp_ms must fit in u64")
         values = (
             float(stop_equity),
             float(stop_peak_strategy_equity),
@@ -69,6 +72,8 @@ def _make_mock_pbr():
             raise ValueError("stop_peak_strategy_equity must be >= stop_equity")
         if previous_no_restart_peak_strategy_equity < 0.0:
             raise ValueError("previous no-restart peak must be >= 0")
+        if drawdown_ema < 0.0:
+            raise ValueError("drawdown_ema must be >= 0")
         if not (0.0 < red_threshold <= no_restart_drawdown_threshold <= 1.0):
             raise ValueError(
                 "no_restart_drawdown_threshold must satisfy red_threshold <= threshold <= 1"
@@ -89,8 +94,12 @@ def _make_mock_pbr():
         )
         cooldown_until_ms = None
         if not no_restart and cooldown_minutes_after_red > 0.0:
-            cooldown_ms = max(1, round(cooldown_minutes_after_red * 60_000.0))
-            cooldown_until_ms = int(stop_timestamp_ms) + int(cooldown_ms)
+            cooldown_ms_f64 = math.floor(cooldown_minutes_after_red * 60_000.0 + 0.5)
+            if not math.isfinite(cooldown_ms_f64) or cooldown_ms_f64 > float(u64_max):
+                raise ValueError("cooldown_minutes_after_red is too large")
+            # Rust's positive float-to-u64 cast saturates, as does the timestamp add.
+            cooldown_ms = max(1, min(u64_max, int(cooldown_ms_f64)))
+            cooldown_until_ms = min(u64_max, stop_timestamp_ms + cooldown_ms)
         return {
             "no_restart_peak_strategy_equity": peak,
             "no_restart_drawdown_raw": raw,
@@ -507,6 +516,46 @@ def mock_pbr(monkeypatch):
     import passivbot
 
     monkeypatch.setattr(passivbot, "pbr", stub_module, raising=False)
+
+
+def _red_episode_finalization_kwargs(**overrides):
+    kwargs = {
+        "restart_after_red_policy": "always",
+        "stop_timestamp_ms": 1_000,
+        "stop_equity": 90.0,
+        "stop_peak_strategy_equity": 100.0,
+        "previous_no_restart_peak_strategy_equity": 100.0,
+        "drawdown_ema": 0.1,
+        "red_threshold": 0.05,
+        "no_restart_drawdown_threshold": 0.2,
+        "cooldown_minutes_after_red": 1.0,
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_mock_hsl_red_episode_finalization_rejects_negative_drawdown_ema():
+    fn = _make_mock_pbr().hsl_red_episode_finalization
+
+    with pytest.raises(ValueError, match="drawdown_ema must be >= 0"):
+        fn(**_red_episode_finalization_kwargs(drawdown_ema=-0.01))
+
+
+def test_mock_hsl_red_episode_finalization_rejects_oversized_cooldown():
+    fn = _make_mock_pbr().hsl_red_episode_finalization
+
+    with pytest.raises(ValueError, match="cooldown_minutes_after_red is too large"):
+        fn(**_red_episode_finalization_kwargs(cooldown_minutes_after_red=1.0e20))
+
+
+def test_mock_hsl_red_episode_finalization_saturates_cooldown_deadline():
+    fn = _make_mock_pbr().hsl_red_episode_finalization
+    u64_max = (1 << 64) - 1
+
+    result = fn(**_red_episode_finalization_kwargs(stop_timestamp_ms=u64_max - 5))
+
+    assert result["cooldown_until_ms"] == u64_max
+    assert result["disposition"] == "cooldown"
 
 
 def _dummy_config():


### PR DESCRIPTION
Scope category: test infrastructure

## Scope
- update the custom passivbot_rust test stub with the current Rust-owned HSL red-episode finalization contract
- make four finalization fixtures satisfy red_threshold <= no_restart_drawdown_threshold
- mock the asynchronous coin replay startup wrapper that start_bot now invokes

Non-goals: no production code changes, no HSL policy changes, no exchange behavior changes, no logging-overhaul changes.

## Behavior impact
None in production. The previously failing and hanging HSL tests now exercise the current runtime interfaces and invariants.

Expected VPS action: none.

## Validation
- exact source-stamped Rust extension rebuilt and verified
- five previously failing or hanging tests: 5 passed
- pytest -q tests/test_unstucking_safeguards.py tests/test_passivbot_balance_split.py: passed
- full headless pytest suite with MPLBACKEND=Agg: passed at 100 percent
- git diff --check: passed

## Reviewer focus
Please verify that the local stub mirrors the current Rust finalization outputs used by these tests, the threshold values preserve each test intention, and the startup test now intercepts the actual production call boundary.