### PR TITLE
Bind restart plan to stable target preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- `passivbot tool live-restart-smoke-plan` can now bind an explicitly
+  confirmed tmux session into its pre-restart readiness phase with
+  `--target-session-name`. The generated local-only target preflight requires
+  2-5 stable identity samples, remains non-executing, and makes the missing
+  target gate visible when no session is configured.
+
 - Added bounded `--samples` and `--interval-s` stability checks to
   `passivbot tool live-restart-target-report`. Multi-sample reports fail if any
   local preflight is hard-red or if a window's canonical pane ID, pane PID,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,31 +22,37 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/restart-target-stability`, based on canonical
-  `6cb8bc3c73c1e5b8c7ed1e70fa953e07a8e6b85e` after PR #1287.
-- PR: #1288, `Verify exact restart targets across samples`; semantic
-  implementation head `97e47aa326`. Slice: add bounded multi-sample stability
-  proof to the local-only exact tmux target preflight.
-- Triggering evidence: PR #1287 now proves exact pane/process ownership, but a
-  one-shot result can become stale before a future signal. The deployed target
-  report resolved all five bots exactly; the immediate process state included
-  one natural `D` that cleared by the settled repeat, reinforcing the need for
-  a bounded stable pre-action identity window.
-- Scope: sample the existing complete local target report up to five times,
-  retain bounded per-window observations, and fail if any sample is hard-red or
-  any pane ID, pane PID, bot PID, or ownership proof changes.
-- Behavior boundary: read-only sampling and verdict only. No signals, process
-  starts/control, SSH, git actions, network/exchange access, credential loading,
-  file writes, or restart execution.
-- Validation: focused stable/changed/failed/bounds/CLI regressions plus existing
+- Branch: `codex/restart-plan-target-gate`, based on canonical
+  `e004ede7ddaa4935bc8bf69739285724656198d3` after PR #1288.
+- PR: pending. Slice: bind the deployed stable exact-target report into the
+  existing plan-only restart smoke workflow as an explicit pre-action gate.
+- Triggering evidence: PR #1288's immediate and settled three-sample reports
+  proved stable pane IDs, pane PIDs, bot PIDs, and ownership for all five bots,
+  but `live-restart-smoke-plan` still does not emit that required gate.
+- Scope: add an explicit target session plus bounded 2-5 sample/window options,
+  emit the exact local-only target-report command in pre-restart readiness, and
+  project its required verdict in complete and summary output.
+- Behavior boundary: command generation only. The planner remains plan-only and
+  does not inspect tmux, run the target report, signal or start processes, use
+  SSH/git, contact a network/exchange, load credentials, or write files.
+- Validation: focused planner/CLI/summary/bounds regressions plus existing
   target, process, restart-plan, compilation, and docs checks.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: pull and run the target report with three bounded
-  samples; no bot restart or process signal is expected.
+- Expected VPS action: pull and inspect a compact plan with the exact session;
+  no bot restart, tmux action, or process signal is expected.
 
 ## Deployed Baseline
 
+- Canonical `master` and VPS5 are
+  `e004ede7ddaa4935bc8bf69739285724656198d3`, PR #1288. VPS5 fast-forwarded
+  cleanly from `6cb8bc3c` without a restart or process signal; all five pane
+  IDs/PIDs, bot PIDs, and unrelated `misc:0.0` PID `434835` remained unchanged.
+- Immediate and settled three-sample local-only target reports were `ok=true`
+  and `sampling.stable=true`, with `3/3` successful samples, five stable
+  targets, zero failed samples, zero changed targets, and no issues. Immediate
+  process state `R=2,S=3` settled to `R=4,S=1`; no exchange request, process
+  action, or event was manufactured.
 - Canonical `master` and VPS5 are
   `6cb8bc3c73c1e5b8c7ed1e70fa953e07a8e6b85e`, PR #1287. VPS5 fast-forwarded
   from `7a12430a` with a tracked-clean checkout. Configured pane process IDs
