### PR TITLE
logging: demote successful fill timing detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Successful fill-refresh and fetcher-request timing detail now stays at DEBUG
+  instead of appearing in the normal live console. Fetcher request errors,
+  actual fills, degraded warnings, structured refresh summaries, refresh
+  behavior, and failure propagation are unchanged.
+
 - Completed staged account-refresh timing lines now stay at DEBUG unless the
   cohort takes at least ten seconds. Interesting sub-ten-second samples remain
   available as structured INFO events, and periodic timing summaries,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,39 +22,50 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/staged-refresh-console-threshold`.
-- Base: `a97a815a52ce66eac274bee7f0b2ac31f496ee37`, canonical `master`
-  after PR #1239.
-- Slice: keep completed staged account-refresh timing lines at DEBUG unless the
-  cohort wall time reaches ten seconds.
-- Triggering evidence: the measured five-bot console sample contained 33
-  immediate `[state] staged refresh timings` INFO lines, about 13.2 records per
-  bot-hour and more than 20% of the non-action INFO budget. Natural post-PR
-  #1239 startup output again included sub-ten-second completed timing lines.
-- Scope: decouple console/text level from the existing `interesting` predicate.
-  Preserve structured INFO timing events for pending confirmations, meaningful
-  changes, unusual plans, and ten-second cohorts; preserve periodic summaries
-  for routine samples.
-- Behavior boundary: preserve timing calculations, fetch plans, concurrency,
-  exchange calls, readiness, `staged refresh still waiting` transitions,
-  structured event payloads, order/risk behavior, Rust, backtest, and optimizer
-  behavior.
+- Branch: `codex/fill-timing-console-detail`.
+- Base: `9441fa45091f557145cb56f4fce00374b636a8cd`, canonical `master`
+  after PR #1240.
+- Slice: keep successful fill-refresh and fetcher-request timing detail at
+  DEBUG; request-error timing remains INFO.
+- Triggering evidence: natural post-ready output retained successful
+  `[fills] refresh timing` lines at `1600-7608ms` and a successful
+  `[fills] fetcher request timing` line at `33850ms`. These are maintenance
+  diagnostics, while actual fills have dedicated operator records and complete
+  `fills.refresh_summary` events remain durable off console/text.
+- Scope: remove source, fill-count, and elapsed-time INFO promotion from the
+  completed refresh timing line, and remove elapsed-time INFO promotion from
+  successful fetcher request timing. Preserve request-error INFO visibility.
+- Behavior boundary: preserve refresh selection and execution, cache/history
+  coverage, actual fill records, warnings and degraded states, structured event
+  payloads, error propagation, order/risk behavior, Rust, backtest, and
+  optimizer behavior.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: after merge, one authorized exact five-bot restart may
-  activate the console threshold. Validate natural INFO absence below ten
-  seconds and retained INFO at or above ten seconds; do not manufacture state,
-  exchange, readiness, or trading events.
+  activate the level changes. Validate natural successful fill timing absence
+  from INFO while structured summaries and normal fill behavior continue; do
+  not manufacture fills, failures, state, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 checkout:
-  `a97a815a52ce66eac274bee7f0b2ac31f496ee37`, PR #1239; tracked status clean
+  `9441fa45091f557145cb56f4fce00374b636a8cd`, PR #1240; tracked status clean
   and expected untracked artifacts preserved.
 - VPS5 runs the same head in bot PIDs
-  `944582/944692/944584/944476/944694`. The exact pane PIDs remain
+  `945997/945999/946001/946002/946003`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1240 was activated with one exact five-bot graceful restart. Every old
+  bot exited naturally after one SIGINT round; no escalation was required.
+  The immediate window caught one real KuCoin authoritative-state timeout and
+  active startup HSL replay. Both aged out before the settled two-minute smoke,
+  which was `ok=true` with `176/176` remote calls and `32/32`
+  account-critical calls successful, six successful fill refreshes, all five
+  expected processes/configs in state `R`, and zero hard, log, monitor,
+  process, or event-pipeline failures. Natural INFO completed staged-refresh
+  lines were all at or above ten seconds (`10061-13600ms`), while structured
+  INFO retained interesting sub-threshold samples at `2190ms`, `5948ms`, and
+  `7431ms`, proving the sink boundary without manufactured events.
 - PR #1239 was activated with one exact five-bot graceful restart. Every old
   bot exited naturally after one SIGINT round; no escalation was required.
   The immediate startup window retained one real KuCoin authoritative-state
@@ -623,9 +634,12 @@ naturally validated: all five bots completed market-ready cycles without the
 1002-1050 character aggregate appearing in normal INFO logs. PR #1239's bounded
 candle-fetch warning and durable remote-call redaction are also merged and
 deployed. Its settled smoke is green; no natural candle-fetch failure occurred
-in the bounded post-restart window. The active slice above now moves completed
-sub-ten-second staged-refresh timing detail off the normal console while
-retaining structured INFO events for interesting samples.
+in the bounded post-restart window. PR #1240's staged-refresh console threshold
+is merged, deployed, and naturally validated: completed INFO lines were all at
+or above ten seconds while interesting sub-threshold structured INFO samples
+remained durable. The active slice above now removes successful fill-refresh
+timing detail from the normal console while preserving actual fills, request
+errors, warnings, and structured summaries.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -8311,3 +8311,26 @@ VPS5 deployment status:
   slice keeps those completed lines at DEBUG while preserving interesting
   structured INFO events, periodic timing summaries, readiness, and refresh
   behavior.
+
+### 2026-07-15: Staged Refresh Threshold Deployed And Fill Timing Follow-Up
+
+- PR #1240 merged to canonical `master` at `9441fa4509` after exact-head Hermes
+  and Grok approval plus green Python and Rust CI. VPS5 fast-forwarded cleanly,
+  and all five exact bots exited naturally after one SIGINT round. Exact pane
+  PIDs and unrelated `misc:0.0` PID `434835` remained unchanged.
+- The immediate window caught one real KuCoin authoritative-state timeout and
+  active startup HSL replay. Both aged out before the settled two-minute smoke,
+  which was `ok=true` with `176/176` remote calls and `32/32`
+  account-critical calls successful, six successful fill refreshes, five
+  matching processes/configs all in state `R`, and zero hard, log, monitor,
+  process, or event-pipeline failures.
+- Natural completed staged-refresh INFO lines were all at or above ten seconds
+  (`10061-13600ms`). Complete structured INFO still retained interesting
+  sub-threshold samples at `2190ms`, `5948ms`, and `7431ms`, proving the level
+  boundary without manufacturing state or trading events.
+- Natural post-ready output also retained successful `[fills] refresh timing`
+  detail at `1600-7608ms` and a successful `[fills] fetcher request timing`
+  line at `33850ms`. The active `codex/fill-timing-console-detail` slice keeps
+  successful timing diagnostics at DEBUG while preserving request-error INFO,
+  actual fill lines, warnings, structured `fills.refresh_summary` events,
+  refresh behavior, and failure propagation.

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -4518,12 +4518,7 @@ class FillEventsManager:
                 self.fetcher.api = original_api
             fetch_elapsed_ms = int(max(0.0, (time.monotonic() - fetch_started) * 1000.0))
             if request_stats.count or fetch_elapsed_ms >= 5_000:
-                level = (
-                    logging.INFO
-                    if fetch_elapsed_ms >= 10_000
-                    or request_stats.error_count
-                    else logging.DEBUG
-                )
+                level = logging.INFO if request_stats.error_count else logging.DEBUG
                 logger.log(
                     level,
                     "[fills] fetcher request timing | exchange=%s user=%s fetcher=%s "

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -10278,13 +10278,12 @@ class Passivbot:
                 or "confirm" in str(source)
                 or "staged" in str(source)
             )
-            log_level = (
+            structured_event_level = (
                 logging.INFO
                 if new_events or blocking_or_confirmation_refresh or elapsed_ms >= 30_000
                 else logging.DEBUG
             )
-            logging.log(
-                log_level,
+            logging.debug(
                 "[fills] refresh timing | source=%s mode=%s | elapsed=%dms | before=%d after=%d new=%d | lookback=%s scope=%s coverage_ready=%s coverage_reason=%s overlap_minutes=%s pending_pnl=%d",
                 source,
                 refresh_mode,
@@ -10323,7 +10322,7 @@ class Passivbot:
                 coverage_before=coverage_status,
                 coverage_after=post_refresh_coverage_status,
                 overlap_minutes=overlap_minutes,
-                level=logging.getLevelName(log_level).lower(),
+                level=logging.getLevelName(structured_event_level).lower(),
             )
 
             return pnls_complete and coverage_ready_after

--- a/tests/test_fill_events_manager.py
+++ b/tests/test_fill_events_manager.py
@@ -4639,7 +4639,9 @@ async def test_manager_refresh_records_successful_empty_refresh(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_manager_refresh_logs_fetcher_request_timing(tmp_path: Path, caplog):
+async def test_manager_refresh_logs_slow_successful_fetcher_request_timing_at_debug(
+    tmp_path: Path, caplog, monkeypatch
+):
     cache_dir = tmp_path / "fills_request_timing"
 
     class _Api:
@@ -4665,15 +4667,27 @@ async def test_manager_refresh_logs_fetcher_request_timing(tmp_path: Path, caplo
         fetcher=_ApiFetcher(),
         cache_path=cache_dir,
     )
+    monotonic_times = iter([0.0] * 7 + [11.0])
+    with monkeypatch.context() as timing_patch:
+        timing_patch.setattr(
+            fem.time,
+            "monotonic",
+            lambda: next(monotonic_times, 11.0),
+        )
+        with caplog.at_level(logging.DEBUG, logger=fem.logger.name):
+            await manager.refresh(start_ms=123, end_ms=456)
 
-    with caplog.at_level(logging.DEBUG, logger=fem.logger.name):
-        await manager.refresh(start_ms=123, end_ms=456)
-
-    messages = [record.message for record in caplog.records]
-    assert any("[fills] fetcher request timing" in msg for msg in messages)
-    assert any("requests=3" in msg for msg in messages)
-    assert any("fetch_b:n=2" in msg for msg in messages)
-    assert any("range=1970-01-01 00:00:00..1970-01-01 00:00:00" in msg for msg in messages)
+    timing_records = [
+        record
+        for record in caplog.records
+        if "[fills] fetcher request timing" in record.message
+    ]
+    assert len(timing_records) == 1
+    assert timing_records[0].levelno == logging.DEBUG
+    assert "elapsed=11000ms" in timing_records[0].message
+    assert "requests=3" in timing_records[0].message
+    assert "fetch_b:n=2" in timing_records[0].message
+    assert "range=1970-01-01 00:00:00..1970-01-01 00:00:00" in timing_records[0].message
 
 
 @pytest.mark.asyncio
@@ -4703,11 +4717,16 @@ async def test_manager_refresh_logs_fetcher_error_detail(tmp_path: Path, caplog)
         with pytest.raises(RuntimeError, match="remote timeout detail"):
             await manager.refresh(start_ms=123, end_ms=456)
 
-    messages = [record.message for record in caplog.records]
-    assert any("[fills] fetcher request timing" in msg for msg in messages)
-    assert any("fetch_a:n=1" in msg for msg in messages)
-    assert any("err_type=RuntimeError" in msg for msg in messages)
-    assert any("err_msg=remote timeout detail" in msg for msg in messages)
+    timing_records = [
+        record
+        for record in caplog.records
+        if "[fills] fetcher request timing" in record.message
+    ]
+    assert len(timing_records) == 1
+    assert timing_records[0].levelno == logging.INFO
+    assert "fetch_a:n=1" in timing_records[0].message
+    assert "err_type=RuntimeError" in timing_records[0].message
+    assert "err_msg=remote timeout detail" in timing_records[0].message
 
 
 def test_fill_event_cache_disk_full_raises_clear_error(tmp_path: Path, monkeypatch, sample_events):

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -3451,8 +3451,8 @@ async def test_update_pnls_routine_empty_refresh_timing_demoted_to_debug(
         def set_history_scope(self, scope):
             self.history_scope = scope
 
-    times = iter([1_000_000, 1_015_000])
-    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: next(times, 1_015_000))
+    times = iter([1_000_000, 1_030_000])
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: next(times, 1_030_000))
     bot.stop_signal_received = False
     bot.config = {
         "live": {
@@ -3480,7 +3480,91 @@ async def test_update_pnls_routine_empty_refresh_timing_demoted_to_debug(
     ]
     assert len(fill_timing_records) == 1
     assert fill_timing_records[0].levelno == logging.DEBUG
-    assert "elapsed=15000ms" in fill_timing_records[0].message
+    assert "elapsed=30000ms" in fill_timing_records[0].message
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("source", "add_new_fill"),
+    [
+        ("staged_blocking", False),
+        ("routine_prefetch:minute_boundary", True),
+    ],
+    ids=["staged_source", "new_fill"],
+)
+async def test_update_pnls_completed_refresh_timing_trigger_cases_stay_debug(
+    monkeypatch, caplog, source, add_new_fill
+):
+    bot = Passivbot.__new__(Passivbot)
+    cached_event = SimpleNamespace(
+        timestamp=1_700_000_000_000,
+        id="fill-1",
+        source_ids=["fill-1"],
+    )
+    refreshed_events = [cached_event]
+    if add_new_fill:
+        refreshed_events.append(
+            SimpleNamespace(
+                timestamp=1_700_000_060_000,
+                id="fill-2",
+                source_ids=["fill-2"],
+            )
+        )
+
+    class _Manager:
+        def __init__(self):
+            self._events = [cached_event]
+            self.history_scope = "all"
+
+        async def refresh_latest(self, **kwargs):
+            self._events = list(refreshed_events)
+
+        def get_events(self):
+            return list(self._events)
+
+        def get_history_scope(self):
+            return self.history_scope
+
+        def set_history_scope(self, scope):
+            self.history_scope = scope
+
+    times = iter([1_000_000, 1_001_000])
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: next(times, 1_001_000))
+    bot.stop_signal_received = False
+    bot.config = {
+        "live": {
+            "fills_recent_overlap_minutes": 10.0,
+            "pnls_max_lookback_days": "all",
+        }
+    }
+    bot._authoritative_pending_confirmations = {}
+    bot._pnls_manager = _Manager()
+    bot.init_pnls = AsyncMock()
+    bot.live_value = lambda key: "all" if key == "pnls_max_lookback_days" else None
+    bot.get_exchange_time = lambda: 1_700_000_060_000
+    bot._log_new_fill_events = lambda new_events: None
+    bot._monitor_record_event = lambda *args, **kwargs: None
+    bot._monitor_record_error = lambda *args, **kwargs: None
+    refresh_summaries = []
+    bot._emit_fills_refresh_summary_event = lambda **kwargs: refresh_summaries.append(
+        kwargs
+    )
+    bot.logging_level = 0
+    bot._health_rate_limits = 0
+
+    with caplog.at_level(logging.DEBUG):
+        result = await bot.update_pnls(source=source)
+
+    assert result is True
+    fill_timing_records = [
+        record for record in caplog.records if "[fills] refresh timing" in record.message
+    ]
+    assert len(fill_timing_records) == 1
+    assert fill_timing_records[0].levelno == logging.DEBUG
+    assert f"source={source}" in fill_timing_records[0].message
+    assert f"new={int(add_new_fill)}" in fill_timing_records[0].message
+    assert len(refresh_summaries) == 1
+    assert refresh_summaries[0]["level"] == "info"
 
 
 def test_min_effective_cost_blocks_are_aggregated(caplog):


### PR DESCRIPTION
## Summary

- keep completed `[fills] refresh timing` detail at DEBUG regardless of source,
  new-fill count, or elapsed time
- keep successful `[fills] fetcher request timing` detail at DEBUG regardless
  of elapsed time, while preserving request-error timing at INFO
- preserve structured refresh-summary classification and record the deployed
  PR #1240 runtime evidence in the logging-overhaul status ledger

## Evidence

Natural post-ready VPS5 output retained successful refresh timing lines at
1600-7608ms and a successful fetcher request timing line at 33850ms. Actual
fills already have dedicated operator records, while complete
`fills.refresh_summary` events remain durable off console/text.

The deployed PR #1240 baseline settled green at exact master `9441fa4509`:
176/176 remote calls and 32/32 account-critical calls succeeded, six fill
refreshes succeeded, all five expected processes/configs were running, and
hard/log/monitor/process/pipeline failures were zero.

## Behavior Boundary

No refresh selection, exchange request, cache/history coverage, fill/PnL,
readiness, order, risk, Rust, backtest, or optimizer behavior changes. Actual
fill records, warnings/degraded states, request-error visibility, structured
event payloads, structured INFO classification, and failure propagation remain
unchanged.

## Validation

- complete `tests/test_passivbot_balance_split.py`: passed
- complete `tests/test_fill_events_manager.py`: passed
- `python -m py_compile src/passivbot.py src/fill_events_manager.py`: passed
- `src/tools/check_ai_docs.py`: 0 errors, existing aggregate word-count warning
- `git diff --check`: passed

## Deployment

After merge, activate with one authorized exact five-bot graceful restart on
VPS5. Validate natural absence of successful fill timing detail from INFO while
structured summaries and normal fill behavior continue. Do not manufacture
fills, failures, state, or trading events.
