### PR TITLE
Compact staged refresh timing logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Slow staged account-refresh timings and periodic timing summaries now use a
+  compact structured console/text projection. The existing ten-second detail
+  threshold, complete event payloads, legacy fallback, refresh calls, and
+  trading behavior are unchanged.
+
 - HSL startup settings now use a compact INFO projection that retains the
   configured thresholds, spans, mode, tier ratios, actions, and restart policy
   within the normal console line budget. HSL validation, state reconstruction,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/compact-state-refresh-console`, based on canonical
   `0dea5c0698f77c20610352aed43ef47969814423` after PR #1250.
-- PR: pending, `Compact staged-refresh timing console output`.
+- PR: #1251, `Compact staged-refresh timing console output`.
 - Slice: make the existing structured `state.refresh_timing` event the sole
   normal console/text owner for admitted slow refreshes and periodic summaries.
 - Triggering evidence: the PR #1250 restart naturally printed five admitted

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,20 +22,21 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/compact-hsl-startup-console`, based on canonical
-  `9aef070e4a4a5b911b56f9dafb2457aacee0875a` after PR #1249.
-- PR: #1250, `Compact HSL startup settings line`.
-- Slice: compact only the INFO HSL-enabled settings projection while retaining
-  the side and every currently displayed setting.
-- Triggering evidence: the PR #1249 restart naturally printed one HSL settings
-  line per enabled side at 310-314 visible characters, above the normal
-  240-character record budget.
-- Scope: retain red threshold, EMA span, cooldown, no-restart threshold, signal
-  mode, yellow/orange ratios, orange action, panic-close type, and restart
-  policy with concise stable labels and bounded numeric rendering.
-- Behavior boundary: observability-only; no exchange calls, cache or task
-  mutation, HSL parsing/validation/state/replay/decision change, Rust, order,
-  risk, backtest, optimizer, or trading behavior.
+- Branch: `codex/compact-state-refresh-console`, based on canonical
+  `0dea5c0698f77c20610352aed43ef47969814423` after PR #1250.
+- PR: pending, `Compact staged-refresh timing console output`.
+- Slice: make the existing structured `state.refresh_timing` event the sole
+  normal console/text owner for admitted slow refreshes and periodic summaries.
+- Triggering evidence: the PR #1250 restart naturally printed five admitted
+  slow-refresh lines at 252-305 visible characters. The longest retained a
+  four-surface plan, per-surface timings, parallel execution, and scheduler or
+  lock residual context.
+- Scope: preserve the exact ten-second detail threshold, complete structured
+  payloads, and legacy logging fallback; compact only the human projection.
+  Interesting sub-ten-second events remain durable but console/text-hidden.
+- Behavior boundary: observability-only; no refresh plan, exchange call,
+  readiness, state application, Rust, order, risk, backtest, optimizer, or
+  trading behavior.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green CI
   while Grok is halted.
 - Expected VPS action: after merge, one authorized exact five-bot restart.
@@ -45,12 +46,23 @@ Estimated completion:
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `9aef070e4a4a5b911b56f9dafb2457aacee0875a`, PR #1249. The tracked checkout
+  `0dea5c0698f77c20610352aed43ef47969814423`, PR #1250. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `958819/958821/958823/958825/958827`. The exact pane PIDs remain
+  `959818/959820/959822/959824/959826`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1250 was activated with one exact five-bot graceful restart. Every old
+  bot exited naturally within 24 seconds after one SIGINT round; no escalation
+  was used. Natural forager HSL settings lines measured 163-167 visible
+  characters, versus 310-314 before, while retaining every configured setting.
+  One KuCoin timeout cycle and active GateIO replay appeared in the first
+  startup window and recovered naturally. The final two-minute smoke was
+  `ok=true` with zero hard/log/monitor/process/pipeline failures, `43/43`
+  account-critical calls successful, eight successful fill refreshes, no
+  active HSL replay, five config-valid processes in states `R=4,S=1`, and a
+  clean tracked checkout. One non-account-critical remote failure remained
+  non-hard evidence.
 - PR #1249 was activated with one exact five-bot graceful restart. Every old
   bot exited naturally within 24 seconds after one SIGINT round; no escalation
   was used. Eleven logical lock-hold warnings then occurred naturally at
