### PR TITLE
Fix trailing fill association across position snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ All notable user-facing changes will be documented in this file.
 - Live trailing restart reconciliation now preserves authoritative position-update
   timestamps from CCXT and raw exchange payloads and no longer
   treats position creation time as proof that fill history is current. Exchanges
-  without an update timestamp require the latest fill's recorded after-state to
-  match the live position. Unchanged position snapshots no longer associate a
-  prefetched fill with the old position state, preventing a later real position
-  change from waiting for an additional fill.
+  without an update timestamp remain fail-closed until a successful fill refresh
+  after the position snapshot reports an after-state matching the live position.
+  Unchanged position snapshots no longer associate a prefetched fill with the old
+  position state, preventing a later real position change from waiting for an
+  additional fill.
 
 - Exact live restart target sampling now binds pane/PID stability to an opaque
   fingerprint of the complete parsed supervisor command contract before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Live trailing restart reconciliation now preserves authoritative position-update
+  timestamps from CCXT and raw exchange payloads and no longer
+  treats position creation time as proof that fill history is current. Exchanges
+  without an update timestamp require the latest fill's recorded after-state to
+  match the live position. Unchanged position snapshots no longer associate a
+  prefetched fill with the old position state, preventing a later real position
+  change from waiting for an additional fill.
+
 - Exact live restart target sampling now binds pane/PID stability to an opaque
   fingerprint of the complete parsed supervisor command contract before
   report redaction or truncation, failing closed when that contract changes or

--- a/src/exchanges/binance.py
+++ b/src/exchanges/binance.py
@@ -106,6 +106,7 @@ class BinanceBot(CCXTBot):
                     "size": size,
                     "price": float(elm["entryPrice"]),
                 }
+                self._preserve_position_timing(elm, normalized)
                 margin_mode = self._extract_live_margin_mode(elm)
                 if margin_mode is not None:
                     normalized["margin_mode"] = margin_mode

--- a/src/exchanges/bybit.py
+++ b/src/exchanges/bybit.py
@@ -110,6 +110,7 @@ class BybitBot(CCXTBot):
                 "size": float(elm["contracts"]),
                 "price": float(elm["entryPrice"]),
             }
+            self._preserve_position_timing(elm, normalized)
             margin_mode = self._extract_live_margin_mode(elm)
             if margin_mode is not None:
                 normalized["margin_mode"] = margin_mode

--- a/src/exchanges/ccxt_bot.py
+++ b/src/exchanges/ccxt_bot.py
@@ -397,12 +397,41 @@ class CCXTBot(Passivbot):
                     "size": contracts,
                     "price": float(elm.get("entryPrice", 0)),
                 }
+                self._preserve_position_timing(elm, normalized)
                 margin_mode = self._extract_live_margin_mode(elm)
                 if margin_mode is not None:
                     normalized["margin_mode"] = margin_mode
                     self._record_live_margin_mode(normalized["symbol"], margin_mode)
                 positions.append(normalized)
         return positions
