### PR TITLE
Expose planning defer health in smoke reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Staged-readiness smoke summaries now include bounded existing
+  `planning.defer_summary` evidence such as defer counts, windows, required
+  surfaces, retry mode, and redacted symbol samples. Registered optional
+  section selectors also remain valid when their event family is naturally
+  absent from the selected window.
+
 - Live smoke reports now expose bounded existing
   `forager.feature_unavailable` evidence across full, summary, brief, and
   section-selective output. The projection does not change smoke verdicts,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,9 +24,11 @@ Estimated completion:
 
 - Branch: `codex/smoke-planning-defer-health`, based on canonical
   `e3640fa7338db2b64942a0773464f6499982dd8a` after PR #1271.
-- PR: pending. Slice: expose existing `planning.defer_summary` evidence in the
-  staged-readiness smoke projection and keep registered optional section
-  selectors valid when their event family is naturally absent.
+- PR: #1272, `Expose planning defer health in smoke reports`; semantic
+  implementation head `8fa8ff3ba6`. Slice: expose existing
+  `planning.defer_summary` evidence in the staged-readiness smoke projection
+  and keep registered optional section selectors valid when their event family
+  is naturally absent.
 - Triggering evidence: PR #1271's bounded VPS5 `--section forager_features`
   check returned exit 2 because zero natural events omitted the optional
   section before selector validation. The adjacent structured-only planning

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,22 +22,24 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/smoke-forager-feature-health`, based on canonical
-  `9869263d74829f163b0bc8010fa18d1bf41de055` after PR #1270.
-- PR: #1271, `Expose forager feature health in smoke reports`; semantic
-  implementation head `47b084b62e`. Slice: expose existing
-  `forager.feature_unavailable` events in full, summary, brief, and
-  section-selective live smoke reports.
-- Triggering evidence: the producer already emits bounded structured-only
-  candidate, missing-feature, age, fetch-budget, and symbol-sample context, and
-  `live-performance-report` consumes it. Smoke reports currently omit it.
-- Scope: aggregate latest event data per bot/position side, retain bounded
-  redacted symbol samples, and expose report-level counts and maxima.
+- Branch: `codex/smoke-planning-defer-health`, based on canonical
+  `e3640fa7338db2b64942a0773464f6499982dd8a` after PR #1271.
+- PR: pending. Slice: expose existing `planning.defer_summary` evidence in the
+  staged-readiness smoke projection and keep registered optional section
+  selectors valid when their event family is naturally absent.
+- Triggering evidence: PR #1271's bounded VPS5 `--section forager_features`
+  check returned exit 2 because zero natural events omitted the optional
+  section before selector validation. The adjacent structured-only planning
+  defer summaries are also not consumed by staged-readiness reporting.
+- Scope: project latest per-group defer counts, windows, missing/invalid/
+  required surfaces, retry mode, and bounded redacted symbol samples; repair
+  selector validation without forcing absent sections into report output.
 - Behavior boundary: read-only report projection only. No smoke verdict,
-  attention classification, console output, event production, forager
-  selection, readiness, exchange access, or trading changes.
-- Validation: producer-shaped report fixtures, full/summary/brief/section
-  projection tests, full smoke-report tests, compilation, and docs checks.
+  attention classification, console output, event production, planning,
+  readiness, exchange access, or trading changes.
+- Validation: producer-shaped report fixtures, absent-section CLI regression,
+  full/summary/brief/section projection tests, full smoke-report tests,
+  compilation, and docs checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
 - Expected VPS action: pull and run bounded report/smoke checks after merge;
@@ -46,8 +48,19 @@ Estimated completion:
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `9869263d74829f163b0bc8010fa18d1bf41de055`, PR #1270. The tracked checkout
+  `e3640fa7338db2b64942a0773464f6499982dd8a`, PR #1271. The tracked checkout
   is clean and expected untracked artifacts are preserved.
+- PR #1271 required no restart. Exact bot PIDs
+  `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
+  `misc:0.0` PID `434835` remained unchanged. The settled two-minute smoke was
+  `ok=true` with zero hard/log/monitor/process/pipeline failures, `186/186`
+  remote and `55/55` account-critical calls successful, `9/9` fill refreshes
+  successful, and all five processes/configs matched in states `R=4,S=1`
+  with no uninterruptible sleep. Fourteen non-hard EMA readiness events
+  remained durable.
+- No `forager.feature_unavailable` event occurred naturally in the bounded
+  window. The zero-event section probe exposed the registered-selector defect
+  addressed by the active slice; no event or trading activity was manufactured.
 - PR #1270 required no restart. VPS5 fast-forwarded cleanly while exact bot
   PIDs `985592/985594/985596/985598/985600`, all five pane parents, and
   unrelated `misc:0.0` PID `434835` remained unchanged.
