### PR TITLE
Expose forager eligibility health in smoke reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live smoke reports now expose bounded existing
+  `forager.eligibility_changed` evidence across full, summary, brief, and
+  section-selective output, including approved/ignored add/remove counts,
+  source kind, position side, and redacted symbol samples. The projection does
+  not change smoke verdicts, console output, eligibility, or trading behavior.
+
 - Staged-readiness smoke summaries now include bounded existing
   `planning.defer_summary` evidence such as defer counts, windows, required
   surfaces, retry mode, and redacted symbol samples. Registered optional

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,9 +24,10 @@ Estimated completion:
 
 - Branch: `codex/smoke-forager-eligibility-health`, based on canonical
   `af69725ed04b9a9a0402634455fd6bb05d71d7f5` after PR #1272.
-- PR: pending, `Expose forager eligibility health in smoke reports`. Slice:
-  expose existing `forager.eligibility_changed` evidence in full, summary,
-  brief, and section-selective smoke reports.
+- PR: #1273, `Expose forager eligibility health in smoke reports`; semantic
+  implementation head `7fdea0047f`. Slice: expose existing
+  `forager.eligibility_changed` evidence in full, summary, brief, and
+  section-selective smoke reports.
 - Triggering evidence: the settled PR #1272 VPS5 smoke naturally contained one
   `forager.eligibility_changed` event while the smoke report omitted that
   operator-relevant approved/ignored membership transition.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,26 +22,22 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/smoke-planning-defer-health`, based on canonical
-  `e3640fa7338db2b64942a0773464f6499982dd8a` after PR #1271.
-- PR: #1272, `Expose planning defer health in smoke reports`; semantic
-  implementation head `8fa8ff3ba6`. Slice: expose existing
-  `planning.defer_summary` evidence in the staged-readiness smoke projection
-  and keep registered optional section selectors valid when their event family
-  is naturally absent.
-- Triggering evidence: PR #1271's bounded VPS5 `--section forager_features`
-  check returned exit 2 because zero natural events omitted the optional
-  section before selector validation. The adjacent structured-only planning
-  defer summaries are also not consumed by staged-readiness reporting.
-- Scope: project latest per-group defer counts, windows, missing/invalid/
-  required surfaces, retry mode, and bounded redacted symbol samples; repair
-  selector validation without forcing absent sections into report output.
+- Branch: `codex/smoke-forager-eligibility-health`, based on canonical
+  `af69725ed04b9a9a0402634455fd6bb05d71d7f5` after PR #1272.
+- PR: pending, `Expose forager eligibility health in smoke reports`. Slice:
+  expose existing `forager.eligibility_changed` evidence in full, summary,
+  brief, and section-selective smoke reports.
+- Triggering evidence: the settled PR #1272 VPS5 smoke naturally contained one
+  `forager.eligibility_changed` event while the smoke report omitted that
+  operator-relevant approved/ignored membership transition.
+- Scope: aggregate bounded latest approved/ignored add/remove counts by bot,
+  source kind, list kind, operation, and position side with redacted symbol
+  samples.
 - Behavior boundary: read-only report projection only. No smoke verdict,
-  attention classification, console output, event production, planning,
-  readiness, exchange access, or trading changes.
-- Validation: producer-shaped report fixtures, absent-section CLI regression,
-  full/summary/brief/section projection tests, full smoke-report tests,
-  compilation, and docs checks.
+  attention classification, console output, event production, eligibility,
+  exchange access, configuration, or trading changes.
+- Validation: producer-shaped report fixtures, full/summary/brief/section and
+  absent-section tests, full smoke-report tests, compilation, and docs checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
 - Expected VPS action: pull and run bounded report/smoke checks after merge;
@@ -50,8 +46,19 @@ Estimated completion:
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `e3640fa7338db2b64942a0773464f6499982dd8a`, PR #1271. The tracked checkout
+  `af69725ed04b9a9a0402634455fd6bb05d71d7f5`, PR #1272. The tracked checkout
   is clean and expected untracked artifacts are preserved.
+- PR #1272 required no restart. Exact bot PIDs
+  `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
+  `misc:0.0` PID `434835` remained unchanged. The settled two-minute smoke was
+  `ok=true` with zero hard/log/monitor/process failures, `279/279` remote and
+  `44/44` account-critical calls successful, `7/7` fill refreshes successful,
+  and all five processes/configs matched in states `R=3,S=2` with no
+  uninterruptible sleep. Twelve non-hard EMA readiness events remained durable.
+- The previously failing absent `forager_features` selector returned a valid
+  base-only report. The focused staged-readiness section returned a valid
+  zero-event projection. No natural `planning.defer_summary` occurred in the
+  bounded window, and no event or trading activity was manufactured.
 - PR #1271 required no restart. Exact bot PIDs
   `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
   `misc:0.0` PID `434835` remained unchanged. The settled two-minute smoke was
@@ -1003,9 +1010,9 @@ projection are also merged and deployed without restart. PR #1269's configured
 startup-budget events are merged and deployed with the same non-enforcement
 boundary. PR #1270's matching performance projection is also merged and
 deployed without restart. PR #1271's forager feature-unavailability projection
-is merged and deployed without restart. The active follow-up repairs its
-naturally exposed absent-section selector path and adds the adjacent existing
-planning defer summaries to staged-readiness reporting.
+and PR #1272's planning-defer/absent-selector projection are merged and deployed
+without restart. The active follow-up exposes naturally observed existing
+forager eligibility membership-change evidence in smoke reports.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,29 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1271)
+## Latest Canonical Deployment (PR #1272)
+
+- PR #1272 merged to `master` as
+  `af69725ed04b9a9a0402634455fd6bb05d71d7f5`. It adds existing bounded
+  `planning.defer_summary` evidence to staged-readiness smoke reports and keeps
+  registered optional selectors valid when their event family is absent,
+  without changing verdicts or runtime behavior.
+- VPS5 fast-forwarded cleanly with no restart. Exact bot PIDs
+  `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
+  `misc:0.0` PID `434835` remained unchanged; tracked state stayed clean.
+- The final two-minute smoke was `ok=true` with zero hard/log/monitor/process
+  failures, `279/279` remote and `44/44` account-critical calls successful,
+  seven successful fill refreshes, and all five matching/config-valid
+  processes in states `R=3,S=2` with no uninterruptible sleep. Twelve non-hard
+  EMA readiness events remained durable.
+- The formerly failing absent `forager_features` selector returned a valid
+  base-only report, and the staged-readiness selector returned a valid
+  zero-event section. No planning-defer event occurred naturally. The same
+  settled window contained one existing `forager.eligibility_changed` event;
+  the next report-only slice exposes that membership transition without
+  manufacturing events or changing eligibility.
+
+## Previous Canonical Deployment (PR #1271)
 
 - PR #1271 merged to `master` as
   `e3640fa7338db2b64942a0773464f6499982dd8a`. It projects existing bounded

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -307,9 +307,13 @@ Related detailed plans:
      `forager.feature_unavailable` evidence to smoke reports. Its no-restart
      VPS5 deploy stayed hard-green with all five bots matched. A naturally
      empty event window exposed that the registered `forager_features` section
