### PR TITLE
Report data-packet smoke health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live smoke reports now expose bounded latest-per-bot-and-kind health from
+  existing `data_packet.updated` events: packet kinds, quality, freshness,
+  source, revision, safe coverage counts, and warning/error counts. Raw packet
+  references, hashes, timestamps, values, and warning/error text remain
+  query-only; smoke verdicts, exchange access, and trading behavior are
+  unchanged.
+
 - Live smoke reports now include bounded latest-per-bot planning-output health
   from existing `rust_orchestrator.returned` and `action.planned` events. The
   projection correlates cycle and remote-call IDs, Rust timing and order

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,24 +22,21 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/smoke-planned-action-health`, based on canonical
-  `6378d40a55116f94fe65f1b24f4981101d838e74` after PR #1276.
-- PR: #1277, `Report planning-output smoke health`; semantic implementation
-  head `3796c32849`. Slice: project existing `rust_orchestrator.returned` and
-  `action.planned` events into bounded planning-output smoke health.
-- Triggering evidence: a bounded post-PR #1276 inventory naturally contained
-  36 correlated Rust-return/action-planned pairs across all five bots. The
-  existing smoke report inventoried those event types but did not summarize
-  their output or expose pairing and count mismatches.
-- Scope: retain the latest Rust and planned-action observation per bot, pair
-  them by cycle and remote-call IDs, and expose bounded Rust elapsed/order
-  counts, planned order type/position-side/execution-type counts, redacted
-  symbol samples, truncation, and order-count mismatch coverage. Keep raw
-  orders, quantities, prices, and hashes query-only.
+- Branch: `codex/smoke-data-packet-health`, based on canonical
+  `deee460a18f1f532a4c3a4c6e89a4befd5469d2a` after PR #1277.
+- PR: pending. Slice: project existing `data_packet.updated` events into
+  bounded latest-per-bot-and-kind smoke health.
+- Triggering evidence: the focused post-PR #1277 five-minute inventory
+  naturally contained 87 packet-update events while smoke reports exposed no
+  packet quality, freshness, source, or coverage summary.
+- Scope: retain the latest packet observation per bot and packet kind, and
+  expose bounded kind, quality, freshness, source, revision, safe coverage,
+  and warning/error counts. Keep raw references, hashes, timestamps, values,
+  and warning/error text query-only.
 - Behavior boundary: read-only report projection only. No smoke verdict,
   attention classification, console output, event production, exchange access,
-  planning, configuration, or trading changes.
-- Validation: focused latest-per-bot/correlation/redaction regression, full
+  packet production, readiness, configuration, or trading changes.
+- Validation: focused latest-per-kind/latest-revision/redaction regression, full
   smoke-report tests, compilation, and docs checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
@@ -49,22 +46,20 @@ Estimated completion:
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `6378d40a55116f94fe65f1b24f4981101d838e74`, PR #1276. The tracked checkout
+  `deee460a18f1f532a4c3a4c6e89a4befd5469d2a`, PR #1277. The tracked checkout
   is clean and expected untracked artifacts are preserved.
-- PR #1276 required no restart. Exact bot PIDs
+- PR #1277 required no restart. Exact bot PIDs
   `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
