### PR TITLE
Preserve restart smoke window fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable user-facing changes will be documented in this file.
   It binds stable exact-target evidence and bounded post-restart monitor/log,
   shutdown, startup, and repository evidence to the expected head, supervisor
   fingerprint, and target count without executing report producers or
-  controlling processes.
+  controlling processes. Event and log windows retain and compare exact bounded
+  epoch-millisecond values, and dropped hard-looking log evidence fails closed.
 
 - Live trailing restart reconciliation now preserves authoritative position-update
   timestamps from CCXT and raw exchange payloads and no longer

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/restart-smoke-window-fidelity`, based on canonical
   `46a28795dec40acbee0dbaa3602be955bbecf23e` after PR #1301.
-- PR: pending. Slice: preserve exact bounded smoke-window timestamps and reject
+- PR: #1302. Slice: preserve exact bounded smoke-window timestamps and reject
   dropped hard-looking log evidence.
 - Triggering evidence: live PR #1301 validation projected both modern event
   bounds as `1000000000` because epoch milliseconds reused a generic count

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,31 +22,43 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/restart-smoke-evidence-contract`, based on canonical
-  `e1a4837914c1e4768cd7963bba47212499d32937` after PR #1300.
-- PR: #1301. Slice: add a pure post-restart evidence evaluator over existing
-  full target-report and smoke-report JSON artifacts.
-- Triggering evidence: the executor now proves exact action boundaries, but the
-  subsequent operator smoke evidence still depends on manual interpretation of
-  two independently generated reports.
-- Scope: require an exact repository head, private supervisor fingerprint, and
-  target count; fail closed unless target sampling is stable and the full smoke
-  report proves a bounded monitor/log window, clean repository, complete
-  shutdown lifecycle counts, and distinct startup timing coverage.
+- Branch: `codex/restart-smoke-window-fidelity`, based on canonical
+  `46a28795dec40acbee0dbaa3602be955bbecf23e` after PR #1301.
+- PR: pending. Slice: preserve exact bounded smoke-window timestamps and reject
+  dropped hard-looking log evidence.
+- Triggering evidence: live PR #1301 validation projected both modern event
+  bounds as `1000000000` because epoch milliseconds reused a generic count
+  clamp. The same lossy values were used for event/log equality, so different
+  modern windows could compare equal. The log gate also ignored nonzero
+  `dropped_unparsed_hard_matches` from the opt-in drop policy.
+- Scope: validate epoch milliseconds against a fixed bounded range, compare and
+  project the exact values, and require both retained and dropped hard-log
+  counts to be well-formed zeroes.
 - Behavior boundary: read two local JSON files and emit bounded sanitized JSON.
   The evaluator does not execute report producers, SSH, signal or start
   processes, contact a network or exchange, load credentials, or write files.