-     selector was rejected when the optional section was omitted; the active
-     follow-up repairs selector validation and adds existing
-     `planning.defer_summary` evidence to staged readiness.
+     selector was rejected when the optional section was omitted.
+   - 2026-07-16: PR #1272 repaired registered absent-section selection and
+     added existing `planning.defer_summary` evidence to staged readiness. Its
+     no-restart VPS5 deploy stayed hard-green, and focused zero-event selectors
+     succeeded. The settled window naturally contained one existing
+     `forager.eligibility_changed` event that smoke reports still omitted; the
+     active follow-up adds that bounded membership-transition projection.
 
    Remaining refinements: safe pull/stop/start orchestration remains open.
    The concise and brief summaries are intentionally bounded; further changes

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -132,6 +132,8 @@ EMA_READINESS_GROUP_LIMIT = 20
 EMA_READINESS_REASON_SYMBOL_SAMPLE_LIMIT = 8
 FORAGER_FEATURE_HEALTH_GROUP_LIMIT = 20
 FORAGER_FEATURE_SYMBOL_SAMPLE_LIMIT = 8
+FORAGER_ELIGIBILITY_HEALTH_GROUP_LIMIT = 20
+FORAGER_ELIGIBILITY_SYMBOL_SAMPLE_LIMIT = 8
 STAGED_READINESS_GROUP_LIMIT = 20
 STAGED_READINESS_VALUE_LIMIT = 8
 STAGED_READINESS_SYMBOL_SAMPLE_LIMIT = 8
