### PR TITLE
Report initial-entry eligibility smoke health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable user-facing changes will be documented in this file.
 ## Unreleased
 
 - Staged-readiness smoke reports now include bounded latest-per-bot
+  `entry.initial_eligibility` aggregates: evaluated and record totals, outcome
+  and reason counts, truncation coverage, and correlation IDs. Raw per-symbol
+  records remain query-only, and smoke verdicts, entry eligibility, exchange
+  access, and trading behavior are unchanged.
+
+- Staged-readiness smoke reports now include bounded latest-per-bot
   `planning.symbol_state` evidence across full, summary, brief, and selected
   output. The projection reports availability counts, unavailable reasons,
   order classes, surfaces, and redacted symbol samples without changing smoke

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,24 +22,22 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/smoke-planning-symbol-state-health`, based on canonical
-  `bcbfa12808a00e39c1e4eb78e43e13746be553fa` after PR #1274.
-- PR: #1275, `Report planning symbol-state smoke health`; semantic
-  implementation head `23696ded95`. Slice: project existing
-  `planning.symbol_state` events into the staged-readiness smoke health surface.
-- Triggering evidence: the fresh post-PR #1274 two-minute event inventory
-  naturally contained 18 `planning.symbol_state` events, while staged-readiness
-  health exposed only staged cycle degradation, `planning.unavailable`, and
-  `planning.defer_summary` evidence.
-- Scope: retain the latest symbol-state observation per bot and expose bounded
-  record/status counts, unavailable reasons, order classes, surfaces, and
-  redacted symbol samples in full, summary, brief, and selected staged-readiness
-  output.
+- Branch: `codex/smoke-entry-initial-eligibility-health`, based on canonical
+  `e5603244565807167494ffc53898f98f736f876a` after PR #1275.
+- PR: pending. Slice: project existing `entry.initial_eligibility` aggregates
+  into the staged-readiness smoke health surface.
+- Triggering evidence: the settled post-PR #1275 two-minute inventory naturally
+  contained 12 `entry.initial_eligibility` events while staged-readiness health
+  exposed only planning and staged-cycle families. A bounded query confirmed
+  producer-owned outcome and reason counts plus bounded per-symbol records.
+- Scope: retain the latest eligibility observation per bot and expose bounded
+  evaluated/record totals, outcome/reason counts, truncation coverage, and
+  correlation IDs. Keep raw per-symbol records query-only.
 - Behavior boundary: read-only report projection only. No smoke verdict,
   attention classification, console output, event production, exchange access,
-  planning, configuration, or trading changes.
-- Validation: focused latest-per-bot/redaction regression, full smoke-report
-  tests, compilation, and docs checks.
+  entry eligibility, planning, configuration, or trading changes.
+- Validation: focused latest-per-bot/bounded-record regression, full
+  smoke-report tests, compilation, and docs checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
 - Expected VPS action: pull and run bounded report/smoke checks after merge;
@@ -48,8 +46,20 @@ Estimated completion:
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `bcbfa12808a00e39c1e4eb78e43e13746be553fa`, PR #1274. The tracked checkout
+  `e5603244565807167494ffc53898f98f736f876a`, PR #1275. The tracked checkout
   is clean and expected untracked artifacts are preserved.
+- PR #1275 required no restart. Exact bot PIDs
+  `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
+  `misc:0.0` PID `434835` remained unchanged. The bounded two-minute smoke was
+  `ok=true` with zero hard/log/monitor/process failures, `291/291` remote and
+  `58/58` account-critical calls successful, `9/9` fill refreshes successful,
+  and five exact/config-valid live processes. Transient preflight/report `D`
+  samples cleared to a final exact process state of `R=4,S=1`.
+- The focused staged-readiness report naturally projected 13
+  `planning.symbol_state` events across four bots, with bounded latest-per-bot
+  status, reason, order-class, surface, and redacted symbol evidence. The same
+  settled inventory contained 12 natural `entry.initial_eligibility` events,
+  exposing the active follow-up. No event or trading activity was manufactured.
 - PR #1274 required no restart. Exact bot PIDs
   `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
   `misc:0.0` PID `434835` remained unchanged. The fresh two-minute smoke was
@@ -1040,11 +1050,11 @@ startup-budget events are merged and deployed with the same non-enforcement
 boundary. PR #1270's matching performance projection is also merged and
 deployed without restart. PR #1271's forager feature-unavailability projection
 and PR #1272's planning-defer/absent-selector projection are merged and deployed
-without restart. PR #1273's forager eligibility projection and PR #1274's
-requested-window event inventory are also merged, deployed, and naturally
-validated. The active follow-up projects the already-emitted
-`planning.symbol_state` family into bounded latest-per-bot staged-readiness
-health without changing verdicts or runtime behavior.
+without restart. PR #1273's forager eligibility projection, PR #1274's
+requested-window event inventory, and PR #1275's planning symbol-state health
+are also merged, deployed, and naturally validated. The active follow-up adds
+bounded latest-per-bot `entry.initial_eligibility` aggregates to staged
+readiness without copying raw records or changing verdicts/runtime behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,8 +24,10 @@ Estimated completion:
 
 - Branch: `codex/smoke-entry-initial-eligibility-health`, based on canonical
   `e5603244565807167494ffc53898f98f736f876a` after PR #1275.
-- PR: pending. Slice: project existing `entry.initial_eligibility` aggregates
-  into the staged-readiness smoke health surface.
+- PR: #1276, `Report initial-entry eligibility smoke health`; semantic
+  implementation head `b3840ed5df`. Slice: project existing
+  `entry.initial_eligibility` aggregates into the staged-readiness smoke health
+  surface.
 - Triggering evidence: the settled post-PR #1275 two-minute inventory naturally
   contained 12 `entry.initial_eligibility` events while staged-readiness health
   exposed only planning and staged-cycle families. A bounded query confirmed

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,26 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1274)
+## Latest Canonical Deployment (PR #1275)
+
+- PR #1275 merged to `master` as
+  `e5603244565807167494ffc53898f98f736f876a`. It projects existing
+  `planning.symbol_state` events into bounded latest-per-bot staged-readiness
+  health without changing verdicts or runtime behavior.
+- VPS5 fast-forwarded cleanly with no restart. Exact bot PIDs
+  `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
+  `misc:0.0` PID `434835` remained unchanged; tracked state stayed clean.
+- The bounded two-minute smoke was `ok=true` with zero hard/log/monitor/process
+  failures, `291/291` remote and `58/58` account-critical calls successful,
+  nine successful fill refreshes, and five exact/config-valid live processes.
+  Transient `D` samples cleared to a final exact state of `R=4,S=1`.
+- The focused report naturally projected 13 symbol-state events across four
+  bots with bounded aggregate and redacted symbol evidence. The same settled
+  inventory contained 12 natural `entry.initial_eligibility` events, motivating
+  the next report-only aggregate slice. No event or trading activity was
+  manufactured.
+
+## Previous Canonical Deployment (PR #1274)
 
 - PR #1274 merged to `master` as
   `bcbfa12808a00e39c1e4eb78e43e13746be553fa`. It scopes monitor event-type

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -2874,6 +2874,7 @@ def _staged_readiness_event(live_event: dict[str, Any]) -> bool:
         EventTypes.PLANNING_UNAVAILABLE,
         EventTypes.PLANNING_DEFER_SUMMARY,
         EventTypes.PLANNING_SYMBOL_STATE,