@@ -1124,10 +1130,11 @@ signal; its full VPS smoke remained intentionally unrun after the
 production-action rejection. PR #1285's dedicated local-only
 `live-process-report` path is also merged, deployed, and naturally validated
 with five stable exact processes and recovered uninterruptible observations.
-PR #1286's aggregate-only follow-up and PR #1287's exact tmux target preflight
-are merged, deployed, and naturally validated without process control. The
-active `codex/restart-target-stability` slice closes the pre-action identity
-race with bounded read-only samples and still does not add restart execution.
+PR #1286's aggregate-only follow-up, PR #1287's exact tmux target preflight,
+and PR #1288's bounded target-identity stability are merged, deployed, and
+naturally validated without process control. The active
+`codex/restart-plan-target-gate` slice binds that stable local-only verdict into
+the existing non-executing restart plan.
 
 Do not create progress-only PRs or resume unrelated logging work from stale
 worktrees.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,8 +24,10 @@ Estimated completion:
 
 - Branch: `codex/restart-plan-target-gate`, based on canonical
   `e004ede7ddaa4935bc8bf69739285724656198d3` after PR #1288.
-- PR: pending. Slice: bind the deployed stable exact-target report into the
-  existing plan-only restart smoke workflow as an explicit pre-action gate.
+- PR: #1289, `Bind restart plan to stable target preflight`; semantic
+  implementation head `9011d4e0f5`. Slice: bind the deployed stable
+  exact-target report into the existing plan-only restart smoke workflow as an
+  explicit pre-action gate.
 - Triggering evidence: PR #1288's immediate and settled three-sample reports
   proved stable pane IDs, pane PIDs, bot PIDs, and ownership for all five bots,
   but `live-restart-smoke-plan` still does not emit that required gate.

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -9186,6 +9186,20 @@ active branch, PR, review gate, and rollout instructions.
   `codex/restart-target-stability` adds a bounded pre-action identity window
   without making restart execution available.
 
+### 2026-07-16: Stable Restart Targets Deployed
+
+- PR #1288 merged to canonical `master` at `e004ede7dd` after exact-head
+  Hermes approval and green Python/Rust CI. VPS5 fast-forwarded cleanly without
+  a restart or process signal; all five pane IDs/PIDs, bot PIDs, and unrelated
+  `misc:0.0` PID `434835` remained unchanged.
+- Immediate and settled three-sample local-only target reports were `ok=true`
+  and `sampling.stable=true`, with five stable targets, `3/3` successful
+  samples, zero failed samples, zero changed targets, and no issues. Immediate
+  process state `R=2,S=3` settled to `R=4,S=1` naturally.
+- No exchange request, process action, or event was manufactured. Active
+  `codex/restart-plan-target-gate` adds the exact stable report command and
+  required verdict to the existing non-executing restart plan.
+
 ### 2026-07-16: Brief Process Report Deployed
 
 - PR #1286 merged to canonical `master` at `7a12430abf` after exact-head

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -330,6 +330,10 @@ Related detailed plans:
      ownership proof for all five configured bots. Immediate and settled target
      reports were hard-green without process action; the active follow-up adds
      bounded identity stability across a pre-action sample window.
+   - 2026-07-16: PR #1288 deployed bounded target identity stability. Immediate
+     and settled three-sample reports retained all five exact targets with zero
+     changed identities or failed samples. The active follow-up binds this
+     local-only hard gate into the non-executing restart smoke plan.
 
    Remaining refinements: safe pull/stop/start orchestration remains open.
    The concise and brief summaries are intentionally bounded; further changes
@@ -1194,7 +1198,7 @@ Related detailed plans:
 | 2026-06-30 | #3/#4 Live restart/smoke automation and startup budget tracking | PR #886 / `60c79c3a` | Exposed existing startup timing evidence in `live-smoke-report --summary` and `--brief`; VPS5 5-minute smoke stayed hard-green and showed the new `startup_timings` brief key | Safe pull/stop/start orchestration and durable startup budget config/events remain open |
 | 2026-06-30 | #3 Live restart/smoke automation | PR #888 / `4b435d33` | Exposed bounded text-log window counters in `live-smoke-report --brief`; VPS5 5-minute smoke stayed hard-green and showed `logs.window.lines_skipped_before=1730` | Safe pull/stop/start orchestration remains open |
 | 2026-06-30 | #3 Live restart/smoke automation | PR #890 / `1498abc9` | Exposed `event_window.enabled` in `live-smoke-report --brief`; VPS5 5-minute smoke stayed hard-green and showed `event_window.enabled=true` | Safe pull/stop/start orchestration remains open |
