### PR TITLE
Detect secret query fragments in log inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- The read-only log secret inventory now detects credential-like query
+  parameters in scheme-less request paths and query fragments as well as full
+  URLs, without returning matched values.
+
 - Brief live smoke reports now summarize startup elapsed/phase budget status
   coverage, distinguishing unavailable and no-baseline assessments from
   within-budget phases without changing startup behavior or thresholds.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,8 +24,10 @@ Estimated completion:
 
 - Branch: `codex/log-secret-query-fragments`, based on canonical
   `4015a3b3f145d58db3e1a873ec4cc5ce465368f7` after PR #1266.
-- PR: pending. Slice: detect secret-like query parameters in scheme-less
-  request paths and query fragments in the read-only historical log inventory.
+- PR: #1267, `Detect secret query fragments in log inventory`; semantic head
+  `361ad1e6bf9de9b5c912059c17522b6ab7da52ac`. Slice: detect secret-like
+  query parameters in scheme-less request paths and query fragments in the
+  read-only historical log inventory.
 - Triggering evidence: the inventory recognizes credential parameters inside
   full HTTP/websocket URLs, but misses forms such as
   `GET /path?apiKey=[value]` because the generic labeled matcher deliberately

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,36 +22,42 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/startup-budget-coverage-summary`, based on canonical
-  `fc4a134fb7b856ea426afb750559ff7ae94c7a07` after PR #1265.
-- PR: #1266, `Expose startup budget coverage in brief reports`; semantic head
-  `cfebc940406900606d7d8852f77f4238473dcf4c`. Slice: make brief startup
-  timing reports distinguish assessed budgets from unavailable or no-baseline
-  projections.
-- Triggering evidence: `_brief_startup_timings()` counts phases over budget but
-  does not expose the existing elapsed/phase budget statuses, so
-  `over_budget_phases=0` can conceal incomplete assessment coverage.
-- Scope: aggregate the existing report-only budget status fields in the brief
-  projection and add focused local fixtures for complete, incomplete, and
-  malformed metadata.
-- Behavior boundary: read-only report projection; no runtime events, startup
-  phase logic, budget thresholds, enforcement, exchange access, bot process
-  changes, Rust, risk, order, or trading behavior.
-- Validation: focused smoke-report tests, Python compilation, docs checks, and
-  a bounded VPS5 report-only smoke after merge.
+- Branch: `codex/log-secret-query-fragments`, based on canonical
+  `4015a3b3f145d58db3e1a873ec4cc5ce465368f7` after PR #1266.
+- PR: pending. Slice: detect secret-like query parameters in scheme-less
+  request paths and query fragments in the read-only historical log inventory.
+- Triggering evidence: the inventory recognizes credential parameters inside
+  full HTTP/websocket URLs, but misses forms such as
+  `GET /path?apiKey=[value]` because the generic labeled matcher deliberately
+  excludes `?` and `&` prefixes.
+- Scope: broaden only the existing value-free query-parameter classification
+  and add focused full-URL, scheme-less, redacted, benign, and leakage tests.
+- Behavior boundary: read-only local tooling; no source values/lines, artifact
+  mutation or remediation, exchange access, bot process changes, Rust, risk,
+  order, or trading behavior.
+- Validation: focused inventory tests, Python compilation, a 1 MB classifier
+  timing smoke, docs checks, and a bounded VPS5 inventory after merge.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: pull and run a bounded read-only smoke report only; no
-  bot restart.
+- Expected VPS action: pull and run a bounded read-only inventory only; no bot
+  restart or remediation.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `fc4a134fb7b856ea426afb750559ff7ae94c7a07`, PR #1265. The tracked checkout
+  `4015a3b3f145d58db3e1a873ec4cc5ce465368f7`, PR #1266. The tracked checkout
   is clean and expected untracked artifacts are preserved.
 - VPS5 runs merged master in bot PIDs
   `979190/979193/979196/979199/979202`. The exact pane parents are unchanged,
   and unrelated `misc:0.0` PID `434835` is unchanged.
+- PR #1266 required no restart. A four-hour, current-segment-only brief report
+  scanned six monitor files and 19,163 records with zero monitor parse errors,
+  and emitted the new startup budget coverage fields. Startup timing rows had
+  already rotated out, so all coverage counts were naturally zero. The
+  section-only report retained two hard and 319 attention problem events and
+  was not represented as a green deploy-health verdict. Exact bot and
+  `misc:0.0` PIDs remained unchanged; a transient GateIO `D` sample cleared to
+  `R` after 20 seconds.
 - PR #1265 required no restart. Its bounded read-only VPS5 dry run scanned 40
   of 1,182 discovered files with a 250,000-byte decompressed cap per file,
   skipped six symlinks, and reported zero discovery or read errors. Ten
@@ -939,8 +945,10 @@ validated: successful stop summaries and hourly scheduler jitter remain at
 DEBUG while cancellation errors remain at ERROR. PR #1265's bounded,
 value-free historical secret-log inventory is also merged and deployed; its
 dry run confirmed retained credential-bearing logs without exposing values or
-changing artifacts. The active startup-budget coverage slice makes incomplete
-brief-report assessment visible without changing startup or budget behavior.
+changing artifacts. PR #1266's brief startup-budget coverage is also merged
+and deployed without restart; its bounded report emitted the new fields while
+retaining natural problem-event verdicts. The active inventory follow-up closes
+the scheme-less credential-query detection gap without remediation.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,25 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1265)
+## Latest Canonical Deployment (PR #1266)
+
+- PR #1266 merged to `master` as
+  `4015a3b3f145d58db3e1a873ec4cc5ce465368f7`. It adds existing startup
+  elapsed/phase budget status coverage to the brief smoke projection without
+  changing events, baselines, thresholds, startup, or trading behavior.
+- VPS5 fast-forwarded cleanly with no restart. A bounded four-hour
+  current-segment-only report scanned six monitor files and 19,163 records
+  with zero monitor parse errors, and emitted the new coverage fields. Startup
+  timing rows had rotated out, so their counts were naturally zero.
+- The section-only report retained two hard and 319 attention problem events
+  and was not treated as a green deploy-health verdict. Exact bot PIDs and
+  unrelated `misc:0.0` PID `434835` remained unchanged. A transient GateIO
+  `D` sample cleared to `R` after 20 seconds.
+- Static follow-up confirmed the inventory's query classifier still required
+  an HTTP/websocket scheme; the next read-only slice recognizes scheme-less
+  request paths and query fragments without retaining values.
+
+## Previous Canonical Deployment (PR #1265)
 
 - PR #1265 merged to `master` as
   `fc4a134fb7b856ea426afb750559ff7ae94c7a07`. It adds a bounded, value-free,

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -1014,9 +1014,11 @@ Related detailed plans:
     for unsupported or malformed breakdowns.
 
 21. [ ] Historical secret-bearing text-log inventory and remediation.
-    Status: partial. The active `codex/log-secret-inventory` slice adds only the
-    bounded, value-free, read-only inventory and dry-run validation contract.
-    Quarantine or purge remains separate and requires explicit operator
+    Status: partial. PR #1265 merged and deployed the bounded, value-free,
+    read-only inventory and dry-run validation contract. The active
+    `codex/log-secret-query-fragments` follow-up recognizes credential query
+    parameters in scheme-less request paths while preserving the same report
+    schema. Quarantine or purge remains separate and requires explicit operator
     approval. A read-only VPS5 console-length audit on 2026-07-15
     accidentally admitted old untimestamped traceback fragments and confirmed
     that retained May text logs include raw private websocket URLs/tokens and
@@ -1035,6 +1037,13 @@ Related detailed plans:
     that preserves the minimum forensic metadata required for incident review.
     Do not rewrite, delete, rotate, upload, or copy existing VPS artifacts
     without explicit authorization.
+
+    Work log:
+    - 2026-07-16: PR #1265's bounded VPS5 dry run scanned 40 of 1,182 files,
+      identified ten retained May logs with private websocket/query credential
+      classes, emitted no values or source lines, and changed no artifacts.
+    - 2026-07-16: Active `codex/log-secret-query-fragments` closes the verified
+      scheme-less query detection gap without remediation or schema changes.
 
     Required validation: fixtures for private websocket URLs, authorization
     material, signatures, API keys, query tokens, raw HTTP bodies, and benign

--- a/src/live/log_secret_inventory.py
+++ b/src/live/log_secret_inventory.py
@@ -47,9 +47,10 @@ _BEARER_BASIC_RE = re.compile(
 _PEM_PRIVATE_KEY_RE = re.compile(
     r"-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----", re.IGNORECASE
 )
-_SECRET_URL_QUERY_RE = re.compile(
-    r"\b(?:https?|wss?)://[^\s\"'<>]*[?&](?:api[_-]?key|api[_-]?secret|token|"
-    r"signature|password|passphrase|secret)=(?!\[redacted\](?:[&#\s]|$))[^\s\"'<>&#]+",
+_SECRET_QUERY_RE = re.compile(
+    r"[?&](?:api[_-]?key|api[_-]?secret|token|"
+    r"signature|password|passphrase|secret)="
+    r"(?!\[redacted\](?:\W|$))[^\s\"'<>&#]+",
     re.IGNORECASE,
 )
 _RAW_HTTP_BODY_HTML_RE = re.compile(
@@ -92,7 +93,7 @@ def classify_secret_like_text(text: str) -> dict[str, int]:
     )
     counts["bearer_basic_schemes"] = len(_BEARER_BASIC_RE.findall(text))
     counts["pem_private_keys"] = len(_PEM_PRIVATE_KEY_RE.findall(text))
-    counts["secret_url_query_params"] = len(_SECRET_URL_QUERY_RE.findall(text))
+    counts["secret_url_query_params"] = len(_SECRET_QUERY_RE.findall(text))
     counts["raw_http_body_html_markers"] = len(_RAW_HTTP_BODY_HTML_RE.findall(text))
     counts["labeled_secret_values"] = sum(
         1

--- a/tests/test_log_secret_inventory.py
+++ b/tests/test_log_secret_inventory.py
@@ -50,6 +50,31 @@ def test_classifies_all_required_secret_classes_and_ignores_benign_lookalikes():
     assert classify_secret_like_text("response body:")["raw_http_body_html_markers"] == 0
 
 
+def test_classifies_scheme_less_secret_query_params_without_retaining_values(tmp_path: Path):
+    secrets = ("path-api-key-secret", "signature-secret", "token-secret", "full-url-secret")
+    text = "\n".join(
+        [
+            f"GET /private/orders?apiKey={secrets[0]}",
+            f"GET /private/orders?limit=10&signature={secrets[1]}&token={secrets[2]}",
+            "GET /private/orders?token=[redacted]&signature=[redacted]",
+            'response={"url":"/private/orders?token=[redacted]"}',
+            "query=/private/orders?signature=[redacted], status=failed",
+            "GET /private/orders?api_key_count=2&token_present=true&signature_enabled=true",
+            f"https://example.invalid/path?password={secrets[3]}",
+        ]
+    )
+
+    counts = classify_secret_like_text(text)
+
+    assert counts["secret_url_query_params"] == 4
+    assert counts["labeled_secret_values"] == 0
+
+    (tmp_path / "service.log").write_text(text)
+    serialized = json.dumps(build_log_secret_inventory(tmp_path), sort_keys=True)
+
+    assert all(secret not in serialized for secret in secrets)
+
+
 def test_report_is_value_free_and_root_relative(tmp_path: Path):
     secrets = (
         "private-ws-token",


### PR DESCRIPTION
## Scope

- Category: read-only tooling.
- Detect credential-like query parameters after `?` or `&` in scheme-less request paths and query fragments.
- Preserve the existing `secret_url_query_params` report class and full-URL detection.
- Record PR #1266's no-restart VPS5 report evidence and refresh the active logging-overhaul handoff.

## Behavior and non-goals

- Redacted query values remain excluded, including values followed by JSON or prose punctuation.
- Reports remain value-free and retain no matched text or source lines.
- No report schema, scan bound, artifact mutation/remediation, exchange access, process, Rust, risk, order, or trading behavior changes.
- Query-shaped prose can now be classified intentionally; the inventory is advisory rather than a zero-false-positive proof.

## Validation

- `pytest -q tests/test_log_secret_inventory.py tests/test_ai_docs.py tests/test_live_event_registry_docs.py` -> 14 passed.
- `python -m py_compile src/live/log_secret_inventory.py tests/test_log_secret_inventory.py` -> passed.
- `PYTHONPATH=src python src/tools/check_ai_docs.py` -> 0 errors, one pre-existing word-budget warning.
- Added-line silent-handling audit -> no matches.
- `git diff --check` -> clean.
- 1 MB classifier timing smoke -> about 0.06 seconds, one scheme-less query match.

## Reviewer focus

- Verify scheme-less and full-URL query detection, multi-parameter counting, and redacted delimiter handling.
- Verify benign `*_count`, `*_present`, and `*_enabled` lookalikes remain excluded.
- Verify serialized output cannot retain the matched values.
- Expected VPS action after merge: pull plus one bounded read-only inventory; no restart and no remediation.
