### PR TITLE
Add bounded memory snapshot event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Material live memory snapshots now emit a bounded `resource.memory_snapshot`
+  event and one compact operator line instead of a 457-525 character cache and
+  task diagnostic. The complete bounded samples remain available in structured
+  and monitor sinks, detailed diagnostics remain at DEBUG, and collection,
+  cadence, admission, and trading behavior are unchanged.
+
 - Intermediate HSL coin-history replay progress now appears on the normal live
   console at most once every 30 seconds. The first progress update, completion,
   complete structured progress events, replay behavior, and safety readiness

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -130,6 +130,25 @@ success remains INFO until the connector can prove whether it changed state; fai
 existing operator-visible warning or error. The event route remains structured/monitor-only, and
 event emission failure must not change exchange configuration control flow or results.
 
+## Memory Snapshots
+
+`resource.memory_snapshot` records the existing material memory diagnostic when it first becomes
+available or when absolute process-RSS movement reaches the producer's 25 percent boundary. It does
+not add a collection pass, timer, threshold, cache traversal, task inspection, or trading control.
+Routine samples remain available only in the protected DEBUG text path.
+
+The bounded payload contains finite RSS bytes and percent delta; cache bytes, candle count, symbol
+count, and at most three symbol samples; timeframe-cache bytes, range count, and at most three
+symbol/timeframe samples; and task total, pending count, and at most four sanitized task-name/count
+entries. Samples use strict length and character allowlists and exclude URLs, query strings,
+exception text, paths, raw payloads, and secrets.
+
+The event is the sole normal console/text owner when the structured console is available. Its
+compact projection reports aggregate RSS, cache, timeframe-cache, and task counts and must satisfy
+the normal 240-character budget. The legacy compact INFO line is a fallback only when the event
+console or emitter is unavailable. Event or sink failure remains isolated and must not change the
+producer's prior-RSS state, cadence, collection, cache state, tasks, or trading behavior.
+
 ## Dynamic Registry Values
 
 - `authoritative_reason_code(surface)` produces `authoritative_<surface>`.

--- a/docs/ai/generated/live_event_registry.md
+++ b/docs/ai/generated/live_event_registry.md
@@ -80,6 +80,7 @@ The code-owned registries live in `src/live/event_bus.py`. Payload and emission 
 - `remote_call.started`
 - `remote_call.succeeded`
 - `remote_call.throttled`
+- `resource.memory_snapshot`
 - `risk.entry_cooldown_delta_anchored`
 - `risk.mode_changed`
 - `risk.realized_loss_gate_blocked`
@@ -123,6 +124,7 @@ The code-owned registries live in `src/live/event_bus.py`. Payload and emission 
 - `load`
 - `logging`
 - `market`
+- `memory`
 - `mode`
 - `order`
 - `planning`
@@ -198,6 +200,7 @@ The code-owned registries live in `src/live/event_bus.py`. Payload and emission 
 - `limit_order_create_market_distance`
 - `low_balance`
 - `market_snapshot_diagnostic_skipped`
+- `memory_snapshot`
 - `min_effective_cost_blocked`
 - `new_fill`
 - `new_fill_batch`

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -45,10 +45,11 @@ Estimated completion:
   naturally occurring failures; do not manufacture exchange, failure, state,
   or trading events.
 
-## Parallel Implementation Slice
+## Parallel Review Slice
 
 - Branch: `codex/memory-snapshot-event`, based independently on deployed
   `c6fba829031f64a9ecd59eadcaaecf36db40236c`.
