### PR TITLE
Bound coin-list membership console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Approved/ignored coin membership changes now use one bounded structured
+  console/text projection with per-side counts and symbol samples instead of
+  unbounded legacy symbol lists. Existing structured event data, membership
+  calculation, list mutation, and trading behavior are unchanged.
+
 - Exchange clock-offset recovery warnings and durable time-sync diagnostics no
   longer retain raw exception text. They keep the stable exception class,
   source, recovery status, and bounded client outcome details within the normal

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/bound-approved-coin-delta-console`, based on canonical
   `e41118f0424ff3d4161e308b8844af5f35a8b7a9` after PR #1259.
-- PR: pending, `Bound coin-list membership console output`.
+- PR: #1260, `Bound coin-list membership console output`.
 - Slice: make the existing `forager.eligibility_changed` event the sole normal
   console/text owner for approved/ignored coin membership changes, with
   per-side counts and bounded symbol samples.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,36 +22,49 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/bound-clock-offset-refresh-console`, based on canonical
-  `a64159cf1d29c42113433c1990b38d9b8e1bd8fe` after PR #1258.
-- PR: #1259, `Bound exchange time-sync diagnostics`.
-- Slice: remove raw exception text from exchange clock-offset recovery/no-hook
-  warnings and durable `exchange.time_sync` diagnostics while retaining the
-  stable exception class, source, recovery result, and bounded client outcomes.
-- Triggering evidence: fresh post-PR #1258 VPS5 logs contained one natural
-  post-ready KuCoin clock-offset recovery warning at 266 visible characters,
-  including raw `InvalidNonce` exception text.
-- Scope: bound and redact only the human warning projection and corresponding
-  structured diagnostic field; preserve time-sync recovery, client refresh,
-  retry/caller policy, and all stable outcome facts.
-- Behavior boundary: observability-only; no clock-offset calculation, client
-  refresh, exception classification, retry, exchange call, Rust, order, risk,
+- Branch: `codex/bound-approved-coin-delta-console`, based on canonical
+  `e41118f0424ff3d4161e308b8844af5f35a8b7a9` after PR #1259.
+- PR: pending, `Bound coin-list membership console output`.
+- Slice: make the existing `forager.eligibility_changed` event the sole normal
+  console/text owner for approved/ignored coin membership changes, with
+  per-side counts and bounded symbol samples.
+- Triggering evidence: fresh post-PR #1259 VPS5 startup logs contained natural
+  `added to approved_coins` records at 245-250 visible characters on Binance,
+  GateIO, and Hyperliquid. Each printed the complete changed symbol list and
+  exceeded the normal 240-character record budget.
+- Scope: add only a bounded structured console/text formatter and bounded
+  legacy fallback; preserve event admission and the existing structured/
+  monitor payload.
+- Behavior boundary: observability-only; no membership calculation, list
+  mutation, forager selection, config, exchange call, Rust, order, risk,
   backtest, optimizer, or trading behavior.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green CI
   while Grok is halted.
 - Expected VPS action: after merge, one authorized exact five-bot restart.
-  Validate natural time-sync warnings when available and settled smoke; do not
-  manufacture timestamp failures, exchange, state, risk, or trading events.
+  Validate the natural startup membership records and settled smoke; do not
+  manufacture exchange, state, risk, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `a64159cf1d29c42113433c1990b38d9b8e1bd8fe`, PR #1258. The tracked checkout
+  `e41118f0424ff3d4161e308b8844af5f35a8b7a9`, PR #1259. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `971695/971697/971699/971701/971703`. The exact pane PIDs remain
+  `972601/972603/972605/972607/972609`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1259 was activated after one exact five-bot SIGINT round; old PIDs
+  `971695/971697/971699/971701/971703` all exited naturally within 28 seconds
+  without escalation. The settled three-minute smoke was `ok=true` with zero
+  hard/log/monitor/process failures, `483/486` remote and `49/50`
+  account-critical calls successful, seven successful fill refreshes, all
+  three observed HSL replays completed, five matching/config-valid processes,
+  and a clean tracked checkout. The three recoverable remote failures were one
+  Binance `InvalidNonce` and two KuCoin candle timeouts. The natural Binance
+  clock-offset recovery line measured 203 visible characters, retained stable
+  recovery facts, and contained no raw exception text. A transient report-time
+  `D` sample cleared on direct process inspection. The same exact new logs
+  exposed natural approved-coin membership lines at 245-250 characters.
 - PR #1258 was activated after one exact five-bot SIGINT round; old PIDs
   `970778/970780/970782/970784/970786` all exited naturally within 24 seconds
   without escalation. The settled two-minute smoke was `ok=true` with zero
