### PR TITLE
Add restart smoke evidence evaluator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Added `passivbot tool live-restart-smoke-evidence`, a pure fail-closed
+  evaluator for already-generated full restart target and smoke JSON reports.
+  It binds stable exact-target evidence and bounded post-restart monitor/log,
+  shutdown, startup, and repository evidence to the expected head, supervisor
+  fingerprint, and target count without executing report producers or
+  controlling processes.
+
 - Live trailing restart reconciliation now preserves authoritative position-update
   timestamps from CCXT and raw exchange payloads and no longer
   treats position creation time as proof that fill history is current. Exchanges

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/restart-smoke-evidence-contract`, based on canonical
   `e1a4837914c1e4768cd7963bba47212499d32937` after PR #1300.
-- PR: pending. Slice: add a pure post-restart evidence evaluator over existing
+- PR: #1301. Slice: add a pure post-restart evidence evaluator over existing
   full target-report and smoke-report JSON artifacts.
 - Triggering evidence: the executor now proves exact action boundaries, but the
   subsequent operator smoke evidence still depends on manual interpretation of

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,38 +22,38 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/restart-executor-artifact-fingerprint`, integrated with
-  canonical `491f319251076b82799a5212efe2d797c56b1b31` after PR #1296.
-- PR: #1300. Slice: require the operator to confirm the exact Rust build-input
-  fingerprint authorized for restart execution.
-- Triggering evidence: PR #1298's VPS5 fail-closed probe proved the checked-out
-  source and loaded extension stamp matched, but also showed that VPS5's
-  fingerprint `7869bc3d...` differed from the clean local fingerprint
-  `d14a5363...` because the intentionally fingerprinted, ignored `Cargo.lock`
-  differs by host. The current executor accepts either self-consistent value
-  without an independent operator confirmation.
-- Scope: require an exact expected 64-character Rust source fingerprint and
-  prove `expected == observed build inputs == loaded extension stamp` before
-  target sampling, immediately before the first signal, and before relaunch.
-- Behavior boundary: local restart/deploy behavior. The executor does not SSH,
-  pull/build code, contact exchanges directly, write files directly, use broad
-  process-pattern signals, or apply automatic SIGTERM/SIGKILL. Relaunched live
-  bots resume their configured exchange access and normal runtime file writes.
-- Validation: focused runtime-contract, executor, target-report, planner,
-  smoke-report, CLI, secrecy, timeout, duplicate-process, TOCTOU, compilation,
-  and docs regressions.
+- Branch: `codex/restart-smoke-evidence-contract`, based on canonical
+  `e1a4837914c1e4768cd7963bba47212499d32937` after PR #1300.
+- PR: pending. Slice: add a pure post-restart evidence evaluator over existing
+  full target-report and smoke-report JSON artifacts.
+- Triggering evidence: the executor now proves exact action boundaries, but the
+  subsequent operator smoke evidence still depends on manual interpretation of
+  two independently generated reports.
+- Scope: require an exact repository head, private supervisor fingerprint, and
+  target count; fail closed unless target sampling is stable and the full smoke
+  report proves a bounded monitor/log window, clean repository, complete
+  shutdown lifecycle counts, and distinct startup timing coverage.
+- Behavior boundary: read two local JSON files and emit bounded sanitized JSON.
+  The evaluator does not execute report producers, SSH, signal or start
+  processes, contact a network or exchange, load credentials, or write files.
+- Validation: focused evaluator, CLI dispatch/exit, malformed-input, redaction,
+  target-contract, smoke-contract, compilation, and docs regressions.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: pull and exercise only the executor's fail-closed
-  pre-action contract with a deliberately wrong expected Rust fingerprint;
-  leave running bots unchanged.
+- Expected VPS action: pull and evaluate freshly generated bounded target and
+  smoke JSON artifacts. Do not restart or signal bots.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `491f319251076b82799a5212efe2d797c56b1b31` after docs-only PR #1295 and
-  behavior-changing PR #1296. Both merged with exact-current-head Hermes and
-  green Python/Rust CI. VPS5 fast-forwarded cleanly from `4a7a6753` and the
+  `e1a4837914c1e4768cd7963bba47212499d32937` after PR #1300. Exact-head Hermes
+  and Python/Rust CI were green. VPS5 fast-forwarded without a restart or
+  signal; a deliberately wrong expected Rust fingerprint failed before target
+  sampling with `action_started=false`, and the final 3/3 target report retained
+  the same five PIDs, zero extras or issues, and exact states `R=3,S=2`.
+  Repository state stayed tracked-clean and unrelated `misc:0.0` remained `%8`,
+  PID `434835`.
+- PR #1296 previously fast-forwarded VPS5 cleanly from `4a7a6753` and the
   exact local executor gracefully restarted only panes
   `%358/%359/%360/%361/%362`. Old PIDs
   `1015403/1015406/1015410/1015412/1015414` exited; replacement PIDs

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,24 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PRs #1296 And #1295)
+## Latest Canonical Deployment (PR #1300)
+
+- PR #1300 merged as canonical
+  `e1a4837914c1e4768cd7963bba47212499d32937` after exact-current-head Hermes
+  approval and green Python/Rust CI. It requires an operator-confirmed Rust
+  build-input fingerprint and rehashes the inputs after loaded-extension
+  verification at every runtime boundary, detecting ignored-input drift inside
+  the check.
+- VPS5 fast-forwarded cleanly from `491f3192` without restarting or signalling
+  bots. A deliberately wrong expected fingerprint failed before target sampling
+  with `action_started=false`. The final 3/3 exact-target report retained the
+  same five PIDs, zero extras or issues, and states `R=3,S=2`; tracked state and
+  unrelated `misc:0.0` remained unchanged.
+- The active follow-up makes post-restart target and smoke evidence
+  machine-evaluable from already generated full JSON reports. Automatic report
+  collection, pull/build orchestration, and force escalation remain separate.
+
+## Previous Canonical Deployment (PRs #1296 And #1295)
 
 - Docs-only PR #1295 and behavior-changing PR #1296 merged as canonical
   `491f319251076b82799a5212efe2d797c56b1b31` after exact-current-head Hermes

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -359,6 +359,12 @@ Related detailed plans:
      private exact-pane relaunch, and stable final verification. It deliberately
      omits SSH, git pull, Rust rebuild, direct exchange access, and automatic
      force escalation.
