### PR TITLE
Bound trailing and unstuck console materiality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Five-minute `trailing.status` and `unstuck.status` snapshots now remain
+  complete in structured and monitor sinks while normal console/text output is
+  limited to first observations, qualitative or material numeric transitions,
+  and hourly reminders. Unstuck allowance movement uses five-percent relative
+  hysteresis; trailing ratio and price movement use explicit 0.05 percentage-
+  point and 0.5-percent boundaries. Trading, risk, planning, and event cadence
+  are unchanged.
+
 - Material live memory snapshots now emit a bounded `resource.memory_snapshot`
   event and one compact operator line instead of a 457-525 character cache and
   task diagnostic. The complete bounded samples remain available in structured

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -144,6 +144,29 @@ must not retain `latest_error`. These projections are observability-only: error 
 timestamp recovery, restart thresholds, backoff, and trading behavior remain owned by the existing
 execution-loop policy.
 
+## Trailing And Unstuck Status Materiality
+
+`trailing.status` and `unstuck.status` retain one complete observation every five minutes while the
+corresponding status producer is active. `operator_visible=false` suppresses only console and
+durable text projection; structured and monitor sinks still receive the event. Missing visibility
+metadata remains operator-visible. The first observation, a qualitative transition, a material
+numeric transition, and the existing hourly reminder use `operator_visible=true`. The `changed`
+field is true only for the first or materially changed observation, not for an unchanged hourly
+reminder.
+
+Unstuck allowance materiality uses five-percent relative hysteresis against the last
+operator-visible baseline. Status, over-budget crossing, configured overrides, candidate symbol,
+and existing target fields remain qualitative transition inputs. Trailing visibility is owned per
+`symbol`/`pside`/`kind` item so one changing position does not expose unrelated repeats. Its
+threshold and retracement ratios are material at an absolute ratio delta of `0.0005` (0.05
+percentage points); threshold and retracement prices are material at a relative delta of `0.005`
+(0.5 percent). Qualitative status, support, and trigger flags remain immediate.
+
+These thresholds affect human projection only. They must not change Rust planning, order emission,
+position handling, unstuck eligibility, trailing calculations, the five-minute observation cadence,
+or event payload values. Legacy direct INFO logging remains a fallback only when the structured
+console is unavailable and follows the same producer-owned admission decision.
+
 ## Memory Snapshots
 
 `resource.memory_snapshot` records the existing material memory diagnostic when it first becomes

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/trailing-unstuck-console-materiality`, based on canonical
   `de5f21c96d92aab1c465e0be40035ed3ec6a6d0a` after PR #1245.
-- PR: pending publication, `Bound trailing and unstuck console materiality`.
+- PR: #1246, `Bound trailing and unstuck console materiality`.
 - Slice: retain complete five-minute `trailing.status` and `unstuck.status`
   observations in structured/monitor sinks while limiting console/text output
   to first observations, qualitative or material numeric transitions, and

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,42 +22,52 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/memory-snapshot-event`, integrated with canonical `master`
-  after PR #1244.
-- PR: #1245, `Add bounded memory snapshot event`.
-- Slice: publish the existing material memory diagnostic as bounded
-  `resource.memory_snapshot` data and project one compact operator line.
-- Triggering evidence: current post-PR #1243 VPS5 segments produced natural
-  `[memory]` INFO records measuring 457-525 characters. They mixed RSS, cache
-  totals and samples, timeframe-cache ranges, and task names into one line,
-  exceeding the 240-character normal-console budget.
-- Scope: preserve the existing collection pass, initial-or-25-percent RSS
-  admission, and prior-RSS state; retain bounded detail in the event/monitor
-  payload and full developer detail at DEBUG; use a compact legacy fallback
-  only when the structured console is unavailable.
+- Branch: `codex/trailing-unstuck-console-materiality`, based on canonical
+  `de5f21c96d92aab1c465e0be40035ed3ec6a6d0a` after PR #1245.
+- PR: pending publication, `Bound trailing and unstuck console materiality`.
+- Slice: retain complete five-minute `trailing.status` and `unstuck.status`
+  observations in structured/monitor sinks while limiting console/text output
+  to first observations, qualitative or material numeric transitions, and
+  hourly reminders.
+- Triggering evidence: one natural Hyperliquid segment emitted 27 trailing and
+  20 unstuck INFO lines from `18:24:16Z` through `20:39:13Z`. Trailing status
+  repeated about every five minutes because ratios changed below displayed
+  precision; unstuck allowance oscillated around `-1.70` to `-1.76` while each
+  repeat was marked changed.
+- Scope: producer-owned `operator_visible`; five-percent relative unstuck
+  allowance hysteresis; per-item trailing materiality at 0.05 percentage points
+  for ratios and 0.5 percent for prices; generic console/text suppression only
+  when visibility is explicitly false. Missing metadata remains visible.
 - Behavior boundary: observability-only; no exchange calls, cache or task
-  mutation, timing change, Rust, order, risk, backtest, or optimizer behavior.
-- Integration boundary: PR #1244 merged as `bff64d3a82a6b227cf70514ffd08916f9c2c9cb7`.
-  The #1245 integration preserves both additive validator sets and both event
-  contracts; all function bodies and tests merged automatically. The temporary
-  maintainer-authorized gate while Grok is halted is exact-head Hermes plus
-  green CI, with prior semantic approval carried only under the proportional
-  mechanical-delta contract.
-- Expected VPS action: after merge, deploy PRs #1244 and #1245 together with
-  one authorized exact five-bot restart. Validate normal operation, the natural
-  initial memory projection, and naturally occurring incidents only; do not
-  manufacture exchange, failure, state, or trading events.
+  mutation, planning or status calculation change, cadence increase, Rust,
+  order, risk, backtest, or optimizer behavior.
+- Review gate: temporary maintainer-authorized exact-head Hermes plus green CI
+  while Grok is halted.
+- Expected VPS action: after merge, one authorized exact five-bot restart.
+  Validate five-minute durable observations and natural console suppression;
+  do not manufacture trailing, unstuck, exchange, state, or trading events.
 
 ## Deployed Baseline
 