-  `misc:0.0` PID `434835` remained unchanged. The bounded two-minute smoke was
-  `ok=true` with zero hard/log/monitor/process failures, `233/233` remote and
-  `63/63` account-critical calls successful, `8/8` fill refreshes successful,
-  and five exact/config-valid live processes. Transient exact-process `D`
-  samples cleared immediately to final states `R=3,S=2`.
-- The focused staged-readiness report naturally projected 18
-  `entry.initial_eligibility` events across all five bots. The latest
-  observations covered 152 records: 12 blocked candidates and 140 no-candidate
-  outcomes, with three bots reporting producer truncation. A bounded five-minute
-  inventory also found 36 naturally correlated Rust-return/action-planned
-  pairs across all five bots, exposing the active follow-up. No event or trading
-  activity was manufactured.
+  `misc:0.0` PID `434835` remained unchanged. Immediate and settled bounded
+  two-minute smokes were `ok=true` with zero hard/log/monitor/process failures,
+  `189/189` and `191/191` remote calls successful, and five exact/config-valid
+  live processes in final states `R=4,S=1`.
+- The immediate planning-output projection retained correlated latest pairs on
+  all five bots with zero order-count mismatches. The focused five-minute
+  report naturally projected 60 events as 30 Rust-return/action-planned pairs,
+  retained all five latest correlations, and found zero mismatches. The same
+  window contained 87 natural packet-update events, exposing the active
+  follow-up. No event or trading activity was manufactured.
 - PR #1274 required no restart. Exact bot PIDs
   `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
   `misc:0.0` PID `434835` remained unchanged. The fresh two-minute smoke was
@@ -1058,9 +1053,10 @@ and PR #1272's planning-defer/absent-selector projection are merged and deployed
 without restart. PR #1273's forager eligibility projection, PR #1274's
 requested-window event inventory, and PR #1275's planning symbol-state health
 are also merged, deployed, and naturally validated. PR #1276's initial-entry
-eligibility health is merged, deployed, and naturally validated. The active
-follow-up adds bounded latest-per-bot correlated planning-output health without
-copying raw orders or changing verdicts/runtime behavior.
+eligibility health and PR #1277's correlated planning-output health are merged,
+deployed, and naturally validated. The active follow-up adds bounded
+latest-per-bot-and-kind data-packet health without copying raw packet metadata
+or changing verdicts/runtime behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,8 @@ Estimated completion:
 
 - Branch: `codex/smoke-data-packet-health`, based on canonical
   `deee460a18f1f532a4c3a4c6e89a4befd5469d2a` after PR #1277.
-- PR: pending. Slice: project existing `data_packet.updated` events into
+- PR: #1278, `Report data-packet smoke health`; semantic implementation head
+  `e940064301`. Slice: project existing `data_packet.updated` events into
   bounded latest-per-bot-and-kind smoke health.
 - Triggering evidence: the focused post-PR #1277 five-minute inventory
   naturally contained 87 packet-update events while smoke reports exposed no

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,27 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1276)
+## Latest Canonical Deployment (PR #1277)
+
+- PR #1277 merged to `master` as
+  `deee460a18f1f532a4c3a4c6e89a4befd5469d2a`. It projects existing
+  `rust_orchestrator.returned` and `action.planned` events into bounded
+  correlated latest-per-bot planning-output health without copying raw orders,
+  quantities, prices, or hashes or changing verdicts/runtime behavior.
+- VPS5 fast-forwarded cleanly with no restart. Exact bot PIDs
+  `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
+  `misc:0.0` PID `434835` remained unchanged; tracked state stayed clean.
+- Immediate and settled two-minute smokes were `ok=true` with zero
+  hard/log/monitor/process failures, `189/189` and `191/191` remote calls
+  successful, and five exact/config-valid live processes. Final exact states
+  were `R=4,S=1`.
+- The focused five-minute report naturally projected 60 planning-output events
+  as 30 correlated pairs across all five bots with zero latest count
+  mismatches. The same window contained 87 packet-update events, motivating the
+  next report-only packet-health slice. No event or trading activity was
+  manufactured.
+
+## Previous Canonical Deployment (PR #1276)
 
 - PR #1276 merged to `master` as
   `6378d40a55116f94fe65f1b24f4981101d838e74`. It projects existing

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -162,6 +162,7 @@ HSL_REPLAY_HEALTH_GROUP_LIMIT = 20
 HSL_REPLAY_STALE_ACTIVE_EVENT_AGE_MS = 5 * 60 * 1000
 HSL_REPLAY_LONG_RUNNING_ACTIVE_MS = 10 * 60 * 1000
 EXCHANGE_CONFIG_REFRESH_HEALTH_GROUP_LIMIT = 20
