### PR TITLE
Bound initial entry distance-gate console volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,12 @@ All notable user-facing changes will be documented in this file.
   Complete debug diagnostics, candle-health calculations, fetch behavior,
   readiness checks, and trading behavior are unchanged.
 
-- Initial-entry distance-gate blocked/cleared events now use a bounded compact
-  console/text projection while retaining the complete structured payload,
-  existing event admission, and legacy fallback. Entry eligibility, distance
-  calculation, gate decisions, order creation, and trading behavior are
-  unchanged.
+- Initial-entry distance-gate blocked events now retain every existing
+  per-symbol structured/monitor record while limiting console/text and legacy
+  fallback output to one bot-level representative per five minutes, with
+  bounded active/suppressed counts. Cleared transitions remain immediate; entry
+  eligibility, distance calculation, gate decisions, order creation, and
+  trading behavior are unchanged.
 
 - Close-EMA carry-forward warnings now use a bounded structured console/text
   projection with counts, symbol/span examples, age, fallback streak, and a

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,6 +24,8 @@ Estimated completion:
 
 - Branch: `codex/aggregate-entry-distance-gate-console`, based on canonical
   `452bd621424def1e626e5fa73b551b52ef1b2773` after PR #1261.
+- PR: #1262, `Bound initial entry distance-gate console volume`; semantic head
+  `d4a815e91455b12eecfc695c1ad026b2fb839d8a`.
 - Slice: preserve the existing per-symbol initial-entry distance-gate blocked
   records in structured/monitor sinks while admitting at most one blocked
   console/text representative per bot per five minutes.
@@ -35,6 +37,11 @@ Estimated completion:
   thresholds, market fetches, exchange behavior, or event durability changes.
 - Validation: focused event/gate and event-pipeline/formatter tests, Python
   compilation, docs and generated-registry checks, and diff whitespace check.
+- Review gate: temporary maintainer-authorized exact-head Hermes plus green
+  Python and Rust CI while Grok is halted.
+- Expected VPS action: after merge, one authorized exact five-bot graceful
+  restart and natural blocked-event/durable-event observation; do not
+  manufacture trading, risk, lock, or state events.
 
 ## Deployed Baseline
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,34 +22,37 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/compact-hsl-risk-disclaimer`, based on canonical
-  `3eec4466c4ae4aa76ba54f92bcc6604c80643d0d` after PR #1260.
-- PR: #1261, `Compact startup HSL safety warning`.
-- Slice: compact the once-per-enabled-side startup HSL safety warning while
-  retaining every operator-relevant condition and the risk documentation path.
-- Triggering evidence: fresh post-PR #1260 VPS5 logs contained one
-  241-character Binance HSL safety warning, the only record above the normal
-  240-character budget across the exact new log segments.
-- Scope: change only the warning literal and focused regression assertions;
-  preserve WARNING admission and once-per-enabled-side behavior.
-- Behavior boundary: observability-only; no HSL configuration, replay, history
-  reconstruction, risk calculation, exchange call, Rust, order, backtest,
-  optimizer, or trading behavior.
-- Review gate: temporary maintainer-authorized exact-head Hermes plus green CI
-  while Grok is halted.
-- Expected VPS action: after merge, one authorized exact five-bot restart.
-  Validate the natural startup HSL warning and settled smoke; do not
-  manufacture exchange, state, risk, or trading events.
+- Branch: `codex/aggregate-entry-distance-gate-console`, based on canonical
+  `452bd621424def1e626e5fa73b551b52ef1b2773` after PR #1261.
+- Slice: preserve the existing per-symbol initial-entry distance-gate blocked
+  records in structured/monitor sinks while admitting at most one blocked
+  console/text representative per bot per five minutes.
+- Triggering evidence: the PR #1261 post-deploy window retained 10 blocked
+  records in five minutes, 26% of 38 records, with no line over 240 characters.
+- Scope: producer-owned operator visibility, bounded active/suppressed counts,
+  compact projection, and legacy INFO fallback ownership only.
+- Behavior boundary: observability-only; no Rust, order construction/filtering,
+  thresholds, market fetches, exchange behavior, or event durability changes.
+- Validation: focused event/gate and event-pipeline/formatter tests, Python
+  compilation, docs and generated-registry checks, and diff whitespace check.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `3eec4466c4ae4aa76ba54f92bcc6604c80643d0d`, PR #1260. The tracked checkout
+  `452bd621424def1e626e5fa73b551b52ef1b2773`, PR #1261. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `973301/973303/973305/973307/973309`. The exact pane PIDs remain
+  `974157/974160/974161/974163/974165`. The exact pane PIDs remain
   `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
   is unchanged.