-- Canonical `master` is `bff64d3a82a6b227cf70514ffd08916f9c2c9cb7`,
-  PR #1244. VPS5 remains on `c6fba829031f64a9ecd59eadcaaecf36db40236c`,
-  PR #1243, pending the combined #1244/#1245 deployment; its tracked status is
-  clean and expected untracked artifacts are preserved.
-- VPS5 runs the PR #1243 head in bot PIDs
-  `948822/948824/948826/948828/948830`. The exact pane PIDs remain
+- Canonical `master` and VPS5 are
+  `de5f21c96d92aab1c465e0be40035ed3ec6a6d0a`, PR #1245. The tracked checkout
+  is clean and expected untracked artifacts are preserved.
+- VPS5 runs merged master in bot PIDs
+  `951819/951822/951825/951828/951830`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PRs #1244 and #1245 were activated together with one exact five-bot graceful
+  restart. Every old bot exited naturally after one SIGINT round; KuCoin was
+  last at 40 seconds, with no escalation. A real immediate KuCoin timeout
+  recovered without intervention and naturally proved the bounded #1244
+  incident line: operation, error type, endpoint, and action remained visible,
+  while raw URL and traceback text were absent from the new log.
+- All five bots naturally emitted `resource.memory_snapshot`; the complete
+  bounded payloads reached monitor storage and compact console lines measured
+  84-107 characters. The final two-minute smoke was `ok=true` with `217/217`
+  remote calls and `54/54` account-critical calls successful, six successful
+  fill refreshes, five matching processes/configs in states `R=4,S=1`, and
+  zero hard, log, monitor, process, or event-pipeline failures.
 - PR #1243 was activated with one exact five-bot graceful restart. Every old
   bot exited naturally after one SIGINT round; KuCoin was last at 35 seconds,
   and no escalation was required. Natural Binance, GateIO, and KuCoin replay
@@ -679,8 +689,10 @@ window. PR #1243's HSL replay console cadence is merged, deployed, and
 naturally validated: intermediate console progress stayed at least 30 seconds
 apart while complete structured progress remained durable. Its restart exposed
 the execution-loop incident projection addressed by merged PR #1244. PR #1245
-is the active memory-snapshot integration slice; both producer changes remain
-pending one combined VPS5 activation.
+is also merged and deployed: bounded execution incidents and compact memory
+snapshots are naturally validated with a settled hard-green smoke. The active
+slice applies producer-owned materiality to repeated trailing and unstuck human
+projections while preserving their five-minute durable observations.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -8402,3 +8402,31 @@ VPS5 deployment status:
   `codex/execution-incident-projection` slice replaces that family with a
   bounded signature while preserving counters, restart/backoff, timestamp
   recovery, exchange calls, and trading behavior.
+
+### 2026-07-15: Incident And Memory Projections Deployed; Risk Status Follow-Up
+
+- PR #1244 merged as `bff64d3a82` and PR #1245 merged as `de5f21c96d` under
+  the temporary maintainer-authorized Hermes-plus-CI gate while Grok was
+  halted. PR #1245's current-master integration retained both additive event
+  contracts; direct target-relative diff proofs and 428 focused tests showed
+  no semantic production/test delta from its approved head.
+- VPS5 fast-forwarded cleanly and activated both PRs with one exact five-bot
+  restart. All old bots exited naturally after one SIGINT round; KuCoin was
+  last at 40 seconds. Exact pane PIDs and unrelated `misc:0.0` PID `434835`
+  remained unchanged.
+- One natural KuCoin startup timeout made the immediate window red, then
+  recovered without intervention. Its normal log retained a bounded operation,
+  exception type, endpoint, and action without a raw URL or traceback. All five
+  bots naturally emitted complete `resource.memory_snapshot` monitor payloads
+  and compact 84-107 character console lines.
+- The final two-minute smoke was `ok=true` with `217/217` remote calls and
+  `54/54` account-critical calls successful, six successful fill refreshes,
+  five config-valid processes in states `R=4,S=1`, and zero hard, log,
+  monitor, process, or event-pipeline failures. The checkout was clean at the
+  exact merged head.
+- The preceding Hyperliquid segment contained 27 trailing and 20 unstuck INFO
+  lines over about 135 minutes. Sub-display-precision trailing drift and
+  `-1.70` to `-1.76` allowance oscillation repeatedly appeared as changed. The
+  active `codex/trailing-unstuck-console-materiality` slice preserves every
+  five-minute structured observation while applying explicit producer-owned
+  transition and numeric materiality to console/text output.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -4068,9 +4068,13 @@ VPS5 deployment status:
 | Operator tools | In progress | `live-event-query`, trace summaries, order trace reconstruction, cycle trace reconstruction, time-window filters, severity-level filters, problem-event filters, event-file discovery metadata, `live-smoke-report` startup baselines/process liveness/remote-call failures/remote-call timings/remote-call health groups and top-level totals/account-critical health/risk-events/execution-health/shutdown-events/time windows/unparseable-log policy/brief smoke counters/brief problem-event groups/supervisor duplicate-extra process diagnostics, incident bundle trace/process/time-window/problem-event reports and query-scope filters, ID filters, `ticker-endpoint-probe` account-critical/time-sync/candle-freshness/fill-history-sample/rate-limit health summaries and account-only mode, `live-config-preflight` offline config summaries, `live-performance-report` timing aggregation with summary/filter, decision-boundary, input-staleness including market snapshot staleness, startup phase timing summaries, HSL replay pair/rate/stage summaries, forager/EMA readiness, cache warmup, resource-pressure percentiles, and unified operation-duration support | Cross-bot incident workflow, safe restart orchestration, bounded historical performance-report scans, active probe expansion beyond current endpoint/freshness summaries |
 | Operational restart goals | Split to adjacent work | PR #619 shutdown progress; PR #622 warm-cache startup; PR #656/#668 cache integrity smoke doctor | Continue separate reviewed PRs for shutdown/warmup/cache proof improvements |
 
-## Current Work
+## Historical Work Snapshot (Superseded)
 
