### PR TITLE
Bound candle-fetch failure console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Candle-fetch retry and exhaustion warnings now fit the normal rendered
+  console record budget while retaining exchange, symbol/timeframe, attempt,
+  elapsed time, exception class, and action. Structured diagnostics, redaction,
+  retry behavior, candle readiness, and trading behavior are unchanged.
+
 - Required-EMA-unavailable warnings now use a bounded structured console/text
   projection with counts, classified cause, nontradable-until-fresh action,
   and compact symbol/error/EMA identity. The complete structured payload,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/bound-candle-fetch-failure-console`, based on canonical
   `b1a637c0def5349b6d6fb94de34c8c6c044bd307` after PR #1257.
-- PR: pending, `Bound candle-fetch failure console output`.
+- PR: #1258, `Bound candle-fetch failure console output`.
 - Slice: keep candle-fetch retry/exhaustion warnings within the normal console
   record budget while retaining operation, exchange, symbol/timeframe,
   attempt, elapsed time, exception class, and action.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,36 +22,46 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/compact-required-ema-unavailable-console`, based on canonical
-  `8db319a5b4e56dceffb59cb95f7baefab3e0da90` after PR #1256.
-- PR: #1257, `Compact required-EMA unavailable console output`.
-- Slice: bound the required-EMA-unavailable warning within the normal record
-  budget while retaining the unavailable count, classified cause, explicit
-  nontradable-until-fresh action, and a bounded symbol/EMA diagnostic sample.
-- Triggering evidence: fresh post-PR #1256 VPS5 logs contained recurring
-  required-EMA-unavailable warnings at 374-447 visible characters on Binance,
-  GateIO, OKX, and Hyperliquid.
-- Scope: preserve the complete structured `ema.unavailable` payload,
-  nontradable decision, reason semantics, producer cadence, and calculations;
-  compact only the throttled human console/text projection.
-- Behavior boundary: observability-only; no EMA collection/calculation,
-  readiness or nontradable decision, cadence, exchange call, Rust, order,
-  risk, backtest, optimizer, or trading behavior.
+- Branch: `codex/bound-candle-fetch-failure-console`, based on canonical
+  `b1a637c0def5349b6d6fb94de34c8c6c044bd307` after PR #1257.
+- PR: pending, `Bound candle-fetch failure console output`.
+- Slice: keep candle-fetch retry/exhaustion warnings within the normal console
+  record budget while retaining operation, exchange, symbol/timeframe,
+  attempt, elapsed time, exception class, and action.
+- Triggering evidence: fresh post-PR #1257 VPS5 logs contained two natural
+  post-ready KuCoin `ccxt_fetch_ohlcv_failed` retry warnings at 256-257 visible
+  characters.
+- Scope: preserve complete structured remote-call evidence, retry/exhaustion
+  classification, redaction, and developer diagnostics; compact only the
+  human warning projection.
+- Behavior boundary: observability-only; no candle fetch, retry/backoff,
+  timeout, cache/readiness, exchange call, Rust, order, risk, backtest,
+  optimizer, or trading behavior.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green CI
   while Grok is halted.
 - Expected VPS action: after merge, one authorized exact five-bot restart.
-  Validate natural required-EMA-unavailable lines when available and settled
-  smoke; do not manufacture exchange, state, risk, or trading events.
+  Validate natural candle-fetch warnings when available and settled smoke; do
+  not manufacture exchange, state, risk, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `8db319a5b4e56dceffb59cb95f7baefab3e0da90`, PR #1256. The tracked checkout
+  `b1a637c0def5349b6d6fb94de34c8c6c044bd307`, PR #1257. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `968739/968741/968743/968745/968747`. The exact pane PIDs remain
+  `970778/970780/970782/970784/970786`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1257 was activated after one exact five-bot SIGINT round; old PIDs
+  `968739/968741/968743/968745/968747` all exited naturally within 16 seconds
+  without escalation. The settled two-minute smoke was `ok=true` with zero
+  hard/log/monitor/process failures, `241/241` remote and `58/58`
+  account-critical calls successful, nine successful fill refreshes, no active
+  HSL replay, all five exact processes in state `R`, and a clean tracked
+  checkout. No candidate-required-EMA condition occurred naturally in the new
+  segments, so no compact target line was manufactured; zero legacy summary
+  duplicates appeared. The exact new logs then exposed two natural post-ready
+  KuCoin candle-fetch retry warnings at 256-257 visible characters.
 - PR #1256 was activated after one exact five-bot SIGINT round; old PIDs
   `967753/967755/967757/967759/967760` all exited naturally within eight
   seconds without escalation. Four natural periodic health lines on Binance,