@@ -2512,6 +2514,182 @@ def _summarize_forager_feature_health(
             "truncated": max(
                 0,
                 latest_unavailable_count - len(symbol_sample.get("sample", [])),
+            ),
+        }
+    return summary
+
+
+def _forager_eligibility_health_group(
+    *,
+    bot_key: str,
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+    path: Path,
+    line_no: int,
+) -> dict[str, Any]:
+    data = live_event.get("data")
+    payload = data if isinstance(data, dict) else {}
+    changes = []
+    raw_changes = payload.get("changes")
+    if isinstance(raw_changes, list):
+        for raw_change in raw_changes:
+            if not isinstance(raw_change, dict):
+                continue
+            count = int(_non_negative_int(raw_change.get("count")) or 0)
+            symbols = _summary_symbol_sample(
+                {
+                    "count": count,
+                    "sample": raw_change.get("symbols"),
+                },
+                limit=FORAGER_ELIGIBILITY_SYMBOL_SAMPLE_LIMIT,
+            )
+            count = max(count, _count_from_summary(symbols))
+            change = {
+                "pside": _redact_log_text(
+                    str(raw_change.get("pside") or "unknown"),
+                    max_len=20,
+                ),
+                "count": count,
+            }
+            if symbols:
+                change["symbols"] = symbols
+            changes.append(change)
+    return {
+        "bot": bot_key,
+        "source": _redact_log_text(
+            str(payload.get("source") or "unknown"),
+            max_len=40,
+        ),
+        "list_kind": _redact_log_text(
+            str(payload.get("list_kind") or "unknown"),
+            max_len=40,
+        ),
+        "operation": _redact_log_text(
+            str(payload.get("operation") or "unknown"),
+            max_len=20,
+        ),
+        "count": 1,
+        "latest_ts": row.get("ts"),
+        "latest_seq": row.get("seq"),
+        "latest_path": str(path),
+        "latest_line": int(line_no),
+        "latest_data": {"changes": changes} if changes else {},
+    }
+
+
+def _merge_forager_eligibility_health_group(
+    groups: dict[tuple[str, str, str, str], dict[str, Any]],
+    group: dict[str, Any],
+) -> None:
+    key = (
+        str(group["bot"]),
+        str(group["source"]),
+        str(group["list_kind"]),
+        str(group["operation"]),
+    )
+    existing = groups.get(key)
+    if existing is None:
+        groups[key] = group
+        return
+    existing["count"] = int(existing.get("count", 0)) + 1
+    current_key = _sort_event_position_key(
+        ts=group.get("latest_ts"),
+        seq=group.get("latest_seq"),
+        path=group.get("latest_path") or "",
+        line_no=int(group.get("latest_line") or 0),
+    )
+    existing_key = _sort_event_position_key(
+        ts=existing.get("latest_ts"),
+        seq=existing.get("latest_seq"),
+        path=existing.get("latest_path") or "",
+        line_no=int(existing.get("latest_line") or 0),
+    )
+    if current_key > existing_key:
+        for field in (
+            "latest_ts",
+            "latest_seq",
+            "latest_path",
+            "latest_line",
+            "latest_data",
+        ):
+            existing[field] = group.get(field)
+
+
+def _summarize_forager_eligibility_health(
+    groups: dict[tuple[str, str, str, str], dict[str, Any]],
+    event_type_counts: Counter[str],
+) -> dict[str, Any]:
+    ordered = sorted(
+        groups.values(),
+        key=lambda item: (
+            -int(_non_negative_int(item.get("latest_ts")) or 0),
+            -int(item.get("count") or 0),
+            str(item.get("bot") or ""),
+            str(item.get("list_kind") or ""),
+            str(item.get("operation") or ""),
+        ),
+    )
+    latest_changed_total = 0
+    latest_by_list_kind: Counter[str] = Counter()
+    latest_by_operation: Counter[str] = Counter()
+    latest_by_pside: Counter[str] = Counter()
+    latest_by_source: Counter[str] = Counter()
+    latest_symbols: Counter[str] = Counter()
+    for group in groups.values():
+        latest_data = group.get("latest_data")
+        changes = (
+            latest_data.get("changes")
+            if isinstance(latest_data, dict)
+            and isinstance(latest_data.get("changes"), list)
+            else []
+        )
+        group_changed = 0
+        for change in changes:
+            if not isinstance(change, dict):
+                continue
+            count = int(_non_negative_int(change.get("count")) or 0)
+            group_changed += count
+            latest_by_pside[str(change.get("pside") or "unknown")] += count
+            symbol_summary = change.get("symbols")
+            if isinstance(symbol_summary, dict):
+                for symbol in symbol_summary.get("sample") or []:
+                    latest_symbols[str(symbol)] += 1
+        latest_changed_total += group_changed
+        latest_by_list_kind[str(group.get("list_kind") or "unknown")] += group_changed
+        latest_by_operation[str(group.get("operation") or "unknown")] += group_changed
+        latest_by_source[str(group.get("source") or "unknown")] += group_changed
+    compact_groups = [
+        {
+            key: value
+            for key, value in group.items()
+            if key not in {"latest_path", "latest_line", "latest_seq"}
+            and value not in (None, {}, [])
+        }
+        for group in ordered[:FORAGER_ELIGIBILITY_HEALTH_GROUP_LIMIT]
+    ]
+    summary = {
+        "total": sum(int(group.get("count", 0)) for group in groups.values()),
+        "bots": len({group.get("bot") for group in groups.values()}),
+        "event_types": dict(event_type_counts.most_common()),
+        "latest_changed_total": latest_changed_total,
+        "latest_by_list_kind": dict(latest_by_list_kind.most_common()),
+        "latest_by_operation": dict(latest_by_operation.most_common()),
+        "latest_by_pside": dict(latest_by_pside.most_common()),
+        "latest_by_source": dict(latest_by_source.most_common()),
+        "groups_truncated": len(ordered) > FORAGER_ELIGIBILITY_HEALTH_GROUP_LIMIT,
+        "groups": compact_groups,
+    }
+    if latest_changed_total:
+        symbol_sample = _symbol_sample(
+            latest_symbols,
+            limit=FORAGER_ELIGIBILITY_SYMBOL_SAMPLE_LIMIT,
+        )
+        summary["latest_changed_symbols"] = {
+            "count": latest_changed_total,
+            "sample": symbol_sample.get("sample", []),
+            "truncated": max(
+                0,
+                latest_changed_total - len(symbol_sample.get("sample", [])),
             ),
         }
     return summary
