### PR TITLE
Add Binance archive tiers to v2 OHLCV downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable user-facing changes will be documented in this file.
   query-only; smoke verdicts, exchange access, and trading behavior are
   unchanged.
 
+- Binance backtest OHLCV downloads now fill the current v2 store from checksum-verified Binance
+  Vision monthly archives first, parallel daily archives second, and CCXT last. Monthly archives
+  are limited to sufficiently incomplete published months, recent days stay on CCXT, existing
+  valid rows are never overwritten, and CCXT repairs archive failures or real gaps within archive
+  data. The legacy downloader path is not re-enabled.
+
 - Live smoke reports now include bounded latest-per-bot planning-output health
   from existing `rust_orchestrator.returned` and `action.planned` events. The
   projection correlates cycle and remote-call IDs, Rust timing and order

--- a/docs/ai/features/candlestick_manager.md
+++ b/docs/ai/features/candlestick_manager.md
@@ -4,6 +4,11 @@
 
 1. Prefer existing local data before remote calls.
 2. For backtest preparation, use v2 OHLCV chunks first, legacy raw shards second, and targeted remote fetches last.
+   For missing Binance futures 1m data in the current v2 path, remote source priority is Binance
+   Vision monthly archives, Binance Vision daily archives, then CCXT. More than seven days of
+   missing bars in an eligible closed month selects the monthly archive. Eligible days with more
+   than 1,000 missing bars select daily archives. Small gaps, recent days, archive failures, and
+   any gaps remaining inside a successful archive are repaired through CCXT.
 3. Treat exchange-side late starts and early ends as coverage metadata, not local corruption.
 4. Fill only internal gaps within the configured tolerance. Larger internal gaps must be repaired,
    excluded from the returned tradable window, or fail; do not make them tradable via synthetic rows.
@@ -26,6 +31,10 @@
    continuity gaps, not for unknown stale tails caused by refresh budget or REST delay.
 6. Projection is stateless per read. Real candles always win on the next read, and bounded internal
    gaps continue to use the normal synthetic gap path with replacement/invalidation tracking.
+7. Binance monthly and daily archive requests are parallel within each tier, verify the published
+   SHA-256 sidecar before parsing, and write only invalid v2 rows. Monthly archives are attempted
+   only after Binance's first-Monday publication window plus a buffer; daily archives exclude the
+   current day and two preceding complete UTC days.
 
 Cache paths use `to_standard_exchange_name()` rather than raw CCXT identifiers such as
 `binanceusdm` or `kucoinfutures`.
@@ -47,9 +56,13 @@ Cache paths use `to_standard_exchange_name()` rather than raw CCXT identifiers s
 2. Replacement/invalidation behavior when real data arrives.
 3. Pagination boundary correctness per exchange.
 4. Backtest/live parity for live tail-gap EMA projection behavior.
+5. Binance archive threshold, publication-lag, checksum, source-order, non-overwrite, and CCXT
+   fallback behavior, including public unauthenticated download smokes.
 
 ## Key Code
 
 - `src/candlestick_manager.py`
