### PR TITLE
Bound restart smoke event-window scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ All notable user-facing changes will be documented in this file.
   local target and bounded smoke reports in memory and immediately evaluate the
   sanitized restart evidence contract. It performs only local filesystem and
   bounded `tmux`/`ps`/`git` inventory reads; it does not write intermediate
-  reports, pull or build code, contact exchanges, or control processes.
+  reports, pull or build code, contact exchanges, or control processes. Exact
+  historical event windows select only managed rotation segments whose encoded
+  intervals overlap the requested bounds, require retained predecessor coverage,
+  and fail closed before content scanning when names, per-bot counts, global
+  counts, or selected bytes exceed the bounded policy. Sanitized output reports
+  aggregate selection completeness, counts, scan bytes, and code-owned issues.
 
 - Live trailing restart reconciliation now preserves authoritative position-update
   timestamps from CCXT and raw exchange payloads and no longer

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -24,7 +24,7 @@ Estimated completion:
 
 - Branch: `codex/restart-smoke-window-selection`, based on canonical
   `9e8d1343e0f1f43fc3207d611a8b06d88af8b6c0` after PR #1303.
-- PR: pending. Slice: bound exact historical smoke collection by managed event
+- PR: #1305. Slice: bound exact historical smoke collection by managed event
   rotation intervals instead of decompressing the complete retained archive.
 - Triggering evidence: the first VPS5 #1303 collector run discovered 1,012 event
   segments totaling about 801 MB and remained CPU-active beyond ten minutes.

--- a/docs/plans/live_logging_overhaul_current_status.md
+++ b/docs/plans/live_logging_overhaul_current_status.md
@@ -22,39 +22,53 @@ Estimated completion:
 
 ## Active Review Slice
 
-- Branch: `codex/restart-smoke-collection-contract`, based on canonical
-  `0b5503b2a9ee4817618b7aca25dab417af4292dd` after PR #1302.
-- PR: #1303. Slice: collect exact local restart target and bounded smoke
-  evidence in memory, then immediately apply the existing sanitized evaluator.
-- Triggering evidence: PR #1302 proved the evaluator on retained real artifacts,
-  but operators still have to run two producers, retain two full reports, and
-  manually bind them into a third command.
-- Scope: require caller-confirmed head, supervisor fingerprint, target count,
-  session, config, and exact window; compose the existing bounded target and
-  smoke producers without intermediate report files; emit only the sanitized
-  evaluator verdict plus bounded collection-policy metadata.
-- Behavior boundary: local filesystem reads and bounded local `tmux`/`ps`/`git`
-  inventory subprocesses are allowed. SSH, pull/build, network or exchange
-  access, credentials, process signals/starts, force escalation, and file writes
-  remain excluded.
-- Validation: focused collection ordering/input/negative/redaction/CLI tests plus
-  existing target, smoke, evaluator, CLI, compilation, and docs regressions.
+- Branch: `codex/restart-smoke-window-selection`, based on canonical
+  `9e8d1343e0f1f43fc3207d611a8b06d88af8b6c0` after PR #1303.
+- PR: pending. Slice: bound exact historical smoke collection by managed event
+  rotation intervals instead of decompressing the complete retained archive.
+- Triggering evidence: the first VPS5 #1303 collector run discovered 1,012 event
+  segments totaling about 801 MB and remained CPU-active beyond ten minutes.
+  The exact collector PID was interrupted without touching bot panes. A
+  two-recent-segment cap returned in 20.9 seconds but correctly failed closed
+  because it omitted the restart lifecycle. An in-memory interval prototype
+  selected 10 overlapping segments and returned the full green verdict in 37.3
+  seconds.
+- Scope: parse code-owned UTC rotation-close labels, require predecessor coverage
+  for every discovered bot event stream, read only overlapping segments, and
+  fail before content scanning on malformed names, missing coverage, more than
+  eight files per bot, more than 128 files total, or more than 128 MiB selected.
+- Behavior boundary: the selector is opt-in for the restart collector; general
+  smoke-report behavior is unchanged. Local reads and bounded `tmux`/`ps`/`git`
+  inventory remain allowed. SSH, pull/build, network or exchange access,
+  credentials, process signals/starts, force escalation, and file writes remain
+  excluded.
+- Validation: synthetic overlap, gzip/UUID, malformed-name, missing-coverage,
+  per-bot/global-file/byte-limit, collection wiring/redaction, existing smoke,
+  CLI, compilation, and docs regressions.
 - Review gate: temporary maintainer-authorized exact-head Hermes plus green
   Python and Rust CI while Grok is halted.
-- Expected VPS action: pull and run the collector against the retained exact PR
-  #1296 restart window, plus caller-expectation negative checks. Do not restart
-  or signal bots.
+- Expected VPS action: pull and rerun the collector against exact PR #1296 bounds
+  `1784316350000..1784317500000`, then verify malformed-expectation rejection.
+  Do not restart or signal bots.
 
 ## Deployed Baseline
 
 - Canonical `master` and VPS5 are
