### PR TITLE
Bound approved-coins startup log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- CLI overrides of `live.approved_coins` now use a bounded startup log summary
+  with per-side counts and three-symbol samples instead of printing the full
+  old and new collections. Config application and non-target config-change
+  logging are unchanged.
+
 - Visible `trailing.status` console/text records now use a compact operator
   projection that fits the normal line budget while retaining status, position
   identity, mode, trigger gates, material threshold/retracement values, current

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/bound-approved-coins-console`, based on canonical
   `e3c6332c6b1f4ff692f94867f9dbfaf182cc0684` after PR #1247.
-- PR: pending, `Bound approved-coins startup log`.
+- PR: #1248, `Bound approved-coins startup log`.
 - Slice: bound only the INFO config-change projection for
   `live.approved_coins` while preserving complete applied config values.
 - Triggering evidence: the PR #1247 restart naturally printed a 678-character

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,36 +22,42 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/compact-trailing-status-console`, based on canonical
-  `fc5c2cae88817744ebe330ad9c1b321087d70250` after PR #1246.
-- PR: #1247, `Compact trailing status console projection`.
-- Slice: compact only the operator-facing `trailing.status` console/text
-  formatter while preserving complete structured and monitor payloads.
-- Triggering evidence: the first natural post-PR #1246 Hyperliquid trailing
-  record was 311 visible characters. It repeated long field names for status,
-  threshold and retracement gates even though the structured event retained all
-  detail, exceeding the normal 240-character record budget.
-- Scope: retain action/status, symbol and position side, selected mode, gate
-  states, material threshold/retracement values, current price, and available
-  cycle correlation using compact human labels.
+- Branch: `codex/bound-approved-coins-console`, based on canonical
+  `e3c6332c6b1f4ff692f94867f9dbfaf182cc0684` after PR #1247.
+- PR: pending, `Bound approved-coins startup log`.
+- Slice: bound only the INFO config-change projection for
+  `live.approved_coins` while preserving complete applied config values.
+- Triggering evidence: the PR #1247 restart naturally printed a 678-character
+  KuCoin CLI-override line containing the full prior list and duplicate long/
+  short collections, exceeding the normal 240-character record budget.
+- Scope: retain the config path, old/new shapes, per-side counts, and at most
+  three deterministic symbol samples plus explicit truncation counts.
 - Behavior boundary: observability-only; no exchange calls, cache or task
-  mutation, event admission or payload change, planning or status calculation
-  change, cadence change, Rust, order, risk, backtest, or optimizer behavior.
+  mutation, config application or schema change, non-target config log change,
+  Rust, order, risk, backtest, optimizer, or trading behavior.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green CI
   while Grok is halted.
 - Expected VPS action: after merge, one authorized exact five-bot restart.
-  Validate the next naturally visible trailing line and settled smoke; do not
-  manufacture trailing, exchange, state, or trading events.
+  Validate the natural KuCoin startup override line and settled smoke; do not
+  manufacture exchange, state, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `fc5c2cae88817744ebe330ad9c1b321087d70250`, PR #1246. The tracked checkout
+  `e3c6332c6b1f4ff692f94867f9dbfaf182cc0684`, PR #1247. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `953285/953287/953289/953291/953292`. The exact pane PIDs remain
+  `955304/955366/955200/955422/955306`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1247 was activated with one exact five-bot graceful restart. Every old
+  bot exited naturally after one SIGINT round, with no escalation. The
+  immediate five-minute smoke was hard-green with `338/338` remote and `93/93`
+  account-critical calls successful. The settled smoke remained `ok=true`
+  with zero hard failures and `55/55` account-critical calls successful; one
+  non-account-critical candle timeout remained non-hard evidence, and two
+  report-time `D` samples cleared to exact `R/S` states. Natural Hyperliquid
+  output proved the compact trailing projection at 211 visible characters.
 - PR #1246 was activated with one exact five-bot graceful restart. Every old
   bot exited naturally after one SIGINT round; KuCoin was last at about 30
   seconds, with no escalation. The first natural cadence emitted five durable
