### PR TITLE
Bind restart execution to expected Rust build inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ All notable user-facing changes will be documented in this file.
 
 - Added `passivbot tool live-restart-executor`, an explicit local executor for
   exact tmux targets that already pass the bounded stable target report. It
-  requires the expected Git commit, a tracked-clean checkout, a Rust extension
-  stamped for the current Rust sources, the expected full supervisor-command
-  fingerprint, and `--execute`,
+  requires the expected Git commit, a tracked-clean checkout, an
+  operator-confirmed Rust build-input fingerprint, a Rust extension stamped
+  with that same fingerprint, the expected full supervisor-command fingerprint,
+  and `--execute`,
   sends one Ctrl-C round only to verified panes, waits a bounded time for exact
   process exits, rechecks repository/runtime artifacts plus the private
   supervisor snapshot and pane/process identity before typing launch commands,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ All notable user-facing changes will be documented in this file.
   exact tmux targets that already pass the bounded stable target report. It
   requires the expected Git commit, a tracked-clean checkout, an
   operator-confirmed Rust build-input fingerprint, a Rust extension stamped
-  with that same fingerprint, the expected full supervisor-command fingerprint,
+  with that same fingerprint, a final rehash that detects ignored build-input
+  drift during verification, the expected full supervisor-command fingerprint,
   and `--execute`,
   sends one Ctrl-C round only to verified panes, waits a bounded time for exact
   process exits, rechecks repository/runtime artifacts plus the private

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,18 +22,19 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/restart-executor-runtime-contract`, based on canonical
-  `7b833471c1e770ceb8650a4c3b395713b6a76dcb` after PR #1297.
-- PR: #1298, `Bind live restart execution to repository runtime`. Slice: bind
-  the local restart executor to the intended repository and compiled Rust
-  runtime before any process action.
-- Triggering evidence: PR #1297 proved exact local stop/relaunch mechanics but
-  did not verify that the executor was running from the intended clean commit
-  or that the importable Rust extension matched that checkout's Rust sources.
-- Scope: require an exact expected 40-character repository head, zero tracked
-  changes, and an exact Rust source-fingerprint stamp; repeat the contract
-  immediately before the first signal and before relaunch; preserve untracked
-  artifacts and keep paths and launch commands out of the report.
+- Branch: `codex/restart-executor-artifact-fingerprint`, based on canonical
+  `4a7a6753bff00f9b8749d9707f9bdccc4b3a5ffc` after PR #1298.
+- PR: pending. Slice: require the operator to confirm the exact Rust build-input
+  fingerprint authorized for restart execution.
+- Triggering evidence: PR #1298's VPS5 fail-closed probe proved the checked-out
+  source and loaded extension stamp matched, but also showed that VPS5's
+  fingerprint `7869bc3d...` differed from the clean local fingerprint
+  `d14a5363...` because the intentionally fingerprinted, ignored `Cargo.lock`
+  differs by host. The current executor accepts either self-consistent value
+  without an independent operator confirmation.
+- Scope: require an exact expected 64-character Rust source fingerprint and
+  prove `expected == observed build inputs == loaded extension stamp` before
+  target sampling, immediately before the first signal, and before relaunch.
 - Behavior boundary: local restart/deploy behavior. The executor does not SSH,
   pull/build code, contact exchanges directly, write files directly, use broad
   process-pattern signals, or apply automatic SIGTERM/SIGKILL. Relaunched live
@@ -44,18 +45,20 @@ Estimated completion:
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
 - Expected VPS action: pull and exercise only the executor's fail-closed
-  pre-action contract with a deliberately wrong expected head; leave running
-  bots unchanged.
+  pre-action contract with a deliberately wrong expected Rust fingerprint;
+  leave running bots unchanged.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `7b833471c1e770ceb8650a4c3b395713b6a76dcb`, PR #1297. VPS5 fast-forwarded
-  cleanly from `0f366b6f` without a restart or process signal. The executor CLI
-  and help loaded successfully; a post-deploy 3/3 target report was hard-green
-  with all five exact targets relaunch-ready, zero issues, and the same private
-  command fingerprint. Bot PIDs `1015403/1015406/1015410/1015412/1015414`, pane
-  parents, and unrelated `misc:0.0` PID `434835` remained unchanged.
+  `4a7a6753bff00f9b8749d9707f9bdccc4b3a5ffc`, PR #1298. Exact-head Hermes and
+  both CI jobs were green. VPS5 fast-forwarded cleanly from `7b833471` without a
+  restart or process signal. A deliberately wrong expected head returned exit
+  1 with `action_started=false`, no target preflight, zero tracked changes, and
+  a source-matched Rust extension. The post-deploy 3/3 target report was
+  hard-green with all five unchanged bot PIDs relaunch-ready, exact states
+  `R=3,S=2`, zero issues, and the unchanged private command fingerprint.
+  Unrelated `misc:0.0` remained `%8`, PID `434835`.
 - PR #1294 first
   fast-forwarded cleanly as `3de024c76d5c07bda2b4e64400c1a204d6be38a8`
   and produced a hard-green 3/3 stable target report with all five targets,

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/restart-executor-artifact-fingerprint`, based on canonical
   `4a7a6753bff00f9b8749d9707f9bdccc4b3a5ffc` after PR #1298.
