### PR TITLE
Harden WEEX reconciliation contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable user-facing changes will be documented in this file.
 
 ## Unreleased
 
+- Hardened WEEX live reconciliation by requiring explicit combined/separated
+  position mode and long/short open-order sides, and by adaptively splitting
+  full fill-history windows so endpoint ordering cannot silently omit fills.
+
 - Added live WEEX USDT perpetual-futures support through CCXT, including
   authenticated account state, simultaneous long/short order placement and
   cancellation, per-symbol combined-position/margin/leverage setup, live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable user-facing changes will be documented in this file.
 - Updated the live CCXT dependency from 4.5.48 to 4.5.66. WEEX uses a narrowly
   scoped compatibility handler for its documented successful configuration
   response, which upstream CCXT 4.5.66 otherwise raises as an exchange error.
+  The Requests and aiohttp pins are aligned with CCXT 4.5.66's declared
+  dependencies.
 
 - Live trailing restart reconciliation now preserves authoritative position-update
   timestamps from CCXT and raw exchange payloads and no longer

--- a/docs/ai/features/exchange_integrations.md
+++ b/docs/ai/features/exchange_integrations.md
@@ -168,6 +168,9 @@ Handling in Passivbot:
    CCXT's generic `hedged` boolean calls this WEEX mode false.
 4. Treat missing or ambiguous `positionSide` on orders and fills as an error;
    do not infer it from buy/sell alone.
+5. Require the raw symbol configuration to explicitly report `COMBINED` or
+   `SEPARATED`; CCXT's normalized `hedged=false` is not sufficient evidence
+   because it also represents missing or unknown raw mode state.
 
 Primary reference: [WEEX V3 place-order API](https://www.weex.com/api-doc/contract/Transaction_API/PlaceOrder).
 
@@ -225,8 +228,10 @@ seven days per query, and retains up to 365 days.
 
 Handling:
 
-1. Split requested history into seven-day windows and page forward by fill
-   timestamp within each window.
+1. Split requested history into seven-day windows. Recursively bisect every
+   full 100-row response into disjoint time windows until each response proves
+   completeness below the limit; fail closed if one millisecond is saturated.
+   Do not assume the endpoint returns oldest-first rows.
 2. Preserve exchange trade and order IDs, explicit position side, realized PnL,
    and fees; enrich missing Passivbot client-order IDs from order detail.
 3. Keep WEEX historical 1m backtest-data downloading out of the live adapter;

--- a/docs/ai/features/fill_events_manager.md
+++ b/docs/ai/features/fill_events_manager.md
@@ -36,6 +36,9 @@
 3. Historical retention limits can make old PnL records unavailable.
 4. WEEX trade-detail queries are limited to 100 rows and seven days per request,
    with up to 365 days of retention; its client order id may require an order-detail lookup.
+   Full responses are recursively split into disjoint time windows because the endpoint does not
+   guarantee row ordering or expose a stable cursor. Saturation within one millisecond is unavailable
+   rather than silently treated as complete.
 
 ## Failure Semantics And Risks
 

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -4,7 +4,7 @@ colorama==0.4.6
 pyecharts==1.9.1
 deap==1.4.3
 pymoo>=0.6.0
-aiohttp==3.13.1
+aiohttp==3.14.1
 websockets==12.0
 msgpack==1.1.0
 plotly==6.0.1
@@ -12,5 +12,5 @@ dash==2.18.2
 dash-bootstrap-components==1.6.0
 psutil==5.9.8; python_version < "3.14"
 psutil==7.2.2; python_version >= "3.14"
-requests==2.32.3
+requests==2.34.2
 dictdiffer==0.9.0

--- a/src/exchanges/weex.py
+++ b/src/exchanges/weex.py
@@ -114,7 +114,9 @@ class WeexBot(CCXTBot):
 
             position_mode = await self.cca.fetch_position_mode(symbol)
             current_margin = await self.cca.fetch_margin_mode(symbol)
-            is_separated = bool(position_mode.get("hedged"))
+            is_separated = self._require_explicit_position_mode(
+                position_mode, symbol
+            )
             current_margin_mode = str(
                 current_margin.get("marginMode") or ""
             ).lower()
@@ -146,6 +148,49 @@ class WeexBot(CCXTBot):
                 format_exchange_config_response(result),
                 (time.time() - started) * 1000.0,
             )
