### PR TITLE
Restore AI commands compatibility route

### DIFF
--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -60,7 +60,7 @@ generated registries remain test failures.
 
 ## Temporary Compatibility Paths
 
-`principles.yaml`, `pr_auto_review_loop.md`, and `code_review_prompt.md` remain as narrow routes for
-active external automations. Their canonical content lives in `principles.md`,
-`runbooks/pr_review.md`, and `validation.md`. Remove the routes only after every scheduled consumer
-has migrated and a changed-head wake proves the new reads succeed.
+`principles.yaml`, `commands.md`, `pr_auto_review_loop.md`, and `code_review_prompt.md` remain as
+narrow routes for active external automations. Their canonical content lives in `principles.md`,
+`runbooks/commands.md`, `runbooks/pr_review.md`, and `validation.md`. Remove the routes only after
+every scheduled consumer has migrated and a changed-head wake proves the new reads succeed.

--- a/docs/ai/commands.md
+++ b/docs/ai/commands.md
@@ -1,0 +1,10 @@
+# Development Commands Compatibility Route
+
+This path is temporarily retained for active external automations that still load the former
+commands document.
+
+The canonical setup, test, backtest, optimizer, Rust-build, and execution-safety commands live in
+`runbooks/commands.md`. Read and follow that document in full.
+
+Remove this compatibility route only after every scheduled consumer has migrated and a changed-head
+wake has successfully loaded the canonical runbook.

--- a/tests/test_ai_docs.py
+++ b/tests/test_ai_docs.py
@@ -1,6 +1,18 @@
+from pathlib import Path
+
 from tools.check_ai_docs import check_ai_docs
+
+
+AI_DOCS_DIR = Path(__file__).resolve().parents[1] / "docs" / "ai"
 
 
 def test_ai_documentation_has_no_structural_errors():
     errors = [issue for issue in check_ai_docs() if issue.level == "error"]
     assert errors == []
+
+
+def test_commands_compatibility_route_points_to_canonical_runbook():
+    compatibility_route = AI_DOCS_DIR / "commands.md"
+
+    assert compatibility_route.is_file()
+    assert "`runbooks/commands.md`" in compatibility_route.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- restore `docs/ai/commands.md` as a narrow redirect to canonical `docs/ai/runbooks/commands.md`
- declare that route in the temporary-compatibility list
- add a regression test requiring the redirect to exist and point at the canonical runbook

## Why

This resolves the sole actionable finding from the exact-head Codex Sol review on cutover PR #1228. Current external review automation still loads the former path, so deleting it before a successful consumer migration violates the repository compatibility-route policy.

## Scope

AI documentation routing only. No runtime, trading, configuration, migration, exchange, logging implementation, CI, deployment, or VPS behavior changes.

## Validation

- `git diff --check`
- `src/tools/check_ai_docs.py`: 0 errors; one existing documentation-size warning
- generated live-event registry: current
- `tests/test_ai_docs.py tests/test_live_event_registry_docs.py`: 3 passed

## Reviewer focus

- the redirect contains no duplicated normative commands
- compatibility removal remains gated on migrated scheduled consumers and a successful changed-head wake
- the regression test fails if the route is removed or stops pointing to the canonical runbook

No authenticated exchange request, live bot, SSH, deployment, VPS, or remote-process action was performed.