+
+    @staticmethod
+    def _preserve_position_timing(source: dict, normalized: dict) -> None:
+        """Preserve exchange position timing needed for trailing restart safety.
+
+        CCXT's unified ``timestamp`` is not consistently a last-update time.  In
+        particular, WEEX maps it to ``createdTime`` and exposes the authoritative
+        ``updatedTime`` separately as ``lastUpdateTimestamp``.  Keep both the
+        unified timing fields and the raw ``info`` payload so Passivbot can
+        distinguish a latest-update timestamp from an open-time fallback.
+        """
+        for key in (
+            "timestamp",
+            "timestamp_ms",
+            "lastUpdateTimestamp",
+            "updateTime",
+            "updatedTime",
+            "uTime",
+            "open_time",
+            "openTime",
+            "createdTime",
+            "createTime",
+            "cTime",
+        ):
+            if source.get(key) not in (None, ""):
+                normalized[key] = source[key]
+        if isinstance(source.get("info"), dict):
+            normalized["info"] = deepcopy(source["info"])
 
     def _get_position_side(self, elm: dict) -> str:
         """Hook: Derive position_side from position data.

--- a/src/exchanges/hyperliquid.py
+++ b/src/exchanges/hyperliquid.py
@@ -392,7 +392,7 @@ class HyperliquidBot(CCXTBot):
         info_position = {}
         if isinstance(position.get("info"), dict):
             info_position = position["info"].get("position", {}) or {}
-        return {
+        normalized = {
             "symbol": position["symbol"],
             "position_side": side,
             "size": contracts,
@@ -405,6 +405,8 @@ class HyperliquidBot(CCXTBot):
                 or 0.0
             ),
         }
+        self._preserve_position_timing(position, normalized)
+        return normalized
 
     async def _fetch_hip3_positions(self, *, include_raw: bool = False):
         """Fetch HIP-3 positions via dex-scoped CCXT routes."""

--- a/src/exchanges/okx.py
+++ b/src/exchanges/okx.py
@@ -75,6 +75,7 @@ class OKXBot(CCXTBot):
                     "size": contracts,
                     "price": float(elm.get("entryPrice", 0)),
                 }
+                self._preserve_position_timing(elm, normalized)
                 margin_mode = self._extract_live_margin_mode(elm)
                 if margin_mode is not None:
                     normalized["margin_mode"] = margin_mode

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -7762,10 +7762,15 @@ class Passivbot:
         return anchor_ts if anchor_ts > 0 else None
 
     def _position_anchor_timestamp_from_row(self, position: dict) -> int | None:
+        update_ts = self._position_update_timestamp_from_row(position)
+        if update_ts is not None:
+            return update_ts
         candidates = [
             position.get("open_time"),
             position.get("openTime"),
             position.get("createdTime"),
+            position.get("createTime"),
+            position.get("cTime"),
         ]
         info = position.get("info")
         if isinstance(info, dict):
@@ -7774,6 +7779,8 @@ class Passivbot:
                     info.get("open_time"),
                     info.get("openTime"),
                     info.get("createdTime"),
+                    info.get("createTime"),
+                    info.get("cTime"),
                 ]
             )
         candidates.extend(
@@ -7789,18 +7796,45 @@ class Passivbot:
                     info.get("timestamp_ms"),
                 ]
             )
-        candidates.append(position.get("updatedTime"))
-        if isinstance(info, dict):
-            candidates.append(info.get("updatedTime"))
         for candidate in candidates:
             anchor_ts = self._parse_position_anchor_timestamp_ms(candidate)
             if anchor_ts is not None:
                 return anchor_ts
         return None
 
+    def _position_update_timestamp_from_row(self, position: dict) -> int | None:
+        """Return an exchange-reported latest position update time, if available.
+
+        Open/creation time and CCXT's generic ``timestamp`` are intentionally
+        excluded: exchanges such as WEEX map that unified field to creation time.
+        Those fields remain valid candle-anchor fallbacks, but cannot prove that
+        cached fill history includes the latest position-changing fill.
+        """
+        update_keys = (
+            "lastUpdateTimestamp",
+            "updateTime",
+            "updatedTime",
+            "update_time",
+            "updated_at",
+            "uTime",
+        )
+        candidates = [position.get(key) for key in update_keys]
+        info = position.get("info")
+        if isinstance(info, dict):
+            candidates.extend(info.get(key) for key in update_keys)
+        for candidate in candidates:
+            update_ts = self._parse_position_anchor_timestamp_ms(candidate)
+            if update_ts is not None:
+                return update_ts
+        return None
+
     def _position_anchor_timestamp_ms(self, symbol: str, pside: str) -> int | None:
         position = self.positions.get(symbol, {}).get(pside, {})
         return self._position_anchor_timestamp_from_row(position)
+
+    def _position_update_timestamp_ms(self, symbol: str, pside: str) -> int | None:
+        position = self.positions.get(symbol, {}).get(pside, {})
+        return self._position_update_timestamp_from_row(position)
 
     @staticmethod
     def _fill_position_change_epoch(event, event_index: int) -> str:
@@ -7821,11 +7855,45 @@ class Passivbot:
             event = events[event_index]
             key = (str(event.symbol), str(event.position_side))
             if key not in anchors:
-                anchors[key] = {
+                anchor = {
                     "timestamp": int(event.timestamp),
                     "epoch": self._fill_position_change_epoch(event, event_index),
                 }
+                for field in ("psize", "pprice"):
+                    try:
+                        value = float(getattr(event, field))
+                    except (AttributeError, TypeError, ValueError, OverflowError):
+                        continue
+                    if math.isfinite(value):
+                        anchor[field] = value
+                anchors[key] = anchor
         return anchors
+
+    def _fill_anchor_matches_position_state(
+        self, symbol: str, state: tuple[float, float], anchor: dict | None
+    ) -> bool:
+        """Whether a fill's recorded after-state matches an exchange position."""
+        if anchor is None or "psize" not in anchor or "pprice" not in anchor:
+            return False
+        position_size, position_price = state
+        fill_size = abs(float(anchor["psize"]))
+        fill_price = float(anchor["pprice"])
+        if not all(
+            math.isfinite(value)
+            for value in (position_size, position_price, fill_size, fill_price)
+        ):
+            return False
+        qty_step = abs(float(getattr(self, "qty_steps", {}).get(symbol, 0.0) or 0.0))
+        price_step = abs(
+            float(getattr(self, "price_steps", {}).get(symbol, 0.0) or 0.0)
+        )
+        c_mult = abs(float(getattr(self, "c_mults", {}).get(symbol, 1.0) or 1.0))
+        position_size_in_fill_units = abs(position_size) * c_mult
+        qty_tolerance = max(qty_step * c_mult * 0.5, 1e-12)
+        price_tolerance = max(price_step * 0.5, abs(position_price) * 1e-9, 1e-12)
+        return abs(fill_size - position_size_in_fill_units) <= qty_tolerance and abs(
+            fill_price - position_price
+        ) <= price_tolerance
 
     def _latest_fill_position_change_epochs(self) -> dict[tuple[str, str], str]:
         """Return the newest known fill identity for each symbol and position side."""
@@ -7961,6 +8029,12 @@ class Passivbot:
         pending_fill_min_timestamps = dict(
             getattr(self, "_trailing_pending_fill_min_timestamps", {}) or {}
         )
+        pending_position_states = dict(
+            getattr(self, "_trailing_pending_position_states", {}) or {}
+        )
+        associated_fill_epochs = dict(
+            getattr(self, "_trailing_position_snapshot_fill_epochs", {}) or {}
+        )
         current_epochs: dict[tuple[str, str], str] = {}
 
         for symbol, psides in required_trailing.items():
@@ -7974,6 +8048,7 @@ class Passivbot:
                         None if anchor is None else int(anchor["timestamp"])
                     )
                     minimum_timestamp = pending_fill_min_timestamps.get(epoch_key)