+
+    def _require_explicit_position_mode(
+        self, position_mode: dict, symbol: str
+    ) -> bool:
+        """Return whether WEEX explicitly reports SEPARATED mode.
+
+        CCXT maps an absent or unknown ``separatedType`` to ``hedged=False``.
+        That is not evidence of COMBINED mode, so inspect the raw symbol row and
+        reject missing, ambiguous, or internally inconsistent state.
+        """
+        if not isinstance(position_mode, dict):
+            raise ValueError(f"{symbol}: invalid WEEX position mode response")
+        raw = position_mode.get("info")
+        rows = raw if isinstance(raw, list) else [raw]
+        market_id = str((self.markets_dict.get(symbol) or {}).get("id") or "")
+        candidates = [row for row in rows if isinstance(row, dict)]
+        if market_id:
+            matching = [
+                row
+                for row in candidates
+                if str(row.get("symbol") or "") == market_id
+            ]
+            if len(matching) != 1:
+                raise ValueError(
+                    f"{symbol}: WEEX position mode response missing unique symbol row"
+                )
+            candidates = matching
+        if len(candidates) != 1:
+            raise ValueError(
+                f"{symbol}: WEEX position mode response did not contain exactly one symbol row"
+            )
+        separated_type = str(candidates[0].get("separatedType") or "").upper()
+        if separated_type not in {"COMBINED", "SEPARATED"}:
+            raise ValueError(
+                f"{symbol}: WEEX position mode missing explicit COMBINED/SEPARATED state"
+            )
+        is_separated = separated_type == "SEPARATED"
+        hedged = position_mode.get("hedged")
+        if not isinstance(hedged, bool) or hedged != is_separated:
+            raise ValueError(
+                f"{symbol}: WEEX normalized position mode disagrees with raw state"
+            )
+        return is_separated
 
     def _build_order_params(self, order: dict) -> dict:
         """Build the exact WEEX V3 hedge-order contract.
@@ -180,6 +225,18 @@ class WeexBot(CCXTBot):
         if position_side not in {"long", "short"}:
             raise ValueError(
                 "weex fill missing explicit LONG/SHORT positionSide"
+            )
+        return position_side
+
+    def _get_position_side_for_order(self, order: dict) -> str:
+        """Require WEEX's explicit hedge side on every futures order."""
+        info = order.get("info") or {}
+        if not isinstance(info, dict):
+            raise ValueError("weex order has invalid raw info payload")
+        position_side = str(info.get("positionSide") or "").lower()
+        if position_side not in {"long", "short"}:
+            raise ValueError(
+                "weex order missing explicit LONG/SHORT positionSide"
             )
         return position_side
 

--- a/src/fill_events_manager.py
+++ b/src/fill_events_manager.py
@@ -5732,36 +5732,39 @@ class WeexFetcher(BaseFetcher):
         window_start = start_ms
         while window_start <= end_ms:
             window_end = min(end_ms, window_start + self.WINDOW_MS - 1)
-            cursor = window_start
-            while cursor <= window_end:
+            pending_windows = [(window_start, window_end)]
+            while pending_windows:
+                query_start, query_end = pending_windows.pop()
                 trades = await self.api.fetch_my_trades(
                     symbol=None,
-                    since=cursor,
+                    since=query_start,
                     limit=self.trade_limit,
-                    params={"type": "swap", "until": window_end},
+                    params={"type": "swap", "until": query_end},
                 )
                 if not trades:
-                    break
-                timestamps = []
+                    continue
                 for trade in trades:
                     event = self._normalize_trade(trade)
-                    timestamps.append(event["timestamp"])
-                    if event["timestamp"] < start_ms or event["timestamp"] > end_ms:
-                        continue
+                    if (
+                        event["timestamp"] < query_start
+                        or event["timestamp"] > query_end
+                    ):
+                        raise RuntimeError(
+                            "WEEX fill endpoint returned a trade outside the requested window"
+                        )
                     collected[event["id"]] = event
                 if len(trades) < self.trade_limit:
