### PR TITLE
Define console verbosity policy from VPS5 evidence

### DIFF
--- a/docs/ai/case_studies/live_console_verbosity_vps5_20260714.md
+++ b/docs/ai/case_studies/live_console_verbosity_vps5_20260714.md
@@ -1,0 +1,54 @@
+# VPS5 Console Verbosity Baseline, 2026-07-14
+
+This case study records the production evidence used to sharpen the default console contract in
+`../logging_policy.md`. It is historical rationale, not a runtime target or a claim about later
+versions.
+
+## Method
+
+The sample used read-only tmux scrollback from five live bots on VPS5. No process was signalled or
+restarted, and no exchange request was initiated for the audit. ANSI control sequences were
+removed. A logical record began with the normal UTC timestamp/level/exchange prefix; continuation
+rows up to the next timestamp were counted as physical terminal rows.
+
+The current-run sample covered `2026-07-14T18:04:50Z` through `19:12:29Z`. A steady-state slice
+excluded the first ten minutes and covered `18:15:00Z` through `19:13:51Z`. The host was not fully
+healthy throughout: KuCoin experienced real request timeouts. That makes the sample useful for
+both routine-volume and incident-projection analysis.
+
+## Results
+
+Across the full current-run sample:
+
+- 2,010 logical records and 3,177 displayed rows in 1.128 hours
+- 1,783 records/hour and 2,818 rows/hour across five bots
+- about 357 records/hour and 564 rows/hour per bot
+- 675 `[warmup]`, 461 `[balance]`, and 282 `[boot]` INFO records; these three routine families were
+  70.5% of all logical records
+- 688 displayed rows came from only 19 error or degraded-health records because repeated timeout
+  tracebacks expanded to roughly 83-86 rows each
+
+The post-startup slice remained at 1,543 logical records/hour and 2,463 displayed rows/hour across
+the five bots. Dominant recurring behavior included:
+
+- per-symbol warmup bundles repeated after the bot was already ready
+- `[boot]` candle-index rebuild start/completion lines during normal maintenance
+- REST balance lines for small positive and negative mark-to-market changes while the snapshot
+  anchor remained unchanged
+- per-cycle forager selections and staged-refresh timing detail
+- multi-row candle/EMA context lists
+- repeated full KuCoin timeout tracebacks in both operation-error and degraded-health records
+
+The tracebacks were operationally important, but printing each full stack obscured the concise
+error signature, repeat count, and recovery state. Conversely, fills, position changes, order
+outcomes, periodic health summaries, and safety transitions were a small fraction of the volume and
+remained the most useful facts to retain.
+
+## Conclusion
+
+The main problem was not too many structured events. It was projection: routine maintenance and
+continuous numeric jitter were admitted to an operator sink, while a small number of incidents
+expanded into hundreds of terminal rows. The durable remedy is event-specific transition and
+aggregation policy plus bounded one-line incident summaries. A global rate limiter would be less
+safe because it could hide an unrelated fill, exchange write, or risk transition during a noisy
+period.

--- a/docs/ai/logging_policy.md
+++ b/docs/ai/logging_policy.md
@@ -64,6 +64,66 @@ Legacy stdlib lines may temporarily serve as fallback when structured console pr
 disabled or unavailable. New work should not duplicate an event in both paths without an explicit
 migration reason.
 