-- Validation: focused evaluator, CLI dispatch/exit, malformed-input, redaction,
-  target-contract, smoke-contract, compilation, and docs regressions.
+- Validation: focused exact-window, mismatched-window, malformed timestamp,
+  dropped-hard-log, evaluator, compilation, and docs regressions.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: pull and evaluate freshly generated bounded target and
-  smoke JSON artifacts. Do not restart or signal bots.
+- Expected VPS action: pull and re-evaluate the saved exact PR #1296 restart
+  window plus a deliberately mismatched-window copy. Do not restart or signal
+  bots.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `e1a4837914c1e4768cd7963bba47212499d32937` after PR #1300. Exact-head Hermes
+  `46a28795dec40acbee0dbaa3602be955bbecf23e` after PR #1301. Exact-head Hermes
+  and Python/Rust CI were green. VPS5 fast-forwarded without a restart or
+  signal. The exact PR #1296 shutdown-through-startup window evaluated green
+  with 3/3 stable targets, five stopping/stopped lifecycles, startup timing for
+  five bots, 24 bounded monitor segments, eight text logs, and zero hard
+  failures. A wider three-hour report correctly evaluated red on 30 real hard
+  events. Final pane parents and bot PIDs were unchanged; the checkout remained
+  tracked-clean and `misc:0.0` remained `%8`, PID `434835`. Validation exposed
+  the lossy timestamp projection addressed by the active follow-up.
+- PR #1300 previously deployed at
+  `e1a4837914c1e4768cd7963bba47212499d32937`. Exact-head Hermes
   and Python/Rust CI were green. VPS5 fast-forwarded without a restart or
   signal; a deliberately wrong expected Rust fingerprint failed before target
   sampling with `action_started=false`, and the final 3/3 target report retained

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,23 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1300)
+## Latest Canonical Deployment (PR #1301)
+
+- PR #1301 merged as canonical
+  `46a28795dec40acbee0dbaa3602be955bbecf23e` after exact-current-head Hermes
+  approval and green Python/Rust CI. It adds a pure, bounded evaluator for
+  already-generated full restart target and smoke JSON reports.
+- VPS5 fast-forwarded without a restart or signal. The real PR #1296
+  shutdown-through-startup window evaluated green with all five lifecycle and
+  startup cohorts, zero hard failures, stable exact targets, and a clean exact
+  repository head. A wider three-hour window correctly evaluated red on 30
+  existing hard events. Bot and pane PIDs plus `misc:0.0` remained unchanged.
+- The deploy exposed a fidelity defect: generic count projection clamped both
+  modern epoch-ms bounds to `1000000000` and the log-bound comparison reused
+  those lossy values. The active follow-up preserves exact bounded timestamps
+  and fails closed on dropped hard-looking log evidence.
+
+## Previous Canonical Deployment (PR #1300)
 
 - PR #1300 merged as canonical
   `e1a4837914c1e4768cd7963bba47212499d32937` after exact-current-head Hermes
@@ -28,7 +44,7 @@ merge, live smoke evidence changes, or new gaps are discovered.
   with `action_started=false`. The final 3/3 exact-target report retained the
   same five PIDs, zero extras or issues, and states `R=3,S=2`; tracked state and
   unrelated `misc:0.0` remained unchanged.
-- The active follow-up makes post-restart target and smoke evidence
+- The following slice made post-restart target and smoke evidence
   machine-evaluable from already generated full JSON reports. Automatic report
   collection, pull/build orchestration, and force escalation remain separate.
 

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -365,6 +365,12 @@ Related detailed plans:
      target sampling or action, and all five bot PIDs remained unchanged. The
      active follow-up adds a pure evaluator for already-generated full target
      and smoke JSON reports; automatic report collection remains later work.
+   - 2026-07-17: PR #1301 merged and deployed the pure target/smoke evidence
+     evaluator without restarting bots. A real shutdown-through-startup window
+     passed all gates and a wider window correctly failed on existing hard
+     events. Deployment also exposed lossy epoch-ms projection and comparison;
+     the active follow-up preserves exact bounded timestamps and rejects
+     dropped hard-looking log evidence. Automatic collection remains later.
 
    Remaining refinements: safe pull/build and post-restart smoke orchestration
    remain open, as does any separately reviewed force-escalation policy.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -456,6 +456,10 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   private supervisor fingerprint, a clean exact repository head, bounded
   monitor and text-log windows with no hard evidence, complete shutdown event
   counts, and distinct startup timing coverage for the expected targets. The
+  event and text-log bounds are compared as exact validated epoch-millisecond
+  values and projected without count clamping. Both retained hard log matches
+  and contextless hard-looking matches suppressed by the opt-in drop policy
+  must be well-formed zeroes.
   result is bounded and sanitized: it does not copy paths, commands, bot names,
   symbols, log samples, or arbitrary input payloads. The command only reads the
   two named local files; it does not run report producers, SSH, signal or start

--- a/src/live/restart_smoke_evidence.py
+++ b/src/live/restart_smoke_evidence.py
@@ -10,6 +10,7 @@ SCHEMA_VERSION = 1
 MAX_ISSUES = 16
 MAX_BOT_IDENTIFIER_CHARS = 160
 MAX_PROJECTED_COUNT = 1_000_000_000