-                    break
-                last_timestamp = max(timestamps) if timestamps else 0
-                if last_timestamp < cursor:
+                    continue
+                if query_start >= query_end:
                     raise RuntimeError(
-                        "WEEX fill pagination did not advance within the requested window"
+                        "WEEX fill history is saturated within one millisecond; "
+                        "completeness cannot be proven"
                     )
-                next_cursor = last_timestamp + 1
-                if next_cursor <= cursor:
-                    raise RuntimeError(
-                        "WEEX fill pagination cannot safely advance past a full page"
-                    )
-                cursor = next_cursor
+                midpoint = query_start + (query_end - query_start) // 2
+                # LIFO order keeps requests chronological while every split is
+                # disjoint, so response ordering cannot create skipped fills.
+                pending_windows.append((midpoint + 1, query_end))
+                pending_windows.append((query_start, midpoint))
             window_start = window_end + 1
 
         events = sorted(collected.values(), key=lambda event: event["timestamp"])

--- a/tests/exchanges/test_weex.py
+++ b/tests/exchanges/test_weex.py
@@ -178,6 +178,36 @@ def test_weex_order_params_survive_ccxt_request_construction(
     assert "postOnly" not in request
 
 
+@pytest.mark.parametrize(
+    ("raw_position_side", "expected"),
+    [("LONG", "long"), ("SHORT", "short")],
+)
+def test_weex_open_order_requires_explicit_position_side(
+    raw_position_side, expected
+):
+    bot = _bot()
+
+    assert (
+        bot._get_position_side_for_order(
+            {"info": {"positionSide": raw_position_side}}
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize("raw_info", [{}, {"positionSide": "BOTH"}, "invalid"])
+def test_weex_open_order_rejects_missing_or_ambiguous_position_side(raw_info):
+    bot = _bot()
+
+    with pytest.raises(ValueError, match="positionSide|raw info"):
+        bot._get_position_side_for_order(
+            {
+                "clientOrderId": "entry_initial_normal_long",
+                "info": raw_info,
+            }
+        )
+
+
 def test_weex_signed_order_contains_required_auth_and_no_reduce_only():
     bot = _bot(time_in_force="gtc")
     exchange = _ccxt_exchange()
@@ -266,7 +296,12 @@ async def test_weex_symbol_config_sets_combined_margin_and_leverage():
 
         async def fetch_position_mode(self, symbol):
             self.calls.append(("fetch_position_mode", symbol))
-            return {"hedged": True}
+            return {
+                "hedged": True,
+                "info": [
+                    {"symbol": "BTCUSDT", "separatedType": "SEPARATED"}
+                ],
+            }
 
         async def fetch_margin_mode(self, symbol):
             self.calls.append(("fetch_margin_mode", symbol))
@@ -282,6 +317,7 @@ async def test_weex_symbol_config_sets_combined_margin_and_leverage():
 
     bot = _bot()
     bot.cca = _Api()
+    bot.markets_dict = {SYMBOL: _market()}
     bot.max_leverage = {SYMBOL: 400}
     bot._get_margin_mode_for_symbol = lambda symbol: "cross"
     bot._calc_leverage_for_symbol = lambda symbol: 10
@@ -299,7 +335,12 @@ async def test_weex_symbol_config_skips_unchanged_mode_but_sets_leverage():
             self.calls = []
 
         async def fetch_position_mode(self, symbol):
-            return {"hedged": False}
+            return {
+                "hedged": False,
+                "info": [
+                    {"symbol": "BTCUSDT", "separatedType": "COMBINED"}
+                ],
+            }
 
         async def fetch_margin_mode(self, symbol):
             return {"marginMode": "cross"}
@@ -313,6 +354,7 @@ async def test_weex_symbol_config_skips_unchanged_mode_but_sets_leverage():
 
     bot = _bot()
     bot.cca = _Api()
+    bot.markets_dict = {SYMBOL: _market()}
     bot._get_margin_mode_for_symbol = lambda symbol: "cross"
     bot._calc_leverage_for_symbol = lambda symbol: 7
 
@@ -321,9 +363,60 @@ async def test_weex_symbol_config_skips_unchanged_mode_but_sets_leverage():
     assert bot.cca.calls == [(7, SYMBOL, {"marginMode": "cross"})]
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "position_mode",
+    [
+        {"hedged": False, "info": []},
+        {
+            "hedged": False,
+            "info": [{"symbol": "BTCUSDT", "separatedType": "UNKNOWN"}],
+        },
+        {
+            "hedged": False,
+            "info": [{"symbol": "ETHUSDT", "separatedType": "COMBINED"}],
+        },
+        {
+            "hedged": False,
+            "info": [{"symbol": "BTCUSDT", "separatedType": "SEPARATED"}],
+        },
+    ],
+)
+async def test_weex_symbol_config_rejects_unproven_or_inconsistent_position_mode(
+    position_mode,
+):
+    class _Api:
+        def __init__(self):
+            self.leverage_calls = []
+
+        async def fetch_position_mode(self, symbol):
+            return position_mode
+
+        async def fetch_margin_mode(self, symbol):
+            return {"marginMode": "cross"}
+
+        async def set_position_mode(self, *args, **kwargs):
+            raise AssertionError("invalid mode state must fail before mutation")
+
+        async def set_leverage(self, *args, **kwargs):
+            self.leverage_calls.append((args, kwargs))
+
+    bot = _bot()
+    bot.cca = _Api()
+    bot.markets_dict = {SYMBOL: _market()}
+    bot._get_margin_mode_for_symbol = lambda symbol: "cross"
+    bot._calc_leverage_for_symbol = lambda symbol: 7
+
+    with pytest.raises(ValueError, match="position mode"):
+        await bot.update_exchange_config_by_symbols([SYMBOL])
+
+    assert bot.cca.leverage_calls == []
+
+
 class _FakeWeexApi:
-    def __init__(self, batches):
-        self.batches = list(batches)
+    def __init__(self, trades, *, newest_first=False):
+        self.trades = list(trades)
+        self.newest_first = bool(newest_first)
         self.trade_calls = []
         self.order_calls = []
 
@@ -331,7 +424,17 @@ class _FakeWeexApi:
         self.trade_calls.append(
             {"symbol": symbol, "since": since, "limit": limit, "params": dict(params or {})}
         )
-        return self.batches.pop(0) if self.batches else []
+        until = int((params or {})["until"])
+        eligible = [
+            trade
+            for trade in self.trades
+            if int(since) <= int(trade["timestamp"]) <= until
+        ]
+        eligible.sort(
+            key=lambda trade: int(trade["timestamp"]),
+            reverse=self.newest_first,
+        )
+        return eligible[: int(limit)]
 
     async def fetch_order(self, order_id, symbol):
         self.order_calls.append((order_id, symbol))
@@ -364,10 +467,12 @@ async def test_weex_fetcher_windows_paginates_normalizes_and_enriches():
     day = 24 * 60 * 60 * 1000
     api = _FakeWeexApi(
         [
-            [_trade("t1", "o1", day), _trade("t2", "o2", day + 1)],
-            [_trade("t3", "o3", day + 2)],
-            [_trade("t4", "o4", 8 * day)],
-        ]
+            _trade("t1", "o1", day),
+            _trade("t2", "o2", day + 1),
+            _trade("t3", "o3", day + 2),
+            _trade("t4", "o4", 8 * day),
+        ],
+        newest_first=True,
     )
     fetcher = WeexFetcher(api, trade_limit=2, now_func=lambda: 9 * day)
     detail_cache = {}
@@ -386,6 +491,17 @@ async def test_weex_fetcher_windows_paginates_normalizes_and_enriches():
         for call in api.trade_calls
     )
     assert set(detail_cache) == {"t1", "t2", "t3", "t4"}