@@ -832,9 +842,11 @@ merged, deployed, and naturally validated: three forager selection lines
 measured 182-185 visible characters with a hard-green settled smoke. PR #1256
 is also merged, deployed, and naturally validated: four periodic health lines
 measured 202-209 visible characters while preserving all operator-relevant
-health facts. The active slice compacts the naturally observed 374-447
-character required-EMA-unavailable warnings without changing EMA readiness,
-nontradable decisions, cadence, or trading behavior.
+health facts. PR #1257 is also merged and deployed with a hard-green settled
+smoke. Its candidate-required-EMA target did not occur naturally in the new
+segments, and zero legacy summary duplicates appeared. The active slice bounds
+the naturally observed 256-257 character candle-fetch retry warnings without
+changing fetch, retry, readiness, or trading behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,30 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1256)
+## Latest Canonical Deployment (PR #1257)
+
+- PR #1257 merged to `master` as `b1a637c0def5349b6d6fb94de34c8c6c044bd307`
+  after exact-head Hermes approval and green Python/Rust CI while Grok was
+  temporarily halted. It makes the structured `ema.unavailable` event the
+  normal candidate-required-EMA console/text owner at the existing
+  fifteen-minute cadence; the complete payload, EMA readiness and nontradable
+  decisions, calculations, and trading behavior are unchanged.
+- VPS5 fast-forwarded cleanly and sent one SIGINT round to exact old PIDs
+  `968739/968741/968743/968745/968747`; all exited naturally within 16 seconds
+  without escalation. Pane PIDs and unrelated `misc:0.0` PID `434835` were
+  preserved. Final PIDs are `970778/970780/970782/970784/970786` for
+  Binance/KuCoin/GateIO/OKX/Hyperliquid respectively.
+- The settled two-minute smoke was `ok=true` with zero hard/log/monitor/process
+  failures, `241/241` remote and `58/58` account-critical calls successful,
+  nine successful fill refreshes, no active HSL replay, all five exact
+  processes in state `R`, and clean tracked `master`.
+- No candidate-required-EMA condition occurred naturally in the new segments,
+  so no target line was manufactured; zero legacy summary duplicates appeared.
+  The same exact logs contained two natural post-ready KuCoin
+  `ccxt_fetch_ohlcv_failed` retry warnings at 256-257 visible characters. The
+  next slice bounds that human warning projection.
+
+## Previous Canonical Deployment (PR #1256)
 
 - PR #1256 merged to `master` as `8db319a5b4e56dceffb59cb95f7baefab3e0da90`
   after exact-head Hermes approval and green Python/Rust CI while Grok was

--- a/src/candlestick_manager.py
+++ b/src/candlestick_manager.py
@@ -1321,8 +1321,9 @@ class CandlestickManager:
         except Exception:
             ex = self.exchange_name
         base = [f"[candle] event={event}"]
-        # In debug modes, include caller info for traceability
-        if self.debug_level >= 1:
+        # In debug modes, include caller info for traceability. The bounded OHLCV
+        # failure warning retains its incident signature without this low-value detail.
+        if self.debug_level >= 1 and event != "ccxt_fetch_ohlcv_failed":
             try:
                 caller = get_caller_name()
                 base.append(f"called_by={caller}")

