### PR TITLE
Compact HSL startup settings log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- HSL startup settings now use a compact INFO projection that retains the
+  configured thresholds, spans, mode, tier ratios, actions, and restart policy
+  within the normal console line budget. HSL validation, state reconstruction,
+  risk decisions, and trading behavior are unchanged.
+
 - Candle fetch-lock hold warnings now retain the affected exchange, symbol,
   timeframe, and compact local-holder identity/timing without repeating the
   deterministic lock path, duplicated owner scope, configured timeout, or

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/compact-hsl-startup-console`, based on canonical
   `9aef070e4a4a5b911b56f9dafb2457aacee0875a` after PR #1249.
-- PR: pending, `Compact HSL startup settings line`.
+- PR: #1250, `Compact HSL startup settings line`.
 - Slice: compact only the INFO HSL-enabled settings projection while retaining
   the side and every currently displayed setting.
 - Triggering evidence: the PR #1249 restart naturally printed one HSL settings

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,37 +22,44 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/compact-candle-lock-warning`, based on canonical
-  `75bf6cd67f61b902fb5ca4399939c2b2e5945088` after PR #1248.
-- PR: #1249, `Compact candle lock-hold warnings`.
-- Slice: compact only the normal `fetch_lock_hold_timeout` warning while
-  retaining one warning per affected symbol.
-- Triggering evidence: the PR #1248 restart naturally printed six simultaneous
-  OKX lock-hold warnings at 346-349 visible characters. Each repeated the
-  deterministic lock path, configured timeout, implied action, and owner
-  exchange/symbol/timeframe already carried by top-level scope.
-- Scope: retain event, exchange, symbol, timeframe, and compact holder
-  PID/task/attempt/actual-held timing; preserve full owner scope for the
-  separate stale-wait warning path.
+- Branch: `codex/compact-hsl-startup-console`, based on canonical
+  `9aef070e4a4a5b911b56f9dafb2457aacee0875a` after PR #1249.
+- PR: pending, `Compact HSL startup settings line`.
+- Slice: compact only the INFO HSL-enabled settings projection while retaining
+  the side and every currently displayed setting.
+- Triggering evidence: the PR #1249 restart naturally printed one HSL settings
+  line per enabled side at 310-314 visible characters, above the normal
+  240-character record budget.
+- Scope: retain red threshold, EMA span, cooldown, no-restart threshold, signal
+  mode, yellow/orange ratios, orange action, panic-close type, and restart
+  policy with concise stable labels and bounded numeric rendering.
 - Behavior boundary: observability-only; no exchange calls, cache or task
-  mutation, lock scheduling/acquisition/release, timeout/retry/exception or
-  warning-cadence change, Rust, order, risk, backtest, optimizer, or trading
-  behavior.
+  mutation, HSL parsing/validation/state/replay/decision change, Rust, order,
+  risk, backtest, optimizer, or trading behavior.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green CI
   while Grok is halted.
 - Expected VPS action: after merge, one authorized exact five-bot restart.
-  Observe the warning only if it occurs naturally, and run settled smoke; do
-  not manufacture lock contention, exchange, state, or trading events.
+  Validate the natural startup settings lines and settled smoke; do not
+  manufacture exchange, state, risk, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `75bf6cd67f61b902fb5ca4399939c2b2e5945088`, PR #1248. The tracked checkout
+  `9aef070e4a4a5b911b56f9dafb2457aacee0875a`, PR #1249. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `957519/957674/957669/957739/957675`. The exact pane PIDs remain
+  `958819/958821/958823/958825/958827`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1249 was activated with one exact five-bot graceful restart. Every old
+  bot exited naturally within 24 seconds after one SIGINT round; no escalation
+  was used. Eleven logical lock-hold warnings then occurred naturally at
+  205-218 visible characters, versus 346-349 before the change, while retaining
+  per-symbol scope and compact holder identity/timing. Immediate and settled
+  smoke were hard-green. The final fresh window had `216/216` remote and
+  `52/52` account-critical calls successful, seven successful fill refreshes,
+  five config-valid processes, zero hard/log/monitor/pipeline failures, no
+  active HSL replay, and a clean tracked checkout.
 - PR #1248 was activated with one exact five-bot graceful restart. Every old
   bot exited naturally within ten seconds after one SIGINT round. Natural
   KuCoin output reduced the approved-coin override line from 678 to 154 visible
