### PR TITLE
Add exact-target graceful restart executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool live-restart-executor`, an explicit local executor for
+  exact tmux targets that already pass the bounded stable target report. It
+  requires the expected full supervisor-command fingerprint and `--execute`,
+  sends one Ctrl-C round only to verified panes, waits a bounded time for exact
+  process exits, rechecks pane/process identity before typing private launch
+  commands, and verifies stable replacements. It never pulls code or applies
+  an automatic force signal; partial or changed state fails closed for manual
+  recovery.
+
 - Exact live restart target sampling now binds pane/PID stability to an opaque
   fingerprint of the complete parsed supervisor command contract before
   report redaction or truncation, failing closed when that contract changes or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ All notable user-facing changes will be documented in this file.
   exact tmux targets that already pass the bounded stable target report. It
   requires the expected full supervisor-command fingerprint and `--execute`,
   sends one Ctrl-C round only to verified panes, waits a bounded time for exact
-  process exits, rechecks pane/process identity before typing private launch
-  commands, and verifies stable replacements. It never pulls code or applies
+  process exits, rechecks the private supervisor snapshot plus pane/process
+  identity before typing launch commands, and verifies stable replacements. It
+  never pulls code or applies
   an automatic force signal; partial or changed state fails closed for manual
   recovery.
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,51 +22,61 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/full-supervisor-fingerprint`, based on canonical
-  `393aec15a49d6b6cf4f6bda37ed8a2dab00b5f2c` after PR #1291.
-- PR: #1294, `Bind restart fingerprint to full supervisor commands`. Slice:
-  make the exact-target supervisor fingerprint cover complete private canonical
-  commands before report redaction or truncation.
-- Triggering evidence: direct post-merge inspection found PR #1291 derived its
-  fingerprint from public redacted/truncated process-report fields. Materially
-  different launch commands could therefore share a digest, which is not a
-  sufficient prerequisite for future execution.
-- Scope: derive the opaque SHA-256 fingerprint while the process report still
-  owns full private canonical commands, expose only the digest, validate its
-  complete value-safe shape in the target report, and fail closed when it is
-  absent or malformed.
-- Behavior boundary: read-only classification only. No configured command,
-  tmux action, process control, restart execution, network/exchange access,
-  credential access, SSH/git action, or file write is added.
-- Validation: focused fingerprint ordering/change/content, target sampling,
-  planner shape, CLI, process, incident, compilation, and docs regressions.
+- Branch: `codex/local-graceful-restart-executor`, integrated with canonical
+  `0f366b6f6e6b05ab0bd748b012c2c86ed85f978c` after PR #1293.
+- PR: pending, `Add exact-target graceful restart executor`. Slice: execute the
+  already-reviewed exact-target restart contract locally without adding remote
+  deployment or force-escalation behavior.
+- Triggering evidence: PRs #1287-#1294 established exact pane/process ownership,
+  stable sampled identities, pane-parent relaunch readiness, and an opaque
+  fingerprint over complete private supervisor commands. VPS5 deployment of
+  PR #1293 then exercised the same manual contract successfully for all five
+  configured panes.
+- Scope: require explicit `--execute`, exact session name, expected supervisor
+  fingerprint, stable sampled preflight, and an immediate action snapshot;
+  send one Ctrl-C round only to exact panes; wait for exact PIDs; recheck the
+  process set, pane set, pane parents, and shell readiness; relaunch only exited
+  targets from private commands; and require stable final verification.
+- Behavior boundary: local restart/deploy behavior. The executor does not SSH,
+  pull/build code, contact exchanges directly, write files directly, use broad
+  process-pattern signals, or apply automatic SIGTERM/SIGKILL. Relaunched live
+  bots resume their configured exchange access and normal runtime file writes.
+- Validation: focused executor, target-report, planner, smoke-report, CLI,
+  command secrecy, timeout, duplicate-process, TOCTOU, compilation, and docs
+  regressions.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: pull and run the local-only three-sample target report,
-  confirming that all five targets retain a stable full-command fingerprint;
-  no bot restart, tmux action, or process signal is expected.
+- Expected VPS action: pull, verify CLI/help plus a local-only target report,
+  and leave running bots unchanged. The new executor itself does not require a
+  restart to become available for a later authorized deployment.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `393aec15a49d6b6cf4f6bda37ed8a2dab00b5f2c`, PR #1291. VPS5 fast-forwarded
-  cleanly from `04209762`; the five configured bot panes were then restarted so
-  the already-merged behavior-changing PR #1292 would be loaded. Exact panes
+  `0f366b6f6e6b05ab0bd748b012c2c86ed85f978c`, PR #1293. PR #1294 first
+  fast-forwarded cleanly as `3de024c76d5c07bda2b4e64400c1a204d6be38a8`
+  and produced a hard-green 3/3 stable target report with all five targets,
+  zero issues, fingerprint
+  `01d200d4a38c5c85a2123b5210224a18cdef08d0a8be3efc48edb4a159fc5db4`,
+  and no command exposure. PR #1293 then fast-forwarded cleanly without a Rust
+  rebuild.
+- The five configured bot panes were restarted to load PR #1293. Exact panes
   `%358/%359/%360/%361/%362` and pane parents
   `856294/856332/856364/856398/856434` remained stable. Old bot PIDs