@@ -858,9 +871,12 @@ smoke. Its candidate-required-EMA target did not occur naturally in the new
 segments, and zero legacy summary duplicates appeared. PR #1258 is merged,
 deployed, and naturally validated: the observed candle-fetch retry warning
 measured 201 visible characters with zero legacy caller-bearing duplicates and
-a hard-green settled smoke. The active slice bounds and redacts the naturally
-observed 266-character clock-offset recovery warning without changing
-time-sync or trading behavior.
+a hard-green settled smoke. PR #1259 is also merged, deployed, and naturally
+validated: a real Binance `InvalidNonce` recovery produced a 203-character
+clock-offset line with no raw exception text and the settled smoke was
+hard-green. The active slice migrates the naturally observed 245-250-character
+coin-membership lists to one bounded structured console/text owner without
+changing eligibility or trading behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,34 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1258)
+## Latest Canonical Deployment (PR #1259)
+
+- PR #1259 merged to `master` as
+  `e41118f0424ff3d4161e308b8844af5f35a8b7a9` after exact-head Hermes approval
+  and green Python/Rust CI while Grok was temporarily halted. It removes raw
+  exception text from exchange time-sync human and durable diagnostics while
+  retaining stable exception class, source, recovery status, and bounded
+  client outcomes; refresh, retry, and trading behavior are unchanged.
+- VPS5 fast-forwarded cleanly and sent one SIGINT round to exact old PIDs
+  `971695/971697/971699/971701/971703`; all exited naturally within 28 seconds
+  without escalation. Pane PIDs and unrelated `misc:0.0` PID `434835` were
+  preserved. Final PIDs are `972601/972603/972605/972607/972609` for
+  Binance/KuCoin/GateIO/OKX/Hyperliquid respectively.
+- The settled three-minute smoke was `ok=true` with zero
+  hard/log/monitor/process failures, `483/486` remote and `49/50`
+  account-critical calls successful, seven successful fill refreshes, all
+  three observed HSL replays completed, five matching/config-valid processes,
+  and clean tracked `master`. One Binance `InvalidNonce` and two KuCoin candle
+  timeouts were recoverable non-hard failures; a report-time `D` sample cleared
+  on direct process inspection.
+- The real Binance timestamp incident naturally emitted a 203-character
+  clock-offset recovery line retaining action, source, recovery, bounded client
+  outcomes, and `InvalidNonce` class with no raw exception text. The exact new
+  startup logs then exposed `added to approved_coins` lines at 245-250 visible
+  characters on Binance, GateIO, and Hyperliquid; the next slice migrates that
+  family to one bounded structured console/text owner.
+
+## Previous Canonical Deployment (PR #1258)
 
 - PR #1258 merged to `master` as
   `a64159cf1d29c42113433c1990b38d9b8e1bd8fe` after exact-head Hermes approval

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -807,7 +807,7 @@ DEFAULT_ROUTES: dict[str, EventRoute] = {
         console=True, text=True, throttle_interval_ms=5 * 60 * 1000
     ),
     EventTypes.FORAGER_FEATURE_UNAVAILABLE: EventRoute(console=False, text=False),
-    EventTypes.FORAGER_ELIGIBILITY_CHANGED: EventRoute(console=False, text=False),
+    EventTypes.FORAGER_ELIGIBILITY_CHANGED: EventRoute(console=True, text=True),
     EventTypes.CONFIG_MARKET_COMPATIBILITY: EventRoute(console=False, text=False),
     EventTypes.EMA_BUNDLE_STARTED: EventRoute(console=False, text=False),
     EventTypes.EMA_BUNDLE_COMPLETED: EventRoute(console=False, text=False),
@@ -2594,6 +2594,95 @@ def _format_initial_entry_distance_gate_console(event: LiveEvent) -> str:
     return " ".join(parts)
 
 