+                    expected_position_state = pending_position_states.get(epoch_key)
                     if (
                         current_epoch is None
                         or not current_epoch.startswith("fill:")
@@ -7981,6 +8056,12 @@ class Passivbot:
                         or (
                             minimum_timestamp is not None
                             and current_timestamp < int(minimum_timestamp)
+                        )
+                        or (
+                            expected_position_state is not None
+                            and not self._fill_anchor_matches_position_state(
+                                symbol, expected_position_state, anchor
+                            )
                         )
                     ):
                         self.trailing_prices[symbol][pside] = (
@@ -7994,6 +8075,8 @@ class Passivbot:
                         continue
                     pending_fill_confirmations.pop(epoch_key, None)
                     pending_fill_min_timestamps.pop(epoch_key, None)
+                    pending_position_states.pop(epoch_key, None)
+                    associated_fill_epochs[epoch_key] = current_epoch
                 if anchor is None:
                     self.trailing_prices[symbol][pside] = _trailing_bundle_default_dict()
                     unavailable_reasons["missing_position_change_anchor"].add(symbol)
@@ -8006,6 +8089,8 @@ class Passivbot:
         self._trailing_position_change_epochs = current_epochs
         self._trailing_pending_fill_confirmations = pending_fill_confirmations
         self._trailing_pending_fill_min_timestamps = pending_fill_min_timestamps
+        self._trailing_pending_position_states = pending_position_states
+        self._trailing_position_snapshot_fill_epochs = associated_fill_epochs
 
         # Build concurrent fetches per symbol that has position changes
         fetch_plan = {}
@@ -13474,6 +13559,9 @@ class Passivbot:
             anchor_ts = self._position_anchor_timestamp_from_row(elm)
             if anchor_ts is not None:
                 normalized_position["timestamp"] = anchor_ts
+            update_ts = self._position_update_timestamp_from_row(elm)
+            if update_ts is not None:
+                normalized_position["lastUpdateTimestamp"] = update_ts
             positions_new[symbol][pside] = normalized_position
         self.positions = positions_new
         position_state = {
@@ -13495,7 +13583,6 @@ class Passivbot:
             key: str(anchor["epoch"]) for key, anchor in current_fill_anchors.items()
         }
         self._trailing_authoritative_position_state = position_state
-        self._trailing_position_snapshot_fill_epochs = current_fill_epochs
         if not hasattr(self, "trailing_prices"):
             self.trailing_prices = {}
         pending = dict(
@@ -13503,6 +13590,9 @@ class Passivbot:
         )
         pending_min_timestamps = dict(
             getattr(self, "_trailing_pending_fill_min_timestamps", {}) or {}
+        )
+        pending_position_states = dict(
+            getattr(self, "_trailing_pending_position_states", {}) or {}
         )
         if previous_position_state is not None:
             for key in set(previous_position_state) | set(position_state):
@@ -13516,34 +13606,49 @@ class Passivbot:
                 new_size = position_state.get(key, (0.0, 0.0))[0]
                 if new_size != 0.0 and self.is_trailing(symbol, pside):
                     pending[key] = previous_snapshot_fill_epochs.get(key)
-                    position_ts = self._position_anchor_timestamp_ms(symbol, pside)
+                    position_ts = self._position_update_timestamp_ms(symbol, pside)
                     if position_ts is None:
                         pending_min_timestamps.pop(key, None)
                     else:
                         pending_min_timestamps[key] = position_ts
+                    pending_position_states.pop(key, None)
                 else:
                     pending.pop(key, None)
                     pending_min_timestamps.pop(key, None)
+                    pending_position_states.pop(key, None)
         else:
+            previous_snapshot_fill_epochs = dict(current_fill_epochs)
             for key, state in position_state.items():
                 symbol, pside = key
                 if state[0] == 0.0 or not self.is_trailing(symbol, pside):
                     continue
-                position_ts = self._position_anchor_timestamp_ms(symbol, pside)
+                position_ts = self._position_update_timestamp_ms(symbol, pside)
                 fill_anchor = current_fill_anchors.get(key)
-                if position_ts is None or (
-                    fill_anchor is not None
-                    and int(fill_anchor["timestamp"]) >= position_ts
-                ):
+                if position_ts is not None:
+                    fill_is_current = fill_anchor is not None and int(
+                        fill_anchor["timestamp"]
+                    ) >= position_ts
+                else:
+                    fill_is_current = self._fill_anchor_matches_position_state(
+                        symbol, state, fill_anchor
+                    )
+                if fill_is_current:
                     continue
                 self.trailing_prices.setdefault(symbol, {})
                 self.trailing_prices[symbol][pside] = _trailing_bundle_default_dict()
                 pending[key] = (
                     None if fill_anchor is None else str(fill_anchor["epoch"])
                 )
-                pending_min_timestamps[key] = position_ts
+                if position_ts is None:
+                    pending_min_timestamps.pop(key, None)
+                    pending_position_states[key] = state
+                else:
+                    pending_min_timestamps[key] = position_ts
+                    pending_position_states.pop(key, None)
+        self._trailing_position_snapshot_fill_epochs = previous_snapshot_fill_epochs
         self._trailing_pending_fill_confirmations = pending
         self._trailing_pending_fill_min_timestamps = pending_min_timestamps
+        self._trailing_pending_position_states = pending_position_states
         return fetched_positions_old, self.fetched_positions
 
     def _apply_balance_snapshot(self, balance_raw) -> bool:

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -1117,6 +1117,8 @@ class Passivbot:
         self._authoritative_refresh_epoch_changed = set()
         self._authoritative_refresh_plan_surfaces = set()
         self._authoritative_pending_confirmations = {}
+        self._trailing_fill_refresh_started_generation = 0
+        self._trailing_fill_refresh_generation = 0
         self._authoritative_barrier_last_log_key = None
         self._authoritative_barrier_last_log_ms = 0
         self.freshness_ledger = FreshnessLedger(now_ms=utc_ms())
@@ -8029,11 +8031,17 @@ class Passivbot:
         pending_fill_min_timestamps = dict(
             getattr(self, "_trailing_pending_fill_min_timestamps", {}) or {}
         )
+        pending_fill_min_generations = dict(
+            getattr(self, "_trailing_pending_fill_min_generations", {}) or {}
+        )
         pending_position_states = dict(
             getattr(self, "_trailing_pending_position_states", {}) or {}
         )
         associated_fill_epochs = dict(
             getattr(self, "_trailing_position_snapshot_fill_epochs", {}) or {}
+        )
+        fill_refresh_generation = int(
+            getattr(self, "_trailing_fill_refresh_generation", 0) or 0
         )
         current_epochs: dict[tuple[str, str], str] = {}
 
@@ -8048,6 +8056,9 @@ class Passivbot:
                         None if anchor is None else int(anchor["timestamp"])
                     )
                     minimum_timestamp = pending_fill_min_timestamps.get(epoch_key)