-  `0b5503b2a9ee4817618b7aca25dab417af4292dd` after PR #1302. Exact-head Hermes
-  and Python/Rust CI were green. VPS5 fast-forwarded without a restart or
-  signal. The retained PR #1296 window evaluated green while preserving exact
-  bounds `1784316350000..1784317500000`; a one-millisecond log-window mismatch
-  and one dropped hard-looking line each failed with `log_scan_invalid`. Pane
-  parents and bot PIDs remained unchanged, the checkout stayed tracked-clean,
-  and `misc:0.0` remained `%8`, PID `434835`.
+  `9e8d1343e0f1f43fc3207d611a8b06d88af8b6c0` after PR #1303. Exact-head Hermes
+  and Python/Rust CI were green. VPS5 fast-forwarded without a bot restart or
+  signal. The first complete-archive collector run was interrupted after more
+  than ten CPU-active minutes by exact collector PID only; all five bot panes
+  retained parent PIDs `856294/856332/856364/856398/856434`, tracked state
+  stayed clean, and `misc:0.0` remained `%8`, PID `434835`. A read-only in-memory
+  interval prototype selected 10/1,012 segments and recovered five stopping,
+  five stopped, and five startup cohorts with zero hard failures in 37.3
+  seconds. This is triggering evidence for the active bounded-selection slice,
+  not yet deployed collector behavior.
+- PR #1302 previously deployed at
+  `0b5503b2a9ee4817618b7aca25dab417af4292dd`. The retained PR #1296 window
+  evaluated green with exact bounds `1784316350000..1784317500000`; a
+  one-millisecond mismatch and one dropped hard-looking line each failed with
+  `log_scan_invalid` while panes and `misc:0.0` remained unchanged.
 - PR #1301 previously deployed at
   `46a28795dec40acbee0dbaa3602be955bbecf23e`. Exact-head Hermes
   and Python/Rust CI were green. VPS5 fast-forwarded without a restart or

--- a/docs/plans/live_logging_overhaul_progress.md
+++ b/docs/plans/live_logging_overhaul_progress.md
@@ -15,7 +15,24 @@ merge, live smoke evidence changes, or new gaps are discovered.
 - Do not use this file for design churn; unresolved design details belong in the
   plan or a focused handoff doc.
 
-## Latest Canonical Deployment (PR #1302)
+## Latest Canonical Deployment (PR #1303)
+
+- PR #1303 merged as canonical
+  `9e8d1343e0f1f43fc3207d611a8b06d88af8b6c0` after exact-current-head Hermes
+  approval and green Python/Rust CI. It composes stable target sampling, exact
+  smoke-window collection, and sanitized evidence evaluation in memory without
+  intermediate reports or process control.
+- VPS5 fast-forwarded without a bot restart or signal. The first real collector
+  run discovered 1,012 retained event segments totaling about 801 MB and stayed
+  CPU-active beyond ten minutes. Only the exact collector PID was interrupted;
+  all five bot panes, `misc:0.0`, and tracked checkout state remained unchanged.
+- A two-recent-segment cap returned in 20.9 seconds but correctly failed closed
+  because it omitted the restart lifecycle. A read-only interval-selection
+  prototype then selected 10 overlapping segments and returned the complete
+  five-bot green lifecycle verdict in 37.3 seconds. The active follow-up makes
+  that selection fail closed under explicit per-bot, global-file, and byte caps.
+
+## Previous Canonical Deployment (PR #1302)
 
 - PR #1302 merged as canonical
   `0b5503b2a9ee4817618b7aca25dab417af4292dd` after exact-current-head Hermes
@@ -26,10 +43,9 @@ merge, live smoke evidence changes, or new gaps are discovered.
   one-millisecond mismatch and dropped-hard count each evaluated red with
   `log_scan_invalid`. All five pane parents and bot PIDs plus `misc:0.0` remained
   unchanged, and tracked state stayed clean.
-- The active follow-up directly composes the existing target, smoke, and evidence
-  builders in memory so operators no longer need intermediate full-report files.
-  Pull/build, SSH, process control, exchange access, and force escalation remain
-  separate.
+- PR #1303 directly composed the existing target, smoke, and evidence builders
+  in memory. Pull/build, SSH, process control, exchange access, and force
+  escalation remain separate.
 
 ## Previous Canonical Deployment (PR #1301)
 

--- a/docs/plans/live_ops_improvement_backlog.md
+++ b/docs/plans/live_ops_improvement_backlog.md
@@ -377,6 +377,14 @@ Related detailed plans:
      dropped-hard in-memory variants failed as expected. The active follow-up
      composes target, smoke, and evaluation in memory without intermediate full
      report files or process control.
