### PR TITLE
Compact forager selection console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Forager selection transitions now use a bounded operator summary with slot,
+  selected/incumbent, hysteresis, reason, ranking, and replacement context.
+  Complete structured and DEBUG diagnostics, transition cadence, Rust-owned
+  selection behavior, and trading behavior are unchanged.
+
 - Candle-health transition summaries now retain their aggregate counts and
   bounded missing-candle examples within the normal console record budget.
   Complete debug diagnostics, candle-health calculations, fetch behavior,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/compact-forager-selection-console`, based on canonical
   `e7f87e18085f1bd53e2f6975ba5ecd4c14e60745` after PR #1254.
-- PR: pending, `Compact forager selection console output`.
+- PR: #1255, `Compact forager selection console output`.
 - Slice: bound the Rust-owned forager selection transition INFO projection
   within the normal record budget while retaining useful selected/incumbent,
   hysteresis, reason, ranking, and replacement context.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,36 +22,48 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/compact-candle-health-console`, based on canonical
-  `048f1a722afe11a5e3aeda2340859893d6c8bb49` after PR #1253.
-- PR: #1254, `Compact candle-health console summaries`.
-- Slice: bound the existing candle-health transition INFO summary within the
-  normal record budget while retaining aggregate health counts and useful
-  whole-field missing-candle examples.
-- Triggering evidence: the PR #1253 deployment produced natural candle-health
-  summaries at 257-263 visible characters on Binance, GateIO, and OKX. They
-  were the longest recurring over-budget family in the exact new log files.
-- Scope: preserve the complete debug diagnostic payload, transition key and
-  cadence, actionable missing/stale/synthetic calculations, and full report;
+- Branch: `codex/compact-forager-selection-console`, based on canonical
+  `e7f87e18085f1bd53e2f6975ba5ecd4c14e60745` after PR #1254.
+- PR: pending, `Compact forager selection console output`.
+- Slice: bound the Rust-owned forager selection transition INFO projection
+  within the normal record budget while retaining useful selected/incumbent,
+  hysteresis, reason, ranking, and replacement context.
+- Triggering evidence: the PR #1254 deployment produced natural forager
+  selection lines at 247-250 visible characters on Binance, GateIO, and OKX.
+  They were the largest remaining recurring over-budget family in the exact
+  new log files.
+- Scope: preserve the complete structured selection event and DEBUG score/
+  component/event diagnostics, transition keys and cadence, and Rust output;
   compact only the human INFO projection.
-- Behavior boundary: observability-only; no candle fetch/cache, health
-  calculation, readiness, exchange call, Rust, order, risk, backtest,
-  optimizer, or trading behavior.
+- Behavior boundary: observability-only; no candidate scoring, hysteresis,
+  forager selection, exchange call, Rust, order, risk, backtest, optimizer, or
+  trading behavior.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green CI
   while Grok is halted.
 - Expected VPS action: after merge, one authorized exact five-bot restart.
-  Validate natural candle-health transition lines and settled smoke; do not
+  Validate natural forager selection transition lines and settled smoke; do not
   manufacture exchange, state, risk, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `048f1a722afe11a5e3aeda2340859893d6c8bb49`, PR #1253. The tracked checkout
+  `e7f87e18085f1bd53e2f6975ba5ecd4c14e60745`, PR #1254. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `965117/965119/965121/965123/965124`. The exact pane PIDs remain
+  `966831/966834/966836/966837/966838`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1254 was activated after one exact five-bot SIGINT round; all old bots
+  exited naturally within eight seconds and no escalation was used. Four
+  natural candle-health summaries on Binance, GateIO, OKX, and Hyperliquid
+  measured 156-211 visible characters, retained aggregate counts, whole
+  samples, and `+N more`, and none exceeded 240. The final two-minute smoke was
+  `ok=true` with zero hard/log/monitor/process failures, `301/301` remote and
+  `33/33` account-critical calls successful, seven successful fill refreshes,
+  no active HSL replay, five matching/config-valid processes in normal `R/S`
+  states, and a clean tracked checkout. The exact new logs then exposed
+  natural forager selection lines at 247-250 characters on Binance, GateIO,
+  and OKX.
 - PR #1253 was activated after one exact five-bot SIGINT round; all old bots
   exited naturally within four seconds and no escalation was used. Natural
   initial-entry distance-gate records appeared 16 times across Binance,
