### PR TITLE
Compact candle-health console summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Candle-health transition summaries now retain their aggregate counts and
+  bounded missing-candle examples within the normal console record budget.
+  Complete debug diagnostics, candle-health calculations, fetch behavior,
+  readiness checks, and trading behavior are unchanged.
+
 - Initial-entry distance-gate blocked/cleared events now use a bounded compact
   console/text projection while retaining the complete structured payload,
   existing event admission, and legacy fallback. Entry eligibility, distance

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,35 +22,49 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/compact-entry-distance-console`, based on canonical
-  `4ccf1e2523a217caa78b3ce3acbf2c949590926d` after PR #1252.
-- PR: #1253, `Compact initial-entry distance-gate output`.
-- Slice: compact the existing structured initial-entry distance-gate
-  blocked/cleared console/text projection within the normal record budget.
-- Triggering evidence: the PR #1252 deployment produced 21 natural blocked
-  lines at 222-270 visible characters; 20 exceeded 240. Repeated machine
-  action/type/reason labels dominated the human projection.
-- Scope: preserve complete structured payloads, event admission/routes, zero
-  numeric values, structured console ownership, and exact legacy fallback;
-  compact only the human projection.
-- Behavior boundary: observability-only; no entry eligibility, distance or
-  tolerance calculation, gate decision, exchange call, Rust, order creation,
-  risk, backtest, optimizer, or trading behavior.
+- Branch: `codex/compact-candle-health-console`, based on canonical
+  `048f1a722afe11a5e3aeda2340859893d6c8bb49` after PR #1253.
+- PR: pending, `Compact candle-health console summaries`.
+- Slice: bound the existing candle-health transition INFO summary within the
+  normal record budget while retaining aggregate health counts and useful
+  whole-field missing-candle examples.
+- Triggering evidence: the PR #1253 deployment produced natural candle-health
+  summaries at 257-263 visible characters on Binance, GateIO, and OKX. They
+  were the longest recurring over-budget family in the exact new log files.
+- Scope: preserve the complete debug diagnostic payload, transition key and
+  cadence, actionable missing/stale/synthetic calculations, and full report;
+  compact only the human INFO projection.
+- Behavior boundary: observability-only; no candle fetch/cache, health
+  calculation, readiness, exchange call, Rust, order, risk, backtest,
+  optimizer, or trading behavior.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green CI
   while Grok is halted.
 - Expected VPS action: after merge, one authorized exact five-bot restart.
-  Validate natural entry-gate lines and settled smoke; do not
+  Validate natural candle-health transition lines and settled smoke; do not
   manufacture exchange, state, risk, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `4ccf1e2523a217caa78b3ce3acbf2c949590926d`, PR #1252. The tracked checkout
+  `048f1a722afe11a5e3aeda2340859893d6c8bb49`, PR #1253. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `963164/963166/964008/963169/963170`. The exact pane PIDs remain
+  `965117/965119/965121/965123/965124`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1253 was activated after one exact five-bot SIGINT round; all old bots
+  exited naturally within four seconds and no escalation was used. Natural
+  initial-entry distance-gate records appeared 16 times across Binance,
+  GateIO, and OKX at 181-190 visible characters, with zero records above 240
+  and zero legacy duplicates. The initial window included active expected HSL
+  replay and one recoverable KuCoin authoritative-state timeout cycle. The
+  final two-minute smoke was `ok=true` with zero hard/log/monitor/process
+  failures, `52/52` account-critical calls successful, eight successful fill
+  refreshes, no active HSL replay, five matching/config-valid processes in
+  normal `R/S` states, and a clean tracked checkout. One non-account-critical
+  KuCoin OHLCV fetch timeout remained non-hard evidence. The exact new logs
+  then exposed natural candle-health summaries at 257-263 characters on
+  Binance, GateIO, and OKX.
 - PR #1252 was activated after one exact five-bot SIGINT round; all old bots
   exited naturally within ten seconds and no escalation was used. GateIO's
   first new process then failed closed during HSL replay because one required
@@ -776,8 +790,11 @@ deployed, and naturally validated: admitted staged-refresh lines measured
 settled smoke. PR #1252 is merged, deployed, and naturally validated: compact
 close-EMA warnings measured 158-225 visible characters with zero post-deploy
 legacy duplicates and a hard-green settled smoke after one bounded GateIO
-retry. The active slice compacts the naturally observed 222-270 character
-initial-entry distance-gate lines without changing entry or trading behavior.
+retry. PR #1253 is also merged, deployed, and naturally validated: 16
+initial-entry distance-gate lines measured 181-190 visible characters with
+zero legacy duplicates and a hard-green settled smoke. The active slice
+compacts the naturally observed 257-263 character candle-health summaries
+without changing candle or trading behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/compact-candle-health-console`, based on canonical
   `048f1a722afe11a5e3aeda2340859893d6c8bb49` after PR #1253.
