### PR TITLE
Report planning symbol-state smoke health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Staged-readiness smoke reports now include bounded latest-per-bot
+  `planning.symbol_state` evidence across full, summary, brief, and selected
+  output. The projection reports availability counts, unavailable reasons,
+  order classes, surfaces, and redacted symbol samples without changing smoke
+  verdicts, console output, planning, exchange access, or trading behavior.
+
 - Time-bounded live smoke reports now scope monitor event-type inventory and
   sampled cycle IDs to the requested event window. Full-file validation and
   scanned-record counters remain unchanged.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,25 +22,23 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/smoke-window-event-inventory`, based on canonical
-  `20238b50792da0a69b6fa2b13272c75ea4a0eade` after PR #1273.
-- PR: #1274, `Scope smoke event inventory to requested window`; semantic
-  implementation head `69aa1ae1d7`. Slice: make time-bounded smoke-report
-  event inventory obey the same requested window as the report's health and
-  bot projections.
-- Triggering evidence: PR #1273's VPS5 deploy showed that a current-only
-  30-minute section report could list `forager.eligibility_changed` in the
-  monitor-wide event-type inventory even though no matching event was present
-  in the requested window. A bounded current-plus-rotated 180-minute query was
-  required to find the six natural events used to validate the new section.
-- Scope: count monitor event types and sampled cycle IDs only after the
-  existing `since_ms`/`until_ms` filter. Keep full-file parsing, validation,
-  issue reporting, and scanned-record counters unchanged.
+- Branch: `codex/smoke-planning-symbol-state-health`, based on canonical
+  `bcbfa12808a00e39c1e4eb78e43e13746be553fa` after PR #1274.
+- PR: pending. Slice: project existing `planning.symbol_state` events into the
+  staged-readiness smoke health surface.
+- Triggering evidence: the fresh post-PR #1274 two-minute event inventory
+  naturally contained 18 `planning.symbol_state` events, while staged-readiness
+  health exposed only staged cycle degradation, `planning.unavailable`, and
+  `planning.defer_summary` evidence.
+- Scope: retain the latest symbol-state observation per bot and expose bounded
+  record/status counts, unavailable reasons, order classes, surfaces, and
+  redacted symbol samples in full, summary, brief, and selected staged-readiness
+  output.
 - Behavior boundary: read-only report projection only. No smoke verdict,
   attention classification, console output, event production, exchange access,
-  configuration, or trading changes.
-- Validation: focused time-window regression, full smoke-report tests,
-  compilation, and docs checks.
+  planning, configuration, or trading changes.
+- Validation: focused latest-per-bot/redaction regression, full smoke-report
+  tests, compilation, and docs checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
 - Expected VPS action: pull and run bounded report/smoke checks after merge;
@@ -49,8 +47,22 @@ Estimated completion:
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `20238b50792da0a69b6fa2b13272c75ea4a0eade`, PR #1273. The tracked checkout
+  `bcbfa12808a00e39c1e4eb78e43e13746be553fa`, PR #1274. The tracked checkout
   is clean and expected untracked artifacts are preserved.
+- PR #1274 required no restart. Exact bot PIDs
+  `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
+  `misc:0.0` PID `434835` remained unchanged. The fresh two-minute smoke was
+  `ok=true` with zero hard/log/monitor/process failures, `248/248` remote and
+  `57/57` account-critical calls successful, `8/8` fill refreshes successful,
+  and all five processes/configs matched in state `R` with no uninterruptible
+  sleep.
+- One natural KuCoin `forager.eligibility_changed` event appeared in a bounded
+  30-minute window and the scoped monitor inventory counted exactly one. A
+  fresh two-minute focused report contained no eligibility section and omitted
+  that event type from inventory, directly validating the requested-window
+  boundary. The historical 30-minute report retained four hard failures and
+  was not represented as deploy-green. No event or trading activity was
+  manufactured.
 - PR #1273 required no restart. Exact bot PIDs
   `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
   `misc:0.0` PID `434835` remained unchanged. The settled two-minute smoke was
@@ -1027,10 +1039,11 @@ startup-budget events are merged and deployed with the same non-enforcement
 boundary. PR #1270's matching performance projection is also merged and
 deployed without restart. PR #1271's forager feature-unavailability projection
 and PR #1272's planning-defer/absent-selector projection are merged and deployed
-without restart. PR #1273's forager eligibility projection is also merged,
-deployed, and naturally validated from six rotated events across all five bots.
-The active follow-up makes the monitor event-type and sampled-cycle inventory
-obey the same requested time window as the report health projections.
+without restart. PR #1273's forager eligibility projection and PR #1274's
+requested-window event inventory are also merged, deployed, and naturally
+validated. The active follow-up projects the already-emitted
+`planning.symbol_state` family into bounded latest-per-bot staged-readiness
+health without changing verdicts or runtime behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,8 +24,9 @@ Estimated completion:
 
 - Branch: `codex/smoke-planning-symbol-state-health`, based on canonical
   `bcbfa12808a00e39c1e4eb78e43e13746be553fa` after PR #1274.
-- PR: pending. Slice: project existing `planning.symbol_state` events into the
-  staged-readiness smoke health surface.
+- PR: #1275, `Report planning symbol-state smoke health`; semantic
+  implementation head `23696ded95`. Slice: project existing
+  `planning.symbol_state` events into the staged-readiness smoke health surface.
 - Triggering evidence: the fresh post-PR #1274 two-minute event inventory
   naturally contained 18 `planning.symbol_state` events, while staged-readiness
   health exposed only staged cycle degradation, `planning.unavailable`, and

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,28 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1273)
+## Latest Canonical Deployment (PR #1274)
+
+- PR #1274 merged to `master` as
+  `bcbfa12808a00e39c1e4eb78e43e13746be553fa`. It scopes monitor event-type
+  inventory and sampled cycle IDs to the requested smoke-report time window
+  while preserving full-file validation and scanned-record counters.
+- VPS5 fast-forwarded cleanly with no restart. Exact bot PIDs
+  `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
+  `misc:0.0` PID `434835` remained unchanged; tracked state stayed clean.
+- A bounded 30-minute report observed one natural KuCoin eligibility event and
+  counted that event type exactly once. A fresh two-minute focused report had
+  no eligibility event and omitted the event type from inventory, directly
+  validating the fixed boundary. The fresh smoke was `ok=true` with zero
+  hard/log/monitor/process failures, `248/248` remote and `57/57`
+  account-critical calls successful, eight successful fill refreshes, and all
+  five exact/config-valid processes in state `R` with no uninterruptible sleep.
+- The same fresh event inventory naturally contained 18
+  `planning.symbol_state` events. The next report-only slice adds bounded
+  latest-per-bot symbol-state evidence to staged-readiness health; no event or
+  trading activity was manufactured.
+
+## Previous Canonical Deployment (PR #1273)
 
 - PR #1273 merged to `master` as
   `20238b50792da0a69b6fa2b13272c75ea4a0eade`. It projects existing bounded

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -2873,6 +2873,7 @@ def _staged_readiness_event(live_event: dict[str, Any]) -> bool:
     return event_type in {
         EventTypes.PLANNING_UNAVAILABLE,
         EventTypes.PLANNING_DEFER_SUMMARY,
+        EventTypes.PLANNING_SYMBOL_STATE,
     }
 
 