+### Admission Rules
+
+Default INFO console admission is based on operator value, not merely on the producer's level.
+
+- Emit exchange writes and outcomes, fills, position changes, safety actions, and new fatal
+  failures immediately.
+- Emit gates, fallbacks, connectivity, readiness, mode, and risk state on transition: entered,
+  materially changed, recovered, or cleared. Unchanged repeats stay in structured/debug sinks.
+- Emit one initial account snapshot. Thereafter, emit balance only for a material wallet/account
+  change or an attributable settlement such as realized PnL, funding, fee, deposit, or withdrawal.
+  Mark-to-market equity jitter and unchanged snapshot anchors are not console changes.
+- Emit startup work as phase milestones. While a phase blocks readiness, bounded progress may appear
+  at most once every 30 seconds. Per-symbol warmup, candle-index rebuild, cache maintenance, and
+  successful refresh detail are DEBUG after readiness; post-ready maintenance must not use `[boot]`.
+- Emit forager selection when the selected set or its availability materially changes. Persistent
+  churn receives at most one aggregate every five minutes; candidate and feature detail stays off
+  the console.
+- Emit one periodic healthy summary per bot at most every 15 minutes. Degradation and recovery are
+  immediate and do not wait for that cadence.
+- Emit held-position trailing, unstuck, HSL, WEL, and TWEL state on transition or material threshold
+  movement, not on every planning cycle.
+
+The structured event remains durable even when its console projection is suppressed. Suppression
+must not alter event production, trading decisions, counters, or monitor history.
+Each family that uses numeric materiality or hysteresis must define that boundary explicitly and
+test values on both sides; the console sink must not invent a generic threshold after emission.
+
+### Incident Projection
+
+The normal console projects an incident as a bounded signature, not a traceback:
+
+1. Emit the first occurrence immediately with component, operation, exception class, status/code
+   when safe, affected scope, action, and correlation id.
+2. Aggregate equivalent repeats and emit a compact count at most every five minutes. Emit recovery
+   once when the condition clears.
+3. Keep sanitized tracebacks in the protected developer text/structured diagnostic path. A terminal
+   outer-process failure may tell the operator where that detail was retained, but must not dump it
+   into the normal console.
+
+Distinct safety transitions and distinct failed exchange writes are never coalesced merely to meet
+a volume target.
+
+### Shape And Volume Budget
+
+A normal console record should fit in 240 visible characters and no more than two terminal rows at
+160 columns. Summaries use counts, maxima, and at most three samples plus `+N more`; tables, banners,
+tracebacks, and unbounded symbol lists are not normal steady-state records.
+
+After readiness, a healthy bot should target:
+
+- at most 60 INFO records and 90 displayed rows per hour
+- at most 10 INFO records in any minute, excluding direct exchange actions/outcomes, fills,
+  position changes, and safety transitions
+- no non-action family above 20% of steady-state INFO without an explicit operator-value rationale
+
+These are review and VPS-smoke acceptance budgets, not hard runtime drop limits. Measure both
+timestamped logical records and terminal rows after wrapping. If the budget is exceeded, change the
+producer's transition, aggregation, routing, or formatting policy; do not add a global sampler that
+can hide unrelated events. Startup is assessed separately because readiness milestones are bursty.
+
 ## Fallback Visibility
 
 Trading-critical fallbacks follow `error_contract.md` and include the relevant input/symbol,
@@ -76,3 +136,5 @@ visibly rather than being ignored.
 2. Can they distinguish waiting, degraded operation, and failure?
 3. Can developers correlate a decision without exposing secrets or unbounded payloads?
 4. Does sink failure remain isolated from trading behavior?
+5. Is each INFO record a new operator fact, transition, action, or bounded summary?
+6. Do steady-state logical-record and displayed-row measurements satisfy the console budget?


### PR DESCRIPTION
## Scope

- category: docs
- define concrete admission, incident, shape, and volume rules for the operator console sink
- record the read-only VPS5 baseline that motivated the policy
- no runtime, routing-table, event payload, trading, exchange, or configuration changes

This PR is orthogonal to #1221 and may be reviewed independently.

## Behavior impact

None in this PR. The policy is the reference for later logging-overhaul implementation slices.

The proposed healthy post-readiness target is at most 60 INFO records and 90 displayed rows per bot per hour. It is explicitly a review/smoke target, not a global runtime drop limit. Exchange actions/outcomes, fills, position changes, and safety transitions remain immediate.

## VPS evidence

Read-only tmux scrollback from five bots was sampled without signalling processes or initiating exchange requests. The current-run window contained 2,010 logical records and 3,177 displayed rows in 1.128 hours. Warmup, balance, and boot maintenance were 70.5% of logical records; 19 timeout/error-burst records expanded to 688 rows because of repeated tracebacks.

## Validation

- `PYTHONPATH=src python src/tools/check_ai_docs.py` - 0 errors, existing repository word-count warning
- `PYTHONPATH=src python -m pytest tests/test_ai_docs.py -q` - 2 passed
- `git diff --check` - passed

## Reviewer focus

- whether the admission rules preserve immediate operator visibility for actions and safety transitions
- whether the numeric budgets are useful acceptance criteria without becoming unsafe runtime suppression
- whether traceback handling retains enough concise incident context while respecting redaction and boundedness

## VPS action

None. Docs only.
