### PR TITLE
Document the v8.0.0 breaking release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+## v8.0.0 - 2026-07-14
+
 - Restored the documented offline HSL restart smoke by pinning its fixture to
   the intended per-side HSL contract and updating its post-flatten drawdown
   assertion to the current panic-fill-anchored finalization semantics. Coin-mode

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@
 
 :warning: **Used at one's own risk** :warning:
 
-Current development target on `v8`: `v8.0.0`
+Current stable major version: **v8.0.0**.
+
+> **Upgrading from v7:** v8 is a breaking config and strategy release. Do not
+> start v8 live with an unreviewed v7 config. Read the
+> [v8.0.0 upgrade notes](docs/release_notes_v8.0.0.md) and use the explicit
+> `passivbot tool migrate-config-v7` helper when preserving v7 trailing-grid
+> behavior.
 
 
 ## Overview
@@ -37,6 +43,27 @@ Passivbot manages underperforming, or "stuck", positions by realizing small loss
 To install Passivbot and its dependencies, follow the steps below.
 
 Passivbot requires **Python 3.12**. Earlier versions are not supported.
+
+### Upgrading a v7 config
+
+V8 does not silently reinterpret v7 strategy fields. To preserve v7
+trailing-grid behavior while moving the config into canonical v8 shape, run:
+
+```sh
+passivbot tool migrate-config-v7 \
+  path/to/config_v7.json \
+  path/to/config_v8_trailing_grid_v7.json \
+  --report path/to/v7_migration_report.json
+```
+
+The helper writes the deprecated compatibility strategy `trailing_grid_v7`;
+it does not translate the config into the new `trailing_martingale` strategy.
+If unsupported or ambiguous fields require manual review, the command returns
+nonzero and does not write the output config unless
+`--allow-manual-review-output` is explicitly supplied. Review the report and
+backtest the result before considering a live run. New configs and new
+optimization work should start from
+`configs/examples/default_trailing_martingale_long.json`.
 
 ### Step 1: Clone the Repository
 

