### PR TITLE
Add strategy equity drawdown backtest plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Backtests now write `drawdown.png` alongside the existing summary plots,
+  showing drawdown from the running peak of collateral-agnostic strategy equity.
+
 ## v8.0.0 - 2026-07-14
 
 - Restored the documented offline HSL restart smoke by pinning its fixture to

--- a/src/plotting.py
+++ b/src/plotting.py
@@ -743,6 +743,55 @@ def plot_fills_forager(
     return plt
 
 
+def create_strategy_equity_drawdown_figure(
+    bal_eq: pd.DataFrame,
+    figsize=(21, 8),
+    *,
+    autoplot: bool | None = None,
+    return_figures: bool | None = None,
+) -> dict:
+    figures: dict = {}
+    if "strategy_equity" not in bal_eq.columns:
+        return figures
+
+    strategy_eq = pd.to_numeric(bal_eq["strategy_equity"], errors="coerce")
+    if not strategy_eq.notna().any():
+        return figures
+
+    peak_strategy_eq = strategy_eq.cummax()
+    drawdown = (peak_strategy_eq - strategy_eq) / peak_strategy_eq
+
+    autoplot = (_ipy_display is not None) if autoplot is None else autoplot
+    if return_figures is None:
+        return_figures = not autoplot
+
+    fig, ax = plt.subplots(1, 1, figsize=figsize)
+    x = bal_eq.index.to_numpy()
+    drawdown_values = drawdown.to_numpy()
+    ax.fill_between(x, 0.0, drawdown_values, alpha=0.25, color="tab:red")
+    ax.plot(x, drawdown_values, linewidth=1.0, color="tab:red")
+    ax.set_title("Strategy Equity Drawdown")
+    ax.set_ylabel("Drawdown")
+    ax.set_xlabel("Time")
+    ax.grid(True, linestyle="--", alpha=0.3)
+    fig.tight_layout()
+
+    if return_figures:
+        figures["drawdown"] = fig
+    if autoplot:
+        if _ipy_display is not None:
+            _ipy_display(fig)
+        else:  # pragma: no cover
+            try:
+                fig.show()
+            except Exception:
+                pass
+    if not return_figures:
+        plt.close(fig)
+
+    return figures if return_figures else {}
+
+
 def create_forager_balance_figures(
     bal_eq: pd.DataFrame,
     figsize=(21, 13),
@@ -839,6 +888,15 @@ def create_forager_balance_figures(
                     pass
         if not return_figures:
             plt.close(fig)
+
+    figures.update(
+        create_strategy_equity_drawdown_figure(
+            df,
+            figsize=(figsize[0], 8),
+            autoplot=autoplot,
+            return_figures=return_figures,
+        )
+    )
 
     return figures if return_figures else {}
 

--- a/tests/test_backtest_analysis.py
+++ b/tests/test_backtest_analysis.py
@@ -15,7 +15,10 @@ from backtest import (
     parse_disabled_plot_groups,
     process_forager_fills,
 )
-from plotting import create_forager_hard_stop_drawdown_figure
+from plotting import (
+    create_forager_balance_figures,
+    create_forager_hard_stop_drawdown_figure,
+)
 
 
 def _make_analysis_entry(value):
@@ -637,6 +640,29 @@ def test_process_forager_fills_includes_strategy_equity_column():
     assert "strategy_equity" in bal_eq.columns
     assert np.isclose(bal_eq["strategy_equity"].iloc[0], 1000.0)
     assert np.isclose(bal_eq["strategy_equity"].iloc[-1], 995.0)
+
+
+def test_create_forager_balance_figures_adds_strategy_equity_drawdown():
+    idx = pd.date_range("2025-01-01", periods=4, freq="1h")
+    bal_eq = pd.DataFrame(
+        {
+            "usd_total_equity": [100.0, 90.0, 120.0, 96.0],
+            "strategy_equity": [100.0, 90.0, 120.0, 96.0],
+            "btc_total_equity": [1.0, 0.9, 1.2, 0.96],
+        },
+        index=idx,
+    )
+
+    figures = create_forager_balance_figures(
+        bal_eq,
+        autoplot=False,
+        return_figures=True,
+    )
+
+    assert "drawdown" in figures
+    plotted_drawdown = figures["drawdown"].axes[0].lines[0].get_ydata()
+    np.testing.assert_allclose(plotted_drawdown, [0.0, 0.1, 0.0, 0.2])
+    plotting.plt.close("all")
 
 
 def test_post_process_disable_plotting_skips_all_figure_generation(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- add drawdown.png to the existing backtest balance summary artifacts
- compute drawdown from strategy equity as (running peak - equity) / running peak
- keep the plot in the existing balance plot group so it inherits backtest.balance_sample_divider
- document the new artifact and add regression coverage for the plotted series

## Validation

- MPLBACKEND=Agg MPLCONFIGDIR=/private/tmp/passivbot_mpl ./venv/bin/pytest -q tests/test_backtest_analysis.py tests/test_backtest_artifacts.py (36 passed)
- offline SOL ema_anchor backtest from an existing local HLCV artifact (2.64 s end to end; drawdown.png produced)
- offline BTC/ETH trailing-martingale backtests from an existing local HLCV artifact with balance_sample_divider 60 and 1 (2.72 s and 2.78 s; drawdown.png produced in both)
- isolated drawdown create plus PNG save benchmark: 74-79 ms median for 96 and 5,759 points, so no additional sampling path was needed
- git diff --check
- Python compileall for the changed Python files