+MAX_EPOCH_MS = 253_402_300_799_999
 _GIT_HEAD_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 _SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
@@ -31,6 +32,10 @@ def _is_int(value: Any) -> bool:
 
 def _is_non_negative_int(value: Any) -> bool:
     return _is_int(value) and value >= 0
+
+
+def _is_epoch_ms(value: Any) -> bool:
+    return _is_int(value) and 0 <= value <= MAX_EPOCH_MS
 
 
 def _count(value: Any) -> int:
@@ -220,18 +225,23 @@ def _repository_gate(
     }
 
 
-def _window_gate(window: Any) -> tuple[bool, int, int]:
+def _window_gate(window: Any) -> tuple[bool, int | None, int | None]:
     row = window if isinstance(window, dict) else {}
     since_ms = row.get("since_ms")
     until_ms = row.get("until_ms")
+    valid_since_ms = _is_epoch_ms(since_ms)
+    valid_until_ms = _is_epoch_ms(until_ms)
     ok = (
         row.get("enabled") is True
-        and _is_int(since_ms)
-        and _is_int(until_ms)
-        and since_ms >= 0
+        and valid_since_ms
+        and valid_until_ms
         and until_ms > since_ms
     )
-    return ok, _count(since_ms), _count(until_ms)
+    return (
+        ok,
+        since_ms if valid_since_ms else None,
+        until_ms if valid_until_ms else None,
+    )
 
 
 def _event_window_gate(report: dict[str, Any]) -> dict[str, Any]:
@@ -268,6 +278,7 @@ def _logs_gate(report: dict[str, Any], event_window: dict[str, Any]) -> dict[str
     )
     files_scanned = _count(logs.get("files_scanned"))
     hard_matches = _count(logs.get("hard_matches"))
