### PR TITLE
Fix live trailing extrema reset parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live trailing extrema now reset independently per symbol and position side
+  after every confirmed fill. Ordinary trailing closes are withheld and stale
+  trailing orders retired until post-fill candles establish fresh extrema,
+  while panic/HSL exits remain available. Trailing-martingale monitor
+  diagnostics now use the Rust close formula and report its exact wallet
+  exposure and volatility inputs.
+
 - Exact live restart targets now classify whether the bot is a child of its
   tmux pane parent and therefore has a bounded candidate relaunch path after a
   required post-stop pane recheck. The report exposes only method/proof

--- a/passivbot-rust/src/closes.rs
+++ b/passivbot-rust/src/closes.rs
@@ -1,6 +1,6 @@
 use crate::dynamic::{calc_dynamic_distance_multiplier, DynamicDistanceInputs};
 use crate::entries::{calc_min_entry_qty, wallet_exposure_limit_with_allowance};
-use crate::strategies::TrailingMartingaleCloseParams;
+use crate::strategies::{StrategySide, TrailingMartingaleCloseParams};
 use crate::types::{
     BotParams, ExchangeParams, Order, OrderType, Position, RuntimeOrderContext, StateParams,
     TrailingPriceBundle,
@@ -9,6 +9,38 @@ use crate::utils::{
     calc_wallet_exposure, cost_to_qty, quantize_price, quantize_qty, round_, round_dn, round_up,
     RoundingMode,
 };
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TrailingMartingaleCloseThresholdTerms {
+    pub base: f64,
+    pub wallet_exposure: f64,
+    pub volatility_ema_1m: f64,
+    pub volatility_ema_1h: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TrailingMartingaleCloseDiagnostic {
+    pub kind: &'static str,
+    pub pside: &'static str,
+    pub selected_mode: &'static str,
+    pub order_type: String,
+    pub qty: f64,
+    pub price: f64,
+    pub triggered: bool,
+    pub status: &'static str,
+    pub threshold_pct: f64,
+    pub threshold_met: bool,
+    pub threshold_terms: TrailingMartingaleCloseThresholdTerms,
+    pub retracement_pct: f64,
+    pub retracement_met: bool,
+    pub wallet_exposure: f64,
+    pub effective_wallet_exposure_limit: f64,
+    pub wallet_exposure_ratio: f64,
+    pub volatility_ema_1m: f64,
+    pub volatility_ema_1h: f64,
+    pub extrema: TrailingPriceBundle,
+}
 
 pub(crate) fn sort_closes_by_price(closes: &mut [Order], descending: bool, context: &str) {
     for order in closes.iter() {
@@ -686,6 +718,130 @@ pub fn calc_next_close_short(
             close_params,
             position,
         )
+    }
+}
+
+pub fn calc_trailing_martingale_close_diagnostic(
+    side: StrategySide,
+    exchange_params: &ExchangeParams,
+    state_params: &StateParams,
+    bot_params: &BotParams,
+    runtime_context: &RuntimeOrderContext,
+    close_params: &TrailingMartingaleCloseParams,
+    position: &Position,
+    trailing_price_bundle: &TrailingPriceBundle,
+) -> TrailingMartingaleCloseDiagnostic {
+    let effective_wallet_exposure_limit =
+        wallet_exposure_limit_with_allowance(bot_params, runtime_context);
+    let wallet_exposure = calc_wallet_exposure(
+        exchange_params.c_mult,
+        state_params.balance,
+        position.size,
+        position.price,
+    );
+    let wallet_exposure_ratio = if effective_wallet_exposure_limit > 0.0 {
+        wallet_exposure / effective_wallet_exposure_limit
+    } else {
+        0.0
+    };
+    let threshold_pct = calc_close_threshold_pct(
+        exchange_params,
+        state_params,
+        bot_params,
+        runtime_context,
+        close_params,
+        position,
+    );
+    let retracement_pct = close_params.retracement_base_pct.max(0.0)
+        * calc_close_retracement_multiplier(state_params, close_params);
+
+    let (pside, threshold_met, retracement_met, order) = match side {
+        StrategySide::Long => (
+            "long",
+            threshold_pct <= 0.0
+                || trailing_price_bundle.max_since_open > position.price * (1.0 + threshold_pct),
+            retracement_pct <= 0.0
+                || trailing_price_bundle.min_since_max
+                    < trailing_price_bundle.max_since_open * (1.0 - retracement_pct),
+            calc_next_close_long(
+                exchange_params,
+                state_params,
+                bot_params,
+                runtime_context,
+                close_params,
+                position,
+                trailing_price_bundle,
+            ),
+        ),
+        StrategySide::Short => (
+            "short",
+            threshold_pct <= 0.0
+                || trailing_price_bundle.min_since_open < position.price * (1.0 - threshold_pct),
+            retracement_pct <= 0.0
+                || trailing_price_bundle.max_since_min
+                    > trailing_price_bundle.min_since_open * (1.0 + retracement_pct),
+            calc_next_close_short(
+                exchange_params,
+                state_params,
+                bot_params,
+                runtime_context,
+                close_params,
+                position,
+                trailing_price_bundle,
+            ),
+        ),
+    };
+    let triggered = order.qty != 0.0
+        && matches!(
+            order.order_type,
+            OrderType::CloseTrailingLong | OrderType::CloseTrailingShort
+        );
+    let selected_mode = match order.order_type {
+        OrderType::CloseTrailingLong | OrderType::CloseTrailingShort => "trailing",
+        OrderType::CloseGridLong | OrderType::CloseGridShort => "grid",
+        OrderType::CloseUnstuckLong | OrderType::CloseUnstuckShort => "unstuck",
+        OrderType::CloseAutoReduceWelLong | OrderType::CloseAutoReduceWelShort => "auto_reduce",
+        OrderType::ClosePanicLong | OrderType::ClosePanicShort => "panic",
+        OrderType::Empty => "none",
+        _ => "other",
+    };
+    let status = if triggered {
+        "triggered"
+    } else if !threshold_met {
+        "waiting_threshold"
+    } else if !retracement_met {
+        "waiting_retracement"
+    } else {
+        "armed"
+    };
+
+    TrailingMartingaleCloseDiagnostic {
+        kind: "close",
+        pside,
+        selected_mode,
+        order_type: order.order_type.to_string(),
+        qty: order.qty,
+        price: order.price,
+        triggered,
+        status,
+        threshold_pct,
+        threshold_met,
+        threshold_terms: TrailingMartingaleCloseThresholdTerms {
+            base: close_params.threshold_base_pct,
+            wallet_exposure: wallet_exposure_ratio * close_params.threshold_we_weight,
+            volatility_ema_1m: state_params.volatility_ema_1m
+                * close_params.threshold_volatility_1m_weight,
+            volatility_ema_1h: state_params.volatility_ema_1h
+                * close_params.threshold_volatility_1h_weight,
+        },
+        retracement_pct,
+        retracement_met,
+        wallet_exposure,
+        effective_wallet_exposure_limit,
+        wallet_exposure_ratio,
+        volatility_ema_1m: state_params.volatility_ema_1m,
+        volatility_ema_1h: state_params.volatility_ema_1h,
+        extrema: trailing_price_bundle.clone(),
     }
 }
 

--- a/passivbot-rust/src/lib.rs
+++ b/passivbot-rust/src/lib.rs
@@ -41,6 +41,10 @@ fn passivbot_rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(calc_new_psize_pprice, m)?)?;
     m.add_function(wrap_pyfunction!(calc_next_entry_long_py, m)?)?;
     m.add_function(wrap_pyfunction!(calc_trailing_grid_v7_diagnostic_py, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        calc_trailing_martingale_close_diagnostic_py,
+        m
+    )?)?;
     m.add_function(wrap_pyfunction!(calc_next_close_long_py, m)?)?;
     m.add_function(wrap_pyfunction!(calc_entries_long_py, m)?)?;
     m.add_function(wrap_pyfunction!(calc_next_entry_short_py, m)?)?;

--- a/passivbot-rust/src/python.rs
+++ b/passivbot-rust/src/python.rs
@@ -5,6 +5,7 @@ use crate::analysis::{
 use crate::backtest::Backtest;
 use crate::closes::{
     calc_closes_long, calc_closes_short, calc_next_close_long, calc_next_close_short,
+    calc_trailing_martingale_close_diagnostic,
 };
 use crate::constants::{LONG, SHORT};
 use crate::entries::{
@@ -2954,12 +2955,17 @@ fn json_usize(value: &Value, key: &str, default: usize) -> usize {
         .unwrap_or(default)
 }
 
+fn json_bool(value: &Value, key: &str, default: bool) -> bool {
+    value.get(key).and_then(Value::as_bool).unwrap_or(default)
+}
+
 fn bot_params_from_trailing_grid_v7_diagnostic_json(value: &Value) -> PyResult<BotParams> {
     let mut bot = BotParams::default();
     bot.wallet_exposure_limit = json_f64(value, "wallet_exposure_limit", 0.0);
     bot.total_wallet_exposure_limit = json_f64(value, "total_wallet_exposure_limit", 0.0);
     bot.n_positions = json_usize(value, "n_positions", 1);
     bot.risk_we_excess_allowance_pct = json_f64(value, "risk_we_excess_allowance_pct", 0.0);
+    bot.risk_wel_enforcer_enabled = json_bool(value, "risk_wel_enforcer_enabled", true);
     bot.risk_wel_enforcer_threshold = json_f64(value, "risk_wel_enforcer_threshold", 0.0);
     if let Some(raw) = value
         .get("risk_we_excess_allowance_mode")
@@ -3039,6 +3045,83 @@ pub fn calc_trailing_grid_v7_diagnostic_py(input_json: &str) -> PyResult<String>
     };
     let out = calc_trailing_grid_v7_diagnostics(
         side, &exchange, &state, &bot, &runtime, &params, &position, &trailing,
+    );
+    serde_json::to_string(&out)
+        .map_err(|err| PyValueError::new_err(format!("failed to serialize diagnostic: {err}")))
+}
+
+#[pyfunction]
+pub fn calc_trailing_martingale_close_diagnostic_py(input_json: &str) -> PyResult<String> {
+    let input: Value = serde_json::from_str(input_json).map_err(|err| {
+        PyValueError::new_err(format!(
+            "invalid trailing_martingale close diagnostic json: {err}"
+        ))
+    })?;
+    let side = match input.get("pside").and_then(Value::as_str).unwrap_or("long") {
+        "long" => StrategySide::Long,
+        "short" => StrategySide::Short,
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "pside must be long or short; got {other:?}"
+            )))
+        }
+    };
+    let exchange: ExchangeParams = serde_json::from_value(
+        input
+            .get("exchange")
+            .cloned()
+            .ok_or_else(|| PyValueError::new_err("missing exchange"))?,
+    )
+    .map_err(|err| PyValueError::new_err(format!("invalid exchange: {err}")))?;
+    let state: StateParams = serde_json::from_value(
+        input
+            .get("state")
+            .cloned()
+            .ok_or_else(|| PyValueError::new_err("missing state"))?,
+    )
+    .map_err(|err| PyValueError::new_err(format!("invalid state: {err}")))?;
+    let position: Position = serde_json::from_value(
+        input
+            .get("position")
+            .cloned()
+            .ok_or_else(|| PyValueError::new_err("missing position"))?,
+    )
+    .map_err(|err| PyValueError::new_err(format!("invalid position: {err}")))?;
+    let trailing: TrailingPriceBundle = serde_json::from_value(
+        input
+            .get("trailing")
+            .cloned()
+            .ok_or_else(|| PyValueError::new_err("missing trailing"))?,
+    )
+    .map_err(|err| PyValueError::new_err(format!("invalid trailing: {err}")))?;
+    let close_params: TrailingMartingaleCloseParams = serde_json::from_value(
+        input
+            .get("close_params")
+            .cloned()
+            .ok_or_else(|| PyValueError::new_err("missing close_params"))?,
+    )
+    .map_err(|err| PyValueError::new_err(format!("invalid close_params: {err}")))?;
+    let bot = bot_params_from_trailing_grid_v7_diagnostic_json(
+        input
+            .get("bot_params")
+            .ok_or_else(|| PyValueError::new_err("missing bot_params"))?,
+    )?;
+    let runtime = RuntimeOrderContext {
+        effective_wallet_exposure_limit: input
+            .get("runtime")
+            .and_then(|runtime| runtime.get("effective_wallet_exposure_limit"))
+            .and_then(Value::as_f64)
+            .unwrap_or(bot.wallet_exposure_limit),
+    };
+    let out = calc_trailing_martingale_close_diagnostic(
+        side,
+        &exchange,
+        &state,
+        &bot,
+        &runtime,
+        &close_params,
+        &position,
+        &trailing,
     );
     serde_json::to_string(&out)
         .map_err(|err| PyValueError::new_err(format!("failed to serialize diagnostic: {err}")))

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -1315,6 +1315,27 @@ def _trailing_unavailable_reasons(bot, symbol: str) -> set[str]:
     return {str(reason) for reason in reasons if reason}
 
 
