### PR TITLE
Add startup budget assessments to performance reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ All notable user-facing changes will be documented in this file.
 - Live configs may now define optional diagnostic `startup_phase_budgets` for
   canonical startup timing phases. Existing `bot.startup_timing` events carry
   configured elapsed and phase budgets, and live smoke reports prefer those
-  explicit values over historical p95 projections. The budgets are reporting
-  metadata only and do not gate startup, readiness, exchange access, or
-  trading.
+  explicit values over historical p95 projections. Live performance reports
+  now retain bounded latest-lifecycle configured-budget assessments and
+  aggregate their status. The budgets are reporting metadata only and do not
+  gate startup, readiness, exchange access, or trading.
 
 - `log-secret-inventory --summary` now emits bounded aggregate scan evidence
   without the per-file paths, ages, or hashes retained by the full report.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,8 +24,10 @@ Estimated completion:
 
 - Branch: `codex/live-performance-startup-budgets`, based on canonical
   `d511341366fea26b48d064f2bbe5b25a4408664b` after PR #1269.
-- PR: pending. Slice: make `live-performance-report` consume the configured
-  startup-budget metadata already carried by `bot.startup_timing` events.
+- PR: #1270, `Add startup budget assessments to performance reports`;
+  semantic implementation head `1d33d6f8a4`. Slice: make
+  `live-performance-report` consume the configured startup-budget metadata
+  already carried by `bot.startup_timing` events.
 - Triggering evidence: PR #1269 made configured startup budgets durable and
   taught smoke reports to assess them, but the parallel startup-readiness
   accumulator in `live-performance-report` still discarded those fields.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,38 +22,45 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/startup-phase-budget-events`, based on canonical
-  `f8ec74792d69e229fd63bf4cdf7ab7a092a79cd4` after PR #1268.
-- PR: #1269, `Add diagnostic startup phase budgets`; semantic head
-  `a7f460b384d1e1e684d71cb390c952ac718a5a3f`. Slice: add optional durable
-  diagnostic budgets to existing `bot.startup_timing` events and make smoke
-  reports prefer them over historical p95 projections.
-- Triggering evidence: PR #1266 made missing/no-baseline startup budget
-  assessments explicit, but the only available budget remained a local prior
-  p95. Operators still could not compare startup timing against an intentional
-  per-phase target carried with the event.
-- Scope: add open `live.startup_phase_budgets` config keyed by canonical phase,
-  with independently optional process-elapsed and since-previous-mark budgets;
-  validate it, copy configured values into existing timing events, and prefer
-  those values in full/summary/brief smoke projections.
-- Behavior boundary: diagnostic metadata and reporting only. Budgets do not
-  gate startup, readiness, exchange access, order construction, or trading.
-  Empty configuration preserves existing event and report behavior.
-- Validation: config roundtrip/rejection tests, event propagation tests, smoke
-  precedence/malformed-metadata tests, focused Python tests, compilation, and
-  docs checks.
+- Branch: `codex/live-performance-startup-budgets`, based on canonical
+  `d511341366fea26b48d064f2bbe5b25a4408664b` after PR #1269.
+- PR: pending. Slice: make `live-performance-report` consume the configured
+  startup-budget metadata already carried by `bot.startup_timing` events.
+- Triggering evidence: PR #1269 made configured startup budgets durable and
+  taught smoke reports to assess them, but the parallel startup-readiness
+  accumulator in `live-performance-report` still discarded those fields.
+- Scope: add bounded latest-lifecycle per-bot elapsed and phase budget
+  assessments plus aggregate status counts. Strictly classify malformed
+  configured budget metadata and preserve the legacy report shape when no
+  configured budget is present.
+- Behavior boundary: read-only report metadata only. No event production,
+  startup, readiness, exchange access, order construction, or trading changes.
+- Validation: focused performance-report regression tests, broader report and
+  config tests, compilation, and docs checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: after merge, pull and gracefully restart only the five
-  configured bot panes, preserving `misc:0.0`, then run bounded settled smoke.
-  Current VPS configs are expected to keep the new map empty, so live smoke
-  proves compatibility rather than manufacturing configured-budget events.
+- Expected VPS action: pull and run bounded report/smoke checks after merge;
+  no bot restart is expected for this read-only reporting slice.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `f8ec74792d69e229fd63bf4cdf7ab7a092a79cd4`, PR #1268. The tracked checkout
+  `d511341366fea26b48d064f2bbe5b25a4408664b`, PR #1269. The tracked checkout
   is clean and expected untracked artifacts are preserved.
+- PR #1269 was activated with one SIGINT at `2026-07-16T11:59:17Z` to exact
+  old PIDs `979190/979193/979196/979199/979202`; all exited naturally within
+  36 seconds. New PIDs are `985592/985594/985596/985598/985600`; all five pane
+  parents and unrelated `misc:0.0` PID `434835` remained unchanged.
+- Immediate smoke was hard-green. One later window retained a real recovered
+  KuCoin fill-refresh timeout and was not treated as deployment green. A fresh
+  two-minute settled window was `ok=true` with zero hard, log, monitor,
+  process, or event-pipeline failures, `46/46` account-critical calls and
+  `7/7` fill refreshes successful, all five expected processes/configs
+  matched, states `R=4,S=1`, no uninterruptible sleep, and no active HSL
+  replay. Two non-hard candle timeouts remained durable.
+- VPS5 intentionally has no configured `startup_phase_budgets`. Reports showed
+  `no_baseline`, with zero invalid configured assessments; no budget event,
+  exchange state, or trading activity was manufactured for validation.
 - PR #1268 required no restart. Its bounded aggregate-only inventory scanned
   40 of 1,182 discovered files and 8,153,519 bytes, reported ten positive and
   25 truncated files, skipped six symlinks, and had zero unreadable files or
@@ -965,9 +972,10 @@ value-free historical secret-log inventory is also merged and deployed; its
 dry run confirmed retained credential-bearing logs without exposing values or
 changing artifacts. PR #1266's brief startup-budget coverage, PR #1267's
 scheme-less credential-query detection, and PR #1268's aggregate-only inventory
-projection are also merged and deployed without restart. The active
-startup-budget slice adds intentional diagnostic targets to existing timing
-events without turning observability into a readiness or trading gate.
+projection are also merged and deployed without restart. PR #1269's configured
+startup-budget events are merged and deployed with the same non-enforcement
+boundary. The active follow-up makes the performance report consume that
+durable metadata consistently with smoke reporting.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,29 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1268)
+## Latest Canonical Deployment (PR #1269)
+
+- PR #1269 merged to `master` as
+  `d511341366fea26b48d064f2bbe5b25a4408664b`. It adds optional configured
+  diagnostic budgets to existing startup timing events and makes smoke reports
+  prefer them over historical p95 projections without enforcing the budgets.
+- VPS5 sent one SIGINT at `2026-07-16T11:59:17Z` to exact old PIDs
+  `979190/979193/979196/979199/979202`; all exited naturally within 36 seconds.
+  New PIDs are `985592/985594/985596/985598/985600`; pane parents and unrelated
+  `misc:0.0` PID `434835` remained unchanged.
+- Immediate smoke was hard-green. A later window retained one real recovered
+  KuCoin fill-refresh timeout and was not treated as green. The fresh final
+  two-minute window was `ok=true` with zero hard/log/monitor/process/pipeline
+  failures, `46/46` account-critical calls and `7/7` fill refreshes successful,
+  five matching/config-valid processes in states `R=4,S=1`, no uninterruptible
+  sleep, no active HSL replay, and a clean tracked checkout.
+- VPS5 intentionally has no configured phase budgets, so reports retained
+  `no_baseline` assessments with zero invalid configured metadata. No budget
+  event or trading activity was manufactured. The next read-only reporting
+  slice makes `live-performance-report` consume the durable configured-budget
+  metadata already assessed by `live-smoke-report`.
+
+## Previous Canonical Deployment (PR #1268)
 
 - PR #1268 merged to `master` as
   `f8ec74792d69e229fd63bf4cdf7ab7a092a79cd4`. It adds an aggregate-only
@@ -29,9 +51,9 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - No source values or lines were emitted, no artifacts were remediated, and no
   process signal was sent. All five configured bot panes and unrelated
   `misc:0.0` remained present.
-- The next substantive slice adds optional durable diagnostic budgets to
-  existing startup timing events and gives those configured targets precedence
-  over historical p95 report projections without enforcing them.
+- PR #1269 subsequently added optional durable diagnostic budgets to existing
+  startup timing events and gave those configured targets report precedence
+  without enforcing them.
 
 ## Previous Canonical Deployment (PR #1267)
 

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -320,10 +320,11 @@ Related detailed plans:
    Status: partial. Startup timing and warmup cache decision events exist, and
    `live-smoke-report` now summarizes latest startup phase timings with rolling
    median/p95 baselines from local monitor events plus report-only budget
-   projections against prior p95 phase baselines. The active slice adds
-   optional durable diagnostic budgets to existing timing events and gives
-   configured values report precedence; enforcement and broader readiness-stage
-   coverage remain out of scope.
+   projections against prior p95 phase baselines. PR #1269 added optional
+   durable diagnostic budgets to existing timing events and gives configured
+   values smoke-report precedence. The active follow-up carries those same
+   assessments into `live-performance-report`; enforcement and broader
+   readiness-stage coverage remain out of scope.
 
    Startup currently has timing events, but the next step is durable budget
    accounting by phase: account-critical fetches, fill/PnL refresh, active
@@ -349,11 +350,14 @@ Related detailed plans:
    - 2026-07-16: PR #1266 made the brief projection aggregate existing
      elapsed/phase budget statuses so unavailable or no-baseline phases cannot
      look implicitly within budget. It remains report-only and non-enforcing.
-   - 2026-07-16: Active `codex/startup-phase-budget-events` adds optional
+   - 2026-07-16: PR #1269 added optional
      `live.startup_phase_budgets`, carries configured targets on existing
      `bot.startup_timing` events, and makes smoke reports prefer them over prior
      p95 projections. The values are diagnostic and never gate startup or
      trading.
+   - 2026-07-16: Active `codex/live-performance-startup-budgets` makes the
+     performance report retain bounded latest-lifecycle configured-budget
+     assessments and aggregate their status without changing startup behavior.
 
 5. [x] Resource pressure telemetry.
    Status: initial implementation merged. `health.summary` events now include

--- a/src/live/performance_report.py
+++ b/src/live/performance_report.py
@@ -1226,6 +1226,69 @@ def _startup_readiness_contract(
     return expected
 
 
+def _startup_config_budget_projection(
+    *,
+    data: dict[str, Any],
+    budget_key: str,
+    latest_ms: int | None,
+) -> dict[str, int | str | None] | None:
+    if data.get("budget_source") != "config" or budget_key not in data:
+        return None
+    raw_budget = data.get(budget_key)
+    if (
+        isinstance(raw_budget, bool)
+        or not isinstance(raw_budget, int)
+        or raw_budget < 0
+    ):
+        return {
+            "status": "invalid_budget",
+            "latest_ms": latest_ms,
+            "budget_ms": None,
+            "usage_pct": None,
+            "over_budget_by_ms": None,
+            "source": "config",
+        }
+    budget_ms = int(raw_budget)
+    over_budget_by_ms = (
+        None if latest_ms is None else max(0, int(latest_ms) - budget_ms)
+    )
+    return {
+        "status": (
+            "unavailable"
+            if latest_ms is None
+            else "over_budget"
+            if over_budget_by_ms
+            else "within_budget"
+        ),
+        "latest_ms": latest_ms,
+        "budget_ms": budget_ms,
+        "usage_pct": _usage_pct(latest_ms, budget_ms),
+        "over_budget_by_ms": over_budget_by_ms,
+        "source": "config",
+    }
+
+
+def _startup_config_budget_assessments(
+    data: dict[str, Any],
+    *,
+    elapsed_ms: int | None,
+    since_previous_ms: int | None,
+) -> dict[str, dict[str, int | str | None]]:
+    assessments = {}
+    for output_key, budget_key, latest_ms in (
+        ("elapsed_budget", "elapsed_budget_ms", elapsed_ms),
+        ("phase_budget", "since_previous_budget_ms", since_previous_ms),
+    ):
+        projection = _startup_config_budget_projection(
+            data=data,
+            budget_key=budget_key,
+            latest_ms=latest_ms,
+        )
+        if projection is not None:
+            assessments[output_key] = projection
+    return assessments
+
+
 class _StartupSourceCompletenessTracker:
     """Track newer incomplete event sources without retaining their rows."""
 
@@ -1303,6 +1366,7 @@ class _StartupReadinessAccumulator:
                 "bot": bot,
                 "_candidates": {},
                 "startup_phases_ms": {},
+                "startup_phase_budgets": {},
                 "latest_ts": None,
             }
             self.bots[bot] = state
@@ -1344,6 +1408,7 @@ class _StartupReadinessAccumulator:
                 "bot": bot,
                 "_candidates": retained,
                 "startup_phases_ms": {},
+                "startup_phase_budgets": {},
                 "latest_ts": None,
             }
         )
@@ -1374,6 +1439,12 @@ class _StartupReadinessAccumulator:
         if event_type == "bot.startup_timing":
             stage = candidate["stage"]
             elapsed_ms = candidate.get("elapsed_ms")
+            phase_budgets = state.setdefault("startup_phase_budgets", {})
+            budget_assessments = candidate.get("budget_assessments")
+            if budget_assessments:
+                phase_budgets[stage] = budget_assessments
+            else:
+                phase_budgets.pop(stage, None)
             if elapsed_ms is None:
                 return
             state["startup_phases_ms"][stage] = int(elapsed_ms)
@@ -1471,6 +1542,7 @@ class _StartupReadinessAccumulator:
                     "_candidates": retained,
                     "_started_order": event_order,
                     "startup_phases_ms": {},
+                    "startup_phase_budgets": {},
                     "latest_ts": int(ts) if ts is not None else None,
                 }
             )
@@ -1521,10 +1593,16 @@ class _StartupReadinessAccumulator:
         if event_type == "bot.startup_timing":
             assert stage is not None
             candidate_key = f"startup:{stage}"
+            since_previous_ms = _non_negative_ms(data.get("since_previous_ms"))
             candidate.update(
                 {
                     "stage": stage,
                     "elapsed_ms": elapsed_ms,
+                    "budget_assessments": _startup_config_budget_assessments(
+                        data,
+                        elapsed_ms=elapsed_ms,
+                        since_previous_ms=since_previous_ms,
+                    ),
                     "contract": contract,
                 }
             )
@@ -1595,6 +1673,7 @@ class _StartupReadinessAccumulator:
         ready_count = 0
         hsl_active_count = 0
         debug_profile_counts: Counter[str] = Counter()
+        startup_budget_status_counts: Counter[str] = Counter()
         limit = max(0, int(group_limit))
         phase_labels = [
             phase
@@ -1618,6 +1697,20 @@ class _StartupReadinessAccumulator:
             }
             if len(phases) > limit:
                 item["startup_phases_truncated"] = True
+            phase_budgets = dict(
+                sorted((state.get("startup_phase_budgets") or {}).items())
+            )
+            for assessments in phase_budgets.values():
+                for projection in assessments.values():
+                    status = projection.get("status")
+                    if isinstance(status, str):
+                        startup_budget_status_counts[status] += 1
+            if phase_budgets:
+                item["startup_phase_budgets"] = dict(
+                    list(phase_budgets.items())[:limit]
+                )
+                if len(phase_budgets) > limit:
+                    item["startup_phase_budgets_truncated"] = True
             readiness_sla = dict(sorted((state.get("readiness_sla") or {}).items()))
             if readiness_sla:
                 item["readiness_sla"] = dict(list(readiness_sla.items())[:limit])
@@ -1648,7 +1741,7 @@ class _StartupReadinessAccumulator:
                 item["debug_profiles"] = debug_profiles
                 debug_profile_counts.update(debug_profiles)
             bot_items.append({key: value for key, value in item.items() if value not in (None, {})})
-        return {
+        result = {
             "bot_count": len(bot_items),
             "ready_count": int(ready_count),
             "hsl_replay_active_count": int(hsl_active_count),
@@ -1683,6 +1776,11 @@ class _StartupReadinessAccumulator:
             "bots_truncated": len(bot_items) > limit,
             "bots": bot_items[:limit],
         }
+        if startup_budget_status_counts:
+            result["startup_budget_status_counts"] = dict(
+                sorted(startup_budget_status_counts.items())
+            )
+        return result
 
 
 _STARTUP_MILESTONE_EVENT_TYPES = {

--- a/tests/test_live_performance_report.py
+++ b/tests/test_live_performance_report.py
@@ -1340,6 +1340,149 @@ def test_live_performance_report_startup_readiness_summary(tmp_path, monkeypatch
     assert bot["hsl_replay"]["latest_event_age_ms"] == 60000
 
 
+def test_live_performance_report_startup_readiness_assesses_configured_budgets(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(event_type="bot.started", seq=1, ts=1000),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=2,
+                ts=2000,
+                data={
+                    "phase": "account",
+                    "elapsed_ms": 3000,
+                    "since_previous_ms": 1600,
+                    "budget_source": "config",
+                    "elapsed_budget_ms": 2500,
+                    "since_previous_budget_ms": 5000,
+                },
+            ),
+        ],
+    )
+
+    report = build_live_performance_report(tmp_path / "monitor")
+    startup = report["startup_readiness"]
+
+    assert startup["startup_budget_status_counts"] == {
+        "over_budget": 1,
+        "within_budget": 1,
+    }
+    assert startup["bots"][0]["startup_phase_budgets"] == {
+        "account": {
+            "elapsed_budget": {
+                "status": "over_budget",
+                "latest_ms": 3000,
+                "budget_ms": 2500,
+                "usage_pct": 120,
+                "over_budget_by_ms": 500,
+                "source": "config",
+            },
+            "phase_budget": {
+                "status": "within_budget",
+                "latest_ms": 1600,
+                "budget_ms": 5000,
+                "usage_pct": 32,
+                "over_budget_by_ms": 0,
+                "source": "config",
+            },
+        }
+    }
+    summary = summarize_live_performance_report(report, group_limit=1)
+    assert summary["startup_readiness"]["startup_budget_status_counts"] == {
+        "over_budget": 1,
+        "within_budget": 1,
+    }
+    assert summary["startup_readiness"]["bots"][0][
+        "startup_phase_budgets"
+    ] == startup["bots"][0]["startup_phase_budgets"]
+
+
+def test_live_performance_report_startup_readiness_rejects_malformed_config_budget(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=1,
+                ts=1000,
+                data={
+                    "phase": "account",
+                    "elapsed_ms": 900,
+                    "since_previous_ms": 800,
+                    "budget_source": "config",
+                    "elapsed_budget_ms": "bad",
+                },
+            ),
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=2,
+                ts=2000,
+                data={
+                    "phase": "hsl",
+                    "elapsed_ms": 2500,
+                    "since_previous_ms": 1600,
+                    "elapsed_budget_ms": 3000,
+                    "since_previous_budget_ms": 2000,
+                },
+            ),
+        ],
+    )
+
+    startup = build_live_performance_report(tmp_path / "monitor")[
+        "startup_readiness"
+    ]
+
+    assert startup["startup_budget_status_counts"] == {"invalid_budget": 1}
+    budgets = startup["bots"][0]["startup_phase_budgets"]
+    assert budgets["account"] == {
+        "elapsed_budget": {
+            "status": "invalid_budget",
+            "latest_ms": 900,
+            "budget_ms": None,
+            "usage_pct": None,
+            "over_budget_by_ms": None,
+            "source": "config",
+        }
+    }
+    assert "phase_budget" not in budgets["account"]
+    assert "hsl" not in budgets
+
+
+def test_live_performance_report_startup_readiness_legacy_shape_has_no_budgets(
+    tmp_path,
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="bot.startup_timing",
+                seq=1,
+                ts=1000,
+                data={
+                    "phase": "account",
+                    "elapsed_ms": 900,
+                    "since_previous_ms": 800,
+                },
+            )
+        ],
+    )
+
+    startup = build_live_performance_report(tmp_path / "monitor")[
+        "startup_readiness"
+    ]
+
+    assert "startup_budget_status_counts" not in startup
+    assert "startup_phase_budgets" not in startup["bots"][0]
+
+
 def test_live_performance_report_rejects_mismatched_startup_readiness_contract(
     tmp_path,
 ):
@@ -1514,7 +1657,12 @@ def test_live_performance_report_startup_readiness_resets_on_restart(tmp_path):
                 event_type="bot.startup_timing",
                 seq=2,
                 ts=1100,
-                data={"stage": "account", "elapsed_ms": 300},
+                data={
+                    "stage": "account",
+                    "elapsed_ms": 300,
+                    "budget_source": "config",
+                    "elapsed_budget_ms": 500,
+                },
             ),
             _monitor_row(
                 event_type="hsl.replay.completed",
@@ -1545,6 +1693,8 @@ def test_live_performance_report_startup_readiness_resets_on_restart(tmp_path):
     assert startup["debug_profile_counts"] == {"state": 1}
     assert "bot_ready_ts" not in bot
     assert "startup_phases_ms" not in bot
+    assert "startup_phase_budgets" not in bot
+    assert "startup_budget_status_counts" not in startup
     assert "hsl_replay" not in bot
 
 


### PR DESCRIPTION
## Scope

- Category: read-only tooling.
- Make `live-performance-report` retain bounded configured startup-budget assessments already carried by `bot.startup_timing` events.
- Report latest-lifecycle elapsed and since-previous budget status per bot, plus aggregate status counts.
- Treat malformed configured budget metadata as `invalid_budget` instead of silently accepting or coercing it.
- Record the verified PR #1269 merge, VPS5 restart, and settled smoke evidence in the operational status, progress ledger, backlog, and changelog.

## Behavior boundary

- No event producer, config, startup, readiness, exchange-call, order, risk, or trading behavior changes.
- Events without `budget_source=config` preserve the previous performance-report shape.
- A new bot lifecycle clears prior phase budget assessments.
- Output remains bounded by the existing startup phase and bot limits.

## VPS action

- After merge: fast-forward the VPS5 checkout and run bounded performance-report/smoke checks.
- No bot restart is expected because this changes only read-only report consumption.

## Validation

- `python -m pytest tests/test_live_performance_report.py -q` (115 passed)
- `python -m pytest tests/test_live_performance_report.py tests/test_live_smoke_report.py tests/test_config_pipeline.py tests/test_passivbot_monitor.py -q` (438 passed; one existing portalocker warning)
- `python -m pytest tests/test_ai_docs.py tests/test_live_event_registry_docs.py -q` (3 passed)
- `python src/tools/check_ai_docs.py` (0 errors; existing word-count warning)
- `python -m py_compile src/live/performance_report.py tests/test_live_performance_report.py`
- `git diff --check`

## Reviewer focus

- Strict configured-budget parsing matches smoke-report semantics.
- Latest-lifecycle/reset behavior cannot retain stale assessments.
- Legacy events and missing independent budget dimensions do not gain misleading output.
- This remains reporting-only and non-enforcing.