+    dropped_unparsed_hard_matches = _count(logs.get("dropped_unparsed_hard_matches"))
     return {
         "ok": (
             window_ok
@@ -276,11 +287,14 @@ def _logs_gate(report: dict[str, Any], event_window: dict[str, Any]) -> dict[str
             and files_scanned > 0
             and logs.get("hard_matches") == 0
             and _is_non_negative_int(logs.get("hard_matches"))
+            and logs.get("dropped_unparsed_hard_matches") == 0
+            and _is_non_negative_int(logs.get("dropped_unparsed_hard_matches"))
         ),
         "window_ok": window_ok,
         "same_bounds_as_events": same_bounds,
         "files_scanned": files_scanned,
         "hard_matches": hard_matches,
+        "dropped_unparsed_hard_matches": dropped_unparsed_hard_matches,
         "attention_matches": _count(logs.get("attention_matches")),
     }
 

--- a/tests/test_live_restart_smoke_evidence.py
+++ b/tests/test_live_restart_smoke_evidence.py
@@ -4,7 +4,10 @@ import json
 
 import pytest
 
-from live.restart_smoke_evidence import build_live_restart_smoke_evidence
+from live.restart_smoke_evidence import (
+    MAX_PROJECTED_COUNT,
+    build_live_restart_smoke_evidence,
+)
 from tools import live_restart_smoke_evidence
 
 
@@ -52,7 +55,11 @@ def _target_report(*, targets: int = 2) -> dict:
 
 
 def _window() -> dict:
-    return {"enabled": True, "since_ms": 1000, "until_ms": 2000}
+    return {
+        "enabled": True,
+        "since_ms": 1_752_789_600_123,
+        "until_ms": 1_752_789_660_456,
+    }
 
 
 def _smoke_report(*, targets: int = 2) -> dict:
@@ -76,6 +83,7 @@ def _smoke_report(*, targets: int = 2) -> dict:
             "files_scanned": 2,
             "hard_matches": 0,
             "attention_matches": 0,
+            "dropped_unparsed_hard_matches": 0,
             "window": _window(),
         },
         "shutdown_events": {
@@ -182,6 +190,53 @@ def test_evaluator_rejects_unbounded_or_inverted_event_window(window):
     assert "event_window_invalid" in _codes(report)
 
 
+def test_evaluator_preserves_exact_modern_window_bounds():
+    smoke = _smoke_report()
+
+    report = _evaluate(smoke_report=smoke)
+
+    assert report["ok"] is True
+    assert report["gates"]["event_window"] == {
+        "ok": True,
+        "since_ms": 1_752_789_600_123,
+        "until_ms": 1_752_789_660_456,
+    }
+    assert report["gates"]["logs"]["same_bounds_as_events"] is True
+
+
+def test_evaluator_rejects_different_modern_log_window_bounds():
+    smoke = _smoke_report()
+    smoke["logs"]["window"]["until_ms"] += 1
+
+    report = _evaluate(smoke_report=smoke)
+
+    assert report["ok"] is False
+    assert "log_scan_invalid" in _codes(report)
+    assert report["gates"]["logs"]["same_bounds_as_events"] is False
+
+
+@pytest.mark.parametrize(
+    "window",
+    [
+        {"enabled": True, "since_ms": True, "until_ms": 1_752_789_660_456},
+        {"enabled": True, "since_ms": -1, "until_ms": 1_752_789_660_456},
+        {
+            "enabled": True,
+            "since_ms": 1_752_789_600_123,
+            "until_ms": 253_402_300_800_000,
+        },
+    ],
+)
+def test_evaluator_rejects_invalid_epoch_window_bounds(window):
+    smoke = _smoke_report()
+    smoke["event_window"] = window
+
+    report = _evaluate(smoke_report=smoke)
+
+    assert report["ok"] is False
+    assert "event_window_invalid" in _codes(report)
+
+
 def test_evaluator_rejects_missing_monitor_and_log_scans():
     smoke = _smoke_report()
     smoke["monitor"].update({"files_scanned": 0, "error_count": 1})
@@ -191,6 +246,42 @@ def test_evaluator_rejects_missing_monitor_and_log_scans():
 
     assert report["ok"] is False
     assert {"monitor_scan_invalid", "log_scan_invalid"} <= _codes(report)
+
+
+@pytest.mark.parametrize(
+    ("dropped_hard_matches", "expected_projected_count"),
+    [
+        (1, 1),
+        (MAX_PROJECTED_COUNT + 1, MAX_PROJECTED_COUNT),
+        (True, 0),
+        ("1", 0),
+        (None, 0),
+    ],
+)
+def test_evaluator_rejects_nonzero_or_malformed_dropped_unparsed_hard_matches(
+    dropped_hard_matches,
+    expected_projected_count,
+):
+    smoke = _smoke_report()
+    smoke["logs"]["dropped_unparsed_hard_matches"] = dropped_hard_matches
+
+    report = _evaluate(smoke_report=smoke)
+
+    assert report["ok"] is False
+    assert "log_scan_invalid" in _codes(report)
+    assert (
+        report["gates"]["logs"]["dropped_unparsed_hard_matches"]
+        == expected_projected_count
+    )
+
+
+def test_evaluator_keeps_dropped_unparsed_attention_as_attention_only():
+    smoke = _smoke_report()
+    smoke["logs"]["dropped_unparsed_attention_matches"] = 3
+
+    report = _evaluate(smoke_report=smoke)
+
+    assert report["ok"] is True
 
 
 def test_evaluator_rejects_smoke_hard_failures_and_invalid_optional_schema():


### PR DESCRIPTION
## Summary
- preserve exact validated epoch-millisecond bounds in restart smoke evidence
- compare log and event windows without generic count clamping
- fail closed when the smoke report dropped contextless hard-looking log matches
- record the PR #1301 deployment evidence that exposed these gaps

## Safety boundary
- reads existing local JSON reports only
- no SSH, signals, process starts, network, exchange access, credentials, or file writes

## Validation
- full Python suite passed
- focused restart/smoke/CLI/docs suite: 286 passed
- Rust suite: 210 passed via passivbot-rust/cargotest.sh
- exact-worktree Rust extension fingerprint verified
- AI docs check: 0 errors, one pre-existing aggregate-size warning
- py_compile and git diff --check passed