+- PR #1261 was activated after one exact five-bot SIGINT at `06:18:37Z`; old
+  PIDs `973301/973303/973305/973307/973309` all exited naturally by `06:19:12Z`
+  without escalation. Natural HSL warning lengths were 224-228 characters, with
+  `0/287` above 240. The final two-minute smoke was `ok=true` with `202/202`
+  remote and `49/49` account-critical calls successful, nine fill refreshes,
+  HSL replay complete, states `R=4,S=1`, zero hard/log/monitor/process/pipeline
+  failures, and a clean head. Transient startup KuCoin `RequestTimeout` and
+  Binance `InvalidNonce` recovered naturally.
 - PR #1260 was activated after one exact five-bot SIGINT round; old PIDs
   `972601/972603/972605/972607/972609` all exited naturally within 24 seconds
   without escalation. The final settled smoke was `ok=true` with zero

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,26 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1260)
+## Latest Canonical Deployment (PR #1261)
+
+- PR #1261 merged to `master` as
+  `452bd621424def1e626e5fa73b551b52ef1b2773`. It compacts the startup HSL
+  safety warning without changing warning admission, HSL configuration, risk,
+  or trading behavior.
+- VPS5 sent one SIGINT at `06:18:37Z` to exact old PIDs
+  `973301/973303/973305/973307/973309`; all exited naturally by `06:19:12Z`
+  without escalation. New PIDs are `974157/974160/974161/974163/974165`.
+- Natural HSL warnings measured 224-228 visible characters, with `0/287` over
+  240. The final two-minute smoke was `ok=true`: `202/202` remote and `49/49`
+  account-critical calls succeeded, nine fill refreshes completed, HSL replay
+  completed, states were `R=4,S=1`, hard/log/monitor/process/pipeline failures
+  were zero, and the head was clean. Transient startup KuCoin `RequestTimeout`
+  and Binance `InvalidNonce` recovered naturally.
+- A five-minute exact-log window retained 10 initial-entry distance-gate blocked
+  records, 26% of 38 records, with no line over 240. The next slice keeps those
+  records durable while bounding blocked console/text output per bot.
+
+## Previous Canonical Deployment (PR #1260)
 
 - PR #1260 merged to `master` as
   `3eec4466c4ae4aa76ba54f92bcc6604c80643d0d` after exact-head Hermes approval

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -2554,6 +2554,13 @@ def _format_initial_entry_distance_gate_console(event: LiveEvent) -> str:
         )
         + "%",
     ) if "tolerance_pct" in data else ()
+    aggregate_candidates = (
+        "active=" + str(min(max(_data_int(data, "active_count") or 0, 0), 999)),
+        "sup=" + str(min(max(_data_int(data, "suppressed_count") or 0, 0), 999)),
+    ) if (
+        event.event_type == EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED
+        and ("active_count" in data or "suppressed_count" in data)
+    ) else ()
     candidates = (
         *cycle_candidate,
         "symbol="
@@ -2583,6 +2590,7 @@ def _format_initial_entry_distance_gate_console(event: LiveEvent) -> str:
         )
         + "%",
         *tolerance_candidate,
