### PR TITLE
Fix delayed trailing extrema confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live trailing extrema now latch an affected position side unavailable as soon
+  as an authoritative position change is observed, and remain unavailable until
+  a newer fill identity plus complete finalized 1m coverage is present.
+  Side-scoped trailing failures no longer suppress valid reconciliation on the
+  unaffected hedge side.
+
 - Live trailing extrema now reset independently per symbol and position side
   after every confirmed fill. Ordinary trailing closes are withheld and stale
   trailing orders retired until post-fill candles establish fresh extrema,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable user-facing changes will be documented in this file.
 ## Unreleased
 
 - Live trailing extrema now latch an affected position side unavailable as soon
-  as an authoritative position change is observed, and remain unavailable until
-  a newer fill identity plus complete finalized 1m coverage is present.
-  Side-scoped trailing failures no longer suppress valid reconciliation on the
-  unaffected hedge side.
+  as an authoritative position change is observed, including the first
+  position snapshot after restart, and remain unavailable until a newer fill
+  identity at or after the authoritative position timestamp plus complete
+  finalized 1m coverage is present. Fill refreshes that arrive before the
+  matching position snapshot confirm against the prior snapshot's fill epoch.
+  Side-scoped trailing failures and panic plans no longer suppress valid
+  reconciliation on the unaffected hedge side.
 
 - Live trailing extrema now reset independently per symbol and position side
   after every confirmed fill. Ordinary trailing closes are withheld and stale

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -1336,15 +1336,20 @@ def _order_is_unavailable_trailing_close(order: dict, unavailable_psides: set[st
     )
 
 
-def _order_targets_unavailable_pside(
-    order: dict, unavailable_psides: set[str]
-) -> bool:
+def _order_position_side(order: dict) -> str:
     pside = str(
         order.get("position_side") or order.get("positionSide") or ""
     ).lower()
     if not pside:
         family = _reduce_only_order_family(order)
         pside = "" if family is None else family[0]
+    return pside
+
+
+def _order_targets_unavailable_pside(
+    order: dict, unavailable_psides: set[str]
+) -> bool:
+    pside = _order_position_side(order)
     return not pside or pside in unavailable_psides
 
 
@@ -1363,26 +1368,26 @@ def filter_trailing_unavailable_reconciliation(
     """
     reasons = _trailing_unavailable_reasons(bot, symbol)
     unavailable_psides = _trailing_unavailable_psides(bot, symbol)
-    has_panic_plan = any(_order_is_panic(order) for order in ideal_orders) or any(
-        _order_is_panic(order) for order in to_create
-    )
+    panic_psides = {
+        pside
+        for order in [*ideal_orders, *to_create]
+        if _order_is_panic(order) and (pside := _order_position_side(order))
+    }
     soft_missing_candles_only = reasons == {"missing_trailing_candles"}
     if not soft_missing_candles_only:
-        if has_panic_plan:
-            filtered_cancel = list(to_cancel)
-            filtered_create = [order for order in to_create if _order_is_panic(order)]
-        else:
-            filtered_cancel = [
-                order
-                for order in to_cancel
-                if not _order_targets_unavailable_pside(order, unavailable_psides)
-                or _order_is_unavailable_trailing_close(order, unavailable_psides)
-            ]
-            filtered_create = [
-                order
-                for order in to_create
-                if not _order_targets_unavailable_pside(order, unavailable_psides)
-            ]
+        filtered_cancel = [
+            order
+            for order in to_cancel
+            if _order_position_side(order) in panic_psides
+            or not _order_targets_unavailable_pside(order, unavailable_psides)
+            or _order_is_unavailable_trailing_close(order, unavailable_psides)
+        ]
+        filtered_create = [
+            order
+            for order in to_create
+            if _order_is_panic(order)
+            or not _order_targets_unavailable_pside(order, unavailable_psides)
+        ]
         dropped = (len(to_cancel) - len(filtered_cancel)) + (
             len(to_create) - len(filtered_create)
         )
@@ -1397,9 +1402,6 @@ def filter_trailing_unavailable_reconciliation(
     ]
     dropped_create = len(to_create) - len(filtered_create)
 
-    if has_panic_plan:
-        return to_cancel, filtered_create, dropped_create, False
-
     ideal_reduce_only_families = {
         family
         for order in ideal_orders
@@ -1408,6 +1410,9 @@ def filter_trailing_unavailable_reconciliation(
     filtered_cancel = []
     dropped_cancel = 0
     for order in to_cancel:
+        if _order_position_side(order) in panic_psides:
+            filtered_cancel.append(order)
+            continue
         if _order_is_reduce_only(order):
             if _order_is_unavailable_trailing_close(order, unavailable_psides):
                 filtered_cancel.append(order)

--- a/src/live/reconciler.py
+++ b/src/live/reconciler.py
@@ -1336,6 +1336,18 @@ def _order_is_unavailable_trailing_close(order: dict, unavailable_psides: set[st
     )
 
 
+def _order_targets_unavailable_pside(
+    order: dict, unavailable_psides: set[str]
+) -> bool:
+    pside = str(
+        order.get("position_side") or order.get("positionSide") or ""
+    ).lower()
+    if not pside:
+        family = _reduce_only_order_family(order)
+        pside = "" if family is None else family[0]
+    return not pside or pside in unavailable_psides
+
+
 def filter_trailing_unavailable_reconciliation(
     bot,
     symbol: str,
@@ -1356,20 +1368,21 @@ def filter_trailing_unavailable_reconciliation(
     )
     soft_missing_candles_only = reasons == {"missing_trailing_candles"}
     if not soft_missing_candles_only:
-        filtered_cancel = (
-            list(to_cancel)
-            if has_panic_plan
-            else [
+        if has_panic_plan:
+            filtered_cancel = list(to_cancel)
+            filtered_create = [order for order in to_create if _order_is_panic(order)]
+        else:
+            filtered_cancel = [
                 order
                 for order in to_cancel
-                if _order_is_unavailable_trailing_close(order, unavailable_psides)
+                if not _order_targets_unavailable_pside(order, unavailable_psides)
+                or _order_is_unavailable_trailing_close(order, unavailable_psides)
             ]
-        )
-        filtered_create = (
-            [order for order in to_create if _order_is_panic(order)]
-            if has_panic_plan
-            else []
-        )
+            filtered_create = [
+                order
+                for order in to_create
+                if not _order_targets_unavailable_pside(order, unavailable_psides)
+            ]
         dropped = (len(to_cancel) - len(filtered_cancel)) + (
             len(to_create) - len(filtered_create)
         )

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -7761,8 +7761,7 @@ class Passivbot:
             return None
         return anchor_ts if anchor_ts > 0 else None
 
-    def _position_anchor_timestamp_ms(self, symbol: str, pside: str) -> int | None:
-        position = self.positions.get(symbol, {}).get(pside, {})
+    def _position_anchor_timestamp_from_row(self, position: dict) -> int | None:
         candidates = [
             position.get("open_time"),
             position.get("openTime"),
@@ -7799,6 +7798,10 @@ class Passivbot:
                 return anchor_ts
         return None
 
+    def _position_anchor_timestamp_ms(self, symbol: str, pside: str) -> int | None:
+        position = self.positions.get(symbol, {}).get(pside, {})
+        return self._position_anchor_timestamp_from_row(position)
+
     @staticmethod
     def _fill_position_change_epoch(event, event_index: int) -> str:
         timestamp = int(event.timestamp)
@@ -7809,39 +7812,41 @@ class Passivbot:
             event_id = f"event_index:{event_index}"
         return f"fill:{timestamp}:{event_id}"
 
-    def _latest_fill_position_change_epochs(self) -> dict[tuple[str, str], str]:
-        """Return the newest known fill identity for each symbol and position side."""
+    def _latest_fill_position_change_anchors(self) -> dict[tuple[str, str], dict]:
+        """Return the newest known fill anchor for each symbol and position side."""
         manager = getattr(self, "_pnls_manager", None)
         events = [] if manager is None else manager.get_events()
-        epochs: dict[tuple[str, str], str] = {}
+        anchors: dict[tuple[str, str], dict] = {}
         for event_index in range(len(events) - 1, -1, -1):
             event = events[event_index]
             key = (str(event.symbol), str(event.position_side))
-            if key not in epochs:
-                epochs[key] = self._fill_position_change_epoch(event, event_index)
-        return epochs
+            if key not in anchors:
+                anchors[key] = {
+                    "timestamp": int(event.timestamp),
+                    "epoch": self._fill_position_change_epoch(event, event_index),
+                }
+        return anchors
+
+    def _latest_fill_position_change_epochs(self) -> dict[tuple[str, str], str]:
+        """Return the newest known fill identity for each symbol and position side."""
+        return {
+            key: str(anchor["epoch"])
+            for key, anchor in self._latest_fill_position_change_anchors().items()
+        }
 
     def _get_last_position_change_anchors(self, symbol=None):
         """Return the latest fill timestamp and identity per trailing position side."""
         anchors = defaultdict(dict)
-        events = [] if self._pnls_manager is None else self._pnls_manager.get_events()
+        fill_anchors = self._latest_fill_position_change_anchors()
         symbols = [symbol] if symbol is not None else list(self.positions)
         for symbol in symbols:
             if symbol not in self.positions:
                 continue
             for pside in ["long", "short"]:
                 if self.has_position(pside, symbol) and self.is_trailing(symbol, pside):
-                    for event_index in range(len(events) - 1, -1, -1):
-                        ev = events[event_index]
-                        if ev.symbol == symbol and ev.position_side == pside:
-                            timestamp = int(ev.timestamp)
-                            anchors[symbol][pside] = {
-                                "timestamp": timestamp,
-                                "epoch": self._fill_position_change_epoch(
-                                    ev, event_index
-                                ),
-                            }
-                            break
+                    fill_anchor = fill_anchors.get((symbol, pside))
+                    if fill_anchor is not None:
+                        anchors[symbol][pside] = dict(fill_anchor)
                     if pside not in anchors.get(symbol, {}):
                         anchor_ts = self._position_anchor_timestamp_ms(symbol, pside)
                         if anchor_ts is not None:
@@ -7953,6 +7958,9 @@ class Passivbot:
         pending_fill_confirmations = dict(
             getattr(self, "_trailing_pending_fill_confirmations", {}) or {}
         )
+        pending_fill_min_timestamps = dict(
+            getattr(self, "_trailing_pending_fill_min_timestamps", {}) or {}
+        )
         current_epochs: dict[tuple[str, str], str] = {}
 
         for symbol, psides in required_trailing.items():
@@ -7962,10 +7970,18 @@ class Passivbot:
                 if epoch_key in pending_fill_confirmations:
                     baseline_epoch = pending_fill_confirmations[epoch_key]
                     current_epoch = None if anchor is None else str(anchor["epoch"])
+                    current_timestamp = (
+                        None if anchor is None else int(anchor["timestamp"])
+                    )
+                    minimum_timestamp = pending_fill_min_timestamps.get(epoch_key)
                     if (
                         current_epoch is None
                         or not current_epoch.startswith("fill:")
                         or current_epoch == baseline_epoch
+                        or (
+                            minimum_timestamp is not None
+                            and current_timestamp < int(minimum_timestamp)
+                        )
                     ):
                         self.trailing_prices[symbol][pside] = (
                             _trailing_bundle_default_dict()
@@ -7977,6 +7993,7 @@ class Passivbot:
                         last_position_changes.get(symbol, {}).pop(pside, None)
                         continue
                     pending_fill_confirmations.pop(epoch_key, None)
+                    pending_fill_min_timestamps.pop(epoch_key, None)
                 if anchor is None:
                     self.trailing_prices[symbol][pside] = _trailing_bundle_default_dict()
                     unavailable_reasons["missing_position_change_anchor"].add(symbol)
@@ -7988,6 +8005,7 @@ class Passivbot:
                     self.trailing_prices[symbol][pside] = _trailing_bundle_default_dict()
         self._trailing_position_change_epochs = current_epochs
         self._trailing_pending_fill_confirmations = pending_fill_confirmations
+        self._trailing_pending_fill_min_timestamps = pending_fill_min_timestamps
 
         # Build concurrent fetches per symbol that has position changes
         fetch_plan = {}
@@ -9038,9 +9056,6 @@ class Passivbot:
 
     def _begin_authoritative_refresh_epoch(self) -> None:
         """Start a new authoritative state refresh cohort for execution gating."""
-        self._authoritative_refresh_start_fill_epochs = (
-            self._latest_fill_position_change_epochs()
-        )
         self._authoritative_refresh_epoch = (
             int(getattr(self, "_authoritative_refresh_epoch", 0) or 0) + 1
         )
@@ -13455,7 +13470,11 @@ class Passivbot:
                     "long": {"size": 0.0, "price": 0.0},
                     "short": {"size": 0.0, "price": 0.0},
                 }
-            positions_new[symbol][pside] = {"size": psize, "price": pprice}
+            normalized_position = {"size": psize, "price": pprice}
+            anchor_ts = self._position_anchor_timestamp_from_row(elm)
+            if anchor_ts is not None:
+                normalized_position["timestamp"] = anchor_ts
+            positions_new[symbol][pside] = normalized_position
         self.positions = positions_new
         position_state = {
             (symbol, pside): (
@@ -13468,16 +13487,24 @@ class Passivbot:
         previous_position_state = getattr(
             self, "_trailing_authoritative_position_state", None
         )
+        previous_snapshot_fill_epochs = dict(
+            getattr(self, "_trailing_position_snapshot_fill_epochs", {}) or {}
+        )
+        current_fill_anchors = self._latest_fill_position_change_anchors()
+        current_fill_epochs = {
+            key: str(anchor["epoch"]) for key, anchor in current_fill_anchors.items()
+        }
         self._trailing_authoritative_position_state = position_state
+        self._trailing_position_snapshot_fill_epochs = current_fill_epochs
+        if not hasattr(self, "trailing_prices"):
+            self.trailing_prices = {}
+        pending = dict(
+            getattr(self, "_trailing_pending_fill_confirmations", {}) or {}
+        )
+        pending_min_timestamps = dict(
+            getattr(self, "_trailing_pending_fill_min_timestamps", {}) or {}
+        )
         if previous_position_state is not None:
-            if not hasattr(self, "trailing_prices"):
-                self.trailing_prices = {}
-            pending = dict(
-                getattr(self, "_trailing_pending_fill_confirmations", {}) or {}
-            )
-            refresh_start_fill_epochs = dict(
-                getattr(self, "_authoritative_refresh_start_fill_epochs", {}) or {}
-            )
             for key in set(previous_position_state) | set(position_state):
                 if previous_position_state.get(key, (0.0, 0.0)) == position_state.get(
                     key, (0.0, 0.0)
@@ -13488,10 +13515,35 @@ class Passivbot:
                 self.trailing_prices[symbol][pside] = _trailing_bundle_default_dict()
                 new_size = position_state.get(key, (0.0, 0.0))[0]
                 if new_size != 0.0 and self.is_trailing(symbol, pside):
-                    pending[key] = refresh_start_fill_epochs.get(key)
+                    pending[key] = previous_snapshot_fill_epochs.get(key)
+                    position_ts = self._position_anchor_timestamp_ms(symbol, pside)
+                    if position_ts is None:
+                        pending_min_timestamps.pop(key, None)
+                    else:
+                        pending_min_timestamps[key] = position_ts
                 else:
                     pending.pop(key, None)
-            self._trailing_pending_fill_confirmations = pending
+                    pending_min_timestamps.pop(key, None)
+        else:
+            for key, state in position_state.items():
+                symbol, pside = key
+                if state[0] == 0.0 or not self.is_trailing(symbol, pside):
+                    continue
+                position_ts = self._position_anchor_timestamp_ms(symbol, pside)
+                fill_anchor = current_fill_anchors.get(key)
+                if position_ts is None or (
+                    fill_anchor is not None
+                    and int(fill_anchor["timestamp"]) >= position_ts
+                ):
+                    continue
+                self.trailing_prices.setdefault(symbol, {})
+                self.trailing_prices[symbol][pside] = _trailing_bundle_default_dict()
+                pending[key] = (
+                    None if fill_anchor is None else str(fill_anchor["epoch"])
+                )
+                pending_min_timestamps[key] = position_ts
+        self._trailing_pending_fill_confirmations = pending
+        self._trailing_pending_fill_min_timestamps = pending_min_timestamps
         return fetched_positions_old, self.fetched_positions
 
     def _apply_balance_snapshot(self, balance_raw) -> bool:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -7799,6 +7799,28 @@ class Passivbot:
                 return anchor_ts
         return None
 
+    @staticmethod
+    def _fill_position_change_epoch(event, event_index: int) -> str:
+        timestamp = int(event.timestamp)
+        event_id = getattr(event, "id", None) or getattr(
+            event, "client_order_id", None
+        )
+        if not event_id:
+            event_id = f"event_index:{event_index}"
+        return f"fill:{timestamp}:{event_id}"
+
+    def _latest_fill_position_change_epochs(self) -> dict[tuple[str, str], str]:
+        """Return the newest known fill identity for each symbol and position side."""
+        manager = getattr(self, "_pnls_manager", None)
+        events = [] if manager is None else manager.get_events()
+        epochs: dict[tuple[str, str], str] = {}
+        for event_index in range(len(events) - 1, -1, -1):
+            event = events[event_index]
+            key = (str(event.symbol), str(event.position_side))
+            if key not in epochs:
+                epochs[key] = self._fill_position_change_epoch(event, event_index)
+        return epochs
+
     def _get_last_position_change_anchors(self, symbol=None):
         """Return the latest fill timestamp and identity per trailing position side."""
         anchors = defaultdict(dict)
@@ -7813,14 +7835,11 @@ class Passivbot:
                         ev = events[event_index]
                         if ev.symbol == symbol and ev.position_side == pside:
                             timestamp = int(ev.timestamp)
-                            event_id = getattr(ev, "id", None) or getattr(
-                                ev, "client_order_id", None
-                            )
-                            if not event_id:
-                                event_id = f"event_index:{event_index}"
                             anchors[symbol][pside] = {
                                 "timestamp": timestamp,
-                                "epoch": f"fill:{timestamp}:{event_id}",
+                                "epoch": self._fill_position_change_epoch(
+                                    ev, event_index
+                                ),
                             }
                             break
                     if pside not in anchors.get(symbol, {}):
@@ -7831,6 +7850,37 @@ class Passivbot:
                                 "epoch": f"position:{anchor_ts}",
                             }
         return anchors
+
+    def _completed_trailing_candle_subset(
+        self, arr: np.ndarray, changed_ts: int
+    ) -> np.ndarray | None:
+        """Return dense finalized 1m candles after a fill, or None if incomplete.
+
+        CandlestickManager may synthesize only confirmed internal no-trade gaps as
+        zero-volume candles. Those dense rows match backtest continuity and are
+        accepted here; missing leading minutes or an open tail are not.
+        """
+        now_ms = self._completed_candle_health_now_ms()
+        latest_finalized = (now_ms // ONE_MIN_MS) * ONE_MIN_MS - ONE_MIN_MS
+        first_eligible = (int(changed_ts) // ONE_MIN_MS + 1) * ONE_MIN_MS
+        if latest_finalized < first_eligible:
+            return None
+        subset = arr[
+            (arr["ts"] >= first_eligible) & (arr["ts"] <= latest_finalized)
+        ]
+        if subset.size == 0:
+            return None
+        subset = np.sort(subset, order="ts")
+        timestamps = subset["ts"].astype(np.int64)
+        expected_count = (latest_finalized - first_eligible) // ONE_MIN_MS + 1
+        if (
+            timestamps.size != expected_count
+            or int(timestamps[0]) != first_eligible
+            or int(timestamps[-1]) != latest_finalized
+            or (timestamps.size > 1 and np.any(np.diff(timestamps) != ONE_MIN_MS))
+        ):
+            return None
+        return subset
 
     def get_last_position_changes(self, symbol=None):
         """Return the most recent fill timestamp per symbol/side for trailing logic."""
@@ -7900,22 +7950,44 @@ class Passivbot:
                     required_trailing[symbol].add(pside)
 
         previous_epochs = getattr(self, "_trailing_position_change_epochs", {}) or {}
+        pending_fill_confirmations = dict(
+            getattr(self, "_trailing_pending_fill_confirmations", {}) or {}
+        )
         current_epochs: dict[tuple[str, str], str] = {}
 
         for symbol, psides in required_trailing.items():
             for pside in psides:
                 anchor = position_change_anchors.get(symbol, {}).get(pside)
+                epoch_key = (symbol, pside)
+                if epoch_key in pending_fill_confirmations:
+                    baseline_epoch = pending_fill_confirmations[epoch_key]
+                    current_epoch = None if anchor is None else str(anchor["epoch"])
+                    if (
+                        current_epoch is None
+                        or not current_epoch.startswith("fill:")
+                        or current_epoch == baseline_epoch
+                    ):
+                        self.trailing_prices[symbol][pside] = (
+                            _trailing_bundle_default_dict()
+                        )
+                        unavailable_reasons[
+                            "position_fill_confirmation_pending"
+                        ].add(symbol)
+                        unavailable_psides[symbol].add(pside)
+                        last_position_changes.get(symbol, {}).pop(pside, None)
+                        continue
+                    pending_fill_confirmations.pop(epoch_key, None)
                 if anchor is None:
                     self.trailing_prices[symbol][pside] = _trailing_bundle_default_dict()
                     unavailable_reasons["missing_position_change_anchor"].add(symbol)
                     unavailable_psides[symbol].add(pside)
                     continue
-                epoch_key = (symbol, pside)
                 epoch = str(anchor["epoch"])
                 current_epochs[epoch_key] = epoch
                 if previous_epochs.get(epoch_key) != epoch:
                     self.trailing_prices[symbol][pside] = _trailing_bundle_default_dict()
         self._trailing_position_change_epochs = current_epochs
+        self._trailing_pending_fill_confirmations = pending_fill_confirmations
 
         # Build concurrent fetches per symbol that has position changes
         fetch_plan = {}
@@ -7964,12 +8036,13 @@ class Passivbot:
             for pside, changed_ts in last_position_changes[symbol].items():
                 if pside not in required_trailing.get(symbol, set()):
                     continue
-                mask = arr["ts"] > int(changed_ts)
-                if not np.any(mask):
-                    unavailable_reasons["missing_trailing_candles"].add(symbol)
+                subset = self._completed_trailing_candle_subset(arr, int(changed_ts))
+                if subset is None:
+                    unavailable_reasons[
+                        "incomplete_trailing_candle_coverage"
+                    ].add(symbol)
                     unavailable_psides[symbol].add(pside)
                     continue
-                subset = arr[mask]
                 try:
                     bundle = _trailing_bundle_from_arrays(
                         subset["h"], subset["l"], subset["c"]
@@ -8965,6 +9038,9 @@ class Passivbot:
 
     def _begin_authoritative_refresh_epoch(self) -> None:
         """Start a new authoritative state refresh cohort for execution gating."""
+        self._authoritative_refresh_start_fill_epochs = (
+            self._latest_fill_position_change_epochs()
+        )
         self._authoritative_refresh_epoch = (
             int(getattr(self, "_authoritative_refresh_epoch", 0) or 0) + 1
         )
@@ -13381,6 +13457,41 @@ class Passivbot:
                 }
             positions_new[symbol][pside] = {"size": psize, "price": pprice}
         self.positions = positions_new
+        position_state = {
+            (symbol, pside): (
+                round(float(position.get("size") or 0.0), 12),
+                round(float(position.get("price") or 0.0), 12),
+            )
+            for symbol, by_pside in positions_new.items()
+            for pside, position in by_pside.items()
+        }
+        previous_position_state = getattr(
+            self, "_trailing_authoritative_position_state", None
+        )
+        self._trailing_authoritative_position_state = position_state
+        if previous_position_state is not None:
+            if not hasattr(self, "trailing_prices"):
+                self.trailing_prices = {}
+            pending = dict(
+                getattr(self, "_trailing_pending_fill_confirmations", {}) or {}
+            )
+            refresh_start_fill_epochs = dict(
+                getattr(self, "_authoritative_refresh_start_fill_epochs", {}) or {}
+            )
+            for key in set(previous_position_state) | set(position_state):
+                if previous_position_state.get(key, (0.0, 0.0)) == position_state.get(
+                    key, (0.0, 0.0)
+                ):
+                    continue
+                symbol, pside = key
+                self.trailing_prices.setdefault(symbol, {})
+                self.trailing_prices[symbol][pside] = _trailing_bundle_default_dict()
+                new_size = position_state.get(key, (0.0, 0.0))[0]
+                if new_size != 0.0 and self.is_trailing(symbol, pside):
+                    pending[key] = refresh_start_fill_epochs.get(key)
+                else:
+                    pending.pop(key, None)
+            self._trailing_pending_fill_confirmations = pending
         return fetched_positions_old, self.fetched_positions
 
     def _apply_balance_snapshot(self, balance_raw) -> bool:

--- a/tests/test_order_orchestration.py
+++ b/tests/test_order_orchestration.py
@@ -932,6 +932,55 @@ async def test_calc_orders_retires_trailing_close_during_fetch_failure():
 
 
 @pytest.mark.asyncio
+async def test_calc_orders_hard_trailing_failure_preserves_unaffected_side_replace():
+    symbol = "BTC/USDT"
+    bot = OrchestrationBot({symbol: 100.0})
+    bot.register_symbol(symbol)
+    bot._orchestrator_trailing_unavailable_symbols = {symbol}
+    bot._orchestrator_trailing_unavailable_reasons = {
+        symbol: ["bundle_compute_failed"]
+    }
+    bot._orchestrator_trailing_unavailable_psides = {symbol: ["long"]}
+    bot.open_orders[symbol] = [
+        _make_order(
+            symbol,
+            "buy",
+            "short",
+            1.0,
+            101.0,
+            "close_trailing_short",
+            reduce_only=True,
+        )
+    ]
+
+    async def fake_calc_ideal_orders(self):
+        return {
+            symbol: [
+                _make_order(
+                    symbol,
+                    "buy",
+                    "short",
+                    1.0,
+                    102.0,
+                    "close_trailing_short",
+                    reduce_only=True,
+                )
+            ]
+        }
+
+    bot.calc_ideal_orders = types.MethodType(fake_calc_ideal_orders, bot)
+
+    to_cancel, to_create = await bot.calc_orders_to_cancel_and_create()
+
+    assert [(order["position_side"], order["price"]) for order in to_cancel] == [
+        ("short", 101.0)
+    ]
+    assert [(order["position_side"], order["price"]) for order in to_create] == [
+        ("short", 102.0)
+    ]
+
+
+@pytest.mark.asyncio
 async def test_calc_orders_allows_same_family_reduce_only_replace_when_trailing_candles_pending():
     symbol = "BTC/USDT"
     bot = OrchestrationBot({symbol: 100.0})

--- a/tests/test_order_orchestration.py
+++ b/tests/test_order_orchestration.py
@@ -981,6 +981,75 @@ async def test_calc_orders_hard_trailing_failure_preserves_unaffected_side_repla
 
 
 @pytest.mark.asyncio
+async def test_calc_orders_unavailable_long_panic_preserves_short_replace():
+    symbol = "BTC/USDT"
+    bot = OrchestrationBot({symbol: 100.0})
+    bot.register_symbol(symbol)
+    bot._orchestrator_trailing_unavailable_symbols = {symbol}
+    bot._orchestrator_trailing_unavailable_reasons = {
+        symbol: ["position_fill_confirmation_pending"]
+    }
+    bot._orchestrator_trailing_unavailable_psides = {symbol: ["long"]}
+    bot.open_orders[symbol] = [
+        _make_order(
+            symbol,
+            "sell",
+            "long",
+            1.0,
+            99.0,
+            "close_grid_long",
+            reduce_only=True,
+        ),
+        _make_order(
+            symbol,
+            "buy",
+            "short",
+            1.0,
+            101.0,
+            "close_trailing_short",
+            reduce_only=True,
+        ),
+    ]
+
+    async def fake_calc_ideal_orders(self):
+        return {
+            symbol: [
+                _make_order(
+                    symbol,
+                    "sell",
+                    "long",
+                    1.0,
+                    98.0,
+                    "close_panic_long",
+                    reduce_only=True,
+                ),
+                _make_order(
+                    symbol,
+                    "buy",
+                    "short",
+                    1.0,
+                    102.0,
+                    "close_trailing_short",
+                    reduce_only=True,
+                ),
+            ]
+        }
+
+    bot.calc_ideal_orders = types.MethodType(fake_calc_ideal_orders, bot)
+
+    to_cancel, to_create = await bot.calc_orders_to_cancel_and_create()
+
+    assert {(order["position_side"], order["price"]) for order in to_cancel} == {
+        ("long", 99.0),
+        ("short", 101.0),
+    }
+    assert {(order["position_side"], order["price"]) for order in to_create} == {
+        ("long", 98.0),
+        ("short", 102.0),
+    }
+
+
+@pytest.mark.asyncio
 async def test_calc_orders_allows_same_family_reduce_only_replace_when_trailing_candles_pending():
     symbol = "BTC/USDT"
     bot = OrchestrationBot({symbol: 100.0})

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1389,6 +1389,115 @@ async def test_position_delta_waits_for_new_fill_identity_across_refresh_cohorts
 
 
 @pytest.mark.asyncio
+async def test_fill_prefetch_before_position_delta_confirms_new_position_epoch():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    old_fill = _DummyFillEvent(symbol, "long", 120_000, "old-fill")
+    bot._pnls_manager = _DummyPnlsManager([old_fill])
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 361_000
+
+    baseline = [
+        {"symbol": symbol, "position_side": "long", "size": 1.0, "price": 100.0}
+    ]
+    changed = [
+        {"symbol": symbol, "position_side": "long", "size": 1.5, "price": 101.0}
+    ]
+    bot._apply_positions_snapshot(baseline)
+    bot._pnls_manager._events.append(
+        _DummyFillEvent(symbol, "long", 240_000, "new-fill")
+    )
+    bot._begin_authoritative_refresh_epoch()
+    bot._apply_positions_snapshot(changed)
+
+    assert bot._trailing_pending_fill_confirmations == {
+        (symbol, "long"): "fill:120000:old-fill"
+    }
+
+    async def complete_new_epoch_candles(*args, **kwargs):
+        return _make_candles(
+            [(300_000, 101.0, 103.0, 100.0, 102.0, 1.0)]
+        )
+
+    bot.cm.get_candles = complete_new_epoch_candles
+    await bot.update_trailing_data()
+
+    assert bot._trailing_pending_fill_confirmations == {}
+    assert bot._orchestrator_trailing_unavailable_symbols == set()
+    assert bot.trailing_prices[symbol]["long"]["max_since_open"] == pytest.approx(
+        103.0
+    )
+
+
+@pytest.mark.asyncio
+async def test_restart_blocks_trailing_when_position_is_newer_than_fill_history():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    bot._pnls_manager = _DummyPnlsManager(
+        [_DummyFillEvent(symbol, "long", 120_000, "old-fill")]
+    )
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 361_000
+
+    bot._apply_positions_snapshot(
+        [
+            {
+                "symbol": symbol,
+                "position_side": "long",
+                "size": 1.0,
+                "price": 101.0,
+                "timestamp": 240_000,
+            }
+        ]
+    )
+
+    assert bot.positions[symbol]["long"]["timestamp"] == 240_000
+    assert bot._trailing_pending_fill_confirmations == {
+        (symbol, "long"): "fill:120000:old-fill"
+    }
+
+    async def old_epoch_candles(*args, **kwargs):
+        return _make_candles(
+            [
+                (180_000, 100.0, 110.0, 90.0, 100.0, 1.0),
+                (240_000, 100.0, 111.0, 89.0, 101.0, 1.0),
+                (300_000, 101.0, 112.0, 88.0, 102.0, 1.0),
+            ]
+        )
+
+    bot.cm.get_candles = old_epoch_candles
+    await bot.update_trailing_data()
+
+    assert bot.trailing_prices[symbol]["long"] == _trailing_default()
+    assert bot._orchestrator_trailing_unavailable_reasons == {
+        symbol: ["position_fill_confirmation_pending"]
+    }
+
+    bot._pnls_manager._events.append(
+        _DummyFillEvent(symbol, "long", 180_000, "late-older-fill")
+    )
+    await bot.update_trailing_data()
+
+    assert bot.trailing_prices[symbol]["long"] == _trailing_default()
+    assert bot._trailing_pending_fill_confirmations == {
+        (symbol, "long"): "fill:120000:old-fill"
+    }
+
+    bot._pnls_manager._events.append(
+        _DummyFillEvent(symbol, "long", 240_000, "matching-fill")
+    )
+    await bot.update_trailing_data()
+
+    assert bot._trailing_pending_fill_confirmations == {}
+    assert bot._orchestrator_trailing_unavailable_symbols == set()
+    assert bot.trailing_prices[symbol]["long"]["max_since_open"] == pytest.approx(
+        112.0
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "rows",
     [

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -797,6 +797,17 @@ def _make_candles(rows):
     return arr
 
 
+def _trailing_default():
+    import passivbot_rust as pbr
+
+    return dict(
+        zip(
+            ("min_since_open", "max_since_min", "max_since_open", "min_since_max"),
+            pbr.trailing_bundle_default_py(),
+        )
+    )
+
+
 def _set_basic_state(bot, symbol="TEST/USDT"):
     bot.active_symbols = [symbol]
     bot.open_orders = {symbol: []}
@@ -1106,6 +1117,7 @@ async def test_new_position_changing_fill_epoch_resets_stale_bundle_before_post_
         (symbol, "long"): "fill:120000:partial-entry"
     }
     bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 241_000
 
     async def no_post_fill_candles(*args, **kwargs):
         return _make_candles([(180_000, 100.0, 101.0, 99.0, 100.5, 1.0)])
@@ -1149,6 +1161,7 @@ async def test_same_timestamp_fill_identity_advances_trailing_epoch():
     )
     bot._trailing_position_change_epochs = {(symbol, "long"): "fill:120000:fill-a"}
     bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 181_000
 
     async def no_newer_candles(*args, **kwargs):
         return _make_candles([(120_000, 100.0, 101.0, 99.0, 100.5, 1.0)])
@@ -1201,11 +1214,12 @@ async def test_fill_epoch_reset_is_isolated_by_symbol_and_position_side():
     bot.is_trailing = lambda sym, pside=None: bool(
         bot.positions.get(sym, {}).get(pside, {}).get("size", 0.0)
     )
+    bot.get_exchange_time = lambda: 181_000
 
     async def candles_after_old_epochs(sym, **kwargs):
         base = 100.0 if sym == symbol_a else 200.0
         return _make_candles(
-            [(150_000, base, base + 2.0, base - 2.0, base + 1.0, 1.0)]
+            [(120_000, base, base + 2.0, base - 2.0, base + 1.0, 1.0)]
         )
 
     bot.cm.get_candles = candles_after_old_epochs
@@ -1287,6 +1301,7 @@ async def test_trailing_anchor_uses_position_timestamp_when_fill_history_is_out_
     bot.positions[symbol]["long"]["timestamp"] = 120_000
     bot._pnls_manager = _DummyPnlsManager([])
     bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 241_000
     candle_calls = []
 
     async def fake_get_candles(sym, *, start_ts, end_ts=None, strict=False):
@@ -1302,6 +1317,133 @@ async def test_trailing_anchor_uses_position_timestamp_when_fill_history_is_out_
     assert candle_calls == [(symbol, 120_000, None, False)]
     assert bot._orchestrator_trailing_unavailable_symbols == set()
     assert bot.trailing_prices[symbol]["long"]["max_since_open"] == pytest.approx(101.0)
+
+
+@pytest.mark.asyncio
+async def test_position_delta_waits_for_new_fill_identity_across_refresh_cohorts():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    old_fill = _DummyFillEvent(symbol, "long", 120_000, "old-fill")
+    bot._pnls_manager = _DummyPnlsManager([old_fill])
+    bot._trailing_position_change_epochs = {
+        (symbol, "long"): "fill:120000:old-fill"
+    }
+    bot.trailing_prices[symbol] = {
+        "long": {
+            "min_since_open": 95.0,
+            "max_since_min": 105.0,
+            "max_since_open": 110.0,
+            "min_since_max": 102.0,
+        },
+        "short": _trailing_default(),
+    }
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 361_000
+
+    baseline = [
+        {"symbol": symbol, "position_side": "long", "size": 1.0, "price": 100.0}
+    ]
+    changed = [
+        {"symbol": symbol, "position_side": "long", "size": 1.5, "price": 101.0}
+    ]
+    bot._apply_positions_snapshot(baseline)
+    bot._begin_authoritative_refresh_epoch()
+    bot._apply_positions_snapshot(changed)
+
+    assert bot.trailing_prices[symbol]["long"] == _trailing_default()
+    assert bot._trailing_pending_fill_confirmations == {
+        (symbol, "long"): "fill:120000:old-fill"
+    }
+
+    async def complete_old_epoch_candles(*args, **kwargs):
+        return _make_candles(
+            [
+                (180_000, 100.0, 101.0, 99.0, 100.0, 1.0),
+                (240_000, 100.0, 102.0, 98.0, 101.0, 1.0),
+                (300_000, 101.0, 103.0, 100.0, 102.0, 1.0),
+            ]
+        )
+
+    bot.cm.get_candles = complete_old_epoch_candles
+    await bot.update_trailing_data()
+    bot._begin_authoritative_refresh_epoch()
+    bot._apply_positions_snapshot(changed)
+    await bot.update_trailing_data()
+
+    assert bot.trailing_prices[symbol]["long"] == _trailing_default()
+    assert bot._orchestrator_trailing_unavailable_reasons == {
+        symbol: ["position_fill_confirmation_pending"]
+    }
+
+    bot._pnls_manager._events.append(
+        _DummyFillEvent(symbol, "long", 240_000, "new-fill")
+    )
+    await bot.update_trailing_data()
+
+    assert bot._trailing_pending_fill_confirmations == {}
+    assert bot._orchestrator_trailing_unavailable_symbols == set()
+    assert bot.trailing_prices[symbol]["long"]["max_since_open"] == pytest.approx(
+        103.0
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [(240_000, 100.0, 102.0, 98.0, 101.0, 1.0)],
+        [(180_000, 100.0, 101.0, 99.0, 100.0, 1.0)],
+    ],
+)
+async def test_trailing_extrema_reject_incomplete_post_fill_coverage(rows):
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    bot._pnls_manager = _DummyPnlsManager(
+        [_DummyFillEvent(symbol, "long", 120_000, "fill-1")]
+    )
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 301_000
+
+    async def partial_candles(*args, **kwargs):
+        return _make_candles(rows)
+
+    bot.cm.get_candles = partial_candles
+    await bot.update_trailing_data()
+
+    assert bot.trailing_prices[symbol]["long"] == _trailing_default()
+    assert bot._orchestrator_trailing_unavailable_reasons == {
+        symbol: ["incomplete_trailing_candle_coverage"]
+    }
+
+
+@pytest.mark.asyncio
+async def test_trailing_extrema_accept_dense_zero_volume_gap_continuity():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    bot._pnls_manager = _DummyPnlsManager(
+        [_DummyFillEvent(symbol, "long", 120_000, "fill-1")]
+    )
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 301_000
+
+    async def dense_candles(*args, **kwargs):
+        return _make_candles(
+            [
+                (180_000, 100.0, 101.0, 99.0, 100.0, 1.0),
+                (240_000, 100.0, 100.0, 100.0, 100.0, 0.0),
+            ]
+        )
+
+    bot.cm.get_candles = dense_candles
+    await bot.update_trailing_data()
+
+    assert bot._orchestrator_trailing_unavailable_symbols == set()
+    assert bot.trailing_prices[symbol]["long"]["max_since_open"] == pytest.approx(
+        101.0
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- preserve reconciliation for the unaffected hedge side during side-scoped trailing failures and same-symbol panic plans
- reset trailing extrema immediately on authoritative position deltas and hold the affected side unavailable until a newer matching fill identity arrives
- bind position deltas to the fill epoch associated with the previous position snapshot so fill-prefetch ordering cannot deadlock confirmation
- preserve authoritative position timestamps across restart and require fill history to reach that timestamp before extrema become tradable
- require dense finalized 1m coverage after the fill, accepting only the candlestick manager's backtest-compatible zero-volume continuity

## Review findings confirmed

- hard trailing-data failures suppressed valid orders on the unaffected position side
- the one-cohort account confirmation barrier could clear while fill history still exposed the old fill epoch
- partial post-fill candle ranges could become tradable despite missing leading or finalized tail minutes
- fill-before-position refresh ordering could use the new fill as its own baseline and latch unavailable indefinitely
- the first post-restart position snapshot discarded authoritative timestamps and could accept stale pre-fill extrema
- a panic on the unavailable side suppressed valid reconciliation for the unaffected hedge side

## Integration

Merged current `master` `393aec15a49d6b6cf4f6bda37ed8a2dab00b5f2c` and preserved both changelog entries. Current head: `a0735fb63174889f62e8d2b2248301fd6a16f9ee`.

## Validation

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_order_orchestration.py tests/test_unstucking_safeguards.py tests/test_passivbot_balance_split.py` (414 passed)
- focused regressions for fill-prefetch ordering, restart timestamp gating including different-but-older delayed fills, and long-panic/short-replacement isolation
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m py_compile src/passivbot.py src/live/reconciler.py tests/test_order_orchestration.py tests/test_unstucking_safeguards.py`
- `git diff --check`

## Expected VPS action

Behavior-changing live orchestration fix: after merge, update VPS5 and gracefully restart/smoke the configured five bot panes under the standing authorization. Preserve `misc:0.0`.

No authenticated exchange calls or live operations were performed during author validation.