### PR TITLE
Bind restart fingerprint to full supervisor commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable user-facing changes will be documented in this file.
 ## Unreleased
 
 - Exact live restart target sampling now binds pane/PID stability to an opaque
-  fingerprint of the parsed supervisor command contract, failing closed when
-  that contract changes without exposing command content.
+  fingerprint of the complete parsed supervisor command contract before
+  report redaction or truncation, failing closed when that contract changes or
+  is unavailable without exposing command content.
 
 - Live trailing extrema now reset independently per symbol and position side
   after every confirmed fill. Ordinary trailing closes are withheld and stale

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/full-supervisor-fingerprint`, based on canonical
   `393aec15a49d6b6cf4f6bda37ed8a2dab00b5f2c` after PR #1291.
-- PR: this PR, `Bind restart fingerprint to full supervisor commands`. Slice:
+- PR: #1294, `Bind restart fingerprint to full supervisor commands`. Slice:
   make the exact-target supervisor fingerprint cover complete private canonical
   commands before report redaction or truncation.
 - Triggering evidence: direct post-merge inspection found PR #1291 derived its

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -1,6 +1,6 @@
 # Live Logging Overhaul Current Status
 
-Updated: 2026-07-16.
+Updated: 2026-07-17.
 
 This is the compact operational source for the active logging-overhaul loop.
 Read it before the historical progress ledger. Update it whenever the active
@@ -22,19 +22,19 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/restart-target-contract-fingerprint`, based on canonical
-  `b490bd75bebd0228628c1b628b46d3f3ac52cee4` after PR #1290.
-- PR: #1291, `Bind restart target sampling to supervisor contract`; semantic
-  implementation head `9667698b6d`. Slice: bind exact pane/PID/relaunch
-  stability to the parsed supervisor command contract across the pre-action
-  sample window.
-- Triggering evidence: PR #1290 proves all five VPS5 bots have stable
-  pane-parent relaunch paths, but target sampling does not yet prove that the
-  parsed supervisor command source stayed unchanged while those targets were
-  sampled.
-- Scope: derive an opaque SHA-256 fingerprint from the parsed expected
-  window/command/config rows, expose no command content, include the contract in
-  bounded sampling stability, and make the planner require that stable verdict.
+- Branch: `codex/full-supervisor-fingerprint`, based on canonical
+  `393aec15a49d6b6cf4f6bda37ed8a2dab00b5f2c` after PR #1291.
+- PR: this PR, `Bind restart fingerprint to full supervisor commands`. Slice:
+  make the exact-target supervisor fingerprint cover complete private canonical
+  commands before report redaction or truncation.
+- Triggering evidence: direct post-merge inspection found PR #1291 derived its
+  fingerprint from public redacted/truncated process-report fields. Materially
+  different launch commands could therefore share a digest, which is not a
+  sufficient prerequisite for future execution.
+- Scope: derive the opaque SHA-256 fingerprint while the process report still
+  owns full private canonical commands, expose only the digest, validate its
+  complete value-safe shape in the target report, and fail closed when it is
+  absent or malformed.
 - Behavior boundary: read-only classification only. No configured command,
   tmux action, process control, restart execution, network/exchange access,
   credential access, SSH/git action, or file write is added.
@@ -43,10 +43,30 @@ Estimated completion:
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
 - Expected VPS action: pull and run the local-only three-sample target report,
-  confirm the supervisor contract is stable, and inspect the compact plan; no
-  bot restart, tmux action, or process signal is expected.
+  confirming that all five targets retain a stable full-command fingerprint;
+  no bot restart, tmux action, or process signal is expected.
 
 ## Deployed Baseline
