### PR TITLE
Compact trailing status console projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Visible `trailing.status` console/text records now use a compact operator
+  projection that fits the normal line budget while retaining status, position
+  identity, mode, trigger gates, material threshold/retracement values, current
+  price, and correlation. Structured and monitor payloads, visibility
+  admission, cadence, trailing calculations, and trading behavior are
+  unchanged.
+
 - Five-minute `trailing.status` and `unstuck.status` snapshots now remain
   complete in structured and monitor sinks while normal console/text output is
   limited to first observations, qualitative or material numeric transitions,

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -167,6 +167,12 @@ position handling, unstuck eligibility, trailing calculations, the five-minute o
 or event payload values. Legacy direct INFO logging remains a fallback only when the structured
 console is unavailable and follows the same producer-owned admission decision.
 
+When a trailing observation is operator-visible, its console/text projection must remain within the
+normal 240-character record budget. Keep the action/status, `symbol`/`pside`, selected mode,
+threshold and retracement gate states and material values, current price, and available correlation
+while using compact labels. Complete diagnostics remain in structured/monitor data; compaction must
+not remove payload fields or change admission, cadence, or behavior.
+
 ## Memory Snapshots
 
 `resource.memory_snapshot` records the existing material memory diagnostic when it first becomes

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,40 +22,48 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/trailing-unstuck-console-materiality`, based on canonical
-  `de5f21c96d92aab1c465e0be40035ed3ec6a6d0a` after PR #1245.
-- PR: #1246, `Bound trailing and unstuck console materiality`.
-- Slice: retain complete five-minute `trailing.status` and `unstuck.status`
-  observations in structured/monitor sinks while limiting console/text output
-  to first observations, qualitative or material numeric transitions, and
-  hourly reminders.
-- Triggering evidence: one natural Hyperliquid segment emitted 27 trailing and
-  20 unstuck INFO lines from `18:24:16Z` through `20:39:13Z`. Trailing status
-  repeated about every five minutes because ratios changed below displayed
-  precision; unstuck allowance oscillated around `-1.70` to `-1.76` while each
-  repeat was marked changed.
-- Scope: producer-owned `operator_visible`; five-percent relative unstuck
-  allowance hysteresis; per-item trailing materiality at 0.05 percentage points
-  for ratios and 0.5 percent for prices; generic console/text suppression only
-  when visibility is explicitly false. Missing metadata remains visible.
+- Branch: `codex/compact-trailing-status-console`, based on canonical
+  `fc5c2cae88817744ebe330ad9c1b321087d70250` after PR #1246.
+- PR: pending publication, `Compact trailing status console projection`.
+- Slice: compact only the operator-facing `trailing.status` console/text
+  formatter while preserving complete structured and monitor payloads.
+- Triggering evidence: the first natural post-PR #1246 Hyperliquid trailing
+  record was 311 visible characters. It repeated long field names for status,
+  threshold and retracement gates even though the structured event retained all
+  detail, exceeding the normal 240-character record budget.
+- Scope: retain action/status, symbol and position side, selected mode, gate
+  states, material threshold/retracement values, current price, and available
+  cycle correlation using compact human labels.
 - Behavior boundary: observability-only; no exchange calls, cache or task
-  mutation, planning or status calculation change, cadence increase, Rust,
-  order, risk, backtest, or optimizer behavior.
+  mutation, event admission or payload change, planning or status calculation
+  change, cadence change, Rust, order, risk, backtest, or optimizer behavior.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green CI
   while Grok is halted.
 - Expected VPS action: after merge, one authorized exact five-bot restart.
-  Validate five-minute durable observations and natural console suppression;
-  do not manufacture trailing, unstuck, exchange, state, or trading events.
+  Validate the next naturally visible trailing line and settled smoke; do not
+  manufacture trailing, exchange, state, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `de5f21c96d92aab1c465e0be40035ed3ec6a6d0a`, PR #1245. The tracked checkout
+  `fc5c2cae88817744ebe330ad9c1b321087d70250`, PR #1246. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `951819/951822/951825/951828/951830`. The exact pane PIDs remain
+  `953285/953287/953289/953291/953292`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1246 was activated with one exact five-bot graceful restart. Every old
+  bot exited naturally after one SIGINT round; KuCoin was last at about 30
+  seconds, with no escalation. The first natural cadence emitted five durable
+  trailing/unstuck events with `changed=true` and `operator_visible=true` plus
+  five human lines. The second cadence emitted five durable events with
+  `changed=false` and `operator_visible=false` and zero human lines, including
+  natural sub-threshold Hyperliquid drift.
+- The final two-minute smoke was `ok=true` with `224/224` remote calls and
+  `56/56` account-critical calls successful, nine successful fill refreshes,
+  five matching/config-valid processes in state `R`, and zero hard, log,
+  monitor, process, or event-pipeline failures. The 311-character first
+  trailing line exposed the active formatter-only follow-up.
 - PRs #1244 and #1245 were activated together with one exact five-bot graceful
   restart. Every old bot exited naturally after one SIGINT round; KuCoin was
   last at 40 seconds, with no escalation. A real immediate KuCoin timeout

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/compact-trailing-status-console`, based on canonical
   `fc5c2cae88817744ebe330ad9c1b321087d70250` after PR #1246.