+        *aggregate_candidates,
     )
     for candidate in candidates:
         if (

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -3542,6 +3542,9 @@ def emit_initial_entry_distance_gate_event(
     signed_dist: float,
     threshold: float,
     tolerance: float | None = None,
+    operator_visible: bool = True,
+    active_count: int | None = None,
+    suppressed_count: int | None = None,
 ) -> None:
     try:
         symbol = str(order.get("symbol") or "")
@@ -3554,12 +3557,17 @@ def emit_initial_entry_distance_gate_event(
             "distance_pct": _safe_float(float(signed_dist) * 100.0),
             "threshold_pct": _safe_float(float(threshold) * 100.0),
             "action": str(action),
+            "operator_visible": bool(operator_visible),
             "order_type": str(
                 order.get("pb_order_type") or order.get("type") or "unknown"
             ),
         }
         if tolerance is not None:
             data["tolerance_pct"] = _safe_float(float(tolerance) * 100.0)
+        if active_count is not None:
+            data["active_count"] = max(0, min(int(active_count), 999))
+        if suppressed_count is not None:
+            data["suppressed_count"] = max(0, min(int(suppressed_count), 999))
         bot._emit_live_event(
             event_type,
             level="info",

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -16916,6 +16916,43 @@ class Passivbot:
             and getattr(pipeline, "console_sink", None) is not None
         )
 
+    def _initial_entry_distance_gate_console_decision(
+        self, now_ms: int
+    ) -> tuple[bool, int, int]:
+        """Choose the bot-level operator projection for an admitted block event."""
+        state = getattr(self, "_initial_entry_distance_gate_console_state", None)
+        if not isinstance(state, dict):
+            state = {}
+            self._initial_entry_distance_gate_console_state = state
+        interval_ms = max(
+            0,
+            int(
+                getattr(
+                    self,
+                    "_initial_entry_distance_gate_console_interval_ms",
+                    5 * 60 * 1000,
+                )
+                or 0
+            ),
+        )
+        last_visible_ms = state.get("last_visible_ms")
+        operator_visible = (
+            last_visible_ms is None
+            or now_ms - int(last_visible_ms) >= interval_ms
+        )
+        suppressed_count = min(int(state.get("suppressed_count", 0) or 0), 999)
+        if operator_visible:
+            state["last_visible_ms"] = now_ms
+            state["suppressed_count"] = 0
+        else:
+            suppressed_count = min(suppressed_count + 1, 999)
+            state["suppressed_count"] = suppressed_count
+        active_state = getattr(self, "_initial_entry_distance_gate_log_state", {})
+        active_count = min(
+            len(active_state) if isinstance(active_state, dict) else 0, 999
+        )
+        return operator_visible, active_count, suppressed_count
+
     def _log_initial_entry_distance_gate_block(
         self,
         order: dict,
@@ -16956,7 +16993,15 @@ class Passivbot:
                 self._resolve_pb_order_type(order),
             )
             return
-        if not self._initial_entry_gate_structured_console_available():
+        (
+            operator_visible,
+            active_count,
+            suppressed_count,
+        ) = self._initial_entry_distance_gate_console_decision(now_ms)
+        if (
+            operator_visible
+            and not self._initial_entry_gate_structured_console_available()
+        ):
             logging.info(
                 "[entry] initial entry staged but not placed | symbol=%s pside=%s qty=%.10g price=%.10g market=%.10g dist=%.4f%% threshold=%.4f%% tolerance=%.4f%% type=%s reason=initial_entry_distance_gate",
                 Passivbot._log_symbol(probe["symbol"]),
@@ -16982,6 +17027,9 @@ class Passivbot:
                 signed_dist=signed_dist,
                 threshold=threshold,
                 tolerance=tolerance,
+                operator_visible=operator_visible,
+                active_count=active_count,
+                suppressed_count=suppressed_count,
             )
 
     def _log_initial_entry_distance_gate_cleared(

--- a/tests/test_initial_entry_distance_gate_events.py
+++ b/tests/test_initial_entry_distance_gate_events.py
@@ -11,7 +11,7 @@ class _FailingConsoleSink:
         raise OSError("console unavailable")
 
 
-def _make_bot_with_event_sink(*, console_sink=None):
+def _make_bot_with_event_sink(*, console_sink=None, monitor_sinks=(), text_sink=None):
     bot = Passivbot.__new__(Passivbot)
     bot.bot_id = "bot_distance_gate"
     bot.exchange = "binance"
@@ -24,8 +24,9 @@ def _make_bot_with_event_sink(*, console_sink=None):
     sink = ListEventSink()
     bot._live_event_pipeline = LiveEventPipeline(
         structured_sinks=[sink],
-        monitor_sinks=[],
+        monitor_sinks=monitor_sinks,
         console_sink=console_sink,
+        text_sink=text_sink,
     )
     return bot, sink
 
@@ -80,6 +81,9 @@ def test_initial_entry_distance_gate_block_emits_structured_event(monkeypatch):
     assert event.data["distance_pct"] == pytest.approx(5.0)
     assert event.data["threshold_pct"] == pytest.approx(1.0)
     assert event.data["tolerance_pct"] == pytest.approx(0.05)
+    assert event.data["operator_visible"] is True
+    assert event.data["active_count"] == 1
+    assert event.data["suppressed_count"] == 0
 
 
 def test_initial_entry_distance_gate_event_respects_info_throttle(monkeypatch, caplog):
@@ -207,6 +211,76 @@ def test_initial_entry_distance_gate_structured_console_owns_block_and_clear(
         assert console_sink.events == gate_events
 
 
+def test_initial_entry_distance_gate_blocks_are_bounded_per_bot_but_remain_durable(
+    monkeypatch, caplog
+):
+    monitor = ListEventSink()
+    console = ListEventSink()
+    text = ListEventSink()
+    bot, structured = _make_bot_with_event_sink(
+        console_sink=console, monitor_sinks=[monitor], text_sink=text
+    )
+    bot._initial_entry_distance_gate_console_interval_ms = 5 * 60 * 1000
+    now_ms = 1_000
+    monkeypatch.setattr("passivbot.utc_ms", lambda: now_ms)
+
+    try:
+        with caplog.at_level(logging.INFO):
+            bot._log_initial_entry_distance_gate_block(
+                _initial_entry_order(),
+                market_price=100_000.0,
+                signed_dist=0.05,
+                threshold=0.01,
+            )
+            now_ms = 2_000
+            bot._log_initial_entry_distance_gate_block(
+                {**_initial_entry_order(), "symbol": "ETH/USDT:USDT"},
+                market_price=100_000.0,
+                signed_dist=0.05,
+                threshold=0.01,
+            )
+            bot._log_initial_entry_distance_gate_cleared(
+                {**_initial_entry_order(), "symbol": "ETH/USDT:USDT"},
+                market_price=96_000.0,
+                signed_dist=0.005,
+                threshold=0.01,
+            )
+            now_ms = 301_000
+            bot._log_initial_entry_distance_gate_block(
+                {**_initial_entry_order(), "symbol": "SOL/USDT:USDT"},
+                market_price=100_000.0,
+                signed_dist=0.05,
+                threshold=0.01,
+            )
+        assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    finally:
+        assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+    events = [
+        event
+        for event in structured.events
+        if event.event_type == EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED
+    ]
+    assert len(events) == 3
+    assert [event.data["operator_visible"] for event in events] == [True, False, True]
+    assert [event.data["active_count"] for event in events] == [1, 2, 2]
+    assert [event.data["suppressed_count"] for event in events] == [0, 1, 1]
+    cleared = [
+        event
+        for event in structured.events
+        if event.event_type == EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED
+    ]
+    assert len(cleared) == 1
+    assert monitor.events == [events[0], events[1], cleared[0], events[2]]
+    assert console.events == [events[0], cleared[0], events[2]]
+    assert text.events == [events[0], cleared[0], events[2]]
+    assert not [
+        record
+        for record in caplog.records
+        if "initial entry staged but not placed" in record.message
+    ]
+
+
 def test_initial_entry_distance_gate_uses_legacy_fallback_without_console_sink(caplog):
     bot, sink = _make_bot_with_event_sink(console_sink=None)
     order = _initial_entry_order()
@@ -215,6 +289,12 @@ def test_initial_entry_distance_gate_uses_legacy_fallback_without_console_sink(c
         with caplog.at_level(logging.INFO):
             bot._log_initial_entry_distance_gate_block(
                 order,
+                market_price=100_000.0,
+                signed_dist=0.05,
+                threshold=0.01,
+            )
+            bot._log_initial_entry_distance_gate_block(
+                {**order, "symbol": "ETH/USDT:USDT"},
                 market_price=100_000.0,
                 signed_dist=0.05,
                 threshold=0.01,
@@ -241,6 +321,7 @@ def test_initial_entry_distance_gate_uses_legacy_fallback_without_console_sink(c
             EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
         }
     ] == [
+        EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
         EventTypes.ENTRY_INITIAL_DISTANCE_GATE_BLOCKED,
         EventTypes.ENTRY_INITIAL_DISTANCE_GATE_CLEARED,
     ]

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -2397,6 +2397,8 @@ def test_console_format_summarizes_initial_entry_distance_gate_block():
             "distance_pct": 2.278481012658,
             "threshold_pct": 1.25,
             "tolerance_pct": 0.1,
+            "active_count": 3,
+            "suppressed_count": 2,
         },
     )
 
@@ -2405,7 +2407,7 @@ def test_console_format_summarizes_initial_entry_distance_gate_block():
     assert rendered == (
         "[entry] blocked cy=cy_entry_gate symbol=BTC/USDT:USDT pside=long "
         "type=entry_initial_normal_long q=0.001 px=98750 mkt=101000 "
-        "d=2.2785% max=1.2500% tol=0.1000%"
+        "d=2.2785% max=1.2500% tol=0.1000% active=3 sup=2"
     )
     assert len(f"2026-07-15T12:34:56Z INFO     [hyperliquid] {rendered}") <= 240
 
@@ -2455,6 +2457,8 @@ def test_console_format_bounds_and_sanitizes_initial_entry_distance_gate_payload
             "distance_pct": 0.0,
             "threshold_pct": 0.0,
             "tolerance_pct": 0.0,
+            "active_count": 50_000,
+            "suppressed_count": 50_000,
         },
     )
     payload_before = dict(event.data)