@@ -735,9 +747,12 @@ PR #1248 is merged, deployed, and naturally validated: its bounded
 to 154 visible characters while retaining counts and bounded samples. PR #1249
 is also merged, deployed, and naturally validated: eleven logical lock-hold
 warnings measured 205-218 visible characters while retaining per-symbol scope
-and compact holder identity/timing. The active slice compacts the naturally
-observed 310-314 character HSL-enabled settings line without changing HSL
-configuration or behavior.
+and compact holder identity/timing. PR #1250 is merged, deployed, and naturally
+validated: the four forager HSL settings lines measured 163-167 visible
+characters while retaining all configured settings. The active slice compacts
+the naturally observed 252-305 character admitted staged-refresh timing lines
+without changing their ten-second threshold, durable payload, or refresh
+behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,35 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1249)
+## Latest Canonical Deployment (PR #1250)
+
+- PR #1250 merged to `master` as `0dea5c0698f77c20610352aed43ef47969814423`
+  after exact-head Hermes approval and green Python/Rust CI while Grok was
+  temporarily halted. It compacts only the HSL-enabled startup settings line;
+  HSL validation, reconstruction, decisions, and trading behavior are
+  unchanged.
+- VPS5 fast-forwarded cleanly and gracefully restarted the five exact bot
+  panes. Old PIDs `958819/958821/958823/958825/958827` exited naturally within
+  24 seconds after one SIGINT round; no escalation was used. Pane PIDs and
+  unrelated `misc:0.0` PID `434835` were preserved. New bot PIDs are
+  `959818/959820/959822/959824/959826` for
+  Binance/KuCoin/GateIO/OKX/Hyperliquid respectively.
+- Natural HSL settings lines measured 163-167 visible characters across the
+  four forager bots, versus 310-314 before, while retaining every configured
+  threshold, span, mode, tier ratio, action, and restart policy.
+- A real KuCoin timeout cycle and active GateIO replay appeared during the
+  first startup window and recovered naturally. The final two-minute smoke was
+  `ok=true` with zero hard/log/monitor/process/pipeline failures, `43/43`
+  account-critical calls successful, eight successful fill refreshes, no
+  active HSL replay, five config-valid processes in states `R=4,S=1`, and a
+  clean tracked repository. One non-account-critical remote failure remained
+  non-hard evidence.
+- The same restart exposed five admitted staged-refresh timing lines at 252-305
+  characters. The next slice makes their existing complete structured event
+  the compact console/text owner while preserving the ten-second threshold and
+  legacy fallback.
+
+## Previous Canonical Deployment (PR #1249)
 
 - PR #1249 merged to `master` as `9aef070e4a4a5b911b56f9dafb2457aacee0875a`
   after exact-head Hermes approval and green Python/Rust CI while Grok was

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -580,6 +580,15 @@ Related detailed plans:
     to the normal 240-character budget without changing event data or
     admission.
 
+    PR #1250 merged and deployed the bounded HSL startup-settings projection.
+    Natural forager lines measured 163-167 characters versus 310-314 before,
+    and the settled smoke was hard-green. The same restart exposed five
+    admitted staged-refresh timing lines at 252-305 characters. The active
+    `codex/compact-state-refresh-console` slice routes only the existing
+    periodic summary and detail at or above the existing ten-second threshold
+    to a compact console/text projection. Complete structured timing data and
+    legacy fallback remain unchanged.
+
     Two post-PR #1220 console observations remain deferred rather than folded
     into the realized-loss slice. Hyperliquid balance lines surfaced signed
     floating-point jitter near `1e-13`; decide a console-only materiality or

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -825,6 +825,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.REMOTE_CALL_SUCCEEDED: EventRoute(console=False),
     EventTypes.REMOTE_CALL_FAILED: EventRoute(console=False),
     EventTypes.REMOTE_CALL_THROTTLED: EventRoute(console=False),
