### PR TITLE
Compact close-EMA fallback warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Close-EMA carry-forward warnings now use a bounded structured console/text
+  projection with counts, symbol/span examples, age, fallback streak, and a
+  classified reason. The existing fifteen-minute warning cadence, complete
+  event payload, legacy fallback, EMA calculations, and trading behavior are
+  unchanged.
+
 - Slow staged account-refresh timings and periodic timing summaries now use a
   compact structured console/text projection. The existing ten-second detail
   threshold, complete event payloads, legacy fallback, refresh calls, and

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,21 +22,21 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/compact-state-refresh-console`, based on canonical
-  `0dea5c0698f77c20610352aed43ef47969814423` after PR #1250.
-- PR: #1251, `Compact staged-refresh timing console output`.
-- Slice: make the existing structured `state.refresh_timing` event the sole
-  normal console/text owner for admitted slow refreshes and periodic summaries.
-- Triggering evidence: the PR #1250 restart naturally printed five admitted
-  slow-refresh lines at 252-305 visible characters. The longest retained a
-  four-surface plan, per-surface timings, parallel execution, and scheduler or
-  lock residual context.
-- Scope: preserve the exact ten-second detail threshold, complete structured
-  payloads, and legacy logging fallback; compact only the human projection.
-  Interesting sub-ten-second events remain durable but console/text-hidden.
-- Behavior boundary: observability-only; no refresh plan, exchange call,
-  readiness, state application, Rust, order, risk, backtest, optimizer, or
-  trading behavior.
+- Branch: `codex/compact-ema-fallback-console`, based on canonical
+  `b6fabcfdbbdd823277c12896b770f008c01bb163` after PR #1251.
+- PR: pending, `Compact close-EMA fallback warning`.
+- Slice: make the existing structured `ema.fallback_used` event the compact
+  normal console/text owner only when close-EMA carry-forward is active.
+- Triggering evidence: a natural Binance close-EMA fallback summary measured
+  308 visible characters for four fallbacks across WLD and ZEC. Its repeated
+  age, streak, span, and reason labels exceeded the normal record budget.
+- Scope: preserve the exact fifteen-minute human warning cadence, complete
+  per-cycle structured/monitor events, classified reason, bounded examples,
+  and legacy fallback. Recovery-only and forager-cached fallback events remain
+  durable but console/text-hidden.
+- Behavior boundary: observability-only; no EMA input, calculation, fallback
+  eligibility/age limit, nontradable handling, exchange call, Rust, order,
+  risk, backtest, optimizer, or trading behavior.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green CI
   while Grok is halted.
 - Expected VPS action: after merge, one authorized exact five-bot restart.
@@ -46,12 +46,23 @@ Estimated completion:
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `0dea5c0698f77c20610352aed43ef47969814423`, PR #1250. The tracked checkout
+  `b6fabcfdbbdd823277c12896b770f008c01bb163`, PR #1251. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `959818/959820/959822/959824/959826`. The exact pane PIDs remain
+  `961227/961230/961232/961233/961234`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1251 was activated with one exact five-bot graceful restart. Every old
+  bot exited naturally within ten seconds after one SIGINT round; no escalation
+  was used. Three natural admitted slow-refresh lines measured 155-171 visible
+  characters, versus 252-305 before, while retaining plans, wall and surface
+  timings, parallel execution, and material residuals. Zero legacy duplicate
+  lines appeared. The final two-minute smoke was `ok=true` with zero hard/log/
+  monitor/process/pipeline failures, `202/203` remote and `46/46`
+  account-critical calls successful, six successful fill refreshes, no active
+  HSL replay, five config-valid processes, and a clean tracked checkout. The
+  single remote failure was non-account-critical; one report-time `D` sample
+  cleared to exact `R` on all five processes.
 - PR #1250 was activated with one exact five-bot graceful restart. Every old
   bot exited naturally within 24 seconds after one SIGINT round; no escalation
   was used. Natural forager HSL settings lines measured 163-167 visible
@@ -749,10 +760,11 @@ is also merged, deployed, and naturally validated: eleven logical lock-hold
 warnings measured 205-218 visible characters while retaining per-symbol scope
 and compact holder identity/timing. PR #1250 is merged, deployed, and naturally
 validated: the four forager HSL settings lines measured 163-167 visible
-characters while retaining all configured settings. The active slice compacts
-the naturally observed 252-305 character admitted staged-refresh timing lines
-without changing their ten-second threshold, durable payload, or refresh
-behavior.
+characters while retaining all configured settings. PR #1251 is also merged,
+deployed, and naturally validated: admitted staged-refresh lines measured
+155-171 visible characters with zero legacy duplicates and a hard-green
+settled smoke. The active slice compacts the naturally observed 308-character
+close-EMA fallback warning without changing EMA fallback or trading behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/compact-ema-fallback-console`, based on canonical
   `b6fabcfdbbdd823277c12896b770f008c01bb163` after PR #1251.