@@ -792,9 +804,11 @@ close-EMA warnings measured 158-225 visible characters with zero post-deploy
 legacy duplicates and a hard-green settled smoke after one bounded GateIO
 retry. PR #1253 is also merged, deployed, and naturally validated: 16
 initial-entry distance-gate lines measured 181-190 visible characters with
-zero legacy duplicates and a hard-green settled smoke. The active slice
-compacts the naturally observed 257-263 character candle-health summaries
-without changing candle or trading behavior.
+zero legacy duplicates and a hard-green settled smoke. PR #1254 is also
+merged, deployed, and naturally validated: four candle-health lines measured
+156-211 visible characters with a hard-green settled smoke. The active slice
+compacts the naturally observed 247-250 character forager selection lines
+without changing selection or trading behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,31 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1253)
+## Latest Canonical Deployment (PR #1254)
+
+- PR #1254 merged to `master` as `e7f87e18085f1bd53e2f6975ba5ecd4c14e60745`
+  after exact-head Hermes approval and green Python/Rust CI while Grok was
+  temporarily halted. It bounds only the candle-health transition INFO
+  projection; full DEBUG diagnostics, transition cadence, candle health,
+  readiness, fetch behavior, and trading behavior are unchanged.
+- VPS5 fast-forwarded cleanly and sent one SIGINT round to exact old PIDs
+  `965117/965119/965121/965123/965124`; all exited naturally within eight
+  seconds, with no escalation. Pane PIDs and unrelated `misc:0.0` PID `434835`
+  were preserved. Final PIDs are `966831/966834/966836/966837/966838` for
+  Binance/KuCoin/GateIO/OKX/Hyperliquid respectively.
+- Four natural candle-health summaries on Binance, GateIO, OKX, and
+  Hyperliquid measured 156-211 visible characters. They retained aggregate
+  counts, up to three whole missing-candle samples, and `+N more`; none
+  exceeded 240.
+- The final two-minute smoke was `ok=true` with zero hard/log/monitor/process
+  failures, `301/301` remote and `33/33` account-critical calls successful,
+  seven successful fill refreshes, no active HSL replay, five matching/
+  config-valid processes in normal `R/S` states, and clean tracked `master`.
+- The same exact new log files contained natural forager selection transition
+  lines at 247-250 visible characters on Binance, GateIO, and OKX. The next
+  slice bounds only that human INFO projection.
+
+## Previous Canonical Deployment (PR #1253)
 
 - PR #1253 merged to `master` as `048f1a722afe11a5e3aeda2340859893d6c8bb49`
   after exact-head Hermes approval and green Python/Rust CI while Grok was

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -617,6 +617,15 @@ Related detailed plans:
     projection while preserving full debug diagnostics, health calculations,
     transition cadence, readiness, fetch behavior, and trading behavior.
 
+    PR #1254 merged and deployed the candle-health projection. Four natural
+    lines measured 156-211 characters, none exceeded 240, and the settled
+    smoke was hard-green. The same exact new logs contained forager selection
+    transitions at 247-250 characters on Binance, GateIO, and OKX. The active
+    `codex/compact-forager-selection-console` slice bounds only that human INFO
+    projection while preserving the structured event, full DEBUG score and
+    hysteresis diagnostics, transition cadence, Rust output, selection, and
+    trading behavior.
+
     Two post-PR #1220 console observations remain deferred rather than folded
     into the realized-loss slice. Hyperliquid balance lines surfaced signed
     floating-point jitter near `1e-13`; decide a console-only materiality or

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -614,6 +614,7 @@ class Passivbot:
     STATUS_OPERATOR_HEARTBEAT_INTERVAL_MS = 60 * 60 * 1000
     # The longest live INFO prefix is 44 characters: timestamp, level, and Hyperliquid.
     CANDLE_HEALTH_CONSOLE_MESSAGE_MAX_LEN = 196
