### PR TITLE
Bound candle-fetch failure diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Candle-fetch retry and exhaustion warnings now use bounded operator
+  signatures instead of retaining raw request parameters and exception text.
+  Structured remote-call events omit raw exception text and replace explicit
+  request URLs with a redacted marker plus stable hash; retries, callback
+  invocation, and candle behavior are unchanged.
+
 - Routine open-tail EMA projection-context aggregates now remain available at
   DEBUG instead of printing thousand-character diagnostics in the normal live
   console. Compact active-tail transitions and warnings, EMA projection,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable user-facing changes will be documented in this file.
 
 - Candle-fetch retry and exhaustion warnings now use bounded operator
   signatures instead of retaining raw request parameters and exception text.
+  Their first occurrence is emitted even during the process's initial
+  five-minute throttle window.
   Structured remote-call events omit raw exception text and replace explicit
   request URLs with a redacted marker plus stable hash; retries, callback
   invocation, and candle behavior are unchanged.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -611,9 +611,11 @@ deployed, and naturally validated: normal logs retain only the producer-owned
 material summary while monitor storage retains the complete Rust event.
 Python-filter selection visibility remains unchanged.
 
-The first fresh cycle after activation emitted five 1002-1050 character
-open-tail EMA context aggregates; the active slice above moves only that routine
-diagnostic to DEBUG.
+PR #1238's open-tail EMA projection-context demotion is merged, deployed, and
+naturally validated: all five bots completed market-ready cycles without the
+1002-1050 character aggregate appearing in normal INFO logs. The active slice
+above now bounds candle-fetch retry/exhaustion warnings and removes raw
+exception prose and request URLs from durable remote-call events.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,37 +22,51 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/open-tail-projection-console-detail`.
-- Base: `a6aad939023f71e2ddeb9ae507505e05935e46b1`, canonical `master`
-  after PR #1237.
-- Slice: keep routine open-tail EMA projection-context aggregates off the
-  normal INFO console while retaining the complete diagnostic at DEBUG.
-- Triggering evidence: the first natural post-PR #1237 cycle emitted one such
-  INFO record on every VPS5 bot. The five lines were 1002-1050 characters long,
-  listed up to eight full symbol/timestamp contexts, and represented 19-39 flat
-  projection contexts per bot rather than a new operator transition.
-- Scope: demote only the throttled `open-tail EMA projection contexts`
-  aggregate from INFO to DEBUG. Preserve its message and 15-minute diagnostic
-  cadence, compact active-tail INFO/WARNING transitions, late structured
-  `candle.tail_projected` events, and all EMA outputs.
-- Behavior boundary: preserve projection eligibility, candle fetching, EMA
-  values, readiness, scheduling, exchange calls, order/risk behavior, Rust,
-  backtest, and optimizer behavior.
+- Branch: `codex/bounded-candle-fetch-warning`.
+- Base: `c70a88b14789fd86146fb9021e9b600bfb65b37a`, canonical `master`
+  after PR #1238.
+- Slice: replace raw candle-fetch failure text in the normal warning sink with
+  one bounded operator signature.
+- Triggering evidence: the first natural post-PR #1238 window contained KuCoin
+  and GateIO candle-fetch timeout warnings measuring 513 and 487 characters.
+  Each duplicated raw exception text and retained a complete request URL plus
+  query parameters, while the useful operator facts were the exchange, symbol,
+  timeframe, attempt, and exception class.
+- Scope: replace `params`, `error`, and `error_repr` in the
+  `ccxt_fetch_ohlcv_failed` warning with bounded attempt/max-attempt, elapsed,
+  error-type, and retry/exhausted fields. Keep retry and terminal transitions
+  independently throttled. Preserve the callback input shape while replacing
+  raw exception text in durable remote-call events with its exception class;
+  explicit URL fields retain only a redacted marker and stable hash.
+- Behavior boundary: preserve candle requests, retry and rate-limit
+  classification, five-minute throttling cadence per transition, exception
+  propagation, callback invocation, readiness, exchange calls, order/risk
+  behavior, Rust, backtest, and optimizer behavior.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: after merge, one authorized exact five-bot restart may
-  activate the level change. Validate from natural projection contexts only; do
-  not manufacture candle, readiness, or trading events.
+  activate the warning format. Validate from a natural candle-fetch failure if
+  one occurs; do not manufacture exchange, candle, readiness, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 checkout:
-  `a6aad939023f71e2ddeb9ae507505e05935e46b1`, PR #1237; tracked status clean
+  `c70a88b14789fd86146fb9021e9b600bfb65b37a`, PR #1238; tracked status clean
   and expected untracked artifacts preserved.
 - VPS5 runs the same head in bot PIDs
-  `941443/941446/941447/941448/941449`. The exact pane PIDs remain
+  `942412/942414/942416/942417/942418`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1238 was activated with one exact five-bot graceful restart. Every old
+  bot exited naturally after one SIGINT round; no escalation was required.
+  The immediate window retained one real KuCoin authoritative-balance timeout
+  and its degraded cycle. The settled two-minute smoke was `ok=true` with
+  `262/264` remote calls and all `41/41` account-critical calls successful, six
+  successful fill refreshes, five valid processes, and zero hard, log,
+  monitor, or event-pipeline failures. The two remote failures were non-hard
+  candle-fetch timeouts. All five bots completed a natural market-ready cycle,
+  normal logs contained zero `open-tail EMA projection contexts` INFO records,
+  and the complete diagnostic remains available at DEBUG.
 - PR #1237 was activated with one exact five-bot graceful restart. Two bots
   exited immediately after one SIGINT round; GateIO and Binance briefly entered
   uninterruptible I/O sleep while KuCoin drained, and all three then exited

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -8266,3 +8266,25 @@ VPS5 deployment status:
   active `codex/open-tail-projection-console-detail` slice retains that routine
   aggregate at DEBUG while preserving compact active-tail warnings, structured
   late-projection events, EMA values, and readiness.
+
+### 2026-07-15: Open-Tail Detail Demotion Deployed And Candle Failure Follow-Up
+
+- PR #1238 merged to canonical `master` at `c70a88b147` after exact-head Hermes
+  and Grok approval plus green Python and Rust CI. VPS5 fast-forwarded cleanly,
+  and all five exact bots exited naturally after one SIGINT round. Exact pane
+  PIDs and unrelated `misc:0.0` PID `434835` remained unchanged.
+- The immediate window retained one real KuCoin authoritative-balance timeout
+  and degraded cycle. The settled two-minute smoke was `ok=true` with `262/264`
+  remote calls and all `41/41` account-critical calls successful, six
+  successful fill refreshes, five valid processes, and zero hard, log,
+  monitor, or event-pipeline failures. The two remaining failures were non-hard
+  candle-fetch timeouts.
+- Every bot completed a natural market-ready cycle and normal INFO logs
+  contained zero `open-tail EMA projection contexts` records, proving the
+  demotion without manufacturing candle or trading events.
+- Those natural candle timeouts exposed the next operator-sink issue: KuCoin
+  and GateIO warnings measured 513 and 487 characters and retained duplicated
+  raw exception text, full request URLs, and query parameters. The active
+  `codex/bounded-candle-fetch-warning` slice replaces the normal text with
+  bounded retry/terminal signatures. Durable remote-call events omit raw
+  exception text; explicit URLs retain only a redacted marker and stable hash.

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -3998,16 +3998,17 @@ class CandlestickManager:
                         "error_repr": err_repr,
                     }
                 )
+                action = "exhausted" if attempt == max_attempts - 1 else "retry"
                 self._throttled_warning(
-                    f"ccxt_fetch_ohlcv_failed:{symbol}:{tf}:{err_type}",
+                    f"ccxt_fetch_ohlcv_failed:{symbol}:{tf}:{err_type}:{action}",
                     "ccxt_fetch_ohlcv_failed",
                     symbol=symbol,
-                    tf=str(tf) if tf is not None else None,
+                    tf=tf_norm,
                     attempt=attempt + 1,
-                    params=params if "params" in locals() else None,
+                    max_attempts=max_attempts,
+                    elapsed_ms=elapsed_ms,
                     error_type=err_type,
-                    error=str(e),
-                    error_repr=err_repr,
+                    action=action,
                 )
                 sleep_s = backoff
                 msg = str(e) or ""

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -1476,8 +1476,8 @@ class CandlestickManager:
         will be emitted again if the condition persists.
         """
         now = time.monotonic()
-        last = self._warning_last_log.get(throttle_key, 0.0)
-        if (now - last) < self._warning_throttle_seconds:
+        last = self._warning_last_log.get(throttle_key)
+        if last is not None and (now - last) < self._warning_throttle_seconds:
             return
         self._warning_last_log[throttle_key] = now
         self._log("warning", event, **fields)

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -4000,7 +4000,7 @@ class CandlestickManager:
                 )
                 action = "exhausted" if attempt == max_attempts - 1 else "retry"
                 self._throttled_warning(
-                    f"ccxt_fetch_ohlcv_failed:{symbol}:{tf}:{err_type}:{action}",
+                    f"ccxt_fetch_ohlcv_failed:{symbol}:{tf_norm}:{err_type}:{action}",
                     "ccxt_fetch_ohlcv_failed",
                     symbol=symbol,
                     tf=tf_norm,

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -5,7 +5,6 @@ import hashlib
 import math
 import re
 from collections import Counter
-from urllib.parse import urlsplit, urlunsplit
 from typing import Any
 
 from live.event_bus import (
@@ -64,30 +63,13 @@ def _sanitize_remote_text(value: Any, *, max_len: int = 500) -> str:
 def _sanitize_remote_url(value: Any) -> tuple[str, str | None]:
     raw = str(value)
     raw_hash = hashlib.sha256(raw.encode("utf-8")).hexdigest()
-    try:
-        parsed = urlsplit(raw)
-    except Exception:
-        return _sanitize_remote_text(raw, max_len=500), raw_hash
-    if parsed.query or parsed.fragment:
-        sanitized = urlunsplit(
-            (
-                parsed.scheme,
-                parsed.netloc,
-                parsed.path,
-                "[redacted]" if parsed.query else "",
-                "[redacted]" if parsed.fragment else "",
-            )
-        )
-    else:
-        sanitized = raw
-    return _sanitize_remote_text(sanitized, max_len=500), raw_hash
+    return "[redacted-url]", raw_hash
 
 
 def _sanitize_remote_fetch_payload(payload: dict[str, Any]) -> dict[str, Any]:
     data = dict(payload)
-    for key in ("error", "error_repr"):
-        if data.get(key) is not None:
-            data[key] = _sanitize_remote_text(data[key], max_len=500)
+    data.pop("error", None)
+    data.pop("error_repr", None)
     if data.get("url") is not None:
         url, url_hash = _sanitize_remote_url(data["url"])
         data["url"] = url

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -14,6 +14,7 @@ from candlestick_manager import (
     CANDLE_DTYPE,
     GAP_REASON_NO_ARCHIVE,
     ONE_MIN_MS,
+    OhlcvFetchError,
     _GAP_MAX_RETRIES,
     _GATEIO_RECENT_1M_LIMIT_CANDLES,
     _floor_minute,
@@ -314,6 +315,92 @@ def test_remote_fetch_callback_exception_is_isolated(tmp_path):
     cm._emit_remote_fetch({"kind": "ccxt_fetch_ohlcv", "stage": "start"})
 
     assert calls == [{"kind": "ccxt_fetch_ohlcv", "stage": "start"}]
+
+
+@pytest.mark.asyncio
+async def test_ccxt_fetch_warning_uses_bounded_signature_and_keeps_callback_payload(
+    tmp_path, monkeypatch, caplog
+):
+    url = "https://api.example.invalid/ohlcv?apiKey=SECRET&signature=abc"
+
+    class UrlBearingError(RuntimeError):
+        pass
+
+    class _Ex:
+        id = "binance"
+
+        async def fetch_ohlcv(self, *_args, **_kwargs):
+            raise UrlBearingError(url)
+
+    callback_payloads = []
+    cm = CandlestickManager(
+        exchange=_Ex(),
+        exchange_name="binance",
+        cache_dir=str(tmp_path / "caches"),
+        remote_fetch_callback=callback_payloads.append,
+    )
+
+    async def no_sleep(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(cm, "_sleep_interruptible", no_sleep)
+    caplog.set_level(logging.WARNING, logger=cm.log.name)
+
+    with pytest.raises(OhlcvFetchError):
+        await cm._ccxt_fetch_ohlcv_once(
+            "BTC/USDT:USDT",
+            since_ms=1_723_456_000_000,
+            limit=100,
+            end_exclusive_ms=1_723_456_060_000,
+            timeframe="1H",
+        )
+
+    warning_records = [
+        record
+        for record in caplog.records
+        if "event=ccxt_fetch_ohlcv_failed" in record.getMessage()
+    ]
+    assert len(warning_records) == 2
+    retry_warning = warning_records[0].getMessage()
+    exhausted_warning = warning_records[1].getMessage()
+    for field in (
+        "exchange=binance",
+        "symbol=BTC",
+        "tf=1h",
+        "attempt=1",
+        "max_attempts=5",
+        "elapsed_ms=",
+        "error_type=UrlBearingError",
+        "action=retry",
+    ):
+        assert field in retry_warning
+    for field in (
+        "exchange=binance",
+        "symbol=BTC",
+        "tf=1h",
+        "attempt=5",
+        "max_attempts=5",
+        "elapsed_ms=",
+        "error_type=UrlBearingError",
+        "action=exhausted",
+    ):
+        assert field in exhausted_warning
+    for raw_value in (
+        url,
+        repr(UrlBearingError(url)),
+        "params=",
+        "error=",
+        "error_repr=",
+    ):
+        assert all(raw_value not in warning for warning in (retry_warning, exhausted_warning))
+    assert len(retry_warning) <= 240
+    assert len(exhausted_warning) <= 240
+
+    error_payloads = [payload for payload in callback_payloads if payload.get("stage") == "error"]
+    assert error_payloads
+    assert error_payloads[0]["params"] == {"until": 1_723_456_059_999}
+    assert error_payloads[0]["error"] == url
+    assert error_payloads[0]["error_repr"] == repr(UrlBearingError(url))
 
 
 @pytest.mark.asyncio

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -351,13 +351,15 @@ async def test_ccxt_fetch_warning_uses_bounded_signature_and_keeps_callback_payl
             warning_records.append(record)
 
     handler = CaptureHandler(level=logging.WARNING)
+    capture_log = logging.Logger(
+        "test.candlestick_manager.ccxt_fetch_warning", level=logging.WARNING
+    )
+    capture_log.propagate = False
+    capture_log.addHandler(handler)
     original_global_disable = logging.root.manager.disable
-    original_disabled = cm.log.disabled
-    original_level = cm.log.level
+    original_log = cm.log
     logging.disable(logging.NOTSET)
-    cm.log.disabled = False
-    cm.log.setLevel(logging.WARNING)
-    cm.log.addHandler(handler)
+    cm.log = capture_log
     try:
         with pytest.raises(OhlcvFetchError):
             await cm._ccxt_fetch_ohlcv_once(
@@ -368,10 +370,9 @@ async def test_ccxt_fetch_warning_uses_bounded_signature_and_keeps_callback_payl
                 timeframe="1H",
             )
     finally:
-        cm.log.removeHandler(handler)
-        cm.log.setLevel(original_level)
-        cm.log.disabled = original_disabled
+        cm.log = original_log
         logging.disable(original_global_disable)
+        capture_log.removeHandler(handler)
         handler.close()
 
     warning_records = [

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -344,6 +344,7 @@ async def test_ccxt_fetch_warning_uses_bounded_signature_and_keeps_callback_payl
         return None
 
     monkeypatch.setattr(cm, "_sleep_interruptible", no_sleep)
+    monkeypatch.setattr("candlestick_manager.time.monotonic", lambda: 50.0)
     warning_records = []
 
     class CaptureHandler(logging.Handler):

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -319,7 +319,7 @@ def test_remote_fetch_callback_exception_is_isolated(tmp_path):
 
 @pytest.mark.asyncio
 async def test_ccxt_fetch_warning_uses_bounded_signature_and_keeps_callback_payload(
-    tmp_path, monkeypatch, caplog
+    tmp_path, monkeypatch
 ):
     url = "https://api.example.invalid/ohlcv?apiKey=SECRET&signature=abc"
 
@@ -344,20 +344,36 @@ async def test_ccxt_fetch_warning_uses_bounded_signature_and_keeps_callback_payl
         return None
 
     monkeypatch.setattr(cm, "_sleep_interruptible", no_sleep)
-    caplog.set_level(logging.WARNING, logger=cm.log.name)
+    warning_records = []
 
-    with pytest.raises(OhlcvFetchError):
-        await cm._ccxt_fetch_ohlcv_once(
-            "BTC/USDT:USDT",
-            since_ms=1_723_456_000_000,
-            limit=100,
-            end_exclusive_ms=1_723_456_060_000,
-            timeframe="1H",
-        )
+    class CaptureHandler(logging.Handler):
+        def emit(self, record):
+            warning_records.append(record)
+
+    handler = CaptureHandler(level=logging.WARNING)
+    original_disabled = cm.log.disabled
+    original_level = cm.log.level
+    cm.log.disabled = False
+    cm.log.setLevel(logging.WARNING)
+    cm.log.addHandler(handler)
+    try:
+        with pytest.raises(OhlcvFetchError):
+            await cm._ccxt_fetch_ohlcv_once(
+                "BTC/USDT:USDT",
+                since_ms=1_723_456_000_000,
+                limit=100,
+                end_exclusive_ms=1_723_456_060_000,
+                timeframe="1H",
+            )
+    finally:
+        cm.log.removeHandler(handler)
+        cm.log.setLevel(original_level)
+        cm.log.disabled = original_disabled
+        handler.close()
 
     warning_records = [
         record
-        for record in caplog.records
+        for record in warning_records
         if "event=ccxt_fetch_ohlcv_failed" in record.getMessage()
     ]
     assert len(warning_records) == 2

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -351,8 +351,10 @@ async def test_ccxt_fetch_warning_uses_bounded_signature_and_keeps_callback_payl
             warning_records.append(record)
 
     handler = CaptureHandler(level=logging.WARNING)
+    original_global_disable = logging.root.manager.disable
     original_disabled = cm.log.disabled
     original_level = cm.log.level
+    logging.disable(logging.NOTSET)
     cm.log.disabled = False
     cm.log.setLevel(logging.WARNING)
     cm.log.addHandler(handler)
@@ -369,6 +371,7 @@ async def test_ccxt_fetch_warning_uses_bounded_signature_and_keeps_callback_payl
         cm.log.removeHandler(handler)
         cm.log.setLevel(original_level)
         cm.log.disabled = original_disabled
+        logging.disable(original_global_disable)
         handler.close()
 
     warning_records = [

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -3057,8 +3057,15 @@ def test_candle_remote_fetch_error_sanitizes_and_keeps_correlation():
             **base,
             "stage": "error",
             "error_type": "AuthError",
-            "error": "token SECRET apiKey=abc Bearer xyz",
-            "error_repr": "Auth(apiKey=SECRET, token=SECRET) " + ("x" * 700),
+            "error": (
+                "token SECRET apiKey=abc Bearer xyz "
+                "GET https://api.example.invalid/private?apiKey=abc&signature=SECRET"
+            ),
+            "error_repr": (
+                "Auth(apiKey=SECRET, token=SECRET, "
+                "url='https://api.example.invalid/private?token=SECRET') "
+                + ("x" * 700)
+            ),
         }
     )
 
@@ -3068,11 +3075,9 @@ def test_candle_remote_fetch_error_sanitizes_and_keeps_correlation():
     assert failed.event_type == EventTypes.REMOTE_CALL_FAILED
     assert failed.remote_call_id == started.remote_call_id
     assert failed.remote_call_group_id == started.remote_call_group_id
-    assert "SECRET" not in failed.data["error"]
-    assert "abc" not in failed.data["error"]
-    assert "xyz" not in failed.data["error"].lower()
-    assert "SECRET" not in failed.data["error_repr"]
-    assert len(failed.data["error_repr"]) <= 514
+    assert failed.data["error_type"] == "AuthError"
+    assert "error" not in failed.data
+    assert "error_repr" not in failed.data
     assert bot._live_event_remote_call_ids == {}
 
 
@@ -3096,7 +3101,7 @@ def test_candle_remote_fetch_url_is_sanitized_and_hashed():
     started, skipped = sink.events
     assert skipped.remote_call_id == started.remote_call_id
     for event in (started, skipped):
-        assert event.data["url"] == "https://data.example/archive.zip?[redacted]#[redacted]"
+        assert event.data["url"] == "[redacted-url]"
         assert event.data["url_hash"]
         assert len(event.data["url_hash"]) == 64
         assert "SECRET" not in event.data["url"]


### PR DESCRIPTION
## Scope

Category: runtime behavior / observability producer.

- Replace raw `ccxt_fetch_ohlcv_failed` console/text payloads with bounded retry and terminal signatures.
- Give retry and exhaustion independent five-minute throttle identities so terminal exhaustion remains visible.
- Drop raw `error` and `error_repr` from durable remote-call events while preserving `error_type`, correlation IDs, and bounded operation context.
- Replace explicit remote-fetch URLs with `[redacted-url]` plus a stable SHA-256 hash.
- Record PR #1238 deployment evidence and the current logging-loop slice.

Non-goals: no candle request, retry/backoff, rate-limit classification, exception propagation, callback invocation, readiness, exchange-call, order, risk, Rust, backtest, or optimizer behavior changes.

## Triggering evidence

The first natural VPS5 window after PR #1238 contained KuCoin and GateIO candle-fetch timeout warnings measuring 513 and 487 characters. Each duplicated raw exception text and retained a full request URL and query parameters. This conflicts with `docs/ai/logging_policy.md` and obscures the useful operator signature.

## Expected behavior impact

Normal warnings contain exchange, symbol, normalized timeframe, attempt/max attempts, elapsed time, exception class, and `retry|exhausted` action. Durable events remain correlated and machine-readable without raw exception prose or request URLs. Trading behavior is unchanged.

## Validation

- `python -m pytest -q tests/test_candlestick_manager.py tests/test_passivbot_monitor.py` (150 passed)
- `python -m pytest -q tests/test_run_fake_live.py` (31 passed)
- `python src/tools/check_ai_docs.py` (0 errors; existing word-count warning)
- `python src/tools/generate_live_event_registry.py --check`
- `python -m pytest -q tests/test_ai_docs.py tests/test_live_event_registry_docs.py` (3 passed)
- `python -m py_compile` on changed Python/tests
- `git diff --check`
- Independent pre-PR review approved the final delta after two findings were fixed.

## Reviewer focus

- Confirm the two throttle identities preserve retry suppression while exposing terminal exhaustion.
- Confirm remote-call events retain enough bounded context after dropping raw exception text.
- Confirm URL hashing/redaction is sink-only and cannot affect request construction or callback behavior.

## VPS action

After merge: pull, gracefully restart only the five exact authorized bot panes, run immediate and settled smoke, and validate the new warning from a natural candle-fetch failure only if one occurs. Do not manufacture exchange, candle, readiness, or trading events.