### PR TITLE
Compact initial-entry distance-gate output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Initial-entry distance-gate blocked/cleared events now use a bounded compact
+  console/text projection while retaining the complete structured payload,
+  existing event admission, and legacy fallback. Entry eligibility, distance
+  calculation, gate decisions, order creation, and trading behavior are
+  unchanged.
+
 - Close-EMA carry-forward warnings now use a bounded structured console/text
   projection with counts, symbol/span examples, age, fallback streak, and a
   classified reason. The existing fifteen-minute warning cadence, complete

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/compact-entry-distance-console`, based on canonical
   `4ccf1e2523a217caa78b3ce3acbf2c949590926d` after PR #1252.
-- PR: pending, `Compact initial-entry distance-gate output`.
+- PR: #1253, `Compact initial-entry distance-gate output`.
 - Slice: compact the existing structured initial-entry distance-gate
   blocked/cleared console/text projection within the normal record budget.
 - Triggering evidence: the PR #1252 deployment produced 21 natural blocked

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,36 +22,46 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/compact-ema-fallback-console`, based on canonical
-  `b6fabcfdbbdd823277c12896b770f008c01bb163` after PR #1251.
-- PR: #1252, `Compact close-EMA fallback warning`.
-- Slice: make the existing structured `ema.fallback_used` event the compact
-  normal console/text owner only when close-EMA carry-forward is active.
-- Triggering evidence: a natural Binance close-EMA fallback summary measured
-  308 visible characters for four fallbacks across WLD and ZEC. Its repeated
-  age, streak, span, and reason labels exceeded the normal record budget.
-- Scope: preserve the exact fifteen-minute human warning cadence, complete
-  per-cycle structured/monitor events, classified reason, bounded examples,
-  and legacy fallback. Recovery-only and forager-cached fallback events remain
-  durable but console/text-hidden.
-- Behavior boundary: observability-only; no EMA input, calculation, fallback
-  eligibility/age limit, nontradable handling, exchange call, Rust, order,
+- Branch: `codex/compact-entry-distance-console`, based on canonical
+  `4ccf1e2523a217caa78b3ce3acbf2c949590926d` after PR #1252.
+- PR: pending, `Compact initial-entry distance-gate output`.
+- Slice: compact the existing structured initial-entry distance-gate
+  blocked/cleared console/text projection within the normal record budget.
+- Triggering evidence: the PR #1252 deployment produced 21 natural blocked
+  lines at 222-270 visible characters; 20 exceeded 240. Repeated machine
+  action/type/reason labels dominated the human projection.
+- Scope: preserve complete structured payloads, event admission/routes, zero
+  numeric values, structured console ownership, and exact legacy fallback;
+  compact only the human projection.
+- Behavior boundary: observability-only; no entry eligibility, distance or
+  tolerance calculation, gate decision, exchange call, Rust, order creation,
   risk, backtest, optimizer, or trading behavior.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green CI
   while Grok is halted.
 - Expected VPS action: after merge, one authorized exact five-bot restart.
-  Validate the natural startup settings lines and settled smoke; do not
+  Validate natural entry-gate lines and settled smoke; do not
   manufacture exchange, state, risk, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `b6fabcfdbbdd823277c12896b770f008c01bb163`, PR #1251. The tracked checkout
+  `4ccf1e2523a217caa78b3ce3acbf2c949590926d`, PR #1252. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `961227/961230/961232/961233/961234`. The exact pane PIDs remain
+  `963164/963166/964008/963169/963170`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1252 was activated after one exact five-bot SIGINT round; all old bots
+  exited naturally within ten seconds and no escalation was used. GateIO's
+  first new process then failed closed during HSL replay because one required
+  held-pair unrealized-PnL minute was unavailable. One bounded exact-pane retry
+  succeeded, reached `bot.ready`, and completed replay. Natural compact
+  close-EMA warnings measured 158, 166, and 225 visible characters on OKX,
+  Binance, and GateIO, with zero legacy duplicates in the post-deploy files.
+  The final two-minute smoke was `ok=true` with zero hard/log/monitor/process/
+  pipeline failures, `347/347` remote and `53/53` account-critical calls
+  successful, seven successful fill refreshes, no active HSL replay, five
+  config-valid processes in state `R`, and a clean tracked checkout.
 - PR #1251 was activated with one exact five-bot graceful restart. Every old
   bot exited naturally within ten seconds after one SIGINT round; no escalation
   was used. Three natural admitted slow-refresh lines measured 155-171 visible
