### PR TITLE
Bound exchange time-sync diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Exchange clock-offset recovery warnings and durable time-sync diagnostics no
+  longer retain raw exception text. They keep the stable exception class,
+  source, recovery status, and bounded client outcome details within the normal
+  rendered console record budget.
+
 - Candle-fetch retry and exhaustion warnings now fit the normal rendered
   console record budget while retaining exchange, symbol/timeframe, attempt,
   elapsed time, exception class, and action. Structured diagnostics, redaction,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/bound-clock-offset-refresh-console`, based on canonical
   `a64159cf1d29c42113433c1990b38d9b8e1bd8fe` after PR #1258.
-- PR: pending, `Bound exchange time-sync diagnostics`.
+- PR: #1259, `Bound exchange time-sync diagnostics`.
 - Slice: remove raw exception text from exchange clock-offset recovery/no-hook
   warnings and durable `exchange.time_sync` diagnostics while retaining the
   stable exception class, source, recovery result, and bounded client outcomes.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,36 +22,47 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/bound-candle-fetch-failure-console`, based on canonical
-  `b1a637c0def5349b6d6fb94de34c8c6c044bd307` after PR #1257.
-- PR: #1258, `Bound candle-fetch failure console output`.
-- Slice: keep candle-fetch retry/exhaustion warnings within the normal console
-  record budget while retaining operation, exchange, symbol/timeframe,
-  attempt, elapsed time, exception class, and action.
-- Triggering evidence: fresh post-PR #1257 VPS5 logs contained two natural
-  post-ready KuCoin `ccxt_fetch_ohlcv_failed` retry warnings at 256-257 visible
-  characters.
-- Scope: preserve complete structured remote-call evidence, retry/exhaustion
-  classification, redaction, and developer diagnostics; compact only the
-  human warning projection.
-- Behavior boundary: observability-only; no candle fetch, retry/backoff,
-  timeout, cache/readiness, exchange call, Rust, order, risk, backtest,
-  optimizer, or trading behavior.
+- Branch: `codex/bound-clock-offset-refresh-console`, based on canonical
+  `a64159cf1d29c42113433c1990b38d9b8e1bd8fe` after PR #1258.
+- PR: pending, `Bound exchange time-sync diagnostics`.
+- Slice: remove raw exception text from exchange clock-offset recovery/no-hook
+  warnings and durable `exchange.time_sync` diagnostics while retaining the
+  stable exception class, source, recovery result, and bounded client outcomes.
+- Triggering evidence: fresh post-PR #1258 VPS5 logs contained one natural
+  post-ready KuCoin clock-offset recovery warning at 266 visible characters,
+  including raw `InvalidNonce` exception text.
+- Scope: bound and redact only the human warning projection and corresponding
+  structured diagnostic field; preserve time-sync recovery, client refresh,
+  retry/caller policy, and all stable outcome facts.
+- Behavior boundary: observability-only; no clock-offset calculation, client
+  refresh, exception classification, retry, exchange call, Rust, order, risk,
+  backtest, optimizer, or trading behavior.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green CI
   while Grok is halted.
 - Expected VPS action: after merge, one authorized exact five-bot restart.
-  Validate natural candle-fetch warnings when available and settled smoke; do
-  not manufacture exchange, state, risk, or trading events.
+  Validate natural time-sync warnings when available and settled smoke; do not
+  manufacture timestamp failures, exchange, state, risk, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `b1a637c0def5349b6d6fb94de34c8c6c044bd307`, PR #1257. The tracked checkout
+  `a64159cf1d29c42113433c1990b38d9b8e1bd8fe`, PR #1258. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `970778/970780/970782/970784/970786`. The exact pane PIDs remain
+  `971695/971697/971699/971701/971703`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1258 was activated after one exact five-bot SIGINT round; old PIDs
+  `970778/970780/970782/970784/970786` all exited naturally within 24 seconds
+  without escalation. The settled two-minute smoke was `ok=true` with zero
+  hard/log/monitor/process failures, `317/317` remote and `31/31`
+  account-critical calls successful, six successful fill refreshes, no active
+  HSL replay, all five exact processes in normal `R/S` states, and a clean
+  tracked checkout. One natural post-ready KuCoin
+  `ccxt_fetch_ohlcv_failed` warning measured 201 visible characters with zero
+  legacy caller-bearing duplicates. The same exact logs exposed one natural
+  post-ready clock-offset recovery warning at 266 visible characters that
+  retained raw exception text.
 - PR #1257 was activated after one exact five-bot SIGINT round; old PIDs
   `968739/968741/968743/968745/968747` all exited naturally within 16 seconds
   without escalation. The settled two-minute smoke was `ok=true` with zero