+    FORAGER_SELECTION_CONSOLE_MESSAGE_MAX_LEN = 196
     _CANDLE_HEALTH_CONSOLE_SAMPLE_LIMIT = 3
     _CANDLE_HEALTH_CONSOLE_SYMBOL_MAX_LEN = 24
     _CANDLE_HEALTH_CONSOLE_TIMEFRAME_MAX_LEN = 8
@@ -11350,6 +11351,110 @@ class Passivbot:
                     examples,
                 )
 
+    @staticmethod
+    def _format_forager_selection_console_token(value: Any, max_len: int) -> str:
+        """Return one bounded token for the human forager-selection projection."""
+        text = str(value)
+        text = "".join(
+            char
+            if char.isascii()
+            and char.isprintable()
+            and not char.isspace()
+            and char not in {",", ";", "|", "=", "<", ">", "[", "]", "(", ")"}
+            else "_"
+            for char in text
+        )
+        if not text:
+            return "?"
+        if len(text) <= max_len:
+            return text
+        return f"{text[: max_len - 3]}..."
+
+    @staticmethod
+    def _format_forager_selection_console_float(value: Any) -> str:
+        """Return a compact finite numeric token for the human selection projection."""
+        try:
+            number = float(value)
+        except (TypeError, ValueError, OverflowError):
+            return "0"
+        if number != number or abs(number) == float("inf"):
+            return "0"
+        return f"{number:.3g}"
+
+    @staticmethod
+    def _format_forager_selection_console_rank(value: Any) -> str:
+        """Return a short rank token without allowing unbounded console width."""
+        try:
+            rank = int(value)
+        except (TypeError, ValueError, OverflowError):
+            return "0"
+        if rank > 999:
+            return "999+"
+        if rank < -999:
+            return "-999+"
+        return str(rank)
+
+    @staticmethod
+    def _format_forager_selection_summary(
+        *,
+        pside: Any,
+        slots_to_fill: Any,
+        selected_symbols: tuple[str, ...],
+        incumbent_symbols: tuple[str, ...],
+        score_hysteresis_pct: Any,
+        reason: Any,
+        top_scores: list[tuple[str, Any, Any]],
+        hysteresis_events: list[tuple[str, str, Any, bool]],
+    ) -> str:
+        """Format the bounded INFO projection without changing diagnostics or admission."""
+        token = Passivbot._format_forager_selection_console_token
+        integer = Passivbot._format_candle_health_console_int
+        number = Passivbot._format_forager_selection_console_float
+
+        def compact_symbols(symbols: tuple[str, ...]) -> str:
+            if not symbols:
+                return "-"
+            shown = [token(symbol, 8) for symbol in symbols[:3]]
+            if len(symbols) > len(shown):
+                shown.append(f"+{integer(len(symbols) - len(shown))}")
+            return ",".join(shown)
+
+        def append_samples(
+            message: str, label: str, samples: list[str], total: int
+        ) -> str:
+            result = message
+            for sample_count in range(1, len(samples) + 1):
+                candidate = f"{message} {label}={','.join(samples[:sample_count])}"
+                omitted = total - sample_count
+                if omitted > 0:
+                    candidate += f",+{integer(omitted)}"
+                if len(candidate) > Passivbot.FORAGER_SELECTION_CONSOLE_MESSAGE_MAX_LEN:
+                    break
+                result = candidate
+            return result
+
+        reason_token = token(reason, 24)
+        if reason_token.endswith("..."):
+            reason_token = token(reason, 8)
+        message = (
+            f"[forager] {token(pside, 8)} selection | "
+            f"slots={integer(slots_to_fill)} "
+            f"selected={compact_symbols(selected_symbols)} "
+            f"incumbents={compact_symbols(incumbent_symbols)} "
+            f"hyst={number(score_hysteresis_pct)} "
+            f"reason={reason_token}"
+        )
+        event_samples = [
+            f"{'kept' if kept_incumbent else 'replaced'}:{token(incumbent, 6)}<->{token(challenger, 6)} gap={number(gap)}"
+            for incumbent, challenger, gap, kept_incumbent in hysteresis_events[:1]
+        ]
+        top_samples = [
+            f"{Passivbot._format_forager_selection_console_rank(rank)}:{token(symbol, 8)}={number(score)}"
+            for symbol, rank, score in top_scores[:3]
+        ]
+        message = append_samples(message, "events", event_samples, len(hysteresis_events))
+        return append_samples(message, "top", top_samples, len(top_scores))
+
     def _log_forager_selection_diagnostics(
         self, out: dict, idx_to_symbol: dict[int, str]
     ) -> None:
@@ -11562,16 +11667,33 @@ class Passivbot:
                     else "selection_changed" if info_changed else "periodic"
                 )
                 logging.info(
-                    "[forager] %s selection | slots=%s selected=%s incumbents=%s "
-                    "hyst=%.6f reason=%s top=%s events=%s",
-                    pside,
-                    int(selection.get("slots_to_fill", 0) or 0),
-                    ",".join(selected_symbols) if selected_symbols else "-",
-                    ",".join(incumbent_symbols) if incumbent_symbols else "-",
-                    float(selection.get("score_hysteresis_pct", 0.0) or 0.0),
-                    reason,
-                    _fmt_top(top_scores, 5, with_components=False),
-                    _fmt_events(events),
+                    Passivbot._format_forager_selection_summary(
+                        pside=pside,
+                        slots_to_fill=selection.get("slots_to_fill", 0),
+                        selected_symbols=selected_symbols,
+                        incumbent_symbols=incumbent_symbols,
+                        score_hysteresis_pct=selection.get(
+                            "score_hysteresis_pct", 0.0
+                        ),
+                        reason=reason,
+                        top_scores=[
+                            (
+                                _symbol(item.get("symbol_idx")),
+                                item.get("rank", index + 1),
+                                item.get("score", 0.0),
+                            )
+                            for index, item in enumerate(top_scores)
+                        ],
+                        hysteresis_events=[
+                            (
+                                _symbol(event.get("incumbent_symbol_idx")),
+                                _symbol(event.get("challenger_symbol_idx")),
+                                event.get("score_gap", 0.0),
+                                bool(event.get("kept_incumbent")),
+                            )
+                            for event in events
+                        ],
+                    )
                 )
                 state["info_key"] = info_key
                 state["event_key"] = event_key

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -3605,6 +3605,210 @@ def test_min_effective_cost_blocks_are_aggregated(caplog):
     assert any("blocked=5 detailed=3 suppressed=0" in msg for msg in infos)
 
 