@@ -725,10 +732,12 @@ smoke were hard-green; report-time `D` samples cleared to exact `R/S` states.
 
 PR #1248 is merged, deployed, and naturally validated: its bounded
 `live.approved_coins` startup projection reduced the exact KuCoin line from 678
-to 154 visible characters while retaining counts and bounded samples. The
-active slice compacts the six naturally observed 346-349 character candle
-lock-hold warnings without changing their per-symbol admission or lock
-behavior.
+to 154 visible characters while retaining counts and bounded samples. PR #1249
+is also merged, deployed, and naturally validated: eleven logical lock-hold
+warnings measured 205-218 visible characters while retaining per-symbol scope
+and compact holder identity/timing. The active slice compacts the naturally
+observed 310-314 character HSL-enabled settings line without changing HSL
+configuration or behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,34 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1248)
+## Latest Canonical Deployment (PR #1249)
+
+- PR #1249 merged to `master` as `9aef070e4a4a5b911b56f9dafb2457aacee0875a`
+  after exact-head Hermes approval and green Python/Rust CI while Grok was
+  temporarily halted. It compacts only the normal candle lock-hold warning;
+  lock ownership, scheduling, timeout, retry, release, and trading behavior are
+  unchanged.
+- VPS5 fast-forwarded cleanly and gracefully restarted the five exact bot
+  panes. Old PIDs `957519/957669/957674/957675/957739` exited naturally within
+  24 seconds after one SIGINT round; no escalation was used. Pane PIDs and
+  unrelated `misc:0.0` PID `434835` were preserved. New bot PIDs are
+  `958819/958821/958823/958825/958827` for
+  Binance/KuCoin/GateIO/OKX/Hyperliquid respectively.
+- Eleven logical post-restart lock-hold warnings occurred naturally at 205-218
+  visible characters, versus the prior 346-349. They retained event,
+  exchange, symbol, timeframe, holder PID/task/attempt, and actual held time.
+- Immediate smoke was hard-green with `92/92` account-critical calls and 21
+  successful fill refreshes. The final fresh two-minute smoke remained
+  `ok=true` with zero hard/log/monitor/process/pipeline failures, `216/216`
+  remote and `52/52` account-critical calls successful, seven successful fill
+  refreshes, five config-valid processes, no active HSL replay, and a clean
+  tracked repository.
+- The same restart exposed the next boundedness gap: the INFO HSL-enabled
+  settings line measured 310-314 characters across the four forager bots. The
+  next slice compacts only that startup projection while retaining every
+  displayed setting and all HSL semantics.
+
+## Previous Canonical Deployment (PR #1248)
 
 - PR #1248 merged to `master` as `75bf6cd67f61b902fb5ca4399939c2b2e5945088`
   after exact-head Hermes approval and green Python/Rust CI while Grok was

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -964,6 +964,32 @@ Related detailed plans:
     formatting and sanitization; and explicit diagnostic-unavailable behavior
     for unsupported or malformed breakdowns.
 
+21. [ ] Historical secret-bearing text-log inventory and remediation.
+    Status: open. A read-only VPS5 console-length audit on 2026-07-15
+    accidentally admitted old untimestamped traceback fragments and confirmed
+    that retained May text logs include raw private websocket URLs/tokens and
+    full exchange error bodies. Current recent-window producers and smoke paths
+    use bounded redacted diagnostics, but historical disk retention still
+    violates the no-secret sink policy. The observed websocket tokens are
+    likely short-lived, but expiry must not be treated as a redaction control.
+    A value-free scan of 306 timestamped lines from the five current canonical
+    logs after the PR #1249 restart found zero private-websocket-query,
+    authorization, API-key-label, or raw-HTML-body matches.
+
+    Target contract: inventory historical secret-like text-log artifacts
+    without printing matched values; report only bounded counts, file identity,
+    age, and stable hashes. Verify the current producers no longer emit each
+    detected class, then define an operator-approved quarantine or purge plan
+    that preserves the minimum forensic metadata required for incident review.
+    Do not rewrite, delete, rotate, upload, or copy existing VPS artifacts
+    without explicit authorization.
+
+    Required validation: fixtures for private websocket URLs, authorization
+    material, signatures, API keys, query tokens, raw HTTP bodies, and benign
+    lookalikes; value-free report output; bounded scanning of large/rotated
+    logs; current-producer regression tests; and a dry-run VPS inventory before
+    any destructive remediation proposal.
+
 ## Merged Work Log
 
 | Date | Item | PR / Commit | Result | Remaining |

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -2456,6 +2456,30 @@ def _equity_hard_stop_coin_active_pside(self, pside: str) -> bool:
     return total_wallet_exposure_limit > 0.0
 
 