--- a/tests/test_candlestick_manager.py
+++ b/tests/test_candlestick_manager.py
@@ -19,6 +19,7 @@ from candlestick_manager import (
     _GATEIO_RECENT_1M_LIMIT_CANDLES,
     _floor_minute,
 )
+from logging_setup import DEFAULT_DATEFMT, DEFAULT_FORMAT_WITH_PREFIX
 
 
 def test_normalize_ccxt_ohlcv_filters_nonfinite_and_nonpositive_rows(tmp_path):
@@ -337,6 +338,7 @@ async def test_ccxt_fetch_warning_uses_bounded_signature_and_keeps_callback_payl
         exchange=_Ex(),
         exchange_name="binance",
         cache_dir=str(tmp_path / "caches"),
+        debug=1,
         remote_fetch_callback=callback_payloads.append,
     )
 
@@ -346,12 +348,18 @@ async def test_ccxt_fetch_warning_uses_bounded_signature_and_keeps_callback_payl
     monkeypatch.setattr(cm, "_sleep_interruptible", no_sleep)
     monkeypatch.setattr("candlestick_manager.time.monotonic", lambda: 50.0)
     warning_records = []
+    rendered_warnings = []
 
     class CaptureHandler(logging.Handler):
         def emit(self, record):
+            record.log_prefix = "kucoin"
             warning_records.append(record)
+            rendered_warnings.append(self.format(record))
 
     handler = CaptureHandler(level=logging.WARNING)
+    formatter = logging.Formatter(DEFAULT_FORMAT_WITH_PREFIX, datefmt=DEFAULT_DATEFMT)
+    formatter.converter = time.gmtime
+    handler.setFormatter(formatter)
     capture_log = logging.Logger(
         "test.candlestick_manager.ccxt_fetch_warning", level=logging.WARNING
     )
@@ -416,6 +424,10 @@ async def test_ccxt_fetch_warning_uses_bounded_signature_and_keeps_callback_payl
         assert all(raw_value not in warning for warning in (retry_warning, exhausted_warning))
     assert len(retry_warning) <= 240
     assert len(exhausted_warning) <= 240
+    assert len(rendered_warnings) == 2
+    assert all(len(warning) <= 240 for warning in rendered_warnings)
+    assert all("called_by=" not in warning for warning in rendered_warnings)
+    assert all("[kucoin]" in warning for warning in rendered_warnings)
 
     error_payloads = [payload for payload in callback_payloads if payload.get("stage") == "error"]
     assert error_payloads


### PR DESCRIPTION
## Summary

- keep rendered `ccxt_fetch_ohlcv_failed` warnings within the normal 240-character console budget
- retain exchange, symbol/timeframe, attempt, elapsed time, exception class, and retry/exhaustion action
- preserve complete structured remote-call diagnostics, redaction, retry/backoff, readiness, and trading behavior

## Trigger

After PR #1257 was deployed, the fresh VPS5 logs contained two natural post-ready KuCoin candle-fetch retry warnings at 256-257 visible characters. The dynamic caller field was the lowest-value part of this repeated human warning.

## Validation

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_candlestick_manager.py -q` (62 passed)
- `python -m py_compile src/candlestick_manager.py tests/test_candlestick_manager.py`
- `git diff --check`
- focused silent-handling audit on the touched diff

## Previous deployment evidence

PR #1257 was merged and activated on VPS5 as `b1a637c0def5349b6d6fb94de34c8c6c044bd307`. All five exact old bot processes exited naturally after one SIGINT round, `misc:0.0` was preserved, and the settled two-minute smoke reported zero hard/log/monitor/process failures, 241/241 successful remote calls, 58/58 successful account-critical calls, nine successful fill refreshes, no active HSL replay, and all five exact processes running.

## Behavior boundary

Observability-only. No candle fetch, retry/backoff, timeout, cache/readiness, exchange call, Rust, order, risk, backtest, optimizer, or trading behavior changes.