@@ -987,8 +1000,10 @@ scheme-less credential-query detection, and PR #1268's aggregate-only inventory
 projection are also merged and deployed without restart. PR #1269's configured
 startup-budget events are merged and deployed with the same non-enforcement
 boundary. PR #1270's matching performance projection is also merged and
-deployed without restart. The active follow-up exposes existing structured-only
-forager feature-unavailability evidence in smoke reports.
+deployed without restart. PR #1271's forager feature-unavailability projection
+is merged and deployed without restart. The active follow-up repairs its
+naturally exposed absent-section selector path and adds the adjacent existing
+planning defer summaries to staged-readiness reporting.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,27 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1270)
+## Latest Canonical Deployment (PR #1271)
+
+- PR #1271 merged to `master` as
+  `e3640fa7338db2b64942a0773464f6499982dd8a`. It projects existing bounded
+  `forager.feature_unavailable` events into full, summary, brief, and selected
+  smoke reports without changing verdicts or runtime behavior.
+- VPS5 fast-forwarded cleanly with no restart. Exact bot PIDs
+  `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
+  `misc:0.0` PID `434835` remained unchanged; tracked state stayed clean.
+- The settled two-minute smoke was `ok=true` with zero hard/log/monitor/
+  process/pipeline failures, `186/186` remote and `55/55` account-critical
+  calls successful, nine successful fill refreshes, and all five matching/
+  config-valid processes in states `R=4,S=1` with no uninterruptible sleep.
+  Fourteen non-hard EMA readiness events remained durable.
+- No forager-feature-unavailable event occurred naturally. The bounded section
+  probe instead exposed that a registered optional selector was rejected when
+  its zero-event section was omitted. The next report-only slice repairs that
+  path and consumes existing `planning.defer_summary` evidence; nothing was
+  manufactured.
+
+## Previous Canonical Deployment (PR #1270)
 
 - PR #1270 merged to `master` as
   `9869263d74829f163b0bc8010fa18d1bf41de055`. It makes the read-only live

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -303,6 +303,13 @@ Related detailed plans:
      stage evidence is. VPS5 deploy smoke at `e1fcb038` was green, but its
      sampled window had `hsl_replay.active_bots=0`, so the active fields were
      not populated by live data in that run.
+   - 2026-07-16: PR #1271 added bounded existing
+     `forager.feature_unavailable` evidence to smoke reports. Its no-restart
+     VPS5 deploy stayed hard-green with all five bots matched. A naturally
+     empty event window exposed that the registered `forager_features` section
+     selector was rejected when the optional section was omitted; the active
+     follow-up repairs selector validation and adds existing
+     `planning.defer_summary` evidence to staged readiness.
 
    Remaining refinements: safe pull/stop/start orchestration remains open.
    The concise and brief summaries are intentionally bounded; further changes

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -134,6 +134,7 @@ FORAGER_FEATURE_HEALTH_GROUP_LIMIT = 20
 FORAGER_FEATURE_SYMBOL_SAMPLE_LIMIT = 8
 STAGED_READINESS_GROUP_LIMIT = 20
 STAGED_READINESS_VALUE_LIMIT = 8
+STAGED_READINESS_SYMBOL_SAMPLE_LIMIT = 8
 EVENT_PIPELINE_HEALTH_GROUP_LIMIT = 20
 RESOURCE_PRESSURE_GROUP_LIMIT = 20
 RESOURCE_PRESSURE_FIELDS = (
@@ -2691,7 +2692,10 @@ def _staged_readiness_event(live_event: dict[str, Any]) -> bool:
     reason_code = str(live_event.get("reason_code") or "")
     if event_type == EventTypes.CYCLE_DEGRADED:
         return reason_code.startswith("staged_execution")
-    return event_type == EventTypes.PLANNING_UNAVAILABLE
+    return event_type in {
+        EventTypes.PLANNING_UNAVAILABLE,
+        EventTypes.PLANNING_DEFER_SUMMARY,
+    }
 
 
 def _string_counts(value: Any) -> dict[str, int]:
@@ -2751,6 +2755,33 @@ def _staged_readiness_timings_ms(value: Any) -> dict[str, int]:
     )
 
 
+def _staged_readiness_symbol_summary(payload: dict[str, Any]) -> dict[str, Any]:
+    symbols: Counter[str] = Counter()
+    raw_symbols = payload.get("symbols")
+    if isinstance(raw_symbols, list):
+        for symbol in raw_symbols:
+            if symbol is None:
+                continue
+            safe_symbol = _redact_log_text(str(symbol), max_len=80)
+            if safe_symbol:
+                symbols[safe_symbol] += 1
+    count = _non_negative_int(payload.get("symbols_count"))
+    if count is None:
+        count = len(symbols)
+    count = max(int(count), len(symbols))
+    if count <= 0:
+        return {}
+    sample = _symbol_sample(
+        symbols,
+        limit=STAGED_READINESS_SYMBOL_SAMPLE_LIMIT,
+    ).get("sample", [])
+    return {
+        "count": count,
+        "sample": sample,
+        "truncated": max(0, count - len(sample)),
+    }
+
+
 def _max_counter_maps(values: Iterable[Any]) -> dict[str, int]:
     out: dict[str, int] = {}
     for value in values:
@@ -2782,16 +2813,38 @@ def _staged_readiness_group(
     payload = data if isinstance(data, dict) else {}
     details = payload.get("details")
     detail_payload = details if isinstance(details, dict) else payload
+    event_type = live_event.get("event_type") or row.get("kind")
+    defer_summary = event_type == EventTypes.PLANNING_DEFER_SUMMARY
     ids = _event_ids(live_event)
     invalid = detail_payload.get("invalid")
     missing_surfaces = _string_counts(detail_payload.get("missing"))
-    invalid_surfaces = _invalid_surface_counts(invalid)
+    invalid_surfaces = (
+        _string_counts(payload.get("invalid_surfaces"))
+        if defer_summary
+        else _invalid_surface_counts(invalid)
+    )
+    required_surfaces = (
+        _string_counts(payload.get("required")) if defer_summary else {}
+    )
     reason_code = _staged_readiness_text(live_event.get("reason_code"))
     latest_context = _staged_readiness_text(detail_payload.get("context"))
     latest_defer_reason = _staged_readiness_text(detail_payload.get("defer_reason"))
     latest_timings_ms = _staged_readiness_timings_ms(payload.get("timings_ms"))
+    latest_defer_count = (
+        _non_negative_int(payload.get("count")) if defer_summary else None
+    )
+    latest_defer_window_s = (
+        _non_negative_int(payload.get("window_s")) if defer_summary else None
+    )
+    latest_defer_symbols = (
+        _staged_readiness_symbol_summary(payload) if defer_summary else {}
+    )
+    latest_will_retry = (
+        _staged_readiness_text(payload.get("will_retry")) if defer_summary else None
+    )
     return {
         "bot": bot_key,
+        "event_type": event_type,
         "reason_code": reason_code,
         "status": live_event.get("status"),
         "level": live_event.get("level"),
@@ -2806,6 +2859,11 @@ def _staged_readiness_group(
         "latest_missing_surfaces": missing_surfaces,
         "latest_invalid_surfaces": invalid_surfaces,
         "latest_timings_ms": latest_timings_ms,
+        "latest_defer_count": latest_defer_count,
+        "latest_defer_window_s": latest_defer_window_s,
+        "latest_defer_symbols": latest_defer_symbols,
+        "latest_required_surfaces": required_surfaces,
+        "latest_will_retry": latest_will_retry,
         "latest_completed_candle_mismatch_counts": _completed_candle_mismatch_counts(
             invalid
         ),
@@ -2826,6 +2884,7 @@ def _merge_staged_readiness_group(
 ) -> None:
     key = (
         group.get("bot"),
+        group.get("event_type"),
         group.get("reason_code"),
         group.get("status"),
     )
@@ -2859,6 +2918,11 @@ def _merge_staged_readiness_group(
             "latest_missing_surfaces",
             "latest_invalid_surfaces",
             "latest_timings_ms",
+            "latest_defer_count",
+            "latest_defer_window_s",
+            "latest_defer_symbols",
+            "latest_required_surfaces",
+            "latest_will_retry",
             "latest_completed_candle_mismatch_counts",
             "latest_missing_surface_count",
             "latest_invalid_surface_count",
@@ -2891,7 +2955,7 @@ def _summarize_staged_readiness_health(
         }
         for group in ordered[:STAGED_READINESS_GROUP_LIMIT]
     ]
-    return {
+    summary = {
         "total": sum(int(group.get("count", 0)) for group in groups.values()),
         "groups_truncated": len(ordered) > STAGED_READINESS_GROUP_LIMIT,
         "event_types": dict(event_type_counts.most_common()),
@@ -2930,6 +2994,61 @@ def _summarize_staged_readiness_health(
         ),
         "groups": compact_groups,
     }
+    defer_groups = [
+        group
+        for group in groups.values()
+        if group.get("event_type") == EventTypes.PLANNING_DEFER_SUMMARY
+    ]
+    if defer_groups:
+        symbol_count = 0
+        symbols: Counter[str] = Counter()
+        for group in defer_groups:
+            symbol_summary = group.get("latest_defer_symbols")
+            if not isinstance(symbol_summary, dict):
+                continue
+            symbol_count += int(
+                _non_negative_int(symbol_summary.get("count")) or 0
+            )
+            for symbol in symbol_summary.get("sample") or []:
+                symbols[str(symbol)] += 1
+        summary.update(
+            {
+                "latest_defer_count_total": sum(
+                    int(_non_negative_int(group.get("latest_defer_count")) or 0)
+                    for group in defer_groups
+                ),
+                "latest_defer_window_s_max": max(
+                    (
+                        int(
+                            _non_negative_int(group.get("latest_defer_window_s"))
+                            or 0
+                        )
+                        for group in defer_groups
+                    ),
+                    default=0,
+                ),
+                "latest_defer_symbol_count_total": symbol_count,
+                "latest_required_surfaces": _sum_counter_maps(
+                    group.get("latest_required_surfaces") for group in defer_groups
+                ),
+                "latest_will_retry": _sum_counter_maps(
+                    {group.get("latest_will_retry"): 1}
+                    for group in defer_groups
+                    if group.get("latest_will_retry") not in (None, "")
+                ),
+            }
+        )
+        if symbol_count:
+            sample = _symbol_sample(
+                symbols,
+                limit=STAGED_READINESS_SYMBOL_SAMPLE_LIMIT,
+            ).get("sample", [])
+            summary["latest_defer_symbols"] = {
+                "count": symbol_count,
+                "sample": sample,
+                "truncated": max(0, symbol_count - len(sample)),
+            }
+    return summary
 
 
 def _safe_counter_mapping(value: Any) -> dict[str, int]:
@@ -7537,14 +7656,6 @@ def _summary_limited_groups(
                 "latest_candidate_error_type_counts"
             )
             or None,
-            "latest_missing_surface_total": summary.get("latest_missing_surface_total"),
-            "latest_invalid_surface_total": summary.get("latest_invalid_surface_total"),
-            "latest_missing_surfaces": summary.get("latest_missing_surfaces") or None,
-            "latest_invalid_surfaces": summary.get("latest_invalid_surfaces") or None,
-            "reason_codes": summary.get("reason_codes") or None,
-            "latest_defer_reasons": summary.get("latest_defer_reasons") or None,
-            "latest_contexts": summary.get("latest_contexts") or None,
-            "latest_timings_ms_max": summary.get("latest_timings_ms_max") or None,
             "latest_queue_depth_total": summary.get("latest_queue_depth_total"),
             "latest_queue_unfinished_total": summary.get(
                 "latest_queue_unfinished_total"
@@ -7737,6 +7848,34 @@ def _summary_limited_groups(
         }.items()
         if value is not None
     }
+
+
+def _summary_staged_readiness_health(
+    summary: dict[str, Any],
+    *,
+    limit: int,
+) -> dict[str, Any]:
+    out = _summary_limited_groups(summary, limit=limit)
+    for key in (
+        "latest_missing_surface_total",
+        "latest_invalid_surface_total",
+        "latest_missing_surfaces",
+        "latest_invalid_surfaces",
+        "reason_codes",
+        "latest_defer_reasons",
+        "latest_contexts",
+        "latest_timings_ms_max",
+        "latest_defer_count_total",
+        "latest_defer_window_s_max",
+        "latest_defer_symbol_count_total",
+        "latest_defer_symbols",
+        "latest_required_surfaces",
+        "latest_will_retry",
+    ):
+        value = summary.get(key)
+        if value not in (None, {}, []):
+            out[key] = value
+    return out
 
 
 def _shareable_summary_group(
@@ -8144,7 +8283,7 @@ def summarize_live_smoke_report(
             exchange_config_refresh_health,
             limit=max_groups,
         ),
-        "staged_readiness_health": _summary_limited_groups(
+        "staged_readiness_health": _summary_staged_readiness_health(
             staged_readiness_health,
             limit=max_groups,
         ),
@@ -8922,10 +9061,21 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         "latest_defer_reasons",
         "latest_contexts",
         "latest_timings_ms_max",
+        "latest_defer_symbols",
+        "latest_required_surfaces",
+        "latest_will_retry",
     ):
         value = staged_readiness_health.get(key)
         if isinstance(value, dict) and value:
             staged_readiness_brief[key] = value
+    for key in (
+        "latest_defer_count_total",
+        "latest_defer_window_s_max",
+        "latest_defer_symbol_count_total",
+    ):
+        value = staged_readiness_health.get(key)
+        if value is not None:
+            staged_readiness_brief[key] = _count_value(value)
     risk_events_brief = {
         "total": _count_value(risk_events.get("total")),
         "event_types": risk_events.get("event_types") or {},
@@ -9410,6 +9560,12 @@ def project_live_smoke_report_sections(
     available = available_live_smoke_report_sections(report)
     available_set = set(available)
     base_selector_set = set(SMOKE_REPORT_SECTION_BASE_SELECTORS)
+    known_optional_sections = set(SMOKE_REPORT_SECTION_ALIASES)
+    known_optional_sections.update(
+        target
+        for targets in SMOKE_REPORT_SECTION_ALIASES.values()
+        for target in targets
+    )
     resolved = []
     resolved_base = []
     unknown = []
@@ -9420,6 +9576,8 @@ def project_live_smoke_report_sections(
         targets = (section, *SMOKE_REPORT_SECTION_ALIASES.get(section, ()))
         matched_targets = [target for target in targets if target in available_set]
         if not matched_targets:
+            if section in known_optional_sections:
+                continue
             unknown.append(section)
             continue
         for target in matched_targets:
@@ -9429,8 +9587,10 @@ def project_live_smoke_report_sections(
         raise ValueError(
             "unknown --section value(s): "
             + ", ".join(unknown)
-            + "; available sections: "
-            + ", ".join(sorted((*available, *base_selector_set)))
+            + "; valid sections: "
+            + ", ".join(
+                sorted((*available_set, *base_selector_set, *known_optional_sections))
+            )
             + "; use all for the full report"
         )
 

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2276,6 +2276,22 @@ def test_live_smoke_report_summarizes_forager_feature_health(tmp_path):
     assert "ema_readiness_health" not in projected
 
 
+def test_live_smoke_report_accepts_registered_optional_section_when_absent(tmp_path):
+    monitor_root = tmp_path / "monitor"
+    _write_ndjson(
+        monitor_root / "binance" / "binance_01" / "events" / "current.ndjson",
+        [],
+    )
+    report = build_live_smoke_report(monitor_root, logs_root=None)
+
+    for selector in ("forager_features", "forager_feature_health"):
+        projected = project_live_smoke_report_sections(report, [selector])
+
+        assert projected["ok"] is True
+        assert "forager_feature_health" not in projected
+        assert "staged_readiness_health" not in projected
+
+
 def test_live_smoke_report_summarizes_exchange_config_refresh_health(tmp_path):
     events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
     _write_ndjson(
@@ -3438,6 +3454,36 @@ def test_live_smoke_report_summarizes_staged_readiness_health(tmp_path):
                 },
             ),
             _monitor_row(
+                event_type="planning.defer_summary",
+                seq=5,
+                ts=1750,
+                status="deferred",
+                level="info",
+                reason_code="completed_candle_target_changed",
+                ids={"cycle_id": "cy_defer_summary"},
+                data={
+                    "count": 20,
+                    "window_s": 1860,
+                    "symbols": [
+                        "BTC/USDT:USDT",
+                        "ETH/USDT:USDT",
+                        "api_key=SHOULD_NOT_RENDER",
+                    ],
+                    "symbols_count": 3,
+                    "symbols_truncated": False,
+                    "missing": ["completed_candles"],
+                    "required": [
+                        "balance",
+                        "completed_candles",
+                        "market_snapshot",
+                    ],
+                    "context": "planning",
+                    "epoch": 42,
+                    "invalid_surfaces": ["completed_candles"],
+                    "will_retry": "automatic",
+                },
+            ),
+            _monitor_row(
                 event_type="cycle.degraded",
                 seq=2,
                 ts=2000,
@@ -3492,31 +3538,56 @@ def test_live_smoke_report_summarizes_staged_readiness_health(tmp_path):
     brief = summarize_live_smoke_report_brief(report)
 
     health = report["staged_readiness_health"]
-    assert health["total"] == 3
+    assert health["total"] == 4
     assert health["bots"] == 1
-    assert health["latest_missing_surface_total"] == 2
-    assert health["latest_invalid_surface_total"] == 3
+    assert health["latest_missing_surface_total"] == 3
+    assert health["latest_invalid_surface_total"] == 4
     assert health["latest_missing_surfaces"] == {
-        "completed_candles": 1,
-        "market_prices": 1,
-    }
-    assert health["latest_invalid_surfaces"] == {
         "completed_candles": 2,
         "market_prices": 1,
     }
-    assert health["event_types"] == {"cycle.degraded": 2, "planning.unavailable": 1}
+    assert health["latest_invalid_surfaces"] == {
+        "completed_candles": 3,
+        "market_prices": 1,
+    }
+    assert health["event_types"] == {
+        "cycle.degraded": 2,
+        "planning.unavailable": 1,
+        "planning.defer_summary": 1,
+    }
     assert health["reason_codes"] == {
         "staged_execution_not_ready": 2,
         "staged_execution_precondition": 1,
+        "completed_candle_target_changed": 1,
     }
     assert health["latest_defer_reasons"] == {"staged_planner_inputs_not_fresh": 2}
     assert health["latest_contexts"] == {
         "rust order calculation": 2,
+        "planning": 1,
     }
     assert health["latest_timings_ms_max"] == {
         "market_state": 303339,
         "planning_universe": 1919,
     }
+    assert health["latest_defer_count_total"] == 20
+    assert health["latest_defer_window_s_max"] == 1860
+    assert health["latest_defer_symbol_count_total"] == 3
+    assert health["latest_defer_symbols"] == {
+        "count": 3,
+        "sample": [
+            "BTC/USDT:USDT",
+            "ETH/USDT:USDT",
+            "api_key=[redacted]",
+        ],
+        "truncated": 0,
+    }
+    assert health["latest_required_surfaces"] == {
+        "balance": 1,
+        "completed_candles": 1,
+        "market_snapshot": 1,
+    }
+    assert health["latest_will_retry"] == {"automatic": 1}
+    assert "SHOULD_NOT_RENDER" not in json.dumps(health)
     assert health["groups"][0]["count"] == 2
     assert health["groups"][0]["latest_ids"] == {"cycle_id": "cy_stage_2"}
     assert health["groups"][0]["latest_context"] == "rust order calculation"
@@ -3531,16 +3602,25 @@ def test_live_smoke_report_summarizes_staged_readiness_health(tmp_path):
     assert health["groups"][0]["latest_completed_candle_mismatch_counts"] == {
         "completed_candle_target_changed": 2
     }
-    assert summary["staged_readiness_health"]["total"] == 3
+    defer_group = next(
+        group
+        for group in health["groups"]
+        if group["event_type"] == "planning.defer_summary"
+    )
+    assert defer_group["latest_defer_count"] == 20
+    assert defer_group["latest_defer_window_s"] == 1860
+    assert defer_group["latest_invalid_surfaces"] == {"completed_candles": 1}
+    assert defer_group["latest_ids"] == {"cycle_id": "cy_defer_summary"}
+    assert summary["staged_readiness_health"]["total"] == 4
     assert summary["staged_readiness_health"]["groups"][0]["latest_ids"] == {
         "cycle_id": "cy_stage_2"
     }
     assert summary["staged_readiness_health"]["latest_missing_surfaces"] == {
-        "completed_candles": 1,
+        "completed_candles": 2,
         "market_prices": 1,
     }
     assert summary["staged_readiness_health"]["latest_invalid_surfaces"] == {
-        "completed_candles": 2,
+        "completed_candles": 3,
         "market_prices": 1,
     }
     assert summary["staged_readiness_health"]["latest_timings_ms_max"] == {
@@ -3548,31 +3628,55 @@ def test_live_smoke_report_summarizes_staged_readiness_health(tmp_path):
         "planning_universe": 1919,
     }
     assert brief["staged_readiness"] == {
-        "total": 3,
+        "total": 4,
         "bots": 1,
-        "latest_missing_surface_total": 2,
-        "latest_invalid_surface_total": 3,
+        "latest_missing_surface_total": 3,
+        "latest_invalid_surface_total": 4,
         "latest_missing_surfaces": {
-            "completed_candles": 1,
-            "market_prices": 1,
-        },
-        "latest_invalid_surfaces": {
             "completed_candles": 2,
             "market_prices": 1,
         },
-        "event_types": {"cycle.degraded": 2, "planning.unavailable": 1},
+        "latest_invalid_surfaces": {
+            "completed_candles": 3,
+            "market_prices": 1,
+        },
+        "event_types": {
+            "cycle.degraded": 2,
+            "planning.unavailable": 1,
+            "planning.defer_summary": 1,
+        },
         "reason_codes": {
             "staged_execution_not_ready": 2,
             "staged_execution_precondition": 1,
+            "completed_candle_target_changed": 1,
         },
         "latest_defer_reasons": {"staged_planner_inputs_not_fresh": 2},
         "latest_contexts": {
             "rust order calculation": 2,
+            "planning": 1,
         },
         "latest_timings_ms_max": {
             "market_state": 303339,
             "planning_universe": 1919,
         },
+        "latest_defer_symbols": {
+            "count": 3,
+            "sample": [
+                "BTC/USDT:USDT",
+                "ETH/USDT:USDT",
+                "api_key=[redacted]",
+            ],
+            "truncated": 0,
+        },
+        "latest_required_surfaces": {
+            "balance": 1,
+            "completed_candles": 1,
+            "market_snapshot": 1,
+        },
+        "latest_will_retry": {"automatic": 1},
+        "latest_defer_count_total": 20,
+        "latest_defer_window_s_max": 1860,
+        "latest_defer_symbol_count_total": 3,
     }
 
 
@@ -6859,6 +6963,35 @@ def test_live_smoke_report_cli_accepts_base_metadata_section(tmp_path, capsys):
     assert "repository" in summary
     assert "monitor" not in summary
     assert "logs" not in summary
+
+
+def test_live_smoke_report_cli_accepts_absent_registered_optional_section(
+    tmp_path,
+    capsys,
+):
+    monitor_root = tmp_path / "monitor"
+    _write_ndjson(
+        monitor_root / "binance" / "binance_01" / "events" / "current.ndjson",
+        [],
+    )
+    assert (
+        live_smoke_report.main(
+            [
+                str(monitor_root),
+                "--logs-root",
+                "",
+                "--summary",
+                "--section",
+                "forager_features",
+                "--compact",
+            ]
+        )
+        == 0
+    )
+
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["ok"] is True
+    assert "forager_feature_health" not in summary
 
 
 def test_live_smoke_report_cli_rejects_unknown_section(capsys):


### PR DESCRIPTION
## Scope

Category: read-only tooling.

- Include existing `planning.defer_summary` events in the established staged-readiness full, summary, brief, and selected smoke projections.
- Retain bounded latest defer counts, windows, missing/invalid/required surfaces, retry mode, and redacted symbol samples.
- Treat registered optional section selectors as valid when the selected event family is naturally absent, while preserving zero-event section omission.
- Record PR #1271's no-restart VPS5 deployment evidence and the naturally discovered selector failure.

## Boundaries

- No smoke verdict or attention-policy changes.
- No event production, console/text routing, planning/readiness, exchange access, order construction, config, or trading changes.
- No authenticated exchange requests or manufactured events.

## VPS action

Pull and run bounded section plus settled smoke checks after merge. No bot restart is expected.

## Validation

- `python -m pytest tests/test_live_smoke_report.py -q` - 94 passed
- `python -m pytest tests/test_passivbot_cli.py -k live_smoke_report -q` - 1 passed (existing matplotlib deprecation warnings)
- `python -m pytest tests/test_ai_docs.py tests/test_live_event_registry_docs.py -q` - 3 passed
- `python src/tools/check_ai_docs.py` - 0 errors, existing word-count warning
- `python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py` - pass
- `git diff --check` - clean

## Reviewer focus

- Producer-shape fidelity for `planning.defer_summary`.
- Count/sample semantics and redaction across latest per-group aggregation.
- Registered absent-section selector behavior without forcing empty sections into output.
- Verdict neutrality and boundedness.

Temporary gate while Grok is halted: exact-current-head Hermes approval plus green Python and Rust CI.

## Residual risk

VPS5 had no natural `forager.feature_unavailable` event in the PR #1271 validation window. The absent-selector defect was reproduced naturally there; the repair and planning-defer projection are fixture-validated and need bounded post-merge VPS confirmation.