@@ -619,7 +625,7 @@ Estimated completion:
 
 - Normal gate: all reviewers currently designated by the maintainer plus green
   CI on the exact head SHA.
-- Temporary gate while Claude is rate-limited: Hermes + Grok 4.5 + green CI.
+- Temporary gate while Grok 4.5 is halted: exact-head Hermes + green CI.
 - Findings from any additional reviewer must still be verified and resolved.
 - Any pushed delta requires current-head re-review.
 
@@ -701,8 +707,16 @@ is also merged and deployed: bounded execution incidents and compact memory
 snapshots are naturally validated with a settled hard-green smoke. PR #1246 is
 merged, deployed, and naturally validated: producer-owned materiality suppresses
 unchanged trailing/unstuck human repeats while preserving five-minute durable
-observations. Active PR #1247 compacts the remaining 311-character visible
-trailing projection without changing its payload, admission, or behavior.
+observations. PR #1247 is also merged, deployed, and naturally validated: its
+compact trailing projection reduced the observed Hyperliquid line from 311 to
+211 visible characters while retaining the operator-relevant state and leaving
+payload, admission, cadence, and behavior unchanged. The restart and settled
+smoke were hard-green; report-time `D` samples cleared to exact `R/S` states.
+
+The active slice bounds the naturally observed 678-character
+`live.approved_coins` startup override line with per-side counts and bounded
+symbol samples. It changes only the config-change log projection; applied
+config values and non-target config logging remain unchanged.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,6 +15,33 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
+## Latest Canonical Deployment (PR #1247)
+
+- PR #1247 merged to `master` as `e3c6332c6b1f4ff692f94867f9dbfaf182cc0684`
+  after exact-head Hermes approval and green Python/Rust CI while Grok was
+  temporarily halted. The change compacts only the human projection of visible
+  `trailing.status` records; structured payloads, materiality admission,
+  cadence, risk calculations, and trading behavior are unchanged.
+- VPS5 fast-forwarded cleanly and gracefully restarted the five exact bot
+  panes. Old PIDs `953285/953287/953289/953291/953292` exited naturally after
+  one SIGINT round; pane PIDs and unrelated `misc:0.0` PID `434835` were
+  preserved. New bot PIDs are `955304/955366/955200/955422/955306` for
+  Binance/KuCoin/GateIO/OKX/Hyperliquid respectively.
+- The immediate five-minute smoke was hard-green with `338/338` remote and
+  `93/93` account-critical calls successful, twenty successful fill refreshes,
+  five expected processes matched, no hard/log/monitor/pipeline failures, and
+  a clean tracked repository. The settled two-minute smoke remained
+  `ok=true`, with zero hard failures and `55/55` account-critical calls
+  successful; one non-account-critical KuCoin candle timeout remained visible
+  as non-hard evidence. Two report-time `D` samples cleared to exact `R/S`
+  states on the quiet follow-up.
+- Natural Hyperliquid output validated the compact formatter at 211 visible
+  characters versus the prior 311, retaining cycle, close/armed state, mode,
+  threshold and retracement gates/values, current price, symbol, and side.
+  The same restart exposed the next boundedness gap: a CLI-approved-coin
+  override printed a 678-character full collection diff. The next slice limits
+  that startup projection without changing the applied config.
+
 ## Historical Status Snapshot (PR #1191)
 
 Snapshot captured: 2026-07-11.