--- a/docs/release_notes_v8.0.0.md
+++ b/docs/release_notes_v8.0.0.md
@@ -1,0 +1,129 @@
+# Passivbot v8.0.0
+
+Passivbot v8 is a major, breaking release. It replaces the v7 strategy and
+configuration contract, moves substantially more trading and risk behavior
+into the shared Rust runtime, and makes the long-developed `v8` branch the
+mainline release.
+
+## Before upgrading
+
+- Use Python 3.12 and a current stable Rust toolchain.
+- Back up the config you currently run and keep the exact v7 revision needed
+  to reproduce its behavior.
+- Do not point v8 at an unreviewed v7 config. Normal v8 loading does not
+  silently convert removed v7 strategy fields.
+- Treat migration as a new deployment: inspect the normalized config, run
+  backtests, and review live-mode, risk, approved-coin, and exchange settings
+  before starting a bot.
+
+## Config migration
+
+The canonical v8 strategy is `trailing_martingale`. Its threshold,
+retracement, quantity, and close-recursion parameters are not aliases for the
+old v7 trailing-grid fields.
+
+For users who want to preserve v7 trailing-grid semantics during the upgrade,
+v8 includes the deprecated compatibility strategy `trailing_grid_v7` and an
+explicit migration tool:
+
+```bash
+passivbot tool migrate-config-v7 \
+  path/to/config_v7.json \
+  path/to/config_v8_trailing_grid_v7.json \
+  --report path/to/v7_migration_report.json
+```
+
+A clean migration writes canonical `config_version: "v8.0.0"` shape with
+`live.strategy_kind = "trailing_grid_v7"`. The tool does not reinterpret the
+config as `trailing_martingale`.
+
+If the report contains dropped, unsupported, or manual-review fields, the
+command returns nonzero and does not write the output by default. The
+`--allow-manual-review-output` option writes a best-effort artifact for manual
+work; it is not an assertion that the result is ready for live trading.
+
+For new configs, copy:
+
+```bash
+cp configs/examples/default_trailing_martingale_long.json my_v8_config.json
+```
+
+See [Config Workflow](config_workflow.md) and
+[Configuration Reference](configuration.md) for the canonical v8 shape.
+
+## Major changes
+
+### Shared Rust trading runtime
+
+- Live trading, backtesting, and optimization use the Rust orchestrator for
+  strategy planning and order intent.
+- Strategy, order, risk, unstuck, HSL transition, and backtest behavior have
+  stronger shared ownership and parity coverage.
+- Required trading inputs fail closed or become explicitly unavailable rather
+  than being replaced with fabricated neutral defaults.
+
+### Strategies and portfolio controls
+
+- `trailing_martingale` is the canonical recursive entry and close strategy.
+- `ema_anchor` is available as an additional canonical strategy.
+- Forager selection, wallet-exposure controls, total-wallet-exposure controls,
+  unstucking, and realized-loss gates have been consolidated and hardened.
+- EMA spans remain floating-point values throughout config derivation and
+  runtime preparation.
+
+### Equity Hard Stop Loss
+
+- HSL supports unified, position-side, and per-coin signal scopes with explicit
+  RED episode, cooldown, restart, and no-restart policies.
+- Coin-mode startup reconstructs exchange-derived history, prioritizes held
+  positions for protective readiness, and may continue non-blocking replay work
+  in the background.
+- Panic-close and protective management paths use dedicated readiness
+  boundaries; incomplete required history remains visible and fail-closed.
+
+Review [Equity Hard Stop Loss](equity_hard_stop_loss.md) and its risk warnings
+before enabling or changing HSL settings.
+
+### Live readiness and exchange safety
+
+- Account and market inputs are tracked through staged freshness and planning
+  snapshots before normal order planning and execution.
+- Ambiguous exchange writes require authoritative confirmation before unsafe
+  retries.
+- Exchange adapters and fill/PnL normalization have expanded coverage,
+  including Bitget UTA behavior and Hyperliquid HIP-3 stock perpetuals.
+
+### Logging, monitoring, and events
+
+- V8 introduces a structured live-event pipeline with bounded console, text,
+  monitor, and structured-data projections.
+- Events carry stable types, reason codes, correlation identifiers, redaction,
+  and sink-isolation behavior for operational queries and incident analysis.
+- The event architecture is part of v8. Console ownership and performance
+  refinements may continue after v8.0.0 without making observability a trading
+  control plane.
+
+### Backtesting, optimization, and data
+
+- Backtesting and optimization use the shared Rust behavior contract and the
+  current nested v8 config schema.
+- OHLCV preparation, coverage validation, cache integrity, suite execution,
+  optimizer checkpointing, deterministic seeds, stepped bounds, and Pareto
+  result handling have been expanded and hardened.
+- The unified `passivbot` CLI is the preferred entry point for live,
+  backtest, optimize, download, and tool commands.
+
+## Upgrade checklist
+
+1. Install v8 in a Python 3.12 virtual environment and rebuild the Rust
+   extension.
+2. Migrate the v7 config or start from the canonical v8 example.
+3. Resolve every migration report item; do not rely on best-effort output as a
+   live-readiness signal.
+4. Re-check API account selection, exchange mode, leverage, approved and
+   ignored coins, exposure limits, HSL, unstuck, and logging settings.
+5. Run a bounded backtest and inspect its fills and analysis artifacts.
+6. Start live trading only through the normal operational process, with logs
+   and monitor output observed closely during the first cycles.
+
+The complete detailed change ledger is in [CHANGELOG.md](../CHANGELOG.md).


### PR DESCRIPTION
## Summary

- mark the accumulated v8 changes as the `v8.0.0` release in `CHANGELOG.md`
- make the breaking v7-to-v8 boundary and migration command prominent in `README.md`
- add focused v8.0.0 release notes covering migration, major runtime changes, logging status, and an operator upgrade checklist

## Scope and non-goals

Documentation and release metadata only. This PR does not change config parsing, migration behavior, trading logic, exchange I/O, logging implementation, CI, or deployment state. It deliberately does not absorb the ongoing logging PR #1221.

## Validation

- `git diff --check origin/v8...HEAD`
- `src/tools/check_ai_docs.py`: 0 errors; one existing documentation-size warning
- generated live-event registry: current
- `tests/test_ai_docs.py tests/test_live_event_registry_docs.py`: 2 passed
- documented migration CLI against tracked master v7.12 `default_trailing_grid_long_npos7.json`: status `ok`, output written, `config_version=v8.0.0`, `strategy_kind=trailing_grid_v7`, no manual-review or dropped fields
- fail-closed migration CLI check against tracked legacy `btc_long.json`: manual review required, nonzero exit, no output written

## Reviewer focus

- accuracy of the breaking-release and migration guidance
- whether the release notes distinguish `trailing_grid_v7` compatibility from canonical `trailing_martingale`
- whether ongoing logging refinements are described without implying they block or change trading behavior
- changelog boundary placement above the accumulated v8 entries

No authenticated exchange, live bot, SSH, deployment, VPS, or remote process action was performed.