@@ -763,8 +773,11 @@ validated: the four forager HSL settings lines measured 163-167 visible
 characters while retaining all configured settings. PR #1251 is also merged,
 deployed, and naturally validated: admitted staged-refresh lines measured
 155-171 visible characters with zero legacy duplicates and a hard-green
-settled smoke. The active slice compacts the naturally observed 308-character
-close-EMA fallback warning without changing EMA fallback or trading behavior.
+settled smoke. PR #1252 is merged, deployed, and naturally validated: compact
+close-EMA warnings measured 158-225 visible characters with zero post-deploy
+legacy duplicates and a hard-green settled smoke after one bounded GateIO
+retry. The active slice compacts the naturally observed 222-270 character
+initial-entry distance-gate lines without changing entry or trading behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,34 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1251)
+## Latest Canonical Deployment (PR #1252)
+
+- PR #1252 merged to `master` as `4ccf1e2523a217caa78b3ce3acbf2c949590926d`
+  after exact-head Hermes approval and green Python/Rust CI while Grok was
+  temporarily halted. It makes active close-EMA carry-forward events the
+  compact console/text owner at the unchanged fifteen-minute human cadence;
+  EMA calculations, fallback eligibility, and trading behavior are unchanged.
+- VPS5 fast-forwarded cleanly and sent one SIGINT round to exact old PIDs
+  `961227/961230/961232/961233/961234`; all exited naturally within ten
+  seconds, with no escalation. Pane PIDs and unrelated `misc:0.0` PID `434835`
+  were preserved. GateIO's first replacement failed closed during HSL replay
+  when one required held-pair unrealized-PnL minute was unavailable; one
+  bounded same-pane retry succeeded, reached `bot.ready`, and completed replay.
+  Final PIDs are `963164/963166/964008/963169/963170` for
+  Binance/KuCoin/GateIO/OKX/Hyperliquid respectively.
+- Natural compact close-EMA warnings measured 158, 166, and 225 visible
+  characters on OKX, Binance, and GateIO. They retained fallback and symbol
+  counts, age, streak, span examples, and classified reason; zero legacy
+  duplicate appeared in the post-deploy log files.
+- The final two-minute smoke was `ok=true` with zero hard/log/monitor/process/
+  pipeline failures, `347/347` remote and `53/53` account-critical calls
+  successful, seven successful fill refreshes, no active HSL replay, five
+  matching/config-valid processes in state `R`, and clean tracked `master`.
+- The same window contained 21 natural initial-entry distance-gate blocked
+  lines at 222-270 visible characters; 20 exceeded 240. The next slice compacts
+  only their existing structured human projection.
+
+## Previous Canonical Deployment (PR #1251)
 
 - PR #1251 merged to `master` as `b6fabcfdbbdd823277c12896b770f008c01bb163`
   after exact-head Hermes approval and green Python/Rust CI while Grok was

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -599,6 +599,15 @@ Related detailed plans:
     per-cycle durable events, recovery/forager suppression, and exact legacy
     fallback.
 
+    PR #1252 merged and deployed the close-EMA projection. Three natural lines
+    measured 158-225 characters, zero post-deploy legacy duplicates appeared,
+    and the settled smoke was hard-green after one bounded GateIO startup
+    retry. The same logs contained 21 natural initial-entry distance-gate
+    blocked lines at 222-270 characters, 20 above budget. The active
+    `codex/compact-entry-distance-console` slice compacts only their existing
+    structured human projection while preserving payload, admission, legacy
+    fallback, gate decisions, and trading behavior.
+
     Two post-PR #1220 console observations remain deferred rather than folded
     into the realized-loss slice. Hyperliquid balance lines surfaced signed
     floating-point jitter near `1e-13`; decide a console-only materiality or

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -2393,6 +2393,93 @@ def format_ema_fallback_console(data: Mapping[str, Any]) -> str:
     return " ".join(parts)
 
 
