### PR TITLE
Collect restart smoke evidence in memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ All notable user-facing changes will be documented in this file.
   controlling processes. Event and log windows retain and compare exact bounded
   epoch-millisecond values, and dropped hard-looking log evidence fails closed.
 
+- Added `passivbot tool live-restart-smoke-collect` to collect the existing exact
+  local target and bounded smoke reports in memory and immediately evaluate the
+  sanitized restart evidence contract. It performs only local filesystem and
+  bounded `tmux`/`ps`/`git` inventory reads; it does not write intermediate
+  reports, pull or build code, contact exchanges, or control processes.
+
 - Live trailing restart reconciliation now preserves authoritative position-update
   timestamps from CCXT and raw exchange payloads and no longer
   treats position creation time as proof that fill history is current. Exchanges

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/restart-smoke-collection-contract`, based on canonical
   `0b5503b2a9ee4817618b7aca25dab417af4292dd` after PR #1302.
-- PR: pending. Slice: collect exact local restart target and bounded smoke
+- PR: #1303. Slice: collect exact local restart target and bounded smoke
   evidence in memory, then immediately apply the existing sanitized evaluator.
 - Triggering evidence: PR #1302 proved the evaluator on retained real artifacts,
   but operators still have to run two producers, retain two full reports, and

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,33 +22,41 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/restart-smoke-window-fidelity`, based on canonical
-  `46a28795dec40acbee0dbaa3602be955bbecf23e` after PR #1301.
-- PR: #1302. Slice: preserve exact bounded smoke-window timestamps and reject
-  dropped hard-looking log evidence.
-- Triggering evidence: live PR #1301 validation projected both modern event
-  bounds as `1000000000` because epoch milliseconds reused a generic count
-  clamp. The same lossy values were used for event/log equality, so different
-  modern windows could compare equal. The log gate also ignored nonzero
-  `dropped_unparsed_hard_matches` from the opt-in drop policy.
-- Scope: validate epoch milliseconds against a fixed bounded range, compare and
-  project the exact values, and require both retained and dropped hard-log
-  counts to be well-formed zeroes.
-- Behavior boundary: read two local JSON files and emit bounded sanitized JSON.
-  The evaluator does not execute report producers, SSH, signal or start
-  processes, contact a network or exchange, load credentials, or write files.
-- Validation: focused exact-window, mismatched-window, malformed timestamp,
-  dropped-hard-log, evaluator, compilation, and docs regressions.
+- Branch: `codex/restart-smoke-collection-contract`, based on canonical
+  `0b5503b2a9ee4817618b7aca25dab417af4292dd` after PR #1302.
+- PR: pending. Slice: collect exact local restart target and bounded smoke
+  evidence in memory, then immediately apply the existing sanitized evaluator.
+- Triggering evidence: PR #1302 proved the evaluator on retained real artifacts,
+  but operators still have to run two producers, retain two full reports, and
+  manually bind them into a third command.
+- Scope: require caller-confirmed head, supervisor fingerprint, target count,
+  session, config, and exact window; compose the existing bounded target and
+  smoke producers without intermediate report files; emit only the sanitized
+  evaluator verdict plus bounded collection-policy metadata.
+- Behavior boundary: local filesystem reads and bounded local `tmux`/`ps`/`git`
+  inventory subprocesses are allowed. SSH, pull/build, network or exchange
+  access, credentials, process signals/starts, force escalation, and file writes
+  remain excluded.
+- Validation: focused collection ordering/input/negative/redaction/CLI tests plus
+  existing target, smoke, evaluator, CLI, compilation, and docs regressions.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: pull and re-evaluate the saved exact PR #1296 restart
-  window plus a deliberately mismatched-window copy. Do not restart or signal
-  bots.
+- Expected VPS action: pull and run the collector against the retained exact PR
+  #1296 restart window, plus caller-expectation negative checks. Do not restart
+  or signal bots.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `46a28795dec40acbee0dbaa3602be955bbecf23e` after PR #1301. Exact-head Hermes
+  `0b5503b2a9ee4817618b7aca25dab417af4292dd` after PR #1302. Exact-head Hermes
+  and Python/Rust CI were green. VPS5 fast-forwarded without a restart or
+  signal. The retained PR #1296 window evaluated green while preserving exact
+  bounds `1784316350000..1784317500000`; a one-millisecond log-window mismatch
+  and one dropped hard-looking line each failed with `log_scan_invalid`. Pane
+  parents and bot PIDs remained unchanged, the checkout stayed tracked-clean,
+  and `misc:0.0` remained `%8`, PID `434835`.
+- PR #1301 previously deployed at
+  `46a28795dec40acbee0dbaa3602be955bbecf23e`. Exact-head Hermes
   and Python/Rust CI were green. VPS5 fast-forwarded without a restart or
   signal. The exact PR #1296 shutdown-through-startup window evaluated green
   with 3/3 stable targets, five stopping/stopped lifecycles, startup timing for

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,23 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1301)
+## Latest Canonical Deployment (PR #1302)
+
+- PR #1302 merged as canonical
+  `0b5503b2a9ee4817618b7aca25dab417af4292dd` after exact-current-head Hermes
+  approval and green Python/Rust CI. It preserves and compares exact bounded
+  epoch-ms smoke windows and fails closed on dropped hard-looking log evidence.
+- VPS5 fast-forwarded without a restart or signal. The retained PR #1296 window
+  evaluated green with exact bounds `1784316350000..1784317500000`; an in-memory
+  one-millisecond mismatch and dropped-hard count each evaluated red with
+  `log_scan_invalid`. All five pane parents and bot PIDs plus `misc:0.0` remained
+  unchanged, and tracked state stayed clean.
+- The active follow-up directly composes the existing target, smoke, and evidence
+  builders in memory so operators no longer need intermediate full-report files.
+  Pull/build, SSH, process control, exchange access, and force escalation remain
+  separate.
+
+## Previous Canonical Deployment (PR #1301)
 
 - PR #1301 merged as canonical
   `46a28795dec40acbee0dbaa3602be955bbecf23e` after exact-current-head Hermes

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -371,6 +371,12 @@ Related detailed plans:
      events. Deployment also exposed lossy epoch-ms projection and comparison;
      the active follow-up preserves exact bounded timestamps and rejects
      dropped hard-looking log evidence. Automatic collection remains later.
