### PR TITLE
Scope smoke event inventory to requested window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Time-bounded live smoke reports now scope monitor event-type inventory and
+  sampled cycle IDs to the requested event window. Full-file validation and
+  scanned-record counters remain unchanged.
+
 - Live smoke reports now expose bounded existing
   `forager.eligibility_changed` evidence across full, summary, brief, and
   section-selective output, including approved/ignored add/remove counts,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,23 +22,23 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/smoke-forager-eligibility-health`, based on canonical
-  `af69725ed04b9a9a0402634455fd6bb05d71d7f5` after PR #1272.
-- PR: #1273, `Expose forager eligibility health in smoke reports`; semantic
-  implementation head `7fdea0047f`. Slice: expose existing
-  `forager.eligibility_changed` evidence in full, summary, brief, and
-  section-selective smoke reports.
-- Triggering evidence: the settled PR #1272 VPS5 smoke naturally contained one
-  `forager.eligibility_changed` event while the smoke report omitted that
-  operator-relevant approved/ignored membership transition.
-- Scope: aggregate bounded latest approved/ignored add/remove counts by bot,
-  source kind, list kind, operation, and position side with redacted symbol
-  samples.
+- Branch: `codex/smoke-window-event-inventory`, based on canonical
+  `20238b50792da0a69b6fa2b13272c75ea4a0eade` after PR #1273.
+- PR: pending. Slice: make time-bounded smoke-report event inventory obey the
+  same requested window as the report's health and bot projections.
+- Triggering evidence: PR #1273's VPS5 deploy showed that a current-only
+  30-minute section report could list `forager.eligibility_changed` in the
+  monitor-wide event-type inventory even though no matching event was present
+  in the requested window. A bounded current-plus-rotated 180-minute query was
+  required to find the six natural events used to validate the new section.
+- Scope: count monitor event types and sampled cycle IDs only after the
+  existing `since_ms`/`until_ms` filter. Keep full-file parsing, validation,
+  issue reporting, and scanned-record counters unchanged.
 - Behavior boundary: read-only report projection only. No smoke verdict,
-  attention classification, console output, event production, eligibility,
-  exchange access, configuration, or trading changes.
-- Validation: producer-shaped report fixtures, full/summary/brief/section and
-  absent-section tests, full smoke-report tests, compilation, and docs checks.
+  attention classification, console output, event production, exchange access,
+  configuration, or trading changes.
+- Validation: focused time-window regression, full smoke-report tests,
+  compilation, and docs checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
 - Expected VPS action: pull and run bounded report/smoke checks after merge;
@@ -47,8 +47,21 @@ Estimated completion:
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `af69725ed04b9a9a0402634455fd6bb05d71d7f5`, PR #1272. The tracked checkout
+  `20238b50792da0a69b6fa2b13272c75ea4a0eade`, PR #1273. The tracked checkout
   is clean and expected untracked artifacts are preserved.
+- PR #1273 required no restart. Exact bot PIDs
+  `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
+  `misc:0.0` PID `434835` remained unchanged. The settled two-minute smoke was
+  `ok=true` with zero hard/log/monitor/process failures, `210/210` remote and
+  `55/55` account-critical calls successful, `9/9` fill refreshes successful,
+  and all five processes/configs matched. One report-time OKX `D` sample
+  cleared after ten seconds; the final exact states were `R=4,S=1`.
+- The focused current-plus-rotated 180-minute eligibility report found six
+  natural `forager.eligibility_changed` events across all five bots, including
+  two KuCoin events, and returned bounded redacted symbol samples. Its 17 hard
+  failures belonged to the historical validation window and were not used as
+  the deploy-health verdict. The fresh two-minute smoke was hard-green. No
+  event or trading activity was manufactured.
 - PR #1272 required no restart. Exact bot PIDs
   `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
   `misc:0.0` PID `434835` remained unchanged. The settled two-minute smoke was
@@ -1012,8 +1025,10 @@ startup-budget events are merged and deployed with the same non-enforcement
 boundary. PR #1270's matching performance projection is also merged and
 deployed without restart. PR #1271's forager feature-unavailability projection
 and PR #1272's planning-defer/absent-selector projection are merged and deployed
-without restart. The active follow-up exposes naturally observed existing
-forager eligibility membership-change evidence in smoke reports.
+without restart. PR #1273's forager eligibility projection is also merged,
+deployed, and naturally validated from six rotated events across all five bots.
+The active follow-up makes the monitor event-type and sampled-cycle inventory
+obey the same requested time window as the report health projections.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,8 +24,10 @@ Estimated completion:
 
 - Branch: `codex/smoke-window-event-inventory`, based on canonical
   `20238b50792da0a69b6fa2b13272c75ea4a0eade` after PR #1273.
-- PR: pending. Slice: make time-bounded smoke-report event inventory obey the
-  same requested window as the report's health and bot projections.
+- PR: #1274, `Scope smoke event inventory to requested window`; semantic
+  implementation head `69aa1ae1d7`. Slice: make time-bounded smoke-report
+  event inventory obey the same requested window as the report's health and
+  bot projections.
 - Triggering evidence: PR #1273's VPS5 deploy showed that a current-only
   30-minute section report could list `forager.eligibility_changed` in the
   monitor-wide event-type inventory even though no matching event was present

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,29 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1272)
+## Latest Canonical Deployment (PR #1273)
+
+- PR #1273 merged to `master` as
+  `20238b50792da0a69b6fa2b13272c75ea4a0eade`. It projects existing bounded
+  `forager.eligibility_changed` evidence into full, summary, brief, and
+  section-selective smoke reports without changing verdicts or runtime
+  behavior.
+- VPS5 fast-forwarded cleanly with no restart. Exact bot PIDs
+  `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
+  `misc:0.0` PID `434835` remained unchanged; tracked state stayed clean.
+- A current-plus-rotated 180-minute query found six natural eligibility events
+  across all five bots, including two on KuCoin. The focused report retained
+  bounded redacted symbol samples. The final two-minute smoke was `ok=true`
+  with zero hard/log/monitor/process failures, `210/210` remote and `55/55`
+  account-critical calls successful, nine successful fill refreshes, and all
+  five matching/config-valid processes. One report-time OKX `D` sample cleared
+  after ten seconds to final states `R=4,S=1`.
+- The deploy also proved that monitor event-type inventory was scan-wide even
+  with a requested time window. The next read-only report slice scopes that
+  inventory and sampled cycle IDs to `since_ms`/`until_ms`; no event or trading
+  activity was manufactured.
+
+## Previous Canonical Deployment (PR #1272)
 
 - PR #1272 merged to `master` as
   `af69725ed04b9a9a0402634455fd6bb05d71d7f5`. It adds existing bounded
