### PR TITLE
Make fake fill cache test portable

### DIFF
--- a/tests/test_run_fake_live.py
+++ b/tests/test_run_fake_live.py
@@ -262,9 +262,10 @@ def test_prime_fake_fill_cache_writes_fake_fill_events(tmp_path):
     client = FakeCCXTClient(scenario, quote="USDT")
     bot = type("Bot", (), {"exchange": "fake", "user": "runner_test"})()
     cache_path = _prime_fake_fill_cache(bot, client, cache_root=tmp_path)
-    payload = next(cache_path.glob("*.json")).read_text(encoding="utf-8")
-    assert "boot_entry" in payload
     cache = FillEventCache(cache_path)
+    cached_events = cache.load()
+    assert len(cached_events) == 1
+    assert cached_events[0].client_order_id == "boot_entry"
     assert cache.get_covered_start_ms() == client.get_fill_events(None, None)[0]["timestamp"]
     assert cache.get_history_scope() == "window"
 


### PR DESCRIPTION
## Scope

- Make the fake-live fill-cache regression independent of filesystem glob enumeration order.
- Load the cache through `FillEventCache` and assert the persisted event count and `client_order_id` directly.

## Why

The new clean Ubuntu CI gate exposed that `next(cache_path.glob("*.json"))` may select `metadata.json`; macOS happened to enumerate the daily event file first. Production cache output was correct, but the test read an arbitrary JSON file.

## Non-goals

- No production, fill-cache, exchange, or trading behavior changes.
- No authenticated exchange, live bot, deployment, SSH, restart, or VPS validation.

## Validation

- `pytest -q tests/test_run_fake_live.py -m fake_live`: 23 passed.
- `pytest -q tests/test_fake_exchange.py tests/test_run_fake_live.py`: pass.
- `git diff --check`: pass.
- GitHub Linux CI on the dependent workflow PR reproduced the prior failure at this exact assertion; this PR removes the platform-dependent selection.

## Reviewer focus

- Whether using the public cache load contract is the strongest platform-independent assertion of the test intent.