+def _format_hsl_startup_config(
+    pside: str,
+    *,
+    red_threshold: float,
+    ema_span_minutes: float,
+    cooldown_minutes_after_red: float,
+    no_restart_drawdown_threshold: float,
+    signal_mode: str,
+    ratio_yellow: float,
+    ratio_orange: float,
+    orange_tier_mode: str,
+    panic_close_order_type: str,
+    restart_after_red_policy: str,
+) -> str:
+    """Return the bounded operator-facing HSL startup configuration summary."""
+    return (
+        f"[risk] HSL[{pside}] on | red={red_threshold:.6g} ema={ema_span_minutes:.6g} "
+        f"cd={cooldown_minutes_after_red:.6g} no-r={no_restart_drawdown_threshold:.6g} "
+        f"mode={signal_mode} tiers={ratio_yellow:.6g}/{ratio_orange:.6g} "
+        f"orange={orange_tier_mode} panic={panic_close_order_type} "
+        f"restart={restart_after_red_policy}"
+    )
+
+
 def _parse_hsl_config(self) -> dict[str, dict[str, Any]]:
     signal_mode = self._equity_hard_stop_signal_mode()
     out = {}
@@ -2543,22 +2567,19 @@ def _parse_hsl_config(self) -> dict[str, dict[str, Any]]:
                     pside,
                 )
             logging.info(
-                "[risk] HSL[%s] enabled | red_threshold=%.6f ema_span_minutes=%.3f "
-                "cooldown_minutes_after_red=%.3f "
-                "no_restart_drawdown_threshold=%.6f signal_mode=%s "
-                "yellow_ratio=%.3f orange_ratio=%.3f "
-                "orange_mode=%s panic_close=%s restart_after_red=%s",
-                pside,
-                red_threshold,
-                ema_span_minutes,
-                cooldown_minutes_after_red,
-                no_restart_drawdown_threshold,
-                signal_mode,
-                ratio_yellow,
-                ratio_orange,
-                orange_tier_mode,
-                panic_close_order_type,
-                restart_after_red_policy,
+                _format_hsl_startup_config(
+                    pside,
+                    red_threshold=red_threshold,
+                    ema_span_minutes=ema_span_minutes,
+                    cooldown_minutes_after_red=cooldown_minutes_after_red,
+                    no_restart_drawdown_threshold=no_restart_drawdown_threshold,
+                    signal_mode=signal_mode,
+                    ratio_yellow=ratio_yellow,
+                    ratio_orange=ratio_orange,
+                    orange_tier_mode=orange_tier_mode,
+                    panic_close_order_type=panic_close_order_type,
+                    restart_after_red_policy=restart_after_red_policy,
+                )
             )
     return out
 

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -221,36 +221,56 @@ def test_compact_sparse_replay_indices_keep_rolling_window_expiry_boundary():
     assert indices.tolist() == [0, 2, 3, 4, 5, 9]
 
 
-def test_parse_hsl_config_warns_about_history_reinterpretation(caplog):
-    bot = FakeHslBot(config={"live": {"hsl_signal_mode": "coin"}})
+def test_parse_hsl_config_logs_compact_complete_startup_summary(caplog):
+    bot = FakeHslBot(config={"live": {"hsl_signal_mode": "unified"}})
     values = {
         "hsl_enabled": True,
-        "hsl_red_threshold": 0.05,
-        "hsl_ema_span_minutes": 120.0,
-        "hsl_cooldown_minutes_after_red": 60.0,
-        "hsl_no_restart_drawdown_threshold": 0.08,
-        "hsl_tier_ratios": {"yellow": 0.5, "orange": 0.75},
-        "hsl_tier_ratios.yellow": 0.5,
-        "hsl_tier_ratios.orange": 0.75,
+        "hsl_red_threshold": 0.123456789,
+        "hsl_ema_span_minutes": 1.23456789e308,
+        "hsl_cooldown_minutes_after_red": 1.23456789e308,
+        "hsl_no_restart_drawdown_threshold": 0.987654321,
+        "hsl_tier_ratios": {"yellow": 0.3456789, "orange": 0.8765432},
+        "hsl_tier_ratios.yellow": 0.3456789,
+        "hsl_tier_ratios.orange": 0.8765432,
         "hsl_orange_tier_mode": "tp_only_with_active_entry_cancellation",
-        "hsl_panic_close_order_type": "limit",
+        "hsl_panic_close_order_type": "market",
         "hsl_restart_after_red_policy": "threshold",
     }