+
+
+@pytest.mark.asyncio
+async def test_weex_fetcher_fails_closed_when_one_millisecond_is_saturated():
+    api = _FakeWeexApi(
+        [_trade("t1", "o1", 1_000), _trade("t2", "o2", 1_000)]
+    )
+    fetcher = WeexFetcher(api, trade_limit=2)
+
+    with pytest.raises(RuntimeError, match="saturated within one millisecond"):
+        await fetcher.fetch(1_000, 1_000, {})
 
 
 def test_weex_fetcher_rejects_ambiguous_position_side():

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,4 +1,7 @@
+from importlib.metadata import requires, version
 from pathlib import Path
+
+from packaging.requirements import Requirement
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -18,3 +21,55 @@ def test_live_requirements_include_psutil_for_health_telemetry():
 
     assert 'psutil==5.9.8; python_version < "3.14"' in requirements
     assert 'psutil==7.2.2; python_version >= "3.14"' in requirements
+
+
+def _pinned_version(requirements: set[str], package_name: str) -> str:
+    parsed = [Requirement(row) for row in requirements if not row.startswith("-")]
+    matches = [
+        requirement
+        for requirement in parsed
+        if requirement.name.casefold() == package_name.casefold() and requirement.marker is None
+    ]
+    assert len(matches) == 1
+    requirement = matches[0]
+    specifiers = list(requirement.specifier)
+    assert len(specifiers) == 1 and specifiers[0].operator == "=="
+    return specifiers[0].version
+
+
+def test_project_pins_satisfy_ccxt_runtime_dependencies():
+    ccxt_version = _pinned_version(_requirements("requirements-live.txt"), "ccxt")
+    assert version("ccxt") == ccxt_version
+
+    project_requirements = _requirements("requirements-live.txt") | _requirements(
+        "requirements-full.txt"
+    )
+    active_project_pins = {
+        requirement.name.casefold(): requirement.specifier
+        for row in project_requirements
+        if not row.startswith("-")
+        and ((requirement := Requirement(row)).marker is None or requirement.marker.evaluate())
+    }
+    ccxt_dependencies = [
+        Requirement(row)
+        for row in requires("ccxt") or []
+        if (Requirement(row).marker is None or Requirement(row).marker.evaluate())
+    ]
+    overlapping_dependencies = {
+        dependency.name.casefold(): dependency for dependency in ccxt_dependencies
+        if dependency.name.casefold() in active_project_pins
+    }
+
+    assert {"aiohttp", "requests"} <= overlapping_dependencies.keys()
+    for package_name, dependency in overlapping_dependencies.items():
+        project_specifier = active_project_pins[package_name]
+        exact_project_versions = [
+            specifier.version
+            for specifier in project_specifier
+            if specifier.operator == "=="
+        ]
+        assert exact_project_versions
+        assert all(
+            dependency.specifier.contains(project_version, prereleases=True)
+            for project_version in exact_project_versions
+        )


