### PR TITLE
Compact startup lifecycle console logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Startup lifecycle output now has one normal human-ready signal: structured
+  startup timing. `bot.started` keeps its structured console/text projection
+  with a legacy fallback only when that projection is unavailable, while
+  durable `bot.ready` stays out of console/text. Decorative READY banners,
+  duplicate execution-loop startup lines, and routine warmup/maintainer detail
+  no longer add INFO noise. Background candle-warmup success detail is DEBUG
+  under `[candle]`; failure remains immediate ERROR. Startup timing, task
+  scheduling, monitor persistence, and trading behavior are unchanged.
+
 - The startup HSL safety warning now uses compact mode/budget/threshold wording
   so its complete deposit, withdrawal, balance-override, configuration-change,
   and history-reinterpretation warning fits the normal console record budget.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -906,9 +906,15 @@ validated: a real Binance `InvalidNonce` recovery produced a 203-character
 clock-offset line with no raw exception text and the settled smoke was
 hard-green. PR #1260 is also merged, deployed, and naturally validated: all
 five approved-coin membership lines measured 130-150 visible characters with
-zero legacy duplicates and a hard-green settled smoke. The active slice
-compacts the only remaining over-budget new record, a 241-character startup HSL
-safety warning, without changing warning admission, risk, or trading behavior.
+zero legacy duplicates and a hard-green settled smoke. PR #1261's compact
+startup HSL warning and PR #1262's initial-entry distance-gate admission are
+also merged, deployed, and naturally validated. The active PR #1263
+consolidates startup lifecycle console ownership: `bot.started` owns the
+structured human start signal with a legacy fallback, `bot.ready` remains
+durable structured/monitor data, startup timing owns the human ready signal,
+and routine warmup/maintainer detail moves to DEBUG while the legacy READY
+banner is removed. It does not change startup task ordering, exchange calls,
+risk, or trading behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,10 +24,11 @@ Estimated completion:
 
 - Branch: `codex/compact-startup-lifecycle-console`, based on canonical
   `82a56bb15445a1effff8501aa9f66540009b8f3f` after PR #1262.