-- PR: pending, `Compact close-EMA fallback warning`.
+- PR: #1252, `Compact close-EMA fallback warning`.
 - Slice: make the existing structured `ema.fallback_used` event the compact
   normal console/text owner only when close-EMA carry-forward is active.
 - Triggering evidence: a natural Binance close-EMA fallback summary measured

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,36 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1250)
+## Latest Canonical Deployment (PR #1251)
+
+- PR #1251 merged to `master` as `b6fabcfdbbdd823277c12896b770f008c01bb163`
+  after exact-head Hermes approval and green Python/Rust CI while Grok was
+  temporarily halted. It makes the existing structured staged-refresh timing
+  event the compact console/text owner at the unchanged ten-second threshold;
+  refresh calls, state application, and trading behavior are unchanged.
+- VPS5 fast-forwarded cleanly and gracefully restarted the five exact bot
+  panes. Old PIDs `959818/959820/959822/959824/959826` exited naturally within
+  ten seconds after one SIGINT round; no escalation was used. Pane PIDs and
+  unrelated `misc:0.0` PID `434835` were preserved. New bot PIDs are
+  `961227/961230/961232/961233/961234` for
+  Binance/KuCoin/GateIO/OKX/Hyperliquid respectively.
+- Three natural admitted slow-refresh lines measured 155-171 visible
+  characters, versus 252-305 before, while retaining plan, wall and per-surface
+  timings, parallel execution, and material residuals. Hyperliquid retained
+  its combined `pos+bal` surface. No legacy duplicate appeared.
+- The immediate smoke was hard-green with `181/181` remote and `56/56`
+  account-critical calls successful, thirteen successful fill refreshes, and
+  five config-valid processes while expected HSL replay was active. The final
+  two-minute smoke remained `ok=true` with zero hard/log/monitor/process/
+  pipeline failures, `202/203` remote and `46/46` account-critical calls
+  successful, six successful fill refreshes, no active HSL replay, and a clean
+  tracked repository. The one remote failure was non-account-critical; one
+  report-time `D` sample cleared to exact `R` on all five processes.
+- A natural retained Binance close-EMA fallback summary measured 308 visible
+  characters. The next slice makes its existing structured event the bounded
+  console/text owner while preserving warning cadence and EMA behavior.
+
+## Previous Canonical Deployment (PR #1250)
 
 - PR #1250 merged to `master` as `0dea5c0698f77c20610352aed43ef47969814423`
   after exact-head Hermes approval and green Python/Rust CI while Grok was

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -589,6 +589,16 @@ Related detailed plans:
     to a compact console/text projection. Complete structured timing data and
     legacy fallback remain unchanged.
 
+    PR #1251 merged and deployed the staged-refresh projection. Three natural
+    admitted lines measured 155-171 characters versus 252-305 before, zero
+    legacy duplicates appeared, and the settled smoke was hard-green. A
+    retained natural Binance close-EMA fallback summary measured 308
+    characters. The active `codex/compact-ema-fallback-console` slice makes the
+    existing `ema.fallback_used` event its compact console/text owner only for
+    active close fallbacks, preserving the fifteen-minute warning cadence,
+    per-cycle durable events, recovery/forager suppression, and exact legacy
+    fallback.
+
     Two post-PR #1220 console observations remain deferred rather than folded
     into the realized-loss slice. Hyperliquid balance lines surfaced signed
     floating-point jitter near `1e-13`; decide a console-only materiality or

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -811,7 +811,9 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.CONFIG_MARKET_COMPATIBILITY: EventRoute(console=False, text=False),
     EventTypes.EMA_BUNDLE_STARTED: EventRoute(console=False, text=False),
     EventTypes.EMA_BUNDLE_COMPLETED: EventRoute(console=False, text=False),
