### PR TITLE
Compact candle lock-hold warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Candle fetch-lock hold warnings now retain the affected exchange, symbol,
+  timeframe, and compact local-holder identity/timing without repeating the
+  deterministic lock path, duplicated owner scope, configured timeout, or
+  implied action. Watchdog timing, lock behavior, and warning cadence are
+  unchanged.
+
 - CLI overrides of `live.approved_coins` now use a bounded startup log summary
   with per-side counts and three-symbol samples instead of printing the full
   old and new collections. Config application and non-target config-change

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,34 +22,44 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/bound-approved-coins-console`, based on canonical
-  `e3c6332c6b1f4ff692f94867f9dbfaf182cc0684` after PR #1247.
-- PR: #1248, `Bound approved-coins startup log`.
-- Slice: bound only the INFO config-change projection for
-  `live.approved_coins` while preserving complete applied config values.
-- Triggering evidence: the PR #1247 restart naturally printed a 678-character
-  KuCoin CLI-override line containing the full prior list and duplicate long/
-  short collections, exceeding the normal 240-character record budget.
-- Scope: retain the config path, old/new shapes, per-side counts, and at most
-  three deterministic symbol samples plus explicit truncation counts.
+- Branch: `codex/compact-candle-lock-warning`, based on canonical
+  `75bf6cd67f61b902fb5ca4399939c2b2e5945088` after PR #1248.
+- PR: pending, `Compact candle lock-hold warnings`.
+- Slice: compact only the normal `fetch_lock_hold_timeout` warning while
+  retaining one warning per affected symbol.
+- Triggering evidence: the PR #1248 restart naturally printed six simultaneous
+  OKX lock-hold warnings at 346-349 visible characters. Each repeated the
+  deterministic lock path, configured timeout, implied action, and owner
+  exchange/symbol/timeframe already carried by top-level scope.
+- Scope: retain event, exchange, symbol, timeframe, and compact holder
+  PID/task/attempt/actual-held timing; preserve full owner scope for the
+  separate stale-wait warning path.
 - Behavior boundary: observability-only; no exchange calls, cache or task
-  mutation, config application or schema change, non-target config log change,
-  Rust, order, risk, backtest, optimizer, or trading behavior.
+  mutation, lock scheduling/acquisition/release, timeout/retry/exception or
+  warning-cadence change, Rust, order, risk, backtest, optimizer, or trading
+  behavior.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green CI
   while Grok is halted.
 - Expected VPS action: after merge, one authorized exact five-bot restart.
-  Validate the natural KuCoin startup override line and settled smoke; do not
-  manufacture exchange, state, or trading events.
+  Observe the warning only if it occurs naturally, and run settled smoke; do
+  not manufacture lock contention, exchange, state, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `e3c6332c6b1f4ff692f94867f9dbfaf182cc0684`, PR #1247. The tracked checkout
+  `75bf6cd67f61b902fb5ca4399939c2b2e5945088`, PR #1248. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `955304/955366/955200/955422/955306`. The exact pane PIDs remain
+  `957519/957674/957669/957739/957675`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1248 was activated with one exact five-bot graceful restart. Every old
+  bot exited naturally within ten seconds after one SIGINT round. Natural
+  KuCoin output reduced the approved-coin override line from 678 to 154 visible
+  characters. Real pre- and post-restart KuCoin timeouts recovered without
+  intervention; the final fresh smoke was hard-green with `56/56`
+  account-critical calls successful, nine successful fill refreshes, five
+  config-valid processes in exact `R/S` states, and a clean tracked checkout.
 - PR #1247 was activated with one exact five-bot graceful restart. Every old
   bot exited naturally after one SIGINT round, with no escalation. The
   immediate five-minute smoke was hard-green with `338/338` remote and `93/93`
@@ -713,10 +723,12 @@ compact trailing projection reduced the observed Hyperliquid line from 311 to
 payload, admission, cadence, and behavior unchanged. The restart and settled
 smoke were hard-green; report-time `D` samples cleared to exact `R/S` states.
 
-The active slice bounds the naturally observed 678-character
-`live.approved_coins` startup override line with per-side counts and bounded
-symbol samples. It changes only the config-change log projection; applied
-config values and non-target config logging remain unchanged.
+PR #1248 is merged, deployed, and naturally validated: its bounded
+`live.approved_coins` startup projection reduced the exact KuCoin line from 678
+to 154 visible characters while retaining counts and bounded samples. The
+active slice compacts the six naturally observed 346-349 character candle
+lock-hold warnings without changing their per-symbol admission or lock
+behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/compact-candle-lock-warning`, based on canonical
   `75bf6cd67f61b902fb5ca4399939c2b2e5945088` after PR #1248.
