### PR TITLE
Demote routine maintainer lifecycle console detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Successful maintainer cancellation summaries and hourly scheduler-jitter
+  detail now remain available at DEBUG instead of adding routine INFO lines.
+  Maintainer cancellation failures remain ERROR. Task cancellation, scheduler
+  timing, exchange calls, and trading behavior are unchanged.
+
 - Startup lifecycle output now has one normal human-ready signal: structured
   startup timing. `bot.started` keeps its structured console/text projection
   with a legacy fallback only when that projection is unavailable, while

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,9 +24,10 @@ Estimated completion:
 
 - Branch: `codex/demote-maintainer-lifecycle-detail`, based on canonical
   `e6d2461a54c9e446a3aee4ff367653aedafa8494` after PR #1263.
-- PR: pending. Slice: keep successful maintainer stop summaries and hourly
-  scheduler-jitter detail at DEBUG while preserving cancellation failures at
-  ERROR.
+- PR: #1264, `Demote routine maintainer lifecycle console detail`; semantic
+  head `714ab5bf83d24b1bce5e01e927c476b0c1294eca`. Slice: keep successful
+  maintainer stop summaries and hourly scheduler-jitter detail at DEBUG while
+  preserving cancellation failures at ERROR.
 - Triggering evidence: the exact five post-PR #1263 startup segments retained
   four empty `stopped data maintainers: {}` INFO lines and five routine hourly
   jitter INFO lines after adjacent startup detail had moved to DEBUG.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,25 +22,22 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/compact-startup-lifecycle-console`, based on canonical
-  `82a56bb15445a1effff8501aa9f66540009b8f3f` after PR #1262.
-- PR: #1263, `Compact startup lifecycle console logging`; semantic head
-  `6bee544c61ba381de56a9e6b7a138294c5ef14aa`. Slice: consolidate startup
-  console ownership: retain structured `bot.started` visibility with its
-  legacy-console fallback, use startup timing as the human-ready signal, and
-  keep durable `bot.ready` out of console/text.
-- Triggering evidence: a fresh five-file startup sample had 281 lines,
-  including 78 `[boot]` lines, 10 decorative READY separators, a duplicate
-  readiness path, and 8 random-jitter detail lines.
-- Scope: startup lifecycle routing plus DEBUG-only warmup/maintainer detail.
-  Background candle-warmup success detail is `[candle]` DEBUG; its failure
-  remains immediate ERROR.
-- Behavior boundary: observability-only; no Rust, task timing, waits, task
-  starts, exception behavior, monitor persistence, exchange behavior, or
+- Branch: `codex/demote-maintainer-lifecycle-detail`, based on canonical
+  `e6d2461a54c9e446a3aee4ff367653aedafa8494` after PR #1263.
+- PR: pending. Slice: keep successful maintainer stop summaries and hourly
+  scheduler-jitter detail at DEBUG while preserving cancellation failures at
+  ERROR.
+- Triggering evidence: the exact five post-PR #1263 startup segments retained
+  four empty `stopped data maintainers: {}` INFO lines and five routine hourly
+  jitter INFO lines after adjacent startup detail had moved to DEBUG.
+- Scope: log-level-only maintainer lifecycle projection and removal of the
+  redundant close-wrapper stop summary.
+- Behavior boundary: observability-only; no Rust, cancellation calls, task
+  timing, waits, scheduler cadence, exception behavior, exchange behavior, or
   trading behavior changes.
-- Validation: focused event-bus, startup-monitor, and candle-warmup tests, a
-  two-step offline fake-live startup smoke, Python compilation, docs and
-  generated-registry checks, and diff whitespace check.
+- Validation: focused maintainer success/failure level tests, broader startup
+  and monitor tests, Python compilation, docs checks, and diff whitespace
+  check.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
 - Expected VPS action: after merge, one authorized exact five-bot graceful
@@ -50,11 +47,21 @@ Estimated completion:
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `82a56bb15445a1effff8501aa9f66540009b8f3f`, PR #1262. The tracked checkout
+  `e6d2461a54c9e446a3aee4ff367653aedafa8494`, PR #1263. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `975507/975510/975511/975513/975515`. The exact pane parents are unchanged,
+  `977722/977725/977728/977731/977734`. The exact pane parents are unchanged,
   and unrelated `misc:0.0` PID `434835` is unchanged.
+- PR #1263 was activated with one SIGINT at `2026-07-16T07:54:15Z` to old
+  PIDs `975507/975510/975511/975513/975515`; all exited naturally by
+  `07:54:37Z`. The settled smoke was `ok=true` with zero hard, log, monitor,
+  process, or event-pipeline failures, `251/252` remote and all `37/37`
+  account-critical calls successful, seven successful fill refreshes, and five
+  exact processes in states `R=4,S=1`. One non-hard KuCoin candle timeout was
+  retained. Every bot emitted exactly one `[bot] started`, one
+  `phase=startup-ready`, zero removed lifecycle INFO lines, and a durable
+  `bot.ready` event; Hyperliquid also completed full warmup in the bounded
+  window.
 - PR #1262 merged as `82a56bb15445a1effff8501aa9f66540009b8f3f` and was
   activated with one SIGINT at `2026-07-16T06:54:33Z` to old PIDs
   `974157/974160/974161/974163/974165`; all exited naturally by `06:54:56Z`.
@@ -908,13 +915,14 @@ hard-green. PR #1260 is also merged, deployed, and naturally validated: all
 five approved-coin membership lines measured 130-150 visible characters with
 zero legacy duplicates and a hard-green settled smoke. PR #1261's compact
 startup HSL warning and PR #1262's initial-entry distance-gate admission are
-also merged, deployed, and naturally validated. The active PR #1263
-consolidates startup lifecycle console ownership: `bot.started` owns the
-structured human start signal with a legacy fallback, `bot.ready` remains
-durable structured/monitor data, startup timing owns the human ready signal,
-and routine warmup/maintainer detail moves to DEBUG while the legacy READY
-banner is removed. It does not change startup task ordering, exchange calls,
-risk, or trading behavior.
+also merged, deployed, and naturally validated. PR #1263's startup lifecycle
+console consolidation is also merged, deployed, and naturally validated:
+every bot emitted exactly one human start and ready signal, durable
+`bot.ready` remained present, and removed lifecycle INFO lines stayed absent.
+The active maintainer-detail slice demotes successful stop summaries and hourly
+scheduler jitter to DEBUG while preserving cancellation errors at ERROR. It
+does not change task cancellation, scheduler timing, exchange calls, risk, or
+trading behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -25,7 +25,7 @@ Estimated completion:
 - Branch: `codex/demote-maintainer-lifecycle-detail`, based on canonical
   `e6d2461a54c9e446a3aee4ff367653aedafa8494` after PR #1263.
 - PR: #1264, `Demote routine maintainer lifecycle console detail`; semantic
-  head `714ab5bf83d24b1bce5e01e927c476b0c1294eca`. Slice: keep successful
+  head `714ab5bf83bba93b8551e3af88a2a9e86fc70c2a`. Slice: keep successful
   maintainer stop summaries and hourly scheduler-jitter detail at DEBUG while
   preserving cancellation failures at ERROR.
 - Triggering evidence: the exact five post-PR #1263 startup segments retained

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,29 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1262)
+## Latest Canonical Deployment (PR #1263)
+
+- PR #1263 merged to `master` as
+  `e6d2461a54c9e446a3aee4ff367653aedafa8494`. It consolidates startup
+  lifecycle console ownership while retaining structured/monitor durability;
+  task ordering, waits, exchange calls, and trading behavior are unchanged.
+- VPS5 sent one SIGINT at `2026-07-16T07:54:15Z` to exact old PIDs
+  `975507/975510/975511/975513/975515`; all exited naturally by `07:54:37Z`.
+  New PIDs are `977722/977725/977728/977731/977734`; pane parents and unrelated
+  `misc:0.0` PID `434835` were unchanged.
+- The settled two-minute smoke was `ok=true` with zero hard, log, monitor,
+  process, or event-pipeline failures, `251/252` remote and all `37/37`
+  account-critical calls successful, seven successful fill refreshes, five
+  matching/config-valid processes in states `R=4,S=1`, and a clean tracked
+  checkout. One non-hard KuCoin candle timeout was retained.
+- Every bot naturally emitted exactly one `[bot] started`, one retained
+  `phase=startup-ready`, zero removed lifecycle INFO lines, and a durable
+  `bot.ready` event. Hyperliquid also completed full warmup without the demoted
+  success/jitter detail. The same exact startup segments retained four empty
+  maintainer-stop summaries and five hourly scheduler-jitter INFO lines; the
+  next slice demotes only that routine detail.
+
+## Previous Canonical Deployment (PR #1262)
 
 - PR #1262 merged to `master` as
   `82a56bb15445a1effff8501aa9f66540009b8f3f`. It keeps every initial-entry

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -7695,9 +7695,9 @@ class Passivbot:
                     logging.error(f"error stopping WS_ohlcvs_1m_tasks {key} {e}")
             if res0s:
                 if verbose:
-                    logging.info(f"stopped ohlcvs watcher tasks {res0s}")
+                    logging.debug(f"stopped ohlcvs watcher tasks {res0s}")
         if verbose:
-            logging.info(f"stopped data maintainers: {res}")
+            logging.debug(f"stopped data maintainers: {res}")
         return res
 
     def has_position(self, pside=None, symbol=None):
@@ -17899,7 +17899,7 @@ class Passivbot:
         # Random jitter (0–120s) so multiple bots on the same VPS don't fire
         # init_markets simultaneously and blow through IP-based rate limits.
         jitter_s = random.uniform(0, 120)
-        logging.info("[hourly] starting maintenance cycle (jitter=%.1fs)", jitter_s)
+        logging.debug("[hourly] starting maintenance cycle (jitter=%.1fs)", jitter_s)
         while not self.stop_signal_received:
             try:
                 now = utc_ms()
@@ -18299,7 +18299,7 @@ class Passivbot:
 
     async def close(self):
         """Stop background tasks and close exchange clients."""
-        logging.info(f"Stopped data maintainers: {self.stop_data_maintainers()}")
+        self.stop_data_maintainers()
         await self.cca.close()
         if self.ccp is not None:
             await self.ccp.close()

--- a/tests/test_maintainer_logging.py
+++ b/tests/test_maintainer_logging.py
@@ -19,6 +19,14 @@ class _FailingTask:
         raise RuntimeError("cancel failed")
 
 
+class _AsyncClient:
+    def __init__(self, calls):
+        self.calls = calls
+
+    async def close(self):
+        self.calls.append("cca")
+
+
 def test_stop_data_maintainers_keeps_success_detail_at_debug(caplog):
     bot = SimpleNamespace(
         maintainers={"hourly": _Task()},
@@ -43,6 +51,29 @@ def test_stop_data_maintainers_keeps_cancellation_failures_at_error(caplog):
     assert result == {}
     assert "error stopping maintainer hourly cancel failed" in caplog.text
     assert any(record.levelno == logging.ERROR for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_close_stops_maintainers_once_without_duplicate_info(caplog):
+    calls = []
+
+    def stop_data_maintainers():
+        calls.append("stop")
+        return {"hourly": True}
+
+    bot = SimpleNamespace(
+        stop_data_maintainers=stop_data_maintainers,
+        cca=_AsyncClient(calls),
+        ccp=None,
+        _close_live_event_pipeline=lambda timeout: calls.append(("pipeline", timeout)),
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        await Passivbot.close(bot)
+
+    assert calls == ["stop", "cca", ("pipeline", 2.0)]
+    assert "stopped data maintainers" not in caplog.text
+    assert not [record for record in caplog.records if record.levelno == logging.INFO]
 
 
 @pytest.mark.asyncio

--- a/tests/test_maintainer_logging.py
+++ b/tests/test_maintainer_logging.py
@@ -1,0 +1,57 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from passivbot import Passivbot
+
+
+class _Task:
+    def __init__(self, result=True):
+        self.result = result
+
+    def cancel(self):
+        return self.result
+
+
+class _FailingTask:
+    def cancel(self):
+        raise RuntimeError("cancel failed")
+
+
+def test_stop_data_maintainers_keeps_success_detail_at_debug(caplog):
+    bot = SimpleNamespace(
+        maintainers={"hourly": _Task()},
+        WS_ohlcvs_1m_tasks={"BTC": _Task(False)},
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        result = Passivbot.stop_data_maintainers(bot)
+
+    assert result == {"hourly": True}
+    assert "stopped data maintainers: {'hourly': True}" in caplog.text
+    assert "stopped ohlcvs watcher tasks {'BTC': False}" in caplog.text
+    assert not [record for record in caplog.records if record.levelno == logging.INFO]
+
+
+def test_stop_data_maintainers_keeps_cancellation_failures_at_error(caplog):
+    bot = SimpleNamespace(maintainers={"hourly": _FailingTask()})
+
+    with caplog.at_level(logging.DEBUG):
+        result = Passivbot.stop_data_maintainers(bot)
+
+    assert result == {}
+    assert "error stopping maintainer hourly cancel failed" in caplog.text
+    assert any(record.levelno == logging.ERROR for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_hourly_maintenance_jitter_is_debug_only(caplog, monkeypatch):
+    bot = SimpleNamespace(stop_signal_received=True)
+    monkeypatch.setattr("passivbot.random.uniform", lambda _start, _end: 42.0)
+
+    with caplog.at_level(logging.DEBUG):
+        await Passivbot.maintain_hourly_cycle(bot)
+
+    assert "[hourly] starting maintenance cycle (jitter=42.0s)" in caplog.text
+    assert not [record for record in caplog.records if record.levelno == logging.INFO]


### PR DESCRIPTION
## Scope

Category: observability / console-text projection.

Keeps routine maintainer lifecycle detail available at DEBUG instead of normal INFO:
- successful data-maintainer and legacy OHLCV watcher cancellation summaries move from INFO to DEBUG
- hourly maintenance scheduler-jitter detail moves from INFO to DEBUG
- the close wrapper no longer emits a second successful stop summary
- cancellation failures remain ERROR

Natural VPS5 evidence after PR #1263 showed four empty `stopped data maintainers: {}` INFO lines and five hourly scheduler-jitter INFO lines across the exact five fresh startup segments.

## Behavior Boundary

Observability-only. This does not change cancellation calls or return values, task scheduling, jitter values, sleeps, scheduler cadence, exception handling, exchange calls, Rust, order/risk logic, or trading behavior. Boot stagger remains INFO because it explains a real pre-init delay.

Expected VPS action after merge: authorized exact five-bot graceful restart plus natural startup and settled smoke validation. Preserve `misc:0.0`; do not manufacture events.

## Author Validation

- 3 focused maintainer logging tests passed
- 266 event-bus/startup/monitor/candle-budget tests passed
- 137 AI-doc, event-registry, and HSL coin-mode tests passed
- `python -m py_compile src/passivbot.py tests/test_maintainer_logging.py`
- `python src/tools/check_ai_docs.py`: 0 errors, one pre-existing word-count warning
- generated live-event registry check current
- added-line silent-handling scan clean
- `git diff --check`
- Offline fake-live, local fake exchange only:
  `PYTHONPATH=src .../python src/tools/run_fake_live.py configs/fake_live_hsl_btc.hjson scenarios/fake_live/minimal.hjson --max-steps 2 --output-dir /private/tmp/passivbot-fake-live-maintainer-detail --log-level 1`
  - completed two steps successfully
  - retained normal startup timing and lifecycle output
  - emitted no hourly scheduler-jitter INFO line

## Deployment Evidence Carried From PR #1263

PR #1263 deployed at `e6d2461a54c9e446a3aee4ff367653aedafa8494`. One exact SIGINT round at `2026-07-16T07:54:15Z` stopped old PIDs `975507/975510/975511/975513/975515` naturally by `07:54:37Z`; new PIDs are `977722/977725/977728/977731/977734`; pane parents and `misc:0.0` PID `434835` were unchanged.

The settled smoke was `ok=true` with zero hard/log/monitor/process/pipeline failures, `251/252` remote and all `37/37` account-critical calls successful, seven successful fill refreshes, and five matching/config-valid processes in states `R=4,S=1`. One non-hard KuCoin candle timeout was retained. Every bot emitted exactly one `[bot] started`, one `phase=startup-ready`, zero removed lifecycle INFO lines, and a durable `bot.ready` event; Hyperliquid also completed full warmup.

## Reviewer Focus

Please verify:
- only successful routine detail is demoted
- cancellation failures remain ERROR
- cancellation/task/scheduler behavior is unchanged
- the close wrapper still invokes maintainer cancellation exactly once
- tests pin the intended INFO/DEBUG/ERROR boundary