@@ -2933,9 +2934,28 @@ def _staged_readiness_timings_ms(value: Any) -> dict[str, int]:
     )
 
 
-def _staged_readiness_symbol_summary(payload: dict[str, Any]) -> dict[str, Any]:
+def _staged_readiness_count_map(value: Any) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    counts: Counter[str] = Counter()
+    for key, raw in value.items():
+        parsed = _non_negative_int(raw)
+        if key is None or parsed is None:
+            continue
+        safe_key = _redact_log_text(str(key), max_len=80)
+        if safe_key:
+            counts[safe_key] += int(parsed)
+    return dict(counts.most_common(STAGED_READINESS_VALUE_LIMIT))
+
+
+def _staged_readiness_symbol_summary(
+    payload: dict[str, Any],
+    *,
+    symbols_key: str = "symbols",
+    count_key: str = "symbols_count",
+) -> dict[str, Any]:
     symbols: Counter[str] = Counter()
-    raw_symbols = payload.get("symbols")
+    raw_symbols = payload.get(symbols_key)
     if isinstance(raw_symbols, list):
         for symbol in raw_symbols:
             if symbol is None:
@@ -2943,7 +2963,7 @@ def _staged_readiness_symbol_summary(payload: dict[str, Any]) -> dict[str, Any]:
             safe_symbol = _redact_log_text(str(symbol), max_len=80)
             if safe_symbol:
                 symbols[safe_symbol] += 1