+   - 2026-07-17: PR #1302 merged and deployed exact epoch-ms fidelity plus the
+     dropped-hard fail-closed gate without restarting bots. The retained real
+     restart window passed with exact bounds; one-millisecond mismatch and
+     dropped-hard in-memory variants failed as expected. The active follow-up
+     composes target, smoke, and evaluation in memory without intermediate full
+     report files or process control.
 
    Remaining refinements: safe pull/build and post-restart smoke orchestration
    remain open, as does any separately reviewed force-escalation policy.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -467,6 +467,20 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   Use `--compact` for single-line JSON. Exit status is zero only when every hard
   gate passes; non-hard attention evidence remains visible without making the
   verdict red.
+- `passivbot tool live-restart-smoke-collect SUPERVISOR_CONFIG MONITOR_ROOT
+  --session-name SESSION --expected-repository-head COMMIT
+  --expected-supervisor-fingerprint SHA256 --expected-targets N --since-ms MS
+  --until-ms MS` directly composes the existing exact target sampler, full
+  bounded-window smoke report, and sanitized evidence evaluator in memory. The
+  caller-confirmed head, private fingerprint, target count, and exact window are
+  never derived from the reports being checked. Rotated monitor segments are
+  included, process inspection is owned by the target report rather than
+  duplicated in smoke collection, and contextless log rows use the existing
+  drop policy whose dropped hard-looking count must remain zero. The command
+  emits no raw target or smoke report and writes no intermediate file. It may
+  run bounded local `tmux`, `ps`, and `git` inventory reads; it does not SSH,
+  pull/build, contact a network or exchange, access credentials, signal/start
+  processes, or perform force escalation. Use `--compact` for single-line JSON.
 - `passivbot tool live-performance-report` summarizes local live monitor event timings for
   operator performance analysis. It is read-only and does not contact exchanges. Use
   `--recent-minutes` for a time window, `--summary` for a bounded operator projection, and