+    EventTypes.STATE_REFRESH_TIMING: EventRoute(console=True, text=True),
     EventTypes.RUST_ORCHESTRATOR_CALLED: EventRoute(console=False),
     EventTypes.RUST_ORCHESTRATOR_RETURNED: EventRoute(
         console=True, text=True, throttle_interval_ms=60_000
@@ -2098,6 +2099,8 @@ def _operator_sink_event_visible(event: LiveEvent) -> bool:
     data = event.data if isinstance(event.data, Mapping) else {}
     if data.get("operator_visible") is False:
         return False
+    if event.event_type == EventTypes.STATE_REFRESH_TIMING:
+        return data.get("summary") is True or _state_refresh_timing_wall_ms(data) >= 10_000
     if event.event_type == EventTypes.FILL_INGESTED:
         return True
     if event.event_type == EventTypes.FORAGER_SELECTION:
@@ -2118,6 +2121,133 @@ def _console_sink_event_visible(event: LiveEvent) -> bool:
     return True
 
 
+_STATE_REFRESH_CONSOLE_LABELS = {
+    "balance": "bal",
+    "fills": "fills",
+    "open_orders": "orders",
+    "positions": "pos",
+    "positions_balance": "pos+bal",
+}
+_STATE_REFRESH_CONSOLE_LABEL_MAX = 7
+_STATE_REFRESH_CONSOLE_MAX_MS = (1 << 63) - 1
+
+
+def _state_refresh_timing_wall_ms(data: Mapping[str, Any]) -> int:
+    try:
+        value = int(data.get("wall_ms", 0))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+    return max(0, min(value, _STATE_REFRESH_CONSOLE_MAX_MS))
+
+
+def _format_state_refresh_console_label(value: object) -> str:
+    label = _STATE_REFRESH_CONSOLE_LABELS.get(str(value), None)
+    if label is not None:
+        return label
+    label = _format_console_label(value)
+    return label[:_STATE_REFRESH_CONSOLE_LABEL_MAX]
+
+
+def _format_state_refresh_console_ms(value: object) -> str:
+    try:
+        milliseconds = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return "-"
+    milliseconds = max(0, min(milliseconds, _STATE_REFRESH_CONSOLE_MAX_MS))
+    if milliseconds < 1_000_000:
+        return str(milliseconds)
+    return f"{milliseconds:.4g}"
+
+
+def _format_state_refresh_console_stats(value: object) -> str:
+    if not isinstance(value, Mapping):
+        return "-"
+    return "/".join(
+        _format_state_refresh_console_ms(value.get(key)) for key in ("min", "mean", "max")
+    )
+
+
+def _format_state_refresh_console_labels(value: object) -> str:
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        return "-"
+    labels = [_format_state_refresh_console_label(item) for item in value]
+    labels = [label for label in labels if label and label != "-"]
+    if len(labels) <= 4:
+        return ",".join(labels) or "-"
+    return ",".join(labels[:3]) + ",+more"
+
+
+def _format_state_refresh_console_timings(value: object) -> str:
+    if not isinstance(value, Mapping):
+        return "-"
+    timings = [
+        (_format_state_refresh_console_label(surface), _format_state_refresh_console_ms(elapsed))
+        for surface, elapsed in value.items()
+    ]
+    timings.sort(key=lambda item: item[0])
+    if len(timings) <= 4:
+        shown = timings
+        suffix = ""
+    else:
+        shown = timings[:3]
+        suffix = ",+more"
+    return ",".join(f"{surface}:{elapsed}" for surface, elapsed in shown) + suffix or "-"
+
+
+def _format_state_refresh_console_slowest_surface(value: object) -> str:
+    if not isinstance(value, Mapping) or not value:
+        return "-"
+    candidates: list[tuple[int, str, Mapping[str, Any]]] = []
+    for surface, stats in value.items():
+        if not isinstance(stats, Mapping):
+            continue
+        try:
+            maximum = int(stats.get("max", 0))
+        except (TypeError, ValueError, OverflowError):
+            maximum = 0
+        candidates.append((max(0, maximum), _format_state_refresh_console_label(surface), stats))
+    if not candidates:
+        return "-"
+    _maximum, surface, stats = max(candidates, key=lambda item: (item[0], item[1]))
+    return f"{surface}:{_format_state_refresh_console_stats(stats)}"
+
+
+def format_state_refresh_timing_console(data: Mapping[str, Any]) -> str:
+    """Render bounded operator projections for staged-refresh timing events."""
+    plan = _format_state_refresh_console_labels(data.get("plan"))
+    if data.get("summary") is True:
+        try:
+            count = max(0, int(data.get("count", 0)))
+        except (TypeError, ValueError, OverflowError):
+            count = 0
+        count_label = str(min(count, 1_000_000))
+        if count > 1_000_000:
+            count_label += "+"
+        return " ".join(
+            (
+                "[state] refresh summary",
+                f"plan={plan}",
+                f"n={count_label}",
+                f"wall_ms={_format_state_refresh_console_stats(data.get('wall_ms'))}",
+                f"slow={_format_state_refresh_console_slowest_surface(data.get('surfaces_ms'))}",
+                f"resid_ms={_format_state_refresh_console_stats(data.get('residual_ms'))}",
+            )
+        )
+
+    parts = [
+        "[state] refresh",
+        f"plan={plan}",
+        f"wall={_format_state_refresh_console_ms(data.get('wall_ms'))}ms",
+        f"surfaces_ms={_format_state_refresh_console_timings(data.get('timings_ms'))}",
+    ]
+    if data.get("parallel") is True:
+        parts.append("parallel")
+    residual_ms = _state_refresh_timing_wall_ms({"wall_ms": data.get("residual_ms")})
+    if residual_ms >= 500:
+        parts.append(f"residual={_format_state_refresh_console_ms(residual_ms)}ms")
+    return " ".join(parts)
+
+
 def format_console_event(event: LiveEvent) -> str:
     if (
         event.event_type == EventTypes.HEALTH_SUMMARY
@@ -2134,6 +2264,9 @@ def format_console_event(event: LiveEvent) -> str:
         return _format_console_balance_changed(event)
     if event.event_type == EventTypes.RESOURCE_MEMORY_SNAPSHOT:
         return format_memory_snapshot_console(event.data)
+    if event.event_type == EventTypes.STATE_REFRESH_TIMING:
+        data = event.data if isinstance(event.data, Mapping) else {}
+        return format_state_refresh_timing_console(data)
     if event.event_type == EventTypes.TRAILING_STATUS:
         trailing_status = _format_console_trailing_status(event)
         if trailing_status is not None:

--- a/src/live/state_refresh.py
+++ b/src/live/state_refresh.py
@@ -17,6 +17,15 @@ def _utc_ms() -> int:
     return int(utc_ms())
 
 
+def _state_refresh_structured_console_available(bot) -> bool:
+    pipeline = getattr(bot, "_live_event_pipeline", None)
+    return bool(
+        getattr(bot, "live_event_console_enabled", False)
+        and callable(getattr(pipeline, "emit", None))
+        and getattr(pipeline, "console_sink", None) is not None
+    )
+
+
 async def refresh_authoritative_state(bot) -> bool:
     """Refresh authoritative account state before planning/execution."""
     if bot.stop_signal_received:
@@ -381,6 +390,8 @@ def log_staged_refresh_timings(
             epoch_changed=epoch_changed,
             level="info",
         )
+    if wall_ms >= 10_000 and _state_refresh_structured_console_available(bot):
+        return
     logging.log(
         console_log_level,
         "[state] staged refresh timings | plan=%s | wall=%dms | surface_sum=%dms | surface_max=%dms | parallel=%s | %s%s",
@@ -464,6 +475,9 @@ def record_staged_refresh_timing_summary(
         residual=summary["residual"],
         surfaces=surfaces,
     )
+    if _state_refresh_structured_console_available(bot):
+        summaries.pop(plan_key, None)
+        return
     logging.info(
         "[state] staged refresh timing summary | plan=%s | count=%d since=%s | wall=%s | surface_sum=%s | surface_max=%s | residual=%s | %s",
         plan_key,

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -25,6 +25,7 @@ from live.event_bus import (
     authoritative_reason_code,
     format_console_event,
     format_memory_snapshot_console,
+    format_state_refresh_timing_console,
     live_event_debug_profile_enabled,
     normalize_live_event_console_enabled,
     normalize_live_event_debug_profiles,
@@ -382,6 +383,10 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.RESOURCE_MEMORY_SNAPSHOT].monitor is True
     assert DEFAULT_ROUTES[EventTypes.RESOURCE_MEMORY_SNAPSHOT].console is True
     assert DEFAULT_ROUTES[EventTypes.RESOURCE_MEMORY_SNAPSHOT].text is True
+    assert DEFAULT_ROUTES[EventTypes.STATE_REFRESH_TIMING].structured is True
+    assert DEFAULT_ROUTES[EventTypes.STATE_REFRESH_TIMING].monitor is True
+    assert DEFAULT_ROUTES[EventTypes.STATE_REFRESH_TIMING].console is True
+    assert DEFAULT_ROUTES[EventTypes.STATE_REFRESH_TIMING].text is True
     assert DEFAULT_ROUTES[EventTypes.HSL_STATUS].console is True
     assert DEFAULT_ROUTES[EventTypes.HSL_STATUS].text is True
     assert DEFAULT_ROUTES[EventTypes.TRAILING_STATUS].console is True
@@ -1561,6 +1566,136 @@ def test_memory_snapshot_console_formatter_is_compact_and_omits_samples():
     assert format_console_event(
         LiveEvent(EventTypes.RESOURCE_MEMORY_SNAPSHOT, data=data)
     ) == message
+
+
+def test_state_refresh_timing_console_formatters_retain_operator_timing_signals():
+    detail = {
+        "plan": ["balance", "fills", "open_orders", "positions"],
+        "timings_ms": {
+            "balance": 2500,
+            "fills": 4000,
+            "open_orders": 2000,
+            "positions": 3000,
+        },
+        "wall_ms": 10_000,
+        "residual_ms": 6000,
+        "parallel": True,
+    }
+    summary = {
+        "summary": True,
+        "plan": ["balance", "fills", "open_orders", "positions"],
+        "count": 60,
+        "wall_ms": {"min": 100, "mean": 130, "max": 159},
+        "residual_ms": {"min": 0, "mean": 10, "max": 20},
+        "surfaces_ms": {
+            "balance": {"min": 90, "mean": 120, "max": 140},
+            "open_orders": {"min": 100, "mean": 130, "max": 159},
+        },
+    }
+
+    assert format_state_refresh_timing_console(detail) == (
+        "[state] refresh plan=bal,fills,orders,pos wall=10000ms "
+        "surfaces_ms=bal:2500,fills:4000,orders:2000,pos:3000 parallel residual=6000ms"
+    )
+    assert format_state_refresh_timing_console(summary) == (
+        "[state] refresh summary plan=bal,fills,orders,pos n=60 "
+        "wall_ms=100/130/159 slow=orders:100/130/159 resid_ms=0/10/20"
+    )
+
+
+def test_state_refresh_timing_console_and_text_admission_preserves_detail_durability():
+    structured = ListEventSink()
+    console = ListEventSink()
+    text = ListEventSink()
+    pipeline = LiveEventPipeline(
+        structured_sinks=[structured],
+        monitor_sinks=[],
+        console_sink=console,
+        text_sink=text,
+    )
+    hidden_detail = LiveEvent(
+        EventTypes.STATE_REFRESH_TIMING,
+        data={"wall_ms": 9999, "timings_ms": {"balance": 9999}},
+    )
+    admitted_detail = LiveEvent(
+        EventTypes.STATE_REFRESH_TIMING,
+        data={"wall_ms": 10_000, "timings_ms": {"balance": 10_000}},
+    )
+    aggregate = LiveEvent(
+        EventTypes.STATE_REFRESH_TIMING,
+        data={"summary": True, "wall_ms": {"min": 1, "mean": 2, "max": 3}},
+    )
+
+    pipeline.emit(hidden_detail)
+    pipeline.emit(admitted_detail)
+    pipeline.emit(aggregate)
+
+    assert console.events == [admitted_detail, aggregate]
+    assert text.events == [admitted_detail, aggregate]
+    assert pipeline.flush(timeout=2.0) is True
+    assert structured.events == [hidden_detail, admitted_detail, aggregate]
+    assert pipeline.close(timeout=2.0) is True
+
+
+def test_state_refresh_timing_console_formatters_are_bounded_without_mutating_payload():
+    maximum = (1 << 63) - 1
+    detail_data = {
+        "plan": ["unbounded-plan-name"] * 5,
+        "timings_ms": {f"unbounded-surface-{idx}": maximum for idx in range(5)},
+        "wall_ms": maximum,
+        "residual_ms": maximum,
+        "parallel": True,
+    }
+    summary_data = {
+        "summary": True,
+        "plan": ["unbounded-plan-name"] * 5,
+        "count": maximum,
+        "wall_ms": {"min": maximum, "mean": maximum, "max": maximum},
+        "residual_ms": {"min": maximum, "mean": maximum, "max": maximum},
+        "surfaces_ms": {
+            "unbounded-surface": {"min": maximum, "mean": maximum, "max": maximum}
+        },
+    }
+    detail_event = LiveEvent(EventTypes.STATE_REFRESH_TIMING, data=detail_data)
+    summary_event = LiveEvent(EventTypes.STATE_REFRESH_TIMING, data=summary_data)
+    detail_before = detail_event.to_dict()
+    summary_before = summary_event.to_dict()
+
+    detail_message = format_console_event(detail_event)
+    summary_message = format_console_event(summary_event)
+    longest_prefix = "2026-07-15T23:45:40Z WARNING  [hyperliquid] "
+
+    assert len(longest_prefix + detail_message) <= 240
+    assert "plan=unbound,unbound,unbound,+more" in detail_message
+    assert "wall=" in detail_message
+    assert "surfaces_ms=" in detail_message
+    assert "parallel" in detail_message
+    assert "residual=" in detail_message
+    assert len(longest_prefix + summary_message) <= 240
+    assert "plan=unbound,unbound,unbound,+more" in summary_message
+    assert "wall_ms=" in summary_message
+    assert "slow=unbound:" in summary_message
+    assert "resid_ms=" in summary_message
+    assert detail_event.to_dict() == detail_before
+    assert summary_event.to_dict() == summary_before
+
+
+def test_state_refresh_timing_console_formatter_names_combined_position_balance_surface():
+    message = format_state_refresh_timing_console(
+        {
+            "plan": ["balance", "fills", "open_orders", "positions"],
+            "timings_ms": {
+                "fills": 1384,
+                "open_orders": 12372,
+                "positions_balance": 13376,
+            },
+            "wall_ms": 13381,
+            "residual_ms": 5,
+            "parallel": True,
+        }
+    )
+
+    assert "surfaces_ms=fills:1384,orders:12372,pos+bal:13376" in message
 
 
 def test_console_format_summarizes_order_wave_payload():

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -10407,6 +10407,129 @@ def test_staged_refresh_timing_summary_emits_structured_event(monkeypatch):
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_staged_refresh_timing_threshold_uses_structured_console_owner(caplog, monkeypatch):
+    structured_sink = ListEventSink()
+    console_sink = ListEventSink()
+    text_sink = ListEventSink()
+    bot = Passivbot.__new__(Passivbot)
+    bot.live_event_console_enabled = True
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[structured_sink],
+        monitor_sinks=[],
+        console_sink=console_sink,
+        text_sink=text_sink,
+    )
+    bot._authoritative_pending_confirmations = {}
+    bot._authoritative_refresh_epoch_changed = set()
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 1_000_000)
+
+    with caplog.at_level(logging.DEBUG):
+        bot._log_staged_refresh_timings(
+            {"balance", "fills", "open_orders", "positions"},
+            {"balance": 2500, "fills": 4000, "open_orders": 2000, "positions": 3000},
+            9999,
+        )
+        bot._log_staged_refresh_timings(
+            {"balance", "fills", "open_orders", "positions"},
+            {"balance": 2500, "fills": 4000, "open_orders": 2000, "positions": 3000},
+            10_000,
+        )
+
+    legacy_records = [
+        record
+        for record in caplog.records
+        if "[state] staged refresh timings" in record.message
+    ]
+    assert [(record.levelno, record.message) for record in legacy_records] == [
+        (
+            logging.DEBUG,
+            "[state] staged refresh timings | plan=balance,fills,open_orders,positions | "
+            "wall=9999ms | surface_sum=11500ms | surface_max=4000ms | parallel=yes | "
+            "balance=2500ms fills=4000ms open_orders=2000ms positions=3000ms "
+            "residual=5999ms residual_hint=scheduler_or_lock_wait",
+        )
+    ]
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert len(structured_sink.events) == 1
+    event = structured_sink.events[0]
+    assert event.data["wall_ms"] == 10_000
+    assert event.data["timings_ms"] == {
+        "balance": 2500,
+        "fills": 4000,
+        "open_orders": 2000,
+        "positions": 3000,
+    }
+    assert console_sink.events == [event]
+    assert text_sink.events == [event]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_staged_refresh_timing_uses_exact_legacy_fallback_without_console(caplog, monkeypatch):
+    structured_sink = ListEventSink()
+    bot = Passivbot.__new__(Passivbot)
+    bot.live_event_console_enabled = True
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[structured_sink],
+        monitor_sinks=[],
+        console_sink=None,
+    )
+    bot._authoritative_pending_confirmations = {}
+    bot._authoritative_refresh_epoch_changed = set()
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 1_000_000)
+
+    with caplog.at_level(logging.INFO):
+        bot._log_staged_refresh_timings(
+            {"balance", "fills", "open_orders", "positions"},
+            {"balance": 2500, "fills": 4000, "open_orders": 2000, "positions": 3000},
+            10_000,
+        )
+
+    assert [record.message for record in caplog.records] == [
+        "[state] staged refresh timings | plan=balance,fills,open_orders,positions | "
+        "wall=10000ms | surface_sum=11500ms | surface_max=4000ms | parallel=yes | "
+        "balance=2500ms fills=4000ms open_orders=2000ms positions=3000ms "
+        "residual=6000ms residual_hint=scheduler_or_lock_wait"
+    ]
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert structured_sink.events[0].data["wall_ms"] == 10_000
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_staged_refresh_timing_summary_uses_structured_console_owner(caplog, monkeypatch):
+    structured_sink = ListEventSink()
+    console_sink = ListEventSink()
+    bot = Passivbot.__new__(Passivbot)
+    bot.live_event_console_enabled = True
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[structured_sink],
+        monitor_sinks=[],
+        console_sink=console_sink,
+    )
+    bot._authoritative_pending_confirmations = {}
+    bot._authoritative_refresh_epoch_changed = set()
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: 1_000_000)
+
+    with caplog.at_level(logging.INFO):
+        for i in range(60):
+            bot._log_staged_refresh_timings(
+                {"open_orders"},
+                {"open_orders": 100 + i},
+                100 + i,
+            )
+
+    assert not [
+        record
+        for record in caplog.records
+        if "[state] staged refresh timing summary" in record.message
+    ]
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert len(structured_sink.events) == 1
+    event = structured_sink.events[0]
+    assert event.data["summary"] is True
+    assert console_sink.events == [event]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_staged_refresh_timing_summary_includes_debug_moderate_refreshes(
     caplog, monkeypatch
 ):