-### In Progress: HSL Replay ETA Smoke Report
+This block records the in-progress handoff from 2026-06-30 and is not the
+current automation target. Use `live_logging_overhaul_current_status.md` for the
+active branch, PR, review gate, and rollout instructions.
+
+### Historical: HSL Replay ETA Smoke Report
 
 - Branch: `codex/v8-smoke-hsl-replay-eta`.
 - Scope: read-only live smoke report projection and tests.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -568,6 +568,13 @@ Related detailed plans:
     warning. Migrate that detail with the same emitter/pipeline/sink fallback
     contract while preserving every gate decision and throttle.
 
+    PR #1246 is the active risk-status materiality slice. It keeps every
+    five-minute trailing and unstuck observation in structured/monitor sinks
+    while limiting console/text projection to first observations, qualitative
+    or material numeric transitions, and hourly reminders. The change is
+    observability-only and leaves status calculation, planning, risk, and order
+    behavior unchanged.
+
     Two post-PR #1220 console observations remain deferred rather than folded
     into the realized-loss slice. Hyperliquid balance lines surfaced signed
     floating-point jitter near `1e-13`; decide a console-only materiality or

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -2066,11 +2066,12 @@ def _hsl_status_operator_visible(event: LiveEvent) -> bool:
 
 
 def _operator_sink_event_visible(event: LiveEvent) -> bool:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    if data.get("operator_visible") is False:
+        return False
     if event.event_type == EventTypes.FILL_INGESTED:
-        data = event.data if isinstance(event.data, Mapping) else {}
-        return data.get("operator_visible") is not False
+        return True
     if event.event_type == EventTypes.FORAGER_SELECTION:
-        data = event.data if isinstance(event.data, Mapping) else {}
         return str(data.get("source") or "") != "rust_orchestrator"
     if event.event_type == EventTypes.HSL_STATUS:
         return _hsl_status_operator_visible(event)

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -4356,6 +4356,7 @@ def _trailing_status_summary(payload: dict[str, Any]) -> dict[str, Any]:
         ),
         "unsupported_reason": str(payload.get("unsupported_reason") or "") or None,
         "changed": bool(payload.get("changed", False)),
+        "operator_visible": bool(payload.get("operator_visible", True)),
     }
     return {key: value for key, value in out.items() if value is not None}
 
