### PR TITLE
Add diagnostic startup phase budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live configs may now define optional diagnostic `startup_phase_budgets` for
+  canonical startup timing phases. Existing `bot.startup_timing` events carry
+  configured elapsed and phase budgets, and live smoke reports prefer those
+  explicit values over historical p95 projections. The budgets are reporting
+  metadata only and do not gate startup, readiness, exchange access, or
+  trading.
+
 - `log-secret-inventory --summary` now emits bounded aggregate scan evidence
   without the per-file paths, ages, or hashes retained by the full report.
 

--- a/configs/examples/default_trailing_martingale_long.json
+++ b/configs/examples/default_trailing_martingale_long.json
@@ -441,6 +441,7 @@
         "order_match_tolerance_pct": 0.0002,
         "pnls_max_lookback_days": 30.0,
         "recv_window_ms": 5000,
+        "startup_phase_budgets": {},
         "strategy_kind": "trailing_martingale",
         "time_in_force": "good_till_cancelled",
         "user": "bybit_01",

--- a/docs/ai/features/live_events.md
+++ b/docs/ai/features/live_events.md
@@ -12,6 +12,21 @@ eligibility, replay order, or runtime decisions.
 
 The generated value reference is `../generated/live_event_registry.md`.
 
+## Startup Timing Budgets
+
+`live.startup_phase_budgets` may define optional diagnostic budgets for the canonical
+`bot.startup_timing` phases `account`, `active-candle`, `full-warmup`, `hsl`, `market`, and
+`startup`. Each phase may carry `elapsed_ms`, measured from process startup, and
+`since_previous_ms`, measured from the preceding startup timing mark. Configured values are copied
+to the existing event as `elapsed_budget_ms` and `since_previous_budget_ms` with
+`budget_source=config`.
+
+These fields are reporting metadata only. They must not delay, fail, skip, or otherwise control
+startup, readiness, exchange access, order construction, or trading. Smoke reports prefer a valid
+event-carried configured budget for that dimension and retain the prior local p95 projection only
+when no configured value is present. Malformed event-carried configured metadata is reported as
+`invalid_budget`; it must not be silently replaced by a historical baseline.
+
 ## Fill Console Projection
 
 `fill.ingested` is the canonical normal-fill event. Every new fill remains present in structured

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,33 +22,44 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/log-secret-inventory-summary`, based on canonical
-  `951e42d07303d5c78ca31d4df9ee5f21e5b931cb` after PR #1267.
-- PR: #1268, `Add bounded log secret inventory summary`; semantic head
-  `0db1a8d847a2528407a4a868a33d55239ee6a97f`. Slice: add a bounded
-  aggregate-only projection to the read-only historical log inventory.
-- Triggering evidence: the 40-file bounded #1267 VPS smoke emitted roughly
-  6,000 tokens even with compact JSON because every per-file path, age, size,
-  status, and hash remained present.
-- Scope: add `--summary` while preserving the full report as the default. The
-  projection retains scan limits, discovery/read/skip counts, total bytes,
-  positive/truncated file counts, and aggregate class counts, but omits the
-  per-file array, paths, ages, and hashes.
-- Behavior boundary: read-only local tooling; no source values/lines, artifact
-  mutation or remediation, exchange access, bot process changes, Rust, risk,
-  order, or trading behavior.
-- Validation: focused inventory/CLI tests, Python compilation, docs checks,
-  and a bounded VPS5 summary inventory after merge.
+- Branch: `codex/startup-phase-budget-events`, based on canonical
+  `f8ec74792d69e229fd63bf4cdf7ab7a092a79cd4` after PR #1268.
+- PR: pending. Slice: add optional durable diagnostic budgets to existing
+  `bot.startup_timing` events and make smoke reports prefer them over historical
+  p95 projections.
+- Triggering evidence: PR #1266 made missing/no-baseline startup budget
+  assessments explicit, but the only available budget remained a local prior
+  p95. Operators still could not compare startup timing against an intentional
+  per-phase target carried with the event.
+- Scope: add open `live.startup_phase_budgets` config keyed by canonical phase,
+  with independently optional process-elapsed and since-previous-mark budgets;
+  validate it, copy configured values into existing timing events, and prefer
+  those values in full/summary/brief smoke projections.
+- Behavior boundary: diagnostic metadata and reporting only. Budgets do not
+  gate startup, readiness, exchange access, order construction, or trading.
+  Empty configuration preserves existing event and report behavior.
+- Validation: config roundtrip/rejection tests, event propagation tests, smoke
+  precedence/malformed-metadata tests, focused Python tests, compilation, and
+  docs checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: pull and run a bounded read-only inventory only; no bot
-  restart or remediation.
+- Expected VPS action: after merge, pull and gracefully restart only the five
+  configured bot panes, preserving `misc:0.0`, then run bounded settled smoke.
+  Current VPS configs are expected to keep the new map empty, so live smoke
+  proves compatibility rather than manufacturing configured-budget events.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `951e42d07303d5c78ca31d4df9ee5f21e5b931cb`, PR #1267. The tracked checkout
+  `f8ec74792d69e229fd63bf4cdf7ab7a092a79cd4`, PR #1268. The tracked checkout
   is clean and expected untracked artifacts are preserved.
+- PR #1268 required no restart. Its bounded aggregate-only inventory scanned
+  40 of 1,182 discovered files and 8,153,519 bytes, reported ten positive and
+  25 truncated files, skipped six symlinks, and had zero unreadable files or
+  discovery errors. It retained the #1267 class counts of 144 secret-query and
+  143 private-websocket-query matches without per-file paths, ages, or hashes.
+  All five configured bot panes and unrelated `misc:0.0` remained present; no
+  process signal or remediation occurred.
 - PR #1267 required no restart. Its 40-file, 250,000-byte bounded inventory
   found 144 secret-query matches versus 143 private-websocket-query matches,
   proving one additional non-websocket query fragment was classified. The scan
@@ -951,10 +962,11 @@ validated: successful stop summaries and hourly scheduler jitter remain at
 DEBUG while cancellation errors remain at ERROR. PR #1265's bounded,
 value-free historical secret-log inventory is also merged and deployed; its
 dry run confirmed retained credential-bearing logs without exposing values or
-changing artifacts. PR #1266's brief startup-budget coverage and PR #1267's
-scheme-less credential-query detection are also merged and deployed without
-restart. The active #1268 inventory follow-up adds aggregate-only output
-without remediation or changing the full report default.
+changing artifacts. PR #1266's brief startup-budget coverage, PR #1267's
+scheme-less credential-query detection, and PR #1268's aggregate-only inventory
+projection are also merged and deployed without restart. The active
+startup-budget slice adds intentional diagnostic targets to existing timing
+events without turning observability into a readiness or trading gate.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,9 +24,10 @@ Estimated completion:
 
 - Branch: `codex/startup-phase-budget-events`, based on canonical
   `f8ec74792d69e229fd63bf4cdf7ab7a092a79cd4` after PR #1268.
-- PR: pending. Slice: add optional durable diagnostic budgets to existing
-  `bot.startup_timing` events and make smoke reports prefer them over historical
-  p95 projections.
+- PR: #1269, `Add diagnostic startup phase budgets`; semantic head
+  `a7f460b384d1e1e684d71cb390c952ac718a5a3f`. Slice: add optional durable
+  diagnostic budgets to existing `bot.startup_timing` events and make smoke
+  reports prefer them over historical p95 projections.
 - Triggering evidence: PR #1266 made missing/no-baseline startup budget
   assessments explicit, but the only available budget remained a local prior
   p95. Operators still could not compare startup timing against an intentional

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,25 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1267)
+## Latest Canonical Deployment (PR #1268)
+
+- PR #1268 merged to `master` as
+  `f8ec74792d69e229fd63bf4cdf7ab7a092a79cd4`. It adds an aggregate-only
+  projection to the bounded read-only log secret inventory while preserving
+  the full per-file report as the default.
+- VPS5 fast-forwarded cleanly with no restart. The summary scanned 40 of 1,182
+  discovered files and 8,153,519 bytes, reported ten positive and 25 truncated
+  files, skipped six symlinks, and had zero unreadable files or discovery
+  errors. It retained aggregate counts of 144 secret-query and 143 private
+  websocket-query matches without per-file paths, ages, or hashes.
+- No source values or lines were emitted, no artifacts were remediated, and no
+  process signal was sent. All five configured bot panes and unrelated
+  `misc:0.0` remained present.
+- The next substantive slice adds optional durable diagnostic budgets to
+  existing startup timing events and gives those configured targets precedence
+  over historical p95 report projections without enforcing them.
+
+## Previous Canonical Deployment (PR #1267)
 
 - PR #1267 merged to `master` as
   `951e42d07303d5c78ca31d4df9ee5f21e5b931cb`. It extends the value-free
@@ -30,8 +48,8 @@ merge, live smoke evidence changes, or new gaps are discovered.
   process signal was sent. All five configured bot panes and unrelated
   `misc:0.0` remained present.
 - Even compact JSON was roughly 6,000 tokens because it retained every
-  per-file row. The next read-only slice adds an aggregate-only summary
-  projection while preserving the full report as the default.
+  per-file row; PR #1268 added an aggregate-only summary while preserving the
+  full report as the default.
 
 ## Previous Canonical Deployment (PR #1266)
 

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -320,8 +320,10 @@ Related detailed plans:
    Status: partial. Startup timing and warmup cache decision events exist, and
    `live-smoke-report` now summarizes latest startup phase timings with rolling
    median/p95 baselines from local monitor events plus report-only budget
-   projections against prior p95 phase baselines. Explicit durable phase budget
-   configuration/events are not implemented.
+   projections against prior p95 phase baselines. The active slice adds
+   optional durable diagnostic budgets to existing timing events and gives
+   configured values report precedence; enforcement and broader readiness-stage
+   coverage remain out of scope.
 
    Startup currently has timing events, but the next step is durable budget
    accounting by phase: account-critical fetches, fill/PnL refresh, active
@@ -344,10 +346,14 @@ Related detailed plans:
      reports retain the latest lifecycle's per-bot startup snapshot independent
      of current-before-rotated file traversal while preserving historical
      aggregate distributions.
-   - 2026-07-16: Active `codex/startup-budget-coverage-summary` slice makes the
-     brief projection aggregate existing elapsed/phase budget statuses so
-     unavailable or no-baseline phases cannot look implicitly within budget.
-     It remains report-only and non-enforcing.
+   - 2026-07-16: PR #1266 made the brief projection aggregate existing
+     elapsed/phase budget statuses so unavailable or no-baseline phases cannot
+     look implicitly within budget. It remains report-only and non-enforcing.
+   - 2026-07-16: Active `codex/startup-phase-budget-events` adds optional
+     `live.startup_phase_budgets`, carries configured targets on existing
+     `bot.startup_timing` events, and makes smoke reports prefer them over prior
+     p95 projections. The values are diagnostic and never gate startup or
+     trading.
 
 5. [x] Resource pressure telemetry.
    Status: initial implementation merged. `health.summary` events now include
@@ -1017,9 +1023,10 @@ Related detailed plans:
     Status: partial. PR #1265 merged and deployed the bounded, value-free,
     read-only inventory and dry-run validation contract. PR #1267 recognizes
     credential query parameters in scheme-less request paths while preserving
-    the same report schema. PR #1268's active aggregate-summary follow-up removes
-    per-file detail from shareable/operator output while preserving aggregate
-    scan evidence. Quarantine or purge remains separate and requires explicit
+    the same report schema. PR #1268 merged and deployed an aggregate-summary
+    projection that removes per-file detail from shareable/operator output
+    while preserving aggregate scan evidence. Quarantine or purge remains
+    separate and requires explicit
     operator approval. A read-only VPS5 console-length audit on 2026-07-15
     accidentally admitted old untimestamped traceback fragments and confirmed
     that retained May text logs include raw private websocket URLs/tokens and
@@ -1046,9 +1053,9 @@ Related detailed plans:
     - 2026-07-16: PR #1267's bounded VPS5 scan classified 144 secret-query
       matches versus 143 private-websocket-query matches, proving one additional
       non-websocket query fragment was found without exposing values.
-    - 2026-07-16: PR #1268 adds an
-      aggregate-only projection after compact full output still measured roughly
-      6,000 tokens for 40 file rows.
+    - 2026-07-16: PR #1268's bounded VPS5 summary scanned 40 of 1,182 files and
+      8,153,519 bytes, retained the 144/143 query-class counts, omitted
+      per-file paths/ages/hashes, and reported zero read or discovery errors.
 
     Required validation: fixtures for private websocket URLs, authorization
     material, signatures, API keys, query tokens, raw HTTP bodies, and benign

--- a/docs/plans/live_performance_readiness_goals.md
+++ b/docs/plans/live_performance_readiness_goals.md
@@ -319,7 +319,10 @@ classification when enough source events exist.
   exchange write from existing events. PR #1196 added true local fresh-entry
   eligibility evidence, and PR #1197 projects its first qualifying event as
   startup readiness. PR #1198 adds distinct local connector-call boundary
-  evidence without claiming exchange receipt or acknowledgement.
+  evidence without claiming exchange receipt or acknowledgement. The active
+  startup-budget slice adds optional configured elapsed and since-previous
+  diagnostic targets to the same timing events; smoke reports prefer those
+  targets over prior p95 projections, but they never gate readiness or trading.
 - [ ] Startup: process start to held-position protective HSL ready.
 - [ ] Startup: process start to fresh-entry ready.
 - [ ] Startup: process start to first planning cycle started/completed.

--- a/src/config/hydrate.py
+++ b/src/config/hydrate.py
@@ -17,6 +17,7 @@ Path = tuple[str, ...]
 
 PARTIALLY_OPEN_CONFIG_PATHS: set[Path] = {
     ("backtest", "aggregate"),
+    ("live", "startup_phase_budgets"),
 }
 BACKTEST_INHERITED_LIVE_KEYS: tuple[str, ...] = (
     "fee_pct_fallback",

--- a/src/config/schema.py
+++ b/src/config/schema.py
@@ -430,6 +430,7 @@ def get_template_config():
                 "order_match_tolerance_pct": 0.0002,
                 "pnls_max_lookback_days": 30.0,
                 "recv_window_ms": 5000,
+                "startup_phase_budgets": {},
                 "strategy_kind": "trailing_martingale",
                 "time_in_force": "good_till_cancelled",
                 "user": "bybit_01",

--- a/src/config/validate.py
+++ b/src/config/validate.py
@@ -1,5 +1,8 @@
 import math
 
+from live.event_bus import STARTUP_TIMING_PHASES
+from risk_limits import normalize_we_excess_allowance_mode
+
 from .access import require_config_dict
 from .bot import (
     normalize_twel_enforcer_policy,
@@ -13,7 +16,34 @@ from .strategy import (
     get_active_strategy_side,
     normalize_strategy_kind,
 )
-from risk_limits import normalize_we_excess_allowance_mode
+
+_STARTUP_BUDGET_KEYS = frozenset({"elapsed_ms", "since_previous_ms"})
+
+
+def _validate_startup_phase_budgets(live_config: dict) -> None:
+    budgets = live_config.get("startup_phase_budgets")
+    if not isinstance(budgets, dict):
+        raise TypeError("config.live.startup_phase_budgets must be a dict")
+    for phase, phase_budgets in budgets.items():
+        if phase not in STARTUP_TIMING_PHASES:
+            allowed = ", ".join(sorted(STARTUP_TIMING_PHASES))
+            raise ValueError(
+                "config.live.startup_phase_budgets phase must be one of: " + allowed
+            )
+        path = f"config.live.startup_phase_budgets.{phase}"
+        if not isinstance(phase_budgets, dict):
+            raise TypeError(f"{path} must be a dict")
+        unknown = sorted(set(phase_budgets) - _STARTUP_BUDGET_KEYS)
+        if unknown:
+            raise ValueError(f"{path} has unknown keys: {', '.join(unknown)}")
+        if not phase_budgets:
+            raise ValueError(f"{path} must define at least one budget")
+        for key, value in phase_budgets.items():
+            value_path = f"{path}.{key}"
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{value_path} must be an integer")
+            if value < 0:
+                raise ValueError(f"{value_path} must be >= 0")
 
 
 def validate_config(
@@ -86,6 +116,7 @@ def validate_config(
     normalize_hsl_cooldown_position_policy(
         config["live"]["hsl_position_during_cooldown_policy"]
     )
+    _validate_startup_phase_budgets(config["live"])
     ticker_strategy = str(
         config["live"].get("market_snapshot_ticker_strategy", "auto")
     ).lower()

--- a/src/live/event_bus.py
+++ b/src/live/event_bus.py
@@ -104,7 +104,7 @@ _STARTUP_PHASE_READINESS_CONTRACTS: Mapping[str, tuple[str, str]] = MappingProxy
         "full-warmup": ("background_candles_complete", "entry_blocker"),
     }
 )
-_STARTUP_TIMING_PHASES = frozenset(
+STARTUP_TIMING_PHASES = frozenset(
     {
         "account",
         "active-candle",
@@ -140,7 +140,7 @@ def startup_timing_phase(data: object) -> str | None:
     value = phase or stage
     if not value:
         return None
-    return value if value in _STARTUP_TIMING_PHASES else "other"
+    return value if value in STARTUP_TIMING_PHASES else "other"
 
 
 class EventTypes:

--- a/src/live/event_emitters.py
+++ b/src/live/event_emitters.py
@@ -1498,6 +1498,9 @@ def _emit_startup_timing_event_unchecked(
     elapsed_ms: int,
     since_previous_ms: int,
     details: str = "",
+    elapsed_budget_ms: int | None = None,
+    since_previous_budget_ms: int | None = None,
+    budget_source: str | None = None,
 ) -> None:
     elapsed = _safe_int(elapsed_ms)
     since_previous = _safe_int(since_previous_ms)
@@ -1514,6 +1517,17 @@ def _emit_startup_timing_event_unchecked(
         data.update(readiness_contract)
     if details:
         data["details"] = str(details)
+    configured_budgets = {
+        "elapsed_budget_ms": _safe_int(elapsed_budget_ms),
+        "since_previous_budget_ms": _safe_int(since_previous_budget_ms),
+    }
+    if budget_source == "config" and any(
+        value is not None and value >= 0 for value in configured_budgets.values()
+    ):
+        data["budget_source"] = "config"
+        for key, value in configured_budgets.items():
+            if value is not None and value >= 0:
+                data[key] = int(value)
     if live_event_debug_profile_enabled(bot, "startup"):
         data["debug_profile"] = "startup"
         data["debug"] = _startup_debug_payload(data)

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -57,9 +57,17 @@ LOG_LINE_TS_PATTERN = re.compile(
 )
 STARTUP_TIMING_BASELINE_WINDOW = 20
 STARTUP_BUDGET_STATUSES = frozenset(
-    {"unavailable", "no_baseline", "within_budget", "over_budget"}
+    {
+        "unavailable",
+        "no_baseline",
+        "invalid_budget",
+        "within_budget",
+        "over_budget",
+    }
 )
-STARTUP_BUDGET_INCOMPLETE_STATUSES = frozenset({"unavailable", "no_baseline"})
+STARTUP_BUDGET_INCOMPLETE_STATUSES = frozenset(
+    {"unavailable", "no_baseline", "invalid_budget"}
+)
 DEFAULT_PROCESS_MATCH = "passivbot live"
 LOG_WINDOW_UNPARSED_POLICIES = {"keep", "drop"}
 DEFAULT_LOG_WINDOW_UNPARSED_POLICY = "keep"
@@ -5834,7 +5842,38 @@ def _startup_budget_projection(
     *,
     latest_ms: int | None,
     baseline_values: list[int],
+    explicit_budget_ms: int | None = None,
+    explicit_budget_invalid: bool = False,
 ) -> dict[str, int | str | None]:
+    if explicit_budget_invalid:
+        return {
+            "status": "invalid_budget",
+            "latest_ms": latest_ms,
+            "budget_ms": None,
+            "baseline_samples": len(baseline_values),
+            "usage_pct": None,
+            "over_budget_by_ms": None,
+            "source": "config",
+        }
+    if explicit_budget_ms is not None:
+        over_budget_by_ms = (
+            None if latest_ms is None else max(0, latest_ms - explicit_budget_ms)
+        )
+        return {
+            "status": (
+                "unavailable"
+                if latest_ms is None
+                else "over_budget"
+                if over_budget_by_ms
+                else "within_budget"
+            ),
+            "latest_ms": latest_ms,
+            "budget_ms": explicit_budget_ms,
+            "baseline_samples": len(baseline_values),
+            "usage_pct": _usage_pct(latest_ms, explicit_budget_ms),
+            "over_budget_by_ms": over_budget_by_ms,
+            "source": "config",
+        }
     if latest_ms is None:
         return {
             "status": "unavailable",
@@ -5897,6 +5936,16 @@ def _startup_timing_record(
         "path": str(path),
         "line": int(line_no),
     }
+    if data.get("budget_source") == "config":
+        record["budget_source"] = "config"
+        for key in ("elapsed_budget_ms", "since_previous_budget_ms"):
+            if key not in data:
+                continue
+            value = _non_negative_int(data.get(key))
+            if value is None:
+                record[f"{key}_invalid"] = True
+            else:
+                record[key] = value
     contract = startup_phase_readiness_contract(phase)
     if (
         contract is not None
@@ -5996,10 +6045,18 @@ def _summarize_startup_timings(
                 "elapsed_budget": _startup_budget_projection(
                     latest_ms=latest_elapsed,
                     baseline_values=elapsed_budget_values,
+                    explicit_budget_ms=latest.get("elapsed_budget_ms"),
+                    explicit_budget_invalid=bool(
+                        latest.get("elapsed_budget_ms_invalid")
+                    ),
                 ),
                 "phase_budget": _startup_budget_projection(
                     latest_ms=latest_phase,
                     baseline_values=phase_budget_values,
+                    explicit_budget_ms=latest.get("since_previous_budget_ms"),
+                    explicit_budget_invalid=bool(
+                        latest.get("since_previous_budget_ms_invalid")
+                    ),
                 ),
                 "latest_elapsed_vs_p95_pct": _usage_pct(
                     latest_elapsed, elapsed_summary["p95_ms"]
@@ -7533,7 +7590,7 @@ def _summary_startup_timings(
 def _brief_startup_budget_status(projection: Any) -> tuple[str, bool]:
     status = projection.get("status") if isinstance(projection, dict) else None
     if isinstance(status, str) and status in STARTUP_BUDGET_STATUSES:
-        return status, False
+        return status, status == "invalid_budget"
     return "unavailable", True
 
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -3349,6 +3349,26 @@ class Passivbot:
         since_previous_s = max(0.0, (now_ms - previous_ms) / 1000.0)
         marks[label] = now_ms
         self._startup_timing_last_mark_ms = now_ms
+        budget_kwargs = {}
+        startup_phase_budgets = get_optional_live_value(
+            getattr(self, "config", {}), "startup_phase_budgets", {}
+        )
+        if isinstance(startup_phase_budgets, dict):
+            phase_budgets = startup_phase_budgets.get(label)
+            if isinstance(phase_budgets, dict):
+                for config_key, event_key in (
+                    ("elapsed_ms", "elapsed_budget_ms"),
+                    ("since_previous_ms", "since_previous_budget_ms"),
+                ):
+                    value = phase_budgets.get(config_key)
+                    if (
+                        isinstance(value, int)
+                        and not isinstance(value, bool)
+                        and value >= 0
+                    ):
+                        budget_kwargs[event_key] = value
+                if budget_kwargs:
+                    budget_kwargs["budget_source"] = "config"
         if not Passivbot._live_event_console_available(self):
             suffix = f" | {details}" if details else ""
             logging.info(
@@ -3364,6 +3384,7 @@ class Passivbot:
             elapsed_ms=max(0, int(now_ms - started_ms)),
             since_previous_ms=max(0, int(now_ms - previous_ms)),
             details=str(details or ""),
+            **budget_kwargs,
         )
 
     def _force_cold_startup(self) -> bool:

--- a/tests/test_config_pipeline.py
+++ b/tests/test_config_pipeline.py
@@ -51,6 +51,44 @@ def _strategy_side(config, pside, kind=None):
     return config["bot"][pside]["strategy"][kind]
 
 
+def test_startup_phase_budgets_validate_and_roundtrip():
+    source = get_template_config()
+    assert source["live"]["startup_phase_budgets"] == {}
+    source["live"]["startup_phase_budgets"] = {
+        "account": {"elapsed_ms": 120_000, "since_previous_ms": 60_000},
+        "full-warmup": {"elapsed_ms": 900_000},
+    }
+
+    prepared = prepare_config(source, verbose=False, target="canonical", runtime=None)
+
+    assert prepared["live"]["startup_phase_budgets"] == source["live"][
+        "startup_phase_budgets"
+    ]
+
+
+@pytest.mark.parametrize(
+    "budgets,error_type,error_match",
+    [
+        ([], TypeError, "startup_phase_budgets must be a dict"),
+        ({"unknown": {"elapsed_ms": 1}}, ValueError, "phase must be one of"),
+        ({"account": []}, TypeError, "account must be a dict"),
+        ({"account": {}}, ValueError, "must define at least one budget"),
+        ({"account": {"other_ms": 1}}, ValueError, "unknown keys"),
+        ({"account": {"elapsed_ms": True}}, TypeError, "must be an integer"),
+        ({"account": {"elapsed_ms": 1.5}}, TypeError, "must be an integer"),
+        ({"account": {"elapsed_ms": -1}}, ValueError, "must be >= 0"),
+    ],
+)
+def test_startup_phase_budgets_reject_invalid_values(
+    budgets, error_type, error_match
+):
+    source = get_template_config()
+    source["live"]["startup_phase_budgets"] = budgets
+
+    with pytest.raises(error_type, match=error_match):
+        prepare_config(source, verbose=False, target="canonical", runtime=None)
+
+
 @pytest.mark.parametrize("strategy_kind", list(get_supported_strategy_kinds()))
 def test_rust_strategy_spec_matches_python_template_defaults(strategy_kind):
     source = get_template_config()

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -3738,6 +3738,96 @@ def test_live_smoke_report_startup_budget_no_baseline(tmp_path):
     assert brief["startup_timings"]["invalid_or_missing_budget_assessments"] == 0
 
 
+def test_live_smoke_report_prefers_event_configured_startup_budgets(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=1,
+                ts=1000,
+                reason_code="startup_phase_ready",
+                data={
+                    "phase": "account",
+                    "elapsed_ms": 2_000,
+                    "since_previous_ms": 2_000,
+                },
+            ),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=2,
+                ts=2000,
+                reason_code="startup_phase_ready",
+                data={
+                    "phase": "account",
+                    "elapsed_ms": 3_000,
+                    "since_previous_ms": 3_000,
+                    "budget_source": "config",
+                    "elapsed_budget_ms": 2_500,
+                    "since_previous_budget_ms": 5_000,
+                },
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    phase = report["startup_timings"][0]["phases"]["account"]
+
+    assert phase["elapsed_budget"] == {
+        "status": "over_budget",
+        "latest_ms": 3_000,
+        "budget_ms": 2_500,
+        "baseline_samples": 1,
+        "usage_pct": 120,
+        "over_budget_by_ms": 500,
+        "source": "config",
+    }
+    assert phase["phase_budget"] == {
+        "status": "within_budget",
+        "latest_ms": 3_000,
+        "budget_ms": 5_000,
+        "baseline_samples": 1,
+        "usage_pct": 60,
+        "over_budget_by_ms": 0,
+        "source": "config",
+    }
+
+
+def test_live_smoke_report_marks_malformed_configured_budget_incomplete(tmp_path):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=1,
+                ts=1000,
+                reason_code="startup_phase_ready",
+                data={
+                    "phase": "account",
+                    "elapsed_ms": 2_000,
+                    "since_previous_ms": 2_000,
+                    "budget_source": "config",
+                    "elapsed_budget_ms": "bad",
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    phase = report["startup_timings"][0]["phases"]["account"]
+    brief = summarize_live_smoke_report_brief(report)
+
+    assert phase["elapsed_budget"]["status"] == "invalid_budget"
+    assert phase["elapsed_budget"]["source"] == "config"
+    assert brief["startup_timings"]["elapsed_budget_status_counts"] == {
+        "invalid_budget": 1
+    }
+    assert brief["startup_timings"]["incomplete_budget_phases"] == 1
+    assert brief["startup_timings"]["invalid_or_missing_budget_assessments"] == 1
+
+
 def test_brief_startup_timings_counts_budget_coverage_and_malformed_metadata():
     brief = smoke_report_module._brief_startup_timings(
         [

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -216,6 +216,47 @@ def test_startup_timing_mark_emits_structured_event(monkeypatch, caplog):
     assert bot._live_event_pipeline.close(timeout=2.0) is True
 
 
+def test_startup_timing_event_carries_configured_diagnostic_budgets(monkeypatch):
+    import passivbot as pb_mod
+
+    sink = ListEventSink()
+    clock_values = iter([1_000, 3_500])
+    monkeypatch.setattr(pb_mod, "utc_ms", lambda: next(clock_values))
+
+    class FakeBot:
+        _startup_timing_begin = pb_mod.Passivbot._startup_timing_begin
+        _startup_timing_mark = pb_mod.Passivbot._startup_timing_mark
+        _emit_live_event = pb_mod.Passivbot._emit_live_event
+
+        def __init__(self):
+            self.exchange = "gateio"
+            self.user = "gateio_01"
+            self.bot_id = "bot_1"
+            self.config = {
+                "live": {
+                    "startup_phase_budgets": {
+                        "account": {
+                            "elapsed_ms": 10_000,
+                            "since_previous_ms": 5_000,
+                        }
+                    }
+                }
+            }
+            self._live_event_pipeline = LiveEventPipeline(
+                structured_sinks=[sink], monitor_sinks=[]
+            )
+
+    bot = FakeBot()
+    bot._startup_timing_begin()
+    bot._startup_timing_mark("account")
+
+    assert bot._live_event_pipeline.flush(timeout=2.0) is True
+    assert sink.events[0].data["budget_source"] == "config"
+    assert sink.events[0].data["elapsed_budget_ms"] == 10_000
+    assert sink.events[0].data["since_previous_budget_ms"] == 5_000
+    assert bot._live_event_pipeline.close(timeout=2.0) is True
+
+
 def test_startup_timing_debug_profile_adds_bounded_phase_shape(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- add optional validated live.startup_phase_budgets for canonical startup timing phases
- carry configured elapsed and since-previous targets on existing bot.startup_timing events
- make live smoke reports prefer explicit configured targets over prior-p95 projections

## Behavior boundary
These budgets are diagnostic metadata only. They do not gate startup, readiness, exchange access, order construction, risk, or trading. Empty configuration preserves the existing event shape and report behavior.

## Validation
- 412 focused/config/docs tests passed
- changed production modules compile
- AI docs check: 0 errors, existing word-count warning only
- generated live-event registry is current
- git diff --check

## Deploy plan
After merge, fast-forward VPS5 and gracefully restart only the five configured bot panes while preserving misc:0.0, then run bounded settled smoke. Current VPS configs are expected to keep the new map empty, so live validation will prove compatibility rather than manufacture configured-budget events.