+
+- Canonical `master` and VPS5 are
+  `393aec15a49d6b6cf4f6bda37ed8a2dab00b5f2c`, PR #1291. VPS5 fast-forwarded
+  cleanly from `04209762`; the five configured bot panes were then restarted so
+  the already-merged behavior-changing PR #1292 would be loaded. Exact panes
+  `%358/%359/%360/%361/%362` and pane parents
+  `856294/856332/856364/856398/856434` remained stable. Old bot PIDs
+  `1003995/1003997/1003999/1004001/1004002` exited after one exact-pane Ctrl-C
+  round, and replacement PIDs
+  `1013205/1013207/1013209/1013210/1013211` matched the same ownership contract.
+- Immediate and settled bounded smokes were `ok=true` with zero hard monitor,
+  log, process, fill-refresh, or account-critical failures and all five expected
+  processes matched. The settled target report collected 3/3 stable samples,
+  reported zero changed targets, and retained all five relaunch-ready paths.
+  Unrelated `misc:0.0` remained `%8`, PID `434835`. One ordinary OHLCV timeout
+  recovered naturally; no direct exchange probe or event was manufactured.
+- An initial host-alias mistake fast-forwarded the tracked-clean optimizer host
+  `vpsopt3` checkout to the same canonical master. No process there was
+  signalled, stopped, or restarted; subsequent deployment and all smoke
+  evidence used the correct `vps5` host.
 
 - Canonical `master` and VPS5 are
   `b490bd75bebd0228628c1b628b46d3f3ac52cee4`, PR #1290. VPS5 fast-forwarded

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,28 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1277)
+## Latest Canonical Deployment (PR #1291)
+
+- PR #1291 merged to `master` as
+  `393aec15a49d6b6cf4f6bda37ed8a2dab00b5f2c`. It binds bounded exact-target
+  sampling to an opaque parsed supervisor command-contract fingerprint without
+  exposing or executing configured commands.
+- VPS5 fast-forwarded cleanly from `04209762`. The five configured panes and
+  pane parents stayed stable while one exact-pane Ctrl-C round stopped old bot
+  PIDs `1003995/1003997/1003999/1004001/1004002`; replacements
+  `1013205/1013207/1013209/1013210/1013211` loaded already-merged PR #1292.
+  Unrelated `misc:0.0` remained `%8`, PID `434835`.
+- Immediate and settled bounded smokes were hard-green, with all five expected
+  processes matched and zero monitor/log/process, fill-refresh, or
+  account-critical failures. A final 3/3 sample target report retained stable
+  exact identities, the supervisor contract, and all five relaunch paths. One
+  ordinary OHLCV timeout recovered naturally. No direct exchange probe or event
+  was manufactured.
+- Post-merge inspection found the fingerprint used public redacted/truncated
+  command fields. The active follow-up moves hashing before report sanitization
+  and fails closed on an absent or malformed full-command contract.
+
+## Previous Canonical Deployment (PR #1277)
 
 - PR #1277 merged to `master` as
   `deee460a18f1f532a4c3a4c6e89a4befd5469d2a`. It projects existing

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -343,6 +343,12 @@ Related detailed plans:
      command exposure or process control. The active follow-up binds sampled
      target stability to an opaque parsed supervisor command-contract
      fingerprint so configuration drift fails closed before future execution.
+   - 2026-07-17: PR #1291 merged and deployed the sampled supervisor-contract
+     fingerprint. Post-merge inspection found its source rows were already
+     redacted and truncated for public process output. The active follow-up
+     computes the digest from full private canonical commands before
+     sanitization and validates the value-safe contract shape before target
+     sampling can pass.
 
    Remaining refinements: safe pull/stop/start orchestration remains open.
    The concise and brief summaries are intentionally bounded; further changes

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -404,9 +404,10 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   and ownership proof across a bounded pre-action window; any hard-red sample
   or identity change makes the report fail.
   The sampled identity also includes an opaque SHA-256 fingerprint of the