-- PR: pending publication, `Compact trailing status console projection`.
+- PR: #1247, `Compact trailing status console projection`.
 - Slice: compact only the operator-facing `trailing.status` console/text
   formatter while preserving complete structured and monitor payloads.
 - Triggering evidence: the first natural post-PR #1246 Hyperliquid trailing

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -698,9 +698,11 @@ naturally validated: intermediate console progress stayed at least 30 seconds
 apart while complete structured progress remained durable. Its restart exposed
 the execution-loop incident projection addressed by merged PR #1244. PR #1245
 is also merged and deployed: bounded execution incidents and compact memory
-snapshots are naturally validated with a settled hard-green smoke. The active
-slice applies producer-owned materiality to repeated trailing and unstuck human
-projections while preserving their five-minute durable observations.
+snapshots are naturally validated with a settled hard-green smoke. PR #1246 is
+merged, deployed, and naturally validated: producer-owned materiality suppresses
+unchanged trailing/unstuck human repeats while preserving five-minute durable
+observations. Active PR #1247 compacts the remaining 311-character visible
+trailing projection without changing its payload, admission, or behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -8434,3 +8434,28 @@ active branch, PR, review gate, and rollout instructions.
   active `codex/trailing-unstuck-console-materiality` slice preserves every
   five-minute structured observation while applying explicit producer-owned
   transition and numeric materiality to console/text output.
+
+### 2026-07-15: Risk Status Materiality Deployed; Trailing Format Follow-Up
+
+- PR #1246 merged as `fc5c2cae88` after exact-head Hermes approval and green
+  Python/Rust CI under the temporary maintainer-authorized Hermes-plus-CI gate.
+  The stale progress-ledger current-work block was explicitly marked historical
+  after Hermes identified the contradictory handoff.
+- VPS5 fast-forwarded cleanly and activated the PR with one exact five-bot
+  restart. All old bots exited naturally after one SIGINT round; KuCoin was
+  last at about 30 seconds. Exact pane PIDs and unrelated `misc:0.0` PID
+  `434835` remained unchanged.
+- The first natural cadence emitted five durable trailing/unstuck events with
+  `changed=true` and `operator_visible=true` plus five console lines. The second
+  cadence emitted five durable events with `changed=false` and
+  `operator_visible=false` and zero console lines. Hyperliquid naturally varied
+  below the configured materiality boundaries, proving data retention and
+  human suppression without manufactured activity.
+- The final two-minute smoke was `ok=true`: `224/224` remote and `56/56`
+  account-critical calls succeeded, nine fill refreshes succeeded, five exact
+  processes/configs were in state `R`, and hard/log/monitor/process/pipeline
+  failures were zero. The repository was clean at the exact merged head.
+- The first visible Hyperliquid trailing line measured 311 characters and
+  repeated verbose field names already represented in the complete event. The
+  active `codex/compact-trailing-status-console` follow-up is formatter-only and
+  targets the normal 240-character budget without changing payload or behavior.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -568,12 +568,16 @@ Related detailed plans:
     warning. Migrate that detail with the same emitter/pipeline/sink fallback
     contract while preserving every gate decision and throttle.
 