+_INITIAL_ENTRY_DISTANCE_GATE_CONSOLE_RECORD_LIMIT = 188
+_INITIAL_ENTRY_DISTANCE_GATE_CONSOLE_CYCLE_LIMIT = 24
+_INITIAL_ENTRY_DISTANCE_GATE_CONSOLE_SYMBOL_LIMIT = 24
+_INITIAL_ENTRY_DISTANCE_GATE_CONSOLE_PSIDE_LIMIT = 8
+_INITIAL_ENTRY_DISTANCE_GATE_CONSOLE_TYPE_LIMIT = 32
+
+
+def _bounded_initial_entry_distance_gate_console_text(
+    value: object, *, limit: int
+) -> str:
+    """Return a sanitized, bounded display token for the gate projection."""
+    return _format_console_label(value).replace(" ", "-")[:limit] or "-"
+
+
+def _format_initial_entry_distance_gate_console_pct(value: float | None) -> str:
+    if value is None or not math.isfinite(value):
+        return "-"
+    return f"{value:.4f}"
+
+
+def _format_initial_entry_distance_gate_console(event: LiveEvent) -> str:
+    """Render a compact blocked or cleared initial-entry distance-gate transition."""
+    data = event.data if isinstance(event.data, Mapping) else {}
+    transition = (
+        "blocked"
+        if event.event_type == EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED
+        else "cleared"
+    )
+    parts = ["[entry]", transition]
+    cycle_candidate = (
+        (
+            "cy="
+            + _bounded_initial_entry_distance_gate_console_text(
+                event.cycle_id,
+                limit=_INITIAL_ENTRY_DISTANCE_GATE_CONSOLE_CYCLE_LIMIT,
+            ),
+        )
+        if event.cycle_id
+        else ()
+    )
+    tolerance_candidate = (
+        "tol="
+        + _format_initial_entry_distance_gate_console_pct(
+            _data_number(data, "tolerance_pct")
+        )
+        + "%",
+    ) if "tolerance_pct" in data else ()
+    candidates = (
+        *cycle_candidate,
+        "symbol="
+        + _bounded_initial_entry_distance_gate_console_text(
+            event.symbol, limit=_INITIAL_ENTRY_DISTANCE_GATE_CONSOLE_SYMBOL_LIMIT
+        ),
+        "pside="
+        + _bounded_initial_entry_distance_gate_console_text(
+            event.pside, limit=_INITIAL_ENTRY_DISTANCE_GATE_CONSOLE_PSIDE_LIMIT
+        ),
+        "type="
+        + _bounded_initial_entry_distance_gate_console_text(
+            _data_str(data, "order_type"),
+            limit=_INITIAL_ENTRY_DISTANCE_GATE_CONSOLE_TYPE_LIMIT,
+        ),
+        f"q={_format_console_number(_data_number(data, 'qty'))}",
+        f"px={_format_console_number(_data_number(data, 'price'))}",
+        f"mkt={_format_console_number(_data_number(data, 'market_price'))}",
+        "d="
+        + _format_initial_entry_distance_gate_console_pct(
+            _data_number(data, "distance_pct")
+        )
+        + "%",
+        "max="
+        + _format_initial_entry_distance_gate_console_pct(
+            _data_number(data, "threshold_pct")
+        )
+        + "%",
+        *tolerance_candidate,
+    )
+    for candidate in candidates:
+        if (
+            len(" ".join((*parts, candidate)))
+            > _INITIAL_ENTRY_DISTANCE_GATE_CONSOLE_RECORD_LIMIT
+        ):
+            break
+        parts.append(candidate)
+    return " ".join(parts)
+
+
 def format_console_event(event: LiveEvent) -> str:
     if (
         event.event_type == EventTypes.HEALTH_SUMMARY
@@ -2411,6 +2498,11 @@ def format_console_event(event: LiveEvent) -> str:
         return format_memory_snapshot_console(event.data)
     if event.event_type == EventTypes.EMA_FALLBACK_USED:
         return format_ema_fallback_console(event.data)
+    if event.event_type in {
+        EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
+        EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
+    }:
+        return _format_initial_entry_distance_gate_console(event)
     if event.event_type == EventTypes.STATE_REFRESH_TIMING:
         data = event.data if isinstance(event.data, Mapping) else {}
         return format_state_refresh_timing_console(data)

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -2211,12 +2211,73 @@ def test_console_format_summarizes_initial_entry_distance_gate_block():
         },
     )
 