+   - 2026-07-17: PR #1300 merged and deployed operator-confirmed Rust
+     build-input fingerprints plus an in-check final rehash at every executor
+     runtime boundary. A deliberately wrong VPS5 fingerprint failed before
+     target sampling or action, and all five bot PIDs remained unchanged. The
+     active follow-up adds a pure evaluator for already-generated full target
+     and smoke JSON reports; automatic report collection remains later work.
 
    Remaining refinements: safe pull/build and post-restart smoke orchestration
    remain open, as does any separately reviewed force-escalation policy.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -448,6 +448,21 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   exchange access and normal runtime file writes. Run the read-only target
   report first, retain the Rust fingerprint from build verification, and pass
   both exact fingerprints; command content is never emitted.
+- `passivbot tool live-restart-smoke-evidence TARGET_REPORT_JSON
+  SMOKE_REPORT_JSON --expected-repository-head COMMIT
+  --expected-supervisor-fingerprint SHA256 --expected-targets N` evaluates two
+  already-generated full JSON reports against one bounded post-restart evidence
+  contract. It requires stable multi-sample exact targets, the caller-confirmed
+  private supervisor fingerprint, a clean exact repository head, bounded
+  monitor and text-log windows with no hard evidence, complete shutdown event
+  counts, and distinct startup timing coverage for the expected targets. The
+  result is bounded and sanitized: it does not copy paths, commands, bot names,
+  symbols, log samples, or arbitrary input payloads. The command only reads the
+  two named local files; it does not run report producers, SSH, signal or start
+  processes, contact a network or exchange, load credentials, or write files.
+  Use `--compact` for single-line JSON. Exit status is zero only when every hard
+  gate passes; non-hard attention evidence remains visible without making the
+  verdict red.
 - `passivbot tool live-performance-report` summarizes local live monitor event timings for
   operator performance analysis. It is read-only and does not contact exchanges. Use
   `--recent-minutes` for a time window, `--summary` for a bounded operator projection, and