--- a/src/config_utils.py
+++ b/src/config_utils.py
@@ -128,9 +128,79 @@ def _format_optimize_limits_change_for_log(
     return " | ".join(parts)
 
 
+_APPROVED_COINS_LOG_SAMPLE_SIZE = 3
+_APPROVED_COINS_LOG_SYMBOL_MAX_LENGTH = 8
+
+
+def _format_approved_coins_symbol_for_log(value: Any) -> str:
+    if not isinstance(value, str):
+        return f"<{type(value).__name__}>"
+    symbol = value[:_APPROVED_COINS_LOG_SYMBOL_MAX_LENGTH].replace("\n", " ").replace(
+        "\r", " "
+    )
+    if len(value) > _APPROVED_COINS_LOG_SYMBOL_MAX_LENGTH:
+        return f"{symbol}..."
+    return symbol
+
+
+def _format_approved_coins_collection_for_log(value: list[Any]) -> str:
+    count = len(value)
+    if not count:
+        return "0[]"
+    sample = [
+        _format_approved_coins_symbol_for_log(symbol)
+        for symbol in value[:_APPROVED_COINS_LOG_SAMPLE_SIZE]
+    ]
+    if count > _APPROVED_COINS_LOG_SAMPLE_SIZE:
+        sample.append(f"+{count - _APPROVED_COINS_LOG_SAMPLE_SIZE}")
+    return f"{count}[{','.join(sample)}]"
+
+
+def _format_approved_coins_list_for_log(value: list[Any]) -> str:
+    return f"list:{_format_approved_coins_collection_for_log(value)}"
+
+
+def _format_approved_coins_shape_for_log(value: Any) -> str:
+    if isinstance(value, list):
+        return _format_approved_coins_list_for_log(value)
+    if isinstance(value, dict):
+        return f"dict:{len(value)}"
+    if isinstance(value, str):
+        return f"str:{len(value)}"
+    if isinstance(value, (tuple, set, frozenset)):
+        return f"{type(value).__name__}:{len(value)}"
+    if value is None:
+        return "none"
+    return f"type={type(value).__name__}"
+
+
+def _format_approved_coins_change_for_log(old_value: Any, new_value: Any) -> str:
+    def format_value(value: Any) -> str:
+        if (
+            isinstance(value, dict)
+            and set(value) == {"long", "short"}
+            and isinstance(value["long"], list)
+            and isinstance(value["short"], list)
+        ):
+            return (
+                "sides("
+                f"long:{_format_approved_coins_collection_for_log(value['long'])},"
+                f"short:{_format_approved_coins_collection_for_log(value['short'])}"
+                ")"
+            )
+        return _format_approved_coins_shape_for_log(value)
+
+    return (
+        "changed live.approved_coins "
+        f"{format_value(old_value)} -> {format_value(new_value)}"
+    )
+
+
 def _format_config_change_message(
     full_path: str, old_value: Any, new_value: Any
 ) -> tuple[str, tuple[Any, ...]]:
+    if full_path == "live.approved_coins":
+        return _format_approved_coins_change_for_log(old_value, new_value), ()
     if full_path == "optimize.limits":
         custom = _format_optimize_limits_change_for_log(old_value, new_value)
         if custom is not None:

--- a/tests/test_config_utils_helpers.py
+++ b/tests/test_config_utils_helpers.py
@@ -1111,6 +1111,91 @@ def test_update_config_with_args_logs_optimize_limits_as_diff(caplog):
     assert " -> " not in target[-1]
 
 
+def test_update_config_with_args_bounds_approved_coins_cli_override_log(caplog):
+    config = get_template_config()
+    old_coins = ["BTC", "ETH", "SOL", "XRP", "DOGE"]
+    override_coins = ["ADA", "AVAX", "DOT", "LINK", "MATIC", "ATOM"]
+    config["live"]["approved_coins"] = old_coins
+    args = SimpleNamespace()
+    vars(args)["live.approved_coins"] = override_coins
+
+    with caplog.at_level(logging.INFO):
+        update_config_with_args(config, args, verbose=True)
+
+    assert config["live"]["approved_coins"] == {
+        "long": override_coins,
+        "short": override_coins,
+    }
+    message = next(
+        rec.message
+        for rec in caplog.records
+        if rec.message.startswith("[config] changed live.approved_coins")
+    )
+    assert "list:5[BTC,ETH,SOL,+2]" in message
+    assert "sides(long:6[ADA,AVAX,DOT,+3]" in message
+    assert "short:6[ADA,AVAX,DOT,+3]" in message
+    assert len("2026-07-15T22:24:59Z INFO     [config] " + message) <= 240
+
+
+def test_approved_coins_change_log_samples_deterministically():
+    value = {"long": ["SOL", "BTC", "ETH", "XRP"], "short": ["DOGE"]}
+
+    message, args = config_utils._format_config_change_message(
+        "live.approved_coins", value, value
+    )
+
+    assert args == ()
+    assert message == (
+        "changed live.approved_coins sides("
+        "long:4[SOL,BTC,ETH,+1],short:1[DOGE]) -> "
+        "sides(long:4[SOL,BTC,ETH,+1],short:1[DOGE])"
+    )
+
+
+def test_approved_coins_change_log_stays_within_info_budget_for_large_mappings():
+    old_value = [f"OLD-SYMBOL-{i:03d}-LONG" for i in range(100)]
+    new_value = {
+        "long": [f"LONG-SYMBOL-{i:03d}-LONG" for i in range(100)],
+        "short": [f"SHORT-SYMBOL-{i:03d}-LONG" for i in range(100)],
+    }
+
+    message, args = config_utils._format_config_change_message(
+        "live.approved_coins", old_value, new_value
+    )
+
+    assert args == ()
+    assert "list:100[OLD-SYMB...,OLD-SYMB...,OLD-SYMB...,+97]" in message
+    assert "long:100[LONG-SYM...,LONG-SYM...,LONG-SYM...,+97]" in message
+    assert "short:100[SHORT-SY...,SHORT-SY...,SHORT-SY...,+97]" in message
+    assert len("2026-07-15T22:24:59Z INFO     [config] " + message) <= 240
+
+
+def test_approved_coins_change_log_bounds_malformed_and_unexpected_values():
+    malformed = {"long": "X" * 1_000, "extra": ["Y" * 1_000]}
+
+    message, args = config_utils._format_config_change_message(
+        "live.approved_coins", malformed, object()
+    )
+
+    assert args == ()
+    assert message == "changed live.approved_coins dict:2 -> type=object"
+    assert len(message) < 240
+    assert "X" * 20 not in message
+    assert "Y" * 20 not in message
+
+
+def test_config_change_log_keeps_non_target_generic_formatting():
+    old_value = {"value": [1, 2]}
+    new_value = {"value": [3, 4]}
+
+    message, args = config_utils._format_config_change_message(
+        "backtest.start_date", old_value, new_value
+    )
+
+    assert message == "changed %s %s -> %s"
+    assert args == ("backtest.start_date", old_value, new_value)
+
+
 def test_backtest_filter_min_cost_inherits_from_live():
     cfg = get_template_config()
     cfg["live"]["filter_by_min_effective_cost"] = True


### PR DESCRIPTION
## Summary

- bound `live.approved_coins` config-change INFO output with collection counts, three-symbol samples, and explicit truncation counts
- preserve actual config application, malformed-shape safety, `optimize.limits` formatting, and generic config-change behavior
- record PR #1247 merge/deploy evidence and the temporary Hermes-only review gate

## Triggering evidence

The PR #1247 VPS5 restart naturally printed a 678-character KuCoin startup line containing the full previous approved-coin list and duplicate long/short override collections. The representative replacement is about 158 visible characters including the timestamp/level/tag prefix; a pathological long-symbol regression remains at 227, within the 240-character console policy budget.

## Validation

- `PYTHONPATH=/private/tmp/passivbot-approved-coins-console/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_config_utils_helpers.py -q`
- `PYTHONPATH=/private/tmp/passivbot-approved-coins-console/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/config_utils.py tests/test_config_utils_helpers.py`
- `PYTHONPATH=/private/tmp/passivbot-approved-coins-console/src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python src/tools/check_ai_docs.py` (0 errors; existing aggregate word-count warning only)
- `git diff --check`
- added-line silent-handling scan: no matches

## Behavior boundary

Observability-only. No config/schema/application change, exchange call, event route, cache/task mutation, Rust, order, risk, backtest, optimizer, or trading behavior change.

## Review gate

Temporary maintainer-authorized gate while Grok 4.5 is halted: exact-head Hermes approval plus green CI. Any additional reviewer finding still requires verification.

## VPS plan

After merge, gracefully restart only the five exact authorized bot panes, preserve `misc:0.0`, validate the natural KuCoin startup override line, and run bounded immediate/settled smoke checks. Do not manufacture exchange, state, or trading events.
