### PR TITLE
Fix HSL episode flatten replay and cooldown anchoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
-- HSL replay now recognizes every fill-derived scope flatten as an episode
-  boundary, including close-and-reentry transitions within one replay minute
-  and compact coin replay without historical unrealized PnL. RED cooldowns
-  anchor to an episode-bounded flattening fill regardless of close order type;
-  when that fill is temporarily unavailable, live supervision performs a
-  rate-limited fill refresh and otherwise defers instead of using stale
+- HSL replay now recognizes every ordered, fill-derived scope flatten as an
+  episode boundary, including multiple close-and-reentry transitions within
+  one replay minute and compact coin replay without historical unrealized PnL.
+  RED cooldowns anchor to an episode-bounded flattening fill regardless of
+  close order type; when an initial or cooldown-repanic flatten fill is
+  temporarily unavailable, live supervision performs a rate-limited,
+  episode-bounded fill refresh and otherwise defers instead of using stale
   pre-episode evidence or inventing the current time.
 
 - Live trailing restart reconciliation now preserves authoritative position-update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ All notable user-facing changes will be documented in this file.
   close order type; when an initial or cooldown-repanic flatten fill is
   temporarily unavailable, live supervision performs a rate-limited,
   episode-bounded fill refresh and otherwise defers instead of using stale
-  pre-episode evidence or inventing the current time.
+  pre-episode evidence, intervention entries, partial closes, or an invented
+  current-time timestamp. Intra-minute replay also reconstructs the account
+  balance at each ordered episode boundary so later fills cannot change an
+  earlier episode's drawdown or no-restart outcome.
 
 - Added `passivbot tool live-restart-smoke-evidence`, a pure fail-closed
   evaluator for already-generated full restart target and smoke JSON reports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- HSL replay now recognizes every fill-derived scope flatten as an episode
+  boundary even when compact coin replay omits historical unrealized PnL. RED
+  cooldowns anchor to the actual flattening fill regardless of close order
+  type; if that fill is temporarily unavailable, live finalization defers
+  instead of inventing the current time.
+
 - Added `passivbot tool live-restart-executor`, an explicit local executor for
   exact tmux targets that already pass the bounded stable target report. It
   requires the expected Git commit, a tracked-clean checkout, a Rust extension

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -21,6 +21,7 @@ current task.
 | CCXT dependency upgrade | `runbooks/ccxt_upgrade.md` |
 | Rust/PyO3 build, extension loading, Rust tests | `runbooks/rust_extension.md` |
 | Strategy schema, order logic, risk, unstuck | `architecture.md`, `error_contract.md`, `features/strategy_runtime.md` |
+| Equity Hard Stop Loss episodes, replay, flattening, cooldown | `error_contract.md`, `features/equity_hard_stop_loss.md`, `features/fill_events_manager.md` |
 | Candles, OHLCV coverage, gaps, projections | `error_contract.md`, `features/candlestick_manager.md`; add `features/exchange_integrations.md` for remote fetch behavior |
 | Fill/PnL ingestion, fees, coverage | `error_contract.md`, `features/fill_events_manager.md`, relevant exchange contract |
 | Commands, tests, backtests, optimizer, execution safety | `runbooks/commands.md` |

--- a/docs/ai/features/README.md
+++ b/docs/ai/features/README.md
@@ -8,6 +8,7 @@ Open only the contract for the subsystem being changed.
 | Stock perpetuals (HIP-3) | `stock_perps.md` |
 | Candles, cache continuity, and projections | `candlestick_manager.md` |
 | Fill/PnL ingestion and coverage | `fill_events_manager.md` |
+| Equity Hard Stop Loss episodes and cooldown boundaries | `equity_hard_stop_loss.md` |
 | Raw versus snapped balance | `balance_routing.md` |
 | Monitor persistence, recovery, rotation, retention | `monitor_persistence.md` |
 | Monitor relay/dashboard | `monitor_relay.md` |

--- a/docs/ai/features/equity_hard_stop_loss.md
+++ b/docs/ai/features/equity_hard_stop_loss.md
@@ -17,11 +17,13 @@ HSL drawdown state is scoped by `live.hsl_signal_mode`:
 3. A RED-seen episode remains entry-blocked until its scope is confirmed flat. Its cooldown begins
    at the flattening fill, not at the RED sample, order submission, bot restart, or observation time.
 4. Compact replay derives non-flat/flat transitions from fill events independently of candle or
-   unrealized-PnL availability. Missing price replay may defer drawdown evaluation, but it must not
-   hide an episode boundary.
+   unrealized-PnL availability. Multiple boundaries inside one replay minute retain their exact
+   fill order, realized PnL, fees, and account balance at each boundary. Missing price replay may
+   defer drawdown evaluation, but it must not hide an episode boundary.
 5. Current flat state is not a timestamp. If the flattening fill is not yet available, live
    finalization and cooldown anchoring defer visibly while protective entry blocking remains active;
-   they never substitute the current time.
+   they never substitute the current time. Cooldown re-panic finalization must replay fills from a
+   proven non-flat intervention snapshot; an entry or partial-close fill is not flatten evidence.
 6. Restart reconstruction uses exchange state, fill/PnL history, candles where required, config, and
    current time. Local latch and replay-cache files are accelerators or diagnostics, not authority.
 

--- a/docs/ai/features/equity_hard_stop_loss.md
+++ b/docs/ai/features/equity_hard_stop_loss.md
@@ -1,0 +1,42 @@
+# Equity Hard Stop Loss Episode Contract
+
+HSL drawdown state is scoped by `live.hsl_signal_mode`:
+
+| Mode | Episode scope | Episode ends when |
+|---|---|---|
+| `coin` | one `coin+pside` | that position is fully closed |
+| `pside` | all positions on one `pside` | every position on that side is fully closed |
+| `unified` | the whole account | every position is fully closed |
+
+## Invariants
+
+1. The drawdown tracker resets after every proven episode end. The next episode begins after the
+   flattening fill timestamp.
+2. A flattening fill ends the episode regardless of its order type or origin. Panic, take-profit,
+   grid-close, manual, and external exchange fills have identical boundary semantics.
+3. A RED-seen episode remains entry-blocked until its scope is confirmed flat. Its cooldown begins
+   at the flattening fill, not at the RED sample, order submission, bot restart, or observation time.
+4. Compact replay derives non-flat/flat transitions from fill events independently of candle or
+   unrealized-PnL availability. Missing price replay may defer drawdown evaluation, but it must not
+   hide an episode boundary.
+5. Current flat state is not a timestamp. If the flattening fill is not yet available, live
+   finalization and cooldown anchoring defer visibly while protective entry blocking remains active;
+   they never substitute the current time.
+6. Restart reconstruction uses exchange state, fill/PnL history, candles where required, config, and
+   current time. Local latch and replay-cache files are accelerators or diagnostics, not authority.
+
+## Failure Semantics
+
+Incomplete fill coverage follows `../error_contract.md`. A required episode boundary is unavailable
+until supported by fill evidence. The affected HSL scope remains protective and retries after an
+authoritative refresh; unrelated scopes remain available.
+
+## Code And Tests
+
+- Replay and live finalization: `src/passivbot_hsl.py`
+- Live orchestration bindings: `src/passivbot.py`
+- Coin replay and cooldown regressions: `tests/test_hsl_coin_mode.py`
+- Pside/unified finalization coverage: `tests/test_unstucking_safeguards.py`
+
+User-facing behavior and configuration are documented in `../../equity_hard_stop_loss.md` and
+`../../equity_hard_stop_loss_cooldown_contracts.md`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,7 +152,7 @@ Each `pside` has the same parameter set:
 - **hsl_cooldown_minutes_after_red**:
   - Minutes to wait before auto-restart after a RED halt on that `pside`.
   - `0.0` means halt without auto-restart.
-  - Restart-time HSL replay treats a historical RED panic close that fully closed all positions on that `pside` as a completed RED stop and resets tracking from after that panic before evaluating later cooldown/restart behavior.
+  - HSL resets tracking after every fill that fully flattens the configured signal scope, regardless of order type. A RED-seen episode's cooldown begins at that flattening fill; restart replay reconstructs the same boundary before evaluating later behavior.
 - **hsl_no_restart_drawdown_threshold**:
   - Terminal no-restart threshold for that `pside`.
   - Evaluated from persistent cross-restart HSL drawdown.
@@ -423,7 +423,7 @@ See [docs/forager.md](forager.md) for a full description of motivation, ranking 
 - **execution_delay_seconds**: Wait `x` seconds after executing to exchange.
 - **hedge_mode**: Requests simultaneous long and short positions on the same coin when the exchange supports it. Effective behavior is `config.live.hedge_mode AND exchange_capability`; on one-way-only venues the live bot will still run one-way even if this is `true`.
 - **hsl_position_during_cooldown_policy**: Live-only policy for a position that appears on a halted `pside` during HSL RED cooldown.
-  - `panic`: panic-close it again and restart the cooldown after all positions on that `pside` are fully closed.
+  - `panic`: panic-close it again and restart the cooldown from the fill that fully flattens the configured HSL scope.
   - `normal`: treat it as an explicit operator override once a real open position appears during cooldown; while there are no open positions the bot still blocks fresh initials on that `pside`, and only after the position appears does it clear the halt and restart HSL drawdown tracking from the current state.
   - `manual`: leave that position in `manual` mode while keeping the original cooldown running and blocking fresh initials.
   - `tp_only`: keep the original cooldown running, block new entries, and allow only close management on that `pside`.

--- a/docs/equity_hard_stop_loss.md
+++ b/docs/equity_hard_stop_loss.md
@@ -137,24 +137,31 @@ The opposite `pside` can continue running if its own HSL remains green/orange/ye
 
 In both live and backtests, `hsl_no_restart_drawdown_threshold` is evaluated against persistent cross-restart HSL drawdown for that `pside`, not just the local RED-halt snapshot. Values below `hsl_red_threshold` are treated as `hsl_red_threshold`.
 
-### Restart Replay Contract
+### Episode And Restart Replay Contract
 
-The intended HSL contract after a valid RED panic is:
+An HSL episode ends when its configured scope becomes fully flat:
 
-1. once a `pside` panic-close has finalized and all positions on that `pside` are fully closed, that RED stop is considered complete
-2. that `pside`'s HSL equity tracker is then reset from after that panic
-3. any later cooldown, restart, and future RED decisions for that `pside` are measured from the post-panic state, not from pre-panic peaks
+1. `coin`: the affected `coin+pside` position is fully closed
+2. `pside`: all positions on that `pside` are fully closed
+3. `unified`: all account positions are fully closed
+
+Every episode end resets the scope's drawdown tracker after the flattening fill. The close may be a
+panic, take-profit, grid close, manual close, or other exchange fill. A panic order type is not
+required. If the episode saw RED, its cooldown begins at that same flattening fill.
 
 This contract applies both to live runtime and to restart-time history replay.
 
-In practical terms, restart replay must treat a historical RED panic close that fully closed all
-positions on that `pside` as a completed RED stop even if:
+In practical terms, restart replay must recognize any historical fill that fully flattened the
+configured scope as an episode boundary even if:
 
-1. the panic-close was split across multiple fills
+1. the close was split across multiple fills
 2. re-entry happened later in the same minute
 3. the old pre-panic drawdown would otherwise still be above the RED threshold
 
-Without this reset, a restarted bot could incorrectly inherit stale pre-panic peaks and repanic immediately after cooldown or after restart. `hsl_no_restart_drawdown_threshold` is the intended protection against repeated unfavorable restart cycles, not stale pre-panic equity tracking.
+Without this reset, a restarted bot could incorrectly inherit stale prior-episode peaks and enter a
+new cooldown after restart. Missing flatten-fill evidence defers finalization; current time is never
+used as a substitute episode boundary. `hsl_no_restart_drawdown_threshold` is the intended
+protection against repeated unfavorable restart cycles, not stale prior-episode equity tracking.
 
 ### Live Cooldown Intervention Policy
 
@@ -165,7 +172,7 @@ that is currently halted in RED cooldown.
 
 1. `panic`
    - panic-close that position immediately
-   - once all positions on that `pside` are fully closed, restart the cooldown timer from that new panic-close
+   - once the configured scope is fully closed, restart the cooldown timer from its flattening fill
    - this is the safest default
 2. `normal`
    - treat the position as an explicit operator override

--- a/docs/equity_hard_stop_loss_cooldown_contracts.md
+++ b/docs/equity_hard_stop_loss_cooldown_contracts.md
@@ -1,10 +1,9 @@
 # Equity Hard Stop Loss Cooldown Contracts
 
-This file defines the intended target contract for
+This file defines the contract for
 `live.hsl_position_during_cooldown_policy`.
 
