### PR TITLE
Suppress raw-only balance jitter from live console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Raw-only wallet-balance jitter no longer appears on the normal live console
+  when the hysteresis-snapped balance is unchanged. The complete
+  `balance.changed` event remains available in structured, monitor, and durable
+  text sinks; snapped changes and events without valid materiality metadata
+  remain console-visible.
+
 - Realized-loss gate blocks now use their structured warning as the sole normal
   console/text line when a live-event console sink is available. The legacy
   warning remains the fallback; gate decisions, diagnostics, and throttling are

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -1,6 +1,6 @@
 # Live Logging Overhaul Current Status
 
-Updated: 2026-07-13.
+Updated: 2026-07-15.
 
 This is the compact operational source for the active logging-overhaul loop.
 Read it before the historical progress ledger. Update it whenever the active
@@ -22,22 +22,24 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/v8-realized-loss-gate-console-migration`.
-- Base: `a0897f83932db5e6888c1c96f8f1c668d452013f`, the `v8.0.0`
-  cutover merge on canonical `master`.
-- Slice: realized-loss gate console ownership.
-- Triggering evidence: `_log_realized_loss_gate_blocks` writes a detailed
-  legacy warning immediately before emitting the already console/text-routed
-  `risk.realized_loss_gate_blocked` event. Existing tests asserted both paths,
-  confirming direct duplicate ownership.
-- Scope: make the existing structured realized-loss gate event the sole normal
-  console/text owner when an enabled live-event pipeline has an actual console
-  sink. Preserve the legacy warning when the emitter, pipeline, or console sink
-  is unavailable. Enqueue or sink degradation must remain single-owner and
-  surface through pipeline health rather than trigger dynamic dual writing.
-- Behavior boundary: preserve Rust-owned diagnostics, per-symbol/pside/order
-  type throttling, warning severity, event payload and routing, configuration,
-  gate decisions, order filtering, exchange calls, and all trading behavior.
+- Branch: `codex/balance-console-materiality`.
+- Base: `991dadb69124e838a4a3b63fff65036a223b4195`, the PR #1231
+  console-verbosity policy merge on canonical `master`.
+- Slice: console-only suppression of raw wallet-balance jitter.
+- Triggering evidence: the VPS5 console-volume study found balance and warmup
+  families dominated healthy output. The merged policy requires balance after
+  the initial snapshot to represent a material or attributable account change,
+  while the current pipeline projects every raw-balance movement even when the
+  hysteresis-snapped balance is unchanged.
+- Scope: suppress `balance.changed` from the console only when its finite
+  `balance_snapped_delta` is zero. Preserve structured, monitor, and durable text
+  delivery. Keep snapped changes and events with absent or malformed
+  materiality metadata console-visible. Remove the legacy 15-minute raw-only
+  fallback line while retaining snapped-change fallback output.
+- Behavior boundary: preserve balance calculation, hysteresis, event payload,
+  event production, monitor history, durable text, equity diagnostics,
+  scheduling, exchange calls, order/risk behavior, Rust, backtest, and optimizer
+  behavior.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: restart and observe only after this slice merges;
@@ -45,12 +47,24 @@ Estimated completion:
 
 ## Deployed Baseline
 
-- Remote `v8`: `9773889ecb8a396bec31e1e11c326aed9fa2cbe7`, PR #1220
-- VPS5 repository: `9773889ecb8a396bec31e1e11c326aed9fa2cbe7`, PR #1220; exact
-  tracked status clean and expected untracked artifacts preserved
-- VPS5 expected bots: five; running with PR #1220 restart PIDs
-  `913308/913310/913312/913314/913316`; pane PIDs unchanged; unrelated
+- Canonical `master`: `991dadb69124e838a4a3b63fff65036a223b4195`, PR #1231.
+- VPS5 repository: `dacd66adebfd230999aebf7f9fbd34a5b2990490`, PR #1221; exact
+  tracked status clean and expected untracked artifacts preserved.
+- VPS5 expected bots: five; running with PR #1221 restart PIDs
+  `927721/927781/927842/927899/927963`; pane PIDs unchanged; unrelated
   `misc:0.0` remains PID `434835`
+- PR #1231 merged at `991dadb69124e838a4a3b63fff65036a223b4195`.
+  It defines evidence-based console admission, incident projection, and volume
+  budgets. It is documentation-only, so no VPS5 restart was required.
+- PR #1221 merged and deployed at
+  `dacd66adebfd230999aebf7f9fbd34a5b2990490`. It made the structured
+  realized-loss gate warning the sole normal console/text owner while preserving
+  the legacy fallback and all gate behavior. Only the five exact bot panes were
+  gracefully restarted; unrelated processes and local artifacts were preserved.
+  After transient GateIO/KuCoin timeouts and HSL replay completed naturally, the
+  final two-minute smoke was `ok=true`: `198/198` remote calls, `49/49`
+  account-critical calls, six successful fill refreshes, five expected
+  processes, and zero hard, log-attention, monitor, or event-pipeline failures.
 - PR #1220 merged and deployed at
   `9773889ecb8a396bec31e1e11c326aed9fa2cbe7`. It made structured
   min-effective-cost block events own normal per-block console/text output
@@ -519,8 +533,10 @@ migration, PR #1217's execution-loop error-burst console migration, PR #1218's
 ambiguous-cancel console migration, PR #1219's entry-distance-gate console
 migration, and PR #1220's min-effective-cost console migration are merged and
 deployed. Natural post-PR #1220 GateIO output proved structured single
-ownership. Static follow-up found direct legacy/structured dual ownership for
-realized-loss gate blocks, tracked by the active slice above.
+ownership. PR #1221's realized-loss gate console migration is also merged and
+deployed with a settled hard-green smoke. PR #1231's console-verbosity policy is
+merged without a runtime deployment. Its first implementation follow-up is the
+active raw-only balance-console materiality slice above.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -8164,3 +8164,20 @@ VPS5 deployment status:
   monitor configuration, trading behavior, or lock-holder attribution.
 - Expected VPS action: exact five-bot graceful restart, immediate and settled
   smoke, and before/after monitor maintenance plus lock-wait evidence.
+
+### 2026-07-15: Console Policy And Raw-Balance Materiality
+
+- PR #1221 merged and deployed to VPS5 at `dacd66adeb`. Only the five exact bot
+  panes restarted. After transient remote timeouts and HSL replay recovered, the
+  final bounded two-minute smoke was `ok=true` with `198/198` remote calls,
+  `49/49` account-critical calls, six successful fill refreshes, five expected
+  processes, and zero hard, log-attention, monitor, or event-pipeline failures.
+- PR #1231 merged to canonical `master` at `991dadb691`. Its VPS5 evidence-based
+  console policy makes operator value and transition/materiality the INFO
+  admission contract; the docs-only merge required no restart.
+- Active branch `codex/balance-console-materiality` suppresses only raw-balance
+  jitter from the console when finite snapped delta is zero. Structured,
+  monitor, and durable text delivery remain unchanged. Snapped changes and
+  unclassifiable events fail visible. The legacy raw-only fallback line is also
+  removed; no balance, hysteresis, equity, scheduling, exchange, risk, order,
+  Rust, backtest, or optimizer behavior changes.

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -2027,6 +2027,17 @@ def _operator_sink_event_visible(event: LiveEvent) -> bool:
     return True
 
 
+def _console_sink_event_visible(event: LiveEvent) -> bool:
+    if not _operator_sink_event_visible(event):
+        return False
+    if event.event_type == EventTypes.BALANCE_CHANGED:
+        data = event.data if isinstance(event.data, Mapping) else {}
+        snapped_delta = _data_number(data, "balance_snapped_delta")
+        # Missing or malformed materiality metadata must remain operator-visible.
+        return snapped_delta is None or snapped_delta != 0.0
+    return True
+
+
 def format_console_event(event: LiveEvent) -> str:
     if (
         event.event_type == EventTypes.HEALTH_SUMMARY
@@ -2830,7 +2841,7 @@ class LiveEventPipeline:
         if (
             route.console
             and self.console_sink is not None
-            and _operator_sink_event_visible(live_event)
+            and _console_sink_event_visible(live_event)
             and self._should_emit_throttled_sink("console", live_event, route)
         ):
             self._write_sink("console", self.console_sink, live_event)

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -9677,8 +9677,6 @@ class Passivbot:
             self._previous_balance_raw = 0.0
         if not hasattr(self, "_previous_balance_snapped"):
             self._previous_balance_snapped = 0.0
-        if not hasattr(self, "_last_raw_only_log_time"):
-            self._last_raw_only_log_time = 0.0
         balance_raw = self.get_raw_balance()
         balance_snapped = self.get_hysteresis_snapped_balance()
         if (
@@ -9686,13 +9684,10 @@ class Passivbot:
             or balance_snapped != self._previous_balance_snapped
         ):
             snap_changed = balance_snapped != self._previous_balance_snapped
-            raw_only = not snap_changed
-            now = time.time()
-            should_log = snap_changed or (now - self._last_raw_only_log_time >= 900.0)
             try:
                 equity = balance_raw + (await self.calc_upnl_sum())
                 self._monitor_last_equity = float(equity)
-                if should_log and not Passivbot._live_event_console_available(self):
+                if snap_changed and not Passivbot._live_event_console_available(self):
                     logging.info(
                         "[balance] raw %.6f -> %.6f | snap %.6f -> %.6f | equity: %.4f source: %s",
                         self._previous_balance_raw,
@@ -9702,8 +9697,6 @@ class Passivbot:
                         equity,
                         source,
                     )
-                if should_log and raw_only:
-                    self._last_raw_only_log_time = now
                 self._monitor_record_event(
                     "account.balance",
                     ("account", "balance"),

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -2155,6 +2155,68 @@ def test_operator_visibility_suppresses_fill_console_and_text_only():
     assert pipeline.close(timeout=2.0) is True
 
 
+def test_balance_raw_only_change_skips_console_but_preserves_durable_sinks():
+    structured = ListEventSink()
+    monitor = ListEventSink()
+    console = ListEventSink()
+    text = ListEventSink()
+    pipeline = LiveEventPipeline(
+        structured_sinks=[structured],
+        monitor_sinks=[monitor],
+        console_sink=console,
+        text_sink=text,
+    )
+    event = LiveEvent(
+        EventTypes.BALANCE_CHANGED,
+        data={
+            "previous_balance_raw": 1_000.0,
+            "balance_raw": 999.5,
+            "balance_raw_delta": -0.5,
+            "previous_balance_snapped": 1_000.0,
+            "balance_snapped": 1_000.0,
+            "balance_snapped_delta": 0.0,
+            "equity": 999.5,
+            "source": "REST",
+        },
+    )
+
+    pipeline.emit(event)
+
+    assert pipeline.flush(timeout=2.0) is True
+    assert structured.events == [event]
+    assert monitor.events == [event]
+    assert console.events == []
+    assert text.events == [event]
+    assert pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"balance_snapped_delta": 1.0},
+        {},
+        {"balance_snapped_delta": float("nan")},
+        {"balance_snapped_delta": float("inf")},
+    ],
+)
+def test_balance_console_keeps_material_and_unclassifiable_changes_visible(data):
+    console = ListEventSink()
+    text = ListEventSink()
+    pipeline = LiveEventPipeline(
+        structured_sinks=[],
+        monitor_sinks=[],
+        console_sink=console,
+        text_sink=text,
+    )
+    event = LiveEvent(EventTypes.BALANCE_CHANGED, data=data)
+
+    pipeline.emit(event)
+
+    assert console.events == [event]
+    assert text.events == [event]
+    assert pipeline.close(timeout=2.0) is True
+
+
 @pytest.mark.parametrize(
     ("action", "old_size", "old_price", "new_size", "new_price"),
     [

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -3571,6 +3571,61 @@ async def test_handle_balance_update_suppresses_legacy_log_when_event_console_ac
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+@pytest.mark.asyncio
+async def test_handle_balance_update_keeps_raw_only_change_off_legacy_console(caplog):
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+
+    class FakeBot:
+        _current_live_event_cycle_id = pb_mod.Passivbot._current_live_event_cycle_id
+        _emit_balance_changed_event = pb_mod.Passivbot._emit_balance_changed_event
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+        _live_event_console_available = pb_mod.Passivbot._live_event_console_available
+        _monitor_record_event = pb_mod.Passivbot._monitor_record_event
+
+        def __init__(self):
+            self.exchange = "binance"
+            self.user = "binance_01"
+            self.bot_id = "bot_1"
+            self.live_event_console_enabled = False
+            self._live_event_current_cycle_id = "cy_raw_only"
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink],
+                monitor_sinks=[],
+            )
+            self.monitor_publisher = RecorderPublisher()
+            self._previous_balance_raw = 90.0
+            self._previous_balance_snapped = 95.0
+            self._monitor_last_equity = 0.0
+            self.execution_scheduled = False
+
+        def get_raw_balance(self):
+            return 100.0
+
+        def get_hysteresis_snapped_balance(self):
+            return 95.0
+
+        async def calc_upnl_sum(self):
+            return 7.5
+
+    bot = FakeBot()
+
+    with caplog.at_level(logging.INFO):
+        await pb_mod.Passivbot.handle_balance_update(bot, source="REST")
+
+    assert bot.execution_scheduled is True
+    assert not any("[balance] raw" in record.message for record in caplog.records)
+    assert bot.monitor_publisher.events[-1]["kind"] == "account.balance"
+    assert bot.monitor_publisher.events[-1]["payload"]["equity"] == pytest.approx(107.5)
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = sink.events[-1]
+    assert event.event_type == EventTypes.BALANCE_CHANGED
+    assert event.data["balance_raw_delta"] == pytest.approx(10.0)
+    assert event.data["balance_snapped_delta"] == pytest.approx(0.0)
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_risk_mode_changed_event_emits_structured_summary():
     import passivbot as pb_mod
 


### PR DESCRIPTION
## Summary

- suppress `balance.changed` from the console only when finite `balance_snapped_delta` is zero
- preserve structured, monitor, and durable text delivery for every raw balance change
- keep snapped changes and missing/non-finite materiality metadata console-visible
- remove the legacy 15-minute raw-only INFO fallback while retaining snapped-change fallback output
- record PR #1221 VPS5 deployment evidence and PR #1231 policy completion in the active logging ledgers

## Behavior boundary

No balance calculation, hysteresis, equity, scheduling, exchange call, order, risk, Rust, backtest, or optimizer behavior changes. This is console admission only.

## Validation

- `git diff --check`
- Python syntax compile for changed code/tests
- `tests/test_live_event_bus.py tests/test_passivbot_monitor.py`
- `tests/test_ai_docs.py tests/test_live_event_registry_docs.py`
- `src/tools/check_ai_docs.py` (0 errors, existing word-count warning)
- `src/tools/generate_live_event_registry.py --check`

## Operations

No SSH or exchange contact occurred for this slice. After merge, the runtime projection change warrants the authorized five-bot VPS5 restart and bounded smoke before further dependent logging work.