--- a/src/live/restart_smoke_collection.py
+++ b/src/live/restart_smoke_collection.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+from live.restart_smoke_evidence import (
+    MAX_ISSUES,
+    SCHEMA_VERSION,
+    build_live_restart_smoke_evidence,
+    validate_live_restart_smoke_epoch_window,
+    validate_live_restart_smoke_expectations,
+)
+from live.restart_smoke_targets import (
+    MAX_TARGET_SAMPLE_INTERVAL_S,
+    MAX_TARGET_SAMPLES,
+    build_live_restart_target_report,
+)
+from live.smoke_report import build_live_smoke_report, default_logs_root_for_monitor
+
+
+DEFAULT_TARGET_SAMPLES = 3
+DEFAULT_TARGET_SAMPLE_INTERVAL_S = 1.0
+
+SAFETY_CONTRACT = {
+    "local_only": True,
+    "read_only": True,
+    "local_filesystem_reads": True,
+    "subprocess_execution": True,
+    "bounded_local_subprocess_inventory": ["git", "ps", "tmux"],
+    "network": False,
+    "exchange_access": False,
+    "credential_store_access": False,
+    "process_control": False,
+    "signals_processes": False,
+    "starts_processes": False,
+    "writes_files": False,
+    "ssh": False,
+    "git_pull": False,
+    "builds": False,
+}
+
+
+def _required_text(value: str | Path, *, label: str) -> str:
+    if value is None:
+        raise ValueError(f"{label} must be non-empty")
+    text = str(value).strip()
+    if not text:
+        raise ValueError(f"{label} must be non-empty")
+    return text
+
+
+def _validate_collection_inputs(
+    *,
+    supervisor_config: str | Path,
+    session_name: str,
+    monitor_root: str | Path,
+    expected_repository_head: str,
+    expected_supervisor_fingerprint: str,
+    expected_targets: int,
+    since_ms: int,
+    until_ms: int,
+) -> None:
+    _required_text(supervisor_config, label="supervisor_config")
+    _required_text(session_name, label="session_name")
+    _required_text(monitor_root, label="monitor_root")
+    validate_live_restart_smoke_expectations(
+        expected_repository_head=expected_repository_head,
+        expected_supervisor_fingerprint=expected_supervisor_fingerprint,
+        expected_targets=expected_targets,
+    )
+    validate_live_restart_smoke_epoch_window(since_ms=since_ms, until_ms=until_ms)
+
+
+def _collection_policy(
+    *,
+    target_samples: int,
+    target_sample_interval_s: float,
+    since_ms: int,
+    until_ms: int,
+    logs_root_was_supplied: bool,
+) -> dict[str, Any]:
+    return {
+        "target_sampling": {
+            "samples": target_samples,
+            "sample_interval_s": target_sample_interval_s,
+        },
+        "smoke_collection": {
+            "include_rotated": True,
+            "include_processes": False,
+            "log_window_unparsed_policy": "drop",
+            "logs_root_source": "caller" if logs_root_was_supplied else "monitor_default",
+            "event_window": {"since_ms": since_ms, "until_ms": until_ms},
+        },
+    }
+
+
+def build_live_restart_smoke_collection(
+    supervisor_config: str | Path,
+    *,
+    session_name: str,
+    monitor_root: str | Path,
+    expected_repository_head: str,
+    expected_supervisor_fingerprint: str,
+    expected_targets: int,
+    since_ms: int,
+    until_ms: int,
+    logs_root: str | Path | None = None,
+    target_samples: int = DEFAULT_TARGET_SAMPLES,
+    target_sample_interval_s: float = DEFAULT_TARGET_SAMPLE_INTERVAL_S,
+) -> dict[str, Any]:
+    """Collect and evaluate bounded local restart-smoke evidence in memory."""
+    _validate_collection_inputs(
+        supervisor_config=supervisor_config,
+        session_name=session_name,
+        monitor_root=monitor_root,
+        expected_repository_head=expected_repository_head,
+        expected_supervisor_fingerprint=expected_supervisor_fingerprint,
+        expected_targets=expected_targets,
+        since_ms=since_ms,
+        until_ms=until_ms,
+    )
+    if (
+        type(target_samples) is not int
+        or target_samples < 2
+        or target_samples > MAX_TARGET_SAMPLES
+    ):
+        raise ValueError(
+            f"target_samples must be between 2 and {MAX_TARGET_SAMPLES}"
+        )
+    if (
+        not isinstance(target_sample_interval_s, (int, float))
+        or isinstance(target_sample_interval_s, bool)
+        or not math.isfinite(target_sample_interval_s)
+        or target_sample_interval_s < 0.0
+        or target_sample_interval_s > MAX_TARGET_SAMPLE_INTERVAL_S
+    ):
+        raise ValueError(
+            "target_sample_interval_s must be between 0 and "
+            f"{MAX_TARGET_SAMPLE_INTERVAL_S:g}"
+        )
+
+    if logs_root is not None:
+        _required_text(logs_root, label="logs_root")
+    target_report = build_live_restart_target_report(
+        supervisor_config,
+        session_name=session_name,
+        config_base_dir=Path.cwd(),
+        samples=target_samples,
+        sample_interval_s=float(target_sample_interval_s),
+    )
+    resolved_logs_root = (
+        logs_root
+        if logs_root is not None
+        else default_logs_root_for_monitor(monitor_root)
+    )
+    smoke_report = build_live_smoke_report(
+        monitor_root,
+        logs_root=resolved_logs_root,
+        include_rotated=True,
+        include_processes=False,
+        since_ms=since_ms,
+        until_ms=until_ms,
+        log_window_unparsed_policy="drop",
+    )
+    evaluation = build_live_restart_smoke_evidence(
+        target_report,
+        smoke_report,
+        expected_repository_head=expected_repository_head,
+        expected_supervisor_fingerprint=expected_supervisor_fingerprint,
+        expected_targets=expected_targets,
+    )
+    return {
+        "tool": "live-restart-smoke-collect",
+        "schema_version": SCHEMA_VERSION,
+        "ok": evaluation["ok"],
+        "hard_failures": evaluation["hard_failures"],
+        "issues": evaluation["issues"][:MAX_ISSUES],
+        "safety": SAFETY_CONTRACT,
+        "collection": _collection_policy(
+            target_samples=target_samples,
+            target_sample_interval_s=float(target_sample_interval_s),
+            since_ms=since_ms,
+            until_ms=until_ms,
+            logs_root_was_supplied=logs_root is not None,
+        ),
+        "gates": evaluation["gates"],
+        "evidence": evaluation["evidence"],
+    }