@@ -4368,6 +4369,7 @@ def emit_trailing_status_event(
     kind: str,
     payload: dict[str, Any],
     changed: bool,
+    operator_visible: bool,
 ) -> None:
     try:
         data = _trailing_status_summary(
@@ -4376,6 +4378,7 @@ def emit_trailing_status_event(
                 "kind": str(kind),
                 "pside": str(pside),
                 "changed": bool(changed),
+                "operator_visible": bool(operator_visible),
             }
         )
         bot._emit_live_event(
@@ -4405,6 +4408,7 @@ def emit_unstuck_status_event(
     *,
     side_statuses: dict[str, dict[str, Any]],
     changed: bool,
+    operator_visible: bool,
 ) -> None:
     try:
         sides = {
@@ -4431,6 +4435,7 @@ def emit_unstuck_status_event(
             reason_code=ReasonCodes.UNSTUCK_STATUS,
             data={
                 "changed": bool(changed),
+                "operator_visible": bool(operator_visible),
                 "status_counts": status_counts,
                 "over_budget_sides": over_budget_sides,
                 "sides": sides,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -2503,7 +2503,7 @@ class Passivbot:
         delta = abs(current - baseline)
         boundary = denominator * cls.UNSTUCK_ALLOWANCE_MATERIALITY_RELATIVE_DELTA
         return delta > boundary or math.isclose(
-            delta, boundary, rel_tol=1e-12, abs_tol=1e-12
+            delta, boundary, rel_tol=1e-12, abs_tol=0.0
         )
 
     @staticmethod
@@ -2707,13 +2707,11 @@ class Passivbot:
         if relative:
             boundary = max(abs(baseline), 1e-12) * cls.TRAILING_PRICE_MATERIALITY_RELATIVE_DELTA
             return delta > boundary or math.isclose(
-                delta, boundary, rel_tol=1e-12, abs_tol=1e-12
+                delta, boundary, rel_tol=1e-12, abs_tol=0.0
             )
-        return delta > cls.TRAILING_RATIO_MATERIALITY_ABSOLUTE_DELTA or math.isclose(
-            delta,
-            cls.TRAILING_RATIO_MATERIALITY_ABSOLUTE_DELTA,
-            rel_tol=1e-12,
-            abs_tol=1e-12,
+        boundary = cls.TRAILING_RATIO_MATERIALITY_ABSOLUTE_DELTA
+        return delta > boundary or math.isclose(
+            delta, boundary, rel_tol=1e-12, abs_tol=0.0
         )
 
     def _trailing_status_operator_decision(

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -608,6 +608,11 @@ def compute_live_warmup_windows(
 
 
 class Passivbot:
+    UNSTUCK_ALLOWANCE_MATERIALITY_RELATIVE_DELTA = 0.05
+    TRAILING_RATIO_MATERIALITY_ABSOLUTE_DELTA = 0.0005
+    TRAILING_PRICE_MATERIALITY_RELATIVE_DELTA = 0.005
+    STATUS_OPERATOR_HEARTBEAT_INTERVAL_MS = 60 * 60 * 1000
+
     _begin_live_event_cycle = live_event_emitters.begin_live_event_cycle
     _current_live_event_cycle_id = live_event_emitters.current_live_event_cycle_id
     _emit_live_cycle_completed = live_event_emitters.emit_live_cycle_completed
@@ -1268,18 +1273,16 @@ class Passivbot:
         # Unstuck logging throttle
         self._unstuck_last_log_ms = 0
         self._unstuck_log_interval_ms = 5 * 60 * 1000  # 5 minutes
-        self._unstuck_unchanged_info_log_interval_ms = 60 * 60 * 1000  # 1 hour
-        self._unstuck_last_status_signature = None
-        self._unstuck_last_status_info_ms = 0
+        self._unstuck_unchanged_info_log_interval_ms = self.STATUS_OPERATOR_HEARTBEAT_INTERVAL_MS
+        self._unstuck_operator_visible_baseline_by_pside = {}
+        self._unstuck_operator_visible_ms_by_pside = {}
         self._unstuck_last_selection_signature = None
         self._unstuck_last_selection_info_ms = 0
-        self._unstuck_allowance_log_hyst_snap_pct = 0.002
-        self._unstuck_allowance_log_snap_by_pside = {}
         self._trailing_last_status_check_ms = 0
         self._trailing_status_check_interval_ms = 5 * 60 * 1000
-        self._trailing_unchanged_info_log_interval_ms = 60 * 60 * 1000
-        self._trailing_last_status_signature = None
-        self._trailing_last_status_info_ms = 0
+        self._trailing_unchanged_info_log_interval_ms = self.STATUS_OPERATOR_HEARTBEAT_INTERVAL_MS
+        self._trailing_operator_visible_baseline_by_key = {}
+        self._trailing_operator_visible_ms_by_key = {}
 
         # Realized-loss gate logging throttle
         self._loss_gate_last_log_ms = {}
@@ -2432,9 +2435,6 @@ class Passivbot:
                 signature_parts.append((pside, "no_history"))
             else:
                 allowance = info["allowance"]
-                snapped_allowance = self._get_hysteresis_snapped_unstuck_allowance(
-                    pside, allowance
-                )
                 overrides_str = self._format_unstuck_override_pcts_for_logging(
                     info.get("override_loss_allowance_pcts", {})
                 )
@@ -2453,7 +2453,7 @@ class Passivbot:
                     (
                         pside,
                         "over_budget" if allowance < 0 else "ok",
-                        round(float(snapped_allowance), 2),
+                        round(float(allowance), 2),
                         tuple(sorted(info.get("override_loss_allowance_pcts", {}).items())),
                         str(info.get("next_symbol") or ""),
                         round(
@@ -2485,25 +2485,84 @@ class Passivbot:
         ) = self._get_unstuck_status_snapshot_parts_and_signature()
         return parts, signature
 
-    def _get_hysteresis_snapped_unstuck_allowance(
-        self, pside: str, allowance_raw: float
-    ) -> float:
-        """Return the hysteresis-snapped allowance used for INFO log change detection."""
-        snaps = getattr(self, "_unstuck_allowance_log_snap_by_pside", None)
-        if snaps is None:
-            snaps = {}
-            self._unstuck_allowance_log_snap_by_pside = snaps
-        prev = snaps.get(pside)
-        if prev is None:
-            snaps[pside] = float(allowance_raw)
-            return float(allowance_raw)
-        denom = max(abs(float(allowance_raw)), 1e-9)
-        threshold = float(
-            getattr(self, "_unstuck_allowance_log_hyst_snap_pct", 0.002) or 0.002
+    @staticmethod
+    def _status_materiality_number(value: Any) -> float | None:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return None
+        return number if math.isfinite(number) else None
+
+    @classmethod
+    def _unstuck_allowance_materially_changed(
+        cls, baseline: float | None, current: float | None
+    ) -> bool:
+        if baseline is None or current is None:
+            return baseline != current
+        denominator = max(abs(baseline), 1e-12)
+        delta = abs(current - baseline)
+        boundary = denominator * cls.UNSTUCK_ALLOWANCE_MATERIALITY_RELATIVE_DELTA
+        return delta > boundary or math.isclose(
+            delta, boundary, rel_tol=1e-12, abs_tol=1e-12
         )
-        if abs(float(allowance_raw) - float(prev)) / denom > threshold:
-            snaps[pside] = float(allowance_raw)
-        return float(snaps[pside])
+
+    @staticmethod
+    def _unstuck_status_qualitative_signature(info: dict) -> tuple:
+        return (
+            str(info.get("status") or "unknown"),
+            Passivbot._status_materiality_number(info.get("allowance")) is not None
+            and Passivbot._status_materiality_number(info.get("allowance")) < 0.0,
+            tuple(sorted((info.get("override_loss_allowance_pcts") or {}).items())),
+            str(info.get("next_symbol") or ""),
+            info.get("next_target_price"),
+            info.get("next_target_distance_ratio"),
+            info.get("next_unstuck_trigger_distance_ratio"),
+        )
+
+    def _unstuck_status_operator_decision(
+        self, side_infos: dict[str, dict], now_ms: int
+    ) -> tuple[bool, bool]:
+        baselines = getattr(self, "_unstuck_operator_visible_baseline_by_pside", None)
+        if not isinstance(baselines, dict):
+            baselines = {}
+            self._unstuck_operator_visible_baseline_by_pside = baselines
+        visible_ms = getattr(self, "_unstuck_operator_visible_ms_by_pside", None)
+        if not isinstance(visible_ms, dict):
+            visible_ms = {}
+            self._unstuck_operator_visible_ms_by_pside = visible_ms
+        heartbeat_interval_ms = int(
+            getattr(
+                self,
+                "_unstuck_unchanged_info_log_interval_ms",
+                self.STATUS_OPERATOR_HEARTBEAT_INTERVAL_MS,
+            )
+        )
+        operator_visible = False
+        material_changed = False
+        for pside, info in sorted(side_infos.items()):
+            current = dict(info or {})
+            qualitative = self._unstuck_status_qualitative_signature(current)
+            allowance = self._status_materiality_number(current.get("allowance"))
+            baseline = baselines.get(pside)
+            changed = baseline is None or (
+                qualitative != baseline["qualitative"]
+                or self._unstuck_allowance_materially_changed(
+                    baseline["allowance"], allowance
+                )
+            )
+            heartbeat = (
+                not changed
+                and now_ms - int(visible_ms.get(pside, 0) or 0) >= heartbeat_interval_ms
+            )
+            if changed or heartbeat:
+                baselines[pside] = {
+                    "qualitative": qualitative,
+                    "allowance": allowance,
+                }
+                visible_ms[pside] = now_ms
+                operator_visible = True
+                material_changed = material_changed or changed
+        return operator_visible, material_changed
 
     def _maybe_log_unstuck_status(self) -> None:
         """Log unstuck status on meaningful change, with an hourly INFO heartbeat."""
@@ -2514,24 +2573,18 @@ class Passivbot:
         (
             side_infos,
             parts,
-            signature,
+            _signature,
         ) = self._get_unstuck_status_snapshot_parts_and_signature()
-        status_changed = signature != getattr(
-            self, "_unstuck_last_status_signature", None
+        operator_visible, status_changed = self._unstuck_status_operator_decision(
+            side_infos, now_ms
         )
-        last_info_ms = int(getattr(self, "_unstuck_last_status_info_ms", 0) or 0)
-        if (
-            status_changed
-            or (now_ms - last_info_ms) >= self._unstuck_unchanged_info_log_interval_ms
-        ):
-            if not Passivbot._live_event_console_available(self):
-                logging.info("[unstuck] %s", " | ".join(parts))
-            self._emit_unstuck_status_event(
-                side_statuses=side_infos,
-                changed=status_changed,
-            )
-            self._unstuck_last_status_info_ms = now_ms
-            self._unstuck_last_status_signature = signature
+        if operator_visible and not Passivbot._live_event_console_available(self):
+            logging.info("[unstuck] %s", " | ".join(parts))
+        self._emit_unstuck_status_event(
+            side_statuses=side_infos,
+            changed=status_changed,
+            operator_visible=operator_visible,
+        )
 
     def _maybe_log_unstuck_selection(
         self,
@@ -2617,53 +2670,106 @@ class Passivbot:
         return number if math.isfinite(number) else float(default)
 
     @staticmethod
-    def _trailing_status_signature(items: list[dict]) -> tuple:
-        signature = []
-        for item in items:
-            payload = item.get("payload", {}) if isinstance(item, dict) else {}
-            if not isinstance(payload, dict):
-                payload = {}
-            signature.append(
-                (
-                    item.get("symbol"),
-                    item.get("pside"),
-                    item.get("kind"),
-                    bool(payload.get("diagnostics_supported", True)),
-                    str(
-                        payload.get("status")
-                        or payload.get("trailing_status")
-                        or "unknown"
-                    ),
-                    bool(payload.get("threshold_met"))
-                    if "threshold_met" in payload
-                    else None,
-                    bool(payload.get("retracement_met"))
-                    if "retracement_met" in payload
-                    else None,
-                    round(
-                        Passivbot._trailing_status_float(payload.get("threshold_pct")),
-                        8,
-                    ),
-                    round(
-                        Passivbot._trailing_status_float(
-                            payload.get("retracement_pct")
-                        ),
-                        8,
-                    ),
-                    round(
-                        Passivbot._trailing_status_float(payload.get("threshold_price")),
-                        8,
-                    ),
-                    round(
-                        Passivbot._trailing_status_float(
-                            payload.get("retracement_price")
-                        ),
-                        8,
-                    ),
-                    str(payload.get("unsupported_reason") or ""),
-                )
+    def _trailing_status_qualitative_signature(payload: dict) -> tuple:
+        return (
+            bool(payload.get("diagnostics_supported", True)),
+            str(payload.get("strategy_kind") or ""),
+            str(payload.get("status") or payload.get("trailing_status") or "unknown"),
+            str(payload.get("selected_mode") or ""),
+            str(payload.get("order_type") or ""),
+            bool(payload.get("triggered", False)),
+            bool(payload.get("threshold_met")) if "threshold_met" in payload else None,
+            bool(payload.get("retracement_met"))
+            if "retracement_met" in payload
+            else None,
+            str(payload.get("unsupported_reason") or ""),
+        )
+
+    @staticmethod
+    def _trailing_status_item_key(item: dict) -> tuple[str, str, str]:
+        return (
+            str(item.get("symbol") or ""),
+            str(item.get("pside") or ""),
+            str(item.get("kind") or "position"),
+        )
+
+    @classmethod
+    def _trailing_status_number_materially_changed(
+        cls,
+        baseline: float | None,
+        current: float | None,
+        *,
+        relative: bool,
+    ) -> bool:
+        if baseline is None or current is None:
+            return baseline != current
+        delta = abs(current - baseline)
+        if relative:
+            boundary = max(abs(baseline), 1e-12) * cls.TRAILING_PRICE_MATERIALITY_RELATIVE_DELTA
+            return delta > boundary or math.isclose(
+                delta, boundary, rel_tol=1e-12, abs_tol=1e-12
             )
-        return tuple(sorted(signature))
+        return delta > cls.TRAILING_RATIO_MATERIALITY_ABSOLUTE_DELTA or math.isclose(
+            delta,
+            cls.TRAILING_RATIO_MATERIALITY_ABSOLUTE_DELTA,
+            rel_tol=1e-12,
+            abs_tol=1e-12,
+        )
+
+    def _trailing_status_operator_decision(
+        self, item: dict, now_ms: int
+    ) -> tuple[bool, bool]:
+        key = self._trailing_status_item_key(item)
+        payload = dict(item.get("payload", {}) or {})
+        baselines = getattr(self, "_trailing_operator_visible_baseline_by_key", None)
+        if not isinstance(baselines, dict):
+            baselines = {}
+            self._trailing_operator_visible_baseline_by_key = baselines
+        visible_ms = getattr(self, "_trailing_operator_visible_ms_by_key", None)
+        if not isinstance(visible_ms, dict):
+            visible_ms = {}
+            self._trailing_operator_visible_ms_by_key = visible_ms
+        values = {
+            name: self._status_materiality_number(payload.get(name))
+            for name in (
+                "threshold_pct",
+                "retracement_pct",
+                "threshold_price",
+                "retracement_price",
+            )
+        }
+        qualitative = self._trailing_status_qualitative_signature(payload)
+        baseline = baselines.get(key)
+        material_changed = baseline is None or qualitative != baseline["qualitative"]
+        if not material_changed:
+            for name in ("threshold_pct", "retracement_pct"):
+                if self._trailing_status_number_materially_changed(
+                    baseline["values"][name], values[name], relative=False
+                ):
+                    material_changed = True
+                    break
+        if not material_changed:
+            for name in ("threshold_price", "retracement_price"):
+                if self._trailing_status_number_materially_changed(
+                    baseline["values"][name], values[name], relative=True
+                ):
+                    material_changed = True
+                    break
+        heartbeat_interval_ms = int(
+            getattr(
+                self,
+                "_trailing_unchanged_info_log_interval_ms",
+                self.STATUS_OPERATOR_HEARTBEAT_INTERVAL_MS,
+            )
+        )
+        heartbeat = (
+            not material_changed
+            and now_ms - int(visible_ms.get(key, 0) or 0) >= heartbeat_interval_ms
+        )
+        if material_changed or heartbeat:
+            baselines[key] = {"qualitative": qualitative, "values": values}
+            visible_ms[key] = now_ms
+        return material_changed or heartbeat, material_changed
 
     def _unsupported_trailing_status_item(
         self,
@@ -2821,38 +2927,31 @@ class Passivbot:
         except Exception as exc:
             logging.debug("[trailing] failed building status event items: %s", exc)
             return
-        if not items:
-            return
-        signature = self._trailing_status_signature(items)
-        status_changed = signature != getattr(
-            self, "_trailing_last_status_signature", None
-        )
-        last_info_ms = int(getattr(self, "_trailing_last_status_info_ms", 0) or 0)
-        unchanged_interval = int(
-            getattr(
-                self,
-                "_trailing_unchanged_info_log_interval_ms",
-                60 * 60 * 1000,
-            )
-            or 0
-        )
-        if (
-            not status_changed
-            and unchanged_interval > 0
-            and (now_ms - last_info_ms) < unchanged_interval
+        active_keys = {self._trailing_status_item_key(item) for item in items}
+        for state_name in (
+            "_trailing_operator_visible_baseline_by_key",
+            "_trailing_operator_visible_ms_by_key",
         ):
+            state = getattr(self, state_name, None)
+            if not isinstance(state, dict):
+                continue
+            for key in set(state).difference(active_keys):
+                state.pop(key, None)
+        if not items:
             return
         for item in items:
             payload = dict(item.get("payload", {}) or {})
+            operator_visible, status_changed = self._trailing_status_operator_decision(
+                item, now_ms
+            )
             self._emit_trailing_status_event(
                 symbol=str(item.get("symbol") or ""),
                 pside=str(item.get("pside") or ""),
                 kind=str(item.get("kind") or "position"),
                 payload=payload,
                 changed=status_changed,
+                operator_visible=operator_visible,
             )
-        self._trailing_last_status_signature = signature
-        self._trailing_last_status_info_ms = now_ms
 
     async def start_bot(self):
         """Initialise state, warm cached data, and launch background loops."""

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -2298,7 +2298,7 @@ def test_console_format_fills_ingested_summary_does_not_claim_zero_for_all_pendi
     )
 
 
-def test_operator_visibility_suppresses_fill_console_and_text_only():
+def test_operator_visibility_suppresses_all_operator_sinks_only():
     structured = ListEventSink()
     monitor = ListEventSink()
     console = ListEventSink()
@@ -2309,18 +2309,25 @@ def test_operator_visibility_suppresses_fill_console_and_text_only():
         console_sink=console,
         text_sink=text,
     )
-    event = LiveEvent(
+    fill_event = LiveEvent(
         EventTypes.FILL_INGESTED,
         data={"operator_visible": False, "qty": 1.0, "price": 100.0},
     )
+    trailing_event = LiveEvent(
+        EventTypes.TRAILING_STATUS,
+        data={"operator_visible": False, "threshold_pct": 0.01},
+    )
+    missing_metadata_event = LiveEvent(EventTypes.TRAILING_STATUS, data={})
 
-    pipeline.emit(event)
+    pipeline.emit(fill_event)
+    pipeline.emit(trailing_event)
+    pipeline.emit(missing_metadata_event)
 
     assert pipeline.flush(timeout=2.0) is True
-    assert structured.events == [event]
-    assert monitor.events == [event]
-    assert console.events == []
-    assert text.events == []
+    assert structured.events == [fill_event, trailing_event, missing_metadata_event]
+    assert monitor.events == [fill_event, trailing_event, missing_metadata_event]
+    assert console.events == [missing_metadata_event]
+    assert text.events == [missing_metadata_event]
     assert pipeline.close(timeout=2.0) is True
 
 

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -4036,10 +4036,8 @@ def test_unstuck_status_logs_info_on_change_then_hourly(monkeypatch, caplog):
     bot._unstuck_last_log_ms = 0
     bot._unstuck_log_interval_ms = 5 * 60 * 1000
     bot._unstuck_unchanged_info_log_interval_ms = 60 * 60 * 1000
-    bot._unstuck_allowance_log_hyst_snap_pct = 0.002
-    bot._unstuck_allowance_log_snap_by_pside = {}
-    bot._unstuck_last_status_signature = None
-    bot._unstuck_last_status_info_ms = 0
+    bot._unstuck_operator_visible_baseline_by_pside = {}
+    bot._unstuck_operator_visible_ms_by_pside = {}
     bot._monitor_runtime_unstuck_hints = {
         "long": {
             "next_symbol": "BTC/USDT:USDT",
@@ -4098,9 +4096,15 @@ def test_unstuck_status_logs_info_on_change_then_hourly(monkeypatch, caplog):
     unstuck_logs = [
         record.message for record in caplog.records if "[unstuck]" in record.message
     ]
-    assert len(unstuck_logs) == 4
+    assert len(unstuck_logs) == 3
     assert len(captured_events) == 4
-    assert [event["changed"] for event in captured_events] == [True, True, True, False]
+    assert [event["changed"] for event in captured_events] == [True, True, False, False]
+    assert [event["operator_visible"] for event in captured_events] == [
+        True,
+        True,
+        False,
+        True,
+    ]
     assert captured_events[0]["side_statuses"]["long"]["allowance"] == pytest.approx(
         -41.01
     )
@@ -4121,10 +4125,8 @@ def test_unstuck_status_suppresses_legacy_log_when_event_console_active(
     bot._unstuck_last_log_ms = 0
     bot._unstuck_log_interval_ms = 5 * 60 * 1000
     bot._unstuck_unchanged_info_log_interval_ms = 60 * 60 * 1000
-    bot._unstuck_allowance_log_hyst_snap_pct = 0.002
-    bot._unstuck_allowance_log_snap_by_pside = {}
-    bot._unstuck_last_status_signature = None
-    bot._unstuck_last_status_info_ms = 0
+    bot._unstuck_operator_visible_baseline_by_pside = {}
+    bot._unstuck_operator_visible_ms_by_pside = {}
     bot._monitor_runtime_unstuck_hints = {}
     captured_events = []
     bot._emit_unstuck_status_event = lambda **kwargs: captured_events.append(kwargs)
@@ -4147,25 +4149,34 @@ def test_unstuck_status_suppresses_legacy_log_when_event_console_active(
     assert not any("[unstuck]" in record.message for record in caplog.records)
 
 
-def test_hysteresis_snapped_unstuck_allowance_updates_only_after_threshold():
+def test_unstuck_allowance_materiality_uses_five_percent_boundary():
+    baseline = -41.0
+
+    assert not Passivbot._unstuck_allowance_materially_changed(baseline, -43.049)
+    assert Passivbot._unstuck_allowance_materially_changed(baseline, -43.05)
+
     bot = Passivbot.__new__(Passivbot)
-    bot._unstuck_allowance_log_hyst_snap_pct = 0.002
-    bot._unstuck_allowance_log_snap_by_pside = {}
+    bot._unstuck_unchanged_info_log_interval_ms = 60 * 60 * 1000
+    bot._unstuck_operator_visible_baseline_by_pside = {}
+    bot._unstuck_operator_visible_ms_by_pside = {}
+    first = bot._unstuck_status_operator_decision(
+        {"long": {"status": "ok", "allowance": -100.0}}, now_ms=1
+    )
+    gradual = bot._unstuck_status_operator_decision(
+        {"long": {"status": "ok", "allowance": -103.0}}, now_ms=2
+    )
+    accumulated = bot._unstuck_status_operator_decision(
+        {"long": {"status": "ok", "allowance": -105.0}}, now_ms=3
+    )
 
-    first = bot._get_hysteresis_snapped_unstuck_allowance("long", -41.00)
-    small = bot._get_hysteresis_snapped_unstuck_allowance("long", -41.03)
-    large = bot._get_hysteresis_snapped_unstuck_allowance("long", -41.20)
-
-    assert first == pytest.approx(-41.00)
-    assert small == pytest.approx(-41.00)
-    assert large == pytest.approx(-41.20)
+    assert first == (True, True)
+    assert gradual == (False, False)
+    assert accumulated == (True, True)
 
 
 def test_unstuck_status_reports_coin_override_loss_allowance_pct():
     bot = Passivbot.__new__(Passivbot)
     bot._pnls_manager = object()
-    bot._unstuck_allowance_log_hyst_snap_pct = 0.002
-    bot._unstuck_allowance_log_snap_by_pside = {}
     bot.coin_overrides = {
         "HYPE/USDT:USDT": {"bot": {"long": {"unstuck_loss_allowance_pct": 0.005}}},
         "BTC/USDT:USDT": {"bot": {"long": {}}},
@@ -4289,8 +4300,8 @@ def test_trailing_status_emits_on_change_then_hourly(monkeypatch):
     bot._trailing_last_status_check_ms = 0
     bot._trailing_status_check_interval_ms = 5 * 60 * 1000
     bot._trailing_unchanged_info_log_interval_ms = 60 * 60 * 1000
-    bot._trailing_last_status_signature = None
-    bot._trailing_last_status_info_ms = 0
+    bot._trailing_operator_visible_baseline_by_key = {}
+    bot._trailing_operator_visible_ms_by_key = {}
     captured_events = []
     bot._emit_trailing_status_event = lambda **kwargs: captured_events.append(kwargs)
     now = [5 * 60 * 1000]
@@ -4326,12 +4337,105 @@ def test_trailing_status_emits_on_change_then_hourly(monkeypatch):
     now[0] += 60 * 60 * 1000
     bot._maybe_log_trailing_status()
 
-    assert len(captured_events) == 3
-    assert [event["changed"] for event in captured_events] == [True, True, False]
+    assert len(captured_events) == 5
+    assert [event["changed"] for event in captured_events] == [True, False, True, False, False]
+    assert [event["operator_visible"] for event in captured_events] == [
+        True,
+        False,
+        True,
+        False,
+        True,
+    ]
     assert captured_events[0]["symbol"] == "BTC/USDT:USDT"
     assert captured_events[0]["pside"] == "long"
     assert captured_events[0]["kind"] == "entry"
-    assert captured_events[1]["payload"]["status"] == "waiting_retracement"
+    assert captured_events[2]["payload"]["status"] == "waiting_retracement"
+
+
+def test_trailing_status_materiality_boundaries_and_per_item_visibility(monkeypatch):
+    assert not Passivbot._trailing_status_number_materially_changed(
+        0.01, 0.010499, relative=False
+    )
+    assert Passivbot._trailing_status_number_materially_changed(
+        0.01, 0.0105, relative=False
+    )
+    assert not Passivbot._trailing_status_number_materially_changed(
+        100.0, 100.499, relative=True
+    )
+    assert Passivbot._trailing_status_number_materially_changed(
+        100.0, 100.5, relative=True
+    )
+
+    bot = Passivbot.__new__(Passivbot)
+    bot._trailing_last_status_check_ms = 0
+    bot._trailing_status_check_interval_ms = 5 * 60 * 1000
+    bot._trailing_unchanged_info_log_interval_ms = 60 * 60 * 1000
+    bot._trailing_operator_visible_baseline_by_key = {}
+    bot._trailing_operator_visible_ms_by_key = {}
+    captured_events = []
+    bot._emit_trailing_status_event = lambda **kwargs: captured_events.append(kwargs)
+    now = [5 * 60 * 1000]
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now[0])
+    items = [
+        {
+            "symbol": "BTC/USDT:USDT",
+            "pside": "long",
+            "kind": "entry",
+            "payload": {"status": "waiting_threshold", "threshold_pct": 0.01},
+        },
+        {
+            "symbol": "ETH/USDT:USDT",
+            "pside": "long",
+            "kind": "entry",
+            "payload": {"status": "waiting_threshold", "threshold_pct": 0.01},
+        },
+    ]
+    bot._build_trailing_status_items = lambda: deepcopy(items)
+
+    bot._maybe_log_trailing_status()
+    now[0] += 5 * 60 * 1000
+    items[0]["payload"]["threshold_pct"] = 0.0105
+    bot._maybe_log_trailing_status()
+
+    assert [event["operator_visible"] for event in captured_events] == [
+        True,
+        True,
+        True,
+        False,
+    ]
+    assert [event["changed"] for event in captured_events] == [True, True, True, False]
+
+
+def test_trailing_status_reappearing_item_is_operator_visible(monkeypatch):
+    bot = Passivbot.__new__(Passivbot)
+    bot._trailing_last_status_check_ms = 0
+    bot._trailing_status_check_interval_ms = 5 * 60 * 1000
+    bot._trailing_unchanged_info_log_interval_ms = 60 * 60 * 1000
+    bot._trailing_operator_visible_baseline_by_key = {}
+    bot._trailing_operator_visible_ms_by_key = {}
+    captured_events = []
+    bot._emit_trailing_status_event = lambda **kwargs: captured_events.append(kwargs)
+    now = [5 * 60 * 1000]
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now[0])
+    item = {
+        "symbol": "BTC/USDT:USDT",
+        "pside": "long",
+        "kind": "entry",
+        "payload": {"status": "waiting_threshold", "threshold_pct": 0.01},
+    }
+    items = [deepcopy(item)]
+    bot._build_trailing_status_items = lambda: deepcopy(items)
+
+    bot._maybe_log_trailing_status()
+    items.clear()
+    now[0] += 5 * 60 * 1000
+    bot._maybe_log_trailing_status()
+    items.append(deepcopy(item))
+    now[0] += 5 * 60 * 1000
+    bot._maybe_log_trailing_status()
+
+    assert [event["operator_visible"] for event in captured_events] == [True, True]
+    assert [event["changed"] for event in captured_events] == [True, True]
 
 
 @pytest.mark.asyncio

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -4152,6 +4152,7 @@ def test_unstuck_status_suppresses_legacy_log_when_event_console_active(
 def test_unstuck_allowance_materiality_uses_five_percent_boundary():
     baseline = -41.0
 
+    assert not Passivbot._unstuck_allowance_materially_changed(0.0, 0.0)
     assert not Passivbot._unstuck_allowance_materially_changed(baseline, -43.049)
     assert Passivbot._unstuck_allowance_materially_changed(baseline, -43.05)
 
@@ -4353,6 +4354,9 @@ def test_trailing_status_emits_on_change_then_hourly(monkeypatch):
 
 
 def test_trailing_status_materiality_boundaries_and_per_item_visibility(monkeypatch):
+    assert not Passivbot._trailing_status_number_materially_changed(
+        0.0, 0.0, relative=True
+    )
     assert not Passivbot._trailing_status_number_materially_changed(
         0.01, 0.010499, relative=False
     )

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -3725,6 +3725,7 @@ def test_unstuck_status_event_emits_structured_summary():
             "short": {"status": "disabled"},
         },
         changed=True,
+        operator_visible=True,
     )
 
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
@@ -3735,6 +3736,7 @@ def test_unstuck_status_event_emits_structured_summary():
     assert event.component == "risk.unstuck.status"
     assert event.tags == ("risk", "unstuck", "summary")
     assert event.data["changed"] is True
+    assert event.data["operator_visible"] is True
     assert event.data["status_counts"] == {"disabled": 1, "ok": 1}
     assert event.data["over_budget_sides"] == ["long"]
     long = event.data["sides"]["long"]
@@ -3801,6 +3803,7 @@ def test_trailing_status_event_emits_structured_summary():
             "position_price": 100_000.0,
             "position_size": 0.01,
         },
+        operator_visible=True,
     )
 
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
@@ -3813,6 +3816,7 @@ def test_trailing_status_event_emits_structured_summary():
     assert event.component == "risk.trailing.status"
     assert event.tags == ("risk", "trailing", "position")
     assert event.data["changed"] is True
+    assert event.data["operator_visible"] is True
     assert event.data["kind"] == "close"
     assert event.data["trailing_status"] == "waiting_retracement"
     assert event.data["selected_mode"] == "trailing"


### PR DESCRIPTION
## Summary
- keep every existing five-minute `trailing.status` and `unstuck.status` observation in structured and monitor sinks
- admit console/text projection only for first observations, qualitative/material transitions, and hourly reminders
- make visibility producer-owned per trailing item and per unstuck side, while preserving legacy INFO fallback when structured console is unavailable

## Materiality contract
- unstuck allowance: 5% relative delta from the last operator-visible baseline
- trailing ratios: 0.0005 absolute ratio delta (0.05 percentage points)
- trailing prices: 0.005 relative delta (0.5%)
- qualitative status/support/mode/order/trigger and existing unstuck target fields remain immediate transition inputs
- missing `operator_visible` metadata remains visible; only explicit false suppresses console/text

## Non-goals
- no Rust, planning, order, risk, exchange, cache, task, backtest, optimizer, or cadence changes
- no suppression from structured or monitor storage

## Evidence and validation
- natural Hyperliquid segment: 27 trailing and 20 unstuck INFO lines over about 135 minutes, driven by sub-display-precision drift and small allowance oscillation
- focused event-bus, producer, monitor, registry-doc, and AI-doc tests: green
- changed Python modules/tests compile successfully
- `src/tools/check_ai_docs.py`: 0 errors, one existing aggregate word-count warning
- `git diff --check`: clean

## Review and rollout
Temporary maintainer-authorized gate while Grok is halted: exact-head Hermes approval plus green CI. After merge, deploy with one authorized exact five-bot graceful restart and validate only naturally occurring trailing/unstuck observations; do not manufacture exchange, state, or trading events.

Reviewer focus: producer baseline lifecycle, boundary equality, per-item independence, and preservation of structured/monitor completeness.