-It is the normative spec for future implementation and regression tests. It may
-be stricter or cleaner than the current implementation at any given moment.
+It is the normative contract for implementation and regression tests.
 
 See also:
 
@@ -14,7 +13,7 @@ See also:
 
 ## Goal
 
-After a valid RED panic on one `pside`, restart behavior must be derivable from:
+After a RED-seen episode ends, restart behavior must be derivable from:
 
 1. current exchange state
 2. fill history
@@ -25,18 +24,22 @@ No local persistent marker may be required.
 
 ## Core Definitions
 
-For one `pside`, define:
+For the configured HSL scope, define:
 
-1. `P`
-   - latest `close_panic_{pside}` fill timestamp
+1. `F`
+   - the fill timestamp that made the scope fully flat
+   - the order type is irrelevant
 2. `cooldown_end`
-   - `P + hsl_cooldown_minutes_after_red`
+   - `F + hsl_cooldown_minutes_after_red`
 3. `E`
-   - first non-panic entry fill on that `pside` after `P`
-4. `all_positions_closed_now`
-   - exchange currently reports no open positions for that `pside`
+   - first entry fill in that scope after `F`
+4. `scope_flat_now`
+   - exchange currently reports no open positions in that scope
 5. `open_position_now`
-   - exchange currently reports an open position for that `pside`
+   - exchange currently reports an open position in that scope
+
+The scope is one `coin+pside` in `coin` mode, all positions on one `pside` in
+`pside` mode, and all account positions in `unified` mode.
 
 Important distinction:
 
@@ -52,18 +55,18 @@ These must not be confused.
 
 ## Global Rules
 
-Apply in order for one `pside`:
+Apply in order for the configured scope:
 
-1. If no `P` exists:
-   - ordinary HSL replay
-   - no reconstructed cooldown
+1. If a RED-seen scope is flat but no `F` is available:
+   - defer finalization and cooldown anchoring
+   - keep the scope protective; never substitute the current time
 2. If `now >= cooldown_end`:
    - cooldown is over
    - restart normal operation
-   - HSL drawdown baseline is post-panic
+   - HSL drawdown baseline is post-flatten
 3. If `now < cooldown_end` and no `E` exists:
    - cooldown episode is still active
-   - if `all_positions_closed_now`: wait
+   - if `scope_flat_now`: wait
    - if `open_position_now`: unresolved panic residue, not operator intervention
 4. If `now < cooldown_end` and `E` exists:
    - cooldown intervention happened
@@ -71,9 +74,10 @@ Apply in order for one `pside`:
 
 Shared invariants:
 
-1. after a valid panic close fully closes all positions on that `pside`, HSL drawdown tracking resets from after the panic
-2. while cooldown is active and the side has no open positions, the bot must not open fresh initials on that `pside`
-3. unresolved panic residue must still allow the bot to continue panic-close handling
+1. HSL drawdown tracking resets after every fill that fully flattens the configured scope, regardless of order type
+2. cooldown after a RED-seen episode begins at that flattening fill
+3. while cooldown is active and the scope has no open positions, the bot must not open fresh initials in that scope
+4. unresolved panic residue must still allow the bot to continue panic-close handling
 
 ## Supported Policies
 
@@ -115,7 +119,7 @@ Contract:
 Important:
 
 1. while the side still has no open positions and no `E` exists, do not open fresh initials
-2. reset boundary is the first post-panic non-panic entry `E`
+2. reset boundary is the first post-flatten entry `E`
 3. not the latest DCA add
 4. not a local marker
 
@@ -130,8 +134,8 @@ Intent:
 Contract:
 
 1. if intervention exists, panic-close it again
-2. once all positions on that `pside` are fully closed, reset drawdown baseline from after the new panic
-3. restart cooldown from the new panic timestamp
+2. once the configured scope is fully closed, reset drawdown baseline from after its flattening fill
+3. restart cooldown from that flattening fill timestamp
 
 Note:
 

--- a/docs/risk_management.md
+++ b/docs/risk_management.md
@@ -287,6 +287,9 @@ This stateless contract has important operational consequences:
    just parameter tuning.
 6. If HSL replay data is missing or incomplete, the bot should fail or defer
    visibly rather than substituting a safe-looking neutral drawdown.
+7. HSL episodes end when their configured scope becomes fully flat, by any
+   close type. The tracker resets after that fill, and a RED cooldown begins
+   there; current time is not a valid fallback for missing fill evidence.
 
 See the dedicated guide:
 

--- a/src/passivbot.py
+++ b/src/passivbot.py
@@ -2015,11 +2015,11 @@ class Passivbot:
     _equity_hard_stop_latest_panic_fill_timestamp_optional_ms = (
         pb_hsl._equity_hard_stop_latest_panic_fill_timestamp_optional_ms
     )
-    _equity_hard_stop_latest_flatten_fill_timestamp_ms = (
-        pb_hsl._equity_hard_stop_latest_flatten_fill_timestamp_ms
-    )
     _equity_hard_stop_latest_flatten_fill_timestamp_optional_ms = (
         pb_hsl._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms
+    )
+    _equity_hard_stop_defer_missing_flatten_fill = (
+        pb_hsl._equity_hard_stop_defer_missing_flatten_fill
     )
     _get_exchange_fee_rates = pb_hsl._get_exchange_fee_rates
     _orchestrator_exchange_params = pb_hsl._orchestrator_exchange_params

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -2416,6 +2416,8 @@ def _equity_hard_stop_make_state(self) -> dict[str, Any]:
         "last_cooldown_log_ms": 0,
         "cooldown_intervention_active": False,
         "cooldown_repanic_reset_pending": False,
+        "cooldown_repanic_since_ms": None,
+        "cooldown_repanic_start_sizes": None,
         "last_cooldown_intervention_log_ms": 0,
         "last_missing_flatten_fill_log_ms": 0,
         "last_missing_flatten_fill_refresh_ms": 0,
@@ -2917,6 +2919,8 @@ def _equity_hard_stop_reset_state(self) -> None:
         state["last_cooldown_log_ms"] = 0
         state["cooldown_intervention_active"] = False
         state["cooldown_repanic_reset_pending"] = False
+        state["cooldown_repanic_since_ms"] = None
+        state["cooldown_repanic_start_sizes"] = None
         state["last_cooldown_intervention_log_ms"] = 0
         state["last_missing_flatten_fill_log_ms"] = 0
         state["last_missing_flatten_fill_refresh_ms"] = 0
@@ -2994,15 +2998,17 @@ def _equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
     *,
     symbol: Optional[str] = None,
     since_ms: Optional[int] = None,
+    replay_start_sizes: Optional[dict[str, float]] = None,
 ) -> Optional[int]:
-    """Latest fill timestamp for the scope, regardless of order type.
+    """Return fill evidence for the scope's transition to flat.
 
     B2.1 contract: the episode ends (and cooldown anchors) at the fill that
     makes the scoped position set flat, by any means - not only bot-emitted
-    panic fills. Once the scope is flat, its latest fill is that flattening
-    fill.
+    panic fills. Ordinary finalization uses the latest episode-bounded fill
+    once authoritative state is flat. Cooldown re-panic finalization supplies
+    ``replay_start_sizes`` to prove the exact fill that makes the scope flat.
     """
-    latest_ts: Optional[int] = None
+    candidates: list[Any] = []
     if self._pnls_manager is not None:
         for event in self._pnls_manager.get_events():
             if _equity_hard_stop_fill_pside(event) != pside:
@@ -3012,8 +3018,47 @@ def _equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
             event_ts = _equity_hard_stop_fill_timestamp_ms(event)
             if since_ms is not None and event_ts < int(since_ms):
                 continue
-            latest_ts = event_ts if latest_ts is None else max(latest_ts, event_ts)
-    return latest_ts
+            candidates.append(event)
+    if replay_start_sizes is None:
+        return max(
+            (_equity_hard_stop_fill_timestamp_ms(event) for event in candidates),
+            default=None,
+        )
+
+    # Cooldown re-panic finalization starts from an authoritative non-flat
+    # position snapshot. Replay later scoped fills from those sizes and accept
+    # only the first fill that actually makes the whole scope flat. This keeps
+    # cached intervention entries and partial closes from masquerading as the
+    # episode-ending fill while the real close is still unavailable.
+    flat_epsilon = _hsl_flat_epsilon(0.0)
+    running_sizes = {
+        str(replay_symbol): abs(float(size))
+        for replay_symbol, size in replay_start_sizes.items()
+        if math.isfinite(float(size)) and abs(float(size)) > flat_epsilon
+    }
+    if not running_sizes:
+        return None
+    for event in sorted(candidates, key=_equity_hard_stop_fill_timestamp_ms):
+        event_symbol = _equity_hard_stop_fill_symbol(event)
+        action = str(
+            _equity_hard_stop_event_value(event, "action", "") or ""
+        ).lower()
+        qty = _equity_hard_stop_fill_replay_qty(event)
+        if not event_symbol or action not in {"increase", "decrease"}:
+            return None
+        if qty is None or qty <= 0.0:
+            return None
+        if action == "increase":
+            running_sizes[event_symbol] = (
+                running_sizes.get(event_symbol, 0.0) + float(qty)
+            )
+        else:
+            running_sizes[event_symbol] = max(
+                0.0, running_sizes.get(event_symbol, 0.0) - float(qty)
+            )
+        if not any(size > flat_epsilon for size in running_sizes.values()):
+            return _equity_hard_stop_fill_timestamp_ms(event)
+    return None
 
 
 def _equity_hard_stop_defer_missing_flatten_fill(
@@ -3053,6 +3098,7 @@ async def _equity_hard_stop_flatten_fill_timestamp_with_refresh(
     *,
     symbol: Optional[str] = None,
     since_ms: Optional[int],
+    replay_start_sizes: Optional[dict[str, float]] = None,
 ) -> Optional[int]:
     """Return episode-bounded flatten evidence, refreshing fills when absent.
 
@@ -3070,6 +3116,7 @@ async def _equity_hard_stop_flatten_fill_timestamp_with_refresh(
         pside,
         symbol=symbol,
         since_ms=int(since_ms),
+        replay_start_sizes=replay_start_sizes,
     )
     if stop_ts_ms is not None:
         return int(stop_ts_ms)