-- PR: pending, `Compact candle-health console summaries`.
+- PR: #1254, `Compact candle-health console summaries`.
 - Slice: bound the existing candle-health transition INFO summary within the
   normal record budget while retaining aggregate health counts and useful
   whole-field missing-candle examples.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,33 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1252)
+## Latest Canonical Deployment (PR #1253)
+
+- PR #1253 merged to `master` as `048f1a722afe11a5e3aeda2340859893d6c8bb49`
+  after exact-head Hermes approval and green Python/Rust CI while Grok was
+  temporarily halted. It compacts only the structured initial-entry
+  distance-gate blocked/cleared console projection; payload, admission,
+  fallback, gate decisions, and trading behavior are unchanged.
+- VPS5 fast-forwarded cleanly and sent one SIGINT round to exact old PIDs
+  `963164/963166/964008/963169/963170`; all exited naturally within four
+  seconds, with no escalation. Pane PIDs and unrelated `misc:0.0` PID `434835`
+  were preserved. Final PIDs are `965117/965119/965121/965123/965124` for
+  Binance/KuCoin/GateIO/OKX/Hyperliquid respectively.
+- Sixteen natural blocked records across Binance, GateIO, and OKX measured
+  181-190 visible characters. None exceeded 240 and zero legacy duplicate
+  appeared in the exact post-deploy log files.
+- The initial window contained active expected HSL replay and one recoverable
+  KuCoin authoritative-state timeout cycle. The final two-minute smoke was
+  `ok=true` with zero hard/log/monitor/process failures, `52/52`
+  account-critical calls successful, eight successful fill refreshes, no
+  active HSL replay, five matching/config-valid processes in normal `R/S`
+  states, and clean tracked `master`. One non-account-critical KuCoin OHLCV
+  timeout remained non-hard evidence.
+- The same exact new log files contained natural candle-health transition
+  summaries at 257-263 visible characters on Binance, GateIO, and OKX. The
+  next slice bounds only that human INFO projection.
+
+## Previous Canonical Deployment (PR #1252)
 
 - PR #1252 merged to `master` as `4ccf1e2523a217caa78b3ce3acbf2c949590926d`
   after exact-head Hermes approval and green Python/Rust CI while Grok was

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -608,6 +608,15 @@ Related detailed plans:
     structured human projection while preserving payload, admission, legacy
     fallback, gate decisions, and trading behavior.
 
+    PR #1253 merged and deployed the initial-entry distance-gate projection.
+    Sixteen natural blocked lines measured 181-190 characters, none exceeded
+    240, zero legacy duplicates appeared, and the settled smoke was hard-green.
+    The same exact new logs contained candle-health transition summaries at
+    257-263 characters on Binance, GateIO, and OKX. The active
+    `codex/compact-candle-health-console` slice bounds only that human INFO
+    projection while preserving full debug diagnostics, health calculations,
+    transition cadence, readiness, fetch behavior, and trading behavior.
+
     Two post-PR #1220 console observations remain deferred rather than folded
     into the realized-loss slice. Hyperliquid balance lines surfaced signed
     floating-point jitter near `1e-13`; decide a console-only materiality or

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -612,6 +612,12 @@ class Passivbot:
     TRAILING_RATIO_MATERIALITY_ABSOLUTE_DELTA = 0.0005
     TRAILING_PRICE_MATERIALITY_RELATIVE_DELTA = 0.005
     STATUS_OPERATOR_HEARTBEAT_INTERVAL_MS = 60 * 60 * 1000
+    # The longest live INFO prefix is 44 characters: timestamp, level, and Hyperliquid.
+    CANDLE_HEALTH_CONSOLE_MESSAGE_MAX_LEN = 196
+    _CANDLE_HEALTH_CONSOLE_SAMPLE_LIMIT = 3
+    _CANDLE_HEALTH_CONSOLE_SYMBOL_MAX_LEN = 24
+    _CANDLE_HEALTH_CONSOLE_TIMEFRAME_MAX_LEN = 8
+    _CANDLE_HEALTH_CONSOLE_INT_MAX = 999_999
 
     _begin_live_event_cycle = live_event_emitters.begin_live_event_cycle
     _current_live_event_cycle_id = live_event_emitters.current_live_event_cycle_id