+def _trailing_unavailable_psides(bot, symbol: str) -> set[str]:
+    by_symbol = getattr(bot, "_orchestrator_trailing_unavailable_psides", {}) or {}
+    if isinstance(by_symbol, dict) and symbol in by_symbol:
+        psides = by_symbol.get(symbol, [])
+        if isinstance(psides, str):
+            return {psides}
+        return {str(pside).lower() for pside in psides if pside}
+    # Compatibility for callers/tests that only expose the older symbol-level state.
+    return {"long", "short"}
+
+
+def _order_is_unavailable_trailing_close(order: dict, unavailable_psides: set[str]) -> bool:
+    family = _reduce_only_order_family(order)
+    if family is None:
+        return False
+    pside, order_family = family
+    return order_family == "close_trailing" and (
+        not pside or pside in unavailable_psides
+    )
+
+
 def filter_trailing_unavailable_reconciliation(
     bot,
     symbol: str,
@@ -1324,22 +1345,42 @@ def filter_trailing_unavailable_reconciliation(
 ) -> tuple[list[dict], list[dict], int, bool]:
     """Constrain reconciliation when trailing data is unavailable.
 
-    Missing anchors/fetch failures can make regular trailing closes unsafe, so keep
-    preserving the symbol. The short post-fill window with no newer candle is softer:
-    block new entries, but allow entry cleanup and reduce-only/panic exits.
+    Ordinary trailing closes require post-fill extrema. Suppress their creation and
+    retire existing trailing orders while preserving independent reduce-only and panic
+    exits. Missing anchors/fetch failures otherwise preserve the symbol.
     """
     reasons = _trailing_unavailable_reasons(bot, symbol)
+    unavailable_psides = _trailing_unavailable_psides(bot, symbol)
     has_panic_plan = any(_order_is_panic(order) for order in ideal_orders) or any(
         _order_is_panic(order) for order in to_create
     )
     soft_missing_candles_only = reasons == {"missing_trailing_candles"}
-    if not soft_missing_candles_only and not has_panic_plan:
-        return [], [], len(to_cancel) + len(to_create), True
+    if not soft_missing_candles_only:
+        filtered_cancel = (
+            list(to_cancel)
+            if has_panic_plan
+            else [
+                order
+                for order in to_cancel
+                if _order_is_unavailable_trailing_close(order, unavailable_psides)
+            ]
+        )
+        filtered_create = (
+            [order for order in to_create if _order_is_panic(order)]
+            if has_panic_plan
+            else []
+        )
+        dropped = (len(to_cancel) - len(filtered_cancel)) + (
+            len(to_create) - len(filtered_create)
+        )
+        fully_blocked = not filtered_cancel and not filtered_create
+        return filtered_cancel, filtered_create, dropped, fully_blocked
 
     filtered_create = [
         order
         for order in to_create
-        if _order_is_reduce_only(order) or _order_is_panic(order)
+        if (_order_is_reduce_only(order) or _order_is_panic(order))
+        and not _order_is_unavailable_trailing_close(order, unavailable_psides)
     ]
     dropped_create = len(to_create) - len(filtered_create)
 
@@ -1355,6 +1396,9 @@ def filter_trailing_unavailable_reconciliation(
     dropped_cancel = 0
     for order in to_cancel:
         if _order_is_reduce_only(order):
+            if _order_is_unavailable_trailing_close(order, unavailable_psides):
+                filtered_cancel.append(order)
+                continue
             family = _reduce_only_order_family(order)
             if family is None or family not in ideal_reduce_only_families:
                 dropped_cancel += 1

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -7799,9 +7799,9 @@ class Passivbot:
                 return anchor_ts
         return None
 
-    def get_last_position_changes(self, symbol=None):
-        """Return the most recent fill timestamp per symbol/side for trailing logic."""
-        last_position_changes = defaultdict(dict)
+    def _get_last_position_change_anchors(self, symbol=None):
+        """Return the latest fill timestamp and identity per trailing position side."""
+        anchors = defaultdict(dict)
         events = [] if self._pnls_manager is None else self._pnls_manager.get_events()
         symbols = [symbol] if symbol is not None else list(self.positions)
         for symbol in symbols:
@@ -7809,15 +7809,39 @@ class Passivbot:
                 continue
             for pside in ["long", "short"]:
                 if self.has_position(pside, symbol) and self.is_trailing(symbol, pside):
-                    for ev in reversed(events):
+                    for event_index in range(len(events) - 1, -1, -1):
+                        ev = events[event_index]
                         if ev.symbol == symbol and ev.position_side == pside:
-                            last_position_changes[symbol][pside] = int(ev.timestamp)
+                            timestamp = int(ev.timestamp)
+                            event_id = getattr(ev, "id", None) or getattr(
+                                ev, "client_order_id", None
+                            )
+                            if not event_id:
+                                event_id = f"event_index:{event_index}"
+                            anchors[symbol][pside] = {
+                                "timestamp": timestamp,
+                                "epoch": f"fill:{timestamp}:{event_id}",
+                            }
                             break
-                    if pside not in last_position_changes.get(symbol, {}):
+                    if pside not in anchors.get(symbol, {}):
                         anchor_ts = self._position_anchor_timestamp_ms(symbol, pside)
                         if anchor_ts is not None:
-                            last_position_changes[symbol][pside] = anchor_ts
-        return last_position_changes
+                            anchors[symbol][pside] = {
+                                "timestamp": anchor_ts,
+                                "epoch": f"position:{anchor_ts}",
+                            }
+        return anchors
+
+    def get_last_position_changes(self, symbol=None):
+        """Return the most recent fill timestamp per symbol/side for trailing logic."""
+        anchors = self._get_last_position_change_anchors(symbol)
+        return {
+            symbol: {
+                pside: int(anchor["timestamp"])
+                for pside, anchor in pside_anchors.items()
+            }
+            for symbol, pside_anchors in anchors.items()
+        }
 
     # Legacy: wait_for_ohlcvs_1m_to_update removed (CandlestickManager handles freshness)
 
@@ -7841,16 +7865,25 @@ class Passivbot:
         if not hasattr(self, "trailing_prices"):
             self.trailing_prices = {}
         unavailable_reasons: dict[str, set[str]] = defaultdict(set)
+        unavailable_psides: dict[str, set[str]] = defaultdict(set)
         self._orchestrator_trailing_unavailable_symbols = set()
         self._orchestrator_trailing_unavailable_reasons = {}
-        last_position_changes = self.get_last_position_changes()
+        self._orchestrator_trailing_unavailable_psides = {}
+        position_change_anchors = self._get_last_position_change_anchors()
+        last_position_changes = {
+            symbol: {
+                pside: int(anchor["timestamp"])
+                for pside, anchor in pside_anchors.items()
+            }
+            for symbol, pside_anchors in position_change_anchors.items()
+        }
         symbols = (
             set(self.trailing_prices)
             | set(last_position_changes)
             | set(self.active_symbols)
         )
 
-        # Initialize missing containers without erasing the last known trailing bundle.
+        # Initialize missing containers. Bundles are reset below when their fill epoch changes.
         for symbol in symbols:
             self.trailing_prices.setdefault(symbol, {})
             self.trailing_prices[symbol].setdefault(
@@ -7866,15 +7899,23 @@ class Passivbot:
                 if self.has_position(pside, symbol) and self.is_trailing(symbol, pside):
                     required_trailing[symbol].add(pside)
 
+        previous_epochs = getattr(self, "_trailing_position_change_epochs", {}) or {}
+        current_epochs: dict[tuple[str, str], str] = {}
+
         for symbol, psides in required_trailing.items():
-            pside_changes = (
-                last_position_changes[symbol]
-                if symbol in last_position_changes
-                else {}
-            )
             for pside in psides:
-                if pside not in pside_changes:
+                anchor = position_change_anchors.get(symbol, {}).get(pside)
+                if anchor is None:
+                    self.trailing_prices[symbol][pside] = _trailing_bundle_default_dict()
                     unavailable_reasons["missing_position_change_anchor"].add(symbol)
+                    unavailable_psides[symbol].add(pside)
+                    continue
+                epoch_key = (symbol, pside)
+                epoch = str(anchor["epoch"])
+                current_epochs[epoch_key] = epoch
+                if previous_epochs.get(epoch_key) != epoch:
+                    self.trailing_prices[symbol][pside] = _trailing_bundle_default_dict()
+        self._trailing_position_change_epochs = current_epochs
 
         # Build concurrent fetches per symbol that has position changes
         fetch_plan = {}
@@ -7905,6 +7946,7 @@ class Passivbot:
                 results[sym] = await task
             except Exception as e:
                 unavailable_reasons["candle_fetch_failed"].add(sym)
+                unavailable_psides[sym].update(required_trailing.get(sym, set()))
                 logging.debug("failed to fetch candles for trailing %s: %s", sym, e)
                 results[sym] = None
 
@@ -7914,6 +7956,7 @@ class Passivbot:
                 continue
             if arr.size == 0:
                 unavailable_reasons["missing_trailing_candles"].add(symbol)
+                unavailable_psides[symbol].update(required_trailing.get(symbol, set()))
                 continue
             if symbol not in last_position_changes:
                 continue
@@ -7924,6 +7967,7 @@ class Passivbot:
                 mask = arr["ts"] > int(changed_ts)
                 if not np.any(mask):
                     unavailable_reasons["missing_trailing_candles"].add(symbol)
+                    unavailable_psides[symbol].add(pside)
                     continue
                 subset = arr[mask]
                 try:
@@ -7933,6 +7977,7 @@ class Passivbot:
                     self.trailing_prices[symbol][pside] = bundle
                 except Exception as e:
                     unavailable_reasons["bundle_compute_failed"].add(symbol)
+                    unavailable_psides[symbol].add(pside)
                     logging.debug(
                         "failed to compute trailing bundle for %s %s: %s",
                         symbol,
@@ -7958,6 +8003,11 @@ class Passivbot:
         self._orchestrator_trailing_unavailable_reasons = {
             symbol: sorted(reasons)
             for symbol, reasons in sorted(unavailable_by_symbol.items())
+        }
+        self._orchestrator_trailing_unavailable_psides = {
+            symbol: sorted(psides)
+            for symbol, psides in sorted(unavailable_psides.items())
+            if psides
         }
 
     def symbol_is_eligible(self, symbol):

--- a/src/passivbot_monitor.py
+++ b/src/passivbot_monitor.py
@@ -15,6 +15,7 @@ from trailing_diagnostics import (
     build_trailing_grid_v7_diagnostic,
     build_trailing_close_diagnostic,
     build_trailing_entry_diagnostic,
+    build_trailing_martingale_close_diagnostic,
     normalize_trailing_extrema,
 )
 from risk_limits import (
@@ -1127,6 +1128,19 @@ def _monitor_h1_logrange_for_span(self, symbol: str, span: float) -> float:
         return 0.0
 
 
+def _monitor_m1_logrange_for_span(self, symbol: str, span: float) -> float:
+    m1_log_range_emas = getattr(self, "_monitor_runtime_m1_log_range_emas", {})
+    if not isinstance(m1_log_range_emas, dict):
+        return 0.0
+    symbol_entry = m1_log_range_emas.get(symbol, {})
+    if not isinstance(symbol_entry, dict):
+        return 0.0
+    try:
+        return float(symbol_entry.get(float(span), 0.0) or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def _monitor_h1_entry_logrange(self, pside: str, symbol: str) -> float:
     try:
         span = _monitor_strategy_value(self, pside, "offset_volatility_ema_span_1h", symbol)
@@ -1139,20 +1153,11 @@ def _monitor_h1_entry_logrange(self, pside: str, symbol: str) -> float:
 
 
 def _monitor_m1_entry_logrange(self, pside: str, symbol: str) -> float:
-    m1_log_range_emas = getattr(self, "_monitor_runtime_m1_log_range_emas", {})
-    if not isinstance(m1_log_range_emas, dict):
-        return 0.0
-    symbol_entry = m1_log_range_emas.get(symbol, {})
-    if not isinstance(symbol_entry, dict):
-        return 0.0
     try:
         span = _monitor_strategy_value(self, pside, "entry_volatility_ema_span_1m", symbol)
     except Exception:
         return 0.0
-    try:
-        return float(symbol_entry.get(span, 0.0) or 0.0)
-    except (TypeError, ValueError):
-        return 0.0
+    return _monitor_m1_logrange_for_span(self, symbol, span)
 
 
 def _monitor_trailing_extrema(bundle: dict[str, Any]) -> dict[str, float]:
@@ -1249,11 +1254,58 @@ def _build_monitor_trailing_close_payload(
     pside: str,
     *,
     balance_raw: float,
+    balance_strategy: float,
     current_price: float,
     position_size: float,
     position_price: float,
     trailing_bundle: dict[str, float],
 ) -> Optional[dict[str, Any]]:
+    strategy_kind = str(
+        (getattr(self, "config", {}).get("live", {}) or {}).get("strategy_kind")
+        or ""
+    ).strip().lower()
+    if strategy_kind == "trailing_martingale":
+        strategy_params = self._strategy_params_to_rust_dict(pside, symbol)
+        volatility_ema_span_1m = float(strategy_params["volatility_ema_span_1m"])
+        volatility_ema_span_1h = float(strategy_params["volatility_ema_span_1h"])
+        inputs = {
+            "symbol": symbol,
+            "pside": pside,
+            "current_price": float(current_price),
+            "exchange": self._orchestrator_exchange_params(symbol),
+            "state": {
+                "balance": float(balance_strategy),
+                "order_book": {
+                    "bid": float(current_price),
+                    "ask": float(current_price),
+                },
+                "ema_bands": {"upper": 0.0, "lower": 0.0},
+                "volatility_ema_1m": float(
+                    _monitor_m1_logrange_for_span(
+                        self, symbol, volatility_ema_span_1m
+                    )
+                ),
+                "volatility_ema_1h": float(
+                    _monitor_h1_logrange_for_span(
+                        self, symbol, volatility_ema_span_1h
+                    )
+                ),
+            },
+            "bot_params": self._bot_params_to_rust_dict(pside, symbol),
+            "runtime": {
+                "effective_wallet_exposure_limit": float(
+                    self.bp(pside, "wallet_exposure_limit", symbol)
+                )
+            },
+            "close_params": dict(strategy_params["close"]),
+            "position": {
+                "size": float(position_size),
+                "price": float(position_price),
+            },
+            "trailing": dict(trailing_bundle),
+        }
+        return build_trailing_martingale_close_diagnostic(inputs)
+
     inputs = {
         "symbol": symbol,
         "pside": pside,
@@ -1381,7 +1433,10 @@ def _build_monitor_trailing_section(
     *,
     balance_raw: float,
     market: dict[str, dict[str, Any]],
+    balance_strategy: Optional[float] = None,
 ) -> dict[str, dict[str, Any]]:
+    if balance_strategy is None:
+        balance_strategy = balance_raw
     config = getattr(self, "config", {})
     live_cfg = config.get("live", {}) if isinstance(config, dict) else {}
     strategy_kind = str(live_cfg.get("strategy_kind") or "").strip().lower()
@@ -1439,6 +1494,7 @@ def _build_monitor_trailing_section(
                     symbol,
                     pside,
                     balance_raw=balance_raw,
+                    balance_strategy=balance_strategy,
                     current_price=current_price,
                     position_size=position_size,
                     position_price=position_price,
@@ -1625,7 +1681,11 @@ async def _build_monitor_snapshot(self, *, now_ms: Optional[int] = None) -> dict
         },
         "hsl": {pside: self._monitor_hsl_payload(pside) for pside in ("long", "short")},
         "market": market,
-        "trailing": self._build_monitor_trailing_section(balance_raw=balance_raw, market=market),
+        "trailing": self._build_monitor_trailing_section(
+            balance_raw=balance_raw,
+            balance_strategy=balance_snapped,
+            market=market,
+        ),
         "forager": await self._build_monitor_forager_section(),
         "unstuck": self._build_monitor_unstuck_section(),
         "recent": self._build_monitor_recent_section(),

--- a/src/trailing_diagnostics.py
+++ b/src/trailing_diagnostics.py
@@ -484,6 +484,69 @@ def build_trailing_close_diagnostic(inputs: Mapping[str, Any]) -> Optional[dict[
     }
 
 
+def build_trailing_martingale_close_diagnostic(
+    inputs: Mapping[str, Any],
+) -> Optional[dict[str, Any]]:
+    position = inputs.get("position")
+    if not isinstance(position, Mapping):
+        return None
+    position_size = _float(position.get("size"))
+    position_price = _float(position.get("price"))
+    current_price = _float(inputs.get("current_price"))
+    if position_size == 0.0 or position_price <= 0.0 or current_price <= 0.0:
+        return None
+
+    payload = json.loads(
+        pbr.calc_trailing_martingale_close_diagnostic_py(json.dumps(dict(inputs)))
+    )
+    if not isinstance(payload, dict):
+        raise TypeError("Rust trailing_martingale close diagnostic must return an object")
+    pside = str(inputs.get("pside") or "long")
+    threshold_pct = _float(payload.get("threshold_pct"))
+    retracement_pct = _float(payload.get("retracement_pct"))
+    extrema = normalize_trailing_extrema(payload.get("extrema", {}))
+    if pside == "long":
+        threshold_price = (
+            position_price * (1.0 + threshold_pct) if threshold_pct > 0.0 else None
+        )
+        retracement_price = (
+            extrema["max_since_open"] * (1.0 - retracement_pct)
+            if retracement_pct > 0.0
+            else None
+        )
+    else:
+        threshold_price = (
+            position_price * (1.0 - threshold_pct) if threshold_pct > 0.0 else None
+        )
+        retracement_price = (
+            extrema["min_since_open"] * (1.0 + retracement_pct)
+            if retracement_pct > 0.0
+            else None
+        )
+    payload.update(
+        {
+            "symbol": str(inputs.get("symbol") or ""),
+            "current_price": current_price,
+            "position_price": position_price,
+            "position_size": position_size,
+            "threshold_price": threshold_price,
+            "retracement_price": retracement_price,
+            "current_vs_threshold_ratio": (
+                current_price / threshold_price - 1.0
+                if threshold_price is not None and threshold_price > 0.0
+                else None
+            ),
+            "current_vs_retracement_ratio": (
+                current_price / retracement_price - 1.0
+                if retracement_price is not None and retracement_price > 0.0
+                else None
+            ),
+            "extrema": extrema,
+        }
+    )
+    return payload
+
+
 def build_trailing_grid_v7_diagnostic(inputs: Mapping[str, Any]) -> Optional[dict[str, Any]]:
     strategy_params = inputs.get("strategy_params")
     if not isinstance(strategy_params, Mapping):

--- a/tests/test_order_orchestration.py
+++ b/tests/test_order_orchestration.py
@@ -347,13 +347,23 @@ async def test_calc_orders_preserves_orders_when_trailing_anchor_unavailable():
 
 
 @pytest.mark.asyncio
-async def test_calc_orders_allows_panic_close_when_trailing_candles_pending():
+@pytest.mark.parametrize(
+    "unavailable_reason",
+    [
+        "missing_trailing_candles",
+        "missing_position_change_anchor",
+        "candle_fetch_failed",
+    ],
+)
+async def test_calc_orders_allows_panic_close_when_trailing_unavailable(
+    unavailable_reason,
+):
     symbol = "BTC/USDT"
     bot = OrchestrationBot({symbol: 100.0})
     bot.register_symbol(symbol)
     bot._orchestrator_trailing_unavailable_symbols = {symbol}
     bot._orchestrator_trailing_unavailable_reasons = {
-        symbol: ["missing_trailing_candles"]
+        symbol: [unavailable_reason]
     }
 
     bot.open_orders[symbol] = [
@@ -763,7 +773,7 @@ async def test_calc_orders_blocks_entry_creates_when_trailing_candles_pending():
 
 
 @pytest.mark.asyncio
-async def test_calc_orders_preserves_mismatched_reduce_only_cancel_when_trailing_candles_pending():
+async def test_calc_orders_retires_stale_trailing_close_when_trailing_candles_pending():
     symbol = "BTC/USDT"
     bot = OrchestrationBot({symbol: 100.0})
     bot.register_symbol(symbol)
@@ -803,8 +813,122 @@ async def test_calc_orders_preserves_mismatched_reduce_only_cancel_when_trailing
 
     to_cancel, to_create = await bot.calc_orders_to_cancel_and_create()
 
-    assert to_cancel == []
+    assert [bot._resolve_pb_order_type(order) for order in to_cancel] == [
+        "close_trailing_long"
+    ]
     assert [order["pb_order_type"] for order in to_create] == ["close_grid_long"]
+
+
+@pytest.mark.asyncio
+async def test_calc_orders_blocks_new_trailing_close_when_trailing_candles_pending():
+    symbol = "BTC/USDT"
+    bot = OrchestrationBot({symbol: 100.0})
+    bot.register_symbol(symbol)
+    bot._orchestrator_trailing_unavailable_symbols = {symbol}
+    bot._orchestrator_trailing_unavailable_reasons = {
+        symbol: ["missing_trailing_candles"]
+    }
+    bot._orchestrator_trailing_unavailable_psides = {symbol: ["long"]}
+
+    async def fake_calc_ideal_orders(self):
+        return {
+            symbol: [
+                _make_order(
+                    symbol,
+                    "sell",
+                    "long",
+                    1.0,
+                    99.0,
+                    "close_trailing_long",
+                    reduce_only=True,
+                )
+            ]
+        }
+
+    bot.calc_ideal_orders = types.MethodType(fake_calc_ideal_orders, bot)
+
+    to_cancel, to_create = await bot.calc_orders_to_cancel_and_create()
+
+    assert to_cancel == []
+    assert to_create == []
+
+
+@pytest.mark.asyncio
+async def test_calc_orders_trailing_unavailable_is_position_side_scoped():
+    symbol = "BTC/USDT"
+    bot = OrchestrationBot({symbol: 100.0})
+    bot.register_symbol(symbol)
+    bot._orchestrator_trailing_unavailable_symbols = {symbol}
+    bot._orchestrator_trailing_unavailable_reasons = {
+        symbol: ["missing_trailing_candles"]
+    }
+    bot._orchestrator_trailing_unavailable_psides = {symbol: ["long"]}
+
+    async def fake_calc_ideal_orders(self):
+        return {
+            symbol: [
+                _make_order(
+                    symbol,
+                    "sell",
+                    "long",
+                    1.0,
+                    99.0,
+                    "close_trailing_long",
+                    reduce_only=True,
+                ),
+                _make_order(
+                    symbol,
+                    "buy",
+                    "short",
+                    1.0,
+                    101.0,
+                    "close_trailing_short",
+                    reduce_only=True,
+                ),
+            ]
+        }
+
+    bot.calc_ideal_orders = types.MethodType(fake_calc_ideal_orders, bot)
+
+    to_cancel, to_create = await bot.calc_orders_to_cancel_and_create()
+
+    assert to_cancel == []
+    assert [order["pb_order_type"] for order in to_create] == ["close_trailing_short"]
+
+
+@pytest.mark.asyncio
+async def test_calc_orders_retires_trailing_close_during_fetch_failure():
+    symbol = "BTC/USDT"
+    bot = OrchestrationBot({symbol: 100.0})
+    bot.register_symbol(symbol)
+    bot._orchestrator_trailing_unavailable_symbols = {symbol}
+    bot._orchestrator_trailing_unavailable_reasons = {
+        symbol: ["candle_fetch_failed"]
+    }
+    bot._orchestrator_trailing_unavailable_psides = {symbol: ["long"]}
+    bot.open_orders[symbol] = [
+        _make_order(
+            symbol,
+            "sell",
+            "long",
+            1.0,
+            101.0,
+            "close_trailing_long",
+            reduce_only=True,
+        )
+    ]
+
+    async def fake_calc_ideal_orders(self):
+        return {symbol: []}
+
+    bot.calc_ideal_orders = types.MethodType(fake_calc_ideal_orders, bot)
+
+    to_cancel, to_create = await bot.calc_orders_to_cancel_and_create()
+
+    assert [bot._resolve_pb_order_type(order) for order in to_cancel] == [
+        "close_trailing_long"
+    ]
+    assert to_create == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_passivbot_monitor.py
+++ b/tests/test_passivbot_monitor.py
@@ -20,6 +20,16 @@ from live.event_bus import (
 )
 
 
+@pytest.fixture
+def require_real_passivbot_rust_module():
+    import passivbot_rust as pbr
+
+    if getattr(pbr, "__is_stub__", False):
+        pytest.fail(
+            "trailing-martingale monitor tests require the real passivbot_rust extension"
+        )
+
+
 class RecorderPublisher:
     def __init__(self):
         self.events = []
@@ -5981,6 +5991,96 @@ def test_monitor_trailing_section_includes_trailing_grid_v7_diagnostics():
     assert close["status"] == "waiting_threshold"
     assert close["threshold_price"] == pytest.approx(102.0)
     assert close["projected_retracement_price"] == pytest.approx(102.0 * 0.99)
+
+
+def test_monitor_trailing_martingale_close_uses_exact_runtime_ema_spans(
+    require_real_passivbot_rust_module,
+):
+    import passivbot_monitor as monitor_mod
+
+    symbol = "HYPE/USDT:USDT"
+
+    class FakeBot:
+        config = {"live": {"strategy_kind": "trailing_martingale"}}
+        _monitor_runtime_m1_log_range_emas = {
+            symbol: {374.0: 0.99, 1323.0: 0.0014553489538740175}
+        }
+        _monitor_runtime_h1_log_range_emas = {
+            symbol: {24.0: 0.99, 668.0: 0.013108943219306139}
+        }
+
+        def _strategy_params_to_rust_dict(self, pside, requested_symbol):
+            assert pside == "long"
+            assert requested_symbol == symbol
+            return {
+                "volatility_ema_span_1m": 1323.0,
+                "volatility_ema_span_1h": 668.0,
+                "close": {
+                    "qty_pct": 0.23,
+                    "threshold_base_pct": -0.0143,
+                    "threshold_we_weight": -0.0278,
+                    "threshold_volatility_1h_weight": 0.19,
+                    "threshold_volatility_1m_weight": 7.93,
+                    "retracement_base_pct": 0.0001,
+                    "retracement_volatility_1h_weight": 12.11,
+                    "retracement_volatility_1m_weight": 4.49,
+                },
+            }
+
+        def _orchestrator_exchange_params(self, requested_symbol):
+            assert requested_symbol == symbol
+            return {
+                "qty_step": 0.1,
+                "price_step": 0.001,
+                "min_qty": 0.1,
+                "min_cost": 1.0,
+                "c_mult": 1.0,
+                "maker_fee": 0.0002,
+                "taker_fee": 0.00055,
+            }
+
+        def _bot_params_to_rust_dict(self, pside, requested_symbol):
+            assert pside == "long"
+            assert requested_symbol == symbol
+            return {
+                "wallet_exposure_limit": 0.5,
+                "total_wallet_exposure_limit": 1.5,
+                "n_positions": 3,
+                "risk_we_excess_allowance_pct": 0.66,
+                "risk_we_excess_allowance_mode": "bounded",
+                "risk_wel_enforcer_enabled": False,
+                "risk_wel_enforcer_threshold": 1.0,
+            }
+
+        def bp(self, pside, key, requested_symbol):
+            assert pside == "long"
+            assert requested_symbol == symbol
+            assert key == "wallet_exposure_limit"
+            return 0.5
+
+    payload = monitor_mod._build_monitor_trailing_close_payload(
+        FakeBot(),
+        symbol,
+        "long",
+        balance_raw=100.0,
+        balance_strategy=99.88140021,
+        current_price=60.6695,
+        position_size=0.1,
+        position_price=60.675,
+        trailing_bundle={
+            "min_since_open": 1.7976931348623157e308,
+            "max_since_min": 0.0,
+            "max_since_open": 0.0,
+            "min_since_max": 1.7976931348623157e308,
+        },
+    )
+
+    assert payload is not None
+    assert payload["volatility_ema_1m"] == pytest.approx(0.0014553489538740175)
+    assert payload["volatility_ema_1h"] == pytest.approx(0.013108943219306139)
+    assert payload["volatility_ema_1m"] != pytest.approx(0.99)
+    assert payload["volatility_ema_1h"] != pytest.approx(0.99)
+    assert payload["qty"] == pytest.approx(0.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_trailing_diagnostics.py
+++ b/tests/test_trailing_diagnostics.py
@@ -8,6 +8,7 @@ import pytest
 from trailing_diagnostics import (
     build_trailing_diagnostic,
     build_trailing_inputs_from_snapshot,
+    build_trailing_martingale_close_diagnostic,
     selected_mode_from_order_type,
 )
 from trailing_diagnostics_tool import (
@@ -16,6 +17,16 @@ from trailing_diagnostics_tool import (
     execute_command,
     render_screen,
 )
+
+
+@pytest.fixture
+def require_real_passivbot_rust_module():
+    import passivbot_rust as pbr
+
+    if getattr(pbr, "__is_stub__", False):
+        pytest.fail(
+            "trailing-martingale parity tests require the real passivbot_rust extension"
+        )
 
 
 def _sample_config():
@@ -90,6 +101,120 @@ def _sample_snapshot():
             },
         }
     }
+
+
+def _hype_trailing_martingale_close_inputs():
+    return {
+        "symbol": "HYPE/USDT:USDT",
+        "pside": "long",
+        "current_price": 60.6695,
+        "exchange": {
+            "qty_step": 0.1,
+            "price_step": 0.001,
+            "min_qty": 0.1,
+            "min_cost": 1.0,
+            "c_mult": 1.0,
+            "maker_fee": 0.0002,
+            "taker_fee": 0.00055,
+        },
+        "state": {
+            "balance": 99.88140021,
+            "order_book": {"bid": 60.6695, "ask": 60.6695},
+            "ema_bands": {"upper": 60.6695, "lower": 60.6695},
+            "volatility_ema_1m": 0.0014553489538740175,
+            "volatility_ema_1h": 0.013108943219306139,
+        },
+        "bot_params": {
+            "wallet_exposure_limit": 0.5,
+            "total_wallet_exposure_limit": 1.5,
+            "n_positions": 3,
+            "risk_we_excess_allowance_pct": 0.66,
+            "risk_we_excess_allowance_mode": "bounded",
+            "risk_wel_enforcer_enabled": False,
+            "risk_wel_enforcer_threshold": 1.0,
+        },
+        "runtime": {"effective_wallet_exposure_limit": 0.5},
+        "close_params": {
+            "qty_pct": 0.23,
+            "threshold_base_pct": -0.0143,
+            "threshold_we_weight": -0.0278,
+            "threshold_volatility_1h_weight": 0.19,
+            "threshold_volatility_1m_weight": 7.93,
+            "retracement_base_pct": 0.0001,
+            "retracement_volatility_1h_weight": 12.11,
+            "retracement_volatility_1m_weight": 4.49,
+        },
+        "position": {"size": 0.1, "price": 60.675},
+        "trailing": {
+            "min_since_open": sys.float_info.max,
+            "max_since_min": 0.0,
+            "max_since_open": 0.0,
+            "min_since_max": sys.float_info.max,
+        },
+    }
+
+
+def test_trailing_martingale_close_diagnostic_uses_rust_dynamic_terms(
+    require_real_passivbot_rust_module,
+):
+    inputs = _hype_trailing_martingale_close_inputs()
+
+    diagnostic = build_trailing_martingale_close_diagnostic(inputs)
+
+    wallet_exposure = 0.1 * 60.675 / inputs["state"]["balance"]
+    effective_wel = 0.5 * 1.66
+    wallet_exposure_ratio = wallet_exposure / effective_wel
+    expected_threshold = (
+        -0.0143
+        + wallet_exposure_ratio * -0.0278
+        + inputs["state"]["volatility_ema_1m"] * 7.93
+        + inputs["state"]["volatility_ema_1h"] * 0.19
+    )
+    expected_retracement = 0.0001 * (
+        1.0
+        + inputs["state"]["volatility_ema_1m"] * 4.49
+        + inputs["state"]["volatility_ema_1h"] * 12.11
+    )
+
+    assert diagnostic is not None
+    assert diagnostic["threshold_pct"] == pytest.approx(expected_threshold)
+    assert diagnostic["retracement_pct"] == pytest.approx(expected_retracement)
+    assert sum(diagnostic["threshold_terms"].values()) == pytest.approx(expected_threshold)
+    assert diagnostic["effective_wallet_exposure_limit"] == pytest.approx(effective_wel)
+    assert diagnostic["wallet_exposure_ratio"] == pytest.approx(wallet_exposure_ratio)
+    assert diagnostic["volatility_ema_1m"] == pytest.approx(
+        inputs["state"]["volatility_ema_1m"]
+    )
+    assert diagnostic["volatility_ema_1h"] == pytest.approx(
+        inputs["state"]["volatility_ema_1h"]
+    )
+    assert diagnostic["threshold_pct"] != pytest.approx(-0.014500652114747214)
+
+
+def test_trailing_martingale_reset_extrema_cannot_emit_ordinary_trailing_close(
+    require_real_passivbot_rust_module,
+):
+    inputs = _hype_trailing_martingale_close_inputs()
+
+    reset = build_trailing_martingale_close_diagnostic(inputs)
+    inputs["trailing"] = {
+        "min_since_open": 60.0,
+        "max_since_min": 61.0,
+        "max_since_open": 61.0,
+        "min_since_max": 60.0,
+    }
+    seeded = build_trailing_martingale_close_diagnostic(inputs)
+
+    assert reset is not None
+    assert reset["order_type"] == "close_trailing_long"
+    assert reset["qty"] == pytest.approx(0.0)
+    assert reset["triggered"] is False
+    assert reset["status"] == "waiting_retracement"
+    assert seeded is not None
+    assert seeded["order_type"] == "close_trailing_long"
+    assert seeded["qty"] < 0.0
+    assert seeded["triggered"] is True
+    assert seeded["status"] == "triggered"
 
 
 def test_build_trailing_inputs_from_snapshot_extracts_required_fields():

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -818,10 +818,19 @@ def _set_basic_state(bot, symbol="TEST/USDT"):
 
 
 class _DummyFillEvent:
-    def __init__(self, symbol: str, position_side: str, timestamp: int):
+    def __init__(
+        self,
+        symbol: str,
+        position_side: str,
+        timestamp: int,
+        event_id: str | None = None,
+        pb_order_type: str = "unknown",
+    ):
         self.symbol = symbol
         self.position_side = position_side
         self.timestamp = timestamp
+        self.id = event_id
+        self.pb_order_type = pb_order_type
 
 
 class _DummyPnlsManager:
@@ -1032,8 +1041,11 @@ async def test_trailing_fetch_failure_preserves_bundle_and_marks_symbol_unavaila
         }
     }
     bot._pnls_manager = _DummyPnlsManager(
-        [_DummyFillEvent(symbol, "long", 120_000)]
+        [_DummyFillEvent(symbol, "long", 120_000, "fill-1")]
     )
+    bot._trailing_position_change_epochs = {
+        (symbol, "long"): "fill:120000:fill-1"
+    }
     bot.is_trailing = lambda sym, pside=None: pside == "long"
 
     async def fail_get_candles(*args, **kwargs):
@@ -1048,6 +1060,166 @@ async def test_trailing_fetch_failure_preserves_bundle_and_marks_symbol_unavaila
     assert bot._orchestrator_trailing_unavailable_symbols == {symbol}
     assert any("[trailing]" in record.message for record in caplog.records)
     assert any("candle_fetch_failed" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "latest_order_type",
+    ["entry_grid_long", "close_grid_long", "close_trailing_long"],
+)
+async def test_new_position_changing_fill_epoch_resets_stale_bundle_before_post_fill_candle(
+    latest_order_type,
+):
+    import passivbot_rust as pbr
+
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    stale_bundle = {
+        "min_since_open": 95.0,
+        "max_since_min": 105.0,
+        "max_since_open": 110.0,
+        "min_since_max": 102.0,
+    }
+    bot.trailing_prices = {
+        symbol: {
+            "long": dict(stale_bundle),
+            "short": dict(stale_bundle),
+        }
+    }
+    first_fill = _DummyFillEvent(
+        symbol,
+        "long",
+        120_000,
+        "partial-entry",
+        "entry_initial_normal_long",
+    )
+    latest_fill = _DummyFillEvent(
+        symbol,
+        "long",
+        180_000,
+        "latest-fill",
+        latest_order_type,
+    )
+    bot._pnls_manager = _DummyPnlsManager([first_fill, latest_fill])
+    bot._trailing_position_change_epochs = {
+        (symbol, "long"): "fill:120000:partial-entry"
+    }
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+
+    async def no_post_fill_candles(*args, **kwargs):
+        return _make_candles([(180_000, 100.0, 101.0, 99.0, 100.5, 1.0)])
+
+    bot.cm.get_candles = no_post_fill_candles
+
+    await bot.update_trailing_data()
+
+    assert bot.trailing_prices[symbol]["long"] == dict(
+        zip(
+            ("min_since_open", "max_since_min", "max_since_open", "min_since_max"),
+            pbr.trailing_bundle_default_py(),
+        )
+    )
+    assert bot._orchestrator_trailing_unavailable_psides == {symbol: ["long"]}
+    assert bot._trailing_position_change_epochs[(symbol, "long")] == (
+        "fill:180000:latest-fill"
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_timestamp_fill_identity_advances_trailing_epoch():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    bot.trailing_prices = {
+        symbol: {
+            "long": {
+                "min_since_open": 95.0,
+                "max_since_min": 105.0,
+                "max_since_open": 110.0,
+                "min_since_max": 102.0,
+            }
+        }
+    }
+    bot._pnls_manager = _DummyPnlsManager(
+        [
+            _DummyFillEvent(symbol, "long", 120_000, "fill-a"),
+            _DummyFillEvent(symbol, "long", 120_000, "fill-b"),
+        ]
+    )
+    bot._trailing_position_change_epochs = {(symbol, "long"): "fill:120000:fill-a"}
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+
+    async def no_newer_candles(*args, **kwargs):
+        return _make_candles([(120_000, 100.0, 101.0, 99.0, 100.5, 1.0)])
+
+    bot.cm.get_candles = no_newer_candles
+
+    await bot.update_trailing_data()
+
+    assert bot.trailing_prices[symbol]["long"]["max_since_open"] == 0.0
+    assert bot._trailing_position_change_epochs[(symbol, "long")] == (
+        "fill:120000:fill-b"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fill_epoch_reset_is_isolated_by_symbol_and_position_side():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol_a = _set_basic_state(bot, "AAA/USDT")
+    symbol_b = "BBB/USDT"
+    bot.active_symbols.append(symbol_b)
+    bot.positions[symbol_a]["short"] = {"size": -1.0, "price": 100.0}
+    bot.positions[symbol_b] = {
+        "long": {"size": 1.0, "price": 200.0},
+        "short": {"size": 0.0, "price": 0.0},
+    }
+    old_bundle = {
+        "min_since_open": 90.0,
+        "max_since_min": 110.0,
+        "max_since_open": 115.0,
+        "min_since_max": 95.0,
+    }
+    bot.trailing_prices = {
+        symbol_a: {"long": dict(old_bundle), "short": dict(old_bundle)},
+        symbol_b: {"long": dict(old_bundle), "short": dict(old_bundle)},
+    }
+    bot._pnls_manager = _DummyPnlsManager(
+        [
+            _DummyFillEvent(symbol_a, "long", 100_000, "a-long-1"),
+            _DummyFillEvent(symbol_a, "short", 100_000, "a-short-1"),
+            _DummyFillEvent(symbol_b, "long", 100_000, "b-long-1"),
+            _DummyFillEvent(symbol_a, "long", 200_000, "a-long-2"),
+        ]
+    )
+    bot._trailing_position_change_epochs = {
+        (symbol_a, "long"): "fill:100000:a-long-1",
+        (symbol_a, "short"): "fill:100000:a-short-1",
+        (symbol_b, "long"): "fill:100000:b-long-1",
+    }
+    bot.is_trailing = lambda sym, pside=None: bool(
+        bot.positions.get(sym, {}).get(pside, {}).get("size", 0.0)
+    )
+
+    async def candles_after_old_epochs(sym, **kwargs):
+        base = 100.0 if sym == symbol_a else 200.0
+        return _make_candles(
+            [(150_000, base, base + 2.0, base - 2.0, base + 1.0, 1.0)]
+        )
+
+    bot.cm.get_candles = candles_after_old_epochs
+
+    await bot.update_trailing_data()
+
+    assert bot.trailing_prices[symbol_a]["long"]["max_since_open"] == 0.0
+    assert bot.trailing_prices[symbol_a]["short"]["max_since_open"] == pytest.approx(
+        102.0
+    )
+    assert bot.trailing_prices[symbol_b]["long"]["max_since_open"] == pytest.approx(
+        202.0
+    )
+    assert bot._orchestrator_trailing_unavailable_psides == {symbol_a: ["long"]}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- reset live trailing extrema independently per symbol and position side whenever the latest confirmed fill identity changes
- suppress ordinary trailing-close creation and retire stale trailing orders until post-fill candles establish fresh extrema, while preserving independent reduce-only and panic/HSL exits
- replace the legacy trailing-martingale monitor calculation with a Rust-backed diagnostic that reports the exact threshold terms, retracement, WEL, volatility EMA inputs, extrema, and generated order

## Root cause
Live preserved the previous trailing bundle when no finalized candle existed after a new fill. The reconciler then allowed all reduce-only creations during `missing_trailing_candles`, including `close_trailing`, so Rust could act on extrema from the preceding position state. Backtest already resets the side-local bundle after every fill.

The old monitor diagnostic was also not the Rust formula: it multiplied the base threshold by a shared volatility multiplier, omitted the wallet-exposure term, and reused threshold weights for retracement.

## Validation
- `python -m pytest -q tests/test_unstucking_safeguards.py tests/test_order_orchestration.py tests/test_trailing_diagnostics.py tests/test_passivbot_monitor.py` (273 passed)
- `cargo test --no-default-features --offline` (210 passed)
- `cargo check --tests --offline`
- `cargo fmt --check`
- runtime extension source fingerprint verified against the rebuilt editable artifact
- `git diff --check`

No authenticated exchange calls or live-bot operations were performed. The captured historical monitor event did not retain its raw 1m/1h EMA inputs, so the PR does not present reconstructed values as exact historical evidence; the corrected monitor payload records them going forward.