-    EventTypes.EMA_FALLBACK_USED: EventRoute(console=False, text=False),
+    EventTypes.EMA_FALLBACK_USED: EventRoute(
+        console=True, text=True, throttle_interval_ms=15 * 60 * 1000
+    ),
     EventTypes.EMA_UNAVAILABLE: EventRoute(console=False, text=False),
     EventTypes.CANDLE_COVERAGE_CHECKED: EventRoute(console=False, text=False),
     EventTypes.CANDLE_TAIL_PROJECTED: EventRoute(console=False, text=False),
@@ -998,6 +1000,7 @@ _CONSOLE_EVENT_TAGS = {
     EventTypes.POSITION_CHANGED: "pos",
     EventTypes.BALANCE_CHANGED: "balance",
     EventTypes.RESOURCE_MEMORY_SNAPSHOT: "memory",
+    EventTypes.EMA_FALLBACK_USED: "ema",
     EventTypes.RISK_MODE_CHANGED: "risk",
     EventTypes.HSL_TRANSITION: "risk",
     EventTypes.HSL_STATUS: "risk",
@@ -2107,6 +2110,8 @@ def _operator_sink_event_visible(event: LiveEvent) -> bool:
         return str(data.get("source") or "") != "rust_orchestrator"
     if event.event_type == EventTypes.HSL_STATUS:
         return _hsl_status_operator_visible(event)
+    if event.event_type == EventTypes.EMA_FALLBACK_USED:
+        return (_data_int(data, "close_fallback_count") or 0) > 0
     return True
 
 
@@ -2248,6 +2253,146 @@ def format_state_refresh_timing_console(data: Mapping[str, Any]) -> str:
     return " ".join(parts)
 
 
+_EMA_FALLBACK_CONSOLE_TOKEN_LIMIT = 16
+_EMA_FALLBACK_CONSOLE_REASON_LIMIT = 18
+_EMA_FALLBACK_CONSOLE_SAMPLE_LIMIT = 2
+_EMA_FALLBACK_CONSOLE_EXAMPLE_LIMIT = 2
+_EMA_FALLBACK_CONSOLE_RECORD_LIMIT = 188
+_EMA_FALLBACK_CONSOLE_COUNT_LIMIT = 999_999_999
+
+
+def _bounded_ema_console_text(value: object, *, limit: int) -> str:
+    """Return a compact token without exposing arbitrary payload text."""
+    cleaned = re.sub(r"\s+", "-", str(value or "").strip())
+    bounded = "".join(
+        char for index, char in enumerate(cleaned) if index < max(0, int(limit))
+    )
+    return bounded or "-"
+
+
+def _bounded_ema_console_count(value: object) -> str:
+    try:
+        count = max(0, int(value))
+    except (TypeError, ValueError, OverflowError):
+        return "-"
+    if count > _EMA_FALLBACK_CONSOLE_COUNT_LIMIT:
+        return f"{_EMA_FALLBACK_CONSOLE_COUNT_LIMIT}+"
+    return str(count)
+
+
+def _bounded_ema_console_span(value: object) -> str:
+    try:
+        span = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return "-"
+    if not math.isfinite(span):
+        return "-"
+    return f"{span:.6g}"
+
+
+def _bounded_ema_console_reason(value: object, *, limit: int) -> str:
+    reason = str(value or "").strip()
+    if reason.startswith("non-finite close EMA value"):
+        return "non_finite"
+    if re.fullmatch(r"[A-Za-z0-9_.-]+", reason):
+        return _bounded_ema_console_text(reason, limit=limit)
+    if ":" in reason:
+        error_type = reason.split(":", 1)[0].strip()
+        if re.fullmatch(r"[A-Za-z0-9_.-]+", error_type):
+            return _bounded_ema_console_text(error_type, limit=limit)
+    return "error"
+
+
+def _ema_fallback_examples(data: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    examples = data.get("examples")
+    if not isinstance(examples, Mapping):
+        return []
+    close_fallback = examples.get("close_fallback")
+    if not isinstance(close_fallback, (list, tuple)):
+        return []
+    return [item for item in close_fallback if isinstance(item, Mapping)]
+
+
+def _format_ema_fallback_console_example(
+    example: Mapping[str, Any],
+    *,
+    symbol_limit: int = _EMA_FALLBACK_CONSOLE_TOKEN_LIMIT,
+    span_limit: int = _EMA_FALLBACK_CONSOLE_SAMPLE_LIMIT,
+    reason_limit: int = _EMA_FALLBACK_CONSOLE_REASON_LIMIT,
+) -> str:
+    spans = example.get("spans")
+    if isinstance(spans, (list, tuple)):
+        span_text = ",".join(
+            _bounded_ema_console_span(span)
+            for index, span in enumerate(spans)
+            if index < span_limit
+        )
+    else:
+        span_text = "-"
+    if not span_text:
+        span_text = "-"
+    return "".join(
+        (
+            _bounded_ema_console_text(example.get("symbol"), limit=symbol_limit),
+            f"[{span_text}]",
+            f" age={_bounded_ema_console_count(example.get('max_age_ms'))}ms",
+            f" n={_bounded_ema_console_count(example.get('max_fallbacks'))}",
+            f" why={_bounded_ema_console_reason(example.get('reason'), limit=reason_limit)}",
+        )
+    )
+
+
+def format_ema_fallback_console(data: Mapping[str, Any]) -> str:
+    """Render the close-EMA fallback warning without generic event decoration."""
+    examples = _ema_fallback_examples(data)
+    max_age_ms = max(
+        (_data_int(example, "max_age_ms") or 0 for example in examples), default=0
+    )
+    max_fallbacks = max(
+        (_data_int(example, "max_fallbacks") or 0 for example in examples), default=0
+    )
+    symbols = data.get("close_fallback_symbols")
+    if isinstance(symbols, Mapping):
+        sample_values = symbols.get("sample")
+        symbol_count = _bounded_ema_console_count(symbols.get("count"))
+    else:
+        sample_values = ()
+        symbol_count = "-"
+    if isinstance(sample_values, (list, tuple, set, frozenset)):
+        sample = ",".join(
+            _bounded_ema_console_text(
+                value, limit=_EMA_FALLBACK_CONSOLE_TOKEN_LIMIT
+            )
+            for index, value in enumerate(sample_values)
+            if index < _EMA_FALLBACK_CONSOLE_SAMPLE_LIMIT
+        )
+    else:
+        sample = "-"
+    parts = [
+        "[ema] close fallback",
+        f"n={_bounded_ema_console_count(data.get('close_fallback_count'))}",
+        f"sym={symbol_count}({sample or '-'})",
+        f"age={_bounded_ema_console_count(max_age_ms)}ms",
+        f"streak={_bounded_ema_console_count(max_fallbacks)}",
+    ]
+    emitted_examples = 0
+    for example in examples:
+        if emitted_examples >= _EMA_FALLBACK_CONSOLE_EXAMPLE_LIMIT:
+            break
+        candidate = f"ex={_format_ema_fallback_console_example(example)}"
+        if len(" ".join((*parts, candidate))) > _EMA_FALLBACK_CONSOLE_RECORD_LIMIT:
+            candidate = "ex=" + _format_ema_fallback_console_example(
+                example, symbol_limit=8, span_limit=1, reason_limit=8
+            )
+        if len(" ".join((*parts, candidate))) > _EMA_FALLBACK_CONSOLE_RECORD_LIMIT:
+            break
+        parts.append(candidate)
+        emitted_examples += 1
+    if not emitted_examples:
+        parts.append("ex=-")
+    return " ".join(parts)
+
+
 def format_console_event(event: LiveEvent) -> str:
     if (
         event.event_type == EventTypes.HEALTH_SUMMARY
@@ -2264,6 +2409,8 @@ def format_console_event(event: LiveEvent) -> str:
         return _format_console_balance_changed(event)
     if event.event_type == EventTypes.RESOURCE_MEMORY_SNAPSHOT:
         return format_memory_snapshot_console(event.data)
+    if event.event_type == EventTypes.EMA_FALLBACK_USED:
+        return format_ema_fallback_console(event.data)
     if event.event_type == EventTypes.STATE_REFRESH_TIMING:
         data = event.data if isinstance(event.data, Mapping) else {}
         return format_state_refresh_timing_console(data)

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -748,6 +748,16 @@ class Passivbot:
             and getattr(self, "_live_event_pipeline", None) is not None
         )
 
+    def _ema_fallback_structured_console_available(self) -> bool:
+        """Return True when the EMA fallback event owns the normal console warning."""
+        pipeline = getattr(self, "_live_event_pipeline", None)
+        return bool(
+            callable(getattr(self, "_emit_ema_fallback_used_event", None))
+            and Passivbot._live_event_console_available(self)
+            and callable(getattr(pipeline, "emit", None))
+            and getattr(pipeline, "console_sink", None) is not None
+        )
+
     @staticmethod
     def _log_symbol(symbol: Any) -> str:
         """Return a compact operator-facing symbol label for logs only."""
@@ -15708,7 +15718,12 @@ class Passivbot:
                 max_fallbacks,
                 "; ".join(examples),
             )
-        if close_ema_fallbacks:
+        close_fallback_structured_console = (
+            Passivbot._ema_fallback_structured_console_available(self)
+            if close_ema_fallbacks
+            else False
+        )
+        if close_ema_fallbacks and not close_fallback_structured_console:
             fallback_count = sum(len(items) for items in close_ema_fallbacks.values())
             max_fallbacks = max(
                 count

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -24,6 +24,7 @@ from live.event_bus import (
     ReasonCodes,
     authoritative_reason_code,
     format_console_event,
+    format_ema_fallback_console,
     format_memory_snapshot_console,
     format_state_refresh_timing_console,
     live_event_debug_profile_enabled,
@@ -322,7 +323,6 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.ACTION_PLANNED,
         EventTypes.EMA_BUNDLE_STARTED,
         EventTypes.EMA_BUNDLE_COMPLETED,
-        EventTypes.EMA_FALLBACK_USED,
         EventTypes.EMA_UNAVAILABLE,
         EventTypes.CANDLE_COVERAGE_CHECKED,
         EventTypes.CANDLE_TAIL_PROJECTED,
@@ -348,6 +348,10 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.CONFIG_MARKET_COMPATIBILITY].monitor is True
     assert DEFAULT_ROUTES[EventTypes.CONFIG_MARKET_COMPATIBILITY].console is False
     assert DEFAULT_ROUTES[EventTypes.CONFIG_MARKET_COMPATIBILITY].text is False
+    ema_fallback_route = DEFAULT_ROUTES[EventTypes.EMA_FALLBACK_USED]
+    assert ema_fallback_route.console is True
+    assert ema_fallback_route.text is True
+    assert ema_fallback_route.throttle_interval_ms == 15 * 60 * 1000
     assert DEFAULT_ROUTES[EventTypes.ORDER_WAVE_COMPLETED].console is True
     assert DEFAULT_ROUTES[EventTypes.ORDER_WAVE_COMPLETED].text is True
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CREATE_DEFERRED].console is False
@@ -1566,6 +1570,165 @@ def test_memory_snapshot_console_formatter_is_compact_and_omits_samples():
     assert format_console_event(
         LiveEvent(EventTypes.RESOURCE_MEMORY_SNAPSHOT, data=data)
     ) == message
+
+
+def test_ema_fallback_console_route_hides_recovery_and_forager_events_but_keeps_them_durable():
+    structured = ListEventSink()
+    console = ListEventSink()
+    text = ListEventSink()
+    pipeline = LiveEventPipeline(
+        structured_sinks=[structured],
+        monitor_sinks=[],
+        console_sink=console,
+        text_sink=text,
+    )
+    recovery = LiveEvent(
+        EventTypes.EMA_FALLBACK_USED,
+        ts_ms=1_000,
+        data={"close_fallback_count": 0, "close_recovered_count": 2},
+    )
+    forager = LiveEvent(
+        EventTypes.EMA_FALLBACK_USED,
+        ts_ms=1_001,
+        data={"close_fallback_count": 0, "forager_cached_fallback_count": 2},
+    )
+    close_first = LiveEvent(
+        EventTypes.EMA_FALLBACK_USED,
+        ts_ms=2_000,
+        data={"close_fallback_count": 1},
+    )
+    close_throttled = LiveEvent(
+        EventTypes.EMA_FALLBACK_USED,
+        ts_ms=2_000 + 15 * 60 * 1000 - 1,
+        data={"close_fallback_count": 1},
+    )
+    close_boundary = LiveEvent(
+        EventTypes.EMA_FALLBACK_USED,
+        ts_ms=2_000 + 15 * 60 * 1000,
+        data={"close_fallback_count": 1},
+    )
+
+    for event in (recovery, forager, close_first, close_throttled, close_boundary):
+        pipeline.emit(event)
+
+    assert console.events == [close_first, close_boundary]
+    assert text.events == [close_first, close_boundary]
+    assert pipeline.flush(timeout=2.0) is True
+    assert structured.events == [
+        recovery,
+        forager,
+        close_first,
+        close_throttled,
+        close_boundary,
+    ]
+    assert pipeline.close(timeout=2.0) is True
+
+
+def test_ema_fallback_console_formatter_retains_compact_warning_semantics():
+    data = {
+        "close_fallback_count": 3,
+        "close_fallback_symbols": {
+            "count": 2,
+            "sample": ["BTC/USDT:USDT", "ETH/USDT:USDT"],
+            "truncated": 0,
+        },
+        "examples": {
+            "close_fallback": [
+                {
+                    "symbol": "BTC/USDT:USDT",
+                    "spans": [10.0, 20.0],
+                    "max_age_ms": 120_000,
+                    "max_fallbacks": 3,
+                    "reason": "previous_ema_timeout",
+                },
+                {
+                    "symbol": "ETH/USDT:USDT",
+                    "spans": [30.0],
+                    "max_age_ms": 60_000,
+                    "max_fallbacks": 2,
+                    "reason": "cache_read_timeout",
+                },
+            ]
+        },
+    }
+    event = LiveEvent(EventTypes.EMA_FALLBACK_USED, status="recovered", data=data)
+    before = event.to_dict()
+
+    message = format_ema_fallback_console(event.data)
+
+    assert message.startswith("[ema] close fallback n=3 sym=2(BTC/USDT:USDT,ETH/USDT:USDT)")
+    assert "age=120000ms" in message
+    assert "streak=3" in message
+    assert "ex=BTC/USDT:USDT[10,20] age=120000ms n=3 why=previous_ema_time" in message
+    assert "recovered" not in message
+    assert "reason=" not in message
+    assert format_console_event(event) == message
+    assert event.to_dict() == before
+
+
+def test_ema_fallback_console_formatter_classifies_exception_reason_without_message():
+    message = format_ema_fallback_console(
+        {
+            "close_fallback_count": 1,
+            "close_fallback_symbols": {"count": 1, "sample": ["BTC/USDT:USDT"]},
+            "examples": {
+                "close_fallback": [
+                    {
+                        "symbol": "BTC/USDT:USDT",
+                        "spans": [60.0],
+                        "max_age_ms": 1000,
+                        "max_fallbacks": 1,
+                        "reason": "RequestTimeout: https://private.example/token",
+                    }
+                ]
+            },
+        }
+    )
+
+    assert "why=RequestTimeout" in message
+    assert "private.example" not in message
+
+
+def test_ema_fallback_console_formatter_is_bounded_without_mutating_payload():
+    maximum = (1 << 63) - 1
+    data = {
+        "close_fallback_count": maximum,
+        "close_fallback_symbols": {
+            "count": maximum,
+            "sample": ["X" * 10_000, "Y" * 10_000, "ignored"],
+        },
+        "examples": {
+            "close_fallback": [
+                {
+                    "symbol": "A" * 10_000,
+                    "spans": [1e300, 1e-300, 999.0],
+                    "max_age_ms": maximum,
+                    "max_fallbacks": maximum,
+                    "reason": "timeout " * 10_000,
+                },
+                {
+                    "symbol": "B" * 10_000,
+                    "spans": [2e300],
+                    "max_age_ms": maximum,
+                    "max_fallbacks": maximum,
+                    "reason": "stale " * 10_000,
+                },
+            ]
+        },
+    }
+    event = LiveEvent(EventTypes.EMA_FALLBACK_USED, data=data)
+    before = event.to_dict()
+
+    message = format_console_event(event)
+    longest_prefix = "2026-07-15T23:45:40Z WARNING  [hyperliquid] "
+
+    assert len(longest_prefix + message) <= 240
+    assert "n=999999999+" in message
+    assert "sym=999999999+(XXXXXXXXXXXXXXXX,YYYYYYYYYYYYYYYY)" in message
+    assert "age=999999999+ms" in message
+    assert "streak=999999999+" in message
+    assert "ex=AAAAAAAA" in message
+    assert event.to_dict() == before
 
 
 def test_state_refresh_timing_console_formatters_retain_operator_timing_signals():

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -790,8 +790,50 @@ async def test_kucoin_avax_close_ema_fallback_uses_previous_ema_not_price(caplog
     warning_messages = [
         record.message for record in caplog.records if record.levelno >= logging.WARNING
     ]
-    assert any("close EMA fallback summary" in message for message in warning_messages)
+    fallback_summaries = [
+        message for message in warning_messages if "close EMA fallback summary" in message
+    ]
+    assert len(fallback_summaries) == 1
     assert not any("close EMA fallback AVAX" in message for message in warning_messages)
+
+
+@pytest.mark.asyncio
+async def test_close_ema_fallback_event_console_owns_normal_warning(caplog, monkeypatch):
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "AVAX/USDT:USDT"
+    spans = (10.0, (10.0 * 20.0) ** 0.5, 20.0)
+    bot = _BundleReproBot(
+        symbol,
+        close_mode="timeout",
+        prev_close_ema={span: 100.0 for span in spans},
+    )
+    emitted = []
+    bot.live_event_console_enabled = True
+    bot._live_event_pipeline = type(
+        "Pipeline", (), {"console_sink": object(), "emit": lambda self, event: event}
+    )()
+
+    def emit_ema_fallback(bot_arg, **kwargs):
+        emitted.append((bot_arg, kwargs))
+
+    monkeypatch.setattr(
+        pb_mod.Passivbot,
+        "_emit_ema_fallback_used_event",
+        staticmethod(emit_ema_fallback),
+    )
+    bot._emit_ema_fallback_used_event = emit_ema_fallback
+
+    with caplog.at_level(logging.WARNING):
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(bot, [symbol], bot.PB_modes)
+
+    assert len(emitted) == 1
+    assert emitted[0][0] is bot
+    assert emitted[0][1]["close_ema_fallbacks"]
+    assert not any("close EMA fallback summary" in record.message for record in caplog.records)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- make the existing `ema.fallback_used` event the compact normal console/text owner only while close-EMA carry-forward is active
- keep recovery-only and forager-cached events durable but hidden from operator sinks
- preserve the complete structured payload, exact 15-minute warning cadence, and legacy warning fallback
- record PR #1251 deploy evidence and the natural 308-character trigger

## Behavior boundary
Observability-only. No EMA inputs, calculations, fallback eligibility or age limits, nontradable handling, exchange calls, Rust, order, risk, backtest, optimizer, or trading behavior changes.

## Runtime evidence
A natural Binance warning after PR #1251 measured 308 visible characters. The equivalent compact projection is 223 characters and retains fallback count, symbol count/sample, max age, streak, span examples, and classified reason without exposing arbitrary exception text.

PR #1251 deployed cleanly on VPS5: one exact five-bot SIGINT round, all old bots exited naturally within 10 seconds, settled smoke `ok=true`, zero hard/log/monitor/process/pipeline failures, `202/203` remote and `46/46` account-critical calls successful, six fill refreshes, no active HSL replay, five config-valid processes, and clean tracked master.

## Validation
- `python -m pytest -q tests/test_live_event_bus.py tests/test_missing_ema_fix.py tests/test_passivbot_monitor.py` (242 passed)
- `python -m py_compile src/live/event_bus.py src/passivbot.py src/tools/check_ai_docs.py`
- `python src/tools/check_ai_docs.py` (0 errors; one existing aggregate word-count warning)
- `git diff --check`
- added-line silent-handling audit clean

## Review gate
Temporary maintainer-authorized gate while Grok is halted: exact-current-head Hermes approval plus green Python and Rust CI.