-- PR: pending. Slice: require the operator to confirm the exact Rust build-input
+- PR: #1300. Slice: require the operator to confirm the exact Rust build-input
   fingerprint authorized for restart execution.
 - Triggering evidence: PR #1298's VPS5 fail-closed probe proved the checked-out
   source and loaded extension stamp matched, but also showed that VPS5's

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,8 +22,8 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/restart-executor-artifact-fingerprint`, based on canonical
-  `4a7a6753bff00f9b8749d9707f9bdccc4b3a5ffc` after PR #1298.
+- Branch: `codex/restart-executor-artifact-fingerprint`, integrated with
+  canonical `491f319251076b82799a5212efe2d797c56b1b31` after PR #1296.
 - PR: #1300. Slice: require the operator to confirm the exact Rust build-input
   fingerprint authorized for restart execution.
 - Triggering evidence: PR #1298's VPS5 fail-closed probe proved the checked-out
@@ -51,7 +51,19 @@ Estimated completion:
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `4a7a6753bff00f9b8749d9707f9bdccc4b3a5ffc`, PR #1298. Exact-head Hermes and
+  `491f319251076b82799a5212efe2d797c56b1b31` after docs-only PR #1295 and
+  behavior-changing PR #1296. Both merged with exact-current-head Hermes and
+  green Python/Rust CI. VPS5 fast-forwarded cleanly from `4a7a6753` and the
+  exact local executor gracefully restarted only panes
+  `%358/%359/%360/%361/%362`. Old PIDs
+  `1015403/1015406/1015410/1015412/1015414` exited; replacement PIDs
+  `1019670/1019679/1019673/1019681/1019676` retained the same pane parents and
+  private supervisor fingerprint. The executor and independent settled target
+  reports were hard-green with 3/3 stable samples, all five targets
+  relaunch-ready, zero extras or duplicates, and zero issues. VPS5 remained
+  tracked-clean; unrelated `misc:0.0` remained `%8`, PID `434835`. No direct
+  exchange probe or event was manufactured.
+- PR #1298 merged as `4a7a6753bff00f9b8749d9707f9bdccc4b3a5ffc`. Exact-head Hermes and
   both CI jobs were green. VPS5 fast-forwarded cleanly from `7b833471` without a
   restart or process signal. A deliberately wrong expected head returned exit
   1 with `action_started=false`, no target preflight, zero tracked changes, and

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,28 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1297)
+## Latest Canonical Deployment (PR #1298)
+
+- PR #1298 merged as `4a7a6753bff00f9b8749d9707f9bdccc4b3a5ffc`
+  after exact-head Hermes approval and green Python/Rust CI. It requires the
+  local restart executor to prove an exact Git head, zero tracked changes, and
+  a source-matched loaded Rust extension before target sampling and again at
+  both process-action boundaries.
+- VPS5 fast-forwarded cleanly from `7b833471` without a restart or signal. A
+  deliberately wrong expected head returned exit 1 with
+  `action_started=false`, no target preflight, zero tracked changes, and a Rust
+  source/stamp match at `7869bc3d...`. The final 3/3 exact-target report was
+  hard-green with all five unchanged bot PIDs relaunch-ready, states `R=3,S=2`,
+  zero issues, and the unchanged private supervisor fingerprint. Unrelated
+  `misc:0.0` remained `%8`, PID `434835`.
+- The tracked Rust Git tree matched the clean local tree, but its local
+  fingerprint was `d14a5363...` because ignored `Cargo.lock` is intentionally
+  included and differs by host. The active follow-up requires the operator to
+  confirm the expected host-local Rust fingerprint rather than accepting any
+  internally self-consistent source/stamp pair. No exchange request, process
+  action, or event was manufactured.
+
+## Previous Canonical Deployment (PR #1297)
 
 - PR #1297 merged as `7b833471c1e770ceb8650a4c3b395713b6a76dcb`
   after exact-head Hermes approval and green Python/Rust CI. It added the first

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,25 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1298)
+## Latest Canonical Deployment (PRs #1296 And #1295)
+
+- Docs-only PR #1295 and behavior-changing PR #1296 merged as canonical
+  `491f319251076b82799a5212efe2d797c56b1b31` after exact-current-head Hermes
+  approval and green Python/Rust CI. PR #1296 hardens trailing-fill association
+  across position snapshots and requires post-snapshot fill confirmation when
+  authoritative position-update timestamps are unavailable.
+- VPS5 fast-forwarded cleanly from `4a7a6753`. The exact local executor stopped
+  only old bot PIDs `1015403/1015406/1015410/1015412/1015414` in panes
+  `%358/%359/%360/%361/%362` and relaunched replacement PIDs
+  `1019670/1019679/1019673/1019681/1019676` under the same pane parents and
+  private supervisor fingerprint. Repository and Rust source/stamp checks
+  remained exact and tracked-clean at every action boundary.
+- Executor verification and the independent settled report were hard-green
+  with 3/3 stable samples, five relaunch-ready targets, no extras or duplicates,
+  and zero issues. Unrelated `misc:0.0` remained `%8`, PID `434835`. No direct
+  exchange probe or event was manufactured.
+
+## Previous Canonical Deployment (PR #1298)
 
 - PR #1298 merged as `4a7a6753bff00f9b8749d9707f9bdccc4b3a5ffc`
   after exact-head Hermes approval and green Python/Rust CI. It requires the

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -419,13 +419,18 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   stable sampling verdict.
 - `passivbot tool live-restart-executor SUPERVISOR_CONFIG --session-name
   SESSION --expected-repository-head COMMIT