-  parsed supervisor window/command/config contract. The report never emits the
-  command content, but fails closed when that contract changes during the
-  pre-action sample window.
+  complete parsed supervisor window/command/config contract, computed from
+  private canonical commands before public report redaction or truncation. The
+  report never emits the command content, and fails closed when the contract is
+  unavailable, malformed, or changes during the pre-action sample window.
   Each resolved target also classifies whether the matched bot is a child of
   the pane PID and therefore has a candidate relaunch path through that exact
   pane after the bot exits. The report exposes the bounded relaunch method,

--- a/src/live/restart_smoke_targets.py
+++ b/src/live/restart_smoke_targets.py
@@ -56,6 +56,7 @@ def _valid_supervisor_contract(
         and contract.get("algorithm") == "sha256"
         and len(fingerprint) == 64
         and all(character in "0123456789abcdef" for character in fingerprint)
+        and type(contract.get("target_count")) is int
         and contract.get("target_count") == expected_targets
         and contract.get("command_content_exposed") is False
     )

--- a/src/live/restart_smoke_targets.py
+++ b/src/live/restart_smoke_targets.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import json
 import math
 import subprocess
 import time
@@ -47,33 +45,20 @@ def _bounded_text(value: Any, *, max_len: int) -> str:
     return f"{text[:max_len]}...<truncated>"
 
 