@@ -844,9 +855,12 @@ is also merged, deployed, and naturally validated: four periodic health lines
 measured 202-209 visible characters while preserving all operator-relevant
 health facts. PR #1257 is also merged and deployed with a hard-green settled
 smoke. Its candidate-required-EMA target did not occur naturally in the new
-segments, and zero legacy summary duplicates appeared. The active slice bounds
-the naturally observed 256-257 character candle-fetch retry warnings without
-changing fetch, retry, readiness, or trading behavior.
+segments, and zero legacy summary duplicates appeared. PR #1258 is merged,
+deployed, and naturally validated: the observed candle-fetch retry warning
+measured 201 visible characters with zero legacy caller-bearing duplicates and
+a hard-green settled smoke. The active slice bounds and redacts the naturally
+observed 266-character clock-offset recovery warning without changing
+time-sync or trading behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,31 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1257)
+## Latest Canonical Deployment (PR #1258)
+
+- PR #1258 merged to `master` as
+  `a64159cf1d29c42113433c1990b38d9b8e1bd8fe` after exact-head Hermes approval
+  and green Python/Rust CI while Grok was temporarily halted. It omits dynamic
+  caller identity only from the human `ccxt_fetch_ohlcv_failed` warning;
+  structured remote-call diagnostics, retry/backoff, readiness, and trading
+  behavior are unchanged.
+- VPS5 fast-forwarded cleanly and sent one SIGINT round to exact old PIDs
+  `970778/970780/970782/970784/970786`; all exited naturally within 24 seconds
+  without escalation. Pane PIDs and unrelated `misc:0.0` PID `434835` were
+  preserved. Final PIDs are `971695/971697/971699/971701/971703` for
+  Binance/KuCoin/GateIO/OKX/Hyperliquid respectively.
+- The settled two-minute smoke was `ok=true` with zero
+  hard/log/monitor/process failures, `317/317` remote and `31/31`
+  account-critical calls successful, six successful fill refreshes, no active
+  HSL replay, all five exact processes in normal `R/S` states, and clean
+  tracked `master`.
+- One natural post-ready KuCoin `ccxt_fetch_ohlcv_failed` warning measured 201
+  visible characters with zero legacy caller-bearing duplicates. The same
+  exact logs exposed one natural post-ready clock-offset recovery warning at
+  266 visible characters that retained raw exception text; the next slice
+  bounds and redacts that diagnostic projection.
+
+## Previous Canonical Deployment (PR #1257)
 
 - PR #1257 merged to `master` as `b1a637c0def5349b6d6fb94de34c8c6c044bd307`
   after exact-head Hermes approval and green Python/Rust CI while Grok was

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -66,6 +66,13 @@ _MEMORY_SNAPSHOT_SENSITIVE_TASK_RE = re.compile(
 _EXECUTION_LOOP_ERROR_STATUS_RE = re.compile(r"[0-9]{1,3}")
 _EXECUTION_LOOP_ERROR_CODE_RE = re.compile(r"-?[A-Za-z0-9][A-Za-z0-9_-]{0,47}")
 _EXECUTION_LOOP_ERROR_ENDPOINT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,47}")
+_EXCHANGE_TIME_SYNC_SOURCE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
+_EXCHANGE_TIME_SYNC_CLIENT_RE = re.compile(
+    r"[A-Za-z_][A-Za-z0-9_]{0,15}:[A-Za-z0-9?.+\-]+->[A-Za-z0-9?.+\-]+"
+    r"|[A-Za-z_][A-Za-z0-9_]{0,15}:[A-Za-z_][A-Za-z0-9_]{0,63}"
+)
+_EXCHANGE_TIME_SYNC_ERROR_TYPE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{0,79}")
+_EXCHANGE_TIME_SYNC_CLIENT_SAMPLE_LIMIT = 8
 
 
 def _sanitize_remote_text(value: Any, *, max_len: int = 500) -> str:
@@ -112,6 +119,16 @@ def _bounded_execution_loop_error_field(
         return fallback
     try:
         text = str(value).strip()
+    except Exception:
+        return fallback
+    return text if pattern.fullmatch(text) else fallback
+
+
+def _bounded_exchange_time_sync_field(
+    value: Any, pattern: re.Pattern[str], *, fallback: str = "unknown"
+) -> str:
+    try:
+        text = str(value)
     except Exception:
         return fallback
     return text if pattern.fullmatch(text) else fallback
@@ -593,8 +610,14 @@ def _emit_exchange_time_sync_event_unchecked(
     failed_clients: list[str] | tuple[str, ...],
     hook_available: bool,
 ) -> None:
-    synced = [str(item) for item in list(synced_clients or [])[:8]]
-    failed = [str(item) for item in list(failed_clients or [])[:8]]
+    synced = [
+        _bounded_exchange_time_sync_field(item, _EXCHANGE_TIME_SYNC_CLIENT_RE)
+        for item in list(synced_clients or [])[:_EXCHANGE_TIME_SYNC_CLIENT_SAMPLE_LIMIT]
+    ]
+    failed = [
+        _bounded_exchange_time_sync_field(item, _EXCHANGE_TIME_SYNC_CLIENT_RE)
+        for item in list(failed_clients or [])[:_EXCHANGE_TIME_SYNC_CLIENT_SAMPLE_LIMIT]
+    ]
     recovered = bool(synced)
     if not hook_available:
         status = "skipped"
@@ -618,9 +641,12 @@ def _emit_exchange_time_sync_event_unchecked(
         status=status,
         reason_code=reason_code,
         data={
-            "source": str(source or "unknown"),
-            "error_type": type(error).__name__,
-            "error": _sanitize_remote_text(error, max_len=500),
+            "source": _bounded_exchange_time_sync_field(
+                source, _EXCHANGE_TIME_SYNC_SOURCE_RE
+            ),
+            "error_type": _bounded_exchange_time_sync_field(
+                type(error).__name__, _EXCHANGE_TIME_SYNC_ERROR_TYPE_RE
+            ),
             "hook_available": bool(hook_available),
             "recovered": recovered,
             "synced_clients": synced,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -615,10 +615,14 @@ class Passivbot:
     # The longest live INFO prefix is 44 characters: timestamp, level, and Hyperliquid.
     CANDLE_HEALTH_CONSOLE_MESSAGE_MAX_LEN = 196
     FORAGER_SELECTION_CONSOLE_MESSAGE_MAX_LEN = 196
+    EXCHANGE_TIME_SYNC_CONSOLE_MESSAGE_MAX_LEN = 196
     _CANDLE_HEALTH_CONSOLE_SAMPLE_LIMIT = 3
     _CANDLE_HEALTH_CONSOLE_SYMBOL_MAX_LEN = 24
     _CANDLE_HEALTH_CONSOLE_TIMEFRAME_MAX_LEN = 8
     _CANDLE_HEALTH_CONSOLE_INT_MAX = 999_999
+    _EXCHANGE_TIME_SYNC_CONSOLE_SOURCE_MAX_LEN = 24
+    _EXCHANGE_TIME_SYNC_CONSOLE_ERROR_TYPE_MAX_LEN = 24
+    _EXCHANGE_TIME_SYNC_CONSOLE_CLIENT_MAX_LEN = 12
 
     _begin_live_event_cycle = live_event_emitters.begin_live_event_cycle
     _current_live_event_cycle_id = live_event_emitters.current_live_event_cycle_id
@@ -813,6 +817,77 @@ class Passivbot:
             symbol,
             Passivbot._log_order_type(order),
             type(error).__name__,
+        )
+
+    @staticmethod
+    def _format_exchange_time_sync_console_token(value: Any, max_len: int) -> str:
+        """Return a bounded single-field token for clock-offset recovery warnings."""
+        text = str(value)
+        text = "".join(
+            char
+            if char.isascii()
+            and char.isprintable()
+            and not char.isspace()
+            and char not in {"[", "]", ",", "|"}
+            else "_"
+            for char in text
+        )
+        if not text:
+            return "?"
+        if len(text) <= max_len:
+            return text
+        return f"{text[: max_len - 3]}..."
+
+    @staticmethod
+    def _format_exchange_time_sync_offset(value: Any) -> str:
+        """Return a numeric clock-offset token without retaining arbitrary option values."""
+        try:
+            number = float(value)
+        except (TypeError, ValueError, OverflowError):
+            return "?"
+        if not math.isfinite(number):
+            return "?"
+        return f"{number:.6g}"
+
+    @staticmethod
+    def _format_exchange_time_sync_warning(
+        *,
+        source: Any,
+        error: BaseException,
+        synced_clients: list[str],
+        failed_clients: list[str],
+        hook_available: bool,
+    ) -> str:
+        """Format the bounded legacy console projection for time-sync recovery."""
+        token = Passivbot._format_exchange_time_sync_console_token
+
+        def client_summary(clients: list[str]) -> str:
+            if not clients:
+                return "-"
+            sample = token(
+                clients[0], Passivbot._EXCHANGE_TIME_SYNC_CONSOLE_CLIENT_MAX_LEN
+            )
+            if len(clients) > 1:
+                sample += f",+{len(clients) - 1}"
+            return sample
+
+        recovered = bool(synced_clients)
+        if not hook_available:
+            action = "no_hook"
+            status = "skipped"
+        elif recovered and not failed_clients:
+            action = "offset_refreshed"
+            status = "succeeded"
+        else:
+            action = "offset_refresh_partial"
+            status = "degraded"
+        return (
+            f"[time] clock offset | action={action} "
+            f"source={token(source, Passivbot._EXCHANGE_TIME_SYNC_CONSOLE_SOURCE_MAX_LEN)} "
+            f"status={status} recovered={str(recovered).lower()} "
+            f"synced={len(synced_clients)}[{client_summary(synced_clients)}] "
+            f"failed={len(failed_clients)}[{client_summary(failed_clients)}] "
+            f"error_type={token(type(error).__name__, Passivbot._EXCHANGE_TIME_SYNC_CONSOLE_ERROR_TYPE_MAX_LEN)}"
         )
 
     async def _handle_order_write_failures(
@@ -2189,15 +2264,22 @@ class Passivbot:
                 if inspect.isawaitable(result):
                     await result
                 after = (getattr(client, "options", {}) or {}).get("timeDifference")
-                synced_clients.append(f"{client_name}:{before}->{after}")
+                synced_clients.append(
+                    f"{client_name}:{Passivbot._format_exchange_time_sync_offset(before)}"
+                    f"->{Passivbot._format_exchange_time_sync_offset(after)}"
+                )
             except Exception as sync_exc:
                 failed_clients.append(f"{client_name}:{type(sync_exc).__name__}")
         if not synced_clients and not failed_clients:
             logging.warning(
-                "[time] exchange timestamp/nonce error but no CCXT time-sync hook is available | source=%s error_type=%s error=%s",
-                source,
-                type(exc).__name__,
-                str(exc),
+                "%s",
+                Passivbot._format_exchange_time_sync_warning(
+                    source=source,
+                    error=exc,
+                    synced_clients=synced_clients,
+                    failed_clients=failed_clients,
+                    hook_available=False,
+                ),
             )
             self._emit_exchange_time_sync_event(
                 source=source,
@@ -2213,12 +2295,14 @@ class Passivbot:
         self._exchange_time_sync_last_log_ms = now_ms
         logging.log(
             level,
-            "[time] refreshed exchange clock offset after timestamp/nonce error | source=%s clients=%s failed=%s error_type=%s error=%s",
-            source,
-            ",".join(synced_clients) if synced_clients else "-",
-            ",".join(failed_clients) if failed_clients else "-",
-            type(exc).__name__,
-            str(exc),
+            "%s",
+            Passivbot._format_exchange_time_sync_warning(
+                source=source,
+                error=exc,
+                synced_clients=synced_clients,
+                failed_clients=failed_clients,
+                hook_available=True,
+            ),
         )
         self._emit_exchange_time_sync_event(
             source=source,

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -10141,9 +10141,11 @@ async def test_exchange_time_sync_recovery_refreshes_ccxt_clients(caplog):
         ),
     )
 
-    exc = RuntimeError(
-        'binanceusdm {"code":-1021,"msg":"Timestamp for this request is outside of the recvWindow."}'
+    raw_error = (
+        'binanceusdm {"code":-1021,"msg":"Timestamp for this request is outside of '
+        'the recvWindow.","apiKey":"supersecret"}'
     )
+    exc = RuntimeError(raw_error)
     with caplog.at_level(logging.WARNING):
         recovered = await bot._maybe_recover_exchange_time_sync(
             exc, source="test"
@@ -10154,7 +10156,13 @@ async def test_exchange_time_sync_recovery_refreshes_ccxt_clients(caplog):
     bot.ccp.load_time_difference.assert_awaited_once()
     assert bot.cca.options["timeDifference"] == 25
     assert bot.ccp.options["timeDifference"] == 30
-    assert any("[time] refreshed exchange clock offset" in r.message for r in caplog.records)
+    warnings = [record.message for record in caplog.records if record.levelno == logging.WARNING]
+    assert warnings == [
+        "[time] clock offset | action=offset_refreshed source=test status=succeeded "
+        "recovered=true synced=2[cca:10->25,+1] failed=0[-] error_type=RuntimeError"
+    ]
+    assert raw_error not in warnings[0]
+    assert "supersecret" not in warnings[0]
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     assert len(sink.events) == 1
     event = sink.events[0]
@@ -10169,6 +10177,9 @@ async def test_exchange_time_sync_recovery_refreshes_ccxt_clients(caplog):
     assert event.data["recovered"] is True
     assert event.data["synced_clients"] == ["cca:10->25", "ccp:-5->30"]
     assert event.data["failed_clients"] == []
+    assert "error" not in event.data
+    assert raw_error not in str(event.data)
+    assert "supersecret" not in str(event.data)
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
@@ -10193,7 +10204,12 @@ async def test_exchange_time_sync_no_hook_emits_unavailable_event(caplog):
         )
 
     assert recovered is False
-    assert any("no CCXT time-sync hook" in r.message for r in caplog.records)
+    warnings = [record.message for record in caplog.records if record.levelno == logging.WARNING]
+    assert warnings == [
+        "[time] clock offset | action=no_hook source=fetch_balance status=skipped "
+        "recovered=false synced=0[-] failed=0[-] error_type=RuntimeError"
+    ]
+    assert "supersecret" not in warnings[0]
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     assert len(sink.events) == 1
     event = sink.events[0]
@@ -10205,9 +10221,41 @@ async def test_exchange_time_sync_no_hook_emits_unavailable_event(caplog):
     assert event.data["recovered"] is False
     assert event.data["synced_count"] == 0
     assert event.data["failed_count"] == 0
-    assert "supersecret" not in event.data["error"]
-    assert "[redacted]" in event.data["error"]
+    assert event.data["error_type"] == "RuntimeError"
+    assert "error" not in event.data
+    assert "supersecret" not in str(event.data)
     assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_exchange_time_sync_warning_stays_within_full_console_line_budget():
+    error_type = type("TimeSync" + ("Error" * 100), (RuntimeError,), {})
+    raw_error = "timestamp failure apiKey=supersecret " + ("x" * 500)
+    message = Passivbot._format_exchange_time_sync_warning(
+        source="refresh_" + ("source" * 100),
+        error=error_type(raw_error),
+        synced_clients=["cca:" + ("1" * 100) + "->" + ("2" * 100)],
+        failed_clients=["ccp:" + ("RequestTimeout" * 100)],
+        hook_available=True,
+    )
+    record = logging.LogRecord(
+        "test", logging.WARNING, __file__, 0, "%s", (message,), None
+    )
+    record.created = 0.0
+    record.log_prefix = "hyperliquid"
+    formatter = logging.Formatter(DEFAULT_FORMAT_WITH_PREFIX, datefmt=DEFAULT_DATEFMT)
+    formatter.converter = time.gmtime
+    rendered = formatter.format(record)
+
+    assert raw_error not in message
+    assert "supersecret" not in message
+    assert "\n" not in message
+    assert "\r" not in message
+    assert "\t" not in message
+    assert len(message) <= Passivbot.EXCHANGE_TIME_SYNC_CONSOLE_MESSAGE_MAX_LEN
+    assert Passivbot.EXCHANGE_TIME_SYNC_CONSOLE_MESSAGE_MAX_LEN == 240 - (
+        len(rendered) - len(message)
+    )
+    assert len(rendered) <= 240
 
 
 @pytest.mark.asyncio
@@ -10256,7 +10304,11 @@ async def test_run_execution_loop_recovers_timestamp_error_without_traceback(cap
     bot.cca.load_time_difference.assert_awaited_once()
     bot.restart_bot_on_too_many_errors.assert_awaited_once()
     bot.execute_to_exchange.assert_not_awaited()
-    assert any("[time] refreshed exchange clock offset" in r.message for r in caplog.records)
+    assert any(
+        "[time] clock offset | action=offset_refreshed "
+        "source=run_execution_loop status=succeeded" in r.message
+        for r in caplog.records
+    )
     assert not [r for r in caplog.records if "error with run_execution_loop" in r.message]
 
 


### PR DESCRIPTION
## Summary

- bound the legacy exchange clock-offset recovery/no-hook warning within the 240-character rendered console budget
- remove raw exception text from both the human warning and durable `exchange.time_sync` payload
- retain source, action/status/recovery, stable exception class, counts, and bounded client outcomes

## Scope

Category: observability producer and console/text projection.

Touched surfaces are the existing Python time-sync warning formatter, the existing structured event emitter, focused offline regression tests, changelog, and logging-overhaul status ledgers.

Non-goals: no clock-offset calculation, CCXT client refresh, exception classification, retry/caller policy, exchange request, Rust, order, risk, backtest, optimizer, or trading behavior changes.

## Trigger

Fresh post-PR #1258 VPS5 logs contained one natural post-ready KuCoin clock-offset recovery warning at 266 visible characters. It retained raw `InvalidNonce` exception text, which is outside the bounded stable incident-signature policy.

## Validation

- `pytest tests/test_passivbot_balance_split.py -q` (240 passed)
- `pytest tests/test_live_event_bus.py -q` (125 passed)
- `python -m py_compile src/passivbot.py src/live/event_emitters.py tests/test_passivbot_balance_split.py`
- `PYTHONPATH=src python src/tools/check_ai_docs.py` (0 errors, one pre-existing word-count warning)
- `git diff --check`
- focused touched-diff silent-handling audit

All tests are offline and mocked; no exchange request was made.

## Previous deployment evidence

PR #1258 was merged and activated on VPS5 as `a64159cf1d29c42113433c1990b38d9b8e1bd8fe`. All five exact old bot processes exited naturally within 24 seconds after one SIGINT round, `misc:0.0` was preserved, and the settled two-minute smoke reported zero hard/log/monitor/process failures, 317/317 successful remote calls, 31/31 successful account-critical calls, six successful fill refreshes, no active HSL replay, and all five exact processes in normal `R/S` states. A natural candle-fetch failure warning measured 201 visible characters with zero legacy caller-bearing duplicates.

## Expected VPS action

After merge, use the standing authorization for one exact five-bot restart and bounded immediate/settled smoke. Observe a natural time-sync incident only if it occurs; do not manufacture timestamp or exchange failures.

## Reviewer focus

- observability isolation: formatting/sanitization must not alter recovery return values or retry policy
- raw exception text must not reach console, text, or durable event data
- bounded human output must retain enough stable recovery context

Residual risk: the exact target requires a naturally occurring exchange timestamp/nonce error and may not recur during the bounded post-merge observation window.