-    PR #1246 is the active risk-status materiality slice. It keeps every
+    PR #1246 merged and deployed the risk-status materiality slice. It keeps every
     five-minute trailing and unstuck observation in structured/monitor sinks
     while limiting console/text projection to first observations, qualitative
     or material numeric transitions, and hourly reminders. The change is
     observability-only and leaves status calculation, planning, risk, and order
-    behavior unchanged.
+    behavior unchanged. Two natural post-restart cadences proved both durable
+    detail and suppression; settled smoke was hard-green. The first visible
+    trailing line still measured 311 characters, so the active
+    `codex/compact-trailing-status-console` follow-up compacts that formatter to
+    the normal 240-character budget without changing event data or admission.
 
     Two post-PR #1220 console observations remain deferred rather than folded
     into the realized-loss slice. Hyperliquid balance lines surfaced signed

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -576,8 +576,9 @@ Related detailed plans:
     behavior unchanged. Two natural post-restart cadences proved both durable
     detail and suppression; settled smoke was hard-green. The first visible
     trailing line still measured 311 characters, so the active
-    `codex/compact-trailing-status-console` follow-up compacts that formatter to
-    the normal 240-character budget without changing event data or admission.
+    PR #1247, `codex/compact-trailing-status-console`, compacts that formatter
+    to the normal 240-character budget without changing event data or
+    admission.
 
     Two post-PR #1220 console observations remain deferred rather than folded
     into the realized-loss slice. Hyperliquid balance lines surfaced signed

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -1893,16 +1893,53 @@ def _console_trailing_status_summary(event: LiveEvent) -> list[str]:
         reason = _data_str(data, "unsupported_reason")
         if reason:
             parts.append(f"unsupported={reason}")
-        return parts
+    return parts
+
+
+def _compact_trailing_console_label(value: object, *, limit: int) -> str:
+    label = _format_console_label(value)
+    if len(label) <= limit:
+        return label
+    return label[: limit - 3] + "..."
+
+
+def _format_console_trailing_status(event: LiveEvent) -> str | None:
+    data = event.data if isinstance(event.data, Mapping) else {}
+    if data.get("diagnostics_supported") is False:
+        return None
+
+    parts = ["[trailing]"]
+    if event.status:
+        parts.append(event.status)
+    if event.cycle_id:
+        parts.append(f"cycle={_compact_trailing_console_label(event.cycle_id, limit=36)}")
+
+    kind = _data_str(data, "kind")
     trailing_status = _data_str(data, "trailing_status")
-    if trailing_status:
-        parts.append(f"trailing_status={trailing_status}")
+    if kind and trailing_status:
+        parts.append(
+            f"{_compact_trailing_console_label(kind, limit=12)}/"
+            f"{_compact_trailing_console_label(trailing_status, limit=24)}"
+        )
+    elif kind:
+        parts.append(f"kind={_compact_trailing_console_label(kind, limit=12)}")
+    elif trailing_status:
+        parts.append(f"status={_compact_trailing_console_label(trailing_status, limit=24)}")
+
     selected_mode = _data_str(data, "selected_mode")
     if selected_mode:
-        parts.append(f"mode={selected_mode}")
+        parts.append(f"mode={_compact_trailing_console_label(selected_mode, limit=20)}")
+
+    gate_states: list[str] = []
     threshold_met = data.get("threshold_met")
     if threshold_met is not None:
-        parts.append(f"threshold_met={'yes' if bool(threshold_met) else 'no'}")
+        gate_states.append(f"t:{'y' if bool(threshold_met) else 'n'}")
+    retracement_met = data.get("retracement_met")
+    if retracement_met is not None:
+        gate_states.append(f"r:{'y' if bool(retracement_met) else 'n'}")
+    if gate_states:
+        parts.append(f"gates={'/'.join(gate_states)}")
+
     threshold_pct = _data_number(data, "threshold_pct")
     threshold_price = _data_number(data, "threshold_price")
     if threshold_pct is not None and threshold_price:
@@ -1910,13 +1947,8 @@ def _console_trailing_status_summary(event: LiveEvent) -> list[str]:
     elif threshold_pct is not None:
         parts.append(f"threshold={threshold_pct * 100.0:.4f}%")
     elif threshold_price:
-        parts.append(f"threshold_price={threshold_price:g}")
-    threshold_dist = _data_number(data, "current_vs_threshold_ratio")
-    if threshold_dist is not None:
-        parts.append(f"threshold_dist={threshold_dist * 100.0:.4f}%")
-    retracement_met = data.get("retracement_met")
-    if retracement_met is not None:
-        parts.append(f"retracement_met={'yes' if bool(retracement_met) else 'no'}")
+        parts.append(f"threshold={threshold_price:g}")
+
     retracement_pct = _data_number(data, "retracement_pct")
     retracement_price = _data_number(data, "retracement_price")
     if retracement_pct is not None and retracement_price:
@@ -1924,19 +1956,16 @@ def _console_trailing_status_summary(event: LiveEvent) -> list[str]:
     elif retracement_pct is not None:
         parts.append(f"retracement={retracement_pct * 100.0:.4f}%")
     elif retracement_price:
-        parts.append(f"retracement_price={retracement_price:g}")
-    retracement_dist = _data_number(data, "current_vs_retracement_ratio")
-    if retracement_dist is not None:
-        parts.append(f"retracement_dist={retracement_dist * 100.0:.4f}%")
-    projected = _data_number(data, "threshold_projection_retracement_price")
-    if projected and retracement_pct is not None:
-        parts.append(f"if_threshold_retrace={retracement_pct * 100.0:.4f}%@{projected:g}")
-    elif projected:
-        parts.append(f"if_threshold_retrace_price={projected:g}")
+        parts.append(f"retracement={retracement_price:g}")
+
     current_price = _data_number(data, "current_price")
     if current_price:
-        parts.append(f"current={current_price:g}")
-    return parts
+        parts.append(f"cur={current_price:g}")
+    if event.symbol:
+        parts.append(f"symbol={_compact_trailing_console_label(event.symbol, limit=48)}")
+    if event.pside:
+        parts.append(f"pside={_compact_trailing_console_label(event.pside, limit=8)}")
+    return " ".join(parts)
 
 
 def _console_unstuck_status_summary(event: LiveEvent) -> list[str]:
@@ -2105,6 +2134,10 @@ def format_console_event(event: LiveEvent) -> str:
         return _format_console_balance_changed(event)
     if event.event_type == EventTypes.RESOURCE_MEMORY_SNAPSHOT:
         return format_memory_snapshot_console(event.data)
+    if event.event_type == EventTypes.TRAILING_STATUS:
+        trailing_status = _format_console_trailing_status(event)
+        if trailing_status is not None:
+            return trailing_status
     base = f"[{_console_tag(event)}]"
     if event.status:
         base += f" {event.status}"

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -1997,12 +1997,50 @@ def test_console_format_summarizes_trailing_status():
     )
 
     assert format_console_event(event) == (
-        "[trailing] succeeded cycle=cy_trailing kind=entry "
-        "trailing_status=waiting_threshold mode=grid threshold_met=no threshold=1.2500%@98750 "
-        "threshold_dist=2.2785% retracement_met=no retracement=0.4000%@99145 "
-        "retracement_dist=1.8710% if_threshold_retrace=0.4000%@99145 current=101000 "
-        "symbol=BTC/USDT:USDT pside=long reason=trailing_status"
+        "[trailing] succeeded cycle=cy_trailing entry/waiting_threshold mode=grid "
+        "gates=t:n/r:n threshold=1.2500%@98750 retracement=0.4000%@99145 cur=101000 "
+        "symbol=BTC/USDT:USDT pside=long"
     )