@@ -3110,6 +3157,7 @@ async def _equity_hard_stop_flatten_fill_timestamp_with_refresh(
                 pside,
                 symbol=symbol,
                 since_ms=int(since_ms),
+                replay_start_sizes=replay_start_sizes,
             )
     if stop_ts_ms is None:
         self._equity_hard_stop_defer_missing_flatten_fill(
@@ -4299,12 +4347,11 @@ async def _equity_hard_stop_refresh_cooldown_after_repanic(
     state = self._hsl_state(pside)
     cooldown_minutes = float(self.hsl[pside]["cooldown_minutes_after_red"])
     cooldown_ms = max(0, int(round(cooldown_minutes * 60_000.0))) if cooldown_minutes > 0.0 else 0
-    previous_stop_ts = None
-    if state.get("last_stop_event") is not None:
-        previous_stop_ts = int(state["last_stop_event"]["stop_event_timestamp_ms"]) + 1
+    repanic_since_ms = state.get("cooldown_repanic_since_ms")
     stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
         pside,
-        since_ms=previous_stop_ts,
+        since_ms=repanic_since_ms,
+        replay_start_sizes=state.get("cooldown_repanic_start_sizes") or {},
     )
     if stop_ts_ms is None:
         self._equity_hard_stop_defer_missing_flatten_fill(pside, now_ms)
@@ -4334,6 +4381,8 @@ async def _equity_hard_stop_refresh_cooldown_after_repanic(
     state["cooldown_until_ms"] = cooldown_until_ms
     state["cooldown_intervention_active"] = False
     state["cooldown_repanic_reset_pending"] = False
+    state["cooldown_repanic_since_ms"] = None
+    state["cooldown_repanic_start_sizes"] = None
     state["last_cooldown_intervention_log_ms"] = 0
     state["last_missing_flatten_fill_log_ms"] = 0
     state["last_missing_flatten_fill_refresh_ms"] = 0
@@ -4370,13 +4419,12 @@ async def _equity_hard_stop_refresh_coin_cooldown_after_repanic(
     state = self._hsl_coin_state(pside, symbol)
     cooldown_minutes = float(self.hsl[pside]["cooldown_minutes_after_red"])
     cooldown_ms = max(0, int(round(cooldown_minutes * 60_000.0))) if cooldown_minutes > 0.0 else 0
-    previous_stop_ts = None
-    if state.get("last_stop_event") is not None:
-        previous_stop_ts = int(state["last_stop_event"]["stop_event_timestamp_ms"]) + 1
+    repanic_since_ms = state.get("cooldown_repanic_since_ms")
     stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
         pside,
         symbol=symbol,
-        since_ms=previous_stop_ts,
+        since_ms=repanic_since_ms,
+        replay_start_sizes=state.get("cooldown_repanic_start_sizes") or {},
     )
     if stop_ts_ms is None:
         self._equity_hard_stop_defer_missing_flatten_fill(
@@ -4411,6 +4459,8 @@ async def _equity_hard_stop_refresh_coin_cooldown_after_repanic(
     state["cooldown_until_ms"] = cooldown_until_ms
     state["cooldown_intervention_active"] = False
     state["cooldown_repanic_reset_pending"] = False
+    state["cooldown_repanic_since_ms"] = None
+    state["cooldown_repanic_start_sizes"] = None
     state["last_cooldown_intervention_log_ms"] = 0
     state["cooldown_unresolved_residue"] = False
     state["pending_stop_event"] = None
@@ -4470,6 +4520,8 @@ async def _equity_hard_stop_handle_position_during_cooldown(self, pside: str, no
             )
         state["cooldown_intervention_active"] = False
         state["cooldown_repanic_reset_pending"] = False
+        state["cooldown_repanic_since_ms"] = None
+        state["cooldown_repanic_start_sizes"] = None
         state["last_cooldown_intervention_log_ms"] = 0
         state["cooldown_unresolved_residue"] = False
         return False
@@ -4501,7 +4553,22 @@ async def _equity_hard_stop_handle_position_during_cooldown(self, pside: str, no
         )
         return True
 
-    state["cooldown_repanic_reset_pending"] = policy == "panic"
+    if policy == "panic":
+        if not state["cooldown_repanic_reset_pending"]:
+            state["cooldown_repanic_since_ms"] = int(now_ms) + 1
+            state["cooldown_repanic_start_sizes"] = {
+                position_symbol: abs(
+                    float(position.get(pside, {}).get("size", 0.0) or 0.0)
+                )
+                for position_symbol, position in self.positions.items()
+                if float(position.get(pside, {}).get("size", 0.0) or 0.0)
+                != 0.0
+            }
+        state["cooldown_repanic_reset_pending"] = True
+    else:
+        state["cooldown_repanic_reset_pending"] = False
+        state["cooldown_repanic_since_ms"] = None
+        state["cooldown_repanic_start_sizes"] = None
     return False
 
 
@@ -4532,6 +4599,8 @@ async def _equity_hard_stop_handle_coin_position_during_cooldown(
             )
         state["cooldown_intervention_active"] = False
         state["cooldown_repanic_reset_pending"] = False
+        state["cooldown_repanic_since_ms"] = None
+        state["cooldown_repanic_start_sizes"] = None
         state["last_cooldown_intervention_log_ms"] = 0
         state["cooldown_unresolved_residue"] = False
         return False
@@ -4567,6 +4636,18 @@ async def _equity_hard_stop_handle_coin_position_during_cooldown(
         return True
 
     if policy == "panic":
+        if not state["cooldown_repanic_reset_pending"]:
+            state["cooldown_repanic_since_ms"] = int(now_ms) + 1
+            state["cooldown_repanic_start_sizes"] = {
+                symbol: abs(
+                    float(
+                        self.positions.get(symbol, {})
+                        .get(pside, {})
+                        .get("size", 0.0)
+                        or 0.0
+                    )
+                )
+            }
         state["cooldown_repanic_reset_pending"] = True
         self._equity_hard_stop_set_coin_runtime_forced_mode(pside, symbol, "panic")
     elif policy == "manual":
@@ -4598,6 +4679,8 @@ def _equity_hard_stop_reset_after_restart(self, pside: str) -> None:
     state["last_cooldown_log_ms"] = 0
     state["cooldown_intervention_active"] = False
     state["cooldown_repanic_reset_pending"] = False
+    state["cooldown_repanic_since_ms"] = None
+    state["cooldown_repanic_start_sizes"] = None
     state["last_cooldown_intervention_log_ms"] = 0
     state["last_missing_flatten_fill_log_ms"] = 0
     state["last_missing_flatten_fill_refresh_ms"] = 0
@@ -6036,6 +6119,11 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                             boundary_abs_realized = (
                                 row_start_abs_realized + realized_delta_at_flatten
                             )
+                            boundary_balance = (
+                                row_balance
+                                - row_realized_delta
+                                + realized_delta_at_flatten
+                            )
                             peak_realized, window_last_realized = rolling_realized_at(
                                 flatten_ts, boundary_abs_realized
                             )
@@ -6046,7 +6134,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                                 pside,
                                 symbol,
                                 flatten_ts,
-                                row_balance,
+                                boundary_balance,
                                 peak_realized,
                                 window_last_realized,
                                 0.0,
@@ -7713,18 +7801,18 @@ async def _equity_hard_stop_run_coin_red_supervisor(self) -> None:
                     now_ms = int(self.get_exchange_time())
                     flatten_since_ms = state.get("pending_red_since_ms")
                     if state["halted"] and state["cooldown_repanic_reset_pending"]:
-                        last_stop_event = state.get("last_stop_event")
-                        flatten_since_ms = (
-                            int(last_stop_event["stop_event_timestamp_ms"]) + 1
-                            if last_stop_event is not None
-                            and last_stop_event.get("stop_event_timestamp_ms") is not None
-                            else None
-                        )
+                        flatten_since_ms = state.get("cooldown_repanic_since_ms")
                     stop_ts_ms = await self._equity_hard_stop_flatten_fill_timestamp_with_refresh(
                         pside,
                         now_ms,
                         symbol=symbol,
                         since_ms=flatten_since_ms,
+                        replay_start_sizes=(
+                            state.get("cooldown_repanic_start_sizes") or {}
+                            if state["halted"]
+                            and state["cooldown_repanic_reset_pending"]
+                            else None
+                        ),
                     )
                     if stop_ts_ms is not None:
                         if not (

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -2416,6 +2416,7 @@ def _equity_hard_stop_make_state(self) -> dict[str, Any]:
         "cooldown_intervention_active": False,
         "cooldown_repanic_reset_pending": False,
         "last_cooldown_intervention_log_ms": 0,
+        "last_missing_flatten_fill_log_ms": 0,
         "cooldown_unresolved_residue": False,
         "pnl_reset_timestamp_ms": None,
     }
@@ -3011,29 +3012,33 @@ def _equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
     return latest_ts
 
 
-def _equity_hard_stop_latest_flatten_fill_timestamp_ms(
+def _equity_hard_stop_defer_missing_flatten_fill(
     self,
     pside: str,
+    now_ms: int,
     *,
     symbol: Optional[str] = None,
-    since_ms: Optional[int] = None,
-    fallback_ms: Optional[int] = None,
-) -> int:
-    latest_ts = _equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
-        self,
-        pside,
-        symbol=symbol,
-        since_ms=since_ms,
+) -> None:
+    """Keep the scope protective until its episode-end fill is available."""
+    state = (
+        self._hsl_coin_state(pside, symbol)
+        if symbol is not None
+        else self._hsl_state(pside)
     )
-    if latest_ts is not None:
-        return int(latest_ts)
-    # No fill evidence inside the window: fall back to the latest panic fill
-    # (pre-refinement anchor), then the caller-provided fallback.
-    return self._equity_hard_stop_latest_panic_fill_timestamp_ms(
-        pside,
-        symbol=symbol,
-        since_ms=since_ms,
-        fallback_ms=fallback_ms,
+    state["pending_stop_event"] = None
+    state["red_flat_confirmations"] = 0
+    last_log_ms = int(state.get("last_missing_flatten_fill_log_ms", 0) or 0)
+    if (
+        last_log_ms != 0
+        and int(now_ms) - last_log_ms < self._equity_hard_stop_cooldown_log_interval_ms
+    ):
+        return
+    state["last_missing_flatten_fill_log_ms"] = int(now_ms)
+    scope = f"{pside}:{symbol}" if symbol is not None else pside
+    logging.error(
+        "[risk] HSL[%s] scope is flat but its flatten-fill evidence is unavailable; "
+        "episode finalization and cooldown anchoring deferred",
+        scope,
     )
 
 
@@ -4117,7 +4122,8 @@ async def _equity_hard_stop_compute_coin_stop_event(
 ) -> dict:
     state = self._hsl_coin_state(pside, symbol)
     metrics = state["last_metrics"]
-    if metrics is None or int(metrics.get("timestamp_ms", 0) or 0) != int(stop_event_ts_ms):
+    metrics_ts_ms = int((metrics or {}).get("timestamp_ms", 0) or 0)
+    if metrics is None or metrics_ts_ms < int(stop_event_ts_ms):
         metrics = self._equity_hard_stop_apply_coin_sample(
             pside,
             symbol,
@@ -4125,6 +4131,9 @@ async def _equity_hard_stop_compute_coin_stop_event(
             float(self.get_raw_balance()),
             float(await self._calc_upnl_sum_strict(pside, symbol)),
         )
+    # If fill refresh lagged behind position refresh, the scope may already
+    # have a newer flat sample. Reuse it while retaining the fill timestamp as
+    # the episode/cooldown boundary; Rust runtimes reject time travel.
     return {
         "position_side": pside,
         "symbol": symbol,
@@ -4190,18 +4199,23 @@ def _equity_hard_stop_position_symbols(self, pside: str) -> list[str]:
     return sorted(out)
 
 
-async def _equity_hard_stop_refresh_cooldown_after_repanic(self, pside: str, now_ms: int) -> None:
+async def _equity_hard_stop_refresh_cooldown_after_repanic(
+    self, pside: str, now_ms: int
+) -> bool:
     state = self._hsl_state(pside)
     cooldown_minutes = float(self.hsl[pside]["cooldown_minutes_after_red"])
     cooldown_ms = max(0, int(round(cooldown_minutes * 60_000.0))) if cooldown_minutes > 0.0 else 0
     previous_stop_ts = None
     if state.get("last_stop_event") is not None:
         previous_stop_ts = int(state["last_stop_event"]["stop_event_timestamp_ms"]) + 1
-    stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_ms(
+    stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
         pside,
         since_ms=previous_stop_ts,
-        fallback_ms=now_ms,
     )
+    if stop_ts_ms is None:
+        self._equity_hard_stop_defer_missing_flatten_fill(pside, now_ms)
+        return False
+    state["last_missing_flatten_fill_log_ms"] = 0
     cooldown_until_ms = stop_ts_ms + cooldown_ms if cooldown_ms > 0 else None
     stop_event = await self._equity_hard_stop_compute_stop_event(pside, stop_ts_ms)
     payload = self._equity_hard_stop_build_latch_payload(
@@ -4251,25 +4265,33 @@ async def _equity_hard_stop_refresh_cooldown_after_repanic(self, pside: str, now
             status="started",
             reason_code="repanic_reset",
         )
+    return True
 
 
 async def _equity_hard_stop_refresh_coin_cooldown_after_repanic(
     self, pside: str, symbol: str, now_ms: int
-) -> None:
+) -> bool:
     state = self._hsl_coin_state(pside, symbol)
     cooldown_minutes = float(self.hsl[pside]["cooldown_minutes_after_red"])
     cooldown_ms = max(0, int(round(cooldown_minutes * 60_000.0))) if cooldown_minutes > 0.0 else 0
     previous_stop_ts = None
     if state.get("last_stop_event") is not None:
         previous_stop_ts = int(state["last_stop_event"]["stop_event_timestamp_ms"]) + 1
-    stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_ms(
+    stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
         pside,
         symbol=symbol,
         since_ms=previous_stop_ts,
-        fallback_ms=now_ms,
     )
+    if stop_ts_ms is None:
+        self._equity_hard_stop_defer_missing_flatten_fill(
+            pside, now_ms, symbol=symbol
+        )
+        return False
+    state["last_missing_flatten_fill_log_ms"] = 0
     cooldown_until_ms = stop_ts_ms + cooldown_ms if cooldown_ms > 0 else None
-    stop_event = await self._equity_hard_stop_compute_coin_stop_event(pside, symbol, stop_ts_ms)
+    stop_event = await self._equity_hard_stop_compute_coin_stop_event(
+        pside, symbol, stop_ts_ms
+    )
     payload = self._equity_hard_stop_build_latch_payload(
         pside,
         symbol=symbol,
@@ -4326,6 +4348,7 @@ async def _equity_hard_stop_refresh_coin_cooldown_after_repanic(
             status="started",
             reason_code="coin_repanic_reset",
         )
+    return True
 
 
 async def _equity_hard_stop_handle_position_during_cooldown(self, pside: str, now_ms: int) -> bool:
@@ -5617,7 +5640,8 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                 ignored_panic_marker_timestamps: set[int] = set()
 
                 def replay_size_at(row_ts_ms: int) -> float:
-                    nonlocal replay_event_idx, replay_size, replay_flattened_at_ms
+                    nonlocal replay_event_idx, replay_size
+                    nonlocal replay_was_nonflat, replay_flattened_at_ms
                     boundary_ts_ms = int(row_ts_ms) + 60_000
                     while replay_event_idx < len(replay_events):
                         event_ts, action, qty = replay_events[replay_event_idx]
@@ -5625,6 +5649,14 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                             break
                         if action == "increase":
                             replay_size += qty
+                            if replay_size > flat_epsilon:
+                                # Episode boundaries come from fills, not from
+                                # whether this row has enough price data to
+                                # evaluate UPnL. Compact coin replay may
+                                # deliberately omit historical UPnL for a pair
+                                # that is flat now, but the later flatten must
+                                # still end and reset that episode.
+                                replay_was_nonflat = True
                         else:
                             replay_size = max(0.0, replay_size - qty)
                             if replay_size <= flat_epsilon:
@@ -5817,6 +5849,14 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     if not require_coin_timeline_value:
                         continue
                     replay_position_size = replay_size_at(ts)
+                    replay_is_nonflat = replay_position_size > flat_epsilon
+                    replay_flattened_this_row = (
+                        not replay_ambiguous
+                        and replay_was_nonflat
+                        and not replay_is_nonflat
+                        and replay_flattened_at_ms is not None
+                        and replay_flattened_at_ms < ts + 60_000
+                    )
                     if not has_realized:
                         if source_row is not None:
                             _equity_hard_stop_history_coin_value(
@@ -5897,16 +5937,6 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     applied_rows += 1
                     rows += 1
                     pair_rows_applied[(pside, symbol)] = int(applied_rows)
-                    replay_is_nonflat = replay_position_size > flat_epsilon
-                    replay_flattened_this_row = (
-                        not replay_ambiguous
-                        and replay_was_nonflat
-                        and not replay_is_nonflat
-                        and replay_flattened_at_ms is not None
-                        and replay_flattened_at_ms < ts + 60_000
-                    )
-                    if replay_is_nonflat:
-                        replay_was_nonflat = True
                     if marker is None:
                         if not replay_flattened_this_row:
                             continue
@@ -6833,18 +6863,22 @@ async def _equity_hard_stop_check_coin(self) -> Optional[dict]:
                     )
                 )
                 if not has_position and entry_orders == 0 and nonpanic_close_orders == 0:
-                    stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_ms(
+                    stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
                         pside,
                         symbol=symbol,
-                        since_ms=state.get("pending_red_since_ms"),
-                        fallback_ms=ts_ms,
                     )
-                    state["pending_stop_event"] = (
-                        await self._equity_hard_stop_compute_coin_stop_event(
-                            pside, symbol, stop_ts_ms
+                    if stop_ts_ms is None:
+                        self._equity_hard_stop_defer_missing_flatten_fill(
+                            pside, ts_ms, symbol=symbol
                         )
-                    )
-                    state["red_flat_confirmations"] += 1
+                    else:
+                        state["last_missing_flatten_fill_log_ms"] = 0
+                        state["pending_stop_event"] = (
+                            await self._equity_hard_stop_compute_coin_stop_event(
+                                pside, symbol, stop_ts_ms
+                            )
+                        )
+                        state["red_flat_confirmations"] += 1
                 else:
                     state["red_flat_confirmations"] = 0
                     state["pending_stop_event"] = None
@@ -7078,7 +7112,7 @@ def _equity_hard_stop_log_red_progress(
 async def _equity_hard_stop_finalize_red_stop(
     self,
     pside: str,
-    stop_event: Optional[dict] = None,
+    stop_event: dict,
     *,
     finalized_without_order: bool = False,
     flat_confirmations: int | None = None,
@@ -7088,25 +7122,9 @@ async def _equity_hard_stop_finalize_red_stop(
 ) -> None:
     state = self._hsl_state(pside)
     cfg = self.hsl[pside]
-    stop_ts_ms = int(self.get_exchange_time())
+    stop_ts_ms = int(stop_event["stop_event_timestamp_ms"])
     stop_event_anchor_source = "provided_stop_event"
     stop_event_anchor_fallback_used = False
-    if stop_event is None:
-        fallback_stop_ts_ms = stop_ts_ms
-        latest_panic_ts = self._equity_hard_stop_latest_panic_fill_timestamp_optional_ms(
-            pside,
-            since_ms=state.get("pending_red_since_ms"),
-        )
-        if latest_panic_ts is None:
-            stop_ts_ms = fallback_stop_ts_ms
-            stop_event_anchor_source = "current_time_fallback"
-            stop_event_anchor_fallback_used = True
-        else:
-            stop_ts_ms = int(latest_panic_ts)
-            stop_event_anchor_source = "panic_fill"
-        stop_event = await self._equity_hard_stop_compute_stop_event(pside, stop_ts_ms)
-    else:
-        stop_ts_ms = int(stop_event["stop_event_timestamp_ms"])
     no_restart_drawdown_threshold = float(cfg["no_restart_drawdown_threshold"])
     finalization = self._equity_hard_stop_red_episode_finalization(
         pside,
@@ -7227,7 +7245,7 @@ async def _equity_hard_stop_finalize_coin_red_stop(
     self,
     pside: str,
     symbol: str,
-    stop_event: Optional[dict] = None,
+    stop_event: dict,
     *,
     finalized_without_order: bool = False,
     flat_confirmations: int | None = None,
@@ -7235,26 +7253,9 @@ async def _equity_hard_stop_finalize_coin_red_stop(
     nonpanic_close_orders: int | None = None,
 ) -> None:
     state = self._hsl_coin_state(pside, symbol)
-    stop_ts_ms = int(self.get_exchange_time())
+    stop_ts_ms = int(stop_event["stop_event_timestamp_ms"])
     stop_event_anchor_source = "provided_stop_event"
     stop_event_anchor_fallback_used = False
-    if stop_event is None:
-        fallback_stop_ts_ms = stop_ts_ms
-        latest_panic_ts = self._equity_hard_stop_latest_panic_fill_timestamp_optional_ms(
-            pside,
-            symbol=symbol,
-            since_ms=state.get("pending_red_since_ms"),
-        )
-        if latest_panic_ts is None:
-            stop_ts_ms = fallback_stop_ts_ms
-            stop_event_anchor_source = "current_time_fallback"
-            stop_event_anchor_fallback_used = True
-        else:
-            stop_ts_ms = int(latest_panic_ts)
-            stop_event_anchor_source = "panic_fill"
-        stop_event = await self._equity_hard_stop_compute_coin_stop_event(pside, symbol, stop_ts_ms)
-    else:
-        stop_ts_ms = int(stop_event["stop_event_timestamp_ms"])
     finalization = self._equity_hard_stop_red_episode_finalization(
         pside,
         stop_event,
@@ -7396,15 +7397,21 @@ async def _equity_hard_stop_run_red_supervisor(self) -> None:
                 n_positions = self._equity_hard_stop_count_open_positions(pside)
                 entry_orders, nonpanic_close_orders = self._equity_hard_stop_count_blocking_open_orders(pside)
                 if n_positions == 0 and entry_orders == 0 and nonpanic_close_orders == 0:
-                    stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_ms(
+                    stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
                         pside,
-                        since_ms=state.get("pending_red_since_ms"),
-                        fallback_ms=int(self.get_exchange_time()),
                     )
-                    state["pending_stop_event"] = await self._equity_hard_stop_compute_stop_event(
-                        pside, stop_ts_ms
-                    )
-                    state["red_flat_confirmations"] += 1
+                    if stop_ts_ms is None:
+                        self._equity_hard_stop_defer_missing_flatten_fill(
+                            pside, int(self.get_exchange_time())
+                        )
+                    else:
+                        state["last_missing_flatten_fill_log_ms"] = 0
+                        state["pending_stop_event"] = (
+                            await self._equity_hard_stop_compute_stop_event(
+                                pside, stop_ts_ms
+                            )
+                        )
+                        state["red_flat_confirmations"] += 1
                 else:
                     state["red_flat_confirmations"] = 0
                     state["pending_stop_event"] = None
@@ -7523,18 +7530,22 @@ async def _equity_hard_stop_run_coin_red_supervisor(self) -> None:
                     self._equity_hard_stop_count_blocking_open_orders_symbol(pside, symbol)
                 )
                 if not has_position and entry_orders == 0 and nonpanic_close_orders == 0:
-                    stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_ms(
+                    stop_ts_ms = self._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
                         pside,
                         symbol=symbol,
-                        since_ms=state.get("pending_red_since_ms"),
-                        fallback_ms=int(self.get_exchange_time()),
                     )
-                    state["pending_stop_event"] = (
-                        await self._equity_hard_stop_compute_coin_stop_event(
-                            pside, symbol, stop_ts_ms
+                    if stop_ts_ms is None:
+                        self._equity_hard_stop_defer_missing_flatten_fill(
+                            pside, int(self.get_exchange_time()), symbol=symbol
                         )
-                    )
-                    state["red_flat_confirmations"] += 1
+                    else:
+                        state["last_missing_flatten_fill_log_ms"] = 0
+                        state["pending_stop_event"] = (
+                            await self._equity_hard_stop_compute_coin_stop_event(
+                                pside, symbol, stop_ts_ms
+                            )
+                        )
+                        state["red_flat_confirmations"] += 1
                 else:
                     state["red_flat_confirmations"] = 0
                     state["pending_stop_event"] = None

--- a/src/passivbot_hsl.py
+++ b/src/passivbot_hsl.py
@@ -3254,7 +3254,7 @@ def _equity_hard_stop_coin_episode_start_covered(self, pside: str, symbol: str) 
     if ambiguous:
         return False
     running = size
-    for _ts, action, qty in reversed(replay_events):
+    for _ts, action, qty, _realized_delta in reversed(replay_events):
         running = running - qty if action == "increase" else running + qty
         if running <= flat_epsilon:
             return True
@@ -3832,8 +3832,8 @@ def _hsl_compact_sparse_replay_indices(
 
 def _equity_hard_stop_coin_replay_events(
     fill_events: list[Any], pside: str, symbol: str, *, qty_step: float = 0.0
-) -> tuple[list[tuple[int, str, float]], bool]:
-    replay_events: list[tuple[int, str, float]] = []
+) -> tuple[list[tuple[int, str, float, float]], bool]:
+    replay_events: list[tuple[int, str, float, float]] = []
     ambiguous = False
     replay_size = 0.0
     flat_epsilon = _hsl_flat_epsilon(qty_step)
@@ -3847,11 +3847,26 @@ def _equity_hard_stop_coin_replay_events(
         if action not in {"increase", "decrease"} or qty is None or qty <= 0.0:
             ambiguous = True
             continue
+        try:
+            realized_delta = float(
+                _equity_hard_stop_event_value(event, "pnl", 0.0) or 0.0
+            ) + float(_equity_hard_stop_fee_cost(event))
+        except (TypeError, ValueError):
+            ambiguous = True
+            continue
+        if not math.isfinite(realized_delta):
+            ambiguous = True
+            continue
         replay_events.append(
-            (_equity_hard_stop_fill_timestamp_ms(event), action, float(qty))
+            (
+                _equity_hard_stop_fill_timestamp_ms(event),
+                action,
+                float(qty),
+                realized_delta,
+            )
         )
     replay_events.sort(key=lambda item: item[0])
-    for _event_ts, action, qty in replay_events:
+    for _event_ts, action, qty, _realized_delta in replay_events:
         if action == "increase":
             replay_size += qty
         else:
@@ -3862,11 +3877,11 @@ def _equity_hard_stop_coin_replay_events(
 
 
 def _equity_hard_stop_coin_replay_size_at(
-    replay_events: list[tuple[int, str, float]], row_ts_ms: int
+    replay_events: list[tuple[int, str, float, float]], row_ts_ms: int
 ) -> float:
     boundary_ts_ms = int(row_ts_ms) + 60_000
     size = 0.0
-    for event_ts, action, qty in replay_events:
+    for event_ts, action, qty, _realized_delta in replay_events:
         if int(event_ts) >= boundary_ts_ms:
             break
         if action == "increase":
@@ -5689,7 +5704,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     sparse_boundary_timestamps.append(int(replay_start_boundary_ts))
                 if contract["cooldown_until_ms"] is not None:
                     sparse_boundary_timestamps.append(int(contract["cooldown_until_ms"]))
-                for event_ts, _action, _qty in replay_events:
+                for event_ts, _action, _qty, _realized_delta in replay_events:
                     sparse_boundary_timestamps.append(
                         int(event_ts) // _HSL_REPLAY_MATRIX_INTERVAL_MS
                         * _HSL_REPLAY_MATRIX_INTERVAL_MS
@@ -5715,37 +5730,92 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     window_max_points.clear()
                     window_base_realized = 0.0
 
+                def rolling_realized_at(
+                    sample_ts: int, sample_abs_realized: float
+                ) -> tuple[float, float]:
+                    nonlocal window_base_realized
+                    last_realized = float(sample_abs_realized) - reset_baseline_realized
+                    start_ms = (
+                        None
+                        if lookback_ms is None
+                        else int(sample_ts) - int(lookback_ms)
+                    )
+                    reset_ts = state["pnl_reset_timestamp_ms"]
+                    if reset_ts is not None:
+                        start_ms = (
+                            int(reset_ts)
+                            if start_ms is None
+                            else max(start_ms, int(reset_ts))
+                        )
+                    window_points.append((int(sample_ts), last_realized))
+                    while (
+                        window_max_points
+                        and window_max_points[-1][1] <= last_realized
+                    ):
+                        window_max_points.pop()
+                    window_max_points.append((int(sample_ts), last_realized))
+                    if start_ms is not None:
+                        while window_points and window_points[0][0] < start_ms:
+                            _old_ts, old_value = window_points.popleft()
+                            window_base_realized = float(old_value)
+                        while (
+                            window_max_points
+                            and window_max_points[0][0] < start_ms
+                        ):
+                            window_max_points.popleft()
+                    window_last_realized = (
+                        float(last_realized) - window_base_realized
+                        if window_points
+                        else 0.0
+                    )
+                    peak_realized = max(
+                        0.0,
+                        (
+                            float(window_max_points[0][1]) - window_base_realized
+                            if window_max_points
+                            else 0.0
+                        ),
+                    )
+                    return peak_realized, window_last_realized
+
                 replay_event_idx = 0
                 replay_size = 0.0
                 flat_epsilon = _hsl_flat_epsilon(qty_step)
-                replay_was_nonflat = False
-                replay_flattened_at_ms: Optional[int] = None
                 ignored_panic_marker_timestamps: set[int] = set()
 
-                def replay_size_at(row_ts_ms: int) -> float:
+                def replay_transitions_at(
+                    row_ts_ms: int,
+                ) -> tuple[float, list[tuple[int, float]], float]:
                     nonlocal replay_event_idx, replay_size
-                    nonlocal replay_was_nonflat, replay_flattened_at_ms
                     boundary_ts_ms = int(row_ts_ms) + 60_000
+                    realized_delta = 0.0
+                    flatten_boundaries: list[tuple[int, float]] = []
                     while replay_event_idx < len(replay_events):
-                        event_ts, action, qty = replay_events[replay_event_idx]
+                        event_ts, action, qty, event_realized_delta = replay_events[
+                            replay_event_idx
+                        ]
                         if int(event_ts) >= boundary_ts_ms:
                             break
+                        was_nonflat = replay_size > flat_epsilon
+                        realized_delta += float(event_realized_delta)
                         if action == "increase":
                             replay_size += qty
-                            if replay_size > flat_epsilon:
-                                # Episode boundaries come from fills, not from
-                                # whether this row has enough price data to
-                                # evaluate UPnL. Compact coin replay may
-                                # deliberately omit historical UPnL for a pair
-                                # that is flat now, but the later flatten must
-                                # still end and reset that episode.
-                                replay_was_nonflat = True
                         else:
                             replay_size = max(0.0, replay_size - qty)
-                            if replay_size <= flat_epsilon:
-                                replay_flattened_at_ms = int(event_ts)
+                            if was_nonflat and replay_size <= flat_epsilon:
+                                # Preserve every zero crossing in fill order.
+                                # The cumulative realized delta lets the row's
+                                # aggregate realized value be split at the
+                                # exact episode boundary.
+                                flatten_boundaries.append(
+                                    (int(event_ts), float(realized_delta))
+                                )
                         replay_event_idx += 1
-                    return float(replay_size)
+                    return (
+                        float(replay_size),
+                        flatten_boundaries,
+                        float(realized_delta),
+                    )
 
                 if compact_replay is not None:
                     compact_values = compact_pair_values.get((pside, symbol))
@@ -5931,14 +6001,12 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     )
                     if not require_coin_timeline_value:
                         continue
-                    replay_position_size = replay_size_at(ts)
+                    (
+                        replay_position_size,
+                        flatten_boundaries,
+                        row_realized_delta,
+                    ) = replay_transitions_at(ts)
                     replay_is_nonflat = replay_position_size > flat_epsilon
-                    replay_flattened_this_row = (
-                        not replay_ambiguous
-                        and replay_was_nonflat
-                        and replay_flattened_at_ms is not None
-                        and replay_flattened_at_ms < ts + 60_000
-                    )
                     if not has_realized:
                         if source_row is not None:
                             _equity_hard_stop_history_coin_value(
@@ -5956,110 +6024,134 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                         )
                     abs_realized = float(realized_value)
                     seen_coin_timeline_fields = True
-                    last_realized = abs_realized - reset_baseline_realized
-                    start_ms = None if lookback_ms is None else ts - int(lookback_ms)
-                    reset_ts = state["pnl_reset_timestamp_ms"]
-                    if reset_ts is not None:
-                        start_ms = int(reset_ts) if start_ms is None else max(start_ms, int(reset_ts))
-                    window_points.append((ts, last_realized))
-                    while window_max_points and window_max_points[-1][1] <= last_realized:
-                        window_max_points.pop()
-                    window_max_points.append((ts, last_realized))
-                    if start_ms is not None:
-                        while window_points and window_points[0][0] < start_ms:
-                            _old_ts, old_value = window_points.popleft()
-                            window_base_realized = float(old_value)
-                        while window_max_points and window_max_points[0][0] < start_ms:
-                            window_max_points.popleft()
-                    window_last_realized = (
-                        float(last_realized) - window_base_realized if window_points else 0.0
-                    )
-                    peak_realized = max(
-                        0.0,
-                        (
-                            float(window_max_points[0][1]) - window_base_realized
-                            if window_max_points
-                            else 0.0
-                        ),
-                    )
-                    if not has_unrealized and require_coin_timeline_value:
-                        if replay_ambiguous or replay_position_size > flat_epsilon:
-                            if not require_coin_timeline_fields:
-                                continue
-                            if source_row is not None:
-                                _equity_hard_stop_history_coin_value(
-                                    source_row,
-                                    "unrealized_pnl_by_coin_pside",
-                                    symbol,
-                                    pside,
-                                    require_key=True,
-                                    require_value=True,
-                                )
-                            raise ValueError(
-                                "coin HSL replay missing required "
-                                "unrealized_pnl_by_coin_pside value for "
-                                f"{pside}:{symbol} at {ts}"
-                            )
-                        else:
-                            current_upnl = 0.0
-                    else:
-                        current_upnl = float(unrealized_value)
-                    self._equity_hard_stop_prime_coin_runtime_for_replay(pside, symbol, ts)
                     marker = latest_panic_by_coin_minute.get((pside, symbol, ts))
-                    episode_upnl = (
-                        0.0
-                        if replay_flattened_this_row and replay_is_nonflat
-                        else current_upnl
-                    )
-                    metrics = self._equity_hard_stop_apply_coin_metrics_sample(
-                        pside,
-                        symbol,
-                        ts,
-                        row_balance,
-                        peak_realized,
-                        window_last_realized,
-                        episode_upnl,
-                        latch_red=False,
-                    )
-                    applied_rows += 1
-                    rows += 1
-                    pair_rows_applied[(pside, symbol)] = int(applied_rows)
-                    if marker is None:
-                        if not replay_flattened_this_row:
-                            continue
-                        if bool(metrics.get("red_seen_in_episode")):
-                            # The episode crossed RED and ended by an ordinary
-                            # (non-panic) scope-flattening fill. Per the B2.1
-                            # contract, cooldown/no-restart evidence is canonical
-                            # from the reconstructed episode, not from bot panic
-                            # markers; anchor the stop at the flatten fill.
-                            stop_ts = int(replay_flattened_at_ms)
-                            stop_source = "red_episode_flatten"
-                            # A later increase in the same minute starts a new
-                            # episode. Preserve the row-end occupancy after
-                            # consuming this flatten boundary so a subsequent
-                            # close is also observable.
-                            replay_was_nonflat = replay_is_nonflat
-                            replay_flattened_at_ms = None
-                        else:
-                            # Ordinary, non-panic flattening of a RED-free episode
-                            # just ends the episode with no stop accounting.
-                            reset_ts = int(replay_flattened_at_ms) + 1
-                            state["pnl_reset_timestamp_ms"] = reset_ts
-                            reset_baseline_realized = abs_realized
-                            self._equity_hard_stop_reset_coin_after_restart(pside, symbol)
+                    metrics = None
+                    stop_ts = None
+                    stop_source = None
+                    stop_abs_realized = abs_realized
+
+                    if flatten_boundaries and not replay_ambiguous:
+                        row_start_abs_realized = abs_realized - row_realized_delta
+                        for flatten_ts, realized_delta_at_flatten in flatten_boundaries:
+                            boundary_abs_realized = (
+                                row_start_abs_realized + realized_delta_at_flatten
+                            )
+                            peak_realized, window_last_realized = rolling_realized_at(
+                                flatten_ts, boundary_abs_realized
+                            )
+                            self._equity_hard_stop_prime_coin_runtime_for_replay(
+                                pside, symbol, flatten_ts
+                            )
+                            metrics = self._equity_hard_stop_apply_coin_metrics_sample(
+                                pside,
+                                symbol,
+                                flatten_ts,
+                                row_balance,
+                                peak_realized,
+                                window_last_realized,
+                                0.0,
+                                latch_red=False,
+                            )
+                            applied_rows += 1
+                            rows += 1
+                            pair_rows_applied[(pside, symbol)] = int(applied_rows)
+                            boundary_marker = (
+                                marker
+                                if marker is not None
+                                and int(marker["timestamp"]) == int(flatten_ts)
+                                else None
+                            )
+                            if boundary_marker is not None and not (
+                                _equity_hard_stop_replay_marker_confirms_red(metrics)
+                            ):
+                                ignored_panic_marker_timestamps.add(int(flatten_ts))
+                                logging.warning(
+                                    "[risk] HSL[%s:%s] ignored historical coin panic marker without reconstructed RED | "
+                                    "stop_ts=%s drawdown_raw=%.6f drawdown_ema=%.6f drawdown_score=%.6f "
+                                    "red_threshold=%.6f source=panic_fill_flatten",
+                                    pside,
+                                    symbol,
+                                    int(flatten_ts),
+                                    float(metrics["drawdown_raw"]),
+                                    float(metrics["drawdown_ema"]),
+                                    float(metrics["drawdown_score"]),
+                                    float(metrics["red_threshold"]),
+                                )
+                                boundary_marker = None
+                            if boundary_marker is not None or bool(
+                                metrics.get("red_seen_in_episode")
+                            ):
+                                stop_ts = int(flatten_ts)
+                                stop_source = (
+                                    "panic_fill_flatten"
+                                    if boundary_marker is not None
+                                    else "red_episode_flatten"
+                                )
+                                stop_abs_realized = boundary_abs_realized
+                                break
+
+                            # RED-free episodes still end at every zero
+                            # crossing. Reset before evaluating a later
+                            # re-entry/flatten inside the same replay minute.
+                            state["pnl_reset_timestamp_ms"] = int(flatten_ts) + 1
+                            reset_baseline_realized = boundary_abs_realized
+                            self._equity_hard_stop_reset_coin_after_restart(
+                                pside, symbol
+                            )
                             state = self._hsl_coin_state(pside, symbol)
                             reset_rolling_window()
-                            replay_was_nonflat = replay_is_nonflat
                             logging.info(
                                 "[risk] HSL[%s:%s] replay reset current episode after flat fill | flat_ts=%s",
                                 pside,
                                 symbol,
-                                int(replay_flattened_at_ms),
+                                int(flatten_ts),
                             )
-                            replay_flattened_at_ms = None
+                        if stop_ts is None:
                             continue
                     else:
+                        peak_realized, window_last_realized = rolling_realized_at(
+                            ts, abs_realized
+                        )
+                    if stop_ts is None:
+                        if not has_unrealized and require_coin_timeline_value:
+                            if replay_ambiguous or replay_position_size > flat_epsilon:
+                                if not require_coin_timeline_fields:
+                                    continue
+                                if source_row is not None:
+                                    _equity_hard_stop_history_coin_value(
+                                        source_row,
+                                        "unrealized_pnl_by_coin_pside",
+                                        symbol,
+                                        pside,
+                                        require_key=True,
+                                        require_value=True,
+                                    )
+                                raise ValueError(
+                                    "coin HSL replay missing required "
+                                    "unrealized_pnl_by_coin_pside value for "
+                                    f"{pside}:{symbol} at {ts}"
+                                )
+                            current_upnl = 0.0
+                        else:
+                            current_upnl = float(unrealized_value)
+                        self._equity_hard_stop_prime_coin_runtime_for_replay(
+                            pside, symbol, ts
+                        )
+                        metrics = self._equity_hard_stop_apply_coin_metrics_sample(
+                            pside,
+                            symbol,
+                            ts,
+                            row_balance,
+                            peak_realized,
+                            window_last_realized,
+                            current_upnl,
+                            latch_red=False,
+                        )
+                        applied_rows += 1
+                        rows += 1
+                        pair_rows_applied[(pside, symbol)] = int(applied_rows)
+                        if marker is None:
+                            continue
                         stop_ts = int(marker["timestamp"])
                         stop_source = "panic_fill_flatten"
                         if not _equity_hard_stop_replay_marker_confirms_red(metrics):
@@ -6117,7 +6209,7 @@ async def _equity_hard_stop_initialize_coin_from_history(self) -> None:
                     )
                     state["pnl_reset_timestamp_ms"] = stop_ts + 1
                     state["pending_red_since_ms"] = None
-                    reset_baseline_realized = abs_realized
+                    reset_baseline_realized = stop_abs_realized
                     reset_rolling_window()
                     if no_restart_latched:
                         state["halted"] = True
@@ -7619,18 +7711,31 @@ async def _equity_hard_stop_run_coin_red_supervisor(self) -> None:
                 )
                 if not has_position and entry_orders == 0 and nonpanic_close_orders == 0:
                     now_ms = int(self.get_exchange_time())
+                    flatten_since_ms = state.get("pending_red_since_ms")
+                    if state["halted"] and state["cooldown_repanic_reset_pending"]:
+                        last_stop_event = state.get("last_stop_event")
+                        flatten_since_ms = (
+                            int(last_stop_event["stop_event_timestamp_ms"]) + 1
+                            if last_stop_event is not None
+                            and last_stop_event.get("stop_event_timestamp_ms") is not None
+                            else None
+                        )
                     stop_ts_ms = await self._equity_hard_stop_flatten_fill_timestamp_with_refresh(
                         pside,
                         now_ms,
                         symbol=symbol,
-                        since_ms=state.get("pending_red_since_ms"),
+                        since_ms=flatten_since_ms,
                     )
                     if stop_ts_ms is not None:
-                        state["pending_stop_event"] = (
-                            await self._equity_hard_stop_compute_coin_stop_event(
-                                pside, symbol, stop_ts_ms
+                        if not (
+                            state["halted"]
+                            and state["cooldown_repanic_reset_pending"]
+                        ):
+                            state["pending_stop_event"] = (
+                                await self._equity_hard_stop_compute_coin_stop_event(
+                                    pside, symbol, stop_ts_ms
+                                )
                             )
-                        )
                         state["red_flat_confirmations"] += 1
                 else:
                     state["red_flat_confirmations"] = 0

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -4864,8 +4864,11 @@ async def test_coin_hsl_replay_splits_same_minute_flatten_and_reentry(compact):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("compact", [False, True])
-async def test_coin_hsl_replay_uses_first_of_multiple_same_minute_flattens(compact):
-    """Later-episode PnL must not be attached to the first RED episode."""
+@pytest.mark.parametrize("later_pnl", [-30.0, 60.0])
+async def test_coin_hsl_replay_uses_first_of_multiple_same_minute_flattens(
+    compact, later_pnl
+):
+    """Later-episode PnL and balance must not alter the first RED episode."""
     symbol = "A"
     first_flatten_ts = 150_000
     history = _red_episode_history(
@@ -4890,17 +4893,21 @@ async def test_coin_hsl_replay_uses_first_of_multiple_same_minute_flattens(compa
                 "pside": "long",
                 "action": "decrease",
                 "qty": 1.0,
-                "pnl": -30.0,
+                "pnl": later_pnl,
             },
         ]
     )
-    # The minute aggregate contains both losses. Only the first -30 belongs
-    # to the RED episode ending at 150_000; using -60 would cross the terminal
-    # no-restart threshold and demonstrate the attribution bug.
+    # The row closes at account balance 100 - 30 + later_pnl. The first RED
+    # episode nevertheless ended with balance 70 at 150_000. Reusing the row's
+    # ending balance either hides RED after the later profit or falsely makes
+    # the earlier episode terminal after the later loss.
     for row in history["timeline"]:
         if row["timestamp"] == 120_000:
-            row["realized_pnl"] = -60.0
-            row["realized_pnl_by_coin_pside"][symbol]["long"] = -60.0
+            row["balance"] = 70.0 + later_pnl
+            row["realized_pnl"] = -30.0 + later_pnl
+            row["realized_pnl_by_coin_pside"][symbol]["long"] = (
+                -30.0 + later_pnl
+            )
     bot = _flat_position_bot(symbol)
     bot.get_exchange_time = lambda: 180_000
 

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -937,7 +937,7 @@ def test_coin_panic_supervision_requires_red_active_now():
 
 
 @pytest.mark.asyncio
-async def test_recovered_red_episode_finalizes_from_check_path():
+async def test_recovered_red_episode_finalizes_from_check_path(caplog):
     # Codex blocker regression on the red split: RED latches, the sample
     # recovers while the position is open (panic pauses, tp-only holds), the
     # position later flattens normally, and the episode MUST still be
@@ -986,8 +986,8 @@ async def test_recovered_red_episode_finalizes_from_check_path():
     )
     assert state["halted"] is False
 
-    # The position closes normally under tp-only; two check cycles confirm
-    # flat and finalize the episode: halt + cooldown, no RED re-activation.
+    # The position closes normally under tp-only. Flat exchange state without
+    # its close fill is not enough to invent a cooldown anchor.
     bot.positions = {
         symbol: {"long": {"size": 0.0, "price": 0.0}, "short": {"size": 0.0}}
     }
@@ -995,13 +995,32 @@ async def test_recovered_red_episode_finalizes_from_check_path():
     now_box["ts"] = 240_000
     await bot._equity_hard_stop_check_coin()
     state = bot._hsl_coin_state("long", symbol)
+    assert state["red_flat_confirmations"] == 0
+    assert state["halted"] is False
+    assert "flatten-fill evidence is unavailable" in caplog.text
+    bot._pnls_manager = make_fake_pnls_manager(
+        [
+            {
+                "timestamp": 230_000,
+                "symbol": symbol,
+                "pside": "long",
+                "pb_order_type": "close_grid_long",
+                "pnl": 0.0,
+                "fee_paid": 0.0,
+            }
+        ]
+    )
+    now_box["ts"] = 300_000
+    await bot._equity_hard_stop_check_coin()
+    state = bot._hsl_coin_state("long", symbol)
     assert state["red_flat_confirmations"] == 1
     assert state["halted"] is False
-    now_box["ts"] = 300_000
+    now_box["ts"] = 360_000
     await bot._equity_hard_stop_check_coin()
     state = bot._hsl_coin_state("long", symbol)
     assert state["halted"] is True
     assert state["cooldown_until_ms"] is not None
+    assert state["last_stop_event"]["stop_event_timestamp_ms"] == 230_000
 
 
 def test_forced_mode_refresher_preserves_paused_red(monkeypatch):
@@ -1161,8 +1180,8 @@ def test_coin_episode_start_covered_reconstruction():
 
 def test_cooldown_anchor_uses_scope_flattening_fill():
     # B2.1: cooldown anchors at the fill that flattened the scope, by any
-    # means. A manual close after the last panic fill must win; with no fills
-    # in the window the panic-fill fallback and then the caller fallback hold.
+    # means. A manual close after the last panic fill must win; with no fill
+    # evidence the anchor remains unavailable rather than becoming "now".
     bot = make_coin_bot()
     events = [
         SimpleNamespace(
@@ -1176,24 +1195,24 @@ def test_cooldown_anchor_uses_scope_flattening_fill():
     ]
     bot._pnls_manager = SimpleNamespace(get_events=lambda: events)
     assert (
-        bot._equity_hard_stop_latest_flatten_fill_timestamp_ms(
-            "long", symbol="A", since_ms=60_000, fallback_ms=999_000
+        bot._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
+            "long", symbol="A", since_ms=60_000
         )
         == 150_000
     )
-    # Window that excludes both fills: caller fallback.
+    # Window that excludes both fills: anchor unavailable.
     assert (
-        bot._equity_hard_stop_latest_flatten_fill_timestamp_ms(
-            "long", symbol="A", since_ms=200_000, fallback_ms=999_000
+        bot._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
+            "long", symbol="A", since_ms=200_000
         )
-        == 999_000
+        is None
     )
     # Other-pair fills never leak into the anchor.
     assert (
-        bot._equity_hard_stop_latest_flatten_fill_timestamp_ms(
-            "long", symbol="B", since_ms=60_000, fallback_ms=999_000
+        bot._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
+            "long", symbol="B", since_ms=60_000
         )
-        == 999_000
+        is None
     )
 
 
@@ -1704,7 +1723,8 @@ def bind_hsl_methods(bot):
         "_equity_hard_stop_validate_balance_source_for_history_replay",
         "_equity_hard_stop_balance_override_active",
         "_equity_hard_stop_position_symbols",
-        "_equity_hard_stop_latest_flatten_fill_timestamp_ms",
+        "_equity_hard_stop_latest_flatten_fill_timestamp_optional_ms",
+        "_equity_hard_stop_defer_missing_flatten_fill",
         "_equity_hard_stop_signal_values",
         "_equity_hard_stop_refresh_halted_runtime_forced_modes",
         "_equity_hard_stop_infer_coin_replay_contract",
@@ -1723,7 +1743,7 @@ def bind_hsl_methods(bot):
         "_hsl_replay_load_extend_and_reconcile_cache",
         "_hsl_reuse_assemble_history",
         "_equity_hard_stop_set_red_paused_runtime_forced_modes",
-        "_equity_hard_stop_latest_flatten_fill_timestamp_ms",
+        "_equity_hard_stop_latest_flatten_fill_timestamp_optional_ms",
         "_equity_hard_stop_coverage_allow_incomplete",
         "_equity_hard_stop_coin_episode_start_covered",
         "_equity_hard_stop_refresh_halted_runtime_forced_modes",
@@ -4427,6 +4447,86 @@ async def test_compact_sparse_replay_matches_dense_state_across_flat_gaps():
 
 
 @pytest.mark.asyncio
+async def test_compact_replay_resets_flat_episode_when_historical_upnl_is_omitted():
+    """Regression for queen_bee XLM: a flat historical pair has no candle replay.
+
+    Fill-derived non-flat/flat transitions still own the episode boundary. The
+    RED episode ended on July 1, so after its 36-hour cooldown expires its
+    realized loss must not leak into the empty current episode.
+    """
+    import numpy as np
+
+    symbol = "XLM/USDC:USDC"
+    entry_ts = 1_782_900_182_624
+    flatten_ts = 1_782_903_432_626
+    now_ms = flatten_ts + 2_160 * 60_000 + 120_000
+    first_minute = entry_ts // 60_000 * 60_000
+    last_minute = now_ms // 60_000 * 60_000
+    timestamps = np.arange(
+        first_minute,
+        last_minute + 60_000,
+        60_000,
+        dtype=np.int64,
+    )
+    flatten_minute = flatten_ts // 60_000 * 60_000
+    realized = np.where(timestamps < flatten_minute, 0.0, -30.0)
+    unrealized = np.where(timestamps < flatten_minute, np.nan, 0.0)
+    history = {
+        "hsl_coin_compact_replay": {
+            "timestamps": timestamps,
+            "balances": np.full(len(timestamps), 100.0, dtype=np.float64),
+            "realized_pnl": realized.copy(),
+            "pair_values": {
+                ("long", symbol): {
+                    "realized_pnl": realized,
+                    # Coin replay omits prices/UPnL while a historical pair is
+                    # open when it is flat now and has no panic marker.
+                    "unrealized_pnl": unrealized,
+                }
+            },
+        },
+        "panic_flatten_events": [],
+        "fill_events": [
+            {
+                "timestamp": entry_ts,
+                "symbol": symbol,
+                "pside": "long",
+                "action": "increase",
+                "qty": 62.0,
+                "pnl": 0.0,
+            },
+            {
+                "timestamp": flatten_ts,
+                "symbol": symbol,
+                "pside": "long",
+                "action": "decrease",
+                "qty": 62.0,
+                "pnl": -30.0,
+                "pb_order_type": "close_grid_long",
+            },
+        ],
+    }
+    bot = _flat_position_bot(symbol)
+    bot.hsl["long"]["cooldown_minutes_after_red"] = 2_160.0
+    bot.get_exchange_time = lambda: now_ms
+
+    async def fake_history(current_balance=None, **kwargs):
+        return history
+
+    bot.get_balance_equity_history = fake_history
+
+    await bot._equity_hard_stop_initialize_coin_from_history()
+
+    state = bot._hsl_coin_state("long", symbol)
+    assert state["halted"] is False
+    assert state["cooldown_until_ms"] is None
+    assert state["pnl_reset_timestamp_ms"] == flatten_ts + 1
+    assert state["last_metrics"]["tier"] == "green"
+    assert state["last_metrics"]["realized_pnl"] == pytest.approx(0.0)
+    assert symbol not in bot._runtime_forced_modes["long"]
+
+
+@pytest.mark.asyncio
 async def test_compact_replay_keeps_held_and_ambiguous_pairs_dense():
     import numpy as np
 
@@ -4757,7 +4857,7 @@ async def test_coin_hsl_check_defers_stop_event_until_flat_confirmation():
 
 
 @pytest.mark.asyncio
-async def test_coin_hsl_finalize_uses_latest_panic_fill_for_reset_boundary():
+async def test_coin_hsl_finalize_uses_latest_flatten_fill_for_reset_boundary():
     from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
 
     bot = make_coin_bot()
@@ -4786,7 +4886,14 @@ async def test_coin_hsl_finalize_uses_latest_panic_fill_for_reset_boundary():
         ]
     )
 
-    await bot._equity_hard_stop_finalize_coin_red_stop("long", symbol)
+    stop_ts_ms = bot._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
+        "long", symbol=symbol, since_ms=state["pending_red_since_ms"]
+    )
+    assert stop_ts_ms == 170_000
+    stop_event = await bot._equity_hard_stop_compute_coin_stop_event(
+        "long", symbol, stop_ts_ms
+    )
+    await bot._equity_hard_stop_finalize_coin_red_stop("long", symbol, stop_event)
 
     assert state["last_stop_event"]["stop_event_timestamp_ms"] == 170_000
     assert state["pnl_reset_timestamp_ms"] == 170_001
@@ -4827,9 +4934,13 @@ async def test_coin_hsl_finalize_emits_flat_without_order_event():
     state = bot._hsl_coin_state("long", symbol)
     state["pending_red_since_ms"] = 120_000
 
+    stop_event = await bot._equity_hard_stop_compute_coin_stop_event(
+        "long", symbol, 180_000
+    )
     await bot._equity_hard_stop_finalize_coin_red_stop(
         "long",
         symbol,
+        stop_event,
         finalized_without_order=True,
         flat_confirmations=2,
         entry_orders=0,
@@ -4858,9 +4969,9 @@ async def test_coin_hsl_finalize_emits_flat_without_order_event():
     assert event.data["nonpanic_close_orders"] == 0
     assert event.data["flat_confirmations"] == 2
     assert event.data["stop_event_timestamp_ms"] == 180_000
-    assert event.data["stop_event_anchor_source"] == "current_time_fallback"
+    assert event.data["stop_event_anchor_source"] == "provided_stop_event"
     assert event.data["stop_event_anchor_timestamp_ms"] == 180_000
-    assert event.data["stop_event_anchor_fallback_used"] is True
+    assert event.data["stop_event_anchor_fallback_used"] is False
     assert event.data["cooldown_until_ms"] == 480_000
     assert event.data["drawdown_raw"] == 0.0
     red_events = [
@@ -4882,7 +4993,7 @@ async def test_coin_hsl_finalize_emits_flat_without_order_event():
 
 
 @pytest.mark.asyncio
-async def test_coin_hsl_finalize_flat_without_order_event_records_panic_fill_anchor():
+async def test_coin_hsl_finalize_flat_without_order_event_records_flatten_fill_anchor():
     from live.event_bus import EventTypes, ListEventSink, LiveEventPipeline
 
     bot = make_coin_bot()
@@ -4911,9 +5022,17 @@ async def test_coin_hsl_finalize_flat_without_order_event_records_panic_fill_anc
         ]
     )
 
+    stop_ts_ms = bot._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
+        "long", symbol=symbol, since_ms=state["pending_red_since_ms"]
+    )
+    assert stop_ts_ms == 170_000
+    stop_event = await bot._equity_hard_stop_compute_coin_stop_event(
+        "long", symbol, stop_ts_ms
+    )
     await bot._equity_hard_stop_finalize_coin_red_stop(
         "long",
         symbol,
+        stop_event,
         finalized_without_order=True,
         flat_confirmations=2,
         entry_orders=0,
@@ -4930,7 +5049,7 @@ async def test_coin_hsl_finalize_flat_without_order_event_records_panic_fill_anc
     event = events[0]
     assert event.cycle_id == "cy_coin_flat_fill_anchor"
     assert event.data["stop_event_timestamp_ms"] == 170_000
-    assert event.data["stop_event_anchor_source"] == "panic_fill"
+    assert event.data["stop_event_anchor_source"] == "provided_stop_event"
     assert event.data["stop_event_anchor_timestamp_ms"] == 170_000
     assert event.data["stop_event_anchor_fallback_used"] is False
     assert event.data["cooldown_until_ms"] == 470_000
@@ -4956,7 +5075,10 @@ async def test_coin_hsl_finalize_does_not_duplicate_prior_red_trigger_event():
     state["pending_red_since_ms"] = 120_000
     state["red_trigger_event_emitted"] = True
 
-    await bot._equity_hard_stop_finalize_coin_red_stop("long", symbol)
+    stop_event = await bot._equity_hard_stop_compute_coin_stop_event(
+        "long", symbol, 170_000
+    )
+    await bot._equity_hard_stop_finalize_coin_red_stop("long", symbol, stop_event)
 
     assert bot._live_event_pipeline.flush(timeout=2.0) is True
     red_events = [event for event in sink.events if event.event_type == EventTypes.HSL_RED_TRIGGERED]

--- a/tests/test_hsl_coin_mode.py
+++ b/tests/test_hsl_coin_mode.py
@@ -4863,6 +4863,63 @@ async def test_coin_hsl_replay_splits_same_minute_flatten_and_reentry(compact):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("compact", [False, True])
+async def test_coin_hsl_replay_uses_first_of_multiple_same_minute_flattens(compact):
+    """Later-episode PnL must not be attached to the first RED episode."""
+    symbol = "A"
+    first_flatten_ts = 150_000
+    history = _red_episode_history(
+        symbol,
+        flatten_pnl=-30.0,
+        rows_upnl=[0.0, 0.0],
+        flatten_ts=first_flatten_ts,
+    )
+    history["fill_events"].extend(
+        [
+            {
+                "timestamp": 160_000,
+                "symbol": symbol,
+                "pside": "long",
+                "action": "increase",
+                "qty": 1.0,
+                "pnl": 0.0,
+            },
+            {
+                "timestamp": 170_000,
+                "symbol": symbol,
+                "pside": "long",
+                "action": "decrease",
+                "qty": 1.0,
+                "pnl": -30.0,
+            },
+        ]
+    )
+    # The minute aggregate contains both losses. Only the first -30 belongs
+    # to the RED episode ending at 150_000; using -60 would cross the terminal
+    # no-restart threshold and demonstrate the attribution bug.
+    for row in history["timeline"]:
+        if row["timestamp"] == 120_000:
+            row["realized_pnl"] = -60.0
+            row["realized_pnl_by_coin_pside"][symbol]["long"] = -60.0
+    bot = _flat_position_bot(symbol)
+    bot.get_exchange_time = lambda: 180_000
+
+    async def fake_history(current_balance=None, **kwargs):
+        return _coin_history_as_compact(history, symbol) if compact else history
+
+    bot.get_balance_equity_history = fake_history
+
+    await bot._equity_hard_stop_initialize_coin_from_history()
+
+    state = bot._hsl_coin_state("long", symbol)
+    assert state["halted"] is True
+    assert state["no_restart_latched"] is False
+    assert state["last_stop_event"]["stop_event_timestamp_ms"] == first_flatten_ts
+    assert state["pnl_reset_timestamp_ms"] == first_flatten_ts + 1
+    assert state["cooldown_until_ms"] == first_flatten_ts + 300_000
+
+
+@pytest.mark.asyncio
 async def test_coin_hsl_history_replay_does_not_latch_recovered_red_without_panic_marker():
     bot = make_coin_bot()
     symbol = "A"

--- a/tests/test_order_orchestration.py
+++ b/tests/test_order_orchestration.py
@@ -839,7 +839,23 @@ async def test_red_supervisor_refreshes_late_flatten_fill_and_exits():
 @pytest.mark.asyncio
 async def test_coin_red_supervisor_refreshes_late_cooldown_repanic_fill():
     symbol = "BTC/USDT:USDT"
-    events = [{"timestamp": 90_000, "pside": "long", "symbol": symbol}]
+    events = [
+        {"timestamp": 90_000, "pside": "long", "symbol": symbol},
+        {
+            "timestamp": 150_000,
+            "pside": "long",
+            "symbol": symbol,
+            "action": "increase",
+            "qty": 1.0,
+        },
+        {
+            "timestamp": 165_000,
+            "pside": "long",
+            "symbol": symbol,
+            "action": "increase",
+            "qty": 1.0,
+        },
+    ]
 
     class FakeBot:
         _equity_hard_stop_supervisor_running = False
@@ -863,6 +879,8 @@ async def test_coin_red_supervisor_refreshes_late_cooldown_repanic_fill():
                 "pending_stop_event": None,
                 "last_stop_event": {"stop_event_timestamp_ms": 120_000},
                 "cooldown_repanic_reset_pending": True,
+                "cooldown_repanic_since_ms": 160_000,
+                "cooldown_repanic_start_sizes": {symbol: 1.0},
                 "last_missing_flatten_fill_log_ms": 0,
                 "last_missing_flatten_fill_refresh_ms": 0,
             }
@@ -888,7 +906,13 @@ async def test_coin_red_supervisor_refreshes_late_cooldown_repanic_fill():
         async def update_pnls(self, *, source, since_ms=None):
             self.refresh_sources.append((source, since_ms))
             events.append(
-                {"timestamp": 170_000, "pside": "long", "symbol": symbol}
+                {
+                    "timestamp": 170_000,
+                    "pside": "long",
+                    "symbol": symbol,
+                    "action": "decrease",
+                    "qty": 2.0,
+                }
             )
             return True
 
@@ -908,7 +932,10 @@ async def test_coin_red_supervisor_refreshes_late_cooldown_repanic_fill():
         ):
             assert (
                 self._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
-                    pside, symbol=requested_symbol, since_ms=120_001
+                    pside,
+                    symbol=requested_symbol,
+                    since_ms=160_000,
+                    replay_start_sizes={symbol: 1.0},
                 )
                 == 170_000
             )
@@ -941,7 +968,7 @@ async def test_coin_red_supervisor_refreshes_late_cooldown_repanic_fill():
     await Passivbot._equity_hard_stop_run_coin_red_supervisor(bot)
 
     assert bot.state["cooldown_repanic_reset_pending"] is False
-    assert bot.refresh_sources == [("hsl_flatten_confirmation", 120_001)]
+    assert bot.refresh_sources == [("hsl_flatten_confirmation", 160_000)]
     assert bot._equity_hard_stop_supervisor_running is False
 
 

--- a/tests/test_order_orchestration.py
+++ b/tests/test_order_orchestration.py
@@ -837,6 +837,115 @@ async def test_red_supervisor_refreshes_late_flatten_fill_and_exits():
 
 
 @pytest.mark.asyncio
+async def test_coin_red_supervisor_refreshes_late_cooldown_repanic_fill():
+    symbol = "BTC/USDT:USDT"
+    events = [{"timestamp": 90_000, "pside": "long", "symbol": symbol}]
+
+    class FakeBot:
+        _equity_hard_stop_supervisor_running = False
+        _equity_hard_stop_cooldown_log_interval_ms = 60_000
+        stop_signal_received = False
+        _equity_hard_stop_latest_flatten_fill_timestamp_optional_ms = (
+            Passivbot._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms
+        )
+        _equity_hard_stop_defer_missing_flatten_fill = (
+            Passivbot._equity_hard_stop_defer_missing_flatten_fill
+        )
+        _equity_hard_stop_flatten_fill_timestamp_with_refresh = (
+            Passivbot._equity_hard_stop_flatten_fill_timestamp_with_refresh
+        )
+
+        def __init__(self):
+            self.state = {
+                "red_flat_confirmations": 0,
+                "halted": True,
+                "pending_red_since_ms": None,
+                "pending_stop_event": None,
+                "last_stop_event": {"stop_event_timestamp_ms": 120_000},
+                "cooldown_repanic_reset_pending": True,
+                "last_missing_flatten_fill_log_ms": 0,
+                "last_missing_flatten_fill_refresh_ms": 0,
+            }
+            self._equity_hard_stop_coin = {"long": {symbol: self.state}}
+            self._pnls_manager = types.SimpleNamespace(get_events=lambda: events)
+            self.refresh_sources = []
+
+        def _hsl_psides(self):
+            return ("long",)
+
+        def _hsl_coin_state(self, pside, requested_symbol):
+            assert requested_symbol == symbol
+            return self.state
+
+        def _equity_hard_stop_coin_needs_panic_supervision(
+            self, pside, requested_symbol, state
+        ):
+            return bool(state["cooldown_repanic_reset_pending"])
+
+        async def refresh_protective_authoritative_state(self):
+            return True
+
+        async def update_pnls(self, *, source, since_ms=None):
+            self.refresh_sources.append((source, since_ms))
+            events.append(
+                {"timestamp": 170_000, "pside": "long", "symbol": symbol}
+            )
+            return True
+
+        def get_exchange_time(self):
+            return 180_000
+
+        def _equity_hard_stop_has_open_position_symbol(self, pside, requested_symbol):
+            return False
+
+        def _equity_hard_stop_count_blocking_open_orders_symbol(
+            self, pside, requested_symbol
+        ):
+            return 0, 0
+
+        async def _equity_hard_stop_refresh_coin_cooldown_after_repanic(
+            self, pside, requested_symbol, now_ms
+        ):
+            assert (
+                self._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
+                    pside, symbol=requested_symbol, since_ms=120_001
+                )
+                == 170_000
+            )
+            self.state["cooldown_repanic_reset_pending"] = False
+            return True
+
+        def _equity_hard_stop_apply_coin_sample(self, *args, **kwargs):
+            return {"red_active_now": True}
+
+        async def _calc_upnl_sum_strict(self, *args):
+            return 0.0
+
+        def get_raw_balance(self):
+            return 100.0
+
+        def _equity_hard_stop_set_coin_runtime_forced_mode(self, *args):
+            pass
+
+        async def calc_protective_panic_orders_to_cancel_and_create(self):
+            return [], []
+
+        async def execute_order_plan_to_exchange(self, *args, **kwargs):
+            pass
+
+        def live_value(self, key):
+            return 0.0
+
+    bot = FakeBot()
+
+    await Passivbot._equity_hard_stop_run_coin_red_supervisor(bot)
+
+    assert bot.state["cooldown_repanic_reset_pending"] is False
+    assert bot.refresh_sources == [("hsl_flatten_confirmation", 120_001)]
+    assert bot._equity_hard_stop_supervisor_running is False
+
+
+@pytest.mark.asyncio
 async def test_calc_orders_blocks_entry_creates_when_trailing_candles_pending():
     symbol = "BTC/USDT"
     bot = OrchestrationBot({symbol: 100.0})

--- a/tests/test_passivbot_hsl_bindings.py
+++ b/tests/test_passivbot_hsl_bindings.py
@@ -53,7 +53,8 @@ def test_passivbot_uses_passivbot_hsl_module_for_hsl_methods():
         "_hsl_replay_load_extend_and_reconcile_cache",
         "_hsl_reuse_assemble_history",
         "_equity_hard_stop_set_red_paused_runtime_forced_modes",
-        "_equity_hard_stop_latest_flatten_fill_timestamp_ms",
+        "_equity_hard_stop_latest_flatten_fill_timestamp_optional_ms",
+        "_equity_hard_stop_defer_missing_flatten_fill",
         "_equity_hard_stop_coverage_allow_incomplete",
         "_equity_hard_stop_coin_episode_start_covered",
     } <= assigned_names

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -2627,6 +2627,8 @@ async def test_hsl_cooldown_panic_refreshes_anchor(monkeypatch):
     assert changed is False
     assert state["cooldown_intervention_active"] is True
     assert state["cooldown_repanic_reset_pending"] is True
+    assert state["cooldown_repanic_since_ms"] == 150_001
+    assert state["cooldown_repanic_start_sizes"] == {symbol: 1.0}
     assert bot._equity_hard_stop_halted_mode("long", symbol) == "panic"
 
     bot.positions[symbol]["long"]["size"] = 0.0
@@ -2637,6 +2639,8 @@ async def test_hsl_cooldown_panic_refreshes_anchor(monkeypatch):
                 "symbol": symbol,
                 "pside": "long",
                 "pb_order_type": "close_panic_long",
+                "action": "decrease",
+                "qty": 1.0,
             }
         ]
     )
@@ -2674,6 +2678,8 @@ async def test_hsl_cooldown_panic_refreshes_anchor(monkeypatch):
     assert state["cooldown_until_ms"] == 230_000
     assert state["cooldown_intervention_active"] is False
     assert state["cooldown_repanic_reset_pending"] is False
+    assert state["cooldown_repanic_since_ms"] is None
+    assert state["cooldown_repanic_start_sizes"] is None
     assert captured["write"][1]["cooldown_until_ms"] == 230_000
 
 

--- a/tests/test_unstucking_safeguards.py
+++ b/tests/test_unstucking_safeguards.py
@@ -3429,7 +3429,8 @@ async def test_hard_stop_finalize_red_stop_terminal_latches_and_stops(monkeypatc
 
     monkeypatch.setattr(bot, "_equity_hard_stop_compute_stop_event", fake_compute)
     monkeypatch.setattr(bot, "_equity_hard_stop_write_latch", fake_write)
-    await bot._equity_hard_stop_finalize_red_stop("long")
+    stop_event = await bot._equity_hard_stop_compute_stop_event("long", 0)
+    await bot._equity_hard_stop_finalize_red_stop("long", stop_event)
 
     assert bot.stop_signal_received is False
     assert _hsl_state(bot)["halted"] is True
@@ -3470,7 +3471,8 @@ async def test_hard_stop_finalize_red_stop_equal_threshold_latches_terminal(
 
     monkeypatch.setattr(bot, "_equity_hard_stop_compute_stop_event", fake_compute)
     monkeypatch.setattr(bot, "_equity_hard_stop_write_latch", fake_write)
-    await bot._equity_hard_stop_finalize_red_stop("long")
+    stop_event = await bot._equity_hard_stop_compute_stop_event("long", 0)
+    await bot._equity_hard_stop_finalize_red_stop("long", stop_event)
 
     assert bot.stop_signal_received is False
     assert _hsl_state(bot)["halted"] is True
@@ -3521,7 +3523,8 @@ async def test_hard_stop_finalize_red_stop_autorestarts_after_cooldown(monkeypat
 
     monkeypatch.setattr(bot, "_equity_hard_stop_compute_stop_event", fake_compute)
     monkeypatch.setattr(bot, "_equity_hard_stop_write_latch", fake_write)
-    await bot._equity_hard_stop_finalize_red_stop("long")
+    stop_event = await bot._equity_hard_stop_compute_stop_event("long", 0)
+    await bot._equity_hard_stop_finalize_red_stop("long", stop_event)
 
     assert bot.stop_signal_received is False
     assert _hsl_state(bot)["halted"] is True
@@ -3546,7 +3549,7 @@ async def test_hard_stop_finalize_red_stop_autorestarts_after_cooldown(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_hard_stop_finalize_red_stop_uses_latest_panic_fill_timestamp(monkeypatch):
+async def test_hard_stop_finalize_red_stop_uses_scope_flattening_fill_timestamp(monkeypatch):
     cfg = _dummy_config()
     bot = _make_dummy_bot(cfg)
     symbol = _set_basic_state(bot)
@@ -3586,7 +3589,12 @@ async def test_hard_stop_finalize_red_stop_uses_latest_panic_fill_timestamp(monk
     monkeypatch.setattr(bot, "_equity_hard_stop_compute_stop_event", fake_compute)
     monkeypatch.setattr(bot, "_equity_hard_stop_write_latch", fake_write)
 
-    await bot._equity_hard_stop_finalize_red_stop("long")
+    stop_ts_ms = bot._equity_hard_stop_latest_flatten_fill_timestamp_optional_ms(
+        "long", since_ms=state["pending_red_since_ms"]
+    )
+    assert stop_ts_ms == 170_000
+    stop_event = await bot._equity_hard_stop_compute_stop_event("long", stop_ts_ms)
+    await bot._equity_hard_stop_finalize_red_stop("long", stop_event)
 
     assert captured["compute"] == ("long", 170_000)
     assert state["last_stop_event"]["stop_event_timestamp_ms"] == 170_000
@@ -3644,7 +3652,8 @@ async def test_hard_stop_finalize_red_stop_uses_persistent_no_restart_peak(monke
     monkeypatch.setattr(bot, "_equity_hard_stop_compute_stop_event", fake_compute)
     monkeypatch.setattr(bot, "_equity_hard_stop_write_latch", fake_write)
 
-    await bot._equity_hard_stop_finalize_red_stop("long")
+    stop_event = await bot._equity_hard_stop_compute_stop_event("long", 0)
+    await bot._equity_hard_stop_finalize_red_stop("long", stop_event)
 
     assert _hsl_state(bot)["no_restart_latched"] is False
     assert _hsl_state(bot)["no_restart_peak_strategy_equity"] == pytest.approx(110.0)
@@ -3656,7 +3665,8 @@ async def test_hard_stop_finalize_red_stop_uses_persistent_no_restart_peak(monke
 
     bot._equity_hard_stop_reset_after_restart("long")
     assert _hsl_state(bot)["red_trigger_event_emitted"] is False
-    await bot._equity_hard_stop_finalize_red_stop("long")
+    stop_event = await bot._equity_hard_stop_compute_stop_event("long", 0)
+    await bot._equity_hard_stop_finalize_red_stop("long", stop_event)
 
     assert _hsl_state(bot)["halted"] is True
     assert _hsl_state(bot)["no_restart_latched"] is True


### PR DESCRIPTION
## Summary

- derive HSL episode boundaries from fill transitions even when compact coin replay omits historical UPnL
- reset each scoped episode on any full flatten, regardless of close order type
- anchor RED cooldowns to the actual flattening fill and defer when that fill is unavailable instead of substituting current time
- add the canonical coin/pside/unified episode contract and update user-facing HSL docs

## Root cause

On queen_bee, XLM long was fully closed by an ordinary `close_grid_long` fill at `2026-07-01T10:57:12.626Z`. Because the pair was flat at startup and had no panic marker, compact replay did not fetch historical prices for it. The replay loop consumed the fill-derived position changes, but rows with missing historical UPnL continued before recording that the episode had been non-flat. The later flatten therefore did not reset the episode, stale realized loss leaked into the empty current episode, and startup created a fresh RED cooldown on July 17.

Live finalization also had a second contract violation: if a flat scope's fill was unavailable, it could fall back to the current exchange time and fabricate a new cooldown anchor.

## Changes

- record fill-derived non-flat state before any missing-UPnL deferral
- recognize the later fill-derived flatten and reset replay state at `flatten_ts + 1`
- require supervisors/finalizers to use a real flatten-fill timestamp; missing evidence stays protective and retries visibly
- reuse newer flat coin metrics if fill refresh arrives later, while retaining the older fill timestamp as the episode boundary
- add a queen_bee-shaped XLM regression with a 2160-minute cooldown and an ordinary grid close
- document the lifecycle in `docs/ai/features/equity_hard_stop_loss.md` and remove stale panic-only wording

## Impact

After the July 1 XLM flatten, the prior episode is reset and its 2160-minute cooldown expires normally. Restart on July 17 no longer reconstructs a new XLM RED cooldown from the closed episode.

## Validation

- `pytest -q tests/test_hsl_coin_mode.py tests/test_passivbot_hsl_bindings.py`
- `pytest -q tests/test_unstucking_safeguards.py`
- `pytest -q tests/test_equity_hard_stop_rolling_peak.py tests/test_hsl_incomplete_history_override.py tests/test_hsl_metric_regression.py tests/test_hsl_startup_preview.py`
- `pytest -q tests/test_order_orchestration.py`
- HSL fake-live RED/cooldown scenario tests, including pside and coin protective supervisor
- `PYTHONPATH=src python src/tools/check_ai_docs.py`
- `PYTHONPATH=src python src/tools/generate_live_event_registry.py --check`
- `pytest -q tests/test_ai_docs.py tests/test_live_event_registry_docs.py`

The AI docs check passes with the repository's existing advisory word-count warning.