-| 2026-07-16 | #3 Live restart/smoke automation | PR #1288 / semantic head `97e47aa326`, after PR #1287 / `6cb8bc3c73` | PR #1287 deployed five exact canonical pane targets with stable pane/bot PIDs and natural `D` recovery; PR #1288 requires bounded target identity stability without signals | Review and validate target stability; safe pull/stop/start execution remains open |
+| 2026-07-16 | #3 Live restart/smoke automation | Active `codex/restart-plan-target-gate`, after PR #1288 / `e004ede7dd` | PR #1288 deployed two hard-green three-sample reports with five stable exact targets and zero changed identities; active work binds that local-only gate into the non-executing restart plan | Review and validate plan binding; safe pull/stop/start execution remains open |
 | 2026-06-30 | #2 Event query and timeline CLI extensions | PR #892 / `7e7ce16f` | Added `live-event-query --level` filtering for structured event severity; VPS5 query smoke matched 33 warning-level events with `ok=true` and all five bots still running | Cross-bot incident workflow remains open; Binance config-refresh traceback classification added as item #18 |
 | 2026-06-30 | #18 Binance hourly hedge-mode/config refresh classification | PR #894 / `796ceb38` | Added off-console/text `exchange.config_refresh` events for hourly maintenance refresh success/failure with sanitized bounded error fields and fail-loud behavior preserved | Live emission evidence after next bot restart; smoke/report classification remains open |
 | 2026-06-30 | #18 Binance hourly hedge-mode/config refresh classification | PR #896 / `53b8accb` | Added `live-smoke-report` full/summary/brief health projections for `exchange.config_refresh`, excluding raw error text; VPS5 no-restart smoke stayed hard-green and showed the new brief section | Live emission evidence after next bot restart; smoke/report classification remains open |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -379,9 +379,17 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   path to avoid overwriting prior evidence. The pre-restart readiness phase also
   includes one deduplicated `live-config-preflight` command for each configured
   live config path found in the supervisor config, plus a skip count for any
-  configured live command whose config path could not be derived. Use planner
+  configured live command whose config path could not be derived. Use
+  `--target-session-name SESSION` to append the exact local-only
+  `live-restart-target-report` gate to that phase. The planner defaults to
+  three samples five seconds apart; use `--target-samples N` (2-5) and
+  `--target-interval-s SECONDS` (greater than 0, at most 30) to change the
+  bounded stability window.
+  The command is only emitted, never run. Omitting the exact session keeps the
+  plan valid and explicitly marks the stable target gate unconfigured. Use
   `--summary` when you only need the bot count, phase names, preflight commands,
-  smoke command, and incident-bundle command without every per-bot phase detail.
+  target-preflight verdict requirement, smoke command, and incident-bundle
+  command without every per-bot phase detail.
 - `passivbot tool live-restart-target-report SUPERVISOR_CONFIG --session-name
   SESSION` performs the local-only exact-target preflight required before any
   future restart executor may signal a pane. It joins expected supervisor

