### PR TITLE
Expose forager feature health in smoke reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live smoke reports now expose bounded existing
+  `forager.feature_unavailable` evidence across full, summary, brief, and
+  section-selective output. The projection does not change smoke verdicts,
+  console output, forager selection, readiness, or trading behavior.
+
 - Live configs may now define optional diagnostic `startup_phase_budgets` for
   canonical startup timing phases. Existing `bot.startup_timing` events carry
   configured elapsed and phase budgets, and live smoke reports prefer those

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,8 +24,10 @@ Estimated completion:
 
 - Branch: `codex/smoke-forager-feature-health`, based on canonical
   `9869263d74829f163b0bc8010fa18d1bf41de055` after PR #1270.
-- PR: pending. Slice: expose existing `forager.feature_unavailable` events in
-  full, summary, brief, and section-selective live smoke reports.
+- PR: #1271, `Expose forager feature health in smoke reports`; semantic
+  implementation head `47b084b62e`. Slice: expose existing
+  `forager.feature_unavailable` events in full, summary, brief, and
+  section-selective live smoke reports.
 - Triggering evidence: the producer already emits bounded structured-only
   candidate, missing-feature, age, fetch-budget, and symbol-sample context, and
   `live-performance-report` consumes it. Smoke reports currently omit it.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,23 +22,20 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/live-performance-startup-budgets`, based on canonical
-  `d511341366fea26b48d064f2bbe5b25a4408664b` after PR #1269.
-- PR: #1270, `Add startup budget assessments to performance reports`;
-  semantic implementation head `1d33d6f8a4`. Slice: make
-  `live-performance-report` consume the configured startup-budget metadata
-  already carried by `bot.startup_timing` events.
-- Triggering evidence: PR #1269 made configured startup budgets durable and
-  taught smoke reports to assess them, but the parallel startup-readiness
-  accumulator in `live-performance-report` still discarded those fields.
-- Scope: add bounded latest-lifecycle per-bot elapsed and phase budget
-  assessments plus aggregate status counts. Strictly classify malformed
-  configured budget metadata and preserve the legacy report shape when no
-  configured budget is present.
-- Behavior boundary: read-only report metadata only. No event production,
-  startup, readiness, exchange access, order construction, or trading changes.
-- Validation: focused performance-report regression tests, broader report and
-  config tests, compilation, and docs checks.
+- Branch: `codex/smoke-forager-feature-health`, based on canonical
+  `9869263d74829f163b0bc8010fa18d1bf41de055` after PR #1270.
+- PR: pending. Slice: expose existing `forager.feature_unavailable` events in
+  full, summary, brief, and section-selective live smoke reports.
+- Triggering evidence: the producer already emits bounded structured-only
+  candidate, missing-feature, age, fetch-budget, and symbol-sample context, and
+  `live-performance-report` consumes it. Smoke reports currently omit it.
+- Scope: aggregate latest event data per bot/position side, retain bounded
+  redacted symbol samples, and expose report-level counts and maxima.
+- Behavior boundary: read-only report projection only. No smoke verdict,
+  attention classification, console output, event production, forager
+  selection, readiness, exchange access, or trading changes.
+- Validation: producer-shaped report fixtures, full/summary/brief/section
+  projection tests, full smoke-report tests, compilation, and docs checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
 - Expected VPS action: pull and run bounded report/smoke checks after merge;
@@ -47,8 +44,19 @@ Estimated completion:
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `d511341366fea26b48d064f2bbe5b25a4408664b`, PR #1269. The tracked checkout
+  `9869263d74829f163b0bc8010fa18d1bf41de055`, PR #1270. The tracked checkout
   is clean and expected untracked artifacts are preserved.
+- PR #1270 required no restart. VPS5 fast-forwarded cleanly while exact bot
+  PIDs `985592/985594/985596/985598/985600`, all five pane parents, and
+  unrelated `misc:0.0` PID `434835` remained unchanged.
+- A bounded performance report was `ok=true` with zero errors or warnings and
+  preserved the legacy no-budget shape for naturally unconfigured startup
+  events. The two-minute smoke was `ok=true` with zero hard, log, monitor,
+  process, or event-pipeline failures, `147/147` remote and `37/37`
+  account-critical calls successful, `9/9` fill refreshes successful, all five
+  processes/configs matched in states `R=4,S=1`, and no uninterruptible sleep.
+  Fifteen non-hard attention events remained durable: eleven EMA readiness,
+  two staged-cycle degradation, and two websocket reconnect events.
 - PR #1269 was activated with one SIGINT at `2026-07-16T11:59:17Z` to exact
   old PIDs `979190/979193/979196/979199/979202`; all exited naturally within
   36 seconds. New PIDs are `985592/985594/985596/985598/985600`; all five pane
@@ -976,8 +984,9 @@ changing artifacts. PR #1266's brief startup-budget coverage, PR #1267's
 scheme-less credential-query detection, and PR #1268's aggregate-only inventory
 projection are also merged and deployed without restart. PR #1269's configured
 startup-budget events are merged and deployed with the same non-enforcement
-boundary. The active follow-up makes the performance report consume that
-durable metadata consistently with smoke reporting.
+boundary. PR #1270's matching performance projection is also merged and
+deployed without restart. The active follow-up exposes existing structured-only
+forager feature-unavailability evidence in smoke reports.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,27 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1269)
+## Latest Canonical Deployment (PR #1270)
+
+- PR #1270 merged to `master` as
+  `9869263d74829f163b0bc8010fa18d1bf41de055`. It makes the read-only live
+  performance report retain latest-lifecycle configured startup-budget
+  assessments and aggregate their status without changing startup or trading.
+- VPS5 fast-forwarded cleanly with no restart. Exact bot PIDs
+  `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
+  `misc:0.0` PID `434835` remained unchanged.
+- A bounded performance report was `ok=true` with zero errors or warnings and
+  retained the legacy no-budget shape for naturally unconfigured events. The
+  final two-minute smoke was `ok=true` with zero hard/log/monitor/process/
+  pipeline failures, `147/147` remote and `37/37` account-critical calls
+  successful, nine successful fill refreshes, and all five matching/config-
+  valid processes in states `R=4,S=1` with no uninterruptible sleep.
+- Fifteen non-hard attention events remained durable: eleven EMA readiness,
+  two staged-cycle degradation, and two websocket reconnect events. The next
+  report-only slice exposes existing structured forager feature-unavailability
+  evidence in live smoke reports without changing verdicts or behavior.
+
+## Previous Canonical Deployment (PR #1269)
 
 - PR #1269 merged to `master` as
   `d511341366fea26b48d064f2bbe5b25a4408664b`. It adds optional configured
