### PR TITLE
Bound HSL replay console progress cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Intermediate HSL coin-history replay progress now appears on the normal live
+  console at most once every 30 seconds. The first progress update, completion,
+  complete structured progress events, replay behavior, and safety readiness
+  are unchanged.
+
 - OKX per-symbol margin-mode/leverage configuration now emits bounded structured
   outcome events. Explicit already-configured responses stay available at DEBUG
   instead of appearing as routine INFO, while confirmed responses and failures

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,45 +22,52 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/okx-config-outcome-event`.
-- PR: #1242.
-- Base: `953ac80e316d1dcb4f64f852fba9a89f06c70638`, canonical `master`
-  after PR #1241.
-- Slice: migrate OKX per-symbol margin-mode/leverage outcomes into the existing
-  structured `exchange.config_refresh` family and keep explicit unchanged
-  responses at DEBUG.
-- Triggering evidence: the logging policy reserves INFO for new operator facts,
-  while OKX's explicit `59107` already-configured response currently prints as
-  a successful INFO line. Unlike normal responses, this outcome proves that no
-  exchange setting changed. A read-only four-hour VPS5 sample contained nine
-  normal OKX `margin=ok` outcomes and no `59107`; normal outcomes remain INFO
-  and provide a natural post-deploy producer path, while the unchanged branch
-  must be validated locally rather than manufactured live.
-- Scope: add bounded per-symbol `confirmed|unchanged|failed` outcome metadata,
-  retain normal success and failure operator lines, and demote only the explicit
-  unchanged line. Reuse the existing event type, route, and reason codes.
-- Behavior boundary: preserve exchange calls and requested values, task and
-  exception control flow, success/failure handling, log visibility for confirmed
-  outcomes and failures, sink isolation, order/risk behavior, Rust, backtest,
-  and optimizer behavior. Raw responses and exception text do not enter the new
-  connector-local event payload.
+- Branch: `codex/hsl-replay-console-cadence`.
+- PR: query live GitHub metadata after publication.
+- Base: `3072878525317d6d7e0811ef191e48cabedcf8fc`, canonical `master`
+  after PR #1242.
+- Slice: bound intermediate HSL coin-history replay progress on the normal
+  console to one update per 30 seconds while retaining complete structured
+  replay progress.
+- Triggering evidence: the authorized post-PR #1242 VPS5 restart produced 27
+  Binance, 26 GateIO, 14 KuCoin, and 16 OKX reconstruction-progress INFO
+  records. Several pair-completion records arrived seconds apart because the
+  producer's per-pair `force` path bypasses its normal cadence. Each replay
+  already had a distinct start and completion line, and the logging policy caps
+  blocking startup progress at one console update per 30 seconds.
+- Scope: separate durable-event cadence from console cadence, preserve the
+  first progress line and final completion, and prevent forced pair-boundary
+  events from forcing extra console records.
+- Behavior boundary: preserve every current `hsl.replay.progress` event and
+  payload, replay ordering, readiness and safety state, yields, calculations,
+  exchange behavior, Rust, backtest, and optimizer behavior.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: after merge, one authorized exact five-bot restart may
-  activate the event producer and level change. Validate natural OKX startup
-  outcomes, normal operation, and structured delivery. Absence of a natural
-  unchanged outcome is acceptable; do not manufacture exchange responses,
-  failures, state, or trading events.
+  activate the console cadence. Validate natural HSL startup replay counts,
+  completion visibility, structured progress retention, and normal operation.
+  Do not manufacture replay, exchange, failure, state, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 checkout:
-  `953ac80e316d1dcb4f64f852fba9a89f06c70638`, PR #1241; tracked status clean
+  `3072878525317d6d7e0811ef191e48cabedcf8fc`, PR #1242; tracked status clean
   and expected untracked artifacts preserved.
 - VPS5 runs the same head in bot PIDs
-  `946686/946688/946690/946692/946694`. The exact pane PIDs remain
+  `947807/947809/947811/947813/947815`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1242 was activated with one exact five-bot graceful restart. Every old
+  bot exited naturally after one SIGINT round; KuCoin was last at 40 seconds,
+  and no escalation was required. One real KuCoin authoritative-state timeout
+  made the first settled window red, then recovered without intervention. The
+  final two-minute smoke was `ok=true` with `198/198` remote calls and `46/46`
+  account-critical calls successful, eight successful fill refreshes, five
+  matching processes/configs in state `R`, and zero hard, log, monitor,
+  process, or event-pipeline failures. No natural OKX config-refresh outcome
+  occurred in the bounded window and none was manufactured. Fresh HSL replay
+  progress counts of `27/26/14/16` on Binance/GateIO/KuCoin/OKX exposed the
+  active console-cadence follow-up.
 - PR #1241 was activated with one exact five-bot graceful restart. Every old
   bot exited naturally after one SIGINT round; no escalation was required.
   The settled smoke was `ok=true` with `225/225` remote calls and `48/48`
@@ -654,9 +661,11 @@ is merged, deployed, and naturally validated: completed INFO lines were all at
 or above ten seconds while interesting sub-threshold structured INFO samples
 remained durable. PR #1241's successful fill-refresh timing demotion is also
 merged, deployed, and naturally validated: successful timing detail is absent
-from normal INFO while structured refresh summaries remain available. The
-active slice above now gives OKX configuration outcomes bounded structured
-evidence and demotes only explicit unchanged responses.
+from normal INFO while structured refresh summaries remain available. PR
+#1242's bounded OKX configuration outcomes are merged and deployed with a
+hard-green settled smoke. No natural config outcome occurred in the bounded
+window. The active slice above instead addresses the naturally observed HSL
+replay progress burst while preserving its durable event history.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -23,7 +23,7 @@ Estimated completion:
 ## Active Review Slice
 
 - Branch: `codex/hsl-replay-console-cadence`.
-- PR: query live GitHub metadata after publication.
+- PR: #1243, `Bound HSL replay console progress cadence`.
 - Base: `3072878525317d6d7e0811ef191e48cabedcf8fc`, canonical `master`
   after PR #1242.
 - Slice: bound intermediate HSL coin-history replay progress on the normal

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -8358,3 +8358,26 @@ VPS5 deployment status:
   deploy while the unchanged branch remains a local regression-test claim.
   The same window exposed nine Binance mixed leverage/unchanged lines; that
   separate connector contract is intentionally outside this OKX-scoped PR.
+
+### 2026-07-15: OKX Config Outcomes Deployed And HSL Progress Follow-Up
+
+- PR #1242 merged to canonical `master` at `3072878525` after exact-head Hermes
+  and Grok approval plus green Python and Rust CI. VPS5 fast-forwarded cleanly,
+  and all five exact bots exited naturally after one SIGINT round. KuCoin was
+  last at 40 seconds; no escalation was required. Exact pane PIDs and unrelated
+  `misc:0.0` PID `434835` remained unchanged.
+- One real KuCoin authoritative-state timeout made the first settled window
+  red, then recovered without intervention. The final two-minute smoke was
+  `ok=true` with `198/198` remote calls and `46/46` account-critical calls
+  successful, eight successful fill refreshes, five matching processes/configs
+  in state `R`, and zero hard, log, monitor, process, or event-pipeline
+  failures. The checkout was clean at the exact merged head.
+- No natural OKX config-refresh outcome occurred in the bounded post-restart
+  window, so neither an unchanged response nor any exchange state was
+  manufactured for validation.
+- Natural HSL startup replay produced 27 Binance, 26 GateIO, 14 KuCoin, and 16
+  OKX reconstruction-progress INFO records. Pair-boundary force bypassed the
+  producer cadence and created seconds-apart bursts despite distinct start and
+  completion records. The active `codex/hsl-replay-console-cadence` slice keeps
+  all structured progress events but caps intermediate console progress at one
+  update per 30 seconds.

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -5307,7 +5307,8 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
         total_scanned_rows = 0
         replay_started_s = time.monotonic()
         pre_replay_elapsed_s = max(0.0, replay_started_s - history_loaded_s)
-        last_progress_log_s = replay_started_s
+        last_progress_event_s = replay_started_s
+        last_progress_console_s: float | None = None
         replay_symbols = set(symbols)
         active_pairs = tuple(
             (pside, symbol)
@@ -5379,29 +5380,34 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
             *,
             force: bool = False,
         ) -> None:
-            nonlocal last_progress_log_s
+            nonlocal last_progress_event_s, last_progress_console_s
             now_s = time.monotonic()
-            if not force and now_s - last_progress_log_s < 15.0:
+            if not force and now_s - last_progress_event_s < 15.0:
                 return
-            last_progress_log_s = now_s
+            last_progress_event_s = now_s
             elapsed_s = max(0.0, now_s - replay_started_s)
             rows_per_second = float(rows) / elapsed_s if elapsed_s > 0.0 else None
             scanned_rows_per_second = (
                 float(total_scanned_rows) / elapsed_s if elapsed_s > 0.0 else None
             )
             pair_elapsed_s = max(0.0, now_s - pair_started_s)
-            logging.info(
-                "[risk] HSL coin history reconstruction progress | pair=%d/%d pside=%s symbol=%s applied_rows=%d scanned_rows=%d total_rows=%d total_scanned_rows=%d elapsed=%.1fs",
-                pair_idx,
-                len(active_pairs),
-                pside,
-                symbol,
-                applied_rows,
-                scanned_rows,
-                rows,
-                total_scanned_rows,
-                now_s - replay_started_s,
-            )
+            if (
+                last_progress_console_s is None
+                or now_s - last_progress_console_s >= 30.0
+            ):
+                last_progress_console_s = now_s
+                logging.info(
+                    "[risk] HSL coin history reconstruction progress | pair=%d/%d pside=%s symbol=%s applied_rows=%d scanned_rows=%d total_rows=%d total_scanned_rows=%d elapsed=%.1fs",
+                    pair_idx,
+                    len(active_pairs),
+                    pside,
+                    symbol,
+                    applied_rows,
+                    scanned_rows,
+                    rows,
+                    total_scanned_rows,
+                    now_s - replay_started_s,
+                )
             _emit_hsl_replay_event(
                 self,
                 "hsl.replay.progress",

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -2023,6 +2023,80 @@ async def test_coin_hsl_history_replay_emits_lifecycle_events():
 
 
 @pytest.mark.asyncio
+async def test_coin_hsl_replay_forced_pair_events_do_not_bypass_console_cadence(
+    monkeypatch, caplog
+):
+    from live.event_bus import EventTypes
+
+    bot = make_coin_bot()
+    symbols = ("A", "B", "C", "D")
+    emitted_events = []
+    clock = {"now_s": 0.0}
+
+    def emit_live_event(event_type, **kwargs):
+        emitted_events.append(SimpleNamespace(event_type=event_type, **kwargs))
+        return object()
+
+    async def fake_history(current_balance=None, **kwargs):
+        return {
+            "timeline": [
+                {
+                    "timestamp": 60_000,
+                    "balance": 100.0,
+                    "realized_pnl": 0.0,
+                    "realized_pnl_by_coin_pside": {
+                        symbol: {"long": 0.0, "short": 0.0} for symbol in symbols
+                    },
+                    "unrealized_pnl_by_coin_pside": {
+                        symbol: {"long": 0.0, "short": 0.0} for symbol in symbols
+                    },
+                }
+            ],
+            "panic_flatten_events": [],
+            "fill_events": [],
+        }
+
+    async def advance_clock_for_pair(pside=None, symbol=None):
+        clock["now_s"] = {"A": 10.0, "B": 20.0, "C": 30.0, "D": 40.0}[symbol]
+        return 0.0
+
+    bot._live_event_pipeline = object()
+    bot._emit_live_event = emit_live_event
+    bot.get_balance_equity_history = fake_history
+    bot._calc_upnl_sum_strict = advance_clock_for_pair
+    monkeypatch.setattr(hsl, "time", SimpleNamespace(monotonic=lambda: clock["now_s"]))
+
+    with caplog.at_level(logging.INFO):
+        await bot._equity_hard_stop_initialize_coin_from_history()
+
+    pair_events = [
+        event
+        for event in emitted_events
+        if event.event_type == EventTypes.HSL_REPLAY_PROGRESS
+        and event.reason_code == "pair_replay_progress"
+    ]
+    assert [(event.symbol, event.data["pair_idx"]) for event in pair_events] == [
+        ("A", 1),
+        ("A", 1),
+        ("B", 2),
+        ("C", 3),
+        ("D", 4),
+    ]
+    progress_logs = [
+        record.getMessage()
+        for record in caplog.records
+        if "HSL coin history reconstruction progress" in record.getMessage()
+    ]
+    assert len(progress_logs) == 2
+    assert "pair=1/4 pside=long symbol=A" in progress_logs[0]
+    assert "pair=3/4 pside=long symbol=C" in progress_logs[1]
+    assert any(
+        "HSL coin history reconstruction completed" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
 async def test_coin_hsl_history_replay_reports_scanned_optional_rows_without_apply():
     from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
 


### PR DESCRIPTION
## Scope

Scope category: observability producer.

VPS5 post-PR #1242 evidence showed 27 Binance, 26 GateIO, 14 KuCoin, and 16 OKX HSL reconstruction-progress INFO records during one startup replay per bot. Forced pair-boundary events bypassed the producer cadence and produced seconds-apart console bursts.

This PR separates the existing durable-event cadence from a 30-second console cadence. It preserves the first progress line, final completion line, every current `hsl.replay.progress` event and payload, and all replay calculations/readiness behavior. It also records the #1242 deployment and the active slice in the logging-overhaul status and ledger.

## Non-goals

- No exchange calls or order/risk decisions change.
- No HSL replay ordering, yields, calculations, safety readiness, or event payload changes.
- No Rust, backtest, optimizer, config, or connector changes.

## Expected impact

Intermediate HSL replay progress appears on the normal console no more than once per 30 seconds. Structured and monitor history remains complete under the existing cadence and per-pair forced emissions.

## Validation

- `PYTHONPATH=src .../python -m pytest -q tests/test_hsl_coin_mode.py` (134 passed)
- `PYTHONPATH=src .../python -m pytest -q tests/test_live_performance_report.py tests/test_live_smoke_report.py` (passed)
- `PYTHONPATH=src .../python -m py_compile src/passivbot_hsl.py tests/test_hsl_coin_mode.py`
- `python src/tools/check_ai_docs.py` (0 errors; existing aggregate word-count warning)
- `git diff --check` and touched-hunk silent-handling audit

## VPS action

After merge, gracefully restart only the five exact authorized VPS5 bot panes. Validate natural HSL replay console counts, completion visibility, structured progress retention, process/config health, and settled smoke. Do not manufacture replay, exchange, failure, state, or trading events.

## Reviewer focus

Verify that `force=True` still preserves every pair-boundary event but cannot bypass the independent console cadence, and that the test proves both properties without changing replay timing. Residual risk is limited to natural post-deploy replay duration: very short replays may expose only first progress plus completion, by design.