### PR TITLE
Demote oversized open-tail projection detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Routine open-tail EMA projection-context aggregates now remain available at
+  DEBUG instead of printing thousand-character diagnostics in the normal live
+  console. Compact active-tail transitions and warnings, EMA projection,
+  readiness, and trading behavior are unchanged.
+
 - Rust-orchestrated forager selection changes now have one normal console/text
   owner: the producer's materiality-aware INFO summary. Their complete
   `forager.selection` events remain available in structured and monitor sinks

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,40 +22,51 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/forager-selection-console-ownership`.
-- Base: `d4b3055da68bfc4a1ff8f8e2c953c93318d8b3f5`, canonical `master`
-  after PR #1236.
-- Slice: give Rust-orchestrated material forager selection changes one normal
-  console/text owner while retaining every complete `forager.selection` event
-  in durable sinks and preserving Python-filter selection visibility.
-- Triggering evidence: fresh post-PR #1236 logs emitted paired summaries for
-  each initial material selection on Binance, GateIO, and OKX: one structured
-  `[forager] succeeded ...` line and one producer-owned `[forager] long
-  selection ...` line. Later changes continued to use the two independent
-  cadence/materiality paths.
-- Scope: suppress only Rust-orchestrator events from the operator sinks. Keep
-  their structured and monitor delivery enabled, keep the compact formatter for
-  queries, leave Python-filter events console/text-visible, and leave the Rust
-  producer's selected-set/slot/replacement materiality and 30-minute heartbeat
-  unchanged.
-- Behavior boundary: preserve event production and payloads, forager scoring,
-  selection, hysteresis, scheduling, exchange calls, order/risk behavior, Rust,
+- Branch: `codex/open-tail-projection-console-detail`.
+- Base: `a6aad939023f71e2ddeb9ae507505e05935e46b1`, canonical `master`
+  after PR #1237.
+- Slice: keep routine open-tail EMA projection-context aggregates off the
+  normal INFO console while retaining the complete diagnostic at DEBUG.
+- Triggering evidence: the first natural post-PR #1237 cycle emitted one such
+  INFO record on every VPS5 bot. The five lines were 1002-1050 characters long,
+  listed up to eight full symbol/timestamp contexts, and represented 19-39 flat
+  projection contexts per bot rather than a new operator transition.
+- Scope: demote only the throttled `open-tail EMA projection contexts`
+  aggregate from INFO to DEBUG. Preserve its message and 15-minute diagnostic
+  cadence, compact active-tail INFO/WARNING transitions, late structured
+  `candle.tail_projected` events, and all EMA outputs.
+- Behavior boundary: preserve projection eligibility, candle fetching, EMA
+  values, readiness, scheduling, exchange calls, order/risk behavior, Rust,
   backtest, and optimizer behavior.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: after merge, one authorized exact five-bot restart may
-  activate the projection change. Validate from natural selections only; do not
-  manufacture selection or trading events.
+  activate the level change. Validate from natural projection contexts only; do
+  not manufacture candle, readiness, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 checkout:
-  `d4b3055da68bfc4a1ff8f8e2c953c93318d8b3f5`, PR #1236; tracked status clean
+  `a6aad939023f71e2ddeb9ae507505e05935e46b1`, PR #1237; tracked status clean
   and expected untracked artifacts preserved.
 - VPS5 runs the same head in bot PIDs
-  `940154/940128/940093/939941/940094`. The exact pane PIDs remain
+  `941443/941446/941447/941448/941449`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1237 was activated with one exact five-bot graceful restart. Two bots
+  exited immediately after one SIGINT round; GateIO and Binance briefly entered
+  uninterruptible I/O sleep while KuCoin drained, and all three then exited
+  naturally within the bounded wait without escalation. The immediate smoke
+  was `ok=true` with `19/19` remote and `14/14` account-critical calls
+  successful. The settled smoke remained `ok=true`: `249/251` remote calls and
+  all `47/47` account-critical calls succeeded, six fill refreshes succeeded,
+  all five processes/configs matched, and hard, log-attention, monitor, and
+  pipeline failures were zero. The two remote failures were non-hard KuCoin
+  candle-fetch timeouts.
+- Natural Binance, GateIO, and OKX logs now contain only the producer-owned
+  materiality-aware forager selection INFO lines; no structured `[forager]
+  succeeded` duplicate appeared. Exact Rust `forager.selection` records remain
+  present in monitor storage, proving durable delivery was preserved.
 - PR #1236 was activated with one exact five-bot graceful restart. All old bots
   exited naturally after one SIGINT round; no escalation was required. A
   startup KuCoin authoritative-open-orders timeout aged out. The settled
@@ -67,7 +78,7 @@ Estimated completion:
 - Natural post-restart logs contain zero `forager refresh complete` INFO lines
   on all five bots while normal candle/cache activity continued. The same logs
   exposed paired structured and producer-owned INFO summaries for material
-  forager selections, which triggers the active ownership slice above.
+  forager selections, which triggered PR #1237's ownership fix.
 - PRs #1233, #1234, and #1235 were activated together with one exact five-bot
   graceful restart. Four old bots exited within ten seconds; KuCoin exited
   naturally after a bounded uninterruptible wait, with no escalation. The
@@ -581,9 +592,14 @@ VPS5. The settled smoke is green, and natural output proves the warmup and
 candle-index level boundaries. PR #1236's forager-refresh completion demotion is
 also merged, deployed, and naturally absent from the normal INFO logs. Fresh
 output then exposed dual console ownership for Rust-orchestrated material
-forager selections; the active slice above retains the producer's
-materiality-aware summary and removes only those events' second console/text
-projection. Python-filter selection visibility remains unchanged.
+forager selections. PR #1237's source-scoped ownership fix is also merged,
+deployed, and naturally validated: normal logs retain only the producer-owned
+material summary while monitor storage retains the complete Rust event.
+Python-filter selection visibility remains unchanged.
+
+The first fresh cycle after activation emitted five 1002-1050 character
+open-tail EMA context aggregates; the active slice above moves only that routine
+diagnostic to DEBUG.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -8242,3 +8242,27 @@ VPS5 deployment status:
   Rust-orchestrator events' independent console/text projection. Python-filter
   selection events remain operator-visible; the Rust producer's selected-set,
   slot, and replacement materiality plus periodic heartbeat remain unchanged.
+
+### 2026-07-15: Forager Selection Ownership Deployed And Open-Tail Follow-Up
+
+- PR #1237 merged to canonical `master` at `a6aad93902` after exact-head Hermes
+  and Grok approval plus green Python and Rust CI. VPS5 fast-forwarded cleanly.
+  Two bots exited immediately after one SIGINT round; GateIO and Binance briefly
+  entered uninterruptible I/O sleep while KuCoin drained, then all three exited
+  naturally within the bounded wait. Exact pane PIDs and unrelated `misc:0.0`
+  PID `434835` remained unchanged.
+- The immediate smoke was `ok=true` with `19/19` remote calls and `14/14`
+  account-critical calls successful. The settled smoke was also `ok=true` with
+  `249/251` remote calls, all `47/47` account-critical calls, six successful
+  fill refreshes, five valid processes, and zero hard, log-attention, monitor,
+  or event-pipeline failures. Two KuCoin candle-fetch timeouts were non-hard.
+- Natural Binance, GateIO, and OKX logs retained only the richer producer-owned
+  material selection INFO line. Exact Rust `forager.selection` records remained
+  in monitor storage, proving the structured/monitor path stayed durable while
+  the duplicate operator projection was removed.
+- The first fresh cycle emitted one `open-tail EMA projection contexts` INFO
+  record on every bot. The lines measured 1002-1050 characters and expanded up
+  to eight symbol timestamp contexts for 19-39 flat projections per bot. The
+  active `codex/open-tail-projection-console-detail` slice retains that routine
+  aggregate at DEBUG while preserving compact active-tail warnings, structured
+  late-projection events, EMA values, and readiness.

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -14780,7 +14780,7 @@ class Passivbot:
                     examples.append(Passivbot._log_symbol(sym))
             log_ema_issue(
                 ("open_tail_projection_context_summary",),
-                logging.INFO,
+                logging.DEBUG,
                 "[candle] open-tail EMA projection contexts | symbols=%d | %s",
                 len(projection_contexts),
                 "; ".join(examples),

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -901,7 +901,7 @@ async def test_orchestrator_ema_bundle_marks_flat_forager_candidate_required_m1_
 
 
 @pytest.mark.asyncio
-async def test_orchestrator_ema_bundle_late_projection_marks_candidate_unavailable(
+async def test_orchestrator_ema_bundle_projection_context_summary_is_debug(
     monkeypatch,
     caplog,
 ):
@@ -909,12 +909,9 @@ async def test_orchestrator_ema_bundle_late_projection_marks_candidate_unavailab
 
     now_ms = 2_000_000
     monkeypatch.setattr(pb_mod, "utc_ms", lambda: now_ms)
-    symbol = "LATE/USDT:USDT"
+    symbols = ["LATE_A/USDT:USDT", "LATE_B/USDT:USDT"]
 
     class FakeCM:
-        def __init__(self):
-            self.health_calls = 0
-
         def get_last_refresh_ms(self, symbol):
             return now_ms - 30_000
 
@@ -922,9 +919,6 @@ async def test_orchestrator_ema_bundle_late_projection_marks_candidate_unavailab
             return 0
 
         def get_completed_candle_health(self, symbol, windows=None, now_ms=None):
-            self.health_calls += 1
-            if windows == {"1m": 1} and self.health_calls == 1:
-                return {"ok": True, "timeframes": {"1m": {"coverage_ok": True}}}
             return {
                 "ok": False,
                 "timeframes": {
@@ -1002,7 +996,10 @@ async def test_orchestrator_ema_bundle_late_projection_marks_candidate_unavailab
                 "strategy_kind": "trailing_martingale",
             }
         }
-        positions = {symbol: {"long": {"size": 0.0}, "short": {"size": 0.0}}}
+        positions = {
+            symbol: {"long": {"size": 0.0}, "short": {"size": 0.0}}
+            for symbol in symbols
+        }
         open_orders = {}
         PB_modes = {"long": {}, "short": {}}
         active_symbols = []
@@ -1062,30 +1059,60 @@ async def test_orchestrator_ema_bundle_late_projection_marks_candidate_unavailab
     bot = FakeBot()
     events = []
     bot._live_event_current_cycle_id = "cy_tail"
+    bot._orchestrator_ema_issue_last_log_ms = {
+        ("open_tail_projection_context_summary",): now_ms - 15 * 60 * 1000
+    }
 
     def emit_live_event(event_type, *args, **kwargs):
         events.append((event_type, kwargs))
         return object()
 
     bot._emit_live_event = emit_live_event
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.DEBUG):
         (
             m1_close_emas,
             m1_volume_emas,
             m1_log_range_emas,
-            _h1_log_range_emas,
+            h1_log_range_emas,
             volumes_long,
             log_ranges_long,
         ) = await pb_mod.Passivbot._load_orchestrator_ema_bundle(
-            bot, [symbol], modes=bot.PB_modes
+            bot, symbols, modes=bot.PB_modes
         )
 
-    assert m1_close_emas[symbol]
-    assert m1_volume_emas[symbol][5.0] == pytest.approx(42.0)
-    assert m1_log_range_emas[symbol] == {}
-    assert volumes_long[symbol] == pytest.approx(42.0)
-    assert symbol not in log_ranges_long
-    assert bot._orchestrator_ema_unavailable_symbols == {symbol}
+    projection_summary_records = [
+        record
+        for record in caplog.records
+        if "open-tail EMA projection contexts" in record.message
+    ]
+    assert len(projection_summary_records) == 1
+    assert projection_summary_records[0].levelno == logging.DEBUG
+    assert "symbols=2" in projection_summary_records[0].message
+    assert bot._orchestrator_ema_issue_last_log_ms[
+        ("open_tail_projection_context_summary",)
+    ] == now_ms
+    assert not any(
+        "open-tail EMA projection contexts" in record.message
+        and record.levelno == logging.INFO
+        for record in caplog.records
+    )
+    for symbol in symbols:
+        assert set(m1_close_emas[symbol]) == {10.0, 20.0, (10.0 * 20.0) ** 0.5}
+        assert all(
+            value == pytest.approx(100.0)
+            for value in m1_close_emas[symbol].values()
+        )
+        assert m1_volume_emas[symbol][5.0] == pytest.approx(42.0)
+        assert m1_log_range_emas[symbol] == {}
+        assert h1_log_range_emas[symbol] == {}
+        assert volumes_long[symbol] == pytest.approx(42.0)
+        assert symbol not in log_ranges_long
+        assert (
+            bot._orchestrator_ema_projection_details[symbol]["tail_gap_age_ms"]
+            == 60_000
+        )
+    assert bot._orchestrator_ema_projection_symbols == set(symbols)
+    assert bot._orchestrator_ema_unavailable_symbols == set(symbols)
     assert not any(
         "late open-tail EMA projection context" in record.message
         and record.levelno >= logging.INFO
@@ -1096,13 +1123,17 @@ async def test_orchestrator_ema_bundle_late_projection_marks_candidate_unavailab
         for event_type, kwargs in events
         if event_type == EventTypes.CANDLE_TAIL_PROJECTED
     ]
-    assert len(tail_events) == 1
-    assert tail_events[0]["cycle_id"] == "cy_tail"
-    assert tail_events[0]["symbol"] == symbol
-    assert tail_events[0]["reason_code"] == "late_open_tail_projection"
-    assert tail_events[0]["data"]["latest_expected_ts"] == 1_920_000
-    assert tail_events[0]["data"]["last_cached_ts"] == 1_860_000
-    assert tail_events[0]["data"]["tail_gap_age_ms"] == 60_000
+    assert len(tail_events) == len(symbols)
+    assert {event["cycle_id"] for event in tail_events} == {"cy_tail"}
+    assert {event["symbol"] for event in tail_events} == set(symbols)
+    assert {event["reason_code"] for event in tail_events} == {
+        "late_open_tail_projection"
+    }
+    assert {event["data"]["latest_expected_ts"] for event in tail_events} == {
+        1_920_000
+    }
+    assert {event["data"]["last_cached_ts"] for event in tail_events} == {1_860_000}
+    assert {event["data"]["tail_gap_age_ms"] for event in tail_events} == {60_000}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- keep the throttled `open-tail EMA projection contexts` aggregate available at DEBUG instead of INFO
- preserve its complete payload and 15-minute diagnostic cadence
- preserve compact active-tail INFO/WARNING transitions, late structured `candle.tail_projected` events, EMA values, and readiness behavior

## Runtime Evidence

The first natural cycle after PR #1237 emitted one aggregate on every VPS5 bot. The five lines measured 1002-1050 characters, expanded up to eight symbol/timestamp contexts, and represented 19-39 flat projection contexts per bot rather than a new operator transition.

PR #1237 is deployed at `a6aad93902`. Immediate and settled smoke reports were `ok=true`. The settled report recorded `249/251` successful remote calls, all `47/47` account-critical calls successful, six successful fill refreshes, five valid processes, and zero hard, log-attention, monitor, or event-pipeline failures. Its natural selection output and durable monitor events also validated the prior single-owner slice.

## Validation

- `tests/test_live_candle_budget.py`: 43 passed
- focused projection/active-tail tests: 3 passed
- `tests/test_run_fake_live.py`: 31 passed
- AI docs and live-event registry docs: 3 passed
- `py_compile src/passivbot.py`
- AI documentation check: 0 errors, existing word-count warning only
- `git diff --check`
- bounded Terra pre-PR review: no findings

The regression uses two projection contexts and verifies one DEBUG aggregate, no INFO aggregate, unchanged projected EMA maps/readiness, and preserved per-symbol late-projection events.

## Behavior Boundary

No projection eligibility, candle fetch, EMA value, readiness, event payload, scheduling, exchange call, order, risk, Rust, backtest, or optimizer behavior changes.