-    count = _non_negative_int(payload.get("symbols_count"))
+    count = _non_negative_int(payload.get(count_key))
     if count is None:
         count = len(symbols)
     count = max(int(count), len(symbols))
@@ -2993,6 +3013,9 @@ def _staged_readiness_group(
     detail_payload = details if isinstance(details, dict) else payload
     event_type = live_event.get("event_type") or row.get("kind")
     defer_summary = event_type == EventTypes.PLANNING_DEFER_SUMMARY
+    symbol_state = event_type == EventTypes.PLANNING_SYMBOL_STATE
+    state_summary = payload.get("summary")
+    state_summary = state_summary if isinstance(state_summary, dict) else {}
     ids = _event_ids(live_event)
     invalid = detail_payload.get("invalid")
     missing_surfaces = _string_counts(detail_payload.get("missing"))
@@ -3020,6 +3043,15 @@ def _staged_readiness_group(
     latest_will_retry = (
         _staged_readiness_text(payload.get("will_retry")) if defer_summary else None
     )
+    latest_symbol_state_symbols = (
+        _staged_readiness_symbol_summary(
+            payload,
+            symbols_key="unavailable_symbols",
+            count_key="unavailable_symbols_count",
+        )
+        if symbol_state
+        else {}
+    )
     return {
         "bot": bot_key,
         "event_type": event_type,
@@ -3042,6 +3074,37 @@ def _staged_readiness_group(
         "latest_defer_symbols": latest_defer_symbols,
         "latest_required_surfaces": required_surfaces,
         "latest_will_retry": latest_will_retry,
+        "latest_symbol_state_record_count": (
+            _non_negative_int(state_summary.get("record_count"))
+            if symbol_state
+            else None
+        ),
+        "latest_symbol_state_status_counts": (
+            _staged_readiness_count_map(state_summary.get("status_counts"))
+            if symbol_state
+            else {}
+        ),
+        "latest_symbol_state_unavailable_count": (
+            _non_negative_int(payload.get("unavailable_count"))
+            if symbol_state
+            else None
+        ),
+        "latest_symbol_state_unavailable_by_reason": (
+            _staged_readiness_count_map(payload.get("unavailable_by_reason"))
+            if symbol_state
+            else {}
+        ),
+        "latest_symbol_state_unavailable_by_order_class": (
+            _staged_readiness_count_map(payload.get("unavailable_by_order_class"))
+            if symbol_state
+            else {}
+        ),
+        "latest_symbol_state_unavailable_by_surface": (
+            _staged_readiness_count_map(payload.get("unavailable_by_surface"))
+            if symbol_state
+            else {}
+        ),
+        "latest_symbol_state_unavailable_symbols": latest_symbol_state_symbols,
         "latest_completed_candle_mismatch_counts": _completed_candle_mismatch_counts(
             invalid
         ),
@@ -3101,6 +3164,13 @@ def _merge_staged_readiness_group(
             "latest_defer_symbols",
             "latest_required_surfaces",
             "latest_will_retry",
+            "latest_symbol_state_record_count",
+            "latest_symbol_state_status_counts",
+            "latest_symbol_state_unavailable_count",
+            "latest_symbol_state_unavailable_by_reason",
+            "latest_symbol_state_unavailable_by_order_class",
+            "latest_symbol_state_unavailable_by_surface",
+            "latest_symbol_state_unavailable_symbols",
             "latest_completed_candle_mismatch_counts",
             "latest_missing_surface_count",
             "latest_invalid_surface_count",
@@ -3222,6 +3292,101 @@ def _summarize_staged_readiness_health(
                 limit=STAGED_READINESS_SYMBOL_SAMPLE_LIMIT,
             ).get("sample", [])
             summary["latest_defer_symbols"] = {
+                "count": symbol_count,
+                "sample": sample,
+                "truncated": max(0, symbol_count - len(sample)),
+            }
+    symbol_state_groups_by_bot: dict[str, dict[str, Any]] = {}
+    for group in groups.values():
+        if group.get("event_type") != EventTypes.PLANNING_SYMBOL_STATE:
+            continue
+        bot = str(group.get("bot") or "unknown")
+        previous = symbol_state_groups_by_bot.get(bot)
+        if previous is None or _sort_event_position_key(
+            ts=group.get("latest_ts"),
+            seq=group.get("latest_seq"),
+            path=group.get("latest_path") or "",
+            line_no=int(group.get("latest_line") or 0),
+        ) > _sort_event_position_key(
+            ts=previous.get("latest_ts"),
+            seq=previous.get("latest_seq"),
+            path=previous.get("latest_path") or "",
+            line_no=int(previous.get("latest_line") or 0),
+        ):
+            symbol_state_groups_by_bot[bot] = group
+    symbol_state_groups = list(symbol_state_groups_by_bot.values())
+    if symbol_state_groups:
+        symbol_count = 0
+        symbols: Counter[str] = Counter()
+        for group in symbol_state_groups:
+            symbol_summary = group.get("latest_symbol_state_unavailable_symbols")
+            if not isinstance(symbol_summary, dict):
+                continue
+            symbol_count += int(_non_negative_int(symbol_summary.get("count")) or 0)
+            for symbol in symbol_summary.get("sample") or []:
+                symbols[str(symbol)] += 1
+        summary.update(
+            {
+                "latest_symbol_state_bots": len(symbol_state_groups),
+                "latest_symbol_state_record_total": sum(
+                    int(
+                        _non_negative_int(
+                            group.get("latest_symbol_state_record_count")
+                        )
+                        or 0
+                    )
+                    for group in symbol_state_groups
+                ),
+                "latest_symbol_state_status_counts": _staged_readiness_count_map(
+                    _sum_counter_maps(
+                        group.get("latest_symbol_state_status_counts")
+                        for group in symbol_state_groups
+                    )
+                ),
+                "latest_symbol_state_unavailable_total": sum(
+                    int(
+                        _non_negative_int(
+                            group.get("latest_symbol_state_unavailable_count")
+                        )
+                        or 0
+                    )
+                    for group in symbol_state_groups
+                ),
+                "latest_symbol_state_unavailable_by_reason": (
+                    _staged_readiness_count_map(
+                        _sum_counter_maps(
+                            group.get("latest_symbol_state_unavailable_by_reason")
+                            for group in symbol_state_groups
+                        )
+                    )
+                ),
+                "latest_symbol_state_unavailable_by_order_class": (
+                    _staged_readiness_count_map(
+                        _sum_counter_maps(
+                            group.get(
+                                "latest_symbol_state_unavailable_by_order_class"
+                            )
+                            for group in symbol_state_groups
+                        )
+                    )
+                ),
+                "latest_symbol_state_unavailable_by_surface": (
+                    _staged_readiness_count_map(
+                        _sum_counter_maps(
+                            group.get("latest_symbol_state_unavailable_by_surface")
+                            for group in symbol_state_groups
+                        )
+                    )
+                ),
+                "latest_symbol_state_unavailable_symbol_count_total": symbol_count,
+            }
+        )
+        if symbol_count:
+            sample = _symbol_sample(
+                symbols,
+                limit=STAGED_READINESS_SYMBOL_SAMPLE_LIMIT,
+            ).get("sample", [])
+            summary["latest_symbol_state_unavailable_symbols"] = {
                 "count": symbol_count,
                 "sample": sample,
                 "truncated": max(0, symbol_count - len(sample)),
@@ -8106,6 +8271,15 @@ def _summary_staged_readiness_health(
         "latest_defer_symbols",
         "latest_required_surfaces",
         "latest_will_retry",
+        "latest_symbol_state_bots",
+        "latest_symbol_state_record_total",
+        "latest_symbol_state_status_counts",
+        "latest_symbol_state_unavailable_total",
+        "latest_symbol_state_unavailable_by_reason",
+        "latest_symbol_state_unavailable_by_order_class",
+        "latest_symbol_state_unavailable_by_surface",
+        "latest_symbol_state_unavailable_symbol_count_total",
+        "latest_symbol_state_unavailable_symbols",
     ):
         value = summary.get(key)
         if value not in (None, {}, []):
@@ -9319,6 +9493,11 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         "latest_defer_symbols",
         "latest_required_surfaces",
         "latest_will_retry",
+        "latest_symbol_state_status_counts",
+        "latest_symbol_state_unavailable_by_reason",
+        "latest_symbol_state_unavailable_by_order_class",
+        "latest_symbol_state_unavailable_by_surface",
+        "latest_symbol_state_unavailable_symbols",
     ):
         value = staged_readiness_health.get(key)
         if isinstance(value, dict) and value:
@@ -9327,6 +9506,10 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         "latest_defer_count_total",
         "latest_defer_window_s_max",
         "latest_defer_symbol_count_total",
+        "latest_symbol_state_bots",
+        "latest_symbol_state_record_total",
+        "latest_symbol_state_unavailable_total",
+        "latest_symbol_state_unavailable_symbol_count_total",
     ):
         value = staged_readiness_health.get(key)
         if value is not None:

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -3808,6 +3808,161 @@ def test_live_smoke_report_summarizes_staged_readiness_health(tmp_path):
     }
 
 
+def test_live_smoke_report_summarizes_latest_planning_symbol_state_per_bot(tmp_path):
+    binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        binance_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="planning.symbol_state",
+                seq=1,
+                ts=1000,
+                level="debug",
+                reason_code="snapshot_symbol_state",
+                ids={"cycle_id": "cy_old", "snapshot_id": "snap_old"},
+                data={
+                    "context": "rust order calculation",
+                    "summary": {
+                        "cycle_id": 1,
+                        "record_count": 99,
+                        "status_counts": {"unavailable": 99},
+                    },
+                    "unavailable_count": 99,
+                    "unavailable_by_reason": {"stale_old_reason": 99},
+                    "unavailable_by_order_class": {"initial_entry": 99},
+                    "unavailable_by_surface": {"market_prices": 99},
+                    "unavailable_symbols": ["OLD/USDT:USDT"],
+                    "unavailable_symbols_count": 99,
+                },
+            ),
+            _monitor_row(
+                event_type="planning.symbol_state",
+                seq=2,
+                ts=2000,
+                level="debug",
+                reason_code="snapshot_symbol_state",
+                ids={"cycle_id": "cy_new", "snapshot_id": "snap_new"},
+                data={
+                    "context": "rust order calculation",
+                    "summary": {
+                        "cycle_id": 2,
+                        "record_count": 4,
+                        "status_counts": {"available": 2, "unavailable": 2},
+                    },
+                    "unavailable_count": 2,
+                    "unavailable_by_reason": {
+                        "market_prices_too_old": 1,
+                        "missing_canonical_candles": 1,
+                    },
+                    "unavailable_by_order_class": {
+                        "hsl_panic_close": 1,
+                        "initial_entry": 1,
+                    },
+                    "unavailable_by_surface": {
+                        "canonical_candles": 1,
+                        "market_prices": 1,
+                    },
+                    "unavailable_symbols": [
+                        "BTC/USDT:USDT",
+                        "api_key=SHOULD_NOT_RENDER",
+                    ],
+                    "unavailable_symbols_count": 2,
+                    "records_sample": [
+                        {"symbol": "api_key=SHOULD_NOT_RENDER"}
+                    ],
+                },
+            ),
+        ],
+    )
+    _write_ndjson(
+        gateio_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="planning.symbol_state",
+                seq=1,
+                ts=1500,
+                exchange="gateio",
+                user="gateio_01",
+                level="debug",
+                reason_code="snapshot_symbol_state",
+                ids={"cycle_id": "cy_gate", "snapshot_id": "snap_gate"},
+                data={
+                    "context": "rust order calculation",
+                    "summary": {
+                        "cycle_id": 3,
+                        "record_count": 3,
+                        "status_counts": {"available": 2, "unavailable": 1},
+                    },
+                    "unavailable_count": 1,
+                    "unavailable_by_reason": {"market_prices_too_old": 1},
+                    "unavailable_by_order_class": {"initial_entry": 1},
+                    "unavailable_by_surface": {"market_prices": 1},
+                    "unavailable_symbols": ["ETH/USDT:USDT"],
+                    "unavailable_symbols_count": 1,
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    summary = summarize_live_smoke_report(report)
+    brief = summarize_live_smoke_report_brief(report)
+    section = project_live_smoke_report_sections(report, ["staged_readiness"])
+
+    health = report["staged_readiness_health"]
+    assert health["total"] == 3
+    assert health["bots"] == 2
+    assert health["event_types"] == {"planning.symbol_state": 3}
+    assert health["latest_symbol_state_bots"] == 2
+    assert health["latest_symbol_state_record_total"] == 7
+    assert health["latest_symbol_state_status_counts"] == {
+        "available": 4,
+        "unavailable": 3,
+    }
+    assert health["latest_symbol_state_unavailable_total"] == 3
+    assert health["latest_symbol_state_unavailable_by_reason"] == {
+        "market_prices_too_old": 2,
+        "missing_canonical_candles": 1,
+    }
+    assert health["latest_symbol_state_unavailable_by_order_class"] == {
+        "initial_entry": 2,
+        "hsl_panic_close": 1,
+    }
+    assert health["latest_symbol_state_unavailable_by_surface"] == {
+        "market_prices": 2,
+        "canonical_candles": 1,
+    }
+    assert health["latest_symbol_state_unavailable_symbols"] == {
+        "count": 3,
+        "sample": [
+            "BTC/USDT:USDT",
+            "ETH/USDT:USDT",
+            "api_key=[redacted]",
+        ],
+        "truncated": 0,
+    }
+    assert "stale_old_reason" not in json.dumps(health)
+    assert "SHOULD_NOT_RENDER" not in json.dumps(health)
+    binance_group = next(
+        group for group in health["groups"] if group["bot"] == "binance/binance_01"
+    )
+    assert binance_group["count"] == 2
+    assert binance_group["latest_ids"] == {
+        "cycle_id": "cy_new",
+        "snapshot_id": "snap_new",
+    }
+    for projected in (summary["staged_readiness_health"], brief["staged_readiness"]):
+        assert projected["latest_symbol_state_record_total"] == 7
+        assert projected["latest_symbol_state_unavailable_total"] == 3
+        assert projected["latest_symbol_state_unavailable_by_reason"] == {
+            "market_prices_too_old": 2,
+            "missing_canonical_candles": 1,
+        }
+        assert "SHOULD_NOT_RENDER" not in json.dumps(projected)
+    assert section["staged_readiness_health"] == health
+
+
 def test_live_smoke_report_problem_events_include_state_refresh_progress(tmp_path):
     events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- add existing `planning.symbol_state` events to staged-readiness smoke health
- retain latest-per-bot record/status and unavailable reason/order-class/surface counts
- expose bounded redacted symbol samples in full, summary, brief, and selected output
- record PR #1274 merge/deploy evidence

## Behavior boundary
Read-only smoke-report projection only. No verdict, attention, console, producer, planning, exchange, configuration, or trading changes.

## Validation
- `python -m pytest tests/test_live_smoke_report.py -q` (96 passed)
- `python -m pytest tests/test_live_incident_bundle.py tests/test_ai_docs.py tests/test_live_event_registry_docs.py -q` (28 passed)
- `python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py`
- `git diff --check`

## Deploy evidence baseline
PR #1274 merged as `bcbfa12808a00e39c1e4eb78e43e13746be553fa` and VPS5 fast-forwarded without restart. Exact five bot PIDs, pane parents, and `misc:0.0` remained unchanged. Fresh two-minute smoke was hard-green with 248/248 remote calls, 57/57 account-critical calls, 8/8 fill refreshes, and all five exact/config-valid processes in state R. A fresh focused window omitted absent eligibility events from both the section and event inventory, directly validating #1274.