+DATA_PACKET_HEALTH_GROUP_LIMIT = 20
 RISK_EVENT_TYPES = {
     EventTypes.RISK_MODE_CHANGED,
     EventTypes.HSL_TRANSITION,
@@ -2864,6 +2865,171 @@ def _summarize_exchange_config_refresh_health(
         "failed_bots": len(failed_bots),
         "latest_failed_bots": len(latest_failed_bots),
         "recovered_bots": len(recovered_bots),
+        "groups": compact_groups,
+    }
+
+
+def _data_packet_safe_text(value: Any, *, max_len: int = 80) -> str | None:
+    if value is None:
+        return None
+    redacted = _redact_log_text(str(value), max_len=max_len)
+    return redacted or None
+
+
+def _data_packet_coverage(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    coverage: dict[str, Any] = {}
+    if isinstance(value.get("value_present"), bool):
+        coverage["value_present"] = bool(value["value_present"])
+    row_count = _non_negative_int(value.get("row_count"))
+    if row_count is not None:
+        coverage["row_count"] = int(row_count)
+    return coverage
+
+
+def _data_packet_health_group(
+    *,
+    bot_key: str,
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+    path: Path,
+    line_no: int,
+) -> dict[str, Any]:
+    payload = live_event.get("data")
+    payload = payload if isinstance(payload, dict) else {}
+    freshness = payload.get("freshness")
+    freshness = freshness if isinstance(freshness, dict) else {}
+    ids = _event_ids(live_event)
+    warnings = payload.get("warnings")
+    errors = payload.get("errors")
+    return {
+        "bot": bot_key,
+        "event_type": live_event.get("event_type") or row.get("kind"),
+        "count": 1,
+        "packet_kind": _data_packet_safe_text(payload.get("kind")) or "unknown",
+        "status": _data_packet_safe_text(live_event.get("status")),
+        "reason_code": _data_packet_safe_text(live_event.get("reason_code")),
+        "latest_ts": row.get("ts"),
+        "latest_seq": row.get("seq"),
+        "latest_path": str(path),
+        "latest_line": int(line_no),
+        "latest_ids": {
+            key: ids.get(key)
+            for key in ("cycle_id", "snapshot_id")
+            if ids.get(key) is not None
+        },
+        "latest_scope": _data_packet_safe_text(payload.get("scope")),
+        "latest_revision": _non_negative_int(payload.get("revision")),
+        "latest_source": _data_packet_safe_text(payload.get("source")),
+        "latest_quality": _data_packet_safe_text(payload.get("quality")),
+        "latest_freshness_status": _data_packet_safe_text(freshness.get("status")),
+        "latest_freshness_age_ms": _non_negative_int(freshness.get("age_ms")),
+        "latest_freshness_max_age_ms": _non_negative_int(
+            freshness.get("max_age_ms")
+        ),
+        "latest_freshness_reason": _data_packet_safe_text(freshness.get("reason")),
+        "latest_coverage": _data_packet_coverage(payload.get("coverage")),
+        "latest_warning_count": len(warnings) if isinstance(warnings, list) else 0,
+        "latest_error_count": len(errors) if isinstance(errors, list) else 0,
+    }
+
+
+def _merge_data_packet_health_group(
+    groups: dict[tuple[str, str], dict[str, Any]],
+    group: dict[str, Any],
+) -> None:
+    key = (str(group.get("bot") or "unknown"), str(group.get("packet_kind")))
+    existing = groups.get(key)
+    if existing is None:
+        groups[key] = group
+        return
+    existing["count"] = int(existing.get("count") or 0) + 1
+    current_key = _sort_event_position_key(
+        ts=group.get("latest_ts"),
+        seq=group.get("latest_seq"),
+        path=group.get("latest_path") or "",
+        line_no=int(group.get("latest_line") or 0),
+    )
+    existing_key = _sort_event_position_key(
+        ts=existing.get("latest_ts"),
+        seq=existing.get("latest_seq"),
+        path=existing.get("latest_path") or "",
+        line_no=int(existing.get("latest_line") or 0),
+    )
+    if current_key > existing_key:
+        count = existing["count"]
+        existing.update(group)
+        existing["count"] = count
+
+
+def _summarize_data_packet_health(
+    groups: dict[tuple[str, str], dict[str, Any]],
+    event_type_counts: Counter[str],
+) -> dict[str, Any]:
+    ordered = sorted(
+        groups.values(),
+        key=lambda group: _sort_event_position_key(
+            ts=group.get("latest_ts"),
+            seq=group.get("latest_seq"),
+            path=group.get("latest_path") or "",
+            line_no=int(group.get("latest_line") or 0),
+        ),
+        reverse=True,
+    )
+    packet_kinds: Counter[str] = Counter()
+    latest_qualities: Counter[str] = Counter()
+    latest_freshness_statuses: Counter[str] = Counter()
+    latest_sources: Counter[str] = Counter()
+    latest_row_count_total = 0
+    latest_value_present_packets = 0
+    latest_value_missing_packets = 0
+    for group in groups.values():
+        packet_kinds[str(group.get("packet_kind") or "unknown")] += int(
+            group.get("count") or 0
+        )
+        latest_qualities[str(group.get("latest_quality") or "unknown")] += 1
+        latest_freshness_statuses[
+            str(group.get("latest_freshness_status") or "unknown")
+        ] += 1
+        latest_sources[str(group.get("latest_source") or "unknown")] += 1
+        coverage = group.get("latest_coverage")
+        coverage = coverage if isinstance(coverage, dict) else {}
+        latest_row_count_total += int(
+            _non_negative_int(coverage.get("row_count")) or 0
+        )
+        if coverage.get("value_present") is True:
+            latest_value_present_packets += 1
+        elif coverage.get("value_present") is False:
+            latest_value_missing_packets += 1
+    compact_groups = [
+        {
+            key: value
+            for key, value in group.items()
+            if key not in {"latest_path", "latest_line", "latest_seq"}
+            and value not in (None, {}, [])
+        }
+        for group in ordered[:DATA_PACKET_HEALTH_GROUP_LIMIT]
+    ]
+    return {
+        "total": sum(int(group.get("count") or 0) for group in groups.values()),
+        "event_types": dict(event_type_counts.most_common()),
+        "bots": len({str(group.get("bot")) for group in groups.values()}),
+        "latest_packets": len(groups),
+        "packet_kinds": dict(packet_kinds.most_common()),
+        "latest_qualities": dict(latest_qualities.most_common()),
+        "latest_freshness_statuses": dict(latest_freshness_statuses.most_common()),
+        "latest_sources": dict(latest_sources.most_common()),
+        "latest_warning_packets": sum(
+            1 for group in groups.values() if int(group.get("latest_warning_count") or 0)
+        ),
+        "latest_error_packets": sum(
+            1 for group in groups.values() if int(group.get("latest_error_count") or 0)
+        ),
+        "latest_row_count_total": latest_row_count_total,
+        "latest_value_present_packets": latest_value_present_packets,
+        "latest_value_missing_packets": latest_value_missing_packets,
+        "groups_truncated": len(ordered) > DATA_PACKET_HEALTH_GROUP_LIMIT,
         "groups": compact_groups,
     }
 
@@ -7412,6 +7578,8 @@ def _scan_events(
     forager_eligibility_health_event_type_counts: Counter[str] = Counter()
     exchange_config_refresh_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     exchange_config_refresh_event_type_counts: Counter[str] = Counter()
+    data_packet_health_groups: dict[tuple[str, str], dict[str, Any]] = {}
+    data_packet_health_event_type_counts: Counter[str] = Counter()
     staged_readiness_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     staged_readiness_event_type_counts: Counter[str] = Counter()
     planning_output_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -7685,6 +7853,18 @@ def _scan_events(
                                 line_no=line_no,
                             ),
                         )
+                    if event_type == EventTypes.DATA_PACKET_UPDATED:
+                        data_packet_health_event_type_counts[str(event_type)] += 1
+                        _merge_data_packet_health_group(
+                            data_packet_health_groups,
+                            _data_packet_health_group(
+                                bot_key=bot_key,
+                                row=row,
+                                live_event=live_event,
+                                path=path,
+                                line_no=line_no,
+                            ),
+                        )
                     if _staged_readiness_event(live_event):
                         staged_readiness_event_type_counts[str(event_type)] += 1
                         _merge_staged_readiness_group(
@@ -7925,6 +8105,10 @@ def _scan_events(
         "exchange_config_refresh_health": _summarize_exchange_config_refresh_health(
             exchange_config_refresh_groups,
             exchange_config_refresh_event_type_counts,
+        ),
+        "data_packet_health": _summarize_data_packet_health(
+            data_packet_health_groups,
+            data_packet_health_event_type_counts,
         ),
         "staged_readiness_health": _summarize_staged_readiness_health(
             staged_readiness_groups,
@@ -8385,6 +8569,7 @@ def build_live_smoke_report(
         "exchange_config_refresh_health": event_scan[
             "exchange_config_refresh_health"
         ],
+        "data_packet_health": event_scan["data_packet_health"],
         "staged_readiness_health": event_scan["staged_readiness_health"],
         "planning_output_health": event_scan["planning_output_health"],
         "event_pipeline_health": event_scan["event_pipeline_health"],
@@ -8753,7 +8938,7 @@ def _summary_staged_readiness_health(
     return out
 
 
-def _summary_planning_output_health(
+def _summary_unfiltered_health_groups(
     summary: dict[str, Any],
     *,
     limit: int,
@@ -8771,6 +8956,22 @@ def _summary_planning_output_health(
         or len(groups) > limit,
         "groups": groups[:limit],
     }
+
+
+def _summary_planning_output_health(
+    summary: dict[str, Any],
+    *,
+    limit: int,
+) -> dict[str, Any]:
+    return _summary_unfiltered_health_groups(summary, limit=limit)
+
+
+def _summary_data_packet_health(
+    summary: dict[str, Any],
+    *,
+    limit: int,
+) -> dict[str, Any]:
+    return _summary_unfiltered_health_groups(summary, limit=limit)
 
 
 def _shareable_summary_group(
@@ -8987,6 +9188,11 @@ def summarize_live_smoke_report(
         if isinstance(report.get("exchange_config_refresh_health"), dict)
         else {}
     )
+    data_packet_health = (
+        report.get("data_packet_health")
+        if isinstance(report.get("data_packet_health"), dict)
+        else {}
+    )
     staged_readiness_health = (
         report.get("staged_readiness_health")
         if isinstance(report.get("staged_readiness_health"), dict)
@@ -9196,6 +9402,10 @@ def summarize_live_smoke_report(
         ),
         "exchange_config_refresh_health": _summary_limited_groups(
             exchange_config_refresh_health,
+            limit=max_groups,
+        ),
+        "data_packet_health": _summary_data_packet_health(
+            data_packet_health,
             limit=max_groups,
         ),
         "staged_readiness_health": _summary_staged_readiness_health(
@@ -9913,6 +10123,11 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         if isinstance(report.get("exchange_config_refresh_health"), dict)
         else {}
     )
+    data_packet_health = (
+        report.get("data_packet_health")
+        if isinstance(report.get("data_packet_health"), dict)
+        else {}
+    )
     staged_readiness_health = (
         report.get("staged_readiness_health")
         if isinstance(report.get("staged_readiness_health"), dict)
@@ -10237,6 +10452,11 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             ),
             "event_types": exchange_config_refresh_health.get("event_types") or {},
         },
+        "data_packets": {
+            key: value
+            for key, value in data_packet_health.items()
+            if key not in {"groups", "groups_truncated"}
+        },
         "staged_readiness": staged_readiness_brief,
         "planning_output": {
             key: value
@@ -10493,6 +10713,7 @@ SMOKE_REPORT_SECTION_BASE_SELECTORS = frozenset(
 SMOKE_REPORT_SECTION_ALIASES: dict[str, tuple[str, ...]] = {
     "account_critical_remote_calls": ("account_critical_remote_call_health",),
     "cache": ("cache_health",),
+    "data_packets": ("data_packet_health",),
     "ema_readiness": ("ema_readiness_health",),
     "event_pipeline": ("event_pipeline_health",),
     "exchange_config_refresh": ("exchange_config_refresh_health",),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -4245,6 +4245,138 @@ def test_live_smoke_report_summarizes_latest_planning_output_per_bot(tmp_path):
     assert section["planning_output_health"] == health
 
 
+def test_live_smoke_report_summarizes_latest_data_packets_without_raw_refs(tmp_path):
+    binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        binance_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="data_packet.updated",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_old"},
+                data={
+                    "kind": "positions",
+                    "scope": "global",
+                    "revision": 1,
+                    "source": "authoritative_surface",
+                    "quality": "ok",
+                    "freshness": {"status": "fresh"},
+                    "coverage": {"row_count": 99},
+                    "raw_ref": "positions:API_KEY_SHOULD_NOT_RENDER",
+                    "raw_hash": "HASH_SHOULD_NOT_RENDER",
+                },
+            ),
+            _monitor_row(
+                event_type="data_packet.updated",
+                seq=2,
+                ts=2000,
+                ids={"cycle_id": "cy_new"},
+                data={
+                    "kind": "positions",
+                    "scope": "global",
+                    "revision": 2,
+                    "source": "authoritative_surface",
+                    "quality": "ok",
+                    "freshness": {"status": "fresh", "age_ms": 4},
+                    "coverage": {"row_count": 2, "unsafe": "SHOULD_NOT_RENDER"},
+                    "warnings": ["api_key=WARNING_SHOULD_NOT_RENDER"],
+                },
+            ),
+            _monitor_row(
+                event_type="data_packet.updated",
+                seq=3,
+                ts=2100,
+                ids={"cycle_id": "cy_new"},
+                data={
+                    "kind": "balance",
+                    "scope": "global",
+                    "revision": 2,
+                    "source": "authoritative_surface",
+                    "quality": "ok",
+                    "freshness": {"status": "fresh"},
+                    "coverage": {"value_present": True},
+                    "balance_value": "VALUE_SHOULD_NOT_RENDER",
+                },
+            ),
+        ],
+    )
+    _write_ndjson(
+        gateio_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="data_packet.updated",
+                seq=1,
+                ts=1500,
+                exchange="gateio",
+                user="gateio_01",
+                ids={"cycle_id": "cy_gate"},
+                data={
+                    "kind": "open_orders",
+                    "scope": "global",
+                    "revision": 7,
+                    "source": "websocket",
+                    "quality": "degraded",
+                    "freshness": {
+                        "status": "stale",
+                        "age_ms": 6000,
+                        "max_age_ms": 5000,
+                        "reason": "packet_age_exceeded",
+                    },
+                    "coverage": {"row_count": 4},
+                    "errors": ["secret=ERROR_SHOULD_NOT_RENDER"],
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    summary = summarize_live_smoke_report(report)
+    brief = summarize_live_smoke_report_brief(report)
+    section = project_live_smoke_report_sections(report, ["data_packets"])
+
+    health = report["data_packet_health"]
+    assert health["total"] == 4
+    assert health["event_types"] == {"data_packet.updated": 4}
+    assert health["bots"] == 2
+    assert health["latest_packets"] == 3
+    assert health["packet_kinds"] == {
+        "positions": 2,
+        "balance": 1,
+        "open_orders": 1,
+    }
+    assert health["latest_qualities"] == {"ok": 2, "degraded": 1}
+    assert health["latest_freshness_statuses"] == {"fresh": 2, "stale": 1}
+    assert health["latest_sources"] == {"authoritative_surface": 2, "websocket": 1}
+    assert health["latest_warning_packets"] == 1
+    assert health["latest_error_packets"] == 1
+    assert health["latest_row_count_total"] == 6
+    assert health["latest_value_present_packets"] == 1
+    assert health["latest_value_missing_packets"] == 0
+    positions = next(
+        group for group in health["groups"] if group["packet_kind"] == "positions"
+    )
+    assert positions["count"] == 2
+    assert positions["latest_revision"] == 2
+    assert positions["latest_coverage"] == {"row_count": 2}
+    assert positions["latest_ids"] == {"cycle_id": "cy_new"}
+    for projected in (
+        health,
+        summary["data_packet_health"],
+        brief["data_packets"],
+    ):
+        assert projected["latest_packets"] == 3
+        serialized = json.dumps(projected)
+        assert "SHOULD_NOT_RENDER" not in serialized
+        assert "raw_ref" not in serialized
+        assert "raw_hash" not in serialized
+        assert '"warnings"' not in serialized
+        assert '"errors"' not in serialized
+        assert "VALUE_SHOULD_NOT_RENDER" not in serialized
+    assert section["data_packet_health"] == health
+
+
 def test_live_smoke_report_problem_events_include_state_refresh_progress(tmp_path):
     events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- project existing `data_packet.updated` events into bounded latest-per-bot-and-kind smoke health
- expose packet kind, quality, freshness, source, revision, safe coverage, and warning/error counts across full, summary, brief, and selected output
- keep raw references, hashes, timestamps, values, and warning/error text query-only; verdicts and runtime behavior are unchanged

## Validation
- `python -m pytest -q tests/test_live_smoke_report.py tests/test_live_incident_bundle.py tests/test_live_event_registry_docs.py tests/test_ai_docs.py` (127 passed)
- `python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py`
- `PYTHONPATH=src python src/tools/check_ai_docs.py` (0 errors; one pre-existing word-count warning)
- `git diff --check`

## Deployment evidence carried forward
PR #1277 is deployed on VPS5 at `deee460a18` with no restart. Exact bot PIDs, pane parents, and `misc:0.0` remained unchanged. Immediate and settled two-minute smokes were `ok=true` with zero hard/log/monitor/process failures and 189/189 then 191/191 remote calls successful. The focused five-minute report naturally projected 60 planning-output events as 30 correlated pairs across all five bots with zero latest count mismatches; the same window contained 87 natural packet-update events. No event or trading activity was manufactured.

## VPS expectation
Report-only change: pull and bounded smoke/report validation after merge; no bot restart expected.