-def _supervisor_contract(expected_rows: list[dict[str, Any]]) -> dict[str, Any]:
-    canonical_rows = sorted(
-        (
-            {
-                "window_name": str(row.get("name") or "").strip(),
-                "command": str(
-                    row.get("command") or row.get("command_key") or ""
-                ).strip(),
-                "config_path": str(row.get("config_path") or "").strip(),
-            }
-            for row in expected_rows
-        ),
-        key=lambda row: (row["window_name"], row["command"], row["config_path"]),
+def _valid_supervisor_contract(
+    contract: dict[str, Any],
+    *,
+    expected_targets: int,
+) -> bool:
+    fingerprint = str(contract.get("fingerprint") or "").strip()
+    return (
+        contract.get("source") == "parsed_supervisor_config"
+        and contract.get("algorithm") == "sha256"
+        and len(fingerprint) == 64
+        and all(character in "0123456789abcdef" for character in fingerprint)
+        and contract.get("target_count") == expected_targets
+        and contract.get("command_content_exposed") is False
     )
-    payload = json.dumps(
-        canonical_rows,
-        ensure_ascii=True,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
-    return {
-        "source": "parsed_supervisor_config",
-        "algorithm": "sha256",
-        "fingerprint": hashlib.sha256(payload).hexdigest(),
-        "target_count": len(canonical_rows),
-        "command_content_exposed": False,
-    }
 
 
 def _tmux_pane_inventory() -> tuple[list[dict[str, Any]], str | None]:
@@ -165,7 +150,12 @@ def _build_live_restart_target_snapshot(
     )
     expected = processes.get("expected")
     expected_rows = expected if isinstance(expected, list) else []
-    supervisor_contract = _supervisor_contract(expected_rows)
+    raw_supervisor_contract = processes.get("supervisor_contract")
+    supervisor_contract = (
+        raw_supervisor_contract
+        if isinstance(raw_supervisor_contract, dict)
+        else {}
+    )
     panes, scan_error = _tmux_pane_inventory()
     session_panes = [
         pane for pane in panes if pane.get("session_name") == confirmed_session
@@ -174,6 +164,16 @@ def _build_live_restart_target_snapshot(
     issues: list[dict[str, Any]] = []
     if scan_error is not None:
         issues.append({"code": scan_error, "severity": "error"})
+    if not _valid_supervisor_contract(
+        supervisor_contract,
+        expected_targets=len(expected_rows),
+    ):
+        issues.append(
+            {
+                "code": "supervisor_contract_unavailable",
+                "severity": "error",
+            }
+        )
     if len(expected_rows) > MAX_RESTART_TARGETS:
         issues.append(
             {

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gzip
+import hashlib
 import json
 import math
 import re
@@ -6936,6 +6937,35 @@ def _parse_tmuxp_live_commands(config_path: str | Path | None) -> dict[str, Any]
     }
 
 
+def _supervisor_command_contract(
+    expected_rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    canonical_rows = sorted(
+        (
+            {
+                "window_name": str(row.get("name") or "").strip(),
+                "command": str(row.get("_match_key") or "").strip(),
+                "config_path": str(row.get("config_path") or "").strip(),
+            }
+            for row in expected_rows
+        ),
+        key=lambda row: (row["window_name"], row["command"], row["config_path"]),
+    )
+    payload = json.dumps(
+        canonical_rows,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return {
+        "source": "parsed_supervisor_config",
+        "algorithm": "sha256",
+        "fingerprint": hashlib.sha256(payload).hexdigest(),
+        "target_count": len(canonical_rows),
+        "command_content_exposed": False,
+    }
+
+
 def _ps_process_rows() -> tuple[list[str], str | None]:
     commands = [
         ["ps", "-eo", "pid=,ppid=,etimes=,stat=,pcpu=,pmem=,rss=,command="],
@@ -7552,6 +7582,7 @@ def _build_process_report(
         }
 
     config = _parse_tmuxp_live_commands(supervisor_config)
+    supervisor_contract = _supervisor_command_contract(config["expected"])
     running_scans: list[dict[str, Any]] = []
     for sample_index in range(process_samples):
         if sample_index > 0 and process_sample_interval_s > 0.0:
@@ -7625,6 +7656,11 @@ def _build_process_report(
             "exists": config.get("exists"),
             "error": config.get("error"),
         },
+        **(
+            {"supervisor_contract": supervisor_contract}
+            if supervisor_config is not None
+            else {}
+        ),
         "expected_total": len(expected),
         "running_live_total": len(running),
         "matched_expected": max(0, len(expected) - len(missing)),

--- a/tests/test_live_restart_target_report.py
+++ b/tests/test_live_restart_target_report.py
@@ -286,6 +286,26 @@ def test_live_restart_target_report_fails_without_valid_full_supervisor_contract
     }
 
 
+@pytest.mark.parametrize(
+    ("target_count", "expected_targets"),
+    [(True, 1), (False, 0)],
+)
+def test_supervisor_contract_rejects_boolean_target_count(
+    target_count,
+    expected_targets,
+):
+    assert not target_module._valid_supervisor_contract(
+        {
+            "source": "parsed_supervisor_config",
+            "algorithm": "sha256",
+            "fingerprint": "a" * 64,
+            "target_count": target_count,
+            "command_content_exposed": False,
+        },
+        expected_targets=expected_targets,
+    )
+
+
 def test_tmux_pane_inventory_only_lists_and_bounds_metadata(monkeypatch):
     captured = {}
 

--- a/tests/test_live_restart_target_report.py
+++ b/tests/test_live_restart_target_report.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 import live.restart_smoke_targets as target_module
+import live.smoke_report as smoke_report_module
 from live.restart_smoke_targets import build_live_restart_target_report
 from passivbot_cli import main as cli_main
 from tools import live_restart_target_report
@@ -33,6 +34,16 @@ def _process_report(*names: str) -> dict:
         "enabled": True,
         "ok": True,
         "hard_failures": 0,
+        "supervisor_contract": smoke_report_module._supervisor_command_contract(
+            [
+                {
+                    "name": row["name"],
+                    "_match_key": row["command"],
+                    "config_path": row["config_path"],
+                }
+                for row in expected
+            ]
+        ),
         "expected_total": len(expected),
         "matched_expected": len(expected),
         "running_live_total": len(expected),
@@ -181,13 +192,30 @@ def test_live_restart_target_report_resolves_exact_panes_and_ignores_other_sessi
     assert "private.json" not in json.dumps(report, sort_keys=True)
 
 
-def test_supervisor_contract_fingerprint_is_stable_and_content_free():
-    rows = _process_report("binance_01", "gateio_01")["expected"]
-    first = target_module._supervisor_contract(rows)
-    reordered = target_module._supervisor_contract(list(reversed(rows)))
+def test_supervisor_contract_fingerprint_uses_full_private_commands():
+    hidden_suffix = "S" * 600
+    rows = [
+        {
+            "name": "binance_01",
+            "_match_key": (
+                "passivbot live configs/private.json -u binance_01 "
+                f"--api-key FIRST-{hidden_suffix}"
+            ),
+            "config_path": "configs/private.json",
+        },
+        {
+            "name": "gateio_01",
+            "_match_key": "passivbot live configs/private.json -u gateio_01",
+            "config_path": "configs/private.json",
+        },
+    ]
+    first = smoke_report_module._supervisor_command_contract(rows)
+    reordered = smoke_report_module._supervisor_command_contract(list(reversed(rows)))
     changed_rows = [dict(row) for row in rows]
-    changed_rows[0]["command"] += " --debug"
-    changed = target_module._supervisor_contract(changed_rows)
+    changed_rows[0]["_match_key"] = changed_rows[0]["_match_key"].replace(
+        "FIRST-", "SECOND-"
+    )
+    changed = smoke_report_module._supervisor_command_contract(changed_rows)
 
     assert first == reordered
     assert first["fingerprint"] != changed["fingerprint"]
@@ -195,6 +223,67 @@ def test_supervisor_contract_fingerprint_is_stable_and_content_free():
     serialized = json.dumps(first, sort_keys=True)
     assert "passivbot live" not in serialized
     assert "private.json" not in serialized
+    assert "FIRST" not in serialized
+    assert hidden_suffix not in serialized
+
+
+@pytest.mark.parametrize(
+    "contract",
+    [
+        None,
+        {
+            "source": "parsed_supervisor_config",
+            "algorithm": "sha256",
+            "fingerprint": "not-a-digest",
+            "target_count": 1,
+            "command_content_exposed": False,
+        },
+        {
+            "source": "parsed_supervisor_config",
+            "algorithm": "sha256",
+            "fingerprint": "a" * 64,
+            "target_count": 2,
+            "command_content_exposed": False,
+        },
+        {
+            "source": "parsed_supervisor_config",
+            "algorithm": "sha256",
+            "fingerprint": "a" * 64,
+            "target_count": 1,
+            "command_content_exposed": True,
+        },
+    ],
+)
+def test_live_restart_target_report_fails_without_valid_full_supervisor_contract(
+    monkeypatch,
+    contract,
+):
+    processes = _process_report("binance_01")
+    if contract is None:
+        processes.pop("supervisor_contract")
+    else:
+        processes["supervisor_contract"] = contract
+    monkeypatch.setattr(
+        target_module,
+        "build_live_process_report",
+        lambda **_kwargs: processes,
+    )
+    monkeypatch.setattr(
+        target_module,
+        "_tmux_pane_inventory",
+        lambda: ([_pane("passivbot", "binance_01", 0, 20)], None),
+    )
+
+    report = build_live_restart_target_report(
+        "bots.yaml",
+        session_name="passivbot",
+    )
+
+    assert report["ok"] is False
+    assert report["hard_failures"] == 1
+    assert {issue["code"] for issue in report["issues"]} == {
+        "supervisor_contract_unavailable"
+    }
 
 
 def test_tmux_pane_inventory_only_lists_and_bounds_metadata(monkeypatch):

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -8260,6 +8260,12 @@ def test_live_smoke_report_process_status_matches_supervisor_config(
     assert report["processes"]["enabled"] is True
     assert report["processes"]["ok"] is False
     assert report["processes"]["expected_total"] == 2
+    contract = report["processes"]["supervisor_contract"]
+    assert contract["target_count"] == 2
+    assert len(contract["fingerprint"]) == 64
+    assert contract["command_content_exposed"] is False
+    assert "passivbot live" not in json.dumps(contract, sort_keys=True)
+    assert "forager.json" not in json.dumps(contract, sort_keys=True)
     assert report["processes"]["matched_expected"] == 1
     assert report["processes"]["running_live_total"] == 1
     assert report["processes"]["missing_expected"] == [
@@ -8277,6 +8283,52 @@ def test_live_smoke_report_process_status_matches_supervisor_config(
     assert report["processes"]["running"][0]["age_s"] == 42
     assert report["processes"]["running"][0]["account"] == "binance_01"
     assert report["processes"]["running"][0]["config_path"] == "configs/forager.json"
+
+
+def test_live_process_report_fingerprints_commands_before_public_redaction(
+    tmp_path,
+    monkeypatch,
+):
+    hidden_suffix = "S" * 600
+
+    def write_supervisor(path, secret_prefix):
+        path.write_text(
+            "\n".join(
+                [
+                    "session_name: passivbot",
+                    "windows:",
+                    "  - window_name: binance_01",
+                    "    panes:",
+                    (
+                        "      - passivbot live configs/private.json "
+                        f"-u binance_01 api_key={secret_prefix}-{hidden_suffix}"
+                    ),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    first_path = tmp_path / "first.yaml"
+    second_path = tmp_path / "second.yaml"
+    write_supervisor(first_path, "FIRST")
+    write_supervisor(second_path, "SECOND")
+    monkeypatch.setattr(smoke_report_module, "_ps_process_rows", lambda: ([], None))
+
+    first = smoke_report_module.build_live_process_report(
+        supervisor_config=first_path,
+    )
+    second = smoke_report_module.build_live_process_report(
+        supervisor_config=second_path,
+    )
+
+    assert first["supervisor_contract"]["fingerprint"] != second[
+        "supervisor_contract"
+    ]["fingerprint"]
+    serialized = json.dumps([first, second], sort_keys=True)
+    assert "FIRST" not in serialized
+    assert "SECOND" not in serialized
+    assert hidden_suffix not in serialized
 
 
 def test_live_smoke_report_process_status_parses_no_rss_etimes_passivbot_rows(


### PR DESCRIPTION
## Scope

- Category: read-only tooling / restart-deploy prerequisite
- Compute the supervisor SHA-256 contract from complete private canonical launch commands before process-report redaction or truncation.
- Expose only the existing value-safe digest metadata.
- Make exact-target preflight reject absent or malformed source, algorithm, digest, target count, or exposure metadata.
- Record PR #1291 VPS5 deploy/restart/smoke evidence in the active status and progress ledger.

## Non-goals

- No tmux action, process signal/control, bot start, SSH, git pull, exchange/API call, credential-store access, or file-writing executor.
- No trading, strategy, risk, order, Rust, configuration, or live event behavior changes.

## Behavior impact

Previously, materially different supervisor commands could share a fingerprint when their difference was hidden by public redaction or the 400-character report bound. The target gate now fingerprints the complete in-memory canonical command while keeping command content out of reports, and fails closed if the contract shape cannot be trusted.

## VPS action

Pull and run the local-only three-sample target report. No bot restart or process signal is expected.

## Validation

- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_restart_target_report.py tests/test_live_restart_smoke_plan.py tests/test_live_smoke_report.py`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_live_process_report.py tests/test_live_incident_bundle.py`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python -m pytest -q tests/test_ai_docs.py`
- `PYTHONPATH=src /Users/eiriknarjord/repos/passivbot-2/venv/bin/python src/tools/check_ai_docs.py` (0 errors; existing word-count warning)
- Python compileall for changed Python/tests
- `git diff --check`

One initial combined test run hit the pre-existing process-wide `time.sleep` monkeypatch interference in a process-sampling test; the isolated test passed and the complete focused suite passed on rerun.

## Reviewer focus

- Verify hashing occurs before sanitization and no command material reaches public output.
- Verify malformed contract metadata fails the exact-target gate.
- Verify the change remains read-only and is a sufficient prerequisite for future exact-target execution.