### PR TITLE
Document PR review target branch cutovers

### DIFF
--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -63,4 +63,6 @@ generated registries remain test failures.
 `principles.yaml`, `commands.md`, `pr_auto_review_loop.md`, and `code_review_prompt.md` remain as
 narrow routes for active external automations. Their canonical content lives in `principles.md`,
 `runbooks/commands.md`, `runbooks/pr_review.md`, and `validation.md`. Remove the routes only after
-every scheduled consumer has migrated and a changed-head wake proves the new reads succeed.
+every scheduled consumer has migrated and a changed-head wake proves the new reads succeed. Review
+schedulers must also migrate base-branch filters and compact state after a default-branch cutover;
+the proving wake must discover a PR against the new target rather than merely load the new path.

--- a/docs/ai/pr_auto_review_loop.md
+++ b/docs/ai/pr_auto_review_loop.md
@@ -6,5 +6,9 @@ The canonical durable polling, recovery, trigger, validation, and verdict contra
 `runbooks/pr_review.md`. Read and follow that document in full. Do not fall back to an older cached
 copy when the canonical path is available.
 
+Use each PR's current base ref as its target. Repository-default loops must resolve the live default
+branch from GitHub metadata and must not continue polling a cached historical branch after a branch
+cutover.
+
 Remove this compatibility route only after every scheduled reviewer has been migrated and a
 changed-head wake has successfully loaded the canonical runbook.

--- a/docs/ai/runbooks/pr_review.md
+++ b/docs/ai/runbooks/pr_review.md
@@ -34,11 +34,26 @@ another's request for changes, and old-head verdicts do not apply to a new head.
 head, decision, and submission time instead of collapsing review history. Ambiguity wakes semantic
 review rather than being resolved by the polling tier.
 
+### Target Selection And Branch Cutovers
+
+- Treat each PR's current base ref and base SHA as its authoritative review target. Do not infer the
+  target from the feature-branch name, an old prompt, or cached scheduler state.
+- Repository-default review loops resolve the current default branch from live GitHub metadata.
+  A loop intentionally scoped to a non-default branch records that exception explicitly rather than
+  hardcoding a historical default.
+- Persist the observed base ref and default branch in compact state. A PR base-ref change or a
+  default-branch change for a default-target loop materially changes review scope: invalidate the
+  cached merge base and gate digest, refetch exact refs, and perform a fresh integrated review.
+- After a default-branch cutover, update scheduler filters, protected-check configuration, and
+  compact cache. Before retiring the old target or compatibility routes, require a changed-head wake
+  to discover a PR against the new default and load this canonical runbook successfully.
+
 ### Cost-Aware Polling
 
 Unchanged polls are deterministic metadata work, not semantic-review work:
 
-1. Fetch open-PR metadata including number, draft state, head SHA, update time, and CI summary.
+1. Fetch open-PR metadata including number, draft state, base ref/SHA, head SHA, update time, and CI
+   summary. Default-target loops also fetch the repository's current default branch.
 2. Compare it with compact saved state.
 3. Fetch reviews/comments and wake semantic review only for a new or materially changed PR.
 4. Do not fetch diffs, create worktrees, rerun tests, or invoke a reasoning model for an unchanged
@@ -65,9 +80,10 @@ not justify weakening it.
 
 ### Semantic Review Triggers
 
-Review when a ready PR is new, its head changes, its effective merge base changes materially, a
-maintainer requests re-review, or new evidence invalidates the prior conclusion. A CI-only state
-change does not duplicate semantic review. Do not approve drafts unless explicitly requested.
+Review when a ready PR is new, its head or base ref changes, its effective merge base changes
+materially, a default-target loop observes a new repository default, a maintainer requests
+re-review, or new evidence invalidates the prior conclusion. A CI-only state change does not
+duplicate semantic review. Do not approve drafts unless explicitly requested.
 
 After a changed head, review the delta and then the integrated full PR. Post one current verdict;
 do not repeat unchanged approvals or status narration.
@@ -82,6 +98,8 @@ polling cadence, and reviewer narration alone cannot prevent a new or unreviewed
 - A stale check, comment, or approval cannot satisfy the current-head gate.
 - The posting path re-fetches the head immediately before publishing the verdict.
 - Merge readiness still requires every configured review and CI gate to be green for the same head.
