### PR TITLE
Bind live restart execution to repository runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ All notable user-facing changes will be documented in this file.
 
 - Added `passivbot tool live-restart-executor`, an explicit local executor for
   exact tmux targets that already pass the bounded stable target report. It
-  requires the expected full supervisor-command fingerprint and `--execute`,
+  requires the expected Git commit, a tracked-clean checkout, a Rust extension
+  stamped for the current Rust sources, the expected full supervisor-command
+  fingerprint, and `--execute`,
   sends one Ctrl-C round only to verified panes, waits a bounded time for exact
-  process exits, rechecks the private supervisor snapshot plus pane/process
-  identity before typing launch commands, and verifies stable replacements. It
-  never pulls code or applies
+  process exits, rechecks repository/runtime artifacts plus the private
+  supervisor snapshot and pane/process identity before typing launch commands,
+  and verifies stable replacements. It never pulls or builds code or applies
   an automatic force signal; partial or changed state fails closed for manual
   recovery.
 

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,8 +24,9 @@ Estimated completion:
 
 - Branch: `codex/restart-executor-runtime-contract`, based on canonical
   `7b833471c1e770ceb8650a4c3b395713b6a76dcb` after PR #1297.
-- PR: pending. Slice: bind the local restart executor to the intended repository
-  and compiled Rust runtime before any process action.
+- PR: #1298, `Bind live restart execution to repository runtime`. Slice: bind
+  the local restart executor to the intended repository and compiled Rust
+  runtime before any process action.
 - Triggering evidence: PR #1297 proved exact local stop/relaunch mechanics but
   did not verify that the executor was running from the intended clean commit
   or that the importable Rust extension matched that checkout's Rust sources.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,38 +22,40 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/local-graceful-restart-executor`, integrated with canonical
-  `0f366b6f6e6b05ab0bd748b012c2c86ed85f978c` after PR #1293.
-- PR: #1297, `Add exact-target graceful restart executor`. Slice: execute the
-  already-reviewed exact-target restart contract locally without adding remote
-  deployment or force-escalation behavior.
-- Triggering evidence: PRs #1287-#1294 established exact pane/process ownership,
-  stable sampled identities, pane-parent relaunch readiness, and an opaque
-  fingerprint over complete private supervisor commands. VPS5 deployment of
-  PR #1293 then exercised the same manual contract successfully for all five
-  configured panes.
-- Scope: require explicit `--execute`, exact session name, expected supervisor
-  fingerprint, stable sampled preflight, and an immediate action snapshot;
-  send one Ctrl-C round only to exact panes; wait for exact PIDs; recheck the
-  process set, pane set, pane parents, and shell readiness; relaunch only exited
-  targets from private commands; and require stable final verification.
+- Branch: `codex/restart-executor-runtime-contract`, based on canonical
+  `7b833471c1e770ceb8650a4c3b395713b6a76dcb` after PR #1297.
+- PR: pending. Slice: bind the local restart executor to the intended repository
+  and compiled Rust runtime before any process action.
+- Triggering evidence: PR #1297 proved exact local stop/relaunch mechanics but
+  did not verify that the executor was running from the intended clean commit
+  or that the importable Rust extension matched that checkout's Rust sources.
+- Scope: require an exact expected 40-character repository head, zero tracked
+  changes, and an exact Rust source-fingerprint stamp; repeat the contract
+  immediately before the first signal and before relaunch; preserve untracked
+  artifacts and keep paths and launch commands out of the report.
 - Behavior boundary: local restart/deploy behavior. The executor does not SSH,
   pull/build code, contact exchanges directly, write files directly, use broad
   process-pattern signals, or apply automatic SIGTERM/SIGKILL. Relaunched live
   bots resume their configured exchange access and normal runtime file writes.
