### PR TITLE
Reduce routine warmup console noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Routine successful candle-warmup details now remain available at DEBUG
+  instead of filling the normal live console. Startup readiness milestones,
+  degraded/failure visibility, structured cache decisions, and warmup behavior
+  are unchanged.
+
 - Backtests now write `drawdown.png` alongside the existing summary plots,
   showing drawdown from the running peak of collateral-agnostic strategy equity.
 

--- a/docs/ai/runbooks/pr_review.md
+++ b/docs/ai/runbooks/pr_review.md
@@ -10,7 +10,8 @@ Review is read-only unless the user explicitly asks for implementation. Do not p
 SSH, signal processes, contact authenticated exchange endpoints, or run a live bot merely because
 those actions might strengthen a review.
 
-An approval applies only to the reviewed head SHA and merge base.
+An approval applies only to the reviewed head SHA and merge base unless the proportional mechanical
+delta exception below is documented and satisfied.
 
 ## Durable Autonomous Loop
 
@@ -30,9 +31,10 @@ Do not persist credentials, full comments, diffs, test output, or exchange data.
 repository refs remain authoritative.
 
 Scope review state by reviewer identity and head SHA. One reviewer's approval does not supersede
-another's request for changes, and old-head verdicts do not apply to a new head. Preserve reviewer,
-head, decision, and submission time instead of collapsing review history. Ambiguity wakes semantic
-review rather than being resolved by the polling tier.
+another's request for changes, and old-head verdicts do not apply to a semantically changed head.
+The proportional mechanical-delta contract below is the only carry-forward exception. Preserve
+reviewer, head, decision, and submission time instead of collapsing review history. Ambiguity wakes
+semantic review rather than being resolved by the polling tier.
 
 ### Target Selection And Branch Cutovers
 
@@ -88,16 +90,39 @@ duplicate semantic review. Do not approve drafts unless explicitly requested.
 After a changed head, review the delta and then the integrated full PR. Post one current verdict;
 do not repeat unchanged approvals or status narration.
 
+### Proportional Mechanical Delta Review
+
+Do not require a redundant full semantic review when a changed head only integrates the current
+target branch or resolves a mechanical conflict without changing the already-reviewed behavior.
+The final adjudicator may carry the prior semantic verdict forward when all of these are true:
+
+1. The target-relative production, test, configuration, and contract diff is unchanged from the
+   semantically reviewed scope.
+2. The new commit delta is inspected directly and contains only mechanical integration work, such
+   as preserving both sides of a changelog/ledger conflict, formatting, or an equivalent no-op.
+3. The integrated branch is mergeable and required CI is green.
+4. The PR records the old reviewed head, new head, target SHA, exact mechanical delta, validation,
+   and the reason a full re-review is unnecessary.
+
+This exception does not apply to code, test-contract, configuration, dependency, generated
+contract, runtime, or substantive documentation changes, nor when the effective merge-base change
+alters integrated behavior. Those changes require a current-head semantic delta and integrated
+review. If an obsolete request-for-changes names only the resolved mechanical blocker, a maintainer
+may dismiss or supersede it with the recorded mechanical-delta evidence; that is not a degraded
+gate. Repository-enforced CI and protection still apply.
+
 ### Enforceable Review Gates
 
 When repository policy makes semantic review mandatory, publish the result as a status or check
 bound to the exact head SHA and enforce that check with repository merge protection. Comments,
 polling cadence, and reviewer narration alone cannot prevent a new or unreviewed head from merging.
 
-- A new head makes the semantic-review check pending until that head is reviewed.
-- A stale check, comment, or approval cannot satisfy the current-head gate.
+- A semantically changed head makes the semantic-review check pending until that head is reviewed.
+- A stale check, comment, or approval alone cannot satisfy the current-head gate. A current-head
+  mechanical-delta check may explicitly carry the prior semantic verdict under the contract above.
 - The posting path re-fetches the head immediately before publishing the verdict.