--- a/src/live/restart_smoke_evidence.py
+++ b/src/live/restart_smoke_evidence.py
@@ -44,15 +44,15 @@ def _count(value: Any) -> int:
     return min(value, MAX_PROJECTED_COUNT)
 
 
-def _valid_head(value: str) -> bool:
-    return bool(_GIT_HEAD_PATTERN.fullmatch(value))
+def _valid_head(value: Any) -> bool:
+    return type(value) is str and bool(_GIT_HEAD_PATTERN.fullmatch(value))
 
 
-def _valid_fingerprint(value: str) -> bool:
-    return bool(_SHA256_PATTERN.fullmatch(value))
+def _valid_fingerprint(value: Any) -> bool:
+    return type(value) is str and bool(_SHA256_PATTERN.fullmatch(value))
 
 
-def _validate_expected_inputs(
+def validate_live_restart_smoke_expectations(
     *,
     expected_repository_head: str,
     expected_supervisor_fingerprint: str,
@@ -72,6 +72,17 @@ def _validate_expected_inputs(
         raise ValueError(
             f"expected_targets must be between 1 and {MAX_RESTART_TARGETS}"
         )
+
+
+def validate_live_restart_smoke_epoch_window(
+    *, since_ms: int, until_ms: int
+) -> None:
+    if not _is_epoch_ms(since_ms) or not _is_epoch_ms(until_ms):
+        raise ValueError(
+            f"since_ms and until_ms must be epoch-ms integers between 0 and {MAX_EPOCH_MS}"
+        )
+    if until_ms <= since_ms:
+        raise ValueError("until_ms must be greater than since_ms")
 
 
 def _issue(issues: list[dict[str, Any]], code: str) -> None:
@@ -357,7 +368,7 @@ def build_live_restart_smoke_evidence(
     expected_targets: int,
 ) -> dict[str, Any]:
     """Evaluate existing bounded reports without performing any live operation."""
-    _validate_expected_inputs(
+    validate_live_restart_smoke_expectations(
         expected_repository_head=expected_repository_head,
         expected_supervisor_fingerprint=expected_supervisor_fingerprint,
         expected_targets=expected_targets,

--- a/src/passivbot_cli/main.py
+++ b/src/passivbot_cli/main.py
@@ -152,6 +152,10 @@ TOOL_COMMANDS: dict[str, CommandSpec] = {
         "tools.live_restart_smoke_evidence",
         "evaluate bounded local restart smoke evidence without live operations",
     ),
+    "live-restart-smoke-collect": CommandSpec(
+        "tools.live_restart_smoke_collection",
+        "collect and evaluate bounded local restart smoke evidence",
+    ),
     "live-restart-executor": CommandSpec(
         "tools.live_restart_executor",
         "gracefully restart exact verified local tmux targets",

--- a/src/tools/live_restart_smoke_collection.py
+++ b/src/tools/live_restart_smoke_collection.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SRC_ROOT = Path(__file__).resolve().parents[1]
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from live.restart_smoke_collection import (  # noqa: E402
+    DEFAULT_TARGET_SAMPLE_INTERVAL_S,
+    DEFAULT_TARGET_SAMPLES,
+    build_live_restart_smoke_collection,
+)
+from live.restart_smoke_evidence import (  # noqa: E402
+    validate_live_restart_smoke_epoch_window,
+    validate_live_restart_smoke_expectations,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="passivbot tool live-restart-smoke-collect",
+        description=(
+            "Collect bounded local restart-target and smoke evidence in memory, "
+            "then emit a sanitized verdict without controlling processes."
+        ),
+    )
+    parser.add_argument("supervisor_config", help="Tmuxp-style supervisor config.")
+    parser.add_argument("monitor_root", help="Monitor root to scan.")
+    parser.add_argument("--session-name", required=True)
+    parser.add_argument("--logs-root")
+    parser.add_argument("--expected-repository-head", required=True)
+    parser.add_argument("--expected-supervisor-fingerprint", required=True)
+    parser.add_argument("--expected-targets", required=True, type=int)
+    parser.add_argument("--since-ms", required=True, type=int)
+    parser.add_argument("--until-ms", required=True, type=int)
+    parser.add_argument(
+        "--target-samples",
+        type=int,
+        default=DEFAULT_TARGET_SAMPLES,
+    )
+    parser.add_argument(
+        "--target-sample-interval-s",
+        type=float,
+        default=DEFAULT_TARGET_SAMPLE_INTERVAL_S,
+    )
+    parser.add_argument("--compact", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        validate_live_restart_smoke_expectations(
+            expected_repository_head=args.expected_repository_head,
+            expected_supervisor_fingerprint=args.expected_supervisor_fingerprint,
+            expected_targets=args.expected_targets,
+        )
+        validate_live_restart_smoke_epoch_window(
+            since_ms=args.since_ms,
+            until_ms=args.until_ms,
+        )
+        report = build_live_restart_smoke_collection(
+            args.supervisor_config,
+            session_name=args.session_name,
+            monitor_root=args.monitor_root,
+            logs_root=args.logs_root,
+            expected_repository_head=args.expected_repository_head,
+            expected_supervisor_fingerprint=args.expected_supervisor_fingerprint,
+            expected_targets=args.expected_targets,
+            since_ms=args.since_ms,
+            until_ms=args.until_ms,
+            target_samples=args.target_samples,
+            target_sample_interval_s=args.target_sample_interval_s,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+    print(json.dumps(report, indent=None if args.compact else 2, sort_keys=True))
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_live_restart_smoke_collection.py
+++ b/tests/test_live_restart_smoke_collection.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import live.restart_smoke_collection as collection_module
+from live.restart_smoke_collection import build_live_restart_smoke_collection
+from tools import live_restart_smoke_collection
+
+
+HEAD = "a" * 40
+FINGERPRINT = "b" * 64
+SINCE_MS = 1_752_789_600_123
+UNTIL_MS = 1_752_789_660_456
+
+
+def _target_report(*, targets: int = 2) -> dict:
+    return {
+        "tool": "live-restart-target-report",
+        "schema_version": 1,
+        "ok": True,
+        "hard_failures": 0,
+        "issues": [],
+        "expected_targets": targets,
+        "resolved_targets": targets,
+        "relaunch_ready_targets": targets,
+        "extra_panes": [],
+        "supervisor_contract": {
+            "source": "parsed_supervisor_config",
+            "algorithm": "sha256",
+            "fingerprint": FINGERPRINT,
+            "target_count": targets,
+            "command_content_exposed": False,
+        },
+        "sampling": {
+            "requested_samples": 3,
+            "collected_samples": 3,
+            "successful_samples": 3,
+            "failed_samples": 0,
+            "stable": True,
+            "supervisor_contract_stable": True,
+            "supervisor_contract_changed": False,
+            "stable_targets": targets,
+            "changed_target_count": 0,
+        },
+        "targets": [
+            {
+                "window_name": "private_bot",
+                "pane_id": "%999",
+                "process_pid": 123456,
+                "current_command": "private command",
+            }
+        ],
+    }
+
+
+def _smoke_report(*, head: str = HEAD, attention: bool = False) -> dict:
+    window = {"enabled": True, "since_ms": SINCE_MS, "until_ms": UNTIL_MS}
+    return {
+        "tool": "live-smoke-report",
+        "schema_version": 1,
+        "ok": True,
+        "attention": attention,
+        "hard_failures": 0,
+        "attention_count": 1 if attention else 0,
+        "repository": {
+            "is_git_repo": True,
+            "head_full": head,
+            "dirty": False,
+            "tracked_changes": 0,
+            "error": None,
+            "root": "/private/repository",
+        },
+        "event_window": window,
+        "monitor": {
+            "root": "/private/monitor",
+            "files_scanned": 2,
+            "error_count": 0,
+            "warning_count": 1 if attention else 0,
+        },
+        "logs": {
+            "root": "/private/logs",
+            "files_scanned": 2,
+            "hard_matches": 0,
+            "attention_matches": 1 if attention else 0,
+            "dropped_unparsed_hard_matches": 0,
+            "window": window,
+            "samples": ["secret log line"],
+        },
+        "shutdown_events": {
+            "event_types": {"bot.stopping": 2, "bot.stopped": 2}
+        },
+        "startup_timings": [
+            {"bot": "private/bot-one", "phases": {"startup": {}}},
+            {"bot": "private/bot-two", "phases": {"startup": {}}},
+        ],
+    }
+
+
+def _kwargs() -> dict:
+    return {
+        "supervisor_config": "private-supervisor.yaml",
+        "session_name": "private-session",
+        "monitor_root": "private-monitor",
+        "logs_root": "private-logs",
+        "expected_repository_head": HEAD,
+        "expected_supervisor_fingerprint": FINGERPRINT,
+        "expected_targets": 2,
+        "since_ms": SINCE_MS,
+        "until_ms": UNTIL_MS,
+    }
+
+
+def test_collection_calls_producers_in_order_and_projects_sanitized_verdict(monkeypatch):
+    calls: list[tuple[str, tuple, dict]] = []
+
+    def fake_target(*args, **kwargs):
+        calls.append(("target", args, kwargs))
+        return _target_report()
+
+    def fake_smoke(*args, **kwargs):
+        calls.append(("smoke", args, kwargs))
+        return _smoke_report()
+
+    monkeypatch.setattr(collection_module, "build_live_restart_target_report", fake_target)
+    monkeypatch.setattr(collection_module, "build_live_smoke_report", fake_smoke)
+
+    report = build_live_restart_smoke_collection(**_kwargs())
+
+    assert report["ok"] is True
+    assert report["safety"] == {
+        "local_only": True,
+        "read_only": True,
+        "local_filesystem_reads": True,
+        "subprocess_execution": True,
+        "bounded_local_subprocess_inventory": ["git", "ps", "tmux"],
+        "network": False,
+        "exchange_access": False,
+        "credential_store_access": False,
+        "process_control": False,
+        "signals_processes": False,
+        "starts_processes": False,
+        "writes_files": False,
+        "ssh": False,
+        "git_pull": False,
+        "builds": False,
+    }
+    assert [call[0] for call in calls] == ["target", "smoke"]
+    assert calls[0][1] == ("private-supervisor.yaml",)
+    assert calls[0][2] == {
+        "session_name": "private-session",
+        "config_base_dir": collection_module.Path.cwd(),
+        "samples": 3,
+        "sample_interval_s": 1.0,
+    }
+    assert calls[1][1] == ("private-monitor",)
+    assert calls[1][2] == {
+        "logs_root": "private-logs",
+        "include_rotated": True,
+        "include_processes": False,
+        "since_ms": SINCE_MS,
+        "until_ms": UNTIL_MS,
+        "log_window_unparsed_policy": "drop",
+    }
+    assert report["collection"] == {
+        "target_sampling": {"samples": 3, "sample_interval_s": 1.0},
+        "smoke_collection": {
+            "include_rotated": True,
+            "include_processes": False,
+            "log_window_unparsed_policy": "drop",
+            "logs_root_source": "caller",
+            "event_window": {"since_ms": SINCE_MS, "until_ms": UNTIL_MS},
+        },
+    }
+    serialized = json.dumps(report, sort_keys=True)
+    for secret in (
+        "private-supervisor.yaml",
+        "private-session",
+        "private-monitor",
+        "private-logs",
+        "/private/repository",
+        "/private/logs",
+        "private command",
+        "secret log line",
+        FINGERPRINT,
+    ):
+        assert secret not in serialized
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"expected_repository_head": "A" * 40},
+        {"expected_supervisor_fingerprint": True},
+        {"expected_targets": True},
+        {"since_ms": True},
+        {"until_ms": SINCE_MS},
+        {"until_ms": 253_402_300_800_000},
+    ],
+)
+def test_invalid_expectations_or_bounds_fail_before_producers(monkeypatch, override):
+    calls: list[str] = []
+    kwargs = _kwargs()
+    kwargs.update(override)
+    monkeypatch.setattr(
+        collection_module,
+        "build_live_restart_target_report",
+        lambda *_args, **_kwargs: calls.append("target"),
+    )
+    monkeypatch.setattr(
+        collection_module,
+        "build_live_smoke_report",
+        lambda *_args, **_kwargs: calls.append("smoke"),
+    )
+
+    with pytest.raises(ValueError):
+        build_live_restart_smoke_collection(**kwargs)
+
+    assert calls == []
+
+
+def test_collection_uses_monitor_default_logs_root_without_exposing_path(monkeypatch):
+    captured: dict = {}
+    monkeypatch.setattr(
+        collection_module,
+        "default_logs_root_for_monitor",
+        lambda _root: "/private/default-logs",
+    )
+    monkeypatch.setattr(
+        collection_module,
+        "build_live_restart_target_report",
+        lambda *_args, **_kwargs: _target_report(),
+    )
+
+    def fake_smoke(*_args, **kwargs):
+        captured.update(kwargs)
+        return _smoke_report()
+
+    monkeypatch.setattr(collection_module, "build_live_smoke_report", fake_smoke)
+    kwargs = _kwargs()
+    kwargs.pop("logs_root")
+
+    report = build_live_restart_smoke_collection(**kwargs)
+
+    assert captured["logs_root"] == "/private/default-logs"
+    assert report["collection"]["smoke_collection"]["logs_root_source"] == "monitor_default"
+    assert "/private/default-logs" not in json.dumps(report, sort_keys=True)
+
+
+def test_red_evidence_stays_red_and_attention_stays_non_hard(monkeypatch):
+    monkeypatch.setattr(
+        collection_module,
+        "build_live_restart_target_report",
+        lambda *_args, **_kwargs: _target_report(),
+    )
+    monkeypatch.setattr(
+        collection_module,
+        "build_live_smoke_report",
+        lambda *_args, **_kwargs: _smoke_report(head="c" * 40),
+    )
+
+    report = build_live_restart_smoke_collection(**_kwargs())
+
+    assert report["ok"] is False
+    assert report["hard_failures"] == 1
+    assert report["issues"] == [
+        {"code": "repository_mismatch", "severity": "error", "count": 1}
+    ]
+
+    monkeypatch.setattr(
+        collection_module,
+        "build_live_smoke_report",
+        lambda *_args, **_kwargs: _smoke_report(attention=True),
+    )
+    attention_report = build_live_restart_smoke_collection(**_kwargs())
+
+    assert attention_report["ok"] is True
+    assert attention_report["hard_failures"] == 0
+    assert attention_report["evidence"]["attention"]["reported"] is True
+
+
+def test_cli_compact_output_and_exit_codes(monkeypatch, capsys):
+    green = {
+        "tool": "live-restart-smoke-collect",
+        "schema_version": 1,
+        "ok": True,
+        "hard_failures": 0,
+    }
+    monkeypatch.setattr(
+        live_restart_smoke_collection,
+        "build_live_restart_smoke_collection",
+        lambda *_args, **_kwargs: green,
+    )
+    argv = [
+        "supervisor.yaml",
+        "monitor",
+        "--session-name",
+        "passivbot",
+        "--expected-repository-head",
+        HEAD,
+        "--expected-supervisor-fingerprint",
+        FINGERPRINT,
+        "--expected-targets",
+        "2",
+        "--since-ms",
+        str(SINCE_MS),
+        "--until-ms",
+        str(UNTIL_MS),
+        "--compact",
+    ]
+
+    assert live_restart_smoke_collection.main(argv) == 0
+    assert capsys.readouterr().out == json.dumps(green, sort_keys=True) + "\n"
+
+    monkeypatch.setattr(
+        live_restart_smoke_collection,
+        "build_live_restart_smoke_collection",
+        lambda *_args, **_kwargs: {**green, "ok": False, "hard_failures": 1},
+    )
+    assert live_restart_smoke_collection.main(argv) == 1
+
+
+def test_cli_rejects_invalid_bounds_before_collection(monkeypatch):
+    called = False
+
+    def fake_collection(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("collection should not run")
+
+    monkeypatch.setattr(
+        live_restart_smoke_collection,
+        "build_live_restart_smoke_collection",
+        fake_collection,
+    )
+    with pytest.raises(SystemExit) as exc:
+        live_restart_smoke_collection.main(
+            [
+                "supervisor.yaml",
+                "monitor",
+                "--session-name",
+                "passivbot",
+                "--expected-repository-head",
+                HEAD,
+                "--expected-supervisor-fingerprint",
+                FINGERPRINT,
+                "--expected-targets",
+                "2",
+                "--since-ms",
+                str(UNTIL_MS),
+                "--until-ms",
+                str(SINCE_MS),
+            ]
+        )
+
+    assert exc.value.code == 2
+    assert called is False

--- a/tests/test_live_restart_smoke_evidence.py
+++ b/tests/test_live_restart_smoke_evidence.py
@@ -7,12 +7,34 @@ import pytest
 from live.restart_smoke_evidence import (
     MAX_PROJECTED_COUNT,
     build_live_restart_smoke_evidence,
+    validate_live_restart_smoke_expectations,
 )
 from tools import live_restart_smoke_evidence
 
 
 HEAD = "a" * 40
 FINGERPRINT = "b" * 64
+
+
+@pytest.mark.parametrize(
+    ("head", "fingerprint", "targets"),
+    [
+        ("A" * 40, FINGERPRINT, 2),
+        (HEAD, "B" * 64, 2),
+        (True, FINGERPRINT, 2),
+        (HEAD, True, 2),
+        (HEAD, FINGERPRINT, True),
+    ],
+)
+def test_public_expectation_validator_rejects_malformed_values(
+    head, fingerprint, targets
+):
+    with pytest.raises(ValueError):
+        validate_live_restart_smoke_expectations(
+            expected_repository_head=head,
+            expected_supervisor_fingerprint=fingerprint,
+            expected_targets=targets,
+        )
 
 
 def _target_report(*, targets: int = 2) -> dict:

--- a/tests/test_passivbot_cli.py
+++ b/tests/test_passivbot_cli.py
@@ -394,6 +394,63 @@ def test_live_restart_smoke_evidence_tool_dispatch_forwards_module_and_prog(monk
     assert captured["prog_env"] == "passivbot tool live-restart-smoke-evidence"
 
 
+def test_live_restart_smoke_collect_tool_dispatch_forwards_module_and_prog(monkeypatch):
+    captured = {}
+
+    def fake_invoke_module_main(module_name):
+        captured["module_name"] = module_name
+        captured["argv"] = sys.argv[:]
+        captured["prog_env"] = os.environ.get("PASSIVBOT_CLI_PROG")
+        return True, 0
+
+    monkeypatch.setattr(cli_main, "_invoke_module_main", fake_invoke_module_main)
+    monkeypatch.setattr(cli_main, "_missing_full_install_markers", lambda: [])
+
+    assert (
+        cli_main.main(
+            [
+                "tool",
+                "live-restart-smoke-collect",
+                "supervisor.yaml",
+                "monitor",
+                "--session-name",
+                "passivbot",
+                "--expected-repository-head",
+                "a" * 40,
+                "--expected-supervisor-fingerprint",
+                "b" * 64,
+                "--expected-targets",
+                "2",
+                "--since-ms",
+                "1752789600123",
+                "--until-ms",
+                "1752789660456",
+            ]
+        )
+        == 0
+    )
+
+    assert captured["module_name"] == "tools.live_restart_smoke_collection"
+    assert captured["argv"] == [
+        "passivbot tool live-restart-smoke-collect",
+        "supervisor.yaml",
+        "monitor",
+        "--session-name",
+        "passivbot",
+        "--expected-repository-head",
+        "a" * 40,
+        "--expected-supervisor-fingerprint",
+        "b" * 64,
+        "--expected-targets",
+        "2",
+        "--since-ms",
+        "1752789600123",
+        "--until-ms",
+        "1752789660456",
+    ]
+    assert captured["prog_env"] == "passivbot tool live-restart-smoke-collect"
+
+
 def test_live_process_report_tool_dispatch_forwards_module_and_prog(monkeypatch):
     captured = {}
 


### PR DESCRIPTION
## Scope

Category: read-only tooling.

- add `passivbot tool live-restart-smoke-collect`
- compose exact target sampling, bounded-window smoke collection, and the sanitized evidence evaluator in memory
- require caller-confirmed head, supervisor fingerprint, target count, session, config, and exact epoch-ms bounds before collection
- record PR #1302 merge/deploy evidence

## Behavior and non-goals

The command performs local filesystem reads and bounded local `tmux`/`ps`/`git` inventory subprocesses already owned by the existing producers. It emits no raw intermediate target or smoke report and writes no file. It does not SSH, pull/build, access a network, exchange, credential store, signal/start processes, or perform force escalation. It does not import the restart executor.

Expected VPS action: pull and run the collector against the retained exact restart window plus caller-expectation negative checks. No bot restart or signal.

## Validation

- complete Python suite passed
- focused collector/evaluator/target/smoke/CLI/docs suite: 241 passed
- Rust suite: 210 passed via `passivbot-rust/cargotest.sh`
- exact-worktree Rust extension fingerprint verified
- `py_compile` passed
- AI docs check: 0 errors, one pre-existing aggregate-size warning
- generated live event registry check passed
- `git diff --check` passed

## Reviewer focus

- expected values are independently supplied and validated before producer calls
- outer output cannot leak raw reports, paths, commands, bot identifiers, log samples, or the private fingerprint
- safety metadata accurately distinguishes local inventory subprocesses from process control

Residual risk: target sampling occurs before historical smoke scanning, so the verdict proves the current exact target cohort plus the caller-selected retained event/log window; it does not perform or prove a new restart.