### PR TITLE
Deduplicate Rust forager selection console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Rust-orchestrated forager selection changes now have one normal console/text
+  owner: the producer's materiality-aware INFO summary. Their complete
+  `forager.selection` events remain available in structured and monitor sinks
+  without printing a second independently throttled summary. Python-filter
+  selection events retain their existing console/text projection.
+
 - Successful background forager candle-refresh completions now remain available
   at DEBUG instead of repeating in the normal live console. Refresh scheduling,
   wall-time-cap notices, failures, and candle behavior are unchanged.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,38 +22,52 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/forager-refresh-console-detail`.
-- Base: `f88274a715e6db347500e2cbc601e11ef6b16a71`, canonical `master`
-  after PR #1235.
-- Slice: keep successful background forager candle-refresh completion detail
-  off the normal INFO console while retaining it at DEBUG.
-- Triggering evidence: in the first bounded post-readiness window after the
-  PRs #1233-#1235 activation restart, successful forager-refresh completion was
-  already the dominant routine non-action family. Six completions appeared in
-  about six minutes across Binance, GateIO, and OKX; GateIO emitted three in
-  under three minutes. These are successful post-ready maintenance outcomes,
-  not readiness milestones or failures.
-- Scope: demote only the successful `forager refresh complete` line to DEBUG.
-  Preserve refresh scheduling, cadence, fetches, counters, wall-time-cap INFO
-  notices, failures, readiness, and structured events.
-- Behavior boundary: preserve candle fetching, cache acceptance, readiness,
-  scheduling, exchange calls, order/risk behavior, Rust, backtest, and optimizer
-  behavior.
+- Branch: `codex/forager-selection-console-ownership`.
+- Base: `d4b3055da68bfc4a1ff8f8e2c953c93318d8b3f5`, canonical `master`
+  after PR #1236.
+- Slice: give Rust-orchestrated material forager selection changes one normal
+  console/text owner while retaining every complete `forager.selection` event
+  in durable sinks and preserving Python-filter selection visibility.
+- Triggering evidence: fresh post-PR #1236 logs emitted paired summaries for
+  each initial material selection on Binance, GateIO, and OKX: one structured
+  `[forager] succeeded ...` line and one producer-owned `[forager] long
+  selection ...` line. Later changes continued to use the two independent
+  cadence/materiality paths.
+- Scope: suppress only Rust-orchestrator events from the operator sinks. Keep
+  their structured and monitor delivery enabled, keep the compact formatter for
+  queries, leave Python-filter events console/text-visible, and leave the Rust
+  producer's selected-set/slot/replacement materiality and 30-minute heartbeat
+  unchanged.
+- Behavior boundary: preserve event production and payloads, forager scoring,
+  selection, hysteresis, scheduling, exchange calls, order/risk behavior, Rust,
+  backtest, and optimizer behavior.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: after merge, one authorized exact five-bot restart may
-  activate the level change. Validate from natural maintenance only; do not
-  manufacture candle-refresh events.
+  activate the projection change. Validate from natural selections only; do not
+  manufacture selection or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 checkout:
-  `f88274a715e6db347500e2cbc601e11ef6b16a71`, PR #1235; tracked status clean
+  `d4b3055da68bfc4a1ff8f8e2c953c93318d8b3f5`, PR #1236; tracked status clean
   and expected untracked artifacts preserved.
 - VPS5 runs the same head in bot PIDs
-  `938583/938585/938587/938588/938589`. The exact pane PIDs remain
+  `940154/940128/940093/939941/940094`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1236 was activated with one exact five-bot graceful restart. All old bots
+  exited naturally after one SIGINT round; no escalation was required. A
+  startup KuCoin authoritative-open-orders timeout aged out. The settled
+  two-minute smoke was `ok=true`: `216/216` remote calls and all `57/57`
+  account-critical calls succeeded, eight fill refreshes succeeded, all five
+  processes/configs matched, and hard, log-attention, monitor, and pipeline
+  failures were zero. One sampled `D` state cleared immediately, with all five
+  processes then observed running in their original panes.
+- Natural post-restart logs contain zero `forager refresh complete` INFO lines
+  on all five bots while normal candle/cache activity continued. The same logs
+  exposed paired structured and producer-owned INFO summaries for material
+  forager selections, which triggers the active ownership slice above.
 - PRs #1233, #1234, and #1235 were activated together with one exact five-bot
   graceful restart. Four old bots exited within ten seconds; KuCoin exited
   naturally after a bounded uninterruptible wait, with no escalation. The
@@ -564,9 +578,12 @@ and PR #1232's canonical-master review contract are merged. PR #1233's
 raw-balance materiality change, PR #1234's warmup-detail demotion, and PR
 #1235's candle-index maintenance demotion are merged, deployed, and active on
 VPS5. The settled smoke is green, and natural output proves the warmup and
-candle-index level boundaries. The resulting post-readiness sample identified
-successful forager candle-refresh completion as the dominant routine non-action
-family; the active slice above moves only that success detail to DEBUG.
+candle-index level boundaries. PR #1236's forager-refresh completion demotion is
+also merged, deployed, and naturally absent from the normal INFO logs. Fresh
+output then exposed dual console ownership for Rust-orchestrated material
+forager selections; the active slice above retains the producer's
+materiality-aware summary and removes only those events' second console/text
+projection. Python-filter selection visibility remains unchanged.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -8220,3 +8220,25 @@ VPS5 deployment status:
   `codex/forager-refresh-console-detail` slice moves only this successful
   post-ready maintenance detail to DEBUG while preserving wall-cap notices,
   failures, scheduling, fetches, and trading behavior.
+
+### 2026-07-15: Forager Refresh Demotion Deployed And Selection Ownership
+
+- PR #1236 merged to canonical `master` at `d4b3055da6`. VPS5 fast-forwarded
+  cleanly and all five exact bots exited naturally after one SIGINT round.
+  Their pane PIDs and unrelated `misc:0.0` PID `434835` remained unchanged;
+  expected untracked artifacts were preserved.
+- The immediate smoke caught one KuCoin authoritative-open-orders timeout.
+  The settled two-minute report was `ok=true` with `216/216` remote calls and
+  `57/57` account-critical calls successful, eight successful fill refreshes,
+  all five processes/configs matched, and zero hard, log-attention, monitor, or
+  pipeline failures. One sampled `D` process state cleared immediately.
+- Fresh logs contain zero `forager refresh complete` INFO lines on all five
+  bots while normal candle/cache activity continued. Natural material forager
+  selections on Binance, GateIO, and OKX instead exposed two console owners:
+  the structured `[forager] succeeded ...` route and the producer's richer,
+  materiality-aware `[forager] long selection ...` summary.
+- The active `codex/forager-selection-console-ownership` slice keeps every
+  `forager.selection` event in structured and monitor sinks but removes the
+  Rust-orchestrator events' independent console/text projection. Python-filter
+  selection events remain operator-visible; the Rust producer's selected-set,
+  slot, and replacement materiality plus periodic heartbeat remain unchanged.

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -2022,6 +2022,9 @@ def _operator_sink_event_visible(event: LiveEvent) -> bool:
     if event.event_type == EventTypes.FILL_INGESTED:
         data = event.data if isinstance(event.data, Mapping) else {}
         return data.get("operator_visible") is not False
+    if event.event_type == EventTypes.FORAGER_SELECTION:
+        data = event.data if isinstance(event.data, Mapping) else {}
+        return str(data.get("source") or "") != "rust_orchestrator"
     if event.event_type == EventTypes.HSL_STATUS:
         return _hsl_status_operator_visible(event)
     return True

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -1674,9 +1674,72 @@ def test_console_format_summarizes_forager_selection():
 def test_forager_selection_console_route_is_throttled():
     route = DEFAULT_ROUTES[EventTypes.FORAGER_SELECTION]
 
+    assert route.structured is True
+    assert route.monitor is True
     assert route.console is True
     assert route.text is True
     assert route.throttle_interval_ms == 5 * 60 * 1000
+
+
+def test_rust_forager_selection_event_skips_console_and_text_only():
+    structured = ListEventSink()
+    monitor = ListEventSink()
+    console = ListEventSink()
+    text = ListEventSink()
+    pipeline = LiveEventPipeline(
+        structured_sinks=[structured],
+        monitor_sinks=[monitor],
+        console_sink=console,
+        text_sink=text,
+    )
+    event = LiveEvent(
+        EventTypes.FORAGER_SELECTION,
+        status="succeeded",
+        pside="long",
+        data={
+            "selected_symbols": ["BTC/USDT:USDT"],
+            "slots_to_fill": 1,
+            "source": "rust_orchestrator",
+        },
+    )
+
+    pipeline.emit(event)
+
+    assert pipeline.flush(timeout=2.0) is True
+    assert structured.events == [event]
+    assert monitor.events == [event]
+    assert console.events == []
+    assert text.events == []
+    assert pipeline.close(timeout=2.0) is True
+
+
+def test_python_forager_selection_event_remains_operator_visible():
+    structured = ListEventSink()
+    monitor = ListEventSink()
+    console = ListEventSink()
+    text = ListEventSink()
+    pipeline = LiveEventPipeline(
+        structured_sinks=[structured],
+        monitor_sinks=[monitor],
+        console_sink=console,
+        text_sink=text,
+    )
+    event = LiveEvent(
+        EventTypes.FORAGER_SELECTION,
+        status="skipped",
+        pside="long",
+        reason_code="all_features_unavailable",
+        data={"selected_symbols": [], "source": "python_filter"},
+    )
+
+    pipeline.emit(event)
+
+    assert pipeline.flush(timeout=2.0) is True
+    assert structured.events == [event]
+    assert monitor.events == [event]
+    assert console.events == [event]
+    assert text.events == [event]
+    assert pipeline.close(timeout=2.0) is True
 
 
 def test_console_format_summarizes_hsl_status_distance_to_red():


### PR DESCRIPTION
## Summary

- suppress the console/text projection only for `forager.selection` events whose source is `rust_orchestrator`
- retain structured and monitor delivery for every event
- preserve the existing console/text projection for Python-filter selection success and skipped outcomes
- keep the Rust producer's selected-set, slot, replacement materiality, and periodic INFO heartbeat as the single operator-facing owner

## Evidence

Fresh VPS5 logs after PR #1236 showed paired Rust-selection summaries on Binance, GateIO, and OKX: a structured `[forager] succeeded ...` projection and the richer producer-owned `[forager] long selection ...` line. The projection paths used independent throttles.

PR #1236 is deployed at `d4b3055da6`. Its settled two-minute smoke was `ok=true` with `216/216` remote calls, `57/57` account-critical calls, eight successful fill refreshes, five valid processes, and zero hard, log-attention, monitor, or event-pipeline failures. Natural logs contain zero `forager refresh complete` INFO lines after that deployment.

## Validation

- `tests/test_live_event_bus.py`: 107 passed
- focused forager producer tests: 3 passed
- `tests/test_run_fake_live.py`: 31 passed
- AI docs and live-event registry docs: 3 passed
- `py_compile src/live/event_bus.py`
- AI documentation check: 0 errors, existing word-count warning only
- `git diff --check`
- bounded Terra pre-PR review: initial Python-path visibility finding fixed; revised diff has no findings

## Behavior Boundary

No event production, payload, forager scoring, selection, hysteresis, scheduling, exchange call, order, risk, Rust, backtest, or optimizer behavior changes. No Python-filter operator visibility change.