### PR DESCRIPTION
## Summary

- require raw WEEX symbol configuration to explicitly confirm `COMBINED` or `SEPARATED` position mode before leverage setup
- require every WEEX open order to carry explicit `LONG` or `SHORT` `positionSide`
- replace timestamp-cursor fill pagination with disjoint adaptive time-window bisection, including fail-closed handling when a single millisecond reaches the endpoint limit
- align the Requests and aiohttp pins with CCXT 4.5.66 and enforce compatible overlapping pins in the requirements contract test
- add regression coverage and update the exchange/fill contracts plus changelog

## Root cause

CCXT maps missing or unknown WEEX `separatedType` state to `hedged=false`, which was indistinguishable from confirmed combined mode. WEEX also inherited generic open-order side inference despite its explicit hedge-side contract. Fill pagination assumed full pages were returned oldest-first even though the endpoint provides no ordering guarantee or stable cursor. The CCXT upgrade also left older exact Requests and aiohttp pins that made a clean installation impossible.

## Validation

- `./venv/bin/python -m pytest tests/exchanges/test_weex.py -q` — 34 passed
- focused exchange, CCXT-upgrade, fill/PnL, trailing, HSL, orchestration, and balance suites — passed
- `./venv/bin/python -m pytest -q` — passed at 100%
- `./venv/bin/python -m pip install --dry-run --ignore-installed -r requirements.txt` — clean resolution
- installed validation environment: CCXT 4.5.66, aiohttp 3.14.1, Requests 2.34.2
- `PYTHONPATH=src ./venv/bin/python src/tools/check_ai_docs.py` — 0 errors (existing documentation-size warning)
- `PYTHONPATH=src ./venv/bin/python src/tools/generate_live_event_registry.py --check` — current

No authenticated exchange requests or live bot actions were performed for this follow-up.