@@ -33,9 +53,9 @@ merge, live smoke evidence changes, or new gaps are discovered.
   sleep, no active HSL replay, and a clean tracked checkout.
 - VPS5 intentionally has no configured phase budgets, so reports retained
   `no_baseline` assessments with zero invalid configured metadata. No budget
-  event or trading activity was manufactured. The next read-only reporting
-  slice makes `live-performance-report` consume the durable configured-budget
-  metadata already assessed by `live-smoke-report`.
+  event or trading activity was manufactured. PR #1270 subsequently made
+  `live-performance-report` consume the durable configured-budget metadata
+  already assessed by `live-smoke-report`.
 
 ## Previous Canonical Deployment (PR #1268)
 

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -322,8 +322,8 @@ Related detailed plans:
    median/p95 baselines from local monitor events plus report-only budget
    projections against prior p95 phase baselines. PR #1269 added optional
    durable diagnostic budgets to existing timing events and gives configured
-   values smoke-report precedence. The active follow-up carries those same
-   assessments into `live-performance-report`; enforcement and broader
+   values smoke-report precedence. PR #1270 carries those same assessments
+   into `live-performance-report`; enforcement and broader
    readiness-stage coverage remain out of scope.
 
    Startup currently has timing events, but the next step is durable budget
@@ -355,7 +355,7 @@ Related detailed plans:
      `bot.startup_timing` events, and makes smoke reports prefer them over prior
      p95 projections. The values are diagnostic and never gate startup or
      trading.