+                    minimum_fill_generation = pending_fill_min_generations.get(
+                        epoch_key
+                    )
                     expected_position_state = pending_position_states.get(epoch_key)
                     if (
                         current_epoch is None
@@ -8056,6 +8067,11 @@ class Passivbot:
                         or (
                             minimum_timestamp is not None
                             and current_timestamp < int(minimum_timestamp)
+                        )
+                        or (
+                            minimum_fill_generation is not None
+                            and fill_refresh_generation
+                            < int(minimum_fill_generation)
                         )
                         or (
                             expected_position_state is not None
@@ -8075,6 +8091,7 @@ class Passivbot:
                         continue
                     pending_fill_confirmations.pop(epoch_key, None)
                     pending_fill_min_timestamps.pop(epoch_key, None)
+                    pending_fill_min_generations.pop(epoch_key, None)
                     pending_position_states.pop(epoch_key, None)
                     associated_fill_epochs[epoch_key] = current_epoch
                 if anchor is None:
@@ -8089,6 +8106,7 @@ class Passivbot:
         self._trailing_position_change_epochs = current_epochs
         self._trailing_pending_fill_confirmations = pending_fill_confirmations
         self._trailing_pending_fill_min_timestamps = pending_fill_min_timestamps
+        self._trailing_pending_fill_min_generations = pending_fill_min_generations
         self._trailing_pending_position_states = pending_position_states
         self._trailing_position_snapshot_fill_epochs = associated_fill_epochs
 
@@ -10716,6 +10734,21 @@ class Passivbot:
         if self.stop_signal_received:
             return False
 
+        fill_refresh_attempt_generation = (
+            max(
+                int(
+                    getattr(
+                        self, "_trailing_fill_refresh_started_generation", 0
+                    )
+                    or 0
+                ),
+                int(getattr(self, "_trailing_fill_refresh_generation", 0) or 0),
+            )
+            + 1
+        )
+        self._trailing_fill_refresh_started_generation = (
+            fill_refresh_attempt_generation
+        )
         refresh_started_ms = utc_ms()
         refresh_mode = "unknown"
         overlap_minutes: Optional[float] = None
@@ -10934,6 +10967,9 @@ class Passivbot:
                 self._clear_fill_coverage_retry_defer()
                 self._record_authoritative_surface(
                     "fills", self._fill_events_signature(all_events)
+                )
+                self._trailing_fill_refresh_generation = (
+                    fill_refresh_attempt_generation
                 )
             elif pnls_complete and not coverage_ready_after:
                 self._record_fill_coverage_retry_defer(post_refresh_coverage_status)
@@ -13591,9 +13627,20 @@ class Passivbot:
         pending_min_timestamps = dict(
             getattr(self, "_trailing_pending_fill_min_timestamps", {}) or {}
         )
+        pending_min_fill_generations = dict(
+            getattr(self, "_trailing_pending_fill_min_generations", {}) or {}
+        )
         pending_position_states = dict(
             getattr(self, "_trailing_pending_position_states", {}) or {}
         )
+        fill_refresh_started_generation = max(
+            int(
+                getattr(self, "_trailing_fill_refresh_started_generation", 0)
+                or 0
+            ),
+            int(getattr(self, "_trailing_fill_refresh_generation", 0) or 0),
+        )
+        request_post_position_fill_confirmation = False
         if previous_position_state is not None:
             for key in set(previous_position_state) | set(position_state):
                 if previous_position_state.get(key, (0.0, 0.0)) == position_state.get(
@@ -13609,12 +13656,19 @@ class Passivbot:
                     position_ts = self._position_update_timestamp_ms(symbol, pside)
                     if position_ts is None:
                         pending_min_timestamps.pop(key, None)
+                        pending_min_fill_generations[key] = (
+                            fill_refresh_started_generation + 1
+                        )
+                        pending_position_states[key] = position_state[key]
+                        request_post_position_fill_confirmation = True
                     else:
                         pending_min_timestamps[key] = position_ts
-                    pending_position_states.pop(key, None)
+                        pending_min_fill_generations.pop(key, None)
+                        pending_position_states.pop(key, None)
                 else:
                     pending.pop(key, None)
                     pending_min_timestamps.pop(key, None)
+                    pending_min_fill_generations.pop(key, None)
                     pending_position_states.pop(key, None)
         else:
             previous_snapshot_fill_epochs = dict(current_fill_epochs)
@@ -13629,25 +13683,38 @@ class Passivbot:
                         fill_anchor["timestamp"]
                     ) >= position_ts
                 else:
-                    fill_is_current = self._fill_anchor_matches_position_state(
-                        symbol, state, fill_anchor
-                    )
+                    # A reconstructed same-state fill cannot prove freshness on
+                    # restart: unseen round-trip fills may return to the same
+                    # size and average price.  Require a successful fill refresh
+                    # that starts in a later authoritative cohort.
+                    fill_is_current = False
                 if fill_is_current:
+                    pending_min_fill_generations.pop(key, None)
+                    pending_position_states.pop(key, None)
                     continue
                 self.trailing_prices.setdefault(symbol, {})
                 self.trailing_prices[symbol][pside] = _trailing_bundle_default_dict()
-                pending[key] = (
-                    None if fill_anchor is None else str(fill_anchor["epoch"])
-                )
                 if position_ts is None:
+                    pending[key] = None
                     pending_min_timestamps.pop(key, None)
+                    pending_min_fill_generations[key] = (
+                        fill_refresh_started_generation + 1
+                    )
                     pending_position_states[key] = state
+                    request_post_position_fill_confirmation = True
                 else:
+                    pending[key] = (
+                        None if fill_anchor is None else str(fill_anchor["epoch"])
+                    )
                     pending_min_timestamps[key] = position_ts
+                    pending_min_fill_generations.pop(key, None)
                     pending_position_states.pop(key, None)
+        if request_post_position_fill_confirmation:
+            self._request_authoritative_confirmation({"fills"})
         self._trailing_position_snapshot_fill_epochs = previous_snapshot_fill_epochs
         self._trailing_pending_fill_confirmations = pending
         self._trailing_pending_fill_min_timestamps = pending_min_timestamps
+        self._trailing_pending_fill_min_generations = pending_min_fill_generations
         self._trailing_pending_position_states = pending_position_states
         return fetched_positions_old, self.fetched_positions
 

--- a/tests/exchanges/test_ccxt_bot_hooks.py
+++ b/tests/exchanges/test_ccxt_bot_hooks.py
@@ -850,6 +850,33 @@ class TestFetchPositionsHooks:
         assert len(result) == 1
         assert result[0]["symbol"] == "ETH/USDT:USDT"
 
+    def test_normalize_positions_preserves_ccxt_update_and_raw_timing(
+        self, bot_with_mock_cca
+    ):
+        """WEEX exposes creation and latest-update time through different fields."""
+        bot = bot_with_mock_cca
+        fetched = [
+            {
+                "symbol": "BTC/USDT:USDT",
+                "side": "long",
+                "contracts": 0.5,
+                "entryPrice": 50_000,
+                "timestamp": 120_000,
+                "lastUpdateTimestamp": 240_000,
+                "info": {"createdTime": "120000", "updatedTime": "240000"},
+            }
+        ]
+
+        result = bot._normalize_positions(fetched)
+
+        assert result[0]["timestamp"] == 120_000
+        assert result[0]["lastUpdateTimestamp"] == 240_000
+        assert result[0]["info"] == {
+            "createdTime": "120000",
+            "updatedTime": "240000",
+        }
+        assert result[0]["info"] is not fetched[0]["info"]
+
     @pytest.mark.asyncio
     async def test_fetch_positions_uses_hooks(self, bot_with_mock_cca):
         """fetch_positions should use _do_fetch_positions and _normalize_positions."""

--- a/tests/test_passivbot_balance_split.py
+++ b/tests/test_passivbot_balance_split.py
@@ -4845,6 +4845,8 @@ async def test_update_pnls_all_lookback_uses_incremental_refresh_when_cache_is_f
     bot._monitor_record_error = lambda *args, **kwargs: None
     bot.logging_level = 0
     bot._health_rate_limits = 0
+    bot._trailing_fill_refresh_started_generation = 4
+    bot._trailing_fill_refresh_generation = 4
 
     result = await bot.update_pnls()
 
@@ -4855,6 +4857,7 @@ async def test_update_pnls_all_lookback_uses_incremental_refresh_when_cache_is_f
         last_refresh_overlap_ms=10 * 60 * 1000,
     )
     assert bot._pnls_manager.history_scope == "all"
+    assert bot._trailing_fill_refresh_generation == 5
 
 
 @pytest.mark.asyncio
@@ -7916,6 +7919,7 @@ async def test_planning_snapshot_freezes_data_packet_revisions_through_cycle(mon
             "position_side": "long",
             "size": 0.1,
             "price": 100.0,
+            "lastUpdateTimestamp": 120_000,
         }
     ]
     bot, _counts = _counted_staged_account_refresh_bot(

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -1351,10 +1351,22 @@ async def test_position_delta_waits_for_new_fill_identity_across_refresh_cohorts
     bot.get_exchange_time = lambda: 361_000
 
     baseline = [
-        {"symbol": symbol, "position_side": "long", "size": 1.0, "price": 100.0}
+        {
+            "symbol": symbol,
+            "position_side": "long",
+            "size": 1.0,
+            "price": 100.0,
+            "lastUpdateTimestamp": 120_000,
+        }
     ]
     changed = [
-        {"symbol": symbol, "position_side": "long", "size": 1.5, "price": 101.0}
+        {
+            "symbol": symbol,
+            "position_side": "long",
+            "size": 1.5,
+            "price": 101.0,
+            "lastUpdateTimestamp": 240_000,
+        }
     ]
     bot._apply_positions_snapshot(baseline)
     bot._begin_authoritative_refresh_epoch()
@@ -1410,10 +1422,22 @@ async def test_fill_prefetch_before_position_delta_confirms_new_position_epoch()
     bot.get_exchange_time = lambda: 361_000
 
     baseline = [
-        {"symbol": symbol, "position_side": "long", "size": 1.0, "price": 100.0}
+        {
+            "symbol": symbol,
+            "position_side": "long",
+            "size": 1.0,
+            "price": 100.0,
+            "lastUpdateTimestamp": 120_000,
+        }
     ]
     changed = [
-        {"symbol": symbol, "position_side": "long", "size": 1.5, "price": 101.0}
+        {
+            "symbol": symbol,
+            "position_side": "long",
+            "size": 1.5,
+            "price": 101.0,
+            "lastUpdateTimestamp": 240_000,
+        }
     ]
     bot._apply_positions_snapshot(baseline)
     bot._pnls_manager._events.append(
@@ -1454,10 +1478,22 @@ async def test_unchanged_position_snapshot_does_not_associate_prefetched_fill():
     bot.get_exchange_time = lambda: 361_000
 
     baseline = [
-        {"symbol": symbol, "position_side": "long", "size": 1.0, "price": 100.0}
+        {
+            "symbol": symbol,
+            "position_side": "long",
+            "size": 1.0,
+            "price": 100.0,
+            "lastUpdateTimestamp": 120_000,
+        }
     ]
     changed = [
-        {"symbol": symbol, "position_side": "long", "size": 1.5, "price": 101.0}
+        {
+            "symbol": symbol,
+            "position_side": "long",
+            "size": 1.5,
+            "price": 101.0,
+            "lastUpdateTimestamp": 240_000,
+        }
     ]
     bot._apply_positions_snapshot(baseline)
     bot._pnls_manager._events.append(
@@ -1519,14 +1555,17 @@ def test_restart_without_update_timestamp_requires_matching_fill_after_state():
 
     assert bot.positions[symbol]["long"]["timestamp"] == 240_000
     assert bot._trailing_pending_fill_confirmations == {
-        (symbol, "long"): "fill:120000:stale-fill"
+        (symbol, "long"): None
     }
+    assert bot._trailing_pending_fill_min_generations == {(symbol, "long"): 1}
     assert bot._trailing_pending_position_states == {
         (symbol, "long"): (1.0, 101.0)
     }
+    assert "fills" in bot._authoritative_pending_confirmations
 
 
-def test_restart_without_update_timestamp_accepts_matching_fill_after_state():
+@pytest.mark.asyncio
+async def test_restart_same_state_waits_for_post_position_fill_refresh():
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
@@ -1538,6 +1577,11 @@ def test_restart_without_update_timestamp_accepts_matching_fill_after_state():
         ]
     )
     bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 361_000
+    # A fill refresh already in flight before the position snapshot cannot
+    # satisfy the post-position watermark even if it completes later.
+    bot._trailing_fill_refresh_started_generation = 1
+    bot._trailing_fill_refresh_generation = 0
 
     bot._apply_positions_snapshot(
         [
@@ -1551,10 +1595,136 @@ def test_restart_without_update_timestamp_accepts_matching_fill_after_state():
         ]
     )
 
+    assert bot._trailing_pending_fill_confirmations == {(symbol, "long"): None}
+    assert bot._trailing_pending_fill_min_generations == {(symbol, "long"): 2}
+    assert "fills" in bot._authoritative_pending_confirmations
+
+    async def complete_post_round_trip_candles(*args, **kwargs):
+        return _make_candles(
+            [(300_000, 101.0, 103.0, 100.0, 102.0, 1.0)]
+        )
+
+    bot.cm.get_candles = complete_post_round_trip_candles
+    await bot.update_trailing_data()
+
+    assert bot._trailing_pending_fill_confirmations == {(symbol, "long"): None}
+    assert bot._orchestrator_trailing_unavailable_reasons == {
+        symbol: ["position_fill_confirmation_pending"]
+    }
+
+    bot._trailing_fill_refresh_generation = 1
+    await bot.update_trailing_data()
+    assert bot._trailing_pending_fill_confirmations == {(symbol, "long"): None}
+
+    # Two fills unseen by the pre-snapshot cache return to the identical live
+    # size and average price.  Only the later fill refresh may confirm them.
+    bot._pnls_manager._events.extend(
+        [
+            _DummyFillEvent(
+                symbol, "long", 180_000, "round-trip-close", psize=0.0, pprice=0.0
+            ),
+            _DummyFillEvent(
+                symbol, "long", 240_000, "round-trip-reopen", psize=1.0, pprice=101.0
+            ),
+        ]
+    )
+    bot._trailing_fill_refresh_started_generation = 2
+    bot._trailing_fill_refresh_generation = 2
+    await bot.update_trailing_data()
+
     assert bot._trailing_pending_fill_confirmations == {}
     assert bot._trailing_position_snapshot_fill_epochs == {
-        (symbol, "long"): "fill:120000:current-fill"
+        (symbol, "long"): "fill:240000:round-trip-reopen"
     }
+    assert bot._orchestrator_trailing_unavailable_symbols == set()
+
+
+@pytest.mark.asyncio
+async def test_runtime_delta_without_update_time_rejects_mismatched_prefetched_fill():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    bot._pnls_manager = _DummyPnlsManager(
+        [
+            _DummyFillEvent(
+                symbol, "long", 120_000, "old-fill", psize=1.0, pprice=100.0
+            )
+        ]
+    )
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 361_000
+    bot._trailing_fill_refresh_started_generation = 1
+    bot._trailing_fill_refresh_generation = 1
+
+    bot._apply_positions_snapshot(
+        [
+            {
+                "symbol": symbol,
+                "position_side": "long",
+                "size": 1.0,
+                "price": 100.0,
+                "lastUpdateTimestamp": 120_000,
+            }
+        ]
+    )
+    bot._pnls_manager._events.append(
+        _DummyFillEvent(
+            symbol, "long", 180_000, "mismatched-fill", psize=1.2, pprice=100.5
+        )
+    )
+    bot._trailing_fill_refresh_started_generation = 2
+    bot._trailing_fill_refresh_generation = 2
+    bot._apply_positions_snapshot(
+        [
+            {
+                "symbol": symbol,
+                "position_side": "long",
+                "size": 1.5,
+                "price": 101.0,
+            }
+        ]
+    )
+
+    assert bot._trailing_pending_fill_confirmations == {
+        (symbol, "long"): "fill:120000:old-fill"
+    }
+    assert bot._trailing_pending_fill_min_generations == {(symbol, "long"): 3}
+    assert bot._trailing_pending_position_states == {
+        (symbol, "long"): (1.5, 101.0)
+    }
+    assert "fills" in bot._authoritative_pending_confirmations
+
+    async def complete_matching_epoch_candles(*args, **kwargs):
+        return _make_candles(
+            [(300_000, 101.0, 103.0, 100.0, 102.0, 1.0)]
+        )
+
+    bot.cm.get_candles = complete_matching_epoch_candles
+    bot._trailing_fill_refresh_started_generation = 3
+    bot._trailing_fill_refresh_generation = 3
+    await bot.update_trailing_data()
+
+    assert bot._trailing_pending_fill_confirmations == {
+        (symbol, "long"): "fill:120000:old-fill"
+    }
+    assert bot._orchestrator_trailing_unavailable_reasons == {
+        symbol: ["position_fill_confirmation_pending"]
+    }
+
+    bot._pnls_manager._events.append(
+        _DummyFillEvent(
+            symbol, "long", 240_000, "matching-fill", psize=1.5, pprice=101.0
+        )
+    )
+    bot._trailing_fill_refresh_started_generation = 4
+    bot._trailing_fill_refresh_generation = 4
+    await bot.update_trailing_data()
+
+    assert bot._trailing_pending_fill_confirmations == {}
+    assert bot._trailing_position_snapshot_fill_epochs == {
+        (symbol, "long"): "fill:240000:matching-fill"
+    }
+    assert bot._orchestrator_trailing_unavailable_symbols == set()
 
 
 @pytest.mark.asyncio

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -836,12 +836,18 @@ class _DummyFillEvent:
         timestamp: int,
         event_id: str | None = None,
         pb_order_type: str = "unknown",
+        psize: float | None = None,
+        pprice: float | None = None,
     ):
         self.symbol = symbol
         self.position_side = position_side
         self.timestamp = timestamp
         self.id = event_id
         self.pb_order_type = pb_order_type
