### PR TITLE
Add bounded process-state sampling to live smoke reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live smoke reports can now opt into bounded repeated process-table sampling
+  to distinguish observed, persistent, and recovered uninterruptible-sleep
+  states while reporting stable PIDs, command/PID churn, and aggregate state
+  observations. The default remains one process snapshot, the final sample
+  retains the existing liveness/config verdict contract, and the sampler never
+  signals or restarts a process.
+
 - Live smoke reports now expose bounded cycle terminal-outcome health from
   existing `cycle.completed` and `cycle.degraded` events. The projection shows
   latest successful/degraded outcomes, successful completion after the latest

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,37 +22,50 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/smoke-cycle-recovery-health`, based on canonical
-  `8ba5f5e71a4bf44ea002a519ae05d91c7a261dd8` after PR #1280.
-- PR: #1282, `Report cycle recovery smoke health`; semantic implementation head
-  `6235f16f61`. Slice: project existing `cycle.completed` and
-  `cycle.degraded` events into bounded latest-per-bot terminal-outcome and
-  recovery health.
-- Triggering evidence: the post-PR #1280 five-minute inventory naturally
-  contained 35 successful cycle completions and one degraded cycle. A later
-  fresh window caught a real KuCoin account-state timeout and then subsequent
-  successful calls/cycles, while smoke retained the hard event without a
-  bounded cycle-level recovery projection.
-- Scope: expose terminal event counts, latest successful/degraded outcome,
-  successful completion after the latest observed degradation, elapsed time,
-  order-change presence, degraded reason, correlation ID, and seven code-owned
-  phase durations. Keep arbitrary payload details, exception text, raw
-  references, symbols, and unknown timing keys out of the projection.
-- Behavior boundary: read-only report projection only. No smoke verdict,
-  attention classification, console output, event production, exchange access,
-  packet production, readiness, configuration, or trading changes.
-- Validation: focused terminal-order/recovery/allowlist regression, full
-  smoke-report tests, compilation, and docs checks.
+- Branch: `codex/smoke-process-state-sampling`, based on canonical
+  `82bfa98e202a3fbba71937d751e1d0c651e33f72` after PR #1282.
+- PR: pending. Slice: add opt-in bounded repeated process-table sampling to
+  distinguish transient, persistent, and recovered uninterruptible-sleep
+  observations during smoke checks.
+- Triggering evidence: PR #1282's settled cycle report was green and naturally
+  proved KuCoin completion after a retained nonce degradation. The final exact
+  process check then caught the unchanged KuCoin PID in `D` for about 20
+  seconds before three consecutive `R` samples. The existing one-shot process
+  projection could show either sample but not the observed recovery.
+- Scope: sample the existing canonical live-process scan up to a strict count
+  and interval bound, use the last sample for established liveness/config
+  checks, and expose bounded stable-PID, state-observation, command/PID churn,
+  observed/persistent/recovered `D`, and per-PID summary evidence.
+- Behavior boundary: read-only smoke tooling only. The single-snapshot default
+  and smoke verdict remain unchanged; sampling never signals, stops, starts, or
+  restarts processes and does not contact exchanges.
+- Validation: focused recovery/persistence/churn/redaction and bounds
+  regressions, full smoke-report tests, compilation, and docs checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: pull and run bounded report/smoke checks after merge;
-  no bot restart is expected for this read-only reporting slice.
+- Expected VPS action: pull and run an opt-in bounded process-sampling smoke
+  after merge; no bot restart is expected for this read-only tooling slice.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `8ba5f5e71a4bf44ea002a519ae05d91c7a261dd8`, PR #1280. The tracked checkout
+  `82bfa98e202a3fbba71937d751e1d0c651e33f72`, PR #1282. The tracked checkout
   is clean and expected untracked artifacts are preserved.
+- PR #1282 required no restart or process signal. Exact bot PIDs
+  `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
+  `misc:0.0` PID `434835` remained unchanged. The immediate focused report
+  projected 37 completions and two degradations across all five bots and
+  correctly retained a latest KuCoin `InvalidNonce` degradation. The fresh
+  two-minute smoke was `ok=true` with zero hard failures, `193/194` remote
+  calls, `56/57` account-critical calls, `9/9` fill refreshes, and five exact
+  processes/configs matched.
+- The settled focused report was `ok=true` with zero hard failures and 20
+  completions plus one retained degradation. All five latest outcomes were
+  successful, and KuCoin was explicitly counted as completed after its latest
+  degradation. A final exact process check caught that same KuCoin PID in `D`
+  for about 20 seconds before three consecutive `R` samples, exposing the
+  active process-sampling follow-up. No event or trading activity was
+  manufactured.
 - PR #1280 required no restart. Exact bot PIDs
   `985592/985594/985596/985598/985600`, all five pane parents, and unrelated
   `misc:0.0` PID `434835` remained unchanged. The immediate two-minute smoke