+
+
+def test_console_format_compacts_trailing_status_with_long_identifiers():
+    cycle_id = "cy_20260715_123456789012345678901234"
+    symbol = "LONG-UNDERLYING-NAME-2026-PERP/USDC:USDC"
+    event = LiveEvent(
+        EventTypes.TRAILING_STATUS,
+        status="succeeded",
+        cycle_id=cycle_id,
+        symbol=symbol,
+        pside="long",
+        reason_code="trailing_status",
+        data={
+            "kind": "close",
+            "trailing_status": "armed",
+            "selected_mode": "auto_reduce",
+            "threshold_met": True,
+            "threshold_pct": -0.019649,
+            "threshold_price": 887.25,
+            "retracement_met": True,
+            "retracement_pct": 0.000212,
+            "retracement_price": 1049.58,
+            "current_price": 902.465,
+            "current_vs_threshold_ratio": -0.140163,
+            "current_vs_retracement_ratio": -0.140163,
+            "threshold_projection_retracement_price": 1030.0,
+        },
+    )
+
+    rendered = format_console_event(event)
+
+    assert rendered == (
+        f"[trailing] succeeded cycle={cycle_id} close/armed mode=auto_reduce "
+        "gates=t:y/r:y threshold=-1.9649%@887.25 retracement=0.0212%@1049.58 cur=902.465 "
+        f"symbol={symbol} pside=long"
+    )
+    assert len(rendered) <= 240
+    assert event.data["current_vs_threshold_ratio"] == -0.140163
+    assert event.data["current_vs_retracement_ratio"] == -0.140163
+    assert event.data["threshold_projection_retracement_price"] == 1030.0
 
 
 def test_console_format_summarizes_unsupported_trailing_status():


### PR DESCRIPTION
## Summary
- replace the verbose operator-facing `trailing.status` formatter with compact status/mode/gate labels
- retain threshold and retracement ratios/prices, current price, symbol/pside, and cycle correlation
- keep complete structured/monitor payloads, routing, visibility admission, cadence, and behavior unchanged

## Triggering evidence
After deploying PR #1246, the first natural Hyperliquid trailing line measured 311 visible characters. The next unchanged five-minute observation remained durable with `changed=false operator_visible=false` and produced no console line, proving materiality worked while the admitted formatter still exceeded the normal 240-character budget.

## Non-goals
- no producer, payload, event route, admission, cadence, Rust, planning, risk, order, exchange, cache, backtest, or optimizer changes
- distance/projection diagnostics remain available in structured/monitor data instead of the compact human line

## Validation
- `pytest -q tests/test_live_event_bus.py tests/test_live_event_registry_docs.py tests/test_ai_docs.py`
- `py_compile` on changed Python/test files
- live-event registry generated-doc check with worktree-local `PYTHONPATH=src`
- AI-doc checker: 0 errors, one existing aggregate word-count warning
- added-line silent-handling audit and `git diff --check` clean
- regression covers long cycle/symbol identifiers and enforces <=240 characters

## Review and rollout
Temporary maintainer-authorized gate while Grok is halted: exact-head Hermes approval plus green CI. After merge, deploy with one authorized exact five-bot graceful restart and validate the next naturally visible trailing line; do not manufacture exchange, state, or trading events.

Reviewer focus: compact-field semantics, threshold/retracement information retention, unsupported-diagnostics fallback, and budget behavior with long identifiers.