### PR TITLE
Report cycle recovery smoke health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live smoke reports now expose bounded cycle terminal-outcome health from
+  existing `cycle.completed` and `cycle.degraded` events. The projection shows
+  latest successful/degraded outcomes, successful completion after the latest
+  observed degradation, elapsed time, order-change presence, and allowlisted
+  phase maxima without copying arbitrary payload details or exception text.
+  Existing hard-failure verdicts, cycle execution, exchange access, and trading
+  behavior are unchanged.
+
 - Live smoke reports now expose bounded latest-per-bot planning-snapshot health
   from existing `snapshot.built` events: required-surface and age coverage,
   market-snapshot freshness and missing counts, availability status counts,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,8 +24,10 @@ Estimated completion:
 
 - Branch: `codex/smoke-cycle-recovery-health`, based on canonical
   `8ba5f5e71a4bf44ea002a519ae05d91c7a261dd8` after PR #1280.
-- PR: pending. Slice: project existing `cycle.completed` and `cycle.degraded`
-  events into bounded latest-per-bot terminal-outcome and recovery health.
+- PR: #1282, `Report cycle recovery smoke health`; semantic implementation head
+  `6235f16f61`. Slice: project existing `cycle.completed` and
+  `cycle.degraded` events into bounded latest-per-bot terminal-outcome and
+  recovery health.
 - Triggering evidence: the post-PR #1280 five-minute inventory naturally
   contained 35 successful cycle completions and one degraded cycle. A later
   fresh window caught a real KuCoin account-state timeout and then subsequent

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,24 +22,24 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/smoke-planning-snapshot-health`, based on canonical
-  `0990d351c690b5270d8c53f3c1ad5bf5d54650a5` after PR #1279.
-- PR: #1280, `Report planning-snapshot smoke health`; semantic implementation
-  head `886d1311e6`. Slice: project existing `snapshot.built` events into
-  bounded latest-per-bot planning-snapshot health.
-- Triggering evidence: the focused post-PR #1278 five-minute inventory
-  naturally contained 35 snapshot-build events while smoke reports exposed no
-  required-surface, freshness, missing-market, availability, or packet-count
-  summary.
-- Scope: retain the latest snapshot observation per bot and expose bounded
-  required-surface and age coverage, market-snapshot counts and freshness,
-  availability status counts, packet counts, and correlation IDs. Keep symbol
-  lists, packet rows, raw references, hashes, values, and embedded availability
-  records query-only.
+- Branch: `codex/smoke-cycle-recovery-health`, based on canonical
+  `8ba5f5e71a4bf44ea002a519ae05d91c7a261dd8` after PR #1280.
+- PR: pending. Slice: project existing `cycle.completed` and `cycle.degraded`
+  events into bounded latest-per-bot terminal-outcome and recovery health.
+- Triggering evidence: the post-PR #1280 five-minute inventory naturally
+  contained 35 successful cycle completions and one degraded cycle. A later
+  fresh window caught a real KuCoin account-state timeout and then subsequent
+  successful calls/cycles, while smoke retained the hard event without a
+  bounded cycle-level recovery projection.
+- Scope: expose terminal event counts, latest successful/degraded outcome,
+  successful completion after the latest observed degradation, elapsed time,
+  order-change presence, degraded reason, correlation ID, and seven code-owned
+  phase durations. Keep arbitrary payload details, exception text, raw
+  references, symbols, and unknown timing keys out of the projection.
 - Behavior boundary: read-only report projection only. No smoke verdict,
   attention classification, console output, event production, exchange access,
   packet production, readiness, configuration, or trading changes.
-- Validation: focused latest-per-bot/aggregate/redaction regression, full
+- Validation: focused terminal-order/recovery/allowlist regression, full
   smoke-report tests, compilation, and docs checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
@@ -48,11 +48,23 @@ Estimated completion:
 
 ## Deployed Baseline
 
-- VPS5's deployed logging baseline is
-  `ccd1cc68956edd8c509fb2b86b759c801e3868b8`, PR #1278. Canonical `master`
-  has since advanced to `0990d351c690b5270d8c53f3c1ad5bf5d54650a5`
-  through unrelated Binance archive PR #1279. The VPS5 tracked checkout is
-  clean and expected untracked artifacts are preserved.
+- Canonical `master` and VPS5 are
+  `8ba5f5e71a4bf44ea002a519ae05d91c7a261dd8`, PR #1280. The tracked checkout
+  is clean and expected untracked artifacts are preserved.
+- PR #1280 required no restart. Exact bot PIDs
+  `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
+  `misc:0.0` PID `434835` remained unchanged. The immediate two-minute smoke
+  was `ok=true` with `197/197` remote calls, `54/54` account-critical calls,
+  `9/9` fill refreshes, and five exact/config-valid processes.
+- A focused five-minute report naturally projected 34 snapshots across all five
+  bots, with zero missing or stale markets. An intermediate fresh smoke caught
+  a real KuCoin balance/positions/open-orders `RequestTimeout` and correctly
+  remained hard-red; all processes were already in `R`, later calls succeeded,
+  and the event was not hidden. The final fresh two-minute smoke was `ok=true`
+  with zero hard/log/monitor/process failures, `242/242` remote calls, `55/55`
+  account-critical calls, `12/12` fill refreshes, and 16 snapshots across all
+  five bots with zero missing or stale markets. No event or trading activity
+  was manufactured.
 - PR #1278 required no restart. Exact bot PIDs
   `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
   `misc:0.0` PID `434835` remained unchanged. Immediate and settled bounded
@@ -1060,11 +1072,11 @@ without restart. PR #1273's forager eligibility projection, PR #1274's
 requested-window event inventory, and PR #1275's planning symbol-state health
 are also merged, deployed, and naturally validated. PR #1276's initial-entry
 eligibility health, PR #1277's correlated planning-output health, and PR
-#1278's latest-per-bot-and-kind data-packet health are merged, deployed, and
-naturally validated. The active follow-up adds bounded latest-per-bot
-planning-snapshot health without copying symbol lists, packet rows, raw packet
-metadata, or embedded availability records, and without changing verdicts or
-runtime behavior.
+#1278's latest-per-bot-and-kind data-packet health and PR #1280's planning
+snapshot health are merged, deployed, and naturally validated. The active
+follow-up adds bounded cycle terminal-outcome and recovery health without
+copying arbitrary payload details or exception text, and without changing
+verdicts or runtime behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -165,6 +165,16 @@ EXCHANGE_CONFIG_REFRESH_HEALTH_GROUP_LIMIT = 20
 DATA_PACKET_HEALTH_GROUP_LIMIT = 20
 PLANNING_SNAPSHOT_HEALTH_GROUP_LIMIT = 20
 PLANNING_SNAPSHOT_VALUE_LIMIT = 8
+CYCLE_HEALTH_GROUP_LIMIT = 20
+CYCLE_HEALTH_PHASES = (
+    "authoritative",
+    "planning_universe",
+    "market_state",
+    "execute",
+    "monitor_flush",
+    "execution_delay",
+    "scheduled_wait",
+)
 RISK_EVENT_TYPES = {
     EventTypes.RISK_MODE_CHANGED,
     EventTypes.HSL_TRANSITION,
@@ -3300,6 +3310,197 @@ def _summarize_planning_snapshot_health(
         "latest_data_packet_count_total": data_packet_count_total,
         "groups_truncated": len(ordered) > PLANNING_SNAPSHOT_HEALTH_GROUP_LIMIT,
         "groups": compact_groups,
+    }
+
+
+def _cycle_health_position(record: dict[str, Any] | None) -> tuple[int, int, str, int]:
+    record = record if isinstance(record, dict) else {}
+    return _sort_event_position_key(
+        ts=record.get("ts"),
+        seq=record.get("seq"),
+        path=record.get("path") or "",
+        line_no=int(record.get("line") or 0),
+    )
+
+
+def _cycle_health_record(
+    *,
+    row: dict[str, Any],
+    live_event: dict[str, Any],
+    path: Path,
+    line_no: int,
+) -> dict[str, Any]:
+    event_type = str(live_event.get("event_type") or row.get("kind") or "")
+    payload = live_event.get("data")
+    payload = payload if isinstance(payload, dict) else {}
+    ids = _event_ids(live_event)
+    timings = payload.get("timings_ms")
+    timings = timings if isinstance(timings, dict) else {}
+    phase_timings = {
+        phase: int(duration)
+        for phase in CYCLE_HEALTH_PHASES
+        if (duration := _non_negative_int(timings.get(phase))) is not None
+    }
+    orders_changed = payload.get("orders_changed")
+    return {
+        "event_type": event_type,
+        "ts": row.get("ts"),
+        "seq": row.get("seq"),
+        "path": str(path),
+        "line": int(line_no),
+        "cycle_id": ids.get("cycle_id"),
+        "status": _data_packet_safe_text(live_event.get("status")),
+        "reason_code": _data_packet_safe_text(live_event.get("reason_code")),
+        "level": _data_packet_safe_text(live_event.get("level")),
+        "elapsed_ms": _non_negative_int(payload.get("elapsed_ms")),
+        "phase_timings_ms": phase_timings,
+        "orders_changed": orders_changed if isinstance(orders_changed, bool) else None,
+    }
+
+
+def _merge_cycle_health_group(
+    groups: dict[str, dict[str, Any]],
+    *,
+    bot_key: str,
+    record: dict[str, Any],
+) -> None:
+    key = str(bot_key or "unknown")
+    group = groups.setdefault(
+        key,
+        {
+            "bot": key,
+            "count": 0,
+            "event_types": Counter(),
+            "latest_event": None,
+            "latest_completed": None,
+            "latest_degraded": None,
+        },
+    )
+    group["count"] = int(group.get("count") or 0) + 1
+    event_type = str(record.get("event_type") or "unknown")
+    event_types = group.get("event_types")
+    if not isinstance(event_types, Counter):
+        event_types = Counter(event_types or {})
+        group["event_types"] = event_types
+    event_types[event_type] += 1
+    if _cycle_health_position(record) > _cycle_health_position(
+        group.get("latest_event")
+    ):
+        group["latest_event"] = record
+    target = None
+    if event_type == EventTypes.CYCLE_COMPLETED:
+        target = "latest_completed"
+    elif event_type == EventTypes.CYCLE_DEGRADED:
+        target = "latest_degraded"
+    if target and _cycle_health_position(record) > _cycle_health_position(
+        group.get(target)
+    ):
+        group[target] = record
+
+
+def _public_cycle_health_record(record: Any) -> dict[str, Any]:
+    if not isinstance(record, dict):
+        return {}
+    return {
+        key: value
+        for key, value in record.items()
+        if key not in {"seq", "path", "line"} and value not in (None, {}, [])
+    }
+
+
+def _summarize_cycle_health(
+    groups: dict[str, dict[str, Any]],
+    event_type_counts: Counter[str],
+) -> dict[str, Any]:
+    latest_outcomes: Counter[str] = Counter()
+    latest_degraded_reasons: Counter[str] = Counter()
+    latest_phase_max_ms: dict[str, int] = {}
+    completed_after_degraded_bots = 0
+    latest_degraded_bots = 0
+    latest_completed_bots = 0
+    latest_degraded_observed_bots = 0
+    latest_orders_changed_bots = 0
+    latest_elapsed_ms_max = 0
+    compact_groups: list[dict[str, Any]] = []
+    ordered = sorted(
+        groups.values(),
+        key=lambda group: _cycle_health_position(group.get("latest_event")),
+        reverse=True,
+    )
+    for group in ordered:
+        completed = group.get("latest_completed")
+        completed = completed if isinstance(completed, dict) else None
+        degraded = group.get("latest_degraded")
+        degraded = degraded if isinstance(degraded, dict) else None
+        completed_position = _cycle_health_position(completed)
+        degraded_position = _cycle_health_position(degraded)
+        completed_after_degraded = bool(
+            completed is not None
+            and degraded is not None
+            and completed_position > degraded_position
+        )
+        if completed is not None:
+            latest_completed_bots += 1
+            elapsed_ms = int(_non_negative_int(completed.get("elapsed_ms")) or 0)
+            latest_elapsed_ms_max = max(latest_elapsed_ms_max, elapsed_ms)
+            if completed.get("orders_changed") is True:
+                latest_orders_changed_bots += 1
+            phase_timings = completed.get("phase_timings_ms")
+            if isinstance(phase_timings, dict):
+                for phase in CYCLE_HEALTH_PHASES:
+                    duration = _non_negative_int(phase_timings.get(phase))
+                    if duration is not None:
+                        latest_phase_max_ms[phase] = max(
+                            int(duration), latest_phase_max_ms.get(phase, 0)
+                        )
+        if degraded is not None:
+            latest_degraded_observed_bots += 1
+            latest_degraded_reasons[
+                str(degraded.get("reason_code") or "unknown")
+            ] += 1
+        if completed_after_degraded:
+            completed_after_degraded_bots += 1
+        if degraded is not None and (
+            completed is None or degraded_position > completed_position
+        ):
+            outcome = "degraded"
+            latest_degraded_bots += 1
+        elif completed is not None:
+            outcome = "succeeded"
+        else:
+            outcome = "unknown"
+        latest_outcomes[outcome] += 1
+        compact_groups.append(
+            {
+                "bot": group.get("bot"),
+                "count": int(group.get("count") or 0),
+                "event_types": dict(
+                    Counter(group.get("event_types") or {}).most_common()
+                ),
+                "latest_outcome": outcome,
+                "completed_after_latest_degraded": completed_after_degraded,
+                "latest_event": _public_cycle_health_record(group.get("latest_event")),
+                "latest_completed": _public_cycle_health_record(completed),
+                "latest_degraded": _public_cycle_health_record(degraded),
+            }
+        )
+    return {
+        "total": sum(int(group.get("count") or 0) for group in groups.values()),
+        "event_types": dict(event_type_counts.most_common()),
+        "bots": len(groups),
+        "completed": int(event_type_counts.get(EventTypes.CYCLE_COMPLETED) or 0),
+        "degraded": int(event_type_counts.get(EventTypes.CYCLE_DEGRADED) or 0),
+        "latest_outcomes": dict(latest_outcomes.most_common()),
+        "latest_completed_bots": latest_completed_bots,
+        "latest_degraded_observed_bots": latest_degraded_observed_bots,
+        "latest_degraded_bots": latest_degraded_bots,
+        "completed_after_latest_degraded_bots": completed_after_degraded_bots,
+        "latest_degraded_reasons": dict(latest_degraded_reasons.most_common()),
+        "latest_elapsed_ms_max": latest_elapsed_ms_max,
+        "latest_orders_changed_bots": latest_orders_changed_bots,
+        "latest_phase_max_ms": latest_phase_max_ms,
+        "groups_truncated": len(compact_groups) > CYCLE_HEALTH_GROUP_LIMIT,
+        "groups": compact_groups[:CYCLE_HEALTH_GROUP_LIMIT],
     }
 
 
@@ -7851,6 +8052,8 @@ def _scan_events(
     data_packet_health_event_type_counts: Counter[str] = Counter()
     planning_snapshot_health_groups: dict[str, dict[str, Any]] = {}
     planning_snapshot_health_event_type_counts: Counter[str] = Counter()
+    cycle_health_groups: dict[str, dict[str, Any]] = {}
+    cycle_health_event_type_counts: Counter[str] = Counter()
     staged_readiness_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
     staged_readiness_event_type_counts: Counter[str] = Counter()
     planning_output_groups: dict[tuple[Any, ...], dict[str, Any]] = {}
@@ -8150,6 +8353,21 @@ def _scan_events(
                                 line_no=line_no,
                             ),
                         )
+                    if event_type in {
+                        EventTypes.CYCLE_COMPLETED,
+                        EventTypes.CYCLE_DEGRADED,
+                    }:
+                        cycle_health_event_type_counts[str(event_type)] += 1
+                        _merge_cycle_health_group(
+                            cycle_health_groups,
+                            bot_key=bot_key,
+                            record=_cycle_health_record(
+                                row=row,
+                                live_event=live_event,
+                                path=path,
+                                line_no=line_no,
+                            ),
+                        )
                     if _staged_readiness_event(live_event):
                         staged_readiness_event_type_counts[str(event_type)] += 1
                         _merge_staged_readiness_group(
@@ -8398,6 +8616,10 @@ def _scan_events(
         "planning_snapshot_health": _summarize_planning_snapshot_health(
             planning_snapshot_health_groups,
             planning_snapshot_health_event_type_counts,
+        ),
+        "cycle_health": _summarize_cycle_health(
+            cycle_health_groups,
+            cycle_health_event_type_counts,
         ),
         "staged_readiness_health": _summarize_staged_readiness_health(
             staged_readiness_groups,
@@ -8860,6 +9082,7 @@ def build_live_smoke_report(
         ],
         "data_packet_health": event_scan["data_packet_health"],
         "planning_snapshot_health": event_scan["planning_snapshot_health"],
+        "cycle_health": event_scan["cycle_health"],
         "staged_readiness_health": event_scan["staged_readiness_health"],
         "planning_output_health": event_scan["planning_output_health"],
         "event_pipeline_health": event_scan["event_pipeline_health"],
@@ -9488,6 +9711,11 @@ def summarize_live_smoke_report(
         if isinstance(report.get("planning_snapshot_health"), dict)
         else {}
     )
+    cycle_health = (
+        report.get("cycle_health")
+        if isinstance(report.get("cycle_health"), dict)
+        else {}
+    )
     staged_readiness_health = (
         report.get("staged_readiness_health")
         if isinstance(report.get("staged_readiness_health"), dict)
@@ -9705,6 +9933,10 @@ def summarize_live_smoke_report(
         ),
         "planning_snapshot_health": _summary_unfiltered_health_groups(
             planning_snapshot_health,
+            limit=max_groups,
+        ),
+        "cycle_health": _summary_unfiltered_health_groups(
+            cycle_health,
             limit=max_groups,
         ),
         "staged_readiness_health": _summary_staged_readiness_health(
@@ -10432,6 +10664,11 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
         if isinstance(report.get("planning_snapshot_health"), dict)
         else {}
     )
+    cycle_health = (
+        report.get("cycle_health")
+        if isinstance(report.get("cycle_health"), dict)
+        else {}
+    )
     staged_readiness_health = (
         report.get("staged_readiness_health")
         if isinstance(report.get("staged_readiness_health"), dict)
@@ -10766,6 +11003,11 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             for key, value in planning_snapshot_health.items()
             if key not in {"groups", "groups_truncated"}
         },
+        "cycles": {
+            key: value
+            for key, value in cycle_health.items()
+            if key not in {"groups", "groups_truncated"}
+        },
         "staged_readiness": staged_readiness_brief,
         "planning_output": {
             key: value
@@ -11022,6 +11264,7 @@ SMOKE_REPORT_SECTION_BASE_SELECTORS = frozenset(
 SMOKE_REPORT_SECTION_ALIASES: dict[str, tuple[str, ...]] = {
     "account_critical_remote_calls": ("account_critical_remote_call_health",),
     "cache": ("cache_health",),
+    "cycles": ("cycle_health",),
     "data_packets": ("data_packet_health",),
     "ema_readiness": ("ema_readiness_health",),
     "event_pipeline": ("event_pipeline_health",),

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -4560,6 +4560,163 @@ def test_live_smoke_report_summarizes_latest_planning_snapshots_without_raw_data
     assert section["planning_snapshot_health"] == health
 
 
+def test_live_smoke_report_summarizes_cycle_completion_after_degradation(tmp_path):
+    binance_events = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    gateio_events = tmp_path / "monitor" / "gateio" / "gateio_01" / "events"
+    _write_ndjson(
+        binance_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=500,
+                level="debug",
+                reason_code="",
+                ids={"cycle_id": "cy_older"},
+                data={"elapsed_ms": 9999, "orders_changed": False},
+            ),
+            _monitor_row(
+                event_type="cycle.degraded",
+                seq=2,
+                ts=1000,
+                status="degraded",
+                level="error",
+                reason_code="RequestTimeout",
+                ids={"cycle_id": "cy_failed"},
+                data={
+                    "timings_ms": {
+                        "authoritative": 900,
+                        "UNSAFE_PHASE_SHOULD_NOT_RENDER": 9999,
+                    },
+                    "details": "DETAILS_SHOULD_NOT_RENDER",
+                    "exception": "EXCEPTION_SHOULD_NOT_RENDER",
+                },
+            ),
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=3,
+                ts=2000,
+                status="succeeded",
+                level="debug",
+                reason_code="",
+                ids={"cycle_id": "cy_recovered"},
+                data={
+                    "elapsed_ms": 120,
+                    "timings_ms": {
+                        "authoritative": 40,
+                        "execute": 50,
+                        "monitor_flush": 30,
+                        "UNSAFE_PHASE_SHOULD_NOT_RENDER": 9999,
+                    },
+                    "orders_changed": True,
+                    "raw_ref": "RAW_REF_SHOULD_NOT_RENDER",
+                },
+            ),
+        ],
+    )
+    _write_ndjson(
+        gateio_events / "current.ndjson",
+        [
+            _monitor_row(
+                event_type="cycle.completed",
+                seq=1,
+                ts=1500,
+                exchange="gateio",
+                user="gateio_01",
+                status="succeeded",
+                level="debug",
+                reason_code="",
+                ids={"cycle_id": "cy_gate_ok"},
+                data={
+                    "elapsed_ms": 80,
+                    "timings_ms": {"execute": 60},
+                    "orders_changed": False,
+                },
+            ),
+            _monitor_row(
+                event_type="cycle.degraded",
+                seq=2,
+                ts=2500,
+                exchange="gateio",
+                user="gateio_01",
+                status="degraded",
+                reason_code="stale_state",
+                ids={"cycle_id": "cy_gate_bad"},
+                data={"details": "GATE_DETAILS_SHOULD_NOT_RENDER"},
+            ),
+        ],
+    )
+
+    report = build_live_smoke_report(tmp_path / "monitor", logs_root=None)
+    summary = summarize_live_smoke_report(report)
+    brief = summarize_live_smoke_report_brief(report)
+    section = project_live_smoke_report_sections(report, ["cycles"])
+
+    health = report["cycle_health"]
+    assert health["total"] == 5
+    assert health["event_types"] == {
+        "cycle.completed": 3,
+        "cycle.degraded": 2,
+    }
+    assert health["bots"] == 2
+    assert health["completed"] == 3
+    assert health["degraded"] == 2
+    assert health["latest_outcomes"] == {"succeeded": 1, "degraded": 1}
+    assert health["latest_completed_bots"] == 2
+    assert health["latest_degraded_observed_bots"] == 2
+    assert health["latest_degraded_bots"] == 1
+    assert health["completed_after_latest_degraded_bots"] == 1
+    assert health["latest_degraded_reasons"] == {
+        "RequestTimeout": 1,
+        "stale_state": 1,
+    }
+    assert health["latest_elapsed_ms_max"] == 120
+    assert health["latest_orders_changed_bots"] == 1
+    assert health["latest_phase_max_ms"] == {
+        "authoritative": 40,
+        "execute": 60,
+        "monitor_flush": 30,
+    }
+    binance = next(
+        group for group in health["groups"] if group["bot"] == "binance/binance_01"
+    )
+    assert binance["count"] == 3
+    assert binance["event_types"] == {
+        "cycle.completed": 2,
+        "cycle.degraded": 1,
+    }
+    assert binance["latest_outcome"] == "succeeded"
+    assert binance["completed_after_latest_degraded"] is True
+    assert binance["latest_completed"] == {
+        "event_type": "cycle.completed",
+        "ts": 2000,
+        "cycle_id": "cy_recovered",
+        "status": "succeeded",
+        "level": "debug",
+        "elapsed_ms": 120,
+        "phase_timings_ms": {
+            "authoritative": 40,
+            "execute": 50,
+            "monitor_flush": 30,
+        },
+        "orders_changed": True,
+    }
+    assert binance["latest_degraded"]["reason_code"] == "RequestTimeout"
+    gateio = next(
+        group for group in health["groups"] if group["bot"] == "gateio/gateio_01"
+    )
+    assert gateio["latest_outcome"] == "degraded"
+    assert gateio["completed_after_latest_degraded"] is False
+    for projected in (health, summary["cycle_health"], brief["cycles"]):
+        assert projected["completed_after_latest_degraded_bots"] == 1
+        serialized = json.dumps(projected)
+        assert "SHOULD_NOT_RENDER" not in serialized
+        assert "raw_ref" not in serialized
+        assert '"details"' not in serialized
+        assert '"exception"' not in serialized
+    assert section["cycle_health"] == health
+
+
 def test_live_smoke_report_problem_events_include_state_refresh_progress(tmp_path):
     events_dir = tmp_path / "monitor" / "kucoin" / "kucoin_01" / "events"
     _write_ndjson(


### PR DESCRIPTION
## Summary
- project existing `cycle.completed` and `cycle.degraded` events into bounded latest-per-bot terminal-outcome health
- show successful completion after the latest observed degradation, elapsed/order-change facts, degraded reasons, cycle IDs, and seven code-owned phase maxima
- support full, summary, brief, and `cycles` section output

## Safety boundary
- read-only report projection; existing hard events and smoke verdicts are unchanged
- no event production, exchange access, cycle execution, readiness, configuration, or trading changes
- arbitrary payload details, exception text, raw references, symbols, and unknown timing keys remain excluded

## Validation
- `python -m pytest -q tests/test_live_smoke_report.py` -> 101 passed
- `python -m pytest -q tests/test_live_incident_bundle.py tests/test_live_event_registry_docs.py tests/test_ai_docs.py` -> 28 passed
- `python -m py_compile src/live/smoke_report.py tests/test_live_smoke_report.py`
- `python src/tools/check_ai_docs.py` -> 0 errors; repository word-count warning only
- `git diff --check`

## Deploy evidence from PR #1280
- VPS5 fast-forwarded to `8ba5f5e71a` without restart; exact five bot PIDs, pane parents, and `misc:0.0` stayed unchanged
- immediate smoke: hard-green, remote `197/197`, account-critical `54/54`, fills `9/9`, five exact/config-valid processes
- focused snapshot report: 34 natural events across all five bots, zero missing/stale markets
- an intermediate fresh window caught a real KuCoin account-state timeout and remained hard-red; later calls/cycles succeeded and the event was not hidden
- final fresh smoke: hard-green, remote `242/242`, account-critical `55/55`, fills `12/12`, 16 snapshots across all five bots with zero missing/stale markets
- no bot restart, event manufacture, or direct exchange contact

## Expected VPS action
Pull and run bounded `--section cycles` plus fresh smoke after merge; no bot restart expected.