--- a/src/live/restart_smoke_evidence.py
+++ b/src/live/restart_smoke_evidence.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from live.restart_smoke_targets import MAX_RESTART_TARGETS, MAX_TARGET_SAMPLES
+
+
+SCHEMA_VERSION = 1
+MAX_ISSUES = 16
+MAX_BOT_IDENTIFIER_CHARS = 160
+MAX_PROJECTED_COUNT = 1_000_000_000
+_GIT_HEAD_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+SAFETY_CONTRACT = {
+    "local_only": True,
+    "read_only": True,
+    "subprocess_execution": False,
+    "signals_processes": False,
+    "starts_processes": False,
+    "network": False,
+    "exchange_access": False,
+    "writes_files": False,
+}
+
+
+def _is_int(value: Any) -> bool:
+    return type(value) is int
+
+
+def _is_non_negative_int(value: Any) -> bool:
+    return _is_int(value) and value >= 0
+
+
+def _count(value: Any) -> int:
+    if not _is_non_negative_int(value):
+        return 0
+    return min(value, MAX_PROJECTED_COUNT)
+
+
+def _valid_head(value: str) -> bool:
+    return bool(_GIT_HEAD_PATTERN.fullmatch(value))
+
+
+def _valid_fingerprint(value: str) -> bool:
+    return bool(_SHA256_PATTERN.fullmatch(value))
+
+
+def _validate_expected_inputs(
+    *,
+    expected_repository_head: str,
+    expected_supervisor_fingerprint: str,
+    expected_targets: int,
+) -> None:
+    if not _valid_head(expected_repository_head):
+        raise ValueError("expected_repository_head must be 40 lowercase hex characters")
+    if not _valid_fingerprint(expected_supervisor_fingerprint):
+        raise ValueError(
+            "expected_supervisor_fingerprint must be 64 lowercase hex characters"
+        )
+    if (
+        not _is_int(expected_targets)
+        or expected_targets < 1
+        or expected_targets > MAX_RESTART_TARGETS
+    ):
+        raise ValueError(
+            f"expected_targets must be between 1 and {MAX_RESTART_TARGETS}"
+        )
+
+
+def _issue(issues: list[dict[str, Any]], code: str) -> None:
+    if len(issues) < MAX_ISSUES:
+        issues.append({"code": code, "severity": "error", "count": 1})
+
+
+def _target_gate(
+    report: dict[str, Any],
+    *,
+    expected_targets: int,
+    expected_supervisor_fingerprint: str,
+) -> dict[str, Any]:
+    contract = report.get("supervisor_contract")
+    contract = contract if isinstance(contract, dict) else {}
+    sampling = report.get("sampling")
+    sampling = sampling if isinstance(sampling, dict) else {}
+    report_issues = report.get("issues")
+    report_issues = report_issues if isinstance(report_issues, list) else None
+    extra_panes = report.get("extra_panes")
+    extra_panes = extra_panes if isinstance(extra_panes, list) else None
+
+    expected_value = report.get("expected_targets")
+    resolved_value = report.get("resolved_targets")
+    relaunch_ready_value = report.get("relaunch_ready_targets")
+    requested_value = sampling.get("requested_samples")
+    collected_value = sampling.get("collected_samples")
+    successful_value = sampling.get("successful_samples")
+    failed_value = sampling.get("failed_samples")
+    stable_targets_value = sampling.get("stable_targets")
+    changed_targets_value = sampling.get("changed_target_count")
+    expected_count = _count(expected_value)
+    resolved_count = _count(resolved_value)
+    relaunch_ready_count = _count(relaunch_ready_value)
+    requested_samples = _count(requested_value)
+    successful_samples = _count(successful_value)
+    failed_samples = _count(failed_value)
+    stable_targets = _count(stable_targets_value)
+    changed_targets = _count(changed_targets_value)
+
+    tool_schema_ok = (
+        report.get("tool") == "live-restart-target-report"
+        and report.get("schema_version") == 1
+        and _is_non_negative_int(report.get("schema_version"))
+    )
+    report_health_ok = (
+        report.get("ok") is True
+        and report.get("hard_failures") == 0
+        and _is_non_negative_int(report.get("hard_failures"))
+        and report_issues == []
+    )
+    target_counts_ok = (
+        expected_value == expected_targets
+        and resolved_value == expected_targets
+        and relaunch_ready_value == expected_targets
+        and _is_non_negative_int(expected_value)
+        and _is_non_negative_int(resolved_value)
+        and _is_non_negative_int(relaunch_ready_value)
+        and extra_panes == []
+    )
+    supervisor_contract_ok = (
+        contract.get("source") == "parsed_supervisor_config"
+        and contract.get("algorithm") == "sha256"
+        and contract.get("fingerprint") == expected_supervisor_fingerprint
+        and contract.get("target_count") == expected_targets
+        and _is_non_negative_int(contract.get("target_count"))
+        and contract.get("command_content_exposed") is False
+    )
+    sampling_ok = (
+        _is_non_negative_int(requested_value)
+        and 2 <= requested_value <= MAX_TARGET_SAMPLES
+        and collected_value == requested_value
+        and successful_value == requested_value
+        and failed_value == 0
+        and _is_non_negative_int(collected_value)
+        and _is_non_negative_int(successful_value)
+        and _is_non_negative_int(failed_value)
+        and sampling.get("stable") is True
+        and sampling.get("supervisor_contract_stable") is True
+        and sampling.get("supervisor_contract_changed") is False
+        and stable_targets_value == expected_targets
+        and changed_targets_value == 0
+        and _is_non_negative_int(stable_targets_value)
+        and _is_non_negative_int(changed_targets_value)
+    )
+    ok = (
+        tool_schema_ok
+        and report_health_ok
+        and target_counts_ok
+        and supervisor_contract_ok
+        and sampling_ok
+    )
+    return {
+        "ok": ok,
+        "tool_schema_ok": tool_schema_ok,
+        "report_health_ok": report_health_ok,
+        "target_counts_ok": target_counts_ok,
+        "supervisor_contract_ok": supervisor_contract_ok,
+        "sampling_ok": sampling_ok,
+        "expected_targets": expected_targets,
+        "expected_count": expected_count,
+        "resolved_count": resolved_count,
+        "relaunch_ready_count": relaunch_ready_count,
+        "extra_pane_count": len(extra_panes) if extra_panes is not None else 0,
+        "requested_samples": requested_samples,
+        "successful_samples": successful_samples,
+        "failed_samples": failed_samples,
+        "stable_targets": stable_targets,
+        "changed_target_count": changed_targets,
+    }
+
+
+def _smoke_contract_gate(report: dict[str, Any]) -> dict[str, Any]:
+    tool_ok = "tool" not in report or report.get("tool") == "live-smoke-report"
+    schema_ok = "schema_version" not in report or (
+        report.get("schema_version") == 1
+        and _is_non_negative_int(report.get("schema_version"))
+    )
+    hard_failures = _count(report.get("hard_failures"))
+    report_ok = (
+        report.get("ok") is True
+        and report.get("hard_failures") == 0
+        and _is_non_negative_int(report.get("hard_failures"))
+    )
+    return {
+        "ok": tool_ok and schema_ok and report_ok,
+        "tool_schema_ok": tool_ok and schema_ok,
+        "report_ok": report_ok,
+        "hard_failures": hard_failures,
+    }
+
+
+def _repository_gate(
+    report: dict[str, Any], *, expected_repository_head: str
+) -> dict[str, Any]:
+    repository = report.get("repository")
+    repository = repository if isinstance(repository, dict) else {}
+    head_matches_expected = repository.get("head_full") == expected_repository_head
+    tracked_clean = (
+        repository.get("is_git_repo") is True
+        and repository.get("error") is None
+        and repository.get("dirty") is False
+        and repository.get("tracked_changes") == 0
+        and _is_non_negative_int(repository.get("tracked_changes"))
+    )
+    return {
+        "ok": head_matches_expected and tracked_clean,
+        "head_matches_expected": head_matches_expected,
+        "tracked_clean": tracked_clean,
+        "tracked_change_count": _count(repository.get("tracked_changes")),
+    }
+
+
+def _window_gate(window: Any) -> tuple[bool, int, int]:
+    row = window if isinstance(window, dict) else {}
+    since_ms = row.get("since_ms")
+    until_ms = row.get("until_ms")
+    ok = (
+        row.get("enabled") is True
+        and _is_int(since_ms)
+        and _is_int(until_ms)
+        and since_ms >= 0
+        and until_ms > since_ms
+    )
+    return ok, _count(since_ms), _count(until_ms)
+
+
+def _event_window_gate(report: dict[str, Any]) -> dict[str, Any]:
+    ok, since_ms, until_ms = _window_gate(report.get("event_window"))
+    return {"ok": ok, "since_ms": since_ms, "until_ms": until_ms}
+
+
+def _monitor_gate(report: dict[str, Any]) -> dict[str, Any]:
+    monitor = report.get("monitor")
+    monitor = monitor if isinstance(monitor, dict) else {}
+    files_scanned = _count(monitor.get("files_scanned"))
+    error_count = _count(monitor.get("error_count"))
+    return {
+        "ok": (
+            _is_non_negative_int(monitor.get("files_scanned"))
+            and files_scanned > 0
+            and monitor.get("error_count") == 0
+            and _is_non_negative_int(monitor.get("error_count"))
+        ),
+        "files_scanned": files_scanned,
+        "error_count": error_count,
+        "warning_count": _count(monitor.get("warning_count")),
+    }
+
+
+def _logs_gate(report: dict[str, Any], event_window: dict[str, Any]) -> dict[str, Any]:
+    logs = report.get("logs")
+    logs = logs if isinstance(logs, dict) else {}
+    window_ok, since_ms, until_ms = _window_gate(logs.get("window"))
+    same_bounds = (
+        window_ok
+        and since_ms == event_window["since_ms"]
+        and until_ms == event_window["until_ms"]
+    )
+    files_scanned = _count(logs.get("files_scanned"))
+    hard_matches = _count(logs.get("hard_matches"))
+    return {
+        "ok": (
+            window_ok
+            and same_bounds
+            and _is_non_negative_int(logs.get("files_scanned"))
+            and files_scanned > 0
+            and logs.get("hard_matches") == 0
+            and _is_non_negative_int(logs.get("hard_matches"))
+        ),
+        "window_ok": window_ok,
+        "same_bounds_as_events": same_bounds,
+        "files_scanned": files_scanned,
+        "hard_matches": hard_matches,
+        "attention_matches": _count(logs.get("attention_matches")),
+    }
+
+
+def _shutdown_gate(report: dict[str, Any], *, expected_targets: int) -> dict[str, Any]:
+    shutdown = report.get("shutdown_events")
+    shutdown = shutdown if isinstance(shutdown, dict) else {}
+    event_types = shutdown.get("event_types")
+    event_types = event_types if isinstance(event_types, dict) else {}
+    stopping_count = _count(event_types.get("bot.stopping"))
+    stopped_count = _count(event_types.get("bot.stopped"))
+    return {
+        "ok": (
+            _is_non_negative_int(event_types.get("bot.stopping"))
+            and _is_non_negative_int(event_types.get("bot.stopped"))
+            and stopping_count >= expected_targets
+            and stopped_count >= expected_targets
+        ),
+        "stopping_count": stopping_count,
+        "stopped_count": stopped_count,
+    }
+
+
+def _startup_gate(report: dict[str, Any], *, expected_targets: int) -> dict[str, Any]:
+    rows = report.get("startup_timings")
+    rows = rows if isinstance(rows, list) else []
+    bot_rows = {
+        row.get("bot")
+        for row in rows
+        if isinstance(row, dict)
+        and isinstance(row.get("bot"), str)
+        and 0 < len(row["bot"]) <= MAX_BOT_IDENTIFIER_CHARS
+        and isinstance(row.get("phases"), dict)
+        and bool(row["phases"])
+    }
+    startup_bot_count = min(len(bot_rows), MAX_PROJECTED_COUNT)
+    return {
+        "ok": startup_bot_count >= expected_targets,
+        "startup_bot_count": startup_bot_count,
+    }
+
+
+def _attention_evidence(
+    report: dict[str, Any], monitor: dict[str, Any], logs: dict[str, Any]
+) -> dict[str, Any]:
+    return {
+        "reported": report.get("attention") is True,
+        "reported_count": _count(report.get("attention_count")),
+        "monitor_warning_count": monitor["warning_count"],
+        "log_attention_matches": logs["attention_matches"],
+    }
+
+
+def build_live_restart_smoke_evidence(
+    target_report: dict[str, Any],
+    smoke_report: dict[str, Any],
+    *,
+    expected_repository_head: str,
+    expected_supervisor_fingerprint: str,
+    expected_targets: int,
+) -> dict[str, Any]:
+    """Evaluate existing bounded reports without performing any live operation."""
+    _validate_expected_inputs(
+        expected_repository_head=expected_repository_head,
+        expected_supervisor_fingerprint=expected_supervisor_fingerprint,
+        expected_targets=expected_targets,
+    )
+    if not isinstance(target_report, dict) or not isinstance(smoke_report, dict):
+        raise ValueError("target_report and smoke_report must be JSON objects")
+
+    target = _target_gate(
+        target_report,
+        expected_targets=expected_targets,
+        expected_supervisor_fingerprint=expected_supervisor_fingerprint,
+    )
+    smoke = _smoke_contract_gate(smoke_report)
+    repository = _repository_gate(
+        smoke_report, expected_repository_head=expected_repository_head
+    )
+    event_window = _event_window_gate(smoke_report)
+    monitor = _monitor_gate(smoke_report)
+    logs = _logs_gate(smoke_report, event_window)
+    shutdown = _shutdown_gate(smoke_report, expected_targets=expected_targets)
+    startup = _startup_gate(smoke_report, expected_targets=expected_targets)
+
+    issues: list[dict[str, Any]] = []
+    if not target["ok"]:
+        _issue(issues, "target_contract_invalid")
+    if not smoke["tool_schema_ok"]:
+        _issue(issues, "smoke_contract_invalid")
+    if not smoke["report_ok"]:
+        _issue(issues, "smoke_hard_failures")
+    if not repository["ok"]:
+        _issue(issues, "repository_mismatch")
+    if not event_window["ok"]:
+        _issue(issues, "event_window_invalid")
+    if not monitor["ok"]:
+        _issue(issues, "monitor_scan_invalid")
+    if not logs["ok"]:
+        _issue(issues, "log_scan_invalid")
+    if not shutdown["ok"]:
+        _issue(issues, "shutdown_evidence_missing")
+    if not startup["ok"]:
+        _issue(issues, "startup_evidence_missing")
+
+    return {
+        "tool": "live-restart-smoke-evidence",
+        "schema_version": SCHEMA_VERSION,
+        "ok": not issues,
+        "hard_failures": len(issues),
+        "issues": issues,
+        "safety": SAFETY_CONTRACT,
+        "gates": {
+            "target_contract": target,
+            "smoke_contract": smoke,
+            "repository": repository,
+            "event_window": event_window,
+            "monitor": monitor,
+            "logs": logs,
+            "shutdown": shutdown,
+            "startup": startup,
+        },
+        "evidence": {
+            "attention": _attention_evidence(smoke_report, monitor, logs),
+        },
+    }

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -148,6 +148,10 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "tools.live_restart_target_report",
         "resolve exact local tmux restart targets without process control",
     ),
