### PR TITLE
Report planning-snapshot smoke health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live smoke reports now expose bounded latest-per-bot planning-snapshot health
+  from existing `snapshot.built` events: required-surface and age coverage,
+  market-snapshot freshness and missing counts, availability status counts,
+  packet counts, and correlation IDs. Symbol lists, packet rows, raw references,
+  hashes, values, and embedded availability records remain query-only; smoke
+  verdicts, snapshot construction, exchange access, and trading behavior are
+  unchanged.
+
 - Live smoke reports now expose bounded latest-per-bot-and-kind health from
   existing `data_packet.updated` events: packet kinds, quality, freshness,
   source, revision, safe coverage counts, and warning/error counts. Raw packet

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -23,7 +23,7 @@ Estimated completion:
 ## Active Review Slice
 
 - Branch: `codex/smoke-planning-snapshot-health`, based on canonical
-  `0990d351c6302453cb39f55f991d5b0989a42c3b` after PR #1279.
+  `0990d351c690b5270d8c53f3c1ad5bf5d54650a5` after PR #1279.
 - PR: #1280, `Report planning-snapshot smoke health`; semantic implementation
   head `886d1311e6`. Slice: project existing `snapshot.built` events into
   bounded latest-per-bot planning-snapshot health.
@@ -50,7 +50,7 @@ Estimated completion:
 
 - VPS5's deployed logging baseline is
   `ccd1cc68956edd8c509fb2b86b759c801e3868b8`, PR #1278. Canonical `master`
-  has since advanced to `0990d351c6302453cb39f55f991d5b0989a42c3b`
+  has since advanced to `0990d351c690b5270d8c53f3c1ad5bf5d54650a5`
   through unrelated Binance archive PR #1279. The VPS5 tracked checkout is
   clean and expected untracked artifacts are preserved.
 - PR #1278 required no restart. Exact bot PIDs

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,8 +24,9 @@ Estimated completion:
 
 - Branch: `codex/smoke-planning-snapshot-health`, based on canonical
   `0990d351c6302453cb39f55f991d5b0989a42c3b` after PR #1279.
-- PR: pending. Slice: project existing `snapshot.built` events into bounded
-  latest-per-bot planning-snapshot health.
+- PR: #1280, `Report planning-snapshot smoke health`; semantic implementation
+  head `886d1311e6`. Slice: project existing `snapshot.built` events into
+  bounded latest-per-bot planning-snapshot health.
 - Triggering evidence: the focused post-PR #1278 five-minute inventory
   naturally contained 35 snapshot-build events while smoke reports exposed no
   required-surface, freshness, missing-market, availability, or packet-count

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,22 +22,23 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/smoke-data-packet-health`, based on canonical
-  `deee460a18f1f532a4c3a4c6e89a4befd5469d2a` after PR #1277.
-- PR: #1278, `Report data-packet smoke health`; semantic implementation head
-  `e940064301`. Slice: project existing `data_packet.updated` events into
-  bounded latest-per-bot-and-kind smoke health.
-- Triggering evidence: the focused post-PR #1277 five-minute inventory
-  naturally contained 87 packet-update events while smoke reports exposed no
-  packet quality, freshness, source, or coverage summary.
-- Scope: retain the latest packet observation per bot and packet kind, and
-  expose bounded kind, quality, freshness, source, revision, safe coverage,
-  and warning/error counts. Keep raw references, hashes, timestamps, values,
-  and warning/error text query-only.
+- Branch: `codex/smoke-planning-snapshot-health`, based on canonical
+  `0990d351c6302453cb39f55f991d5b0989a42c3b` after PR #1279.
+- PR: pending. Slice: project existing `snapshot.built` events into bounded
+  latest-per-bot planning-snapshot health.
+- Triggering evidence: the focused post-PR #1278 five-minute inventory
+  naturally contained 35 snapshot-build events while smoke reports exposed no
+  required-surface, freshness, missing-market, availability, or packet-count
+  summary.
+- Scope: retain the latest snapshot observation per bot and expose bounded
+  required-surface and age coverage, market-snapshot counts and freshness,
+  availability status counts, packet counts, and correlation IDs. Keep symbol
+  lists, packet rows, raw references, hashes, values, and embedded availability
+  records query-only.
 - Behavior boundary: read-only report projection only. No smoke verdict,
   attention classification, console output, event production, exchange access,
   packet production, readiness, configuration, or trading changes.
-- Validation: focused latest-per-kind/latest-revision/redaction regression, full
+- Validation: focused latest-per-bot/aggregate/redaction regression, full
   smoke-report tests, compilation, and docs checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
@@ -46,21 +47,24 @@ Estimated completion:
 
 ## Deployed Baseline
 
-- Canonical `master` and VPS5 are
-  `deee460a18f1f532a4c3a4c6e89a4befd5469d2a`, PR #1277. The tracked checkout
-  is clean and expected untracked artifacts are preserved.
-- PR #1277 required no restart. Exact bot PIDs
+- VPS5's deployed logging baseline is
+  `ccd1cc68956edd8c509fb2b86b759c801e3868b8`, PR #1278. Canonical `master`
+  has since advanced to `0990d351c6302453cb39f55f991d5b0989a42c3b`
+  through unrelated Binance archive PR #1279. The VPS5 tracked checkout is
+  clean and expected untracked artifacts are preserved.
+- PR #1278 required no restart. Exact bot PIDs
   `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
   `misc:0.0` PID `434835` remained unchanged. Immediate and settled bounded
   two-minute smokes were `ok=true` with zero hard/log/monitor/process failures,