+        if psize is not None:
+            self.psize = psize
+        if pprice is not None:
+            self.pprice = pprice
 
 
 class _DummyPnlsManager:
@@ -1276,7 +1282,7 @@ def test_position_anchor_timestamp_skips_malformed_candidates():
     assert bot._position_anchor_timestamp_ms(symbol, "long") == 120_000
 
 
-def test_position_anchor_timestamp_prefers_open_fields_over_update_fields():
+def test_position_anchor_timestamp_prefers_update_fields_over_open_fields():
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
@@ -1288,7 +1294,8 @@ def test_position_anchor_timestamp_prefers_open_fields_over_update_fields():
         }
     )
 
-    assert bot._position_anchor_timestamp_ms(symbol, "long") == 120_000
+    assert bot._position_anchor_timestamp_ms(symbol, "long") == 360_000
+    assert bot._position_update_timestamp_ms(symbol, "long") == 360_000
 
 
 @pytest.mark.asyncio
@@ -1324,7 +1331,9 @@ async def test_position_delta_waits_for_new_fill_identity_across_refresh_cohorts
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
-    old_fill = _DummyFillEvent(symbol, "long", 120_000, "old-fill")
+    old_fill = _DummyFillEvent(
+        symbol, "long", 120_000, "old-fill", psize=1.0, pprice=100.0
+    )
     bot._pnls_manager = _DummyPnlsManager([old_fill])
     bot._trailing_position_change_epochs = {
         (symbol, "long"): "fill:120000:old-fill"
@@ -1393,7 +1402,9 @@ async def test_fill_prefetch_before_position_delta_confirms_new_position_epoch()
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
-    old_fill = _DummyFillEvent(symbol, "long", 120_000, "old-fill")
+    old_fill = _DummyFillEvent(
+        symbol, "long", 120_000, "old-fill", psize=1.0, pprice=100.0
+    )
     bot._pnls_manager = _DummyPnlsManager([old_fill])
     bot.is_trailing = lambda sym, pside=None: pside == "long"
     bot.get_exchange_time = lambda: 361_000
@@ -1431,6 +1442,122 @@ async def test_fill_prefetch_before_position_delta_confirms_new_position_epoch()
 
 
 @pytest.mark.asyncio
+async def test_unchanged_position_snapshot_does_not_associate_prefetched_fill():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    old_fill = _DummyFillEvent(
+        symbol, "long", 120_000, "old-fill", psize=1.0, pprice=100.0
+    )
+    bot._pnls_manager = _DummyPnlsManager([old_fill])
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+    bot.get_exchange_time = lambda: 361_000
+
+    baseline = [
+        {"symbol": symbol, "position_side": "long", "size": 1.0, "price": 100.0}
+    ]
+    changed = [
+        {"symbol": symbol, "position_side": "long", "size": 1.5, "price": 101.0}
+    ]
+    bot._apply_positions_snapshot(baseline)
+    bot._pnls_manager._events.append(
+        _DummyFillEvent(
+            symbol, "long", 240_000, "new-fill", psize=1.5, pprice=101.0
+        )
+    )
+
+    bot._apply_positions_snapshot(baseline)
+    assert bot._trailing_position_snapshot_fill_epochs == {
+        (symbol, "long"): "fill:120000:old-fill"
+    }
+
+    bot._apply_positions_snapshot(changed)
+    assert bot._trailing_pending_fill_confirmations == {
+        (symbol, "long"): "fill:120000:old-fill"
+    }
+
+    async def complete_new_epoch_candles(*args, **kwargs):
+        return _make_candles(
+            [(300_000, 101.0, 103.0, 100.0, 102.0, 1.0)]
+        )
+
+    bot.cm.get_candles = complete_new_epoch_candles
+    await bot.update_trailing_data()
+
+    assert bot._trailing_pending_fill_confirmations == {}
+    assert bot._trailing_position_snapshot_fill_epochs == {
+        (symbol, "long"): "fill:240000:new-fill"
+    }
+    assert bot._orchestrator_trailing_unavailable_symbols == set()
+
+
+def test_restart_without_update_timestamp_requires_matching_fill_after_state():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    bot._pnls_manager = _DummyPnlsManager(
+        [
+            _DummyFillEvent(
+                symbol, "long", 120_000, "stale-fill", psize=1.0, pprice=100.0
+            )
+        ]
+    )
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+
+    bot._apply_positions_snapshot(
+        [
+            {
+                "symbol": symbol,
+                "position_side": "long",
+                "size": 1.0,
+                "price": 101.0,
+                # CCXT may expose position creation time here; it is not recency proof.
+                "timestamp": 240_000,
+            }
+        ]
+    )
+
+    assert bot.positions[symbol]["long"]["timestamp"] == 240_000
+    assert bot._trailing_pending_fill_confirmations == {
+        (symbol, "long"): "fill:120000:stale-fill"
+    }
+    assert bot._trailing_pending_position_states == {
+        (symbol, "long"): (1.0, 101.0)
+    }
+
+
+def test_restart_without_update_timestamp_accepts_matching_fill_after_state():
+    cfg = _dummy_config()
+    bot = _make_dummy_bot(cfg)
+    symbol = _set_basic_state(bot)
+    bot._pnls_manager = _DummyPnlsManager(
+        [
+            _DummyFillEvent(
+                symbol, "long", 120_000, "current-fill", psize=1.0, pprice=101.0
+            )
+        ]
+    )
+    bot.is_trailing = lambda sym, pside=None: pside == "long"
+
+    bot._apply_positions_snapshot(
+        [
+            {
+                "symbol": symbol,
+                "position_side": "long",
+                "size": 1.0,
+                "price": 101.0,
+                "timestamp": 60_000,
+            }
+        ]
+    )
+
+    assert bot._trailing_pending_fill_confirmations == {}
+    assert bot._trailing_position_snapshot_fill_epochs == {
+        (symbol, "long"): "fill:120000:current-fill"
+    }
+
+
+@pytest.mark.asyncio
 async def test_restart_blocks_trailing_when_position_is_newer_than_fill_history():
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
@@ -1448,7 +1575,7 @@ async def test_restart_blocks_trailing_when_position_is_newer_than_fill_history(
                 "position_side": "long",
                 "size": 1.0,
                 "price": 101.0,
-                "timestamp": 240_000,
+                "lastUpdateTimestamp": 240_000,
             }
         ]
     )