### PR DESCRIPTION
## Summary

- route existing `state.refresh_timing` events to console/text only for periodic summaries and detail already admitted by the existing `wall_ms >= 10_000` threshold
- replace 252-305 character staged-refresh lines with bounded human projections while retaining complete structured payloads
- preserve sub-threshold structured durability, exact legacy fallback, refresh plans/calls, state application, and trading behavior

## Evidence

- PR #1250 deployed cleanly to VPS5 at `0dea5c0698f77c20610352aed43ef47969814423`
- natural HSL startup lines reduced from 310-314 to 163-167 visible characters
- settled smoke: `ok=true`, zero hard/log/monitor/process/pipeline failures, 43/43 account-critical calls, eight successful fill refreshes, no active HSL replay, five config-valid processes
- the same deployment naturally produced five admitted staged-refresh lines at 252-305 characters
- the longest observed 305-character case projects to 171 characters with plan, wall time, every surface timing, parallel mode, and residual retained

## Validation

- `python -m pytest -q tests/test_live_event_bus.py tests/test_passivbot_balance_split.py` (347 passed)
- `python -m py_compile src/live/event_bus.py src/live/state_refresh.py src/tools/check_ai_docs.py`
- `python src/tools/check_ai_docs.py` (0 errors; existing aggregate word-count warning)
- `git diff --check`

## Behavior boundary

Observability-only. No exchange calls, refresh admission, readiness, state mutation, Rust, order, risk, backtest, optimizer, or trading behavior changes.

Temporary review gate while Grok is halted: exact-current-head Hermes approval plus green Python/Rust CI.
