### PR TITLE
Reduce candle index console noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Successful candle-index maintenance now stays available at DEBUG under the
+  `[candle]` tag instead of appearing as repeated `[boot]` INFO output after
+  readiness. Index rebuild behavior and failure visibility are unchanged.
+
 - Routine successful candle-warmup details now remain available at DEBUG
   instead of filling the normal live console. Startup readiness milestones,
   degraded/failure visibility, structured cache decisions, and warmup behavior

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,32 +22,30 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/warmup-console-detail-levels`.
-- Base: `a869aedea161ca4fbd11f801a6ff91be2b215354`, canonical `master`
-  after PR #1230.
-- Slice: keep routine successful candle-warmup detail off the normal INFO
-  console while preserving DEBUG and structured diagnostics.
-- Triggering evidence: the current five VPS5 logs contain 512 `[warmup]` INFO
-  lines since the PR #1221 restart. Repeated kickoff, target, slot, window,
-  progress, cache-decision, and forager-trigger lines dominate this family even
-  though they are neither durable state changes nor readiness transitions.
-- Scope: demote those seven routine text producers to DEBUG. Preserve
-  `cache.warmup_decision`, `bot.startup_timing`, `bot.ready`, startup
-  start/completion milestones, and every degraded/failure signal. Also codify
-  proportional carry-forward of semantic approval for directly verified
-  mechanical integration deltas.
-- Behavior boundary: preserve candle fetching, cache acceptance, concurrency,
-  awaits, forager selection, readiness, scheduling, exchange calls, order/risk
-  behavior, Rust, backtest, and optimizer behavior.
+- Branch: `codex/candle-index-console-detail`.
+- Base: `e1dcf3164a88b77762e3cd3ed3e40b834513469a`, canonical `master`
+  after PR #1234.
+- Slice: keep successful candle-index maintenance detail off the normal INFO
+  console and stop labeling post-ready maintenance as `[boot]`.
+- Triggering evidence: the current five VPS5 logs contain 168 successful
+  candle-index start/completion lines: Binance 54, KuCoin 20, GateIO 16, OKX
+  72, and Hyperliquid 6. Repeated one-symbol post-ready rebuilds dominate this
+  family even though they are neither readiness milestones nor failures.
+- Scope: demote successful index-rebuild start/completion text to DEBUG under
+  `[candle]`. Preserve rebuild calls, ranges, counters, failure visibility,
+  startup readiness milestones, and all structured events.
+- Behavior boundary: preserve candle fetching, index rebuilding, cache
+  acceptance, readiness, scheduling, exchange calls, order/risk behavior,
+  Rust, backtest, and optimizer behavior.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: after merge, one authorized exact five-bot restart may
-  activate and validate both PR #1233 and this slice. Do not manufacture balance
-  or warmup events.
+  activate and validate PRs #1233, #1234, and this slice. Do not manufacture
+  balance, warmup, or candle-maintenance events.
 
 ## Deployed Baseline
 
-- Canonical `master`: `a869aedea161ca4fbd11f801a6ff91be2b215354`, PR #1230.
+- Canonical `master`: `e1dcf3164a88b77762e3cd3ed3e40b834513469a`, PR #1234.
 - VPS5 repository checkout: `22ca1a78fa16c2dad827fcf39a6b1fb245302c2b`,
   PR #1233; tracked status clean and expected untracked artifacts preserved.
 - VPS5 running-process baseline remains PR #1221 code until the next authorized
@@ -62,6 +60,10 @@ Estimated completion:
   jitter from the console while preserving structured, monitor, and durable
   text delivery. Runtime activation and natural-event validation await the next
   authorized restart.
+- PR #1234 merged at `e1dcf3164a88b77762e3cd3ed3e40b834513469a`.
+  It moves routine successful warmup detail to DEBUG while preserving startup
+  milestones, failures, structured cache decisions, and all warmup behavior.
+  Runtime activation awaits the next authorized restart.
 - PR #1221 merged and deployed at
   `dacd66adebfd230999aebf7f9fbd34a5b2990490`. It made the structured
   realized-loss gate warning the sole normal console/text owner while preserving

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -545,9 +545,12 @@ ownership. PR #1221's realized-loss gate console migration is also merged and
 deployed with a settled hard-green smoke. PR #1231's console-verbosity policy
 and PR #1232's canonical-master review contract are merged. PR #1233's
 raw-balance materiality change is merged and present in the VPS5 checkout but
-not yet active in the running processes. Its next implementation follow-up is
-the active warmup-detail slice above. After that slice, evaluate post-ready
-`[boot]` candle-index maintenance chatter.
+not yet active in the running processes. PR #1234's warmup-detail demotion is
+also merged, with runtime activation pending the same authorized restart. The
+active candle-index maintenance demotion is described above. After it merges,
+activate PRs #1233, #1234, and the candle-index slice in one authorized exact
+five-bot restart, run settled smoke validation, and use the resulting natural
+INFO stream to select the next dominant non-action console family.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -8189,3 +8189,11 @@ VPS5 deployment status:
   window, progress, cache-decision, and forager-trigger details to DEBUG while
   preserving readiness milestones, failures, structured cache decisions, and
   all warmup behavior.
+- PR #1234 received exact-head Hermes and Grok 4.5 approval with green CI and
+  merged to canonical `master` at `e1dcf3164a`. Its runtime activation remains
+  pending the next authorized exact five-bot restart.
+- The same five current logs contain 168 successful candle-index
+  start/completion INFO lines: Binance 54, KuCoin 20, GateIO 16, OKX 72, and
+  Hyperliquid 6. Repeated post-ready one-symbol maintenance calls are mislabeled
+  `[boot]`; the active `codex/candle-index-console-detail` slice retains this
+  detail at DEBUG under `[candle]` without changing index work or failures.

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -4533,8 +4533,8 @@ class Passivbot:
             return
 
         started = utc_ms()
-        logging.info(
-            "[boot] rebuilding candle index for %d symbols (recent ranges only)...",
+        logging.debug(
+            "[candle] rebuilding index for %d symbols (recent ranges only)",
             len(symbols),
         )
 
@@ -4574,8 +4574,8 @@ class Passivbot:
 
         updated_total, removed_total = await asyncio.to_thread(_rebuild_sync)
         elapsed_s = max(0.0, (utc_ms() - started) / 1000.0)
-        logging.info(
-            "[boot] candle index rebuild complete: updated=%d removed=%d elapsed=%.2fs",
+        logging.debug(
+            "[candle] index rebuild complete: updated=%d removed=%d elapsed=%.2fs",
             updated_total,
             removed_total,
             elapsed_s,

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -5,6 +5,53 @@ import pytest
 from live.event_bus import EventTypes
 
 
+@pytest.mark.asyncio
+async def test_candle_index_rebuild_success_detail_is_debug(monkeypatch, caplog):
+    import passivbot as pb_mod
+
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: 1_000_000)
+
+    class FakeCM:
+        def __init__(self):
+            self.calls = []
+
+        def rebuild_index_for_range(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+            return {"updated": 7, "removed": 2}
+
+    class FakeBot:
+        stop_signal_received = False
+        cm = FakeCM()
+        _shutdown_requested = pb_mod.Passivbot._shutdown_requested
+
+    caplog.set_level(logging.DEBUG)
+    bot = FakeBot()
+
+    await pb_mod.Passivbot.rebuild_required_candle_indices(
+        bot,
+        ["BTC/USDT:USDT"],
+        {"BTC/USDT:USDT": 120},
+        {"BTC/USDT:USDT": 0},
+        900_000,
+        0,
+    )
+
+    assert bot.cm.calls == [
+        (
+            ("BTC/USDT:USDT", 0, 900_000),
+            {"timeframe": "1m", "log_level": "debug"},
+        )
+    ]
+    records = [record for record in caplog.records if "[candle]" in record.message]
+    assert [record.levelno for record in records] == [logging.DEBUG, logging.DEBUG]
+    assert records[0].message == (
+        "[candle] rebuilding index for 1 symbols (recent ranges only)"
+    )
+    assert records[1].message == (
+        "[candle] index rebuild complete: updated=7 removed=2 elapsed=0.00s"
+    )
+
+
 def _forager_score_weights(volume=0.0, ema_readiness=0.0, volatility=0.0):
     return {
         "volume": float(volume),


### PR DESCRIPTION
## Summary

- move successful candle-index rebuild start/completion detail from INFO to DEBUG
- use the candle tag instead of labeling post-ready maintenance as boot work
- preserve index ranges, calls, results, failure visibility, readiness, and trading behavior
- record the 168-line VPS5 evidence and current loop state

## Evidence

The five current VPS5 bot logs contain 168 successful index start/completion lines:

- Binance: 54
- KuCoin: 20
- GateIO: 16
- OKX: 72
- Hyperliquid: 6

Repeated one-symbol calls occur after readiness and are routine maintenance, not new operator facts.

## Validation

- `pytest tests/test_live_candle_budget.py -q` -> 42 passed
- `pytest tests/test_ai_docs.py tests/test_live_event_registry_docs.py -q` -> 3 passed
- `pytest tests/test_run_fake_live.py -m fake_live -q` -> 23 passed; existing deprecation warnings only
- `python -m py_compile src/passivbot.py tests/test_live_candle_budget.py` -> pass
- `python src/tools/check_ai_docs.py` -> 0 errors; existing word-count warning only
- `git diff --check` -> pass

## Non-goals

No candle fetching, index rebuilding, cache acceptance, scheduling, readiness, exchange, order, risk, Rust, backtest, or optimizer behavior changes. No VPS process action and no manufactured events.

Post-merge VPS activation remains contingent on explicit authorization to restart the exact five bot panes.