@@ -2466,6 +2470,7 @@ def test_console_format_bounds_and_sanitizes_initial_entry_distance_gate_payload
     assert "\n" not in rendered
     assert "\t" not in rendered
     assert "q=0 px=0 mkt=0 d=0.0000% max=0.0000% tol=0.0000%" in rendered
+    assert "active=999 sup=999" in rendered
     assert event.data == payload_before
 
 


### PR DESCRIPTION
## Scope
- Category: observability producer and console/text projection.
- Preserve every existing per-symbol initial-entry distance-gate blocked event in structured and monitor sinks.
- Admit blocked events to console/text and the legacy INFO fallback at most once per bot per five minutes, with bounded active and suppressed counts.
- Keep cleared transitions immediate.

## Non-goals
- No Rust, order construction, order filtering, distance threshold, market fetch, exchange, backtest, optimizer, configuration, or trading behavior changes.
- Existing per-key one-hour blocked-event admission remains unchanged.

## VPS evidence
PR #1261 deployed as `452bd62142`. One exact five-bot SIGINT at `06:18:37Z`; all old processes exited naturally by `06:19:12Z`. New PIDs are `974157/974160/974161/974163/974165`; `misc:0.0` remained untouched.

Natural HSL warnings measured 224-228 visible characters, with `0/287` above 240. Final two-minute smoke was `ok=true`: `202/202` remote calls, `49/49` account-critical calls, nine fill refreshes, HSL replay complete, `R=4,S=1`, zero hard/log/monitor/process/pipeline failures, and a clean deployed checkout. Startup KuCoin `RequestTimeout` and Binance `InvalidNonce` recovered naturally.

The next five-minute console sample contained 10 initial-entry distance-gate blocked records out of 38 total records (26%), with no line above 240 characters.

## Validation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_initial_entry_distance_gate_events.py tests/test_live_event_bus.py` (135 passed)
- `PYTHONPATH=src .../python -m py_compile src/passivbot.py src/live/event_emitters.py src/live/event_bus.py`
- `PYTHONPATH=src .../python src/tools/check_ai_docs.py` (0 errors; pre-existing word-count warning)
- `PYTHONPATH=src .../python src/tools/generate_live_event_registry.py --check`
- `git diff --check`

## Expected VPS action
After merge, perform one authorized exact five-bot graceful restart and verify natural blocked-event volume plus durable structured events. Do not manufacture trading, risk, lock, or state events.

## Reviewer focus
Please verify operator admission cannot affect durable delivery or gate decisions, suppression is bot-local and bounded, legacy fallback cannot bypass the cadence, and clear transitions remain immediate.