+- PR: #1245, `Add bounded memory snapshot event`.
 - Slice: publish the existing material memory diagnostic as bounded
   `resource.memory_snapshot` data and project one compact operator line.
 - Triggering evidence: current post-PR #1243 VPS5 segments produced natural

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,41 +22,66 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/hsl-replay-console-cadence`.
-- PR: #1243, `Bound HSL replay console progress cadence`.
-- Base: `3072878525317d6d7e0811ef191e48cabedcf8fc`, canonical `master`
-  after PR #1242.
-- Slice: bound intermediate HSL coin-history replay progress on the normal
-  console to one update per 30 seconds while retaining complete structured
-  replay progress.
-- Triggering evidence: the authorized post-PR #1242 VPS5 restart produced 27
-  Binance, 26 GateIO, 14 KuCoin, and 16 OKX reconstruction-progress INFO
-  records. Several pair-completion records arrived seconds apart because the
-  producer's per-pair `force` path bypasses its normal cadence. Each replay
-  already had a distinct start and completion line, and the logging policy caps
-  blocking startup progress at one console update per 30 seconds.
-- Scope: separate durable-event cadence from console cadence, preserve the
-  first progress line and final completion, and prevent forced pair-boundary
-  events from forcing extra console records.
-- Behavior boundary: preserve every current `hsl.replay.progress` event and
-  payload, replay ordering, readiness and safety state, yields, calculations,
-  exchange behavior, Rust, backtest, and optimizer behavior.
+- Branch: `codex/execution-incident-projection`.
+- PR: #1244, `Bound execution-loop incident projection`.
+- Base: `c6fba829031f64a9ecd59eadcaaecf36db40236c`, canonical `master`
+  after PR #1243.
+- Slice: replace raw execution-loop exception output with a bounded incident
+  signature in normal console, monitor, and structured burst projections.
+- Triggering evidence: the authorized post-PR #1243 restart produced a natural
+  KuCoin execution-loop timeout whose normal tmux output included a full
+  request URL, an unconditional traceback, and an untagged error-budget line.
+- Scope: retain exception class, bounded status/code and endpoint, action,
+  cycle, and error-budget state; keep stack frames available only at DEBUG
+  without the exception value; remove raw exception text and URLs from this
+  incident family.
+- Behavior boundary: preserve exception propagation policy, error counters,
+  restart threshold and backoff, timestamp recovery, burst cadence, exchange
+  calls, order behavior, Rust, backtest, and optimizer behavior.
 - Publication state, exact head, mergeability, CI, and current-head reviewer
   verdicts: query live GitHub metadata; do not embed self-invalidating values.
 - Expected VPS action: after merge, one authorized exact five-bot restart may
-  activate the console cadence. Validate natural HSL startup replay counts,
-  completion visibility, structured progress retention, and normal operation.
-  Do not manufacture replay, exchange, failure, state, or trading events.
+  activate the bounded projection. Validate normal operation and inspect only
+  naturally occurring failures; do not manufacture exchange, failure, state,
+  or trading events.
+
+## Parallel Implementation Slice
+
+- Branch: `codex/memory-snapshot-event`, based independently on deployed
+  `c6fba829031f64a9ecd59eadcaaecf36db40236c`.
+- Slice: publish the existing material memory diagnostic as bounded
+  `resource.memory_snapshot` data and project one compact operator line.
+- Triggering evidence: current post-PR #1243 VPS5 segments produced natural
+  `[memory]` INFO records measuring 457-525 characters. They mixed RSS, cache
+  totals and samples, timeframe-cache ranges, and task names into one line,
+  exceeding the 240-character normal-console budget.
+- Scope: preserve the existing collection pass, initial-or-25-percent RSS
+  admission, and prior-RSS state; retain bounded detail in the event/monitor
+  payload and full developer detail at DEBUG; use a compact legacy fallback
+  only when the structured console is unavailable.
+- Behavior boundary: observability-only; no exchange calls, cache or task
+  mutation, timing change, Rust, order, risk, backtest, or optimizer behavior.
+- Merge/deploy order: this slice is semantically independent from PR #1244.
+  Each PR keeps its own exact-head review and CI gate. Merge-order-only docs
+  conflicts require direct no-production-delta adjudication.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 checkout:
-  `3072878525317d6d7e0811ef191e48cabedcf8fc`, PR #1242; tracked status clean
+  `c6fba829031f64a9ecd59eadcaaecf36db40236c`, PR #1243; tracked status clean
   and expected untracked artifacts preserved.
 - VPS5 runs the same head in bot PIDs
-  `947807/947809/947811/947813/947815`. The exact pane PIDs remain
+  `948822/948824/948826/948828/948830`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1243 was activated with one exact five-bot graceful restart. Every old
+  bot exited naturally after one SIGINT round; KuCoin was last at 35 seconds,
+  and no escalation was required. Natural Binance, GateIO, and KuCoin replay
+  progress lines were all at least 30 seconds apart while complete structured
+  progress remained durable. The final two-minute smoke was `ok=true` with
+  `204/204` remote calls and `55/55` account-critical calls successful, eight
+  successful fill refreshes, five matching processes/configs, and zero hard,
+  log, monitor, process, or event-pipeline failures.
 - PR #1242 was activated with one exact five-bot graceful restart. Every old
   bot exited naturally after one SIGINT round; KuCoin was last at 40 seconds,
   and no escalation was required. One real KuCoin authoritative-state timeout
@@ -664,8 +689,11 @@ merged, deployed, and naturally validated: successful timing detail is absent
 from normal INFO while structured refresh summaries remain available. PR
 #1242's bounded OKX configuration outcomes are merged and deployed with a
 hard-green settled smoke. No natural config outcome occurred in the bounded
-window. The active slice above instead addresses the naturally observed HSL
-replay progress burst while preserving its durable event history.
+window. PR #1243's HSL replay console cadence is merged, deployed, and
+naturally validated: intermediate console progress stayed at least 30 seconds
+apart while complete structured progress remained durable. The active review
+slice addresses the naturally observed raw execution-loop incident projection;
+the independent implementation slice addresses over-budget memory snapshots.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -8381,3 +8381,24 @@ VPS5 deployment status:
   completion records. The active `codex/hsl-replay-console-cadence` slice keeps
   all structured progress events but caps intermediate console progress at one
   update per 30 seconds.
+
+### 2026-07-15: HSL Cadence Deployed And Execution Incident Follow-Up
+
+- PR #1243 merged to canonical `master` at `c6fba82903` after exact-head
+  Hermes and Grok approval plus green Python and Rust CI. VPS5 fast-forwarded
+  cleanly, and all five exact bots exited naturally after one SIGINT round;
+  KuCoin was last at 35 seconds. Pane PIDs and unrelated `misc:0.0` PID
+  `434835` remained unchanged.
+- Natural Binance, GateIO, and KuCoin replay progress lines were all at least
+  30 seconds apart. A five-minute structured window retained 102 replay
+  progress events while the console projected only 15 intermediate lines,
+  proving durable detail was preserved. The final two-minute smoke was
+  `ok=true` with `204/204` remote and `55/55` account-critical calls
+  successful, eight fill refreshes, five matching processes/configs, and no
+  hard, log, monitor, process, or event-pipeline failures.
+- Two real KuCoin startup timeouts recovered without intervention. The normal
+  tmux console exposed a full request URL, an unconditional traceback, and an
+  untagged error-budget line. The active
+  `codex/execution-incident-projection` slice replaces that family with a
+  bounded signature while preserving counters, restart/backoff, timestamp
+  recovery, exchange calls, and trading behavior.

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -151,6 +151,7 @@ class EventTypes:
     BOT_SHUTDOWN_STAGE = "bot.shutdown.stage"
     BOT_STOPPED = "bot.stopped"
     HEALTH_SUMMARY = "health.summary"
+    RESOURCE_MEMORY_SNAPSHOT = "resource.memory_snapshot"
     MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED = "market.snapshot_diagnostic_skipped"
     CYCLE_STARTED = "cycle.started"
     CYCLE_COMPLETED = "cycle.completed"
@@ -265,6 +266,7 @@ class EventTags:
     LOAD = "load"
     LOGGING = "logging"
     MARKET = "market"
+    MEMORY = "memory"
     MODE = "mode"
     ORDER = "order"
     PLANNING = "planning"
@@ -317,6 +319,7 @@ class ReasonCodes:
     LOW_BALANCE = "low_balance"
     MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED = "market_snapshot_diagnostic_skipped"
     MIN_EFFECTIVE_COST_BLOCKED = "min_effective_cost_blocked"
+    MEMORY_SNAPSHOT = "memory_snapshot"
     NEW_FILL = "new_fill"
     NEW_FILL_BATCH = "new_fill_batch"
     OPEN_TAIL_PROJECTION = "open_tail_projection"
@@ -479,6 +482,7 @@ PHASE1_EVENT_TYPES = {
     EventTypes.BOT_SHUTDOWN_STAGE,
     EventTypes.BOT_STOPPED,
     EventTypes.HEALTH_SUMMARY,
+    EventTypes.RESOURCE_MEMORY_SNAPSHOT,
     EventTypes.CYCLE_STARTED,
     EventTypes.CYCLE_COMPLETED,
     EventTypes.CYCLE_DEGRADED,
@@ -781,6 +785,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.BOT_SHUTDOWN_STAGE: EventRoute(console=True, text=True),
     EventTypes.BOT_STOPPED: EventRoute(console=True, text=True),
     EventTypes.HEALTH_SUMMARY: EventRoute(console=True, text=True),
+    EventTypes.RESOURCE_MEMORY_SNAPSHOT: EventRoute(console=True, text=True),
     EventTypes.MARKET_SNAPSHOT_DIAGNOSTIC_SKIPPED: EventRoute(
         console=False, text=False
     ),
@@ -991,6 +996,7 @@ _CONSOLE_EVENT_TAGS = {
     EventTypes.FILLS_INGESTED_SUMMARY: "fill",
     EventTypes.POSITION_CHANGED: "pos",
     EventTypes.BALANCE_CHANGED: "balance",
+    EventTypes.RESOURCE_MEMORY_SNAPSHOT: "memory",
     EventTypes.RISK_MODE_CHANGED: "risk",
     EventTypes.HSL_TRANSITION: "risk",
     EventTypes.HSL_STATUS: "risk",
@@ -1469,6 +1475,47 @@ def _format_console_balance_changed(event: LiveEvent) -> str:
         f"{'snap':<5}{snapped_transition} | "
         f"equity={equity} source={source}"
     )
+
+
+def format_memory_snapshot_console(data: Mapping[str, Any]) -> str:
+    """Project a bounded memory snapshot without retaining diagnostic samples."""
+    rss_bytes = _data_int(data, "rss_bytes")
+    delta_pct = _data_number(data, "rss_delta_pct")
+    cache = data.get("cache") if isinstance(data.get("cache"), Mapping) else {}
+    timeframe_cache = (
+        data.get("timeframe_cache")
+        if isinstance(data.get("timeframe_cache"), Mapping)
+        else {}
+    )
+    tasks = data.get("tasks") if isinstance(data.get("tasks"), Mapping) else {}
+
+    parts = ["[memory]"]
+    if rss_bytes is not None:
+        parts.append(f"rss={rss_bytes / 1024.0 / 1024.0:.1f}MiB")
+    if delta_pct is not None and math.isfinite(delta_pct):
+        parts.append(f"delta={delta_pct:+.1f}%")
+    cache_bytes = _data_int(cache, "bytes")
+    cache_symbols = _data_int(cache, "symbols")
+    if cache_bytes is not None:
+        cache_part = f"cache={cache_bytes / 1024.0 / 1024.0:.1f}MiB"
+        if cache_symbols is not None:
+            cache_part += f"/{cache_symbols}sym"
+        parts.append(cache_part)
+    tf_bytes = _data_int(timeframe_cache, "bytes")
+    tf_ranges = _data_int(timeframe_cache, "ranges")
+    if tf_bytes is not None:
+        tf_part = f"tf={tf_bytes / 1024.0 / 1024.0:.1f}MiB"
+        if tf_ranges is not None:
+            tf_part += f"/{tf_ranges}rng"
+        parts.append(tf_part)
+    total_tasks = _data_int(tasks, "total")
+    pending_tasks = _data_int(tasks, "pending")
+    if total_tasks is not None:
+        task_part = f"tasks={total_tasks}"
+        if pending_tasks is not None:
+            task_part += f"/{pending_tasks}"
+        parts.append(task_part)
+    return " ".join(parts)[:240]
 
 
 def _console_risk_mode_changed_summary(event: LiveEvent) -> list[str]:
@@ -2055,6 +2102,8 @@ def format_console_event(event: LiveEvent) -> str:
         return _format_console_position_changed(event)
     if event.event_type == EventTypes.BALANCE_CHANGED:
         return _format_console_balance_changed(event)
+    if event.event_type == EventTypes.RESOURCE_MEMORY_SNAPSHOT:
+        return format_memory_snapshot_console(event.data)
     base = f"[{_console_tag(event)}]"
     if event.status:
         base += f" {event.status}"

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -54,6 +54,15 @@ _EXCHANGE_CONFIG_EVENT_RESPONSE_CODE_RE = re.compile(r"-?[0-9]{1,12}")
 _EXCHANGE_CONFIG_EVENT_ERROR_TYPE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
 _EXCHANGE_CONFIG_EVENT_OUTCOMES = {"confirmed", "unchanged", "failed"}
 _LIVE_EVENT_LEVELS = {"debug", "info", "warning", "error"}
+_MEMORY_SNAPSHOT_MAX_BYTES = (1 << 63) - 1
+_MEMORY_SNAPSHOT_MAX_COUNT = 1_000_000_000
+_MEMORY_SNAPSHOT_MAX_DELTA_PCT = 1_000_000.0
+_MEMORY_SNAPSHOT_SYMBOL_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:/-]{0,95}")
+_MEMORY_SNAPSHOT_TIMEFRAME_RE = re.compile(r"[1-9][0-9]{0,5}[smhdwM]")
+_MEMORY_SNAPSHOT_TASK_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_.-]{0,95}")
+_MEMORY_SNAPSHOT_SENSITIVE_TASK_RE = re.compile(
+    r"(?i)(?:api(?:_?key)?|secret|token|password|authorization|cookie)"
+)
 
 
 def _sanitize_remote_text(value: Any, *, max_len: int = 500) -> str:
@@ -1103,6 +1112,188 @@ def _safe_int(value: Any) -> int | None:
     try:
         return int(value)
     except (TypeError, ValueError):
+        return None
+
+
+def _bounded_memory_snapshot_int(value: Any, *, maximum: int) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number) or number < 0.0:
+        return None
+    return min(int(number), maximum)
+
+
+def _bounded_memory_snapshot_delta(value: Any) -> float | None:
+    number = _safe_finite_float(value)
+    if number is None:
+        return None
+    return round(
+        max(-_MEMORY_SNAPSHOT_MAX_DELTA_PCT, min(number, _MEMORY_SNAPSHOT_MAX_DELTA_PCT)),
+        6,
+    )
+
+
+def _bounded_memory_snapshot_label(
+    value: Any, pattern: re.Pattern[str], *, reject_sensitive: bool = False
+) -> str:
+    if not isinstance(value, str):
+        return "unknown"
+    if (
+        "://" in value
+        or "//" in value
+        or not pattern.fullmatch(value)
+        or (reject_sensitive and _MEMORY_SNAPSHOT_SENSITIVE_TASK_RE.search(value))
+    ):
+        return "unknown"
+    return value
+
+
+def _memory_snapshot_cache_samples(value: Any, *, timeframe: bool) -> list[dict[str, Any]]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    samples: list[dict[str, Any]] = []
+    for raw in value[:3]:
+        if not isinstance(raw, (list, tuple)):
+            continue
+        if timeframe and len(raw) == 3 and isinstance(raw[0], tuple) and len(raw[0]) == 2:
+            symbol_raw, timeframe_raw = raw[0]
+            bytes_raw, candles_raw = raw[1:]
+        elif timeframe and len(raw) == 4:
+            symbol_raw, timeframe_raw, bytes_raw, candles_raw = raw
+        elif not timeframe and len(raw) == 3:
+            symbol_raw, bytes_raw, candles_raw = raw
+            timeframe_raw = None
+        else:
+            continue
+        symbol = _bounded_memory_snapshot_label(symbol_raw, _MEMORY_SNAPSHOT_SYMBOL_RE)
+        sample: dict[str, Any] = {"symbol": symbol}
+        if timeframe:
+            sample["timeframe"] = _bounded_memory_snapshot_label(
+                timeframe_raw, _MEMORY_SNAPSHOT_TIMEFRAME_RE
+            )
+        bytes_ = _bounded_memory_snapshot_int(
+            bytes_raw, maximum=_MEMORY_SNAPSHOT_MAX_BYTES
+        )
+        candles = _bounded_memory_snapshot_int(
+            candles_raw, maximum=_MEMORY_SNAPSHOT_MAX_COUNT
+        )
+        if bytes_ is None or candles is None:
+            continue
+        sample["bytes"] = bytes_
+        sample["candles"] = candles
+        samples.append(sample)
+    return samples
+
+
+def _memory_snapshot_task_samples(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    samples: list[dict[str, Any]] = []
+    for raw in value[:4]:
+        if not isinstance(raw, (list, tuple)) or len(raw) != 2:
+            continue
+        count = _bounded_memory_snapshot_int(
+            raw[1], maximum=_MEMORY_SNAPSHOT_MAX_COUNT
+        )
+        if count is None:
+            continue
+        samples.append(
+            {
+                "name": _bounded_memory_snapshot_label(
+                    raw[0], _MEMORY_SNAPSHOT_TASK_NAME_RE, reject_sensitive=True
+                ),
+                "count": count,
+            }
+        )
+    return samples
+
+
+def emit_memory_snapshot_event(
+    bot: Any,
+    *,
+    rss_bytes: Any,
+    rss_delta_pct: Any = None,
+    cache_bytes: Any = None,
+    cache_candles: Any = None,
+    cache_symbols: Any = None,
+    cache_samples: Any = None,
+    timeframe_cache_bytes: Any = None,
+    timeframe_cache_ranges: Any = None,
+    timeframe_cache_samples: Any = None,
+    task_total: Any = None,
+    task_pending: Any = None,
+    task_samples: Any = None,
+) -> Any:
+    """Emit a bounded, observability-only memory snapshot event."""
+    try:
+        emit = getattr(bot, "_emit_live_event", None)
+        if not callable(emit):
+            return None
+        data: dict[str, Any] = {}
+        bounded_rss = _bounded_memory_snapshot_int(
+            rss_bytes, maximum=_MEMORY_SNAPSHOT_MAX_BYTES
+        )
+        if bounded_rss is None:
+            return None
+        data["rss_bytes"] = bounded_rss
+        delta = _bounded_memory_snapshot_delta(rss_delta_pct)
+        if delta is not None:
+            data["rss_delta_pct"] = delta
+        cache: dict[str, Any] = {}
+        for key, raw_value, maximum in (
+            ("bytes", cache_bytes, _MEMORY_SNAPSHOT_MAX_BYTES),
+            ("candles", cache_candles, _MEMORY_SNAPSHOT_MAX_COUNT),
+            ("symbols", cache_symbols, _MEMORY_SNAPSHOT_MAX_COUNT),
+        ):
+            bounded = _bounded_memory_snapshot_int(raw_value, maximum=maximum)
+            if bounded is not None:
+                cache[key] = bounded
+        samples = _memory_snapshot_cache_samples(cache_samples, timeframe=False)
+        if samples:
+            cache["samples"] = samples
+        if cache:
+            data["cache"] = cache
+        timeframe_cache: dict[str, Any] = {}
+        for key, raw_value, maximum in (
+            ("bytes", timeframe_cache_bytes, _MEMORY_SNAPSHOT_MAX_BYTES),
+            ("ranges", timeframe_cache_ranges, _MEMORY_SNAPSHOT_MAX_COUNT),
+        ):
+            bounded = _bounded_memory_snapshot_int(raw_value, maximum=maximum)
+            if bounded is not None:
+                timeframe_cache[key] = bounded
+        samples = _memory_snapshot_cache_samples(timeframe_cache_samples, timeframe=True)
+        if samples:
+            timeframe_cache["samples"] = samples
+        if timeframe_cache:
+            data["timeframe_cache"] = timeframe_cache
+        tasks: dict[str, Any] = {}
+        for key, raw_value in (("total", task_total), ("pending", task_pending)):
+            bounded = _bounded_memory_snapshot_int(
+                raw_value, maximum=_MEMORY_SNAPSHOT_MAX_COUNT
+            )
+            if bounded is not None:
+                tasks[key] = bounded
+        samples = _memory_snapshot_task_samples(task_samples)
+        if samples:
+            tasks["samples"] = samples
+        if tasks:
+            data["tasks"] = tasks
+        return emit(
+            EventTypes.RESOURCE_MEMORY_SNAPSHOT,
+            level="info",
+            component="resource.memory",
+            tags=(EventTags.RESOURCE, EventTags.MEMORY),
+            cycle_id=current_live_event_cycle_id(bot),
+            status="succeeded",
+            reason_code=ReasonCodes.MEMORY_SNAPSHOT,
+            data=data,
+        )
+    except Exception as exc:
+        logging.debug("[event] failed to emit memory snapshot event: %s", exc)
         return None
 
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -61,6 +61,7 @@ from live.events import DiagnosticEvent, emit_diagnostic_event, run_diagnostic_s
 from live.event_bus import (
     ConsoleSummarySink,
     EventTypes,
+    format_memory_snapshot_console,
     format_periodic_health_summary,
     LIVE_EVENT_CONSOLE_ENV,
     LIVE_EVENT_DEBUG_PROFILE_ENV,
@@ -646,6 +647,7 @@ class Passivbot:
         live_event_emitters.emit_rust_orchestrator_returned_event
     )
     _emit_balance_changed_event = live_event_emitters.emit_balance_changed_event
+    _emit_memory_snapshot_event = live_event_emitters.emit_memory_snapshot_event
     _emit_fills_refresh_summary_event = (
         live_event_emitters.emit_fills_refresh_summary_event
     )
@@ -3460,9 +3462,14 @@ class Passivbot:
         cache_candles = None
         cache_symbols = None
         cache_top = None
+        cache_top_samples = None
         tf_cache_bytes = None
         tf_cache_ranges = None
         tf_cache_top = None
+        tf_cache_top_samples = None
+        total_tasks = None
+        pending = None
+        task_top_samples = None
         try:
             cache = getattr(self.cm, "_cache", {}) if hasattr(self, "cm") else {}
             cache_symbols = len(cache)
@@ -3477,6 +3484,7 @@ class Passivbot:
             cache_candles = sum(rows for _, _, rows in stats)
             if stats:
                 top = sorted(stats, key=lambda item: item[1], reverse=True)[:3]
+                cache_top_samples = top
                 cache_top = ", ".join(
                     f"{Passivbot._log_symbol(sym)}:{bytes_ / (1024 * 1024):.1f}MiB/{rows}"
                     for sym, bytes_, rows in top
@@ -3505,6 +3513,7 @@ class Passivbot:
                 tf_cache_bytes = sum(size for _, size, _ in tf_stats)
                 tf_cache_ranges = len(tf_stats)
                 top_tf = sorted(tf_stats, key=lambda item: item[1], reverse=True)[:3]
+                tf_cache_top_samples = top_tf
                 tf_cache_top = ", ".join(
                     f"{Passivbot._log_symbol(sym)}:{tf}:{bytes_ / (1024 * 1024):.1f}MiB/{rows}"
                     for (sym, tf), bytes_, rows in top_tf
@@ -3519,7 +3528,7 @@ class Passivbot:
                 pct_change = 100.0 * (rss - prev_rss) / prev_rss
         parts = [f"[memory] rss={rss / (1024 * 1024):.2f} MiB"]
         if pct_change is not None:
-            parts.append(f"Δ={pct_change:+.2f}% vs previous snapshot")
+            parts.append(f"delta={pct_change:+.2f}% vs previous snapshot")
         if cache_bytes is not None:
             cache_mib = cache_bytes / (1024 * 1024)
             cache_desc = f"cm_cache={cache_mib:.2f} MiB"
@@ -3558,23 +3567,68 @@ class Passivbot:
                 if not name:
                     name = type(t).__name__
                 task_counts[name] = task_counts.get(name, 0) + 1
+            task_top_samples = sorted(
+                task_counts.items(), key=lambda kv: kv[1], reverse=True
+            )[:4]
             top_tasks = ", ".join(
-                f"{name}:{count}"
-                for name, count in sorted(
-                    task_counts.items(), key=lambda kv: kv[1], reverse=True
-                )[:4]
+                f"{name}:{count}" for name, count in task_top_samples
             )
             parts.append(f"tasks={total_tasks} pending={pending}")
             if top_tasks:
                 parts.append(f"task_top={top_tasks}")
         except Exception:
             pass
-        log_level = (
-            logging.INFO
-            if self._memory_snapshot_is_interesting(prev=prev, pct_change=pct_change)
-            else logging.DEBUG
+        detail_message = "; ".join(parts)
+        interesting = self._memory_snapshot_is_interesting(
+            prev=prev, pct_change=pct_change
         )
-        logging.log(log_level, "%s", "; ".join(parts))
+        if interesting:
+            emit_memory_snapshot = getattr(self, "_emit_memory_snapshot_event", None)
+            pipeline = getattr(self, "_live_event_pipeline", None)
+            structured_console_available = bool(
+                callable(emit_memory_snapshot)
+                and Passivbot._live_event_console_available(self)
+                and getattr(pipeline, "console_sink", None) is not None
+            )
+            if callable(emit_memory_snapshot):
+                try:
+                    emit_memory_snapshot(
+                        rss_bytes=rss,
+                        rss_delta_pct=pct_change,
+                        cache_bytes=cache_bytes,
+                        cache_candles=cache_candles,
+                        cache_symbols=cache_symbols,
+                        cache_samples=cache_top_samples,
+                        timeframe_cache_bytes=tf_cache_bytes,
+                        timeframe_cache_ranges=tf_cache_ranges,
+                        timeframe_cache_samples=tf_cache_top_samples,
+                        task_total=total_tasks,
+                        task_pending=pending,
+                        task_samples=task_top_samples,
+                    )
+                except Exception as exc:
+                    logging.debug("[event] failed to emit memory snapshot event: %s", exc)
+            if not structured_console_available:
+                logging.info(
+                    "%s",
+                    format_memory_snapshot_console(
+                        {
+                            "rss_bytes": rss,
+                            "rss_delta_pct": pct_change,
+                            "cache": {
+                                "bytes": cache_bytes,
+                                "candles": cache_candles,
+                                "symbols": cache_symbols,
+                            },
+                            "timeframe_cache": {
+                                "bytes": tf_cache_bytes,
+                                "ranges": tf_cache_ranges,
+                            },
+                            "tasks": {"total": total_tasks, "pending": pending},
+                        }
+                    ),
+                )
+        logging.debug("%s", detail_message)
         self._mem_log_prev = {"timestamp": now_ms, "rss": rss}
         if cache_bytes is not None:
             self._mem_log_prev["cm_cache_bytes"] = cache_bytes

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -8,6 +8,7 @@ import time
 import pytest
 
 import live.event_bus as live_event_bus_module
+import live.event_emitters as live_event_emitters
 from live.event_bus import (
     DEFAULT_ROUTES,
     EventRoute,
@@ -23,6 +24,7 @@ from live.event_bus import (
     ReasonCodes,
     authoritative_reason_code,
     format_console_event,
+    format_memory_snapshot_console,
     live_event_debug_profile_enabled,
     normalize_live_event_console_enabled,
     normalize_live_event_debug_profiles,
@@ -82,6 +84,10 @@ def test_live_event_tag_registry_values_are_unique_and_query_safe():
 
 def test_market_compatibility_event_type_is_stable():
     assert EventTypes.CONFIG_MARKET_COMPATIBILITY == "config.market_compatibility"
+
+
+def test_memory_snapshot_event_type_is_stable():
+    assert EventTypes.RESOURCE_MEMORY_SNAPSHOT == "resource.memory_snapshot"
 
 
 def test_startup_phase_readiness_contract_is_bounded_and_defensive():
@@ -372,6 +378,10 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.BOT_SHUTDOWN_STAGE].text is True
     assert DEFAULT_ROUTES[EventTypes.HEALTH_SUMMARY].console is True
     assert DEFAULT_ROUTES[EventTypes.HEALTH_SUMMARY].text is True
+    assert DEFAULT_ROUTES[EventTypes.RESOURCE_MEMORY_SNAPSHOT].structured is True
+    assert DEFAULT_ROUTES[EventTypes.RESOURCE_MEMORY_SNAPSHOT].monitor is True
+    assert DEFAULT_ROUTES[EventTypes.RESOURCE_MEMORY_SNAPSHOT].console is True
+    assert DEFAULT_ROUTES[EventTypes.RESOURCE_MEMORY_SNAPSHOT].text is True
     assert DEFAULT_ROUTES[EventTypes.HSL_STATUS].console is True
     assert DEFAULT_ROUTES[EventTypes.HSL_STATUS].text is True
     assert DEFAULT_ROUTES[EventTypes.TRAILING_STATUS].console is True
@@ -1455,6 +1465,102 @@ def test_console_format_is_compact_and_operator_facing():
         "pside=long reason=stale_ema entries deferred"
     )
     assert format_console_event(event) == expected
+
+
+def test_memory_snapshot_event_payload_is_bounded_and_monitor_safe():
+    class Bot:
+        def __init__(self):
+            self.calls = []
+
+        def _emit_live_event(self, event_type, **kwargs):
+            self.calls.append((event_type, kwargs))
+            return kwargs
+
+    bot = Bot()
+    live_event_emitters.emit_memory_snapshot_event(
+        bot,
+        rss_bytes=198 * 1024 * 1024,
+        rss_delta_pct=91.0,
+        cache_bytes=5 * 1024 * 1024,
+        cache_candles=100,
+        cache_symbols=39,
+        cache_samples=[
+            ("BTC/USDT:USDT", 2**70, 10),
+            ("https://example.invalid/secret", 3, 4),
+            ("X" * 128, 5, 6),
+            ("ignored", 7, 8),
+        ],
+        timeframe_cache_bytes=4 * 1024 * 1024,
+        timeframe_cache_ranges=115,
+        timeframe_cache_samples=[
+            ("ETH/USDT:USDT", "1m", 9, 10),
+            ("SOL/USDT:USDT", "https://bad", 11, 12),
+            ("X" * 128, "1h", 13, 14),
+            ("ignored", "1m", 15, 16),
+        ],
+        task_total=5,
+        task_pending=5,
+        task_samples=[
+            ("run_forever", 1),
+            ("secret_worker", 2),
+            ("X" * 128, 3),
+            ("Worker-1", 4),
+            ("ignored", 5),
+        ],
+    )
+
+    assert len(bot.calls) == 1
+    event_type, kwargs = bot.calls[0]
+    assert event_type == EventTypes.RESOURCE_MEMORY_SNAPSHOT
+    assert kwargs["level"] == "info"
+    assert kwargs["reason_code"] == ReasonCodes.MEMORY_SNAPSHOT
+    assert kwargs["tags"] == (
+        EventTags.RESOURCE,
+        EventTags.MEMORY,
+    )
+    data = kwargs["data"]
+    assert data["rss_bytes"] == 198 * 1024 * 1024
+    assert data["rss_delta_pct"] == 91.0
+    assert data["cache"]["bytes"] == 5 * 1024 * 1024
+    assert len(data["cache"]["samples"]) == 3
+    assert data["cache"]["samples"][0]["bytes"] == (1 << 63) - 1
+    assert data["cache"]["samples"][1]["symbol"] == "unknown"
+    assert data["cache"]["samples"][2]["symbol"] == "unknown"
+    assert len(data["timeframe_cache"]["samples"]) == 3
+    assert data["timeframe_cache"]["samples"][1]["timeframe"] == "unknown"
+    assert len(data["tasks"]["samples"]) == 4
+    assert data["tasks"]["samples"][1]["name"] == "unknown"
+    assert data["tasks"]["samples"][2]["name"] == "unknown"
+    monitor_payload = LiveEvent(event_type, data=data).to_monitor_event()[2]
+    serialized = json.dumps(monitor_payload, sort_keys=True)
+    assert "https://" not in serialized
+    assert "secret" not in serialized
+    assert "X" * 128 not in serialized
+
+
+def test_memory_snapshot_console_formatter_is_compact_and_omits_samples():
+    data = {
+        "rss_bytes": 198 * 1024 * 1024,
+        "rss_delta_pct": 91.0,
+        "cache": {
+            "bytes": 5 * 1024 * 1024,
+            "symbols": 39,
+            "samples": [{"symbol": "private-task-name", "bytes": 1, "candles": 1}],
+        },
+        "timeframe_cache": {"bytes": 4 * 1024 * 1024, "ranges": 115},
+        "tasks": {"total": 5, "pending": 5, "samples": [{"name": "private"}]},
+    }
+    message = format_memory_snapshot_console(data)
+
+    assert message == (
+        "[memory] rss=198.0MiB delta=+91.0% cache=5.0MiB/39sym "
+        "tf=4.0MiB/115rng tasks=5/5"
+    )
+    assert len(message) <= 240
+    assert "private" not in message
+    assert format_console_event(
+        LiveEvent(EventTypes.RESOURCE_MEMORY_SNAPSHOT, data=data)
+    ) == message
 
 
 def test_console_format_summarizes_order_wave_payload():

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -3897,7 +3897,137 @@ def test_memory_snapshot_is_interesting_only_initially_or_on_large_change():
         bot._memory_snapshot_is_interesting(prev={"rss": 100}, pct_change=10.0) is False
     )
     assert (
+        bot._memory_snapshot_is_interesting(prev={"rss": 100}, pct_change=24.999)
+        is False
+    )
+    assert (
+        bot._memory_snapshot_is_interesting(prev={"rss": 100}, pct_change=25.0)
+        is True
+    )
+    assert (
+        bot._memory_snapshot_is_interesting(prev={"rss": 100}, pct_change=-25.0)
+        is True
+    )
+    assert (
         bot._memory_snapshot_is_interesting(prev={"rss": 100}, pct_change=30.0) is True
+    )
+
+
+def _memory_snapshot_bot():
+    bot = Passivbot.__new__(Passivbot)
+    bot.cm = SimpleNamespace(
+        _cache={
+            "BTC/USDT:USDT": np.zeros((3, 6), dtype=np.float64),
+            "ETH/USDT:USDT": np.zeros((2, 6), dtype=np.float64),
+        },
+        _tf_range_cache={
+            "BTC/USDT:USDT": {("1m", 1): (np.zeros((4, 6), dtype=np.float64),)},
+        },
+    )
+    bot._mem_log_prev = None
+    bot.live_event_console_enabled = False
+    bot._live_event_pipeline = None
+    return bot
+
+
+def test_memory_snapshot_event_falls_back_to_compact_info_and_keeps_debug_detail(
+    monkeypatch, caplog
+):
+    bot = _memory_snapshot_bot()
+    emitted = []
+    bot._emit_memory_snapshot_event = lambda **kwargs: emitted.append(kwargs)
+    monkeypatch.setattr(
+        passivbot_module, "_get_process_rss_bytes", lambda: 198 * 1024 * 1024
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        bot._log_memory_snapshot(now_ms=1_000)
+
+    assert len(emitted) == 1
+    assert emitted[0]["rss_bytes"] == 198 * 1024 * 1024
+    assert len(emitted[0]["cache_samples"]) == 2
+    assert len(emitted[0]["timeframe_cache_samples"]) == 1
+    info_messages = [
+        record.message
+        for record in caplog.records
+        if record.levelno == logging.INFO and record.message.startswith("[memory]")
+    ]
+    assert info_messages == [
+        "[memory] rss=198.0MiB cache=0.0MiB/2sym tf=0.0MiB/1rng"
+    ]
+    assert all(len(message) <= 240 for message in info_messages)
+    assert any("cm_top=BTC" in record.message for record in caplog.records)
+    assert bot._mem_log_prev == {
+        "timestamp": 1_000,
+        "rss": 198 * 1024 * 1024,
+        "cm_cache_bytes": 240,
+    }
+
+
+def test_memory_snapshot_structured_console_owns_info_and_routine_stays_debug(
+    monkeypatch, caplog
+):
+    bot = _memory_snapshot_bot()
+    emitted = []
+    bot._emit_memory_snapshot_event = lambda **kwargs: emitted.append(kwargs)
+    bot.live_event_console_enabled = True
+    bot._live_event_pipeline = SimpleNamespace(console_sink=object())
+    monkeypatch.setattr(
+        passivbot_module, "_get_process_rss_bytes", lambda: 198 * 1024 * 1024
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        bot._log_memory_snapshot(now_ms=1_000)
+
+    assert len(emitted) == 1
+    assert not any(
+        record.levelno == logging.INFO and record.message.startswith("[memory]")
+        for record in caplog.records
+    )
+    assert any(
+        record.levelno == logging.DEBUG and record.message.startswith("[memory]")
+        for record in caplog.records
+    )
+
+    caplog.clear()
+    bot._mem_log_prev = {"timestamp": 1_000, "rss": 200 * 1024 * 1024}
+    monkeypatch.setattr(
+        passivbot_module, "_get_process_rss_bytes", lambda: 220 * 1024 * 1024
+    )
+    with caplog.at_level(logging.DEBUG):
+        bot._log_memory_snapshot(now_ms=2_000)
+
+    assert len(emitted) == 1
+    assert not any(
+        record.levelno == logging.INFO and record.message.startswith("[memory]")
+        for record in caplog.records
+    )
+    assert any(
+        record.levelno == logging.DEBUG and record.message.startswith("[memory]")
+        for record in caplog.records
+    )
+
+
+def test_memory_snapshot_event_failure_isolated_from_snapshot_state(monkeypatch, caplog):
+    bot = _memory_snapshot_bot()
+
+    def fail_emit(**kwargs):
+        del kwargs
+        raise OSError("event sink unavailable")
+
+    bot._emit_memory_snapshot_event = fail_emit
+    monkeypatch.setattr(
+        passivbot_module, "_get_process_rss_bytes", lambda: 198 * 1024 * 1024
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        bot._log_memory_snapshot(now_ms=1_000)
+
+    assert bot._mem_log_prev["timestamp"] == 1_000
+    assert bot._mem_log_prev["rss"] == 198 * 1024 * 1024
+    assert any(
+        "failed to emit memory snapshot event" in record.message
+        for record in caplog.records
     )
 
 


### PR DESCRIPTION
## Scope

Category: observability producer.

Publishes the existing material process-memory diagnostic as a bounded
`resource.memory_snapshot` event and projects one compact operator line. The
event carries aggregate RSS/cache/task values plus bounded sanitized samples;
full developer detail remains at DEBUG.

The producer keeps its existing collection pass, 30-minute schedule,
initial-or-25%-RSS admission boundary, and `_mem_log_prev` update semantics.

## Non-goals

- no cache or task mutation
- no exchange requests
- no order, risk, strategy, Rust, backtest, or optimizer changes
- no new timer, collection traversal, or sampling threshold
- no dependency on open PR #1244; only current-status docs may need mechanical
  merge-order reconciliation

## Behavior impact

When the structured console is available, the event owns normal console/text
output. Otherwise one compact legacy INFO line remains as fallback. Routine
snapshots stay DEBUG-only. Event and sink failures remain observability-only.

## VPS action

After merge: pull and perform one authorized exact five-bot graceful
restart/smoke. Validate a natural initial memory snapshot, the <=240-character
console projection, durable structured payload, and normal bot operation. Do
not manufacture exchange, failure, state, or trading events.

## Validation

- affected suite: 423 passed across `tests/test_live_event_bus.py`,
  `tests/test_passivbot_balance_split.py`, `tests/test_passivbot_monitor.py`, and
  `tests/test_live_event_registry_docs.py`
- `py_compile` for changed Python/test files: passed
- generated live-event registry check: passed
- AI docs check: 0 errors, 1 existing aggregate word-count warning
- `git diff --check`: passed

## Reviewer focus

- structured-console single ownership and compact fallback
- 25% admission boundary and prior-RSS state preservation
- sample bounds/redaction and monitor safety
- sink-failure isolation
- no extra collection work or trading/runtime control changes

Residual risk: a failed best-effort event sink can drop this diagnostic, as
intended, but must not affect bot behavior.