@@ -32,10 +54,11 @@ merge, live smoke evidence changes, or new gaps are discovered.
   EMA readiness events remained durable.
 - The formerly failing absent `forager_features` selector returned a valid
   base-only report, and the staged-readiness selector returned a valid
-  zero-event section. No planning-defer event occurred naturally. The same
-  settled window contained one existing `forager.eligibility_changed` event;
-  the next report-only slice exposes that membership transition without
-  manufacturing events or changing eligibility.
+  zero-event section. No planning-defer event occurred naturally. The
+  monitor-wide inventory listed `forager.eligibility_changed`, but later
+  window-scoped query evidence showed that event was not in the settled
+  two-minute window. PR #1273 subsequently exposed and validated six natural
+  rotated eligibility events without manufacturing activity.
 
 ## Previous Canonical Deployment (PR #1271)
 

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -6882,7 +6882,6 @@ def _scan_events(
                     event_type = live_event.get("event_type") or row.get("kind")
                     if event_type:
                         event_type = str(event_type)
-                        monitor_event_type_counts[event_type] += 1
                         if row.get("kind") and str(row.get("kind")) != event_type:
                             issues.append(
                                 _monitor_issue(
@@ -6919,8 +6918,6 @@ def _scan_events(
                     cycle_id = ids.get("cycle_id")
                     if cycle_id is None:
                         missing_cycle_id += 1
-                    else:
-                        cycle_counts[str(cycle_id)] += 1
                     row_ts = _non_negative_int(row.get("ts"))
                     if since_ms is not None or until_ms is not None:
                         if row_ts is None:
@@ -6933,6 +6930,10 @@ def _scan_events(
                             events_skipped_after += 1
                             continue
                     events_considered += 1
+                    if event_type:
+                        monitor_event_type_counts[event_type] += 1
+                    if cycle_id is not None:
+                        cycle_counts[str(cycle_id)] += 1
                     bot_key = _bot_key(live_event, row)
                     bot = bots[bot_key]
                     bot["events"] += 1

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -6170,6 +6170,10 @@ def test_live_smoke_report_time_window_filters_structured_problem_events(tmp_pat
         "events_skipped_after": 0,
         "invalid_window_ts": 0,
     }
+    assert report["monitor"]["event_types"] == {"cycle.completed": 1}
+    assert report["monitor"]["cycle_ids_sample"] == [
+        {"cycle_id": "cy_fresh", "events": 1}
+    ]
     assert report["bots"] == [
         {
             "bot": "binance/binance_01",


### PR DESCRIPTION
## Summary

- scope monitor `event_types` and sampled `cycle_ids` to the existing `since_ms` / `until_ms` filter
- keep full selected-file parsing, validation issues, and scanned-record counters unchanged
- record PR #1273's no-restart VPS5 deploy evidence and correct the earlier scan-wide eligibility inference

## Boundary

Read-only smoke-report correctness only. No verdict, attention classification, event production, console output, exchange access, configuration, or trading behavior changes.

## Validation

- `pytest tests/test_live_smoke_report.py -q` (95 passed)
- `pytest tests/test_live_incident_bundle.py -q` (25 passed)
- `pytest tests/test_ai_docs.py tests/test_live_event_registry_docs.py -q` (3 passed)
- `python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py`
- `PYTHONPATH=src python src/tools/check_ai_docs.py` (0 errors; existing word-count warning)
- `PYTHONPATH=src python src/tools/generate_live_event_registry.py --check`
- `git diff --check`

The broader local CLI collection is blocked before tests run because the shared checkout's loaded Rust extension is stale against current Rust sources. This PR changes no Rust code; clean Python and Rust CI remain required.

## VPS5 Evidence From PR #1273

- VPS5 fast-forwarded to `20238b50792da0a69b6fa2b13272c75ea4a0eade` with no restart
- exact bot PIDs, all five pane parents, and `misc:0.0` stayed unchanged
- a bounded current-plus-rotated 180-minute query found six natural `forager.eligibility_changed` events across all five bots; the focused section retained bounded redacted samples
- fresh two-minute smoke: `ok=true`, zero hard/log/monitor/process failures, 210/210 remote calls, 55/55 account-critical calls, and 9/9 fill refreshes successful
- one report-time OKX `D` sample cleared after ten seconds; final exact states were `R=4,S=1`
- no event or trading activity was manufactured
