### PR TITLE
Add read-only historical log secret inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- A new read-only `log-secret-inventory` tool scans bounded current and rotated
+  text-log input for secret-like artifact classes without returning matched
+  values or source lines. Reports contain only aggregate class counts, bounded
+  root-relative file identity, age, size, scan status, and stable hashes. The
+  tool never rewrites, deletes, quarantines, copies, or uploads log artifacts.
+
 - Successful maintainer cancellation summaries and hourly scheduler-jitter
   detail now remain available at DEBUG instead of adding routine INFO lines.
   Maintainer cancellation failures remain ERROR. Task cancellation, scheduler

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -928,10 +928,11 @@ also merged, deployed, and naturally validated. PR #1263's startup lifecycle
 console consolidation is also merged, deployed, and naturally validated:
 every bot emitted exactly one human start and ready signal, durable
 `bot.ready` remained present, and removed lifecycle INFO lines stayed absent.
-The active maintainer-detail slice demotes successful stop summaries and hourly
-scheduler jitter to DEBUG while preserving cancellation errors at ERROR. It
-does not change task cancellation, scheduler timing, exchange calls, risk, or
-trading behavior.
+PR #1264's maintainer-detail demotion is also merged, deployed, and naturally
+validated: successful stop summaries and hourly scheduler jitter remain at
+DEBUG while cancellation errors remain at ERROR. The active PR #1265 slice
+adds only bounded, value-free historical secret-log inventory; artifact
+remediation remains separate and requires explicit operator approval.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,37 +22,44 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/demote-maintainer-lifecycle-detail`, based on canonical
-  `e6d2461a54c9e446a3aee4ff367653aedafa8494` after PR #1263.
-- PR: #1264, `Demote routine maintainer lifecycle console detail`; semantic
-  head `714ab5bf83bba93b8551e3af88a2a9e86fc70c2a`. Slice: keep successful
-  maintainer stop summaries and hourly scheduler-jitter detail at DEBUG while
-  preserving cancellation failures at ERROR.
-- Triggering evidence: the exact five post-PR #1263 startup segments retained
-  four empty `stopped data maintainers: {}` INFO lines and five routine hourly
-  jitter INFO lines after adjacent startup detail had moved to DEBUG.
-- Scope: log-level-only maintainer lifecycle projection and removal of the
-  redundant close-wrapper stop summary.
-- Behavior boundary: observability-only; no Rust, cancellation calls, task
-  timing, waits, scheduler cadence, exception behavior, exchange behavior, or
-  trading behavior changes.
-- Validation: focused maintainer success/failure level tests, broader startup
-  and monitor tests, Python compilation, docs checks, and diff whitespace
-  check.
+- Branch: `codex/log-secret-inventory`, based on canonical
+  `8e55f3642841b0730afc7e7b2b73632a8e7d8071` after PR #1264.
+- PR: pending. Slice: add the non-destructive inventory half of backlog item
+  #21 for historical secret-bearing text logs.
+- Triggering evidence: a 2026-07-15 read-only audit confirmed retained old logs
+  contain private websocket credentials and raw exchange error bodies, while a
+  bounded sample of current canonical logs was clean.
+- Scope: a bounded text/gzip scanner and value-free JSON CLI reporting only
+  secret-class counts, root-relative file identity, age, size, scan status, and
+  stable hashes.
+- Behavior boundary: read-only local tooling; no raw match values or lines, log
+  mutation, quarantine, deletion, copy/upload, exchange access, bot process
+  changes, Rust, risk, order, or trading behavior.
+- Validation: class and benign-lookalike fixtures, serialized-output leakage
+  assertions, stable ordering/hashes, gzip and scan-bound coverage, CLI tests,
+  Python compilation, docs checks, and a VPS5 dry-run inventory.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: after merge, one authorized exact five-bot graceful
-  restart and natural startup observation only; do not manufacture trading,
-  risk, lock, or state events.
+- Expected VPS action: pull and run a bounded read-only inventory only; no bot
+  restart and no artifact remediation without separate operator approval.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `e6d2461a54c9e446a3aee4ff367653aedafa8494`, PR #1263. The tracked checkout
+  `8e55f3642841b0730afc7e7b2b73632a8e7d8071`, PR #1264. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
-  `977722/977725/977728/977731/977734`. The exact pane parents are unchanged,
+  `979190/979193/979196/979199/979202`. The exact pane parents are unchanged,
   and unrelated `misc:0.0` PID `434835` is unchanged.
+- PR #1264 was activated with one SIGINT at `2026-07-16T08:34:29Z` to old
+  PIDs `977722/977725/977728/977731/977734`; all exited naturally within 23
+  seconds. The settled two-minute smoke was `ok=true` with zero hard, log,
+  monitor, process, or event-pipeline failures, `281/281` remote and `28/28`
+  account-critical calls successful, six successful fill refreshes, and five
+  exact processes in state `R`. All five fresh logs contained zero INFO
+  matches for successful maintainer-stop, OHLCV-watcher-stop, or hourly-jitter
+  detail. No cancellation failure occurred naturally, and none was
+  manufactured.
 - PR #1263 was activated with one SIGINT at `2026-07-16T07:54:15Z` to old
   PIDs `975507/975510/975511/975513/975515`; all exited naturally by
   `07:54:37Z`. The settled smoke was `ok=true` with zero hard, log, monitor,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,8 +24,9 @@ Estimated completion:
 
 - Branch: `codex/log-secret-inventory`, based on canonical
   `8e55f3642841b0730afc7e7b2b73632a8e7d8071` after PR #1264.
-- PR: pending. Slice: add the non-destructive inventory half of backlog item
-  #21 for historical secret-bearing text logs.
+- PR: #1265, `Add read-only historical log secret inventory`; semantic head
+  `6340b87e021882929f998b4df8ee198e60231461`. Slice: add the non-destructive
+  inventory half of backlog item #21 for historical secret-bearing text logs.
 - Triggering evidence: a 2026-07-15 read-only audit confirmed retained old logs
   contain private websocket credentials and raw exchange error bodies, while a
   bounded sample of current canonical logs was clean.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,30 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1263)
+## Latest Canonical Deployment (PR #1264)
+
+- PR #1264 merged to `master` as
+  `8e55f3642841b0730afc7e7b2b73632a8e7d8071`. It keeps successful maintainer
+  stop and hourly scheduler-jitter detail at DEBUG while retaining
+  cancellation failures at ERROR; cancellation, scheduler, exchange, and
+  trading behavior are unchanged.
+- VPS5 sent one SIGINT at `2026-07-16T08:34:29Z` to exact old PIDs
+  `977722/977725/977728/977731/977734`; all exited naturally within 23 seconds.
+  New PIDs are `979190/979193/979196/979199/979202`; pane parents and unrelated
+  `misc:0.0` PID `434835` were unchanged.
+- The settled two-minute smoke was `ok=true` with zero hard, log, monitor,
+  process, or event-pipeline failures, `281/281` remote and all `28/28`
+  account-critical calls successful, six successful fill refreshes, five
+  matching/config-valid processes in state `R`, and a clean tracked checkout.
+- The five fresh logs contained zero INFO matches for successful maintainer
+  stop, OHLCV-watcher stop, or hourly scheduler-jitter detail. No cancellation
+  error occurred naturally, and none was manufactured. A short console audit
+  found no justified follow-up demotion: HSL replay progress and slow staged
+  refreshes already follow deliberate admission contracts, while websocket
+  aggregation needs a longer incident sample. The next substantive slice is
+  the non-destructive historical secret-log inventory from backlog item #21.
+
+## Previous Canonical Deployment (PR #1263)
 
 - PR #1263 merged to `master` as
   `e6d2461a54c9e446a3aee4ff367653aedafa8494`. It consolidates startup

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -1011,7 +1011,10 @@ Related detailed plans:
     for unsupported or malformed breakdowns.
 
 21. [ ] Historical secret-bearing text-log inventory and remediation.
-    Status: open. A read-only VPS5 console-length audit on 2026-07-15
+    Status: partial. The active `codex/log-secret-inventory` slice adds only the
+    bounded, value-free, read-only inventory and dry-run validation contract.
+    Quarantine or purge remains separate and requires explicit operator
+    approval. A read-only VPS5 console-length audit on 2026-07-15
     accidentally admitted old untimestamped traceback fragments and confirmed
     that retained May text logs include raw private websocket URLs/tokens and
     full exchange error bodies. Current recent-window producers and smoke paths

--- a/src/live/log_secret_inventory.py
+++ b/src/live/log_secret_inventory.py
@@ -1,0 +1,242 @@
+"""Bounded, value-free inventory of secret-like material in retained logs."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import re
+import time
+from collections import Counter
+from pathlib import Path
+from typing import BinaryIO
+
+
+DEFAULT_MAX_FILES = 200
+DEFAULT_MAX_BYTES_PER_FILE = 1_000_000
+
+SECRET_CLASSES = (
+    "private_websocket_query_credentials",
+    "authorization_cookie_headers",
+    "labeled_secret_values",
+    "bearer_basic_schemes",
+    "pem_private_keys",
+    "secret_url_query_params",
+    "raw_http_body_html_markers",
+)
+
+_PRIVATE_WEBSOCKET_QUERY_RE = re.compile(
+    r"\bwss?://[^\s\"'<>]*[?&](?:api[_-]?key|api[_-]?secret|token|signature|"
+    r"password|passphrase|secret)=(?!\[redacted\](?:[&#\s]|$))[^\s\"'<>&#]+",
+    re.IGNORECASE,
+)
+_HEADER_RE = re.compile(
+    r'^\s*[\"\']?(?:authorization|proxy-authorization|x-mbx-apikey|cookie|set-cookie)'
+    r'[\"\']?\s*:\s*(?P<value>[^\r\n]+)',
+    re.IGNORECASE | re.MULTILINE,
+)
+_LABELED_SECRET_RE = re.compile(
+    r"(?<![A-Za-z0-9_?&-])[\"']?"
+    r"(?P<label>api[_ -]?key|api[_ -]?secret|token|signature|password|"
+    r"passphrase|private[_ -]?key)[\"']?\s*[:=]\s*"
+    r"(?P<value>\[redacted\]|\"[^\"\r\n]*\"|'[^'\r\n]*'|[^\s,;&}\]\r\n]+)",
+    re.IGNORECASE,
+)
+_BEARER_BASIC_RE = re.compile(
+    r"\b(?:bearer|basic)\s+(?!\[redacted\](?:\s|$))[^\s,;\"']+", re.IGNORECASE
+)
+_PEM_PRIVATE_KEY_RE = re.compile(
+    r"-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----", re.IGNORECASE
+)
+_SECRET_URL_QUERY_RE = re.compile(
+    r"\b(?:https?|wss?)://[^\s\"'<>]*[?&](?:api[_-]?key|api[_-]?secret|token|"
+    r"signature|password|passphrase|secret)=(?!\[redacted\](?:[&#\s]|$))[^\s\"'<>&#]+",
+    re.IGNORECASE,
+)
+_RAW_HTTP_BODY_HTML_RE = re.compile(
+    r"\b(?:request|response)\s+body\s*[:=]\s*(?=\S)|"
+    r"\braw[_ -]?body\s*[:=]\s*(?=\S)|<!doctype\s+html|<html\b|<body\b",
+    re.IGNORECASE,
+)
+
+
+def _is_redacted(value: str) -> bool:
+    return value.lstrip(" \t\"'").lower().startswith("[redacted]")
+
+
+def _is_fully_redacted(value: str) -> bool:
+    if _is_redacted(value):
+        return True
+    remainder = re.sub(r"\[redacted\]", "", value, flags=re.IGNORECASE)
+    remainder = re.sub(
+        r"(?i)\b(?:bearer|basic|api[_ -]?key|apikey)\b", "", remainder
+    )
+    remainder = re.sub(r"[A-Za-z0-9_.-]+\s*=", "", remainder)
+    return re.search(r"[A-Za-z0-9]", remainder) is None
+
+
+def _is_benign_label(label: str, value: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]+", "", label.lower())
+    if normalized.endswith(("count", "counts", "length", "len", "present", "enabled")):
+        return True
+    return _is_fully_redacted(value)
+
+
+def classify_secret_like_text(text: str) -> dict[str, int]:
+    """Return classification counts without retaining any matched source values."""
+    counts = Counter({name: 0 for name in SECRET_CLASSES})
+    counts["private_websocket_query_credentials"] = len(_PRIVATE_WEBSOCKET_QUERY_RE.findall(text))
+    counts["authorization_cookie_headers"] = sum(
+        1
+        for match in _HEADER_RE.finditer(text)
+        if not _is_fully_redacted(match.group("value"))
+    )
+    counts["bearer_basic_schemes"] = len(_BEARER_BASIC_RE.findall(text))
+    counts["pem_private_keys"] = len(_PEM_PRIVATE_KEY_RE.findall(text))
+    counts["secret_url_query_params"] = len(_SECRET_URL_QUERY_RE.findall(text))
+    counts["raw_http_body_html_markers"] = len(_RAW_HTTP_BODY_HTML_RE.findall(text))
+    counts["labeled_secret_values"] = sum(
+        1
+        for match in _LABELED_SECRET_RE.finditer(text)
+        if not _is_benign_label(match.group("label"), match.group("value"))
+    )
+    return dict(counts)
+
+
+def _normalized_error_type(exc: BaseException) -> str:
+    """Expose only a bounded type, never exception text or a source path."""
+    if isinstance(exc, PermissionError):
+        return "PermissionError"
+    if isinstance(exc, FileNotFoundError):
+        return "FileNotFoundError"
+    if isinstance(exc, gzip.BadGzipFile):
+        return "BadGzipFile"
+    if isinstance(exc, EOFError):
+        return "EOFError"
+    if isinstance(exc, UnicodeError):
+        return "UnicodeError"
+    return "OSError"
+
+
+def _open_log(path: Path) -> BinaryIO:
+    if path.name.lower().endswith(".gz"):
+        return gzip.open(path, "rb")
+    return path.open("rb")
+
+
+def _scan_file(path: Path, relative_path: str, *, max_bytes_per_file: int, now_s: int) -> dict:
+    try:
+        stat = path.stat()
+    except OSError as exc:
+        return {
+            "path": relative_path,
+            "status": "unreadable",
+            "error_type": _normalized_error_type(exc),
+            "class_counts": {name: 0 for name in SECRET_CLASSES},
+        }
+
+    summary = {
+        "path": relative_path,
+        "status": "scanned",
+        "size_bytes": int(stat.st_size),
+        "mtime_epoch_s": int(stat.st_mtime),
+        "age_seconds": max(0, int(now_s - stat.st_mtime)),
+        "compressed": path.name.lower().endswith(".gz"),
+        "bytes_scanned": 0,
+        "truncated": False,
+        "sha256": None,
+        "sha256_scope": None,
+        "class_counts": {name: 0 for name in SECRET_CLASSES},
+    }
+    try:
+        with _open_log(path) as stream:
+            data = stream.read(max_bytes_per_file + 1)
+    except (OSError, EOFError, UnicodeError) as exc:
+        summary.update(
+            {
+                "status": "unreadable",
+                "error_type": _normalized_error_type(exc),
+                "class_counts": {name: 0 for name in SECRET_CLASSES},
+            }
+        )
+        return summary
+
+    summary["truncated"] = len(data) > max_bytes_per_file
+    data = data[:max_bytes_per_file]
+    summary["bytes_scanned"] = len(data)
+    summary["sha256"] = hashlib.sha256(data).hexdigest()
+    if summary["compressed"]:
+        summary["sha256_scope"] = (
+            "decompressed_content_prefix"
+            if summary["truncated"]
+            else "decompressed_content"
+        )
+    else:
+        summary["sha256_scope"] = "content_prefix" if summary["truncated"] else "full_content"
+    summary["class_counts"] = classify_secret_like_text(data.decode("utf-8", errors="replace"))
+    return summary
+
+
+def _iter_regular_files(root: Path) -> tuple[list[tuple[str, Path]], int, int]:
+    """Discover regular files in deterministic root-relative order."""
+    entries: list[tuple[str, Path]] = []
+    discovery_errors = 0
+    symlinks_skipped = 0
+    try:
+        for path in root.rglob("*"):
+            try:
+                if path.is_symlink():
+                    symlinks_skipped += 1
+                    continue
+                if path.is_file():
+                    entries.append((path.relative_to(root).as_posix(), path))
+            except OSError:
+                discovery_errors += 1
+    except OSError:
+        discovery_errors += 1
+    entries.sort(key=lambda item: item[0])
+    return entries, discovery_errors, symlinks_skipped
+
+
+def build_log_secret_inventory(
+    logs_root: str | Path,
+    *,
+    max_files: int = DEFAULT_MAX_FILES,
+    max_bytes_per_file: int = DEFAULT_MAX_BYTES_PER_FILE,
+    now_s: int | None = None,
+) -> dict:
+    """Build an offline, bounded report without exposing source text or values."""
+    if max_files < 0:
+        raise ValueError("max_files must be non-negative")
+    if max_bytes_per_file <= 0:
+        raise ValueError("max_bytes_per_file must be positive")
+
+    root = Path(logs_root)
+    if not root.is_dir():
+        raise ValueError("logs_root must be an existing directory")
+    now = int(time.time() if now_s is None else now_s)
+    candidates, discovery_errors, symlinks_skipped = _iter_regular_files(root)
+    selected = candidates[:max_files]
+    files = [
+        _scan_file(path, relative_path, max_bytes_per_file=max_bytes_per_file, now_s=now)
+        for relative_path, path in selected
+    ]
+    class_counts = Counter({name: 0 for name in SECRET_CLASSES})
+    for file_summary in files:
+        class_counts.update(file_summary["class_counts"])
+    unreadable_files = sum(file_summary["status"] == "unreadable" for file_summary in files)
+    return {
+        "report_type": "log_secret_inventory",
+        "read_only": True,
+        "root": ".",
+        "limits": {"max_files": max_files, "max_bytes_per_file": max_bytes_per_file},
+        "summary": {
+            "files_discovered": len(candidates),
+            "files_scanned": len(files),
+            "files_skipped_max_files": max(0, len(candidates) - len(files)),
+            "files_unreadable": unreadable_files,
+            "discovery_errors": discovery_errors,
+            "symlinks_skipped": symlinks_skipped,
+        },
+        "class_counts": dict(class_counts),
+        "files": files,
+    }

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -103,6 +103,10 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "tools.live_event_query",
         "query structured live event NDJSON",
     ),
+    "log-secret-inventory": CommandSpec(
+        "tools.log_secret_inventory",
+        "read-only value-free inventory of secret-like local log material",
+    ),
     "live-incident-bundle": CommandSpec(
         "tools.live_incident_bundle",
         "collect local live incident evidence into a tarball",

--- a/src/tools/log_secret_inventory.py
+++ b/src/tools/log_secret_inventory.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[1]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from live.log_secret_inventory import (  # noqa: E402
+    DEFAULT_MAX_BYTES_PER_FILE,
+    DEFAULT_MAX_FILES,
+    build_log_secret_inventory,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="passivbot tool log-secret-inventory",
+        description="Read-only, value-free inventory of secret-like material in local logs.",
+    )
+    parser.add_argument("logs_root", nargs="?", default="logs", help="Local log directory to scan.")
+    parser.add_argument("--max-files", type=int, default=DEFAULT_MAX_FILES)
+    parser.add_argument("--max-bytes-per-file", type=int, default=DEFAULT_MAX_BYTES_PER_FILE)
+    parser.add_argument("--compact", action="store_true", help="Emit compact single-line JSON.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        report = build_log_secret_inventory(
+            args.logs_root,
+            max_files=args.max_files,
+            max_bytes_per_file=args.max_bytes_per_file,
+        )
+    except ValueError as exc:
+        print(f"passivbot tool log-secret-inventory: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_log_secret_inventory.py
+++ b/tests/test_log_secret_inventory.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import gzip
+import json
+from pathlib import Path
+
+import pytest
+
+from live.log_secret_inventory import (
+    SECRET_CLASSES,
+    build_log_secret_inventory,
+    classify_secret_like_text,
+)
+from passivbot_cli import main as cli_main
+from tools import log_secret_inventory
+
+
+def test_classifies_all_required_secret_classes_and_ignores_benign_lookalikes():
+    text = "\n".join(
+        [
+            "wss://stream.example/private?token=private-ws-token",
+            "Authorization: ApiKey header-secret",
+            "Cookie: session=cookie-secret",
+            "X-MBX-APIKEY: exchange-header-secret",
+            "Authorization: [redacted]",
+            "Authorization: ApiKey [redacted]",
+            "Cookie: session=[redacted]; other=[redacted]",
+            "api_key=key-secret",
+            '{"apiKey":"json-key-secret","token":"json-token-secret"}',
+            "api_key_count=2",
+            "token_count: 7",
+            "password: [redacted]",
+            "Bearer bearer-secret",
+            "Bearer [redacted]",
+            "Basic dXNlcjpwYXNz",
+            "-----BEGIN PRIVATE KEY-----",
+            "https://example.invalid/path?signature=query-secret",
+            "https://example.invalid/path?token=[redacted]",
+            "response body: <html><body>private response</body></html>",
+            "response body:",
+        ]
+    )
+
+    counts = classify_secret_like_text(text)
+
+    assert set(counts) == set(SECRET_CLASSES)
+    assert all(counts[name] > 0 for name in SECRET_CLASSES)
+    assert counts["labeled_secret_values"] == 3
+    assert counts["authorization_cookie_headers"] == 3
+    assert classify_secret_like_text("response body:")["raw_http_body_html_markers"] == 0
+
+
+def test_report_is_value_free_and_root_relative(tmp_path: Path):
+    secrets = (
+        "private-ws-token",
+        "header-secret",
+        "cookie-secret",
+        "key-secret",
+        "bearer-secret",
+        "query-secret",
+        "private-response-marker",
+    )
+    (tmp_path / "nested").mkdir()
+    (tmp_path / "nested" / "service.log").write_text(
+        "\n".join(
+            [
+                f"wss://stream.example/private?token={secrets[0]}",
+                f"Authorization: ApiKey {secrets[1]}",
+                f"Cookie: session={secrets[2]}",
+                f"api_key={secrets[3]}",
+                f"Bearer {secrets[4]}",
+                "-----BEGIN PRIVATE KEY-----",
+                f"https://example.invalid/path?signature={secrets[5]}",
+                f"response body: <html>{secrets[6]}</html>",
+            ]
+        )
+    )
+
+    report = build_log_secret_inventory(tmp_path, now_s=2_000_000_000)
+    serialized = json.dumps(report, sort_keys=True)
+
+    assert all(secret not in serialized for secret in secrets)
+    assert "Authorization:" not in serialized
+    assert report["root"] == "."
+    assert report["files"][0]["path"] == "nested/service.log"
+    assert report["files"][0]["class_counts"]["authorization_cookie_headers"] == 2
+    assert report["read_only"] is True
+    assert all(report["class_counts"][name] > 0 for name in SECRET_CLASSES)
+
+
+def test_order_and_prefix_hashes_are_deterministic(tmp_path: Path):
+    (tmp_path / "z.log").write_bytes(b"second")
+    (tmp_path / "a.log").write_bytes(b"first")
+
+    first = build_log_secret_inventory(tmp_path, now_s=2_000_000_000)
+    second = build_log_secret_inventory(tmp_path, now_s=2_000_000_000)
+
+    assert first == second
+    assert [item["path"] for item in first["files"]] == ["a.log", "z.log"]
+    assert len(first["files"][0]["sha256"]) == 64
+    assert first["files"][0]["sha256_scope"] == "full_content"
+
+
+def test_file_and_byte_bounds_are_explicit(tmp_path: Path):
+    (tmp_path / "a.log").write_bytes(b"Authorization: Bearer too-long")
+    (tmp_path / "b.log").write_text("token=another-secret")
+
+    report = build_log_secret_inventory(tmp_path, max_files=1, max_bytes_per_file=8, now_s=0)
+
+    assert report["summary"]["files_discovered"] == 2
+    assert report["summary"]["files_scanned"] == 1
+    assert report["summary"]["files_skipped_max_files"] == 1
+    assert report["files"][0]["bytes_scanned"] == 8
+    assert report["files"][0]["truncated"] is True
+    assert report["files"][0]["sha256_scope"] == "content_prefix"
+
+
+def test_scans_gzip_rotated_logs_with_uncompressed_byte_cap(tmp_path: Path):
+    path = tmp_path / "service.log.1.gz"
+    with gzip.open(path, "wb") as stream:
+        stream.write(b"Bearer gzip-secret\n" + b"x" * 100)
+
+    report = build_log_secret_inventory(tmp_path, max_bytes_per_file=32, now_s=0)
+
+    summary = report["files"][0]
+    assert summary["compressed"] is True
+    assert summary["truncated"] is True
+    assert summary["sha256_scope"] == "decompressed_content_prefix"
+    assert summary["class_counts"]["bearer_basic_schemes"] == 1
+
+    full_summary = build_log_secret_inventory(
+        tmp_path, max_bytes_per_file=1_000, now_s=0
+    )["files"][0]
+    assert full_summary["truncated"] is False
+    assert full_summary["sha256_scope"] == "decompressed_content"
+
+
+def test_unreadable_gzip_is_bounded_to_error_type_without_exception_text(tmp_path: Path):
+    path = tmp_path / "broken.log.gz"
+    path.write_bytes(b"not a gzip stream")
+
+    report = build_log_secret_inventory(tmp_path, now_s=0)
+    summary = report["files"][0]
+
+    assert summary["status"] == "unreadable"
+    assert summary["error_type"] == "BadGzipFile"
+    assert "not a gzip" not in json.dumps(report)
+
+
+def test_symlinked_files_are_not_followed_outside_root(tmp_path: Path):
+    outside = tmp_path.parent / "outside-secret.log"
+    outside.write_text("token=outside-secret")
+    (tmp_path / "linked.log").symlink_to(outside)
+
+    report = build_log_secret_inventory(tmp_path, now_s=0)
+
+    assert report["summary"]["files_discovered"] == 0
+    assert report["summary"]["symlinks_skipped"] == 1
+    assert "outside-secret" not in json.dumps(report)
+
+
+def test_invalid_bounds_and_root_raise_or_return_nonzero(tmp_path: Path, capsys):
+    with pytest.raises(ValueError, match="max_files"):
+        build_log_secret_inventory(tmp_path, max_files=-1)
+    with pytest.raises(ValueError, match="existing directory"):
+        build_log_secret_inventory(tmp_path / "missing")
+
+    assert log_secret_inventory.main([str(tmp_path / "missing"), "--compact"]) == 2
+    assert "existing directory" in capsys.readouterr().err
+
+
+def test_tool_compact_json_output(tmp_path: Path, capsys):
+    (tmp_path / "current.log").write_text("token=tool-secret")
+
+    assert log_secret_inventory.main([str(tmp_path), "--compact"]) == 0
+    output = capsys.readouterr().out
+
+    assert "\n" not in output.rstrip("\n")
+    assert "tool-secret" not in output
+    assert json.loads(output)["class_counts"]["labeled_secret_values"] == 1
+
+
+def test_unified_cli_dispatches_log_secret_inventory(tmp_path: Path, capsys):
+    (tmp_path / "current.log").write_text("token=cli-secret")
+
+    assert (
+        cli_main.main(
+            ["tool", "log-secret-inventory", str(tmp_path), "--compact"]
+        )
+        == 0
+    )
+    output = capsys.readouterr().out
+
+    assert "cli-secret" not in output
+    assert json.loads(output)["class_counts"]["labeled_secret_values"] == 1

--- a/tests/test_passivbot_cli.py
+++ b/tests/test_passivbot_cli.py
@@ -146,6 +146,7 @@ def test_tool_help_lists_supported_tools(capsys):
     assert "hyperliquid-position-probe" in out
     assert "inspect-ohlcvs" in out
     assert "live-event-query" in out
+    assert "log-secret-inventory" in out
     assert "merge-paretos" in out
     assert "monitor-dev" in out
     assert "monitor-relay" in out


### PR DESCRIPTION
## Scope

- Category: read-only tooling.
- Add `passivbot tool log-secret-inventory [logs_root]` for bounded current/rotated text and gzip inventory.
- Report only secret-class counts, root-relative file identity, age, size, scan status, and hash scope/digest.
- Update the logging-overhaul status, deployment ledger, backlog, and changelog.

## Non-goals and behavior

- No matched values, source lines, raw bodies, exception text, or absolute root path in output.
- No rewrite, delete, quarantine, copy, upload, exchange access, process action, Rust, risk, order, or trading behavior.
- Symlinked files are skipped. File count and decompressed bytes per file are explicitly capped.
- Remediation remains a separate operator-approved task.

## Validation

- `python -m pytest -q tests/test_log_secret_inventory.py tests/test_ai_docs.py tests/test_live_event_registry_docs.py` -> 13 passed.
- `python -m py_compile` for all touched Python modules/tests -> passed.
- `PYTHONPATH=src python src/tools/check_ai_docs.py` -> 0 errors, one pre-existing word-budget warning.
- `git diff --check` -> clean.
- Direct unified CLI help/dispatch and compact JSON leakage assertions -> passed.
- 1 MB classification timing smoke -> about 0.07 seconds locally.

The focused existing `tests/test_passivbot_cli.py` item cannot collect in the shared local venv because its pre-existing Rust extension is stale against current Rust sources. Rust is unchanged in this PR; the new lightweight unified-dispatch regression passes, and fresh Python/Rust CI is authoritative for the full matrix.

## Reviewer focus

- Verify the report cannot retain matched secret material or exception/path context beyond the documented root-relative file identity.
- Verify gzip decompression and scan bounds, redacted-value exclusions, symlink handling, and hash-scope semantics.
- Expected VPS action after merge: pull plus one bounded read-only inventory; no restart and no remediation.