-    bot._hsl_psides = lambda: ["long"]
+    bot._hsl_psides = lambda: ["short"]
     bot._equity_hard_stop_signal_mode = MethodType(
         hsl._equity_hard_stop_signal_mode,
         bot,
     )
     bot.bot_value = lambda pside, key: values[key]
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO):
         parsed = hsl._parse_hsl_config(bot)
 
-    assert parsed["long"]["enabled"] is True
+    assert parsed == {
+        "short": {
+            "enabled": True,
+            "red_threshold": 0.123456789,
+            "ema_span_minutes": 1.23456789e308,
+            "cooldown_minutes_after_red": 1.23456789e308,
+            "no_restart_drawdown_threshold": 0.987654321,
+            "tier_ratios": {"yellow": 0.3456789, "orange": 0.8765432},
+            "orange_tier_mode": "tp_only_with_active_entry_cancellation",
+            "panic_close_order_type": "market",
+            "restart_after_red_policy": "threshold",
+        }
+    }
     messages = [record.getMessage() for record in caplog.records]
     assert any("docs/equity_hard_stop_loss_risks.md" in message for message in messages)
     assert any("Deposits, withdrawals" in message for message in messages)
     assert any("HSL mode changes" in message for message in messages)
+    startup = next(message for message in messages if message.startswith("[risk] HSL[short] on"))
+    assert startup == (
+        "[risk] HSL[short] on | red=0.123457 ema=1.23457e+308 cd=1.23457e+308 "
+        "no-r=0.987654 mode=unified tiers=0.345679/0.876543 "
+        "orange=tp_only_with_active_entry_cancellation panic=market restart=threshold"
+    )
+    normal_console_prefix = "2026-07-15T12:34:56Z INFO     [hyperliquid] "
+    assert len(normal_console_prefix + startup) <= 240
 
 
 def test_hsl_replay_matrix_row_derives_upnl_from_rust_pnl_helpers():


### PR DESCRIPTION
Scope category: observability producer

Runtime scope
- Compact only the INFO HSL-enabled startup settings projection.
- Retain side, red threshold, EMA span, cooldown, no-restart threshold, signal mode, tier ratios, orange action, panic-close type, and restart policy.
- Use deterministic six-significant-figure display formatting and concise stable labels.
- Preserve the separate HSL risk warning.

Documentation scope
- Record exact PR #1249 merge, deploy, natural warning-length, and hard-green smoke evidence.
- Record a separate non-destructive backlog item for historical secret-bearing text logs found during the VPS length audit.
- Current post-restart value-free scan covered 306 canonical timestamped lines and found zero private websocket query, authorization, API-key-label, or raw-HTML-body matches.

Explicit non-goals
- No HSL parsing, validation, state, replay, risk decision, order, Rust, backtest, optimizer, exchange-call, or trading behavior change.
- No deletion, rewrite, rotation, upload, or copy of historical VPS log artifacts.

Triggering evidence
The PR #1249 restart naturally printed the HSL-enabled settings line at 310-314 visible characters across the four forager bots. The longest supported test shape, including the normal timestamp/level/hyperliquid prefix, is 240 characters; normal deployed values are shorter.

Validation
- tests/test_hsl_coin_mode.py: 134 passed
- python -m py_compile src/passivbot_hsl.py tests/test_hsl_coin_mode.py
- PYTHONPATH=src python src/tools/check_ai_docs.py: 0 errors, one existing aggregate word-count warning
- added-line silent-handling scan: no matches
- git diff --check

Reviewer focus
- Every existing HSL setting remains visible with unambiguous labels.
- Numeric display rounding cannot affect parsed config or HSL behavior.
- Longest supported prefix/enum/numeric shape remains within 240 characters.
- Deployment evidence and historical-log backlog wording are accurate and non-destructive.

Review gate
Temporary maintainer-authorized exact-head Hermes plus green Python/Rust CI while Grok is halted.

VPS action
After merge, gracefully restart only the five exact authorized bot panes, verify the natural HSL startup lines, and run bounded immediate/settled smoke checks. Do not manufacture exchange, state, risk, or trading events.