+- `src/binance_ohlcv_archive.py`
+- `src/hlcv_preparation.py`
 - `src/tools/verify_hlcvs_data.py`
 - `exchange_integrations.md`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,6 +14,12 @@ For the recommended user workflow, examples, and best practices, see [Config Wor
 - **compress_cache**: Set to `true` to save disk space. Set to `false` for faster loading.
 - **end_date**: End date of backtest, e.g., `2024-06-23`. Set to `'now'` to use today's date as the end date.
 - **exchanges**: Exchanges from which to fetch 1m OHLCV data for backtesting and optimizing. The most exercised choices are `binance` and `bybit`, which are also the current default profile. `bitget` and `gateio` are supported, with the GateIO history caveat below. `kucoin` has archive-fetch support but should be treated as experimental for backtesting until broader real-data smoke coverage is collected. Use short exchange names in configs; Passivbot converts to CCXT-specific IDs such as `binanceusdm` and `kucoinfutures` only when it talks to CCXT.
+  Binance backtests fill missing v2 1m data from Binance Vision monthly archives first, eligible
+  daily archives second, and CCXT last. Monthly archives are used only for closed, published months
+  with more than seven days of missing candles; daily archives are used for older days with more
+  than 1,000 missing candles. Recent or small gaps and gaps inside archive data fall back to CCXT.
+  Archive downloads run concurrently within each tier and are verified against Binance's SHA-256
+  sidecars before being written to the v2 store.
   **GateIO note:** If you already have `caches/ohlcv/gateio` data on disk, delete it before a fresh run so Passivbot rebuilds the cache with base-volume-normalized data.
   GateIO's public 1m OHLCV endpoint only serves a recent window of roughly 10,000 candles; use `backtest.ohlcv_source_dir` or another candle source for older GateIO backtests.
 - **coin_sources**: Optional mapping of `coin -> exchange` used to override the automatic exchange selection when multiple exchanges are configured. Scenarios may add more overrides; conflicting assignments raise an error.

--- a/src/binance_ohlcv_archive.py
+++ b/src/binance_ohlcv_archive.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import hashlib
+from io import BytesIO
+import logging
+from typing import Literal, Optional
+import zipfile
+
+import aiohttp
+import numpy as np
+import pandas as pd
+
+
+BINANCE_ARCHIVE_BASE_URL = "https://data.binance.vision/data/futures/um"
+BINANCE_MONTHLY_MIN_MISSING_CANDLES = 7 * 24 * 60
+BINANCE_DAILY_MIN_MISSING_CANDLES = 1000
+BINANCE_DAILY_LAG_DAYS = 2
+BINANCE_MONTHLY_PUBLICATION_BUFFER_HOURS = 24
+BINANCE_ARCHIVE_MAX_CONCURRENCY = 6
+
+
+ArchiveKind = Literal["monthly", "daily"]
+
+
+class BinanceArchiveError(RuntimeError):
+    pass
+
+
+class BinanceArchiveIntegrityError(BinanceArchiveError):
+    pass
+
+
+@dataclass(frozen=True)
+class BinanceArchiveRequest:
+    kind: ArchiveKind
+    symbol_code: str
+    period_key: str
+    start_ts: int
+    end_ts: int
+    missing_candles: int
+
+    @property
+    def filename(self) -> str:
+        return f"{self.symbol_code}-1m-{self.period_key}.zip"
+
+    @property
+    def url(self) -> str:
+        return (
+            f"{BINANCE_ARCHIVE_BASE_URL}/{self.kind}/klines/"
+            f"{self.symbol_code}/1m/{self.filename}"
+        )
+
+
+@dataclass(frozen=True)
+class BinanceArchiveResult:
+    request: BinanceArchiveRequest
+    status: Literal["ok", "not_found", "error"]
+    frame: Optional[pd.DataFrame] = None
+    error: Optional[str] = None
+
+
+def _utc_datetime(ts_ms: int) -> datetime:
+    return datetime.fromtimestamp(int(ts_ms) / 1000, tz=timezone.utc)
+
+
+def _datetime_to_ms(value: datetime) -> int:
+    return int(value.timestamp() * 1000)
+
+
+def _month_bounds(year: int, month: int) -> tuple[int, int]:
+    start = datetime(year, month, 1, tzinfo=timezone.utc)
+    if month == 12:
+        next_month = datetime(year + 1, 1, 1, tzinfo=timezone.utc)
+    else:
+        next_month = datetime(year, month + 1, 1, tzinfo=timezone.utc)
+    return _datetime_to_ms(start), _datetime_to_ms(next_month) - 60_000
+
+
+def _day_bounds(day: datetime) -> tuple[int, int]:
+    start = datetime(day.year, day.month, day.day, tzinfo=timezone.utc)
+    return _datetime_to_ms(start), _datetime_to_ms(start + timedelta(days=1)) - 60_000
+
+
+def first_monday_after_month(year: int, month: int) -> datetime:
+    if month == 12:
+        candidate = datetime(year + 1, 1, 1, tzinfo=timezone.utc)
+    else:
+        candidate = datetime(year, month + 1, 1, tzinfo=timezone.utc)
+    return candidate + timedelta(days=(7 - candidate.weekday()) % 7)
+
+
+def monthly_archive_eligible(
+    year: int,
+    month: int,
+    *,
+    now_ms: int,
+    publication_buffer_hours: int = BINANCE_MONTHLY_PUBLICATION_BUFFER_HOURS,
+) -> bool:
+    now = _utc_datetime(now_ms)
+    if (year, month) >= (now.year, now.month):
+        return False
+    available_at = first_monday_after_month(year, month) + timedelta(
+        hours=max(0, int(publication_buffer_hours))
+    )
+    return now >= available_at
+
+
+def daily_archive_eligible(
+    year: int,
+    month: int,
+    day: int,
+    *,
+    now_ms: int,
+    lag_days: int = BINANCE_DAILY_LAG_DAYS,
+) -> bool:
+    day_start = datetime(year, month, day, tzinfo=timezone.utc)
+    today_start = datetime.combine(
+        _utc_datetime(now_ms).date(), datetime.min.time(), tzinfo=timezone.utc
+    )
+    return day_start + timedelta(days=1 + max(0, int(lag_days))) <= today_start
+
+
+def plan_binance_archive_requests(
+    timestamps: np.ndarray,
+    valid: np.ndarray,
+    *,
+    symbol_code: str,
+    now_ms: int,
+    monthly_min_missing_candles: int = BINANCE_MONTHLY_MIN_MISSING_CANDLES,
+    daily_min_missing_candles: int = BINANCE_DAILY_MIN_MISSING_CANDLES,
+) -> tuple[list[BinanceArchiveRequest], list[BinanceArchiveRequest]]:
+    ts = np.asarray(timestamps, dtype=np.int64)
+    mask = np.asarray(valid, dtype=np.bool_)
+    if ts.ndim != 1 or mask.ndim != 1 or len(ts) != len(mask):
+        raise ValueError("timestamps and valid must be matching one-dimensional arrays")
+    if len(ts) == 0 or mask.all():
+        return [], []
+
+    missing_ts = ts[~mask]
+    missing_datetimes = missing_ts.astype("datetime64[ms]")
+    month_keys = missing_datetimes.astype("datetime64[M]").astype(np.int64)
+    unique_months, monthly_counts = np.unique(month_keys, return_counts=True)
+
+    monthly: list[BinanceArchiveRequest] = []
+    monthly_periods: set[int] = set()
+    for month_key, count in zip(unique_months.tolist(), monthly_counts.tolist()):
+        year_offset, month_offset = divmod(int(month_key), 12)
+        year = 1970 + year_offset
+        month = month_offset + 1
+        if int(count) <= int(monthly_min_missing_candles):
+            continue
+        if not monthly_archive_eligible(year, month, now_ms=now_ms):
+            continue
+        start_ts, end_ts = _month_bounds(year, month)
+        monthly.append(
+            BinanceArchiveRequest(
+                kind="monthly",
+                symbol_code=symbol_code,
+                period_key=f"{year:04d}-{month:02d}",
+                start_ts=start_ts,
+                end_ts=end_ts,
+                missing_candles=int(count),
+            )
+        )
+        monthly_periods.add(int(month_key))
+
+    daily_candidate_mask = ~np.isin(month_keys, np.fromiter(monthly_periods, dtype=np.int64))
+    daily_keys = missing_datetimes[daily_candidate_mask].astype("datetime64[D]").astype(np.int64)
+    unique_days, daily_counts = np.unique(daily_keys, return_counts=True)
+
+    daily: list[BinanceArchiveRequest] = []
+    for day_key, count in zip(unique_days.tolist(), daily_counts.tolist()):
+        if int(count) <= int(daily_min_missing_candles):
+            continue
+        day_dt = datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(days=int(day_key))
+        year, month, day = day_dt.year, day_dt.month, day_dt.day
+        if not daily_archive_eligible(year, month, day, now_ms=now_ms):
+            continue
+        start_ts, end_ts = _day_bounds(datetime(year, month, day, tzinfo=timezone.utc))
+        daily.append(
+            BinanceArchiveRequest(
+                kind="daily",
+                symbol_code=symbol_code,
+                period_key=f"{year:04d}-{month:02d}-{day:02d}",
+                start_ts=start_ts,
+                end_ts=end_ts,
+                missing_candles=int(count),
+            )
+        )
+    return monthly, daily
+
+
+def _parse_checksum(payload: bytes, filename: str) -> str:
+    try:
+        text = payload.decode("utf-8").strip()
+    except UnicodeDecodeError as exc:
+        raise BinanceArchiveIntegrityError("checksum sidecar is not UTF-8") from exc
+    if not text:
+        raise BinanceArchiveIntegrityError("checksum sidecar is empty")
+    fields = text.split()
+    digest = fields[0].lower() if fields else ""
+    if len(digest) != 64 or any(ch not in "0123456789abcdef" for ch in digest):
+        raise BinanceArchiveIntegrityError("checksum sidecar has an invalid SHA-256 digest")
+    if len(fields) > 1 and fields[-1].lstrip("*") != filename:
+        raise BinanceArchiveIntegrityError(
+            f"checksum sidecar names {fields[-1]!r}, expected {filename!r}"
+        )
+    return digest
+
+
+def _parse_archive_zip(raw: bytes, request: BinanceArchiveRequest) -> pd.DataFrame:
+    columns = ["timestamp", "open", "high", "low", "close", "volume"]
+    try:
+        with zipfile.ZipFile(BytesIO(raw), "r") as archive:
+            members = [name for name in archive.namelist() if not name.endswith("/")]
+            if not members:
+                raise BinanceArchiveIntegrityError("archive contains no files")
+            frames = []
+            for name in members:
+                with archive.open(name) as handle:
+                    frame = pd.read_csv(handle, header=None)
+                if frame.shape[1] < len(columns):
+                    raise BinanceArchiveIntegrityError(
+                        f"archive member {name!r} has only {frame.shape[1]} columns"
+                    )
+                frame = frame.iloc[:, : len(columns)].copy()
+                frame.columns = columns
+                frames.append(frame)
+    except zipfile.BadZipFile as exc:
+        raise BinanceArchiveIntegrityError("archive is not a valid ZIP file") from exc
+
+    frame = pd.concat(frames, ignore_index=True)
+    for column in columns:
+        frame[column] = pd.to_numeric(frame[column], errors="coerce")
+    frame = frame.dropna(subset=columns).reset_index(drop=True)
+    if frame.empty:
+        raise BinanceArchiveIntegrityError("archive contains no valid OHLCV rows")
+
+    frame["timestamp"] = frame["timestamp"].astype(np.int64)
+    frame = frame[
+        (frame["timestamp"] >= int(request.start_ts))
+        & (frame["timestamp"] <= int(request.end_ts))
+    ]
+    if frame.empty:
+        raise BinanceArchiveIntegrityError("archive contains no rows in the requested period")
+    if bool((frame["timestamp"] % 60_000 != 0).any()):
+        raise BinanceArchiveIntegrityError("archive contains unaligned 1m timestamps")
+
+    value_columns = ["open", "high", "low", "close", "volume"]
+    values = frame[value_columns].to_numpy(dtype=np.float64, copy=False)
+    if not np.isfinite(values).all():
+        raise BinanceArchiveIntegrityError("archive contains non-finite OHLCV values")
+    if bool((frame["volume"] < 0).any()):
+        raise BinanceArchiveIntegrityError("archive contains negative volume")
+    if bool(
+        (
+            (frame["low"] > frame["high"])
+            | (frame["open"] < frame["low"])
+            | (frame["open"] > frame["high"])
+            | (frame["close"] < frame["low"])
+            | (frame["close"] > frame["high"])
+        ).any()
+    ):
+        raise BinanceArchiveIntegrityError("archive contains invalid OHLC price bounds")
+
+    duplicate_rows = frame[frame["timestamp"].duplicated(keep=False)]
+    if not duplicate_rows.empty:
+        for _, group in duplicate_rows.groupby("timestamp", sort=False):
+            group_values = group[value_columns].to_numpy(dtype=np.float64, copy=False)
+            if not np.all(group_values == group_values[0]):
+                raise BinanceArchiveIntegrityError(
+                    f"archive contains conflicting rows for timestamp {int(group.iloc[0]['timestamp'])}"
+                )
+    return (
+        frame.sort_values("timestamp", kind="mergesort")
+        .drop_duplicates(subset=["timestamp"], keep="last")
+        .reset_index(drop=True)
+    )
+
+
+class BinanceOhlcvArchiveClient:
+    def __init__(
+        self,
+        *,
+        max_concurrency: int = BINANCE_ARCHIVE_MAX_CONCURRENCY,
+        session: Optional[aiohttp.ClientSession] = None,
+        logger: Optional[logging.Logger] = None,
+    ) -> None:
+        self._session = session
+        self._owns_session = session is None
+        self._sem = asyncio.Semaphore(max(1, int(max_concurrency)))
+        self.log = logger or logging.getLogger(__name__)
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        if self._session is None or self._session.closed:
+            timeout = aiohttp.ClientTimeout(total=180, connect=20, sock_read=120)
+            connector = aiohttp.TCPConnector(
+                limit=BINANCE_ARCHIVE_MAX_CONCURRENCY,
+                limit_per_host=BINANCE_ARCHIVE_MAX_CONCURRENCY,
+                ttl_dns_cache=300,
+                enable_cleanup_closed=True,
+            )
+            self._session = aiohttp.ClientSession(timeout=timeout, connector=connector)
+            self._owns_session = True
+        return self._session
+
+    async def aclose(self) -> None:
+        if self._owns_session and self._session is not None and not self._session.closed:
+            await self._session.close()
+
+    async def _get(self, url: str) -> tuple[int, bytes]:
+        session = await self._get_session()
+        async with self._sem:
+            async with session.get(url) as response:
+                if response.status == 404:
+                    return 404, b""
+                response.raise_for_status()
+                return response.status, await response.read()
+
+    async def fetch(self, request: BinanceArchiveRequest) -> BinanceArchiveResult:
+        try:
+            checksum_status, checksum_payload = await self._get(request.url + ".CHECKSUM")
+            if checksum_status == 404:
+                return BinanceArchiveResult(request=request, status="not_found")
+            expected_digest = _parse_checksum(checksum_payload, request.filename)
+            archive_status, raw = await self._get(request.url)
+            if archive_status == 404:
+                return BinanceArchiveResult(request=request, status="not_found")
+            actual_digest = hashlib.sha256(raw).hexdigest()
+            if actual_digest != expected_digest:
+                raise BinanceArchiveIntegrityError(
+                    f"SHA-256 mismatch: expected {expected_digest}, got {actual_digest}"
+                )
+            frame = await asyncio.to_thread(_parse_archive_zip, raw, request)
+            return BinanceArchiveResult(request=request, status="ok", frame=frame)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            return BinanceArchiveResult(
+                request=request,
+                status="error",
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+    async def fetch_many(
+        self, requests: list[BinanceArchiveRequest]
+    ) -> list[BinanceArchiveResult]:
+        if not requests:
+            return []
+        tasks = [asyncio.create_task(self.fetch(request)) for request in requests]
+        try:
+            return list(await asyncio.gather(*tasks))
+        except BaseException:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
+
+
+def symbol_to_archive_code(symbol: str) -> str:
+    value = str(symbol or "")
+    if "/" in value:
+        base, remainder = value.split("/", 1)
+        quote = remainder.split(":", 1)[0]
+        return f"{base}{quote}".replace("-", "").upper()
+    return value.replace("/", "").replace(":", "").replace("-", "").upper()
+
+
+__all__ = [
+    "BINANCE_DAILY_LAG_DAYS",
+    "BINANCE_DAILY_MIN_MISSING_CANDLES",
+    "BINANCE_MONTHLY_MIN_MISSING_CANDLES",
+    "BINANCE_MONTHLY_PUBLICATION_BUFFER_HOURS",
+    "BinanceArchiveIntegrityError",
+    "BinanceArchiveRequest",
+    "BinanceArchiveResult",
+    "BinanceOhlcvArchiveClient",
+    "daily_archive_eligible",
+    "first_monday_after_month",
+    "monthly_archive_eligible",
+    "plan_binance_archive_requests",
+    "symbol_to_archive_code",
+]

--- a/src/hlcv_preparation.py
+++ b/src/hlcv_preparation.py
@@ -16,6 +16,13 @@ import numpy as np
 import pandas as pd
 
 from candlestick_manager import CandlestickManager, OhlcvTerminalEmptyPage
+from binance_ohlcv_archive import (
+    BinanceArchiveRequest,
+    BinanceArchiveResult,
+    BinanceOhlcvArchiveClient,
+    plan_binance_archive_requests,
+    symbol_to_archive_code,
+)
 from backtest_dataset_materializer import BacktestDatasetMaterializer, materialize_frames
 from ohlcv_catalog import KNOWN_GAP_RETRY_MS, OhlcvCatalog
 from ohlcv_legacy_import import import_legacy_range_into_store
@@ -251,6 +258,7 @@ class HLCVManager:
             self.cm_progress_log_interval_seconds = 0.0
         self.force_refetch_gaps = bool(force_refetch_gaps)
         self.cm: Optional[CandlestickManager] = None
+        self.binance_archive_client: Optional[BinanceOhlcvArchiveClient] = None
         self.ohlcv_source_dir = str(ohlcv_source_dir) if ohlcv_source_dir else None
         self.tradfi_for_stock_perps = _has_stock_perp_calendar_context(self.ohlcv_source_dir)
 
@@ -301,6 +309,11 @@ class HLCVManager:
 
     async def aclose(self) -> None:
         """Close CandlestickManager resources (not the ccxt exchange)."""
+        if self.binance_archive_client is not None:
+            try:
+                await self.binance_archive_client.aclose()
+            finally:
+                self.binance_archive_client = None
         if self.cm is None:
             return
         try:
@@ -308,6 +321,11 @@ class HLCVManager:
         except Exception:
             pass
         self.cm = None
+
+    def get_binance_archive_client(self) -> BinanceOhlcvArchiveClient:
+        if self.binance_archive_client is None:
+            self.binance_archive_client = BinanceOhlcvArchiveClient()
+        return self.binance_archive_client
 
     def close(self) -> None:
         """Best-effort sync close for CandlestickManager resources."""
@@ -2591,6 +2609,43 @@ async def _fetch_invalid_windows_into_v2_store_results(
     allow_pre_inception_prefix: bool = False,
 ) -> list[V2FetchResult]:
     results: list[V2FetchResult] = []
+    archive_capable = to_standard_exchange_name(exchange) == "binance" and callable(
+        getattr(om, "get_binance_archive_client", None)
+    )
+    archive_rows = (
+        await _fetch_binance_archives_into_v2_store(
+            om=om,
+            catalog=catalog,
+            store=store,
+            exchange=exchange,
+            coin=coin,
+            symbol=symbol,
+            timestamps=timestamps,
+            valid=valid,
+        )
+        if archive_capable
+        else 0
+    )
+    if archive_rows:
+        refreshed = store.read_range(
+            exchange,
+            "1m",
+            symbol,
+            int(timestamps[0]),
+            int(timestamps[-1]),
+        )
+        timestamps = refreshed.timestamps
+        valid = refreshed.valid
+        if valid.all():
+            return [
+                V2FetchResult(
+                    True,
+                    "binance_archive_ok",
+                    wrote_rows=int(archive_rows),
+                    first_ts=int(timestamps[0]),
+                    last_ts=int(timestamps[-1]),
+                )
+            ]
     full_start_ts = int(timestamps[0])
     full_end_ts = int(timestamps[-1])
     context_ms = max(
@@ -2600,7 +2655,12 @@ async def _fetch_invalid_windows_into_v2_store_results(
     for window_start_ts, window_end_ts in _iter_invalid_windows(timestamps, valid):
         fetch_start_ts = max(full_start_ts, int(window_start_ts) - context_ms)
         fetch_end_ts = min(full_end_ts, int(window_end_ts) + context_ms)
-        raw_result = await _fetch_coin_range_into_v2_store(
+        fetch_range = (
+            _fetch_coin_range_via_ccxt_into_v2_store
+            if archive_capable
+            else _fetch_coin_range_into_v2_store
+        )
+        raw_result = await fetch_range(
             om=om,
             catalog=catalog,
             store=store,
@@ -2620,6 +2680,246 @@ async def _fetch_invalid_windows_into_v2_store_results(
         if not result:
             break
     return results
+
+
+def _archive_attempt_number(
+    catalog: OhlcvCatalog,
+    *,
+    exchange: str,
+    symbol: str,
+    request: BinanceArchiveRequest,
+) -> int:
+    exact_attempts = [
+        item.attempt
+        for item in catalog.list_fetch_attempts(
+            exchange,
+            "1m",
+            symbol,
+            int(request.start_ts),
+            int(request.end_ts),
+        )
+        if int(item.start_ts) == int(request.start_ts)
+        and int(item.end_ts) == int(request.end_ts)
+    ]
+    return max(exact_attempts, default=0) + 1
+
+
+def _record_binance_archive_result(
+    catalog: OhlcvCatalog,
+    *,
+    exchange: str,
+    symbol: str,
+    result: BinanceArchiveResult,
+    latency_ms: int,
+) -> None:
+    request = result.request
+    frame_rows = int(len(result.frame)) if result.frame is not None else 0
+    note_parts = [
+        f"source=binance_{request.kind}_archive",
+        f"period={request.period_key}",
+        f"missing_candles={request.missing_candles}",
+        f"archive_rows={frame_rows}",
+    ]
+    if result.error:
+        note_parts.append(f"error={result.error}")
+    catalog.record_fetch_attempt(
+        exchange=exchange,
+        timeframe="1m",
+        symbol=symbol,
+        start_ts=int(request.start_ts),
+        end_ts=int(request.end_ts),
+        attempt=_archive_attempt_number(
+            catalog,
+            exchange=exchange,
+            symbol=symbol,
+            request=request,
+        ),
+        outcome=f"archive_{request.kind}_{result.status}",
+        latency_ms=int(latency_ms),
+        note=" ".join(note_parts),
+    )
+
+
+def _write_binance_archive_results(
+    *,
+    store: OhlcvStore,
+    exchange: str,
+    symbol: str,
+    results: Sequence[BinanceArchiveResult],
+) -> int:
+    successful = [
+        result
+        for result in results
+        if result.status == "ok" and result.frame is not None and not result.frame.empty
+    ]
+    if not successful:
+        return 0
+
+    frames_by_month: dict[tuple[int, int], list[pd.DataFrame]] = defaultdict(list)
+    for result in successful:
+        assert result.frame is not None
+        frame = result.frame.copy()
+        month_keys = pd.to_datetime(frame["timestamp"], unit="ms", utc=True)
+        for (year, month), indices in frame.groupby(
+            [month_keys.dt.year, month_keys.dt.month], sort=True
+        ).groups.items():
+            frames_by_month[(int(year), int(month))].append(frame.loc[indices])
+
+    rows_written = 0
+    for (year, month), frames in sorted(frames_by_month.items()):
+        frame = (
+            pd.concat(frames, ignore_index=True)
+            .sort_values("timestamp", kind="mergesort")
+            .drop_duplicates(subset=["timestamp"], keep="last")
+            .reset_index(drop=True)
+        )
+        month_start = int(datetime(year, month, 1, tzinfo=timezone.utc).timestamp() * 1000)
+        if month == 12:
+            next_month = datetime(year + 1, 1, 1, tzinfo=timezone.utc)
+        else:
+            next_month = datetime(year, month + 1, 1, tzinfo=timezone.utc)
+        month_end = int(next_month.timestamp() * 1000) - 60_000
+        existing = store.read_range(exchange, "1m", symbol, month_start, month_end)
+        offsets = ((frame["timestamp"].to_numpy(dtype=np.int64) - month_start) // 60_000).astype(
+            np.int64,
+            copy=False,
+        )
+        in_bounds = (offsets >= 0) & (offsets < len(existing.valid))
+        if not bool(in_bounds.any()):
+            continue
+        frame = frame.loc[in_bounds].reset_index(drop=True)
+        offsets = offsets[in_bounds]
+        missing_only = ~existing.valid[offsets]
+        if not bool(missing_only.any()):
+            continue
+        frame = frame.loc[missing_only].reset_index(drop=True)
+        timestamps_ms = frame["timestamp"].to_numpy(dtype=np.int64, copy=False)
+        values = np.column_stack(
+            [
+                frame["high"].to_numpy(dtype=np.float32, copy=False),
+                frame["low"].to_numpy(dtype=np.float32, copy=False),
+                frame["close"].to_numpy(dtype=np.float32, copy=False),
+                frame["volume"].to_numpy(dtype=np.float32, copy=False),
+            ]
+        )
+        store.write_rows(exchange, "1m", symbol, timestamps_ms, values)
+        rows_written += int(len(timestamps_ms))
+    return rows_written
+
+
+async def _fetch_binance_archives_into_v2_store(
+    *,
+    om: HLCVManager,
+    catalog: OhlcvCatalog,
+    store: OhlcvStore,
+    exchange: str,
+    coin: str,
+    symbol: str,
+    timestamps: np.ndarray,
+    valid: np.ndarray,
+) -> int:
+    if to_standard_exchange_name(exchange) != "binance":
+        return 0
+    get_client = getattr(om, "get_binance_archive_client", None)
+    if not callable(get_client):
+        return 0
+    if len(timestamps) == 0 or bool(np.asarray(valid, dtype=np.bool_).all()):
+        return 0
+
+    now_ms = utc_ms()
+    symbol_code = symbol_to_archive_code(symbol)
+    monthly_requests, _ = plan_binance_archive_requests(
+        timestamps,
+        valid,
+        symbol_code=symbol_code,
+        now_ms=now_ms,
+    )
+    client = get_client()
+    total_rows_written = 0
+    successful_months: set[str] = set()
+
+    if monthly_requests:
+        started = time.perf_counter()
+        monthly_results = await client.fetch_many(monthly_requests)
+        elapsed_ms = int(round((time.perf_counter() - started) * 1000.0))
+        per_request_latency_ms = max(0, elapsed_ms // max(1, len(monthly_results)))
+        for result in monthly_results:
+            _record_binance_archive_result(
+                catalog,
+                exchange=exchange,
+                symbol=symbol,
+                result=result,
+                latency_ms=per_request_latency_ms,
+            )
+            if result.status == "ok":
+                successful_months.add(result.request.period_key)
+        written = _write_binance_archive_results(
+            store=store,
+            exchange=exchange,
+            symbol=symbol,
+            results=monthly_results,
+        )
+        total_rows_written += written
+        logging.info(
+            "[%s] Binance monthly archive fetch for %s: requested=%d ok=%d rows_written=%d",
+            exchange,
+            coin,
+            len(monthly_results),
+            sum(result.status == "ok" for result in monthly_results),
+            written,
+        )
+
+    refreshed = store.read_range(
+        exchange,
+        "1m",
+        symbol,
+        int(timestamps[0]),
+        int(timestamps[-1]),
+    )
+    _, daily_requests = plan_binance_archive_requests(
+        refreshed.timestamps,
+        refreshed.valid,
+        symbol_code=symbol_code,
+        now_ms=now_ms,
+        monthly_min_missing_candles=sys.maxsize,
+    )
+    if successful_months:
+        daily_requests = [
+            request
+            for request in daily_requests
+            if request.period_key[:7] not in successful_months
+        ]
+
+    if daily_requests:
+        started = time.perf_counter()
+        daily_results = await client.fetch_many(daily_requests)
+        elapsed_ms = int(round((time.perf_counter() - started) * 1000.0))
+        per_request_latency_ms = max(0, elapsed_ms // max(1, len(daily_results)))
+        for result in daily_results:
+            _record_binance_archive_result(
+                catalog,
+                exchange=exchange,
+                symbol=symbol,
+                result=result,
+                latency_ms=per_request_latency_ms,
+            )
+        written = _write_binance_archive_results(
+            store=store,
+            exchange=exchange,
+            symbol=symbol,
+            results=daily_results,
+        )
+        total_rows_written += written
+        logging.info(
+            "[%s] Binance daily archive fetch for %s: requested=%d ok=%d rows_written=%d",
+            exchange,
+            coin,
+            len(daily_results),
+            sum(result.status == "ok" for result in daily_results),
+            written,
+        )
+
+    return total_rows_written
 
 
 def _terminal_empty_page_last_ts(exc: OhlcvTerminalEmptyPage) -> int | None:
@@ -2903,6 +3203,119 @@ async def _retry_unconfirmed_short_tail_range(
 
 
 async def _fetch_coin_range_into_v2_store(
+    *,
+    om: HLCVManager,
+    catalog: OhlcvCatalog,
+    store: OhlcvStore,
+    exchange: str,
+    coin: str,
+    symbol: str,
+    start_ts: int,
+    end_ts: int,
+    allow_unbounded_edge_gaps: bool = False,
+    allow_pre_inception_prefix: bool = False,
+    clear_valid_range_ms: tuple[int, int] | None = None,
+) -> V2FetchResult:
+    if to_standard_exchange_name(exchange) != "binance" or not callable(
+        getattr(om, "get_binance_archive_client", None)
+    ):
+        return await _fetch_coin_range_via_ccxt_into_v2_store(
+            om=om,
+            catalog=catalog,
+            store=store,
+            exchange=exchange,
+            coin=coin,
+            symbol=symbol,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            allow_unbounded_edge_gaps=allow_unbounded_edge_gaps,
+            allow_pre_inception_prefix=allow_pre_inception_prefix,
+            clear_valid_range_ms=clear_valid_range_ms,
+        )
+    if (
+        clear_valid_range_ms is not None
+        or allow_unbounded_edge_gaps
+        or allow_pre_inception_prefix
+    ):
+        return await _fetch_coin_range_via_ccxt_into_v2_store(
+            om=om,
+            catalog=catalog,
+            store=store,
+            exchange=exchange,
+            coin=coin,
+            symbol=symbol,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            allow_unbounded_edge_gaps=allow_unbounded_edge_gaps,
+            allow_pre_inception_prefix=allow_pre_inception_prefix,
+            clear_valid_range_ms=clear_valid_range_ms,
+        )
+
+    existing = store.read_range(exchange, "1m", symbol, int(start_ts), int(end_ts))
+    archive_rows = await _fetch_binance_archives_into_v2_store(
+        om=om,
+        catalog=catalog,
+        store=store,
+        exchange=exchange,
+        coin=coin,
+        symbol=symbol,
+        timestamps=existing.timestamps,
+        valid=existing.valid,
+    )
+    refreshed = store.read_range(exchange, "1m", symbol, int(start_ts), int(end_ts))
+    if refreshed.valid.all():
+        return V2FetchResult(
+            True,
+            "binance_archive_ok",
+            wrote_rows=int(archive_rows),
+            first_ts=int(refreshed.timestamps[0]),
+            last_ts=int(refreshed.timestamps[-1]),
+        )
+
+    invalid_windows = _iter_invalid_windows(refreshed.timestamps, refreshed.valid)
+    results: list[V2FetchResult] = []
+    for window_start_ts, window_end_ts in invalid_windows:
+        result = await _fetch_coin_range_via_ccxt_into_v2_store(
+            om=om,
+            catalog=catalog,
+            store=store,
+            exchange=exchange,
+            coin=coin,
+            symbol=symbol,
+            start_ts=int(window_start_ts),
+            end_ts=int(window_end_ts),
+        )
+        results.append(result)
+        if not result.ok:
+            return V2FetchResult(
+                False,
+                result.reason,
+                wrote_rows=int(archive_rows + sum(item.wrote_rows for item in results)),
+                first_ts=result.first_ts,
+                last_ts=result.last_ts,
+                leading_missing_bars=result.leading_missing_bars,
+                trailing_missing_bars=result.trailing_missing_bars,
+                max_internal_missing_bars=result.max_internal_missing_bars,
+            )
+
+    final = store.read_range(exchange, "1m", symbol, int(start_ts), int(end_ts))
+    remaining = int((~final.valid).sum())
+    total_written = int(archive_rows + sum(item.wrote_rows for item in results))
+    return V2FetchResult(
+        remaining == 0 or any(item.ok for item in results),
+        "ok" if remaining == 0 else "internal_gaps",
+        wrote_rows=total_written,
+        first_ts=(
+            int(final.timestamps[np.flatnonzero(final.valid)[0]]) if final.valid.any() else None
+        ),
+        last_ts=(
+            int(final.timestamps[np.flatnonzero(final.valid)[-1]]) if final.valid.any() else None
+        ),
+        max_internal_missing_bars=remaining,
+    )
+
+
+async def _fetch_coin_range_via_ccxt_into_v2_store(
     *,
     om: HLCVManager,
     catalog: OhlcvCatalog,

--- a/tests/test_binance_ohlcv_archive.py
+++ b/tests/test_binance_ohlcv_archive.py
@@ -1,0 +1,329 @@
+import asyncio
+from datetime import datetime, timezone
+import hashlib
+from io import BytesIO
+import zipfile
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from binance_ohlcv_archive import (
+    BinanceArchiveIntegrityError,
+    BinanceArchiveRequest,
+    BinanceOhlcvArchiveClient,
+    _parse_archive_zip,
+    _parse_checksum,
+    daily_archive_eligible,
+    first_monday_after_month,
+    monthly_archive_eligible,
+    plan_binance_archive_requests,
+    symbol_to_archive_code,
+)
+
+
+def ts(value: str) -> int:
+    return int(datetime.fromisoformat(value).replace(tzinfo=timezone.utc).timestamp() * 1000)
+
+
+def minute_grid(start: str, minutes: int) -> np.ndarray:
+    return np.arange(ts(start), ts(start) + minutes * 60_000, 60_000, dtype=np.int64)
+
+
+def make_zip(rows: list[list[object]], filename: str = "BTCUSDT-1m.csv") -> bytes:
+    csv_payload = "\n".join(",".join(str(value) for value in row) for row in rows).encode()
+    output = BytesIO()
+    with zipfile.ZipFile(output, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(filename, csv_payload)
+    return output.getvalue()
+
+
+def request(kind: str = "daily") -> BinanceArchiveRequest:
+    if kind == "monthly":
+        return BinanceArchiveRequest(
+            kind="monthly",
+            symbol_code="BTCUSDT",
+            period_key="2026-04",
+            start_ts=ts("2026-04-01"),
+            end_ts=ts("2026-04-30T23:59:00"),
+            missing_candles=20_000,
+        )
+    return BinanceArchiveRequest(
+        kind="daily",
+        symbol_code="BTCUSDT",
+        period_key="2026-04-01",
+        start_ts=ts("2026-04-01"),
+        end_ts=ts("2026-04-01T23:59:00"),
+        missing_candles=1440,
+    )
+
+
+def valid_row(timestamp: int, *, close: float = 100.0) -> list[object]:
+    return [
+        timestamp,
+        close,
+        close + 1.0,
+        close - 1.0,
+        close + 0.5,
+        12.0,
+        timestamp + 59_999,
+        0,
+        1,
+        0,
+        0,
+        0,
+    ]
+
+
+def test_archive_urls_use_usdm_monthly_and_daily_paths():
+    monthly = request("monthly")
+    daily = request("daily")
+
+    assert monthly.url.endswith(
+        "/futures/um/monthly/klines/BTCUSDT/1m/BTCUSDT-1m-2026-04.zip"
+    )
+    assert daily.url.endswith(
+        "/futures/um/daily/klines/BTCUSDT/1m/BTCUSDT-1m-2026-04-01.zip"
+    )
+
+
+def test_first_monday_and_monthly_publication_buffer():
+    assert first_monday_after_month(2026, 4) == datetime(2026, 5, 4, tzinfo=timezone.utc)
+    before_buffer = ts("2026-05-04T23:59:59")
+    after_buffer = ts("2026-05-05")
+
+    assert not monthly_archive_eligible(2026, 4, now_ms=before_buffer)
+    assert monthly_archive_eligible(2026, 4, now_ms=after_buffer)
+    assert not monthly_archive_eligible(2026, 5, now_ms=ts("2026-05-31T23:59:00"))
+
+
+def test_daily_archive_requires_two_complete_lag_days():
+    now_ms = ts("2026-07-16T12:00:00")
+    assert daily_archive_eligible(2026, 7, 13, now_ms=now_ms)
+    assert not daily_archive_eligible(2026, 7, 14, now_ms=now_ms)
+    assert not daily_archive_eligible(2026, 7, 16, now_ms=now_ms)
+
+
+def test_monthly_threshold_counts_missing_candles_not_affected_dates():
+    timestamps = minute_grid("2026-04-01", 8 * 24 * 60)
+    valid = np.ones(len(timestamps), dtype=np.bool_)
+    valid[::1440] = False
+
+    monthly, daily = plan_binance_archive_requests(
+        timestamps,
+        valid,
+        symbol_code="BTCUSDT",
+        now_ms=ts("2026-07-16"),
+    )
+
+    assert monthly == []
+    assert daily == []
+
+
+def test_more_than_seven_missing_days_selects_monthly_archive():
+    timestamps = minute_grid("2026-04-01", 8 * 24 * 60 + 1)
+    valid = np.zeros(len(timestamps), dtype=np.bool_)
+
+    monthly, daily = plan_binance_archive_requests(
+        timestamps,
+        valid,
+        symbol_code="BTCUSDT",
+        now_ms=ts("2026-07-16"),
+    )
+
+    assert [item.period_key for item in monthly] == ["2026-04"]
+    assert monthly[0].missing_candles == 8 * 24 * 60 + 1
+    assert daily == []
+
+
+def test_exactly_seven_missing_days_does_not_select_monthly():
+    timestamps = minute_grid("2026-04-01", 7 * 24 * 60)
+    valid = np.zeros(len(timestamps), dtype=np.bool_)
+
+    monthly, daily = plan_binance_archive_requests(
+        timestamps,
+        valid,
+        symbol_code="BTCUSDT",
+        now_ms=ts("2026-07-16"),
+    )
+
+    assert monthly == []
+    assert len(daily) == 7
+
+
+def test_current_month_never_selects_monthly_but_old_days_select_daily():
+    timestamps = minute_grid("2026-07-01", 13 * 24 * 60)
+    valid = np.zeros(len(timestamps), dtype=np.bool_)
+
+    monthly, daily = plan_binance_archive_requests(
+        timestamps,
+        valid,
+        symbol_code="BTCUSDT",
+        now_ms=ts("2026-07-16T12:00:00"),
+    )
+
+    assert monthly == []
+    assert daily[0].period_key == "2026-07-01"
+    assert daily[-1].period_key == "2026-07-13"
+
+
+def test_small_fragment_uses_neither_archive():
+    timestamps = minute_grid("2026-04-01", 1000)
+    valid = np.zeros(len(timestamps), dtype=np.bool_)
+
+    monthly, daily = plan_binance_archive_requests(
+        timestamps,
+        valid,
+        symbol_code="BTCUSDT",
+        now_ms=ts("2026-07-16"),
+    )
+
+    assert monthly == []
+    assert daily == []
+
+
+def test_more_than_one_thousand_missing_bars_selects_daily_archive():
+    timestamps = minute_grid("2026-04-10", 1001)
+    valid = np.zeros(len(timestamps), dtype=np.bool_)
+
+    monthly, daily = plan_binance_archive_requests(
+        timestamps,
+        valid,
+        symbol_code="BTCUSDT",
+        now_ms=ts("2026-07-16"),
+    )
+
+    assert monthly == []
+    assert [item.period_key for item in daily] == ["2026-04-10"]
+    assert daily[0].missing_candles == 1001
+
+
+def test_checksum_parser_validates_digest_and_filename():
+    digest = "a" * 64
+    assert _parse_checksum(f"{digest}  BTCUSDT-1m-2026-04.zip\n".encode(), "BTCUSDT-1m-2026-04.zip") == digest
+
+    with pytest.raises(BinanceArchiveIntegrityError, match="expected"):
+        _parse_checksum(f"{digest}  ETHUSDT.zip\n".encode(), "BTCUSDT.zip")
+    with pytest.raises(BinanceArchiveIntegrityError, match="invalid SHA-256"):
+        _parse_checksum(b"not-a-digest file.zip", "file.zip")
+
+
+def test_zip_parser_preserves_real_internal_gaps():
+    req = request("daily")
+    raw = make_zip([valid_row(req.start_ts), valid_row(req.start_ts + 2 * 60_000)])
+
+    frame = _parse_archive_zip(raw, req)
+
+    assert frame["timestamp"].tolist() == [req.start_ts, req.start_ts + 2 * 60_000]
+
+
+def test_zip_parser_accepts_header_and_identical_duplicate():
+    req = request("daily")
+    header = [
+        "open_time",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "close_time",
+        "quote_volume",
+        "trades",
+        "taker_base",
+        "taker_quote",
+        "ignore",
+    ]
+    row = valid_row(req.start_ts)
+    raw = make_zip([header, row, row])
+
+    frame = _parse_archive_zip(raw, req)
+
+    assert len(frame) == 1
+
+
+def test_zip_parser_rejects_conflicting_duplicates_and_bad_price_bounds():
+    req = request("daily")
+    row = valid_row(req.start_ts)
+    conflicting = valid_row(req.start_ts, close=200.0)
+    with pytest.raises(BinanceArchiveIntegrityError, match="conflicting"):
+        _parse_archive_zip(make_zip([row, conflicting]), req)
+
+    bad = valid_row(req.start_ts)
+    bad[2] = 90.0
+    with pytest.raises(BinanceArchiveIntegrityError, match="price bounds"):
+        _parse_archive_zip(make_zip([bad]), req)
+
+
+def test_symbol_to_archive_code_handles_ccxt_perpetual_symbols():
+    assert symbol_to_archive_code("BTC/USDT:USDT") == "BTCUSDT"
+    assert symbol_to_archive_code("1000SHIB/USDT:USDT") == "1000SHIBUSDT"
+
+
+@pytest.mark.asyncio
+async def test_client_verifies_checksum_and_parses_archive():
+    req = request("daily")
+    raw = make_zip([valid_row(req.start_ts)])
+    digest = hashlib.sha256(raw).hexdigest()
+
+    class FakeClient(BinanceOhlcvArchiveClient):
+        async def _get(self, url):
+            if url.endswith(".CHECKSUM"):
+                return 200, f"{digest}  {req.filename}\n".encode()
+            return 200, raw
+
+    client = FakeClient()
+    result = await client.fetch(req)
+
+    assert result.status == "ok"
+    assert result.frame is not None
+    assert result.frame["timestamp"].tolist() == [req.start_ts]
+
+
+@pytest.mark.asyncio
+async def test_client_checksum_mismatch_and_404_are_fallback_results():
+    req = request("daily")
+    raw = make_zip([valid_row(req.start_ts)])
+
+    class MismatchClient(BinanceOhlcvArchiveClient):
+        async def _get(self, url):
+            if url.endswith(".CHECKSUM"):
+                return 200, f"{'0' * 64}  {req.filename}\n".encode()
+            return 200, raw
+
+    mismatch = await MismatchClient().fetch(req)
+    assert mismatch.status == "error"
+    assert "SHA-256 mismatch" in (mismatch.error or "")
+
+    class MissingClient(BinanceOhlcvArchiveClient):
+        async def _get(self, _url):
+            return 404, b""
+
+    missing = await MissingClient().fetch(req)
+    assert missing.status == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_fetch_many_propagates_cancellation_and_cancels_siblings():
+    requests = [request("daily"), request("monthly")]
+    started = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+    started_count = 0
+
+    class SlowClient(BinanceOhlcvArchiveClient):
+        async def fetch(self, archive_request):
+            nonlocal started_count
+            started_count += 1
+            if started_count == len(requests):
+                started.set()
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                sibling_cancelled.set()
+                raise
+
+    task = asyncio.create_task(SlowClient().fetch_many(requests))
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert sibling_cancelled.is_set()

--- a/tests/test_binance_ohlcv_archive_network.py
+++ b/tests/test_binance_ohlcv_archive_network.py
@@ -1,0 +1,146 @@
+import os
+
+import pytest
+
+from binance_ohlcv_archive import BinanceArchiveRequest, BinanceOhlcvArchiveClient
+from hlcv_preparation import HLCVManager, _fetch_coin_range_into_v2_store
+from ohlcv_catalog import OhlcvCatalog
+from ohlcv_store import OhlcvStore, month_start_ts
+
+
+RUN_NETWORK_TESTS = os.environ.get("PASSIVBOT_RUN_PUBLIC_NETWORK_TESTS") == "1"
+pytestmark = pytest.mark.skipif(
+    not RUN_NETWORK_TESTS,
+    reason="set PASSIVBOT_RUN_PUBLIC_NETWORK_TESTS=1 for public Binance download tests",
+)
+
+
+def archive_request(kind, period_key, start_ts, end_ts, missing_candles):
+    return BinanceArchiveRequest(
+        kind=kind,
+        symbol_code="BTCUSDT",
+        period_key=period_key,
+        start_ts=start_ts,
+        end_ts=end_ts,
+        missing_candles=missing_candles,
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_binance_monthly_and_daily_archives_verify_and_parse_in_parallel():
+    january_start = month_start_ts(2024, 1)
+    february_start = month_start_ts(2024, 2)
+    requests = [
+        archive_request(
+            "monthly",
+            "2024-01",
+            january_start,
+            february_start - 60_000,
+            31 * 1440,
+        ),
+        archive_request(
+            "daily",
+            "2024-02-01",
+            february_start,
+            february_start + 1439 * 60_000,
+            1440,
+        ),
+    ]
+    client = BinanceOhlcvArchiveClient(max_concurrency=2)
+    try:
+        monthly, daily = await client.fetch_many(requests)
+    finally:
+        await client.aclose()
+
+    assert monthly.status == "ok", monthly.error
+    assert daily.status == "ok", daily.error
+    assert monthly.frame is not None and len(monthly.frame) == 31 * 1440
+    assert daily.frame is not None and len(daily.frame) == 1440
+    assert monthly.frame["timestamp"].is_monotonic_increasing
+    assert daily.frame["timestamp"].is_monotonic_increasing
+
+
+@pytest.mark.asyncio
+async def test_real_v2_downloader_uses_monthly_then_daily_archives(tmp_path):
+    catalog = OhlcvCatalog(tmp_path / "ohlcvs" / "catalog.sqlite")
+    store = OhlcvStore(tmp_path / "ohlcvs", catalog)
+    manager = HLCVManager("binance", verbose=False)
+    january_start = month_start_ts(2024, 1)
+    january_ninth = january_start + 8 * 1440 * 60_000
+    february_start = month_start_ts(2024, 2)
+    february_end = february_start + 1439 * 60_000
+
+    try:
+        monthly = await _fetch_coin_range_into_v2_store(
+            om=manager,
+            catalog=catalog,
+            store=store,
+            exchange="binance",
+            coin="BTC",
+            symbol="BTC/USDT:USDT",
+            start_ts=january_start,
+            end_ts=january_ninth,
+        )
+        daily = await _fetch_coin_range_into_v2_store(
+            om=manager,
+            catalog=catalog,
+            store=store,
+            exchange="binance",
+            coin="BTC",
+            symbol="BTC/USDT:USDT",
+            start_ts=february_start,
+            end_ts=february_end,
+        )
+    finally:
+        await manager.aclose()
+
+    assert monthly.ok and monthly.reason == "binance_archive_ok"
+    assert daily.ok and daily.reason == "binance_archive_ok"
+    assert store.read_range(
+        "binance", "1m", "BTC/USDT:USDT", january_start, january_ninth
+    ).valid.all()
+    assert store.read_range(
+        "binance", "1m", "BTC/USDT:USDT", february_start, february_end
+    ).valid.all()
+    attempts = catalog.list_fetch_attempts(
+        "binance", "1m", "BTC/USDT:USDT", january_start, february_end
+    )
+    assert [attempt.outcome for attempt in attempts] == [
+        "archive_monthly_ok",
+        "archive_daily_ok",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_real_v2_downloader_uses_ccxt_for_small_gap(tmp_path):
+    catalog = OhlcvCatalog(tmp_path / "ohlcvs" / "catalog.sqlite")
+    store = OhlcvStore(tmp_path / "ohlcvs", catalog)
+    manager = HLCVManager("binance", verbose=False, gap_tolerance_ohlcvs_minutes=0.0)
+    start_ts = month_start_ts(2024, 2) + 12 * 60 * 60_000
+    end_ts = start_ts + 2 * 60_000
+
+    try:
+        result = await _fetch_coin_range_into_v2_store(
+            om=manager,
+            catalog=catalog,
+            store=store,
+            exchange="binance",
+            coin="BTC",
+            symbol="BTC/USDT:USDT",
+            start_ts=start_ts,
+            end_ts=end_ts,
+        )
+    finally:
+        await manager.aclose()
+        if manager.cc is not None:
+            await manager.cc.close()
+
+    assert result.ok and result.reason == "ok"
+    assert result.wrote_rows == 3
+    assert store.read_range(
+        "binance", "1m", "BTC/USDT:USDT", start_ts, end_ts
+    ).valid.all()
+    attempts = catalog.list_fetch_attempts(
+        "binance", "1m", "BTC/USDT:USDT", start_ts, end_ts
+    )
+    assert [attempt.outcome for attempt in attempts] == ["ok"]

--- a/tests/test_binance_ohlcv_v2_archive.py
+++ b/tests/test_binance_ohlcv_v2_archive.py
@@ -1,0 +1,324 @@
+from datetime import datetime, timezone
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from binance_ohlcv_archive import BinanceArchiveResult
+from hlcv_preparation import (
+    V2FetchResult,
+    _fetch_binance_archives_into_v2_store,
+    _fetch_coin_range_into_v2_store,
+)
+from ohlcv_catalog import OhlcvCatalog
+from ohlcv_store import OhlcvStore, month_start_ts
+
+
+SYMBOL = "BTC/USDT:USDT"
+EXCHANGE = "binance"
+MINUTE_MS = 60_000
+
+
+def ts(value: str) -> int:
+    return int(datetime.fromisoformat(value).replace(tzinfo=timezone.utc).timestamp() * 1000)
+
+
+def archive_frame(timestamps, *, close=100.0):
+    timestamps = np.asarray(timestamps, dtype=np.int64)
+    closes = np.full(len(timestamps), close, dtype=np.float64)
+    return pd.DataFrame(
+        {
+            "timestamp": timestamps,
+            "open": closes,
+            "high": closes + 1.0,
+            "low": closes - 1.0,
+            "close": closes,
+            "volume": np.full(len(timestamps), 10.0, dtype=np.float64),
+        }
+    )
+
+
+def write_rows(store, timestamps, *, close=50.0):
+    timestamps = np.asarray(timestamps, dtype=np.int64)
+    values = np.column_stack(
+        [
+            np.full(len(timestamps), close + 1.0, dtype=np.float32),
+            np.full(len(timestamps), close - 1.0, dtype=np.float32),
+            np.full(len(timestamps), close, dtype=np.float32),
+            np.full(len(timestamps), 5.0, dtype=np.float32),
+        ]
+    )
+    store.write_rows(EXCHANGE, "1m", SYMBOL, timestamps, values)
+
+
+class RecordingArchiveClient:
+    def __init__(self, result_factory):
+        self.result_factory = result_factory
+        self.batches = []
+
+    async def fetch_many(self, requests):
+        self.batches.append(list(requests))
+        return [self.result_factory(request) for request in requests]
+
+
+class ArchiveManager:
+    gap_tolerance_ohlcvs_minutes = 0.0
+
+    def __init__(self, client):
+        self.client = client
+
+    def get_binance_archive_client(self):
+        return self.client
+
+    def update_timestamp_range(self, start_ts, end_ts):
+        self.start_ts = int(start_ts)
+        self.end_ts = int(end_ts)
+
+
+def make_store(tmp_path):
+    catalog = OhlcvCatalog(tmp_path / "ohlcvs" / "catalog.sqlite")
+    return catalog, OhlcvStore(tmp_path / "ohlcvs", catalog)
+
+
+@pytest.mark.asyncio
+async def test_monthly_archive_wins_and_does_not_overwrite_valid_rows(tmp_path, monkeypatch):
+    catalog, store = make_store(tmp_path)
+    start = ts("2026-04-01")
+    end = ts("2026-04-09")
+    timestamps = np.arange(start, end + MINUTE_MS, MINUTE_MS, dtype=np.int64)
+    existing_ts = timestamps[123]
+    write_rows(store, [existing_ts], close=777.0)
+
+    def result_factory(request):
+        return BinanceArchiveResult(request, "ok", archive_frame(timestamps, close=100.0))
+
+    client = RecordingArchiveClient(result_factory)
+    manager = ArchiveManager(client)
+    monkeypatch.setattr("hlcv_preparation.utc_ms", lambda: ts("2026-07-16"))
+
+    before = store.read_range(EXCHANGE, "1m", SYMBOL, start, end)
+    written = await _fetch_binance_archives_into_v2_store(
+        om=manager,
+        catalog=catalog,
+        store=store,
+        exchange=EXCHANGE,
+        coin="BTC",
+        symbol=SYMBOL,
+        timestamps=before.timestamps,
+        valid=before.valid,
+    )
+
+    assert len(client.batches) == 1
+    assert [request.kind for request in client.batches[0]] == ["monthly"]
+    assert written == len(timestamps) - 1
+    after = store.read_range(EXCHANGE, "1m", SYMBOL, start, end)
+    assert after.valid.all()
+    assert after.values[123, 2] == pytest.approx(777.0)
+    attempts = catalog.list_fetch_attempts(EXCHANGE, "1m", SYMBOL, start, end)
+    assert [attempt.outcome for attempt in attempts] == ["archive_monthly_ok"]
+    assert "source=binance_monthly_archive" in attempts[0].note
+
+
+@pytest.mark.asyncio
+async def test_unavailable_monthly_falls_back_to_parallel_daily_archives(tmp_path, monkeypatch):
+    catalog, store = make_store(tmp_path)
+    start = ts("2026-04-01")
+    end = ts("2026-04-09T23:59:00")
+    timestamps = np.arange(start, end + MINUTE_MS, MINUTE_MS, dtype=np.int64)
+
+    def result_factory(request):
+        if request.kind == "monthly":
+            return BinanceArchiveResult(request, "not_found")
+        day_ts = np.arange(request.start_ts, request.end_ts + MINUTE_MS, MINUTE_MS)
+        return BinanceArchiveResult(request, "ok", archive_frame(day_ts))
+
+    client = RecordingArchiveClient(result_factory)
+    manager = ArchiveManager(client)
+    monkeypatch.setattr("hlcv_preparation.utc_ms", lambda: ts("2026-07-16"))
+    before = store.read_range(EXCHANGE, "1m", SYMBOL, start, end)
+
+    written = await _fetch_binance_archives_into_v2_store(
+        om=manager,
+        catalog=catalog,
+        store=store,
+        exchange=EXCHANGE,
+        coin="BTC",
+        symbol=SYMBOL,
+        timestamps=before.timestamps,
+        valid=before.valid,
+    )
+
+    assert [[request.kind for request in batch] for batch in client.batches] == [
+        ["monthly"],
+        ["daily"] * 9,
+    ]
+    assert written == len(timestamps)
+    assert store.read_range(EXCHANGE, "1m", SYMBOL, start, end).valid.all()
+
+
+@pytest.mark.asyncio
+async def test_successful_monthly_real_gap_goes_directly_to_ccxt(tmp_path, monkeypatch):
+    catalog, store = make_store(tmp_path)
+    start = ts("2026-04-01")
+    end = ts("2026-04-09")
+    timestamps = np.arange(start, end + MINUTE_MS, MINUTE_MS, dtype=np.int64)
+    gap_ts = timestamps[5000]
+
+    def result_factory(request):
+        archive_ts = timestamps[timestamps != gap_ts]
+        return BinanceArchiveResult(request, "ok", archive_frame(archive_ts))
+
+    class RepairManager(ArchiveManager):
+        def __init__(self, client):
+            super().__init__(client)
+            self.ccxt_ranges = []
+
+        async def fetch_ohlcvs_for_v2_store(self, coin, *, start_ts, end_ts):
+            self.ccxt_ranges.append((start_ts, end_ts))
+            requested = np.arange(start_ts, end_ts + MINUTE_MS, MINUTE_MS)
+            return archive_frame(requested)
+
+    client = RecordingArchiveClient(result_factory)
+    manager = RepairManager(client)
+    monkeypatch.setattr("hlcv_preparation.utc_ms", lambda: ts("2026-07-16"))
+
+    result = await _fetch_coin_range_into_v2_store(
+        om=manager,
+        catalog=catalog,
+        store=store,
+        exchange=EXCHANGE,
+        coin="BTC",
+        symbol=SYMBOL,
+        start_ts=start,
+        end_ts=end,
+    )
+
+    assert result.ok
+    assert store.read_range(EXCHANGE, "1m", SYMBOL, start, end).valid.all()
+    assert manager.ccxt_ranges == [(gap_ts, gap_ts)]
+    assert len(client.batches) == 1
+    assert client.batches[0][0].kind == "monthly"
+
+
+@pytest.mark.asyncio
+async def test_small_old_gap_and_recent_tail_skip_archives_and_use_ccxt(tmp_path, monkeypatch):
+    catalog, store = make_store(tmp_path)
+    monkeypatch.setattr("hlcv_preparation.utc_ms", lambda: ts("2026-07-16T12:00:00"))
+
+    class CcxtOnlyManager(ArchiveManager):
+        def __init__(self, client):
+            super().__init__(client)
+            self.ccxt_ranges = []
+
+        async def fetch_ohlcvs_for_v2_store(self, coin, *, start_ts, end_ts):
+            self.ccxt_ranges.append((start_ts, end_ts))
+            requested = np.arange(start_ts, end_ts + MINUTE_MS, MINUTE_MS)
+            return archive_frame(requested)
+
+    client = RecordingArchiveClient(lambda request: pytest.fail("archive must not be fetched"))
+    manager = CcxtOnlyManager(client)
+    ranges = [
+        (ts("2026-04-10"), ts("2026-04-10T00:09:00")),
+        (ts("2026-07-14"), ts("2026-07-16T12:00:00")),
+    ]
+    for start, end in ranges:
+        result = await _fetch_coin_range_into_v2_store(
+            om=manager,
+            catalog=catalog,
+            store=store,
+            exchange=EXCHANGE,
+            coin="BTC",
+            symbol=SYMBOL,
+            start_ts=start,
+            end_ts=end,
+        )
+        assert result.ok
+
+    assert client.batches == []
+    assert manager.ccxt_ranges == ranges
+
+
+@pytest.mark.asyncio
+async def test_daily_archives_are_written_once_per_month(tmp_path, monkeypatch):
+    catalog, store = make_store(tmp_path)
+    start = ts("2026-04-01")
+    end = ts("2026-04-02T23:59:00")
+    timestamps = np.arange(start, end + MINUTE_MS, MINUTE_MS, dtype=np.int64)
+
+    def result_factory(request):
+        requested = np.arange(request.start_ts, request.end_ts + MINUTE_MS, MINUTE_MS)
+        return BinanceArchiveResult(request, "ok", archive_frame(requested))
+
+    client = RecordingArchiveClient(result_factory)
+    manager = ArchiveManager(client)
+    monkeypatch.setattr("hlcv_preparation.utc_ms", lambda: ts("2026-07-16"))
+    original_write_rows = store.write_rows
+    calls = []
+
+    def recording_write_rows(*args, **kwargs):
+        calls.append(len(args[3]))
+        return original_write_rows(*args, **kwargs)
+
+    monkeypatch.setattr(store, "write_rows", recording_write_rows)
+    before = store.read_range(EXCHANGE, "1m", SYMBOL, start, end)
+    written = await _fetch_binance_archives_into_v2_store(
+        om=manager,
+        catalog=catalog,
+        store=store,
+        exchange=EXCHANGE,
+        coin="BTC",
+        symbol=SYMBOL,
+        timestamps=before.timestamps,
+        valid=before.valid,
+    )
+
+    assert written == 2880
+    assert calls == [2880]
+    assert len(client.batches) == 1
+    assert len(client.batches[0]) == 2
+
+
+@pytest.mark.asyncio
+async def test_archive_errors_are_logged_and_ccxt_repairs_range(tmp_path, monkeypatch):
+    catalog, store = make_store(tmp_path)
+    start = ts("2026-04-01")
+    end = ts("2026-04-09")
+
+    def result_factory(request):
+        return BinanceArchiveResult(request, "error", error="checksum failed")
+
+    class RepairManager(ArchiveManager):
+        async def fetch_ohlcvs_for_v2_store(self, coin, *, start_ts, end_ts):
+            requested = np.arange(start_ts, end_ts + MINUTE_MS, MINUTE_MS)
+            return archive_frame(requested)
+
+    manager = RepairManager(RecordingArchiveClient(result_factory))
+    monkeypatch.setattr("hlcv_preparation.utc_ms", lambda: ts("2026-07-16"))
+
+    result = await _fetch_coin_range_into_v2_store(
+        om=manager,
+        catalog=catalog,
+        store=store,
+        exchange=EXCHANGE,
+        coin="BTC",
+        symbol=SYMBOL,
+        start_ts=start,
+        end_ts=end,
+    )
+
+    assert result == V2FetchResult(
+        True,
+        "ok",
+        wrote_rows=((end - start) // MINUTE_MS) + 1,
+        first_ts=start,
+        last_ts=end,
+        max_internal_missing_bars=0,
+    )
+    attempts = catalog.list_fetch_attempts(EXCHANGE, "1m", SYMBOL, start, end)
+    outcomes = [attempt.outcome for attempt in attempts]
+    assert "archive_monthly_error" in outcomes
+    assert "archive_daily_error" in outcomes
+    monthly_attempt = next(
+        attempt for attempt in attempts if attempt.outcome == "archive_monthly_error"
+    )
+    assert "checksum failed" in monthly_attempt.note


### PR DESCRIPTION
## Summary

- add a checksum-verified Binance Vision client for monthly and daily USD-M futures 1m archives
- make the current v2 downloader use monthly archives first, parallel daily archives second, and CCXT for recent, small, unavailable, or residual gaps
- preserve all existing valid v2 rows and batch archive writes once per month
- keep the legacy downloader path disabled and document the current behavior

## Selection policy

- monthly: more than 7 days (10,080 bars) missing in a closed month, after Binance's first-Monday publication window plus 24 hours
- daily: more than 1,000 bars missing on a UTC day, excluding today and the two preceding complete days
- CCXT: everything else, plus archive errors and gaps remaining in successful archive payloads

## Validation

- focused archive/v2 unit and integration tests: passed
- existing focused v2/HLCV suite: passed (2 expected skips)
- complete OHLCV/HLCV/candlestick regression selection: passed (expected environment/optional skips only)
- public unauthenticated network tests: monthly and daily Binance archives downloaded concurrently, SHA-256 sidecars verified, exact row counts parsed, v2 monthly/daily writes verified, and a small gap repaired via public CCXT
- shared-cache destructive smoke: backed up BTCUSDT January 2024, repaired a 44,640-row month via monthly archive, a 1,440-row day via daily archive, and a 3-row gap via CCXT; restored all original values, validity flags, and the original catalog checksum
- 2.6-million-row planner benchmark: about 0.07 seconds locally
