### PR TITLE
Report planning-output smoke health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live smoke reports now include bounded latest-per-bot planning-output health
+  from existing `rust_orchestrator.returned` and `action.planned` events. The
+  projection correlates cycle and remote-call IDs, Rust timing and order
+  counts, planned order classifications, redacted symbol samples, truncation,
+  and count mismatches without copying raw orders, quantities, prices, or
+  hashes. Smoke verdicts, planning, exchange access, and trading behavior are
+  unchanged.
+
 - Staged-readiness smoke reports now include bounded latest-per-bot
   `entry.initial_eligibility` aggregates: evaluated and record totals, outcome
   and reason counts, truncation coverage, and correlation IDs. Raw per-symbol

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,8 @@ Estimated completion:
 
 - Branch: `codex/smoke-planned-action-health`, based on canonical
   `6378d40a55116f94fe65f1b24f4981101d838e74` after PR #1276.
-- PR: pending. Slice: project existing `rust_orchestrator.returned` and
+- PR: #1277, `Report planning-output smoke health`; semantic implementation
+  head `3796c32849`. Slice: project existing `rust_orchestrator.returned` and
   `action.planned` events into bounded planning-output smoke health.
 - Triggering evidence: a bounded post-PR #1276 inventory naturally contained
   36 correlated Rust-return/action-planned pairs across all five bots. The

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,23 +22,23 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/smoke-entry-initial-eligibility-health`, based on canonical
-  `e5603244565807167494ffc53898f98f736f876a` after PR #1275.
-- PR: #1276, `Report initial-entry eligibility smoke health`; semantic
-  implementation head `b3840ed5df`. Slice: project existing
-  `entry.initial_eligibility` aggregates into the staged-readiness smoke health
-  surface.
-- Triggering evidence: the settled post-PR #1275 two-minute inventory naturally
-  contained 12 `entry.initial_eligibility` events while staged-readiness health
-  exposed only planning and staged-cycle families. A bounded query confirmed
-  producer-owned outcome and reason counts plus bounded per-symbol records.
-- Scope: retain the latest eligibility observation per bot and expose bounded
-  evaluated/record totals, outcome/reason counts, truncation coverage, and
-  correlation IDs. Keep raw per-symbol records query-only.
+- Branch: `codex/smoke-planned-action-health`, based on canonical
+  `6378d40a55116f94fe65f1b24f4981101d838e74` after PR #1276.
+- PR: pending. Slice: project existing `rust_orchestrator.returned` and
+  `action.planned` events into bounded planning-output smoke health.
+- Triggering evidence: a bounded post-PR #1276 inventory naturally contained
+  36 correlated Rust-return/action-planned pairs across all five bots. The
+  existing smoke report inventoried those event types but did not summarize
+  their output or expose pairing and count mismatches.
+- Scope: retain the latest Rust and planned-action observation per bot, pair
+  them by cycle and remote-call IDs, and expose bounded Rust elapsed/order
+  counts, planned order type/position-side/execution-type counts, redacted
+  symbol samples, truncation, and order-count mismatch coverage. Keep raw
+  orders, quantities, prices, and hashes query-only.
 - Behavior boundary: read-only report projection only. No smoke verdict,
   attention classification, console output, event production, exchange access,
-  entry eligibility, planning, configuration, or trading changes.
-- Validation: focused latest-per-bot/bounded-record regression, full
+  planning, configuration, or trading changes.
+- Validation: focused latest-per-bot/correlation/redaction regression, full
   smoke-report tests, compilation, and docs checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
@@ -48,20 +48,22 @@ Estimated completion:
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `e5603244565807167494ffc53898f98f736f876a`, PR #1275. The tracked checkout
+  `6378d40a55116f94fe65f1b24f4981101d838e74`, PR #1276. The tracked checkout
   is clean and expected untracked artifacts are preserved.
-- PR #1275 required no restart. Exact bot PIDs
+- PR #1276 required no restart. Exact bot PIDs
   `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
   `misc:0.0` PID `434835` remained unchanged. The bounded two-minute smoke was