+  --expected-rust-source-fingerprint SHA256
   --expected-supervisor-fingerprint SHA256 --execute` gracefully
   restarts only the exact local tmux targets proven by the same bounded target
   contract. Before target sampling it requires the exact caller-confirmed
   40-character Git commit, zero tracked changes while preserving untracked
-  artifacts, and a loaded Rust extension whose source stamp exactly matches the
-  checked-out Rust sources. It repeats that runtime contract immediately before
-  the first signal and before relaunch. It also requires the caller-confirmed
+  artifacts, the expected fingerprint recorded by the repository-owned Rust
+  build verification, and a loaded Rust extension whose source stamp exactly
+  matches that fingerprint and the checked-out Rust build inputs. This explicit
+  fingerprint matters because the build inputs include the host-local ignored
+  `Cargo.lock`, so identical Git heads need not produce the same fingerprint.
+  It repeats that runtime contract immediately before the first signal and
+  before relaunch. It also requires the caller-confirmed
   full-command fingerprint, takes an immediate action snapshot, and sends one
   Ctrl-C round to exact pane IDs. After a bounded exact-PID exit wait, it scans
   for unexpected or duplicate live processes, verifies the complete session
@@ -439,8 +444,8 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   recovery; targets that did exit may be relaunched only when every post-stop
   check is still exact. The relaunched live bots resume their configured
   exchange access and normal runtime file writes. Run the read-only target
-  report first and pass its exact opaque fingerprint; command content is never
-  emitted.
+  report first, retain the Rust fingerprint from build verification, and pass
+  both exact fingerprints; command content is never emitted.
 - `passivbot tool live-performance-report` summarizes local live monitor event timings for
   operator performance analysis. It is read-only and does not contact exchanges. Use
   `--recent-minutes` for a time window, `--summary` for a bounded operator projection, and

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -429,8 +429,10 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   matches that fingerprint and the checked-out Rust build inputs. This explicit
   fingerprint matters because the build inputs include the host-local ignored
   `Cargo.lock`, so identical Git heads need not produce the same fingerprint.
-  It repeats that runtime contract immediately before the first signal and
-  before relaunch. It also requires the caller-confirmed
+  Each runtime check rehashes those inputs after extension verification so an
+  ignored input cannot change inside the check unnoticed. It repeats that
+  runtime contract immediately before the first signal and before relaunch. It
+  also requires the caller-confirmed
   full-command fingerprint, takes an immediate action snapshot, and sends one
   Ctrl-C round to exact pane IDs. After a bounded exact-PID exit wait, it scans
   for unexpected or duplicate live processes, verifies the complete session

--- a/src/live/restart_executor.py
+++ b/src/live/restart_executor.py
@@ -162,9 +162,11 @@ def _build_runtime_contract(
             "loaded": False,
             "expected_source_fingerprint": expected_rust_source_fingerprint,
             "source_fingerprint": None,
+            "final_source_fingerprint": None,
             "compiled_source_stamp": None,
             "compiled_sha256": None,
             "source_matched": False,
+            "source_snapshot_stable": None,
         },
         "issues": [],
     }
@@ -235,6 +237,28 @@ def _build_runtime_contract(
     final_status, status_error = _git_contract_output(
         ["status", "--porcelain", "--untracked-files=no"]
     )
+    try:
+        final_fingerprint = source_fingerprint(root / "passivbot-rust")
+    except OSError as exc:
+        rust_report["recheck_error_class"] = exc.__class__.__name__
+        final_fingerprint = None
+        issues.append("rust_source_fingerprint_recheck_unavailable")
+    if (
+        final_fingerprint is None
+        and "rust_source_fingerprint_recheck_unavailable" not in issues
+    ):
+        issues.append("rust_source_fingerprint_recheck_unavailable")
+    rust_report["final_source_fingerprint"] = final_fingerprint
+    source_snapshot_stable = (
+        final_fingerprint is not None
+        and final_fingerprint == fingerprint
+        and final_fingerprint == expected_rust_source_fingerprint
+        and final_fingerprint == compiled_stamp
+    )
+    rust_report["source_snapshot_stable"] = source_snapshot_stable
+    if final_fingerprint is not None and final_fingerprint != fingerprint:
+        issues.append("rust_source_changed_during_runtime_check")
+
     if head_error is not None or status_error is not None:
         issues.append("repository_recheck_unavailable")
     else:

--- a/src/live/restart_executor.py
+++ b/src/live/restart_executor.py
@@ -57,6 +57,7 @@ SAFETY_CONTRACT = {
     "requires_execute_confirmation": True,
     "requires_expected_supervisor_fingerprint": True,
     "requires_expected_repository_head": True,
+    "requires_expected_rust_source_fingerprint": True,
     "requires_tracked_clean_repository": True,
     "requires_source_matched_rust_extension": True,
 }
@@ -114,6 +115,17 @@ def _valid_repository_head(value: str) -> str:
     return head
 
 
+def _valid_rust_source_fingerprint(value: str) -> str:
+    fingerprint = str(value or "").strip()
+    if len(fingerprint) != 64 or any(
+        character not in "0123456789abcdef" for character in fingerprint
+    ):
+        raise ValueError(
+            "expected_rust_source_fingerprint must be 64 lowercase hex characters"
+        )
+    return fingerprint
+
+
 def _issue(code: str, **fields: Any) -> dict[str, Any]:
     return {"code": code, "severity": "error", **fields}
 
@@ -135,7 +147,10 @@ def _git_contract_output(arguments: list[str]) -> tuple[str | None, str | None]:
     return result.stdout.strip(), None
 
 
-def _build_runtime_contract(expected_repository_head: str) -> dict[str, Any]:
+def _build_runtime_contract(
+    expected_repository_head: str,
+    expected_rust_source_fingerprint: str,
+) -> dict[str, Any]:
     report: dict[str, Any] = {
         "ok": False,
         "expected_repository_head": expected_repository_head,
@@ -145,6 +160,7 @@ def _build_runtime_contract(expected_repository_head: str) -> dict[str, Any]:
         "repository_snapshot_stable": None,
         "rust_extension": {
             "loaded": False,
+            "expected_source_fingerprint": expected_rust_source_fingerprint,
             "source_fingerprint": None,
             "compiled_source_stamp": None,
             "compiled_sha256": None,
@@ -190,6 +206,9 @@ def _build_runtime_contract(expected_repository_head: str) -> dict[str, Any]:
     rust_report["source_fingerprint"] = fingerprint
     if fingerprint is None:
         issues.append("rust_source_fingerprint_unavailable")
+        return report
+    if fingerprint != expected_rust_source_fingerprint:
+        issues.append("rust_source_fingerprint_mismatch")
         return report
 
     try:
@@ -476,6 +495,7 @@ def execute_live_restart(
     session_name: str,
     expected_supervisor_fingerprint: str,
     expected_repository_head: str,
+    expected_rust_source_fingerprint: str,
     config_base_dir: Path | None = None,
     preflight_samples: int = DEFAULT_PREFLIGHT_SAMPLES,
     preflight_interval_s: float = DEFAULT_PREFLIGHT_INTERVAL_S,
@@ -493,6 +513,9 @@ def execute_live_restart(
         raise ValueError("session_name must be non-empty")
     expected_fingerprint = _valid_fingerprint(expected_supervisor_fingerprint)
     expected_head = _valid_repository_head(expected_repository_head)
+    expected_rust_fingerprint = _valid_rust_source_fingerprint(
+        expected_rust_source_fingerprint
+    )
     preflight_samples = _bounded_samples(
         preflight_samples, field="preflight_samples"
     )
@@ -515,7 +538,9 @@ def execute_live_restart(
         poll_interval_s, field="poll_interval_s"
     )
 
-    runtime_contract = _build_runtime_contract(expected_head)
+    runtime_contract = _build_runtime_contract(
+        expected_head, expected_rust_fingerprint
+    )
     preflight: dict[str, Any] = {}
     if runtime_contract["ok"]:
         preflight = build_live_restart_target_report(
@@ -527,7 +552,7 @@ def execute_live_restart(
         )
     report: dict[str, Any] = {
         "tool": "live-restart-executor",
-        "schema_version": 2,
+        "schema_version": 3,
         "ok": False,
         "outcome": "preflight_failed",
         "action_started": False,
@@ -605,7 +630,9 @@ def execute_live_restart(
         return report
     report["action_snapshot"] = _preflight_summary(action_snapshot)
 
-    action_runtime_contract = _build_runtime_contract(expected_head)
+    action_runtime_contract = _build_runtime_contract(
+        expected_head, expected_rust_fingerprint
+    )
     report["action_runtime_contract"] = action_runtime_contract
     if (
         not action_runtime_contract["ok"]
@@ -746,7 +773,9 @@ def execute_live_restart(
         report["outcome"] = "manual_recovery_required"
         return report
 
-    relaunch_runtime_contract = _build_runtime_contract(expected_head)
+    relaunch_runtime_contract = _build_runtime_contract(
+        expected_head, expected_rust_fingerprint
+    )
     report["pre_relaunch_runtime_contract"] = relaunch_runtime_contract
     if (
         not relaunch_runtime_contract["ok"]

--- a/src/tools/live_restart_executor.py
+++ b/src/tools/live_restart_executor.py
@@ -34,6 +34,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Exact 40-character lowercase Git commit expected at execution.",
     )
     parser.add_argument(
+        "--expected-rust-source-fingerprint",
+        required=True,
+        help="Exact lowercase SHA-256 fingerprint of the deployed Rust build inputs.",
+    )
+    parser.add_argument(
         "--execute",
         action="store_true",
         help="Confirm exact-pane graceful stop and relaunch execution.",
@@ -60,6 +65,7 @@ def main(argv: list[str] | None = None) -> int:
             session_name=args.session_name,
             expected_supervisor_fingerprint=args.expected_supervisor_fingerprint,
             expected_repository_head=args.expected_repository_head,
+            expected_rust_source_fingerprint=args.expected_rust_source_fingerprint,
             config_base_dir=Path.cwd(),
             preflight_samples=args.preflight_samples,
             preflight_interval_s=args.preflight_interval_s,

--- a/tests/test_live_restart_executor.py
+++ b/tests/test_live_restart_executor.py
@@ -36,9 +36,11 @@ def _runtime_contract(*, ok: bool = True, issue: str | None = None) -> dict:
             "loaded": True,
             "expected_source_fingerprint": RUST_SOURCE_FINGERPRINT,
             "source_fingerprint": RUST_SOURCE_FINGERPRINT,
+            "final_source_fingerprint": RUST_SOURCE_FINGERPRINT,
             "compiled_source_stamp": RUST_SOURCE_FINGERPRINT,
             "compiled_sha256": "d" * 64,
             "source_matched": True,
+            "source_snapshot_stable": True,
         },
         "issues": [issue] if issue else [],
     }
@@ -738,6 +740,7 @@ def test_runtime_contract_binds_clean_head_and_exact_rust_source_stamp(monkeypat
         == RUST_SOURCE_FINGERPRINT
     )
     assert report["rust_extension"]["source_matched"] is True
+    assert report["rust_extension"]["source_snapshot_stable"] is True
     assert "/private/" not in json.dumps(report, sort_keys=True)
 
 
@@ -804,6 +807,53 @@ def test_runtime_contract_rejects_unexpected_rust_source_before_import(monkeypat
     assert report["ok"] is False
     assert report["issues"] == ["rust_source_fingerprint_mismatch"]
     assert report["rust_extension"]["loaded"] is False
+
+
+@pytest.mark.parametrize(
+    ("final_fingerprint", "expected_issue"),
+    [
+        ("e" * 64, "rust_source_changed_during_runtime_check"),
+        (None, "rust_source_fingerprint_recheck_unavailable"),
+    ],
+)
+def test_runtime_contract_rejects_unstable_rust_source_recheck(
+    monkeypatch, final_fingerprint, expected_issue
+):
+    fingerprints = iter([RUST_SOURCE_FINGERPRINT, final_fingerprint])
+    monkeypatch.setattr(
+        executor_module,
+        "_git_contract_output",
+        lambda arguments: (
+            ("/repository" if arguments[-1] == "--show-toplevel" else REPOSITORY_HEAD)
+            if arguments[0] == "rev-parse"
+            else "",
+            None,
+        ),
+    )
+    monkeypatch.setattr(
+        executor_module, "source_fingerprint", lambda _root: next(fingerprints)
+    )
+    monkeypatch.setattr(
+        executor_module.importlib, "import_module", lambda _name: object()
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "verify_loaded_runtime_extension",
+        lambda **_kwargs: {
+            "runtime_compiled_sha256": "d" * 64,
+            "runtime_compiled_source_stamp": RUST_SOURCE_FINGERPRINT,
+        },
+    )
+
+    report = executor_module._build_runtime_contract(
+        REPOSITORY_HEAD, RUST_SOURCE_FINGERPRINT
+    )
+
+    assert report["ok"] is False
+    assert report["issues"] == [expected_issue]
+    assert report["repository_snapshot_stable"] is True
+    assert report["rust_extension"]["source_snapshot_stable"] is False
+    assert report["rust_extension"]["final_source_fingerprint"] == final_fingerprint
 
 
 def test_live_restart_executor_cli_requires_explicit_execute(capsys):

--- a/tests/test_live_restart_executor.py
+++ b/tests/test_live_restart_executor.py
@@ -21,10 +21,10 @@ from tools import live_restart_executor
 
 FINGERPRINT = "a" * 64
 REPOSITORY_HEAD = "b" * 40
+RUST_SOURCE_FINGERPRINT = "c" * 64
 
 
 def _runtime_contract(*, ok: bool = True, issue: str | None = None) -> dict:
-    fingerprint = "c" * 64
     return {
         "ok": ok,
         "expected_repository_head": REPOSITORY_HEAD,
@@ -34,8 +34,9 @@ def _runtime_contract(*, ok: bool = True, issue: str | None = None) -> dict:
         "repository_snapshot_stable": True,
         "rust_extension": {
             "loaded": True,
-            "source_fingerprint": fingerprint,
-            "compiled_source_stamp": fingerprint,
+            "expected_source_fingerprint": RUST_SOURCE_FINGERPRINT,
+            "source_fingerprint": RUST_SOURCE_FINGERPRINT,
+            "compiled_source_stamp": RUST_SOURCE_FINGERPRINT,
             "compiled_sha256": "d" * 64,
             "source_matched": True,
         },
@@ -110,7 +111,7 @@ def _install_happy_dependencies(monkeypatch, targets: list[dict]) -> dict:
     monkeypatch.setattr(
         executor_module,
         "_build_runtime_contract",
-        lambda _expected_head: _runtime_contract(),
+        lambda _expected_head, _expected_rust_fingerprint: _runtime_contract(),
     )
     monkeypatch.setattr(
         executor_module,
@@ -168,6 +169,7 @@ def _execute(**kwargs) -> dict:
         "session_name": "passivbot",
         "expected_supervisor_fingerprint": FINGERPRINT,
         "expected_repository_head": REPOSITORY_HEAD,
+        "expected_rust_source_fingerprint": RUST_SOURCE_FINGERPRINT,
         "preflight_samples": 2,
         "preflight_interval_s": 0.1,
         "shutdown_timeout_s": 1.0,
@@ -191,7 +193,7 @@ def test_live_restart_executor_restarts_only_exact_verified_panes(monkeypatch):
     report = _execute()
 
     assert report["ok"] is True
-    assert report["schema_version"] == 2
+    assert report["schema_version"] == 3
     assert report["outcome"] == "completed"
     assert calls["stop"] == ["%10", "%11"]
     assert calls["start"] == [
@@ -208,6 +210,7 @@ def test_live_restart_executor_restarts_only_exact_verified_panes(monkeypatch):
     assert report["safety"]["configured_live_processes_may_write_files"] is True
     assert report["safety"]["configured_live_processes_may_contact_exchanges"] is True
     assert report["safety"]["requires_expected_repository_head"] is True
+    assert report["safety"]["requires_expected_rust_source_fingerprint"] is True
     assert report["safety"]["requires_tracked_clean_repository"] is True
     assert report["safety"]["requires_source_matched_rust_extension"] is True
 
@@ -224,6 +227,7 @@ def test_live_restart_executor_fails_closed_before_action_on_fingerprint_mismatc
         session_name="passivbot",
         expected_supervisor_fingerprint="b" * 64,
         expected_repository_head=REPOSITORY_HEAD,
+        expected_rust_source_fingerprint=RUST_SOURCE_FINGERPRINT,
         preflight_samples=2,
         preflight_interval_s=0.1,
         execute=True,
@@ -250,11 +254,27 @@ def test_live_restart_executor_requires_full_lowercase_repository_head(monkeypat
     assert calls["stop"] == []
 
 
+@pytest.mark.parametrize("value", ["abc123", "C" * 64])
+def test_live_restart_executor_requires_full_lowercase_rust_fingerprint(
+    monkeypatch, value
+):
+    calls = _install_happy_dependencies(
+        monkeypatch, [_target("binance_01", "%10", 100, 200)]
+    )
+
+    with pytest.raises(ValueError, match="64 lowercase hex"):
+        _execute(expected_rust_source_fingerprint=value)
+
+    assert calls["reports"] == []
+    assert calls["stop"] == []
+
+
 @pytest.mark.parametrize(
     "issue",
     [
         "repository_head_mismatch",
         "repository_tracked_dirty",
+        "rust_source_fingerprint_mismatch",
         "rust_extension_source_mismatch",
     ],
 )
@@ -270,11 +290,15 @@ def test_live_restart_executor_fails_before_target_preflight_on_runtime_contract
     elif issue == "repository_tracked_dirty":
         failed["tracked_clean"] = False
         failed["tracked_changes"] = 1
+    elif issue == "rust_source_fingerprint_mismatch":
+        failed["rust_extension"]["source_fingerprint"] = "e" * 64
     else:
         failed["rust_extension"]["source_matched"] = False
         failed["rust_extension"]["compiled_source_stamp"] = "e" * 64
     monkeypatch.setattr(
-        executor_module, "_build_runtime_contract", lambda _head: failed
+        executor_module,
+        "_build_runtime_contract",
+        lambda _head, _rust_fingerprint: failed,
     )
 
     report = _execute()
@@ -290,12 +314,13 @@ def test_live_restart_executor_rechecks_runtime_before_first_signal(monkeypatch)
     calls = _install_happy_dependencies(
         monkeypatch, [_target("binance_01", "%10", 100, 200)]
     )
-    changed = _runtime_contract(ok=False, issue="repository_tracked_dirty")
-    changed["tracked_clean"] = False
-    changed["tracked_changes"] = 1
+    changed = _runtime_contract(ok=False, issue="rust_source_fingerprint_mismatch")
+    changed["rust_extension"]["source_fingerprint"] = "e" * 64
     contracts = iter([_runtime_contract(), changed])
     monkeypatch.setattr(
-        executor_module, "_build_runtime_contract", lambda _head: next(contracts)
+        executor_module,
+        "_build_runtime_contract",
+        lambda _head, _rust_fingerprint: next(contracts),
     )
 
     report = _execute()
@@ -311,12 +336,13 @@ def test_live_restart_executor_halts_relaunch_on_runtime_drift(monkeypatch):
     calls = _install_happy_dependencies(
         monkeypatch, [_target("binance_01", "%10", 100, 200)]
     )
-    changed = _runtime_contract(ok=False, issue="rust_extension_source_mismatch")
-    changed["rust_extension"]["source_matched"] = False
-    changed["rust_extension"]["compiled_source_stamp"] = "e" * 64
+    changed = _runtime_contract(ok=False, issue="rust_source_fingerprint_mismatch")
+    changed["rust_extension"]["source_fingerprint"] = "e" * 64
     contracts = iter([_runtime_contract(), _runtime_contract(), changed])
     monkeypatch.setattr(
-        executor_module, "_build_runtime_contract", lambda _head: next(contracts)
+        executor_module,
+        "_build_runtime_contract",
+        lambda _head, _rust_fingerprint: next(contracts),
     )
 
     report = _execute()
@@ -700,11 +726,17 @@ def test_runtime_contract_binds_clean_head_and_exact_rust_source_stamp(monkeypat
         },
     )
 
-    report = executor_module._build_runtime_contract(REPOSITORY_HEAD)
+    report = executor_module._build_runtime_contract(
+        REPOSITORY_HEAD, RUST_SOURCE_FINGERPRINT
+    )
 
     assert report["ok"] is True
     assert report["tracked_clean"] is True
     assert report["repository_snapshot_stable"] is True
+    assert (
+        report["rust_extension"]["expected_source_fingerprint"]
+        == RUST_SOURCE_FINGERPRINT
+    )
     assert report["rust_extension"]["source_matched"] is True
     assert "/private/" not in json.dumps(report, sort_keys=True)
 
@@ -736,10 +768,42 @@ def test_runtime_contract_rejects_unstamped_rust_extension(monkeypatch):
         },
     )
 
-    report = executor_module._build_runtime_contract(REPOSITORY_HEAD)
+    report = executor_module._build_runtime_contract(
+        REPOSITORY_HEAD, RUST_SOURCE_FINGERPRINT
+    )
 
     assert report["ok"] is False
     assert report["issues"] == ["rust_extension_source_mismatch"]
+
+
+def test_runtime_contract_rejects_unexpected_rust_source_before_import(monkeypatch):
+    fingerprint = "e" * 64
+    monkeypatch.setattr(
+        executor_module,
+        "_git_contract_output",
+        lambda arguments: (
+            ("/repository" if arguments[-1] == "--show-toplevel" else REPOSITORY_HEAD)
+            if arguments[0] == "rev-parse"
+            else "",
+            None,
+        ),
+    )
+    monkeypatch.setattr(
+        executor_module, "source_fingerprint", lambda _root: fingerprint
+    )
+
+    def unexpected_import(_name):
+        raise AssertionError("extension import must not run after source mismatch")
+
+    monkeypatch.setattr(executor_module.importlib, "import_module", unexpected_import)
+
+    report = executor_module._build_runtime_contract(
+        REPOSITORY_HEAD, RUST_SOURCE_FINGERPRINT
+    )
+
+    assert report["ok"] is False
+    assert report["issues"] == ["rust_source_fingerprint_mismatch"]
+    assert report["rust_extension"]["loaded"] is False
 
 
 def test_live_restart_executor_cli_requires_explicit_execute(capsys):
@@ -753,10 +817,30 @@ def test_live_restart_executor_cli_requires_explicit_execute(capsys):
                 FINGERPRINT,
                 "--expected-repository-head",
                 REPOSITORY_HEAD,
+                "--expected-rust-source-fingerprint",
+                RUST_SOURCE_FINGERPRINT,
             ]
         )
     assert exc_info.value.code == 2
     assert "--execute is required" in capsys.readouterr().err
+
+
+def test_live_restart_executor_cli_requires_expected_rust_fingerprint(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        live_restart_executor.main(
+            [
+                "bots.yaml",
+                "--session-name",
+                "passivbot",
+                "--expected-supervisor-fingerprint",
+                FINGERPRINT,
+                "--expected-repository-head",
+                REPOSITORY_HEAD,
+                "--execute",
+            ]
+        )
+    assert exc_info.value.code == 2
+    assert "--expected-rust-source-fingerprint" in capsys.readouterr().err
 
 
 def test_live_restart_executor_cli_outputs_sanitized_report(monkeypatch, capsys):
@@ -775,6 +859,8 @@ def test_live_restart_executor_cli_outputs_sanitized_report(monkeypatch, capsys)
             FINGERPRINT,
             "--expected-repository-head",
             REPOSITORY_HEAD,
+            "--expected-rust-source-fingerprint",
+            RUST_SOURCE_FINGERPRINT,
             "--execute",
             "--compact",
         ]
@@ -811,6 +897,8 @@ def test_live_restart_executor_tool_dispatch_forwards_module(monkeypatch):
                 FINGERPRINT,
                 "--expected-repository-head",
                 REPOSITORY_HEAD,
+                "--expected-rust-source-fingerprint",
+                RUST_SOURCE_FINGERPRINT,
                 "--execute",
             ]
         )
@@ -827,6 +915,8 @@ def test_live_restart_executor_tool_dispatch_forwards_module(monkeypatch):
             FINGERPRINT,
             "--expected-repository-head",
             REPOSITORY_HEAD,
+            "--expected-rust-source-fingerprint",
+            RUST_SOURCE_FINGERPRINT,
             "--execute",
         ],
         "prog_env": "passivbot tool live-restart-executor",


### PR DESCRIPTION
## Summary
- require an operator-confirmed Rust build-input fingerprint before restart target sampling
- recheck the expected fingerprint before the first signal and before relaunch
- record PR #1298 deployment evidence and document the host-local Cargo.lock distinction

## Safety boundary
- no SSH, pull, build, or direct exchange operation is added
- no signal is sent when the expected fingerprint differs from current build inputs
- untracked artifacts remain preserved and reports remain sanitized

## Validation
- complete Python suite passed before the schema-only report bump
- 210 Rust tests passed
- cargo check --tests passed
- cargo fmt --all --check passed
- focused restart/smoke suite passed after the schema bump
- AI docs check: 0 errors, 1 existing aggregate word-count warning
- AI docs tests passed
- git diff --check passed
- exact worktree Rust extension rebuilt and its source fingerprint matched its compiled stamp

## Deploy plan
After merge, fast-forward the clean VPS5 checkout without restarting bots, run a deliberately wrong expected-Rust-fingerprint fail-closed probe, and verify exact targets plus misc:0.0 remain unchanged.