### PR TITLE
Emit bounded OKX exchange config outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- OKX per-symbol margin-mode/leverage configuration now emits bounded structured
+  outcome events. Explicit already-configured responses stay available at DEBUG
+  instead of appearing as routine INFO, while confirmed responses and failures
+  retain their existing operator visibility and exchange behavior.
+
 - Successful fill-refresh and fetcher-request timing detail now stays at DEBUG
   instead of appearing in the normal live console. Fetcher request errors,
   actual fills, degraded warnings, structured refresh summaries, refresh

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -123,8 +123,8 @@ and distinguish the observed result in `data.outcome`:
 - `unchanged`: the exchange explicitly reported that the requested setting already matched
 - `failed`: the request raised or returned a connector-classified failure
 
-Connector-local payloads include only bounded `context`, `operation`, `outcome`, optional numeric
-`response_code`, `error_type`, and the envelope's `symbol`. They exclude raw responses, exception
+Connector-local payloads include only bounded `context`, `operation`, `outcome`, optional
+digit-only `response_code`, `error_type`, and the envelope's `symbol`. They exclude raw responses, exception
 text, request parameters, URLs, and tracebacks. An explicit unchanged outcome is DEBUG; confirmed
 success remains INFO until the connector can prove whether it changed state; failures retain their
 existing operator-visible warning or error. The event route remains structured/monitor-only, and

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -113,6 +113,23 @@ account-mode fatal events may request a bounded best-effort flush before the exi
 but event failure never suppresses that error. Isolated-only market events remain observational and
 must not alter filtering or existing-position handling.
 
+## Exchange Configuration Outcomes
+
+`exchange.config_refresh` covers both periodic market refreshes and bounded connector-local
+configuration outcomes. Per-symbol connector events use the existing success/failure reason codes
+and distinguish the observed result in `data.outcome`:
+
+- `confirmed`: the exchange returned normally; this does not claim that a setting changed
+- `unchanged`: the exchange explicitly reported that the requested setting already matched
+- `failed`: the request raised or returned a connector-classified failure
+
+Connector-local payloads include only bounded `context`, `operation`, `outcome`, optional numeric
+`response_code`, `error_type`, and the envelope's `symbol`. They exclude raw responses, exception
+text, request parameters, URLs, and tracebacks. An explicit unchanged outcome is DEBUG; confirmed
+success remains INFO until the connector can prove whether it changed state; failures retain their
+existing operator-visible warning or error. The event route remains structured/monitor-only, and
+event emission failure must not change exchange configuration control flow or results.
+
 ## Dynamic Registry Values
 
 - `authoritative_reason_code(surface)` produces `authoritative_<surface>`.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -23,6 +23,7 @@ Estimated completion:
 ## Active Review Slice
 
 - Branch: `codex/okx-config-outcome-event`.