@@ -5049,6 +5055,80 @@ class Passivbot:
             "unhealthy_symbols": sorted(unhealthy),
         }
 
+    @staticmethod
+    def _format_candle_health_console_token(value: Any, max_len: int) -> str:
+        """Return one bounded, single-field token for the candle health console summary."""
+        text = str(value)
+        text = "".join(
+            char
+            if char.isascii()
+            and char.isprintable()
+            and not char.isspace()
+            and char not in {";", "|"}
+            else "_"
+            for char in text
+        )
+        if not text:
+            return "?"
+        if len(text) <= max_len:
+            return text
+        return f"{text[: max_len - 3]}..."
+
+    @staticmethod
+    def _format_candle_health_console_int(value: Any) -> str:
+        """Return a fixed-width-safe integer token for the candle health console summary."""
+        try:
+            number = int(value)
+        except (TypeError, ValueError, OverflowError):
+            return "0"
+        sign = "-" if number < 0 else ""
+        magnitude = abs(number)
+        if magnitude > Passivbot._CANDLE_HEALTH_CONSOLE_INT_MAX:
+            return f"{sign}{Passivbot._CANDLE_HEALTH_CONSOLE_INT_MAX}+"
+        return f"{number}"
+
+    @staticmethod
+    def _format_candle_health_summary(
+        symbol_count: int,
+        unhealthy_surface_count: int,
+        stale_count: int,
+        synthetic_count: int,
+        worst_missing: int,
+        unhealthy_samples: list[tuple[str, str, int, int | None]],
+    ) -> str:
+        """Format the bounded human projection without changing health diagnostics."""
+        integer = Passivbot._format_candle_health_console_int
+        base_message = (
+            "[candle] health: "
+            f"symbols={integer(symbol_count)} "
+            f"unhealthy_surfaces={integer(unhealthy_surface_count)} "
+            f"stale={integer(stale_count)} "
+            f"synthetic={integer(synthetic_count)} "
+            f"worst_missing={integer(worst_missing)}"
+        )
+        message = base_message
+        samples = []
+        for symbol, timeframe, missing, tail in unhealthy_samples[
+            : Passivbot._CANDLE_HEALTH_CONSOLE_SAMPLE_LIMIT
+        ]:
+            sample = (
+                f"{Passivbot._format_candle_health_console_token(symbol, Passivbot._CANDLE_HEALTH_CONSOLE_SYMBOL_MAX_LEN)} "
+                f"{Passivbot._format_candle_health_console_token(timeframe, Passivbot._CANDLE_HEALTH_CONSOLE_TIMEFRAME_MAX_LEN)} "
+                f"missing={integer(missing)}"
+            )
+            if tail is not None:
+                sample += f" tail={integer(tail)}"
+            samples.append(sample)
+        for sample_count in range(1, len(samples) + 1):
+            remainder = len(unhealthy_samples) - sample_count
+            candidate = f"{base_message} | {'; '.join(samples[:sample_count])}"
+            if remainder > 0:
+                candidate += f"; +{integer(remainder)} more"
+            if len(candidate) > Passivbot.CANDLE_HEALTH_CONSOLE_MESSAGE_MAX_LEN:
+                break
+            message = candidate
+        return message
+
     def _maybe_log_candle_health_summary(self) -> None:
         """Log periodic candle health diagnostics without fetching remote data."""
         try:
@@ -5075,6 +5155,7 @@ class Passivbot:
             stale_count = 0
             synthetic_count = 0
             unhealthy_details = []