+        EventTypes.ENTRY_INITIAL_ELIGIBILITY,
     }
 
 
@@ -3014,8 +3015,13 @@ def _staged_readiness_group(
     event_type = live_event.get("event_type") or row.get("kind")
     defer_summary = event_type == EventTypes.PLANNING_DEFER_SUMMARY
     symbol_state = event_type == EventTypes.PLANNING_SYMBOL_STATE
+    initial_eligibility = event_type == EventTypes.ENTRY_INITIAL_ELIGIBILITY
     state_summary = payload.get("summary")
     state_summary = state_summary if isinstance(state_summary, dict) else {}
+    records_truncated = payload.get("records_truncated")
+    records_truncated = (
+        records_truncated if isinstance(records_truncated, bool) else None
+    )
     ids = _event_ids(live_event)
     invalid = detail_payload.get("invalid")
     missing_surfaces = _string_counts(detail_payload.get("missing"))
@@ -3105,6 +3111,29 @@ def _staged_readiness_group(
             else {}
         ),
         "latest_symbol_state_unavailable_symbols": latest_symbol_state_symbols,
+        "latest_initial_entry_evaluated_count": (
+            _non_negative_int(payload.get("evaluated_count"))
+            if initial_eligibility
+            else None
+        ),
+        "latest_initial_entry_records_total": (
+            _non_negative_int(payload.get("records_total"))
+            if initial_eligibility
+            else None
+        ),
+        "latest_initial_entry_outcome_counts": (
+            _staged_readiness_count_map(payload.get("outcome_counts"))
+            if initial_eligibility
+            else {}
+        ),
+        "latest_initial_entry_reason_counts": (
+            _staged_readiness_count_map(payload.get("reason_counts"))
+            if initial_eligibility
+            else {}
+        ),
+        "latest_initial_entry_records_truncated": (
+            records_truncated if initial_eligibility else None
+        ),
         "latest_completed_candle_mismatch_counts": _completed_candle_mismatch_counts(
             invalid
         ),
@@ -3112,7 +3141,13 @@ def _staged_readiness_group(
         "latest_invalid_surface_count": sum(invalid_surfaces.values()),
         "latest_ids": {
             key: ids.get(key)
-            for key in ("cycle_id", "snapshot_id", "plan_id", "action_id")
+            for key in (
+                "cycle_id",
+                "snapshot_id",
+                "plan_id",
+                "order_wave_id",
+                "action_id",
+            )
             if ids.get(key) is not None
         },
         "latest_data": _compact_problem_event_data(live_event),
@@ -3171,6 +3206,11 @@ def _merge_staged_readiness_group(
             "latest_symbol_state_unavailable_by_order_class",
             "latest_symbol_state_unavailable_by_surface",
             "latest_symbol_state_unavailable_symbols",
+            "latest_initial_entry_evaluated_count",
+            "latest_initial_entry_records_total",
+            "latest_initial_entry_outcome_counts",
+            "latest_initial_entry_reason_counts",
+            "latest_initial_entry_records_truncated",
             "latest_completed_candle_mismatch_counts",
             "latest_missing_surface_count",
             "latest_invalid_surface_count",
@@ -3178,6 +3218,32 @@ def _merge_staged_readiness_group(
             "latest_data",
         ):
             existing[field] = group.get(field)
+
+
+def _latest_staged_readiness_groups_by_bot(
+    groups: Iterable[dict[str, Any]],
+    *,
+    event_type: str,
+) -> list[dict[str, Any]]:
+    latest_by_bot: dict[str, dict[str, Any]] = {}
+    for group in groups:
+        if group.get("event_type") != event_type:
+            continue
+        bot = str(group.get("bot") or "unknown")
+        previous = latest_by_bot.get(bot)
+        if previous is None or _sort_event_position_key(
+            ts=group.get("latest_ts"),
+            seq=group.get("latest_seq"),
+            path=group.get("latest_path") or "",
+            line_no=int(group.get("latest_line") or 0),
+        ) > _sort_event_position_key(
+            ts=previous.get("latest_ts"),
+            seq=previous.get("latest_seq"),
+            path=previous.get("latest_path") or "",
+            line_no=int(previous.get("latest_line") or 0),
+        ):
+            latest_by_bot[bot] = group
+    return list(latest_by_bot.values())
 
 
 def _summarize_staged_readiness_health(
@@ -3296,25 +3362,10 @@ def _summarize_staged_readiness_health(
                 "sample": sample,
                 "truncated": max(0, symbol_count - len(sample)),
             }
-    symbol_state_groups_by_bot: dict[str, dict[str, Any]] = {}
-    for group in groups.values():
-        if group.get("event_type") != EventTypes.PLANNING_SYMBOL_STATE:
-            continue
-        bot = str(group.get("bot") or "unknown")
-        previous = symbol_state_groups_by_bot.get(bot)
-        if previous is None or _sort_event_position_key(
-            ts=group.get("latest_ts"),
-            seq=group.get("latest_seq"),
-            path=group.get("latest_path") or "",
-            line_no=int(group.get("latest_line") or 0),
-        ) > _sort_event_position_key(
-            ts=previous.get("latest_ts"),
-            seq=previous.get("latest_seq"),
-            path=previous.get("latest_path") or "",
-            line_no=int(previous.get("latest_line") or 0),
-        ):
-            symbol_state_groups_by_bot[bot] = group
-    symbol_state_groups = list(symbol_state_groups_by_bot.values())
+    symbol_state_groups = _latest_staged_readiness_groups_by_bot(
+        groups.values(),
+        event_type=EventTypes.PLANNING_SYMBOL_STATE,
+    )
     if symbol_state_groups:
         symbol_count = 0
         symbols: Counter[str] = Counter()
@@ -3391,6 +3442,51 @@ def _summarize_staged_readiness_health(
                 "sample": sample,
                 "truncated": max(0, symbol_count - len(sample)),
             }
+    initial_entry_groups = _latest_staged_readiness_groups_by_bot(
+        groups.values(),
+        event_type=EventTypes.ENTRY_INITIAL_ELIGIBILITY,
+    )
+    if initial_entry_groups:
+        summary.update(
+            {
+                "latest_initial_entry_eligibility_bots": len(initial_entry_groups),
+                "latest_initial_entry_evaluated_total": sum(
+                    int(
+                        _non_negative_int(
+                            group.get("latest_initial_entry_evaluated_count")
+                        )
+                        or 0
+                    )
+                    for group in initial_entry_groups
+                ),
+                "latest_initial_entry_records_total": sum(
+                    int(
+                        _non_negative_int(
+                            group.get("latest_initial_entry_records_total")
+                        )
+                        or 0
+                    )
+                    for group in initial_entry_groups
+                ),
+                "latest_initial_entry_outcome_counts": _staged_readiness_count_map(
+                    _sum_counter_maps(
+                        group.get("latest_initial_entry_outcome_counts")
+                        for group in initial_entry_groups
+                    )
+                ),
+                "latest_initial_entry_reason_counts": _staged_readiness_count_map(
+                    _sum_counter_maps(
+                        group.get("latest_initial_entry_reason_counts")
+                        for group in initial_entry_groups
+                    )
+                ),
+                "latest_initial_entry_records_truncated_bots": sum(
+                    1
+                    for group in initial_entry_groups
+                    if group.get("latest_initial_entry_records_truncated") is True
+                ),
+            }
+        )
     return summary
 
 
@@ -8280,6 +8376,12 @@ def _summary_staged_readiness_health(
         "latest_symbol_state_unavailable_by_surface",
         "latest_symbol_state_unavailable_symbol_count_total",
         "latest_symbol_state_unavailable_symbols",
+        "latest_initial_entry_eligibility_bots",
+        "latest_initial_entry_evaluated_total",
+        "latest_initial_entry_records_total",
+        "latest_initial_entry_outcome_counts",
+        "latest_initial_entry_reason_counts",
+        "latest_initial_entry_records_truncated_bots",
     ):
         value = summary.get(key)
         if value not in (None, {}, []):
@@ -9498,6 +9600,8 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         "latest_symbol_state_unavailable_by_order_class",
         "latest_symbol_state_unavailable_by_surface",
         "latest_symbol_state_unavailable_symbols",
+        "latest_initial_entry_outcome_counts",
+        "latest_initial_entry_reason_counts",
     ):
         value = staged_readiness_health.get(key)
         if isinstance(value, dict) and value:
@@ -9510,6 +9614,10 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         "latest_symbol_state_record_total",
         "latest_symbol_state_unavailable_total",
         "latest_symbol_state_unavailable_symbol_count_total",
+        "latest_initial_entry_eligibility_bots",
+        "latest_initial_entry_evaluated_total",
+        "latest_initial_entry_records_total",
+        "latest_initial_entry_records_truncated_bots",
     ):
         value = staged_readiness_health.get(key)
         if value is not None:

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -3963,6 +3963,122 @@ def test_live_smoke_report_summarizes_latest_planning_symbol_state_per_bot(tmp_p
     assert section["staged_readiness_health"] == health
 
 
+def test_live_smoke_report_summarizes_latest_initial_entry_eligibility_per_bot(
+    tmp_path,
+):
+    binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        binance_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="entry.initial_eligibility",
+                seq=1,
+                ts=1000,
+                level="debug",
+                reason_code="fresh_entry_eligibility",
+                ids={"cycle_id": "cy_old", "order_wave_id": "ow_old"},
+                data={
+                    "evaluated_count": 99,
+                    "records_total": 99,
+                    "outcome_counts": {"blocked_candidate": 99},
+                    "reason_counts": {"stale_old_reason": 99},
+                    "records_truncated": True,
+                },
+            ),
+            _monitor_row(
+                event_type="entry.initial_eligibility",
+                seq=2,
+                ts=2000,
+                level="debug",
+                reason_code="fresh_entry_eligibility",
+                ids={"cycle_id": "cy_new", "order_wave_id": "ow_new"},
+                data={
+                    "evaluated_count": 4,
+                    "records_total": 4,
+                    "outcome_counts": {
+                        "blocked_candidate": 1,
+                        "eligible": 1,
+                        "no_candidate": 2,
+                    },
+                    "reason_counts": {
+                        "low_balance": 1,
+                        "rust_no_initial_candidate": 2,
+                    },
+                    "records": [
+                        {"symbol": "api_key=SHOULD_NOT_RENDER"}
+                    ],
+                    "records_truncated": True,
+                },
+            ),
+        ],
+    )
+    _write_ndjson(
+        gateio_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="entry.initial_eligibility",
+                seq=1,
+                ts=1500,
+                exchange="gateio",
+                user="gateio_01",
+                level="debug",
+                reason_code="fresh_entry_eligibility",
+                ids={"cycle_id": "cy_gate", "order_wave_id": "ow_gate"},
+                data={
+                    "evaluated_count": 2,
+                    "records_total": 2,
+                    "outcome_counts": {"no_candidate": 2},
+                    "reason_counts": {"rust_no_initial_candidate": 2},
+                    "records_truncated": False,
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    summary = summarize_live_smoke_report(report)
+    brief = summarize_live_smoke_report_brief(report)
+    section = project_live_smoke_report_sections(report, ["staged_readiness"])
+
+    health = report["staged_readiness_health"]
+    assert health["total"] == 3
+    assert health["bots"] == 2
+    assert health["event_types"] == {"entry.initial_eligibility": 3}
+    assert health["latest_initial_entry_eligibility_bots"] == 2
+    assert health["latest_initial_entry_evaluated_total"] == 6
+    assert health["latest_initial_entry_records_total"] == 6
+    assert health["latest_initial_entry_outcome_counts"] == {
+        "no_candidate": 4,
+        "blocked_candidate": 1,
+        "eligible": 1,
+    }
+    assert health["latest_initial_entry_reason_counts"] == {
+        "rust_no_initial_candidate": 4,
+        "low_balance": 1,
+    }
+    assert health["latest_initial_entry_records_truncated_bots"] == 1
+    assert "stale_old_reason" not in json.dumps(health)
+    assert "SHOULD_NOT_RENDER" not in json.dumps(health)
+    binance_group = next(
+        group for group in health["groups"] if group["bot"] == "binance/binance_01"
+    )
+    assert binance_group["count"] == 2
+    assert binance_group["latest_ids"] == {
+        "cycle_id": "cy_new",
+        "order_wave_id": "ow_new",
+    }
+    for projected in (summary["staged_readiness_health"], brief["staged_readiness"]):
+        assert projected["latest_initial_entry_evaluated_total"] == 6
+        assert projected["latest_initial_entry_outcome_counts"] == {
+            "no_candidate": 4,
+            "blocked_candidate": 1,
+            "eligible": 1,
+        }
+        assert "SHOULD_NOT_RENDER" not in json.dumps(projected)
+    assert section["staged_readiness_health"] == health
+
+
 def test_live_smoke_report_problem_events_include_state_refresh_progress(tmp_path):
     events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- include existing `entry.initial_eligibility` events in staged-readiness smoke intake
- retain the latest observation per bot and aggregate evaluated/record totals, outcome/reason counts, truncation coverage, and correlation IDs
- keep raw per-symbol records query-only and out of full/summary/brief projections

## Behavior boundary
Report projection only. No smoke verdict, attention classification, console output, event production, exchange access, entry eligibility, planning, configuration, or trading behavior changes.

## Validation
- `tests/test_live_smoke_report.py`: 97 passed
- incident/docs/event-registry suites: 28 passed
- focused latest-per-bot/redaction regressions: 2 passed
- `py_compile` and `git diff --check` clean

## Previous deployment evidence
PR #1275 merged as `e5603244565807167494ffc53898f98f736f876a` and VPS5 fast-forwarded without restart. The bounded two-minute smoke was `ok=true` with zero hard/log/monitor/process failures, 291/291 remote calls, 58/58 account-critical calls, and 9/9 fill refreshes successful. Exact bot PIDs and `misc:0.0` remained unchanged; transient D samples cleared to final R=4,S=1. The settled report naturally projected 13 `planning.symbol_state` events across four bots and observed 12 `entry.initial_eligibility` events. No events or trading activity were manufactured.

## Expected deployment
Pull plus bounded report/smoke checks only; no bot restart is expected for this report-only change.