-- PR: not opened. Slice: consolidate startup console ownership: retain
-  structured `bot.started` visibility with its legacy-console fallback, use
-  startup timing as the human-ready signal, and keep durable `bot.ready` out
-  of console/text.
+- PR: #1263, `Compact startup lifecycle console logging`; semantic head
+  `6bee544c61ba381de56a9e6b7a138294c5ef14aa`. Slice: consolidate startup
+  console ownership: retain structured `bot.started` visibility with its
+  legacy-console fallback, use startup timing as the human-ready signal, and
+  keep durable `bot.ready` out of console/text.
 - Triggering evidence: a fresh five-file startup sample had 281 lines,
   including 78 `[boot]` lines, 10 decorative READY separators, a duplicate
   readiness path, and 8 random-jitter detail lines.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,36 +22,48 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/aggregate-entry-distance-gate-console`, based on canonical
-  `452bd621424def1e626e5fa73b551b52ef1b2773` after PR #1261.
-- PR: #1262, `Bound initial entry distance-gate console volume`; semantic head
-  `d4a815e91455b12eecfc695c1ad026b2fb839d8a`.
-- Slice: preserve the existing per-symbol initial-entry distance-gate blocked
-  records in structured/monitor sinks while admitting at most one blocked
-  console/text representative per bot per five minutes.
-- Triggering evidence: the PR #1261 post-deploy window retained 10 blocked
-  records in five minutes, 26% of 38 records, with no line over 240 characters.
-- Scope: producer-owned operator visibility, bounded active/suppressed counts,
-  compact projection, and legacy INFO fallback ownership only.
-- Behavior boundary: observability-only; no Rust, order construction/filtering,
-  thresholds, market fetches, exchange behavior, or event durability changes.
-- Validation: focused event/gate and event-pipeline/formatter tests, Python
-  compilation, docs and generated-registry checks, and diff whitespace check.
+- Branch: `codex/compact-startup-lifecycle-console`, based on canonical
+  `82a56bb15445a1effff8501aa9f66540009b8f3f` after PR #1262.
+- PR: not opened. Slice: consolidate startup console ownership: retain
+  structured `bot.started` visibility with its legacy-console fallback, use
+  startup timing as the human-ready signal, and keep durable `bot.ready` out
+  of console/text.
+- Triggering evidence: a fresh five-file startup sample had 281 lines,
+  including 78 `[boot]` lines, 10 decorative READY separators, a duplicate
+  readiness path, and 8 random-jitter detail lines.
+- Scope: startup lifecycle routing plus DEBUG-only warmup/maintainer detail.
+  Background candle-warmup success detail is `[candle]` DEBUG; its failure
+  remains immediate ERROR.
+- Behavior boundary: observability-only; no Rust, task timing, waits, task
+  starts, exception behavior, monitor persistence, exchange behavior, or
+  trading behavior changes.
+- Validation: focused event-bus, startup-monitor, and candle-warmup tests, a
+  two-step offline fake-live startup smoke, Python compilation, docs and
+  generated-registry checks, and diff whitespace check.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
 - Expected VPS action: after merge, one authorized exact five-bot graceful
-  restart and natural blocked-event/durable-event observation; do not
-  manufacture trading, risk, lock, or state events.
+  restart and natural startup observation only; do not manufacture trading,
+  risk, lock, or state events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `452bd621424def1e626e5fa73b551b52ef1b2773`, PR #1261. The tracked checkout
+  `82a56bb15445a1effff8501aa9f66540009b8f3f`, PR #1262. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `974157/974160/974161/974163/974165`. The exact pane PIDs remain
-  `856294/856332/856364/856398/856434`, and unrelated `misc:0.0` PID `434835`
-  is unchanged.
+  `975507/975510/975511/975513/975515`. The exact pane parents are unchanged,
+  and unrelated `misc:0.0` PID `434835` is unchanged.
+- PR #1262 merged as `82a56bb15445a1effff8501aa9f66540009b8f3f` and was
+  activated with one SIGINT at `2026-07-16T06:54:33Z` to old PIDs
+  `974157/974160/974161/974163/974165`; all exited naturally by `06:54:56Z`.
+  An immediate KuCoin authoritative timeout recovered, and settled smoke was
+  `ok=true` with zero hard failures, `220/222` remote and `43/43`
+  account-critical calls successful, six fill refreshes successful, all three
+  observed HSL replays complete, and five exact processes in state `R`.
+- Eleven natural durable `entry.initial_distance_gate_blocked` events produced
+  three console representatives (one each on Binance, GateIO, and OKX), with
+  eight structured events suppressed; `active_max=4` and `suppressed_max=3`.
 - PR #1261 was activated after one exact five-bot SIGINT at `06:18:37Z`; old
   PIDs `973301/973303/973305/973307/973309` all exited naturally by `06:19:12Z`
   without escalation. Natural HSL warning lengths were 224-228 characters, with

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,28 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1261)
+## Latest Canonical Deployment (PR #1262)
+
+- PR #1262 merged to `master` as
+  `82a56bb15445a1effff8501aa9f66540009b8f3f`. It keeps every initial-entry
+  distance-gate blocked event durable while admitting at most one console/text
+  representative per bot per five minutes; entry eligibility, distance
+  calculation, gate decisions, order creation, and trading behavior are
+  unchanged.
+- VPS5 sent one SIGINT at `2026-07-16T06:54:33Z` to exact old PIDs
+  `974157/974160/974161/974163/974165`; all exited naturally by `06:54:56Z`.
+  New PIDs are `975507/975510/975511/975513/975515`; pane parents and unrelated
+  `misc:0.0` PID `434835` were unchanged.
+- An immediate KuCoin authoritative timeout recovered naturally. The settled
+  smoke was `ok=true` with zero hard failures, `220/222` remote and `43/43`
+  account-critical calls successful, six fill refreshes successful, all three
+  observed HSL replays complete, and five exact processes in state `R`.
+- Eleven natural durable `entry.initial_distance_gate_blocked` events produced
+  three console representatives (one each on Binance, GateIO, and OKX), with
+  eight structured events suppressed; `active_max=4` and `suppressed_max=3`.
+  The next slice consolidates duplicate startup lifecycle console ownership.
+
+## Previous Canonical Deployment (PR #1261)
 
 - PR #1261 merged to `master` as
   `452bd621424def1e626e5fa73b551b52ef1b2773`. It compacts the startup HSL

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -779,7 +779,7 @@ class EventRoute:
 DEFAULT_ROUTE = EventRoute(structured=True, monitor=True, console=False, text=False)
 DEFAULT_ROUTES: dict[str, EventRoute] = {
     EventTypes.BOT_STARTED: EventRoute(console=True, text=True),
-    EventTypes.BOT_READY: EventRoute(console=True, text=True),
+    EventTypes.BOT_READY: EventRoute(),
     EventTypes.BOT_STARTUP_TIMING: EventRoute(console=True, text=True),
     EventTypes.BOT_STOPPING: EventRoute(console=True, text=True),
     EventTypes.BOT_SHUTDOWN_STAGE: EventRoute(console=True, text=True),

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -3102,7 +3102,8 @@ class Passivbot:
         Passivbot._startup_timing_begin(self)
         self._log_startup_banner()
         self._bot_ready = False
-        logging.info("[boot] starting bot %s...", self.exchange)
+        if not Passivbot._live_event_console_available(self):
+            logging.info("[boot] starting bot %s...", self.exchange)
         boot_stage = "start"
         try:
             live_event_debug_profiles = list(
@@ -3235,22 +3236,12 @@ class Passivbot:
                 )
                 return
             self._log_memory_snapshot()
-            logging.info("[boot] starting data maintainers...")
+            logging.debug("[boot] starting data maintainers...")
             boot_stage = "start_data_maintainers"
             await self.start_data_maintainers()
             boot_stage = "start_background_candle_warmup"
             await self.start_background_candle_warmup()
 
-            logging.info("[boot] starting execution loop...")
-            logging.info(
-                "[boot] ══════════════════════════════════════════════════════════════════════"
-            )
-            logging.info(
-                "[boot] READY - Bot initialization complete, entering main trading loop"
-            )
-            logging.info(
-                "[boot] ══════════════════════════════════════════════════════════════════════"
-            )
             Passivbot._startup_timing_mark(self, "startup")
             self._bot_ready = True
             ready_ts = utc_ms()
@@ -4396,7 +4387,7 @@ class Passivbot:
         if max_jitter > 0 and not skip_jitter:
             jitter = random.uniform(0, max_jitter)
             if jitter > 5:
-                logging.info(
+                logging.debug(
                     "[boot] warmup jitter: waiting %.1fs before starting (max=%.0fs)...",
                     jitter,
                     max_jitter,
@@ -4410,11 +4401,11 @@ class Passivbot:
                     )
                     waited += sleep_chunk
                     if waited < jitter:
-                        logging.info(
+                        logging.debug(
                             "[boot] warmup jitter: %.0fs remaining...", jitter - waited
                         )
             else:
-                logging.info(
+                logging.debug(
                     "[boot] warmup jitter: sleeping %.1fs (max=%.0fs)",
                     jitter,
                     max_jitter,
@@ -4781,16 +4772,16 @@ class Passivbot:
     async def _background_candle_warmup_task(self) -> None:
         """Broad approved-coin warmup after bot startup; best-effort and cancellable."""
         try:
-            logging.info("[boot] background candle warmup starting")
+            logging.debug("[candle] background warmup starting")
             await self.warmup_candles_staggered(context="background warmup")
-            logging.info("[boot] background candle warmup complete")
+            logging.debug("[candle] background warmup complete")
             Passivbot._startup_timing_mark(self, "full-warmup")
         except asyncio.CancelledError:
             logging.debug("[shutdown] background candle warmup cancelled")
             raise
         except Exception as exc:
             logging.error(
-                "[boot] background candle warmup failed: %s", exc, exc_info=True
+                "[candle] background warmup failed: %s", exc, exc_info=True
             )
 
     async def start_background_candle_warmup(self) -> None:

--- a/tests/test_live_candle_budget.py
+++ b/tests/test_live_candle_budget.py
@@ -2165,7 +2165,13 @@ async def test_newly_normal_forager_warmup_trigger_is_debug_only(monkeypatch, ca
 
 
 @pytest.mark.asyncio
-async def test_warmup_candles_force_cold_startup_fetches_cached_symbol(monkeypatch):
+@pytest.mark.parametrize(
+    ("jitter", "expected_fragments"),
+    [(3.0, ("sleeping",)), (12.0, ("waiting", "remaining"))],
+)
+async def test_warmup_candles_force_cold_startup_fetches_cached_symbol(
+    monkeypatch, caplog, jitter, expected_fragments
+):
     import passivbot as pb_mod
 
     now_ms = 120 * 60_000
@@ -2221,7 +2227,12 @@ async def test_warmup_candles_force_cold_startup_fetches_cached_symbol(monkeypat
             return []
 
     class FakeBot:
-        config = {"live": {"force_cold_startup": True}}
+        config = {
+            "live": {
+                "force_cold_startup": True,
+                "warmup_jitter_seconds": 30.0,
+            }
+        }
         exchange = "bybit"
         user = "test_user"
         approved_coins_minus_ignored_coins = {"long": set(), "short": set()}
@@ -2253,15 +2264,23 @@ async def test_warmup_candles_force_cold_startup_fetches_cached_symbol(monkeypat
         async def rebuild_required_candle_indices(self, *args, **kwargs):
             return None
 
+    monkeypatch.setattr(pb_mod.random, "uniform", lambda *_args: jitter)
     bot = FakeBot()
-    await pb_mod.Passivbot.warmup_candles_staggered(
-        bot,
-        symbols_override=["CACHED/USDT:USDT"],
-        skip_jitter=True,
-        context="trading-ready warmup",
-    )
+    with caplog.at_level(logging.DEBUG):
+        await pb_mod.Passivbot.warmup_candles_staggered(
+            bot,
+            symbols_override=["CACHED/USDT:USDT"],
+            context="trading-ready warmup",
+        )
 
     assert [symbol for symbol, _ in bot.cm.calls] == ["CACHED/USDT:USDT"]
+    jitter_records = [record for record in caplog.records if "warmup jitter" in record.message]
+    assert all(record.levelno == logging.DEBUG for record in jitter_records)
+    assert len(jitter_records) == len(expected_fragments)
+    assert all(
+        any(fragment in record.message for record in jitter_records)
+        for fragment in expected_fragments
+    )
 
 
 @pytest.mark.asyncio
@@ -2292,6 +2311,56 @@ async def test_background_candle_warmup_is_scheduled_not_awaited():
     assert not task.done()
     bot.release.set()
     await task
+
+
+@pytest.mark.asyncio
+async def test_background_candle_warmup_success_is_debug_and_keeps_timing_mark(caplog):
+    import passivbot as pb_mod
+
+    class FakeBot:
+        live_event_console_enabled = True
+        _live_event_pipeline = object()
+
+        def __init__(self):
+            self.events = []
+
+        async def warmup_candles_staggered(self, **kwargs):
+            assert kwargs == {"context": "background warmup"}
+
+        def _emit_live_event(self, event_type, **kwargs):
+            self.events.append((event_type, kwargs))
+
+    bot = FakeBot()
+
+    with caplog.at_level(logging.DEBUG):
+        await pb_mod.Passivbot._background_candle_warmup_task(bot)
+
+    records = [record for record in caplog.records if "background warmup" in record.message]
+    assert [record.levelno for record in records] == [logging.DEBUG, logging.DEBUG]
+    assert [record.message for record in records] == [
+        "[candle] background warmup starting",
+        "[candle] background warmup complete",
+    ]
+    assert bot.events[0][0] == EventTypes.BOT_STARTUP_TIMING
+    assert bot.events[0][1]["level"] == "info"
+    assert bot.events[0][1]["data"]["phase"] == "full-warmup"
+
+
+@pytest.mark.asyncio
+async def test_background_candle_warmup_failure_remains_error(caplog):
+    import passivbot as pb_mod
+
+    class FakeBot:
+        async def warmup_candles_staggered(self, **kwargs):
+            raise RuntimeError("warmup failed")
+
+    with caplog.at_level(logging.DEBUG):
+        await pb_mod.Passivbot._background_candle_warmup_task(FakeBot())
+
+    records = [record for record in caplog.records if "background warmup failed" in record.message]
+    assert len(records) == 1
+    assert records[0].levelno == logging.ERROR
+    assert records[0].message == "[candle] background warmup failed: warmup failed"
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_event_bus.py
+++ b/tests/test_live_event_bus.py
@@ -383,6 +383,12 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.RISK_MODE_CHANGED].text is True
     assert DEFAULT_ROUTES[EventTypes.HSL_TRANSITION].console is True
     assert DEFAULT_ROUTES[EventTypes.HSL_TRANSITION].text is True
+    assert DEFAULT_ROUTES[EventTypes.BOT_STARTED].console is True
+    assert DEFAULT_ROUTES[EventTypes.BOT_STARTED].text is True
+    assert DEFAULT_ROUTES[EventTypes.BOT_READY].structured is True
+    assert DEFAULT_ROUTES[EventTypes.BOT_READY].monitor is True
+    assert DEFAULT_ROUTES[EventTypes.BOT_READY].console is False
+    assert DEFAULT_ROUTES[EventTypes.BOT_READY].text is False
     assert DEFAULT_ROUTES[EventTypes.BOT_STARTUP_TIMING].console is True
     assert DEFAULT_ROUTES[EventTypes.BOT_STARTUP_TIMING].text is True
     assert DEFAULT_ROUTES[EventTypes.BOT_SHUTDOWN_STAGE].console is True
@@ -407,6 +413,28 @@ def test_route_table_keeps_data_events_off_console_by_default():
     assert DEFAULT_ROUTES[EventTypes.UNSTUCK_SELECTION].text is True
     assert DEFAULT_ROUTES[EventTypes.REALIZED_LOSS_GATE_BLOCKED].console is True
     assert DEFAULT_ROUTES[EventTypes.REALIZED_LOSS_GATE_BLOCKED].text is True
+
+
+def test_bot_ready_remains_durable_when_human_sinks_are_suppressed():
+    structured = ListEventSink()
+    monitor = ListEventSink()
+    console = ListEventSink()
+    text = ListEventSink()
+    pipeline = LiveEventPipeline(
+        structured_sinks=[structured],
+        monitor_sinks=[monitor],
+        console_sink=console,
+        text_sink=text,
+    )
+
+    assert pipeline.emit(LiveEvent(EventTypes.BOT_READY, status="succeeded")) is not None
+    assert pipeline.flush(timeout=2.0) is True
+
+    assert [event.event_type for event in structured.events] == [EventTypes.BOT_READY]
+    assert [event.event_type for event in monitor.events] == [EventTypes.BOT_READY]
+    assert console.events == []
+    assert text.events == []
+    assert pipeline.close(timeout=2.0) is True
 
 
 def test_forager_eligibility_console_formatter_is_bounded_and_preserves_payload():

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -4978,7 +4978,13 @@ def test_order_wave_settlement_emits_confirmation_timeout_once():
 
 
 @pytest.mark.asyncio
-async def test_start_bot_records_startup_error_stop_and_early_snapshot(monkeypatch):
+@pytest.mark.parametrize(
+    ("structured_console", "expect_legacy_start"),
+    [(False, True), (True, False)],
+)
+async def test_start_bot_records_startup_error_stop_and_early_snapshot(
+    monkeypatch, caplog, structured_console, expect_legacy_start
+):
     import passivbot as pb_mod
 
     async def _noop(*args, **kwargs):
@@ -5018,6 +5024,8 @@ async def test_start_bot_records_startup_error_stop_and_early_snapshot(monkeypat
             self._log_silence_watchdog_stage = "idle"
             self._log_silence_watchdog_task = None
             self._bot_ready = False
+            self.live_event_console_enabled = structured_console
+            self._live_event_pipeline = object() if structured_console else None
 
         def _log_startup_banner(self):
             return None
@@ -5043,8 +5051,21 @@ async def test_start_bot_records_startup_error_stop_and_early_snapshot(monkeypat
 
     bot = FakeBot()
 
-    with pytest.raises(RuntimeError, match="maintainers failed"):
-        await pb_mod.Passivbot.start_bot(bot)
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(RuntimeError, match="maintainers failed"):
+            await pb_mod.Passivbot.start_bot(bot)
+
+    start_records = [
+        record for record in caplog.records if record.message.startswith("[boot] starting bot")
+    ]
+    assert bool(start_records) is expect_legacy_start
+    assert all(record.levelno == logging.INFO for record in start_records)
+    maintainer_records = [
+        record
+        for record in caplog.records
+        if record.message == "[boot] starting data maintainers..."
+    ]
+    assert [record.levelno for record in maintainer_records] == [logging.DEBUG]
 
     assert bot.snapshot_flushes
     assert bot.snapshot_flushes[0]["force"] is True


### PR DESCRIPTION
## Scope

Category: observability producer / console-text projection.

Consolidates startup lifecycle output around the existing structured event pipeline:
- retain `bot.started` as the normal start projection, with a legacy INFO fallback only when structured console projection is unavailable
- retain `bot.startup_timing` `phase=startup` as the single human-ready signal
- keep `bot.ready` durable in structured and monitor sinks while removing its duplicate console/text projection
- demote random warmup-jitter and maintainer transition detail to DEBUG
- demote successful background candle-warmup detail to `[candle]` DEBUG while keeping failure at ERROR
- remove the decorative READY banner and duplicate execution-loop startup line

Natural VPS5 evidence after PR #1262 showed 281 records across five fresh startup logs, including 78 `[boot]` records, ten decorative separators, duplicate ready signals, and eight random-jitter detail records.

## Behavior Boundary

Observability-only. This does not change waits, task scheduling/start order, exception behavior, monitor persistence, event payloads, exchange calls, Rust, order/risk logic, or trading behavior.

Expected VPS action after merge: authorized exact five-bot graceful restart plus natural startup and settled smoke validation. Preserve `misc:0.0`; do not manufacture events.

## Author Validation

- `263 passed`: `tests/test_live_event_bus.py tests/test_passivbot_monitor.py tests/test_live_candle_budget.py`
- `3 passed`: AI docs and live-event registry tests
- `python -m py_compile src/passivbot.py src/live/event_bus.py`
- `python src/tools/check_ai_docs.py`: 0 errors, one pre-existing word-count warning
- `git diff --check`
- Offline fake-live, local fake exchange only:
  `PYTHONPATH=src .../python src/tools/run_fake_live.py configs/fake_live_hsl_btc.hjson scenarios/fake_live/minimal.hjson --max-steps 2 --output-dir /private/tmp/passivbot-fake-live-1263 --log-level 1`
  - completed successfully
  - retained `[bot] started`, `startup-ready`, and `full-warmup-ready`
  - emitted no raw `starting bot`, READY banner, `starting execution loop`, or duplicate `[bot] succeeded`

## Deployment Evidence Carried From PR #1262

PR #1262 deployed at `82a56bb15445`. One exact SIGINT round stopped old PIDs `974157/974160/974161/974163/974165` naturally; new PIDs are `975507/975510/975511/975513/975515`; pane parents and `misc:0.0` PID `434835` were unchanged. The settled smoke was `ok=true`, with zero hard failures, `220/222` remote and `43/43` account-critical calls successful, six fill refreshes, all three observed HSL replays complete, and five exact processes in state `R`. Eleven durable entry-distance blocked events yielded three console representatives and eight structured-only suppressed events.

## Reviewer Focus

Please verify:
- `bot.ready` remains durable despite console/text suppression
- structured-console and legacy-start fallback ownership do not duplicate or lose start visibility
- all demotions are diagnostic-only and preserve sleeps/tasks/errors
- startup timing remains the clear human readiness signal
- tests cover route durability and DEBUG/ERROR boundaries
