### PR TITLE
Add trailing parameter inspector CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool trailing-inspect`, an offline one-shot explanation of effective
+  `trailing_martingale` entry and close thresholds, retracements, and analytical prices from a
+  config or explicit parameter overrides.
+
 - Live smoke reports now expose bounded latest-per-bot planning-snapshot health
   from existing `snapshot.built` events: required-surface and age coverage,
   market-snapshot freshness and missing counts, availability status counts,

--- a/docs/ai/features/trailing_diagnostics.md
+++ b/docs/ai/features/trailing_diagnostics.md
@@ -14,6 +14,10 @@
 3. The tool loads canonical config through the staged loader (`load_prepared_config(..., live_only=True, target="canonical")`). It does not instantiate a live `Passivbot`.
 4. Manual mode exists because historical snapshots or offline experiments may not have all required fields.
 5. The wizard asks for the core trailing inputs first and only prompts for the extra sizing/grid parameters when the user opts into advanced mode.
+6. `passivbot tool trailing-inspect` is the smaller one-shot parameter-intuition surface. It uses
+   canonical nested strategy parameters and mirrors the Rust formulas: entry distances are
+   multiplicative, close threshold terms are additive, and close retracement has no wallet-exposure
+   term.
 
 ## Validation
 
@@ -21,11 +25,15 @@
 2. entry/close diagnostics should match the existing monitor trailing slice
 3. command handling should mutate inputs deterministically and support dump/reset/help flows
 4. the tool wrapper should start with `--help` without import errors
+5. the one-shot inspector should cover additive close thresholds, separate entry multipliers,
+   long/short geometry, config extraction, overrides, and unified CLI dispatch
 
 ## Key Code
 
 - `src/trailing_diagnostics.py`
 - `src/trailing_diagnostics_tool.py`
 - `src/tools/trailing_diagnostics.py`
+- `src/tools/trailing_inspect.py`
 - `src/passivbot_monitor.py`
 - `tests/test_trailing_diagnostics.py`
+- `tests/test_trailing_inspect_tool.py`

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -109,6 +109,33 @@ passivbot tool iterative-backtester configs/examples/ema_anchor.json --auto-run 
 passivbot tool iterative-history-plot backtests/.../fills.csv
 ```
 
+## Trailing parameter inspector
+
+`passivbot tool trailing-inspect` explains the effective `trailing_martingale` entry and close
+thresholds for a hypothetical position. It is offline and read-only. It shows each wallet-exposure
+and volatility contribution, the threshold boundary, the retracement distance from the running
+extreme, the nominal confirmation price if the reversal starts exactly at the threshold, and the
+order-reference price used after both conditions pass.
+
+Without `--config`, the command uses the Rust-owned strategy defaults. With `--config`, it loads the
+selected side's canonical `bot.<side>.strategy.trailing_martingale` parameters. Individual flags
+override either source. Percent values use config ratios, so `0.01` means 1%.
+
+```shell
+passivbot tool trailing-inspect \
+  --symbol COIN --side long \
+  --position-size 150 --position-price 20 \
+  --wallet-exposure 0.6 --effective-wallet-exposure-limit 0.9 \
+  --volatility-ema-1m 0.007 --volatility-ema-1h 0.0033
+
+passivbot tool trailing-inspect \
+  --config configs/examples/default_trailing_martingale_long.json \
+  --side long --position-price 20 \
+  --wallet-exposure 0.6 --effective-wallet-exposure-limit 0.9 \
+  --volatility-ema-1m 0.007 --volatility-ema-1h 0.0033 \
+  --entry-threshold-base-pct 0.02 --json
+```
+
 ## Historical data helpers
 
 - `passivbot download` – Pre-warm the v2 OHLCV store using the same config/date/exchange selection as backtesting.

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -220,6 +220,10 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         requires_full=True,
     ),
     "streamline-json": CommandSpec("tools.streamline_json", "reformat config or result JSON"),