@@ -6622,6 +6800,10 @@ def _scan_events(
     ema_readiness_event_type_counts: Counter[str] = Counter()
     forager_feature_health_groups: dict[tuple[str, str], dict[str, Any]] = {}
     forager_feature_health_event_type_counts: Counter[str] = Counter()
+    forager_eligibility_health_groups: dict[
+        tuple[str, str, str, str], dict[str, Any]
+    ] = {}
+    forager_eligibility_health_event_type_counts: Counter[str] = Counter()
     exchange_config_refresh_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     exchange_config_refresh_event_type_counts: Counter[str] = Counter()
     staged_readiness_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -6868,6 +7050,20 @@ def _scan_events(
                                 line_no=line_no,
                             ),
                         )
+                    if event_type == EventTypes.FORAGER_ELIGIBILITY_CHANGED:
+                        forager_eligibility_health_event_type_counts[
+                            str(event_type)
+                        ] += 1
+                        _merge_forager_eligibility_health_group(
+                            forager_eligibility_health_groups,
+                            _forager_eligibility_health_group(
+                                bot_key=bot_key,
+                                row=row,
+                                live_event=live_event,
+                                path=path,
+                                line_no=line_no,
+                            ),
+                        )
                     if event_type == EventTypes.EXCHANGE_CONFIG_REFRESH:
                         exchange_config_refresh_event_type_counts[str(event_type)] += 1
                         _merge_exchange_config_refresh_group(
@@ -7100,6 +7296,10 @@ def _scan_events(
         "forager_feature_health": _summarize_forager_feature_health(
             forager_feature_health_groups,
             forager_feature_health_event_type_counts,
+        ),
+        "forager_eligibility_health": _summarize_forager_eligibility_health(
+            forager_eligibility_health_groups,
+            forager_eligibility_health_event_type_counts,
         ),
         "exchange_config_refresh_health": _summarize_exchange_config_refresh_health(
             exchange_config_refresh_groups,
@@ -7548,6 +7748,15 @@ def build_live_smoke_report(
             if int(event_scan["forager_feature_health"].get("total") or 0)
             else {}
         ),
+        **(
+            {
+                "forager_eligibility_health": event_scan[
+                    "forager_eligibility_health"
+                ]
+            }
+            if int(event_scan["forager_eligibility_health"].get("total") or 0)
+            else {}
+        ),
         "exchange_config_refresh_health": event_scan[
             "exchange_config_refresh_health"
         ],
@@ -7850,6 +8059,31 @@ def _summary_limited_groups(
     }
 
 
+def _summary_forager_eligibility_health(
+    summary: dict[str, Any],
+    *,
+    limit: int,
+) -> dict[str, Any]:
+    groups = summary.get("groups")
+    if not isinstance(groups, list):
+        groups = []
+    limit = max(0, int(limit))
+    return {
+        "total": _count_value(summary.get("total")),
+        "bots": _count_value(summary.get("bots")),
+        "event_types": summary.get("event_types") or {},
+        "latest_changed_total": _count_value(summary.get("latest_changed_total")),
+        "latest_by_list_kind": summary.get("latest_by_list_kind") or {},
+        "latest_by_operation": summary.get("latest_by_operation") or {},
+        "latest_by_pside": summary.get("latest_by_pside") or {},
+        "latest_by_source": summary.get("latest_by_source") or {},
+        "latest_changed_symbols": summary.get("latest_changed_symbols") or {},
+        "groups_truncated": bool(summary.get("groups_truncated"))
+        or len(groups) > limit,
+        "groups": groups[:limit],
+    }
+
+
 def _summary_staged_readiness_health(
     summary: dict[str, Any],
     *,
@@ -8066,6 +8300,11 @@ def summarize_live_smoke_report(
         if isinstance(report.get("forager_feature_health"), dict)
         else {}
     )
+    forager_eligibility_health = (
+        report.get("forager_eligibility_health")
+        if isinstance(report.get("forager_eligibility_health"), dict)
+        else {}
+    )
     fill_refresh_health = (
         report.get("fill_refresh_health")
         if isinstance(report.get("fill_refresh_health"), dict)
@@ -8277,6 +8516,16 @@ def summarize_live_smoke_report(
                 )
             }
             if forager_feature_health
+            else {}
+        ),
+        **(
+            {
+                "forager_eligibility_health": _summary_forager_eligibility_health(
+                    forager_eligibility_health,
+                    limit=max_groups,
+                )
+            }
+            if forager_eligibility_health
             else {}
         ),
         "exchange_config_refresh_health": _summary_limited_groups(
@@ -8971,6 +9220,11 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         if isinstance(report.get("forager_feature_health"), dict)
         else {}
     )
+    forager_eligibility_health = (
+        report.get("forager_eligibility_health")
+        if isinstance(report.get("forager_eligibility_health"), dict)
+        else {}
+    )
     fill_refresh_health = (
         report.get("fill_refresh_health")
         if isinstance(report.get("fill_refresh_health"), dict)
@@ -9260,6 +9514,17 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             if forager_feature_health
             else {}
         ),
+        **(
+            {
+                "forager_eligibility": {
+                    key: value
+                    for key, value in forager_eligibility_health.items()
+                    if key not in {"groups", "groups_truncated"}
+                }
+            }
+            if forager_eligibility_health
+            else {}
+        ),
         "exchange_config_refresh": {
             "total": _count_value(exchange_config_refresh_health.get("total")),
             "bots": _count_value(exchange_config_refresh_health.get("bots")),
@@ -9537,6 +9802,7 @@ SMOKE_REPORT_SECTION_ALIASES: dict[str, tuple[str, ...]] = {
     "event_pipeline": ("event_pipeline_health",),
     "exchange_config_refresh": ("exchange_config_refresh_health",),
     "fill_refresh": ("fill_refresh_health",),
+    "forager_eligibility": ("forager_eligibility_health",),
     "forager_features": ("forager_feature_health",),
     "hsl_replay": ("hsl_replay_health",),
     "remote_calls": ("remote_call_health", "remote_call_timings"),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -2276,6 +2276,128 @@ def test_live_smoke_report_summarizes_forager_feature_health(tmp_path):
     assert "ema_readiness_health" not in projected
 
 
+def test_live_smoke_report_summarizes_forager_eligibility_health(tmp_path):
+    binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        binance_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="forager.eligibility_changed",
+                seq=1,
+                ts=1000,
+                status="succeeded",
+                level="info",
+                data={
+                    "source": "config_sources",
+                    "list_kind": "approved_coins",
+                    "operation": "added",
+                    "changes": [
+                        {
+                            "pside": "long",
+                            "count": 1,
+                            "symbols": ["OLD/USDT:USDT"],
+                        }
+                    ],
+                },
+            ),
+            _monitor_row(
+                event_type="forager.eligibility_changed",
+                seq=2,
+                ts=2000,
+                status="succeeded",
+                level="info",
+                data={
+                    "source": "config_sources",
+                    "list_kind": "approved_coins",
+                    "operation": "added",
+                    "changes": [
+                        {
+                            "pside": "long",
+                            "count": 3,
+                            "symbols": [
+                                "AAVE/USDT:USDT",
+                                "api_key=SHOULD_NOT_RENDER",
+                            ],
+                        },
+                        {
+                            "pside": "short",
+                            "count": 2,
+                            "symbols": ["ARB/USDT:USDT", "WLD/USDT:USDT"],
+                        },
+                    ],
+                },
+            ),
+        ],
+    )
+    _write_ndjson(
+        gateio_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="forager.eligibility_changed",
+                exchange="gateio",
+                user="gateio_01",
+                seq=1,
+                ts=3000,
+                status="succeeded",
+                level="info",
+                data={
+                    "source": "live_value",
+                    "list_kind": "ignored_coins",
+                    "operation": "removed",
+                    "changes": [
+                        {
+                            "pside": "short",
+                            "count": 1,
+                            "symbols": ["ZEC/USDT:USDT"],
+                        }
+                    ],
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    summary = summarize_live_smoke_report(report, max_groups=1)
+    brief = summarize_live_smoke_report_brief(report)
+    projected = project_live_smoke_report_sections(report, ["forager_eligibility"])
+
+    health = report["forager_eligibility_health"]
+    assert report["ok"] is True
+    assert health["total"] == 3
+    assert health["bots"] == 2
+    assert health["event_types"] == {"forager.eligibility_changed": 3}
+    assert health["latest_changed_total"] == 6
+    assert health["latest_by_list_kind"] == {
+        "approved_coins": 5,
+        "ignored_coins": 1,
+    }
+    assert health["latest_by_operation"] == {"added": 5, "removed": 1}
+    assert health["latest_by_pside"] == {"long": 3, "short": 3}
+    assert health["latest_by_source"] == {"config_sources": 5, "live_value": 1}
+    assert health["latest_changed_symbols"]["count"] == 6
+    assert health["groups"][0]["bot"] == "gateio/gateio_01"
+    assert health["groups"][1]["count"] == 2
+    assert health["groups"][1]["latest_data"]["changes"][0]["symbols"] == {
+        "count": 3,
+        "sample": ["AAVE/USDT:USDT", "api_key=[redacted]"],
+        "truncated": 1,
+    }
+    assert "SHOULD_NOT_RENDER" not in json.dumps(health)
+
+    summary_health = summary["forager_eligibility_health"]
+    assert summary_health["latest_changed_total"] == 6
+    assert summary_health["groups_truncated"] is True
+    assert len(summary_health["groups"]) == 1
+    assert brief["forager_eligibility"] == {
+        key: value
+        for key, value in health.items()
+        if key not in {"groups", "groups_truncated"}
+    }
+    assert projected["forager_eligibility_health"] == health
+    assert "forager_feature_health" not in projected
+
+
 def test_live_smoke_report_accepts_registered_optional_section_when_absent(tmp_path):
     monitor_root = tmp_path / "monitor"
     _write_ndjson(
@@ -2284,10 +2406,16 @@ def test_live_smoke_report_accepts_registered_optional_section_when_absent(tmp_p
     )
     report = build_live_smoke_report(monitor_root, logs_root=None)
 
-    for selector in ("forager_features", "forager_feature_health"):
+    for selector in (
+        "forager_eligibility",
+        "forager_eligibility_health",
+        "forager_features",
+        "forager_feature_health",
+    ):
         projected = project_live_smoke_report_sections(report, [selector])
 
         assert projected["ok"] is True
+        assert "forager_eligibility_health" not in projected
         assert "forager_feature_health" not in projected
         assert "staged_readiness_health" not in projected
 
@@ -6974,24 +7102,26 @@ def test_live_smoke_report_cli_accepts_absent_registered_optional_section(
         monitor_root / "binance" / "binance_01" / "events" / "current.ndjson",
         [],
     )
-    assert (
-        live_smoke_report.main(
-            [
-                str(monitor_root),
-                "--logs-root",
-                "",
-                "--summary",
-                "--section",
-                "forager_features",
-                "--compact",
-            ]
+    for selector in ("forager_eligibility", "forager_features"):
+        assert (
+            live_smoke_report.main(
+                [
+                    str(monitor_root),
+                    "--logs-root",
+                    "",
+                    "--summary",
+                    "--section",
+                    selector,
+                    "--compact",
+                ]
+            )
+            == 0
         )
-        == 0
-    )
 
-    summary = json.loads(capsys.readouterr().out)
-    assert summary["ok"] is True
-    assert "forager_feature_health" not in summary
+        summary = json.loads(capsys.readouterr().out)
+        assert summary["ok"] is True
+        assert "forager_eligibility_health" not in summary
+        assert "forager_feature_health" not in summary
 
 
 def test_live_smoke_report_cli_rejects_unknown_section(capsys):


### PR DESCRIPTION
## Scope

Category: read-only tooling.

- Project existing `forager.eligibility_changed` monitor events into full, summary, brief, and section-selective live smoke reports.
- Aggregate bounded latest membership-change counts by bot, source, approved/ignored list, add/remove operation, and position side.
- Retain bounded redacted symbol samples and accept registered eligibility selectors when the optional event family is absent.
- Record PR #1272's no-restart VPS5 deployment and smoke evidence.

Non-goals: no event producer, console/text route, eligibility calculation, config, exchange I/O, smoke verdict/attention, readiness, order, risk, or trading changes.

## Behavior impact

Operators can see durable approved/ignored membership transitions in smoke evidence without opening raw monitor segments. The new projection is observational and does not affect event production or runtime decisions.

Expected VPS action after merge: pull and run bounded focused/settled report smokes; no bot restart.

## Validation

- `python -m pytest tests/test_live_smoke_report.py -q` -> passed (95 tests)
- `python -m pytest tests/test_ai_docs.py tests/test_live_event_registry_docs.py -q` -> 3 passed
- `python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py` -> passed
- `python src/tools/check_ai_docs.py` -> 0 errors, existing word-count warning
- `git diff --check` -> clean

`tests/test_passivbot_cli.py -k live_smoke_report` is blocked during collection by the host venv's pre-existing stale `passivbot_rust` stamp. This PR does not touch Rust or CLI dispatch; the direct CLI selector path is covered in `tests/test_live_smoke_report.py`.

## Reviewer focus

- Producer/consumer fidelity for `data.source`, `list_kind`, `operation`, and per-side `changes`.
- Event-count versus latest membership-count semantics.
- Redaction/boundedness and zero-event optional section behavior.
- Confirm the report-only boundary and unchanged smoke verdict.

Residual risk: natural eligibility changes are sparse; producer-shaped fixtures cover projection fidelity, and a bounded VPS5 focused report should validate the naturally observed event after merge if it remains in the selected window.
