### PR TITLE
Compact required EMA unavailable console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Required-EMA-unavailable warnings now use a bounded structured console/text
+  projection with counts, classified cause, nontradable-until-fresh action,
+  and compact symbol/error/EMA identity. The complete structured payload,
+  existing fifteen-minute human cadence, EMA readiness decisions, and trading
+  behavior are unchanged.
+
 - Periodic health summaries now use compact operator labels and separators so
   uptime, loop, position, balance, order/fill/error, resource, and slow-phase
   context fit the normal console record budget. Complete structured payloads,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,37 +22,48 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/compact-periodic-health-console`, based on canonical
-  `050d01db56f4ac3678944a5e439248edbbb46acb` after PR #1255.
-- PR: #1256, `Compact periodic health console output`.
-- Slice: bound the periodic health INFO projection within the normal record
-  budget while retaining uptime, loop, positions, balance, order/fill/error,
-  resource, and slow-phase context.
-- Triggering evidence: the PR #1255 deployment produced natural periodic
-  health lines at 244-248 visible characters on Binance, GateIO, OKX, and
-  Hyperliquid. This recurring family represented four of the fresh post-ready
-  over-budget records; the other repeated long family was startup-only.
-- Scope: preserve the complete structured `health.summary` payload, event
-  route, producer cadence, calculations, counters, and fallback ownership;
-  compact only the human console/text projection.
-- Behavior boundary: observability-only; no health collection, counters,
-  cadence, exchange call, Rust, order, risk, backtest, optimizer, or trading
-  behavior.
+- Branch: `codex/compact-required-ema-unavailable-console`, based on canonical
+  `8db319a5b4e56dceffb59cb95f7baefab3e0da90` after PR #1256.
+- PR: #1257, `Compact required-EMA unavailable console output`.
+- Slice: bound the required-EMA-unavailable warning within the normal record
+  budget while retaining the unavailable count, classified cause, explicit
+  nontradable-until-fresh action, and a bounded symbol/EMA diagnostic sample.
+- Triggering evidence: fresh post-PR #1256 VPS5 logs contained recurring
+  required-EMA-unavailable warnings at 374-447 visible characters on Binance,
+  GateIO, OKX, and Hyperliquid.
+- Scope: preserve the complete structured `ema.unavailable` payload,
+  nontradable decision, reason semantics, producer cadence, and calculations;
+  compact only the throttled human console/text projection.
+- Behavior boundary: observability-only; no EMA collection/calculation,
+  readiness or nontradable decision, cadence, exchange call, Rust, order,
+  risk, backtest, optimizer, or trading behavior.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green CI
   while Grok is halted.
 - Expected VPS action: after merge, one authorized exact five-bot restart.
-  Validate natural periodic health lines and settled smoke; do not manufacture
-  exchange, state, risk, or trading events.
+  Validate natural required-EMA-unavailable lines when available and settled
+  smoke; do not manufacture exchange, state, risk, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `050d01db56f4ac3678944a5e439248edbbb46acb`, PR #1255. The tracked checkout
+  `8db319a5b4e56dceffb59cb95f7baefab3e0da90`, PR #1256. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `967753/967755/967757/967759/967760`. The exact pane PIDs remain
+  `968739/968741/968743/968745/968747`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1256 was activated after one exact five-bot SIGINT round; old PIDs
+  `967753/967755/967757/967759/967760` all exited naturally within eight
+  seconds without escalation. Four natural periodic health lines on Binance,
+  GateIO, OKX, and Hyperliquid measured 202-209 visible characters and retained
+  uptime, loop, position, balance, order/fill/error, RSS, and slow-phase
+  context. A settled one-minute report was `ok=true` with zero hard failures,
+  `138/138` remote and `29/29` account-critical calls successful, three
+  successful fill refreshes, no active HSL replay, and a clean tracked
+  checkout. A bounded ten-sample process series showed brief rotating
+  filesystem journal/page waits, four all-normal samples, and no persistently
+  blocked PID. The exact new logs then exposed required-EMA-unavailable
+  warnings at 374-447 visible characters on four bots.
 - PR #1255 was activated after one exact five-bot SIGINT round; all old bots
   exited naturally without escalation. Three natural forager selection lines
   on Binance, GateIO, and OKX measured 182-185 visible characters, retained
@@ -818,9 +829,12 @@ zero legacy duplicates and a hard-green settled smoke. PR #1254 is also
 merged, deployed, and naturally validated: four candle-health lines measured
 156-211 visible characters with a hard-green settled smoke. PR #1255 is also
 merged, deployed, and naturally validated: three forager selection lines
-measured 182-185 visible characters with a hard-green settled smoke. The
-active slice compacts the naturally observed 244-248 character periodic health
-lines without changing health collection, cadence, or trading behavior.
+measured 182-185 visible characters with a hard-green settled smoke. PR #1256
+is also merged, deployed, and naturally validated: four periodic health lines
+measured 202-209 visible characters while preserving all operator-relevant
+health facts. The active slice compacts the naturally observed 374-447
+character required-EMA-unavailable warnings without changing EMA readiness,
+nontradable decisions, cadence, or trading behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,32 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1255)
+## Latest Canonical Deployment (PR #1256)
+
+- PR #1256 merged to `master` as `8db319a5b4e56dceffb59cb95f7baefab3e0da90`
+  after exact-head Hermes approval and green Python/Rust CI while Grok was
+  temporarily halted. It compacts only the periodic health console/text
+  projection; the complete structured payload, route, producer cadence,
+  calculations, counters, fallback ownership, and trading behavior are
+  unchanged.
+- VPS5 fast-forwarded cleanly and sent one SIGINT round to exact old PIDs
+  `967753/967755/967757/967759/967760`; all exited naturally within eight
+  seconds without escalation. Pane PIDs and unrelated `misc:0.0` PID `434835`
+  were preserved. Final PIDs are `968739/968741/968743/968745/968747` for
+  Binance/KuCoin/GateIO/OKX/Hyperliquid respectively.
+- Four natural periodic health lines on Binance, GateIO, OKX, and Hyperliquid
+  measured 202-209 visible characters. They retained uptime, loop, position,
+  balance, order/fill/error, RSS, and slow-phase context; none exceeded 240.
+- A settled one-minute report was `ok=true` with zero hard failures, `138/138`
+  remote and `29/29` account-critical calls successful, three successful fill
+  refreshes, no active HSL replay, and clean tracked `master`. A bounded
+  ten-sample process series showed brief rotating filesystem journal/page
+  waits, four all-normal samples, and no persistently blocked PID.
+- The same exact new log files contained required-EMA-unavailable warnings at
+  374-447 visible characters on Binance, GateIO, OKX, and Hyperliquid. The next
+  slice compacts only that throttled human projection.
+
+## Previous Canonical Deployment (PR #1255)
 
 - PR #1255 merged to `master` as `050d01db56f4ac3678944a5e439248edbbb46acb`
   after exact-head Hermes approval and green Python/Rust CI while Grok was

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -814,7 +814,9 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.EMA_FALLBACK_USED: EventRoute(
         console=True, text=True, throttle_interval_ms=15 * 60 * 1000
     ),
-    EventTypes.EMA_UNAVAILABLE: EventRoute(console=False, text=False),
+    EventTypes.EMA_UNAVAILABLE: EventRoute(
+        console=True, text=True, throttle_interval_ms=15 * 60 * 1000
+    ),
     EventTypes.CANDLE_COVERAGE_CHECKED: EventRoute(console=False, text=False),
     EventTypes.CANDLE_TAIL_PROJECTED: EventRoute(console=False, text=False),
     EventTypes.CACHE_LOAD_COMPLETED: EventRoute(console=False, text=False),
@@ -1001,6 +1003,7 @@ _CONSOLE_EVENT_TAGS = {
     EventTypes.BALANCE_CHANGED: "balance",
     EventTypes.RESOURCE_MEMORY_SNAPSHOT: "memory",
     EventTypes.EMA_FALLBACK_USED: "ema",
+    EventTypes.EMA_UNAVAILABLE: "ema",
     EventTypes.RISK_MODE_CHANGED: "risk",
     EventTypes.HSL_TRANSITION: "risk",
     EventTypes.HSL_STATUS: "risk",
@@ -2112,6 +2115,11 @@ def _operator_sink_event_visible(event: LiveEvent) -> bool:
         return _hsl_status_operator_visible(event)
     if event.event_type == EventTypes.EMA_FALLBACK_USED:
         return (_data_int(data, "close_fallback_count") or 0) > 0
+    if event.event_type == EventTypes.EMA_UNAVAILABLE:
+        candidate_unavailable = data.get("candidate_unavailable")
+        return isinstance(candidate_unavailable, Mapping) and (
+            (_data_int(candidate_unavailable, "count") or 0) > 0
+        )
     return True
 
 
@@ -2393,6 +2401,112 @@ def format_ema_fallback_console(data: Mapping[str, Any]) -> str:
     return " ".join(parts)
 
 
+_EMA_UNAVAILABLE_CONSOLE_GROUP_LIMIT = 36
+_EMA_UNAVAILABLE_CONSOLE_ERROR_LIMIT = 24
+_EMA_UNAVAILABLE_CONSOLE_SAMPLE_LIMIT = 2
+_EMA_UNAVAILABLE_CONSOLE_RECORD_LIMIT = 188
+_EMA_UNAVAILABLE_COMPACT_GROUP_LIMIT = 19
+_EMA_UNAVAILABLE_COMPACT_ERROR_LIMIT = 13
+_EMA_UNAVAILABLE_COMPACT_SYMBOL_LIMIT = 14
+_EMA_UNAVAILABLE_EMA_TYPE_RE = re.compile(
+    r"\b(?P<ema_type>m1_close|m1_volume|m1_log_range|h1_log_range)\s+EMA\b",
+    re.IGNORECASE,
+)
+
+
+def _ema_unavailable_console_group(data: Mapping[str, Any]) -> Mapping[str, Any]:
+    groups = data.get("candidate_unavailable_groups")
+    if not isinstance(groups, (list, tuple)):
+        return {}
+    return next((group for group in groups if isinstance(group, Mapping)), {})
+
+
+def _ema_unavailable_console_symbol_preview(
+    group: Mapping[str, Any], *, symbol_limit: int = _EMA_FALLBACK_CONSOLE_TOKEN_LIMIT
+) -> str:
+    symbols = group.get("symbols")
+    if not isinstance(symbols, Mapping):
+        return "-"
+    count = _bounded_ema_console_count(symbols.get("count"))
+    sample_values = symbols.get("sample")
+    if not isinstance(sample_values, (list, tuple, set, frozenset)):
+        return f"{count}(-)"
+    sample = [
+        _bounded_ema_console_text(
+            _format_position_console_coin(value), limit=symbol_limit
+        )
+        for index, value in enumerate(sample_values)
+        if index < _EMA_UNAVAILABLE_CONSOLE_SAMPLE_LIMIT
+    ]
+    try:
+        omitted = max(0, int(symbols.get("count", 0)) - len(sample))
+    except (TypeError, ValueError, OverflowError):
+        omitted = 0
+    if omitted:
+        sample.append(f"+{_bounded_ema_console_count(omitted)}")
+    return f"{count}({','.join(sample) or '-'})"
+
+
+def _ema_unavailable_console_ema_type(group: Mapping[str, Any]) -> str | None:
+    example_error = group.get("example_error")
+    match = _EMA_UNAVAILABLE_EMA_TYPE_RE.search(str(example_error or ""))
+    if match is None:
+        return None
+    return _bounded_ema_console_text(
+        match.group("ema_type"), limit=_EMA_UNAVAILABLE_CONSOLE_ERROR_LIMIT
+    )
+
+
+def format_ema_unavailable_console(data: Mapping[str, Any]) -> str:
+    """Project required EMA unavailability without reducing structured diagnostics."""
+    candidate_unavailable = data.get("candidate_unavailable")
+    count = (
+        _bounded_ema_console_count(candidate_unavailable.get("count"))
+        if isinstance(candidate_unavailable, Mapping)
+        else "-"
+    )
+    group = _ema_unavailable_console_group(data)
+    reason = group.get("reason")
+    parts = [
+        "[ema] unavailable",
+        f"n={count}",
+        "group="
+        + _bounded_ema_console_text(
+            reason, limit=_EMA_UNAVAILABLE_CONSOLE_GROUP_LIMIT
+        ),
+        "action=mark_nontradable_until_fresh",
+        f"sym={_ema_unavailable_console_symbol_preview(group)}",
+    ]
+    error_types = group.get("error_types")
+    if isinstance(error_types, (list, tuple)) and error_types:
+        parts.append(
+            "err="
+            + _bounded_ema_console_text(
+                error_types[0], limit=_EMA_UNAVAILABLE_CONSOLE_ERROR_LIMIT
+            )
+        )
+    ema_type = _ema_unavailable_console_ema_type(group)
+    if ema_type:
+        parts.append(f"ema={ema_type}")
+    message = " ".join(parts)
+    if len(message) <= _EMA_UNAVAILABLE_CONSOLE_RECORD_LIMIT:
+        return message
+
+    parts[2] = "group=" + _bounded_ema_console_text(
+        reason, limit=_EMA_UNAVAILABLE_COMPACT_GROUP_LIMIT
+    )
+    parts[4] = "sym=" + _ema_unavailable_console_symbol_preview(
+        group, symbol_limit=_EMA_UNAVAILABLE_COMPACT_SYMBOL_LIMIT
+    )
+    for index, part in enumerate(parts):
+        if part.startswith("err="):
+            parts[index] = "err=" + _bounded_ema_console_text(
+                error_types[0], limit=_EMA_UNAVAILABLE_COMPACT_ERROR_LIMIT
+            )
+            break
+    return " ".join(parts)
+
+
 _INITIAL_ENTRY_DISTANCE_GATE_CONSOLE_RECORD_LIMIT = 188
 _INITIAL_ENTRY_DISTANCE_GATE_CONSOLE_CYCLE_LIMIT = 24
 _INITIAL_ENTRY_DISTANCE_GATE_CONSOLE_SYMBOL_LIMIT = 24
@@ -2498,6 +2612,8 @@ def format_console_event(event: LiveEvent) -> str:
         return format_memory_snapshot_console(event.data)
     if event.event_type == EventTypes.EMA_FALLBACK_USED:
         return format_ema_fallback_console(event.data)
+    if event.event_type == EventTypes.EMA_UNAVAILABLE:
+        return format_ema_unavailable_console(event.data)
     if event.event_type in {
         EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
         EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -765,6 +765,16 @@ class Passivbot:
             and getattr(pipeline, "console_sink", None) is not None
         )
 
+    def _ema_unavailable_structured_console_available(self) -> bool:
+        """Return True when the EMA unavailable event owns the normal console warning."""
+        pipeline = getattr(self, "_live_event_pipeline", None)
+        return bool(
+            callable(getattr(self, "_emit_ema_unavailable_event", None))
+            and Passivbot._live_event_console_available(self)
+            and callable(getattr(pipeline, "emit", None))
+            and getattr(pipeline, "console_sink", None) is not None
+        )
+
     @staticmethod
     def _log_symbol(symbol: Any) -> str:
         """Return a compact operator-facing symbol label for logs only."""
@@ -15989,7 +15999,12 @@ class Passivbot:
                 "; ".join(examples),
                 interval_ms=15 * 60 * 1000,
             )
-        if candidate_ema_unavailable_details:
+        required_ema_unavailable_structured_console = (
+            Passivbot._ema_unavailable_structured_console_available(self)
+            if candidate_ema_unavailable_details
+            else False
+        )
+        if candidate_ema_unavailable_details and not required_ema_unavailable_structured_console:
             parts = []
             all_symbols: set[str] = set()
             for reason, items in sorted(candidate_ema_unavailable_details.items()):

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -25,6 +25,7 @@ from live.event_bus import (
     authoritative_reason_code,
     format_console_event,
     format_ema_fallback_console,
+    format_ema_unavailable_console,
     format_memory_snapshot_console,
     format_state_refresh_timing_console,
     live_event_debug_profile_enabled,
@@ -323,7 +324,6 @@ def test_route_table_keeps_data_events_off_console_by_default():
         EventTypes.ACTION_PLANNED,
         EventTypes.EMA_BUNDLE_STARTED,
         EventTypes.EMA_BUNDLE_COMPLETED,
-        EventTypes.EMA_UNAVAILABLE,
         EventTypes.CANDLE_COVERAGE_CHECKED,
         EventTypes.CANDLE_TAIL_PROJECTED,
         EventTypes.CACHE_LOAD_COMPLETED,
@@ -352,6 +352,10 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert ema_fallback_route.console is True
     assert ema_fallback_route.text is True
     assert ema_fallback_route.throttle_interval_ms == 15 * 60 * 1000
+    ema_unavailable_route = DEFAULT_ROUTES[EventTypes.EMA_UNAVAILABLE]
+    assert ema_unavailable_route.console is True
+    assert ema_unavailable_route.text is True
+    assert ema_unavailable_route.throttle_interval_ms == 15 * 60 * 1000
     assert DEFAULT_ROUTES[EventTypes.ORDER_WAVE_COMPLETED].console is True
     assert DEFAULT_ROUTES[EventTypes.ORDER_WAVE_COMPLETED].text is True
     assert DEFAULT_ROUTES[EventTypes.EXECUTION_CREATE_DEFERRED].console is False
@@ -1728,6 +1732,124 @@ def test_ema_fallback_console_formatter_is_bounded_without_mutating_payload():
     assert "age=999999999+ms" in message
     assert "streak=999999999+" in message
     assert "ex=AAAAAAAA" in message
+    assert event.to_dict() == before
+
+
+def test_ema_unavailable_console_route_throttles_human_projection_but_keeps_detail_durable():
+    structured = ListEventSink()
+    console = ListEventSink()
+    text = ListEventSink()
+    pipeline = LiveEventPipeline(
+        structured_sinks=[structured],
+        monitor_sinks=[],
+        console_sink=console,
+        text_sink=text,
+    )
+    data = {
+        "candidate_unavailable": {"count": 1, "sample": ["BTC/USDT:USDT"]},
+        "candidate_unavailable_groups": [
+            {
+                "reason": "cache_only_fetch_failed",
+                "symbols": {"count": 1, "sample": ["BTC/USDT:USDT"]},
+                "error_types": ["RuntimeError"],
+                "example_error": "missing required h1_log_range EMA",
+                "per_symbol_diagnostic": "detail must stay structured",
+            }
+        ],
+    }
+    first = LiveEvent(EventTypes.EMA_UNAVAILABLE, ts_ms=1_000, data=data)
+    throttled = LiveEvent(
+        EventTypes.EMA_UNAVAILABLE,
+        ts_ms=1_000 + 15 * 60 * 1000 - 1,
+        data=data,
+    )
+    boundary = LiveEvent(
+        EventTypes.EMA_UNAVAILABLE,
+        ts_ms=1_000 + 15 * 60 * 1000,
+        data=data,
+    )
+
+    for event in (first, throttled, boundary):
+        pipeline.emit(event)
+
+    assert console.events == [first, boundary]
+    assert text.events == [first, boundary]
+    assert pipeline.flush(timeout=2.0) is True
+    assert structured.events == [first, throttled, boundary]
+    assert structured.events[0].data["candidate_unavailable_groups"][0][
+        "per_symbol_diagnostic"
+    ] == "detail must stay structured"
+    assert pipeline.close(timeout=2.0) is True
+
+
+def test_ema_unavailable_console_formatter_is_bounded_and_retains_required_signals():
+    data = {
+        "candidate_unavailable": {
+            "count": 7,
+            "sample": ["BTC/USDT:USDT", "ETH/USDT:USDT", "SOL/USDT:USDT"],
+        },
+        "candidate_unavailable_groups": [
+            {
+                "reason": "cache_only_fetch_failed",
+                "symbols": {
+                    "count": 4,
+                    "sample": [
+                        "BTC/USDT:USDT",
+                        "ETH/USDT:USDT",
+                        "SOL/USDT:USDT",
+                    ],
+                },
+                "error_types": ["MissingLogRangeEma", "RuntimeError"],
+                "example_error": (
+                    "[ema] missing required h1_log_range EMA for BTC/USDT:USDT: "
+                    "span=672 reason=non-finite value"
+                ),
+                "per_symbol_diagnostic": "x" * 10_000,
+            }
+        ],
+    }
+    event = LiveEvent(EventTypes.EMA_UNAVAILABLE, data=data)
+    before = event.to_dict()
+
+    message = format_ema_unavailable_console(event.data)
+    longest_prefix = "2026-07-15T23:45:40Z WARNING  [hyperliquid] "
+
+    assert message == (
+        "[ema] unavailable n=7 group=cache_only_fetch_failed "
+        "action=mark_nontradable_until_fresh sym=4(BTC,ETH,+2) "
+        "err=MissingLogRangeEma ema=h1_log_range"
+    )
+    assert len(longest_prefix + message) <= 240
+    assert "SOL/USDT:USDT" not in message
+    assert "per_symbol_diagnostic" not in message
+    assert format_console_event(event) == message
+    assert event.to_dict() == before
+
+
+def test_ema_unavailable_console_formatter_keeps_identity_under_pathological_lengths():
+    maximum = (1 << 63) - 1
+    data = {
+        "candidate_unavailable": {"count": maximum},
+        "candidate_unavailable_groups": [
+            {
+                "reason": "r" * 10_000,
+                "symbols": {"count": maximum, "sample": ["S" * 10_000] * 3},
+                "error_types": ["E" * 10_000],
+                "example_error": "missing required h1_log_range EMA",
+            }
+        ],
+    }
+    event = LiveEvent(EventTypes.EMA_UNAVAILABLE, data=data)
+    before = event.to_dict()
+
+    message = format_ema_unavailable_console(event.data)
+    longest_prefix = "2026-07-15T23:45:40Z WARNING  [hyperliquid] "
+
+    assert len(message) <= 188
+    assert len(longest_prefix + message) <= 240
+    assert "action=mark_nontradable_until_fresh" in message
+    assert "ema=h1_log_range" in message
+    assert "S" * 15 not in message
     assert event.to_dict() == before
 
 

--- a/tests/test_missing_ema_fix.py
+++ b/tests/test_missing_ema_fix.py
@@ -889,6 +889,62 @@ async def test_candidate_ema_unavailable_logs_single_warning_summary(caplog):
     assert not any("missing required close EMA TAO" in message for message in warning_messages)
 
 
+@pytest.mark.asyncio
+async def test_candidate_ema_unavailable_event_console_owns_normal_warning(caplog, monkeypatch):
+    try:
+        import passivbot as pb_mod
+    except ImportError:
+        pytest.skip("passivbot module not importable in test environment")
+
+    symbol = "AVAX/USDT:USDT"
+    bot = _BundleReproBot(symbol, close_mode="nan")
+    bot.PB_modes = {"long": {}, "short": {}}
+    bot.positions = {
+        symbol: {
+            "long": {"size": 0.0, "price": 0.0},
+            "short": {"size": 0.0, "price": 0.0},
+        }
+    }
+    bot.cm.get_last_refresh_ms = lambda _symbol: int(time.time() * 1000)
+    bot._candle_staleness_ms = lambda _symbol, now_ms=None: 0
+    bot.is_forager_mode = lambda *args, **kwargs: True
+    original_bot_value = bot.bot_value
+
+    def bot_value(pside, key):
+        if key == "forager_score_weights":
+            return {"volume": 1.0, "volatility": 1.0}
+        if key == "forager_volume_drop_pct":
+            return 0.0
+        return original_bot_value(pside, key)
+
+    bot.bot_value = bot_value
+    bot.live_event_console_enabled = True
+    bot._live_event_pipeline = type(
+        "Pipeline", (), {"console_sink": object(), "emit": lambda self, event: event}
+    )()
+    emitted = []
+
+    def emit_ema_unavailable(bot_arg, **kwargs):
+        emitted.append((bot_arg, kwargs))
+
+    monkeypatch.setattr(
+        pb_mod.Passivbot,
+        "_emit_ema_unavailable_event",
+        staticmethod(emit_ema_unavailable),
+    )
+    bot._emit_ema_unavailable_event = emit_ema_unavailable
+
+    with caplog.at_level(logging.WARNING):
+        await pb_mod.Passivbot._load_orchestrator_ema_bundle(bot, [symbol], bot.PB_modes)
+
+    assert len(emitted) == 1
+    assert emitted[0][0] is bot
+    assert emitted[0][1]["candidate_ema_unavailable_details"]
+    assert not any(
+        "required EMA unavailable summary" in record.message for record in caplog.records
+    )
+
+
 def _enable_forager_required_ranking(bot):
     bot.is_forager_mode = lambda *args, **kwargs: True
     original_bot_value = bot.bot_value


### PR DESCRIPTION
## Summary
- route candidate `ema.unavailable` events to console/text at the existing 15-minute human cadence
- replace the 374-447 character legacy warning with a bounded operator projection that retains count, cause, nontradable action, compact symbols, error class, and EMA identity
- preserve the complete structured payload and keep the legacy summary as the no-console fallback
- record PR #1256 merge/deploy evidence and the next-slice trigger

## Behavior boundary
Observability only. EMA collection, calculations, readiness and nontradable decisions, event production, exchange calls, Rust order behavior, risk behavior, and trading behavior are unchanged.

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_missing_ema_fix.py tests/test_passivbot_monitor.py -q`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py src/passivbot.py tests/test_live_event_bus.py tests/test_missing_ema_fix.py`
- `git diff --check`
- touched-area silent-handling audit
- real VPS5-shaped formatter samples: 143 chars for standard symbols and 150 chars for HIP-3 symbols, before the logger prefix

## VPS5 evidence carried forward
PR #1256 merged as `8db319a5b4`, deployed with one exact five-bot SIGINT round, and all old bots exited naturally within eight seconds. Natural periodic health lines measured 202-209 characters. The settled report was `ok=true`, with `138/138` remote calls and `29/29` account-critical calls successful, no hard failures, and no active HSL replay.