-  `1003995/1003997/1003999/1004001/1004002` exited after one exact-pane Ctrl-C
-  round, and replacement PIDs
-  `1013205/1013207/1013209/1013210/1013211` matched the same ownership contract.
-- Immediate and settled bounded smokes were `ok=true` with zero hard monitor,
-  log, process, fill-refresh, or account-critical failures and all five expected
-  processes matched. The settled target report collected 3/3 stable samples,
-  reported zero changed targets, and retained all five relaunch-ready paths.
-  Unrelated `misc:0.0` remained `%8`, PID `434835`. One ordinary OHLCV timeout
-  recovered naturally; no direct exchange probe or event was manufactured.
-- An initial host-alias mistake fast-forwarded the tracked-clean optimizer host
-  `vpsopt3` checkout to the same canonical master. No process there was
-  signalled, stopped, or restarted; subsequent deployment and all smoke
-  evidence used the correct `vps5` host.
+  `1013205/1013207/1013209/1013210/1013211` exited after one exact-pane Ctrl-C
+  round. Replacement PIDs `1015403/1015406/1015410/1015412/1015414` matched the
+  same exact ownership contract and retained the full-command fingerprint.
+  Unrelated `misc:0.0` remained `%8`, PID `434835`.
+- The immediate target report and smoke were `ok=true` with zero hard failures,
+  five stable exact processes, and successful natural account/fill activity. A
+  later bounded window correctly remained red after two real KuCoin
+  account-state `RequestTimeout` failures and one degraded cycle; process
+  sampling observed all temporary `D` states recover without PID churn. The
+  fresh recovery smoke was `ok=true` with zero hard failures, `326/326` remote
+  calls, `61/61` account-critical calls, and nine successful fill refreshes.
+  A quiet exact-PID sample reached `R=4,S=1`; the final target report retained
+  3/3 stable samples, five relaunch-ready targets, zero issues, and the same
+  fingerprint. No direct exchange probe or event was manufactured.
 
 - Canonical `master` and VPS5 are
   `b490bd75bebd0228628c1b628b46d3f3ac52cee4`, PR #1290. VPS5 fast-forwarded

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/local-graceful-restart-executor`, integrated with canonical
   `0f366b6f6e6b05ab0bd748b012c2c86ed85f978c` after PR #1293.
-- PR: pending, `Add exact-target graceful restart executor`. Slice: execute the
+- PR: #1297, `Add exact-target graceful restart executor`. Slice: execute the
   already-reviewed exact-target restart contract locally without adding remote
   deployment or force-escalation behavior.
 - Triggering evidence: PRs #1287-#1294 established exact pane/process ownership,

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,26 +15,34 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1291)
+## Latest Canonical Deployment (PRs #1294 And #1293)
 
-- PR #1291 merged to `master` as
-  `393aec15a49d6b6cf4f6bda37ed8a2dab00b5f2c`. It binds bounded exact-target
-  sampling to an opaque parsed supervisor command-contract fingerprint without
-  exposing or executing configured commands.
-- VPS5 fast-forwarded cleanly from `04209762`. The five configured panes and
-  pane parents stayed stable while one exact-pane Ctrl-C round stopped old bot
-  PIDs `1003995/1003997/1003999/1004001/1004002`; replacements
-  `1013205/1013207/1013209/1013210/1013211` loaded already-merged PR #1292.
-  Unrelated `misc:0.0` remained `%8`, PID `434835`.
-- Immediate and settled bounded smokes were hard-green, with all five expected
-  processes matched and zero monitor/log/process, fill-refresh, or
-  account-critical failures. A final 3/3 sample target report retained stable
-  exact identities, the supervisor contract, and all five relaunch paths. One
-  ordinary OHLCV timeout recovered naturally. No direct exchange probe or event
-  was manufactured.
-- Post-merge inspection found the fingerprint used public redacted/truncated
-  command fields. The active follow-up moves hashing before report sanitization
-  and fails closed on an absent or malformed full-command contract.
+- PR #1294 merged as `3de024c76d5c07bda2b4e64400c1a204d6be38a8`
+  and moved the restart supervisor fingerprint to complete private commands
+  before redaction. VPS5 produced 3/3 stable hard-green target samples for all
+  five configured bots with fingerprint
+  `01d200d4a38c5c85a2123b5210224a18cdef08d0a8be3efc48edb4a159fc5db4`
+  and no command exposure.
+- PR #1293 merged as `0f366b6f6e6b05ab0bd748b012c2c86ed85f978c`
+  and repaired live trailing-extrema position/fill/candle confirmation. VPS5
+  fast-forwarded cleanly and one exact-pane Ctrl-C round stopped old bot PIDs
+  `1013205/1013207/1013209/1013210/1013211`. Replacement PIDs
+  `1015403/1015406/1015410/1015412/1015414` retained exact panes
+  `%358/%359/%360/%361/%362`, pane parents
+  `856294/856332/856364/856398/856434`, and the same fingerprint. Unrelated
+  `misc:0.0` remained `%8`, PID `434835`.
+- The immediate target report and smoke were hard-green with all five exact
+  processes and no hard failures. A later bounded window correctly retained two
+  real KuCoin account-state timeouts and one hard degraded cycle while all
+  sampled `D` states recovered without PID churn. The fresh recovery smoke was
+  hard-green with `326/326` remote calls, `61/61` account-critical calls, nine
+  successful fill refreshes, and zero hard failures. A quiet exact-PID sample
+  reached `R=4,S=1`; the final target report retained 3/3 stable samples, all
+  five relaunch paths, zero issues, and the same fingerprint. No direct
+  exchange probe or event was manufactured.
+- The active follow-up implements the first local exact-target executor over
+  this proven contract. It excludes SSH, git pull/build, direct exchange access,
+  automatic force escalation, and integrated post-restart smoke orchestration.
 
 ## Previous Canonical Deployment (PR #1277)
 

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -239,8 +239,10 @@ Related detailed plans:
    smoke report now also redacts common user/home prefixes from
    `repository.root` for shareable reports and surfaces explicit
    dropped-unparsed attention/hard counters when the opt-in log-window drop
-   policy suppresses contextless hard-looking log fragments. The safe restart
-   orchestration contract is not implemented. A 2026-06-30 follow-up made the
+   policy suppresses contextless hard-looking log fragments. The safe local
+   exact-target restart executor is implemented; repository pull, Rust rebuild,
+   remote-host orchestration, automatic force escalation, and post-restart
+   monitor/log smoke orchestration remain outside it. A 2026-06-30 follow-up made the
    existing startup timing evidence visible in `live-smoke-report --summary`
    and `--brief`, so repeated smoke loops can see slow startup phases without
    opening the full report. Another 2026-06-30 follow-up made bounded text-log
@@ -349,8 +351,17 @@ Related detailed plans:
      computes the digest from full private canonical commands before
      sanitization and validates the value-safe contract shape before target
      sampling can pass.
+   - 2026-07-17: PR #1294 merged and deployed full private-command fingerprint
+     derivation. Three stable VPS5 samples resolved all five configured targets
+     with the same opaque fingerprint and no command exposure. The active
+     follow-up adds the first explicit local executor: one exact-pane Ctrl-C
+     round, bounded exact-PID exit observation, process/pane TOCTOU rechecks,
+     private exact-pane relaunch, and stable final verification. It deliberately
+     omits SSH, git pull, Rust rebuild, direct exchange access, and automatic
+     force escalation.
 
-   Remaining refinements: safe pull/stop/start orchestration remains open.
+   Remaining refinements: safe pull/build and post-restart smoke orchestration
+   remain open, as does any separately reviewed force-escalation policy.
    The concise and brief summaries are intentionally bounded; further changes
    should target missing smoke fields rather than larger chat-facing payloads.
    2026-06-26 VPS5 deploy evidence: after PR #709, one Ctrl+C round stopped

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -414,9 +414,26 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   supervisor-config command source, and mandatory post-stop pane recheck, but
   never emits the configured command or assumes the pane is ready before that
   recheck. Direct pane-process targets remain valid ownership matches but are
-  explicitly relaunch-unready. A future executor
-  must require `relaunch_ready_targets == resolved_targets` in addition to the
-  hard-green stable sampling verdict.
+  explicitly relaunch-unready. The executor requires
+  `relaunch_ready_targets == resolved_targets` in addition to the hard-green
+  stable sampling verdict.
+- `passivbot tool live-restart-executor SUPERVISOR_CONFIG --session-name
+  SESSION --expected-supervisor-fingerprint SHA256 --execute` gracefully
+  restarts only the exact local tmux targets proven by the same bounded target
+  contract. It repeats the sampled preflight, requires the caller-confirmed
+  full-command fingerprint, takes an immediate action snapshot, and sends one
+  Ctrl-C round to exact pane IDs. After a bounded exact-PID exit wait, it scans
+  for unexpected or duplicate live processes, verifies the complete session
+  pane set, parent PIDs, window identities, and shell-ready exited panes, then
+  types the private supervisor commands only into eligible panes. Final startup
+  and multi-sample target verification must retain the same fingerprint.
+  The executor does not SSH, pull code, contact exchanges directly, write files
+  directly, use broad process-pattern signals, or apply SIGTERM/SIGKILL. A
+  timeout or changed process/pane contract is reported as manual recovery;
+  targets that did exit may be relaunched only when every post-stop check is
+  still exact. The relaunched live bots resume their configured exchange access
+  and normal runtime file writes. Run the read-only target report first and
+  pass its exact opaque fingerprint; command content is never emitted.
 - `passivbot tool live-performance-report` summarizes local live monitor event timings for
   operator performance analysis. It is read-only and does not contact exchanges. Use
   `--recent-minutes` for a time window, `--summary` for a bounded operator projection, and

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -425,8 +425,9 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   Ctrl-C round to exact pane IDs. After a bounded exact-PID exit wait, it scans
   for unexpected or duplicate live processes, verifies the complete session
   pane set, parent PIDs, window identities, and shell-ready exited panes, then
-  types the private supervisor commands only into eligible panes. Final startup
-  and multi-sample target verification must retain the same fingerprint.
+  immediately re-reads the private supervisor snapshot and process set before
+  typing commands only into eligible panes. Final startup and multi-sample
+  target verification must retain the same fingerprint.
   The executor does not SSH, pull code, contact exchanges directly, write files
   directly, use broad process-pattern signals, or apply SIGTERM/SIGKILL. A
   timeout or changed process/pane contract is reported as manual recovery;

--- a/src/live/restart_executor.py
+++ b/src/live/restart_executor.py
@@ -560,6 +560,42 @@ def execute_live_restart(
         report["outcome"] = "manual_recovery_required"
         return report
 
+    relaunch_snapshot, relaunch_fingerprint, relaunch_snapshot_error = (
+        _load_launch_snapshot(supervisor_config)
+    )
+    supervisor_stable = (
+        relaunch_snapshot_error is None
+        and relaunch_fingerprint == expected_fingerprint
+        and relaunch_snapshot == launch_snapshot
+    )
+    report["pre_relaunch_supervisor_recheck"] = {
+        "ok": supervisor_stable,
+        "error": relaunch_snapshot_error,
+    }
+    if not supervisor_stable:
+        issues.append(_issue("supervisor_changed_before_relaunch"))
+        report["targets"] = target_results
+        report["hard_failures"] = len(issues)
+        report["outcome"] = "manual_recovery_required"
+        return report
+
+    processes_stable, process_error = _post_stop_process_recheck(
+        launch_snapshot,
+        relaunch_window_names=relaunch_window_names,
+    )
+    report["pre_relaunch_process_recheck"] = {
+        "ok": processes_stable,
+        "error": process_error,
+    }
+    if not processes_stable:
+        issues.append(
+            _issue("process_changed_before_relaunch", reason=process_error)
+        )
+        report["targets"] = target_results
+        report["hard_failures"] = len(issues)
+        report["outcome"] = "manual_recovery_required"
+        return report
+
     for target in targets:
         result = result_by_pid[int(target["process_pid"])]
         if not result["exited"]:

--- a/src/live/restart_executor.py
+++ b/src/live/restart_executor.py
@@ -1,0 +1,626 @@
+from __future__ import annotations
+
+import math
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from live.restart_smoke_targets import (
+    MAX_RESTART_TARGETS,
+    MAX_TARGET_SAMPLE_INTERVAL_S,
+    MAX_TARGET_SAMPLES,
+    _tmux_pane_inventory,
+    build_live_restart_target_report,
+)
+from live.smoke_report import (
+    _parse_tmuxp_live_commands,
+    _running_live_processes,
+    _supervisor_command_contract,
+)
+
+
+DEFAULT_PREFLIGHT_SAMPLES = 3
+DEFAULT_PREFLIGHT_INTERVAL_S = 5.0
+DEFAULT_SHUTDOWN_TIMEOUT_S = 90.0
+DEFAULT_STARTUP_TIMEOUT_S = 180.0
+DEFAULT_POLL_INTERVAL_S = 2.0
+DEFAULT_VERIFICATION_SAMPLES = 3
+DEFAULT_VERIFICATION_INTERVAL_S = 5.0
+MAX_PHASE_TIMEOUT_S = 600.0
+MAX_LAUNCH_COMMAND_CHARS = 8192
+POST_STOP_PANE_SETTLE_TIMEOUT_S = 5.0
+ALLOWED_PANE_SHELL_COMMANDS = {"bash", "dash", "fish", "ksh", "sh", "zsh"}
+
+SAFETY_CONTRACT = {
+    "local_only": True,
+    "direct_network_access": False,
+    "direct_exchange_access": False,
+    "configured_live_processes_may_contact_exchanges": True,
+    "reads": [
+        "tmux_pane_inventory",
+        "process_table",
+        "supervisor_config",
+        "referenced_bot_configs",
+    ],
+    "direct_file_writes": False,
+    "signals_processes": True,
+    "starts_processes": True,
+    "configured_live_processes_may_write_files": True,
+    "signal_method": "tmux_send_keys_exact_pane_ctrl_c",
+    "start_method": "tmux_send_keys_exact_pane_literal_command",
+    "automatic_force_signal": False,
+    "broad_process_pattern_signals": False,
+    "requires_execute_confirmation": True,
+    "requires_expected_supervisor_fingerprint": True,
+}
+
+
+def _bounded_phase_value(value: float, *, field: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= 0.0 or parsed > MAX_PHASE_TIMEOUT_S:
+        raise ValueError(
+            f"{field} must be greater than 0 and at most {MAX_PHASE_TIMEOUT_S:g}"
+        )
+    return parsed
+
+
+def _bounded_samples(value: int, *, field: str) -> int:
+    parsed = int(value)
+    if parsed < 2 or parsed > MAX_TARGET_SAMPLES:
+        raise ValueError(f"{field} must be between 2 and {MAX_TARGET_SAMPLES}")
+    return parsed
+
+
+def _bounded_sample_interval(value: float, *, field: str) -> float:
+    parsed = float(value)
+    if (
+        not math.isfinite(parsed)
+        or parsed <= 0.0
+        or parsed > MAX_TARGET_SAMPLE_INTERVAL_S
+    ):
+        raise ValueError(
+            f"{field} must be greater than 0 and at most "
+            f"{MAX_TARGET_SAMPLE_INTERVAL_S:g}"
+        )
+    return parsed
+
+
+def _valid_fingerprint(value: str) -> str:
+    fingerprint = str(value or "").strip()
+    if len(fingerprint) != 64 or any(
+        character not in "0123456789abcdef" for character in fingerprint
+    ):
+        raise ValueError(
+            "expected_supervisor_fingerprint must be 64 lowercase hex characters"
+        )
+    return fingerprint
+
+
+def _issue(code: str, **fields: Any) -> dict[str, Any]:
+    return {"code": code, "severity": "error", **fields}
+
+
+def _preflight_summary(report: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "ok": bool(report.get("ok")),
+        "hard_failures": int(report.get("hard_failures") or 0),
+        "session_name": report.get("session_name"),
+        "expected_targets": int(report.get("expected_targets") or 0),
+        "resolved_targets": int(report.get("resolved_targets") or 0),
+        "relaunch_ready_targets": int(report.get("relaunch_ready_targets") or 0),
+        "supervisor_contract": report.get("supervisor_contract"),
+        "sampling": report.get("sampling"),
+    }
+
+
+def _load_launch_snapshot(
+    supervisor_config: str | Path,
+) -> tuple[dict[str, dict[str, str]], str | None, str | None]:
+    config = _parse_tmuxp_live_commands(supervisor_config)
+    if config.get("error"):
+        return {}, None, str(config["error"])
+    rows = config.get("expected")
+    expected = rows if isinstance(rows, list) else []
+    if not expected:
+        return {}, None, "no_expected_live_commands"
+    if len(expected) > MAX_RESTART_TARGETS:
+        return {}, None, "expected_target_limit_exceeded"
+
+    commands: dict[str, dict[str, str]] = {}
+    for row in expected:
+        name = str(row.get("name") or "").strip()
+        command = str(row.get("_launch_command") or "").strip()
+        match_key = str(row.get("_match_key") or "").strip()
+        if not name or name in commands:
+            return {}, None, "invalid_or_duplicate_window_name"
+        if (
+            not command
+            or not match_key
+            or len(command) > MAX_LAUNCH_COMMAND_CHARS
+            or any(character in command for character in ("\x00", "\r", "\n"))
+        ):
+            return {}, None, "invalid_launch_command"
+        commands[name] = {"command": command, "match_key": match_key}
+
+    contract = _supervisor_command_contract(expected)
+    fingerprint = str(contract.get("fingerprint") or "").strip()
+    if len(fingerprint) != 64:
+        return {}, None, "invalid_supervisor_contract"
+    return commands, fingerprint, None
+
+
+def _run_tmux(arguments: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            ["tmux", *arguments],
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return f"tmux_failed:{exc.__class__.__name__}"
+    if result.returncode != 0:
+        return "tmux_failed"
+    return None
+
+
+def _send_graceful_interrupt(pane_id: str) -> str | None:
+    return _run_tmux(["send-keys", "-t", pane_id, "C-c"])
+
+
+def _send_launch_command(pane_id: str, command: str) -> str | None:
+    error = _run_tmux(["send-keys", "-t", pane_id, "-l", "--", command])
+    if error is not None:
+        return error
+    return _run_tmux(["send-keys", "-t", pane_id, "Enter"])
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(int(pid), 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _wait_for_process_exits(
+    targets: list[dict[str, Any]],
+    *,
+    timeout_s: float,
+    poll_interval_s: float,
+) -> tuple[dict[int, float], list[int]]:
+    started = time.monotonic()
+    pending = {
+        int(target["process_pid"])
+        for target in targets
+        if int(target.get("process_pid") or 0) > 0
+    }
+    elapsed_by_pid: dict[int, float] = {}
+    deadline = started + timeout_s
+    while pending:
+        now = time.monotonic()
+        for pid in list(pending):
+            if not _pid_alive(pid):
+                elapsed_by_pid[pid] = max(0.0, now - started)
+                pending.remove(pid)
+        if not pending or now >= deadline:
+            break
+        time.sleep(min(poll_interval_s, max(0.0, deadline - now)))
+    return elapsed_by_pid, sorted(pending)
+
+
+def _target_identities(report: dict[str, Any]) -> list[tuple[Any, ...]]:
+    return sorted(
+        (
+            str(target.get("window_name") or ""),
+            str(target.get("pane_id") or ""),
+            int(target.get("pane_pid") or 0),
+            int(target.get("process_pid") or 0),
+            str(target.get("ownership_proof") or ""),
+        )
+        for target in report.get("targets") or []
+    )
+
+
+def _post_stop_process_recheck(
+    launch_snapshot: dict[str, dict[str, str]],
+    *,
+    relaunch_window_names: set[str],
+) -> tuple[bool, str | None]:
+    scan = _running_live_processes(command_match="")
+    if scan.get("scan_error") is not None:
+        return False, "process_scan_failed"
+    running = scan.get("running") if isinstance(scan.get("running"), list) else []
+    expected_match_keys = {
+        row["match_key"] for row in launch_snapshot.values()
+    }
+    if any(
+        str(process.get("_match_key") or "") not in expected_match_keys
+        for process in running
+    ):
+        return False, "unexpected_live_process"
+    for window_name, row in launch_snapshot.items():
+        match_count = sum(
+            1
+            for process in running
+            if str(process.get("_match_key") or "") == row["match_key"]
+        )
+        expected_count = 0 if window_name in relaunch_window_names else 1
+        if match_count != expected_count:
+            return False, "configured_process_count_changed"
+    return True, None
+
+
+def _post_stop_pane_recheck(
+    targets: list[dict[str, Any]],
+    *,
+    session_name: str,
+    relaunch_pane_ids: set[str],
+) -> tuple[bool, str | None]:
+    panes, error = _tmux_pane_inventory()
+    if error is not None:
+        return False, error
+    session_panes = [
+        pane for pane in panes if pane.get("session_name") == session_name
+    ]
+    expected_ids = {str(target.get("pane_id") or "") for target in targets}
+    if {str(pane.get("pane_id") or "") for pane in session_panes} != expected_ids:
+        return False, "session_pane_set_changed"
+    by_id = {str(pane["pane_id"]): pane for pane in session_panes}
+    for target in targets:
+        pane = by_id.get(str(target.get("pane_id") or ""))
+        if pane is None:
+            return False, "pane_missing"
+        if (
+            str(pane.get("window_name") or "")
+            != str(target.get("window_name") or "")
+            or int(pane.get("pane_index") or 0)
+            != int(target.get("pane_index") or 0)
+            or int(pane.get("pane_pid") or 0) != int(target.get("pane_pid") or 0)
+        ):
+            return False, "pane_identity_changed"
+        if str(pane["pane_id"]) in relaunch_pane_ids:
+            current_command = Path(str(pane.get("current_command") or "")).name
+            if current_command not in ALLOWED_PANE_SHELL_COMMANDS:
+                return False, "pane_not_at_shell_prompt"
+    return True, None
+
+
+def _wait_for_post_stop_pane_recheck(
+    targets: list[dict[str, Any]],
+    *,
+    session_name: str,
+    relaunch_pane_ids: set[str],
+    poll_interval_s: float,
+) -> tuple[bool, str | None]:
+    deadline = time.monotonic() + POST_STOP_PANE_SETTLE_TIMEOUT_S
+    while True:
+        ok, error = _post_stop_pane_recheck(
+            targets,
+            session_name=session_name,
+            relaunch_pane_ids=relaunch_pane_ids,
+        )
+        if ok:
+            return True, None
+        now = time.monotonic()
+        if now >= deadline:
+            return False, error
+        time.sleep(min(poll_interval_s, max(0.0, deadline - now)))
+
+
+def _wait_for_startup_report(
+    supervisor_config: str | Path,
+    *,
+    session_name: str,
+    config_base_dir: Path | None,
+    timeout_s: float,
+    poll_interval_s: float,
+    expected_supervisor_fingerprint: str,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_s
+    latest: dict[str, Any] = {}
+    while True:
+        latest = build_live_restart_target_report(
+            supervisor_config,
+            session_name=session_name,
+            config_base_dir=config_base_dir,
+        )
+        observed_fingerprint = str(
+            (latest.get("supervisor_contract") or {}).get("fingerprint") or ""
+        )
+        if latest.get("ok") and observed_fingerprint == expected_supervisor_fingerprint:
+            return latest
+        now = time.monotonic()
+        if now >= deadline:
+            return latest
+        time.sleep(min(poll_interval_s, max(0.0, deadline - now)))
+
+
+def execute_live_restart(
+    supervisor_config: str | Path,
+    *,
+    session_name: str,
+    expected_supervisor_fingerprint: str,
+    config_base_dir: Path | None = None,
+    preflight_samples: int = DEFAULT_PREFLIGHT_SAMPLES,
+    preflight_interval_s: float = DEFAULT_PREFLIGHT_INTERVAL_S,
+    shutdown_timeout_s: float = DEFAULT_SHUTDOWN_TIMEOUT_S,
+    startup_timeout_s: float = DEFAULT_STARTUP_TIMEOUT_S,
+    poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+    verification_samples: int = DEFAULT_VERIFICATION_SAMPLES,
+    verification_interval_s: float = DEFAULT_VERIFICATION_INTERVAL_S,
+    execute: bool = False,
+) -> dict[str, Any]:
+    if not execute:
+        raise ValueError("execute=true confirmation is required")
+    confirmed_session = str(session_name or "").strip()
+    if not confirmed_session:
+        raise ValueError("session_name must be non-empty")
+    expected_fingerprint = _valid_fingerprint(expected_supervisor_fingerprint)
+    preflight_samples = _bounded_samples(
+        preflight_samples, field="preflight_samples"
+    )
+    verification_samples = _bounded_samples(
+        verification_samples, field="verification_samples"
+    )
+    preflight_interval_s = _bounded_sample_interval(
+        preflight_interval_s, field="preflight_interval_s"
+    )
+    verification_interval_s = _bounded_sample_interval(
+        verification_interval_s, field="verification_interval_s"
+    )
+    shutdown_timeout_s = _bounded_phase_value(
+        shutdown_timeout_s, field="shutdown_timeout_s"
+    )
+    startup_timeout_s = _bounded_phase_value(
+        startup_timeout_s, field="startup_timeout_s"
+    )
+    poll_interval_s = _bounded_phase_value(
+        poll_interval_s, field="poll_interval_s"
+    )
+
+    preflight = build_live_restart_target_report(
+        supervisor_config,
+        session_name=confirmed_session,
+        config_base_dir=config_base_dir,
+        samples=preflight_samples,
+        sample_interval_s=preflight_interval_s,
+    )
+    report: dict[str, Any] = {
+        "tool": "live-restart-executor",
+        "schema_version": 1,
+        "ok": False,
+        "outcome": "preflight_failed",
+        "action_started": False,
+        "session_name": confirmed_session,
+        "safety": dict(SAFETY_CONTRACT),
+        "preflight": _preflight_summary(preflight),
+        "issues": [],
+        "targets": [],
+    }
+    issues: list[dict[str, Any]] = report["issues"]
+    sampling = preflight.get("sampling") or {}
+    resolved_targets = int(preflight.get("resolved_targets") or 0)
+    if (
+        not preflight.get("ok")
+        or not sampling.get("stable")
+        or not sampling.get("supervisor_contract_stable")
+        or int(preflight.get("relaunch_ready_targets") or 0) != resolved_targets
+        or resolved_targets <= 0
+    ):
+        issues.append(_issue("preflight_failed"))
+        report["hard_failures"] = len(issues)
+        return report
+
+    contract = preflight.get("supervisor_contract") or {}
+    observed_fingerprint = str(contract.get("fingerprint") or "")
+    if observed_fingerprint != expected_fingerprint:
+        issues.append(_issue("supervisor_fingerprint_mismatch"))
+        report["hard_failures"] = len(issues)
+        return report
+
+    launch_snapshot, snapshot_fingerprint, snapshot_error = _load_launch_snapshot(
+        supervisor_config
+    )
+    if snapshot_error is not None:
+        issues.append(_issue("launch_snapshot_unavailable", reason=snapshot_error))
+        report["hard_failures"] = len(issues)
+        return report
+    if snapshot_fingerprint != expected_fingerprint:
+        issues.append(_issue("supervisor_changed_after_preflight"))
+        report["hard_failures"] = len(issues)
+        return report
+
+    targets = sorted(
+        [dict(target) for target in preflight.get("targets") or []],
+        key=lambda target: str(target.get("window_name") or ""),
+    )
+    if {str(target.get("window_name") or "") for target in targets} != set(
+        launch_snapshot
+    ):
+        issues.append(_issue("launch_target_set_mismatch"))
+        report["hard_failures"] = len(issues)
+        return report
+
+    action_snapshot = build_live_restart_target_report(
+        supervisor_config,
+        session_name=confirmed_session,
+        config_base_dir=config_base_dir,
+    )
+    action_fingerprint = str(
+        (action_snapshot.get("supervisor_contract") or {}).get("fingerprint") or ""
+    )
+    if (
+        not action_snapshot.get("ok")
+        or action_fingerprint != expected_fingerprint
+        or _target_identities(action_snapshot) != _target_identities(preflight)
+    ):
+        issues.append(_issue("target_changed_after_preflight"))
+        report["hard_failures"] = len(issues)
+        return report
+    report["action_snapshot"] = _preflight_summary(action_snapshot)
+
+    target_results: list[dict[str, Any]] = []
+    result_by_pid: dict[int, dict[str, Any]] = {}
+    stop_wait_targets: list[dict[str, Any]] = []
+    report["action_started"] = True
+    report["outcome"] = "restart_in_progress"
+    for target in targets:
+        pid = int(target["process_pid"])
+        result = {
+            "window_name": target["window_name"],
+            "pane_id": target["pane_id"],
+            "pane_pid": target["pane_pid"],
+            "old_process_pid": pid,
+            "stop_requested": False,
+            "exited": False,
+            "relaunch_requested": False,
+            "relaunch_succeeded": False,
+        }
+        target_results.append(result)
+        result_by_pid[pid] = result
+        error = _send_graceful_interrupt(str(target["pane_id"]))
+        if error is not None:
+            result["stop_error"] = error
+            issues.append(
+                _issue(
+                    "graceful_interrupt_failed",
+                    window_name=target["window_name"],
+                    pane_id=target["pane_id"],
+                )
+            )
+            continue
+        result["stop_requested"] = True
+        stop_wait_targets.append(target)
+
+    elapsed_by_pid, still_running = _wait_for_process_exits(
+        stop_wait_targets,
+        timeout_s=shutdown_timeout_s,
+        poll_interval_s=poll_interval_s,
+    )
+    for pid, elapsed_s in elapsed_by_pid.items():
+        result_by_pid[pid]["exited"] = True
+        result_by_pid[pid]["shutdown_elapsed_s"] = round(elapsed_s, 3)
+    if still_running:
+        issues.append(
+            _issue(
+                "shutdown_timeout",
+                timed_out_targets=len(still_running),
+            )
+        )
+
+    relaunch_pane_ids = {
+        str(target["pane_id"])
+        for target in targets
+        if result_by_pid[int(target["process_pid"])]["exited"]
+    }
+    relaunch_window_names = {
+        str(target["window_name"])
+        for target in targets
+        if result_by_pid[int(target["process_pid"])]["exited"]
+    }
+    processes_stable, process_error = _post_stop_process_recheck(
+        launch_snapshot,
+        relaunch_window_names=relaunch_window_names,
+    )
+    report["post_stop_process_recheck"] = {
+        "ok": processes_stable,
+        "error": process_error,
+    }
+    if not processes_stable:
+        issues.append(
+            _issue("post_stop_process_recheck_failed", reason=process_error)
+        )
+        report["targets"] = target_results
+        report["hard_failures"] = len(issues)
+        report["outcome"] = "manual_recovery_required"
+        return report
+
+    panes_stable, pane_error = _wait_for_post_stop_pane_recheck(
+        targets,
+        session_name=confirmed_session,
+        relaunch_pane_ids=relaunch_pane_ids,
+        poll_interval_s=poll_interval_s,
+    )
+    report["post_stop_pane_recheck"] = {
+        "ok": panes_stable,
+        "error": pane_error,
+    }
+    if not panes_stable:
+        issues.append(
+            _issue("post_stop_pane_recheck_failed", reason=pane_error)
+        )
+        report["targets"] = target_results
+        report["hard_failures"] = len(issues)
+        report["outcome"] = "manual_recovery_required"
+        return report
+
+    for target in targets:
+        result = result_by_pid[int(target["process_pid"])]
+        if not result["exited"]:
+            continue
+        result["relaunch_requested"] = True
+        error = _send_launch_command(
+            str(target["pane_id"]),
+            launch_snapshot[str(target["window_name"])]["command"],
+        )
+        if error is not None:
+            result["relaunch_error"] = error
+            issues.append(
+                _issue(
+                    "relaunch_command_failed",
+                    window_name=target["window_name"],
+                    pane_id=target["pane_id"],
+                )
+            )
+            continue
+        result["relaunch_succeeded"] = True
+
+    startup_report = _wait_for_startup_report(
+        supervisor_config,
+        session_name=confirmed_session,
+        config_base_dir=config_base_dir,
+        timeout_s=startup_timeout_s,
+        poll_interval_s=poll_interval_s,
+        expected_supervisor_fingerprint=expected_fingerprint,
+    )
+    if startup_report.get("ok"):
+        verification = build_live_restart_target_report(
+            supervisor_config,
+            session_name=confirmed_session,
+            config_base_dir=config_base_dir,
+            samples=verification_samples,
+            sample_interval_s=verification_interval_s,
+        )
+    else:
+        verification = startup_report
+        issues.append(_issue("startup_verification_timeout"))
+
+    final_by_window = {
+        str(target.get("window_name") or ""): target
+        for target in verification.get("targets") or []
+    }
+    for result in target_results:
+        final = final_by_window.get(str(result["window_name"]))
+        if final is not None:
+            result["final_process_pid"] = final.get("process_pid")
+
+    report["targets"] = target_results
+    report["verification"] = _preflight_summary(verification)
+    verified_fingerprint = str(
+        (verification.get("supervisor_contract") or {}).get("fingerprint") or ""
+    )
+    if verified_fingerprint != expected_fingerprint:
+        issues.append(_issue("supervisor_changed_during_restart"))
+    if not verification.get("ok"):
+        if not any(issue["code"] == "startup_verification_timeout" for issue in issues):
+            issues.append(_issue("stable_verification_failed"))
+    report["hard_failures"] = len(issues)
+    report["ok"] = not issues and bool(verification.get("ok"))
+    report["outcome"] = "completed" if report["ok"] else "recovered_with_errors"
+    return report

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -6925,6 +6925,7 @@ def _parse_tmuxp_live_commands(config_path: str | Path | None) -> dict[str, Any]
                 "name": current_window,
                 "command": _redact_live_command_for_report(command, max_len=400),
                 "command_key": _redact_live_command_for_report(command_key, max_len=400),
+                "_launch_command": command,
                 "_match_key": command_key,
                 **context,
             }
@@ -6944,7 +6945,9 @@ def _supervisor_command_contract(
         (
             {
                 "window_name": str(row.get("name") or "").strip(),
-                "command": str(row.get("_match_key") or "").strip(),
+                "command": str(
+                    row.get("_launch_command") or row.get("_match_key") or ""
+                ).strip(),
                 "config_path": str(row.get("config_path") or "").strip(),
             }
             for row in expected_rows

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -148,6 +148,10 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "tools.live_restart_target_report",
         "resolve exact local tmux restart targets without process control",
     ),
+    "live-restart-executor": CommandSpec(
+        "tools.live_restart_executor",
+        "gracefully restart exact verified local tmux targets",
+    ),
     "inspect-ohlcvs": CommandSpec(
         "tools.inspect_ohlcvs",
         "inspect v2 OHLCV cache metadata and gaps (requires full install)",

--- a/src/tools/live_restart_executor.py
+++ b/src/tools/live_restart_executor.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[1]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from live.restart_executor import execute_live_restart  # noqa: E402
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="passivbot tool live-restart-executor",
+        description=(
+            "Gracefully restart exact verified local tmux targets. This tool "
+            "does not pull code or use automatic force signals."
+        ),
+    )
+    parser.add_argument("supervisor_config", help="Tmuxp-style supervisor config.")
+    parser.add_argument("--session-name", required=True, help="Exact tmux session.")
+    parser.add_argument(
+        "--expected-supervisor-fingerprint",
+        required=True,
+        help="Exact lowercase SHA-256 fingerprint from the target preflight.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Confirm exact-pane graceful stop and relaunch execution.",
+    )
+    parser.add_argument("--shutdown-timeout-s", type=float, default=90.0)
+    parser.add_argument("--startup-timeout-s", type=float, default=180.0)
+    parser.add_argument("--poll-interval-s", type=float, default=2.0)
+    parser.add_argument("--preflight-samples", type=int, default=3)
+    parser.add_argument("--preflight-interval-s", type=float, default=5.0)
+    parser.add_argument("--verification-samples", type=int, default=3)
+    parser.add_argument("--verification-interval-s", type=float, default=5.0)
+    parser.add_argument("--compact", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not args.execute:
+        parser.error("--execute is required; use live-restart-target-report first")
+    try:
+        report = execute_live_restart(
+            args.supervisor_config,
+            session_name=args.session_name,
+            expected_supervisor_fingerprint=args.expected_supervisor_fingerprint,
+            config_base_dir=Path.cwd(),
+            preflight_samples=args.preflight_samples,
+            preflight_interval_s=args.preflight_interval_s,
+            shutdown_timeout_s=args.shutdown_timeout_s,
+            startup_timeout_s=args.startup_timeout_s,
+            poll_interval_s=args.poll_interval_s,
+            verification_samples=args.verification_samples,
+            verification_interval_s=args.verification_interval_s,
+            execute=True,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+    print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_live_restart_executor.py
+++ b/tests/test_live_restart_executor.py
@@ -1,0 +1,562 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+import live.restart_executor as executor_module
+from live.restart_executor import execute_live_restart
+from live.smoke_report import (
+    _parse_tmuxp_live_commands,
+    _supervisor_command_contract,
+    parse_tmuxp_live_commands,
+)
+from passivbot_cli import main as cli_main
+from tools import live_restart_executor
+
+
+FINGERPRINT = "a" * 64
+
+
+def _target(
+    name: str,
+    pane_id: str,
+    pane_pid: int,
+    process_pid: int,
+) -> dict:
+    return {
+        "window_name": name,
+        "target": pane_id,
+        "pane_id": pane_id,
+        "pane_index": 0,
+        "pane_pid": pane_pid,
+        "process_pid": process_pid,
+        "ownership_proof": "matched_process_ppid_equals_pane_pid",
+        "relaunch": {
+            "ready": True,
+            "method": "exact_pane_input_after_verified_exit",
+            "reason": None,
+            "command_source": "supervisor_config",
+            "requires_process_exit": True,
+            "requires_post_stop_pane_recheck": True,
+        },
+    }
+
+
+def _report(*targets: dict, ok: bool = True) -> dict:
+    target_rows = deepcopy(list(targets)) or [
+        _target("binance_01", "%10", 100, 200)
+    ]
+    return {
+        "tool": "live-restart-target-report",
+        "schema_version": 1,
+        "ok": ok,
+        "hard_failures": 0 if ok else 1,
+        "session_name": "passivbot",
+        "expected_targets": len(target_rows),
+        "resolved_targets": len(target_rows),
+        "relaunch_ready_targets": len(target_rows),
+        "supervisor_contract": {
+            "source": "parsed_supervisor_config",
+            "algorithm": "sha256",
+            "fingerprint": FINGERPRINT,
+            "target_count": len(target_rows),
+            "command_content_exposed": False,
+        },
+        "sampling": {
+            "stable": ok,
+            "supervisor_contract_stable": ok,
+            "requested_samples": 3,
+            "collected_samples": 3,
+        },
+        "targets": target_rows,
+    }
+
+
+def _install_happy_dependencies(monkeypatch, targets: list[dict]) -> dict:
+    report = _report(*targets)
+    calls: dict[str, list] = {"stop": [], "start": [], "reports": []}
+
+    def build_report(*_args, **kwargs):
+        calls["reports"].append(kwargs)
+        return deepcopy(report)
+
+    monkeypatch.setattr(executor_module, "build_live_restart_target_report", build_report)
+    monkeypatch.setattr(
+        executor_module,
+        "_load_launch_snapshot",
+        lambda _path: (
+            {
+                target["window_name"]: {
+                    "command": f"private launch {target['window_name']}",
+                    "match_key": f"passivbot live {target['window_name']}",
+                }
+                for target in targets
+            },
+            FINGERPRINT,
+            None,
+        ),
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "_send_graceful_interrupt",
+        lambda pane_id: calls["stop"].append(pane_id),
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "_send_launch_command",
+        lambda pane_id, command: calls["start"].append((pane_id, command)),
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "_wait_for_process_exits",
+        lambda rows, **_kwargs: (
+            {int(row["process_pid"]): float(index + 1) for index, row in enumerate(rows)},
+            [],
+        ),
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "_post_stop_process_recheck",
+        lambda *_args, **_kwargs: (True, None),
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "_wait_for_post_stop_pane_recheck",
+        lambda *_args, **_kwargs: (True, None),
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "_wait_for_startup_report",
+        lambda *_args, **_kwargs: deepcopy(report),
+    )
+    return calls
+
+
+def _execute(**kwargs) -> dict:
+    return execute_live_restart(
+        "bots.yaml",
+        session_name="passivbot",
+        expected_supervisor_fingerprint=FINGERPRINT,
+        preflight_samples=2,
+        preflight_interval_s=0.1,
+        shutdown_timeout_s=1.0,
+        startup_timeout_s=1.0,
+        poll_interval_s=0.1,
+        verification_samples=2,
+        verification_interval_s=0.1,
+        execute=True,
+        **kwargs,
+    )
+
+
+def test_live_restart_executor_restarts_only_exact_verified_panes(monkeypatch):
+    targets = [
+        _target("binance_01", "%10", 100, 200),
+        _target("gateio_01", "%11", 101, 201),
+    ]
+    calls = _install_happy_dependencies(monkeypatch, targets)
+
+    report = _execute()
+
+    assert report["ok"] is True
+    assert report["outcome"] == "completed"
+    assert calls["stop"] == ["%10", "%11"]
+    assert calls["start"] == [
+        ("%10", "private launch binance_01"),
+        ("%11", "private launch gateio_01"),
+    ]
+    assert [row["shutdown_elapsed_s"] for row in report["targets"]] == [1.0, 2.0]
+    assert all(row["relaunch_succeeded"] for row in report["targets"])
+    serialized = json.dumps(report, sort_keys=True)
+    assert "private launch" not in serialized
+    assert report["safety"]["automatic_force_signal"] is False
+    assert report["safety"]["broad_process_pattern_signals"] is False
+    assert report["safety"]["direct_file_writes"] is False
+    assert report["safety"]["configured_live_processes_may_write_files"] is True
+    assert report["safety"]["configured_live_processes_may_contact_exchanges"] is True
+
+
+def test_live_restart_executor_fails_closed_before_action_on_fingerprint_mismatch(
+    monkeypatch,
+):
+    calls = _install_happy_dependencies(
+        monkeypatch, [_target("binance_01", "%10", 100, 200)]
+    )
+
+    report = execute_live_restart(
+        "bots.yaml",
+        session_name="passivbot",
+        expected_supervisor_fingerprint="b" * 64,
+        preflight_samples=2,
+        preflight_interval_s=0.1,
+        execute=True,
+    )
+
+    assert report["ok"] is False
+    assert report["action_started"] is False
+    assert {issue["code"] for issue in report["issues"]} == {
+        "supervisor_fingerprint_mismatch"
+    }
+    assert calls["stop"] == []
+    assert calls["start"] == []
+
+
+def test_live_restart_executor_fails_closed_when_snapshot_changes_after_preflight(
+    monkeypatch,
+):
+    calls = _install_happy_dependencies(
+        monkeypatch, [_target("binance_01", "%10", 100, 200)]
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "_load_launch_snapshot",
+        lambda _path: (
+            {
+                "binance_01": {
+                    "command": "private",
+                    "match_key": "passivbot live binance_01",
+                }
+            },
+            "b" * 64,
+            None,
+        ),
+    )
+
+    report = _execute()
+
+    assert report["action_started"] is False
+    assert {issue["code"] for issue in report["issues"]} == {
+        "supervisor_changed_after_preflight"
+    }
+    assert calls["stop"] == []
+
+
+def test_live_restart_executor_relaunches_only_exited_targets_after_timeout(
+    monkeypatch,
+):
+    targets = [
+        _target("binance_01", "%10", 100, 200),
+        _target("gateio_01", "%11", 101, 201),
+    ]
+    calls = _install_happy_dependencies(monkeypatch, targets)
+    monkeypatch.setattr(
+        executor_module,
+        "_wait_for_process_exits",
+        lambda _rows, **_kwargs: ({200: 0.5}, [201]),
+    )
+
+    report = _execute()
+
+    assert report["ok"] is False
+    assert report["outcome"] == "recovered_with_errors"
+    assert {issue["code"] for issue in report["issues"]} == {"shutdown_timeout"}
+    assert calls["start"] == [("%10", "private launch binance_01")]
+    by_name = {row["window_name"]: row for row in report["targets"]}
+    assert by_name["binance_01"]["relaunch_succeeded"] is True
+    assert by_name["gateio_01"]["relaunch_requested"] is False
+
+
+def test_live_restart_executor_halts_relaunch_when_pane_identity_changes(monkeypatch):
+    calls = _install_happy_dependencies(
+        monkeypatch, [_target("binance_01", "%10", 100, 200)]
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "_wait_for_post_stop_pane_recheck",
+        lambda *_args, **_kwargs: (False, "pane_identity_changed"),
+    )
+
+    report = _execute()
+
+    assert report["ok"] is False
+    assert report["outcome"] == "manual_recovery_required"
+    assert {issue["code"] for issue in report["issues"]} == {
+        "post_stop_pane_recheck_failed"
+    }
+    assert calls["start"] == []
+
+
+def test_live_restart_executor_halts_relaunch_when_process_reappears(monkeypatch):
+    calls = _install_happy_dependencies(
+        monkeypatch, [_target("binance_01", "%10", 100, 200)]
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "_post_stop_process_recheck",
+        lambda *_args, **_kwargs: (False, "configured_process_count_changed"),
+    )
+
+    report = _execute()
+
+    assert report["outcome"] == "manual_recovery_required"
+    assert {issue["code"] for issue in report["issues"]} == {
+        "post_stop_process_recheck_failed"
+    }
+    assert calls["start"] == []
+
+
+def test_live_restart_executor_rejects_target_change_after_preflight(monkeypatch):
+    targets = [_target("binance_01", "%10", 100, 200)]
+    calls = _install_happy_dependencies(monkeypatch, targets)
+    report_calls = 0
+
+    def build_report(*_args, **_kwargs):
+        nonlocal report_calls
+        report_calls += 1
+        report = _report(*targets)
+        if report_calls == 2:
+            report["targets"][0]["process_pid"] = 999
+        return report
+
+    monkeypatch.setattr(executor_module, "build_live_restart_target_report", build_report)
+
+    report = _execute()
+
+    assert report["action_started"] is False
+    assert {issue["code"] for issue in report["issues"]} == {
+        "target_changed_after_preflight"
+    }
+    assert calls["stop"] == []
+
+
+def test_tmux_actions_use_exact_pane_without_shell_or_broad_patterns(monkeypatch):
+    calls: list[list[str]] = []
+
+    def run(args, **_kwargs):
+        calls.append(args)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(executor_module.subprocess, "run", run)
+
+    assert executor_module._send_graceful_interrupt("%17") is None
+    assert executor_module._send_launch_command("%17", "private command") is None
+
+    assert calls == [
+        ["tmux", "send-keys", "-t", "%17", "C-c"],
+        ["tmux", "send-keys", "-t", "%17", "-l", "--", "private command"],
+        ["tmux", "send-keys", "-t", "%17", "Enter"],
+    ]
+    serialized = json.dumps(calls)
+    assert "pkill" not in serialized
+    assert "pgrep" not in serialized
+    assert "SIGTERM" not in serialized
+
+
+def test_post_stop_recheck_requires_shell_only_for_relaunch_targets(monkeypatch):
+    targets = [
+        _target("binance_01", "%10", 100, 200),
+        _target("gateio_01", "%11", 101, 201),
+    ]
+    panes = [
+        {
+            "pane_id": "%10",
+            "session_name": "passivbot",
+            "window_name": "binance_01",
+            "pane_index": 0,
+            "pane_pid": 100,
+            "current_command": "bash",
+        },
+        {
+            "pane_id": "%11",
+            "session_name": "passivbot",
+            "window_name": "gateio_01",
+            "pane_index": 0,
+            "pane_pid": 101,
+            "current_command": "python3",
+        },
+    ]
+    monkeypatch.setattr(executor_module, "_tmux_pane_inventory", lambda: (panes, None))
+
+    assert executor_module._post_stop_pane_recheck(
+        targets,
+        session_name="passivbot",
+        relaunch_pane_ids={"%10"},
+    ) == (True, None)
+    assert executor_module._post_stop_pane_recheck(
+        targets,
+        session_name="passivbot",
+        relaunch_pane_ids={"%10", "%11"},
+    ) == (False, "pane_not_at_shell_prompt")
+
+
+def test_post_stop_process_recheck_prevents_duplicate_relaunch(monkeypatch):
+    snapshot = {
+        "binance_01": {
+            "command": "private binance",
+            "match_key": "passivbot live binance",
+        },
+        "gateio_01": {
+            "command": "private gateio",
+            "match_key": "passivbot live gateio",
+        },
+    }
+    monkeypatch.setattr(
+        executor_module,
+        "_running_live_processes",
+        lambda **_kwargs: {
+            "scan_error": None,
+            "running": [{"_match_key": "passivbot live gateio"}],
+        },
+    )
+    assert executor_module._post_stop_process_recheck(
+        snapshot,
+        relaunch_window_names={"binance_01"},
+    ) == (True, None)
+
+    monkeypatch.setattr(
+        executor_module,
+        "_running_live_processes",
+        lambda **_kwargs: {
+            "scan_error": None,
+            "running": [
+                {"_match_key": "passivbot live binance"},
+                {"_match_key": "passivbot live gateio"},
+            ],
+        },
+    )
+    assert executor_module._post_stop_process_recheck(
+        snapshot,
+        relaunch_window_names={"binance_01"},
+    ) == (False, "configured_process_count_changed")
+
+
+def test_live_restart_executor_rejects_final_fingerprint_drift(monkeypatch):
+    targets = [_target("binance_01", "%10", 100, 200)]
+    _install_happy_dependencies(monkeypatch, targets)
+    changed = _report(*targets)
+    changed["supervisor_contract"]["fingerprint"] = "b" * 64
+    sampled_calls = 0
+
+    def build_report(*_args, **kwargs):
+        nonlocal sampled_calls
+        if int(kwargs.get("samples") or 1) > 1:
+            sampled_calls += 1
+            return _report(*targets) if sampled_calls == 1 else deepcopy(changed)
+        return _report(*targets)
+
+    monkeypatch.setattr(executor_module, "build_live_restart_target_report", build_report)
+
+    report = _execute()
+
+    assert report["ok"] is False
+    assert {issue["code"] for issue in report["issues"]} == {
+        "supervisor_changed_during_restart"
+    }
+
+
+def test_private_launch_source_changes_fingerprint_without_public_exposure(tmp_path):
+    first = tmp_path / "first.yaml"
+    second = tmp_path / "second.yaml"
+    first.write_text(
+        "window_name: binance_01\n"
+        "- cd /one && passivbot live bot.json -u binance_01\n",
+        encoding="utf-8",
+    )
+    second.write_text(
+        "window_name: binance_01\n"
+        "- cd /two && passivbot live bot.json -u binance_01\n",
+        encoding="utf-8",
+    )
+
+    first_private = _parse_tmuxp_live_commands(first)
+    second_private = _parse_tmuxp_live_commands(second)
+    first_public = parse_tmuxp_live_commands(first)
+
+    assert first_private["expected"][0]["_match_key"] == second_private["expected"][0][
+        "_match_key"
+    ]
+    assert _supervisor_command_contract(first_private["expected"])[
+        "fingerprint"
+    ] != _supervisor_command_contract(second_private["expected"])["fingerprint"]
+    assert "_launch_command" not in first_public["expected"][0]
+    assert "/one" not in json.dumps(
+        _supervisor_command_contract(first_private["expected"]), sort_keys=True
+    )
+
+
+def test_live_restart_executor_cli_requires_explicit_execute(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_restart_executor.main(
+            [
+                "bots.yaml",
+                "--session-name",
+                "passivbot",
+                "--expected-supervisor-fingerprint",
+                FINGERPRINT,
+            ]
+        )
+    assert exc_info.value.code == 2
+    assert "--execute is required" in capsys.readouterr().err
+
+
+def test_live_restart_executor_cli_outputs_sanitized_report(monkeypatch, capsys):
+    monkeypatch.setattr(
+        live_restart_executor,
+        "execute_live_restart",
+        lambda *_args, **_kwargs: {"tool": "live-restart-executor", "ok": True},
+    )
+
+    exit_code = live_restart_executor.main(
+        [
+            "bots.yaml",
+            "--session-name",
+            "passivbot",
+            "--expected-supervisor-fingerprint",
+            FINGERPRINT,
+            "--execute",
+            "--compact",
+        ]
+    )
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "ok": True,
+        "tool": "live-restart-executor",
+    }
+
+
+def test_live_restart_executor_tool_dispatch_forwards_module(monkeypatch):
+    captured = {}
+
+    def fake_invoke_module_main(module_name):
+        captured["module_name"] = module_name
+        captured["argv"] = sys.argv[:]
+        captured["prog_env"] = os.environ.get("PASSIVBOT_CLI_PROG")
+        return True, 0
+
+    monkeypatch.setattr(cli_main, "_invoke_module_main", fake_invoke_module_main)
+    monkeypatch.setattr(cli_main, "_missing_full_install_markers", lambda: [])
+
+    assert (
+        cli_main.main(
+            [
+                "tool",
+                "live-restart-executor",
+                "bots.yaml",
+                "--session-name",
+                "passivbot",
+                "--expected-supervisor-fingerprint",
+                FINGERPRINT,
+                "--execute",
+            ]
+        )
+        == 0
+    )
+    assert captured == {
+        "module_name": "tools.live_restart_executor",
+        "argv": [
+            "passivbot tool live-restart-executor",
+            "bots.yaml",
+            "--session-name",
+            "passivbot",
+            "--expected-supervisor-fingerprint",
+            FINGERPRINT,
+            "--execute",
+        ],
+        "prog_env": "passivbot tool live-restart-executor",
+    }

--- a/tests/test_live_restart_executor.py
+++ b/tests/test_live_restart_executor.py
@@ -300,6 +300,75 @@ def test_live_restart_executor_halts_relaunch_when_process_reappears(monkeypatch
     assert calls["start"] == []
 
 
+def test_live_restart_executor_rechecks_processes_immediately_before_relaunch(
+    monkeypatch,
+):
+    calls = _install_happy_dependencies(
+        monkeypatch, [_target("binance_01", "%10", 100, 200)]
+    )
+    rechecks = iter(
+        [
+            (True, None),
+            (False, "configured_process_count_changed"),
+        ]
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "_post_stop_process_recheck",
+        lambda *_args, **_kwargs: next(rechecks),
+    )
+
+    report = _execute()
+
+    assert report["outcome"] == "manual_recovery_required"
+    assert {issue["code"] for issue in report["issues"]} == {
+        "process_changed_before_relaunch"
+    }
+    assert calls["start"] == []
+
+
+def test_live_restart_executor_rechecks_supervisor_before_relaunch(monkeypatch):
+    targets = [_target("binance_01", "%10", 100, 200)]
+    calls = _install_happy_dependencies(monkeypatch, targets)
+    snapshots = iter(
+        [
+            (
+                {
+                    "binance_01": {
+                        "command": "private launch binance_01",
+                        "match_key": "passivbot live binance_01",
+                    }
+                },
+                FINGERPRINT,
+                None,
+            ),
+            (
+                {
+                    "binance_01": {
+                        "command": "changed private launch",
+                        "match_key": "passivbot live binance_01",
+                    }
+                },
+                "b" * 64,
+                None,
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "_load_launch_snapshot",
+        lambda _path: next(snapshots),
+    )
+
+    report = _execute()
+
+    assert report["outcome"] == "manual_recovery_required"
+    assert {issue["code"] for issue in report["issues"]} == {
+        "supervisor_changed_before_relaunch"
+    }
+    assert calls["start"] == []
+
+
 def test_live_restart_executor_rejects_target_change_after_preflight(monkeypatch):
     targets = [_target("binance_01", "%10", 100, 200)]
     calls = _install_happy_dependencies(monkeypatch, targets)


### PR DESCRIPTION
## Scope

Category: restart/deploy behavior.

Adds a local exact-target graceful restart executor over the already-merged target/fingerprint contract.

- requires `--execute`, exact tmux session, and caller-confirmed full supervisor-command fingerprint
- repeats a stable sampled preflight and immediate target identity snapshot
- sends one Ctrl-C round only to exact verified pane IDs
- waits a bounded time for exact process PIDs
- rechecks configured/unexpected live processes, full session pane set, pane parents, window identities, and shell readiness
- immediately re-reads the private supervisor snapshot and process set before relaunch
- relaunches only exited targets by typing private supervisor commands into exact panes
- requires startup plus stable final target/fingerprint verification
- reports changed/partial state as manual recovery

The configured commands remain private and are excluded from public reports.

## Non-goals

- no SSH or remote-host orchestration
- no git pull or Rust rebuild
- no direct exchange or credential access
- no broad process-pattern signals
- no automatic SIGTERM/SIGKILL escalation
- no integrated monitor/log smoke execution
- no trading-path or Rust behavior change

Relaunched live bots resume their configured exchange access and normal runtime file writes; the executor itself performs neither directly.

## VPS action

After merge: pull and verify CLI/help plus a local-only target report. No bot restart or process signal is required to deploy this tool.

This PR records the completed PR #1293 deployment: exact five-pane restart, preserved `misc:0.0`, fresh hard-green recovery smoke, and final 3/3 stable target report.

## Validation

- full Python suite: passed on integrated predecessor `77a94d4550` after repository-helper rebuild/stamp of the current Rust extension
- current-head focused executor/target/planner/smoke suite: 186 passed
- current-head executor unit tests: 17 passed
- `cargo test --no-default-features`: 210 passed
- `cargo check --tests`: passed
- current-head `python -m py_compile` on changed Python/tests: passed
- current-head `git diff --check`: passed
- runtime extension fingerprint verification: exact source/runtime stamp match

Initial full-suite collection failures were caused by the shared venv's stale unstamped Rust artifact. Rebuilding through `rust_utils.check_and_maybe_compile(force=True)` fixed the environment guard; the unchanged integrated suite then passed.

## Reviewer focus

- fail-closed behavior after partial shutdown or target drift
- process/pane/config TOCTOU checks, including the immediate pre-relaunch rechecks
- no duplicate relaunch when a configured process reappears
- private command containment
- bounded shutdown/startup behavior and absence of force escalation