-    assert format_console_event(event) == (
-        "[entry] skipped cycle=cy_entry_gate action=skip_create "
-        "type=entry_initial_normal_long qty=0.001 price=98750 market=101000 "
-        "dist=2.2785% threshold=1.2500% tolerance=0.1000% "
-        "symbol=BTC/USDT:USDT pside=long reason=initial_entry_distance_gate"
+    rendered = format_console_event(event)
+
+    assert rendered == (
+        "[entry] blocked cy=cy_entry_gate symbol=BTC/USDT:USDT pside=long "
+        "type=entry_initial_normal_long q=0.001 px=98750 mkt=101000 "
+        "d=2.2785% max=1.2500% tol=0.1000%"
     )
+    assert len(f"2026-07-15T12:34:56Z INFO     [hyperliquid] {rendered}") <= 240
+
+
+def test_console_format_summarizes_initial_entry_distance_gate_clear():
+    event = LiveEvent(
+        EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
+        status="recovered",
+        cycle_id="cy_entry_gate",
+        symbol="BTC/USDT:USDT",
+        pside="long",
+        side="buy",
+        reason_code="initial_entry_distance_gate",
+        data={
+            "action": "allow_create",
+            "order_type": "entry_initial_normal_long",
+            "qty": 0.001,
+            "price": 98_750.0,
+            "market_price": 99_000.0,
+            "distance_pct": 0.2525252525,
+            "threshold_pct": 1.25,
+        },
+    )
+
+    rendered = format_console_event(event)
+
+    assert rendered == (
+        "[entry] cleared cy=cy_entry_gate symbol=BTC/USDT:USDT pside=long "
+        "type=entry_initial_normal_long q=0.001 px=98750 mkt=99000 "
+        "d=0.2525% max=1.2500%"
+    )
+    assert "tol=" not in rendered
+    assert len(f"2026-07-15T12:34:56Z INFO     [hyperliquid] {rendered}") <= 240
+
+
+def test_console_format_bounds_and_sanitizes_initial_entry_distance_gate_payload():
+    event = LiveEvent(
+        EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
+        symbol="\x1b[31mBTC/USDT:USDT\n" + "x" * 100,
+        pside="long\t" + "y" * 100,
+        data={
+            "action": "skip_create",
+            "order_type": "entry_initial_" + "z" * 1_000 + "\nunsafe",
+            "qty": 0.0,
+            "price": 0.0,
+            "market_price": 0.0,
+            "distance_pct": 0.0,
+            "threshold_pct": 0.0,
+            "tolerance_pct": 0.0,
+        },
+    )
+    payload_before = dict(event.data)
+
+    rendered = format_console_event(event)
+
+    assert len(f"2026-07-15T12:34:56Z INFO     [hyperliquid] {rendered}") <= 240
+    assert "\x1b" not in rendered
+    assert "\n" not in rendered
+    assert "\t" not in rendered
+    assert "q=0 px=0 mkt=0 d=0.0000% max=0.0000% tol=0.0000%" in rendered
+    assert event.data == payload_before
 
 
 def test_console_format_summarizes_min_effective_cost_block():


### PR DESCRIPTION
## Summary

- render structured initial-entry distance-gate blocked/cleared events as bounded operator-facing console/text records
- retain the complete structured payload, event admission/routes, numeric zero values, and legacy fallback
- update logging-overhaul status with PR #1252 deployment evidence and the natural trigger for this slice

## Evidence

- PR #1252 merged as `4ccf1e2523a217caa78b3ce3acbf2c949590926d` and was deployed with one exact five-bot SIGINT round; all old bots exited naturally within ten seconds
- GateIO's first replacement failed closed during HSL replay on a missing required held-pair unrealized-PnL minute; one bounded same-pane retry reached `bot.ready` and completed replay
- the final two-minute smoke was `ok=true`: five exact/config-valid processes in state `R`, `347/347` remote calls and `53/53` account-critical calls successful, seven successful fill refreshes, no active HSL replay, and zero hard/log/monitor/process/pipeline failures
- natural compact close-EMA warnings measured 158, 166, and 225 visible characters with zero legacy duplicates in the exact post-deploy files
- the same exact files contained 21 natural initial-entry distance-gate blocked records at 222-270 visible characters; 20 exceeded the 240-character normal-console budget

## Behavior boundary

This is observability-only. It does not change entry eligibility, distance/tolerance calculations, gate decisions, exchange calls, Rust behavior, order creation, risk, backtests, optimizer behavior, or trading behavior.

## Validation

- `pytest tests/test_live_event_bus.py tests/test_passivbot_balance_split.py tests/test_passivbot_monitor.py` (441 passed)
- `pytest tests/test_live_event_bus.py tests/test_passivbot_balance_split.py -k 'initial_entry_distance or entry_gate or test_console_format'` (59 passed)
- `python -m py_compile src/live/event_bus.py src/tools/check_ai_docs.py`
- `python src/tools/check_ai_docs.py` (0 errors; existing mandatory-context word-count warning only)
- `git diff --check`
- added-line silent-handling audit clean

## Review gate

Temporary maintainer-authorized gate while Grok is halted: exact-current-head Hermes approval plus green Python and Rust CI.