### PR DESCRIPTION
## Summary

Follow-up to the trailing fill lifecycle review of #1293.

- Preserve authoritative position update timestamps through generic and exchange-specific CCXT position normalizers.
- Distinguish latest-update timestamps from open/creation timestamps; creation time remains a candle-anchor fallback but is no longer accepted as proof that fill history is current.
- On restart without an exchange update timestamp, require the latest fill's recorded post-fill size and price to match the live position before enabling ordinary trailing closes.
- Keep the last fill actually associated with a position state across unchanged position snapshots, so a prefetched fill cannot be assigned to the old state and make the subsequent real position delta wait for another fill.
- Add focused restart, fill-prefetch ordering, and CCXT timing regressions plus an Unreleased changelog entry.

## Validation

- `SKIP_CCXT_ASSERT=1 ... pytest -q tests/test_unstucking_safeguards.py tests/exchanges/test_ccxt_bot_hooks.py tests/exchanges/test_ccxt_bot.py tests/ccxt_upgrade/test_order_contracts.py` — 301 passed.
- Python compile check for changed modules and tests — passed.
- `git diff --check` — passed.
- A broad offline suite run completed with only shared-environment failures: the active virtualenv contains the Rust extension and CCXT 4.5.66 from the separate WEEX checkout, while this master worktree expects its own Rust source stamp and CCXT 4.5.48. All 14 observed failures were the Rust stamp/missing-symbol mismatch; none exercised the changed Python lifecycle paths.

No authenticated exchange requests or live bot operations were performed for this PR.