-- PR: pending, `Compact candle lock-hold warnings`.
+- PR: #1249, `Compact candle lock-hold warnings`.
 - Slice: compact only the normal `fetch_lock_hold_timeout` warning while
   retaining one warning per affected symbol.
 - Triggering evidence: the PR #1248 restart naturally printed six simultaneous

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,35 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1247)
+## Latest Canonical Deployment (PR #1248)
+
+- PR #1248 merged to `master` as `75bf6cd67f61b902fb5ca4399939c2b2e5945088`
+  after exact-head Hermes approval and green Python/Rust CI while Grok was
+  temporarily halted. It bounds only the `live.approved_coins` config-change
+  projection; config application, schema, non-target config logs, and trading
+  behavior are unchanged.
+- VPS5 fast-forwarded cleanly and gracefully restarted the five exact bot
+  panes. Old PIDs `955200/955304/955306/955366/955422` exited naturally within
+  ten seconds after one SIGINT round; pane PIDs and unrelated `misc:0.0` PID
+  `434835` were preserved. New bot PIDs are
+  `957519/957674/957669/957739/957675` for
+  Binance/KuCoin/GateIO/OKX/Hyperliquid respectively.
+- Natural KuCoin startup output reduced the exact approved-coin override from
+  678 to 154 visible characters while retaining the old collection count/
+  sample and both 19-coin side counts/samples. Real pre- and post-restart
+  KuCoin timeouts recovered without intervention. The final fresh two-minute
+  smoke was `ok=true` with zero hard/log/monitor/process failures, `56/56`
+  account-critical calls successful, nine successful fill refreshes, all five
+  expected config-valid processes in exact `R/S` states, and a clean tracked
+  repository. One non-account-critical candle timeout remained visible as
+  non-hard evidence.
+- The same restart exposed six simultaneous `fetch_lock_hold_timeout` warnings
+  at 346-349 characters each. They repeated deterministic path and owner-scope
+  fields already present in the warning. The next slice compacts only that
+  projection while preserving one warning per affected symbol and all lock
+  behavior.
+
+## Previous Canonical Deployment (PR #1247)
 
 - PR #1247 merged to `master` as `e3c6332c6b1f4ff692f94867f9dbfaf182cc0684`
   after exact-head Hermes approval and green Python/Rust CI while Grok was

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -1168,7 +1168,7 @@ class CandlestickManager:
             with suppress(Exception):
                 os.utime(path, None)
 
-    def _read_lockfile_owner(self, path: str) -> str:
+    def _read_lockfile_owner(self, path: str, *, compact: bool = False) -> str:
         try:
             with open(path, "r", encoding="utf-8") as f:
                 payload = json.load(f)
@@ -1177,7 +1177,12 @@ class CandlestickManager:
         if not isinstance(payload, dict):
             return "-"
         bits = []
-        for key in ("pid", "exchange", "symbol", "timeframe", "task", "attempt"):
+        keys = (
+            ("pid", "task", "attempt")
+            if compact
+            else ("pid", "exchange", "symbol", "timeframe", "task", "attempt")
+        )
+        for key in keys:
             value = payload.get(key)
             if value is not None:
                 bits.append(f"{key}={value}")
@@ -1214,16 +1219,13 @@ class CandlestickManager:
             record = self._held_fetch_locks.get(key)
             if record is None or float(record.acquired_at) != float(acquired_at):
                 return
-            owner = self._read_lockfile_owner(record.path)
+            owner = self._read_lockfile_owner(record.path, compact=True)
             self._log(
                 "warning",
                 "fetch_lock_hold_timeout",
                 symbol=symbol,
                 timeframe=timeframe,
-                held_seconds=f"{timeout_s:.1f}",
-                lock_path=record.path,
                 owner=owner,
-                action="holder_still_active",
             )
 
         self._cancel_fetch_lock_watchdog(key)

--- a/tests/test_candlestick_manager_locking.py
+++ b/tests/test_candlestick_manager_locking.py
@@ -108,6 +108,7 @@ async def test_fetch_lock_watchdog_logs_stale_local_holder_without_release(tmp_p
         default_window_candles=5,
     )
     cm._lock_hold_timeout_seconds = 0.01