+- PR: #1242.
 - Base: `953ac80e316d1dcb4f64f852fba9a89f06c70638`, canonical `master`
   after PR #1241.
 - Slice: migrate OKX per-symbol margin-mode/leverage outcomes into the existing

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,39 +22,53 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/fill-timing-console-detail`.
-- Base: `9441fa45091f557145cb56f4fce00374b636a8cd`, canonical `master`
-  after PR #1240.
-- Slice: keep successful fill-refresh and fetcher-request timing detail at
-  DEBUG; request-error timing remains INFO.
-- Triggering evidence: natural post-ready output retained successful
-  `[fills] refresh timing` lines at `1600-7608ms` and a successful
-  `[fills] fetcher request timing` line at `33850ms`. These are maintenance
-  diagnostics, while actual fills have dedicated operator records and complete
-  `fills.refresh_summary` events remain durable off console/text.
-- Scope: remove source, fill-count, and elapsed-time INFO promotion from the
-  completed refresh timing line, and remove elapsed-time INFO promotion from
-  successful fetcher request timing. Preserve request-error INFO visibility.
-- Behavior boundary: preserve refresh selection and execution, cache/history
-  coverage, actual fill records, warnings and degraded states, structured event
-  payloads, error propagation, order/risk behavior, Rust, backtest, and
-  optimizer behavior.
+- Branch: `codex/okx-config-outcome-event`.
+- Base: `953ac80e316d1dcb4f64f852fba9a89f06c70638`, canonical `master`
+  after PR #1241.
+- Slice: migrate OKX per-symbol margin-mode/leverage outcomes into the existing
+  structured `exchange.config_refresh` family and keep explicit unchanged
+  responses at DEBUG.
+- Triggering evidence: the logging policy reserves INFO for new operator facts,
+  while OKX's explicit `59107` already-configured response currently prints as
+  a successful INFO line. Unlike normal responses, this outcome proves that no
+  exchange setting changed. A read-only four-hour VPS5 sample contained nine
+  normal OKX `margin=ok` outcomes and no `59107`; normal outcomes remain INFO
+  and provide a natural post-deploy producer path, while the unchanged branch
+  must be validated locally rather than manufactured live.
+- Scope: add bounded per-symbol `confirmed|unchanged|failed` outcome metadata,
+  retain normal success and failure operator lines, and demote only the explicit
+  unchanged line. Reuse the existing event type, route, and reason codes.
+- Behavior boundary: preserve exchange calls and requested values, task and
+  exception control flow, success/failure handling, log visibility for confirmed
+  outcomes and failures, sink isolation, order/risk behavior, Rust, backtest,
+  and optimizer behavior. Raw responses and exception text do not enter the new
+  connector-local event payload.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: after merge, one authorized exact five-bot restart may
-  activate the level changes. Validate natural successful fill timing absence
-  from INFO while structured summaries and normal fill behavior continue; do
-  not manufacture fills, failures, state, or trading events.
+  activate the event producer and level change. Validate natural OKX startup
+  outcomes, normal operation, and structured delivery. Absence of a natural
+  unchanged outcome is acceptable; do not manufacture exchange responses,
+  failures, state, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 checkout:
-  `9441fa45091f557145cb56f4fce00374b636a8cd`, PR #1240; tracked status clean
+  `953ac80e316d1dcb4f64f852fba9a89f06c70638`, PR #1241; tracked status clean
   and expected untracked artifacts preserved.
 - VPS5 runs the same head in bot PIDs
-  `945997/945999/946001/946002/946003`. The exact pane PIDs remain
+  `946686/946688/946690/946692/946694`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1241 was activated with one exact five-bot graceful restart. Every old
+  bot exited naturally after one SIGINT round; no escalation was required.
+  The settled smoke was `ok=true` with `225/225` remote calls and `48/48`
+  account-critical calls successful, eight successful fill refreshes, all HSL
+  replays complete, five matching processes/configs, states `R=4,S=1`, and
+  zero hard, log, monitor, process, or event-pipeline failures. Fresh natural
+  logs contained zero successful fill-refresh or fetcher-request timing INFO
+  lines, while structured smoke evidence retained eight successful refresh
+  summaries. No fill or failure was manufactured.
 - PR #1240 was activated with one exact five-bot graceful restart. Every old
   bot exited naturally after one SIGINT round; no escalation was required.
   The immediate window caught one real KuCoin authoritative-state timeout and
@@ -637,9 +651,11 @@ deployed. Its settled smoke is green; no natural candle-fetch failure occurred
 in the bounded post-restart window. PR #1240's staged-refresh console threshold
 is merged, deployed, and naturally validated: completed INFO lines were all at
 or above ten seconds while interesting sub-threshold structured INFO samples
-remained durable. The active slice above now removes successful fill-refresh
-timing detail from the normal console while preserving actual fills, request
-errors, warnings, and structured summaries.
+remained durable. PR #1241's successful fill-refresh timing demotion is also
+merged, deployed, and naturally validated: successful timing detail is absent
+from normal INFO while structured refresh summaries remain available. The
+active slice above now gives OKX configuration outcomes bounded structured
+evidence and demotes only explicit unchanged responses.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -8334,3 +8334,27 @@ VPS5 deployment status:
   successful timing diagnostics at DEBUG while preserving request-error INFO,
   actual fill lines, warnings, structured `fills.refresh_summary` events,
   refresh behavior, and failure propagation.
+
+### 2026-07-15: Fill Timing Demotion Deployed And OKX Config Outcome Follow-Up
+
+- PR #1241 merged to canonical `master` at `953ac80e31` after exact-head Hermes
+  and Grok approval plus green Python and Rust CI. VPS5 fast-forwarded cleanly,
+  and all five exact bots exited naturally after one SIGINT round. Exact pane
+  PIDs and unrelated `misc:0.0` PID `434835` remained unchanged.
+- The settled smoke was `ok=true` with `225/225` remote calls and `48/48`
+  account-critical calls successful, eight successful fill refreshes, all HSL
+  replays complete, five matching processes/configs, states `R=4,S=1`, and
+  zero hard, log, monitor, process, or event-pipeline failures.
+- Fresh natural logs contained zero successful fill-refresh or fetcher-request
+  timing INFO lines, while the structured smoke window retained all eight
+  successful refresh summaries. No fill or failure was manufactured.
+- Code and policy review identified the next narrow sink boundary: OKX's
+  explicit `59107` already-configured response prints at INFO even though it
+  proves no setting changed. The active `codex/okx-config-outcome-event` slice
+  adds bounded per-symbol structured outcomes and demotes only that unchanged
+  line, preserving normal success/failure visibility and exchange behavior.
+- A read-only four-hour VPS5 sample found nine normal OKX `margin=ok` outcomes
+  and no `59107`, so the normal producer path can be validated naturally after
+  deploy while the unchanged branch remains a local regression-test claim.
+  The same window exposed nine Binance mixed leverage/unchanged lines; that
+  separate connector contract is intentionally outside this OKX-scoped PR.

--- a/src/exchanges/okx.py
+++ b/src/exchanges/okx.py
@@ -223,6 +223,33 @@ class OKXBot(CCXTBot):
         params["positionSide"] = order["position_side"]
         return params
 
+    def _emit_exchange_config_outcome_event(
+        self,
+        *,
+        symbol: str,
+        status: str,
+        outcome: str,
+        level: str,
+        response_code: str | None = None,
+        error: BaseException | None = None,
+    ) -> None:
+        try:
+            self._emit_exchange_config_refresh_event(
+                context="update_exchange_config_by_symbols",
+                operation="set_margin_mode",
+                status=status,
+                symbol=symbol,
+                outcome=outcome,
+                response_code=response_code,
+                error_type=type(error).__name__ if error is not None else None,
+                level=level,
+            )
+        except Exception as exc:
+            logging.debug(
+                "[event] failed to emit OKX exchange config-refresh outcome | error_type=%s",
+                type(exc).__name__,
+            )
+
     async def update_exchange_config_by_symbols(self, symbols: [str]):
         coros_to_call_margin_mode = {}
         for symbol in symbols:
@@ -248,16 +275,39 @@ class OKXBot(CCXTBot):
             log_symbol = symbol_to_coin(symbol, verbose=False) or symbol
             res = None
             to_print = ""
+            unchanged = False
             try:
                 res = await coros_to_call_margin_mode[symbol]
                 to_print += f"margin={format_exchange_config_response(res)}"
+                self._emit_exchange_config_outcome_event(
+                    symbol=symbol,
+                    status="succeeded",
+                    outcome="confirmed",
+                    level="info",
+                )
             except Exception as e:
                 err_str = str(e)
                 if '"code":"59107"' in err_str:
                     to_print += f"margin=ok (unchanged)"
+                    unchanged = True
+                    self._emit_exchange_config_outcome_event(
+                        symbol=symbol,
+                        status="succeeded",
+                        outcome="unchanged",
+                        response_code="59107",
+                        level="debug",
+                    )
                 elif '"code":"51039"' in err_str:
                     logging.warning(
                         f"{log_symbol}: unable to adjust margin mode/leverage (possibly PM or open positions)"
+                    )
+                    self._emit_exchange_config_outcome_event(
+                        symbol=symbol,
+                        status="failed",
+                        outcome="failed",
+                        response_code="51039",
+                        error=e,
+                        level="warning",
                     )
                     continue
                 else:
@@ -266,8 +316,19 @@ class OKXBot(CCXTBot):
                         log_symbol,
                         self._format_exchange_config_error(e),
                     )
+                    if symbol in coros_to_call_margin_mode:
+                        self._emit_exchange_config_outcome_event(
+                            symbol=symbol,
+                            status="failed",
+                            outcome="failed",
+                            error=e,
+                            level="error",
+                        )
             if to_print:
-                logging.info(f"{log_symbol}: {to_print}")
+                if unchanged:
+                    logging.debug(f"{log_symbol}: {to_print}")
+                else:
+                    logging.info(f"{log_symbol}: {to_print}")
 
     async def update_exchange_config(self):
         # Detect current account mode; adjust expectations before attempting changes.

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -49,6 +49,11 @@ _SENSITIVE_VALUE_RE = re.compile(
     r"(\s*(?:[:=]|\s)\s*)([^\s,;&]+)"
 )
 _AUTH_HEADER_RE = re.compile(r"(?i)\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]+")
+_EXCHANGE_CONFIG_EVENT_SYMBOL_RE = re.compile(r"[A-Za-z0-9_./:-]{1,160}")
+_EXCHANGE_CONFIG_EVENT_OUTCOME_RE = re.compile(r"[a-z][a-z_]{0,63}")
+_EXCHANGE_CONFIG_EVENT_RESPONSE_CODE_RE = re.compile(r"-?[0-9]{1,12}")
+_EXCHANGE_CONFIG_EVENT_ERROR_TYPE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
+_LIVE_EVENT_LEVELS = {"debug", "info", "warning", "error"}
 
 
 def _sanitize_remote_text(value: Any, *, max_len: int = 500) -> str:
@@ -76,6 +81,16 @@ def _sanitize_remote_fetch_payload(payload: dict[str, Any]) -> dict[str, Any]:
         if url_hash is not None:
             data["url_hash"] = url_hash
     return data
+
+
+def _bounded_exchange_config_event_field(
+    value: Any,
+    pattern: re.Pattern[str],
+) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if pattern.fullmatch(text) else None
 
 
 def _remote_fetch_payload_key(payload: dict[str, Any]) -> tuple[Any, ...]:
@@ -654,22 +669,41 @@ def _emit_exchange_config_refresh_event_unchecked(
     started_ms: int | None = None,
     elapsed_ms: int | None = None,
     error: BaseException | None = None,
+    symbol: str | None = None,
+    outcome: str | None = None,
+    response_code: str | int | None = None,
+    error_type: str | None = None,
+    level: str | None = None,
 ) -> None:
     status_value = str(status or "unknown")
     failed = status_value == "failed"
+    default_level = "warning" if failed else "debug"
     data: dict[str, Any] = {
         "context": str(context or "unknown"),
         "operation": str(operation or "unknown"),
         "started_ms": int(started_ms) if started_ms is not None else None,
         "elapsed_ms": int(elapsed_ms) if elapsed_ms is not None else None,
+        "symbol": _bounded_exchange_config_event_field(
+            symbol, _EXCHANGE_CONFIG_EVENT_SYMBOL_RE
+        ),
+        "outcome": _bounded_exchange_config_event_field(
+            outcome, _EXCHANGE_CONFIG_EVENT_OUTCOME_RE
+        ),
+        "response_code": _bounded_exchange_config_event_field(
+            response_code, _EXCHANGE_CONFIG_EVENT_RESPONSE_CODE_RE
+        ),
     }
     if error is not None:
         data["error_type"] = type(error).__name__
         data["error"] = _sanitize_remote_text(error, max_len=500)
+    elif error_type is not None:
+        data["error_type"] = _bounded_exchange_config_event_field(
+            error_type, _EXCHANGE_CONFIG_EVENT_ERROR_TYPE_RE
+        )
     _safe_emit(
         bot,
         EventTypes.EXCHANGE_CONFIG_REFRESH,
-        level="warning" if failed else "debug",
+        level=level if level in _LIVE_EVENT_LEVELS else default_level,
         component="exchange.config_refresh",
         tags=(EventTags.EXCHANGE,),
         cycle_id=current_live_event_cycle_id(bot),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -50,9 +50,9 @@ _SENSITIVE_VALUE_RE = re.compile(
 )
 _AUTH_HEADER_RE = re.compile(r"(?i)\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]+")
 _EXCHANGE_CONFIG_EVENT_SYMBOL_RE = re.compile(r"[A-Za-z0-9_./:-]{1,160}")
-_EXCHANGE_CONFIG_EVENT_OUTCOME_RE = re.compile(r"[a-z][a-z_]{0,63}")
 _EXCHANGE_CONFIG_EVENT_RESPONSE_CODE_RE = re.compile(r"-?[0-9]{1,12}")
 _EXCHANGE_CONFIG_EVENT_ERROR_TYPE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
+_EXCHANGE_CONFIG_EVENT_OUTCOMES = {"confirmed", "unchanged", "failed"}
 _LIVE_EVENT_LEVELS = {"debug", "info", "warning", "error"}
 
 
@@ -681,14 +681,17 @@ def _emit_exchange_config_refresh_event_unchecked(
     symbol_value = _bounded_exchange_config_event_field(
         symbol, _EXCHANGE_CONFIG_EVENT_SYMBOL_RE
     )
+    outcome_value = (
+        outcome
+        if isinstance(outcome, str) and outcome in _EXCHANGE_CONFIG_EVENT_OUTCOMES
+        else None
+    )
     data: dict[str, Any] = {
         "context": str(context or "unknown"),
         "operation": str(operation or "unknown"),
         "started_ms": int(started_ms) if started_ms is not None else None,
         "elapsed_ms": int(elapsed_ms) if elapsed_ms is not None else None,
-        "outcome": _bounded_exchange_config_event_field(
-            outcome, _EXCHANGE_CONFIG_EVENT_OUTCOME_RE
-        ),
+        "outcome": outcome_value,
         "response_code": _bounded_exchange_config_event_field(
             response_code, _EXCHANGE_CONFIG_EVENT_RESPONSE_CODE_RE
         ),

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -678,14 +678,14 @@ def _emit_exchange_config_refresh_event_unchecked(
     status_value = str(status or "unknown")
     failed = status_value == "failed"
     default_level = "warning" if failed else "debug"
+    symbol_value = _bounded_exchange_config_event_field(
+        symbol, _EXCHANGE_CONFIG_EVENT_SYMBOL_RE
+    )
     data: dict[str, Any] = {
         "context": str(context or "unknown"),
         "operation": str(operation or "unknown"),
         "started_ms": int(started_ms) if started_ms is not None else None,
         "elapsed_ms": int(elapsed_ms) if elapsed_ms is not None else None,
-        "symbol": _bounded_exchange_config_event_field(
-            symbol, _EXCHANGE_CONFIG_EVENT_SYMBOL_RE
-        ),
         "outcome": _bounded_exchange_config_event_field(
             outcome, _EXCHANGE_CONFIG_EVENT_OUTCOME_RE
         ),
@@ -706,6 +706,7 @@ def _emit_exchange_config_refresh_event_unchecked(
         level=level if level in _LIVE_EVENT_LEVELS else default_level,
         component="exchange.config_refresh",
         tags=(EventTags.EXCHANGE,),
+        symbol=symbol_value,
         cycle_id=current_live_event_cycle_id(bot),
         status=status_value,
         reason_code=(

--- a/tests/test_exchange_config_refresh_event.py
+++ b/tests/test_exchange_config_refresh_event.py
@@ -139,16 +139,16 @@ def test_exchange_config_outcome_metadata_is_bounded_and_value_safe():
     assert len(sink.events) == 2
     valid_event, unsafe_event = sink.events
     assert valid_event.level == "error"
-    assert valid_event.data["symbol"] == "BTC/USDT:USDT"
+    assert valid_event.symbol == "BTC/USDT:USDT"
     assert valid_event.data["outcome"] == "failed"
     assert valid_event.data["response_code"] == "51039"
     assert valid_event.data["error_type"] == "RuntimeError"
     assert "error" not in valid_event.data
     assert not {
-        "symbol",
         "outcome",
         "response_code",
         "error_type",
     }.intersection(unsafe_event.data)
+    assert unsafe_event.symbol is None
     assert "supersecret" not in repr(unsafe_event.data)
     assert bot._live_event_pipeline.close(timeout=2.0) is True

--- a/tests/test_exchange_config_refresh_event.py
+++ b/tests/test_exchange_config_refresh_event.py
@@ -129,7 +129,7 @@ def test_exchange_config_outcome_metadata_is_bounded_and_value_safe():
         operation="set_margin_mode",
         status="failed",
         symbol="https://example.invalid/api?apiKey=supersecret",
-        outcome="failed apiKey=supersecret",
+        outcome="unexpected",
         response_code='{"code":"51039","apiKey":"supersecret"}',
         error_type="RuntimeError apiKey=supersecret",
         level="error",

--- a/tests/test_exchange_config_refresh_event.py
+++ b/tests/test_exchange_config_refresh_event.py
@@ -17,6 +17,7 @@ sys.modules.setdefault(
 )
 
 from passivbot import Passivbot
+from live.event_emitters import emit_exchange_config_refresh_event
 
 
 def _make_bot_with_event_sink():
@@ -106,3 +107,48 @@ async def test_maintenance_exchange_config_emit_failure_preserves_original_error
 
     assert raised.value is exc
     bot.init_markets.assert_awaited_once_with(verbose=False)
+
+
+def test_exchange_config_outcome_metadata_is_bounded_and_value_safe():
+    bot, sink = _make_bot_with_event_sink()
+
+    emit_exchange_config_refresh_event(
+        bot,
+        context="update_exchange_config_by_symbols",
+        operation="set_margin_mode",
+        status="failed",
+        symbol="BTC/USDT:USDT",
+        outcome="failed",
+        response_code="51039",
+        error_type="RuntimeError",
+        level="error",
+    )
+    emit_exchange_config_refresh_event(
+        bot,
+        context="update_exchange_config_by_symbols",
+        operation="set_margin_mode",
+        status="failed",
+        symbol="https://example.invalid/api?apiKey=supersecret",
+        outcome="failed apiKey=supersecret",
+        response_code='{"code":"51039","apiKey":"supersecret"}',
+        error_type="RuntimeError apiKey=supersecret",
+        level="error",
+    )
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert len(sink.events) == 2
+    valid_event, unsafe_event = sink.events
+    assert valid_event.level == "error"
+    assert valid_event.data["symbol"] == "BTC/USDT:USDT"
+    assert valid_event.data["outcome"] == "failed"
+    assert valid_event.data["response_code"] == "51039"
+    assert valid_event.data["error_type"] == "RuntimeError"
+    assert "error" not in valid_event.data
+    assert not {
+        "symbol",
+        "outcome",
+        "response_code",
+        "error_type",
+    }.intersection(unsafe_event.data)
+    assert "supersecret" not in repr(unsafe_event.data)
+    assert bot._live_event_pipeline.close(timeout=2.0) is True

--- a/tests/test_okx_exchange_config.py
+++ b/tests/test_okx_exchange_config.py
@@ -149,3 +149,21 @@ async def test_okx_exchange_config_event_failure_does_not_change_success_control
     emitter.assert_called_once()
     cca.set_margin_mode.assert_awaited_once_with("cross", symbol=SYMBOL, params={"lever": 5})
     assert "margin=ok" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_okx_task_creation_failure_does_not_emit_false_outcome(caplog):
+    cca = types.SimpleNamespace(set_margin_mode=AsyncMock())
+    bot = _make_bot(cca)
+    bot._calc_leverage_for_symbol = Mock(
+        side_effect=RuntimeError("apiKey=SECRET task creation failed")
+    )
+
+    with caplog.at_level(logging.ERROR):
+        await bot.update_exchange_config_by_symbols([SYMBOL])
+
+    cca.set_margin_mode.assert_not_awaited()
+    bot._emit_exchange_config_refresh_event.assert_not_called()
+    assert "task creation failed" in caplog.text
+    assert "cross-margin update failed" in caplog.text
+    assert "SECRET" not in caplog.text

--- a/tests/test_okx_exchange_config.py
+++ b/tests/test_okx_exchange_config.py
@@ -1,0 +1,151 @@
+import logging
+import sys
+import types
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+
+sys.modules.setdefault(
+    "passivbot_rust",
+    types.SimpleNamespace(
+        qty_to_cost=lambda *args, **kwargs: 0.0,
+        round_dynamic=lambda x, y=None: x,
+        calc_order_price_diff=lambda *args, **kwargs: 0.0,
+        hysteresis=lambda x, y, z: x,
+    ),
+)
+
+from exchanges.okx import OKXBot
+
+
+SYMBOL = "BTC/USDT:USDT"
+
+
+def _make_bot(cca, emitter=None):
+    bot = OKXBot.__new__(OKXBot)
+    bot.cca = cca
+    bot._get_margin_mode_for_symbol = lambda symbol: "cross"
+    bot._calc_leverage_for_symbol = lambda symbol: 5
+    bot._emit_exchange_config_refresh_event = emitter or Mock()
+    return bot
+
+
+def _outcome_event_kwargs(bot):
+    bot._emit_exchange_config_refresh_event.assert_called_once()
+    return bot._emit_exchange_config_refresh_event.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_okx_margin_response_emits_confirmed_outcome_and_keeps_info_log(caplog):
+    cca = types.SimpleNamespace(
+        set_margin_mode=AsyncMock(return_value={"code": "0", "apiKey": "SECRET"})
+    )
+    bot = _make_bot(cca)
+
+    with caplog.at_level(logging.INFO):
+        await bot.update_exchange_config_by_symbols([SYMBOL])
+
+    cca.set_margin_mode.assert_awaited_once_with("cross", symbol=SYMBOL, params={"lever": 5})
+    assert _outcome_event_kwargs(bot) == {
+        "context": "update_exchange_config_by_symbols",
+        "operation": "set_margin_mode",
+        "status": "succeeded",
+        "symbol": SYMBOL,
+        "outcome": "confirmed",
+        "response_code": None,
+        "error_type": None,
+        "level": "info",
+    }
+    assert "margin=ok" in caplog.text
+    assert "SECRET" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_okx_59107_emits_unchanged_debug_outcome_and_demotes_legacy_log(caplog):
+    cca = types.SimpleNamespace(
+        set_margin_mode=AsyncMock(side_effect=RuntimeError('{"code":"59107","apiKey":"SECRET"}'))
+    )
+    bot = _make_bot(cca)
+
+    with caplog.at_level(logging.DEBUG):
+        await bot.update_exchange_config_by_symbols([SYMBOL])
+
+    assert _outcome_event_kwargs(bot) == {
+        "context": "update_exchange_config_by_symbols",
+        "operation": "set_margin_mode",
+        "status": "succeeded",
+        "symbol": SYMBOL,
+        "outcome": "unchanged",
+        "response_code": "59107",
+        "error_type": None,
+        "level": "debug",
+    }
+    record = next(record for record in caplog.records if "margin=ok (unchanged)" in record.message)
+    assert record.levelno == logging.DEBUG
+    assert "SECRET" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_okx_51039_emits_warning_failure_outcome_and_continues(caplog):
+    cca = types.SimpleNamespace(
+        set_margin_mode=AsyncMock(side_effect=RuntimeError('{"code":"51039","apiKey":"SECRET"}'))
+    )
+    bot = _make_bot(cca)
+
+    with caplog.at_level(logging.WARNING):
+        await bot.update_exchange_config_by_symbols([SYMBOL])
+
+    assert _outcome_event_kwargs(bot) == {
+        "context": "update_exchange_config_by_symbols",
+        "operation": "set_margin_mode",
+        "status": "failed",
+        "symbol": SYMBOL,
+        "outcome": "failed",
+        "response_code": "51039",
+        "error_type": "RuntimeError",
+        "level": "warning",
+    }
+    assert "unable to adjust margin mode/leverage" in caplog.text
+    assert "SECRET" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_okx_generic_failure_emits_bounded_error_outcome(caplog):
+    cca = types.SimpleNamespace(
+        set_margin_mode=AsyncMock(
+            side_effect=RuntimeError("https://example.invalid/api?apiKey=SECRET")
+        )
+    )
+    bot = _make_bot(cca)
+
+    with caplog.at_level(logging.ERROR):
+        await bot.update_exchange_config_by_symbols([SYMBOL])
+
+    assert _outcome_event_kwargs(bot) == {
+        "context": "update_exchange_config_by_symbols",
+        "operation": "set_margin_mode",
+        "status": "failed",
+        "symbol": SYMBOL,
+        "outcome": "failed",
+        "response_code": None,
+        "error_type": "RuntimeError",
+        "level": "error",
+    }
+    assert "cross-margin update failed" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
+    assert "SECRET" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_okx_exchange_config_event_failure_does_not_change_success_control_flow(caplog):
+    cca = types.SimpleNamespace(set_margin_mode=AsyncMock(return_value={"code": "0"}))
+    emitter = Mock(side_effect=RuntimeError("event sink unavailable"))
+    bot = _make_bot(cca, emitter=emitter)
+
+    with caplog.at_level(logging.INFO):
+        await bot.update_exchange_config_by_symbols([SYMBOL])
+
+    emitter.assert_called_once()
+    cca.set_margin_mode.assert_awaited_once_with("cross", symbol=SYMBOL, params={"lever": 5})
+    assert "margin=ok" in caplog.text


### PR DESCRIPTION
## Scope

Category: observability producer.

- Extend the existing structured-only `exchange.config_refresh` family with bounded per-symbol outcome metadata.
- Emit OKX margin-mode/leverage outcomes as `confirmed`, `unchanged`, or `failed`.
- Keep explicit OKX `59107` already-configured output at DEBUG instead of routine INFO.
- Record PR #1241 deploy evidence and the active logging slice in the compact/history docs.

## Behavior

- Normal OKX responses remain INFO and now emit a structured `confirmed` outcome.
- Explicit `59107` responses emit structured DEBUG `unchanged` outcomes.
- `51039` and generic failures retain existing warning/error logs and control flow, with bounded structured failure metadata.
- Event symbols use the envelope field. Payload data is restricted to bounded context, operation, fixed outcome, digit-only response code, and error type.

## Non-goals

- No exchange calls, parameters, requested leverage/margin mode, task ordering, exception propagation, order behavior, risk behavior, Rust, backtest, or optimizer changes.
- No raw responses, exception text, request parameters, URLs, or tracebacks in connector-local events.
- No Binance/other-connector migration in this PR.
- Observability remains best-effort and cannot control exchange behavior.

## Evidence

A read-only four-hour VPS5 sample on deployed master `953ac80e31` found nine normal OKX `margin=ok` outcomes and no `59107`. The normal path therefore has natural post-deploy validation potential; the unchanged branch is covered locally and will not be manufactured live.

## Validation

- `PYTHONPATH=src .../python -m pytest -q tests/test_okx_exchange_config.py tests/test_exchange_config_refresh_event.py tests/test_exchange_config_updates.py tests/test_live_event_bus.py tests/test_ai_docs.py tests/test_live_event_registry_docs.py` - 155 passed
- `PYTHONPATH=src .../python -m pytest -q tests/test_stock_perps.py` - 44 passed
- `python -m py_compile` on changed Python/test modules - passed
- `src/tools/check_ai_docs.py` - 0 errors, existing word-count warning only
- `src/tools/generate_live_event_registry.py --check` - current
- `git diff --check` - passed
- touched-path silent-handling audit - no new trading-path fallback

No authenticated exchange calls or manufactured events were used.

## Expected VPS action

After merge: fast-forward VPS5, gracefully restart the five exact supervised bots, and run immediate plus settled smoke. Validate natural OKX confirmed events and normal operation. Absence of a natural `59107` is acceptable.

## Reviewer focus

- Exchange control-flow parity, especially task-creation failure and `51039` continue behavior.
- Sink isolation and absence of raw response/exception leakage.
- Event claim precision: `confirmed` does not claim a setting changed.
- Fixed outcome vocabulary and top-level symbol placement.
