### PR TITLE
Bound execution-loop incident projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Execution-loop failures now use a bounded incident signature in normal
+  console, monitor, and structured burst output instead of retaining raw
+  exception text, request URLs, and unconditional tracebacks. Stack frames
+  remain available at DEBUG without the exception value, and the error-budget
+  summary is compact and tagged; retry, restart, and trading behavior are
+  unchanged.
+
 - Intermediate HSL coin-history replay progress now appears on the normal live
   console at most once every 30 seconds. The first progress update, completion,
   complete structured progress events, replay behavior, and safety readiness

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -130,6 +130,20 @@ success remains INFO until the connector can prove whether it changed state; fai
 existing operator-visible warning or error. The event route remains structured/monitor-only, and
 event emission failure must not change exchange configuration control flow or results.
 
+## Execution-Loop Incidents
+
+An execution-loop failure publishes a bounded `error.bot` record and an equivalent first-occurrence
+operator signature. The stable diagnostic fields are operation/source, exception type, optional
+bounded status/code and endpoint, action, and cycle. This family excludes raw exception text,
+request URLs, response payloads, and traceback values. Stack frames may be retained only in the
+protected DEBUG text path and must not include the exception value.
+
+Equivalent repeats use `health.summary` with the execution-error-burst reason. Its latest-failure
+fields are `latest_error_type`, optional `latest_status`, `latest_code`, and `latest_endpoint`; it
+must not retain `latest_error`. These projections are observability-only: error counting,
+timestamp recovery, restart thresholds, backoff, and trading behavior remain owned by the existing
+execution-loop policy.
+
 ## Dynamic Registry Values
 
 - `authoritative_reason_code(surface)` produces `authoritative_<surface>`.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,41 +22,51 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/hsl-replay-console-cadence`.
-- PR: #1243, `Bound HSL replay console progress cadence`.
-- Base: `3072878525317d6d7e0811ef191e48cabedcf8fc`, canonical `master`
-  after PR #1242.
-- Slice: bound intermediate HSL coin-history replay progress on the normal
-  console to one update per 30 seconds while retaining complete structured
-  replay progress.
-- Triggering evidence: the authorized post-PR #1242 VPS5 restart produced 27
-  Binance, 26 GateIO, 14 KuCoin, and 16 OKX reconstruction-progress INFO
-  records. Several pair-completion records arrived seconds apart because the
-  producer's per-pair `force` path bypasses its normal cadence. Each replay
-  already had a distinct start and completion line, and the logging policy caps
-  blocking startup progress at one console update per 30 seconds.
-- Scope: separate durable-event cadence from console cadence, preserve the
-  first progress line and final completion, and prevent forced pair-boundary
-  events from forcing extra console records.
-- Behavior boundary: preserve every current `hsl.replay.progress` event and
-  payload, replay ordering, readiness and safety state, yields, calculations,
-  exchange behavior, Rust, backtest, and optimizer behavior.
+- Branch: `codex/execution-incident-projection`.
+- PR: query live GitHub metadata after publication.
+- Base: `c6fba829031f64a9ecd59eadcaaecf36db40236c`, canonical `master`
+  after PR #1243.
+- Slice: replace raw execution-loop exception output with a bounded incident
+  signature in normal console, monitor, and structured burst projections.
+- Triggering evidence: the authorized post-PR #1243 restart produced a natural
+  KuCoin execution-loop timeout whose normal tmux output included a full
+  request URL, an unconditional traceback, and an untagged error-budget line.
+  Repeated pane captures proved this was the actual operator console rather
+  than only a protected developer sink.
+- Scope: retain exception class, bounded status/code and endpoint, action,
+  cycle, and error-budget state; keep stack frames available only at DEBUG
+  without the exception value; remove raw exception text and URLs from this
+  incident family.
+- Behavior boundary: preserve exception propagation policy, error counters,
+  restart threshold and backoff, timestamp recovery, burst cadence, exchange
+  calls, order behavior, Rust, backtest, and optimizer behavior. Generic
+  startup/process error handling remains unchanged.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: after merge, one authorized exact five-bot restart may
-  activate the console cadence. Validate natural HSL startup replay counts,
-  completion visibility, structured progress retention, and normal operation.
-  Do not manufacture replay, exchange, failure, state, or trading events.
+  activate the bounded projection. Validate normal operation and inspect only
+  naturally occurring failures; do not manufacture exchange, failure, state,
+  or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 checkout:
-  `3072878525317d6d7e0811ef191e48cabedcf8fc`, PR #1242; tracked status clean
+  `c6fba829031f64a9ecd59eadcaaecf36db40236c`, PR #1243; tracked status clean
   and expected untracked artifacts preserved.
 - VPS5 runs the same head in bot PIDs
-  `947807/947809/947811/947813/947815`. The exact pane PIDs remain
+  `948822/948824/948826/948828/948830`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1243 was activated with one exact five-bot graceful restart. Every old
+  bot exited naturally after one SIGINT round; KuCoin was last at 35 seconds,
+  and no escalation was required. Natural Binance, GateIO, and KuCoin replay
+  progress lines were all at least 30 seconds apart while complete structured
+  progress remained durable. The final two-minute smoke was `ok=true` with
+  `204/204` remote calls and `55/55` account-critical calls successful, eight
+  successful fill refreshes, five matching processes/configs, and zero hard,
+  log, monitor, process, or event-pipeline failures. Two real KuCoin startup
+  timeouts in the first five-minute window recovered without intervention and
+  exposed the active incident-projection follow-up.
 - PR #1242 was activated with one exact five-bot graceful restart. Every old
   bot exited naturally after one SIGINT round; KuCoin was last at 40 seconds,
   and no escalation was required. One real KuCoin authoritative-state timeout
@@ -664,8 +674,12 @@ merged, deployed, and naturally validated: successful timing detail is absent
 from normal INFO while structured refresh summaries remain available. PR
 #1242's bounded OKX configuration outcomes are merged and deployed with a
 hard-green settled smoke. No natural config outcome occurred in the bounded
-window. The active slice above instead addresses the naturally observed HSL
-replay progress burst while preserving its durable event history.
+window. PR #1243's HSL replay console cadence is merged, deployed, and
+naturally validated: intermediate console progress stayed at least 30 seconds
+apart while complete structured progress remained durable. Its restart exposed
+the active slice above: a natural execution-loop failure still projected raw
+request URLs, an unconditional traceback, and an untagged error-budget line to
+the operator console.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -23,7 +23,7 @@ Estimated completion:
 ## Active Review Slice
 
 - Branch: `codex/execution-incident-projection`.
-- PR: query live GitHub metadata after publication.
+- PR: #1244, `Bound execution-loop incident projection`.
 - Base: `c6fba829031f64a9ecd59eadcaaecf36db40236c`, canonical `master`
   after PR #1243.
 - Slice: replace raw execution-loop exception output with a bounded incident

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -8381,3 +8381,24 @@ VPS5 deployment status:
   completion records. The active `codex/hsl-replay-console-cadence` slice keeps
   all structured progress events but caps intermediate console progress at one
   update per 30 seconds.
+
+### 2026-07-15: HSL Cadence Deployed And Execution Incident Follow-Up
+
+- PR #1243 merged to canonical `master` at `c6fba82903` after exact-head
+  Hermes and Grok approval plus green Python and Rust CI. VPS5 fast-forwarded
+  cleanly, and all five exact bots exited naturally after one SIGINT round;
+  KuCoin was last at 35 seconds. Pane PIDs and unrelated `misc:0.0` PID
+  `434835` remained unchanged.
+- Natural Binance, GateIO, and KuCoin replay progress lines were all at least
+  30 seconds apart. A five-minute structured window retained 102 replay
+  progress events while the console projected only 15 intermediate lines,
+  proving durable detail was preserved. The final two-minute smoke was
+  `ok=true` with `204/204` remote and `55/55` account-critical calls
+  successful, eight fill refreshes, five matching processes/configs, and no
+  hard, log, monitor, process, or event-pipeline failures.
+- Two real KuCoin startup timeouts recovered without intervention. The normal
+  tmux console exposed a full request URL, an unconditional traceback, and an
+  untagged error-budget line. The active
+  `codex/execution-incident-projection` slice replaces that family with a
+  bounded signature while preserving counters, restart/backoff, timestamp
+  recovery, exchange calls, and trading behavior.

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -54,6 +54,9 @@ _EXCHANGE_CONFIG_EVENT_RESPONSE_CODE_RE = re.compile(r"-?[0-9]{1,12}")
 _EXCHANGE_CONFIG_EVENT_ERROR_TYPE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
 _EXCHANGE_CONFIG_EVENT_OUTCOMES = {"confirmed", "unchanged", "failed"}
 _LIVE_EVENT_LEVELS = {"debug", "info", "warning", "error"}
+_EXECUTION_LOOP_ERROR_STATUS_RE = re.compile(r"[0-9]{1,3}")
+_EXECUTION_LOOP_ERROR_CODE_RE = re.compile(r"-?[A-Za-z0-9][A-Za-z0-9_-]{0,47}")
+_EXECUTION_LOOP_ERROR_ENDPOINT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,47}")
 
 
 def _sanitize_remote_text(value: Any, *, max_len: int = 500) -> str:
@@ -91,6 +94,18 @@ def _bounded_exchange_config_event_field(
         return None
     text = str(value)
     return text if pattern.fullmatch(text) else None
+
+
+def _bounded_execution_loop_error_field(
+    value: Any, pattern: re.Pattern[str], *, fallback: str = "-"
+) -> str:
+    if value is None:
+        return fallback
+    try:
+        text = str(value).strip()
+    except Exception:
+        return fallback
+    return text if pattern.fullmatch(text) else fallback
 
 
 def _remote_fetch_payload_key(payload: dict[str, Any]) -> tuple[Any, ...]:
@@ -1670,7 +1685,12 @@ def _emit_execution_loop_error_burst_event_unchecked(
 ) -> None:
     try:
         top_endpoints = [
-            {"endpoint": str(name), "count": int(n)}
+            {
+                "endpoint": _bounded_execution_loop_error_field(
+                    name, _EXECUTION_LOOP_ERROR_ENDPOINT_RE, fallback="unknown"
+                ),
+                "count": max(0, int(n)),
+            }
             for name, n in endpoints.most_common(5)
         ]
     except Exception:
@@ -1680,12 +1700,21 @@ def _emit_execution_loop_error_burst_event_unchecked(
         "count": max(0, int(count)),
         "window_s": max(0, int(window_s)),
         "top_endpoints": top_endpoints,
-        "latest_error_type": str(latest.get("error_type") or "-"),
-        "latest_status": str(latest.get("status") or "-"),
-        "latest_code": str(latest.get("code") or "-"),
+        "latest_error_type": _bounded_execution_loop_error_field(
+            latest.get("error_type"), _EXCHANGE_CONFIG_EVENT_ERROR_TYPE_RE
+        ),
+        "latest_status": _bounded_execution_loop_error_field(
+            latest.get("status"), _EXECUTION_LOOP_ERROR_STATUS_RE
+        ),
+        "latest_code": _bounded_execution_loop_error_field(
+            latest.get("code"), _EXECUTION_LOOP_ERROR_CODE_RE
+        ),
+        "latest_endpoint": _bounded_execution_loop_error_field(
+            latest.get("endpoint"),
+            _EXECUTION_LOOP_ERROR_ENDPOINT_RE,
+            fallback="unknown",
+        ),
     }
-    if latest.get("error") is not None:
-        data["latest_error"] = _sanitize_remote_text(latest.get("error"), max_len=500)
     _safe_emit(
         bot,
         EventTypes.HEALTH_SUMMARY,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -5332,17 +5332,26 @@ class Passivbot:
             return True
         self._health_errors += 1
         fields = self._execution_loop_error_fields(exc)
+        incident_action = "record_error_restart_backoff"
+        incident_cycle = "abandoned"
         self._monitor_record_event(
             "error.bot",
             ("error", "bot"),
-            {"source": "run_execution_loop", **fields},
+            {
+                "source": "run_execution_loop",
+                **fields,
+                "action": incident_action,
+                "cycle": incident_cycle,
+            },
         )
         logging.error(
-            "[error] operation=run_execution_loop error_type=%s status=%s code=%s endpoint=%s action=record_error_restart_backoff cycle=abandoned",
+            "[error] operation=run_execution_loop error_type=%s status=%s code=%s endpoint=%s action=%s cycle=%s",
             fields["error_type"],
             fields["status"],
             fields["code"],
             fields["endpoint"],
+            incident_action,
+            incident_cycle,
         )
         self._log_execution_loop_error_burst(fields)
         if logging.getLogger().isEnabledFor(logging.DEBUG):

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -5161,46 +5161,90 @@ class Passivbot:
                     return True
         return False
 
+    @staticmethod
+    def _execution_loop_error_field(
+        value: Any, pattern: re.Pattern[str], *, fallback: str = "-"
+    ) -> str:
+        """Return a bounded token for operator and monitor error projections."""
+        if value is None:
+            return fallback
+        try:
+            text = str(value).strip()
+        except Exception:
+            return fallback
+        return text if pattern.fullmatch(text) else fallback
+
     def _execution_loop_error_fields(self, exc: BaseException) -> dict[str, str]:
-        """Return compact fields for execution-loop error logs."""
+        """Return bounded classifications for execution-loop incident projections."""
         fields: dict[str, str] = {
-            "error_type": type(exc).__name__,
+            "error_type": self._execution_loop_error_field(
+                type(exc).__name__, re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
+            ),
             "status": "-",
             "code": "-",
-            "error": str(exc),
+            "endpoint": self._execution_loop_error_endpoint(exc),
         }
         for attr in ("http_status", "status", "status_code"):
-            value = getattr(exc, attr, None)
-            if value not in (None, ""):
-                fields["status"] = str(value)
+            try:
+                value = getattr(exc, attr, None)
+            except Exception:
+                continue
+            status = self._execution_loop_error_field(
+                value, re.compile(r"[0-9]{1,3}")
+            )
+            if status != "-":
+                fields["status"] = status
                 break
         for attr in ("code", "exact", "error_code"):
-            value = getattr(exc, attr, None)
-            if value not in (None, ""):
-                fields["code"] = str(value)
+            try:
+                value = getattr(exc, attr, None)
+            except Exception:
+                continue
+            code = self._execution_loop_error_field(
+                value, re.compile(r"-?[A-Za-z0-9][A-Za-z0-9_-]{0,47}")
+            )
+            if code != "-":
+                fields["code"] = code
                 break
-        info = getattr(exc, "info", None)
+        try:
+            info = getattr(exc, "info", None)
+        except Exception:
+            info = None
         if isinstance(info, dict):
             for key in ("code", "retCode", "errorCode"):
                 value = info.get(key)
-                if value not in (None, ""):
-                    fields["code"] = str(value)
+                code = self._execution_loop_error_field(
+                    value, re.compile(r"-?[A-Za-z0-9][A-Za-z0-9_-]{0,47}")
+                )
+                if code != "-":
+                    fields["code"] = code
                     break
             for key in ("status", "statusCode"):
                 value = info.get(key)
-                if value not in (None, ""):
-                    fields["status"] = str(value)
+                status = self._execution_loop_error_field(
+                    value, re.compile(r"[0-9]{1,3}")
+                )
+                if status != "-":
+                    fields["status"] = status
                     break
         return fields
 
-    def _execution_loop_error_endpoint(self, error: str) -> str:
-        """Extract a compact endpoint label from an exchange error string."""
-        match = re.search(r"https?://[^\s]+", str(error or ""))
+    def _execution_loop_error_endpoint(self, exc: BaseException) -> str:
+        """Extract a bounded endpoint classification without retaining the URL."""
+        try:
+            error = str(exc)
+        except Exception:
+            return "unknown"
+        match = re.search(r"https?://[^\s\"'<>]+", error)
         if not match:
             return "unknown"
         url = match.group(0).split("?", 1)[0].rstrip("/")
         endpoint = url.rsplit("/", 1)[-1]
-        return endpoint or "unknown"
+        return self._execution_loop_error_field(
+            endpoint,
+            re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,47}"),
+            fallback="unknown",
+        )
 
     def _log_execution_loop_error_burst(self, fields: dict[str, str]) -> None:
         """Summarize repeated execution-loop failures without hiding individual errors."""
@@ -5223,7 +5267,11 @@ class Passivbot:
         if not isinstance(endpoints, Counter):
             endpoints = Counter()
             state["endpoints"] = endpoints
-        endpoint = self._execution_loop_error_endpoint(fields.get("error", ""))
+        endpoint = self._execution_loop_error_field(
+            fields.get("endpoint"),
+            re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,47}"),
+            fallback="unknown",
+        )
         endpoints[endpoint] += 1
         count = int(state["count"])
         last_log_ms = int(state.get("last_log_ms", 0) or 0)
@@ -5283,22 +5331,24 @@ class Passivbot:
             await asyncio.sleep(0.5)
             return True
         self._health_errors += 1
-        self._monitor_record_error(
-            "error.bot",
-            exc,
-            tags=("error", "bot"),
-            payload={"source": "run_execution_loop"},
-        )
         fields = self._execution_loop_error_fields(exc)
+        self._monitor_record_event(
+            "error.bot",
+            ("error", "bot"),
+            {"source": "run_execution_loop", **fields},
+        )
         logging.error(
-            "[error] run_execution_loop failed | error_type=%s status=%s code=%s action=record_error_restart_backoff cycle=abandoned error=%s",
+            "[error] operation=run_execution_loop error_type=%s status=%s code=%s endpoint=%s action=record_error_restart_backoff cycle=abandoned",
             fields["error_type"],
             fields["status"],
             fields["code"],
-            fields["error"],
+            fields["endpoint"],
         )
         self._log_execution_loop_error_burst(fields)
-        traceback.print_exception(type(exc), exc, exc.__traceback__)
+        if logging.getLogger().isEnabledFor(logging.DEBUG):
+            stack_frames = "".join(traceback.format_tb(exc.__traceback__))
+            if stack_frames:
+                logging.debug("[error] execution loop stack frames:\n%s", stack_frames)
         await self.restart_bot_on_too_many_errors()
         await asyncio.sleep(1.0)
         return True
@@ -16530,8 +16580,16 @@ class Passivbot:
             x for x in self.error_counts if x > now - 1000 * 60 * 60
         ] + [now]
         max_n_errors_per_hour = 10
+        action = (
+            "restart_at_limit"
+            if len(self.error_counts) >= max_n_errors_per_hour
+            else "continue"
+        )
         logging.info(
-            f"error count: {len(self.error_counts)} of {max_n_errors_per_hour} errors per hour"
+            "[health] error_budget count=%d limit=%d window=1h action=%s",
+            len(self.error_counts),
+            max_n_errors_per_hour,
+            action,
         )
         if len(self.error_counts) >= max_n_errors_per_hour:
             await self.restart_bot()

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -2066,7 +2066,7 @@ def test_console_format_summarizes_health_error_burst_without_raw_error():
             "latest_error_type": "RequestTimeout",
             "latest_status": "-",
             "latest_code": "-",
-            "latest_error": "kucoinfutures GET https://example.invalid/account?apiKey=SECRET",
+            "latest_endpoint": "account-overview",
         },
     )
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -9498,6 +9498,8 @@ async def test_run_execution_loop_records_nonshutdown_cancelled_error(
                 "status": "-",
                 "code": "-",
                 "endpoint": "unknown",
+                "action": "record_error_restart_backoff",
+                "cycle": "abandoned",
             }),
             {},
         )
@@ -9758,6 +9760,8 @@ async def test_run_execution_loop_error_log_includes_type_status_and_action(capl
                 "status": "500",
                 "code": "500000",
                 "endpoint": "account-overview",
+                "action": "record_error_restart_backoff",
+                "cycle": "abandoned",
             }),
             {},
         )

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -9459,6 +9459,10 @@ async def test_run_execution_loop_records_nonshutdown_cancelled_error(
     bot.error_counts = []
     bot._equity_hard_stop_enabled = lambda *args, **kwargs: False
     bot._set_log_silence_watchdog_context = lambda *args, **kwargs: None
+    monitor_events = []
+    bot._monitor_record_event = lambda *args, **kwargs: monitor_events.append(
+        (args, kwargs)
+    )
     bot._monitor_record_error = MagicMock()
     bot._maybe_log_health_summary = lambda: None
     bot._maybe_log_unstuck_status = lambda: None
@@ -9485,13 +9489,26 @@ async def test_run_execution_loop_records_nonshutdown_cancelled_error(
 
     assert result is None
     assert bot._health_errors == 1
-    bot._monitor_record_error.assert_called_once()
+    bot._monitor_record_error.assert_not_called()
+    assert monitor_events == [
+        (
+            ("error.bot", ("error", "bot"), {
+                "source": "run_execution_loop",
+                "error_type": "CancelledError",
+                "status": "-",
+                "code": "-",
+                "endpoint": "unknown",
+            }),
+            {},
+        )
+    ]
     bot.restart_bot_on_too_many_errors.assert_awaited_once()
     bot.execute_to_exchange.assert_not_awaited()
     messages = [record.message for record in caplog.records]
     assert any(
-        "[error] run_execution_loop failed" in message
+        "[error] operation=run_execution_loop" in message
         and "error_type=CancelledError" in message
+        and "endpoint=unknown" in message
         and "action=record_error_restart_backoff" in message
         for message in messages
     )
@@ -9693,6 +9710,10 @@ async def test_run_execution_loop_error_log_includes_type_status_and_action(capl
     bot._health_rate_limits = 0
     bot._equity_hard_stop_enabled = lambda *args, **kwargs: False
     bot._set_log_silence_watchdog_context = lambda *args, **kwargs: None
+    monitor_events = []
+    bot._monitor_record_event = lambda *args, **kwargs: monitor_events.append(
+        (args, kwargs)
+    )
     bot._monitor_record_error = MagicMock()
     bot._maybe_recover_exchange_time_sync = AsyncMock(return_value=False)
     bot.restart_bot_on_too_many_errors = AsyncMock()
@@ -9701,7 +9722,11 @@ async def test_run_execution_loop_error_log_includes_type_status_and_action(capl
     class FakeExchangeError(RuntimeError):
         pass
 
-    exc = FakeExchangeError("kucoinfutures GET https://example.invalid/account-overview")
+    raw_error = (
+        "kucoinfutures GET https://example.invalid/account-overview?api_key=SECRET "
+        "connector said raw-message"
+    )
+    exc = FakeExchangeError(raw_error)
     exc.http_status = 500
     exc.code = "500000"
 
@@ -9718,23 +9743,113 @@ async def test_run_execution_loop_error_log_includes_type_status_and_action(capl
     bot.refresh_authoritative_state = fake_refresh_authoritative_state
     bot.restart_bot_on_too_many_errors.side_effect = fake_restart
 
-    with caplog.at_level(logging.ERROR):
+    with caplog.at_level(logging.DEBUG):
         result = await bot.run_execution_loop()
 
     assert result is None
     assert bot._health_errors == 1
     bot.restart_bot_on_too_many_errors.assert_awaited_once()
+    bot._monitor_record_error.assert_not_called()
+    assert monitor_events == [
+        (
+            ("error.bot", ("error", "bot"), {
+                "source": "run_execution_loop",
+                "error_type": "FakeExchangeError",
+                "status": "500",
+                "code": "500000",
+                "endpoint": "account-overview",
+            }),
+            {},
+        )
+    ]
     messages = [record.message for record in caplog.records]
     assert not any("error with run_execution_loop" in message for message in messages)
     assert any(
-        "[error] run_execution_loop failed" in message
+        "[error] operation=run_execution_loop" in message
         and "error_type=FakeExchangeError" in message
         and "status=500" in message
         and "code=500000" in message
+        and "endpoint=account-overview" in message
         and "cycle=abandoned" in message
         and "action=record_error_restart_backoff" in message
         for message in messages
     )
+    assert all(raw_error not in message for message in messages)
+    assert all("SECRET" not in message for message in messages)
+    debug_stack_messages = [
+        record.message
+        for record in caplog.records
+        if record.levelno == logging.DEBUG and "stack frames" in record.message
+    ]
+    assert len(debug_stack_messages) == 1
+    assert raw_error not in debug_stack_messages[0]
+    assert "FakeExchangeError" not in debug_stack_messages[0]
+
+
+@pytest.mark.asyncio
+async def test_execution_loop_error_normal_info_is_bounded_and_skips_nondebug_frames(
+    caplog, monkeypatch
+):
+    bot = Passivbot.__new__(Passivbot)
+    bot.stop_signal_received = False
+    bot._health_errors = 0
+    bot.error_counts = []
+    bot._maybe_recover_exchange_time_sync = AsyncMock(return_value=False)
+    bot._monitor_record_event = MagicMock()
+    bot.restart_bot = AsyncMock()
+
+    async def fake_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    format_tb = MagicMock()
+    monkeypatch.setattr(passivbot_module.traceback, "format_tb", format_tb)
+    raw_error = "raw-message https://example.invalid/private?api_key=SECRET"
+
+    try:
+        raise RuntimeError(raw_error)
+    except RuntimeError as exc:
+        with caplog.at_level(logging.INFO):
+            assert await bot._handle_execution_loop_failure(
+                exc, allow_time_sync_recovery=False
+            ) is True
+
+    assert bot._health_errors == 1
+    assert len(bot.error_counts) == 1
+    bot.restart_bot.assert_not_awaited()
+    format_tb.assert_not_called()
+    normal_messages = [
+        record.message for record in caplog.records if record.levelno >= logging.INFO
+    ]
+    assert "[health] error_budget count=1 limit=10 window=1h action=continue" in normal_messages
+    assert all(raw_error not in message for message in normal_messages)
+    assert all("SECRET" not in message for message in normal_messages)
+
+
+def test_execution_loop_error_fields_are_bounded_and_classify_unknown_endpoint():
+    bot = Passivbot.__new__(Passivbot)
+
+    class FakeExchangeError(RuntimeError):
+        pass
+
+    exc = FakeExchangeError(
+        "GET https://example.invalid/" + "x" * 80 + "?api_key=SECRET"
+    )
+    exc.status = "500?api_key=SECRET"
+    exc.code = "500000?signature=SIG"
+    exc.info = {"status": "429", "retCode": "RATE_LIMIT"}
+
+    fields = bot._execution_loop_error_fields(exc)
+
+    assert fields == {
+        "error_type": "FakeExchangeError",
+        "status": "429",
+        "code": "RATE_LIMIT",
+        "endpoint": "unknown",
+    }
+    assert "SECRET" not in str(fields)
+    assert "SIG" not in str(fields)
+    assert "example.invalid" not in str(fields)
 
 
 def test_execution_loop_error_burst_summarizes_repeated_endpoints(caplog, monkeypatch):
@@ -9746,7 +9861,7 @@ def test_execution_loop_error_burst_summarizes_repeated_endpoints(caplog, monkey
         "error_type": "RequestTimeout",
         "status": "-",
         "code": "-",
-        "error": "kucoinfutures GET https://api-futures.kucoin.com/api/v1/account-overview?currency=USDT",
+        "endpoint": "account-overview",
     }
 
     with caplog.at_level(logging.WARNING):
@@ -9783,6 +9898,7 @@ def test_execution_loop_error_burst_structured_console_owns_warning(caplog, monk
         "error_type": "RequestTimeout",
         "status": "-",
         "code": "-",
+        "endpoint": "account-overview",
         "error": (
             "kucoinfutures GET https://api-futures.kucoin.com/api/v1/"
             "account-overview?api_key=SECRET&signature=SIG"
@@ -9820,9 +9936,13 @@ def test_execution_loop_error_burst_structured_console_owns_warning(caplog, monk
         {"endpoint": "account-overview", "count": 3}
     ]
     assert event.data["latest_error_type"] == "RequestTimeout"
-    assert "SECRET" not in event.data["latest_error"]
-    assert "SIG" not in event.data["latest_error"]
-    assert "[redacted]" in event.data["latest_error"]
+    assert event.data["latest_status"] == "-"
+    assert event.data["latest_code"] == "-"
+    assert event.data["latest_endpoint"] == "account-overview"
+    assert "latest_error" not in event.data
+    assert "SECRET" not in str(event.data)
+    assert "SIG" not in str(event.data)
+    assert "api-futures.kucoin.com" not in str(event.data)
     assert console_sink.events == [event]
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
@@ -9853,7 +9973,7 @@ def test_execution_loop_error_burst_uses_legacy_fallback_without_structured_cons
         "error_type": "RequestTimeout",
         "status": "-",
         "code": "-",
-        "error": "kucoinfutures GET https://api-futures.kucoin.com/api/v1/account-overview",
+        "endpoint": "account-overview",
     }
 
     with caplog.at_level(logging.WARNING):
@@ -9892,7 +10012,7 @@ def test_execution_loop_error_burst_uses_legacy_fallback_when_emitter_unavailabl
         "error_type": "RequestTimeout",
         "status": "-",
         "code": "-",
-        "error": "kucoinfutures GET https://api-futures.kucoin.com/api/v1/account-overview",
+        "endpoint": "account-overview",
     }
 
     with caplog.at_level(logging.WARNING):
@@ -9926,7 +10046,7 @@ def test_execution_loop_error_burst_keeps_structured_console_owner_when_queue_is
         "error_type": "RequestTimeout",
         "status": "-",
         "code": "-",
-        "error": "kucoinfutures GET https://api-futures.kucoin.com/api/v1/account-overview",
+        "endpoint": "account-overview",
     }
 
     with caplog.at_level(logging.WARNING):
@@ -9947,6 +10067,28 @@ def test_execution_loop_error_burst_keeps_structured_console_owner_when_queue_is
     pipeline._queue.get_nowait()
     pipeline._queue.task_done()
     assert pipeline.close(timeout=2.0) is True
+
+
+@pytest.mark.asyncio
+async def test_execution_loop_error_budget_keeps_count_and_restart_threshold(caplog, monkeypatch):
+    bot = Passivbot.__new__(Passivbot)
+    now = 1_000_000
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now)
+    bot.error_counts = [now - 60 * 60 * 1000] + [now - 1] * 8
+    bot.restart_bot = AsyncMock()
+
+    with caplog.at_level(logging.INFO):
+        await bot.restart_bot_on_too_many_errors()
+        with pytest.raises(Exception, match="too many errors"):
+            await bot.restart_bot_on_too_many_errors()
+
+    assert len(bot.error_counts) == 10
+    bot.restart_bot.assert_awaited_once()
+    messages = [record.message for record in caplog.records]
+    assert messages == [
+        "[health] error_budget count=9 limit=10 window=1h action=continue",
+        "[health] error_budget count=10 limit=10 window=1h action=restart_at_limit",
+    ]
 
 
 def test_staged_refresh_timing_summary_aggregates_routine_fast_refreshes(


### PR DESCRIPTION
## Scope

Category: observability producer.

This PR bounds execution-loop failure projection across the normal console, monitor `error.bot` records, and structured error-burst summaries.

- Classify failures with exception type, bounded status/code, and endpoint.
- Remove raw exception text and request URLs from this incident family.
- Keep stack frames only at DEBUG and omit the exception value.
- Tag and compact the existing hourly error-budget line.
- Record PR #1243 deployment evidence and the active logging-overhaul slice.

## Behavior boundary

No trading, exchange-call, retry, timestamp-recovery, error-counter, restart-threshold, backoff, Rust, backtest, or optimizer behavior changes. Generic startup/process error handling remains unchanged.

## Validation

- 467 tests passed:
  - `tests/test_passivbot_balance_split.py`
  - `tests/test_live_event_bus.py`
  - `tests/test_passivbot_monitor.py`
  - `tests/test_monitor_publisher.py`
- 200 tests passed:
  - `tests/test_live_smoke_report.py`
  - `tests/test_live_performance_report.py`
- `python -m py_compile src/passivbot.py src/live/event_emitters.py`
- AI docs checker: 0 errors; existing aggregate word-count warning only
- Exact base-to-head `git diff --check` and touched-hunk silent-handling audit passed

## Reviewer focus

Please verify the bounded field allowlists, preservation of restart/error-budget semantics, isolation from startup handling, and absence of raw exception/URL retention.

## VPS action

After merge, update the VPS5 checkout and gracefully restart only the five exact supervised bots. Validate with immediate and settled smoke windows and inspect naturally occurring failures only. Do not manufacture exchange, failure, state, or trading events.