+   - 2026-07-17: PR #1303 merged and deployed the in-memory collector without a
+     bot restart or signal. Its first exact retained-window run discovered 1,012
+     event segments totaling about 801 MB and remained CPU-active beyond ten
+     minutes, so the exact collector PID was interrupted while all five bot panes
+     and `misc:0.0` stayed unchanged. A read-only prototype selected the 10
+     rotation intervals overlapping that window and returned the complete green
+     five-bot lifecycle verdict in 37.3 seconds. The active follow-up makes that
+     interval selection fail-closed and caps per-bot, global-file, and byte scope.
 
    Remaining refinements: safe pull/build and post-restart smoke orchestration
    remain open, as does any separately reviewed force-escalation policy.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -473,8 +473,15 @@ Monitor commands are documented in detail in [monitor.md](monitor.md). The CLI s
   --until-ms MS` directly composes the existing exact target sampler, full
   bounded-window smoke report, and sanitized evidence evaluator in memory. The
   caller-confirmed head, private fingerprint, target count, and exact window are
-  never derived from the reports being checked. Rotated monitor segments are
-  included, process inspection is owned by the target report rather than
+  never derived from the reports being checked. Managed rotated event filenames
+  provide interval boundaries so the
+  collector reads only overlapping segments plus explicit coverage evidence;
+  malformed names, missing predecessor coverage, more than eight selected
+  segments per bot, more than 128 selected segments total, or more than 128 MiB
+  of selected event data fail closed before event content scanning. Its output
+  includes only aggregate selection completeness/count/scan-byte evidence and
+  code-owned issue counts, never segment paths. Process
+  inspection is owned by the target report rather than
   duplicated in smoke collection, and contextless log rows use the existing
   drop policy whose dropped hard-looking count must remain zero. The command
   emits no raw target or smoke report and writes no intermediate file. It may

--- a/src/live/restart_smoke_collection.py
+++ b/src/live/restart_smoke_collection.py
@@ -21,6 +21,23 @@ from live.smoke_report import build_live_smoke_report, default_logs_root_for_mon
 
 DEFAULT_TARGET_SAMPLES = 3
 DEFAULT_TARGET_SAMPLE_INTERVAL_S = 1.0
+MAX_WINDOW_EVENT_FILES_PER_BOT = 8
+MAX_WINDOW_EVENT_FILES_TOTAL = 128
+MAX_WINDOW_EVENT_BYTES_TOTAL = 128 * 1024 * 1024
+MAX_SELECTION_ISSUE_CODES = 10
+MAX_PROJECTED_COUNT = 1_000_000_000
+SEGMENT_SELECTION_ISSUE_CODES = frozenset(
+    {
+        "current_event_segment_duplicated",
+        "current_event_segment_missing",
+        "event_segment_name_unparseable",
+        "event_window_segment_limit_exceeded",
+        "event_window_segment_size_failed",
+        "event_window_start_coverage_unavailable",
+        "event_window_total_byte_limit_exceeded",
+        "event_window_total_file_limit_exceeded",
+    }
+)
 
 SAFETY_CONTRACT = {
     "local_only": True,
@@ -79,7 +96,45 @@ def _collection_policy(
     since_ms: int,
     until_ms: int,
     logs_root_was_supplied: bool,
+    smoke_report: dict[str, Any],
 ) -> dict[str, Any]:
+    event_window = smoke_report.get("event_window")
+    event_window = event_window if isinstance(event_window, dict) else {}
+    selection = event_window.get("segment_selection")
+    selection = selection if isinstance(selection, dict) else {}
+
+    def projected_count(key: str) -> int | None:
+        value = selection.get(key)
+        if type(value) is not int or value < 0 or value > MAX_PROJECTED_COUNT:
+            return None
+        return value
+
+    issue_counts = selection.get("issue_counts")
+    issue_counts = issue_counts if isinstance(issue_counts, dict) else {}
+    known_issue_counts = [
+        (str(code), count)
+        for code, count in sorted(issue_counts.items())
+        if str(code) in SEGMENT_SELECTION_ISSUE_CODES
+    ]
+    projected_issue_counts = {
+        code: int(count)
+        for code, count in known_issue_counts[:MAX_SELECTION_ISSUE_CODES]
+        if type(count) is int and 0 < count <= MAX_PROJECTED_COUNT
+    }
+    selection_evidence = {
+        "complete": selection.get("complete") is True,
+        "groups": projected_count("groups"),
+        "files_before_selection": projected_count("files_before_selection"),
+        "candidate_files_selected": projected_count("candidate_files_selected"),
+        "candidate_scan_bytes": projected_count("candidate_scan_bytes"),
+        "files_selected": projected_count("files_selected"),
+        "files_skipped": projected_count("files_skipped"),
+        "issue_counts": projected_issue_counts,
+        "issue_codes_truncated": max(
+            0,
+            len(issue_counts) - len(projected_issue_counts),
+        ),
+    }
     return {
         "target_sampling": {
             "samples": target_samples,
@@ -88,6 +143,11 @@ def _collection_policy(
         "smoke_collection": {
             "include_rotated": True,
             "include_processes": False,
+            "event_segment_selection": "rotation_end_overlap_with_predecessor",
+            "max_window_event_files_per_bot": MAX_WINDOW_EVENT_FILES_PER_BOT,
+            "max_window_event_files_total": MAX_WINDOW_EVENT_FILES_TOTAL,
+            "max_window_event_bytes_total": MAX_WINDOW_EVENT_BYTES_TOTAL,
+            "event_segment_evidence": selection_evidence,
             "log_window_unparsed_policy": "drop",
             "logs_root_source": "caller" if logs_root_was_supplied else "monitor_default",
             "event_window": {"since_ms": since_ms, "until_ms": until_ms},
@@ -161,6 +221,10 @@ def build_live_restart_smoke_collection(
         include_processes=False,
         since_ms=since_ms,
         until_ms=until_ms,
+        select_event_segments_for_window=True,
+        max_window_event_files_per_bot=MAX_WINDOW_EVENT_FILES_PER_BOT,
+        max_window_event_files_total=MAX_WINDOW_EVENT_FILES_TOTAL,
+        max_window_event_bytes_total=MAX_WINDOW_EVENT_BYTES_TOTAL,
         log_window_unparsed_policy="drop",
     )
     evaluation = build_live_restart_smoke_evidence(
@@ -183,6 +247,7 @@ def build_live_restart_smoke_collection(
             since_ms=since_ms,
             until_ms=until_ms,
             logs_root_was_supplied=logs_root is not None,
+            smoke_report=smoke_report,
         ),
         "gates": evaluation["gates"],
         "evidence": evaluation["evidence"],

--- a/src/live/smoke_report.py
+++ b/src/live/smoke_report.py
@@ -9,7 +9,7 @@ import stat
 import subprocess
 import time
 from collections import Counter, defaultdict, deque
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -73,6 +73,11 @@ STARTUP_BUDGET_INCOMPLETE_STATUSES = frozenset(
 DEFAULT_PROCESS_MATCH = "passivbot live"
 LOG_WINDOW_UNPARSED_POLICIES = {"keep", "drop"}
 DEFAULT_LOG_WINDOW_UNPARSED_POLICY = "keep"
+EVENT_SEGMENT_END_PATTERN = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2})"
+    r"(?:\.[0-9a-f]+)?\.ndjson(?:\.gz)?$"
+)
+EVENT_SEGMENT_END_GRANULARITY_MS = 999
 REMOTE_CALL_FAILURE_GROUP_LIMIT = 20
 REMOTE_CALL_HEALTH_GROUP_LIMIT = 20
 REMOTE_CALL_TIMING_GROUP_LIMIT = 20
@@ -8077,6 +8082,7 @@ def _event_window_report(
     event_file_limit_groups: int = 0,
     event_files_before_limit: int = 0,
     event_files_skipped_by_limit: int = 0,
+    segment_selection: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     report = {
         "enabled": since_ms is not None or until_ms is not None,
@@ -8102,6 +8108,8 @@ def _event_window_report(
         report["event_files_before_limit"] = int(event_files_before_limit)
         report["event_files_skipped_by_limit"] = int(event_files_skipped_by_limit)
         report["event_file_limit_order"] = "current_then_recent_mtime"
+    if segment_selection is not None:
+        report["segment_selection"] = dict(segment_selection)
     return report
 
 
@@ -8236,6 +8244,157 @@ def _monitor_issue(
     }
 
 
+def _event_segment_end_upper_ms(path: Path) -> int | None:
+    match = EVENT_SEGMENT_END_PATTERN.match(path.name)
+    if match is None:
+        return None
+    try:
+        parsed = datetime.strptime(match.group("ts"), "%Y-%m-%dT%H-%M-%S").replace(
+            tzinfo=timezone.utc
+        )
+    except ValueError:
+        return None
+    return int(parsed.timestamp() * 1000) + EVENT_SEGMENT_END_GRANULARITY_MS
+
+
+def _event_segment_scan_bytes(path: Path) -> int | None:
+    try:
+        file_size = int(path.stat().st_size)
+        if not path.name.endswith(".gz"):
+            return file_size
+        if file_size < 4:
+            return None
+        with path.open("rb") as stream:
+            stream.seek(-4, 2)
+            trailer = stream.read(4)
+    except OSError:
+        return None
+    if len(trailer) != 4:
+        return None
+    return int.from_bytes(trailer, byteorder="little", signed=False)
+
+
+def _select_event_segments_for_window(
+    files: list[Path],
+    *,
+    since_ms: int,
+    until_ms: int,
+    max_files_per_bot: int,
+    max_total_files: int,
+    max_total_bytes: int,
+) -> tuple[list[Path], dict[str, Any], list[dict[str, Any]]]:
+    if since_ms < 0 or until_ms <= since_ms:
+        raise ValueError("event segment window requires until_ms > since_ms >= 0")
+    if max_files_per_bot <= 0:
+        raise ValueError("max_window_event_files_per_bot must be positive")
+    if max_total_files <= 0:
+        raise ValueError("max_window_event_files_total must be positive")
+    if max_total_bytes <= 0:
+        raise ValueError("max_window_event_bytes_total must be positive")
+
+    grouped: dict[Path, list[Path]] = defaultdict(list)
+    for path in files:
+        grouped[path.parent].append(path)
+
+    selected: list[Path] = []
+    issue_counts: Counter[str] = Counter()
+    limit_exceeded_max = 0
+    for group_files in grouped.values():
+        current_files = [path for path in group_files if path.name == "current.ndjson"]
+        rotated_rows: list[tuple[int, Path]] = []
+        malformed = 0
+        for path in group_files:
+            if path.name == "current.ndjson":
+                continue
+            end_upper_ms = _event_segment_end_upper_ms(path)
+            if end_upper_ms is None:
+                malformed += 1
+                continue
+            rotated_rows.append((end_upper_ms, path))
+        if malformed:
+            issue_counts["event_segment_name_unparseable"] += malformed
+            continue
+        if len(current_files) != 1:
+            issue_counts[
+                "current_event_segment_missing"
+                if not current_files
+                else "current_event_segment_duplicated"
+            ] += 1
+            continue
+
+        rotated_rows.sort(key=lambda item: (item[0], item[1].name))
+        predecessor_indexes = [
+            index
+            for index, (end_upper_ms, _path) in enumerate(rotated_rows)
+            if end_upper_ms < since_ms
+        ]
+        if not predecessor_indexes:
+            issue_counts["event_window_start_coverage_unavailable"] += 1
+            continue
+
+        first_overlap_index = predecessor_indexes[-1] + 1
+        group_selected: list[Path] = []
+        end_covered = False
+        for end_upper_ms, path in rotated_rows[first_overlap_index:]:
+            group_selected.append(path)
+            if end_upper_ms >= until_ms:
+                end_covered = True
+                break
+        if not end_covered:
+            group_selected.append(current_files[0])
+        if len(group_selected) > max_files_per_bot:
+            issue_counts["event_window_segment_limit_exceeded"] += 1
+            limit_exceeded_max = max(limit_exceeded_max, len(group_selected))
+            continue
+        selected.extend(group_selected)
+
+    selected = sorted(set(selected), key=lambda path: (str(path.parent), path.name))
+    candidate_files_selected = len(selected)
+    selected_scan_bytes = 0
+    size_failed = False
+    for path in selected:
+        scan_bytes = _event_segment_scan_bytes(path)
+        if scan_bytes is None:
+            size_failed = True
+        else:
+            selected_scan_bytes += scan_bytes
+    if size_failed:
+        issue_counts["event_window_segment_size_failed"] += 1
+    if candidate_files_selected > max_total_files:
+        issue_counts["event_window_total_file_limit_exceeded"] += 1
+    if selected_scan_bytes > max_total_bytes:
+        issue_counts["event_window_total_byte_limit_exceeded"] += 1
+    if (
+        size_failed
+        or candidate_files_selected > max_total_files
+        or selected_scan_bytes > max_total_bytes
+    ):
+        selected = []
+
+    issues = [
+        {"code": code, "severity": "error", "count": int(count)}
+        for code, count in sorted(issue_counts.items())
+    ]
+    report = {
+        "enabled": True,
+        "complete": not issues and len(grouped) > 0,
+        "strategy": "rotation_end_overlap_with_predecessor",
+        "rotation_end_granularity_ms": EVENT_SEGMENT_END_GRANULARITY_MS + 1,
+        "groups": len(grouped),
+        "files_before_selection": len(files),
+        "candidate_files_selected": candidate_files_selected,
+        "candidate_scan_bytes": selected_scan_bytes,
+        "files_selected": len(selected),
+        "files_skipped": max(0, len(files) - len(selected)),
+        "max_files_per_bot": int(max_files_per_bot),
+        "max_total_files": int(max_total_files),
+        "max_total_bytes": int(max_total_bytes),
+        "limit_exceeded_max_files": int(limit_exceeded_max),
+        "issue_counts": dict(sorted(issue_counts.items())),
+    }
+    return selected, report, issues
+
+
 def _scan_events(
     root: str | Path,
     *,
@@ -8245,8 +8404,13 @@ def _scan_events(
     until_ms: int | None = None,
     event_tail_lines: int = 0,
     max_event_files_per_bot: int = 0,
+    select_segments_for_window: bool = False,
+    max_window_event_files_per_bot: int = 0,
+    max_window_event_files_total: int = 0,
+    max_window_event_bytes_total: int = 0,
 ) -> dict[str, Any]:
     issues: list[dict[str, Any]] = []
+    segment_selection: dict[str, Any] | None = None
     file_discovery: dict[str, Any] = {
         "candidate_files": 0,
         "event_segments": 0,
@@ -8265,6 +8429,35 @@ def _scan_events(
         files = []
         issues.append(
             _monitor_issue(str(root), None, "error", "path_not_found", str(exc))
+        )
+    if select_segments_for_window:
+        if not include_rotated:
+            raise ValueError(
+                "window-aware event segment selection requires include_rotated=True"
+            )
+        if type(since_ms) is not int or type(until_ms) is not int:
+            raise ValueError(
+                "window-aware event segment selection requires exact since_ms and until_ms"
+            )
+        files, segment_selection, selection_issues = (
+            _select_event_segments_for_window(
+                files,
+                since_ms=since_ms,
+                until_ms=until_ms,
+                max_files_per_bot=max_window_event_files_per_bot,
+                max_total_files=max_window_event_files_total,
+                max_total_bytes=max_window_event_bytes_total,
+            )
+        )
+        issues.extend(
+            _monitor_issue(
+                str(root),
+                None,
+                str(issue["severity"]),
+                str(issue["code"]),
+                f"affected_count={int(issue['count'])}",
+            )
+            for issue in selection_issues
         )
     if not files and not issues:
         issues.append(
@@ -8953,6 +9146,7 @@ def _scan_events(
             event_file_limit_groups=event_file_limit_groups,
             event_files_before_limit=event_files_before_limit or len(files),
             event_files_skipped_by_limit=event_files_skipped_by_limit,
+            segment_selection=segment_selection,
         ),
     }
 
@@ -9245,6 +9439,10 @@ def build_live_smoke_report(
     max_log_files: int = 8,
     event_tail_lines: int = 0,
     max_event_files_per_bot: int = 0,
+    select_event_segments_for_window: bool = False,
+    max_window_event_files_per_bot: int = 0,
+    max_window_event_files_total: int = 0,
+    max_window_event_bytes_total: int = 0,
     log_tail_lines: int = 300,
     max_log_matches: int = 50,
     log_window_unparsed_policy: str = DEFAULT_LOG_WINDOW_UNPARSED_POLICY,
@@ -9258,6 +9456,10 @@ def build_live_smoke_report(
         until_ms=until_ms,
         event_tail_lines=event_tail_lines,
         max_event_files_per_bot=max_event_files_per_bot,
+        select_segments_for_window=select_event_segments_for_window,
+        max_window_event_files_per_bot=max_window_event_files_per_bot,
+        max_window_event_files_total=max_window_event_files_total,
+        max_window_event_bytes_total=max_window_event_bytes_total,
     )
     event_report = event_scan["monitor"]
     log_scan = _scan_logs(

--- a/tests/test_live_restart_smoke_collection.py
+++ b/tests/test_live_restart_smoke_collection.py
@@ -57,6 +57,19 @@ def _target_report(*, targets: int = 2) -> dict:
 
 def _smoke_report(*, head: str = HEAD, attention: bool = False) -> dict:
     window = {"enabled": True, "since_ms": SINCE_MS, "until_ms": UNTIL_MS}
+    event_window = {
+        **window,
+        "segment_selection": {
+            "complete": True,
+            "groups": 2,
+            "files_before_selection": 40,
+            "candidate_files_selected": 4,
+            "candidate_scan_bytes": 12345,
+            "files_selected": 4,
+            "files_skipped": 36,
+            "issue_counts": {},
+        },
+    }
     return {
         "tool": "live-smoke-report",
         "schema_version": 1,
@@ -72,7 +85,7 @@ def _smoke_report(*, head: str = HEAD, attention: bool = False) -> dict:
             "error": None,
             "root": "/private/repository",
         },
-        "event_window": window,
+        "event_window": event_window,
         "monitor": {
             "root": "/private/monitor",
             "files_scanned": 2,
@@ -161,6 +174,10 @@ def test_collection_calls_producers_in_order_and_projects_sanitized_verdict(monk
         "include_processes": False,
         "since_ms": SINCE_MS,
         "until_ms": UNTIL_MS,
+        "select_event_segments_for_window": True,
+        "max_window_event_files_per_bot": 8,
+        "max_window_event_files_total": 128,
+        "max_window_event_bytes_total": 134217728,
         "log_window_unparsed_policy": "drop",
     }
     assert report["collection"] == {
@@ -168,6 +185,21 @@ def test_collection_calls_producers_in_order_and_projects_sanitized_verdict(monk
         "smoke_collection": {
             "include_rotated": True,
             "include_processes": False,
+            "event_segment_selection": "rotation_end_overlap_with_predecessor",
+            "max_window_event_files_per_bot": 8,
+            "max_window_event_files_total": 128,
+            "max_window_event_bytes_total": 134217728,
+            "event_segment_evidence": {
+                "complete": True,
+                "groups": 2,
+                "files_before_selection": 40,
+                "candidate_files_selected": 4,
+                "candidate_scan_bytes": 12345,
+                "files_selected": 4,
+                "files_skipped": 36,
+                "issue_counts": {},
+                "issue_codes_truncated": 0,
+            },
             "log_window_unparsed_policy": "drop",
             "logs_root_source": "caller",
             "event_window": {"since_ms": SINCE_MS, "until_ms": UNTIL_MS},
@@ -246,6 +278,44 @@ def test_collection_uses_monitor_default_logs_root_without_exposing_path(monkeyp
     assert captured["logs_root"] == "/private/default-logs"
     assert report["collection"]["smoke_collection"]["logs_root_source"] == "monitor_default"
     assert "/private/default-logs" not in json.dumps(report, sort_keys=True)
+
+
+def test_collection_bounds_and_whitelists_segment_selection_evidence(monkeypatch):
+    smoke = _smoke_report()
+    selection = smoke["event_window"]["segment_selection"]
+    selection.update(
+        {
+            "complete": False,
+            "groups": True,
+            "candidate_scan_bytes": 1_000_000_001,
+            "issue_counts": {
+                "event_window_segment_limit_exceeded": 2,
+                "private-secret-code": 1,
+            },
+        }
+    )
+    monkeypatch.setattr(
+        collection_module,
+        "build_live_restart_target_report",
+        lambda *_args, **_kwargs: _target_report(),
+    )
+    monkeypatch.setattr(
+        collection_module,
+        "build_live_smoke_report",
+        lambda *_args, **_kwargs: smoke,
+    )
+
+    report = build_live_restart_smoke_collection(**_kwargs())
+    evidence = report["collection"]["smoke_collection"]["event_segment_evidence"]
+
+    assert evidence["complete"] is False
+    assert evidence["groups"] is None
+    assert evidence["candidate_scan_bytes"] is None
+    assert evidence["issue_counts"] == {
+        "event_window_segment_limit_exceeded": 2
+    }
+    assert evidence["issue_codes_truncated"] == 1
+    assert "private-secret-code" not in json.dumps(report, sort_keys=True)
 
 
 def test_red_evidence_stays_red_and_attention_stays_non_hard(monkeypatch):

--- a/tests/test_live_smoke_report.py
+++ b/tests/test_live_smoke_report.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gzip
 import json
 import os
 from collections import Counter
@@ -310,6 +311,257 @@ def test_live_smoke_report_max_event_files_per_bot_is_fair(tmp_path):
     assert brief["event_window"]["max_event_files_per_bot"] == 2
     assert brief["event_window"]["event_file_limit_scope"] == "per_bot"
     assert brief["event_window"]["event_files_skipped_by_limit"] == 2
+
+
+def test_live_smoke_report_selects_only_segments_overlapping_exact_window(
+    tmp_path, monkeypatch
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    rows = [
+        ("1970-01-01T00-00-01.ndjson", 1500, "before"),
+        ("1970-01-01T00-00-02.ndjson", 2600, "inside_one"),
+        ("1970-01-01T00-00-03.abcdef12.ndjson.gz", 3400, "inside_two"),
+        ("1970-01-01T00-00-04.ndjson", 4500, "after"),
+        ("current.ndjson", 5000, "current"),
+    ]
+    for name, ts, cycle_id in rows:
+        _write_ndjson(
+            events_dir / name.removesuffix(".gz"),
+            [
+                _monitor_row(
+                    event_type="cycle.completed",
+                    seq=ts,
+                    ts=ts,
+                    ids={"cycle_id": cycle_id},
+                )
+            ],
+        )
+        if name.endswith(".gz"):
+            source = events_dir / name.removesuffix(".gz")
+            with source.open("rb") as src, gzip.open(events_dir / name, "wb") as dst:
+                dst.write(src.read())
+            source.unlink()
+
+    opened = []
+    original_open_text = event_file_rows_module._open_text
+
+    def spy_open_text(path):
+        opened.append(path.name)
+        return original_open_text(path)
+
+    monkeypatch.setattr(event_file_rows_module, "_open_text", spy_open_text)
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        include_rotated=True,
+        since_ms=2500,
+        until_ms=3500,
+        select_event_segments_for_window=True,
+        max_window_event_files_per_bot=64,
+        max_window_event_files_total=128,
+        max_window_event_bytes_total=128 * 1024 * 1024,
+    )
+
+    assert report["ok"] is True
+    assert opened == [
+        "1970-01-01T00-00-02.ndjson",
+        "1970-01-01T00-00-03.abcdef12.ndjson.gz",
+    ]
+    assert report["monitor"]["files_scanned"] == 2
+    assert report["event_window"]["events_considered"] == 2
+    assert report["event_window"]["segment_selection"] == {
+        "enabled": True,
+        "complete": True,
+        "strategy": "rotation_end_overlap_with_predecessor",
+        "rotation_end_granularity_ms": 1000,
+        "groups": 1,
+        "files_before_selection": 5,
+        "candidate_files_selected": 2,
+        "candidate_scan_bytes": (
+            (events_dir / "1970-01-01T00-00-02.ndjson").stat().st_size
+            + len(
+                gzip.decompress(
+                    (
+                        events_dir
+                        / "1970-01-01T00-00-03.abcdef12.ndjson.gz"
+                    ).read_bytes()
+                )
+            )
+        ),
+        "files_selected": 2,
+        "files_skipped": 3,
+        "max_files_per_bot": 64,
+        "max_total_files": 128,
+        "max_total_bytes": 128 * 1024 * 1024,
+        "limit_exceeded_max_files": 0,
+        "issue_counts": {},
+    }
+
+
+@pytest.mark.parametrize(
+    ("rotated_names", "since_ms", "until_ms", "max_files", "issue_code"),
+    [
+        (
+            ["legacy.ndjson", "1970-01-01T00-00-02.ndjson"],
+            2500,
+            3500,
+            64,
+            "event_segment_name_unparseable",
+        ),
+        (
+            ["1970-01-01T00-00-03.ndjson"],
+            2500,
+            3500,
+            64,
+            "event_window_start_coverage_unavailable",
+        ),
+        (
+            [
+                "1970-01-01T00-00-01.ndjson",
+                "1970-01-01T00-00-02.ndjson",
+                "1970-01-01T00-00-03.ndjson",
+                "1970-01-01T00-00-04.ndjson",
+            ],
+            2500,
+            4500,
+            2,
+            "event_window_segment_limit_exceeded",
+        ),
+    ],
+)
+def test_live_smoke_report_window_segment_selection_fails_closed(
+    tmp_path, rotated_names, since_ms, until_ms, max_files, issue_code
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    for index, name in enumerate([*rotated_names, "current.ndjson"], start=1):
+        _write_ndjson(
+            events_dir / name,
+            [
+                _monitor_row(
+                    event_type="cycle.completed",
+                    seq=index,
+                    ts=index * 1000,
+                    ids={"cycle_id": f"cy_{index}"},
+                )
+            ],
+        )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        include_rotated=True,
+        since_ms=since_ms,
+        until_ms=until_ms,
+        select_event_segments_for_window=True,
+        max_window_event_files_per_bot=max_files,
+        max_window_event_files_total=128,
+        max_window_event_bytes_total=128 * 1024 * 1024,
+    )
+
+    assert report["ok"] is False
+    assert report["hard_failures"] >= 1
+    assert report["event_window"]["segment_selection"]["complete"] is False
+    assert report["event_window"]["segment_selection"]["issue_counts"][issue_code]
+    assert any(issue["code"] == issue_code for issue in report["monitor"]["issues"])
+
+
+@pytest.mark.parametrize(
+    ("max_total_files", "max_total_bytes", "issue_code"),
+    [
+        (1, 128 * 1024 * 1024, "event_window_total_file_limit_exceeded"),
+        (128, 1, "event_window_total_byte_limit_exceeded"),
+    ],
+)
+def test_live_smoke_report_window_segment_global_limits_fail_before_content_scan(
+    tmp_path, monkeypatch, max_total_files, max_total_bytes, issue_code
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    for index, name in enumerate(
+        [
+            "1970-01-01T00-00-01.ndjson",
+            "1970-01-01T00-00-02.ndjson",
+            "1970-01-01T00-00-03.ndjson",
+            "current.ndjson",
+        ],
+        start=1,
+    ):
+        _write_ndjson(
+            events_dir / name,
+            [
+                _monitor_row(
+                    event_type="cycle.completed",
+                    seq=index,
+                    ts=index * 1000,
+                    ids={"cycle_id": f"cy_{index}"},
+                )
+            ],
+        )
+    opened = []
+    monkeypatch.setattr(
+        event_file_rows_module,
+        "_open_text",
+        lambda path: opened.append(path) or path.open("rt", encoding="utf-8"),
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        include_rotated=True,
+        since_ms=2500,
+        until_ms=3500,
+        select_event_segments_for_window=True,
+        max_window_event_files_per_bot=8,
+        max_window_event_files_total=max_total_files,
+        max_window_event_bytes_total=max_total_bytes,
+    )
+
+    assert report["ok"] is False
+    assert opened == []
+    selection = report["event_window"]["segment_selection"]
+    assert selection["complete"] is False
+    assert selection["files_selected"] == 0
+    assert selection["issue_counts"][issue_code] == 1
+
+
+def test_live_smoke_report_window_segment_rejects_unreadable_gzip_size(
+    tmp_path, monkeypatch
+):
+    events_dir = tmp_path / "monitor" / "binance" / "binance_01" / "events"
+    _write_ndjson(
+        events_dir / "1970-01-01T00-00-01.ndjson",
+        [_monitor_row(event_type="cycle.completed", seq=1, ts=1000)],
+    )
+    bad_gzip = events_dir / "1970-01-01T00-00-03.ndjson.gz"
+    bad_gzip.write_bytes(b"bad")
+    _write_ndjson(
+        events_dir / "current.ndjson",
+        [_monitor_row(event_type="cycle.completed", seq=2, ts=4000)],
+    )
+    opened = []
+    monkeypatch.setattr(
+        event_file_rows_module,
+        "_open_text",
+        lambda path: opened.append(path) or path.open("rt", encoding="utf-8"),
+    )
+
+    report = build_live_smoke_report(
+        tmp_path / "monitor",
+        logs_root=None,
+        include_rotated=True,
+        since_ms=2500,
+        until_ms=3500,
+        select_event_segments_for_window=True,
+        max_window_event_files_per_bot=8,
+        max_window_event_files_total=128,
+        max_window_event_bytes_total=128 * 1024 * 1024,
+    )
+
+    assert report["ok"] is False
+    assert opened == []
+    selection = report["event_window"]["segment_selection"]
+    assert selection["files_selected"] == 0
+    assert selection["issue_counts"] == {"event_window_segment_size_failed": 1}
 
 
 def test_live_smoke_report_summarizes_monitor_events_and_log_attention(tmp_path):


### PR DESCRIPTION
## Scope

Category: read-only tooling.

Bound exact historical restart-smoke event collection by selecting managed rotation segments whose encoded intervals overlap the requested window. Require retained predecessor coverage and fail before event-content scanning when names, coverage, per-bot file count, global file count, projected uncompressed scan bytes, or gzip sizing are invalid.

The restart collector enables this opt-in policy with fixed limits of 8 files per bot, 128 files total, and 128 MiB projected scan data. Its sanitized output adds aggregate selection completeness, counts, scan bytes, and whitelisted issue counts without paths or event content.

General `live-smoke-report` behavior is unchanged unless the new internal selection mode is requested.

## Triggering evidence

After merged PR #1303 fast-forwarded VPS5 to `9e8d1343e0f1f43fc3207d611a8b06d88af8b6c0`, the first collector run discovered 1,012 event segments totaling about 801 MB and stayed CPU-active beyond ten minutes. Only that exact collector PID was interrupted; all five configured bot panes, `misc:0.0`, and tracked checkout state remained unchanged.

A two-recent-segment cap returned in 20.9 seconds but correctly failed closed because it omitted the restart lifecycle. A read-only in-memory interval prototype selected 10 overlapping segments and returned the complete five-bot green lifecycle verdict in 37.3 seconds.

## Behavior and non-goals

- Reads only local monitor/log/config/process/repository state already used by the collector.
- Does not write reports, pull/build, SSH, contact a network or exchange, access credentials, signal/start processes, or perform force escalation.
- Does not change trading, restart, smoke-verdict, event-production, retention, or general smoke-report defaults.

## Validation

- Complete Python suite passed on the final worktree state.
- Focused smoke/collector/evaluator/target/process/CLI/docs suite passed: 254 tests.
- Rust wrapper passed: 210 tests.
- Exact rebuilt extension source fingerprint matched: `f9f68422597094ce12464c1a891a31d613724644894279d26770ed6e1ef1b846`.
- Changed Python modules compiled.
- AI docs check: 0 errors; existing aggregate-size warning only.
- Generated live-event registry check passed.
- `git diff --check` passed.

## Reviewer focus

- Rotation close-second granularity and predecessor coverage proof.
- Fail-closed behavior for malformed/legacy names, missing current/predecessor coverage, file/byte limits, and malformed gzip sizing.
- Sanitized aggregate projection and unchanged general smoke-report defaults.

## Expected VPS action

Pull and rerun the collector against exact retained PR #1296 bounds `1784316350000..1784317500000`, then verify malformed-expectation rejection. No bot restart or signal.