-- Validation: focused executor, target-report, planner, smoke-report, CLI,
-  command secrecy, timeout, duplicate-process, TOCTOU, compilation, and docs
-  regressions.
+- Validation: focused runtime-contract, executor, target-report, planner,
+  smoke-report, CLI, secrecy, timeout, duplicate-process, TOCTOU, compilation,
+  and docs regressions.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: pull, verify CLI/help plus a local-only target report,
-  and leave running bots unchanged. The new executor itself does not require a
-  restart to become available for a later authorized deployment.
+- Expected VPS action: pull and exercise only the executor's fail-closed
+  pre-action contract with a deliberately wrong expected head; leave running
+  bots unchanged.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `0f366b6f6e6b05ab0bd748b012c2c86ed85f978c`, PR #1293. PR #1294 first
+  `7b833471c1e770ceb8650a4c3b395713b6a76dcb`, PR #1297. VPS5 fast-forwarded
+  cleanly from `0f366b6f` without a restart or process signal. The executor CLI
+  and help loaded successfully; a post-deploy 3/3 target report was hard-green
+  with all five exact targets relaunch-ready, zero issues, and the same private
+  command fingerprint. Bot PIDs `1015403/1015406/1015410/1015412/1015414`, pane
+  parents, and unrelated `misc:0.0` PID `434835` remained unchanged.
+- PR #1294 first
   fast-forwarded cleanly as `3de024c76d5c07bda2b4e64400c1a204d6be38a8`
   and produced a hard-green 3/3 stable target report with all five targets,
   zero issues, fingerprint

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,24 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PRs #1294 And #1293)
+## Latest Canonical Deployment (PR #1297)
+
+- PR #1297 merged as `7b833471c1e770ceb8650a4c3b395713b6a76dcb`
+  after exact-head Hermes approval and green Python/Rust CI. It added the first
+  local exact-target graceful restart executor over the previously proven pane,
+  process, relaunch, and private supervisor-fingerprint contracts.
+- VPS5 fast-forwarded cleanly from `0f366b6f` without a restart or process
+  signal. The executor CLI/help loaded, and the post-deploy 3/3 target report
+  was hard-green with all five exact targets relaunch-ready, zero issues, and
+  the unchanged private command fingerprint. Bot PIDs
+  `1015403/1015406/1015410/1015412/1015414`, all pane parents, and unrelated
+  `misc:0.0` PID `434835` remained unchanged.
+- The active follow-up binds restart authorization to the intended clean Git
+  head and an exactly source-matched Rust extension before any signal and again
+  before relaunch. No exchange request, process action, or event was
+  manufactured during the PR #1297 deployment.
+
+## Previous Canonical Deployment (PRs #1294 And #1293)
 
 - PR #1294 merged as `3de024c76d5c07bda2b4e64400c1a204d6be38a8`
   and moved the restart supervisor fingerprint to complete private commands
@@ -40,9 +57,9 @@ merge, live smoke evidence changes, or new gaps are discovered.
   reached `R=4,S=1`; the final target report retained 3/3 stable samples, all
   five relaunch paths, zero issues, and the same fingerprint. No direct
   exchange probe or event was manufactured.
