### PR TITLE
Replace no-op CI with release gates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,9 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          toolchain: "1.90.0"
+          components: rustfmt, clippy
 
       - name: Install Python dependencies
         run: |
@@ -88,6 +91,9 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          toolchain: "1.90.0"
+          components: rustfmt, clippy
 
       - name: Run Rust tests
         working-directory: passivbot-rust

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,98 @@
 name: CI
-on: [push]
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - v8
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  python:
+    name: Python 3.12
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - run: 'true'
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements-live.txt
+            requirements-full.txt
+            requirements-dev.txt
+            requirements-rust.txt
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+
+      - name: Install Python dependencies
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install -r requirements.txt
+
+      - name: Build and verify the Python Rust extension
+        env:
+          PYTHONPATH: src
+        run: |
+          .venv/bin/python -c "from rust_utils import check_and_maybe_compile; check_and_maybe_compile(force=True)"
+          .venv/bin/python -c "import passivbot_rust; from rust_utils import verify_loaded_runtime_extension; print(verify_loaded_runtime_extension())"
+
+      - name: Validate AI documentation
+        env:
+          PYTHONPATH: src
+        run: |
+          .venv/bin/python src/tools/check_ai_docs.py
+          .venv/bin/python src/tools/generate_live_event_registry.py --check
+          .venv/bin/python -m pytest tests/test_ai_docs.py tests/test_live_event_registry_docs.py
+
+      - name: Run Python test suite
+        env:
+          MPLBACKEND: Agg
+          MPLCONFIGDIR: ${{ runner.temp }}/matplotlib
+          PYTHONPATH: src
+        run: .venv/bin/python -m pytest
+
+      - name: Run release CLI smokes
+        env:
+          MPLBACKEND: Agg
+          MPLCONFIGDIR: ${{ runner.temp }}/matplotlib
+          PYTHONPATH: src
+        run: |
+          .venv/bin/python -c "from passivbot_cli.main import main; raise SystemExit(main(['tool', 'migrate-config-v7', '--help']))"
+          .venv/bin/python src/tools/run_fake_live.py \
+            configs/fake_live_hsl_btc.hjson \
+            scenarios/fake_live/hsl_long_red_restart.hjson \
+            --user ci_fake_hsl_restart \
+            --output-dir "${{ runner.temp }}/fake-live"
+
+  rust:
+    name: Rust
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+
+      - name: Run Rust tests
+        working-directory: passivbot-rust
+        run: cargo test --no-default-features
+
+      - name: Check Rust test targets with default features
+        working-directory: passivbot-rust
+        run: cargo check --tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
           cache: pip
@@ -84,7 +84,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable


### PR DESCRIPTION
## Scope

- Replace the existing no-op CI job with read-only Python 3.12 and Rust release gates.
- Build and fingerprint-verify the PyO3 extension before Python validation.
- Run AI-doc and live-event-registry checks, the full Python suite, migration CLI help, and the documented offline fake-live HSL restart smoke.
- Run Rust tests without extension linkage and compile-check default-feature test targets.
- Pin third-party actions by commit and cancel superseded runs per ref.

## Non-goals

- No production, trading, exchange, config, or documentation behavior changes.
- No authenticated exchange requests, live bot, deployment, SSH, restart, or VPS validation.
- No branch-protection change in this PR; required contexts will be configured only after these jobs exist and pass.

## Validation

- Verified the workflow parses as YAML and `git diff --check` passes.
- Exact local Python release-candidate suite passes with a rebuilt and source-stamp-verified extension.
- `cargo test --no-default-features`: 209 passed.
- `cargo check --tests`: pass.
- AI docs: 0 errors, one existing word-count warning; live-event registry current.
- Migration CLI help: pass.
- Documented offline fake-live HSL restart command: pass.

## Reviewer focus

- GitHub expression/YAML correctness and action pinning.
- Fresh-run dependency/build behavior and timeout adequacy.
- Whether the selected checks form useful release gates without credentials or mutable permissions.