+def test_forager_selection_summary_formatter_exact_format():
+    message = Passivbot._format_forager_selection_summary(
+        pside="long",
+        slots_to_fill=1,
+        selected_symbols=("DOGE", "SOL", "ETH"),
+        incumbent_symbols=("DOGE",),
+        score_hysteresis_pct=0.005,
+        reason="selection_changed",
+        top_scores=[("SOL", 1, 0.625), ("DOGE", 2, 0.623)],
+        hysteresis_events=[("DOGE", "SOL", 0.002, True)],
+    )
+
+    assert message == (
+        "[forager] long selection | slots=1 selected=DOGE,SOL,ETH incumbents=DOGE "
+        "hyst=0.005 reason=selection_changed events=kept:DOGE<->SOL gap=0.002 "
+        "top=1:SOL=0.625,2:DOGE=0.623"
+    )
+
+
+def test_forager_selection_summary_formatter_bounds_hostile_tokens_for_live_console():
+    hostile = "bad, field;|\n\t" + ("x" * 300)
+    message = Passivbot._format_forager_selection_summary(
+        pside=hostile,
+        slots_to_fill=10**20,
+        selected_symbols=tuple(hostile for _ in range(10)),
+        incumbent_symbols=tuple(hostile for _ in range(10)),
+        score_hysteresis_pct=0.005,
+        reason=hostile,
+        top_scores=[(hostile, 10**20, 0.625) for _ in range(10)],
+        hysteresis_events=[(hostile, hostile, 0.002, True) for _ in range(10)],
+    )
+    record = logging.LogRecord(
+        "test", logging.INFO, __file__, 0, "%s", (message,), None
+    )
+    record.created = 0.0
+    record.log_prefix = "hyperliquid"
+    formatter = logging.Formatter(DEFAULT_FORMAT_WITH_PREFIX, datefmt=DEFAULT_DATEFMT)
+    formatter.converter = time.gmtime
+    rendered = formatter.format(record)
+
+    assert "\n" not in message
+    assert "\r" not in message
+    assert "\t" not in message
+    assert hostile not in message
+    assert "selected=bad__...,bad__...,bad__...,+7" in message
+    assert "incumbents=bad__...,bad__...,bad__...,+7" in message
+    assert len(message) <= Passivbot.FORAGER_SELECTION_CONSOLE_MESSAGE_MAX_LEN
+    assert Passivbot.FORAGER_SELECTION_CONSOLE_MESSAGE_MAX_LEN == 240 - (
+        len(rendered) - len(message)
+    )
+    assert len(rendered) <= 240
+
+
+def test_forager_selection_diagnostics_preserves_transition_and_cadence(monkeypatch, caplog):
+    bot = Passivbot.__new__(Passivbot)
+    bot._forager_selection_info_interval_ms = 1_000
+    bot._forager_selection_debug_interval_ms = 1_000
+    now = [1_000]
+    monkeypatch.setattr(passivbot_module, "utc_ms", lambda: now[0])
+    base = {
+        "diagnostics": {
+            "forager_selections": [
+                {
+                    "pside": "long",
+                    "slots_to_fill": 1,
+                    "score_hysteresis_pct": 0.005,
+                    "selected_symbol_indices": [0],
+                    "incumbent_symbol_indices": [0],
+                    "top_scores": [
+                        {"symbol_idx": 0, "rank": 1, "score": 0.625, "selected": True},
+                        {"symbol_idx": 1, "rank": 2, "score": 0.623, "selected": False},
+                    ],
+                    "hysteresis_events": [
+                        {
+                            "incumbent_symbol_idx": 0,
+                            "challenger_symbol_idx": 1,
+                            "score_gap": 0.002,
+                            "kept_incumbent": True,
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    replacement = deepcopy(base)
+    selection = replacement["diagnostics"]["forager_selections"][0]
+    selection["selected_symbol_indices"] = [1]
+    selection["incumbent_symbol_indices"] = [1]
+    selection["hysteresis_events"][0]["kept_incumbent"] = False
+    idx_to_symbol = {0: "SOL/USDT:USDT", 1: "DOGE/USDT:USDT"}
+
+    with caplog.at_level(logging.DEBUG):
+        Passivbot._log_forager_selection_diagnostics(bot, base, idx_to_symbol)
+        now[0] = 1_001
+        Passivbot._log_forager_selection_diagnostics(bot, replacement, idx_to_symbol)
+        now[0] = 2_001
+        Passivbot._log_forager_selection_diagnostics(bot, replacement, idx_to_symbol)
+
+    info_messages = [
+        record.message
+        for record in caplog.records
+        if record.levelno == logging.INFO and "[forager] long selection" in record.message
+    ]
+    debug_messages = [
+        record.message
+        for record in caplog.records
+        if record.levelno == logging.DEBUG and "[forager] long score detail" in record.message
+    ]
+    assert [message.split("reason=", 1)[1].split(" ", 1)[0] for message in info_messages] == [
+        "selection_changed",
+        "hysteresis_replacement",
+        "periodic",
+    ]
+    assert "events=replaced:SOL<->DOGE gap=0.002" in info_messages[1]
+    assert len(debug_messages) == 3
+
+
+def test_forager_selection_compact_info_preserves_structured_and_debug_detail(caplog):
+    bot = Passivbot.__new__(Passivbot)
+    sink = ListEventSink()
+    bot.exchange = "binance"
+    bot.user = "binance_01"
+    bot.bot_id = "bot_1"
+    bot._live_event_current_cycle_id = "cy_forager_compact"
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[sink], monitor_sinks=[]
+    )
+    long_coin = "X" * 80
+    challenger_coin = "Y" * 80
+    symbol = f"{long_coin}/USDT:USDT"
+    challenger = f"{challenger_coin}/USDT:USDT"
+    out = {
+        "diagnostics": {
+            "forager_selections": [
+                {
+                    "pside": "long",
+                    "slots_to_fill": 1,
+                    "score_hysteresis_pct": 0.005,
+                    "selected_symbol_indices": [0],
+                    "incumbent_symbol_indices": [0],
+                    "top_scores": [
+                        {
+                            "symbol_idx": 0,
+                            "rank": 1,
+                            "score": 0.625,
+                            "volume_component": 0.4,
+                            "ema_readiness_component": 0.5,
+                            "volatility_component": 1.0,
+                            "selected": True,
+                            "incumbent": True,
+                        }
+                    ],
+                    "hysteresis_events": [
+                        {
+                            "incumbent_symbol_idx": 0,
+                            "challenger_symbol_idx": 1,
+                            "score_gap": 0.002,
+                            "kept_incumbent": True,
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+
+    with caplog.at_level(logging.DEBUG):
+        Passivbot._log_forager_selection_diagnostics(
+            bot, out, {0: symbol, 1: challenger}
+        )
+
+    info_message = next(
+        record.message
+        for record in caplog.records
+        if record.levelno == logging.INFO and "[forager] long selection" in record.message
+    )
+    debug_message = next(
+        record.message
+        for record in caplog.records
+        if record.levelno == logging.DEBUG and "[forager] long score detail" in record.message
+    )
+    assert long_coin not in info_message
+    assert long_coin in debug_message
+    assert "vol=0.400" in debug_message
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    event = next(
+        event for event in sink.events if event.event_type == EventTypes.FORAGER_SELECTION
+    )
+    assert event.data["selected_symbols"] == [symbol]
+    assert event.data["incumbent_symbols"] == [symbol]
+    assert event.data["top_scores"] == [
+        {
+            "symbol": symbol,
+            "rank": 1,
+            "score": 0.625,
+            "volume_component": 0.4,
+            "ema_readiness_component": 0.5,
+            "volatility_component": 1.0,
+            "selected": True,
+            "incumbent": True,
+        }
+    ]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_forager_selection_diagnostics_log_scores_and_hysteresis(caplog):
     bot = Passivbot.__new__(Passivbot)
     sink = ListEventSink()


### PR DESCRIPTION
## Summary

- bound the Rust-owned forager selection transition INFO projection to a 196-character message budget, leaving room for the longest current timestamp/level/exchange prefix within 240 visible characters
- retain pside, slots, up to three selected/incumbent names, hysteresis, canonical reason, replacement/kept context, up to three ranked scores, and explicit omission counts
- preserve complete structured selection events, full DEBUG score/component/event diagnostics, transition keys and cadence, Rust output, selection behavior, and trading behavior

## Deployment evidence from PR #1254

- PR #1254 merged as `e7f87e18085f1bd53e2f6975ba5ecd4c14e60745`; the exact five old bots exited naturally within eight seconds after one SIGINT round, with no escalation
- new PIDs are `966831/966834/966836/966837/966838`; exact pane PIDs and unrelated `misc:0.0` PID `434835` were preserved
- four natural candle-health summaries on Binance, GateIO, OKX, and Hyperliquid measured 156-211 visible characters, retained counts/whole samples/`+N more`, and none exceeded 240
- the final two-minute smoke was `ok=true`: five matching/config-valid processes in normal `R/S`, zero hard/log/monitor/process failures, `301/301` remote and `33/33` account-critical calls successful, seven successful fill refreshes, no active HSL replay, and clean tracked master

## Trigger

The same exact new log files contained natural forager selection transition lines at 247-250 visible characters on Binance, GateIO, and OKX. The representative compact projection is 190 visible characters with the longest current Hyperliquid prefix.

## Behavior boundary

Observability-only. No candidate scoring, hysteresis logic, transition admission/cadence, structured event routing/payload, Rust output, forager selection, exchange calls, orders, risk, backtests, optimizer, or trading behavior changes.

## Validation

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_passivbot_balance_split.py tests/test_live_candle_budget.py tests/test_passivbot_monitor.py` (370 passed)
- focused formatter/admission/structured preservation tests (4 passed)
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/passivbot.py src/tools/check_ai_docs.py`
- `python src/tools/check_ai_docs.py` (0 errors; existing mandatory-context word-count warning only)
- `git diff --check`
- added-line silent-handling audit: only pre-existing display defaults moved into formatter arguments

## Review gate

Temporary maintainer-authorized gate while Grok is halted: exact-current-head Hermes approval plus green Python and Rust CI.