-- Merge readiness still requires every configured review and CI gate to be green for the same head.
+- Merge readiness still requires every configured semantic review, carried mechanical-delta
+  adjudication where applicable, and CI gate to be green for the integrated current head.
 - A `COMMENT` review remains advisory even when its prose says `APPROVE`; it cannot satisfy a
   required GitHub approval or substitute for a protected status/check.
 
@@ -113,7 +138,7 @@ not a mandatory merge gate.
 
 ## Review Method
 
-1. Read `AGENTS.md`, `docs/ai/principles.md`, `docs/ai/validation.md`, and routed subsystem
+1. Read `AGENTS.md`, `docs/ai/principles.yaml`, `docs/ai/validation.md`, and routed subsystem
    contracts.
 2. Read the PR body and classify affected contracts: documentation/tooling, observability, live
    orchestration, exchange, Rust/trading, backtest, optimizer, config, or data preparation.
@@ -167,7 +192,8 @@ Every verdict records:
 - base-only failures and environmental limitations
 - residual risk and untested surfaces
 
-Never call a PR merge-ready unless required review and CI are green for the same head SHA.
+Never call a PR merge-ready unless required current-head review, or a documented proportional
+mechanical carry-forward, and CI are green for the integrated head SHA.
 
 After a new push, review the delta and re-check the integrated result before superseding the prior
 verdict. Do not post repeated unchanged approvals or polling narration.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,40 +22,46 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/balance-console-materiality`.
-- Base: `991dadb69124e838a4a3b63fff65036a223b4195`, the PR #1231
-  console-verbosity policy merge on canonical `master`.
-- Slice: console-only suppression of raw wallet-balance jitter.
-- Triggering evidence: the VPS5 console-volume study found balance and warmup
-  families dominated healthy output. The merged policy requires balance after
-  the initial snapshot to represent a material or attributable account change,
-  while the current pipeline projects every raw-balance movement even when the
-  hysteresis-snapped balance is unchanged.
-- Scope: suppress `balance.changed` from the console only when its finite
-  `balance_snapped_delta` is zero. Preserve structured, monitor, and durable text
-  delivery. Keep snapped changes and events with absent or malformed
-  materiality metadata console-visible. Remove the legacy 15-minute raw-only
-  fallback line while retaining snapped-change fallback output.
-- Behavior boundary: preserve balance calculation, hysteresis, event payload,
-  event production, monitor history, durable text, equity diagnostics,
-  scheduling, exchange calls, order/risk behavior, Rust, backtest, and optimizer
-  behavior.
+- Branch: `codex/warmup-console-detail-levels`.
+- Base: `a869aedea161ca4fbd11f801a6ff91be2b215354`, canonical `master`
+  after PR #1230.
+- Slice: keep routine successful candle-warmup detail off the normal INFO
+  console while preserving DEBUG and structured diagnostics.
+- Triggering evidence: the current five VPS5 logs contain 512 `[warmup]` INFO
+  lines since the PR #1221 restart. Repeated kickoff, target, slot, window,
+  progress, cache-decision, and forager-trigger lines dominate this family even
+  though they are neither durable state changes nor readiness transitions.
+- Scope: demote those seven routine text producers to DEBUG. Preserve
+  `cache.warmup_decision`, `bot.startup_timing`, `bot.ready`, startup
+  start/completion milestones, and every degraded/failure signal. Also codify
+  proportional carry-forward of semantic approval for directly verified
+  mechanical integration deltas.
+- Behavior boundary: preserve candle fetching, cache acceptance, concurrency,
+  awaits, forager selection, readiness, scheduling, exchange calls, order/risk
+  behavior, Rust, backtest, and optimizer behavior.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
-- Expected VPS action: restart and observe only after this slice merges;
-  this isolated implementation work does not contact VPS5 or exchanges.
+- Expected VPS action: after merge, one authorized exact five-bot restart may
+  activate and validate both PR #1233 and this slice. Do not manufacture balance
+  or warmup events.
 
 ## Deployed Baseline
 
-- Canonical `master`: `991dadb69124e838a4a3b63fff65036a223b4195`, PR #1231.
-- VPS5 repository: `dacd66adebfd230999aebf7f9fbd34a5b2990490`, PR #1221; exact
-  tracked status clean and expected untracked artifacts preserved.
-- VPS5 expected bots: five; running with PR #1221 restart PIDs
-  `927721/927781/927842/927899/927963`; pane PIDs unchanged; unrelated
-  `misc:0.0` remains PID `434835`
+- Canonical `master`: `a869aedea161ca4fbd11f801a6ff91be2b215354`, PR #1230.
+- VPS5 repository checkout: `22ca1a78fa16c2dad827fcf39a6b1fb245302c2b`,
+  PR #1233; tracked status clean and expected untracked artifacts preserved.
+- VPS5 running-process baseline remains PR #1221 code until the next authorized
+  restart. The exact five bot PIDs are still
+  `927721/927781/927842/927899/927963`; pane PIDs and unrelated `misc:0.0`
+  PID `434835` are unchanged.
 - PR #1231 merged at `991dadb69124e838a4a3b63fff65036a223b4195`.
   It defines evidence-based console admission, incident projection, and volume
   budgets. It is documentation-only, so no VPS5 restart was required.
+- PR #1233 merged at `22ca1a78fa16c2dad827fcf39a6b1fb245302c2b`
+  and the VPS5 checkout fast-forwarded cleanly. It suppresses raw-only balance
+  jitter from the console while preserving structured, monitor, and durable
+  text delivery. Runtime activation and natural-event validation await the next
+  authorized restart.
 - PR #1221 merged and deployed at
   `dacd66adebfd230999aebf7f9fbd34a5b2990490`. It made the structured
   realized-loss gate warning the sole normal console/text owner while preserving
@@ -534,9 +540,12 @@ ambiguous-cancel console migration, PR #1219's entry-distance-gate console
 migration, and PR #1220's min-effective-cost console migration are merged and
 deployed. Natural post-PR #1220 GateIO output proved structured single
 ownership. PR #1221's realized-loss gate console migration is also merged and
-deployed with a settled hard-green smoke. PR #1231's console-verbosity policy is
-merged without a runtime deployment. Its first implementation follow-up is the
-active raw-only balance-console materiality slice above.
+deployed with a settled hard-green smoke. PR #1231's console-verbosity policy
+and PR #1232's canonical-master review contract are merged. PR #1233's
+raw-balance materiality change is merged and present in the VPS5 checkout but
+not yet active in the running processes. Its next implementation follow-up is
+the active warmup-detail slice above. After that slice, evaluate post-ready
+`[boot]` candle-index maintenance chatter.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_pr_loop_workflow.md
+++ b/docs/plans/live_logging_overhaul_pr_loop_workflow.md
@@ -109,13 +109,19 @@ State:
 
 ## Review Gate
 
-- Merge only after every currently required reviewer and CI are green on the
-  exact current head SHA.
+- Merge only after every currently required semantic reviewer and CI are green
+  on the exact current head SHA, or after prior semantic approval is carried by
+  a documented current-head mechanical-delta adjudication under the canonical
+  review runbook.
 - Prefer formal GitHub reviews or commit-bound checks. If GitHub forbids
   self-approval, accept a structured comment only when it names the reviewer,
   verdict, and exact head SHA.
-- A head change invalidates prior approval unless the reviewer explicitly
-  carries it to the new head after delta/integrated review.
+- A semantic head change invalidates prior approval unless the reviewer carries
+  it to the new head after delta/integrated review. A conflict-only merge,
+  changelog/ledger preservation, formatting, or equivalent mechanical no-op may
+  retain prior semantic approval under the proportional mechanical-delta
+  contract in `docs/ai/runbooks/pr_review.md`; record the exact delta and keep
+  CI and repository protection green.
 - Findings from optional reviewers still require verification and resolution.
 - Use a degraded gate only with explicit maintainer authorization and record it
   in the PR and historical evidence.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -8175,9 +8175,17 @@ VPS5 deployment status:
 - PR #1231 merged to canonical `master` at `991dadb691`. Its VPS5 evidence-based
   console policy makes operator value and transition/materiality the INFO
   admission contract; the docs-only merge required no restart.
-- Active branch `codex/balance-console-materiality` suppresses only raw-balance
-  jitter from the console when finite snapped delta is zero. Structured,
-  monitor, and durable text delivery remain unchanged. Snapped changes and
-  unclassifiable events fail visible. The legacy raw-only fallback line is also
-  removed; no balance, hysteresis, equity, scheduling, exchange, risk, order,
-  Rust, backtest, or optimizer behavior changes.
+- PR #1232 merged at `9cd1ba3daa` and updated the reusable review contract for
+  canonical `master`.
+- PR #1233 merged at `22ca1a78fa`. The VPS5 checkout fast-forwarded cleanly,
+  preserving expected untracked artifacts, but the five running bot processes
+  still have PR #1221 code loaded pending the next authorized restart. A
+  pre-restart two-minute report matched all five configured processes and the
+  new repository head; one KuCoin `InvalidNonce` failure recovered on the next
+  authoritative fetch.
+- The five current VPS5 logs contain 512 `[warmup]` INFO lines: Binance 168,
+  KuCoin 54, GateIO 52, OKX 222, and Hyperliquid 16. The active
+  `codex/warmup-console-detail-levels` slice moves routine kickoff, target, slot,
+  window, progress, cache-decision, and forager-trigger details to DEBUG while
+  preserving readiness milestones, failures, structured cache decisions, and
+  all warmup behavior.

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -4189,21 +4189,21 @@ class Passivbot:
             wmin, wmax = (
                 (min(wmins), max(wmins)) if wmins else (default_win, default_win)
             )
-            logging.info(
+            logging.debug(
                 f"[warmup] {context}: {n} symbols, concurrency={concurrency}, ttl={int(ttl_ms/1000)}s, window=[{wmin},{wmax}]m"
             )
             try:
                 longest_span = int(math.ceil(wmax / max(1.0, (1.0 + warmup_ratio))))
             except Exception:
                 longest_span = wmax
-            logging.info(
+            logging.debug(
                 "[warmup] target | longest_span=%dm warmup_ratio=%.3g max_warmup_minutes=%s",
                 int(longest_span),
                 float(warmup_ratio),
                 "none" if not max_warmup_minutes else str(int(max_warmup_minutes)),
             )
             try:
-                logging.info(
+                logging.debug(
                     "[warmup] slot view | long: %d/%d open=%s forager=%s symbols=%d | short: %d/%d open=%s forager=%s symbols=%d",
                     pos_counts.get("long", 0),
                     max_counts.get("long", 0),
@@ -4231,7 +4231,7 @@ class Passivbot:
                 long_max = max(long_wins) if long_wins else 0
                 short_min = min(short_wins) if short_wins else 0
                 short_max = max(short_wins) if short_wins else 0
-                logging.info(
+                logging.debug(
                     "[warmup] windows | long:[%d,%d]m short:[%d,%d]m",
                     long_min,
                     long_max,
@@ -4316,7 +4316,7 @@ class Passivbot:
                             remaining = max(0, n - completed)
                             eta_s = int(remaining / max(1e-6, rate))
                             pct = int(100 * completed / n)
-                            logging.info(
+                            logging.debug(
                                 f"[warmup] candles: {completed}/{n} {pct}% elapsed={int(elapsed_s)}s eta~{eta_s}s"
                             )
                             last_log_ms = now_ms
@@ -4330,7 +4330,7 @@ class Passivbot:
             )
             or "none"
         )
-        logging.info(
+        logging.debug(
             "[warmup] cache decision | context=%s timeframe=1m reused=%d cold=%d reasons=%s elapsed=%.2fs",
             context,
             cache_reused_1m,
@@ -13715,7 +13715,7 @@ class Passivbot:
         for symbol in due:
             attempts[symbol] = now_ms
         self._forager_normal_warmup_attempt_ms = attempts
-        logging.info(
+        logging.debug(
             "[warmup] forager-selected normal warmup: %d symbols=%s",
             len(due),
             Passivbot._log_symbols(due, limit=8),

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -1896,18 +1896,20 @@ def test_warmup_candle_cache_decision_rejects_stale_or_forced_cache(monkeypatch)
 
 @pytest.mark.asyncio
 async def test_warmup_candles_reuses_fresh_1m_cache(monkeypatch, caplog):
-    import logging
     import passivbot as pb_mod
 
     now_ms = 120 * 60_000
     latest_expected = now_ms - 60_000
+    cached_symbol = "CACHED/USDT:USDT"
+    cold_symbols = [f"MISS{idx}/USDT:USDT" for idx in range(20)]
+    symbols = [cached_symbol, *cold_symbols]
     monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_ms)
 
     def fake_compute_live_warmup_windows(*args, **kwargs):
         return (
-            {"CACHED/USDT:USDT": 12, "MISS/USDT:USDT": 12},
-            {"CACHED/USDT:USDT": 0, "MISS/USDT:USDT": 0},
-            {"CACHED/USDT:USDT": True, "MISS/USDT:USDT": True},
+            {symbol: 12 for symbol in symbols},
+            {symbol: 0 for symbol in symbols},
+            {symbol: True for symbol in symbols},
         )
 
     monkeypatch.setattr(
@@ -1934,7 +1936,7 @@ async def test_warmup_candles_reuses_fresh_1m_cache(monkeypatch, caplog):
             return None
 
         def get_completed_candle_health(self, symbol, windows, *, now_ms=None):
-            coverage_ok = symbol == "CACHED/USDT:USDT"
+            coverage_ok = symbol == cached_symbol
             return {
                 "ok": coverage_ok,
                 "timeframes": {
@@ -1996,20 +1998,30 @@ async def test_warmup_candles_reuses_fresh_1m_cache(monkeypatch, caplog):
         return object()
 
     bot._emit_live_event = emit_live_event
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.DEBUG):
         await pb_mod.Passivbot.warmup_candles_staggered(
             bot,
-            symbols_override=["CACHED/USDT:USDT", "MISS/USDT:USDT"],
+            symbols_override=symbols,
             skip_jitter=True,
             context="trading-ready warmup",
         )
 
-    assert [symbol for symbol, _ in bot.cm.calls] == ["MISS/USDT:USDT"]
+    assert [symbol for symbol, _ in bot.cm.calls] == sorted(cold_symbols)
+    warmup_records = [
+        record for record in caplog.records if record.message.startswith("[warmup]")
+    ]
+    assert warmup_records
+    assert all(record.levelno == logging.DEBUG for record in warmup_records)
+    assert any("trading-ready warmup" in record.message for record in warmup_records)
+    assert any("target" in record.message for record in warmup_records)
+    assert any("slot view" in record.message for record in warmup_records)
+    assert any("windows" in record.message for record in warmup_records)
+    assert any("candles:" in record.message for record in warmup_records)
     assert any(
         "cache decision" in record.message
         and "reused=1" in record.message
-        and "cold=1" in record.message
-        for record in caplog.records
+        and "cold=20" in record.message
+        for record in warmup_records
     )
     warmup_events = [
         kwargs
@@ -2020,16 +2032,58 @@ async def test_warmup_candles_reuses_fresh_1m_cache(monkeypatch, caplog):
     assert warmup_events[0]["cycle_id"] == "cy_warmup"
     assert warmup_events[0]["reason_code"] == "warmup_cache_decision"
     assert warmup_events[0]["data"]["context"] == "trading-ready warmup"
-    assert warmup_events[0]["data"]["symbol_count"] == 2
+    assert warmup_events[0]["data"]["symbol_count"] == 21
     assert warmup_events[0]["data"]["reused_count"] == 1
-    assert warmup_events[0]["data"]["cold_count"] == 1
+    assert warmup_events[0]["data"]["cold_count"] == 20
     assert warmup_events[0]["data"]["cold_path_required"] is True
     assert warmup_events[0]["data"]["reason_counts"] == {
-        "missing_coverage": 1,
+        "missing_coverage": 20,
         "warm_cache_accepted": 1,
     }
     assert warmup_events[0]["data"]["window_min_candles"] == 12
     assert warmup_events[0]["data"]["window_max_candles"] == 12
+
+
+@pytest.mark.asyncio
+async def test_newly_normal_forager_warmup_trigger_is_debug_only(monkeypatch, caplog):
+    import passivbot as pb_mod
+
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: 1_000_000)
+
+    class FakeBot:
+        _forager_new_normal_warmup_symbols = {"NEW/USDT:USDT"}
+
+        def __init__(self):
+            self.calls = []
+
+        def is_forager_mode(self, pside):
+            return pside == "long"
+
+        async def warmup_candles_staggered(self, **kwargs):
+            self.calls.append(kwargs)
+
+    bot = FakeBot()
+    with caplog.at_level(logging.DEBUG):
+        warmed = await pb_mod.Passivbot._warmup_new_forager_normal_symbols(
+            bot, ["NEW/USDT:USDT"]
+        )
+
+    assert warmed == {"NEW/USDT:USDT"}
+    assert bot.calls == [
+        {
+            "symbols_override": ["NEW/USDT:USDT"],
+            "ttl_ms": 0,
+            "skip_jitter": True,
+            "context": "forager-selected warmup",
+        }
+    ]
+    forager_records = [
+        record
+        for record in caplog.records
+        if "forager-selected normal warmup" in record.message
+    ]
+    assert len(forager_records) == 1
+    assert forager_records[0].levelno == logging.DEBUG
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Scope

Observability producer plus review-workflow documentation.

Current VPS5 logs contain 512 `[warmup]` INFO lines since the last five-bot restart: Binance 168, KuCoin 54, GateIO 52, OKX 222, and Hyperliquid 16. Routine kickoff, target, slot, window, progress, cache-decision, and newly-normal forager-trigger detail dominates that family without representing a readiness transition or failure.

## Changes

- demote those seven routine warmup text producers from INFO to DEBUG
- preserve structured `cache.warmup_decision` emission and payload
- preserve `bot.startup_timing`, `bot.ready`, startup start/completion milestones, and every degraded/failure signal
- add regressions proving routine warmup detail is DEBUG-only while structured ownership and synchronous forager warmup remain intact
- document proportional carry-forward of prior semantic approval for directly verified mechanical integration deltas; code, tests, config, runtime, dependencies, and substantive contracts still require fresh review
- update the current-status and historical ledgers with PR #1233's merged/pulled-but-not-yet-restarted state and this slice's evidence

## Behavior Boundary

No changes to candle fetching, cache acceptance, concurrency, awaits, forager selection, readiness, scheduling, exchange calls, order/risk behavior, Rust, backtest, or optimizer behavior.

## Validation

- `git diff --check`: pass
- `PYTHONPATH=src .../venv/bin/python -m pytest tests/test_live_candle_budget.py -q`: 41 passed
- `PYTHONPATH=src .../venv/bin/python -m pytest tests/test_ai_docs.py tests/test_live_event_registry_docs.py -q`: 3 passed
- `PYTHONPATH=src .../venv/bin/python -m pytest tests/test_run_fake_live.py -m fake_live -q`: 23 passed; existing `utcfromtimestamp` deprecation warnings only
- `PYTHONPATH=src .../venv/bin/python -m py_compile src/passivbot.py tests/test_live_candle_budget.py`: pass
- `src/tools/check_ai_docs.py`: 0 errors; existing documentation word-count warning
- silent-handling scan: no new fallback or exception-handling patterns in the diff

## Reviewer Focus

- INFO admission still preserves every operator-relevant readiness/failure transition
- DEBUG and structured diagnostic ownership remains complete
- tests prove log level and behavior preservation rather than merely exercising the path
- proportional mechanical-delta policy is narrow enough not to weaken semantic review

## VPS Action

After merge, one explicitly authorized graceful restart of the exact five VPS5 bot panes can activate and validate both PR #1233 and this slice. Preserve unrelated panes and local artifacts; observe only natural balance/warmup events and do not contact exchanges manually or manufacture trading events.