-  `ok=true` with zero hard/log/monitor/process failures, `291/291` remote and
-  `58/58` account-critical calls successful, `9/9` fill refreshes successful,
-  and five exact/config-valid live processes. Transient preflight/report `D`
-  samples cleared to a final exact process state of `R=4,S=1`.
-- The focused staged-readiness report naturally projected 13
-  `planning.symbol_state` events across four bots, with bounded latest-per-bot
-  status, reason, order-class, surface, and redacted symbol evidence. The same
-  settled inventory contained 12 natural `entry.initial_eligibility` events,
-  exposing the active follow-up. No event or trading activity was manufactured.
+  `ok=true` with zero hard/log/monitor/process failures, `233/233` remote and
+  `63/63` account-critical calls successful, `8/8` fill refreshes successful,
+  and five exact/config-valid live processes. Transient exact-process `D`
+  samples cleared immediately to final states `R=3,S=2`.
+- The focused staged-readiness report naturally projected 18
+  `entry.initial_eligibility` events across all five bots. The latest
+  observations covered 152 records: 12 blocked candidates and 140 no-candidate
+  outcomes, with three bots reporting producer truncation. A bounded five-minute
+  inventory also found 36 naturally correlated Rust-return/action-planned
+  pairs across all five bots, exposing the active follow-up. No event or trading
+  activity was manufactured.
 - PR #1274 required no restart. Exact bot PIDs
   `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
   `misc:0.0` PID `434835` remained unchanged. The fresh two-minute smoke was
@@ -1054,9 +1056,10 @@ deployed without restart. PR #1271's forager feature-unavailability projection
 and PR #1272's planning-defer/absent-selector projection are merged and deployed
 without restart. PR #1273's forager eligibility projection, PR #1274's
 requested-window event inventory, and PR #1275's planning symbol-state health
-are also merged, deployed, and naturally validated. The active follow-up adds
-bounded latest-per-bot `entry.initial_eligibility` aggregates to staged
-readiness without copying raw records or changing verdicts/runtime behavior.
+are also merged, deployed, and naturally validated. PR #1276's initial-entry
+eligibility health is merged, deployed, and naturally validated. The active
+follow-up adds bounded latest-per-bot correlated planning-output health without
+copying raw orders or changing verdicts/runtime behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,29 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1275)
+## Latest Canonical Deployment (PR #1276)
+
+- PR #1276 merged to `master` as
+  `6378d40a55116f94fe65f1b24f4981101d838e74`. It projects existing
+  `entry.initial_eligibility` events into bounded latest-per-bot
+  staged-readiness health without copying raw per-symbol records or changing
+  verdicts or runtime behavior.
+- VPS5 fast-forwarded cleanly with no restart. Exact bot PIDs
+  `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
+  `misc:0.0` PID `434835` remained unchanged; tracked state stayed clean.
+- The settled bounded two-minute smoke was `ok=true` with zero
+  hard/log/monitor/process failures, `233/233` remote and `63/63`
+  account-critical calls successful, eight successful fill refreshes, and five
+  exact/config-valid live processes. Transient exact-process `D` samples
+  cleared immediately to final states `R=3,S=2`.
+- The focused report naturally projected 18 initial-entry observations across
+  all five bots and 152 latest records: 12 blocked candidates and 140
+  no-candidate outcomes, with producer truncation on three bots. A bounded
+  five-minute inventory also found 36 correlated Rust-return/action-planned
+  pairs, motivating the next report-only aggregate slice. No event or trading
+  activity was manufactured.
+
+## Previous Canonical Deployment (PR #1275)
 
 - PR #1275 merged to `master` as
   `e5603244565807167494ffc53898f98f736f876a`. It projects existing

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -137,6 +137,9 @@ FORAGER_ELIGIBILITY_SYMBOL_SAMPLE_LIMIT = 8
 STAGED_READINESS_GROUP_LIMIT = 20
 STAGED_READINESS_VALUE_LIMIT = 8
 STAGED_READINESS_SYMBOL_SAMPLE_LIMIT = 8