+    cm.debug_level = 1
     key = ("BTC/USDC:USDC", "1m")
     lock_path = cm._fetch_lock_path(*key)
 
@@ -123,9 +124,63 @@ async def test_fetch_lock_watchdog_logs_stale_local_holder_without_release(tmp_p
             assert key in cm._held_fetch_locks
 
     assert key not in cm._held_fetch_locks
-    assert any(
-        "fetch_lock_hold_timeout" in record.message for record in caplog.records
+    warning = next(
+        record for record in caplog.records if "fetch_lock_hold_timeout" in record.message
     )
+    assert "called_by=" in warning.message
+    assert "exchange=fake" in warning.message
+    assert "symbol=BTC" in warning.message
+    assert "timeframe=1m" in warning.message
+    assert "owner=pid=" in warning.message
+    assert "task=" in warning.message
+    assert "attempt=1" in warning.message
+    assert "held_s=" in warning.message
+    assert "lock_path=" not in warning.message
+    assert warning.message.count("exchange=fake") == 1
+    assert warning.message.count("symbol=BTC") == 1
+    assert warning.message.count("timeframe=1m") == 1
+    assert "held_seconds=" not in warning.message
+    assert "action=holder_still_active" not in warning.message
+    rendered = f"2026-07-15 12:34:56,789 WARNING passivbot.candlestick_manager {warning.message}"
+    assert len(rendered) <= 240
+
+
+def test_read_lockfile_owner_defaults_to_full_context_for_stale_waiting(tmp_path):
+    cm = CandlestickManager(
+        exchange=FakeExchange(),
+        exchange_name="hyperliquid",
+        cache_dir=str(tmp_path / "caches"),
+        default_window_candles=5,
+    )
+    path = tmp_path / "fetch.lock"
+    path.write_text(
+        json.dumps(
+            {
+                "pid": 1234,
+                "exchange": "hyperliquid",
+                "symbol": "BTC/USDC:USDC",
+                "timeframe": "1m",
+                "task": "candle-refresh",
+                "attempt": 2,
+                "acquired_at": time.time() - 1.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    owner = cm._read_lockfile_owner(str(path))
+    compact_owner = cm._read_lockfile_owner(str(path), compact=True)
+
+    assert "pid=1234" in owner
+    assert "exchange=hyperliquid" in owner
+    assert "symbol=BTC/USDC:USDC" in owner
+    assert "timeframe=1m" in owner
+    assert "task=candle-refresh" in owner
+    assert "attempt=2" in owner
+    assert "held_s=" in owner
+    assert "exchange=" not in compact_owner
+    assert "symbol=" not in compact_owner
+    assert "timeframe=" not in compact_owner
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Scope category: observability producer\n\nScope\n- Compact only the normal fetch_lock_hold_timeout warning.\n- Retain event, exchange, symbol, timeframe, and compact holder pid/task/attempt/actual-held timing.\n- Preserve full owner scope for the separate fetch_lock_stale_waiting path.\n- Preserve one warning per affected symbol.\n\nTriggering evidence\nThe PR #1248 VPS5 restart naturally printed six simultaneous OKX lock-hold warnings at 346-349 visible characters. Each repeated the deterministic lock path, configured timeout, implied action, and owner exchange/symbol/timeframe already present at top level.\n\nBehavior impact\nObservability-only. No exchange calls, cache/task mutation, lock scheduling/acquisition/release, timeout/retry/exception behavior, warning cadence, Rust, order, risk, backtest, optimizer, or trading behavior changes.\n\nValidation\n- Full candlestick-manager pytest surface: green (all runnable tests passed; expected live-only skips)\n- python -m py_compile src/candlestick_manager.py\n- PYTHONPATH=src python src/tools/check_ai_docs.py: 0 errors, one existing aggregate word-count warning\n- git diff --check\n\nReviewer focus\n- Boundedness and retained incident context\n- No lock/watchdog semantic change\n- Full-context stale-wait warning remains unchanged\n\nReview gate\nTemporary maintainer-authorized exact-head Hermes plus green Python/Rust CI while Grok is halted.\n\nVPS action\nAfter merge, gracefully restart only the five exact authorized bot panes and run bounded immediate/settled smoke checks. Observe this warning only if it occurs naturally; do not manufacture lock contention, exchange, state, or trading events.