-   - 2026-07-16: Active `codex/live-performance-startup-budgets` makes the
+   - 2026-07-16: PR #1270 makes the
      performance report retain bounded latest-lifecycle configured-budget
      assessments and aggregate their status without changing startup behavior.
 
@@ -853,6 +853,10 @@ Related detailed plans:
       active/normal forager symbols, reusing local real-candle EMA metrics
       within the configured forager staleness cap. Candidate-only symbols still
       remain unavailable instead of receiving synthetic ranking tails.
+    - 2026-07-16: Active `codex/smoke-forager-feature-health` exposes the
+      producer's existing structured-only feature-unavailability evidence in
+      bounded smoke-report projections. It does not change readiness or the
+      create-side handoff contract.
 
 18. [ ] Binance hourly hedge-mode/config refresh traceback classification.
     Status: structured event, smoke projection, performance projection, and live

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -130,6 +130,8 @@ SHUTDOWN_EVENT_GROUP_LIMIT = 20
 PROBLEM_EVENT_GROUP_LIMIT = 20
 EMA_READINESS_GROUP_LIMIT = 20
 EMA_READINESS_REASON_SYMBOL_SAMPLE_LIMIT = 8
+FORAGER_FEATURE_HEALTH_GROUP_LIMIT = 20
+FORAGER_FEATURE_SYMBOL_SAMPLE_LIMIT = 8
 STAGED_READINESS_GROUP_LIMIT = 20
 STAGED_READINESS_VALUE_LIMIT = 8
 EVENT_PIPELINE_HEALTH_GROUP_LIMIT = 20
@@ -2362,6 +2364,152 @@ def _summarize_ema_readiness_health(
         ),
         "groups": compact_groups,
     }