@@ -1074,11 +1087,11 @@ without restart. PR #1273's forager eligibility projection, PR #1274's
 requested-window event inventory, and PR #1275's planning symbol-state health
 are also merged, deployed, and naturally validated. PR #1276's initial-entry
 eligibility health, PR #1277's correlated planning-output health, and PR
-#1278's latest-per-bot-and-kind data-packet health and PR #1280's planning
-snapshot health are merged, deployed, and naturally validated. The active
-follow-up adds bounded cycle terminal-outcome and recovery health without
-copying arbitrary payload details or exception text, and without changing
-verdicts or runtime behavior.
+#1278's latest-per-bot-and-kind data-packet health, PR #1280's planning
+snapshot health, and PR #1282's cycle terminal-outcome/recovery health are
+merged, deployed, and naturally validated. The active follow-up makes bounded
+multi-sample process-state recovery visible without changing the single-sample
+default, process control, or runtime behavior.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,9 +24,10 @@ Estimated completion:
 
 - Branch: `codex/smoke-process-state-sampling`, based on canonical
   `82bfa98e202a3fbba71937d751e1d0c651e33f72` after PR #1282.
-- PR: pending. Slice: add opt-in bounded repeated process-table sampling to
-  distinguish transient, persistent, and recovered uninterruptible-sleep
-  observations during smoke checks.
+- PR: #1283, `Add bounded process-state sampling to live smoke reports`;
+  semantic implementation head `cafbeef441`. Slice: add opt-in bounded
+  repeated process-table sampling to distinguish transient, persistent, and
+  recovered uninterruptible-sleep observations during smoke checks.
 - Triggering evidence: PR #1282's settled cycle report was green and naturally
   proved KuCoin completion after a retained nonce degradation. The final exact
   process check then caught the unchanged KuCoin PID in `D` for about 20

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -9170,3 +9170,24 @@ active branch, PR, review gate, and rollout instructions.
   repeated verbose field names already represented in the complete event. The
   active `codex/compact-trailing-status-console` follow-up is formatter-only and
   targets the normal 240-character budget without changing payload or behavior.
+
+### 2026-07-16: Cycle Recovery Health Deployed; Process Sampling Follow-Up
+
+- PR #1282 merged to canonical `master` at `82bfa98e20` after exact-head
+  Hermes approval and green Python/Rust CI under the temporary
+  maintainer-authorized Hermes-plus-CI gate. VPS5 fast-forwarded cleanly
+  without a restart or process signal; the five exact bot PIDs, pane parents,
+  and unrelated `misc:0.0` PID `434835` remained unchanged.
+- The immediate focused report naturally retained a latest KuCoin
+  `InvalidNonce` degradation. The fresh two-minute smoke was `ok=true` with
+  zero hard failures, `193/194` remote calls, `56/57` account-critical calls,
+  `9/9` fill refreshes, and five exact/config-valid processes.
+- The settled focused report was `ok=true`: all five latest cycle outcomes
+  were successful, and KuCoin was counted as completed after the retained
+  degradation. A final exact process check then observed that unchanged
+  KuCoin PID in `D` for about 20 seconds before three consecutive `R` samples.
+  No event, failure, process state, or trading activity was manufactured.
+- The active `codex/smoke-process-state-sampling` follow-up adds opt-in bounded
+  process-state sampling so repeated smoke checks can distinguish observed,
+  persistent, and recovered uninterruptible sleep while preserving the
+  one-snapshot default and existing smoke verdict.

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -314,6 +314,13 @@ Related detailed plans:
      succeeded. The settled window naturally contained one existing
      `forager.eligibility_changed` event that smoke reports still omitted; the
      active follow-up adds that bounded membership-transition projection.
