### PR TITLE
Compact startup HSL safety warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- The startup HSL safety warning now uses compact mode/budget/threshold wording
+  so its complete deposit, withdrawal, balance-override, configuration-change,
+  and history-reinterpretation warning fits the normal console record budget.
+  Warning admission, HSL configuration, risk behavior, and trading behavior are
+  unchanged.
+
 - Approved/ignored coin membership changes now use one bounded structured
   console/text projection with per-side counts and symbol samples instead of
   unbounded legacy symbol lists. Existing structured event data, membership

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/compact-hsl-risk-disclaimer`, based on canonical
   `3eec4466c4ae4aa76ba54f92bcc6604c80643d0d` after PR #1260.
-- PR: pending, `Compact startup HSL safety warning`.
+- PR: #1261, `Compact startup HSL safety warning`.
 - Slice: compact the once-per-enabled-side startup HSL safety warning while
   retaining every operator-relevant condition and the risk documentation path.
 - Triggering evidence: fresh post-PR #1260 VPS5 logs contained one

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,37 +22,44 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/bound-approved-coin-delta-console`, based on canonical
-  `e41118f0424ff3d4161e308b8844af5f35a8b7a9` after PR #1259.
-- PR: #1260, `Bound coin-list membership console output`.
-- Slice: make the existing `forager.eligibility_changed` event the sole normal
-  console/text owner for approved/ignored coin membership changes, with
-  per-side counts and bounded symbol samples.
-- Triggering evidence: fresh post-PR #1259 VPS5 startup logs contained natural
-  `added to approved_coins` records at 245-250 visible characters on Binance,
-  GateIO, and Hyperliquid. Each printed the complete changed symbol list and
-  exceeded the normal 240-character record budget.
-- Scope: add only a bounded structured console/text formatter and bounded
-  legacy fallback; preserve event admission and the existing structured/
-  monitor payload.
-- Behavior boundary: observability-only; no membership calculation, list
-  mutation, forager selection, config, exchange call, Rust, order, risk,
-  backtest, optimizer, or trading behavior.
+- Branch: `codex/compact-hsl-risk-disclaimer`, based on canonical
+  `3eec4466c4ae4aa76ba54f92bcc6604c80643d0d` after PR #1260.
+- PR: pending, `Compact startup HSL safety warning`.
+- Slice: compact the once-per-enabled-side startup HSL safety warning while
+  retaining every operator-relevant condition and the risk documentation path.
+- Triggering evidence: fresh post-PR #1260 VPS5 logs contained one
+  241-character Binance HSL safety warning, the only record above the normal
+  240-character budget across the exact new log segments.
+- Scope: change only the warning literal and focused regression assertions;
+  preserve WARNING admission and once-per-enabled-side behavior.
+- Behavior boundary: observability-only; no HSL configuration, replay, history
+  reconstruction, risk calculation, exchange call, Rust, order, backtest,
+  optimizer, or trading behavior.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green CI
   while Grok is halted.
 - Expected VPS action: after merge, one authorized exact five-bot restart.
-  Validate the natural startup membership records and settled smoke; do not
+  Validate the natural startup HSL warning and settled smoke; do not
   manufacture exchange, state, risk, or trading events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `e41118f0424ff3d4161e308b8844af5f35a8b7a9`, PR #1259. The tracked checkout
+  `3eec4466c4ae4aa76ba54f92bcc6604c80643d0d`, PR #1260. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `972601/972603/972605/972607/972609`. The exact pane PIDs remain
+  `973301/973303/973305/973307/973309`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1260 was activated after one exact five-bot SIGINT round; old PIDs
+  `972601/972603/972605/972607/972609` all exited naturally within 24 seconds
+  without escalation. The final settled smoke was `ok=true` with zero
+  hard/log/monitor/process failures, `371/371` remote and `80/80`
+  account-critical calls successful, 11 successful fill refreshes, no active
+  HSL replay, all five exact processes in normal `R/S` states, and a clean
+  tracked checkout. All five bots naturally emitted the new structured
+  approved-coin membership projection at 130-150 visible characters, versus
+  245-250 before, with zero legacy membership lines. The same exact new logs
+  exposed one 241-character Binance startup HSL safety warning.
 - PR #1259 was activated after one exact five-bot SIGINT round; old PIDs
   `971695/971697/971699/971701/971703` all exited naturally within 28 seconds
   without escalation. The settled three-minute smoke was `ok=true` with zero
@@ -874,9 +881,11 @@ measured 201 visible characters with zero legacy caller-bearing duplicates and
 a hard-green settled smoke. PR #1259 is also merged, deployed, and naturally
 validated: a real Binance `InvalidNonce` recovery produced a 203-character
 clock-offset line with no raw exception text and the settled smoke was