--- a/src/live/restart_smoke_plan.py
+++ b/src/live/restart_smoke_plan.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+import math
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from live.restart_smoke_targets import (
+    MAX_TARGET_SAMPLE_INTERVAL_S,
+    MAX_TARGET_SAMPLES,
+    MAX_TMUX_IDENTIFIER_CHARS,
+)
 from live.smoke_report import (
     DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
     LOG_WINDOW_UNPARSED_POLICIES,
@@ -28,6 +34,9 @@ DEFAULT_INCIDENT_BUNDLE_OUTPUT_HELP = (
 )
 DEFAULT_MONITOR_ROOT = "monitor"
 DEFAULT_LOGS_ROOT = "logs"
+DEFAULT_TARGET_SAMPLES = 3
+DEFAULT_TARGET_SAMPLE_INTERVAL_S = 5.0
+MIN_STABLE_TARGET_SAMPLES = 2
 UNSAFE_PROCESS_SIGNAL_PATTERNS = (
     "pkill -f 'passivbot live'",
     "pgrep -f 'passivbot live' | xargs kill",
@@ -207,6 +216,77 @@ def _repo_check_commands(repo_path: str | Path | None) -> list[str]:
     ]
 
 
+def _target_preflight_plan(
+    supervisor_config: str | Path,
+    *,
+    session_name: str | None,
+    samples: int,
+    sample_interval_s: float,
+) -> dict[str, Any]:
+    samples = int(samples)
+    sample_interval_s = float(sample_interval_s)
+    if samples < MIN_STABLE_TARGET_SAMPLES or samples > MAX_TARGET_SAMPLES:
+        raise ValueError(
+            "target_samples must be between "
+            f"{MIN_STABLE_TARGET_SAMPLES} and {MAX_TARGET_SAMPLES}"
+        )
+    if (
+        not math.isfinite(sample_interval_s)
+        or sample_interval_s <= 0.0
+        or sample_interval_s > MAX_TARGET_SAMPLE_INTERVAL_S
+    ):
+        raise ValueError(
+            "target_sample_interval_s must be greater than 0 and at most "
+            f"{MAX_TARGET_SAMPLE_INTERVAL_S:g}"
+        )
+
+    confirmed_session = None
+    if session_name is not None:
+        confirmed_session = str(session_name).strip()
+        if not confirmed_session:
+            raise ValueError("target_session_name must be non-empty")
+        if len(confirmed_session) > MAX_TMUX_IDENTIFIER_CHARS:
+            raise ValueError(
+                "target_session_name must not exceed "
+                f"{MAX_TMUX_IDENTIFIER_CHARS} characters"
+            )
+
+    command = None
+    if confirmed_session is not None:
+        command = _shell_join(
+            [
+                "passivbot",
+                "tool",
+                "live-restart-target-report",
+                str(supervisor_config),
+                "--session-name",
+                confirmed_session,
+                "--samples",
+                str(samples),
+                "--interval-s",
+                f"{sample_interval_s:g}",
+                "--compact",
+            ]
+        )
+    return {
+        "configured": command is not None,
+        "session_name": confirmed_session,
+        "samples": samples,
+        "sample_interval_s": sample_interval_s,
+        "command": command,
+        "execute": False,
+        "required_for_future_execution": True,
+        "required_verdict": "ok=true and sampling.stable=true",
+        "expected_fields": [
+            "exact confirmed tmux session",
+            "complete expected window and pane inventory",
+            "exact pane ID and pane PID per configured bot",
+            "matched bot PID and pane ownership proof",
+            "multi-sample stable target identity verdict",
+        ],
+    }
+
+
 def _config_preflight_plan(bots: list[dict[str, Any]]) -> dict[str, Any]:
     commands: list[str] = []
     seen: set[str] = set()
@@ -346,6 +426,9 @@ def build_live_restart_smoke_plan(
     summary_smoke_report: bool = False,
     smoke_sections: list[str] | tuple[str, ...] | None = None,
     performance_sections: list[str] | tuple[str, ...] | None = None,
+    target_session_name: str | None = None,
+    target_samples: int = DEFAULT_TARGET_SAMPLES,
+    target_sample_interval_s: float = DEFAULT_TARGET_SAMPLE_INTERVAL_S,
     execute: bool = False,
 ) -> dict[str, Any]:
     if execute:
@@ -383,6 +466,12 @@ def build_live_restart_smoke_plan(
         for section in (performance_sections or ())
         if str(section).strip()
     ]
+    target_preflight_plan = _target_preflight_plan(
+        supervisor_config,
+        session_name=target_session_name,
+        samples=target_samples,
+        sample_interval_s=target_sample_interval_s,
+    )
 
     supervisor = parse_tmuxp_live_commands(supervisor_config)
     bots = list(supervisor.get("expected") or [])
@@ -395,6 +484,8 @@ def build_live_restart_smoke_plan(
         "does_not_start_passivbot_live",
         "does_not_contact_exchanges",
     ]
+    if not target_preflight_plan["configured"]:
+        warnings.append("stable_target_preflight_not_configured")
     issues: list[dict[str, str]] = []
     if supervisor.get("error"):
         issues.append(
@@ -456,6 +547,11 @@ def build_live_restart_smoke_plan(
     )
     config_preflight_plan = _config_preflight_plan(bots)
     config_preflight_commands = list(config_preflight_plan["commands"])
+    target_preflight_commands = (
+        [str(target_preflight_plan["command"])]
+        if target_preflight_plan["configured"]
+        else []
+    )
     planned_bots = []
     for index, bot in enumerate(bots, start=1):
         planned_bots.append(
@@ -498,6 +594,11 @@ def build_live_restart_smoke_plan(
             "smoke_sections": list(smoke_sections),
             "performance_sections": list(performance_sections),
             "incident_bundle_output": _display_path(incident_bundle_output),
+            "target_session_name": target_preflight_plan["session_name"],
+            "target_samples": target_preflight_plan["samples"],
+            "target_sample_interval_s": target_preflight_plan[
+                "sample_interval_s"
+            ],
         },
         "supervisor_config": {
             "path": _display_path(supervisor.get("path")),
@@ -517,6 +618,7 @@ def build_live_restart_smoke_plan(
                     {"command": command, "execute": False}
                     for command in _repo_check_commands(repo_path)
                     + config_preflight_commands
+                    + target_preflight_commands
                 ],
             },
             {
@@ -607,6 +709,7 @@ def build_live_restart_smoke_plan(
                 "cache-related live settings and readiness attention",
             ],
         },
+        "target_preflight": target_preflight_plan,
         "process_signal_safety": _process_signal_safety_contract(),
         "timeout_escalation_ladder": [
             {
@@ -652,6 +755,10 @@ def build_live_restart_smoke_plan(
         "execution_policy": {
             "execute_flag": "not_implemented",
             "future_execution_requires_review": True,
+            "future_execution_requires_stable_target_preflight": True,
+            "stable_target_preflight_configured": target_preflight_plan[
+                "configured"
+            ],
             "rejected_operations": [
                 "ssh",
                 "tmux signal/send-keys",
@@ -682,6 +789,7 @@ def summarize_live_restart_smoke_plan(report: dict[str, Any]) -> dict[str, Any]:
     smoke_report = report.get("smoke_report")
     incident_bundle = report.get("incident_bundle")
     config_preflight = report.get("config_preflight")
+    target_preflight = report.get("target_preflight")
     execution_policy = report.get("execution_policy")
     signal_safety = report.get("process_signal_safety")
     return {
@@ -753,6 +861,48 @@ def summarize_live_restart_smoke_plan(report: dict[str, Any]) -> dict[str, Any]:
                 else None
             ),
         },
+        "target_preflight": {
+            "configured": (
+                target_preflight.get("configured")
+                if isinstance(target_preflight, dict)
+                else False
+            ),
+            "session_name": (
+                target_preflight.get("session_name")
+                if isinstance(target_preflight, dict)
+                else None
+            ),
+            "samples": (
+                target_preflight.get("samples")
+                if isinstance(target_preflight, dict)
+                else None
+            ),
+            "sample_interval_s": (
+                target_preflight.get("sample_interval_s")
+                if isinstance(target_preflight, dict)
+                else None
+            ),
+            "command": (
+                target_preflight.get("command")
+                if isinstance(target_preflight, dict)
+                else None
+            ),
+            "execute": (
+                target_preflight.get("execute")
+                if isinstance(target_preflight, dict)
+                else None
+            ),
+            "required_for_future_execution": (
+                target_preflight.get("required_for_future_execution")
+                if isinstance(target_preflight, dict)
+                else None
+            ),
+            "required_verdict": (
+                target_preflight.get("required_verdict")
+                if isinstance(target_preflight, dict)
+                else None
+            ),
+        },
         "process_signal_safety": {
             "strategy": (
                 signal_safety.get("strategy") if isinstance(signal_safety, dict) else None
@@ -785,6 +935,18 @@ def summarize_live_restart_smoke_plan(report: dict[str, Any]) -> dict[str, Any]:
             ),
             "future_execution_requires_review": (
                 execution_policy.get("future_execution_requires_review")
+                if isinstance(execution_policy, dict)
+                else None
+            ),
+            "future_execution_requires_stable_target_preflight": (
+                execution_policy.get(
+                    "future_execution_requires_stable_target_preflight"
+                )
+                if isinstance(execution_policy, dict)
+                else None
+            ),
+            "stable_target_preflight_configured": (
+                execution_policy.get("stable_target_preflight_configured")
                 if isinstance(execution_policy, dict)
                 else None
             ),

--- a/src/tools/live_restart_smoke_plan.py
+++ b/src/tools/live_restart_smoke_plan.py
@@ -22,6 +22,8 @@ from live.restart_smoke_plan import (  # noqa: E402
     DEFAULT_SHUTDOWN_TIMEOUT_S,
     DEFAULT_SMOKE_WINDOW_MINUTES,
     DEFAULT_STARTUP_WAIT_S,
+    DEFAULT_TARGET_SAMPLE_INTERVAL_S,
+    DEFAULT_TARGET_SAMPLES,
     LOG_WINDOW_UNPARSED_POLICIES,
     build_live_restart_smoke_plan,
     summarize_live_restart_smoke_plan,
@@ -40,6 +42,28 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--repo-path",
         help="Repository path to include in planned git checks.",
+    )
+    parser.add_argument(
+        "--target-session-name",
+        help=(
+            "Exact tmux session to bind into the planned stable target preflight. "
+            "Omit to leave the target gate visibly unconfigured."
+        ),
+    )
+    parser.add_argument(
+        "--target-samples",
+        type=int,
+        default=DEFAULT_TARGET_SAMPLES,
+        help="Stable target samples to plan (default: 3; range: 2-5).",
+    )
+    parser.add_argument(
+        "--target-interval-s",
+        type=float,
+        default=DEFAULT_TARGET_SAMPLE_INTERVAL_S,
+        help=(
+            "Seconds between planned target samples "
+            "(default: 5; greater than 0; max: 30)."
+        ),
     )
     parser.add_argument(
         "--monitor-root",
@@ -220,6 +244,9 @@ def main(argv: list[str] | None = None) -> int:
             summary_smoke_report=bool(args.summary_smoke_report),
             smoke_sections=args.smoke_section,
             performance_sections=args.performance_section,
+            target_session_name=args.target_session_name,
+            target_samples=int(args.target_samples),
+            target_sample_interval_s=float(args.target_interval_s),
             execute=False,
         )
     except (NotImplementedError, ValueError) as exc:

--- a/tests/test_live_restart_smoke_plan.py
+++ b/tests/test_live_restart_smoke_plan.py
@@ -85,6 +85,23 @@ def test_live_restart_smoke_plan_builds_plan_from_supervisor_config(tmp_path):
             "cache-related live settings and readiness attention",
         ],
     }
+    assert report["target_preflight"] == {
+        "configured": False,
+        "session_name": None,
+        "samples": 3,
+        "sample_interval_s": 5.0,
+        "command": None,
+        "execute": False,
+        "required_for_future_execution": True,
+        "required_verdict": "ok=true and sampling.stable=true",
+        "expected_fields": [
+            "exact confirmed tmux session",
+            "complete expected window and pane inventory",
+            "exact pane ID and pane PID per configured bot",
+            "matched bot PID and pane ownership proof",
+            "multi-sample stable target identity verdict",
+        ],
+    }
     assert (
         report["phases"][0]["planned_commands"][-1]["command"]
         == "passivbot tool live-config-preflight configs/forager.json --compact"
@@ -134,6 +151,89 @@ def test_live_restart_smoke_plan_builds_plan_from_supervisor_config(tmp_path):
         "rejected_operations"
     ]
     assert "does_not_start_passivbot_live" in report["warnings"]
+    assert "stable_target_preflight_not_configured" in report["warnings"]
+
+
+def test_live_restart_smoke_plan_binds_stable_target_preflight(tmp_path):
+    supervisor_config = tmp_path / "bots vps5.yaml"
+    _write_supervisor(
+        supervisor_config,
+        [
+            "session_name: passivbot",
+            "windows:",
+            "  - window_name: binance_01",
+            "    panes:",
+            "      - passivbot live configs/forager.json -u binance_01",
+        ],
+    )
+
+    report = build_live_restart_smoke_plan(
+        supervisor_config,
+        target_session_name="passivbot ops",
+        target_samples=4,
+        target_sample_interval_s=2.5,
+    )
+
+    expected_command = (
+        "passivbot tool live-restart-target-report "
+        f"'{supervisor_config}' --session-name 'passivbot ops' "
+        "--samples 4 --interval-s 2.5 --compact"
+    )
+    assert report["ok"] is True
+    assert report["target_preflight"] == {
+        "configured": True,
+        "session_name": "passivbot ops",
+        "samples": 4,
+        "sample_interval_s": 2.5,
+        "command": expected_command,
+        "execute": False,
+        "required_for_future_execution": True,
+        "required_verdict": "ok=true and sampling.stable=true",
+        "expected_fields": [
+            "exact confirmed tmux session",
+            "complete expected window and pane inventory",
+            "exact pane ID and pane PID per configured bot",
+            "matched bot PID and pane ownership proof",
+            "multi-sample stable target identity verdict",
+        ],
+    }
+    assert report["phases"][0]["planned_commands"][-1] == {
+        "command": expected_command,
+        "execute": False,
+    }
+    assert report["execution_policy"][
+        "future_execution_requires_stable_target_preflight"
+    ] is True
+    assert report["execution_policy"]["stable_target_preflight_configured"] is True
+    assert "stable_target_preflight_not_configured" not in report["warnings"]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"target_samples": 1}, "target_samples must be between 2 and 5"),
+        ({"target_samples": 6}, "target_samples must be between 2 and 5"),
+        (
+            {"target_sample_interval_s": -0.1},
+            "target_sample_interval_s must be greater than 0 and at most 30",
+        ),
+        (
+            {"target_sample_interval_s": 0},
+            "target_sample_interval_s must be greater than 0 and at most 30",
+        ),
+        (
+            {"target_sample_interval_s": 31},
+            "target_sample_interval_s must be greater than 0 and at most 30",
+        ),
+        (
+            {"target_session_name": " "},
+            "target_session_name must be non-empty",
+        ),
+    ],
+)
+def test_live_restart_smoke_plan_validates_target_preflight_bounds(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        build_live_restart_smoke_plan("bots.yaml", **kwargs)
 
 
 def test_live_restart_smoke_plan_can_focus_smoke_sections(tmp_path):
@@ -375,7 +475,18 @@ def test_live_restart_smoke_plan_cli_outputs_json(tmp_path, capsys):
 
     assert (
         live_restart_smoke_plan.main(
-            [str(supervisor_config), "--compact", "--shutdown-timeout-s", "30"]
+            [
+                str(supervisor_config),
+                "--compact",
+                "--shutdown-timeout-s",
+                "30",
+                "--target-session-name",
+                "passivbot",
+                "--target-samples",
+                "4",
+                "--target-interval-s",
+                "2.5",
+            ]
         )
         == 0
     )
@@ -406,6 +517,13 @@ def test_live_restart_smoke_plan_cli_outputs_json(tmp_path, capsys):
         in report["incident_bundle"]["command"]
     )
     assert "--compact" in report["incident_bundle"]["command"]
+    assert report["target_preflight"]["configured"] is True
+    assert report["target_preflight"]["session_name"] == "passivbot"
+    assert report["target_preflight"]["samples"] == 4
+    assert report["target_preflight"]["sample_interval_s"] == 2.5
+    assert report["target_preflight"]["command"].endswith(
+        "--session-name passivbot --samples 4 --interval-s 2.5 --compact"
+    )
 
 
 def test_live_restart_smoke_plan_can_disable_planned_event_scan_bounds(
@@ -539,6 +657,7 @@ def test_live_restart_smoke_plan_summary_projects_concise_commands(tmp_path, cap
         supervisor_config,
         repo_path="/srv/passivbot",
         smoke_window_minutes=7,
+        target_session_name="passivbot",
     )
     summary = summarize_live_restart_smoke_plan(full_report)
 
@@ -569,11 +688,29 @@ def test_live_restart_smoke_plan_summary_projects_concise_commands(tmp_path, cap
         "execute": False,
         "skipped_without_config_path_count": 0,
     }
+    assert summary["target_preflight"] == {
+        "configured": True,
+        "session_name": "passivbot",
+        "samples": 3,
+        "sample_interval_s": 5.0,
+        "command": (
+            "passivbot tool live-restart-target-report "
+            f"{supervisor_config} --session-name passivbot --samples 3 "
+            "--interval-s 5 --compact"
+        ),
+        "execute": False,
+        "required_for_future_execution": True,
+        "required_verdict": "ok=true and sampling.stable=true",
+    }
     assert summary["incident_bundle"]["event_segments"] == (
         "disabled_by_default_for_fast_restart_smoke_bundle"
     )
     assert summary["timeout_escalation_ladder"][1]["planned_command_count"] == 2
     assert summary["execution_policy"]["execute_flag"] == "not_implemented"
+    assert summary["execution_policy"][
+        "future_execution_requires_stable_target_preflight"
+    ] is True
+    assert summary["execution_policy"]["stable_target_preflight_configured"] is True
     assert summary["execution_policy"]["rejected_operation_count"] >= 1
     assert summary["warnings"]["count"] == len(full_report["warnings"])
     assert summary["issues"] == {"count": 0, "items": []}


### PR DESCRIPTION
## Scope

- Category: read-only tooling and operational documentation.
- Add explicit `--target-session-name`, bounded `--target-samples` (2-5), and positive `--target-interval-s` (max 30) inputs to the plan-only restart smoke tool.
- Emit the shell-quoted local-only `live-restart-target-report` command in pre-restart readiness and project its required `ok=true and sampling.stable=true` verdict in full and summary output.
- Record PR #1288 deploy evidence and advance the compact logging-overhaul handoff.

## Behavior boundary

The planner still does not execute commands, inspect tmux, run the target report, signal or start processes, use SSH/git, contact a network or exchange, load credentials, or write files. Omitting the exact session preserves a valid plan and exposes `stable_target_preflight_not_configured`.

## Validation

- `python -m pytest -q tests/test_live_restart_smoke_plan.py tests/test_live_restart_target_report.py tests/test_live_process_report.py tests/test_live_incident_bundle.py`: 85 passed.
- `python -m pytest -q tests/test_ai_docs.py tests/test_live_event_registry_docs.py`: 3 passed.
- `python -m compileall -q src/live/restart_smoke_plan.py src/tools/live_restart_smoke_plan.py tests/test_live_restart_smoke_plan.py`: passed.
- `git diff --check`: passed.
- Shared-checkout `tests/test_passivbot_cli.py` collection was not used because its Rust extension freshness guard detected the user checkout's existing source/binary mismatch; focused planner CLI and registry coverage passed without rebuilding the shared venv.

## VPS action

Pull and inspect one compact plan against `/root/bots_vps5.yaml` with exact session `passivbot`. No restart, tmux action, process signal, exchange access, or manufactured event.

## Reviewer focus

Verify that the explicit session confirmation, 2-5 sample bound, positive elapsed interval, shell quoting, summary projection, and non-executing boundary are sufficient prerequisites for a future separately reviewed executor.