+            unhealthy_samples = []
             try:
                 stale_minutes = float(
                     get_optional_live_value(
@@ -5115,14 +5196,19 @@ class Passivbot:
                             stale_count += 1
                     if actionable_missing:
                         tail_note = ""
+                        tail_gap_candles = None
                         if bool(tf_report.get("open_tail_gap", False)):
-                            tail_note = f" tail={int(tf_report.get('tail_gap_candles', 0) or 0)}"
+                            tail_gap_candles = int(
+                                tf_report.get("tail_gap_candles", 0) or 0
+                            )
+                            tail_note = f" tail={tail_gap_candles}"
+                        display_symbol = Passivbot._log_symbol(symbol)
                         unhealthy_details.append(
-                            f"{Passivbot._log_symbol(symbol)} {tf} missing={missing}{tail_note}"
+                            f"{display_symbol} {tf} missing={missing}{tail_note}"
                         )
-            detail = "; ".join(unhealthy_details[:5])
-            if len(unhealthy_details) > 5:
-                detail += f"; +{len(unhealthy_details) - 5} more"
+                        unhealthy_samples.append(
+                            (display_symbol, str(tf), missing, tail_gap_candles)
+                        )
             debug_payload = {
                 symbol: {
                     tf: {
@@ -5160,13 +5246,15 @@ class Passivbot:
             if interesting and key != last_key:
                 self._candle_health_last_log_key = key
                 logging.info(
-                    "[candle] health: symbols=%d unhealthy_surfaces=%d stale=%d synthetic=%d worst_missing=%d%s",
-                    len(symbol_reports),
-                    len(unhealthy_details),
-                    stale_count,
-                    synthetic_count,
-                    worst_missing,
-                    f" | {detail}" if detail else "",
+                    "%s",
+                    Passivbot._format_candle_health_summary(
+                        len(symbol_reports),
+                        len(unhealthy_details),
+                        stale_count,
+                        synthetic_count,
+                        worst_missing,
+                        unhealthy_samples,
+                    ),
                 )
             elif not interesting:
                 logging.debug("[candle] health ok | symbols=%d", len(symbol_reports))

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -40,6 +40,7 @@ import passivbot as passivbot_module
 from config import get_template_config, prepare_config
 from freshness_ledger import ACCOUNT_SURFACES, LIVE_STATE_SURFACES, FreshnessLedger
 from live.planning_availability import PlanningAvailability
+from logging_setup import DEFAULT_DATEFMT, DEFAULT_FORMAT_WITH_PREFIX
 from market_snapshot import MarketSnapshot
 from planning_snapshot import (
     PlanningMarketSnapshot,
@@ -3887,6 +3888,123 @@ def test_candle_health_missing_trailing_1m_gap_is_not_actionable_during_grace():
         )
         is True
     )
+
+
+def test_candle_health_summary_formatter_exact_format():
+    message = Passivbot._format_candle_health_summary(
+        symbol_count=3,
+        unhealthy_surface_count=3,
+        stale_count=2,
+        synthetic_count=4,
+        worst_missing=6,
+        unhealthy_samples=[
+            ("BTC", "1m", 2, 3),
+            ("ETH", "1h", 1, None),
+            ("SOL", "15m", 6, None),
+        ],
+    )
+
+    assert message == (
+        "[candle] health: symbols=3 unhealthy_surfaces=3 stale=2 synthetic=4 "
+        "worst_missing=6 | BTC 1m missing=2 tail=3; ETH 1h missing=1; SOL 15m missing=6"
+    )
+
+
+def test_candle_health_summary_formatter_bounds_hostile_labels_for_live_console():
+    hostile = "bad label;|\n\t" + ("x" * 100)
+    message = Passivbot._format_candle_health_summary(
+        symbol_count=10**20,
+        unhealthy_surface_count=10,
+        stale_count=10**20,
+        synthetic_count=10**20,
+        worst_missing=10**20,
+        unhealthy_samples=[(hostile, hostile, 10**20, 10**20) for _ in range(10)],
+    )
+    record = logging.LogRecord(
+        "test", logging.INFO, __file__, 0, "%s", (message,), None
+    )
+    record.created = 0.0
+    record.log_prefix = "hyperliquid"
+    formatter = logging.Formatter(DEFAULT_FORMAT_WITH_PREFIX, datefmt=DEFAULT_DATEFMT)
+    formatter.converter = time.gmtime
+    rendered = formatter.format(record)
+
+    assert "\n" not in message
+    assert "\r" not in message
+    assert "\t" not in message
+    assert "+9 more" in message
+    assert len(message) <= Passivbot.CANDLE_HEALTH_CONSOLE_MESSAGE_MAX_LEN
+    assert Passivbot.CANDLE_HEALTH_CONSOLE_MESSAGE_MAX_LEN == 240 - (
+        len(rendered) - len(message)
+    )
+    assert len(rendered) <= 240
+
+
+def test_candle_health_summary_projection_preserves_debug_payload_and_transition(monkeypatch, caplog):
+    bot = Passivbot.__new__(Passivbot)
+    bot.active_symbols = ["BTC/USDT:USDT"]
+    bot.open_orders = {}
+    bot.positions = {}
+    bot.config = {"live": {}}
+    report = {
+        "symbols": {
+            "BTC/USDT:USDT": {
+                "timeframes": {
+                    "1m": {
+                        "coverage_ok": False,
+                        "required": True,
+                        "missing_candles": 2,
+                        "last_cached_ts": 0,
+                        "end_ts": 60_000,
+                        "runtime_synthetic_count": 3,
+                        "open_tail_gap": True,
+                        "tail_gap_candles": 2,
+                    }
+                }
+            }
+        }
+    }
+    calls = []
+
+    def build_report(symbols):
+        calls.append(set(symbols))
+        return report
+
+    monkeypatch.setattr(bot, "build_required_candle_health_report", build_report)
+
+    with caplog.at_level(logging.DEBUG):
+        bot._maybe_log_candle_health_summary()
+        bot._maybe_log_candle_health_summary()
+
+    info_messages = [
+        record.message
+        for record in caplog.records
+        if record.levelno == logging.INFO and record.message.startswith("[candle] health:")
+    ]
+    debug_records = [
+        record
+        for record in caplog.records
+        if record.message.startswith("[candle] health diagnostics |")
+    ]
+    assert calls == [{"BTC/USDT:USDT"}, {"BTC/USDT:USDT"}]
+    assert info_messages == [
+        "[candle] health: symbols=1 unhealthy_surfaces=1 stale=0 synthetic=3 "
+        "worst_missing=2 | BTC 1m missing=2 tail=2"
+    ]
+    assert len(debug_records) == 2
+    assert debug_records[0].args[1] == {
+        "BTC/USDT:USDT": {
+            "1m": {
+                "ok": False,
+                "required": True,
+                "missing": 2,
+                "last_cached_ts": 0,
+                "synthetic": 3,
+                "open_tail_gap": True,
+                "tail_gap_candles": 2,
+            }
+        }
+    }
 
 
 def test_memory_snapshot_is_interesting_only_initially_or_on_large_change():


### PR DESCRIPTION
## Summary

- bound the existing candle-health transition INFO summary to a 196-character message budget, leaving room for the longest current timestamp/level/exchange prefix within 240 visible characters
- retain aggregate health counts, up to three whole sanitized missing-candle samples, and `+N more`
- preserve the complete DEBUG diagnostics, transition key/cadence, candle-health calculations, fetch behavior, readiness, and trading behavior

## Deployment evidence from PR #1253

- PR #1253 merged as `048f1a722afe11a5e3aeda2340859893d6c8bb49`; the exact five old bots exited naturally within four seconds after one SIGINT round, with no escalation
- new PIDs are `965117/965119/965121/965123/965124`; exact pane PIDs and unrelated `misc:0.0` PID `434835` were preserved
- 16 natural initial-entry distance-gate blocked records across Binance, GateIO, and OKX measured 181-190 visible characters; none exceeded 240 and zero legacy duplicates appeared
- the final two-minute smoke was `ok=true`: five matching/config-valid processes in normal `R/S`, zero hard/log/monitor/process failures, `52/52` account-critical calls successful, eight successful fill refreshes, no active HSL replay, and clean tracked master
- one non-account-critical KuCoin OHLCV timeout remained non-hard evidence

## Trigger

The same exact new log files contained natural candle-health transition summaries at 257-263 visible characters on Binance, GateIO, and OKX. This was the longest recurring over-budget family in that deployment window.

## Behavior boundary

Observability-only. No candle fetch/cache logic, candle-health calculation, transition admission/cadence, readiness behavior, exchange calls, Rust, orders, risk, backtests, optimizer, or trading behavior changes.

## Validation

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_passivbot_balance_split.py tests/test_live_candle_budget.py tests/test_passivbot_monitor.py` (366 passed)
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/passivbot.py src/tools/check_ai_docs.py`
- `python src/tools/check_ai_docs.py` (0 errors; existing mandatory-context word-count warning only)
- `git diff --check`
- added-line silent-handling audit: only the existing diagnostic `tail_gap_candles` zero default moved into a local variable

## Review gate

Temporary maintainer-authorized gate while Grok is halted: exact-current-head Hermes approval plus green Python and Rust CI.