+
+
+def _forager_feature_health_group(
+    *,
+    bot_key: str,
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+    path: Path,
+    line_no: int,
+) -> dict[str, Any]:
+    data = live_event.get("data")
+    payload = data if isinstance(data, dict) else {}
+    symbols: Counter[str] = Counter()
+    unavailable = payload.get("unavailable")
+    if isinstance(unavailable, list):
+        for symbol in unavailable:
+            safe_symbol = _redact_log_text(str(symbol), max_len=80)
+            if safe_symbol:
+                symbols[safe_symbol] += 1
+    latest_data = {}
+    for key in (
+        "candidate_count",
+        "volume_count",
+        "log_range_count",
+        "max_age_ms",
+        "fetch_budget",
+    ):
+        value = _non_negative_int(payload.get(key))
+        if value is not None:
+            latest_data[key] = int(value)
+    symbol_sample = _symbol_sample(
+        symbols,
+        limit=FORAGER_FEATURE_SYMBOL_SAMPLE_LIMIT,
+    )
+    if symbol_sample:
+        latest_data["unavailable_symbols"] = symbol_sample
+    return {
+        "bot": bot_key,
+        "pside": _redact_log_text(
+            str(live_event.get("pside") or "unknown"),
+            max_len=20,
+        ),
+        "count": 1,
+        "latest_ts": row.get("ts"),
+        "latest_seq": row.get("seq"),
+        "latest_path": str(path),
+        "latest_line": int(line_no),
+        "latest_data": latest_data,
+    }
+
+
+def _merge_forager_feature_health_group(
+    groups: dict[tuple[str, str], dict[str, Any]],
+    group: dict[str, Any],
+) -> None:
+    key = (str(group["bot"]), str(group["pside"]))
+    existing = groups.get(key)
+    if existing is None:
+        groups[key] = group
+        return
+    existing["count"] = int(existing.get("count", 0)) + 1
+    current_key = _sort_event_position_key(
+        ts=group.get("latest_ts"),
+        seq=group.get("latest_seq"),
+        path=group.get("latest_path") or "",
+        line_no=int(group.get("latest_line") or 0),
+    )
+    existing_key = _sort_event_position_key(
+        ts=existing.get("latest_ts"),
+        seq=existing.get("latest_seq"),
+        path=existing.get("latest_path") or "",
+        line_no=int(existing.get("latest_line") or 0),
+    )
+    if current_key > existing_key:
+        for field in (
+            "latest_ts",
+            "latest_seq",
+            "latest_path",
+            "latest_line",
+            "latest_data",
+        ):
+            existing[field] = group.get(field)
+
+
+def _summarize_forager_feature_health(
+    groups: dict[tuple[str, str], dict[str, Any]],
+    event_type_counts: Counter[str],
+) -> dict[str, Any]:
+    ordered = sorted(
+        groups.values(),
+        key=lambda item: (
+            -int(_non_negative_int(item.get("latest_ts")) or 0),
+            -int(item.get("count") or 0),
+            str(item.get("bot") or ""),
+            str(item.get("pside") or ""),
+        ),
+    )
+    latest_values: dict[str, list[int]] = defaultdict(list)
+    latest_symbols: Counter[str] = Counter()
+    for group in groups.values():
+        latest = group.get("latest_data")
+        if not isinstance(latest, dict):
+            continue
+        for key in (
+            "candidate_count",
+            "volume_count",
+            "log_range_count",
+            "max_age_ms",
+            "fetch_budget",
+        ):
+            value = _non_negative_int(latest.get(key))
+            if value is not None:
+                latest_values[key].append(int(value))
+        symbol_summary = latest.get("unavailable_symbols")
+        if isinstance(symbol_summary, dict):
+            for symbol in symbol_summary.get("sample") or []:
+                latest_symbols[str(symbol)] += 1
+    compact_groups = [
+        {
+            key: value
+            for key, value in group.items()
+            if key not in {"latest_path", "latest_line", "latest_seq"}
+            and value not in (None, {}, [])
+        }
+        for group in ordered[:FORAGER_FEATURE_HEALTH_GROUP_LIMIT]
+    ]
+    summary = {
+        "total": sum(int(group.get("count", 0)) for group in groups.values()),
+        "bots": len({group.get("bot") for group in groups.values()}),
+        "event_types": dict(event_type_counts.most_common()),
+        "latest_candidate_count_total": sum(latest_values["candidate_count"]),
+        "latest_volume_count_total": sum(latest_values["volume_count"]),
+        "latest_log_range_count_total": sum(latest_values["log_range_count"]),
+        "latest_fetch_budget_total": sum(latest_values["fetch_budget"]),
+        "groups_truncated": len(ordered) > FORAGER_FEATURE_HEALTH_GROUP_LIMIT,
+        "groups": compact_groups,
+    }
+    if latest_values["max_age_ms"]:
+        summary["latest_max_age_ms_max"] = max(latest_values["max_age_ms"])
+    symbol_sample = _symbol_sample(
+        latest_symbols,
+        limit=FORAGER_FEATURE_SYMBOL_SAMPLE_LIMIT,
+    )
+    if symbol_sample:
+        summary["latest_unavailable_symbols"] = symbol_sample
+    return summary
 
 
 def _exchange_config_refresh_group(
@@ -6349,6 +6497,8 @@ def _scan_events(
     fill_refresh_health_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     ema_readiness_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     ema_readiness_event_type_counts: Counter[str] = Counter()
+    forager_feature_health_groups: dict[tuple[str, str], dict[str, Any]] = {}
+    forager_feature_health_event_type_counts: Counter[str] = Counter()
     exchange_config_refresh_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     exchange_config_refresh_event_type_counts: Counter[str] = Counter()
     staged_readiness_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -6576,6 +6726,18 @@ def _scan_events(
                         _merge_ema_readiness_group(
                             ema_readiness_groups,
                             _ema_readiness_group(
+                                bot_key=bot_key,
+                                row=row,
+                                live_event=live_event,
+                                path=path,
+                                line_no=line_no,
+                            ),
+                        )
+                    if event_type == EventTypes.FORAGER_FEATURE_UNAVAILABLE:
+                        forager_feature_health_event_type_counts[str(event_type)] += 1
+                        _merge_forager_feature_health_group(
+                            forager_feature_health_groups,
+                            _forager_feature_health_group(
                                 bot_key=bot_key,
                                 row=row,
                                 live_event=live_event,
@@ -6811,6 +6973,10 @@ def _scan_events(
         "ema_readiness_health": _summarize_ema_readiness_health(
             ema_readiness_groups,
             ema_readiness_event_type_counts,
+        ),
+        "forager_feature_health": _summarize_forager_feature_health(
+            forager_feature_health_groups,
+            forager_feature_health_event_type_counts,
         ),
         "exchange_config_refresh_health": _summarize_exchange_config_refresh_health(
             exchange_config_refresh_groups,
@@ -7254,6 +7420,11 @@ def build_live_smoke_report(
         "cache_health": event_scan["cache_health"],
         "fill_refresh_health": event_scan["fill_refresh_health"],
         "ema_readiness_health": event_scan["ema_readiness_health"],
+        **(
+            {"forager_feature_health": event_scan["forager_feature_health"]}
+            if int(event_scan["forager_feature_health"].get("total") or 0)
+            else {}
+        ),
         "exchange_config_refresh_health": event_scan[
             "exchange_config_refresh_health"
         ],
@@ -7329,6 +7500,19 @@ def _summary_limited_groups(
             ),
             "latest_unavailable_total": summary.get("latest_unavailable_total"),
             "latest_optional_drop_total": summary.get("latest_optional_drop_total"),
+            "latest_candidate_count_total": summary.get(
+                "latest_candidate_count_total"
+            ),
+            "latest_volume_count_total": summary.get("latest_volume_count_total"),
+            "latest_log_range_count_total": summary.get(
+                "latest_log_range_count_total"
+            ),
+            "latest_fetch_budget_total": summary.get("latest_fetch_budget_total"),
+            "latest_max_age_ms_max": summary.get("latest_max_age_ms_max"),
+            "latest_unavailable_symbols": summary.get(
+                "latest_unavailable_symbols"
+            )
+            or None,
             "latest_candidate_reason_counts": summary.get(
                 "latest_candidate_reason_counts"
             )
@@ -7734,6 +7918,11 @@ def summarize_live_smoke_report(
         if isinstance(report.get("ema_readiness_health"), dict)
         else {}
     )
+    forager_feature_health = (
+        report.get("forager_feature_health")
+        if isinstance(report.get("forager_feature_health"), dict)
+        else {}
+    )
     fill_refresh_health = (
         report.get("fill_refresh_health")
         if isinstance(report.get("fill_refresh_health"), dict)
@@ -7936,6 +8125,16 @@ def summarize_live_smoke_report(
         "ema_readiness_health": _summary_limited_groups(
             ema_readiness_health,
             limit=max_groups,
+        ),
+        **(
+            {
+                "forager_feature_health": _summary_limited_groups(
+                    forager_feature_health,
+                    limit=max_groups,
+                )
+            }
+            if forager_feature_health
+            else {}
         ),
         "exchange_config_refresh_health": _summary_limited_groups(
             exchange_config_refresh_health,
@@ -8624,6 +8823,11 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         if isinstance(report.get("ema_readiness_health"), dict)
         else {}
     )
+    forager_feature_health = (
+        report.get("forager_feature_health")
+        if isinstance(report.get("forager_feature_health"), dict)
+        else {}
+    )
     fill_refresh_health = (
         report.get("fill_refresh_health")
         if isinstance(report.get("fill_refresh_health"), dict)
@@ -8891,6 +9095,17 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         "cache": _brief_cache_health(cache_health),
         "fill_refresh": _brief_fill_refresh_health(fill_refresh_health),
         "ema_readiness": ema_readiness_brief,
+        **(
+            {
+                "forager_features": {
+                    key: value
+                    for key, value in forager_feature_health.items()
+                    if key not in {"groups", "groups_truncated"}
+                }
+            }
+            if forager_feature_health
+            else {}
+        ),
         "exchange_config_refresh": {
             "total": _count_value(exchange_config_refresh_health.get("total")),
             "bots": _count_value(exchange_config_refresh_health.get("bots")),
@@ -9168,6 +9383,7 @@ SMOKE_REPORT_SECTION_ALIASES: dict[str, tuple[str, ...]] = {
     "event_pipeline": ("event_pipeline_health",),
     "exchange_config_refresh": ("exchange_config_refresh_health",),
     "fill_refresh": ("fill_refresh_health",),
+    "forager_features": ("forager_feature_health",),
     "hsl_replay": ("hsl_replay_health",),
     "remote_calls": ("remote_call_health", "remote_call_timings"),
     "resources": ("resource_pressure",),

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -2376,13 +2376,6 @@ def _forager_feature_health_group(
 ) -> dict[str, Any]:
     data = live_event.get("data")
     payload = data if isinstance(data, dict) else {}
-    symbols: Counter[str] = Counter()
-    unavailable = payload.get("unavailable")
-    if isinstance(unavailable, list):
-        for symbol in unavailable:
-            safe_symbol = _redact_log_text(str(symbol), max_len=80)
-            if safe_symbol:
-                symbols[safe_symbol] += 1
     latest_data = {}
     for key in (
         "candidate_count",
@@ -2394,8 +2387,8 @@ def _forager_feature_health_group(
         value = _non_negative_int(payload.get(key))
         if value is not None:
             latest_data[key] = int(value)
-    symbol_sample = _symbol_sample(
-        symbols,
+    symbol_sample = _summary_symbol_sample(
+        payload.get("unavailable"),
         limit=FORAGER_FEATURE_SYMBOL_SAMPLE_LIMIT,
     )
     if symbol_sample:
@@ -2463,6 +2456,7 @@ def _summarize_forager_feature_health(
     )
     latest_values: dict[str, list[int]] = defaultdict(list)
     latest_symbols: Counter[str] = Counter()
+    latest_unavailable_count = 0
     for group in groups.values():
         latest = group.get("latest_data")
         if not isinstance(latest, dict):
@@ -2479,6 +2473,9 @@ def _summarize_forager_feature_health(
                 latest_values[key].append(int(value))
         symbol_summary = latest.get("unavailable_symbols")
         if isinstance(symbol_summary, dict):
+            latest_unavailable_count += int(
+                _non_negative_int(symbol_summary.get("count")) or 0
+            )
             for symbol in symbol_summary.get("sample") or []:
                 latest_symbols[str(symbol)] += 1
     compact_groups = [
@@ -2503,12 +2500,19 @@ def _summarize_forager_feature_health(
     }
     if latest_values["max_age_ms"]:
         summary["latest_max_age_ms_max"] = max(latest_values["max_age_ms"])
-    symbol_sample = _symbol_sample(
-        latest_symbols,
-        limit=FORAGER_FEATURE_SYMBOL_SAMPLE_LIMIT,
-    )
-    if symbol_sample:
-        summary["latest_unavailable_symbols"] = symbol_sample
+    if latest_unavailable_count:
+        symbol_sample = _symbol_sample(
+            latest_symbols,
+            limit=FORAGER_FEATURE_SYMBOL_SAMPLE_LIMIT,
+        )
+        summary["latest_unavailable_symbols"] = {
+            "count": latest_unavailable_count,
+            "sample": symbol_sample.get("sample", []),
+            "truncated": max(
+                0,
+                latest_unavailable_count - len(symbol_sample.get("sample", [])),
+            ),
+        }
     return summary
 
 

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2177,7 +2177,11 @@ def test_live_smoke_report_summarizes_forager_feature_health(tmp_path):
                     "log_range_count": 1,
                     "max_age_ms": 5000,
                     "fetch_budget": 3,
-                    "unavailable": ["OLD/USDT:USDT"],
+                    "unavailable": {
+                        "count": 1,
+                        "sample": ["OLD/USDT:USDT"],
+                        "truncated": 0,
+                    },
                 },
             ),
             _monitor_row(
@@ -2193,10 +2197,14 @@ def test_live_smoke_report_summarizes_forager_feature_health(tmp_path):
                     "log_range_count": 2,
                     "max_age_ms": 7000,
                     "fetch_budget": 4,
-                    "unavailable": [
-                        "AAVE/USDT:USDT",
-                        "api_key=SHOULD_NOT_RENDER",
-                    ],
+                    "unavailable": {
+                        "count": 2,
+                        "sample": [
+                            "AAVE/USDT:USDT",
+                            "api_key=SHOULD_NOT_RENDER",
+                        ],
+                        "truncated": 0,
+                    },
                 },
             ),
         ],
@@ -2219,7 +2227,11 @@ def test_live_smoke_report_summarizes_forager_feature_health(tmp_path):
                     "log_range_count": 0,
                     "max_age_ms": 9000,
                     "fetch_budget": 2,
-                    "unavailable": ["ARB/USDT:USDT"],
+                    "unavailable": {
+                        "count": 1,
+                        "sample": ["ARB/USDT:USDT"],
+                        "truncated": 0,
+                    },
                 },
             )
         ],
@@ -2244,6 +2256,11 @@ def test_live_smoke_report_summarizes_forager_feature_health(tmp_path):
     assert health["groups"][0]["bot"] == "gateio/gateio_01"
     assert health["groups"][1]["count"] == 2
     assert health["groups"][1]["latest_data"]["candidate_count"] == 40
+    assert health["groups"][1]["latest_data"]["unavailable_symbols"] == {
+        "count": 2,
+        "sample": ["AAVE/USDT:USDT", "api_key=[redacted]"],
+        "truncated": 0,
+    }
     assert "SHOULD_NOT_RENDER" not in json.dumps(health)
 
     summary_health = summary["forager_feature_health"]

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2158,6 +2158,107 @@ def test_live_smoke_report_summarizes_ema_readiness_health(tmp_path):
     }
 
 
+def test_live_smoke_report_summarizes_forager_feature_health(tmp_path):
+    binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        binance_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="forager.feature_unavailable",
+                seq=1,
+                ts=1000,
+                status="skipped",
+                level="debug",
+                pside="long",
+                data={
+                    "candidate_count": 30,
+                    "volume_count": 2,
+                    "log_range_count": 1,
+                    "max_age_ms": 5000,
+                    "fetch_budget": 3,
+                    "unavailable": ["OLD/USDT:USDT"],
+                },
+            ),
+            _monitor_row(
+                event_type="forager.feature_unavailable",
+                seq=2,
+                ts=2000,
+                status="skipped",
+                level="debug",
+                pside="long",
+                data={
+                    "candidate_count": 40,
+                    "volume_count": 3,
+                    "log_range_count": 2,
+                    "max_age_ms": 7000,
+                    "fetch_budget": 4,
+                    "unavailable": [
+                        "AAVE/USDT:USDT",
+                        "api_key=SHOULD_NOT_RENDER",
+                    ],
+                },
+            ),
+        ],
+    )
+    _write_ndjson(
+        gateio_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="forager.feature_unavailable",
+                exchange="gateio",
+                user="gateio_01",
+                seq=1,
+                ts=3000,
+                status="skipped",
+                level="debug",
+                pside="short",
+                data={
+                    "candidate_count": 20,
+                    "volume_count": 1,
+                    "log_range_count": 0,
+                    "max_age_ms": 9000,
+                    "fetch_budget": 2,
+                    "unavailable": ["ARB/USDT:USDT"],
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    summary = summarize_live_smoke_report(report, max_groups=1)
+    brief = summarize_live_smoke_report_brief(report)
+    projected = project_live_smoke_report_sections(report, ["forager_features"])
+
+    health = report["forager_feature_health"]
+    assert report["ok"] is True
+    assert health["total"] == 3
+    assert health["bots"] == 2
+    assert health["event_types"] == {"forager.feature_unavailable": 3}
+    assert health["latest_candidate_count_total"] == 60
+    assert health["latest_volume_count_total"] == 4
+    assert health["latest_log_range_count_total"] == 2
+    assert health["latest_fetch_budget_total"] == 6
+    assert health["latest_max_age_ms_max"] == 9000
+    assert health["latest_unavailable_symbols"]["count"] == 3
+    assert health["groups"][0]["bot"] == "gateio/gateio_01"
+    assert health["groups"][1]["count"] == 2
+    assert health["groups"][1]["latest_data"]["candidate_count"] == 40
+    assert "SHOULD_NOT_RENDER" not in json.dumps(health)
+
+    summary_health = summary["forager_feature_health"]
+    assert summary_health["latest_candidate_count_total"] == 60
+    assert summary_health["groups_truncated"] is True
+    assert len(summary_health["groups"]) == 1
+    assert brief["forager_features"] == {
+        key: value
+        for key, value in health.items()
+        if key not in {"groups", "groups_truncated"}
+    }
+    assert projected["forager_feature_health"] == health
+    assert "ema_readiness_health" not in projected
+
+
 def test_live_smoke_report_summarizes_exchange_config_refresh_health(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Scope

- Category: read-only tooling.
- Add bounded full, summary, brief, and `--section forager_features` projections for existing `forager.feature_unavailable` monitor events.
- Aggregate the latest event per bot/position side, including candidate count, unavailable volume/log-range feature counts, maximum age, fetch budget, and a redacted bounded symbol sample.
- Record PR #1270's verified no-restart VPS5 deployment and smoke evidence in the operational status/progress docs.

## Behavior boundary

- No event producer, console/text sink, forager selection, readiness gate, exchange-call, order, risk, or trading behavior changes.
- The new section does not affect smoke `ok`, attention, or hard-failure classification.
- Reports with zero matching events preserve their prior shape.
- Full and summary groups and symbol samples use fixed existing-style bounds; brief output omits group rows.

## VPS action

- After merge: fast-forward the VPS5 checkout and run a bounded `forager_features` report plus settled smoke.
- No bot restart is expected because this changes only read-only report consumption.

## Validation

- `python -m pytest tests/test_live_smoke_report.py -q` (92 passed)
- `python -m pytest tests/test_passivbot_cli.py -q -k live_smoke_report` (1 passed; existing matplotlib deprecation warnings)
- `python -m pytest tests/test_ai_docs.py tests/test_live_event_registry_docs.py -q` (3 passed)
- `python src/tools/check_ai_docs.py` (0 errors; existing word-count warning)
- `python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py`
- `git diff --check`

## Reviewer focus

- Aggregates describe latest bounded samples, not a fabricated total unavailable universe.
- Malformed or secret-like symbol content is bounded and redacted.
- Zero-event compatibility and smoke-verdict invariance.
- Full/summary/brief/section output remains bounded and consistent.