+PLANNING_OUTPUT_HEALTH_GROUP_LIMIT = 20
+PLANNING_OUTPUT_VALUE_LIMIT = 8
+PLANNING_OUTPUT_SYMBOL_SAMPLE_LIMIT = 8
 EVENT_PIPELINE_HEALTH_GROUP_LIMIT = 20
 RESOURCE_PRESSURE_GROUP_LIMIT = 20
 RESOURCE_PRESSURE_FIELDS = (
@@ -2978,6 +2981,348 @@ def _staged_readiness_symbol_summary(
         "count": count,
         "sample": sample,
         "truncated": max(0, count - len(sample)),
+    }
+
+
+def _planning_output_count_map(value: Any) -> dict[str, int]:
+    if not isinstance(value, dict):
+        return {}
+    counts: Counter[str] = Counter()
+    for key, raw in value.items():
+        parsed = _non_negative_int(raw)
+        if key is None or parsed is None:
+            continue
+        safe_key = _redact_log_text(str(key), max_len=80)
+        if safe_key:
+            counts[safe_key] += int(parsed)
+    return dict(counts.most_common(PLANNING_OUTPUT_VALUE_LIMIT))
+
+
+def _planning_output_symbol_summary(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    sample_counts: Counter[str] = Counter()
+    sample = value.get("sample")
+    if isinstance(sample, list):
+        for symbol in sample:
+            if symbol is None:
+                continue
+            safe_symbol = _redact_log_text(str(symbol), max_len=80)
+            if safe_symbol:
+                sample_counts[safe_symbol] += 1
+    count = _non_negative_int(value.get("count"))
+    if count is None:
+        count = len(sample_counts)
+    count = max(int(count), len(sample_counts))
+    if count <= 0:
+        return {}
+    bounded_sample = _symbol_sample(
+        sample_counts,
+        limit=PLANNING_OUTPUT_SYMBOL_SAMPLE_LIMIT,
+    ).get("sample", [])
+    return {
+        "count": count,
+        "sample": bounded_sample,
+        "truncated": max(0, count - len(bounded_sample)),
+    }
+
+
+def _planning_output_event(live_event: dict[str, Any]) -> bool:
+    return live_event.get("event_type") in {
+        EventTypes.RUST_ORCHESTRATOR_RETURNED,
+        EventTypes.ACTION_PLANNED,
+    }
+
+
+def _planning_output_group(
+    *,
+    bot_key: str,
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+    path: Path,
+    line_no: int,
+) -> dict[str, Any]:
+    event_type = live_event.get("event_type") or row.get("kind")
+    payload = live_event.get("data")
+    payload = payload if isinstance(payload, dict) else {}
+    ids = _event_ids(live_event)
+    rust_returned = event_type == EventTypes.RUST_ORCHESTRATOR_RETURNED
+    action_planned = event_type == EventTypes.ACTION_PLANNED
+    orders_truncated = payload.get("orders_truncated")
+    orders_truncated = (
+        orders_truncated if isinstance(orders_truncated, bool) else None
+    )
+    return {
+        "bot": bot_key,
+        "event_type": event_type,
+        "count": 1,
+        "event_types": {str(event_type): 1},
+        "latest_ts": row.get("ts"),
+        "latest_seq": row.get("seq"),
+        "latest_path": str(path),
+        "latest_line": int(line_no),
+        "latest_ids": {
+            key: ids.get(key)
+            for key in ("cycle_id", "remote_call_id")
+            if ids.get(key) is not None
+        },
+        "latest_rust_ts": row.get("ts") if rust_returned else None,
+        "latest_rust_seq": row.get("seq") if rust_returned else None,
+        "latest_rust_path": str(path) if rust_returned else None,
+        "latest_rust_line": int(line_no) if rust_returned else None,
+        "latest_rust_status": live_event.get("status") if rust_returned else None,
+        "latest_rust_elapsed_ms": (
+            _non_negative_int(payload.get("elapsed_ms")) if rust_returned else None
+        ),
+        "latest_rust_order_count": (
+            _non_negative_int(payload.get("order_count")) if rust_returned else None
+        ),
+        "latest_action_ts": row.get("ts") if action_planned else None,
+        "latest_action_seq": row.get("seq") if action_planned else None,
+        "latest_action_path": str(path) if action_planned else None,
+        "latest_action_line": int(line_no) if action_planned else None,
+        "latest_action_status": live_event.get("status") if action_planned else None,
+        "latest_action_order_count": (
+            _non_negative_int(payload.get("order_count")) if action_planned else None
+        ),
+        "latest_action_by_order_type": (
+            _planning_output_count_map(payload.get("by_order_type"))
+            if action_planned
+            else {}
+        ),
+        "latest_action_by_pside": (
+            _planning_output_count_map(payload.get("by_pside"))
+            if action_planned
+            else {}
+        ),
+        "latest_action_by_execution_type": (
+            _planning_output_count_map(payload.get("by_execution_type"))
+            if action_planned
+            else {}
+        ),
+        "latest_action_symbols": (
+            _planning_output_symbol_summary(payload.get("symbols"))
+            if action_planned
+            else {}
+        ),
+        "latest_action_orders_truncated": (
+            orders_truncated if action_planned else None
+        ),
+    }
+
+
+def _planning_output_group_key(group: dict[str, Any]) -> tuple[Any, ...]:
+    ids = group.get("latest_ids")
+    ids = ids if isinstance(ids, dict) else {}
+    cycle_id = ids.get("cycle_id")
+    remote_call_id = ids.get("remote_call_id")
+    if cycle_id is None and remote_call_id is None:
+        return (
+            group.get("bot"),
+            group.get("event_type"),
+            group.get("latest_path"),
+            group.get("latest_line"),
+        )
+    return (group.get("bot"), cycle_id, remote_call_id)
+
+
+def _planning_output_position_key(
+    group: dict[str, Any],
+    *,
+    prefix: str = "latest",
+) -> tuple[int, int, str, int]:
+    return _sort_event_position_key(
+        ts=group.get(f"{prefix}_ts"),
+        seq=group.get(f"{prefix}_seq"),
+        path=group.get(f"{prefix}_path") or "",
+        line_no=int(group.get(f"{prefix}_line") or 0),
+    )
+
+
+def _merge_planning_output_group(
+    groups: dict[tuple[Any, ...], dict[str, Any]],
+    group: dict[str, Any],
+) -> None:
+    key = _planning_output_group_key(group)
+    existing = groups.get(key)
+    if existing is None:
+        groups[key] = group
+        return
+    existing["count"] = int(existing.get("count") or 0) + 1
+    existing["event_types"] = _sum_counter_maps(
+        (existing.get("event_types"), group.get("event_types"))
+    )
+    if _planning_output_position_key(group) > _planning_output_position_key(existing):
+        for field in (
+            "event_type",
+            "latest_ts",
+            "latest_seq",
+            "latest_path",
+            "latest_line",
+            "latest_ids",
+        ):
+            existing[field] = group.get(field)
+    event_type = group.get("event_type")
+    if event_type == EventTypes.RUST_ORCHESTRATOR_RETURNED:
+        if existing.get("latest_rust_ts") is None or _planning_output_position_key(
+            group, prefix="latest_rust"
+        ) > _planning_output_position_key(existing, prefix="latest_rust"):
+            for field in (
+                "latest_rust_ts",
+                "latest_rust_seq",
+                "latest_rust_path",
+                "latest_rust_line",
+                "latest_rust_status",
+                "latest_rust_elapsed_ms",
+                "latest_rust_order_count",
+            ):
+                existing[field] = group.get(field)
+    elif event_type == EventTypes.ACTION_PLANNED:
+        if existing.get("latest_action_ts") is None or _planning_output_position_key(
+            group, prefix="latest_action"
+        ) > _planning_output_position_key(existing, prefix="latest_action"):
+            for field in (
+                "latest_action_ts",
+                "latest_action_seq",
+                "latest_action_path",
+                "latest_action_line",
+                "latest_action_status",
+                "latest_action_order_count",
+                "latest_action_by_order_type",
+                "latest_action_by_pside",
+                "latest_action_by_execution_type",
+                "latest_action_symbols",
+                "latest_action_orders_truncated",
+            ):
+                existing[field] = group.get(field)
+
+
+def _summarize_planning_output_health(
+    groups: dict[tuple[Any, ...], dict[str, Any]],
+    event_type_counts: Counter[str],
+) -> dict[str, Any]:
+    ordered = sorted(
+        groups.values(),
+        key=_planning_output_position_key,
+        reverse=True,
+    )
+    compact_groups = [
+        {
+            key: value
+            for key, value in group.items()
+            if key
+            not in {
+                "latest_path",
+                "latest_line",
+                "latest_seq",
+                "latest_rust_path",
+                "latest_rust_line",
+                "latest_rust_seq",
+                "latest_action_path",
+                "latest_action_line",
+                "latest_action_seq",
+            }
+            and value not in (None, {}, [])
+        }
+        for group in ordered[:PLANNING_OUTPUT_HEALTH_GROUP_LIMIT]
+    ]
+    latest_by_bot: dict[str, dict[str, Any]] = {}
+    for group in groups.values():
+        bot = str(group.get("bot") or "unknown")
+        previous = latest_by_bot.get(bot)
+        if previous is None or _planning_output_position_key(
+            group
+        ) > _planning_output_position_key(previous):
+            latest_by_bot[bot] = group
+    latest_groups = list(latest_by_bot.values())
+    symbol_count = 0
+    symbols: Counter[str] = Counter()
+    for group in latest_groups:
+        symbol_summary = group.get("latest_action_symbols")
+        if not isinstance(symbol_summary, dict):
+            continue
+        symbol_count += int(_non_negative_int(symbol_summary.get("count")) or 0)
+        sample = symbol_summary.get("sample")
+        if isinstance(sample, list):
+            for symbol in sample:
+                if symbol is not None:
+                    symbols[str(symbol)] += 1
+    symbol_sample = _symbol_sample(
+        symbols,
+        limit=PLANNING_OUTPUT_SYMBOL_SAMPLE_LIMIT,
+    ).get("sample", [])
+    return {
+        "total": sum(int(group.get("count") or 0) for group in groups.values()),
+        "event_types": dict(event_type_counts.most_common()),
+        "bots": len(latest_by_bot),
+        "groups_truncated": len(ordered) > PLANNING_OUTPUT_HEALTH_GROUP_LIMIT,
+        "latest_rust_returned_bots": sum(
+            1 for group in latest_groups if group.get("latest_rust_ts") is not None
+        ),
+        "latest_action_planned_bots": sum(
+            1 for group in latest_groups if group.get("latest_action_ts") is not None
+        ),
+        "latest_correlated_bots": sum(
+            1
+            for group in latest_groups
+            if group.get("latest_rust_ts") is not None
+            and group.get("latest_action_ts") is not None
+        ),
+        "latest_rust_elapsed_ms_max": max(
+            (
+                int(_non_negative_int(group.get("latest_rust_elapsed_ms")) or 0)
+                for group in latest_groups
+                if group.get("latest_rust_elapsed_ms") is not None
+            ),
+            default=0,
+        ),
+        "latest_rust_order_count_total": sum(
+            int(_non_negative_int(group.get("latest_rust_order_count")) or 0)
+            for group in latest_groups
+        ),
+        "latest_action_order_count_total": sum(
+            int(_non_negative_int(group.get("latest_action_order_count")) or 0)
+            for group in latest_groups
+        ),
+        "latest_order_count_mismatch_bots": sum(
+            1
+            for group in latest_groups
+            if group.get("latest_rust_order_count") is not None
+            and group.get("latest_action_order_count") is not None
+            and int(group.get("latest_rust_order_count") or 0)
+            != int(group.get("latest_action_order_count") or 0)
+        ),
+        "latest_action_by_order_type": _planning_output_count_map(
+            _sum_counter_maps(
+                group.get("latest_action_by_order_type") for group in latest_groups
+            )
+        ),
+        "latest_action_by_pside": _planning_output_count_map(
+            _sum_counter_maps(
+                group.get("latest_action_by_pside") for group in latest_groups
+            )
+        ),
+        "latest_action_by_execution_type": _planning_output_count_map(
+            _sum_counter_maps(
+                group.get("latest_action_by_execution_type")
+                for group in latest_groups
+            )
+        ),
+        "latest_action_symbols": (
+            {
+                "count": symbol_count,
+                "sample": symbol_sample,
+                "truncated": max(0, symbol_count - len(symbol_sample)),
+            }
+            if symbol_count
+            else {}
+        ),
+        "latest_action_orders_truncated_bots": sum(
+            1
+            for group in latest_groups
+            if group.get("latest_action_orders_truncated") is True
+        ),
+        "groups": compact_groups,
     }
 
 
@@ -7069,6 +7414,8 @@ def _scan_events(
     exchange_config_refresh_event_type_counts: Counter[str] = Counter()
     staged_readiness_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     staged_readiness_event_type_counts: Counter[str] = Counter()
+    planning_output_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
+    planning_output_event_type_counts: Counter[str] = Counter()
     event_pipeline_health_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     event_pipeline_health_event_type_counts: Counter[str] = Counter()
     resource_pressure_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -7350,6 +7697,18 @@ def _scan_events(
                                 line_no=line_no,
                             ),
                         )
+                    if _planning_output_event(live_event):
+                        planning_output_event_type_counts[str(event_type)] += 1
+                        _merge_planning_output_group(
+                            planning_output_groups,
+                            _planning_output_group(
+                                bot_key=bot_key,
+                                row=row,
+                                live_event=live_event,
+                                path=path,
+                                line_no=line_no,
+                            ),
+                        )
                     if event_type == EventTypes.HEALTH_SUMMARY:
                         event_pipeline_health_group = _event_pipeline_health_group(
                             bot_key=bot_key,
@@ -7570,6 +7929,10 @@ def _scan_events(
         "staged_readiness_health": _summarize_staged_readiness_health(
             staged_readiness_groups,
             staged_readiness_event_type_counts,
+        ),
+        "planning_output_health": _summarize_planning_output_health(
+            planning_output_groups,
+            planning_output_event_type_counts,
         ),
         "event_pipeline_health": _summarize_event_pipeline_health(
             event_pipeline_health_groups,
@@ -8023,6 +8386,7 @@ def build_live_smoke_report(
             "exchange_config_refresh_health"
         ],
         "staged_readiness_health": event_scan["staged_readiness_health"],
+        "planning_output_health": event_scan["planning_output_health"],
         "event_pipeline_health": event_scan["event_pipeline_health"],
         "resource_pressure": event_scan["resource_pressure"],
         "hsl_replay_health": event_scan["hsl_replay_health"],
@@ -8389,6 +8753,26 @@ def _summary_staged_readiness_health(
     return out
 
 
+def _summary_planning_output_health(
+    summary: dict[str, Any],
+    *,
+    limit: int,
+) -> dict[str, Any]:
+    groups = summary.get("groups")
+    if not isinstance(groups, list):
+        groups = []
+    limit = max(0, int(limit))
+    return {
+        key: value
+        for key, value in summary.items()
+        if key not in {"groups", "groups_truncated"}
+    } | {
+        "groups_truncated": bool(summary.get("groups_truncated"))
+        or len(groups) > limit,
+        "groups": groups[:limit],
+    }
+
+
 def _shareable_summary_group(
     group: Any,
     *,
@@ -8608,6 +8992,11 @@ def summarize_live_smoke_report(
         if isinstance(report.get("staged_readiness_health"), dict)
         else {}
     )
+    planning_output_health = (
+        report.get("planning_output_health")
+        if isinstance(report.get("planning_output_health"), dict)
+        else {}
+    )
     event_pipeline_health = (
         report.get("event_pipeline_health")
         if isinstance(report.get("event_pipeline_health"), dict)
@@ -8811,6 +9200,10 @@ def summarize_live_smoke_report(
         ),
         "staged_readiness_health": _summary_staged_readiness_health(
             staged_readiness_health,
+            limit=max_groups,
+        ),
+        "planning_output_health": _summary_planning_output_health(
+            planning_output_health,
             limit=max_groups,
         ),
         "event_pipeline_health": _summary_limited_groups(
@@ -9525,6 +9918,11 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         if isinstance(report.get("staged_readiness_health"), dict)
         else {}
     )
+    planning_output_health = (
+        report.get("planning_output_health")
+        if isinstance(report.get("planning_output_health"), dict)
+        else {}
+    )
     event_pipeline_health = (
         report.get("event_pipeline_health")
         if isinstance(report.get("event_pipeline_health"), dict)
@@ -9840,6 +10238,11 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             "event_types": exchange_config_refresh_health.get("event_types") or {},
         },
         "staged_readiness": staged_readiness_brief,
+        "planning_output": {
+            key: value
+            for key, value in planning_output_health.items()
+            if key not in {"groups", "groups_truncated"}
+        },
         "event_pipeline": {
             key: value
             for key, value in {
@@ -10097,6 +10500,7 @@ SMOKE_REPORT_SECTION_ALIASES: dict[str, tuple[str, ...]] = {
     "forager_eligibility": ("forager_eligibility_health",),
     "forager_features": ("forager_feature_health",),
     "hsl_replay": ("hsl_replay_health",),
+    "planning_output": ("planning_output_health",),
     "remote_calls": ("remote_call_health", "remote_call_timings"),
     "resources": ("resource_pressure",),
     "staged_readiness": ("staged_readiness_health",),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -4079,6 +4079,172 @@ def test_live_smoke_report_summarizes_latest_initial_entry_eligibility_per_bot(
     assert section["staged_readiness_health"] == health
 
 
+def test_live_smoke_report_summarizes_latest_planning_output_per_bot(tmp_path):
+    binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        binance_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="rust_orchestrator.returned",
+                seq=1,
+                ts=1000,
+                level="debug",
+                ids={"cycle_id": "cy_old", "remote_call_id": "rust_old"},
+                data={"elapsed_ms": 999, "order_count": 99},
+            ),
+            _monitor_row(
+                event_type="action.planned",
+                seq=2,
+                ts=1001,
+                level="debug",
+                ids={"cycle_id": "cy_old", "remote_call_id": "rust_old"},
+                data={
+                    "order_count": 99,
+                    "by_order_type": {"stale_old_order": 99},
+                    "orders_truncated": True,
+                },
+            ),
+            _monitor_row(
+                event_type="rust_orchestrator.returned",
+                seq=3,
+                ts=2000,
+                level="debug",
+                ids={"cycle_id": "cy_new", "remote_call_id": "rust_new"},
+                data={
+                    "elapsed_ms": 22,
+                    "order_count": 3,
+                    "input_hash": "api_key=INPUT_HASH_SHOULD_NOT_RENDER",
+                    "output_hash": "api_key=OUTPUT_HASH_SHOULD_NOT_RENDER",
+                },
+            ),
+            _monitor_row(
+                event_type="action.planned",
+                seq=4,
+                ts=2001,
+                level="debug",
+                ids={"cycle_id": "cy_new", "remote_call_id": "rust_new"},
+                data={
+                    "order_count": 3,
+                    "by_order_type": {
+                        "entry_initial_normal_long": 2,
+                        "close_grid_long": 1,
+                    },
+                    "by_pside": {"long": 3},
+                    "by_execution_type": {"limit": 3},
+                    "symbols": {
+                        "count": 3,
+                        "sample": ["ETH/USDT:USDT", "ONDO/USDT:USDT", "UNI/USDT:USDT"],
+                        "truncated": 0,
+                    },
+                    "orders_sample": [
+                        {"symbol": "api_key=RAW_ORDER_SHOULD_NOT_RENDER", "qty": 1.0}
+                    ],
+                    "orders_truncated": True,
+                },
+            ),
+        ],
+    )
+    _write_ndjson(
+        gateio_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="rust_orchestrator.returned",
+                seq=1,
+                ts=1500,
+                exchange="gateio",
+                user="gateio_01",
+                level="debug",
+                ids={"cycle_id": "cy_gate", "remote_call_id": "rust_gate"},
+                data={"elapsed_ms": 40, "order_count": 2},
+            ),
+            _monitor_row(
+                event_type="action.planned",
+                seq=2,
+                ts=1501,
+                exchange="gateio",
+                user="gateio_01",
+                level="debug",
+                ids={"cycle_id": "cy_gate", "remote_call_id": "rust_gate"},
+                data={
+                    "order_count": 1,
+                    "by_order_type": {"entry_initial_normal_long": 1},
+                    "by_pside": {"long": 1},
+                    "by_execution_type": {"limit": 1},
+                    "symbols": {
+                        "count": 1,
+                        "sample": ["BTC/USDT:USDT"],
+                        "truncated": 0,
+                    },
+                    "orders_truncated": False,
+                },
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    summary = summarize_live_smoke_report(report)
+    brief = summarize_live_smoke_report_brief(report)
+    section = project_live_smoke_report_sections(report, ["planning_output"])
+
+    health = report["planning_output_health"]
+    assert health["total"] == 6
+    assert health["bots"] == 2
+    assert health["event_types"] == {
+        "rust_orchestrator.returned": 3,
+        "action.planned": 3,
+    }
+    assert health["latest_rust_returned_bots"] == 2
+    assert health["latest_action_planned_bots"] == 2
+    assert health["latest_correlated_bots"] == 2
+    assert health["latest_rust_elapsed_ms_max"] == 40
+    assert health["latest_rust_order_count_total"] == 5
+    assert health["latest_action_order_count_total"] == 4
+    assert health["latest_order_count_mismatch_bots"] == 1
+    assert health["latest_action_by_order_type"] == {
+        "entry_initial_normal_long": 3,
+        "close_grid_long": 1,
+    }
+    assert "stale_old_order" not in health["latest_action_by_order_type"]
+    assert health["latest_action_by_pside"] == {"long": 4}
+    assert health["latest_action_by_execution_type"] == {"limit": 4}
+    assert health["latest_action_symbols"] == {
+        "count": 4,
+        "sample": [
+            "BTC/USDT:USDT",
+            "ETH/USDT:USDT",
+            "ONDO/USDT:USDT",
+            "UNI/USDT:USDT",
+        ],
+        "truncated": 0,
+    }
+    assert health["latest_action_orders_truncated_bots"] == 1
+    binance_group = next(
+        group
+        for group in health["groups"]
+        if group["bot"] == "binance/binance_01"
+        and group["latest_ids"]["cycle_id"] == "cy_new"
+    )
+    assert binance_group["count"] == 2
+    assert binance_group["latest_ids"] == {
+        "cycle_id": "cy_new",
+        "remote_call_id": "rust_new",
+    }
+    for projected in (
+        health,
+        summary["planning_output_health"],
+        brief["planning_output"],
+    ):
+        assert projected["latest_action_order_count_total"] == 4
+        serialized = json.dumps(projected)
+        assert "SHOULD_NOT_RENDER" not in serialized
+        assert "orders_sample" not in serialized
+        assert "input_hash" not in serialized
+        assert "output_hash" not in serialized
+        assert "qty" not in serialized
+    assert section["planning_output_health"] == health
+
+
 def test_live_smoke_report_problem_events_include_state_refresh_progress(tmp_path):
     events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- correlate existing `rust_orchestrator.returned` and `action.planned` events by bot, cycle, and remote call
- expose bounded latest-per-bot Rust timing/order counts, planned-order classifications, redacted symbols, truncation, and count mismatches
- keep raw orders, quantities, prices, and hashes out of smoke projections; verdicts and runtime behavior are unchanged

## Validation
- `python -m pytest -q tests/test_live_smoke_report.py` (98 passed)
- `python -m pytest -q tests/test_live_incident_bundle.py tests/test_live_event_registry_docs.py tests/test_ai_docs.py` (28 passed)
- `python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py`
- `git diff --check`

## Deployment evidence carried forward
PR #1276 is deployed on VPS5 at `6378d40a55` with no restart. Exact bot PIDs, pane parents, and `misc:0.0` remained unchanged. The settled two-minute smoke was `ok=true` with zero hard/log/monitor/process failures, 233/233 remote calls, 63/63 account-critical calls, and 8/8 fill refreshes successful. A bounded five-minute inventory naturally found 36 correlated Rust-return/action-planned pairs across all five bots; no event or trading activity was manufactured.

## VPS expectation
Report-only change: pull and bounded smoke/report validation after merge; no bot restart expected.