+    "trailing-inspect": CommandSpec(
+        "tools.trailing_inspect",
+        "explain trailing_martingale entry and close thresholds",
+    ),
     "ticker-probe": CommandSpec(
         "tools.probe_ticker_capabilities",
         "read-only exchange ticker capability probe",

--- a/src/tools/trailing_inspect.py
+++ b/src/tools/trailing_inspect.py
@@ -1,0 +1,608 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import textwrap
+from copy import deepcopy
+from typing import Any, Mapping, Sequence
+
+
+STRATEGY_KIND = "trailing_martingale"
+
+PARAMETER_FLAGS = {
+    "entry_threshold_base_pct": ("entry", "threshold_base_pct"),
+    "entry_threshold_we_weight": ("entry", "threshold_we_weight"),
+    "entry_threshold_volatility_1h_weight": (
+        "entry",
+        "threshold_volatility_1h_weight",
+    ),
+    "entry_threshold_volatility_1m_weight": (
+        "entry",
+        "threshold_volatility_1m_weight",
+    ),
+    "entry_retracement_base_pct": ("entry", "retracement_base_pct"),
+    "entry_retracement_we_weight": ("entry", "retracement_we_weight"),
+    "entry_retracement_volatility_1h_weight": (
+        "entry",
+        "retracement_volatility_1h_weight",
+    ),
+    "entry_retracement_volatility_1m_weight": (
+        "entry",
+        "retracement_volatility_1m_weight",
+    ),
+    "close_threshold_base_pct": ("close", "threshold_base_pct"),
+    "close_threshold_we_weight": ("close", "threshold_we_weight"),
+    "close_threshold_volatility_1h_weight": (
+        "close",
+        "threshold_volatility_1h_weight",
+    ),
+    "close_threshold_volatility_1m_weight": (
+        "close",
+        "threshold_volatility_1m_weight",
+    ),
+    "close_retracement_base_pct": ("close", "retracement_base_pct"),
+    "close_retracement_volatility_1h_weight": (
+        "close",
+        "retracement_volatility_1h_weight",
+    ),
+    "close_retracement_volatility_1m_weight": (
+        "close",
+        "retracement_volatility_1m_weight",
+    ),
+}
+
+
+def _finite_float(value: Any, label: str) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be a number") from exc
+    if not math.isfinite(number):
+        raise ValueError(f"{label} must be finite")
+    return number
+
+
+def _require_mapping(value: Any, path: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"missing or invalid {path}")
+    return value
+
+
+def _extract_strategy_params(config: Mapping[str, Any], pside: str) -> dict[str, Any]:
+    live = _require_mapping(config.get("live"), "live")
+    strategy_kind = str(live.get("strategy_kind") or STRATEGY_KIND).strip().lower()
+    if strategy_kind != STRATEGY_KIND:
+        raise ValueError(
+            f"config uses live.strategy_kind={strategy_kind!r}; this inspector supports "
+            f"only {STRATEGY_KIND!r}"
+        )
+    bot = _require_mapping(config.get("bot"), "bot")
+    side = _require_mapping(bot.get(pside), f"bot.{pside}")
+    strategies = _require_mapping(side.get("strategy"), f"bot.{pside}.strategy")
+    params = _require_mapping(
+        strategies.get(STRATEGY_KIND),
+        f"bot.{pside}.strategy.{STRATEGY_KIND}",
+    )
+    entry = _require_mapping(params.get("entry"), f"bot.{pside}.strategy.{STRATEGY_KIND}.entry")
+    close = _require_mapping(params.get("close"), f"bot.{pside}.strategy.{STRATEGY_KIND}.close")
+    return {"entry": deepcopy(dict(entry)), "close": deepcopy(dict(close))}
+
+
+def load_parameter_source(config_path: str | None, pside: str) -> tuple[dict[str, Any], str]:
+    if config_path:
+        from config import load_prepared_config
+
+        config = load_prepared_config(
+            config_path,
+            live_only=True,
+            verbose=False,
+            target="canonical",
+            log_info=False,
+        )
+        return _extract_strategy_params(config, pside), f"config {config_path} ({pside})"
+
+    from config.strategy_spec import get_strategy_defaults
+
+    defaults = get_strategy_defaults(STRATEGY_KIND)
+    return _extract_strategy_params(
+        {
+            "live": {"strategy_kind": STRATEGY_KIND},
+            "bot": {
+                pside: {
+                    "strategy": {STRATEGY_KIND: defaults[pside]},
+                }
+            },
+        },
+        pside,
+    ), f"Rust-owned {STRATEGY_KIND} defaults ({pside})"
+
+
+def apply_parameter_overrides(params: dict[str, Any], args: argparse.Namespace) -> list[str]:
+    changed: list[str] = []
+    for dest, (section, name) in PARAMETER_FLAGS.items():
+        value = getattr(args, dest, None)
+        if value is None:
+            continue
+        params[section][name] = _finite_float(value, dest)
+        changed.append(f"{section}.{name}")
+    return changed
+
+
+def _dynamic_multiplier(
+    *,
+    volatility_ema_1m: float,
+    volatility_ema_1h: float,
+    weight_volatility_1m: float,
+    weight_volatility_1h: float,
+    wallet_exposure_ratio: float | None,
+    weight_wallet_exposure: float,
+) -> dict[str, float]:
+    volatility_1h_term = volatility_ema_1h * weight_volatility_1h
+    volatility_1m_term = volatility_ema_1m * weight_volatility_1m
+    wallet_exposure_term = (wallet_exposure_ratio or 0.0) * weight_wallet_exposure
+    raw = 1.0 + volatility_1h_term + volatility_1m_term + wallet_exposure_term
+    return {
+        "base": 1.0,
+        "volatility_1h_term": volatility_1h_term,
+        "volatility_1m_term": volatility_1m_term,
+        "wallet_exposure_term": wallet_exposure_term,
+        "raw": raw,
+        "effective": max(1.0, raw),
+    }
+
+
+def _geometry(
+    *,
+    kind: str,
+    pside: str,
+    position_price: float,
+    threshold_pct: float,
+    retracement_pct: float,
+) -> dict[str, Any]:
+    threshold_direction = -1.0 if (kind, pside) in {("entry", "long"), ("close", "short")} else 1.0
+    retracement_direction = -threshold_direction
+    threshold_gate_active = threshold_pct > 0.0
+    threshold_price = (
+        position_price * (1.0 + threshold_direction * threshold_pct)
+        if threshold_gate_active
+        else None
+    )
+    nominal_confirmation_price = (
+        threshold_price * (1.0 + retracement_direction * retracement_pct)
+        if threshold_price is not None and retracement_pct > 0.0
+        else None
+    )
+    order_reference_price = (
+        position_price
+        * (1.0 + threshold_direction * threshold_pct + retracement_direction * retracement_pct)
+        if threshold_gate_active and retracement_pct > 0.0
+        else None
+    )
+    return {
+        "threshold_gate_active": threshold_gate_active,
+        "threshold_direction": "below" if threshold_direction < 0.0 else "above",
+        "threshold_price": threshold_price,
+        "retracement_direction": "above" if retracement_direction > 0.0 else "below",
+        "nominal_confirmation_price": nominal_confirmation_price,
+        "nominal_confirmation_pct_from_position": (
+            nominal_confirmation_price / position_price - 1.0
+            if nominal_confirmation_price is not None
+            else None
+        ),
+        "order_reference_price": order_reference_price,
+        "order_reference_pct_from_position": (
+            order_reference_price / position_price - 1.0
+            if order_reference_price is not None
+            else None
+        ),
+    }
+
+
+def inspect_trailing(
+    *,
+    symbol: str,
+    pside: str,
+    position_price: float,
+    position_size: float | None,
+    wallet_exposure: float,
+    effective_wallet_exposure_limit: float,
+    volatility_ema_1m: float,
+    volatility_ema_1h: float,
+    params: Mapping[str, Any],
+    parameter_source: str,
+    overridden_parameters: Sequence[str] = (),
+) -> dict[str, Any]:
+    if pside not in {"long", "short"}:
+        raise ValueError("pside must be 'long' or 'short'")
+    position_price = _finite_float(position_price, "position_price")
+    if position_size is not None:
+        position_size = _finite_float(position_size, "position_size")
+    wallet_exposure = _finite_float(wallet_exposure, "wallet_exposure")
+    effective_wallet_exposure_limit = _finite_float(
+        effective_wallet_exposure_limit,
+        "effective_wallet_exposure_limit",
+    )
+    volatility_ema_1m = _finite_float(volatility_ema_1m, "volatility_ema_1m")
+    volatility_ema_1h = _finite_float(volatility_ema_1h, "volatility_ema_1h")
+    if position_price <= 0.0:
+        raise ValueError("position_price must be greater than zero")
+    if wallet_exposure < 0.0:
+        raise ValueError("wallet_exposure must not be negative")
+    if effective_wallet_exposure_limit <= 0.0:
+        raise ValueError("effective_wallet_exposure_limit must be greater than zero")
+    if volatility_ema_1m < 0.0 or volatility_ema_1h < 0.0:
+        raise ValueError("volatility EMAs must not be negative")
+
+    entry = _require_mapping(params.get("entry"), "params.entry")
+    close = _require_mapping(params.get("close"), "params.close")
+    wallet_exposure_ratio = wallet_exposure / effective_wallet_exposure_limit
+
+    entry_threshold_multiplier = _dynamic_multiplier(
+        volatility_ema_1m=volatility_ema_1m,
+        volatility_ema_1h=volatility_ema_1h,
+        weight_volatility_1m=_finite_float(
+            entry.get("threshold_volatility_1m_weight", 0.0),
+            "entry.threshold_volatility_1m_weight",
+        ),
+        weight_volatility_1h=_finite_float(
+            entry.get("threshold_volatility_1h_weight", 0.0),
+            "entry.threshold_volatility_1h_weight",
+        ),
+        wallet_exposure_ratio=wallet_exposure_ratio,
+        weight_wallet_exposure=_finite_float(
+            entry.get("threshold_we_weight", 0.0),
+            "entry.threshold_we_weight",
+        ),
+    )
+    entry_retracement_multiplier = _dynamic_multiplier(
+        volatility_ema_1m=volatility_ema_1m,
+        volatility_ema_1h=volatility_ema_1h,
+        weight_volatility_1m=_finite_float(
+            entry.get("retracement_volatility_1m_weight", 0.0),
+            "entry.retracement_volatility_1m_weight",
+        ),
+        weight_volatility_1h=_finite_float(
+            entry.get("retracement_volatility_1h_weight", 0.0),
+            "entry.retracement_volatility_1h_weight",
+        ),
+        wallet_exposure_ratio=wallet_exposure_ratio,
+        weight_wallet_exposure=_finite_float(
+            entry.get("retracement_we_weight", 0.0),
+            "entry.retracement_we_weight",
+        ),
+    )
+    entry_threshold_base = max(
+        0.0,
+        _finite_float(entry.get("threshold_base_pct", 0.0), "entry.threshold_base_pct"),
+    )
+    entry_retracement_base = _finite_float(
+        entry.get("retracement_base_pct", 0.0),
+        "entry.retracement_base_pct",
+    )
+    entry_threshold_pct = entry_threshold_base * entry_threshold_multiplier["effective"]
+    entry_retracement_pct = max(0.0, entry_retracement_base) * entry_retracement_multiplier[
+        "effective"
+    ]
+
+    close_threshold_base = _finite_float(
+        close.get("threshold_base_pct", 0.0),
+        "close.threshold_base_pct",
+    )
+    close_threshold_terms = {
+        "base": close_threshold_base,
+        "wallet_exposure_term": wallet_exposure_ratio
+        * _finite_float(close.get("threshold_we_weight", 0.0), "close.threshold_we_weight"),
+        "volatility_1h_term": volatility_ema_1h
+        * _finite_float(
+            close.get("threshold_volatility_1h_weight", 0.0),
+            "close.threshold_volatility_1h_weight",
+        ),
+        "volatility_1m_term": volatility_ema_1m
+        * _finite_float(
+            close.get("threshold_volatility_1m_weight", 0.0),
+            "close.threshold_volatility_1m_weight",
+        ),
+    }
+    close_threshold_pct = sum(close_threshold_terms.values())
+    close_retracement_multiplier = _dynamic_multiplier(
+        volatility_ema_1m=volatility_ema_1m,
+        volatility_ema_1h=volatility_ema_1h,
+        weight_volatility_1m=_finite_float(
+            close.get("retracement_volatility_1m_weight", 0.0),
+            "close.retracement_volatility_1m_weight",
+        ),
+        weight_volatility_1h=_finite_float(
+            close.get("retracement_volatility_1h_weight", 0.0),
+            "close.retracement_volatility_1h_weight",
+        ),
+        wallet_exposure_ratio=None,
+        weight_wallet_exposure=0.0,
+    )
+    close_retracement_base = _finite_float(
+        close.get("retracement_base_pct", 0.0),
+        "close.retracement_base_pct",
+    )
+    close_retracement_pct = max(0.0, close_retracement_base) * close_retracement_multiplier[
+        "effective"
+    ]
+
+    return {
+        "symbol": symbol,
+        "pside": pside,
+        "position": {"size": position_size, "price": position_price},
+        "wallet_exposure": wallet_exposure,
+        "effective_wallet_exposure_limit": effective_wallet_exposure_limit,
+        "wallet_exposure_ratio": wallet_exposure_ratio,
+        "volatility_ema_1m": volatility_ema_1m,
+        "volatility_ema_1h": volatility_ema_1h,
+        "parameter_source": parameter_source,
+        "overridden_parameters": list(overridden_parameters),
+        "entry": {
+            "trailing_enabled": entry_retracement_base > 0.0,
+            "threshold_base_pct": entry_threshold_base,
+            "threshold_multiplier": entry_threshold_multiplier,
+            "threshold_pct": entry_threshold_pct,
+            "retracement_base_pct": max(0.0, entry_retracement_base),
+            "retracement_multiplier": entry_retracement_multiplier,
+            "retracement_pct": entry_retracement_pct,
+            "geometry": _geometry(
+                kind="entry",
+                pside=pside,
+                position_price=position_price,
+                threshold_pct=entry_threshold_pct,
+                retracement_pct=entry_retracement_pct,
+            ),
+        },
+        "close": {
+            "trailing_enabled": close_retracement_base > 0.0,
+            "threshold_terms": close_threshold_terms,
+            "threshold_pct": close_threshold_pct,
+            "retracement_base_pct": max(0.0, close_retracement_base),
+            "retracement_multiplier": close_retracement_multiplier,
+            "retracement_pct": close_retracement_pct,
+            "geometry": _geometry(
+                kind="close",
+                pside=pside,
+                position_price=position_price,
+                threshold_pct=close_threshold_pct,
+                retracement_pct=close_retracement_pct,
+            ),
+        },
+    }
+
+
+def _fmt_number(value: float | None) -> str:
+    if value is None:
+        return "-"
+    return f"{value:.10g}"
+
+
+def _fmt_pct(value: float, *, signed: bool = False) -> str:
+    sign = "+" if signed else ""
+    return f"{value * 100.0:{sign}.4f}%"
+
+
+def _format_multiplier(label: str, multiplier: Mapping[str, float]) -> list[str]:
+    named_terms = [
+        ("1h", multiplier["volatility_1h_term"]),
+        ("1m", multiplier["volatility_1m_term"]),
+    ]
+    if multiplier["wallet_exposure_term"] != 0.0:
+        named_terms.append(("WE", multiplier["wallet_exposure_term"]))
+    expression = "1"
+    for term_label, value in named_terms:
+        operator = "+" if value >= 0.0 else "-"
+        expression += f" {operator} {_fmt_pct(abs(value))} [{term_label}]"
+    return [
+        f"  {label} multiplier: {multiplier['effective']:.6f} "
+        f"(max(1, {expression}))"
+    ]
+
+
+def _format_geometry(kind: str, payload: Mapping[str, Any]) -> list[str]:
+    geometry = payload["geometry"]
+    lines: list[str] = []
+    if not payload["trailing_enabled"]:
+        lines.append("  Mode: trailing disabled (retracement_base_pct <= 0); passive recursive orders")
+        if geometry["threshold_gate_active"]:
+            lines.append(
+                f"  Passive threshold/reference: {_fmt_pct(payload['threshold_pct'])} "
+                f"{geometry['threshold_direction']} position price -> "
+                f"{_fmt_number(geometry['threshold_price'])}"
+            )
+        else:
+            lines.append("  Effective threshold <= 0; passive reference is at the current market touch")
+    elif geometry["threshold_gate_active"]:
+        lines.append(
+            f"  Threshold: {_fmt_pct(payload['threshold_pct'])} {geometry['threshold_direction']} "
+            f"position price -> {_fmt_number(geometry['threshold_price'])}"
+        )
+        lines.append(
+            f"  Retracement: {_fmt_pct(payload['retracement_pct'])} "
+            f"{geometry['retracement_direction']} the running extreme"
+        )
+        lines.append(
+            "  If reversal starts exactly at the threshold: confirmation -> "
+            f"{_fmt_number(geometry['nominal_confirmation_price'])} "
+            f"({_fmt_pct(geometry['nominal_confirmation_pct_from_position'], signed=True)} vs position)"
+        )
+        lines.append(
+            "  Emitted-order reference after both conditions: "
+            f"{_fmt_number(geometry['order_reference_price'])} "
+            f"({_fmt_pct(geometry['order_reference_pct_from_position'], signed=True)} vs position)"
+        )
+    else:
+        lines.append(
+            f"  Threshold: {_fmt_pct(payload['threshold_pct'], signed=True)}; gate is active immediately"
+        )
+        lines.append(
+            f"  Retracement: {_fmt_pct(payload['retracement_pct'])} "
+            f"{geometry['retracement_direction']} the running extreme; no fixed target price"
+        )
+    if payload["trailing_enabled"]:
+        lines.append("  Actual confirmation follows the running low/high, not a permanently fixed threshold target.")
+    return lines
+
+
+def render_report(result: Mapping[str, Any]) -> str:
+    position = result["position"]
+    size_text = f"{_fmt_number(position['size'])} @ " if position["size"] is not None else ""
+    lines = [
+        f"Trailing inspection: {result['symbol']} {result['pside']}",
+        f"Position: {size_text}{_fmt_number(position['price'])}",
+        (
+            f"Wallet exposure: {_fmt_pct(result['wallet_exposure'])} / effective limit "
+            f"{_fmt_pct(result['effective_wallet_exposure_limit'])} "
+            f"(ratio {_fmt_pct(result['wallet_exposure_ratio'])})"
+        ),
+        (
+            f"Volatility EMA: 1m {_fmt_pct(result['volatility_ema_1m'])}, "
+            f"1h {_fmt_pct(result['volatility_ema_1h'])}"
+        ),
+        f"Parameters: {result['parameter_source']}",
+    ]
+    if result["overridden_parameters"]:
+        lines.extend(
+            textwrap.wrap(
+                ", ".join(result["overridden_parameters"]),
+                width=100,
+                initial_indent="Overrides: ",
+                subsequent_indent="           ",
+            )
+        )
+
+    entry = result["entry"]
+    lines.extend(["", "ENTRY"])
+    lines.extend(_format_multiplier("Threshold", entry["threshold_multiplier"]))
+    lines.append(
+        f"  Effective threshold: {_fmt_pct(entry['threshold_base_pct'])} × "
+        f"{entry['threshold_multiplier']['effective']:.6f} = {_fmt_pct(entry['threshold_pct'])}"
+    )
+    lines.extend(_format_multiplier("Retracement", entry["retracement_multiplier"]))
+    lines.append(
+        f"  Effective retracement: {_fmt_pct(entry['retracement_base_pct'])} × "
+        f"{entry['retracement_multiplier']['effective']:.6f} = {_fmt_pct(entry['retracement_pct'])}"
+    )
+    lines.extend(_format_geometry("entry", entry))
+
+    close = result["close"]
+    close_terms = close["threshold_terms"]
+    lines.extend(["", "CLOSE"])
+    lines.append(
+        "  Threshold (additive): "
+        f"base {_fmt_pct(close_terms['base'], signed=True)} "
+        f"+ WE {_fmt_pct(close_terms['wallet_exposure_term'], signed=True)} "
+        f"+ 1h {_fmt_pct(close_terms['volatility_1h_term'], signed=True)} "
+        f"+ 1m {_fmt_pct(close_terms['volatility_1m_term'], signed=True)} "
+        f"= {_fmt_pct(close['threshold_pct'], signed=True)}"
+    )
+    lines.extend(_format_multiplier("Retracement", close["retracement_multiplier"]))
+    lines.append(
+        f"  Effective retracement: {_fmt_pct(close['retracement_base_pct'])} × "
+        f"{close['retracement_multiplier']['effective']:.6f} = {_fmt_pct(close['retracement_pct'])}"
+    )
+    lines.extend(_format_geometry("close", close))
+    lines.extend(
+        [
+            "",
+            "Percent inputs use config ratios: 0.01 = 1%.",
+            "Prices are analytical trigger/reference prices before tick rounding, bid/ask limits, or EMA gating.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="passivbot tool trailing-inspect",
+        description=(
+            "Inspect trailing_martingale entry and close thresholds without starting a bot. "
+            "Percent inputs use config ratios (0.01 = 1%)."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        epilog=(
+            "Example:\n"
+            "  passivbot tool trailing-inspect --symbol COIN --side long "
+            "--position-size 150 --position-price 20 --wallet-exposure 0.6 "
+            "--effective-wallet-exposure-limit 0.9 --volatility-ema-1m 0.007 "
+            "--volatility-ema-1h 0.0033\n\n"
+            "Add --config path/to/config.json to use that side's active strategy parameters. "
+            "Any parameter flag below overrides the config/default value."
+        ),
+    )
+    state = parser.add_argument_group("position and market state")
+    state.add_argument("--symbol", default="COIN", help="Display label only")
+    state.add_argument("--side", choices=("long", "short"), default="long")
+    state.add_argument("--position-size", type=float, default=None, help="Display-only position size")
+    state.add_argument("--position-price", type=float, required=True)
+    state.add_argument("--wallet-exposure", type=float, required=True, help="Current WE ratio")
+    state.add_argument(
+        "--effective-wallet-exposure-limit",
+        type=float,
+        required=True,
+        help="Effective per-position WEL used by the strategy",
+    )
+    state.add_argument("--volatility-ema-1m", type=float, default=0.0)
+    state.add_argument("--volatility-ema-1h", type=float, default=0.0)
+    state.add_argument(
+        "--config",
+        default=None,
+        help="Canonical config source; otherwise Rust-owned defaults are used",
+    )
+    state.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+
+    entry_threshold = parser.add_argument_group("entry threshold overrides")
+    entry_threshold.add_argument("--entry-threshold-base-pct", type=float)
+    entry_threshold.add_argument("--entry-threshold-we-weight", type=float)
+    entry_threshold.add_argument("--entry-threshold-volatility-1h-weight", type=float)
+    entry_threshold.add_argument("--entry-threshold-volatility-1m-weight", type=float)
+    entry_retracement = parser.add_argument_group("entry retracement overrides")
+    entry_retracement.add_argument("--entry-retracement-base-pct", type=float)
+    entry_retracement.add_argument("--entry-retracement-we-weight", type=float)
+    entry_retracement.add_argument("--entry-retracement-volatility-1h-weight", type=float)
+    entry_retracement.add_argument("--entry-retracement-volatility-1m-weight", type=float)
+    close_threshold = parser.add_argument_group("close threshold overrides")
+    close_threshold.add_argument("--close-threshold-base-pct", type=float)
+    close_threshold.add_argument("--close-threshold-we-weight", type=float)
+    close_threshold.add_argument("--close-threshold-volatility-1h-weight", type=float)
+    close_threshold.add_argument("--close-threshold-volatility-1m-weight", type=float)
+    close_retracement = parser.add_argument_group("close retracement overrides")
+    close_retracement.add_argument("--close-retracement-base-pct", type=float)
+    close_retracement.add_argument("--close-retracement-volatility-1h-weight", type=float)
+    close_retracement.add_argument("--close-retracement-volatility-1m-weight", type=float)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        params, source = load_parameter_source(args.config, args.side)
+        overridden = apply_parameter_overrides(params, args)
+        result = inspect_trailing(
+            symbol=args.symbol,
+            pside=args.side,
+            position_price=args.position_price,
+            position_size=args.position_size,
+            wallet_exposure=args.wallet_exposure,
+            effective_wallet_exposure_limit=args.effective_wallet_exposure_limit,
+            volatility_ema_1m=args.volatility_ema_1m,
+            volatility_ema_1h=args.volatility_ema_1h,
+            params=params,
+            parameter_source=source,
+            overridden_parameters=overridden,
+        )
+    except (FileNotFoundError, KeyError, RuntimeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(render_report(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_passivbot_cli.py
+++ b/tests/test_passivbot_cli.py
@@ -156,8 +156,29 @@ def test_tool_help_lists_supported_tools(capsys):
     assert "pareto-dash" in out
     assert "pareto-explorer" in out
     assert "streamline-json" in out
+    assert "trailing-inspect" in out
     assert "verify-hlcvs-data" in out
     assert "requires full install" in out
+
+
+def test_trailing_inspect_tool_dispatch_forwards_module_and_prog(monkeypatch):
+    captured = {}
+
+    def fake_invoke_module_main(module_name):
+        captured["module_name"] = module_name
+        captured["argv"] = sys.argv[:]
+        return True, 0
+
+    monkeypatch.setattr(cli_main, "_invoke_module_main", fake_invoke_module_main)
+
+    assert cli_main.main(["tool", "trailing-inspect", "--position-price", "20"]) == 0
+
+    assert captured["module_name"] == "tools.trailing_inspect"
+    assert captured["argv"] == [
+        "passivbot tool trailing-inspect",
+        "--position-price",
+        "20",
+    ]
 
 
 def test_console_main_reexecs_into_active_virtualenv(monkeypatch, tmp_path):

--- a/tests/test_trailing_inspect_tool.py
+++ b/tests/test_trailing_inspect_tool.py
@@ -1,0 +1,196 @@
+import json
+
+import pytest
+
+from tools import trailing_inspect
+
+
+def _params():
+    return {
+        "entry": {
+            "threshold_base_pct": 0.02,
+            "threshold_we_weight": 0.5,
+            "threshold_volatility_1h_weight": 2.0,
+            "threshold_volatility_1m_weight": 10.0,
+            "retracement_base_pct": 0.005,
+            "retracement_we_weight": 0.1,
+            "retracement_volatility_1h_weight": 1.0,
+            "retracement_volatility_1m_weight": 3.0,
+        },
+        "close": {
+            "threshold_base_pct": 0.01,
+            "threshold_we_weight": -0.02,
+            "threshold_volatility_1h_weight": 1.0,
+            "threshold_volatility_1m_weight": 2.0,
+            "retracement_base_pct": 0.004,
+            "retracement_volatility_1h_weight": 4.0,
+            "retracement_volatility_1m_weight": 5.0,
+        },
+    }
+
+
+def _inspect(pside="long"):
+    return trailing_inspect.inspect_trailing(
+        symbol="COIN",
+        pside=pside,
+        position_size=150.0,
+        position_price=20.0,
+        wallet_exposure=0.6,
+        effective_wallet_exposure_limit=0.9,
+        volatility_ema_1m=0.007,
+        volatility_ema_1h=0.0033,
+        params=_params(),
+        parameter_source="test",
+    )
+
+
+def test_inspect_trailing_matches_current_entry_and_close_formulas():
+    result = _inspect()
+
+    we_ratio = 0.6 / 0.9
+    entry_threshold_multiplier = 1.0 + 0.0033 * 2.0 + 0.007 * 10.0 + we_ratio * 0.5
+    entry_retracement_multiplier = 1.0 + 0.0033 * 1.0 + 0.007 * 3.0 + we_ratio * 0.1
+    close_threshold = 0.01 + we_ratio * -0.02 + 0.0033 * 1.0 + 0.007 * 2.0
+    close_retracement_multiplier = 1.0 + 0.0033 * 4.0 + 0.007 * 5.0
+
+    assert result["wallet_exposure_ratio"] == pytest.approx(we_ratio)
+    assert result["entry"]["threshold_multiplier"]["effective"] == pytest.approx(
+        entry_threshold_multiplier
+    )
+    assert result["entry"]["threshold_pct"] == pytest.approx(
+        0.02 * entry_threshold_multiplier
+    )
+    assert result["entry"]["retracement_pct"] == pytest.approx(
+        0.005 * entry_retracement_multiplier
+    )
+    assert result["close"]["threshold_pct"] == pytest.approx(close_threshold)
+    assert result["close"]["retracement_pct"] == pytest.approx(
+        0.004 * close_retracement_multiplier
+    )
+
+
+def test_long_geometry_distinguishes_confirmation_from_order_reference():
+    result = _inspect()
+    entry = result["entry"]
+    threshold = entry["threshold_pct"]
+    retracement = entry["retracement_pct"]
+    threshold_price = 20.0 * (1.0 - threshold)
+
+    assert entry["geometry"]["threshold_direction"] == "below"
+    assert entry["geometry"]["retracement_direction"] == "above"
+    assert entry["geometry"]["threshold_price"] == pytest.approx(threshold_price)
+    assert entry["geometry"]["nominal_confirmation_price"] == pytest.approx(
+        threshold_price * (1.0 + retracement)
+    )
+    assert entry["geometry"]["order_reference_price"] == pytest.approx(
+        20.0 * (1.0 - threshold + retracement)
+    )
+    assert entry["geometry"]["nominal_confirmation_price"] != pytest.approx(
+        entry["geometry"]["order_reference_price"]
+    )
+
+
+def test_short_reverses_entry_and_close_directions():
+    result = _inspect("short")
+
+    assert result["entry"]["geometry"]["threshold_direction"] == "above"
+    assert result["entry"]["geometry"]["retracement_direction"] == "below"
+    assert result["close"]["geometry"]["threshold_direction"] == "below"
+    assert result["close"]["geometry"]["retracement_direction"] == "above"
+
+
+def test_non_positive_retracement_reports_passive_mode():
+    params = _params()
+    params["entry"]["retracement_base_pct"] = 0.0
+    params["close"]["retracement_base_pct"] = -0.01
+
+    result = trailing_inspect.inspect_trailing(
+        symbol="COIN",
+        pside="long",
+        position_size=None,
+        position_price=20.0,
+        wallet_exposure=0.6,
+        effective_wallet_exposure_limit=0.9,
+        volatility_ema_1m=0.007,
+        volatility_ema_1h=0.0033,
+        params=params,
+        parameter_source="test",
+    )
+
+    assert result["entry"]["trailing_enabled"] is False
+    assert result["entry"]["retracement_pct"] == 0.0
+    assert result["close"]["trailing_enabled"] is False
+    assert result["close"]["retracement_pct"] == 0.0
+    report = trailing_inspect.render_report(result)
+    assert report.count("trailing disabled") == 2
+    assert report.count("Passive threshold/reference") == 2
+
+
+def test_extract_strategy_params_requires_canonical_trailing_martingale():
+    config = {
+        "live": {"strategy_kind": "trailing_martingale"},
+        "bot": {
+            "long": {
+                "strategy": {
+                    "trailing_martingale": _params(),
+                }
+            }
+        },
+    }
+
+    assert trailing_inspect._extract_strategy_params(config, "long") == _params()
+    config["live"]["strategy_kind"] = "ema_anchor"
+    with pytest.raises(ValueError, match="supports only"):
+        trailing_inspect._extract_strategy_params(config, "long")
+
+
+def test_main_json_applies_parameter_override(monkeypatch, capsys):
+    monkeypatch.setattr(
+        trailing_inspect,
+        "load_parameter_source",
+        lambda config_path, pside: (_params(), "test defaults"),
+    )
+
+    assert (
+        trailing_inspect.main(
+            [
+                "--position-price",
+                "20",
+                "--wallet-exposure",
+                "0.6",
+                "--effective-wallet-exposure-limit",
+                "0.9",
+                "--entry-threshold-base-pct",
+                "0.03",
+                "--json",
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["entry"]["threshold_base_pct"] == pytest.approx(0.03)
+    assert payload["overridden_parameters"] == ["entry.threshold_base_pct"]
+
+
+def test_main_rejects_non_positive_effective_limit(monkeypatch, capsys):
+    monkeypatch.setattr(
+        trailing_inspect,
+        "load_parameter_source",
+        lambda config_path, pside: (_params(), "test defaults"),
+    )
+
+    assert (
+        trailing_inspect.main(
+            [
+                "--position-price",
+                "20",
+                "--wallet-exposure",
+                "0.6",
+                "--effective-wallet-exposure-limit",
+                "0",
+            ]
+        )
+        == 2
+    )
+    assert "must be greater than zero" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- add an offline trailing-inspect CLI for trailing_martingale entry and close parameter intuition
- load canonical config values or Rust-owned defaults with explicit per-parameter overrides
- report multiplier terms, additive close terms, threshold and retracement geometry, analytical prices, and JSON output
- register and document the tool with focused formula, rendering, config, and dispatch coverage

## Validation
- ./venv/bin/python -m pytest -q tests/test_trailing_inspect_tool.py tests/test_trailing_diagnostics.py tests/test_passivbot_cli.py
- PYTHONPATH=src ./venv/bin/python src/tools/check_ai_docs.py
- PYTHONPATH=src ./venv/bin/python src/tools/generate_live_event_registry.py --check
- ./venv/bin/python -m pytest -q tests/test_ai_docs.py tests/test_live_event_registry_docs.py
- real CLI smoke using configs/examples/default_trailing_martingale_long.json
- git diff --check origin/master...HEAD

The AI documentation checker completed with 0 errors and its existing repository word-count warning.