+- A `COMMENT` review remains advisory even when its prose says `APPROVE`; it cannot satisfy a
+  required GitHub approval or substitute for a protected status/check.
 
 If the automation cannot publish or enforce a SHA-bound check, describe it as advisory monitoring,
 not a mandatory merge gate.
@@ -134,6 +152,10 @@ Use a formal review when available:
 - `APPROVE` when no actionable findings remain
 - `REQUEST_CHANGES` for actionable defects
 - `COMMENT` for clarification or when self-approval is unavailable
+
+When self-approval is unavailable, a `COMMENT` may record the semantic verdict and exact reviewed
+SHAs, but it is not a formal approval. Describe the result as advisory unless a separate protected
+SHA-bound review check records it.
 
 Every verdict records:
 

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -865,6 +865,14 @@ Related detailed plans:
     publish visible without substituting a comment as success. Keep advisory
     review loops clearly labeled until branch protection enforces the check.
 
+    Current evidence: after the v8.0.0 default-branch cutover on 2026-07-14,
+    `master` protection enforced strict `Python 3.12` and `Rust` checks plus
+    conversation resolution, but required zero formal approvals and no
+    semantic-review status/check. Hermes, Grok, or self-authored `COMMENT`
+    verdicts therefore remain advisory until this item is implemented. Reviewer
+    schedulers must also migrate their base-branch filters and compact cache to
+    the live default branch before the cutover can be considered complete.
+
 20. [ ] Per-asset collateral, debt, and valuation balance events.
     Status: open. A 2026-07-14 evaluation confirmed that the existing
     `balance.changed` event and console projection expose only aggregate raw

--- a/tests/test_ai_docs.py
+++ b/tests/test_ai_docs.py
@@ -11,8 +11,15 @@ def test_ai_documentation_has_no_structural_errors():
     assert errors == []
 
 
-def test_commands_compatibility_route_points_to_canonical_runbook():
-    compatibility_route = AI_DOCS_DIR / "commands.md"
+def test_compatibility_routes_point_to_canonical_documents():
+    expected_routes = {
+        "commands.md": "`runbooks/commands.md`",
+        "pr_auto_review_loop.md": "`runbooks/pr_review.md`",
+        "code_review_prompt.md": "`validation.md`",
+        "principles.yaml": "canonical_document: docs/ai/principles.md",
+    }
 
-    assert compatibility_route.is_file()
-    assert "`runbooks/commands.md`" in compatibility_route.read_text(encoding="utf-8")
+    for route_name, canonical_reference in expected_routes.items():
+        compatibility_route = AI_DOCS_DIR / route_name
+        assert compatibility_route.is_file()
+        assert canonical_reference in compatibility_route.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- make each PR's live base ref/SHA the authoritative review target
- require default-target schedulers to resolve the repository default branch from GitHub metadata instead of retaining a historical hardcoded branch
- define default-branch cutovers as material scope changes that invalidate cached merge-base and gate state
- clarify that self-authored `COMMENT` verdicts are advisory and cannot satisfy protected approvals or status checks
- extend compatibility-route regression coverage and record the current semantic-check enforcement gap

## Scope

Documentation and documentation-test contract only. This does not change trading behavior, GitHub branch protection, reviewer credentials, scheduler configuration, CI workflows, deployment, or exchange behavior.

The canonical runbook remains branch-agnostic. It does not hardcode `master`; it requires live default-branch discovery and the PR's actual base ref so future branch changes cannot recreate the same stale-target problem.

## Validation

- `PYTHONPATH=src .../python src/tools/check_ai_docs.py`: 0 errors, one existing warning-only documentation-size warning
- `PYTHONPATH=src .../python src/tools/generate_live_event_registry.py --check`: current
- `PYTHONPATH=src .../python -m pytest -q tests/test_ai_docs.py tests/test_live_event_registry_docs.py`: 3 passed
- `git diff --check`: passed

## Reviewer focus

- whether target/base/default-branch changes invalidate enough cached review state
- whether the compatibility-route removal gate correctly proves discovery against the new target
- whether `COMMENT` versus formal/protected approval semantics are unambiguous
- whether the backlog records current advisory enforcement without duplicating the canonical contract

No SSH, deployment, live process, authenticated exchange, or branch-protection change was performed.