+   - 2026-07-16: PR #1282 added bounded cycle terminal-outcome and recovery
+     health. Its no-restart VPS5 deploy retained a real KuCoin nonce
+     degradation, then proved the next successful cycle. A final exact PID
+     check found that same unchanged process in `D` for about 20 seconds before
+     three consecutive `R` samples. The active read-only follow-up makes this
+     bounded process-state observation/recovery sequence reproducible in the
+     smoke tool without adding restart execution.
 
    Remaining refinements: safe pull/stop/start orchestration remains open.
    The concise and brief summaries are intentionally bounded; further changes

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -6,6 +6,7 @@ import math
 import re
 import stat
 import subprocess
+import time
 from collections import Counter, defaultdict, deque
 from datetime import datetime
 from pathlib import Path
@@ -85,6 +86,9 @@ SMOKE_REPORT_SUMMARY_GROUP_LIMIT = 8
 SMOKE_REPORT_BRIEF_LOG_SAMPLE_LIMIT = 3
 SMOKE_REPORT_BRIEF_REMOTE_CALL_SLOWEST_LIMIT = 3
 SMOKE_REPORT_BRIEF_HSL_REPLAY_ACTIVE_LIMIT = 5
+MAX_PROCESS_SAMPLES = 12
+MAX_PROCESS_SAMPLE_INTERVAL_S = 30.0
+PROCESS_SAMPLE_GROUP_LIMIT = 20
 CURRENT_PROCESS_PRESSURE_FIELDS = (
     "state_counts",
     "uninterruptible_sleep_count",
@@ -97,6 +101,22 @@ CURRENT_PROCESS_PRESSURE_FIELDS = (
     "mem_pct_total",
     "mem_pct_max",
     "mem_reporting_processes",
+)
+PROCESS_SAMPLING_FIELDS = (
+    "enabled",
+    "requested_samples",
+    "completed_samples",
+    "interval_s",
+    "scheduled_span_s",
+    "scan_error_count",
+    "pids_observed",
+    "stable_pids",
+    "command_pid_churn_count",
+    "uninterruptible_observed_count",
+    "uninterruptible_persistent_count",
+    "uninterruptible_recovered_count",
+    "uninterruptible_active_count",
+    "state_observations",
 )
 _SMOKE_REPORT_SECTION_BASE_KEYS = (
     "ok",
@@ -7126,6 +7146,122 @@ def _running_live_processes(*, command_match: str) -> dict[str, Any]:
     }
 
 
+def _summarize_process_sampling(
+    scans: Iterable[dict[str, Any]],
+    *,
+    requested_samples: int,
+    interval_s: float,
+) -> dict[str, Any]:
+    scan_rows = list(scans)
+    completed_samples = len(scan_rows)
+    by_pid: dict[int, dict[str, Any]] = {}
+    command_pids: dict[str, set[int]] = defaultdict(set)
+    state_observations: Counter[str] = Counter()
+
+    for sample_index, scan in enumerate(scan_rows):
+        for process in scan.get("running") or []:
+            pid = process.get("pid")
+            if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+                continue
+            state = str(process.get("stat") or "").strip()[:1].upper()
+            if state:
+                state_observations[state] += 1
+            row = by_pid.setdefault(
+                pid,
+                {
+                    "pid": pid,
+                    "sample_indexes": set(),
+                    "states": Counter(),
+                    "first_state": state or None,
+                    "latest_state": state or None,
+                    "latest_process": process,
+                },
+            )
+            row["sample_indexes"].add(sample_index)
+            if state:
+                row["states"][state] += 1
+                row["latest_state"] = state
+            row["latest_process"] = process
+            match_key = str(process.get("_match_key") or "")
+            if match_key:
+                command_pids[match_key].add(pid)
+
+    groups: list[dict[str, Any]] = []
+    for pid, row in sorted(by_pid.items()):
+        states = row["states"]
+        observed_samples = len(row["sample_indexes"])
+        d_observations = int(states["D"])
+        latest_state = row.get("latest_state")
+        latest_process = row["latest_process"]
+        present_in_final_sample = bool(
+            completed_samples > 0
+            and completed_samples - 1 in row["sample_indexes"]
+        )
+        group = {
+            "pid": pid,
+            "account": latest_process.get("account"),
+            "config_path": latest_process.get("config_path"),
+            "config_key": latest_process.get("config_key"),
+            "sample_count": observed_samples,
+            "states": dict(sorted(states.items())),
+            "first_state": row.get("first_state"),
+            "latest_state": latest_state,
+            "present_in_final_sample": present_in_final_sample,
+            "uninterruptible_observations": d_observations,
+            "observed_uninterruptible": d_observations > 0,
+            "persistent_uninterruptible": bool(
+                completed_samples > 0
+                and observed_samples == completed_samples
+                and d_observations == completed_samples
+            ),
+            "recovered_from_uninterruptible": bool(
+                d_observations > 0
+                and present_in_final_sample
+                and latest_state not in (None, "D")
+            ),
+        }
+        groups.append(
+            {key: value for key, value in group.items() if value is not None}
+        )
+
+    return {
+        "enabled": requested_samples > 1,
+        "requested_samples": requested_samples,
+        "completed_samples": completed_samples,
+        "interval_s": round(float(interval_s), 3),
+        "scheduled_span_s": round(
+            max(0, completed_samples - 1) * float(interval_s), 3
+        ),
+        "scan_error_count": sum(
+            1 for scan in scan_rows if scan.get("scan_error") is not None
+        ),
+        "pids_observed": len(groups),
+        "stable_pids": sum(
+            1 for group in groups if group["sample_count"] == completed_samples
+        ),
+        "command_pid_churn_count": sum(
+            1 for pids in command_pids.values() if len(pids) > 1
+        ),
+        "uninterruptible_observed_count": sum(
+            1 for group in groups if group["observed_uninterruptible"]
+        ),
+        "uninterruptible_persistent_count": sum(
+            1 for group in groups if group["persistent_uninterruptible"]
+        ),
+        "uninterruptible_recovered_count": sum(
+            1 for group in groups if group["recovered_from_uninterruptible"]
+        ),
+        "uninterruptible_active_count": sum(
+            1
+            for group in groups
+            if group["present_in_final_sample"] and group.get("latest_state") == "D"
+        ),
+        "state_observations": dict(sorted(state_observations.items())),
+        "groups": groups[:PROCESS_SAMPLE_GROUP_LIMIT],
+        "groups_truncated": len(groups) > PROCESS_SAMPLE_GROUP_LIMIT,
+    }
+
+
 def _summarize_current_process_pressure(
     processes: Iterable[dict[str, Any]],
 ) -> dict[str, Any]:
@@ -7373,9 +7509,26 @@ def _build_process_report(
     include_processes: bool,
     supervisor_config: str | Path | None,
     process_command_match: str,
+    process_samples: int = 1,
+    process_sample_interval_s: float = 5.0,
     config_base_dir: Path | None = None,
 ) -> dict[str, Any]:
-    enabled = bool(include_processes or supervisor_config)
+    process_samples = int(process_samples)
+    process_sample_interval_s = float(process_sample_interval_s)
+    if process_samples < 1 or process_samples > MAX_PROCESS_SAMPLES:
+        raise ValueError(
+            f"process_samples must be between 1 and {MAX_PROCESS_SAMPLES}"
+        )
+    if (
+        not math.isfinite(process_sample_interval_s)
+        or process_sample_interval_s < 0.0
+        or process_sample_interval_s > MAX_PROCESS_SAMPLE_INTERVAL_S
+    ):
+        raise ValueError(
+            "process_sample_interval_s must be between 0 and "
+            f"{MAX_PROCESS_SAMPLE_INTERVAL_S:g}"
+        )
+    enabled = bool(include_processes or supervisor_config or process_samples > 1)
     if not enabled:
         return {
             "enabled": False,
@@ -7399,7 +7552,14 @@ def _build_process_report(
         }
 
     config = _parse_tmuxp_live_commands(supervisor_config)
-    running_scan = _running_live_processes(command_match=process_command_match)
+    running_scans: list[dict[str, Any]] = []
+    for sample_index in range(process_samples):
+        if sample_index > 0 and process_sample_interval_s > 0.0:
+            time.sleep(process_sample_interval_s)
+        running_scans.append(
+            _running_live_processes(command_match=process_command_match)
+        )
+    running_scan = running_scans[-1]
     running = running_scan["running"]
     expected = config["expected"]
     missing: list[dict[str, Any]] = []
@@ -7455,7 +7615,7 @@ def _build_process_report(
         config_base_dir=config_base_dir,
     )
     hard_failures += int(config_checks.get("hard_failures") or 0)
-    return {
+    report = {
         "enabled": True,
         "ok": hard_failures == 0,
         "hard_failures": hard_failures,
@@ -7479,6 +7639,13 @@ def _build_process_report(
         **_summarize_current_process_pressure(running),
         "config_checks": config_checks,
     }
+    if process_samples > 1:
+        report["sampling"] = _summarize_process_sampling(
+            running_scans,
+            requested_samples=process_samples,
+            interval_s=process_sample_interval_s,
+        )
+    return report
 
 
 def _non_negative_int(value: Any) -> int | None:
@@ -8952,6 +9119,8 @@ def build_live_smoke_report(
     include_processes: bool = False,
     supervisor_config: str | Path | None = None,
     process_command_match: str = DEFAULT_PROCESS_MATCH,
+    process_samples: int = 1,
+    process_sample_interval_s: float = 5.0,
     include_rotated: bool = False,
     since_ms: int | None = None,
     until_ms: int | None = None,
@@ -8987,6 +9156,8 @@ def build_live_smoke_report(
         include_processes=include_processes,
         supervisor_config=supervisor_config,
         process_command_match=process_command_match,
+        process_samples=process_samples,
+        process_sample_interval_s=process_sample_interval_s,
         config_base_dir=repository_root,
     )
     repository_report = _build_repository_report(monitor_root, repo_root=repository_root)
@@ -9799,6 +9970,27 @@ def summarize_live_smoke_report(
             )
             if key in processes
         }
+        | (
+            {
+                "sampling": {
+                    key: processes["sampling"].get(key)
+                    for key in PROCESS_SAMPLING_FIELDS
+                    if key in processes["sampling"]
+                }
+                | {
+                    "groups": (processes["sampling"].get("groups") or [])[
+                        :max_groups
+                    ],
+                    "groups_truncated": bool(
+                        processes["sampling"].get("groups_truncated")
+                        or len(processes["sampling"].get("groups") or [])
+                        > max_groups
+                    ),
+                }
+            }
+            if isinstance(processes.get("sampling"), dict)
+            else {}
+        )
         | {
             "missing_expected_count": len(processes.get("missing_expected") or []),
             "duplicate_configured_command_matches_count": len(
@@ -10883,6 +11075,17 @@ def summarize_live_smoke_report_brief(report: dict[str, Any]) -> dict[str, Any]:
             )
             if key in processes
         }
+        | (
+            {
+                "sampling": {
+                    key: processes["sampling"].get(key)
+                    for key in PROCESS_SAMPLING_FIELDS
+                    if key in processes["sampling"]
+                }
+            }
+            if isinstance(processes.get("sampling"), dict)
+            else {}
+        )
         | {
             "missing_expected_count": len(processes.get("missing_expected") or []),
             "duplicate_configured_command_matches_count": len(

--- a/src/tools/live_smoke_report.py
+++ b/src/tools/live_smoke_report.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 import time
 from pathlib import Path
@@ -13,6 +14,8 @@ if str(SRC_ROOT) not in sys.path:
 from live.smoke_report import (  # noqa: E402
     DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
     LOG_WINDOW_UNPARSED_POLICIES,
+    MAX_PROCESS_SAMPLES,
+    MAX_PROCESS_SAMPLE_INTERVAL_S,
     build_live_smoke_report,
     default_logs_root_for_monitor,
     project_live_smoke_report_sections,
@@ -67,6 +70,26 @@ def build_parser() -> argparse.ArgumentParser:
         "--process-match",
         default="passivbot live",
         help="Substring used before canonicalizing passivbot live process rows.",
+    )
+    parser.add_argument(
+        "--process-samples",
+        type=int,
+        default=1,
+        help=(
+            "Read the local process table this many times and report bounded "
+            "state persistence/recovery. Default 1 preserves snapshot behavior; "
+            f"maximum {MAX_PROCESS_SAMPLES}."
+        ),
+    )
+    parser.add_argument(
+        "--process-sample-interval-s",
+        type=float,
+        default=5.0,
+        help=(
+            "Seconds between opt-in process samples. Used only when "
+            "--process-samples is greater than 1; maximum "
+            f"{MAX_PROCESS_SAMPLE_INTERVAL_S:g}."
+        ),
     )
     parser.add_argument(
         "--include-rotated",
@@ -206,12 +229,30 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("--event-tail-lines must be non-negative")
     if int(args.max_event_files_per_bot) < 0:
         parser.error("--max-event-files-per-bot must be non-negative")
+    if (
+        int(args.process_samples) < 1
+        or int(args.process_samples) > MAX_PROCESS_SAMPLES
+    ):
+        parser.error(
+            f"--process-samples must be between 1 and {MAX_PROCESS_SAMPLES}"
+        )
+    if (
+        not math.isfinite(float(args.process_sample_interval_s))
+        or float(args.process_sample_interval_s) < 0.0
+        or float(args.process_sample_interval_s) > MAX_PROCESS_SAMPLE_INTERVAL_S
+    ):
+        parser.error(
+            "--process-sample-interval-s must be between 0 and "
+            f"{MAX_PROCESS_SAMPLE_INTERVAL_S:g}"
+        )
     report = build_live_smoke_report(
         args.monitor_root,
         logs_root=logs_root,
         include_processes=bool(args.processes),
         supervisor_config=args.supervisor_config,
         process_command_match=str(args.process_match),
+        process_samples=int(args.process_samples),
+        process_sample_interval_s=float(args.process_sample_interval_s),
         include_rotated=bool(args.include_rotated),
         since_ms=since_ms,
         until_ms=until_ms,

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -8177,6 +8177,28 @@ def test_live_smoke_report_cli_rejects_negative_max_event_files_per_bot(capsys):
     assert "--max-event-files-per-bot must be non-negative" in capsys.readouterr().err
 
 
+def test_live_smoke_report_cli_rejects_unbounded_process_sampling(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_smoke_report.main(
+            [
+                "monitor",
+                "--process-samples",
+                str(smoke_report_module.MAX_PROCESS_SAMPLES + 1),
+            ]
+        )
+
+    assert exc_info.value.code == 2
+    assert "--process-samples must be between" in capsys.readouterr().err
+
+    with pytest.raises(SystemExit) as exc_info:
+        live_smoke_report.main(
+            ["monitor", "--process-sample-interval-s", "nan"]
+        )
+
+    assert exc_info.value.code == 2
+    assert "--process-sample-interval-s must be between" in capsys.readouterr().err
+
+
 def test_live_smoke_report_process_status_matches_supervisor_config(
     tmp_path,
     monkeypatch,
@@ -8366,6 +8388,156 @@ def test_live_smoke_report_summarizes_current_process_pressure(
     assert {key: summary["processes"][key] for key in expected} == expected
     assert {key: brief["processes"][key] for key in expected} == expected
     json.dumps(report["processes"], allow_nan=False)
+
+
+def test_live_smoke_report_samples_process_state_recovery_and_persistence(
+    tmp_path,
+    monkeypatch,
+):
+    _write_minimal_monitor_event(tmp_path / "monitor")
+    command = (
+        "/root/passivbot/venv/bin/passivbot live "
+        "configs/forager.json -u binance_01"
+    )
+    gateio_command = (
+        "/root/passivbot/venv/bin/passivbot live "
+        "configs/forager.json -u gateio_01"
+    )
+    scans = iter(
+        [
+            (
+                [
+                    f"123 1 42 Dl+ 1.0 2.0 100 {command}",
+                    f"456 1 42 D 1.0 2.0 100 {gateio_command}",
+                ],
+                None,
+            ),
+            (
+                [
+                    f"123 1 47 Rl+ 1.0 2.0 100 {command}",
+                    f"456 1 47 D 1.0 2.0 100 {gateio_command}",
+                    f"789 1 1 R 1.0 2.0 100 {command}",
+                ],
+                None,
+            ),
+            (
+                [
+                    f"123 1 52 Rl+ 1.0 2.0 100 {command}",
+                    f"456 1 52 D 1.0 2.0 100 {gateio_command}",
+                    f"789 1 6 R 1.0 2.0 100 {command}",
+                ],
+                None,
+            ),
+        ]
+    )
+    sleeps = []
+    monkeypatch.setattr(smoke_report_module, "_ps_process_rows", lambda: next(scans))
+    monkeypatch.setattr(smoke_report_module.time, "sleep", sleeps.append)
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        include_processes=True,
+        process_samples=3,
+        process_sample_interval_s=5.0,
+    )
+    summary = summarize_live_smoke_report(report)
+    brief = summarize_live_smoke_report_brief(report)
+    sampling = report["processes"]["sampling"]
+
+    assert sleeps == [5.0, 5.0]
+    assert sampling == {
+        "enabled": True,
+        "requested_samples": 3,
+        "completed_samples": 3,
+        "interval_s": 5.0,
+        "scheduled_span_s": 10.0,
+        "scan_error_count": 0,
+        "pids_observed": 3,
+        "stable_pids": 2,
+        "command_pid_churn_count": 1,
+        "uninterruptible_observed_count": 2,
+        "uninterruptible_persistent_count": 1,
+        "uninterruptible_recovered_count": 1,
+        "uninterruptible_active_count": 1,
+        "state_observations": {"D": 4, "R": 4},
+        "groups": [
+            {
+                "pid": 123,
+                "account": "binance_01",
+                "config_path": "configs/forager.json",
+                "config_key": "binance_01:configs/forager.json",
+                "sample_count": 3,
+                "states": {"D": 1, "R": 2},
+                "first_state": "D",
+                "latest_state": "R",
+                "present_in_final_sample": True,
+                "uninterruptible_observations": 1,
+                "observed_uninterruptible": True,
+                "persistent_uninterruptible": False,
+                "recovered_from_uninterruptible": True,
+            },
+            {
+                "pid": 456,
+                "account": "gateio_01",
+                "config_path": "configs/forager.json",
+                "config_key": "gateio_01:configs/forager.json",
+                "sample_count": 3,
+                "states": {"D": 3},
+                "first_state": "D",
+                "latest_state": "D",
+                "present_in_final_sample": True,
+                "uninterruptible_observations": 3,
+                "observed_uninterruptible": True,
+                "persistent_uninterruptible": True,
+                "recovered_from_uninterruptible": False,
+            },
+            {
+                "pid": 789,
+                "account": "binance_01",
+                "config_path": "configs/forager.json",
+                "config_key": "binance_01:configs/forager.json",
+                "sample_count": 2,
+                "states": {"R": 2},
+                "first_state": "R",
+                "latest_state": "R",
+                "present_in_final_sample": True,
+                "uninterruptible_observations": 0,
+                "observed_uninterruptible": False,
+                "persistent_uninterruptible": False,
+                "recovered_from_uninterruptible": False,
+            },
+        ],
+        "groups_truncated": False,
+    }
+    assert summary["processes"]["sampling"]["groups"] == sampling["groups"]
+    assert brief["processes"]["sampling"] == {
+        key: sampling[key] for key in smoke_report_module.PROCESS_SAMPLING_FIELDS
+    }
+    assert report["ok"] is True
+    rendered = json.dumps(sampling, sort_keys=True)
+    assert "passivbot live" not in rendered
+    assert "/root/passivbot" not in rendered
+    assert "secret" not in rendered
+
+
+def test_live_smoke_report_rejects_unbounded_process_sampling(tmp_path):
+    _write_minimal_monitor_event(tmp_path / "monitor")
+
+    with pytest.raises(ValueError, match="process_samples must be between"):
+        build_live_smoke_report(
+            tmp_path / "monitor",
+            logs_root=None,
+            include_processes=True,
+            process_samples=smoke_report_module.MAX_PROCESS_SAMPLES + 1,
+        )
+    with pytest.raises(ValueError, match="process_sample_interval_s must be between"):
+        build_live_smoke_report(
+            tmp_path / "monitor",
+            logs_root=None,
+            include_processes=True,
+            process_sample_interval_s=float("inf"),
+        )
 
 
 def test_live_smoke_report_process_status_reports_duplicates_and_extra_live_processes(


### PR DESCRIPTION
## Scope

Category: read-only tooling.

Add opt-in bounded repeated process-table sampling to `live-smoke-report` so operators can distinguish observed, persistent, and recovered uninterruptible-sleep states during a smoke window.

- `--process-samples`: 1-12; default 1 preserves the existing snapshot shape.
- `--process-sample-interval-s`: finite 0-30 seconds; used only between repeated samples.
- The final sample continues to own existing liveness, expected-command, config, and smoke-verdict checks.
- Full/summary output includes bounded per-PID state counts; brief output keeps aggregate-only sampling counters.
- Canonical command/PID variation is counted without exposing raw process commands.

## Explicit non-goals

- No process signal, stop, start, restart, tmux action, SSH action, pull, or exchange contact.
- No new hard/attention classification for transient or persistent `D` observations.
- No event production, console/log projection, configuration, readiness, risk, order, or trading behavior change.
- No default output-shape change when one process snapshot is used.

## Triggering evidence

After report-only PR #1282 deployed to VPS5, cycle health naturally retained a KuCoin `InvalidNonce` degradation and then proved a newer successful cycle. A final exact PID check observed the unchanged KuCoin process in `D` for about 20 seconds before three consecutive `R` samples. Existing one-shot process output could show either point but could not represent the observed recovery.

## Validation

- `pytest -q tests/test_live_smoke_report.py tests/test_live_incident_bundle.py tests/test_live_event_registry_docs.py tests/test_ai_docs.py`: 132 passed
- Focused process recovery/persistence/churn/bounds/redaction tests: passed
- `python -m py_compile src/live/smoke_report.py src/tools/live_smoke_report.py tests/test_live_smoke_report.py`: passed
- `python src/tools/check_ai_docs.py`: 0 errors; existing repository word-count warning only
- `git diff --check`: passed
- Default incident-bundle process summary compatibility regression: passed

## VPS action after merge

Fast-forward the tracked checkout and run a bounded opt-in process-sampling smoke. No bot restart or process signal is expected.

## Reviewer focus

Verify the strict sample/interval bounds, final-sample verdict ownership, default output compatibility, recovered/persistent classification, PID/command variation semantics, and absence of raw command or unsafe process-control behavior.