### PR TITLE
Add bounded log secret inventory summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `log-secret-inventory --summary` now emits bounded aggregate scan evidence
+  without the per-file paths, ages, or hashes retained by the full report.
+
 - The read-only log secret inventory now detects credential-like query
   parameters in scheme-less request paths and query fragments as well as full
   URLs, without returning matched values.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,8 +24,9 @@ Estimated completion:
 
 - Branch: `codex/log-secret-inventory-summary`, based on canonical
   `951e42d07303d5c78ca31d4df9ee5f21e5b931cb` after PR #1267.
-- PR: pending. Slice: add a bounded aggregate-only projection to the read-only
-  historical log inventory.
+- PR: #1268, `Add bounded log secret inventory summary`; semantic head
+  `0db1a8d847cba28d59d83c3a0dd13572db935699`. Slice: add a bounded
+  aggregate-only projection to the read-only historical log inventory.
 - Triggering evidence: the 40-file bounded #1267 VPS smoke emitted roughly
   6,000 tokens even with compact JSON because every per-file path, age, size,
   status, and hash remained present.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,23 +22,22 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/log-secret-query-fragments`, based on canonical
-  `4015a3b3f145d58db3e1a873ec4cc5ce465368f7` after PR #1266.
-- PR: #1267, `Detect secret query fragments in log inventory`; semantic head
-  `361ad1e6bf9de9b5c912059c17522b6ab7da52ac`. Slice: detect secret-like
-  query parameters in scheme-less request paths and query fragments in the
-  read-only historical log inventory.
-- Triggering evidence: the inventory recognizes credential parameters inside
-  full HTTP/websocket URLs, but misses forms such as
-  `GET /path?apiKey=[value]` because the generic labeled matcher deliberately
-  excludes `?` and `&` prefixes.
-- Scope: broaden only the existing value-free query-parameter classification
-  and add focused full-URL, scheme-less, redacted, benign, and leakage tests.
+- Branch: `codex/log-secret-inventory-summary`, based on canonical
+  `951e42d07303d5c78ca31d4df9ee5f21e5b931cb` after PR #1267.
+- PR: pending. Slice: add a bounded aggregate-only projection to the read-only
+  historical log inventory.
+- Triggering evidence: the 40-file bounded #1267 VPS smoke emitted roughly
+  6,000 tokens even with compact JSON because every per-file path, age, size,
+  status, and hash remained present.
+- Scope: add `--summary` while preserving the full report as the default. The
+  projection retains scan limits, discovery/read/skip counts, total bytes,
+  positive/truncated file counts, and aggregate class counts, but omits the
+  per-file array, paths, ages, and hashes.
 - Behavior boundary: read-only local tooling; no source values/lines, artifact
   mutation or remediation, exchange access, bot process changes, Rust, risk,
   order, or trading behavior.
-- Validation: focused inventory tests, Python compilation, a 1 MB classifier
-  timing smoke, docs checks, and a bounded VPS5 inventory after merge.
+- Validation: focused inventory/CLI tests, Python compilation, docs checks,
+  and a bounded VPS5 summary inventory after merge.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
 - Expected VPS action: pull and run a bounded read-only inventory only; no bot
@@ -47,11 +46,15 @@ Estimated completion:
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `4015a3b3f145d58db3e1a873ec4cc5ce465368f7`, PR #1266. The tracked checkout
+  `951e42d07303d5c78ca31d4df9ee5f21e5b931cb`, PR #1267. The tracked checkout
   is clean and expected untracked artifacts are preserved.
-- VPS5 runs merged master in bot PIDs
-  `979190/979193/979196/979199/979202`. The exact pane parents are unchanged,
-  and unrelated `misc:0.0` PID `434835` is unchanged.
+- PR #1267 required no restart. Its 40-file, 250,000-byte bounded inventory
+  found 144 secret-query matches versus 143 private-websocket-query matches,
+  proving one additional non-websocket query fragment was classified. The scan
+  discovered 1,182 files, skipped six symlinks, and had zero discovery or read
+  errors. No values or source lines were emitted and no remediation occurred.
+  All five configured bot panes and unrelated `misc:0.0` remained present; no
+  process signal was sent.
 - PR #1266 required no restart. A four-hour, current-segment-only brief report
   scanned six monitor files and 19,163 records with zero monitor parse errors,
   and emitted the new startup budget coverage fields. Startup timing rows had

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -25,7 +25,7 @@ Estimated completion:
 - Branch: `codex/log-secret-inventory-summary`, based on canonical
   `951e42d07303d5c78ca31d4df9ee5f21e5b931cb` after PR #1267.
 - PR: #1268, `Add bounded log secret inventory summary`; semantic head
-  `0db1a8d847cba28d59d83c3a0dd13572db935699`. Slice: add a bounded
+  `0db1a8d847a2528407a4a868a33d55239ee6a97f`. Slice: add a bounded
   aggregate-only projection to the read-only historical log inventory.
 - Triggering evidence: the 40-file bounded #1267 VPS smoke emitted roughly
   6,000 tokens even with compact JSON because every per-file path, age, size,
@@ -951,10 +951,10 @@ validated: successful stop summaries and hourly scheduler jitter remain at
 DEBUG while cancellation errors remain at ERROR. PR #1265's bounded,
 value-free historical secret-log inventory is also merged and deployed; its
 dry run confirmed retained credential-bearing logs without exposing values or
-changing artifacts. PR #1266's brief startup-budget coverage is also merged
-and deployed without restart; its bounded report emitted the new fields while
-retaining natural problem-event verdicts. The active inventory follow-up closes
-the scheme-less credential-query detection gap without remediation.
+changing artifacts. PR #1266's brief startup-budget coverage and PR #1267's
+scheme-less credential-query detection are also merged and deployed without
+restart. The active #1268 inventory follow-up adds aggregate-only output
+without remediation or changing the full report default.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,25 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1266)
+## Latest Canonical Deployment (PR #1267)
+
+- PR #1267 merged to `master` as
+  `951e42d07303d5c78ca31d4df9ee5f21e5b931cb`. It extends the value-free
+  inventory's existing query classification to scheme-less request paths and
+  fragments without changing report retention or runtime behavior.
+- VPS5 fast-forwarded cleanly with no restart. The bounded 40-file,
+  250,000-byte scan found 144 secret-query matches versus 143 private
+  websocket-query matches, proving one additional non-websocket query fragment
+  was classified. It discovered 1,182 files, skipped six symlinks, and had zero
+  discovery or read errors.
+- No source values or lines were emitted, no artifacts were remediated, and no
+  process signal was sent. All five configured bot panes and unrelated
+  `misc:0.0` remained present.
+- Even compact JSON was roughly 6,000 tokens because it retained every
+  per-file row. The next read-only slice adds an aggregate-only summary
+  projection while preserving the full report as the default.
+
+## Previous Canonical Deployment (PR #1266)
 
 - PR #1266 merged to `master` as
   `4015a3b3f145d58db3e1a873ec4cc5ce465368f7`. It adds existing startup

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -1015,11 +1015,12 @@ Related detailed plans:
 
 21. [ ] Historical secret-bearing text-log inventory and remediation.
     Status: partial. PR #1265 merged and deployed the bounded, value-free,
-    read-only inventory and dry-run validation contract. The active
-    `codex/log-secret-query-fragments` follow-up recognizes credential query
-    parameters in scheme-less request paths while preserving the same report
-    schema. Quarantine or purge remains separate and requires explicit operator
-    approval. A read-only VPS5 console-length audit on 2026-07-15
+    read-only inventory and dry-run validation contract. PR #1267 recognizes
+    credential query parameters in scheme-less request paths while preserving
+    the same report schema. The active aggregate-summary follow-up removes
+    per-file detail from shareable/operator output while preserving aggregate
+    scan evidence. Quarantine or purge remains separate and requires explicit
+    operator approval. A read-only VPS5 console-length audit on 2026-07-15
     accidentally admitted old untimestamped traceback fragments and confirmed
     that retained May text logs include raw private websocket URLs/tokens and
     full exchange error bodies. Current recent-window producers and smoke paths
@@ -1042,8 +1043,12 @@ Related detailed plans:
     - 2026-07-16: PR #1265's bounded VPS5 dry run scanned 40 of 1,182 files,
       identified ten retained May logs with private websocket/query credential
       classes, emitted no values or source lines, and changed no artifacts.
-    - 2026-07-16: Active `codex/log-secret-query-fragments` closes the verified
-      scheme-less query detection gap without remediation or schema changes.
+    - 2026-07-16: PR #1267's bounded VPS5 scan classified 144 secret-query
+      matches versus 143 private-websocket-query matches, proving one additional
+      non-websocket query fragment was found without exposing values.
+    - 2026-07-16: Active `codex/log-secret-inventory-summary` adds an
+      aggregate-only projection after compact full output still measured roughly
+      6,000 tokens for 40 file rows.
 
     Required validation: fixtures for private websocket URLs, authorization
     material, signatures, API keys, query tokens, raw HTTP bodies, and benign

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -1017,7 +1017,7 @@ Related detailed plans:
     Status: partial. PR #1265 merged and deployed the bounded, value-free,
     read-only inventory and dry-run validation contract. PR #1267 recognizes
     credential query parameters in scheme-less request paths while preserving
-    the same report schema. The active aggregate-summary follow-up removes
+    the same report schema. PR #1268's active aggregate-summary follow-up removes
     per-file detail from shareable/operator output while preserving aggregate
     scan evidence. Quarantine or purge remains separate and requires explicit
     operator approval. A read-only VPS5 console-length audit on 2026-07-15
@@ -1046,7 +1046,7 @@ Related detailed plans:
     - 2026-07-16: PR #1267's bounded VPS5 scan classified 144 secret-query
       matches versus 143 private-websocket-query matches, proving one additional
       non-websocket query fragment was found without exposing values.
-    - 2026-07-16: Active `codex/log-secret-inventory-summary` adds an
+    - 2026-07-16: PR #1268 adds an
       aggregate-only projection after compact full output still measured roughly
       6,000 tokens for 40 file rows.
 

--- a/src/live/log_secret_inventory.py
+++ b/src/live/log_secret_inventory.py
@@ -241,3 +241,44 @@ def build_log_secret_inventory(
         "class_counts": dict(class_counts),
         "files": files,
     }
+
+
+def summarize_log_secret_inventory(report: dict) -> dict:
+    """Return a bounded projection without per-file paths or hashes."""
+    files = report.get("files", [])
+    if not isinstance(files, list):
+        files = []
+    positive_files = 0
+    truncated_files = 0
+    bytes_scanned = 0
+    for file_summary in files:
+        if not isinstance(file_summary, dict):
+            continue
+        class_counts = file_summary.get("class_counts", {})
+        if isinstance(class_counts, dict) and any(
+            isinstance(value, int) and value > 0 for value in class_counts.values()
+        ):
+            positive_files += 1
+        if file_summary.get("truncated") is True:
+            truncated_files += 1
+        scanned = file_summary.get("bytes_scanned")
+        if isinstance(scanned, int) and scanned > 0:
+            bytes_scanned += scanned
+
+    summary = dict(report.get("summary", {}))
+    summary.update(
+        {
+            "bytes_scanned": bytes_scanned,
+            "files_positive": positive_files,
+            "files_truncated": truncated_files,
+        }
+    )
+    return {
+        "report_type": report.get("report_type"),
+        "projection": "summary",
+        "read_only": report.get("read_only") is True,
+        "root": report.get("root"),
+        "limits": dict(report.get("limits", {})),
+        "summary": summary,
+        "class_counts": dict(report.get("class_counts", {})),
+    }

--- a/src/tools/log_secret_inventory.py
+++ b/src/tools/log_secret_inventory.py
@@ -13,6 +13,7 @@ from live.log_secret_inventory import (  # noqa: E402
     DEFAULT_MAX_BYTES_PER_FILE,
     DEFAULT_MAX_FILES,
     build_log_secret_inventory,
+    summarize_log_secret_inventory,
 )
 
 
@@ -24,6 +25,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("logs_root", nargs="?", default="logs", help="Local log directory to scan.")
     parser.add_argument("--max-files", type=int, default=DEFAULT_MAX_FILES)
     parser.add_argument("--max-bytes-per-file", type=int, default=DEFAULT_MAX_BYTES_PER_FILE)
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Omit per-file paths and hashes; emit aggregate scan evidence only.",
+    )
     parser.add_argument("--compact", action="store_true", help="Emit compact single-line JSON.")
     return parser
 
@@ -39,6 +45,8 @@ def main(argv: list[str] | None = None) -> int:
     except ValueError as exc:
         print(f"passivbot tool log-secret-inventory: {exc}", file=sys.stderr)
         return 2
+    if args.summary:
+        report = summarize_log_secret_inventory(report)
     print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
     return 0
 

--- a/tests/test_log_secret_inventory.py
+++ b/tests/test_log_secret_inventory.py
@@ -10,6 +10,7 @@ from live.log_secret_inventory import (
     SECRET_CLASSES,
     build_log_secret_inventory,
     classify_secret_like_text,
+    summarize_log_secret_inventory,
 )
 from passivbot_cli import main as cli_main
 from tools import log_secret_inventory
@@ -203,6 +204,48 @@ def test_tool_compact_json_output(tmp_path: Path, capsys):
     assert "\n" not in output.rstrip("\n")
     assert "tool-secret" not in output
     assert json.loads(output)["class_counts"]["labeled_secret_values"] == 1
+
+
+def test_summary_projection_aggregates_scan_evidence_without_file_details(tmp_path: Path):
+    (tmp_path / "a.log").write_text("token=summary-secret")
+    (tmp_path / "b.log").write_bytes(b"x" * 20)
+
+    report = build_log_secret_inventory(
+        tmp_path, max_bytes_per_file=8, now_s=0
+    )
+    summary = summarize_log_secret_inventory(report)
+    serialized = json.dumps(summary, sort_keys=True)
+
+    assert summary["projection"] == "summary"
+    assert summary["summary"]["bytes_scanned"] == 16
+    assert summary["summary"]["files_positive"] == 1
+    assert summary["summary"]["files_truncated"] == 2
+    assert summary["class_counts"]["labeled_secret_values"] == 1
+    assert "files" not in summary
+    assert "a.log" not in serialized
+    assert "sha256" not in serialized
+    assert "summary-secret" not in serialized
+
+
+def test_tool_summary_compact_json_output_omits_file_details(tmp_path: Path, capsys):
+    (tmp_path / "account-name.log").write_text("token=tool-summary-secret")
+
+    assert (
+        log_secret_inventory.main(
+            [str(tmp_path), "--summary", "--compact"]
+        )
+        == 0
+    )
+    output = capsys.readouterr().out
+    report = json.loads(output)
+
+    assert "\n" not in output.rstrip("\n")
+    assert report["projection"] == "summary"
+    assert report["summary"]["files_positive"] == 1
+    assert report["class_counts"]["labeled_secret_values"] == 1
+    assert "files" not in report
+    assert "account-name.log" not in output
+    assert "tool-summary-secret" not in output
 
 
 def test_unified_cli_dispatches_log_secret_inventory(tmp_path: Path, capsys):


### PR DESCRIPTION
## Scope

Category: read-only tooling.

- Add `log-secret-inventory --summary` as an aggregate-only projection.
- Preserve the complete per-file report as the default.
- Retain scan limits, discovery/read/skip counts, total bytes scanned,
  positive/truncated file counts, and aggregate secret-class counts.
- Omit per-file paths, ages, sizes, statuses, and hashes from summary output.

## Non-goals

- No log remediation, mutation, quarantine, deletion, copying, or upload.
- No source values or matched source lines.
- No exchange access, bot process changes, Rust, risk, order, or trading behavior.
- No event-pipeline degradation policy change; that candidate needs a separate
  producer-owned transition/hysteresis contract.

## Evidence

The bounded #1267 VPS5 smoke emitted roughly 6,000 tokens even with compact
JSON because all 40 per-file rows remained in the payload. The new projection
keeps the aggregate evidence needed for operator/automation use without those
rows.

## Validation

- `python -m pytest -q tests/test_log_secret_inventory.py tests/test_ai_docs.py tests/test_live_event_registry_docs.py` (`16 passed`)
- `python -m py_compile src/live/log_secret_inventory.py src/tools/log_secret_inventory.py`
- `python src/tools/check_ai_docs.py` (`0 errors`; existing documentation word-count warning)
- `git diff --check`

## VPS action

After merge: fast-forward VPS5 and run one bounded read-only summary inventory.
No bot restart or process signal.

## Reviewer focus

- Summary completeness without per-file identity leakage.
- Full-report compatibility and CLI flag composition with `--compact`.
- Counter semantics for positive, truncated, and scanned-byte totals.