-  `189/189` and `191/191` remote calls successful, and five exact/config-valid
-  live processes in final states `R=4,S=1`.
-- The immediate planning-output projection retained correlated latest pairs on
-  all five bots with zero order-count mismatches. The focused five-minute
-  report naturally projected 60 events as 30 Rust-return/action-planned pairs,
-  retained all five latest correlations, and found zero mismatches. The same
-  window contained 87 natural packet-update events, exposing the active
-  follow-up. No event or trading activity was manufactured.
+  `170/170` and `173/173` remote calls successful, `45/45` and `47/47`
+  account-critical calls successful, and `5/5` and `9/9` fill refreshes
+  successful. A transient immediate `D=1,R=1,S=3` sample settled to all five
+  exact/config-valid processes in state `R` with no uninterruptible sleep.
+- The focused five-minute data-packet report naturally projected 110 events
+  across all five bots as 15 latest packet observations, three packet kinds per
+  bot. All were fresh and quality `ok`, with zero latest warning/error packets.
+  The same natural inventory contained 35 `snapshot.built` events, exposing the
+  active follow-up. No event or trading activity was manufactured.
 - PR #1274 required no restart. Exact bot PIDs
   `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
   `misc:0.0` PID `434835` remained unchanged. The fresh two-minute smoke was
@@ -1054,10 +1058,12 @@ and PR #1272's planning-defer/absent-selector projection are merged and deployed
 without restart. PR #1273's forager eligibility projection, PR #1274's
 requested-window event inventory, and PR #1275's planning symbol-state health
 are also merged, deployed, and naturally validated. PR #1276's initial-entry
-eligibility health and PR #1277's correlated planning-output health are merged,
-deployed, and naturally validated. The active follow-up adds bounded
-latest-per-bot-and-kind data-packet health without copying raw packet metadata
-or changing verdicts/runtime behavior.
+eligibility health, PR #1277's correlated planning-output health, and PR
+#1278's latest-per-bot-and-kind data-packet health are merged, deployed, and
+naturally validated. The active follow-up adds bounded latest-per-bot
+planning-snapshot health without copying symbol lists, packet rows, raw packet
+metadata, or embedded availability records, and without changing verdicts or
+runtime behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -163,6 +163,8 @@ HSL_REPLAY_STALE_ACTIVE_EVENT_AGE_MS = 5 * 60 * 1000
 HSL_REPLAY_LONG_RUNNING_ACTIVE_MS = 10 * 60 * 1000
 EXCHANGE_CONFIG_REFRESH_HEALTH_GROUP_LIMIT = 20
 DATA_PACKET_HEALTH_GROUP_LIMIT = 20
+PLANNING_SNAPSHOT_HEALTH_GROUP_LIMIT = 20
+PLANNING_SNAPSHOT_VALUE_LIMIT = 8
 RISK_EVENT_TYPES = {
     EventTypes.RISK_MODE_CHANGED,
     EventTypes.HSL_TRANSITION,
@@ -3030,6 +3032,273 @@ def _summarize_data_packet_health(
         "latest_value_present_packets": latest_value_present_packets,
         "latest_value_missing_packets": latest_value_missing_packets,
         "groups_truncated": len(ordered) > DATA_PACKET_HEALTH_GROUP_LIMIT,
+        "groups": compact_groups,
+    }
+
+
+def _planning_snapshot_string_summary(value: Any) -> dict[str, Any]:
+    if not isinstance(value, list):
+        return {}
+    counts: Counter[str] = Counter()
+    for item in value:
+        if item is None:
+            continue
+        safe_item = _redact_log_text(str(item), max_len=80)
+        if safe_item:
+            counts[safe_item] += 1
+    count = sum(counts.values())
+    sample = [item for item, _ in counts.most_common(PLANNING_SNAPSHOT_VALUE_LIMIT)]
+    return (
+        {
+            "count": count,
+            "sample": sample,
+            "truncated": max(0, count - len(sample)),
+        }
+        if count
+        else {}
+    )
+
+
+def _planning_snapshot_surface_ages(value: Any) -> dict[str, Any]:
+    if not isinstance(value, list):
+        return {}
+    age_by_surface: dict[str, int] = {}
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        name = _data_packet_safe_text(item.get("name"))
+        age_ms = _non_negative_int(item.get("age_ms"))
+        if name is None or age_ms is None:
+            continue
+        age_by_surface[name] = max(int(age_ms), age_by_surface.get(name, 0))
+    bounded = sorted(
+        age_by_surface.items(),
+        key=lambda item: (-item[1], item[0]),
+    )[:PLANNING_SNAPSHOT_VALUE_LIMIT]
+    return (
+        {
+            "count": len(age_by_surface),
+            "max_age_ms": max(age_by_surface.values()),
+            "by_surface_max_age_ms": dict(bounded),
+            "truncated": max(0, len(age_by_surface) - len(bounded)),
+        }
+        if age_by_surface
+        else {}
+    )
+
+
+def _planning_snapshot_market_summary(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, Any] = {}
+    for key in (
+        "count",
+        "symbol_count",
+        "missing_count",
+        "max_age_ms",
+        "min_age_ms",
+        "mean_age_ms",
+        "configured_max_age_ms",
+    ):
+        parsed = _non_negative_int(value.get(key))
+        if parsed is not None:
+            out[key] = int(parsed)
+    sources = _planning_snapshot_string_summary(value.get("sources"))
+    if sources:
+        out["sources"] = sources
+    return out
+
+
+def _planning_snapshot_availability(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    out: dict[str, Any] = {}
+    record_count = _non_negative_int(value.get("record_count"))
+    if record_count is not None:
+        out["record_count"] = int(record_count)
+    status_counts = value.get("status_counts")
+    if isinstance(status_counts, dict):
+        safe_counts: Counter[str] = Counter()
+        for status, raw in status_counts.items():
+            parsed = _non_negative_int(raw)
+            safe_status = _data_packet_safe_text(status)
+            if parsed is not None and safe_status:
+                safe_counts[safe_status] += int(parsed)
+        if safe_counts:
+            out["status_counts"] = dict(
+                safe_counts.most_common(PLANNING_SNAPSHOT_VALUE_LIMIT)
+            )
+    return out
+
+
+def _planning_snapshot_health_group(
+    *,
+    bot_key: str,
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+    path: Path,
+    line_no: int,
+) -> dict[str, Any]:
+    payload = live_event.get("data")
+    payload = payload if isinstance(payload, dict) else {}
+    ids = _event_ids(live_event)
+    data_packets = payload.get("data_packets")
+    return {
+        "bot": bot_key,
+        "event_type": live_event.get("event_type") or row.get("kind"),
+        "count": 1,
+        "latest_ts": row.get("ts"),
+        "latest_seq": row.get("seq"),
+        "latest_path": str(path),
+        "latest_line": int(line_no),
+        "latest_ids": {
+            key: ids.get(key)
+            for key in ("cycle_id", "snapshot_id")
+            if ids.get(key) is not None
+        },
+        "latest_context": _data_packet_safe_text(payload.get("context"), max_len=120),
+        "latest_required_surfaces": _planning_snapshot_string_summary(
+            payload.get("required_surfaces")
+        ),
+        "latest_surface_ages": _planning_snapshot_surface_ages(
+            payload.get("surface_ages")
+        ),
+        "latest_market_snapshots": _planning_snapshot_market_summary(
+            payload.get("market_snapshot_summary")
+        ),
+        "latest_planning_availability": _planning_snapshot_availability(
+            payload.get("planning_availability")
+        ),
+        "latest_data_packet_count": (
+            len(data_packets) if isinstance(data_packets, list) else 0
+        ),
+    }
+
+
+def _merge_planning_snapshot_health_group(
+    groups: dict[str, dict[str, Any]],
+    group: dict[str, Any],
+) -> None:
+    key = str(group.get("bot") or "unknown")
+    existing = groups.get(key)
+    if existing is None:
+        groups[key] = group
+        return
+    existing["count"] = int(existing.get("count") or 0) + 1
+    current_key = _sort_event_position_key(
+        ts=group.get("latest_ts"),
+        seq=group.get("latest_seq"),
+        path=group.get("latest_path") or "",
+        line_no=int(group.get("latest_line") or 0),
+    )
+    existing_key = _sort_event_position_key(
+        ts=existing.get("latest_ts"),
+        seq=existing.get("latest_seq"),
+        path=existing.get("latest_path") or "",
+        line_no=int(existing.get("latest_line") or 0),
+    )
+    if current_key > existing_key:
+        count = existing["count"]
+        existing.update(group)
+        existing["count"] = count
+
+
+def _summarize_planning_snapshot_health(
+    groups: dict[str, dict[str, Any]],
+    event_type_counts: Counter[str],
+) -> dict[str, Any]:
+    ordered = sorted(
+        groups.values(),
+        key=lambda group: _sort_event_position_key(
+            ts=group.get("latest_ts"),
+            seq=group.get("latest_seq"),
+            path=group.get("latest_path") or "",
+            line_no=int(group.get("latest_line") or 0),
+        ),
+        reverse=True,
+    )
+    contexts: Counter[str] = Counter()
+    required_surfaces: Counter[str] = Counter()
+    market_sources: Counter[str] = Counter()
+    availability_statuses: Counter[str] = Counter()
+    required_surface_count_total = 0
+    market_snapshot_count_total = 0
+    market_symbol_count_total = 0
+    market_missing_count_total = 0
+    market_max_age_ms_max = 0
+    market_stale_bots = 0
+    planning_record_count_total = 0
+    data_packet_count_total = 0
+    for group in groups.values():
+        contexts[str(group.get("latest_context") or "unknown")] += 1
+        required = group.get("latest_required_surfaces")
+        required = required if isinstance(required, dict) else {}
+        required_surface_count_total += int(
+            _non_negative_int(required.get("count")) or 0
+        )
+        for surface in required.get("sample") or []:
+            required_surfaces[str(surface)] += 1
+        market = group.get("latest_market_snapshots")
+        market = market if isinstance(market, dict) else {}
+        market_snapshot_count_total += int(_non_negative_int(market.get("count")) or 0)
+        market_symbol_count_total += int(
+            _non_negative_int(market.get("symbol_count")) or 0
+        )
+        market_missing_count_total += int(
+            _non_negative_int(market.get("missing_count")) or 0
+        )
+        max_age_ms = int(_non_negative_int(market.get("max_age_ms")) or 0)
+        configured_max_age_ms = int(
+            _non_negative_int(market.get("configured_max_age_ms")) or 0
+        )
+        market_max_age_ms_max = max(market_max_age_ms_max, max_age_ms)
+        if configured_max_age_ms and max_age_ms > configured_max_age_ms:
+            market_stale_bots += 1
+        sources = market.get("sources")
+        sources = sources if isinstance(sources, dict) else {}
+        for source in sources.get("sample") or []:
+            market_sources[str(source)] += 1
+        availability = group.get("latest_planning_availability")
+        availability = availability if isinstance(availability, dict) else {}
+        planning_record_count_total += int(
+            _non_negative_int(availability.get("record_count")) or 0
+        )
+        status_counts = availability.get("status_counts")
+        if isinstance(status_counts, dict):
+            availability_statuses.update(status_counts)
+        data_packet_count_total += int(group.get("latest_data_packet_count") or 0)
+    compact_groups = [
+        {
+            key: value
+            for key, value in group.items()
+            if key not in {"latest_path", "latest_line", "latest_seq"}
+            and value not in (None, {}, [])
+        }
+        for group in ordered[:PLANNING_SNAPSHOT_HEALTH_GROUP_LIMIT]
+    ]
+    return {
+        "total": sum(int(group.get("count") or 0) for group in groups.values()),
+        "event_types": dict(event_type_counts.most_common()),
+        "bots": len(groups),
+        "latest_contexts": dict(contexts.most_common()),
+        "latest_required_surface_count_total": required_surface_count_total,
+        "latest_required_surfaces": dict(
+            required_surfaces.most_common(PLANNING_SNAPSHOT_VALUE_LIMIT)
+        ),
+        "latest_market_snapshot_count_total": market_snapshot_count_total,
+        "latest_market_symbol_count_total": market_symbol_count_total,
+        "latest_market_missing_count_total": market_missing_count_total,
+        "latest_market_max_age_ms_max": market_max_age_ms_max,
+        "latest_market_stale_bots": market_stale_bots,
+        "latest_market_sources": dict(
+            market_sources.most_common(PLANNING_SNAPSHOT_VALUE_LIMIT)
+        ),
+        "latest_planning_record_count_total": planning_record_count_total,
+        "latest_planning_status_counts": dict(
+            availability_statuses.most_common(PLANNING_SNAPSHOT_VALUE_LIMIT)
+        ),
+        "latest_data_packet_count_total": data_packet_count_total,
+        "groups_truncated": len(ordered) > PLANNING_SNAPSHOT_HEALTH_GROUP_LIMIT,
         "groups": compact_groups,
     }
 
@@ -7580,6 +7849,8 @@ def _scan_events(
     exchange_config_refresh_event_type_counts: Counter[str] = Counter()
     data_packet_health_groups: dict[tuple[str, str], dict[str, Any]] = {}
     data_packet_health_event_type_counts: Counter[str] = Counter()
+    planning_snapshot_health_groups: dict[str, dict[str, Any]] = {}
+    planning_snapshot_health_event_type_counts: Counter[str] = Counter()
     staged_readiness_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     staged_readiness_event_type_counts: Counter[str] = Counter()
     planning_output_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -7865,6 +8136,20 @@ def _scan_events(
                                 line_no=line_no,
                             ),
                         )
+                    if event_type == EventTypes.SNAPSHOT_BUILT:
+                        planning_snapshot_health_event_type_counts[
+                            str(event_type)
+                        ] += 1
+                        _merge_planning_snapshot_health_group(
+                            planning_snapshot_health_groups,
+                            _planning_snapshot_health_group(
+                                bot_key=bot_key,
+                                row=row,
+                                live_event=live_event,
+                                path=path,
+                                line_no=line_no,
+                            ),
+                        )
                     if _staged_readiness_event(live_event):
                         staged_readiness_event_type_counts[str(event_type)] += 1
                         _merge_staged_readiness_group(
@@ -8109,6 +8394,10 @@ def _scan_events(
         "data_packet_health": _summarize_data_packet_health(
             data_packet_health_groups,
             data_packet_health_event_type_counts,
+        ),
+        "planning_snapshot_health": _summarize_planning_snapshot_health(
+            planning_snapshot_health_groups,
+            planning_snapshot_health_event_type_counts,
         ),
         "staged_readiness_health": _summarize_staged_readiness_health(
             staged_readiness_groups,
@@ -8570,6 +8859,7 @@ def build_live_smoke_report(
             "exchange_config_refresh_health"
         ],
         "data_packet_health": event_scan["data_packet_health"],
+        "planning_snapshot_health": event_scan["planning_snapshot_health"],
         "staged_readiness_health": event_scan["staged_readiness_health"],
         "planning_output_health": event_scan["planning_output_health"],
         "event_pipeline_health": event_scan["event_pipeline_health"],
@@ -9193,6 +9483,11 @@ def summarize_live_smoke_report(
         if isinstance(report.get("data_packet_health"), dict)
         else {}
     )
+    planning_snapshot_health = (
+        report.get("planning_snapshot_health")
+        if isinstance(report.get("planning_snapshot_health"), dict)
+        else {}
+    )
     staged_readiness_health = (
         report.get("staged_readiness_health")
         if isinstance(report.get("staged_readiness_health"), dict)
@@ -9406,6 +9701,10 @@ def summarize_live_smoke_report(
         ),
         "data_packet_health": _summary_data_packet_health(
             data_packet_health,
+            limit=max_groups,
+        ),
+        "planning_snapshot_health": _summary_unfiltered_health_groups(
+            planning_snapshot_health,
             limit=max_groups,
         ),
         "staged_readiness_health": _summary_staged_readiness_health(
@@ -10128,6 +10427,11 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         if isinstance(report.get("data_packet_health"), dict)
         else {}
     )
+    planning_snapshot_health = (
+        report.get("planning_snapshot_health")
+        if isinstance(report.get("planning_snapshot_health"), dict)
+        else {}
+    )
     staged_readiness_health = (
         report.get("staged_readiness_health")
         if isinstance(report.get("staged_readiness_health"), dict)
@@ -10457,6 +10761,11 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             for key, value in data_packet_health.items()
             if key not in {"groups", "groups_truncated"}
         },
+        "planning_snapshots": {
+            key: value
+            for key, value in planning_snapshot_health.items()
+            if key not in {"groups", "groups_truncated"}
+        },
         "staged_readiness": staged_readiness_brief,
         "planning_output": {
             key: value
@@ -10722,6 +11031,7 @@ SMOKE_REPORT_SECTION_ALIASES: dict[str, tuple[str, ...]] = {
     "forager_features": ("forager_feature_health",),
     "hsl_replay": ("hsl_replay_health",),
     "planning_output": ("planning_output_health",),
+    "planning_snapshots": ("planning_snapshot_health",),
     "remote_calls": ("remote_call_health", "remote_call_timings"),
     "resources": ("resource_pressure",),
     "staged_readiness": ("staged_readiness_health",),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -4377,6 +4377,189 @@ def test_live_smoke_report_summarizes_latest_data_packets_without_raw_refs(tmp_p
     assert section["data_packet_health"] == health
 
 
+def test_live_smoke_report_summarizes_latest_planning_snapshots_without_raw_data(
+    tmp_path,
+):
+    binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        binance_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=1,
+                ts=1000,
+                ids={"cycle_id": "cy_old", "snapshot_id": "snap_old"},
+                data={
+                    "context": "normal_order_calculation",
+                    "symbols": ["OLD_SYMBOL_SHOULD_NOT_RENDER"],
+                    "required_surfaces": ["balance"],
+                    "market_snapshot_summary": {
+                        "count": 99,
+                        "symbol_count": 99,
+                        "missing_count": 99,
+                        "max_age_ms": 99999,
+                        "configured_max_age_ms": 1,
+                    },
+                    "planning_availability": {
+                        "record_count": 99,
+                        "status_counts": {"unavailable": 99},
+                    },
+                },
+            ),
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=2,
+                ts=2000,
+                ids={"cycle_id": "cy_new", "snapshot_id": "snap_new"},
+                data={
+                    "context": "normal_order_calculation",
+                    "symbols": ["RAW_SYMBOL_SHOULD_NOT_RENDER"],
+                    "required_surfaces": [
+                        "balance",
+                        "positions",
+                        "open_orders",
+                        "completed_candles",
+                    ],
+                    "surface_ages": [
+                        {"name": "balance", "age_ms": 10, "epoch": 10},
+                        {"name": "positions", "age_ms": 12, "epoch": 10},
+                        {"name": "open_orders", "age_ms": 14, "epoch": 10},
+                        {"name": "completed_candles", "age_ms": 20, "epoch": 10},
+                        {"name": None, "age_ms": 999999, "raw": "SHOULD_NOT_RENDER"},
+                    ],
+                    "market_snapshot_summary": {
+                        "count": 3,
+                        "symbol_count": 3,
+                        "missing_count": 0,
+                        "max_age_ms": 30,
+                        "min_age_ms": 10,
+                        "mean_age_ms": 20,
+                        "configured_max_age_ms": 5000,
+                        "sources": ["ticker", "mark"],
+                    },
+                    "data_packets": [
+                        {"raw_ref": "REF_SHOULD_NOT_RENDER"},
+                        {"raw_hash": "HASH_SHOULD_NOT_RENDER"},
+                        {"value": "VALUE_SHOULD_NOT_RENDER"},
+                    ],
+                    "planning_availability": {
+                        "cycle_id": 44,
+                        "snapshot_id": "PAYLOAD_ID_SHOULD_NOT_RENDER",
+                        "record_count": 6,
+                        "status_counts": {"available": 5, "unavailable": 1},
+                        "records": ["RECORD_SHOULD_NOT_RENDER"],
+                    },
+                },
+            ),
+        ],
+    )
+    _write_ndjson(
+        gateio_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="snapshot.built",
+                seq=1,
+                ts=1500,
+                exchange="gateio",
+                user="gateio_01",
+                ids={"cycle_id": "cy_gate", "snapshot_id": "snap_gate"},
+                data={
+                    "context": "protective_panic_order_calculation",
+                    "symbols": ["GATE_RAW_SHOULD_NOT_RENDER"],
+                    "required_surfaces": ["balance", "positions"],
+                    "surface_ages": [
+                        {"name": "balance", "age_ms": 6000},
+                        {"name": "positions", "age_ms": 100},
+                    ],
+                    "market_snapshot_summary": {
+                        "count": 1,
+                        "symbol_count": 3,
+                        "missing_count": 2,
+                        "max_age_ms": 7000,
+                        "configured_max_age_ms": 5000,
+                        "sources": ["ticker"],
+                    },
+                    "data_packets": [
+                        {"raw_ref": "GATE_REF_SHOULD_NOT_RENDER"},
+                        {"raw_hash": "GATE_HASH_SHOULD_NOT_RENDER"},
+                    ],
+                    "planning_availability": {
+                        "record_count": 2,
+                        "status_counts": {"unavailable": 2},
+                    },
+                },
+            )
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    summary = summarize_live_smoke_report(report)
+    brief = summarize_live_smoke_report_brief(report)
+    section = project_live_smoke_report_sections(report, ["planning_snapshots"])
+
+    health = report["planning_snapshot_health"]
+    assert health["total"] == 3
+    assert health["event_types"] == {"snapshot.built": 3}
+    assert health["bots"] == 2
+    assert health["latest_contexts"] == {
+        "normal_order_calculation": 1,
+        "protective_panic_order_calculation": 1,
+    }
+    assert health["latest_required_surface_count_total"] == 6
+    assert health["latest_required_surfaces"] == {
+        "balance": 2,
+        "positions": 2,
+        "completed_candles": 1,
+        "open_orders": 1,
+    }
+    assert health["latest_market_snapshot_count_total"] == 4
+    assert health["latest_market_symbol_count_total"] == 6
+    assert health["latest_market_missing_count_total"] == 2
+    assert health["latest_market_max_age_ms_max"] == 7000
+    assert health["latest_market_stale_bots"] == 1
+    assert health["latest_market_sources"] == {"ticker": 2, "mark": 1}
+    assert health["latest_planning_record_count_total"] == 8
+    assert health["latest_planning_status_counts"] == {
+        "available": 5,
+        "unavailable": 3,
+    }
+    assert health["latest_data_packet_count_total"] == 5
+    binance = next(
+        group for group in health["groups"] if group["bot"] == "binance/binance_01"
+    )
+    assert binance["count"] == 2
+    assert binance["latest_ids"] == {
+        "cycle_id": "cy_new",
+        "snapshot_id": "snap_new",
+    }
+    assert binance["latest_surface_ages"] == {
+        "count": 4,
+        "max_age_ms": 20,
+        "by_surface_max_age_ms": {
+            "completed_candles": 20,
+            "open_orders": 14,
+            "positions": 12,
+            "balance": 10,
+        },
+        "truncated": 0,
+    }
+    for projected in (
+        health,
+        summary["planning_snapshot_health"],
+        brief["planning_snapshots"],
+    ):
+        assert projected["latest_market_snapshot_count_total"] == 4
+        serialized = json.dumps(projected)
+        assert "SHOULD_NOT_RENDER" not in serialized
+        assert "raw_ref" not in serialized
+        assert "raw_hash" not in serialized
+        assert '"symbols"' not in serialized
+        assert '"records"' not in serialized
+        assert '"data_packets"' not in serialized
+    assert section["planning_snapshot_health"] == health
+
+
 def test_live_smoke_report_problem_events_include_state_refresh_progress(tmp_path):
     events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- project existing `snapshot.built` events into bounded latest-per-bot smoke health
- expose required-surface/age coverage, market freshness and missing counts, availability statuses, packet counts, and correlation IDs
- support full, summary, brief, and `planning_snapshots` section output

## Safety boundary
- report-only projection; smoke verdicts and attention classification are unchanged
- no event production, exchange access, packet/snapshot production, readiness, configuration, or trading changes
- symbol lists, packet rows, raw references/hashes/values, and embedded availability records stay query-only

## Validation
- `python -m pytest -q tests/test_live_smoke_report.py`
- `python -m pytest -q tests/test_live_incident_bundle.py tests/test_live_event_registry_docs.py tests/test_ai_docs.py`
- focused latest-per-bot/aggregate/redaction regression on rebased head
- `python -m py_compile src/live/smoke_report.py`
- `python src/tools/check_ai_docs.py` (0 errors; repository word-count warning only)
- `git diff --check`

## Deploy evidence from PR #1278
- VPS5 fast-forwarded to `ccd1cc6895` without restart; exact five bot PIDs, pane parents, and `misc:0.0` remained unchanged
- immediate and settled two-minute smokes were hard-green; settled remote `173/173`, account-critical `47/47`, fills `9/9`, all five exact processes in `R`
- focused five-minute packet report found 110 natural events and 15 latest observations, all fresh/ok with zero warning/error packets
- the same natural inventory contained 35 `snapshot.built` events, motivating this slice; no events were manufactured