-- The active follow-up implements the first local exact-target executor over
-  this proven contract. It excludes SSH, git pull/build, direct exchange access,
-  automatic force escalation, and integrated post-restart smoke orchestration.
+- The local exact-target executor followed in PR #1297. It excludes SSH, git
+  pull/build, direct exchange access, automatic force escalation, and integrated
+  post-restart smoke orchestration.
 
 ## Previous Canonical Deployment (PR #1277)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -418,23 +418,29 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   `relaunch_ready_targets == resolved_targets` in addition to the hard-green
   stable sampling verdict.
 - `passivbot tool live-restart-executor SUPERVISOR_CONFIG --session-name
-  SESSION --expected-supervisor-fingerprint SHA256 --execute` gracefully
+  SESSION --expected-repository-head COMMIT
+  --expected-supervisor-fingerprint SHA256 --execute` gracefully
   restarts only the exact local tmux targets proven by the same bounded target
-  contract. It repeats the sampled preflight, requires the caller-confirmed
+  contract. Before target sampling it requires the exact caller-confirmed
+  40-character Git commit, zero tracked changes while preserving untracked
+  artifacts, and a loaded Rust extension whose source stamp exactly matches the
+  checked-out Rust sources. It repeats that runtime contract immediately before
+  the first signal and before relaunch. It also requires the caller-confirmed
   full-command fingerprint, takes an immediate action snapshot, and sends one
   Ctrl-C round to exact pane IDs. After a bounded exact-PID exit wait, it scans
   for unexpected or duplicate live processes, verifies the complete session
   pane set, parent PIDs, window identities, and shell-ready exited panes, then
-  immediately re-reads the private supervisor snapshot and process set before
-  typing commands only into eligible panes. Final startup and multi-sample
-  target verification must retain the same fingerprint.
+  immediately re-reads the runtime contract, private supervisor snapshot, and
+  process set before typing commands only into eligible panes. Final startup
+  and multi-sample target verification must retain the same fingerprint.
   The executor does not SSH, pull code, contact exchanges directly, write files
   directly, use broad process-pattern signals, or apply SIGTERM/SIGKILL. A
-  timeout or changed process/pane contract is reported as manual recovery;
-  targets that did exit may be relaunched only when every post-stop check is
-  still exact. The relaunched live bots resume their configured exchange access
-  and normal runtime file writes. Run the read-only target report first and
-  pass its exact opaque fingerprint; command content is never emitted.
+  timeout or changed runtime/process/pane contract is reported as manual
+  recovery; targets that did exit may be relaunched only when every post-stop
+  check is still exact. The relaunched live bots resume their configured
+  exchange access and normal runtime file writes. Run the read-only target
+  report first and pass its exact opaque fingerprint; command content is never
+  emitted.
 - `passivbot tool live-performance-report` summarizes local live monitor event timings for
   operator performance analysis. It is read-only and does not contact exchanges. Use
   `--recent-minutes` for a time window, `--summary` for a bounded operator projection, and

--- a/src/live/restart_executor.py
+++ b/src/live/restart_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import math
 import os
 import subprocess
@@ -19,6 +20,7 @@ from live.smoke_report import (
     _running_live_processes,
     _supervisor_command_contract,
 )
+from rust_utils import source_fingerprint, verify_loaded_runtime_extension
 
 
 DEFAULT_PREFLIGHT_SAMPLES = 3
@@ -54,6 +56,9 @@ SAFETY_CONTRACT = {
     "broad_process_pattern_signals": False,
     "requires_execute_confirmation": True,
     "requires_expected_supervisor_fingerprint": True,
+    "requires_expected_repository_head": True,
+    "requires_tracked_clean_repository": True,
+    "requires_source_matched_rust_extension": True,
 }
 
 
@@ -98,8 +103,132 @@ def _valid_fingerprint(value: str) -> str:
     return fingerprint
 
 
+def _valid_repository_head(value: str) -> str:
+    head = str(value or "").strip()
+    if len(head) != 40 or any(
+        character not in "0123456789abcdef" for character in head
+    ):
+        raise ValueError(
+            "expected_repository_head must be 40 lowercase hex characters"
+        )
+    return head
+
+
 def _issue(code: str, **fields: Any) -> dict[str, Any]:
     return {"code": code, "severity": "error", **fields}
+
+
+def _git_contract_output(arguments: list[str]) -> tuple[str | None, str | None]:
+    try:
+        result = subprocess.run(
+            ["git", *arguments],
+            cwd=Path.cwd(),
+            capture_output=True,
+            text=True,
+            timeout=10.0,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return None, f"git_failed:{exc.__class__.__name__}"
+    if result.returncode != 0:
+        return None, "git_failed"
+    return result.stdout.strip(), None
+
+
+def _build_runtime_contract(expected_repository_head: str) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "ok": False,
+        "expected_repository_head": expected_repository_head,
+        "observed_repository_head": None,
+        "tracked_clean": None,
+        "tracked_changes": None,
+        "repository_snapshot_stable": None,
+        "rust_extension": {
+            "loaded": False,
+            "source_fingerprint": None,
+            "compiled_source_stamp": None,
+            "compiled_sha256": None,
+            "source_matched": False,
+        },
+        "issues": [],
+    }
+    issues: list[str] = report["issues"]
+
+    root_output, error = _git_contract_output(["rev-parse", "--show-toplevel"])
+    if error is not None or not root_output:
+        issues.append("repository_unavailable")
+        return report
+    root = Path(root_output).resolve()
+
+    head, error = _git_contract_output(["rev-parse", "HEAD"])
+    if error is not None or head is None:
+        issues.append("repository_head_unavailable")
+        return report
+    report["observed_repository_head"] = head
+    if head != expected_repository_head:
+        issues.append("repository_head_mismatch")
+
+    status, error = _git_contract_output(
+        ["status", "--porcelain", "--untracked-files=no"]
+    )
+    if error is not None or status is None:
+        issues.append("repository_status_unavailable")
+        return report
+    changes = [line for line in status.splitlines() if line.strip()]
+    report["tracked_clean"] = not changes
+    report["tracked_changes"] = len(changes)
+    if changes:
+        issues.append("repository_tracked_dirty")
+
+    try:
+        fingerprint = source_fingerprint(root / "passivbot-rust")
+    except OSError as exc:
+        report["rust_extension"]["error_class"] = exc.__class__.__name__
+        issues.append("rust_source_fingerprint_unavailable")
+        return report
+    rust_report = report["rust_extension"]
+    rust_report["source_fingerprint"] = fingerprint
+    if fingerprint is None:
+        issues.append("rust_source_fingerprint_unavailable")
+        return report
+
+    try:
+        importlib.import_module("passivbot_rust")
+        runtime = verify_loaded_runtime_extension(fingerprint=fingerprint)
+    except (ImportError, OSError, RuntimeError, ValueError) as exc:
+        rust_report["error_class"] = exc.__class__.__name__
+        issues.append("rust_extension_verification_failed")
+        return report
+
+    compiled_stamp = runtime.get("runtime_compiled_source_stamp")
+    rust_report.update(
+        {
+            "loaded": True,
+            "compiled_source_stamp": compiled_stamp,
+            "compiled_sha256": runtime.get("runtime_compiled_sha256"),
+            "source_matched": compiled_stamp == fingerprint,
+        }
+    )
+    if compiled_stamp != fingerprint:
+        issues.append("rust_extension_source_mismatch")
+
+    final_head, head_error = _git_contract_output(["rev-parse", "HEAD"])
+    final_status, status_error = _git_contract_output(
+        ["status", "--porcelain", "--untracked-files=no"]
+    )
+    if head_error is not None or status_error is not None:
+        issues.append("repository_recheck_unavailable")
+    else:
+        final_changes = [
+            line for line in (final_status or "").splitlines() if line.strip()
+        ]
+        snapshot_stable = final_head == head and final_changes == changes
+        report["repository_snapshot_stable"] = snapshot_stable
+        if not snapshot_stable:
+            issues.append("repository_changed_during_runtime_check")
+
+    report["ok"] = not issues
+    return report
 
 
 def _preflight_summary(report: dict[str, Any]) -> dict[str, Any]:
@@ -346,6 +475,7 @@ def execute_live_restart(
     *,
     session_name: str,
     expected_supervisor_fingerprint: str,
+    expected_repository_head: str,
     config_base_dir: Path | None = None,
     preflight_samples: int = DEFAULT_PREFLIGHT_SAMPLES,
     preflight_interval_s: float = DEFAULT_PREFLIGHT_INTERVAL_S,
@@ -362,6 +492,7 @@ def execute_live_restart(
     if not confirmed_session:
         raise ValueError("session_name must be non-empty")
     expected_fingerprint = _valid_fingerprint(expected_supervisor_fingerprint)
+    expected_head = _valid_repository_head(expected_repository_head)
     preflight_samples = _bounded_samples(
         preflight_samples, field="preflight_samples"
     )
@@ -384,26 +515,35 @@ def execute_live_restart(
         poll_interval_s, field="poll_interval_s"
     )
 
-    preflight = build_live_restart_target_report(
-        supervisor_config,
-        session_name=confirmed_session,
-        config_base_dir=config_base_dir,
-        samples=preflight_samples,
-        sample_interval_s=preflight_interval_s,
-    )
+    runtime_contract = _build_runtime_contract(expected_head)
+    preflight: dict[str, Any] = {}
+    if runtime_contract["ok"]:
+        preflight = build_live_restart_target_report(
+            supervisor_config,
+            session_name=confirmed_session,
+            config_base_dir=config_base_dir,
+            samples=preflight_samples,
+            sample_interval_s=preflight_interval_s,
+        )
     report: dict[str, Any] = {
         "tool": "live-restart-executor",
-        "schema_version": 1,
+        "schema_version": 2,
         "ok": False,
         "outcome": "preflight_failed",
         "action_started": False,
         "session_name": confirmed_session,
         "safety": dict(SAFETY_CONTRACT),
+        "runtime_contract": runtime_contract,
         "preflight": _preflight_summary(preflight),
         "issues": [],
         "targets": [],
     }
     issues: list[dict[str, Any]] = report["issues"]
+    if not runtime_contract["ok"]:
+        issues.extend(_issue(code) for code in runtime_contract["issues"])
+        report["hard_failures"] = len(issues)
+        return report
+
     sampling = preflight.get("sampling") or {}
     resolved_targets = int(preflight.get("resolved_targets") or 0)
     if (
@@ -464,6 +604,16 @@ def execute_live_restart(
         report["hard_failures"] = len(issues)
         return report
     report["action_snapshot"] = _preflight_summary(action_snapshot)
+
+    action_runtime_contract = _build_runtime_contract(expected_head)
+    report["action_runtime_contract"] = action_runtime_contract
+    if (
+        not action_runtime_contract["ok"]
+        or action_runtime_contract != runtime_contract
+    ):
+        issues.append(_issue("runtime_contract_changed_after_preflight"))
+        report["hard_failures"] = len(issues)
+        return report
 
     target_results: list[dict[str, Any]] = []
     result_by_pid: dict[int, dict[str, Any]] = {}
@@ -591,6 +741,18 @@ def execute_live_restart(
         issues.append(
             _issue("process_changed_before_relaunch", reason=process_error)
         )
+        report["targets"] = target_results
+        report["hard_failures"] = len(issues)
+        report["outcome"] = "manual_recovery_required"
+        return report
+
+    relaunch_runtime_contract = _build_runtime_contract(expected_head)
+    report["pre_relaunch_runtime_contract"] = relaunch_runtime_contract
+    if (
+        not relaunch_runtime_contract["ok"]
+        or relaunch_runtime_contract != runtime_contract
+    ):
+        issues.append(_issue("runtime_contract_changed_before_relaunch"))
         report["targets"] = target_results
         report["hard_failures"] = len(issues)
         report["outcome"] = "manual_recovery_required"

--- a/src/tools/live_restart_executor.py
+++ b/src/tools/live_restart_executor.py
@@ -17,7 +17,8 @@ def build_parser() -> argparse.ArgumentParser:
         prog="passivbot tool live-restart-executor",
         description=(
             "Gracefully restart exact verified local tmux targets. This tool "
-            "does not pull code or use automatic force signals."
+            "requires a clean expected repository/runtime and does not pull or "
+            "build code or use automatic force signals."
         ),
     )
     parser.add_argument("supervisor_config", help="Tmuxp-style supervisor config.")
@@ -26,6 +27,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--expected-supervisor-fingerprint",
         required=True,
         help="Exact lowercase SHA-256 fingerprint from the target preflight.",
+    )
+    parser.add_argument(
+        "--expected-repository-head",
+        required=True,
+        help="Exact 40-character lowercase Git commit expected at execution.",
     )
     parser.add_argument(
         "--execute",
@@ -53,6 +59,7 @@ def main(argv: list[str] | None = None) -> int:
             args.supervisor_config,
             session_name=args.session_name,
             expected_supervisor_fingerprint=args.expected_supervisor_fingerprint,
+            expected_repository_head=args.expected_repository_head,
             config_base_dir=Path.cwd(),
             preflight_samples=args.preflight_samples,
             preflight_interval_s=args.preflight_interval_s,

--- a/tests/test_live_restart_executor.py
+++ b/tests/test_live_restart_executor.py
@@ -20,6 +20,27 @@ from tools import live_restart_executor
 
 
 FINGERPRINT = "a" * 64
+REPOSITORY_HEAD = "b" * 40
+
+
+def _runtime_contract(*, ok: bool = True, issue: str | None = None) -> dict:
+    fingerprint = "c" * 64
+    return {
+        "ok": ok,
+        "expected_repository_head": REPOSITORY_HEAD,
+        "observed_repository_head": REPOSITORY_HEAD,
+        "tracked_clean": True,
+        "tracked_changes": 0,
+        "repository_snapshot_stable": True,
+        "rust_extension": {
+            "loaded": True,
+            "source_fingerprint": fingerprint,
+            "compiled_source_stamp": fingerprint,
+            "compiled_sha256": "d" * 64,
+            "source_matched": True,
+        },
+        "issues": [issue] if issue else [],
+    }
 
 
 def _target(
@@ -88,6 +109,11 @@ def _install_happy_dependencies(monkeypatch, targets: list[dict]) -> dict:
     monkeypatch.setattr(executor_module, "build_live_restart_target_report", build_report)
     monkeypatch.setattr(
         executor_module,
+        "_build_runtime_contract",
+        lambda _expected_head: _runtime_contract(),
+    )
+    monkeypatch.setattr(
+        executor_module,
         "_load_launch_snapshot",
         lambda _path: (
             {
@@ -138,20 +164,21 @@ def _install_happy_dependencies(monkeypatch, targets: list[dict]) -> dict:
 
 
 def _execute(**kwargs) -> dict:
-    return execute_live_restart(
-        "bots.yaml",
-        session_name="passivbot",
-        expected_supervisor_fingerprint=FINGERPRINT,
-        preflight_samples=2,
-        preflight_interval_s=0.1,
-        shutdown_timeout_s=1.0,
-        startup_timeout_s=1.0,
-        poll_interval_s=0.1,
-        verification_samples=2,
-        verification_interval_s=0.1,
-        execute=True,
-        **kwargs,
-    )
+    arguments = {
+        "session_name": "passivbot",
+        "expected_supervisor_fingerprint": FINGERPRINT,
+        "expected_repository_head": REPOSITORY_HEAD,
+        "preflight_samples": 2,
+        "preflight_interval_s": 0.1,
+        "shutdown_timeout_s": 1.0,
+        "startup_timeout_s": 1.0,
+        "poll_interval_s": 0.1,
+        "verification_samples": 2,
+        "verification_interval_s": 0.1,
+        "execute": True,
+    }
+    arguments.update(kwargs)
+    return execute_live_restart("bots.yaml", **arguments)
 
 
 def test_live_restart_executor_restarts_only_exact_verified_panes(monkeypatch):
@@ -164,6 +191,7 @@ def test_live_restart_executor_restarts_only_exact_verified_panes(monkeypatch):
     report = _execute()
 
     assert report["ok"] is True
+    assert report["schema_version"] == 2
     assert report["outcome"] == "completed"
     assert calls["stop"] == ["%10", "%11"]
     assert calls["start"] == [
@@ -179,6 +207,9 @@ def test_live_restart_executor_restarts_only_exact_verified_panes(monkeypatch):
     assert report["safety"]["direct_file_writes"] is False
     assert report["safety"]["configured_live_processes_may_write_files"] is True
     assert report["safety"]["configured_live_processes_may_contact_exchanges"] is True
+    assert report["safety"]["requires_expected_repository_head"] is True
+    assert report["safety"]["requires_tracked_clean_repository"] is True
+    assert report["safety"]["requires_source_matched_rust_extension"] is True
 
 
 def test_live_restart_executor_fails_closed_before_action_on_fingerprint_mismatch(
@@ -192,6 +223,7 @@ def test_live_restart_executor_fails_closed_before_action_on_fingerprint_mismatc
         "bots.yaml",
         session_name="passivbot",
         expected_supervisor_fingerprint="b" * 64,
+        expected_repository_head=REPOSITORY_HEAD,
         preflight_samples=2,
         preflight_interval_s=0.1,
         execute=True,
@@ -203,6 +235,97 @@ def test_live_restart_executor_fails_closed_before_action_on_fingerprint_mismatc
         "supervisor_fingerprint_mismatch"
     }
     assert calls["stop"] == []
+    assert calls["start"] == []
+
+
+def test_live_restart_executor_requires_full_lowercase_repository_head(monkeypatch):
+    calls = _install_happy_dependencies(
+        monkeypatch, [_target("binance_01", "%10", 100, 200)]
+    )
+
+    with pytest.raises(ValueError, match="40 lowercase hex"):
+        _execute(expected_repository_head="abc123")
+
+    assert calls["reports"] == []
+    assert calls["stop"] == []
+
+
+@pytest.mark.parametrize(
+    "issue",
+    [
+        "repository_head_mismatch",
+        "repository_tracked_dirty",
+        "rust_extension_source_mismatch",
+    ],
+)
+def test_live_restart_executor_fails_before_target_preflight_on_runtime_contract(
+    monkeypatch, issue
+):
+    calls = _install_happy_dependencies(
+        monkeypatch, [_target("binance_01", "%10", 100, 200)]
+    )
+    failed = _runtime_contract(ok=False, issue=issue)
+    if issue == "repository_head_mismatch":
+        failed["observed_repository_head"] = "e" * 40
+    elif issue == "repository_tracked_dirty":
+        failed["tracked_clean"] = False
+        failed["tracked_changes"] = 1
+    else:
+        failed["rust_extension"]["source_matched"] = False
+        failed["rust_extension"]["compiled_source_stamp"] = "e" * 64
+    monkeypatch.setattr(
+        executor_module, "_build_runtime_contract", lambda _head: failed
+    )
+
+    report = _execute()
+
+    assert report["action_started"] is False
+    assert {row["code"] for row in report["issues"]} == {issue}
+    assert calls["reports"] == []
+    assert calls["stop"] == []
+    assert calls["start"] == []
+
+
+def test_live_restart_executor_rechecks_runtime_before_first_signal(monkeypatch):
+    calls = _install_happy_dependencies(
+        monkeypatch, [_target("binance_01", "%10", 100, 200)]
+    )
+    changed = _runtime_contract(ok=False, issue="repository_tracked_dirty")
+    changed["tracked_clean"] = False
+    changed["tracked_changes"] = 1
+    contracts = iter([_runtime_contract(), changed])
+    monkeypatch.setattr(
+        executor_module, "_build_runtime_contract", lambda _head: next(contracts)
+    )
+
+    report = _execute()
+
+    assert report["action_started"] is False
+    assert {row["code"] for row in report["issues"]} == {
+        "runtime_contract_changed_after_preflight"
+    }
+    assert calls["stop"] == []
+
+
+def test_live_restart_executor_halts_relaunch_on_runtime_drift(monkeypatch):
+    calls = _install_happy_dependencies(
+        monkeypatch, [_target("binance_01", "%10", 100, 200)]
+    )
+    changed = _runtime_contract(ok=False, issue="rust_extension_source_mismatch")
+    changed["rust_extension"]["source_matched"] = False
+    changed["rust_extension"]["compiled_source_stamp"] = "e" * 64
+    contracts = iter([_runtime_contract(), _runtime_contract(), changed])
+    monkeypatch.setattr(
+        executor_module, "_build_runtime_contract", lambda _head: next(contracts)
+    )
+
+    report = _execute()
+
+    assert report["outcome"] == "manual_recovery_required"
+    assert {row["code"] for row in report["issues"]} == {
+        "runtime_contract_changed_before_relaunch"
+    }
+    assert calls["stop"] == ["%10"]
     assert calls["start"] == []
 
 
@@ -548,6 +671,77 @@ def test_private_launch_source_changes_fingerprint_without_public_exposure(tmp_p
     )
 
 
+def test_runtime_contract_binds_clean_head_and_exact_rust_source_stamp(monkeypatch):
+    fingerprint = "c" * 64
+
+    def git_output(arguments):
+        if arguments == ["rev-parse", "--show-toplevel"]:
+            return "/private/repository", None
+        if arguments == ["rev-parse", "HEAD"]:
+            return REPOSITORY_HEAD, None
+        if arguments == ["status", "--porcelain", "--untracked-files=no"]:
+            return "", None
+        raise AssertionError(arguments)
+
+    monkeypatch.setattr(executor_module, "_git_contract_output", git_output)
+    monkeypatch.setattr(
+        executor_module, "source_fingerprint", lambda _root: fingerprint
+    )
+    monkeypatch.setattr(
+        executor_module.importlib, "import_module", lambda _name: object()
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "verify_loaded_runtime_extension",
+        lambda **_kwargs: {
+            "runtime_compiled_path": "/private/runtime.so",
+            "runtime_compiled_sha256": "d" * 64,
+            "runtime_compiled_source_stamp": fingerprint,
+        },
+    )
+
+    report = executor_module._build_runtime_contract(REPOSITORY_HEAD)
+
+    assert report["ok"] is True
+    assert report["tracked_clean"] is True
+    assert report["repository_snapshot_stable"] is True
+    assert report["rust_extension"]["source_matched"] is True
+    assert "/private/" not in json.dumps(report, sort_keys=True)
+
+
+def test_runtime_contract_rejects_unstamped_rust_extension(monkeypatch):
+    fingerprint = "c" * 64
+    monkeypatch.setattr(
+        executor_module,
+        "_git_contract_output",
+        lambda arguments: (
+            ("/repository" if arguments[-1] == "--show-toplevel" else REPOSITORY_HEAD)
+            if arguments[0] == "rev-parse"
+            else "",
+            None,
+        ),
+    )
+    monkeypatch.setattr(
+        executor_module, "source_fingerprint", lambda _root: fingerprint
+    )
+    monkeypatch.setattr(
+        executor_module.importlib, "import_module", lambda _name: object()
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "verify_loaded_runtime_extension",
+        lambda **_kwargs: {
+            "runtime_compiled_sha256": "d" * 64,
+            "runtime_compiled_source_stamp": None,
+        },
+    )
+
+    report = executor_module._build_runtime_contract(REPOSITORY_HEAD)
+
+    assert report["ok"] is False
+    assert report["issues"] == ["rust_extension_source_mismatch"]
+
+
 def test_live_restart_executor_cli_requires_explicit_execute(capsys):
     with pytest.raises(SystemExit) as exc_info:
         live_restart_executor.main(
@@ -557,6 +751,8 @@ def test_live_restart_executor_cli_requires_explicit_execute(capsys):
                 "passivbot",
                 "--expected-supervisor-fingerprint",
                 FINGERPRINT,
+                "--expected-repository-head",
+                REPOSITORY_HEAD,
             ]
         )
     assert exc_info.value.code == 2
@@ -577,6 +773,8 @@ def test_live_restart_executor_cli_outputs_sanitized_report(monkeypatch, capsys)
             "passivbot",
             "--expected-supervisor-fingerprint",
             FINGERPRINT,
+            "--expected-repository-head",
+            REPOSITORY_HEAD,
             "--execute",
             "--compact",
         ]
@@ -611,6 +809,8 @@ def test_live_restart_executor_tool_dispatch_forwards_module(monkeypatch):
                 "passivbot",
                 "--expected-supervisor-fingerprint",
                 FINGERPRINT,
+                "--expected-repository-head",
+                REPOSITORY_HEAD,
                 "--execute",
             ]
         )
@@ -625,6 +825,8 @@ def test_live_restart_executor_tool_dispatch_forwards_module(monkeypatch):
             "passivbot",
             "--expected-supervisor-fingerprint",
             FINGERPRINT,
+            "--expected-repository-head",
+            REPOSITORY_HEAD,
             "--execute",
         ],
         "prog_env": "passivbot tool live-restart-executor",


### PR DESCRIPTION
## Scope

Category: restart/deploy behavior.

- Require `live-restart-executor` callers to provide the exact 40-character repository head.
- Fail before target sampling unless the checkout is at that head, has zero tracked changes, and the loaded Rust extension has an exact source-fingerprint stamp for the checked-out Rust sources.
- Repeat the repository/runtime contract immediately before the first signal and before relaunch.
- Preserve untracked configs, logs, and other local artifacts; keep repository paths and launch command content out of the report.
- Record the PR #1297 VPS5 deployment evidence in the logging-overhaul status and progress ledger.

## Non-goals

- No SSH, pull, build, force-signal, or broad process-pattern behavior.
- No direct exchange access, credential access, or manufactured trading/risk/state events.
- No integrated post-restart smoke orchestration.

## Behavior impact

Restart execution now fails closed when the local source/runtime cannot prove it is the intended deployment. Repository or compiled-artifact drift after bots stop requires manual recovery and does not type relaunch commands.

## Validation

- `25` executor tests passed.
- `193` focused executor/target/planner/smoke tests passed.
- Complete Python test suite passed after rebuilding and verifying the exact worktree Rust extension.
- Rust source stamp and expected fingerprint both matched `d14a53639580f0f28486811b611b9dea6e7558231781af243c0a36886c766130`.
- `cargo test --no-default-features`: `210` passed.
- `cargo check --tests` passed.
- `cargo fmt --all --check` passed.
- AI docs tests passed; `check_ai_docs.py` reported zero errors and the existing aggregate word-count warning.
- Clean committed-worktree runtime contract returned `ok=true`, exact head, zero tracked changes, a stable repository snapshot, and a source-matched Rust extension.
- `git diff --check` and Python compilation passed.

## Reviewer focus

- Fail-before-signal behavior for head, tracked-status, and extension-stamp mismatches.
- TOCTOU handling across the sampled target preflight and post-stop relaunch boundary.
- Report boundedness and path/command secrecy.
- Manual-recovery behavior when runtime drift is detected after exact PIDs exit.

## VPS action

Pull only. Exercise the deliberately wrong-expected-head path to prove it returns before target sampling or process action, then run the local-only stable target report. Do not restart bots for this deployment.