+_FORAGER_ELIGIBILITY_CONSOLE_RECORD_LIMIT = 188
+_FORAGER_ELIGIBILITY_CONSOLE_TOKEN_LIMIT = 16
+_FORAGER_ELIGIBILITY_CONSOLE_SAMPLE_LIMIT = 3
+_FORAGER_ELIGIBILITY_CONSOLE_COUNT_LIMIT = 999_999_999
+
+
+def _bounded_forager_eligibility_console_token(value: object, *, limit: int) -> str:
+    """Return a one-field, sanitized token for a coin-list console projection."""
+    cleaned = _ANSI_ESCAPE_RE.sub("", str(value or ""))
+    token = "".join(
+        char
+        if char.isascii()
+        and char.isprintable()
+        and not char.isspace()
+        and char not in {",", "=", "|", "[", "]"}
+        else "_"
+        for char in cleaned
+    )
+    token = token[:limit]
+    return token or "-"
+
+
+def _forager_eligibility_console_count(value: object) -> int:
+    try:
+        return min(_FORAGER_ELIGIBILITY_CONSOLE_COUNT_LIMIT, max(0, int(value)))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _format_forager_eligibility_console_count(value: int) -> str:
+    if value >= _FORAGER_ELIGIBILITY_CONSOLE_COUNT_LIMIT:
+        return f"{_FORAGER_ELIGIBILITY_CONSOLE_COUNT_LIMIT}+"
+    return str(value)
+
+
+def format_forager_eligibility_console(data: Mapping[str, Any]) -> str:
+    """Project eligibility membership changes without exposing unbounded symbol lists."""
+    counts = {"long": 0, "short": 0}
+    samples: list[str] = []
+    changes = data.get("changes") if isinstance(data, Mapping) else None
+    if isinstance(changes, (list, tuple)):
+        for change in changes:
+            if not isinstance(change, Mapping):
+                continue
+            pside = str(change.get("pside") or "")
+            if pside not in counts:
+                continue
+            counts[pside] = min(
+                _FORAGER_ELIGIBILITY_CONSOLE_COUNT_LIMIT,
+                counts[pside] + _forager_eligibility_console_count(change.get("count")),
+            )
+            symbols = change.get("symbols")
+            if isinstance(symbols, (list, tuple)):
+                samples.extend(
+                    _bounded_forager_eligibility_console_token(
+                        _format_position_console_coin(symbol),
+                        limit=_FORAGER_ELIGIBILITY_CONSOLE_TOKEN_LIMIT,
+                    )
+                    for symbol in symbols[:12]
+                )
+    samples = sorted(samples)[:_FORAGER_ELIGIBILITY_CONSOLE_SAMPLE_LIMIT]
+    total = min(
+        _FORAGER_ELIGIBILITY_CONSOLE_COUNT_LIMIT, counts["long"] + counts["short"]
+    )
+    omitted = max(0, total - len(samples))
+    message = " ".join(
+        (
+            "[forager]",
+            "list="
+            + _bounded_forager_eligibility_console_token(
+                data.get("list_kind") if isinstance(data, Mapping) else None,
+                limit=_FORAGER_ELIGIBILITY_CONSOLE_TOKEN_LIMIT,
+            ),
+            "op="
+            + _bounded_forager_eligibility_console_token(
+                data.get("operation") if isinstance(data, Mapping) else None,
+                limit=_FORAGER_ELIGIBILITY_CONSOLE_TOKEN_LIMIT,
+            ),
+            "counts=long:"
+            + _format_forager_eligibility_console_count(counts["long"])
+            + ",short:"
+            + _format_forager_eligibility_console_count(counts["short"]),
+            "samples=" + (",".join(samples) or "-"),
+            "omitted=" + _format_forager_eligibility_console_count(omitted),
+        )
+    )
+    return message[:_FORAGER_ELIGIBILITY_CONSOLE_RECORD_LIMIT]
+
+
 def format_console_event(event: LiveEvent) -> str:
     if (
         event.event_type == EventTypes.HEALTH_SUMMARY
@@ -2614,6 +2703,8 @@ def format_console_event(event: LiveEvent) -> str:
         return format_ema_fallback_console(event.data)
     if event.event_type == EventTypes.EMA_UNAVAILABLE:
         return format_ema_unavailable_console(event.data)
+    if event.event_type == EventTypes.FORAGER_ELIGIBILITY_CHANGED:
+        return format_forager_eligibility_console(event.data)
     if event.event_type in {
         EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
         EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -61,6 +61,7 @@ from live.events import DiagnosticEvent, emit_diagnostic_event, run_diagnostic_s
 from live.event_bus import (
     ConsoleSummarySink,
     EventTypes,
+    format_forager_eligibility_console,
     format_memory_snapshot_console,
     format_periodic_health_summary,
     LIVE_EVENT_CONSOLE_ENV,
@@ -777,6 +778,39 @@ class Passivbot:
             and Passivbot._live_event_console_available(self)
             and callable(getattr(pipeline, "emit", None))
             and getattr(pipeline, "console_sink", None) is not None
+        )
+
+    def _forager_eligibility_structured_console_available(self) -> bool:
+        """Return True when eligibility events own normal console/text output."""
+        pipeline = getattr(self, "_live_event_pipeline", None)
+        return bool(
+            callable(getattr(self, "_emit_forager_eligibility_changed_event", None))
+            and Passivbot._live_event_console_available(self)
+            and callable(getattr(pipeline, "emit", None))
+            and getattr(pipeline, "console_sink", None) is not None
+        )
+
+    @staticmethod
+    def _format_forager_eligibility_legacy_console_summary(
+        *, list_kind: str, operation: str, changes: dict[str, set[str]]
+    ) -> str:
+        """Format the bounded legacy fallback from the same membership-change facts."""
+        return format_forager_eligibility_console(
+            {
+                "list_kind": list_kind,
+                "operation": operation,
+                "changes": [
+                    {
+                        "pside": pside,
+                        "count": len(changes.get(pside, set())),
+                        "symbols": sorted(str(symbol) for symbol in changes.get(pside, set()))[
+                            :3
+                        ],
+                    }
+                    for pside in ("long", "short")
+                    if changes.get(pside)
+                ],
+            }
         )
 
     @staticmethod
@@ -18384,57 +18418,24 @@ class Passivbot:
                         pside, self.approved_coins[pside] - self.ignored_coins[pside]
                     )
                 )