+    "live-restart-smoke-evidence": CommandSpec(
+        "tools.live_restart_smoke_evidence",
+        "evaluate bounded local restart smoke evidence without live operations",
+    ),
     "live-restart-executor": CommandSpec(
         "tools.live_restart_executor",
         "gracefully restart exact verified local tmux targets",

--- a/src/tools/live_restart_smoke_evidence.py
+++ b/src/tools/live_restart_smoke_evidence.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+SRC_ROOT = Path(__file__).resolve().parents[1]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from live.restart_smoke_evidence import (  # noqa: E402
+    MAX_RESTART_TARGETS,
+    build_live_restart_smoke_evidence,
+)
+
+
+MAX_INPUT_JSON_BYTES = 16 * 1024 * 1024
+
+
+def _file_state(stat_result: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        stat_result.st_dev,
+        stat_result.st_ino,
+        stat_result.st_size,
+        stat_result.st_mtime_ns,
+        stat_result.st_ctime_ns,
+    )
+
+
+def _load_json_object(path_text: str, *, label: str) -> dict[str, Any]:
+    try:
+        path = Path(path_text)
+        before = path.stat()
+        with path.open("rb") as handle:
+            opened = os.fstat(handle.fileno())
+            raw = handle.read(MAX_INPUT_JSON_BYTES + 1)
+        after = path.stat()
+        if (
+            _file_state(before) != _file_state(opened)
+            or _file_state(opened) != _file_state(after)
+            or opened.st_size != len(raw)
+            or len(raw) > MAX_INPUT_JSON_BYTES
+        ):
+            raise ValueError
+        payload = json.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        raise ValueError(
+            f"{label} must be a readable JSON object within the input limit"
+        ) from None
+    if not isinstance(payload, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="passivbot tool live-restart-smoke-evidence",
+        description=(
+            "Evaluate existing local restart-target and smoke-report JSON evidence "
+            "without running commands or controlling processes."
+        ),
+    )
+    parser.add_argument("target_report_json")
+    parser.add_argument("smoke_report_json")
+    parser.add_argument("--expected-repository-head", required=True)
+    parser.add_argument("--expected-supervisor-fingerprint", required=True)
+    parser.add_argument("--expected-targets", required=True, type=int)
+    parser.add_argument("--compact", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        target_report = _load_json_object(args.target_report_json, label="target report")
+        smoke_report = _load_json_object(args.smoke_report_json, label="smoke report")
+        report = build_live_restart_smoke_evidence(
+            target_report,
+            smoke_report,
+            expected_repository_head=str(args.expected_repository_head),
+            expected_supervisor_fingerprint=str(args.expected_supervisor_fingerprint),
+            expected_targets=args.expected_targets,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+    print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_live_restart_smoke_evidence.py
+++ b/tests/test_live_restart_smoke_evidence.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from live.restart_smoke_evidence import build_live_restart_smoke_evidence
+from tools import live_restart_smoke_evidence
+
+
+HEAD = "a" * 40
+FINGERPRINT = "b" * 64
+
+
+def _target_report(*, targets: int = 2) -> dict:
+    return {
+        "tool": "live-restart-target-report",
+        "schema_version": 1,
+        "ok": True,
+        "hard_failures": 0,
+        "issues": [],
+        "expected_targets": targets,
+        "resolved_targets": targets,
+        "relaunch_ready_targets": targets,
+        "extra_panes": [],
+        "supervisor_contract": {
+            "source": "parsed_supervisor_config",
+            "algorithm": "sha256",
+            "fingerprint": FINGERPRINT,
+            "target_count": targets,
+            "command_content_exposed": False,
+        },
+        "sampling": {
+            "requested_samples": 3,
+            "collected_samples": 3,
+            "successful_samples": 3,
+            "failed_samples": 0,
+            "stable": True,
+            "supervisor_contract_stable": True,
+            "supervisor_contract_changed": False,
+            "stable_targets": targets,
+            "changed_target_count": 0,
+        },
+        "targets": [
+            {
+                "window_name": f"private_bot_{index}",
+                "current_command": "secret command must not project",
+            }
+            for index in range(targets)
+        ],
+    }
+
+
+def _window() -> dict:
+    return {"enabled": True, "since_ms": 1000, "until_ms": 2000}
+
+
+def _smoke_report(*, targets: int = 2) -> dict:
+    return {
+        "tool": "live-smoke-report",
+        "schema_version": 1,
+        "ok": True,
+        "attention": False,
+        "hard_failures": 0,
+        "attention_count": 0,
+        "repository": {
+            "is_git_repo": True,
+            "head_full": HEAD,
+            "dirty": False,
+            "tracked_changes": 0,
+            "error": None,
+        },
+        "event_window": _window(),
+        "monitor": {"files_scanned": 2, "error_count": 0, "warning_count": 0},
+        "logs": {
+            "files_scanned": 2,
+            "hard_matches": 0,
+            "attention_matches": 0,
+            "window": _window(),
+        },
+        "shutdown_events": {
+            "event_types": {"bot.stopping": targets, "bot.stopped": targets}
+        },
+        "startup_timings": [
+            {"bot": f"venue/bot_{index}", "phases": {"startup": {}}}
+            for index in range(targets)
+        ],
+    }
+
+
+def _evaluate(target_report: dict | None = None, smoke_report: dict | None = None) -> dict:
+    return build_live_restart_smoke_evidence(
+        target_report or _target_report(),
+        smoke_report or _smoke_report(),
+        expected_repository_head=HEAD,
+        expected_supervisor_fingerprint=FINGERPRINT,
+        expected_targets=2,
+    )
+
+
+def _codes(report: dict) -> set[str]:
+    return {row["code"] for row in report["issues"]}
+
+
+def test_evaluator_accepts_complete_bounded_evidence():
+    report = _evaluate()
+
+    assert report["ok"] is True
+    assert report["hard_failures"] == 0
+    assert report["issues"] == []
+    assert report["gates"]["target_contract"]["sampling_ok"] is True
+    assert report["gates"]["repository"]["head_matches_expected"] is True
+    assert report["safety"] == {
+        "local_only": True,
+        "read_only": True,
+        "subprocess_execution": False,
+        "signals_processes": False,
+        "starts_processes": False,
+        "network": False,
+        "exchange_access": False,
+        "writes_files": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_count"),
+    [
+        (lambda report: report.update({"resolved_targets": 1}), 1),
+        (
+            lambda report: report["supervisor_contract"].update({"fingerprint": "c" * 64}),
+            1,
+        ),
+        (
+            lambda report: report["sampling"].update(
+                {"stable": False, "changed_target_count": 1}
+            ),
+            1,
+        ),
+    ],
+)
+def test_evaluator_rejects_target_count_fingerprint_and_sampling_failures(
+    mutate, expected_count
+):
+    target = _target_report()
+    mutate(target)
+
+    report = _evaluate(target)
+
+    assert report["ok"] is False
+    assert report["hard_failures"] == expected_count
+    assert _codes(report) == {"target_contract_invalid"}
+
+
+def test_evaluator_rejects_wrong_or_dirty_repository():
+    smoke = _smoke_report()
+    smoke["repository"].update(
+        {"head_full": "c" * 40, "dirty": True, "tracked_changes": 1}
+    )
+
+    report = _evaluate(smoke_report=smoke)
+
+    assert report["ok"] is False
+    assert _codes(report) == {"repository_mismatch"}
+    assert report["gates"]["repository"]["tracked_change_count"] == 1
+
+
+@pytest.mark.parametrize(
+    "window",
+    [
+        {"enabled": False, "since_ms": None, "until_ms": None},
+        {"enabled": True, "since_ms": 2001, "until_ms": 2000},
+        {"enabled": True, "since_ms": 2000, "until_ms": 2000},
+    ],
+)
+def test_evaluator_rejects_unbounded_or_inverted_event_window(window):
+    smoke = _smoke_report()
+    smoke["event_window"] = window
+
+    report = _evaluate(smoke_report=smoke)
+
+    assert report["ok"] is False
+    assert "event_window_invalid" in _codes(report)
+
+
+def test_evaluator_rejects_missing_monitor_and_log_scans():
+    smoke = _smoke_report()
+    smoke["monitor"].update({"files_scanned": 0, "error_count": 1})
+    smoke["logs"].update({"files_scanned": 0, "hard_matches": 1})
+
+    report = _evaluate(smoke_report=smoke)
+
+    assert report["ok"] is False
+    assert {"monitor_scan_invalid", "log_scan_invalid"} <= _codes(report)
+
+
+def test_evaluator_rejects_smoke_hard_failures_and_invalid_optional_schema():
+    smoke = _smoke_report()
+    smoke.update({"ok": False, "hard_failures": 1, "schema_version": 2})
+
+    report = _evaluate(smoke_report=smoke)
+
+    assert report["ok"] is False
+    assert {"smoke_contract_invalid", "smoke_hard_failures"} <= _codes(report)
+    assert report["gates"]["smoke_contract"]["hard_failures"] == 1
+
+
+def test_evaluator_accepts_current_untagged_smoke_report_shape():
+    smoke = _smoke_report()
+    smoke.pop("tool")
+    smoke.pop("schema_version")
+
+    report = _evaluate(smoke_report=smoke)
+
+    assert report["ok"] is True
+
+
+@pytest.mark.parametrize(
+    ("mutate_target", "mutate_smoke", "expected_code"),
+    [
+        (
+            lambda target: target.update({"schema_version": True}),
+            None,
+            "target_contract_invalid",
+        ),
+        (
+            lambda target: target.update({"hard_failures": False}),
+            None,
+            "target_contract_invalid",
+        ),
+        (
+            lambda target: target["sampling"].update({"failed_samples": False}),
+            None,
+            "target_contract_invalid",
+        ),
+        (None, lambda smoke: smoke.update({"schema_version": True}), "smoke_contract_invalid"),
+        (None, lambda smoke: smoke.update({"hard_failures": False}), "smoke_hard_failures"),
+        (
+            None,
+            lambda smoke: smoke["monitor"].update({"error_count": False}),
+            "monitor_scan_invalid",
+        ),
+        (
+            None,
+            lambda smoke: smoke["logs"].update({"hard_matches": False}),
+            "log_scan_invalid",
+        ),
+    ],
+)
+def test_evaluator_rejects_malformed_required_numeric_and_schema_fields(
+    mutate_target, mutate_smoke, expected_code
+):
+    target = _target_report()
+    smoke = _smoke_report()
+    if mutate_target is not None:
+        mutate_target(target)
+    if mutate_smoke is not None:
+        mutate_smoke(smoke)
+
+    report = _evaluate(target, smoke)
+
+    assert report["ok"] is False
+    assert expected_code in _codes(report)
+
+
+def test_evaluator_rejects_bool_target_count_and_supervisor_count_for_one_target():
+    target = _target_report(targets=1)
+    target["expected_targets"] = True
+    target["resolved_targets"] = True
+    target["relaunch_ready_targets"] = True
+    target["supervisor_contract"]["target_count"] = True
+    smoke = _smoke_report(targets=1)
+
+    report = build_live_restart_smoke_evidence(
+        target,
+        smoke,
+        expected_repository_head=HEAD,
+        expected_supervisor_fingerprint=FINGERPRINT,
+        expected_targets=1,
+    )
+
+    assert report["ok"] is False
+    assert _codes(report) == {"target_contract_invalid"}
+
+
+def test_evaluator_rejects_missing_shutdown_and_startup_evidence():
+    smoke = _smoke_report()
+    smoke["shutdown_events"] = {"event_types": {"bot.stopping": 1, "bot.stopped": 1}}
+    smoke["startup_timings"] = [{"bot": "venue/bot_0", "phases": {"startup": {}}}]
+
+    report = _evaluate(smoke_report=smoke)
+
+    assert report["ok"] is False
+    assert {"shutdown_evidence_missing", "startup_evidence_missing"} <= _codes(report)
+
+
+def test_attention_evidence_remains_green():
+    smoke = _smoke_report()
+    smoke.update({"attention": True, "attention_count": 3})
+    smoke["monitor"]["warning_count"] = 2
+    smoke["logs"]["attention_matches"] = 4
+
+    report = _evaluate(smoke_report=smoke)
+
+    assert report["ok"] is True
+    assert report["evidence"]["attention"] == {
+        "reported": True,
+        "reported_count": 3,
+        "monitor_warning_count": 2,
+        "log_attention_matches": 4,
+    }
+
+
+def test_evaluator_redacts_input_paths_commands_samples_and_bot_names():
+    target = _target_report()
+    target["extra_payload"] = {
+        "path": "/private/secret-target.json",
+        "command": "dangerous raw command",
+        "sample": "raw target sample",
+    }
+    smoke = _smoke_report()
+    smoke["monitor"].update(
+        {
+            "root": "/private/secret-monitor",
+            "issues": [{"message": "raw monitor message"}],
+        }
+    )
+    smoke["logs"].update(
+        {
+            "root": "/private/secret-logs",
+            "matches": [{"text": "raw log sample"}],
+        }
+    )
+    smoke["startup_timings"][0]["bot"] = "sensitive-operator-bot"
+
+    output = json.dumps(_evaluate(target, smoke), sort_keys=True)
+
+    for forbidden in (
+        "/private/secret-target.json",
+        "dangerous raw command",
+        "raw target sample",
+        "/private/secret-monitor",
+        "/private/secret-logs",
+        "raw monitor message",
+        "raw log sample",
+        "sensitive-operator-bot",
+    ):
+        assert forbidden not in output
+
+
+def test_cli_emits_compact_report_and_red_exit(tmp_path, capsys):
+    target_path = tmp_path / "target.json"
+    smoke_path = tmp_path / "smoke.json"
+    target_path.write_text(json.dumps(_target_report()), encoding="utf-8")
+    smoke = _smoke_report()
+    smoke["monitor"]["files_scanned"] = 0
+    smoke_path.write_text(json.dumps(smoke), encoding="utf-8")
+
+    result = live_restart_smoke_evidence.main(
+        [
+            str(target_path),
+            str(smoke_path),
+            "--expected-repository-head",
+            HEAD,
+            "--expected-supervisor-fingerprint",
+            FINGERPRINT,
+            "--expected-targets",
+            "2",
+            "--compact",
+        ]
+    )
+
+    assert result == 1
+    assert json.loads(capsys.readouterr().out)["ok"] is False
+
+
+def test_cli_emits_green_exit_for_complete_evidence(tmp_path, capsys):
+    target_path = tmp_path / "target.json"
+    smoke_path = tmp_path / "smoke.json"
+    target_path.write_text(json.dumps(_target_report()), encoding="utf-8")
+    smoke_path.write_text(json.dumps(_smoke_report()), encoding="utf-8")
+
+    result = live_restart_smoke_evidence.main(
+        [
+            str(target_path),
+            str(smoke_path),
+            "--expected-repository-head",
+            HEAD,
+            "--expected-supervisor-fingerprint",
+            FINGERPRINT,
+            "--expected-targets",
+            "2",
+            "--compact",
+        ]
+    )
+
+    assert result == 0
+    assert json.loads(capsys.readouterr().out)["ok"] is True
+
+
+def test_cli_rejects_invalid_json_and_expected_arguments(tmp_path, capsys):
+    target_path = tmp_path / "target.json"
+    smoke_path = tmp_path / "smoke.json"
+    target_path.write_text("[]", encoding="utf-8")
+    smoke_path.write_text(json.dumps(_smoke_report()), encoding="utf-8")
+
+    with pytest.raises(SystemExit) as invalid_json:
+        live_restart_smoke_evidence.main(
+            [
+                str(target_path),
+                str(smoke_path),
+                "--expected-repository-head",
+                HEAD,
+                "--expected-supervisor-fingerprint",
+                FINGERPRINT,
+                "--expected-targets",
+                "2",
+            ]
+        )
+    assert invalid_json.value.code == 2
+    assert "target report must be a JSON object" in capsys.readouterr().err
+
+    target_path.write_text(json.dumps(_target_report()), encoding="utf-8")
+    with pytest.raises(SystemExit) as invalid_expected:
+        live_restart_smoke_evidence.main(
+            [
+                str(target_path),
+                str(smoke_path),
+                "--expected-repository-head",
+                "ABC",
+                "--expected-supervisor-fingerprint",
+                FINGERPRINT,
+                "--expected-targets",
+                "0",
+            ]
+        )
+    assert invalid_expected.value.code == 2
+    assert "expected_repository_head" in capsys.readouterr().err
+
+
+def test_cli_rejects_oversized_json_without_reading_beyond_the_limit(
+    tmp_path, capsys, monkeypatch
+):
+    target_path = tmp_path / "target.json"
+    smoke_path = tmp_path / "smoke.json"
+    target_path.write_bytes(b"x" * 9)
+    smoke_path.write_text(json.dumps(_smoke_report()), encoding="utf-8")
+    monkeypatch.setattr(live_restart_smoke_evidence, "MAX_INPUT_JSON_BYTES", 8)
+
+    with pytest.raises(SystemExit) as oversized:
+        live_restart_smoke_evidence.main(
+            [
+                str(target_path),
+                str(smoke_path),
+                "--expected-repository-head",
+                HEAD,
+                "--expected-supervisor-fingerprint",
+                FINGERPRINT,
+                "--expected-targets",
+                "2",
+            ]
+        )
+
+    assert oversized.value.code == 2
+    assert "within the input limit" in capsys.readouterr().err

--- a/tests/test_passivbot_cli.py
+++ b/tests/test_passivbot_cli.py
@@ -349,6 +349,51 @@ def test_live_smoke_report_tool_dispatch_forwards_module_and_prog(monkeypatch):
     assert captured["prog_env"] == "passivbot tool live-smoke-report"
 
 
+def test_live_restart_smoke_evidence_tool_dispatch_forwards_module_and_prog(monkeypatch):
+    captured = {}
+
+    def fake_invoke_module_main(module_name):
+        captured["module_name"] = module_name
+        captured["argv"] = sys.argv[:]
+        captured["prog_env"] = os.environ.get("PASSIVBOT_CLI_PROG")
+        return True, 0
+
+    monkeypatch.setattr(cli_main, "_invoke_module_main", fake_invoke_module_main)
+    monkeypatch.setattr(cli_main, "_missing_full_install_markers", lambda: [])
+
+    assert (
+        cli_main.main(
+            [
+                "tool",
+                "live-restart-smoke-evidence",
+                "target.json",
+                "smoke.json",
+                "--expected-repository-head",
+                "a" * 40,
+                "--expected-supervisor-fingerprint",
+                "b" * 64,
+                "--expected-targets",
+                "2",
+            ]
+        )
+        == 0
+    )
+
+    assert captured["module_name"] == "tools.live_restart_smoke_evidence"
+    assert captured["argv"] == [
+        "passivbot tool live-restart-smoke-evidence",
+        "target.json",
+        "smoke.json",
+        "--expected-repository-head",
+        "a" * 40,
+        "--expected-supervisor-fingerprint",
+        "b" * 64,
+        "--expected-targets",
+        "2",
+    ]
+    assert captured["prog_env"] == "passivbot tool live-restart-smoke-evidence"
+
+
 def test_live_process_report_tool_dispatch_forwards_module_and_prog(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Summary

- add a pure, bounded evaluator for full restart target and smoke JSON reports
- require exact repository head, private supervisor fingerprint, stable target sampling, clean repository, bounded monitor/log windows, shutdown counts, and distinct startup timing coverage
- emit only sanitized aggregate evidence; never run report producers, control processes, contact a network/exchange, or write files

## Scope and impact

- category: read-only tooling
- behavior impact: machine-evaluate already-generated post-restart evidence; no trading or restart behavior changes
- non-goals: report collection, SSH, pull/build orchestration, signals, process starts, force escalation, credentials, or exchange access
- expected VPS action: pull, generate bounded target/smoke reports with the existing tools, and evaluate them; no bot restart or signal

## Validation

- complete Python test suite passed
- focused evaluator, target-report, executor, smoke-report, CLI, and AI-doc suites passed
- changed modules compile
- AI docs check: 0 errors, 1 existing aggregate-size warning
- git diff check passed

## Deployment evidence carried forward

PR #1300 deployed to VPS5 at `e1a4837914c1e4768cd7963bba47212499d32937` without restarting or signalling bots. A deliberately wrong expected Rust fingerprint failed before target sampling with `action_started=false`. The final 3/3 target report retained the same five PIDs, zero extras/issues, tracked-clean state, and unchanged `misc:0.0`.

## Safety

No authenticated exchange calls or manufactured trading, risk, lock, or state events were used.

## Residual risk

The evaluator proves only the supplied report contents. Automatic collection and provenance linking between the restart action and report generation remain separate follow-up work.