-hard-green. The active slice migrates the naturally observed 245-250-character
-coin-membership lists to one bounded structured console/text owner without
-changing eligibility or trading behavior.
+hard-green. PR #1260 is also merged, deployed, and naturally validated: all
+five approved-coin membership lines measured 130-150 visible characters with
+zero legacy duplicates and a hard-green settled smoke. The active slice
+compacts the only remaining over-budget new record, a 241-character startup HSL
+safety warning, without changing warning admission, risk, or trading behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,31 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1259)
+## Latest Canonical Deployment (PR #1260)
+
+- PR #1260 merged to `master` as
+  `3eec4466c4ae4aa76ba54f92bcc6604c80643d0d` after exact-head Hermes approval
+  and green Python/Rust CI while Grok was temporarily halted. It makes
+  `forager.eligibility_changed` the sole normal structured console/text owner
+  for approved/ignored membership changes, retaining counts and bounded samples
+  with a bounded legacy fallback; membership and trading behavior are
+  unchanged.
+- VPS5 fast-forwarded cleanly and sent one SIGINT round to exact old PIDs
+  `972601/972603/972605/972607/972609`; all exited naturally within 24 seconds
+  without escalation. Pane PIDs and unrelated `misc:0.0` PID `434835` were
+  preserved. Final PIDs are `973301/973303/973305/973307/973309` for
+  Binance/KuCoin/GateIO/OKX/Hyperliquid respectively.
+- The final settled smoke was `ok=true` with zero hard/log/monitor/process
+  failures, `371/371` remote and `80/80` account-critical calls successful, 11
+  successful fill refreshes, no active HSL replay, all five matching/config-
+  valid processes in normal `R/S` states, and clean tracked `master`.
+- All five bots naturally emitted the structured approved-coin membership
+  projection at 130-150 visible characters, versus 245-250 before. Zero legacy
+  membership lines appeared. The exact new segments then exposed one
+  241-character Binance startup HSL safety warning, the only remaining record
+  above the normal budget; the next slice compacts only that warning literal.
+
+## Previous Canonical Deployment (PR #1259)
 
 - PR #1259 merged to `master` as
   `e41118f0424ff3d4161e308b8844af5f35a8b7a9` after exact-head Hermes approval

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -2550,7 +2550,7 @@ def _parse_hsl_config(self) -> dict[str, dict[str, Any]]:
         if enabled:
             logging.warning(
                 "[risk] HSL[%s] enabled; review %s. Deposits, withdrawals, "
-                "balance overrides, HSL mode changes, and HSL budget/threshold "
+                "balance overrides, and HSL mode/budget/threshold "
                 "changes can reinterpret reconstructed history.",
                 pside,
                 _HSL_RISKS_DOC,

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -260,17 +260,24 @@ def test_parse_hsl_config_logs_compact_complete_startup_summary(caplog):
         }
     }
     messages = [record.getMessage() for record in caplog.records]
-    assert any("docs/equity_hard_stop_loss_risks.md" in message for message in messages)
-    assert any("Deposits, withdrawals" in message for message in messages)
-    assert any("HSL mode changes" in message for message in messages)
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    warning = warnings[0].getMessage()
+    assert warning == (
+        "[risk] HSL[short] enabled; review docs/equity_hard_stop_loss_risks.md. "
+        "Deposits, withdrawals, balance overrides, and HSL mode/budget/threshold "
+        "changes can reinterpret reconstructed history."
+    )
     startup = next(message for message in messages if message.startswith("[risk] HSL[short] on"))
     assert startup == (
         "[risk] HSL[short] on | red=0.123457 ema=1.23457e+308 cd=1.23457e+308 "
         "no-r=0.987654 mode=unified tiers=0.345679/0.876543 "
         "orange=tp_only_with_active_entry_cancellation panic=market restart=threshold"
     )
-    normal_console_prefix = "2026-07-15T12:34:56Z INFO     [hyperliquid] "
-    assert len(normal_console_prefix + startup) <= 240
+    warning_prefix = "2026-07-15T12:34:56Z WARNING  [hyperliquid] "
+    info_prefix = "2026-07-15T12:34:56Z INFO     [hyperliquid] "
+    assert len(warning_prefix + warning) <= 240
+    assert len(info_prefix + startup) <= 240
 
 
 def test_hsl_replay_matrix_row_derives_upnl_from_rust_pnl_helpers():


### PR DESCRIPTION
## Summary
- compact the once-per-enabled-side startup HSL safety warning
- retain the risk documentation path and every deposit, withdrawal, balance-override, HSL configuration-change, and history-reinterpretation warning fact
- record the merged/deployed PR #1260 evidence and this production-triggered slice

## Production evidence
Fresh VPS5 logs after PR #1260 contained one 241-character Binance HSL safety warning, the only record above the normal 240-character budget across the exact new segments. The replacement renders at 233 characters with the normal Hyperliquid warning prefix.

## Behavior boundary
Observability-only. This does not change warning admission or level, HSL configuration, replay, history reconstruction, risk calculations, exchange calls, Rust behavior, orders, backtests, optimization, or trading behavior.

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest tests/test_hsl_coin_mode.py` (134 passed)
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/passivbot_hsl.py tests/test_hsl_coin_mode.py`
- `/Users/eiriknarjord/repos/passivbot-2/venv/bin/python src/tools/check_ai_docs.py` (0 errors; one pre-existing word-count warning)
- `git diff --check`

## Rollout
After the proportional gate is green, use the standing exact-five-pane VPS5 restart procedure and validate the naturally recurring startup HSL warning plus settled smoke. Do not manufacture exchange, state, risk, or trading events.
