### PR TITLE
logging: bound staged refresh console timings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Completed staged account-refresh timing lines now stay at DEBUG unless the
+  cohort takes at least ten seconds. Interesting sub-ten-second samples remain
+  available as structured INFO events, and periodic timing summaries,
+  readiness, exchange calls, and trading behavior are unchanged.
+
 - Candle-fetch retry and exhaustion warnings now use bounded operator
   signatures instead of retaining raw request parameters and exception text.
   Their first occurrence is emitted even during the process's initial

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,41 +22,48 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/bounded-candle-fetch-warning`.
-- Base: `c70a88b14789fd86146fb9021e9b600bfb65b37a`, canonical `master`
-  after PR #1238.
-- Slice: replace raw candle-fetch failure text in the normal warning sink with
-  one bounded operator signature.
-- Triggering evidence: the first natural post-PR #1238 window contained KuCoin
-  and GateIO candle-fetch timeout warnings measuring 513 and 487 characters.
-  Each duplicated raw exception text and retained a complete request URL plus
-  query parameters, while the useful operator facts were the exchange, symbol,
-  timeframe, attempt, and exception class.
-- Scope: replace `params`, `error`, and `error_repr` in the
-  `ccxt_fetch_ohlcv_failed` warning with bounded attempt/max-attempt, elapsed,
-  error-type, and retry/exhausted fields. Keep retry and terminal transitions
-  independently throttled. Preserve the callback input shape while replacing
-  raw exception text in durable remote-call events with its exception class;
-  explicit URL fields retain only a redacted marker and stable hash.
-- Behavior boundary: preserve candle requests, retry and rate-limit
-  classification, five-minute throttling cadence per transition, exception
-  propagation, callback invocation, readiness, exchange calls, order/risk
-  behavior, Rust, backtest, and optimizer behavior.
+- Branch: `codex/staged-refresh-console-threshold`.
+- Base: `a97a815a52ce66eac274bee7f0b2ac31f496ee37`, canonical `master`
+  after PR #1239.
+- Slice: keep completed staged account-refresh timing lines at DEBUG unless the
+  cohort wall time reaches ten seconds.
+- Triggering evidence: the measured five-bot console sample contained 33
+  immediate `[state] staged refresh timings` INFO lines, about 13.2 records per
+  bot-hour and more than 20% of the non-action INFO budget. Natural post-PR
+  #1239 startup output again included sub-ten-second completed timing lines.
+- Scope: decouple console/text level from the existing `interesting` predicate.
+  Preserve structured INFO timing events for pending confirmations, meaningful
+  changes, unusual plans, and ten-second cohorts; preserve periodic summaries
+  for routine samples.
+- Behavior boundary: preserve timing calculations, fetch plans, concurrency,
+  exchange calls, readiness, `staged refresh still waiting` transitions,
+  structured event payloads, order/risk behavior, Rust, backtest, and optimizer
+  behavior.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: after merge, one authorized exact five-bot restart may
-  activate the warning format. Validate from a natural candle-fetch failure if
-  one occurs; do not manufacture exchange, candle, readiness, or trading events.
+  activate the console threshold. Validate natural INFO absence below ten
+  seconds and retained INFO at or above ten seconds; do not manufacture state,
+  exchange, readiness, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 checkout:
-  `c70a88b14789fd86146fb9021e9b600bfb65b37a`, PR #1238; tracked status clean
+  `a97a815a52ce66eac274bee7f0b2ac31f496ee37`, PR #1239; tracked status clean
   and expected untracked artifacts preserved.
 - VPS5 runs the same head in bot PIDs
-  `942412/942414/942416/942417/942418`. The exact pane PIDs remain
+  `944582/944692/944584/944476/944694`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1239 was activated with one exact five-bot graceful restart. Every old
+  bot exited naturally after one SIGINT round; no escalation was required.
+  The immediate startup window retained one real KuCoin authoritative-state
+  timeout and degraded cycle. It aged out before the settled two-minute smoke,
+  which was `ok=true` with `219/219` remote calls and `50/50` account-critical
+  calls successful, six successful fill refreshes, five matching processes and
+  configs, states `R=4,S=1`, and zero hard, log, monitor, process, or
+  event-pipeline failures. No natural candle-fetch failure occurred in the
+  bounded post-restart window, so the new warning format was not manufactured.
 - PR #1238 was activated with one exact five-bot graceful restart. Every old
   bot exited naturally after one SIGINT round; no escalation was required.
   The immediate window retained one real KuCoin authoritative-balance timeout
@@ -613,9 +620,12 @@ Python-filter selection visibility remains unchanged.
 
 PR #1238's open-tail EMA projection-context demotion is merged, deployed, and
 naturally validated: all five bots completed market-ready cycles without the
-1002-1050 character aggregate appearing in normal INFO logs. The active slice
-above now bounds candle-fetch retry/exhaustion warnings and removes raw
-exception prose and request URLs from durable remote-call events.
+1002-1050 character aggregate appearing in normal INFO logs. PR #1239's bounded
+candle-fetch warning and durable remote-call redaction are also merged and
+deployed. Its settled smoke is green; no natural candle-fetch failure occurred
+in the bounded post-restart window. The active slice above now moves completed
+sub-ten-second staged-refresh timing detail off the normal console while
+retaining structured INFO events for interesting samples.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -8288,3 +8288,26 @@ VPS5 deployment status:
   `codex/bounded-candle-fetch-warning` slice replaces the normal text with
   bounded retry/terminal signatures. Durable remote-call events omit raw
   exception text; explicit URLs retain only a redacted marker and stable hash.
+
+### 2026-07-15: Bounded Candle Failures Deployed And Refresh Timing Follow-Up
+
+- PR #1239 merged to canonical `master` at `a97a815a52` after exact-head Hermes
+  and Grok approval plus green Python and Rust CI. Its final review fix ensures
+  the first throttled warning is emitted during early process uptime.
+- VPS5 fast-forwarded cleanly and all five exact bots exited naturally after
+  one SIGINT round. Exact pane PIDs and unrelated `misc:0.0` PID `434835`
+  remained unchanged; expected untracked artifacts were preserved.
+- The immediate startup window retained one real KuCoin authoritative-state
+  timeout and degraded cycle. It aged out before the settled two-minute smoke,
+  which was `ok=true` with `219/219` remote calls and `50/50` account-critical
+  calls successful, six successful fill refreshes, five matching processes and
+  configs, states `R=4,S=1`, and zero hard, log, monitor, process, or
+  event-pipeline failures. No natural candle-fetch failure occurred in the
+  bounded post-restart window, so the new warning format was not manufactured.
+- The prior console-volume sample contained 33 immediate completed staged
+  refresh timing INFO lines, about 13.2 records per bot-hour and more than 20%
+  of the non-action budget. Natural post-restart startup output again contained
+  sub-ten-second lines. The active `codex/staged-refresh-console-threshold`
+  slice keeps those completed lines at DEBUG while preserving interesting
+  structured INFO events, periodic timing summaries, readiness, and refresh
+  behavior.

--- a/src/live/state_refresh.py
+++ b/src/live/state_refresh.py
@@ -349,9 +349,7 @@ def log_staged_refresh_timings(
                 residual_ms,
             )
             return
-        log_level = logging.DEBUG
-    else:
-        log_level = logging.INFO
+    console_log_level = logging.INFO if wall_ms >= 10_000 else logging.DEBUG
     parts = [
         f"{surface}={int(timings_ms[surface])}ms" for surface in sorted(timings_ms)
     ]
@@ -359,7 +357,7 @@ def log_staged_refresh_timings(
         parts.append(f"residual={residual_ms}ms")
         parts.append("residual_hint=scheduler_or_lock_wait")
     suffix = " | pending_confirmations=yes" if pending_confirmations else ""
-    if log_level < logging.INFO:
+    if not interesting:
         bot._record_staged_refresh_timing_summary(
             plan,
             timings_ms,
@@ -368,7 +366,7 @@ def log_staged_refresh_timings(
             max_surface_ms,
             residual_ms,
         )
-    if log_level >= logging.INFO:
+    if interesting:
         event_emitters.emit_state_refresh_timing_event(
             bot,
             plan=plan,
@@ -384,7 +382,7 @@ def log_staged_refresh_timings(
             level="info",
         )
     logging.log(
-        log_level,
+        console_log_level,
         "[state] staged refresh timings | plan=%s | wall=%dms | surface_sum=%dms | surface_max=%dms | parallel=%s | %s%s",
         ",".join(sorted(plan)),
         wall_ms,

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -3099,7 +3099,7 @@ def test_log_staged_refresh_timings_logs_only_for_slow_refreshes(caplog):
             "[state] staged refresh timings | plan=balance,fills,open_orders,positions | wall=8500ms | surface_sum=11500ms | surface_max=4000ms | parallel=yes | balance=2500ms fills=4000ms open_orders=2000ms positions=3000ms residual=4500ms residual_hint=scheduler_or_lock_wait",
         ),
         (
-            "INFO",
+            "DEBUG",
             "[state] staged refresh timings | plan=balance,fills,open_orders,positions | wall=4100ms | surface_sum=5100ms | surface_max=1700ms | parallel=yes | balance=1200ms fills=1300ms open_orders=900ms positions=1700ms residual=2400ms residual_hint=scheduler_or_lock_wait",
         ),
         (
@@ -3109,7 +3109,7 @@ def test_log_staged_refresh_timings_logs_only_for_slow_refreshes(caplog):
     ]
 
 
-def test_log_staged_refresh_timings_emits_structured_event():
+def test_log_staged_refresh_timings_keeps_meaningful_change_structured_at_info(caplog):
     sink = ListEventSink()
     bot = Passivbot.__new__(Passivbot)
     bot._live_event_current_cycle_id = "cy_refresh"
@@ -3117,13 +3117,21 @@ def test_log_staged_refresh_timings_emits_structured_event():
     bot._authoritative_pending_confirmations = {}
     bot._authoritative_refresh_epoch_changed = {"positions"}
 
-    bot._log_staged_refresh_timings(
-        {"balance", "positions", "open_orders", "fills"},
-        {"balance": 1200, "positions": 1700, "open_orders": 900, "fills": 1300},
-        4100,
-    )
+    with caplog.at_level(logging.DEBUG):
+        bot._log_staged_refresh_timings(
+            {"balance", "positions", "open_orders", "fills"},
+            {"balance": 1200, "positions": 1700, "open_orders": 900, "fills": 1300},
+            4100,
+        )
 
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    timing_logs = [
+        record
+        for record in caplog.records
+        if "[state] staged refresh timings" in record.message
+    ]
+    assert len(timing_logs) == 1
+    assert timing_logs[0].levelno == logging.DEBUG
     event = sink.events[0]
     assert event.event_type == EventTypes.STATE_REFRESH_TIMING
     assert event.level == "info"


### PR DESCRIPTION
## Scope

- Category: observability producer and operational documentation.
- Make the completed staged account-refresh timing text line INFO only when cohort wall time is at least 10 seconds.
- Keep sub-10-second completed timing detail at DEBUG, including meaningful-change, pending-confirmation, and unusual-plan samples.

## Behavior boundary

- The existing `interesting` predicate still emits the complete structured `state.refresh_timing` event at INFO.
- Routine non-interesting samples still feed the existing periodic timing summary unchanged.
- `staged refresh still waiting` transitions, timing calculations, fetch plans, concurrency, exchange calls, readiness, event payloads, trading decisions, Rust, backtest, and optimizer behavior are unchanged.

## Evidence

- The measured five-bot console sample contained 33 immediate completed staged-refresh timing INFO lines, about 13.2 records per bot-hour and more than 20% of the non-action INFO budget.
- Natural post-PR #1239 startup output again included completed sub-10-second timing lines.
- PR #1239 was deployed with one exact five-bot graceful restart. Its transient KuCoin authoritative-state timeout aged out; the settled two-minute smoke was green with 219/219 remote calls, 50/50 account-critical calls, six successful fill refreshes, five matching bots/configs, and zero hard/log/monitor/process/event-pipeline failures.

## Validation

- `python -m pytest tests/test_passivbot_balance_split.py -q` (219 passed)
- `python -m pytest tests/test_passivbot_monitor.py -k state_refresh_timing -q` (1 passed)
- `python -m py_compile src/live/state_refresh.py tests/test_passivbot_balance_split.py`
- `python src/tools/check_ai_docs.py` (0 errors; existing word-count warning)
- `git diff --check`

## VPS action

After merge, gracefully restart only the five exact VPS5 bot panes and run immediate plus settled bounded smoke checks. Validate natural INFO absence below 10 seconds and retained INFO at or above 10 seconds without manufacturing state, exchange, readiness, or trading events.

## Reviewer focus

- Confirm console level is independent from structured-event admission.
- Confirm periodic summary accounting is unchanged for non-interesting samples.
- Confirm the patch cannot alter refresh execution or trading behavior.