-            # aggregate add/remove logs for readability
-            for k, summary in (("added", added_summary.get("approved_coins", {})),):
-                if summary:
-                    parts = []
-                    for pside, coins in summary.items():
-                        if coins:
-                            parts.append(
-                                f"{pside}: {','.join(sorted(Passivbot._log_symbol(x) for x in coins))}"
-                            )
-                    if parts:
-                        logging.info("added to approved_coins | %s", " | ".join(parts))
-            for k, summary in (("removed", removed_summary.get("approved_coins", {})),):
-                if summary:
-                    parts = []
-                    for pside, coins in summary.items():
-                        if coins:
-                            parts.append(
-                                f"{pside}: {','.join(sorted(Passivbot._log_symbol(x) for x in coins))}"
-                            )
-                    if parts:
-                        logging.info(
-                            "removed from approved_coins | %s", " | ".join(parts)
-                        )
-            for k, summary in (("added", added_summary.get("ignored_coins", {})),):
-                if summary:
-                    parts = []
-                    for pside, coins in summary.items():
-                        if coins:
-                            parts.append(
-                                f"{pside}: {','.join(sorted(Passivbot._log_symbol(x) for x in coins))}"
-                            )
-                    if parts:
-                        logging.info("added to ignored_coins | %s", " | ".join(parts))
-            for k, summary in (("removed", removed_summary.get("ignored_coins", {})),):
-                if summary:
-                    parts = []
-                    for pside, coins in summary.items():
-                        if coins:
-                            parts.append(
-                                f"{pside}: {','.join(sorted(Passivbot._log_symbol(x) for x in coins))}"
-                            )
-                    if parts:
-                        logging.info(
-                            "removed from ignored_coins | %s", " | ".join(parts)
-                        )
+            structured_console_available = (
+                self._forager_eligibility_structured_console_available()
+            )
             for list_kind in ("approved_coins", "ignored_coins"):
                 for operation, summary in (
                     ("added", added_summary.get(list_kind, {})),
                     ("removed", removed_summary.get(list_kind, {})),
                 ):
                     if summary:
+                        if not structured_console_available:
+                            logging.info(
+                                "%s",
+                                Passivbot._format_forager_eligibility_legacy_console_summary(
+                                    list_kind=list_kind,
+                                    operation=operation,
+                                    changes=summary,
+                                ),
+                            )
                         self._emit_forager_eligibility_changed_event(
                             source=source_by_list_kind[list_kind],
                             list_kind=list_kind,

--- a/tests/test_live_coin_lists.py
+++ b/tests/test_live_coin_lists.py
@@ -521,8 +521,13 @@ def test_refresh_approved_ignored_coin_lists_emits_bounded_aggregate_events(capl
         for event in events
         for change in event.data["changes"]
     )
-    assert any("added to approved_coins" in record.message for record in caplog.records)
-    assert any("removed from ignored_coins" in record.message for record in caplog.records)
+    fallback_messages = [
+        record.message for record in caplog.records if record.message.startswith("[forager]")
+    ]
+    assert len(fallback_messages) == 4
+    assert all(len(message) <= 240 for message in fallback_messages)
+    assert all("omitted=" in message for message in fallback_messages)
+    assert all("A03" not in message for message in fallback_messages)
 
     bot.refresh_approved_ignored_coins_lists()
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
@@ -580,5 +585,61 @@ def test_refresh_approved_ignored_coin_lists_ignores_event_emission_failure(capl
     }
     assert bot.approved_coins["short"] == {"SHORT/USDT:USDT"}
     assert bot.ignored_coins == {"long": {"IGNORED/USDT:USDT"}, "short": set()}
-    assert any("added to approved_coins" in record.message for record in caplog.records)
-    assert any("removed from ignored_coins" in record.message for record in caplog.records)
+    fallback_messages = [
+        record.message for record in caplog.records if record.message.startswith("[forager]")
+    ]
+    assert len(fallback_messages) == 4
+    assert all(len(message) <= 240 for message in fallback_messages)
+
+
+def test_refresh_approved_ignored_coin_lists_structured_console_owns_normal_output(caplog):
+    bot = _make_eligibility_event_bot()
+    structured = ListEventSink()
+    console = ListEventSink()
+    text = ListEventSink()
+    bot.live_event_console_enabled = True
+    bot._live_event_pipeline = LiveEventPipeline(
+        structured_sinks=[structured], console_sink=console, text_sink=text
+    )
+
+    with caplog.at_level(logging.INFO):
+        bot.refresh_approved_ignored_coins_lists()
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    events = [
+        event
+        for event in structured.events
+        if event.event_type == EventTypes.FORAGER_ELIGIBILITY_CHANGED
+    ]
+    assert len(events) == 4
+    assert console.events == events
+    assert text.events == events
+    assert not [
+        record for record in caplog.records if record.message.startswith("[forager]")
+    ]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
+def test_refresh_approved_ignored_coin_lists_does_not_restore_legacy_output_on_event_failure(
+    caplog,
+):
+    bot = _make_eligibility_event_bot()
+    bot.live_event_console_enabled = True
+    bot._live_event_pipeline = LiveEventPipeline(console_sink=ListEventSink())
+
+    def fail_emit(*_args, **_kwargs):
+        raise RuntimeError("event sink unavailable")
+
+    bot._emit_live_event = fail_emit
+
+    with caplog.at_level(logging.INFO):
+        bot.refresh_approved_ignored_coins_lists()
+
+    assert bot.approved_coins["long"] == {
+        f"A{index:02d}/USDT:USDT" for index in range(14)
+    }
+    assert bot.ignored_coins == {"long": {"IGNORED/USDT:USDT"}, "short": set()}
+    assert not [
+        record for record in caplog.records if record.message.startswith("[forager]")
+    ]
+    assert bot._live_event_pipeline.close(timeout=2.0) is True

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -26,6 +26,7 @@ from live.event_bus import (
     format_console_event,
     format_ema_fallback_console,
     format_ema_unavailable_console,
+    format_forager_eligibility_console,
     format_memory_snapshot_console,
     format_state_refresh_timing_console,
     live_event_debug_profile_enabled,
@@ -314,9 +315,10 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.DATA_PACKET_UPDATED].structured is True
     assert DEFAULT_ROUTES[EventTypes.DATA_PACKET_UPDATED].monitor is True
     assert DEFAULT_ROUTES[EventTypes.DATA_PACKET_UPDATED].console is False
+    assert DEFAULT_ROUTES[EventTypes.FORAGER_ELIGIBILITY_CHANGED].console is True
+    assert DEFAULT_ROUTES[EventTypes.FORAGER_ELIGIBILITY_CHANGED].text is True
     for event_type in (
         EventTypes.FORAGER_FEATURE_UNAVAILABLE,
-        EventTypes.FORAGER_ELIGIBILITY_CHANGED,
         EventTypes.ENTRY_INITIAL_ELIGIBILITY,
         EventTypes.EXECUTION_CREATE_CONNECTOR_CALL_STARTED,
         EventTypes.EXECUTION_CANCEL_CONNECTOR_CALL_STARTED,
@@ -405,6 +407,71 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.UNSTUCK_SELECTION].text is True
     assert DEFAULT_ROUTES[EventTypes.REALIZED_LOSS_GATE_BLOCKED].console is True
     assert DEFAULT_ROUTES[EventTypes.REALIZED_LOSS_GATE_BLOCKED].text is True
+
+
+def test_forager_eligibility_console_formatter_is_bounded_and_preserves_payload():
+    data = {
+        "source": "config_sources",
+        "list_kind": "approved_coins",
+        "operation": "added",
+        "changes": [
+            {
+                "pside": "long",
+                "count": 5,
+                "symbols": [
+                    "ZZZ/USDT:USDT",
+                    "\x1b[31mBBB\nbad/USDT:USDT",
+                    "AAA/USDT:USDT",
+                    "CCC/USDT:USDT",
+                ],
+            },
+            {"pside": "short", "count": 7, "symbols": ["SHORT/USDT:USDT"]},
+        ],
+    }
+    event = LiveEvent(EventTypes.FORAGER_ELIGIBILITY_CHANGED, data=data)
+    before = event.to_dict()
+
+    message = format_forager_eligibility_console(data)
+
+    assert message == (
+        "[forager] list=approved_coins op=added counts=long:5,short:7 "
+        "samples=AAA,BBB_bad,CCC omitted=9"
+    )
+    assert len(message) <= 240
+    assert len("2026-07-16T05:18:56Z INFO     [hyperliquid] " + message) <= 240
+    assert "\n" not in message
+    assert format_console_event(event) == message
+    assert event.to_dict() == before
+
+
+def test_forager_eligibility_console_route_keeps_event_durable():
+    structured = ListEventSink()
+    monitor = ListEventSink()
+    console = ListEventSink()
+    text = ListEventSink()
+    pipeline = LiveEventPipeline(
+        structured_sinks=[structured],
+        monitor_sinks=[monitor],
+        console_sink=console,
+        text_sink=text,
+    )
+    event = LiveEvent(
+        EventTypes.FORAGER_ELIGIBILITY_CHANGED,
+        data={
+            "list_kind": "ignored_coins",
+            "operation": "removed",
+            "changes": [{"pside": "long", "count": 1, "symbols": ["BTC/USDT:USDT"]}],
+        },
+    )
+
+    pipeline.emit(event)
+
+    assert console.events == [event]
+    assert text.events == [event]
+    assert pipeline.flush(timeout=2.0) is True
+    assert structured.events == [event]
+    assert monitor.events == [event]
+    assert pipeline.close(timeout=2.0) is True
 
 
 def test_redact_payload_recurses_and_payload_hash_is_stable():


### PR DESCRIPTION
## Summary
- route `forager.eligibility_changed` through one bounded structured console/text projection
- retain per-side counts, deterministic symbol samples, and omitted counts within the normal record budget
- keep a bounded legacy fallback only when structured console ownership is unavailable
- record the merged/deployed PR #1259 evidence and this production-triggered slice

## Production evidence
Fresh VPS5 logs after PR #1259 naturally emitted `added to approved_coins` records at 245-250 visible characters on Binance, GateIO, and Hyperliquid. The replacement production-shaped projection is 136 characters including the Hyperliquid log prefix.

## Behavior boundary
Observability-only. This does not change membership calculation, coin-list mutation, event admission, structured/monitor payloads, forager selection, config, exchange calls, Rust behavior, orders, risk, backtests, optimization, or trading behavior.

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_live_event_bus.py tests/test_live_coin_lists.py` (147 passed)
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/live/event_bus.py src/passivbot.py tests/test_live_event_bus.py tests/test_live_coin_lists.py`
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python src/tools/check_ai_docs.py` (0 errors; one pre-existing word-count warning)
- `git diff --check`

## Rollout
After the proportional gate is green, use the standing exact-five-pane VPS5 restart procedure and validate the naturally recurring startup membership records plus settled smoke. Do not manufacture exchange, state, risk, or trading events.
